### PR TITLE
Update Rack::Head documentation to match code behavior [ci-skip]

### DIFF
--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -840,7 +840,7 @@ Allows the method to be overridden if `params[:_method]` is set. This is the mid
 
 #### `Rack::Head`
 
-Converts HEAD requests to GET requests and serves them as so.
+Returns an empty body for all HEAD requests. It leaves all other requests unchanged.
 
 #### Adding Custom Middleware
 

--- a/guides/source/rails_on_rack.md
+++ b/guides/source/rails_on_rack.md
@@ -339,7 +339,7 @@ Much of Action Controller's functionality is implemented as Middlewares. The fol
 
 **`Rack::Head`**
 
-* Converts HEAD requests to `GET` requests and serves them as so.
+* Returns an empty body for all HEAD requests. It leaves all other requests unchanged.
 
 **`Rack::ConditionalGet`**
 


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because the documentation for Rack::Head was left-over from ActionDispatch::Head's documentation. This PR updates the comment.

### Detail 

In commit 449039a86d802871b707dfb51ac1ed96d53526f9, [ActionDispatch::Head](https://github.com/rails/rails/blob/3-2-stable/actionpack/lib/action_dispatch/middleware/head.rb) was replaced with [Rack::Head](https://github.com/rack/rack/blob/main/lib/rack/head.rb) in the middleware. However, the documentation was not changed.

The left-over ActionDisplayt::Head documentation is, unsurprisingly, wrong. Rack::Head code behaviour is not to change HEAD into GET it is to close the body of all HEAD requests. This commit fixes the docs to show this.

[Old behavior: ActionDispatch::Head changing HEAD into GET
](https://github.com/rails/rails/blob/3-2-stable/actionpack/lib/action_dispatch/middleware/head.rb)
[New behavior: Rack::Head closing the body of HEAD requests](https://github.com/rack/rack/blob/main/lib/rack/head.rb)

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [X] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
