### PR TITLE
Lock `bigdecimal` version to 3.1.4 or lower

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -86,7 +86,7 @@ PATH
       marcel (~> 1.0)
     activesupport (7.2.0.alpha)
       base64
-      bigdecimal
+      bigdecimal (< 3.1.5)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       connection_pool (>= 2.2.5)
       drb

--- a/activesupport/activesupport.gemspec
+++ b/activesupport/activesupport.gemspec
@@ -41,5 +41,5 @@ Gem::Specification.new do |s|
   s.add_dependency "minitest",        ">= 5.1"
   s.add_dependency "base64"
   s.add_dependency "drb"
-  s.add_dependency "bigdecimal"
+  s.add_dependency "bigdecimal",      "< 3.1.5"
 end


### PR DESCRIPTION
### Motivation / Background

This commit addresses the Rails CI using Ruby master branch failure because Rails CI enables `RAILS_STRICT_WARNINGS` to raise RuntimeError for warnings.

https://buildkite.com/rails/rails/builds/102621#018c49df-e3de-4c2f-aeb7-6d8f08997da9/1102-1107
```ruby
/rails/activesupport/lib/active_support/core_ext/big_decimal/conversions.rb:4: warning: bigdecimal/util is found in bigdecimal, which will no longer be part of the default gems since Ruby 3.4.0. Add bigdecimal to your Gemfile or gemspec. (RuntimeError)
```

### Detail

According to https://bugs.ruby-lang.org/issues/20058 , This failure has been triggered since https://github.com/ruby/ruby/commit/cc9826503d989df877adbcd94d39a6ff78d0b785 and it will be addressed once the bigdecimal 3.1.5 is available at rubygems.org .

In the meantime, we can workaround this issue by logking `bigdecimal` version to 3.1.4 or lower. This commit should be reverted when the `bigdecimal` 3.1.5 is available at rubygems.org .

### Additional information

<!-- Provide additional information such as benchmarks, reference to other repositories or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
