### PR TITLE
Empty method issue fixed if counter cache negative

### DIFF
--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -228,8 +228,10 @@ module ActiveRecord
       # loaded and you are going to fetch the records anyway it is better to
       # check <tt>collection.length.zero?</tt>.
       def empty?
-        if loaded? || @association_ids || reflection.has_cached_counter?
+        if loaded? || @association_ids
           size.zero?
+        elsif reflection.has_cached_counter?
+          !size.positive?
         else
           target.empty? && !scope.exists?
         end

--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -228,10 +228,8 @@ module ActiveRecord
       # loaded and you are going to fetch the records anyway it is better to
       # check <tt>collection.length.zero?</tt>.
       def empty?
-        if loaded? || @association_ids
+        if loaded? || @association_ids || (reflection.has_cached_counter? && size >= 0)
           size.zero?
-        elsif reflection.has_cached_counter?
-          !size.positive?
         else
           target.empty? && !scope.exists?
         end

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -3216,6 +3216,14 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     MESSAGE
   end
 
+  def test_empty_method_if_counter_cache_negative
+    post = Post.create!(title: "post 1", body: "post 1 body", comments_count: -20)
+
+    assert_queries(1) do
+      assert_predicate post.comments, :empty?
+    end
+  end
+
   private
     def force_signal37_to_load_all_clients_of_firm
       companies(:first_firm).clients_of_firm.load_target


### PR DESCRIPTION
If there's has many association between two tables. Let say, `post` and `comment`. Post has no comments but due to some issue, counter_cache is negative, then `empty?`  method returns false. It should return true as the DB query would return true.

This PR is related to [Counter cache issue](https://github.com/rails/rails/issues/50311) #50311 
