### PR TITLE
Change `SchemaDumper.dump` default stream to `$stdout`

### DIFF
--- a/activerecord/lib/active_record/schema_dumper.rb
+++ b/activerecord/lib/active_record/schema_dumper.rb
@@ -41,7 +41,7 @@ module ActiveRecord
     cattr_accessor :unique_ignore_pattern, default: /^uniq_rails_[0-9a-f]{10}$/
 
     class << self
-      def dump(connection = ActiveRecord::Base.connection, stream = STDOUT, config = ActiveRecord::Base)
+      def dump(connection = ActiveRecord::Base.connection, stream = $stdout, config = ActiveRecord::Base)
         connection.create_schema_dumper(generate_options(config)).dump(stream)
         stream
       end

--- a/activerecord/test/support/schema_dumping_helper.rb
+++ b/activerecord/test/support/schema_dumping_helper.rb
@@ -5,19 +5,21 @@ module SchemaDumpingHelper
     connection = ActiveRecord::Base.connection
     old_ignore_tables = ActiveRecord::SchemaDumper.ignore_tables
     ActiveRecord::SchemaDumper.ignore_tables = connection.data_sources - tables
-    stream = StringIO.new
 
-    ActiveRecord::SchemaDumper.dump(connection, stream)
-    stream.string
+    output, = capture_io do
+      ActiveRecord::SchemaDumper.dump(connection)
+    end
+    output
   ensure
     ActiveRecord::SchemaDumper.ignore_tables = old_ignore_tables
   end
 
   def dump_all_table_schema(ignore_tables = [], connection: ActiveRecord::Base.connection)
     old_ignore_tables, ActiveRecord::SchemaDumper.ignore_tables = ActiveRecord::SchemaDumper.ignore_tables, ignore_tables
-    stream = StringIO.new
-    ActiveRecord::SchemaDumper.dump(connection, stream)
-    stream.string
+    output, = capture_io do
+      ActiveRecord::SchemaDumper.dump(connection)
+    end
+    output
   ensure
     ActiveRecord::SchemaDumper.ignore_tables = old_ignore_tables
   end


### PR DESCRIPTION
In my gem, I extended `SchemaDumper` with a small custom logic and when wrote tests for it (https://github.com/fatkodima/online_migrations/commit/39d2f1b0f19e95597e05e8d1ae4f0b1d71d4a06b#diff-cb07f4a9f75db580d9b7e7bb54c641cb2cab696ef90a9afd64f128fb002a79a7R42-R46) was wondering why `capture_io` is not working. Turned out, that is because `.dump` accepts `STDOUT` (instead of `$stdout`) as a default output stream.

I changed that method's signature to make it easier to test and also changed 2 test helpers to use that.