### PR TITLE
Action Text Source-to-Compiled code drift

### DIFF
--- a/actiontext/app/assets/javascripts/actiontext.esm.js
+++ b/actiontext/app/assets/javascripts/actiontext.esm.js
@@ -508,7 +508,7 @@ function toArray(value) {
 }
 
 class BlobRecord {
-  constructor(file, checksum, url, customHeaders = {}) {
+  constructor(file, checksum, url) {
     this.file = file;
     this.attributes = {
       filename: file.name,
@@ -522,9 +522,6 @@ class BlobRecord {
     this.xhr.setRequestHeader("Content-Type", "application/json");
     this.xhr.setRequestHeader("Accept", "application/json");
     this.xhr.setRequestHeader("X-Requested-With", "XMLHttpRequest");
-    Object.keys(customHeaders).forEach((headerKey => {
-      this.xhr.setRequestHeader(headerKey, customHeaders[headerKey]);
-    }));
     const csrfToken = getMetaValue("csrf-token");
     if (csrfToken != undefined) {
       this.xhr.setRequestHeader("X-CSRF-Token", csrfToken);
@@ -607,12 +604,11 @@ class BlobUpload {
 let id = 0;
 
 class DirectUpload {
-  constructor(file, url, delegate, customHeaders = {}) {
+  constructor(file, url, delegate) {
     this.id = ++id;
     this.file = file;
     this.url = url;
     this.delegate = delegate;
-    this.customHeaders = customHeaders;
   }
   create(callback) {
     FileChecksum.create(this.file, ((error, checksum) => {
@@ -620,7 +616,7 @@ class DirectUpload {
         callback(error);
         return;
       }
-      const blob = new BlobRecord(this.file, checksum, this.url, this.customHeaders);
+      const blob = new BlobRecord(this.file, checksum, this.url);
       notify(this.delegate, "directUploadWillCreateBlobWithXHR", blob.xhr);
       blob.create((error => {
         if (error) {

--- a/actiontext/app/assets/javascripts/actiontext.js
+++ b/actiontext/app/assets/javascripts/actiontext.js
@@ -502,7 +502,7 @@
     }
   }
   class BlobRecord {
-    constructor(file, checksum, url, customHeaders = {}) {
+    constructor(file, checksum, url) {
       this.file = file;
       this.attributes = {
         filename: file.name,
@@ -516,9 +516,6 @@
       this.xhr.setRequestHeader("Content-Type", "application/json");
       this.xhr.setRequestHeader("Accept", "application/json");
       this.xhr.setRequestHeader("X-Requested-With", "XMLHttpRequest");
-      Object.keys(customHeaders).forEach((headerKey => {
-        this.xhr.setRequestHeader(headerKey, customHeaders[headerKey]);
-      }));
       const csrfToken = getMetaValue("csrf-token");
       if (csrfToken != undefined) {
         this.xhr.setRequestHeader("X-CSRF-Token", csrfToken);
@@ -598,12 +595,11 @@
   }
   let id = 0;
   class DirectUpload {
-    constructor(file, url, delegate, customHeaders = {}) {
+    constructor(file, url, delegate) {
       this.id = ++id;
       this.file = file;
       this.url = url;
       this.delegate = delegate;
-      this.customHeaders = customHeaders;
     }
     create(callback) {
       FileChecksum.create(this.file, ((error, checksum) => {
@@ -611,7 +607,7 @@
           callback(error);
           return;
         }
-        const blob = new BlobRecord(this.file, checksum, this.url, this.customHeaders);
+        const blob = new BlobRecord(this.file, checksum, this.url);
         notify(this.delegate, "directUploadWillCreateBlobWithXHR", blob.xhr);
         blob.create((error => {
           if (error) {


### PR DESCRIPTION
### Motivation / Background

When executing `bin/test` locally on `main`, the following error is raised:

```
Run options: --seed 24472

.......[ActiveJob] Enqueued ActiveStorage::AnalyzeJob (Job ID: f2998ceb-b80b-428e-8a9b-50c659b84a36) to Test(default) with arguments: #<GlobalID:0x0000000110030438 @uri=#<URI::GID gid://dummy/ActiveStorage::Blob/1>>
.[ActiveJob] Enqueued ActiveStorage::AnalyzeJob (Job ID: 23beadd0-3ae1-4a20-9d09-8c271a54546c) to Test(default) with arguments: #<GlobalID:0x0000000112a52928 @uri=#<URI::GID gid://dummy/ActiveStorage::Blob/1>>
.[ActiveJob] Enqueued ActiveStorage::AnalyzeJob (Job ID: 1bb5caf7-fda2-4d6d-8d76-74ce4de62599) to Test(default) with arguments: #<GlobalID:0x0000000112a37f38 @uri=#<URI::GID gid://dummy/ActiveStorage::Blob/1>>
..............[ActiveJob] Enqueued ActiveStorage::AnalyzeJob (Job ID: cde515b0-98ad-4abd-9e1e-37ae91f00f3e) to Test(default) with arguments: #<GlobalID:0x00000001131768d0 @uri=#<URI::GID gid://dummy/ActiveStorage::Blob/1>>
.[ActiveJob] Enqueued ActiveStorage::AnalyzeJob (Job ID: 2fa629c2-b865-4c0f-8d9c-e90d032bb2b4) to Test(default) with arguments: #<GlobalID:0x00000001131f9410 @uri=#<URI::GID gid://dummy/ActiveStorage::Blob/1>>
.[ActiveJob] Enqueued ActiveStorage::AnalyzeJob (Job ID: a919f297-1633-4337-8889-843ce1284f15) to Test(default) with arguments: #<GlobalID:0x00000001103b3100 @uri=#<URI::GID gid://dummy/ActiveStorage::Blob/1>>
.......[ActiveJob] Enqueued ActiveStorage::AnalyzeJob (Job ID: eed283fd-f78b-4cbd-8afe-9cb637e1def8) to Test(default) with arguments: #<GlobalID:0x0000000112a9e940 @uri=#<URI::GID gid://dummy/ActiveStorage::Blob/1>>
[ActiveJob] Enqueued BroadcastJob (Job ID: 967d6cd7-8d48-4cd4-9344-5b8522cfdef5) to Test(default) with arguments: "/var/folders/4q/q308vb3s12x2rzrgppdsz0540000gn/T/d20231203-60132-178n3r/broadcast.html", #<GlobalID:0x0000000112a99878 @uri=#<URI::GID gid://dummy/Message/926854805>>
[ActiveJob] [ActiveStorage::AnalyzeJob] [eed283fd-f78b-4cbd-8afe-9cb637e1def8] Performing ActiveStorage::AnalyzeJob (Job ID: eed283fd-f78b-4cbd-8afe-9cb637e1def8) from Test(default) enqueued at 2023-12-03T17:15:25.508670000Z with arguments: #<GlobalID:0x0000000112a92bb8 @uri=#<URI::GID gid://dummy/ActiveStorage::Blob/1>>
[ActiveJob] [ActiveStorage::AnalyzeJob] [eed283fd-f78b-4cbd-8afe-9cb637e1def8] Performed ActiveStorage::AnalyzeJob (Job ID: eed283fd-f78b-4cbd-8afe-9cb637e1def8) from Test(default) in 105.62ms
[ActiveJob] [BroadcastJob] [967d6cd7-8d48-4cd4-9344-5b8522cfdef5] Performing BroadcastJob (Job ID: 967d6cd7-8d48-4cd4-9344-5b8522cfdef5) from Test(default) enqueued at 2023-12-03T17:15:25.509141000Z with arguments: "/var/folders/4q/q308vb3s12x2rzrgppdsz0540000gn/T/d20231203-60132-178n3r/broadcast.html", #<GlobalID:0x0000000112f364d0 @uri=#<URI::GID gid://dummy/Message/926854805>>
[ActiveJob] [BroadcastJob] [967d6cd7-8d48-4cd4-9344-5b8522cfdef5] Performed BroadcastJob (Job ID: 967d6cd7-8d48-4cd4-9344-5b8522cfdef5) from Test(default) in 2.65ms
..............................................................yarn run v1.22.19
$ rollup --config rollup.config.js
Done in 0.53s.
F

Failure:
JavascriptPackageTest#test_compiled_code_is_in_sync_with_source_code [REDACTED/rails/rails/actiontext/test/javascript_package_test.rb:14]:
--- expected
+++ actual
@@ -502,7 +502,7 @@
     }
   }
   class BlobRecord {
-    constructor(file, checksum, url, customHeaders = {}) {
+    constructor(file, checksum, url) {
       this.file = file;
       this.attributes = {
         filename: file.name,
@@ -516,9 +516,6 @@
       this.xhr.setRequestHeader(\"Content-Type\", \"application/json\");
       this.xhr.setRequestHeader(\"Accept\", \"application/json\");
       this.xhr.setRequestHeader(\"X-Requested-With\", \"XMLHttpRequest\");
-      Object.keys(customHeaders).forEach((headerKey => {
-        this.xhr.setRequestHeader(headerKey, customHeaders[headerKey]);
-      }));
       const csrfToken = getMetaValue(\"csrf-token\");
       if (csrfToken != undefined) {
         this.xhr.setRequestHeader(\"X-CSRF-Token\", csrfToken);
@@ -598,12 +595,11 @@
   }
   let id = 0;
   class DirectUpload {
-    constructor(file, url, delegate, customHeaders = {}) {
+    constructor(file, url, delegate) {
       this.id = ++id;
       this.file = file;
       this.url = url;
       this.delegate = delegate;
-      this.customHeaders = customHeaders;
     }
     create(callback) {
       FileChecksum.create(this.file, ((error, checksum) => {
@@ -611,7 +607,7 @@
           callback(error);
           return;
         }
-        const blob = new BlobRecord(this.file, checksum, this.url, this.customHeaders);
+        const blob = new BlobRecord(this.file, checksum, this.url);
         notify(this.delegate, \"directUploadWillCreateBlobWithXHR\", blob.xhr);
         blob.create((error => {
           if (error) {
@@ -1370,7 +1366,7 @@
 }

 class BlobRecord {
-  constructor(file, checksum, url, customHeaders = {}) {
+  constructor(file, checksum, url) {
     this.file = file;
     this.attributes = {
       filename: file.name,
@@ -1384,9 +1380,6 @@
     this.xhr.setRequestHeader(\"Content-Type\", \"application/json\");
     this.xhr.setRequestHeader(\"Accept\", \"application/json\");
     this.xhr.setRequestHeader(\"X-Requested-With\", \"XMLHttpRequest\");
-    Object.keys(customHeaders).forEach((headerKey => {
-      this.xhr.setRequestHeader(headerKey, customHeaders[headerKey]);
-    }));
     const csrfToken = getMetaValue(\"csrf-token\");
     if (csrfToken != undefined) {
       this.xhr.setRequestHeader(\"X-CSRF-Token\", csrfToken);
@@ -1469,12 +1462,11 @@
 let id = 0;

 class DirectUpload {
-  constructor(file, url, delegate, customHeaders = {}) {
+  constructor(file, url, delegate) {
     this.id = ++id;
     this.file = file;
     this.url = url;
     this.delegate = delegate;
-    this.customHeaders = customHeaders;
   }
   create(callback) {
     FileChecksum.create(this.file, ((error, checksum) => {
@@ -1482,7 +1474,7 @@
         callback(error);
         return;
       }
-      const blob = new BlobRecord(this.file, checksum, this.url, this.customHeaders);
+      const blob = new BlobRecord(this.file, checksum, this.url);
       notify(this.delegate, \"directUploadWillCreateBlobWithXHR\", blob.xhr);
       blob.create((error => {
         if (error) {

bin/test test/javascript_package_test.rb:6

Finished in 1.496971s, 63.4615 runs/s, 140.2833 assertions/s.
95 runs, 210 assertions, 1 failures, 0 errors, 0 skips
```

### Detail

This commit aims to synchronize the JavaScript source defined in `app/javascript` with the compiled output defined in `app/assets/javascripts`.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
