### PR TITLE
Render Partial Collection with a layout parameter

### DIFF
--- a/actionview/lib/action_view/renderer/collection_renderer.rb
+++ b/actionview/lib/action_view/renderer/collection_renderer.rb
@@ -127,6 +127,19 @@ module ActionView
       render_collection(collection, context, partial, template, layout, block)
     end
 
+    def render_collection_with_no_partial(collection, paths, context, block)
+      paths.map! { |path| retrieve_variable(path).unshift(path) }
+      iter_vars = paths.flatten.uniq
+
+      collection = MixedCollectionIterator.new(collection, paths)
+
+      layout = if !block && (layout = @options[:layout])
+        find_template(layout.to_s, @locals.keys + iter_vars)
+      end
+
+      render_collection(collection, context, nil, nil, layout, block)
+    end
+
     def render_collection_derive_partial(collection, context, block)
       paths = collection.map { |o| partial_path(o, context) }
 
@@ -138,9 +151,7 @@ module ActionView
           raise NotImplementedError, "render caching requires a template. Please specify a partial when rendering"
         end
 
-        paths.map! { |path| retrieve_variable(path).unshift(path) }
-        collection = MixedCollectionIterator.new(collection, paths)
-        render_collection(collection, context, nil, nil, nil, block)
+        render_collection_with_no_partial(collection, paths, context, block)
       end
     end
 

--- a/actionview/test/actionpack/controller/render_test.rb
+++ b/actionview/test/actionpack/controller/render_test.rb
@@ -568,6 +568,17 @@ class TestController < ActionController::Base
     partial_collection_shorthand_with_different_types_of_records
   end
 
+  def partial_collection_shorthand_with_different_types_of_records_with_layout
+    render partial: [
+      Supplier.new("mark"),
+      Customer.new("craig"),
+      Supplier.new("john"),
+      Customer.new("zach"),
+      Supplier.new("brandon"),
+      Customer.new("dan")
+    ], locals: { greeting: "Bonjour" }, layout: "layouts/record_layout"
+  end
+
   def missing_partial
     render partial: "thisFileIsntHere"
   end
@@ -682,6 +693,7 @@ class RenderTest < ActionController::TestCase
     get :partial, to: "test#partial"
     get :partial_collection, to: "test#partial_collection"
     get :partial_collection_shorthand_with_different_types_of_records, to: "test#partial_collection_shorthand_with_different_types_of_records"
+    get :partial_collection_shorthand_with_different_types_of_records_with_layout, to: "test#partial_collection_shorthand_with_different_types_of_records_with_layout"
     get :partial_collection_shorthand_with_locals, to: "test#partial_collection_shorthand_with_locals"
     get :partial_collection_with_as, to: "test#partial_collection_with_as"
     get :partial_collection_with_as_and_counter, to: "test#partial_collection_with_as_and_counter"
@@ -1451,6 +1463,11 @@ class RenderTest < ActionController::TestCase
   def test_partial_collection_shorthand_with_different_types_of_records
     get :partial_collection_shorthand_with_different_types_of_records
     assert_equal "Bonjour bad customer: mark0Bonjour good customer: craig1Bonjour bad customer: john2Bonjour good customer: zach3Bonjour good customer: brandon4Bonjour bad customer: dan5", @response.body
+  end
+
+  def test_partial_collection_shorthand_with_different_types_of_records_with_layout
+    get :partial_collection_shorthand_with_different_types_of_records_with_layout
+    assert_equal "RECORD -> Bonjour: markRECORD -> Bonjour: craigRECORD -> Bonjour: johnRECORD -> Bonjour: zachRECORD -> Bonjour: brandonRECORD -> Bonjour: dan", @response.body
   end
 
   def test_empty_partial_collection

--- a/actionview/test/fixtures/actionpack/layouts/_record_layout.erb
+++ b/actionview/test/fixtures/actionpack/layouts/_record_layout.erb
@@ -1,0 +1,1 @@
+RECORD -> <%= yield %>

--- a/actionview/test/fixtures/actionpack/suppliers/_supplier.html.erb
+++ b/actionview/test/fixtures/actionpack/suppliers/_supplier.html.erb
@@ -1,0 +1,1 @@
+<%= greeting %>: <%= supplier.name %>

--- a/actionview/test/lib/controller/fake_models.rb
+++ b/actionview/test/lib/controller/fake_models.rb
@@ -37,6 +37,38 @@ end
 class BadCustomer < Customer; end
 class GoodCustomer < Customer; end
 
+Supplier = Struct.new(:name, :id) do
+  extend ActiveModel::Naming
+  include ActiveModel::Conversion
+
+  undef_method :to_json
+
+  def to_xml(options = {})
+    if options[:builder]
+      options[:builder].name name
+    else
+      "<name>#{name}</name>"
+    end
+  end
+
+  def to_js(options = {})
+    "name: #{name.inspect}"
+  end
+  alias :to_text :to_js
+
+  def errors
+    []
+  end
+
+  def persisted?
+    id.present?
+  end
+
+  def cache_key
+    "#{name}/#{id}"
+  end
+end
+
 Post = Struct.new(:title, :author_name, :body, :secret, :persisted, :written_on, :cost) do
   extend ActiveModel::Naming
   include ActiveModel::Conversion


### PR DESCRIPTION
The current implementation does not respect the layout parameter in case of mixed collections.

This commit fixes the issue by ensuring that the code path for mixed collections render the partial inside the provided layout.

### Motivation / Background

Fixes #49590

The current implementation of `render_collection_derive_partial` ignores the layout parameter in case of mixed collections.

### Detail

This Pull Request changes`render_collection_derive_partial` to call a new `render_collection_with_no_partial` method which renders the partial inside the specified layout.

### Additional information

<!-- Provide additional information such as benchmarks, reference to other repositories or alternative solutions. -->