### PR TITLE
Update API doc for ActiveRecord::Relation#none?/#any?/#one? [ci-skip]

### DIFF
--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -291,6 +291,11 @@ module ActiveRecord
     end
 
     # Returns true if there are no records.
+    #
+    # When a pattern argument is given, this method checks whether elements in
+    # the Enumerable match the pattern via the case-equality operator (`===`).
+    #
+    #   posts.none?(Comment) # => true or false
     def none?(*args)
       return true if @none
 
@@ -299,6 +304,11 @@ module ActiveRecord
     end
 
     # Returns true if there are any records.
+    #
+    # When a pattern argument is given, this method checks whether elements in
+    # the Enumerable match the pattern via the case-equality operator (`===`).
+    #
+    #    posts.any?(Post) # => true or false
     def any?(*args)
       return false if @none
 
@@ -307,6 +317,11 @@ module ActiveRecord
     end
 
     # Returns true if there is exactly one record.
+    #
+    # When a pattern argument is given, this method checks whether elements in
+    # the Enumerable match the pattern via the case-equality operator (`===`).
+    #
+    #    posts.one?(Post) # => true or false
     def one?(*args)
       return false if @none
 


### PR DESCRIPTION
### Motivation / Background

I checked https://github.com/rails/rails/issues/50327 and noticed that clear API docs are needed. Some developers are using these methods incorrectly, thinking they're only for Active Record Relation and pass condition argument, but they actually work with Enumerable. These methods treat that argument as a pattern argument.

### Detail

I have added required API doc for these methods so developers won't get confused with the argument meaning.

### Additional information

Original [PR](https://github.com/rails/rails/pull/46728) which updated these methods to support pattern argument.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] [N/A] Tests are added or updated if you fix a bug or add a feature.
* [x] [N/A]  CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
