### PR TITLE
Write server URL to a temporary file when starting Rails

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Write server URL to a temporary file when starting Rails
+
+    *Andy Waite*
+
 *   Use `bin/rails runner --skip-executor` option to not wrap the runner script
     with an Executor.
 

--- a/railties/lib/rails/commands/server/server_command.rb
+++ b/railties/lib/rails/commands/server/server_command.rb
@@ -34,6 +34,7 @@ module Rails
       create_tmp_directories
       setup_dev_caching
       log_to_stdout if options[:log_stdout]
+      write_server_url
 
       super()
     ensure
@@ -56,10 +57,19 @@ module Rails
     end
 
     def served_url
-      "#{options[:SSLEnable] ? 'https' : 'http'}://#{options[:Host]}:#{options[:Port]}" unless use_puma?
+      server_url unless use_puma?
     end
 
     private
+      def server_url
+        "#{options[:SSLEnable] ? 'https' : 'http'}://#{options[:Host]}:#{options[:Port]}"
+      end
+
+      def write_server_url
+        path = File.join(Rails.root, "tmp", "server_url.txt")
+        File.write(path, server_url)
+      end
+
       def setup_dev_caching
         if options[:environment] == "development"
           Rails::DevCaching.enable_by_argument(options[:caching])

--- a/railties/lib/rails/commands/server/server_command.rb
+++ b/railties/lib/rails/commands/server/server_command.rb
@@ -151,7 +151,10 @@ module Rails
 
           if server.serveable?
             print_boot_information(server.server, server.served_url)
-            after_stop_callback = -> { say "Exiting" unless options[:daemon] }
+            after_stop_callback = lambda do
+              FileUtils.rm(server_url_path) if File.exist?(server_url_path)
+              say "Exiting" unless options[:daemon]
+            end
             server.start(after_stop_callback)
           else
             say rack_server_suggestion(options[:using])
@@ -176,6 +179,10 @@ module Rails
             restart_cmd:           restart_command,
             early_hints:           early_hints
           }
+        end
+
+        def server_url_path
+          File.join(Rails.root, "tmp", "server_url.txt")
         end
       end
 

--- a/railties/lib/rails/commands/server/server_command.rb
+++ b/railties/lib/rails/commands/server/server_command.rb
@@ -34,7 +34,7 @@ module Rails
       create_tmp_directories
       setup_dev_caching
       log_to_stdout if options[:log_stdout]
-      write_server_url
+      write_server_url if ENV["RAILS_ENV"] == "development"
 
       super()
     ensure

--- a/railties/test/application/server_test.rb
+++ b/railties/test/application/server_test.rb
@@ -40,7 +40,11 @@ module ApplicationTests
       end
     end
 
-    test "write server URL to a file" do
+    def server_url_path
+      "#{app_path}/tmp/server_url.txt"
+    end
+
+    test "write server URL to a file and delete it during shutdown" do
       skip "PTY unavailable" unless available_pty?
 
       File.open("#{app_path}/config/boot.rb", "w") do |f|
@@ -55,12 +59,12 @@ module ApplicationTests
         pid = Process.spawn("bin/rails server -b localhost -p 3001", chdir: app_path, in: replica, out: replica, err: replica)
         assert_output("Listening", primary)
 
-        path = "#{app_path}/tmp/server_url.txt"
-        assert_path_exists path
-        assert_equal "http://localhost:3001", File.read(path)
+        assert_path_exists server_url_path
+        assert_equal "http://localhost:3001", File.read(server_url_path)
       ensure
         kill(pid) if pid
       end
+      refute_path_exists server_url_path
     end
 
     test "run +server+ blocks after the server starts" do


### PR DESCRIPTION
Co-authored with @vinistock 

Expose the server URL so that external tools are able to know where the server is running.

One example would be for an [LSP](https://en.wikipedia.org/wiki/Language_Server_Protocol) implementation, so that introspection of the server can be provided.

### Detail

Write the file as part of the server initialization.

### Additional information

This could be a step towards implementing [ruby-lsp-rails](https://github.com/Shopify/ruby-lsp-rails) as a built-in Rails feature.

### Questions

Should we delete the `server_url.txt` file when the server is shutdown? If so, where in the code would that be done?

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
