### PR TITLE
Prevent duplicate records when preloading `:has_many` association

### DIFF
--- a/activerecord/lib/active_record/associations/preloader/association.rb
+++ b/activerecord/lib/active_record/associations/preloader/association.rb
@@ -247,8 +247,8 @@ module ActiveRecord
             association = owner.association(reflection.name)
 
             if reflection.collection?
-              association.loaded!
-              association.target.concat(records)
+              not_persisted_records = association.target.reject(&:persisted?)
+              association.target = records + not_persisted_records
             else
               association.target = records.first
             end

--- a/activerecord/test/cases/associations_test.rb
+++ b/activerecord/test/cases/associations_test.rb
@@ -804,6 +804,17 @@ class PreloaderTest < ActiveRecord::TestCase
     end
   end
 
+  def test_preload_does_not_concatenate_duplicate_records
+    post = posts(:welcome)
+    post.reload
+    post.comments.create!(body: "A new comment")
+
+    ActiveRecord::Associations::Preloader.new(records: [post], associations: :comments).call
+
+    assert_equal post.comments.length, post.comments.count
+    assert_equal post.comments.all.to_a, post.comments
+  end
+
   def test_preload_for_hmt_with_conditions
     post = posts(:welcome)
     _normal_category = post.categories.create!(name: "Normal")


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created to fix a bug introduced by https://github.com/rails/rails/pull/50129

We noticed a bug with how records were being preloaded on `main`. If a record had persisted records on an association, those records would be duplicated during preload unless the association was considered `loaded`. On the surface, it seems strange that there would be persisted records that aren't `loaded` on an association, but this is actually quite common. For example:

```ruby
post = Post.new(title: "A good post")
post.comments.create!(body: "I like this!")

post.comments
=> [<Comment id: 5, body: "I like this"...>]
post.association(:comments).loaded?
=> false
```

Even though the new comment has been persisted and associated with with the post, the association isn't considered `loaded` until we've tried to access the actual comments with something like `post.comments.to_a`.

If we tried to preload the post's comments after that new comment was created, we'd end up with duplicate records in the association:

```ruby
post.comments.create!(body: "I like this!")
post.comments
=> [<Comment id: 5, body: "I like this"...>]

preloader = ActiveRecord::Associations::Preloader.new(records: [post], associations: :comments)
preloader.call

post.comments
=> [<Comment id: 5, body: "I like this"...>, <Comment id: 5, body: "I like this"...>]
```

### Detail

This reverts to the previous behavior of replacing the association target with the records found during preload, but preserves any non-persisted records to maintain the fix provided by https://github.com/rails/rails/pull/50129.


### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
