### PR TITLE
Fixed a bug that through association is not preloaded when strict_loading is added

### DIFF
--- a/activerecord/lib/active_record/associations/preloader/association.rb
+++ b/activerecord/lib/active_record/associations/preloader/association.rb
@@ -106,7 +106,7 @@ module ActiveRecord
           @reflection    = reflection
           @preload_scope = preload_scope
           @reflection_scope = reflection_scope
-          @associate     = associate_by_default || !preload_scope || preload_scope.empty_scope?
+          @associate     = associate_by_default || !preload_scope || preload_scope.empty_scope_or_only_strict_loading?
           @model         = owners.first && owners.first.class
           @run = false
         end

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -841,6 +841,10 @@ module ActiveRecord
       @values == klass.unscoped.values
     end
 
+    def empty_scope_or_only_strict_loading? # :nodoc:
+      empty_scope? || @values == klass.unscoped.strict_loading.values
+    end
+
     def has_limit_or_offset? # :nodoc:
       limit_value || offset_value
     end
@@ -851,6 +855,10 @@ module ActiveRecord
 
     class StrictLoadingScope # :nodoc:
       def self.empty_scope?
+        true
+      end
+
+      def empty_scope_or_only_strict_loading? # :nodoc:
         true
       end
 

--- a/activerecord/test/cases/relation_test.rb
+++ b/activerecord/test/cases/relation_test.rb
@@ -119,6 +119,19 @@ module ActiveRecord
       assert_not_predicate FirstPost.all, :empty_scope?
     end
 
+    def test_empty_scope_or_only_strict_loading
+      relation = Relation.new(Post)
+      assert_predicate relation, :empty_scope_or_only_strict_loading?
+      assert_predicate relation.strict_loading, :empty_scope_or_only_strict_loading?
+
+      relation.merge!(relation)
+      assert_predicate relation, :empty_scope_or_only_strict_loading?
+      assert_predicate relation.strict_loading, :empty_scope_or_only_strict_loading?
+
+      assert_not_predicate NullPost.strict_loading.all, :empty_scope_or_only_strict_loading?
+      assert_not_predicate FirstPost.strict_loading.all, :empty_scope_or_only_strict_loading?
+    end
+
     def test_bad_constants_raise_errors
       assert_raises(NameError) do
         ActiveRecord::Relation::HelloWorld


### PR DESCRIPTION
### Motivation / Background

Fix: #49197

```ruby
class User < ActiveRecord::Base
  has_one :profile
  has_one :profile_image, through: :profile
end

relation = User.preload(:profile_image)
relation.first.association(:profile).loaded? #=> true
relation.strict_loading.first.association(:profile).loaded? #=> expected true, got false
```

### Detail


### Additional information

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
