### PR TITLE
[ci skip]Correct example query given in HAVING conditions section

### DIFF
--- a/guides/source/active_record_querying.md
+++ b/guides/source/active_record_querying.md
@@ -1041,7 +1041,7 @@ SQL uses the `HAVING` clause to specify conditions on the `GROUP BY` fields. You
 For example:
 
 ```ruby
-Order.select("created_at, sum(total) as total_price").
+Order.select("created_at as ordered_date, sum(total) as total_price").
   group("created_at").having("sum(total) > ?", 200)
 ```
 


### PR DESCRIPTION
Correct the active_record query example, in the HAVING conditions section, to align with the corresponding given SQL output.