### PR TITLE
Sanitize and treat `ActionText::Content#to_{trix_html,html}` as safe

### DIFF
--- a/actiontext/CHANGELOG.md
+++ b/actiontext/CHANGELOG.md
@@ -1,3 +1,14 @@
+*   Treat `Content#to_html` and `Content#to_trix_html` as safe
+
+    ```ruby
+    content = ActionText::Content.new("<div>hello world</div>")
+
+    content.to_html.html_safe? # => true
+    content.to_trix_html.html_safe? # => true
+    ```
+
+    *Sean Doyle*
+
 *   Compile ESM package that can be used directly in the browser as actiontext.esm.js
 
     *Matias Grunberg*

--- a/actiontext/lib/action_text/html_conversion.rb
+++ b/actiontext/lib/action_text/html_conversion.rb
@@ -5,7 +5,7 @@ module ActionText
     extend self
 
     def node_to_html(node)
-      node.to_html(save_with: Nokogiri::XML::Node::SaveOptions::AS_HTML)
+      node.to_html(save_with: Nokogiri::XML::Node::SaveOptions::AS_HTML).html_safe
     end
 
     def fragment_for_html(html)

--- a/actiontext/test/unit/content_test.rb
+++ b/actiontext/test/unit/content_test.rb
@@ -15,6 +15,20 @@ class ActionText::ContentTest < ActiveSupport::TestCase
     assert_equal content, Marshal.load(Marshal.dump(content))
   end
 
+  test "#to_html is html safe" do
+    html = "<div>a<br></div>"
+    content = content_from_html(html)
+
+    assert_predicate content.to_html, :html_safe?
+  end
+
+  test "#to_trix_html is html safe" do
+    html = "<div>a<br></div>"
+    content = content_from_html(html)
+
+    assert_predicate content.to_trix_html, :html_safe?
+  end
+
   test "roundtrips HTML without additional newlines" do
     html = "<div>a<br></div>"
     content = content_from_html(html)


### PR DESCRIPTION
### Motivation / Background

Prior to this commit, the HTML strings created from `ActionText::Content` instances were not marked as HTML safe, despite the fact that they were parsed and rendered as fragments by Nokogiri.

### Detail

This commit changes `ActionText::HtmlConversion.node_to_html` to mark the Nokogiri-rendered strings as safe.

```ruby
content = ActionText::Content.new("<div>hello world</div>")

content.to_html.html_safe? # => true
content.to_trix_html.html_safe? # => true
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
