### PR TITLE
Take AR affixes into account for Action Mailbox database models

### DIFF
--- a/actionmailbox/CHANGELOG.md
+++ b/actionmailbox/CHANGELOG.md
@@ -1,2 +1,6 @@
+*   Fix all Action Mailbox database related models to respect
+    `ActiveRecord::Base.table_name_prefix` configuration.
+
+    *Chedli Bourguiba*
 
 Please check [7-1-stable](https://github.com/rails/rails/blob/7-1-stable/actionmailbox/CHANGELOG.md) for previous changes.

--- a/actionmailbox/app/models/action_mailbox/inbound_email.rb
+++ b/actionmailbox/app/models/action_mailbox/inbound_email.rb
@@ -25,8 +25,6 @@ module ActionMailbox
   #   inbound_email.mail.from # => 'david@loudthinking.com'
   #   inbound_email.source # Returns the full rfc822 source of the email as text
   class InboundEmail < Record
-    self.table_name = "action_mailbox_inbound_emails"
-
     include Incineratable, MessageId, Routable
 
     has_one_attached :raw_email, service: ActionMailbox.storage_service

--- a/actionmailbox/test/dummy/config/application.rb
+++ b/actionmailbox/test/dummy/config/application.rb
@@ -13,6 +13,9 @@ module Dummy
     # For compatibility with applications that use this config
     config.action_controller.include_all_helpers = false
 
+    config.active_record.table_name_prefix = 'prefix_'
+    config.active_record.table_name_suffix = '_suffix'
+
     # Configuration for the application, engines, and railties goes here.
     #
     # These settings can be overridden in specific environments using the files

--- a/actionmailbox/test/migrations_test.rb
+++ b/actionmailbox/test/migrations_test.rb
@@ -43,7 +43,7 @@ class ActionMailbox::MigrationsTest < ActiveSupport::TestCase
     end
 
     def action_mailbox_tables
-      [:action_mailbox_inbound_emails]
+      @action_mailbox_tables ||= ActionMailbox::Record.descendants.map { |klass| klass.table_name.to_sym }
     end
 
     def primary_key(table)

--- a/actionmailbox/test/models/table_name_test.rb
+++ b/actionmailbox/test/models/table_name_test.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class ActionMailbox::TableNameTest < ActiveSupport::TestCase
+  setup do
+    @old_prefix = ActiveRecord::Base.table_name_prefix
+    @old_suffix = ActiveRecord::Base.table_name_suffix
+
+    ActiveRecord::Base.table_name_prefix = @prefix = "abc_"
+    ActiveRecord::Base.table_name_suffix = @suffix = "_xyz"
+
+    @models = [ActionMailbox::InboundEmail]
+    @models.map(&:reset_table_name)
+  end
+
+  teardown do
+    ActiveRecord::Base.table_name_prefix = @old_prefix
+    ActiveRecord::Base.table_name_suffix = @old_suffix
+
+    @models.map(&:reset_table_name)
+  end
+
+  test "prefix and suffix are added to the Action Mailbox tables' name" do
+    assert_equal(
+      "#{@prefix}action_mailbox_inbound_emails#{@suffix}",
+       ActionMailbox::InboundEmail.table_name
+    )
+  end
+end


### PR DESCRIPTION
Follow up to https://github.com/rails/rails/pull/50247 and https://github.com/rails/rails/pull/50167 cc @jonathanhefner 

This removes the redundant hard coded table names to make the models compatible with `ActiveRecord::Base.{prefix|suffix}`

This also adds prefix/suffix in the dummy app to force the entire test suite to be agnostic to hard-coded table names.