### PR TITLE
Fix `Time.now`/`DateTime.now`/`Date.today` to return results in a system timezone after `#travel_to` in 7-0-stable

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Fix `Time.now/DateTime.now/Date.today' to return results in a system timezone after `#travel_to'.
+
+    There is a bug in the current implementation of #travel_to:
+    it remembers a timezone of its argument, and all stubbed methods start
+    returning results in that remembered timezone. However, the expected
+    behaviour is to return results in a system timezone.
+
+    *Aleksei Chernenkov*
+
 *   Fix ActiveSupport::Deprecation to handle blaming generated code
 
     *Jean Boussier*, *fatkodima*

--- a/activesupport/lib/active_support/testing/time_helpers.rb
+++ b/activesupport/lib/active_support/testing/time_helpers.rb
@@ -162,8 +162,12 @@ module ActiveSupport
           now = date_or_time.to_time.change(usec: 0)
         end
 
+        # +now+ must be in local system timezone, because +now.to_date+ (see stubs below) will use +now+'s timezone!
+        now = now.getlocal
+
         stubbed_time = Time.now if simple_stubs.stubbing(Time, :now)
         simple_stubs.stub_object(Time, :now) { at(now.to_i) }
+        # FIXME: Time.new (without args) must also be stubbed, because it should be equivalent to Time.now
         simple_stubs.stub_object(Date, :today) { jd(now.to_date.jd) }
         simple_stubs.stub_object(DateTime, :now) { jd(now.to_date.jd, now.hour, now.min, now.sec, Rational(now.utc_offset, 86400)) }
 


### PR DESCRIPTION
This is a backport of #50236 for 7-0-stable.

### Motivation / Background

Fix incorrect `Date.today` result value that caused [a bug with the `Faker::Time.backward` method](https://github.com/faker-ruby/faker/issues/2861) in the Faker gem.

### Detail

There is a bug in the current implementation of `#travel_to`: it remembers a timezone of its argument, and all stubbed methods (`Time.now`, `DateTime.now`, `Date.today`) start returning results in that remembered timezone. However, the expected behaviour is to return results in a system timezone.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
