### PR TITLE
`ActiveRecord::Store`: define predicate attribute method

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,18 @@
+*   Define `?`-suffixed attribute presence predicate method from `store_accessor`
+
+    ```ruby
+    class User < ApplicationRecord
+      store_accessor :settings, :remember_me
+    end
+
+    user = User.new
+    user.remember_me?       # => false
+    user.remember_me = true
+    user.remember_me?       # => true
+    ```
+
+    *Sean Doyle*
+
 *   Fix `has_secure_token` calls the setter method on initialize.
 
     *Abeid Ahmed*

--- a/activerecord/lib/active_record/store.rb
+++ b/activerecord/lib/active_record/store.rb
@@ -92,6 +92,10 @@ module ActiveRecord
   #     def volume_adjustment
   #       super.to_i
   #     end
+  #
+  #     def volume_adjustment?
+  #       !volume_adjustment.zero?
+  #     end
   #   end
   module Store
     extend ActiveSupport::Concern
@@ -141,6 +145,10 @@ module ActiveRecord
 
             define_method(accessor_key) do
               read_store_attribute(store_attribute, key)
+            end
+
+            define_method("#{accessor_key}?") do
+              read_store_attribute(store_attribute, key).present?
             end
 
             define_method("#{accessor_key}_changed?") do

--- a/activerecord/test/cases/store_test.rb
+++ b/activerecord/test/cases/store_test.rb
@@ -31,6 +31,25 @@ class StoreTest < ActiveRecord::TestCase
     assert_equal "37signals.com", @john.homepage
   end
 
+  test "checking predicate store attributes through accessors for missing keys" do
+    assert_not @john.settings.key?("homepage")
+    assert_not @john.settings.key?(:homepage)
+    assert_not_predicate @john, :homepage?
+  end
+
+  test "checking predicate store attributes through accessors for truthy values" do
+    assert_predicate @john, :name?
+    assert_predicate @john, :remember_login?
+  end
+
+  test "checking predicate store attributes through accessors for falsy values" do
+    @john.settings = { homepage: nil }
+    @john.preferences = { remember_login: false }
+
+    assert_not_predicate @john, :remember_login?
+    assert_not_predicate @john, :homepage?
+  end
+
   test "writing store attributes does not update unchanged value" do
     admin_user = Admin::User.new(homepage: nil)
     admin_user.homepage = nil


### PR DESCRIPTION
### Motivation / Background

Storing attributes in database columns via the `.store` and `.store_accessor` class methods generates a collection of methods, including an attribute reader.

The methods are similar to the ones generated from `ActiveRecord::AttributeMethods` (and transitively `ActiveModel::AttributeMethods`), but do not include a presence predicate method (like
`ActiveModel::AttributeMethods#attribute_present?`).

### Detail

This commit generates an `#{attribute}?` method that reads from the store attribute, then chains a `#present?` predicate method on the return value.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
