### PR TITLE
Implement `button_to` in terms of `form_tag`

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Render `[accept-charset="UTF-8"]` on `<form>` elements rendered by
+    `button_to`
+
+    *Sean Doyle*
+
 *   Extract `current_page?`, `button_to`, and `link_to` methods to
     `ActionView::Helpers::NavigationHelper`
 

--- a/actionview/lib/action_view/helpers/form_tag_helper.rb
+++ b/actionview/lib/action_view/helpers/form_tag_helper.rb
@@ -1066,6 +1066,28 @@ module ActionView
           end
         end
 
+        def token_tag(token = nil, form_options: {})
+          if token != false && defined?(protect_against_forgery?) && protect_against_forgery?
+            token =
+              if token == true || token.nil?
+                form_authenticity_token(form_options: form_options.merge(authenticity_token: token))
+              else
+                token
+              end
+            options = { type: "hidden", name: request_forgery_protection_token.to_s, value: token }
+            options[:autocomplete] = "off" unless ActionView::Base.remove_hidden_field_autocomplete
+            tag(:input, **options)
+          else
+            ""
+          end
+        end
+
+        def method_tag(method)
+          options = { type: "hidden", name: "_method", value: method.to_s }
+          options[:autocomplete] = "off" unless ActionView::Base.remove_hidden_field_autocomplete
+          tag("input", **options)
+        end
+
         def form_tag_html(html_options)
           extra_tags = extra_tags_for_form(html_options)
           html = tag(:form, html_options, true) + extra_tags

--- a/actionview/lib/action_view/helpers/navigation_helper.rb
+++ b/actionview/lib/action_view/helpers/navigation_helper.rb
@@ -14,16 +14,13 @@ module ActionView
     # This allows you to use the same format for links in views
     # and controllers.
     module NavigationHelper
-      BUTTON_TAG_METHOD_VERBS = %w{patch put delete}.freeze
-
       # Some methods provided here will only work in the context of a request
       # (link_to_unless_current, for instance), which must be provided as a
       # method called #request on the context.
       extend ActiveSupport::Concern
 
       include UrlHelper
-      include TagHelper
-      include ContentExfiltrationPreventionHelper
+      include FormTagHelper
 
       mattr_accessor :button_to_generates_button_tag, default: false
 
@@ -372,23 +369,14 @@ module ActionView
         authenticity_token = html_options.delete("authenticity_token")
 
         method     = (html_options.delete("method").presence || method_for_options(options)).to_s
-        method_tag = BUTTON_TAG_METHOD_VERBS.include?(method) ? method_tag(method) : "".html_safe
 
-        form_method  = method == "get" ? "get" : "post"
         form_options = html_options.delete("form") || {}
         form_options[:class] ||= html_options.delete("form_class") || "button_to"
-        form_options[:method] = form_method
-        form_options[:action] = url
+        form_options[:method] = method
         form_options[:'data-remote'] = true if remote
+        form_options[:enforce_utf8] = false
+        form_options[:authenticity_token] = authenticity_token
 
-        request_token_tag = if form_method == "post"
-          request_method = method.empty? ? "post" : method
-          token_tag(authenticity_token, form_options: { action: url, method: request_method })
-        else
-          ""
-        end
-
-        html_options = convert_options_to_data_attributes(options, html_options)
         html_options["type"] = "submit"
 
         button = if block_given?
@@ -400,16 +388,13 @@ module ActionView
           tag("input", html_options)
         end
 
-        inner_tags = method_tag.safe_concat(button).safe_concat(request_token_tag)
+        inner_tags = button
         if params
           to_form_params(params).each do |param|
-            options = { type: "hidden", name: param[:name], value: param[:value] }
-            options[:autocomplete] = "off" unless ActionView::Base.remove_hidden_field_autocomplete
-            inner_tags.safe_concat tag(:input, **options)
+            inner_tags.safe_concat hidden_field_tag(param[:name], param[:value], id: nil)
           end
         end
-        html = content_tag("form", inner_tags, form_options)
-        prevent_content_exfiltration(html)
+        form_tag(options, form_options) { inner_tags }
       end
 
       # Creates a link tag of the given +name+ using a URL created by the set of

--- a/actionview/lib/action_view/helpers/url_helper.rb
+++ b/actionview/lib/action_view/helpers/url_helper.rb
@@ -3,6 +3,7 @@
 require "active_support/core_ext/array/access"
 require "active_support/core_ext/hash/keys"
 require "active_support/core_ext/string/output_safety"
+require "action_view/helpers/tag_helper"
 
 module ActionView
   module Helpers # :nodoc:

--- a/actionview/test/template/navigation_helper_test.rb
+++ b/actionview/test/template/navigation_helper_test.rb
@@ -93,7 +93,7 @@ class NavigationHelperTest < ActiveSupport::TestCase
   def test_button_to_without_protect_against_forgery_method
     self.class.undef_method(:protect_against_forgery?)
     assert_dom_equal(
-      %{<form method="post" action="http://www.example.com" class="button_to"><button type="submit">Hello</button></form>},
+      %{<form method="post" action="http://www.example.com" accept-charset="UTF-8" class="button_to"><button type="submit">Hello</button></form>},
       button_to("Hello", "http://www.example.com")
     )
   ensure
@@ -104,7 +104,7 @@ class NavigationHelperTest < ActiveSupport::TestCase
     self.request_forgery = true
 
     assert_dom_equal(
-      %{<form method="post" action="http://www.example.com" class="button_to"><button type="submit">Hello</button><input name="form_token" type="hidden" value="token" autocomplete="off" /></form>},
+      %{<form method="post" action="http://www.example.com" accept-charset="UTF-8" class="button_to"><input name="form_token" type="hidden" value="token" autocomplete="off" /><button type="submit">Hello</button></form>},
       button_to("Hello", "http://www.example.com", authenticity_token: "token")
     )
   ensure
@@ -115,7 +115,7 @@ class NavigationHelperTest < ActiveSupport::TestCase
     self.request_forgery = true
 
     assert_dom_equal(
-      %{<form method="post" action="http://www.example.com" class="button_to"><button type="submit">Hello</button><input name="form_token" type="hidden" value="secret" autocomplete="off" /></form>},
+      %{<form method="post" action="http://www.example.com" accept-charset="UTF-8" class="button_to"><input name="form_token" type="hidden" value="secret" autocomplete="off" /><button type="submit">Hello</button></form>},
       button_to("Hello", "http://www.example.com", authenticity_token: true)
     )
   ensure
@@ -126,7 +126,7 @@ class NavigationHelperTest < ActiveSupport::TestCase
     self.request_forgery = true
 
     assert_dom_equal(
-      %{<form method="post" action="http://www.example.com" class="button_to"><button type="submit">Hello</button></form>},
+      %{<form method="post" action="http://www.example.com" accept-charset="UTF-8" class="button_to"><button type="submit">Hello</button></form>},
       button_to("Hello", "http://www.example.com", authenticity_token: false)
     )
   ensure
@@ -134,26 +134,26 @@ class NavigationHelperTest < ActiveSupport::TestCase
   end
 
   def test_button_to_with_straight_url
-    assert_dom_equal %{<form method="post" action="http://www.example.com" class="button_to"><button type="submit">Hello</button></form>}, button_to("Hello", "http://www.example.com")
+    assert_dom_equal %{<form method="post" action="http://www.example.com" accept-charset="UTF-8" class="button_to"><button type="submit">Hello</button></form>}, button_to("Hello", "http://www.example.com")
   end
 
   def test_button_to_with_path
     assert_dom_equal(
-      %{<form method="post" action="/article/Hello" class="button_to"><button type="submit">Hello</button></form>},
+      %{<form method="post" action="/article/Hello" accept-charset="UTF-8" class="button_to"><button type="submit">Hello</button></form>},
       button_to("Hello", article_path("Hello"))
     )
   end
 
   def test_button_to_with_false_url
     assert_dom_equal(
-      %{<form method="post" class="button_to"><button type="submit">Hello</button></form>},
+      %{<form method="post" accept-charset="UTF-8" class="button_to"><button type="submit">Hello</button></form>},
       button_to("Hello", false)
     )
   end
 
   def test_button_to_with_false_url_and_block
     assert_dom_equal(
-      %{<form method="post" class="button_to"><button type="submit">Hello</button></form>},
+      %{<form method="post" accept-charset="UTF-8" class="button_to"><button type="submit">Hello</button></form>},
       button_to(false) { "Hello" }
     )
   end
@@ -162,7 +162,7 @@ class NavigationHelperTest < ActiveSupport::TestCase
     session = Session.new(nil)
 
     assert_dom_equal(
-      %{<form method="post" action="/sessions" class="button_to"><button type="submit">Create Session</button></form>},
+      %{<form method="post" action="/sessions" accept-charset="UTF-8" class="button_to"><button type="submit">Create Session</button></form>},
       button_to("Create Session", session)
     )
   end
@@ -171,7 +171,7 @@ class NavigationHelperTest < ActiveSupport::TestCase
     workshop = Workshop.new(nil)
 
     assert_dom_equal(
-      %{<form method="post" action="/workshops" class="button_to"><button type="submit">Create</button></form>},
+      %{<form method="post" action="/workshops" accept-charset="UTF-8" class="button_to"><button type="submit">Create</button></form>},
       button_to(workshop) { "Create" }
     )
   end
@@ -181,7 +181,7 @@ class NavigationHelperTest < ActiveSupport::TestCase
     session = Session.new(nil)
 
     assert_dom_equal(
-      %{<form method="post" action="/workshops/1/sessions" class="button_to"><button type="submit">Create</button></form>},
+      %{<form method="post" action="/workshops/1/sessions" accept-charset="UTF-8" class="button_to"><button type="submit">Create</button></form>},
       button_to([workshop, session]) { "Create" }
     )
   end
@@ -190,7 +190,7 @@ class NavigationHelperTest < ActiveSupport::TestCase
     workshop = Workshop.new("1")
 
     assert_dom_equal(
-      %{<form method="post" action="/workshops/1" class="button_to"><input type="hidden" name="_method" value="patch" autocomplete="off" /><button type="submit">Update</button></form>},
+      %{<form method="post" action="/workshops/1" accept-charset="UTF-8" class="button_to"><input type="hidden" name="_method" value="patch" autocomplete="off" /><button type="submit">Update</button></form>},
       button_to(workshop) { "Update" }
     )
   end
@@ -199,7 +199,7 @@ class NavigationHelperTest < ActiveSupport::TestCase
     workshop = Workshop.new("1")
 
     assert_dom_equal(
-      %{<form method="post" action="/workshops/1" class="button_to"><input type="hidden" name="_method" value="patch" autocomplete="off" /><button type="submit">Update</button></form>},
+      %{<form method="post" action="/workshops/1" accept-charset="UTF-8" class="button_to"><input type="hidden" name="_method" value="patch" autocomplete="off" /><button type="submit">Update</button></form>},
       button_to(workshop) { "Update" }
     )
   end
@@ -209,7 +209,7 @@ class NavigationHelperTest < ActiveSupport::TestCase
     session = Session.new("1")
 
     assert_dom_equal(
-      %{<form method="post" action="/workshops/1/sessions/1" class="button_to"><input type="hidden" name="_method" value="patch" autocomplete="off" /><button type="submit">Update</button></form>},
+      %{<form method="post" action="/workshops/1/sessions/1" accept-charset="UTF-8" class="button_to"><input type="hidden" name="_method" value="patch" autocomplete="off" /><button type="submit">Update</button></form>},
       button_to([workshop, session]) { "Update" }
     )
   end
@@ -218,7 +218,7 @@ class NavigationHelperTest < ActiveSupport::TestCase
     self.request_forgery = true
 
     assert_dom_equal(
-      %{<form method="post" action="http://www.example.com" class="button_to"><button type="submit">Hello</button><input name="form_token" type="hidden" value="secret" autocomplete="off" /></form>},
+      %{<form method="post" action="http://www.example.com" accept-charset="UTF-8" class="button_to"><input name="form_token" type="hidden" value="secret" autocomplete="off" /><button type="submit">Hello</button></form>},
       button_to("Hello", "http://www.example.com")
     )
   ensure
@@ -226,113 +226,113 @@ class NavigationHelperTest < ActiveSupport::TestCase
   end
 
   def test_button_to_with_form_class
-    assert_dom_equal %{<form method="post" action="http://www.example.com" class="custom-class"><button type="submit">Hello</button></form>}, button_to("Hello", "http://www.example.com", form_class: "custom-class")
+    assert_dom_equal %{<form method="post" action="http://www.example.com" accept-charset="UTF-8" class="custom-class"><button type="submit">Hello</button></form>}, button_to("Hello", "http://www.example.com", form_class: "custom-class")
   end
 
   def test_button_to_with_form_class_escapes
-    assert_dom_equal %{<form method="post" action="http://www.example.com" class="&lt;script&gt;evil_js&lt;/script&gt;"><button type="submit">Hello</button></form>}, button_to("Hello", "http://www.example.com", form_class: "<script>evil_js</script>")
+    assert_dom_equal %{<form method="post" action="http://www.example.com" accept-charset="UTF-8" class="&lt;script&gt;evil_js&lt;/script&gt;"><button type="submit">Hello</button></form>}, button_to("Hello", "http://www.example.com", form_class: "<script>evil_js</script>")
   end
 
   def test_button_to_with_query
-    assert_dom_equal %{<form method="post" action="http://www.example.com/q1=v1&amp;q2=v2" class="button_to"><button type="submit">Hello</button></form>}, button_to("Hello", "http://www.example.com/q1=v1&q2=v2")
+    assert_dom_equal %{<form method="post" action="http://www.example.com/q1=v1&amp;q2=v2" accept-charset="UTF-8" class="button_to"><button type="submit">Hello</button></form>}, button_to("Hello", "http://www.example.com/q1=v1&q2=v2")
   end
 
   def test_button_to_with_value
-    assert_dom_equal %{<form method="post" action="http://www.example.com" class="button_to"><button type="submit" name="key" value="value">Hello</button></form>}, button_to("Hello", "http://www.example.com", name: "key", value: "value")
+    assert_dom_equal %{<form method="post" action="http://www.example.com" accept-charset="UTF-8" class="button_to"><button type="submit" name="key" value="value">Hello</button></form>}, button_to("Hello", "http://www.example.com", name: "key", value: "value")
   end
 
   def test_button_to_with_html_safe_URL
-    assert_dom_equal %{<form method="post" action="http://www.example.com/q1=v1&amp;q2=v2" class="button_to"><button type="submit">Hello</button></form>}, button_to("Hello", raw("http://www.example.com/q1=v1&amp;q2=v2"))
+    assert_dom_equal %{<form method="post" action="http://www.example.com/q1=v1&amp;q2=v2" accept-charset="UTF-8" class="button_to"><button type="submit">Hello</button></form>}, button_to("Hello", raw("http://www.example.com/q1=v1&amp;q2=v2"))
   end
 
   def test_button_to_with_query_and_no_name
-    assert_dom_equal %{<form method="post" action="http://www.example.com?q1=v1&amp;q2=v2" class="button_to"><button type="submit">http://www.example.com?q1=v1&amp;q2=v2</button></form>}, button_to(nil, "http://www.example.com?q1=v1&q2=v2")
+    assert_dom_equal %{<form method="post" action="http://www.example.com?q1=v1&amp;q2=v2" accept-charset="UTF-8" class="button_to"><button type="submit">http://www.example.com?q1=v1&amp;q2=v2</button></form>}, button_to(nil, "http://www.example.com?q1=v1&q2=v2")
   end
 
   def test_button_to_with_javascript_confirm
     assert_dom_equal(
-      %{<form method="post" action="http://www.example.com" class="button_to"><button data-confirm="Are you sure?" type="submit">Hello</button></form>},
+      %{<form method="post" action="http://www.example.com" accept-charset="UTF-8" class="button_to"><button data-confirm="Are you sure?" type="submit">Hello</button></form>},
       button_to("Hello", "http://www.example.com", data: { confirm: "Are you sure?" })
     )
   end
 
   def test_button_to_with_javascript_disable_with
     assert_dom_equal(
-      %{<form method="post" action="http://www.example.com" class="button_to"><button data-disable-with="Greeting..." type="submit">Hello</button></form>},
+      %{<form method="post" action="http://www.example.com" accept-charset="UTF-8" class="button_to"><button data-disable-with="Greeting..." type="submit">Hello</button></form>},
       button_to("Hello", "http://www.example.com", data: { disable_with: "Greeting..." })
     )
   end
 
   def test_button_to_with_remote_and_form_options
     assert_dom_equal(
-      %{<form method="post" action="http://www.example.com" class="custom-class" data-remote="true" data-type="json"><button type="submit">Hello</button></form>},
+      %{<form method="post" action="http://www.example.com" accept-charset="UTF-8" class="custom-class" data-remote="true" data-type="json"><button type="submit">Hello</button></form>},
       button_to("Hello", "http://www.example.com", remote: true, form: { class: "custom-class", "data-type" => "json" })
     )
   end
 
   def test_button_to_with_remote_and_javascript_confirm
     assert_dom_equal(
-      %{<form method="post" action="http://www.example.com" class="button_to" data-remote="true"><button data-confirm="Are you sure?" type="submit">Hello</button></form>},
+      %{<form method="post" action="http://www.example.com" accept-charset="UTF-8" class="button_to" data-remote="true"><button data-confirm="Are you sure?" type="submit">Hello</button></form>},
       button_to("Hello", "http://www.example.com", remote: true, data: { confirm: "Are you sure?" })
     )
   end
 
   def test_button_to_with_remote_and_javascript_disable_with
     assert_dom_equal(
-      %{<form method="post" action="http://www.example.com" class="button_to" data-remote="true"><button data-disable-with="Greeting..." type="submit">Hello</button></form>},
+      %{<form method="post" action="http://www.example.com" accept-charset="UTF-8" class="button_to" data-remote="true"><button data-disable-with="Greeting..." type="submit">Hello</button></form>},
       button_to("Hello", "http://www.example.com", remote: true, data: { disable_with: "Greeting..." })
     )
   end
 
   def test_button_to_with_remote_false
     assert_dom_equal(
-      %{<form method="post" action="http://www.example.com" class="button_to"><button type="submit">Hello</button></form>},
+      %{<form method="post" action="http://www.example.com" accept-charset="UTF-8" class="button_to"><button type="submit">Hello</button></form>},
       button_to("Hello", "http://www.example.com", remote: false)
     )
   end
 
   def test_button_to_enabled_disabled
     assert_dom_equal(
-      %{<form method="post" action="http://www.example.com" class="button_to"><button type="submit">Hello</button></form>},
+      %{<form method="post" action="http://www.example.com" accept-charset="UTF-8" class="button_to"><button type="submit">Hello</button></form>},
       button_to("Hello", "http://www.example.com", disabled: false)
     )
     assert_dom_equal(
-      %{<form method="post" action="http://www.example.com" class="button_to"><button disabled="disabled" type="submit">Hello</button></form>},
+      %{<form method="post" action="http://www.example.com" accept-charset="UTF-8" class="button_to"><button disabled="disabled" type="submit">Hello</button></form>},
       button_to("Hello", "http://www.example.com", disabled: true)
     )
   end
 
   def test_button_to_with_method_delete
     assert_dom_equal(
-      %{<form method="post" action="http://www.example.com" class="button_to"><input type="hidden" name="_method" value="delete" autocomplete="off" /><button type="submit">Hello</button></form>},
+      %{<form method="post" action="http://www.example.com" accept-charset="UTF-8" class="button_to"><input type="hidden" name="_method" value="delete" autocomplete="off" /><button type="submit">Hello</button></form>},
       button_to("Hello", "http://www.example.com", method: :delete)
     )
   end
 
   def test_button_to_with_method_get
     assert_dom_equal(
-      %{<form method="get" action="http://www.example.com" class="button_to"><button type="submit">Hello</button></form>},
+      %{<form method="get" action="http://www.example.com" accept-charset="UTF-8" class="button_to"><button type="submit">Hello</button></form>},
       button_to("Hello", "http://www.example.com", method: :get)
     )
   end
 
   def test_button_to_with_block
     assert_dom_equal(
-      %{<form method="post" action="http://www.example.com" class="button_to"><button type="submit"><span>Hello</span></button></form>},
+      %{<form method="post" action="http://www.example.com" accept-charset="UTF-8" class="button_to"><button type="submit"><span>Hello</span></button></form>},
       button_to("http://www.example.com") { content_tag(:span, "Hello") }
     )
   end
 
   def test_button_to_with_params
     assert_dom_equal(
-      %{<form action="http://www.example.com" class="button_to" method="post"><button type="submit">Hello</button><input type="hidden" name="baz" value="quux" autocomplete="off" /><input type="hidden" name="foo" value="bar" autocomplete="off" /></form>},
+      %{<form action="http://www.example.com" accept-charset="UTF-8" class="button_to" method="post"><button type="submit">Hello</button><input type="hidden" name="baz" value="quux" autocomplete="off" /><input type="hidden" name="foo" value="bar" autocomplete="off" /></form>},
       button_to("Hello", "http://www.example.com", params: { foo: :bar, baz: "quux" })
     )
   end
 
   def test_button_to_with_block_and_hash_url
     assert_dom_equal(
-      %{<form action="/other" class="button_to" method="post"><button class="button" type="submit">Hello</button></form>},
+      %{<form action="/other" accept-charset="UTF-8" class="button_to" method="post"><button class="button" type="submit">Hello</button></form>},
       button_to({ controller: "foo", action: "other" }, class: "button") { "Hello" }
     )
   end
@@ -342,7 +342,7 @@ class NavigationHelperTest < ActiveSupport::TestCase
     ActionView::Helpers::NavigationHelper.button_to_generates_button_tag = false
 
     assert_dom_equal(
-      %{<form method="post" action="http://www.example.com" class="button_to"><input type="submit" value="Save"/></form>},
+      %{<form method="post" action="http://www.example.com" accept-charset="UTF-8" class="button_to"><input type="submit" value="Save"/></form>},
       button_to("Save", "http://www.example.com")
     )
   ensure
@@ -352,7 +352,7 @@ class NavigationHelperTest < ActiveSupport::TestCase
   def test_button_to_with_content_exfiltration_prevention
     with_prepend_content_exfiltration_prevention(true) do
       assert_dom_equal(
-        %{<!-- '"` --><!-- </textarea></xmp> --></option></form><form method="post" action="http://www.example.com" class="button_to"><button type="submit">Hello</button></form>},
+        %{<!-- '"` --><!-- </textarea></xmp> --></option></form><form method="post" action="http://www.example.com" accept-charset="UTF-8" class="button_to"><button type="submit">Hello</button></form>},
         button_to("Hello", "http://www.example.com")
       )
     end
@@ -378,7 +378,7 @@ class NavigationHelperTest < ActiveSupport::TestCase
 
   def test_button_to_with_permitted_strong_params
     assert_dom_equal(
-      %{<form action="http://www.example.com" class="button_to" method="post"><button type="submit">Hello</button><input type="hidden" name="baz" value="quux" autocomplete="off" /><input type="hidden" name="foo" value="bar" autocomplete="off" /></form>},
+      %{<form action="http://www.example.com" accept-charset="UTF-8" class="button_to" method="post"><button type="submit">Hello</button><input type="hidden" name="baz" value="quux" autocomplete="off" /><input type="hidden" name="foo" value="bar" autocomplete="off" /></form>},
       button_to("Hello", "http://www.example.com", params: FakeParams.new)
     )
   end
@@ -391,14 +391,14 @@ class NavigationHelperTest < ActiveSupport::TestCase
 
   def test_button_to_with_nested_hash_params
     assert_dom_equal(
-      %{<form action="http://www.example.com" class="button_to" method="post"><button type="submit">Hello</button><input type="hidden" name="foo[bar]" value="baz" autocomplete="off" /></form>},
+      %{<form action="http://www.example.com" accept-charset="UTF-8" class="button_to" method="post"><button type="submit">Hello</button><input type="hidden" name="foo[bar]" value="baz" autocomplete="off" /></form>},
       button_to("Hello", "http://www.example.com", params: { foo: { bar: "baz" } })
     )
   end
 
   def test_button_to_with_nested_array_params
     assert_dom_equal(
-      %{<form action="http://www.example.com" class="button_to" method="post"><button type="submit">Hello</button><input type="hidden" name="foo[]" value="bar" autocomplete="off" /></form>},
+      %{<form action="http://www.example.com" accept-charset="UTF-8" class="button_to" method="post"><button type="submit">Hello</button><input type="hidden" name="foo[]" value="bar" autocomplete="off" /></form>},
       button_to("Hello", "http://www.example.com", params: { foo: ["bar"] })
     )
   end

--- a/actionview/test/template/url_helper_test.rb
+++ b/actionview/test/template/url_helper_test.rb
@@ -15,6 +15,7 @@ class UrlHelperTest < ActiveSupport::TestCase
     get "/other" => "foo#other"
   end
 
+  include ActionView::Helpers::FormTagHelper
   include ActionView::Helpers::UrlHelper
   include routes.url_helpers
 

--- a/guides/source/action_view_helpers.md
+++ b/guides/source/action_view_helpers.md
@@ -262,7 +262,7 @@ with the value of the `name`.
 would output the following HTML:
 
 ```html
-<form method="post" action="/sessions" class="button_to">
+<form method="post" action="/sessions" class="button_to" accept-charset="UTF-8">
   <input type="submit" value="Sign in" />
 </form>
 ```


### PR DESCRIPTION
### Motivation / Background

While the ergonomics of calling `button_to` match those of `form_for`, `form_with`, or even `form_tag`, the implementation doesn't use much of those helper's existing infrastructure. There are chunks of logic repeated and re-implemented. For example:

* determining the `[action]` and `[method]` attributes for the `<form>`
* rendering an `<input type="hidden" name="_method">` for methods other than `POST` or `GET`
* generating and rendering an authenticity token input
* content exfiltration
* encoding `[data-remote]` for UJS integration


### Detail

This commit implements more of `button_to` in terms of the [form_tag][] helper method defined in `FormTagHelper`. That method handles responsibilities like determining `[method]`, rendering `<input type="hidden">`, etc.

The only outward-facing changes (reflected in test suite cases) involve the order of the `<form>` element's content, and the introduction of an `[accept-charset="UTF-8"]` attribute.

The `<button>` element will be rendered **after** hidden fields instead of **before** (the previous behavior).

Similarly, the `[accept-charset]` attribute wasn't being rendered before, but is rendered by `form_tag`. The `form_tag` helper doesn't currently expose a mechanism to skip that attribute (in the same way that `:enforce_utf8` is being used here to skip the `<input type="hidden">`.


### Additional information

As part of these changes, this commit also excises the `method_tag` and `token_tag` private helpers out of the `UrlHelper` module and into the `FormTagHelper` module, since that's the only remaining call site. The previous implementation relied on the fact that both `UrlHelper` and `FormTagHelper` end up being mixed into an `ActionView::Base` instance, so the cross-module `private` boundary wasn't effective.

In support of that change, this commit includes a `require
"action_view/helpers/tag_helper"` line atop
`actionview/lib/action_view/helpers/url_helper.rb` to ensure the
availability of the `ActionView::Helpers::TagHelper` module methods
(since helpers like `mail_to` invoke helpers such as `content_tag(:a, …)`).

[form_tag]: https://edgeapi.rubyonrails.org/classes/ActionView/Helpers/FormTagHelper.html#method-i-form_tag

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
