### PR TITLE
Add actionview deprecation to 7.2 release note [skip ci]

### DIFF
--- a/guides/source/7_2_release_notes.md
+++ b/guides/source/7_2_release_notes.md
@@ -77,6 +77,8 @@ Please refer to the [Changelog][action-view] for detailed changes.
 
 ### Deprecations
 
+*  Deprecate passing content to void elements when using `tag.br` type tag builders.
+
 ### Notable changes
 
 Action Mailer


### PR DESCRIPTION
We deprecated passing content to void elements when using `tag.br` type tag builders in https://github.com/rails/rails/pull/50159

### Detail

This Pull Request add the deprecation changes to 7.2 release note.


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.

cc: @skipkayhil 
