### PR TITLE
Fix wrong example code: `active_job.message_serializer`

### DIFF
--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -2483,7 +2483,7 @@ Alternatively, you can specify any serializer object that responds to `dump` and
 `load` methods. For example:
 
 ```ruby
-config.active_job.message_serializer = YAML
+config.active_support.message_serializer = YAML
 ```
 
 The default value depends on the `config.load_defaults` target version:


### PR DESCRIPTION
### Motivation / Background

This is a simple documentation correction.

From what I've read, this was probably a miswritten `active_support.message_serializer` rather than `active_job.message_serializer`.

Sorry if I misunderstood something.

### Additional information

It appears that this example was originally added in the following pull request:

- https://github.com/rails/rails/pull/47963

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* ~[ ] Tests are added or updated if you fix a bug or add a feature.~
* ~[ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.~
