### PR TITLE
Introduce `ActiveJob::Base.locator_options`

### DIFF
--- a/activejob/CHANGELOG.md
+++ b/activejob/CHANGELOG.md
@@ -1,3 +1,29 @@
+*   Introduce `ActiveJob::Base.locator_options` to support strict loading
+
+    ```ruby
+    class Article < ApplicationRecord
+      self.strict_loading_by_default = true
+
+      has_and_belongs_to_many :tags
+    end
+
+    class Tag < ApplicationRecord
+      has_and_belongs_to_many :articles
+    end
+
+    class PublishJob < ApplicationJob
+      locator_options "Article", includes: :tags
+
+      def perform(article)
+        article.tags.each do |tag|
+          # ...
+        end
+      end
+    end
+    ```
+
+    *Sean Doyle*
+
 *   Add `ActiveJob::Attributes` for declaring typed attributes that persist across
     job serialization and deserialization. It is included by `ActiveJob::Continuable`
     but can also be used standalone.

--- a/activejob/test/cases/argument_serialization_test.rb
+++ b/activejob/test/cases/argument_serialization_test.rb
@@ -9,6 +9,7 @@ require "active_support/core_ext/integer/time"
 require "active_support/duration"
 require "jobs/kwargs_job"
 require "jobs/arguments_round_trip_job"
+require "jobs/association_loading_job"
 require "support/stubs/strong_parameters"
 
 class ArgumentSerializationTest < ActiveSupport::TestCase
@@ -44,6 +45,7 @@ class ArgumentSerializationTest < ActiveSupport::TestCase
   end
 
   setup do
+    AssociationLoadingJob.locators.clear
     @person = Person.find("5")
     @original_serializers = ActiveJob::Serializers.serializers
   end
@@ -266,17 +268,35 @@ class ArgumentSerializationTest < ActiveSupport::TestCase
     assert_match "Unable to serialize Person without an id.", err.message
   end
 
+  if ENV["AJ_INTEGRATION_TESTS"]
+    test "should locate records compatible with strict loading locator" do
+      AssociationLoadingJob.locator_options "Article", includes: :tags
+
+      article = Article.create!(tags_attributes: [{ name: "a" }, { name: "b" }])
+
+      assert_arguments_roundtrip [article, [:tags]], job_class: AssociationLoadingJob
+    end
+
+    test "should raise a strict loading error when locating records without locator_options configuration" do
+      article = Article.create!(tags_attributes: [{ name: "a" }, { name: "b" }])
+
+      assert_raises ActiveRecord::StrictLoadingViolationError, match: "`Article` is marked for strict_loading" do
+        AssociationLoadingJob.perform_later(article, [:tags])
+      end
+    end
+  end
+
   private
     def assert_arguments_unchanged(*args)
       assert_arguments_roundtrip args
     end
 
-    def assert_arguments_roundtrip(args)
-      assert_equal args, perform_round_trip(args)
+    def assert_arguments_roundtrip(args, **opts)
+      assert_equal args, perform_round_trip(args, **opts)
     end
 
-    def perform_round_trip(args)
-      ArgumentsRoundTripJob.perform_later(*args) # Actually performed inline
+    def perform_round_trip(args, job_class: ArgumentsRoundTripJob)
+      job_class.perform_later(*args) # Actually performed inline
 
       JobBuffer.last_value
     end

--- a/activejob/test/jobs/association_loading_job.rb
+++ b/activejob/test/jobs/association_loading_job.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AssociationLoadingJob < ArgumentsRoundTripJob
+  def perform(record, associations = [])
+    associations.each { |association| record.send(association).load }
+
+    super
+  end
+end

--- a/activejob/test/support/integration/helper.rb
+++ b/activejob/test/support/integration/helper.rb
@@ -16,6 +16,33 @@ Rails::Generators::AppGenerator.start args
 require "#{dummy_app_path}/config/environment.rb"
 
 ActiveRecord::Migrator.migrations_paths = [ Rails.root.join("db/migrate").to_s ]
+
+ActiveRecord::Schema.define do
+  create_table :articles do
+  end
+
+  create_table :articles_tags do |t|
+    t.belongs_to :article
+    t.belongs_to :tag
+  end
+
+  create_table :tags do |t|
+    t.text :name
+  end
+end
+
+class Article < ActiveRecord::Base
+  self.strict_loading_by_default = true
+
+  has_and_belongs_to_many :tags
+
+  accepts_nested_attributes_for :tags
+end
+
+class Tag < ActiveRecord::Base
+  has_and_belongs_to_many :articles
+end
+
 ActiveRecord::Tasks::DatabaseTasks.migrate
 require "rails/test_help"
 


### PR DESCRIPTION
### Motivation / Background

By the time an `ActiveJob::Base#perform` method is invoked, Active
Record instances are already deserialized and reified through GlobalID
integration.

For example, consider the following model and job classes:

```ruby
class ApplicationRecord < ActiveRecord::Base
  self.strict_loading_by_default = true
end

class Article < ApplicationRecord
  has_and_belongs_to_many :tags
end

class Tag < ApplicationRecord
  has_and_belongs_to_many :articles
end

class PublishJob < ApplicationJob
  def perform(article)
    article.tags.each do |tag|
      # ...
    end
  end
end
```

Since application code does not have an opportunity to configure
anything about that loading process (including which associations are
eagerly loaded), it's common for Active Job executions to raise Active
Record strict loading errors:

```
ActiveRecord::StrictLoadingViolationError: `Article` is marked for strict_loading. The Tag association named `:tags` cannot be lazily loaded.
```

### Detail

The `GlobalID::Locator.locate` interface supports optional keyword
options that configure how to query Active Record during the location
process. For example, the [`includes:` keyword argument][:includes] is transformed
into a call to [includes][] while constructing the Active Record query.

This commit introduces the `ActiveJob::Base.locator_options` method to
configure how each test class wants to load records deserialized from
GlobalID values.

```diff
class PublishJob < ApplicationJob
+  locator_options "Article", includes: :tags
+
   def perform(article)
     article.tags.each do |tag|
       # ...
     end
   end
 end
```

The first argument is a class name (in the style of the Active Record
`:class_name` option for associations), and subsequent keyword options
are forwarded to [GlobalID::Locator.locate][:includes].

[:includes]: https://github.com/rails/globalid/tree/main?tab=readme-ov-file#options
[includes]: https://edgeapi.rubyonrails.org/classes/ActiveRecord/QueryMethods.html#method-i-includes

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
