### PR TITLE
Improve concurrency support for SQLite3

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Improve concurrency support for SQLite3
+
+    The SQLite3 `busy_timeout` C API will hold the global interpreter lock (GIL) for the duration of the retry process, disallowing any other Ruby threads from running while this thread is waiting for a database connection to become available. In order to allow concurrent threads to naturally coordinate their order of execution, the `busy_timeout` C API has been replaced with the `busy_handler` C API. This allows the Ruby thread to be put to sleep while waiting for a database connection to become available, allowing other Ruby threads to run in the meantime, while also respecting the `timeout` option.
+
+    *Stephen Margheim*
+
 *   Add support for generated columns in SQLite3 adapter
 
     Generated columns (both stored and dynamic) are supported since version 3.31.0 of SQLite.


### PR DESCRIPTION
### Motivation / Background

As SQLite's popularity grows as a production database engine for Rails applications, so does the need for robust and resilient default configuration. One of the most common issues faced when using SQLite in a Rails application are the occasional `ActiveRecord::StatementInvalid (SQLite3::BusyException: database is locked)` exceptions. These occur when a connection cannot acquire SQLite's database lock within the allotted timeout.

### Detail

This is prone to happen when running your Rails with a multi-threaded server, like Puma in clustered mode, because the SQLite `busy_timeout` C function does not release the Ruby global interpreter lock (GIL). So, while one connection is attempting to acquire the SQLite database lock, no other Ruby threads can perform work or progress. In order to improve concurrency support for ActiveRecord's SQLite3 adapter, we must implement a custom Ruby `busy_handler` function that still respects the timeout, releases the GIL, and doesn't overly thrash.

This implementation achieves these goals by 

1. `sleep`ing while waiting to retry again, thus releasing the GIL
2. only checking if the timeout has passed every 100 retries to minimize Ruby execution
3. `sleep`ing 60 microseconds to ensure other Threads have an opportunity to acquire the GIL and progress

### Additional information

I have written a more in-depth exploration of this problem on my blog: https://fractaledmind.github.io/2023/12/11/sqlite-on-rails-improving-concurrency/. 

Together with https://github.com/rails/rails/pull/50371, this PR is one-half of the story of stabilizing the SQLite3 adapters ability to handle concurrency.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
