### PR TITLE
Lock irb to < 1.10 for now

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -134,6 +134,8 @@ gem "webmock"
 local_gemfile = File.expand_path(".Gemfile", __dir__)
 instance_eval File.read local_gemfile if File.exist? local_gemfile
 
+gem "irb", "< 1.10"
+
 group :test do
   gem "minitest-bisect"
   gem "minitest-ci", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -285,7 +285,7 @@ GEM
       activesupport (>= 6.0.0)
       railties (>= 6.0.0)
     io-console (0.6.0)
-    irb (1.8.3)
+    irb (1.9.1)
       rdoc
       reline (>= 0.3.8)
     jbuilder (2.11.5)
@@ -409,7 +409,7 @@ GEM
     rb-inotify (0.10.1)
       ffi (~> 1.0)
     rbtree (0.4.6)
-    rdoc (6.6.0)
+    rdoc (6.6.1)
       psych (>= 4.0.0)
     redcarpet (3.2.3)
     redis (5.0.5)
@@ -515,7 +515,7 @@ GEM
     stackprof (0.2.23)
     stimulus-rails (1.2.1)
       railties (>= 6.0.0)
-    stringio (3.0.9)
+    stringio (3.1.0)
     sucker_punch (3.1.0)
       concurrent-ruby (~> 1.0)
     syntax_tree (6.1.1)
@@ -591,6 +591,7 @@ DEPENDENCIES
   google-cloud-storage (~> 1.11)
   image_processing (~> 1.2)
   importmap-rails (>= 1.2.3)
+  irb (< 1.10)
   jbuilder
   jsbundling-rails
   json (>= 2.0.0, != 2.7.0)


### PR DESCRIPTION
It breaks various `rails console` related integration tests:

```
Failure:
FullStackConsoleTest#test_sandbox [test/application/console_test.rb:123]:
"> " expected, but got:

(END).
Expected "\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n--More--\r        \r(END)" to include "> ".
```

I tried to figure out a fix, but ran out of time, so in order to fix CI we can lock IRB for now.

I suspect it's no big deal, the way we simulate a TTY is probably confusing irb or reline

FYI: @zzak @st0012 