### PR TITLE
Module#delegate takes a new private `as` parameter

### DIFF
--- a/actioncable/lib/action_cable/channel/broadcasting.rb
+++ b/actioncable/lib/action_cable/channel/broadcasting.rb
@@ -7,10 +7,6 @@ module ActionCable
     module Broadcasting
       extend ActiveSupport::Concern
 
-      included do
-        delegate :broadcasting_for, :broadcast_to, to: :class
-      end
-
       module ClassMethods
         # Broadcast a hash to a unique broadcasting for this <tt>model</tt> in this channel.
         def broadcast_to(model, message)
@@ -38,6 +34,8 @@ module ActionCable
           end
         end
       end
+
+      delegate :broadcasting_for, :broadcast_to, to: :class, as: ClassMethods
     end
   end
 end

--- a/actioncable/lib/action_cable/channel/naming.rb
+++ b/actioncable/lib/action_cable/channel/naming.rb
@@ -18,10 +18,7 @@ module ActionCable
         end
       end
 
-      included do
-        # Delegates to the class's ::channel_name.
-        delegate :channel_name, to: :class
-      end
+      delegate :channel_name, to: :class, as: ClassMethods
     end
   end
 end

--- a/actionview/lib/action_view/layouts.rb
+++ b/actionview/lib/action_view/layouts.rb
@@ -209,11 +209,9 @@ module ActionView
 
     included do
       class_attribute :_layout, instance_accessor: false
-      class_attribute :_layout_conditions, instance_accessor: false, default: {}
+      class_attribute :_layout_conditions, instance_accessor: false, instance_reader: true, default: {}
 
       _write_layout_method
-
-      delegate :_layout_conditions, to: :class
     end
 
     module ClassMethods

--- a/activesupport/test/core_ext/module_test.rb
+++ b/activesupport/test/core_ext/module_test.rb
@@ -586,7 +586,7 @@ class ModuleTest < ActiveSupport::TestCase
       location.delegate(:street, :city, to: :@place, prefix: :the, private: true)
   end
 
-  def test_delegation_arity
+  def test_delegation_arity_to_module
     c = Class.new do
       delegate :zero, :one, :two, to: ArityTester
     end
@@ -594,6 +594,17 @@ class ModuleTest < ActiveSupport::TestCase
     assert_equal 1, c.instance_method(:one).arity
     assert_equal 2, c.instance_method(:two).arity
 
+    e = Class.new do
+      delegate :zero, to: ArityTesterModule
+    end
+
+    assert_equal 0, e.instance_method(:zero).arity
+    assert_nothing_raised do
+      e.new.zero
+    end
+  end
+
+  def test_delegation_arity_to_self_class
     d = Class.new(ArityTester) do
       delegate :zero, :zero_with_block, :zero_with_implicit_block, :one, :one_with_block, :two, :opt,
         :kwargs, :kwargs_with_block, :opt_kwargs, :opt_kwargs_with_block, to: :class
@@ -622,15 +633,6 @@ class ModuleTest < ActiveSupport::TestCase
       d.new.kwargs_with_block(a: 1, b: 2, c: 3)
       d.new.opt_kwargs(a: 1)
       d.new.opt_kwargs_with_block(a: 1, b: 2, c: 3)
-    end
-
-    e = Class.new do
-      delegate :zero, to: ArityTesterModule
-    end
-
-    assert_equal 0, e.instance_method(:zero).arity
-    assert_nothing_raised do
-      e.new.zero
     end
   end
 end


### PR DESCRIPTION
This is a continuation of https://github.com/rails/rails/pull/46875

The behavior of looking up the class method when `to: :class` is passed is a bit error prone because it silently degrades.

By passing the expected owner of the delegated method, we can be more strict, and also generate a delegator in a module rather than having to do it at inclusion time.

I made this argument private API because we want it in Rails, but I'm worried it might be a bit too sharp for public API. I can be convinced otherwise though.
