### PR TITLE
Fix `Preloader` to not generate a query for already loaded association with `query_constraints`

### DIFF
--- a/activerecord/lib/active_record/associations/preloader/association.rb
+++ b/activerecord/lib/active_record/associations/preloader/association.rb
@@ -38,6 +38,8 @@ module ActiveRecord
           end
 
           def load_records_for_keys(keys, &block)
+            return [] if keys.empty?
+
             if association_key_name.is_a?(Array)
               query_constraints = Hash.new { |hsh, key| hsh[key] = Set.new }
 

--- a/activerecord/test/cases/associations_test.rb
+++ b/activerecord/test/cases/associations_test.rb
@@ -1388,6 +1388,15 @@ class PreloaderTest < ActiveRecord::TestCase
     assert_equal sharded_blog_posts(:great_post_blog_one), comment.blog_post
   end
 
+  def test_preload_loaded_belongs_to_association_with_composite_foreign_key
+    comment = sharded_comments(:great_comment_blog_post_one)
+    comment.blog_post
+
+    assert_no_queries do
+      ActiveRecord::Associations::Preloader.new(records: [comment], associations: :blog_post).call
+    end
+  end
+
   def test_preload_has_many_through_association_with_composite_query_constraints
     tag = sharded_tags(:short_read_blog_one)
 


### PR DESCRIPTION
Fixes #50310.

The behavior was introduced in https://github.com/rails/rails/commit/1e9dbf00bd03e518e3605e5a0b9d306d02dab45d#diff-97709b319ca07f6cd3f4d6b8a8c443d0cb3e7487696098be377aa9fa78907a35R38-R44

Previously, for empty `keys`, `scope.where(association_key_name => keys)` would generate a no-op query which was not issued to the database. But with that change, `scope` (which is `select *`) is always loaded. 

That code was also further changed in https://github.com/rails/rails/commit/0bbf4e86cb9a673d3deb6e180c4082276ef1e762#diff-97709b319ca07f6cd3f4d6b8a8c443d0cb3e7487696098be377aa9fa78907a35R42-R50 but it still performs that `select *`.

cc @nvasilevski 
