### PR TITLE
Ignore negative counter caches when checking for existence of the association

### DIFF
--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -229,10 +229,11 @@ module ActiveRecord
       # check <tt>collection.length.zero?</tt>.
       def empty?
         if loaded? || @association_ids || reflection.has_cached_counter?
-          size.zero?
-        else
-          target.empty? && !scope.exists?
+          return false if size > 0
+          return true if size == 0
         end
+
+        target.empty? && !scope.exists?
       end
 
       # Replace this collection with +other_array+. This will perform a diff

--- a/activerecord/test/cases/associations/belongs_to_associations_test.rb
+++ b/activerecord/test/cases/associations/belongs_to_associations_test.rb
@@ -1017,6 +1017,22 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
     assert_equal 1, topic.replies_count
   end
 
+  def test_ignores_negative_counter_cache
+    post = Post.create!(title: "foo", body: "bar", comments_count: -1)
+
+    assert_queries(1) do
+      assert_predicate post.comments, :empty?
+    end
+
+    post.comments.create!(body: "Thank you")
+    post.update!(comments_count: -1)
+    post.reload
+
+    assert_queries(1) do
+      assert_not_predicate post.comments, :empty?
+    end
+  end
+
   def test_association_assignment_sticks
     post = Post.first
 


### PR DESCRIPTION
Fixes #50311.

Due to race conditions, it is possible to get a negative number of counter cache values.
When we are in this situation, we should actually query the association to check if there are any records. 