### PR TITLE
Rails 7.1 is latest, Security Issue Maintenance should not include `6.1.Z`

### DIFF
--- a/guides/source/maintenance_policy.md
+++ b/guides/source/maintenance_policy.md
@@ -78,7 +78,7 @@ there could be breaking changes in the security release. A security release
 should only contain the changes needed to ensure the app is secure so that it's
 easier for applications to remain upgraded.
 
-**Currently included series:** `7.1.Z`, `7.0.Z`, `6.1.Z`.
+**Currently included series:** `7.1.Z`, `7.0.Z`.
 
 Severe Security Issues
 ----------------------


### PR DESCRIPTION
"Security Issues" maintanance level when 7.1. is the latest release series should include `7.1.Z` and `7.0.Z`. Currently also includes `6.1.Z` in Guide published for Rails 7.1, but should not. At https://guides.rubyonrails.org/v7.1/maintenance_policy.html

Based on policy:

> The current release series and the next most recent one will receive patches and new versions in case of a security issue.

There should always be two series listed, not three, and I think `6.1.Z` is actually not in "Security Issues"  level of maintenance at present, now that 7.1.0 is released -- and this guide text is incorrect?

The current "edge"/main guide, written for a 7.2 release, does only list two series, 7.2.Z and 7.1.Z, as expected. https://github.com/rails/rails/blob/fb09e7f1aa89efc82ed090443b9c6198d5f0bb3f/guides/source/maintenance_policy.md

It looks like the listing of three series including `6.1.Z` came from original "Start Rails 7.1 development" commit at 83d85b22074. 