### PR TITLE
Support validation for old Enum API

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Add `_validate` to `enum status:` style Enum API to mirror `validate` for
+    `enum :status` style Enum API.
+
+    *Hartley McGuire*
+
 *   Make `assert_queries` and `assert_no_queries` assertions public.
 
     To assert the expected number of queries are made, Rails internally uses

--- a/activerecord/lib/active_record/enum.rb
+++ b/activerecord/lib/active_record/enum.rb
@@ -219,7 +219,7 @@ module ActiveRecord
         return _enum(name, values, **options)
       end
 
-      definitions = options.slice!(:_prefix, :_suffix, :_scopes, :_default, :_instance_methods)
+      definitions = options.slice!(:_prefix, :_suffix, :_scopes, :_default, :_instance_methods, :_validate)
       options.transform_keys! { |key| :"#{key[1..-1]}" }
 
       definitions.each { |name, values| _enum(name, values, **options) }

--- a/activerecord/test/cases/enum_test.rb
+++ b/activerecord/test/cases/enum_test.rb
@@ -332,6 +332,25 @@ class EnumTest < ActiveRecord::TestCase
     assert_not_predicate invalid_book, :valid?
   end
 
+  test "validation with '_validate: true' option" do
+    klass = Class.new(ActiveRecord::Base) do
+      def self.name; "Book"; end
+      enum status: [:proposed, :written], _validate: true
+    end
+
+    valid_book = klass.new(status: "proposed")
+    assert_predicate valid_book, :valid?
+
+    valid_book = klass.new(status: "written")
+    assert_predicate valid_book, :valid?
+
+    invalid_book = klass.new(status: nil)
+    assert_not_predicate invalid_book, :valid?
+
+    invalid_book = klass.new(status: "unknown")
+    assert_not_predicate invalid_book, :valid?
+  end
+
   test "validation with 'validate: hash' option" do
     klass = Class.new(ActiveRecord::Base) do
       def self.name; "Book"; end


### PR DESCRIPTION
### Motivation / Background

The new, symbol, `#enum` API recently [gained][1] support for a new `validate` option which replaces `ArgumentErrors` with Active Model validation errors.

### Detail

This commit adds `_validate` to the old, keyword argument, `#enum` API to keep the two APIs in sync.

[1]: https://github.com/rails/rails/commit/7c65a4b83b583f4f27f3f20a9fb078b35823d2fe

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
