### PR TITLE
fix LocalCache#read_multi_entries not namespacing keys & not deserializing raw values correctly

### DIFF
--- a/activesupport/lib/active_support/cache.rb
+++ b/activesupport/lib/active_support/cache.rb
@@ -826,7 +826,7 @@ module ActiveSupport
           end
         end
 
-        def deserialize_entry(payload)
+        def deserialize_entry(payload, **)
           payload.nil? ? nil : @coder.load(payload)
         rescue DeserializationError
           nil

--- a/activesupport/lib/active_support/cache/strategy/local_cache.rb
+++ b/activesupport/lib/active_support/cache/strategy/local_cache.rb
@@ -131,17 +131,20 @@ module ActiveSupport
             end
           end
 
-          def read_multi_entries(keys, **options)
+          def read_multi_entries(names, **options)
             return super unless local_cache
 
-            local_entries = local_cache.read_multi_entries(keys)
-            local_entries.transform_values! do |payload|
-              deserialize_entry(payload)&.value
-            end
-            missed_keys = keys - local_entries.keys
+            keys_to_names = names.index_by { |name| normalize_key(name, options) }
 
-            if missed_keys.any?
-              local_entries.merge!(super(missed_keys, **options))
+            local_entries = local_cache.read_multi_entries(keys_to_names.keys)
+            local_entries.transform_keys! { |key| keys_to_names[key] }
+            local_entries.transform_values! do |payload|
+              deserialize_entry(payload, **options)&.value
+            end
+            missed_names = names - local_entries.keys
+
+            if missed_names.any?
+              local_entries.merge!(super(missed_names, **options))
             else
               local_entries
             end

--- a/activesupport/test/cache/behaviors/local_cache_behavior.rb
+++ b/activesupport/test/cache/behaviors/local_cache_behavior.rb
@@ -190,6 +190,7 @@ module LocalCacheBehavior
     @cache.with_local_cache do
       @cache.write(key, 1, raw: true)
       @peek.write(key, 2, raw: true)
+
       @cache.increment(key)
 
       expected = @peek.read(key, raw: true)
@@ -205,6 +206,7 @@ module LocalCacheBehavior
       @peek.write(key, 3, raw: true)
 
       @cache.decrement(key)
+
       expected = @peek.read(key, raw: true)
       assert_equal 2, Integer(expected)
       assert_equal expected, @cache.read(key, raw: true)
@@ -230,12 +232,22 @@ module LocalCacheBehavior
     other_value = SecureRandom.alphanumeric
     @cache.with_local_cache do
       @cache.write(key, value, raw: true)
-      @cache.write(other_key, other_value, raw: true)
+      @peek.write(other_key, other_value, raw: true)
       values = @cache.read_multi(key, other_key, raw: true)
       assert_equal value, @cache.read(key, raw: true)
       assert_equal other_value, @cache.read(other_key, raw: true)
       assert_equal value, values[key]
       assert_equal other_value, values[other_key]
+    end
+  end
+
+  def test_local_cache_of_read_multi_prioritizes_local_entries
+    key = "key#{rand}"
+    @cache.with_local_cache do
+      @cache.write(key, "foo")
+      @cache.send(:bypass_local_cache) { @cache.write(key, "bar") }
+
+      assert_equal({ key => "foo" }, @cache.read_multi(key))
     end
   end
 


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created because there are several issues w/ `read_multi` on cache stores with an active local cache:
- If using a namespace, it does not normalize the keys before looking them up in the cache and thus always falls back to looking them up in the real cache store
- If trying to lookup raw values, it would always silently fail and return `nil` for the values _if it found them in the local cache_ (this was hidden in the current tests by the above issue)

### Detail

This Pull Request changes `LocalCache#read_multi_entries` to normalize the keys before looking them up in the local cache & to pass the options down to `deserialize_entry` to correctly deserialize raw values for memcache and redis stores. It also changes the `ActiveSupport::Cache::Store#deserialize_entry` signature to account for options being passed to it (from memory, null, & file stores).

### Additional information

On any rails app configured to use :mem_cache_store and no namespace (or do have a namespace and run with the changes from the first commit), run this code in a rails console:

```ruby
class LetsMakeItBreak
  def boom
    log_it = -> { puts "@data: #{::ActiveSupport::Cache::Strategy::LocalCache::LocalCacheRegistry.cache_for(Rails.cache.send(:local_cache_key)).instance_variable_get(:@data).inspect}" }

    Rails.cache.with_local_cache do
      log_it.call
      puts "fetch_multi: #{Rails.cache.fetch_multi("blep:one", raw: true) { 1 }}"
      log_it.call
      puts "increment: #{Rails.cache.increment("blep:one", 1, raw: true)}"
      log_it.call
      puts "read: #{Rails.cache.read("blep:one", raw: true)}"
      log_it.call
      puts "read_multi: #{Rails.cache.read_multi("blep:one", raw: true)}"
      log_it.call
    end
  end
end

LetsMakeItBreak.new.boom
```

The output should look like:

```ruby
@data: {}
fetch_multi: {"blep:one"=>1}
@data: {"blep:one"=>"1"}
increment: 2
@data: {"blep:one"=>"2"}
read: 2
@data: {"blep:one"=>"2"}
read_multi: {"blep:one"=>nil}
@data: {"blep:one"=>"2"}
```

You can see the problem on the `read_multi` output! Suddenly, a `nil` appears instead of `"2"`.

If we turn on logging for the cache, we can see a bit more of what is happening:

```ruby
Rails.cache.logger = Logger.new($stdout)
LetsMakeItBreak.new.boom
# ...
D, [2023-12-05T11:30:47.089666 #29076] DEBUG -- : Cache read_multi: 1 key(s) specified ({:compress=>true, :compress_threshold=>1024, :raw=>true})
W, [2023-12-05T11:30:47.089719 #29076]  WARN -- : Unrecognized payload prefix "2"; deserializing as nil
read_multi: {"blep:one"=>nil}
```

The culprit here is that the local cache strategy code was not accounting for the mem cache and redis stores expecting to pass the `raw: true` all the way down to the `deserialize_entry` method. This PR fixes that, and adjusts the overall signature of `ActiveSupport::Cache::Store#deserialize_entry` so the fix doesn't break other built-in stores like file, memory, & null.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
  * I tried to split this into 2 PRs, but fixing the first issue immediately makes the existing tests fail by exposing the second issue
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]` 
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
