### PR TITLE
Infer default `:inverse_of` option for `delegated_type`

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,14 @@
+*   Infer default `:inverse_of` option for `delegated_type` definitions.
+
+    ```ruby
+    class Entry < ApplicationRecord
+      delegated_type :entryable, types: %w[ Message ]
+      # => defaults to inverse_of: :entry
+    end
+    ```
+
+    *Sean Doyle*
+
 *   Add support for `ActiveRecord::Point` type casts using `Hash` values
 
     This allows `ActiveRecord::Point` to be cast or serialized from a hash

--- a/activerecord/lib/active_record/delegated_type.rb
+++ b/activerecord/lib/active_record/delegated_type.rb
@@ -220,6 +220,14 @@ module ActiveRecord
     # [:primary_key]
     #   Specify the method that returns the primary key of associated object used for the convenience methods.
     #   By default this is +id+.
+    # [+:inverse_of+]
+    #   Specifies the name of the #belongs_to association on the associated object
+    #   that is the inverse of this #has_one association. By default, the class
+    #   singularized class name is used unless a <tt>:foreign_key</tt> option is
+    #   also provided. For example, a call to
+    #   <tt>Entry.delegated_type</tt> will default to <tt>inverse_of: :entry</tt>.
+    #   See ActiveRecord::Associations::ClassMethods's overview on Bi-directional
+    #   associations for more detail.
     #
     # Option examples:
     #   class Entry < ApplicationRecord
@@ -229,6 +237,8 @@ module ActiveRecord
     #   Entry#message_uuid      # => returns entryable_uuid, when entryable_type == "Message", otherwise nil
     #   Entry#comment_uuid      # => returns entryable_uuid, when entryable_type == "Comment", otherwise nil
     def delegated_type(role, types:, **options)
+      options[:inverse_of] = model_name.singular unless options.key?(:inverse_of) || options.key?(:foreign_key)
+
       belongs_to role, options.delete(:scope), **options.merge(polymorphic: true)
       define_delegated_type_methods role, types: types, options: options
     end

--- a/activerecord/test/cases/delegated_type_test.rb
+++ b/activerecord/test/cases/delegated_type_test.rb
@@ -3,6 +3,7 @@
 require "cases/helper"
 require "models/account"
 require "models/entry"
+require "models/essay"
 require "models/message"
 require "models/recipient"
 require "models/comment"
@@ -11,12 +12,12 @@ require "models/uuid_message"
 require "models/uuid_comment"
 
 class DelegatedTypeTest < ActiveRecord::TestCase
-  fixtures :comments, :accounts, :posts
+  fixtures :comments, :accounts, :essays
 
   setup do
     @entry_with_message = Entry.create! entryable: Message.new(subject: "Hello world!"), account: accounts(:signals37)
     @entry_with_comment = Entry.create! entryable: comments(:greetings), account: accounts(:signals37)
-    @entry_with_post = Entry.create! thing: posts(:welcome), account: accounts(:signals37)
+    @entry_with_essay = Entry.create! thing: essays(:mary_stay_home), account: accounts(:signals37)
 
     if current_adapter?(:PostgreSQLAdapter)
       @uuid_entry_with_message = UuidEntry.create! uuid: SecureRandom.uuid, entryable: UuidMessage.new(uuid: SecureRandom.uuid, subject: "Hello world!")
@@ -36,7 +37,7 @@ class DelegatedTypeTest < ActiveRecord::TestCase
   test "delegated class with custom foreign_type" do
     assert_equal Message, @entry_with_message.thing_class
     assert_equal Comment, @entry_with_comment.thing_class
-    assert_equal Post, @entry_with_post.thing_class
+    assert_equal Essay, @entry_with_essay.thing_class
   end
 
   test "delegated type name" do
@@ -56,9 +57,9 @@ class DelegatedTypeTest < ActiveRecord::TestCase
   end
 
   test "delegated type predicates with custom foreign_type" do
-    assert_predicate @entry_with_post, :post?
-    assert_not @entry_with_message.post?
-    assert_not @entry_with_comment.post?
+    assert_predicate @entry_with_essay, :essay?
+    assert_not @entry_with_message.essay?
+    assert_not @entry_with_comment.essay?
   end
 
   test "scope" do
@@ -67,7 +68,7 @@ class DelegatedTypeTest < ActiveRecord::TestCase
   end
 
   test "scope with custom foreign_type" do
-    assert_predicate Entry.posts.first, :post?
+    assert_predicate Entry.essays.first, :essay?
   end
 
   test "accessor" do
@@ -94,6 +95,15 @@ class DelegatedTypeTest < ActiveRecord::TestCase
 
     assert_equal @uuid_entry_with_comment.entryable_uuid, @uuid_entry_with_comment.uuid_comment_uuid
     assert_nil @uuid_entry_with_comment.uuid_message_uuid
+  end
+
+  test "association inverse_of" do
+    created = @entry_with_message.message
+    updated = @entry_with_message.build_entryable subject: "Goodbye world!"
+
+    assert_changes -> { @entry_with_message.reload.message }, from: created, to: updated do
+      updated.save!
+    end
   end
 
   test "touch account" do

--- a/activerecord/test/models/comment.rb
+++ b/activerecord/test/models/comment.rb
@@ -1,9 +1,13 @@
 # frozen_string_literal: true
 
+require "models/entryable"
+
 # `counter_cache` requires association class before `attr_readonly`.
 class Post < ActiveRecord::Base; end
 
 class Comment < ActiveRecord::Base
+  include Entryable
+
   scope :limit_by, lambda { |l| limit(l) }
   scope :containing_the_letter_e, -> { where("comments.body LIKE '%e%'") }
   scope :not_again, -> { where("comments.body NOT LIKE '%again%'") }

--- a/activerecord/test/models/entry.rb
+++ b/activerecord/test/models/entry.rb
@@ -5,6 +5,6 @@ class Entry < ActiveRecord::Base
   belongs_to :account, touch: true
 
   # alternate delegation for custom foreign_key/foreign_type
-  delegated_type :thing, types: %w[ Post ],
+  delegated_type :thing, types: %w[ Essay ],
     foreign_key: :entryable_id, foreign_type: :entryable_type
 end

--- a/activerecord/test/models/entryable.rb
+++ b/activerecord/test/models/entryable.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require "models/entry"
+
+module Entryable
+  extend ActiveSupport::Concern
+
+  included do
+    has_one :entry, as: :entryable, touch: true
+  end
+end

--- a/activerecord/test/models/essay.rb
+++ b/activerecord/test/models/essay.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
+require "models/entryable"
+
 class Essay < ActiveRecord::Base
+  include Entryable
+
   belongs_to :author, primary_key: :name
   belongs_to :writer, primary_key: :name, polymorphic: true
   belongs_to :category, primary_key: :name

--- a/activerecord/test/models/message.rb
+++ b/activerecord/test/models/message.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
+require "models/entryable"
+
 class Message < ActiveRecord::Base
-  has_one  :entry, as: :entryable, touch: true
+  include Entryable
+
   has_many :recipients
 end

--- a/activerecord/test/models/uuid_comment.rb
+++ b/activerecord/test/models/uuid_comment.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "models/uuid_entryable"
+
 class UuidComment < ActiveRecord::Base
-  has_one :uuid_entry, as: :entryable
+  include UuidEntryable
 end

--- a/activerecord/test/models/uuid_entryable.rb
+++ b/activerecord/test/models/uuid_entryable.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require "models/uuid_entry"
+
+module UuidEntryable
+  extend ActiveSupport::Concern
+
+  included do
+    has_one :uuid_entry, as: :entryable
+  end
+end

--- a/activerecord/test/models/uuid_message.rb
+++ b/activerecord/test/models/uuid_message.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "models/uuid_entryable"
+
 class UuidMessage < ActiveRecord::Base
-  has_one :uuid_entry, as: :entryable
+  include UuidEntryable
 end


### PR DESCRIPTION
### Motivation / Background

Prior to this commit, delegated types were unable to infer their inverse associations, so saving records built with the generated `#build_ASSOCIATION` methods weren't writing to all the necessary places. For example:

```ruby
entry = Entry.create! entryable: Message.new(subject: "Hello world!")
entry.message.subject # => "Hello world!"

entry.build_entryable(subject: "Goodbye world!").save!
entry.reload.message.subject # => "Hello world!"
```

### Additional information

The fact that the `Entry` test model declared a `delegated_type :entryable` definition with `types: %w[ Message Comment ]` was never reciprocated in the appropriate models.

In order to pass the tests, this commit needed to define the corresponding `has_one :entry` associations. To do so, introduce the `Entryable` concern in the same style as the one mentioned in the documentation. The same extraction is made for a `UuidEntryable` concern mixed into `UuidMessage` and `UuidComment`.

Unfortunately, defining `delegated_type :thing, types: %w[ Post ]` was more tricky to fix. The `Post` test model is widely used, so defining a `has_one` had farther-reaching effects than intended. To resolve that issue, this commit redefines `:thing` to use `types: %w[ Essay ]`, which has much fewer unintended side effects.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
