### PR TITLE
[ci skip] Clarify ConnectionPool timeout options

### DIFF
--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -3592,10 +3592,10 @@ ActiveRecord::ConnectionTimeoutError - could not obtain a database connection wi
 If you get the above error, you might want to increase the size of the
 connection pool by incrementing the `pool` option in `database.yml`
 
-NOTE. If you are running in a multi-threaded environment, there could be a
-chance that several threads may be accessing multiple connections
-simultaneously. So depending on your current request load, you could very well
-have multiple threads contending for a limited number of connections.
+NOTE. If you are running in a multithreaded environment, there could be a chance
+that several threads may be accessing multiple connections simultaneously. So
+depending on your current request load, you could very well have multiple
+threads contending for a limited number of connections.
 
 
 Custom Configuration

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -3560,15 +3560,14 @@ Database Pooling
 Active Record database connections are managed by
 `ActiveRecord::ConnectionAdapters::ConnectionPool` which ensures that a
 connection pool synchronizes the amount of thread access to a limited number of
-database connections. This limit defaults to 5 and can be configured in
-`database.yml`.
+database connections. This limit defaults to 5 and can be configured via the
+`pool` option in `database.yml`.
 
 ```yaml
 development:
   adapter: sqlite3
   database: storage/development.sqlite3
   pool: 5
-  timeout: 5000
 ```
 
 Since the connection pooling is handled inside of Active Record by default, all
@@ -3590,7 +3589,14 @@ ActiveRecord::ConnectionTimeoutError - could not obtain a database connection wi
 ```
 
 If you get the above error, you might want to increase the size of the
-connection pool by incrementing the `pool` option in `database.yml`
+connection pool by incrementing the `pool` option in `database.yml`.
+
+The above timeout can be configured using the `checkout_timeout` option
+(defaults to 5 seconds) in `database.yml`, as well as how long an unused
+connection will be kept in the pool `idle_timeout` (defaults to 300 seconds).
+You can find more information regarding the
+`ActiveRecord::ConnectionAdapters::ConnectionPool` and its options in the
+[documentation](https://api.rubyonrails.org/classes/ActiveRecord/ConnectionAdapters/ConnectionPool.html).
 
 NOTE. If you are running in a multithreaded environment, there could be a chance
 that several threads may be accessing multiple connections simultaneously. So

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -3557,7 +3557,11 @@ Below is a comprehensive list of all the initializers found in Rails in the orde
 Database Pooling
 ----------------
 
-Active Record database connections are managed by `ActiveRecord::ConnectionAdapters::ConnectionPool` which ensures that a connection pool synchronizes the amount of thread access to a limited number of database connections. This limit defaults to 5 and can be configured in `database.yml`.
+Active Record database connections are managed by
+`ActiveRecord::ConnectionAdapters::ConnectionPool` which ensures that a
+connection pool synchronizes the amount of thread access to a limited number of
+database connections. This limit defaults to 5 and can be configured in
+`database.yml`.
 
 ```yaml
 development:
@@ -3567,9 +3571,15 @@ development:
   timeout: 5000
 ```
 
-Since the connection pooling is handled inside of Active Record by default, all application servers (Thin, Puma, Unicorn, etc.) should behave the same. The database connection pool is initially empty. As demand for connections increases it will create them until it reaches the connection pool limit.
+Since the connection pooling is handled inside of Active Record by default, all
+application servers (Thin, Puma, Unicorn, etc.) should behave the same. The
+database connection pool is initially empty. As demand for connections increases
+it will create them until it reaches the connection pool limit.
 
-Any one request will check out a connection the first time it requires access to the database. At the end of the request it will check the connection back in. This means that the additional connection slot will be available again for the next request in the queue.
+Any one request will check out a connection the first time it requires access to
+the database. At the end of the request it will check the connection back in.
+This means that the additional connection slot will be available again for the
+next request in the queue.
 
 If you try to use more connections than are available, Active Record will block
 you and wait for a connection from the pool. If it cannot get a connection, a
@@ -3582,7 +3592,10 @@ ActiveRecord::ConnectionTimeoutError - could not obtain a database connection wi
 If you get the above error, you might want to increase the size of the
 connection pool by incrementing the `pool` option in `database.yml`
 
-NOTE. If you are running in a multi-threaded environment, there could be a chance that several threads may be accessing multiple connections simultaneously. So depending on your current request load, you could very well have multiple threads contending for a limited number of connections.
+NOTE. If you are running in a multi-threaded environment, there could be a
+chance that several threads may be accessing multiple connections
+simultaneously. So depending on your current request load, you could very well
+have multiple threads contending for a limited number of connections.
 
 
 Custom Configuration


### PR DESCRIPTION
### Motivation / Background

Long story short: while trying to configure the timeout(s) for connections in a Zammad installation the current docs lead me to believe the `timeout` option would apply to database connections. This is compounded by the `timeout` and `checkout_timeout` options both default to 5 seconds. See also this Zammad Docs issue https://github.com/zammad/zammad/pull/4883#issuecomment-1815291895.

This Pull Request tries to clarify this in the docs by removing the `timeout` option from the Connection Pooling paragraph and explicitly explaining the Pool timeout options. The changes are broken into different Commits to keep formatting and content changes separate to make understanding what is changed easier. They might be squashed before merging.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
