### PR TITLE
Small refactoring of batching over loaded relation

### DIFF
--- a/activerecord/lib/active_record/relation/batches.rb
+++ b/activerecord/lib/active_record/relation/batches.rb
@@ -345,15 +345,15 @@ module ActiveRecord
           end
         end
 
-        records = records.sort_by { |record| record.id }
+        records.sort_by!(&:id)
 
         if order == :desc
           records.reverse!
         end
 
-        (0...records.size).step(batch_limit).each do |start|
+        records.each_slice(batch_limit) do |subrecords|
           subrelation = relation.spawn
-          subrelation.load_records(records[start, batch_limit])
+          subrelation.load_records(subrecords)
 
           yield subrelation
         end


### PR DESCRIPTION
For `.sort_by!` we avoid allocating an extra array and the code gets shorter and simpler.
For `.each_slice` the code is simpler and so easier to understand.