### PR TITLE
 Fix bug #50315: Foreign key don't handle derive_fk_query_constraints properly.

### DIFF
--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -519,7 +519,7 @@ module ActiveRecord
           derived_fk = derive_foreign_key(infer_from_inverse_of: infer_from_inverse_of)
 
           if active_record.has_query_constraints?
-            derived_fk = derive_fk_query_constraints(derived_fk)
+            derived_fk = derive_fk_query_constraints(derived_fk).last
           end
 
           derived_fk

--- a/activerecord/test/cases/reflection_test.rb
+++ b/activerecord/test/cases/reflection_test.rb
@@ -499,6 +499,14 @@ class ReflectionTest < ActiveRecord::TestCase
     assert_equal "comment_id", FirstPost.reflect_on_association(:comment_with_inverse).foreign_key.to_s
   end
 
+  def test_foreign_key_with_derive_fk_query_constraints
+    Post.query_constraints :author_id, :id
+    author = Author.create!(name: "John Doe")
+    post = Post.new(body: "hello", author: author)
+
+    assert_equal post.author_id, author.id
+  end
+
   def test_foreign_key_is_inferred_from_model_name
     assert_equal "post_id", PostRecord.reflect_on_association(:comments).foreign_key.to_s
   end


### PR DESCRIPTION
This Pull Request fix the bug https://github.com/rails/rails/issues/50315

possibly could fix this issue https://github.com/rails/rails/issues/50256 as well.

### Detail

Foreign key don't handle derive_fk_query_constraints properly. 

### Additional information

Here `#derive_fk_query_constraints` returns an array of two keys. But foreign key should only return the derived foreign key which is the last element of the #derive_fk_query_constraints.

```ruby
     def foreign_key(infer_from_inverse_of: true)
        @foreign_key ||= if options[:query_constraints]
          options[:query_constraints].map { |fk| fk.to_s.freeze }.freeze
        elsif options[:foreign_key]
          options[:foreign_key].to_s
        else
          derived_fk = derive_foreign_key(infer_from_inverse_of: infer_from_inverse_of)

          if active_record.has_query_constraints?
            derived_fk = derive_fk_query_constraints(derived_fk).last
          end

          derived_fk
        end
      end
```

A test coverage has been provided: https://github.com/rails/rails/pull/50372/files#diff-62fd84c8da9a63fa077a6fdea8acaac0df9e275b580aa1359a5c9416077fcd60R502

### Checklist

Before submitting the PR make sure the following are checked:

* [ ] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [ ] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
