### PR TITLE
Document how to transform keys with `ActiveRecord::Store`

### DIFF
--- a/activerecord/test/cases/store_test.rb
+++ b/activerecord/test/cases/store_test.rb
@@ -381,4 +381,24 @@ class StoreTest < ActiveRecord::TestCase
       user.color = "blue"
     end
   end
+
+  test "overrides .read_store_attribute and .write_store_attribute to transform keys" do
+    user_with_camelized_store_attributes = Class.new(Admin::User) do
+      private
+        def read_store_attribute(store_attribute, key)
+          super(store_attribute, key.to_s.camelize(:lower))
+        end
+
+        def write_store_attribute(store_attribute, key, value)
+          super(store_attribute, key.to_s.camelize(:lower), value)
+        end
+    end
+
+    user = user_with_camelized_store_attributes.new(parent_name: "Parent", favorite_food: "Pizza")
+
+    assert_equal "Pizza", user.favorite_food
+    assert_equal "Parent", user.parent_name
+    assert_equal({ "favoriteFood" => "Pizza" }, user.settings)
+    assert_equal({ "name" => "Parent" }, user.parent)
+  end
 end


### PR DESCRIPTION
### Detail

The `ActiveRecord::Store` module declares two `private` methods used
during serialization and deserialization to the store:

* `read_store_attribute` called during deserialization
* `write_store_attribute` called during serialization

Prior to this commit, both methods were declared `private` and neither
were explicitly mentioned by documentation despite the fact that they
were explicitly marked with `:doc:` comments.

Since they're marked with `:doc:` comments, they're included in the
[module's API Documentation page][api], and are therefore part of the
public interface.

This commit adds module-level and
method-level documentation explaining their behaviors. Similar steps were taken in https://github.com/rails/rails/pull/53042, where the `private`-level method declaration was at odds with the documentation.

[api]: https://api.rubyonrails.org/v7.2.1/classes/ActiveRecord/Store.html

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
