### PR TITLE
Tag Builders: render keywords as dasherized HTML attributes

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   Render `Hash` and keyword options as dasherized HTML attributes
+
+    ```ruby
+    tag.button "POST to /clicked", hx: { post: "/clicked", swap: :outerHTML, data: { json: true } }
+
+    # => <button hx-post="/clicked" hx-swap="outerHTML" hx-data="{&quot;json&quot;:true}">POST to /clicked</button>
+    ```
+
+    *Sean Doyle*
+
 *   `ViewReloader#deactivate` removes the `file_system_resolver_hooks` callback
     so forked processes that clear reloaders no longer trigger filesystem scans
     on every `prepend_view_path`.

--- a/actionview/lib/action_view/helpers/tag_helper.rb
+++ b/actionview/lib/action_view/helpers/tag_helper.rb
@@ -32,11 +32,13 @@ module ActionView
 
       ARIA_PREFIXES = ["aria", :aria].to_set.freeze
       DATA_PREFIXES = ["data", :data].to_set.freeze
+      CLASS_PREFIXES = ["class", :class].to_set.freeze
 
       TAG_TYPES = {}
       TAG_TYPES.merge! BOOLEAN_ATTRIBUTES.index_with(:boolean)
       TAG_TYPES.merge! DATA_PREFIXES.index_with(:data)
       TAG_TYPES.merge! ARIA_PREFIXES.index_with(:aria)
+      TAG_TYPES.merge! CLASS_PREFIXES.index_with(:class)
       TAG_TYPES.freeze
 
       PRE_CONTENT_STRINGS             = Hash.new { "" }
@@ -240,7 +242,7 @@ module ActionView
             next if key.blank?
 
             type = TAG_TYPES[key]
-            if type == :data && value.is_a?(Hash)
+            if type != :aria && type != :class && value.is_a?(Hash)
               value.each_pair do |k, v|
                 next if k.blank? || v.nil?
 
@@ -391,6 +393,13 @@ module ActionView
       #
       #   tag.div data: { city_state: %w( Chicago IL ) }
       #   # => <div data-city-state="[&quot;Chicago&quot;,&quot;IL&quot;]"></div>
+      #
+      # In addition to <tt>:data</tt> and <tt>:aria</tt>, nest sub-attribute
+      # hashes for any keys:
+      #
+      #   tag.button "POST to /clicked", hx: { post: "/clicked", swap: :outerHTML }
+      #
+      #   # => <button hx-post="/clicked" hx-swap="outerHTML">POST to /clicked</button>
       #
       # The generated tag names and attributes are escaped by default. This can be disabled using
       # +escape+.

--- a/actionview/test/template/form_helper/form_with_test.rb
+++ b/actionview/test/template/form_helper/form_with_test.rb
@@ -2458,6 +2458,12 @@ class FormWithActsLikeFormForTest < FormWithTest
     assert_match %r|data-remote="true"|, @rendered
   end
 
+  def test_form_with_nested_html_attributes
+    form_with(model: @post, html: { hx: { post: "/path", data: { open: false } } }) { }
+
+    assert_dom "form[hx-post=?][hx-data=?]", "/path", { open: false }.to_json
+  end
+
   def test_fields_returns_block_result
     output = fields(model: Post.new) { |f| "fields" }
     assert_equal "fields", output

--- a/actionview/test/template/form_helper_test.rb
+++ b/actionview/test/template/form_helper_test.rb
@@ -4218,6 +4218,12 @@ class FormHelperTest < ActionView::TestCase
     assert_match %r|data-remote="true"|, @rendered
   end
 
+  def test_form_for_nested_html_attributes
+    form_for(@post, html: { hx: { post: "/path", data: { open: false } } }) { }
+
+    assert_dom "form[hx-post=?][hx-data=?]", "/path", { open: false }.to_json
+  end
+
   def test_fields_for_returns_block_result
     output = fields_for(Post.new) { |f| "fields" }
     assert_equal "fields", output

--- a/actionview/test/template/tag_helper_test.rb
+++ b/actionview/test/template/tag_helper_test.rb
@@ -554,9 +554,19 @@ class TagHelperTest < ActionView::TestCase
     assert_dom_equal "<p>limelight shines!</p>", tag.p("limelight") { " shines!" }
   end
 
+  def test_content_tag_with_nested_html_attributes
+    assert_dom_equal '<p hx-number="1" hx-string="hello" hx-string-with-quotes="double&quot;quote&quot;party&quot;" hx-data="{&quot;open&quot;:false}"></p>',
+      content_tag("p", "", hx: { number: 1, string: "hello", string_with_quotes: 'double"quote"party"', data: { open: false } })
+  end
+
   def test_tag_builder_with_data_attributes
     assert_dom_equal '<p data-number="1" data-string="hello" data-string-with-quotes="double&quot;quote&quot;party&quot;">limelight</p>',
       tag.p("limelight", data: { number: 1, string: "hello", string_with_quotes: 'double"quote"party"' })
+  end
+
+  def test_tag_builder_with_nested_html_attributes
+    assert_dom_equal '<p hx-number="1" hx-string="hello" hx-string-with-quotes="double&quot;quote&quot;party&quot;" hx-data="{&quot;open&quot;:false}"></p>',
+      tag.p("", hx: { number: 1, string: "hello", string_with_quotes: 'double"quote"party"', data: { open: false } })
   end
 
   def test_cdata_section


### PR DESCRIPTION
### Motivation / Background

While [Stimulus][] and [Turbo][] rely on values encoded into `data`-prefixed HTML attributes present in the document, other frameworks like [Alpine.js][] and [htmx][] rely on different prefixes (`x` and `hx`, respectively).

### Detail

To add support for those frameworks and others like them, this commit introduces support for arbitrarily nested `Hash` instances.
    
```ruby
tag.button "POST to /clicked", hx: { post: "/clicked", swap: :outerHTML, data: { json: true } }

# => <button hx-post="/clicked" hx-swap="outerHTML" hx-data="{&quot;json&quot;:true}">POST to /clicked</button>
```

[Stimulus]: https://stimulus.hotwired.dev
[Turbo]: https://turbo.hotwired.dev
[Alpine.js]: https://alpinejs.dev
[htmx]: https://htmx.org

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
