### PR TITLE
Log trace of causes for unhandled exceptions

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/debug_exceptions.rb
+++ b/actionpack/lib/action_dispatch/middleware/debug_exceptions.rb
@@ -142,16 +142,29 @@ module ActionDispatch
 
         message = []
         message << "  "
-        message << "#{wrapper.exception_class_name} (#{wrapper.message}):"
         if wrapper.has_cause?
-          message << "\nCauses:"
+          message << "#{wrapper.exception_class_name} (#{wrapper.message})"
           wrapper.wrapped_causes.each do |wrapped_cause|
-            message << "#{wrapped_cause.exception_class_name} (#{wrapped_cause.message})"
+            message << "Caused by: #{wrapped_cause.exception_class_name} (#{wrapped_cause.message})"
           end
+
+          message << "\nInformation for: #{wrapper.exception_class_name} (#{wrapper.message}):"
+        else
+          message << "#{wrapper.exception_class_name} (#{wrapper.message}):"
         end
+
         message.concat(wrapper.annotated_source_code)
         message << "  "
         message.concat(trace)
+
+        if wrapper.has_cause?
+          wrapper.wrapped_causes.each do |wrapped_cause|
+            message << "\nInformation for cause: #{wrapped_cause.exception_class_name} (#{wrapped_cause.message}):"
+            message.concat(wrapped_cause.annotated_source_code)
+            message << "  "
+            message.concat(wrapped_cause.exception_trace)
+          end
+        end
 
         log_array(logger, message, request)
       end


### PR DESCRIPTION
https://github.com/rails/rails/pull/50145 recently added logging of an exception's causes' messages, which is great as I was going to add that. 

However, the backtraces of the causes are not included in that PR.

This PR adds the backtraces too, which can be helpful. Note that I also changed the "header" part from.

```
RuntimeError (Third error)

Causes:
RuntimeError (Second error)
RuntimeError (First error)
```

To:

```
RuntimeError (Third error)
Caused by: RuntimeError (Second error)
Caused by: RuntimeError (First error)
```

And I highlight that the first backtrace is from the "main" exception with this message: 

```
Infos for: RuntimeError (Third error):
```

Here is a truncated example:

```
RuntimeError (Third error)
Caused by: RuntimeError (Second error)
Caused by: RuntimeError (First error)

Infos for: RuntimeError (Third error):

/home/max/projects/rails/actionpack/test/dispatch/debug_exceptions_test.rb:53:in `rescue in rescue in raise_nested_exceptions'
/home/max/projects/rails/actionpack/test/dispatch/debug_exceptions_test.rb:50:in `rescue in raise_nested_exceptions'
/home/max/projects/rails/actionpack/test/dispatch/debug_exceptions_test.rb:47:in `raise_nested_exceptions'
/home/max/projects/rails/actionpack/test/dispatch/debug_exceptions_test.rb:113:in `call'
/home/max/.rvm/gems/ruby-3.2.2/gems/rack-3.0.8/lib/rack/lint.rb:63:in `response'
/home/max/.rvm/gems/ruby-3.2.2/gems/rack-3.0.8/lib/rack/lint.rb:35:in `call'
/and/way/more

Infos for cause: RuntimeError (Second error):

/home/max/projects/rails/actionpack/test/dispatch/debug_exceptions_test.rb:51:in `rescue in raise_nested_exceptions'
/home/max/projects/rails/actionpack/test/dispatch/debug_exceptions_test.rb:47:in `raise_nested_exceptions'
/home/max/projects/rails/actionpack/test/dispatch/debug_exceptions_test.rb:113:in `call'
/home/max/.rvm/gems/ruby-3.2.2/gems/rack-3.0.8/lib/rack/lint.rb:63:in `response'
/home/max/.rvm/gems/ruby-3.2.2/gems/rack-3.0.8/lib/rack/lint.rb:35:in `call'
/home/max/projects/rails/actionpack/lib/action_dispatch/middleware/debug_exceptions.rb:29:in `call'
/home/max/.rvm/gems/ruby-3.2.2/gems/rack-3.0.8/lib/rack/lint.rb:63:in `response'
/and/way/more

Infos for cause: RuntimeError (First error):

/home/max/projects/rails/actionpack/test/dispatch/debug_exceptions_test.rb:48:in `raise_nested_exceptions'
/home/max/projects/rails/actionpack/test/dispatch/debug_exceptions_test.rb:113:in `call'
/home/max/.rvm/gems/ruby-3.2.2/gems/rack-3.0.8/lib/rack/lint.rb:63:in `response'
/home/max/.rvm/gems/ruby-3.2.2/gems/rack-3.0.8/lib/rack/lint.rb:35:in `call'
/home/max/projects/rails/actionpack/lib/action_dispatch/middleware/debug_exceptions.rb:29:in `call'
/home/max/.rvm/gems/ruby-3.2.2/gems/rack-3.0.8/lib/rack/lint.rb:63:in `response'
/and/way/more
```
