### PR TITLE
Revert backport of #49721

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -48,10 +48,6 @@
 
     *Andrew Novoselac*
 
-*   Fix issue where `bootstrap.rb` overwrites the `level` of a `BroadcastLogger`'s `broadcasts`.
-
-    *Andrew Novoselac*
-
 *   Fix `ActiveSupport::Cache` to handle outdated Marshal payload from Rails 6.1 format.
 
     Active Support's Cache is supposed to treat a Marshal payload that can no longer be

--- a/railties/lib/rails/application/bootstrap.rb
+++ b/railties/lib/rails/application/bootstrap.rb
@@ -54,9 +54,9 @@ module Rails
           )
           logger
         end
+        Rails.logger.level = ActiveSupport::Logger.const_get(config.log_level.to_s.upcase)
 
         unless Rails.logger.is_a?(ActiveSupport::BroadcastLogger)
-          Rails.logger.level = ActiveSupport::Logger.const_get(config.log_level.to_s.upcase)
           broadcast_logger = ActiveSupport::BroadcastLogger.new(Rails.logger)
           broadcast_logger.formatter = Rails.logger.formatter
           Rails.logger = broadcast_logger


### PR DESCRIPTION
In https://github.com/rails/rails/commit/7254e275ea44c48abb934e3ce82666e184d32200, https://github.com/rails/rails/pull/49721 was backported to `7-1-stable`.

As noted in https://github.com/rails/rails/issues/50324 this introduces a breaking change. I think it's fine for this to be on `main` while we work it out but it shouldn't be on the stable branch, so proposing to revert the backport.

Unfortunately this change was included in [7.1.2](https://github.com/rails/rails/blob/v7.1.2/railties/lib/rails/application/bootstrap.rb#L59), but not [7.1.1](https://github.com/rails/rails/blob/v7.1.1/railties/lib/rails/application/bootstrap.rb#L57). I'm not sure if being in a release makes it too late to revert (IMO it should still be reverted).