### PR TITLE
Fix tests for status code change on Rack HEAD

### DIFF
--- a/actionpack/lib/action_dispatch/testing/assertion_response.rb
+++ b/actionpack/lib/action_dispatch/testing/assertion_response.rb
@@ -36,7 +36,7 @@ module ActionDispatch
 
     private
       def code_from_name(name)
-        GENERIC_RESPONSE_CODES[name] || Rack::Utils::SYMBOL_TO_STATUS_CODE[name]
+        GENERIC_RESPONSE_CODES[name] || Rack::Utils.status_code(name)
       end
 
       def name_from_code(code)


### PR DESCRIPTION
### Motivation / Background

Rack was recently [updated][1] with a deprecation for some status codes that have been renamed (most notably, Unprocessable Entity was renamed to Unprocessable Content). Since the deprecation was only added to the `#status_code` method, this has caused test failures for some tests that depend on the `SYMBOLS_TO_STATUS_CODE` hash.

### Detail

This commit replaces the usage of `SYMBOLS_TO_STATUS_CODE` with `#status_code` so that we get the deprecation message instead of a test failure.

[1]: https://github.com/rack/rack/commit/64ad26e3381da2ce1853638a2c4ea241c2ad3729

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
