### PR TITLE
Fix link to config.active_record.protocol_adapters [ci-skip]

### DIFF
--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -2962,10 +2962,11 @@ development:
 
 The `config/database.yml` file can contain ERB tags `<%= %>`. Anything in the tags will be evaluated as Ruby code. You can use this to pull out data from an environment variable or to perform calculations to generate the needed connection information.
 
-When using a `ENV['DATABASE_URL']` or a `url` key in your `config/database.yml` file, Rails allows mapping the protocol
-in the URL to a database adapter that can be configured from within the application. This allows the adapter to be configured
-without modifying the URL set in the deployment environment. See: [`config.active_record.protocol_adapters`](#config-active_record-protocol-adapters).
-
+When using a `ENV['DATABASE_URL']` or a `url` key in your `config/database.yml`
+file, Rails allows mapping the protocol in the URL to a database adapter that
+can be configured from within the application. This allows the adapter to be
+configured without modifying the URL set in the deployment environment. See:
+[`config.active_record.protocol_adapters`](#config-active-record-protocol-adapters).
 
 TIP: You don't have to update the database configurations manually. If you look at the options of the application generator, you will see that one of the options is named `--database`. This option allows you to choose an adapter from a list of the most used relational databases. You can even run the generator repeatedly: `cd .. && rails new blog --database=mysql`. When you confirm the overwriting of the `config/database.yml` file, your application will be configured for MySQL instead of SQLite. Detailed examples of the common database connections are below.
 


### PR DESCRIPTION
Ref #50140 

```
*** BROKEN LINK: #config-active_record-protocol-adapters, perhaps you meant #config-active-record-protocol-adapters.
```