### PR TITLE
[Fix #49874] `has_secure_token` calls the setter method on initialize

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Fix `has_secure_token` calls the setter method on initialize.
+
+    *Abeid Ahmed*
+
 *   When using a `DATABASE_URL`, allow for a configuration to map the protocol in the URL to a specific database
     adapter. This allows decoupling the adapter the application chooses to use from the database connection details
     set in the deployment environment.

--- a/activerecord/lib/active_record/secure_token.rb
+++ b/activerecord/lib/active_record/secure_token.rb
@@ -53,7 +53,7 @@ module ActiveRecord
         define_method("regenerate_#{attribute}") { update! attribute => self.class.generate_unique_secure_token(length: length) }
         set_callback on, on == :initialize ? :after : :before do
           if new_record? && !query_attribute(attribute)
-            write_attribute(attribute, self.class.generate_unique_secure_token(length: length))
+            send("#{attribute}=", self.class.generate_unique_secure_token(length: length))
           end
         end
       end

--- a/activerecord/test/cases/secure_token_test.rb
+++ b/activerecord/test/cases/secure_token_test.rb
@@ -98,4 +98,22 @@ class SecureTokenTest < ActiveRecord::TestCase
 
     assert_predicate user.token, :present?
   end
+
+  def test_token_calls_the_setter_method
+    model = Class.new(ActiveRecord::Base) do
+      self.table_name = "users"
+      has_secure_token on: :initialize
+
+      attr_accessor :modified_token
+
+      def token=(value)
+        super
+        self.modified_token = "#{value}_modified"
+      end
+    end
+
+    user = model.new
+
+    assert_equal "#{user.token}_modified", user.modified_token
+  end
 end


### PR DESCRIPTION
### Motivation / Background

Fixes #49874 

### Detail

The original behavior of `has_secure_token` was to use the `send("#{attribute}=", some_value)` method so that the setter method, if defined, was called. PR #49146 replaced the `send` method with `write_attribute` which doesn't call the setter method and breaks existing applications.

### Additional information

Follow-up to #49146

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
