### PR TITLE
Take AR affixes into account for Action Text database models

### DIFF
--- a/actiontext/CHANGELOG.md
+++ b/actiontext/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Fix all Action Text database related models to respect
+    `ActiveRecord::Base.table_name_prefix` configuration.
+
+    *Chedli Bourguiba*
+
 *   Compile ESM package that can be used directly in the browser as actiontext.esm.js
 
     *Matias Grunberg*

--- a/actiontext/app/models/action_text/encrypted_rich_text.rb
+++ b/actiontext/app/models/action_text/encrypted_rich_text.rb
@@ -2,8 +2,6 @@
 
 module ActionText
   class EncryptedRichText < RichText
-    self.table_name = "action_text_rich_texts"
-
     encrypts :body
   end
 end

--- a/actiontext/app/models/action_text/rich_text.rb
+++ b/actiontext/app/models/action_text/rich_text.rb
@@ -22,8 +22,6 @@ module ActionText
   #   message.content.to_s # => "<div>safeunsafe</div>"
   #   message.content.to_plain_text # => "safeunsafe"
   class RichText < Record
-    self.table_name = "action_text_rich_texts"
-
     ##
     # :method: to_s
     #

--- a/actiontext/test/dummy/app/models/encrypted_message.rb
+++ b/actiontext/test/dummy/app/models/encrypted_message.rb
@@ -1,5 +1,3 @@
-class EncryptedMessage < ApplicationRecord
-  self.table_name = "messages"
-
+class EncryptedMessage < Message
   has_rich_text :content, encrypted: true
 end

--- a/actiontext/test/dummy/config/application.rb
+++ b/actiontext/test/dummy/config/application.rb
@@ -13,6 +13,9 @@ module Dummy
     # For compatibility with applications that use this config
     config.action_controller.include_all_helpers = false
 
+    config.active_record.table_name_prefix = 'prefix_'
+    config.active_record.table_name_suffix = '_suffix'
+
     # Configuration for the application, engines, and railties goes here.
     #
     # These settings can be overridden in specific environments using the files

--- a/actiontext/test/models/table_name_test.rb
+++ b/actiontext/test/models/table_name_test.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class ActionText::TableNameTest < ActiveSupport::TestCase
+  setup do
+    @old_prefix = ActiveRecord::Base.table_name_prefix
+    @old_suffix = ActiveRecord::Base.table_name_suffix
+
+    ActiveRecord::Base.table_name_prefix = @prefix = "abc_"
+    ActiveRecord::Base.table_name_suffix = @suffix = "_xyz"
+
+    @models = [ActionText::RichText, ActionText::EncryptedRichText]
+    @models.map(&:reset_table_name)
+  end
+
+  teardown do
+    ActiveRecord::Base.table_name_prefix = @old_prefix
+    ActiveRecord::Base.table_name_suffix = @old_suffix
+
+    @models.map(&:reset_table_name)
+  end
+
+  test "prefix and suffix are added to the Action Text tables' name" do
+    assert_equal(
+      "#{@prefix}action_text_rich_texts#{@suffix}",
+       ActionText::RichText.table_name
+    )
+    assert_equal(
+      "#{@prefix}action_text_rich_texts#{@suffix}",
+       ActionText::EncryptedRichText.table_name
+    )
+  end
+end


### PR DESCRIPTION
Follow up to https://github.com/rails/rails/pull/50247 and https://github.com/rails/rails/pull/50167 cc @jonathanhefner 

This removes the redundant hard coded table names to make the models compatible with `ActiveRecord::Base.{prefix|suffix}`

This also adds prefix/suffix in the dummy app to force the entire test suite to be agnostic to hard-coded table names.