### PR TITLE
Ensure SQLite transaction default to IMMEDIATE mode

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Use SQLite `IMMEDIATE` transactions when possible.
+
+    Transactions run against the SQLite3 adapter default to IMMEDIATE mode to improve concurrency support and avoid busy exceptions.
+
+    *Stephen Margheim*
+
 *   Raise specific exception when a connection is not defined.
 
      The new `ConnectionNotDefined` exception provides connection name, shard and role accessors indicating the details of the connection that was requested.

--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -411,6 +411,14 @@ module ActiveRecord
       # Begins the transaction (and turns off auto-committing).
       def begin_db_transaction()    end
 
+      def begin_deferred_transaction(isolation_level = nil) # :nodoc:
+        if isolation_level
+          begin_isolated_db_transaction(isolation_level)
+        else
+          begin_db_transaction
+        end
+      end
+
       def transaction_isolation_levels
         {
           read_uncommitted: "READ UNCOMMITTED",

--- a/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
@@ -448,10 +448,14 @@ module ActiveRecord
     # = Active Record Real \Transaction
     class RealTransaction < Transaction
       def materialize!
-        if isolation_level
-          connection.begin_isolated_db_transaction(isolation_level)
+        if joinable?
+          if isolation_level
+            connection.begin_isolated_db_transaction(isolation_level)
+          else
+            connection.begin_db_transaction
+          end
         else
-          connection.begin_db_transaction
+          connection.begin_deferred_transaction(isolation_level)
         end
 
         super

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -120,7 +120,11 @@ module ActiveRecord
         end
 
         @config[:strict] = ConnectionAdapters::SQLite3Adapter.strict_strings_by_default unless @config.key?(:strict)
-        @connection_parameters = @config.merge(database: @config[:database].to_s, results_as_hash: true)
+        @connection_parameters = @config.merge(
+          database: @config[:database].to_s,
+          results_as_hash: true,
+          default_transaction_mode: :immediate,
+        )
         @use_insert_returning = @config.key?(:insert_returning) ? self.class.type_cast_config_to_boolean(@config[:insert_returning]) : true
       end
 

--- a/activerecord/test/cases/locking_test.rb
+++ b/activerecord/test/cases/locking_test.rb
@@ -798,7 +798,7 @@ class PessimisticLockingTest < ActiveRecord::TestCase
 
         a = Thread.new do
           t0 = Time.now
-          Person.transaction do
+          Person.transaction(joinable: false) do
             yield
             b_wakeup.set
             a_wakeup.wait

--- a/activerecord/test/cases/transactions_test.rb
+++ b/activerecord/test/cases/transactions_test.rb
@@ -1386,6 +1386,12 @@ class TransactionTest < ActiveRecord::TestCase
         Topic.reset_column_information
       end
     end
+
+    def test_sqlite_default_transaction_mode_is_immediate
+      assert_queries_match(/BEGIN IMMEDIATE TRANSACTION/i, include_schema: false) do
+        Topic.transaction { Topic.lease_connection.materialize_transactions }
+      end
+    end
   end
 
   def test_transactions_state_from_rollback


### PR DESCRIPTION
### Motivation / Background

As SQLite's popularity grows as a production database engine for Rails applications, so does the need for robust and resilient default configuration. One of the most common issues faced when using SQLite in a Rails application are the occasional ActiveRecord::StatementInvalid (SQLite3::BusyException: database is locked) exceptions. These occur when a DEFERRED transaction attempts to acquire the SQLite database lock in the middle of a transaction once hitting a write query while another connection holds the database lock. Since this occurs in the middle of a transaction, SQLite does not attempt to retry to transaction by calling the set `busy_handler`/`busy_timeout` callback, but instead immediately errors with a busy exception.

### Detail

This PR has considered two different approaches over the course of its existence:

1. globally change the default transaction mode for the SQLite adapter from `DEFERRED` to `IMMEDIATE`
2. only change the transaction mode from `DEFERRED` to `IMMEDIATE` for transactions that Rails uses to wrap ActiveRecord write operations

Various test failures where tests are manually creating transactions, along with a stated preference to not expose a generic `mode` option to the `#transaction` method, which would have no meaning or purpose for other adapters, led me to go with option 2.

With option 2, `ActiveRecord::Base#with_transaction_returning_status` now calls `Adapter#transaction_returning_status` instead of `Adapter#transaction` directly. By default, that method is simply as alias, but the SQLite3 adapter implements the `transaction_returning_status` method to ensure that the immediate transaction mode is used. Transaction mode setting is done via the `use_*_transaction_mode!` methods added to the SQLite3 adapter, which the `test_fixtures.rb` module uses as well to ensure that fixture transactions always use deferred transactions.

### Additional information

Alongside https://github.com/rails/rails/pull/50370, this PR stabilizes SQLite's ability to handle concurrency without throwing intermittent but frequent busy exceptions.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
