### PR TITLE
Fix `Model.none.async_pluck` to return a Promise

### DIFF
--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -260,7 +260,13 @@ module ActiveRecord
     #
     # See also #ids.
     def pluck(*column_names)
-      return [] if @none
+      if @none
+        if @async
+          return Promise::Complete.new([])
+        else
+          return []
+        end
+      end
 
       if loaded? && all_attributes?(column_names)
         result = records.pluck(*column_names)

--- a/activerecord/test/cases/calculations_test.rb
+++ b/activerecord/test/cases/calculations_test.rb
@@ -823,9 +823,13 @@ class CalculationsTest < ActiveRecord::TestCase
     assert_async_equal [1, 2, 3, 4, 5], Topic.order(:id).async_pluck(:id)
   end
 
-  def test_pluck_async_on_loaded_relation
+  def test_async_pluck_on_loaded_relation
     relation = Topic.order(:id).load
     assert_async_equal relation.pluck(:id), relation.async_pluck(:id)
+  end
+
+  def test_async_pluck_none_relation
+    assert_async_equal [], Topic.none.async_pluck(:id)
   end
 
   def test_pluck_with_empty_in


### PR DESCRIPTION
Previously it would return a naked empty array, which is a break of the interface.
