### PR TITLE
Do not instance_eval method into RoutesProxy

### DIFF
--- a/actionpack/lib/action_dispatch/routing/routes_proxy.rb
+++ b/actionpack/lib/action_dispatch/routing/routes_proxy.rb
@@ -29,23 +29,18 @@ module ActionDispatch
 
       def method_missing(method, *args)
         if @helpers.respond_to?(method)
-          instance_eval <<-RUBY, __FILE__, __LINE__ + 1
-            def #{method}(*args)
-              options = args.extract_options!
-              options = url_options.merge((options || {}).symbolize_keys)
+          options = args.extract_options!
+          options = url_options.merge((options || {}).symbolize_keys)
 
-              if @script_namer
-                options[:script_name] = merge_script_names(
-                  options[:script_name],
-                  @script_namer.call(options)
-                )
-              end
+          if @script_namer
+            options[:script_name] = merge_script_names(
+              options[:script_name],
+              @script_namer.call(options)
+            )
+          end
 
-              args << options
-              @helpers.#{method}(*args)
-            end
-          RUBY
-          public_send(method, *args)
+          args << options
+          @helpers.public_send(method, *args)
         else
           super
         end


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created because `instance_eval`-ing in RoutesProxy can result in significant memory retention. This was introduced in https://github.com/rails/rails/pull/46974; it previously used `class_eval`.
 
cc @jhawthorn

### Detail

In this circumstance, `instance_eval` creates an anonymous class that is held by the VM; we saw several hundred accumulate during profiling. Unfortunately, this anonymous class also references the Controller instance, which references instance variables, and their Active Record models... and it can become quite a lot that is retained for quite a while. 

```ruby
irb(#<#<Class:0x00000001087c53e0>...):001> main_app
=>
#<ActionDispatch::Routing::RoutesProxy:0x000000010b4f4e88
 @helpers=#<Module:0x00000001074ab5e8>,
 @routes=#<ActionDispatch::Routing::RouteSet:0x0000000108822c70>,
 @scope=#<WorksController:0x00000000030700>,
 @script_namer=nil>
```


[Profiling and heap dump details are here](https://github.com/sciencehistory/scihist_digicoll/issues/2449#issuecomment-1846303545).

Instead of returning to the previous `class_eval` method definition, the behavior is invoked directly.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
