### PR TITLE
TrilogyAdapter: ignore host if socket is set

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   TrilogyAdapter: ignore `host` if `socket` parameter is set.
+
+    This allows to configure a connection on a UNIX socket via DATABASE_URL:
+
+    ```
+    DATABASE_URL=trilogy://does-not-matter/my_db_production?socket=/var/run/mysql.sock
+    ```
+
+    *Jean Boussier*
+
 *   Make `assert_queries` and `assert_no_queries` assertions public.
 
     To assert the expected number of queries are made, Rails internally uses

--- a/activerecord/lib/active_record/connection_adapters/trilogy_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/trilogy_adapter.rb
@@ -31,7 +31,7 @@ module ActiveRecord
         def new_client(config)
           config[:ssl_mode] = parse_ssl_mode(config[:ssl_mode]) if config[:ssl_mode]
           ::Trilogy.new(config)
-        rescue ::Trilogy::ConnectionError, ::Trilogy::ProtocolError => error
+        rescue ::Trilogy::Error => error
           raise translate_connect_error(config, error)
         end
 
@@ -75,6 +75,10 @@ module ActiveRecord
 
       def initialize(config, *)
         config = config.dup
+
+        # Trilogy ignore `socket` if `host is set. We want the opposite to allow
+        # configuring UNIX domain sockets via `DATABASE_URL`.
+        config.delete(:host) if config[:socket]
 
         # Set FOUND_ROWS capability on the connection so UPDATE queries returns number of rows
         # matched rather than number of rows updated.

--- a/activerecord/test/cases/adapters/trilogy/trilogy_adapter_test.rb
+++ b/activerecord/test/cases/adapters/trilogy/trilogy_adapter_test.rb
@@ -351,6 +351,13 @@ class TrilogyAdapterTest < ActiveRecord::TrilogyTestCase
     ActiveRecord::Base.establish_connection :arunit
   end
 
+  test "socket has precedence over host" do
+    error = assert_raises ActiveRecord::ConnectionNotEstablished do
+      ActiveRecord::ConnectionAdapters::TrilogyAdapter.new(host: "invalid", port: 12345, socket: "/var/invalid.sock").connect!
+    end
+    assert_includes error.message, "/var/invalid.sock"
+  end
+
   # Create a temporary subscription to verify notification is sent.
   # Optionally verify the notification payload includes expected types.
   def assert_notification(notification, expected_payload = {}, &block)


### PR DESCRIPTION
Contrary to mysql2, trilogy will ignore the `socket` config if `host` is set.

This makes it impossible to configure a UNIX domain socket connection via `DATABASE_URL`, as the URL must include a host.
