### PR TITLE
Add test coverage for `rich_text_area` helper

### DIFF
--- a/actiontext/test/template/form_helper_test.rb
+++ b/actiontext/test/template/form_helper_test.rb
@@ -25,19 +25,37 @@ class ActionText::FormHelperTest < ActionView::TestCase
     )
   end
 
-  test "rich text area tag" do
+  test "#rich_text_area_tag helper" do
     message = Message.new
 
-    form_with model: message, scope: :message do |form|
-      rich_text_area_tag :content, message.content, { input: "trix_input_1" }
-    end
+    concat rich_text_area_tag :content, message.content, { input: "trix_input_1" }
 
     assert_dom_equal \
-      '<form action="/messages" accept-charset="UTF-8" method="post">' \
-        '<input type="hidden" name="content" id="trix_input_1" autocomplete="off" />' \
-        '<trix-editor input="trix_input_1" class="trix-content" data-direct-upload-url="http://test.host/rails/active_storage/direct_uploads" data-blob-url-template="http://test.host/rails/active_storage/blobs/redirect/:signed_id/:filename">' \
-        "</trix-editor>" \
-      "</form>",
+      '<input type="hidden" name="content" id="trix_input_1" autocomplete="off" />' \
+      '<trix-editor input="trix_input_1" class="trix-content" data-direct-upload-url="http://test.host/rails/active_storage/direct_uploads" data-blob-url-template="http://test.host/rails/active_storage/blobs/redirect/:signed_id/:filename">' \
+      "</trix-editor>",
+      output_buffer
+  end
+
+  test "#rich_text_area helper" do
+    concat rich_text_area :message, :content, input: "trix_input_1"
+
+    assert_dom_equal \
+      '<input type="hidden" name="message[content]" id="trix_input_1" autocomplete="off" />' \
+      '<trix-editor id="message_content" input="trix_input_1" class="trix-content" data-direct-upload-url="http://test.host/rails/active_storage/direct_uploads" data-blob-url-template="http://test.host/rails/active_storage/blobs/redirect/:signed_id/:filename">' \
+      "</trix-editor>",
+      output_buffer
+  end
+
+  test "#rich_text_area helper renders the :value argument into the hidden field" do
+    message = Message.new content: "<h1>hello world</h1>"
+
+    concat rich_text_area :message, :title, value: message.content, input: "trix_input_1"
+
+    assert_dom_equal \
+      '<input type="hidden" name="message[title]" id="trix_input_1" value="&lt;h1&gt;hello world&lt;/h1&gt;" autocomplete="off" />' \
+      '<trix-editor id="message_title" input="trix_input_1" class="trix-content" data-direct-upload-url="http://test.host/rails/active_storage/direct_uploads" data-blob-url-template="http://test.host/rails/active_storage/blobs/redirect/:signed_id/:filename">' \
+      "</trix-editor>",
       output_buffer
   end
 


### PR DESCRIPTION
### Motivation / Background

Follow-up to [#50252][]

Similar to the reliance on a `FormBuilder` in the helper methods documentation examples, the template test coverage for `#rich_text_area` relied on invocations through a `FormBuilder` instance.

### Detail

This commit adds explicit coverage for calling the `#rich_text_area` helper method directly with both an `object_name` and `method_name` positional arguments.

[#50252]: https://github.com/rails/rails/pull/50252

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
