### PR TITLE
Expose `assert_queries_match` and `assert_no_queries_match` assertions

### DIFF
--- a/actiontext/test/unit/model_test.rb
+++ b/actiontext/test/unit/model_test.rb
@@ -99,7 +99,7 @@ class ActionText::ModelTest < ActiveSupport::TestCase
   test "eager loading" do
     Message.create!(subject: "Subject", content: "<h1>Content</h1>")
 
-    message = assert_queries(2) { Message.with_rich_text_content.last }
+    message = assert_queries_count(2) { Message.with_rich_text_content.last }
     assert_no_queries do
       assert_equal "Content", message.content.to_plain_text
     end
@@ -108,7 +108,7 @@ class ActionText::ModelTest < ActiveSupport::TestCase
   test "eager loading all rich text" do
     Message.create!(subject: "Subject", content: "<h1>Content</h1>", body: "<h2>Body</h2>")
 
-    message = assert_queries(1) { Message.with_all_rich_text.last }
+    message = assert_queries_count(1) { Message.with_all_rich_text.last }
     assert_no_queries do
       assert_equal "Content", message.content.to_plain_text
       assert_equal "Body", message.body.to_plain_text

--- a/actionview/test/activerecord/relation_cache_test.rb
+++ b/actionview/test/activerecord/relation_cache_test.rb
@@ -19,7 +19,7 @@ class RelationCacheTest < ActionView::TestCase
   end
 
   def test_cache_relation_other
-    assert_queries(1) do
+    assert_queries_count(1) do
       cache(Project.all) { concat("Hello World") }
     end
     assert_equal "Hello World", controller.cache_store.read("views/test/hello_world:fa9482a68ce25bf7589b8eddad72f736/projects-#{Project.count}")

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -23,21 +23,28 @@
 
     *Jean Boussier*
 
-*   Make `assert_queries` and `assert_no_queries` assertions public.
+*   Make `assert_queries_count`, `assert_no_queries`, `assert_queries_match` and
+    `assert_no_queries_match` assertions public.
 
-    To assert the expected number of queries are made, Rails internally uses
-    `assert_queries` and `assert_no_queries`. These assertions can be now
-    be used in applications as well.
+    To assert the expected number of queries are made, Rails internally uses `assert_queries_count` and
+    `assert_no_queries`. To assert that specific SQL queries are made, `assert_queries_match` and
+    `assert_no_queries_match` are used. These assertions can now be used in applications as well.
 
     ```ruby
     class ArticleTest < ActiveSupport::TestCase
       test "queries are made" do
-         assert_queries(1) { Article.first }
+        assert_queries_count(1) { Article.first }
+      end
+
+      test "creates a foreign key" do
+        assert_queries_match(/ADD FOREIGN KEY/i, include_schema: true) do
+          @connection.add_foreign_key(:comments, :posts)
+        end
       end
     end
     ```
 
-    *Petrik de Heus*
+    *Petrik de Heus*, *fatkodima*
 
 *   Fix `has_secure_token` calls the setter method on initialize.
 

--- a/activerecord/test/cases/adapters/abstract_mysql_adapter/active_schema_test.rb
+++ b/activerecord/test/cases/adapters/abstract_mysql_adapter/active_schema_test.rb
@@ -99,7 +99,7 @@ class ActiveSchemaTest < ActiveRecord::AbstractMysqlTestCase
   def test_index_in_bulk_change
     %w(SPATIAL FULLTEXT UNIQUE).each do |type|
       expected = "ALTER TABLE `people` ADD #{type} INDEX `index_people_on_last_name` (`last_name`)"
-      assert_sql(expected) do
+      assert_queries_match(expected) do
         ActiveRecord::Base.connection.change_table(:people, bulk: true) do |t|
           t.index :last_name, type: type
         end
@@ -107,7 +107,7 @@ class ActiveSchemaTest < ActiveRecord::AbstractMysqlTestCase
     end
 
     expected = "ALTER TABLE `people` ADD INDEX `index_people_on_last_name` USING btree (`last_name`(10)), ALGORITHM = COPY"
-    assert_sql(expected) do
+    assert_queries_match(expected) do
       ActiveRecord::Base.connection.change_table(:people, bulk: true) do |t|
         t.index :last_name, length: 10, using: :btree, algorithm: :copy
       end

--- a/activerecord/test/cases/adapters/abstract_mysql_adapter/optimizer_hints_test.rb
+++ b/activerecord/test/cases/adapters/abstract_mysql_adapter/optimizer_hints_test.rb
@@ -8,7 +8,7 @@ class OptimizerHintsTest < ActiveRecord::AbstractMysqlTestCase
     fixtures :posts
 
     def test_optimizer_hints
-      assert_sql(%r{\ASELECT /\*\+ NO_RANGE_OPTIMIZATION\(posts index_posts_on_author_id\) \*/}) do
+      assert_queries_match(%r{\ASELECT /\*\+ NO_RANGE_OPTIMIZATION\(posts index_posts_on_author_id\) \*/}) do
         posts = Post.optimizer_hints("NO_RANGE_OPTIMIZATION(posts index_posts_on_author_id)")
         posts = posts.select(:id).where(author_id: [0, 1])
         assert_includes posts.explain, "| index | index_posts_on_author_id | index_posts_on_author_id |"
@@ -16,7 +16,7 @@ class OptimizerHintsTest < ActiveRecord::AbstractMysqlTestCase
     end
 
     def test_optimizer_hints_with_count_subquery
-      assert_sql(%r{\ASELECT /\*\+ NO_RANGE_OPTIMIZATION\(posts index_posts_on_author_id\) \*/}) do
+      assert_queries_match(%r{\ASELECT /\*\+ NO_RANGE_OPTIMIZATION\(posts index_posts_on_author_id\) \*/}) do
         posts = Post.optimizer_hints("NO_RANGE_OPTIMIZATION(posts index_posts_on_author_id)")
         posts = posts.select(:id).where(author_id: [0, 1]).limit(5)
         assert_equal 5, posts.count
@@ -24,13 +24,13 @@ class OptimizerHintsTest < ActiveRecord::AbstractMysqlTestCase
     end
 
     def test_optimizer_hints_is_sanitized
-      assert_sql(%r{\ASELECT /\*\+ NO_RANGE_OPTIMIZATION\(posts index_posts_on_author_id\) \*/}) do
+      assert_queries_match(%r{\ASELECT /\*\+ NO_RANGE_OPTIMIZATION\(posts index_posts_on_author_id\) \*/}) do
         posts = Post.optimizer_hints("/*+ NO_RANGE_OPTIMIZATION(posts index_posts_on_author_id) */")
         posts = posts.select(:id).where(author_id: [0, 1])
         assert_includes posts.explain, "| index | index_posts_on_author_id | index_posts_on_author_id |"
       end
 
-      assert_sql(%r{\ASELECT /\*\+ \*\* // `posts`\.\*, // \*\* \*/}) do
+      assert_queries_match(%r{\ASELECT /\*\+ \*\* // `posts`\.\*, // \*\* \*/}) do
         posts = Post.optimizer_hints("**// `posts`.*, //**")
         posts = posts.select(:id).where(author_id: [0, 1])
         assert_equal({ "id" => 1 }, posts.first.as_json)
@@ -38,7 +38,7 @@ class OptimizerHintsTest < ActiveRecord::AbstractMysqlTestCase
     end
 
     def test_optimizer_hints_with_unscope
-      assert_sql(%r{\ASELECT `posts`\.`id`}) do
+      assert_queries_match(%r{\ASELECT `posts`\.`id`}) do
         posts = Post.optimizer_hints("/*+ NO_RANGE_OPTIMIZATION(posts index_posts_on_author_id) */")
         posts = posts.select(:id).where(author_id: [0, 1])
         posts.unscope(:optimizer_hints).load
@@ -46,7 +46,7 @@ class OptimizerHintsTest < ActiveRecord::AbstractMysqlTestCase
     end
 
     def test_optimizer_hints_with_or
-      assert_sql(%r{\ASELECT /\*\+ NO_RANGE_OPTIMIZATION\(posts index_posts_on_author_id\) \*/}) do
+      assert_queries_match(%r{\ASELECT /\*\+ NO_RANGE_OPTIMIZATION\(posts index_posts_on_author_id\) \*/}) do
         Post.optimizer_hints("NO_RANGE_OPTIMIZATION(posts index_posts_on_author_id)")
           .or(Post.all).load
       end

--- a/activerecord/test/cases/adapters/postgresql/connection_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/connection_test.rb
@@ -24,19 +24,19 @@ module ActiveRecord
     end
 
     def test_encoding
-      assert_queries(1, ignore_none: true) do
+      assert_queries_count(1, include_schema: true) do
         assert_not_nil @connection.encoding
       end
     end
 
     def test_collation
-      assert_queries(1, ignore_none: true) do
+      assert_queries_count(1, include_schema: true) do
         assert_not_nil @connection.collation
       end
     end
 
     def test_ctype
-      assert_queries(1, ignore_none: true) do
+      assert_queries_count(1, include_schema: true) do
         assert_not_nil @connection.ctype
       end
     end

--- a/activerecord/test/cases/adapters/postgresql/optimizer_hints_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/optimizer_hints_test.rb
@@ -12,7 +12,7 @@ class PostgresqlOptimizerHintsTest < ActiveRecord::PostgreSQLTestCase
     end
 
     def test_optimizer_hints
-      assert_sql(%r{\ASELECT /\*\+ SeqScan\(posts\) \*/}) do
+      assert_queries_match(%r{\ASELECT /\*\+ SeqScan\(posts\) \*/}) do
         posts = Post.optimizer_hints("SeqScan(posts)")
         posts = posts.select(:id).where(author_id: [0, 1])
         assert_includes posts.explain, "Seq Scan on posts"
@@ -20,7 +20,7 @@ class PostgresqlOptimizerHintsTest < ActiveRecord::PostgreSQLTestCase
     end
 
     def test_optimizer_hints_with_count_subquery
-      assert_sql(%r{\ASELECT /\*\+ SeqScan\(posts\) \*/}) do
+      assert_queries_match(%r{\ASELECT /\*\+ SeqScan\(posts\) \*/}) do
         posts = Post.optimizer_hints("SeqScan(posts)")
         posts = posts.select(:id).where(author_id: [0, 1]).limit(5)
         assert_equal 5, posts.count
@@ -28,13 +28,13 @@ class PostgresqlOptimizerHintsTest < ActiveRecord::PostgreSQLTestCase
     end
 
     def test_optimizer_hints_is_sanitized
-      assert_sql(%r{\ASELECT /\*\+ SeqScan\(posts\) \*/}) do
+      assert_queries_match(%r{\ASELECT /\*\+ SeqScan\(posts\) \*/}) do
         posts = Post.optimizer_hints("/*+ SeqScan(posts) */")
         posts = posts.select(:id).where(author_id: [0, 1])
         assert_includes posts.explain, "Seq Scan on posts"
       end
 
-      assert_sql(%r{\ASELECT /\*\+  "posts"\.\*,  \*/}) do
+      assert_queries_match(%r{\ASELECT /\*\+  "posts"\.\*,  \*/}) do
         posts = Post.optimizer_hints("**// \"posts\".*, //**")
         posts = posts.select(:id).where(author_id: [0, 1])
         assert_equal({ "id" => 1 }, posts.first.as_json)
@@ -42,7 +42,7 @@ class PostgresqlOptimizerHintsTest < ActiveRecord::PostgreSQLTestCase
     end
 
     def test_optimizer_hints_with_unscope
-      assert_sql(%r{\ASELECT "posts"\."id"}) do
+      assert_queries_match(%r{\ASELECT "posts"\."id"}) do
         posts = Post.optimizer_hints("/*+ SeqScan(posts) */")
         posts = posts.select(:id).where(author_id: [0, 1])
         posts.unscope(:optimizer_hints).load
@@ -50,7 +50,7 @@ class PostgresqlOptimizerHintsTest < ActiveRecord::PostgreSQLTestCase
     end
 
     def test_optimizer_hints_with_or
-      assert_sql(%r{\ASELECT /\*\+ SeqScan\(posts\) \*/}) do
+      assert_queries_match(%r{\ASELECT /\*\+ SeqScan\(posts\) \*/}) do
         Post.optimizer_hints("SeqScan(posts)").or(Post.all).load
       end
 

--- a/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
@@ -462,14 +462,14 @@ module ActiveRecord
         @connection.create_enum "feeling", ["good", "bad"]
 
         # Runs only SELECT, no type map reloading.
-        assert_queries(1, ignore_none: true) do
+        assert_queries_count(1, include_schema: true) do
           result = @connection.select_all "SELECT 'good'::feeling"
           assert_instance_of(PostgreSQLAdapter::OID::Enum,
                              result.column_types["feeling"])
         end
       ensure
         # Reloads type map.
-        assert_sql(/from pg_type/i) do
+        assert_queries_match(/from pg_type/i, include_schema: true) do
           @connection.drop_enum "feeling", if_exists: true
         end
         reset_connection
@@ -481,13 +481,13 @@ module ActiveRecord
         connection.select_all "SELECT 1" # eagerly initialize the connection
 
         silence_warnings do
-          assert_queries 2, ignore_none: true do
+          assert_queries_count(2, include_schema: true) do
             connection.select_all "select 'pg_catalog.pg_class'::regclass"
           end
-          assert_queries 1, ignore_none: true do
+          assert_queries_count(1, include_schema: true) do
             connection.select_all "select 'pg_catalog.pg_class'::regclass"
           end
-          assert_queries 2, ignore_none: true do
+          assert_queries_count(2, include_schema: true) do
             connection.select_all "SELECT NULL::anyarray"
           end
         end
@@ -534,7 +534,7 @@ module ActiveRecord
             self.table_name = "ex"
           end
           attribute = number_klass.arel_table[:number]
-          assert_queries :any, ignore_none: true do
+          assert_queries_count(include_schema: true) do
             @connection.case_insensitive_comparison(attribute, "foo")
           end
           assert_no_queries do

--- a/activerecord/test/cases/annotate_test.rb
+++ b/activerecord/test/cases/annotate_test.rb
@@ -9,7 +9,7 @@ class AnnotateTest < ActiveRecord::TestCase
   def test_annotate_wraps_content_in_an_inline_comment
     quoted_posts_id, quoted_posts = regexp_escape_table_name("posts.id"), regexp_escape_table_name("posts")
 
-    assert_sql(%r{SELECT #{quoted_posts_id} FROM #{quoted_posts} /\* foo \*/}i) do
+    assert_queries_match(%r{SELECT #{quoted_posts_id} FROM #{quoted_posts} /\* foo \*/}i) do
       posts = Post.select(:id).annotate("foo")
       assert posts.first
     end
@@ -18,27 +18,27 @@ class AnnotateTest < ActiveRecord::TestCase
   def test_annotate_is_sanitized
     quoted_posts_id, quoted_posts = regexp_escape_table_name("posts.id"), regexp_escape_table_name("posts")
 
-    assert_sql(%r{SELECT #{quoted_posts_id} FROM #{quoted_posts} /\* \* /foo/ \* \*/}i) do
+    assert_queries_match(%r{SELECT #{quoted_posts_id} FROM #{quoted_posts} /\* \* /foo/ \* \*/}i) do
       posts = Post.select(:id).annotate("*/foo/*")
       assert posts.first
     end
 
-    assert_sql(%r{SELECT #{quoted_posts_id} FROM #{quoted_posts} /\* \*\* //foo// \*\* \*/}i) do
+    assert_queries_match(%r{SELECT #{quoted_posts_id} FROM #{quoted_posts} /\* \*\* //foo// \*\* \*/}i) do
       posts = Post.select(:id).annotate("**//foo//**")
       assert posts.first
     end
 
-    assert_sql(%r{SELECT #{quoted_posts_id} FROM #{quoted_posts} /\* \* \* //foo// \* \* \*/}i) do
+    assert_queries_match(%r{SELECT #{quoted_posts_id} FROM #{quoted_posts} /\* \* \* //foo// \* \* \*/}i) do
       posts = Post.select(:id).annotate("* *//foo//* *")
       assert posts.first
     end
 
-    assert_sql(%r{SELECT #{quoted_posts_id} FROM #{quoted_posts} /\* \* /foo/ \* \*/ /\* \* /bar \*/}i) do
+    assert_queries_match(%r{SELECT #{quoted_posts_id} FROM #{quoted_posts} /\* \* /foo/ \* \*/ /\* \* /bar \*/}i) do
       posts = Post.select(:id).annotate("*/foo/*").annotate("*/bar")
       assert posts.first
     end
 
-    assert_sql(%r{SELECT #{quoted_posts_id} FROM #{quoted_posts} /\* \+ MAX_EXECUTION_TIME\(1\) \*/}i) do
+    assert_queries_match(%r{SELECT #{quoted_posts_id} FROM #{quoted_posts} /\* \+ MAX_EXECUTION_TIME\(1\) \*/}i) do
       posts = Post.select(:id).annotate("+ MAX_EXECUTION_TIME(1)")
       assert posts.first
     end

--- a/activerecord/test/cases/assertions/query_assertions_test.rb
+++ b/activerecord/test/cases/assertions/query_assertions_test.rb
@@ -7,38 +7,131 @@ require "active_record/testing/query_assertions"
 module ActiveRecord
   module Assertions
     class QueryAssertionsTest < ActiveSupport::TestCase
+      extend AdapterHelper
       include QueryAssertions
 
-      def test_assert_queries
-        assert_queries(1) { Post.first }
+      def test_assert_queries_count
+        assert_queries_count(1) { Post.first }
 
         error = assert_raises(Minitest::Assertion) {
-          assert_queries(2) { Post.first }
+          assert_queries_count(2) { Post.first }
         }
         assert_match(/1 instead of 2 queries/, error.message)
 
         error = assert_raises(Minitest::Assertion) {
-          assert_queries(0) { Post.first }
+          assert_queries_count(0) { Post.first }
         }
         assert_match(/1 instead of 0 queries/, error.message)
       end
 
-      def test_assert_queries_with_matcher
+      def test_assert_queries_count_any
+        assert_queries_count { Post.first }
+
+        assert_raises(Minitest::Assertion, match: "1 or more queries expected") {
+          assert_queries_count { }
+        }
+      end
+
+      def test_assert_no_queries
+        assert_no_queries { Post.none }
+
+        assert_raises(Minitest::Assertion, match: "1 instead of 0") {
+          assert_no_queries { Post.first }
+        }
+      end
+
+      def test_assert_queries_match
+        assert_queries_match(/ASC LIMIT/i, count: 1) { Post.first }
+        assert_queries_match(/ASC LIMIT/i) { Post.first }
+
         error = assert_raises(Minitest::Assertion) {
-          assert_queries(1, matcher: /WHERE "posts"."id" = \? LIMIT \?/) do
+          assert_queries_match(/ASC LIMIT/i, count: 2) { Post.first }
+        }
+        assert_match(/1 instead of 2 queries/, error.message)
+
+        error = assert_raises(Minitest::Assertion) {
+          assert_queries_match(/ASC LIMIT/i, count: 0) { Post.first }
+        }
+        assert_match(/1 instead of 0 queries/, error.message)
+      end
+
+      def test_assert_queries_match_with_matcher
+        error = assert_raises(Minitest::Assertion) {
+          assert_queries_match(/WHERE "posts"."id" = \? LIMIT \?/, count: 1) do
             Post.where(id: 1).first
           end
         }
         assert_match(/0 instead of 1 queries/, error.message)
       end
 
-      def test_assert_no_queries
-        assert_no_queries { Post.none }
+      def test_assert_queries_match_when_there_are_no_queries
+        assert_raises(Minitest::Assertion, match: "1 or more queries expected, but none were executed") do
+          assert_queries_match(/something/) { Post.none }
+        end
+      end
+
+      def test_assert_no_queries_match
+        assert_no_queries_match(/something/) { Post.none }
 
         error = assert_raises(Minitest::Assertion) {
-          assert_no_queries { Post.first }
+          assert_no_queries_match(/ORDER BY/i) { Post.first }
         }
         assert_match(/1 instead of 0/, error.message)
+      end
+
+      def test_assert_no_queries_match_matcher
+        assert_raises(Minitest::Assertion, match: "1 instead of 0") do
+          assert_no_queries_match(/ORDER BY/i) do
+            Post.first
+          end
+        end
+      end
+
+      if current_adapter?(:PostgreSQLAdapter)
+        def test_assert_queries_count_include_schema
+          Post.columns # load columns
+          assert_raises(Minitest::Assertion, match: "0 instead of 1 queries were executed") do
+            assert_queries_count(1, include_schema: true) { Post.columns }
+          end
+
+          Post.reset_column_information
+          assert_queries_count(1, include_schema: true) { Post.columns }
+        end
+
+        def test_assert_no_queries_include_schema
+          assert_no_queries { Post.none }
+
+          error = assert_raises(Minitest::Assertion) {
+            assert_no_queries { Post.first }
+          }
+          assert_match(/1 instead of 0/, error.message)
+
+          Post.reset_column_information
+          error = assert_raises(Minitest::Assertion) {
+            assert_no_queries(include_schema: true) { Post.columns }
+          }
+          assert_match(/1 instead of 0/, error.message)
+        end
+
+        def test_assert_queries_match_include_schema
+          Post.columns # load columns
+          assert_raises(Minitest::Assertion, match: "1 or more queries expected") do
+            assert_queries_match(/SELECT/i, include_schema: true) { Post.columns }
+          end
+
+          Post.reset_column_information
+          assert_queries_match(/SELECT/i, include_schema: true) { Post.columns }
+        end
+
+        def test_assert_no_queries_match_include_schema
+          Post.columns # load columns
+          assert_no_queries_match(/SELECT/i, include_schema: true) { Post.columns }
+
+          Post.reset_column_information
+          assert_raises(Minitest::Assertion, match: /\d instead of 0/) do
+            assert_no_queries_match(/SELECT/i, include_schema: true) { Post.columns }
+          end
+        end
       end
     end
   end

--- a/activerecord/test/cases/associations/eager_test.rb
+++ b/activerecord/test/cases/associations/eager_test.rb
@@ -304,7 +304,7 @@ class EagerAssociationTest < ActiveRecord::TestCase
 
   def test_finding_with_includes_on_has_many_association_with_same_include_includes_only_once
     author_id = authors(:david).id
-    author = assert_queries(3) { Author.all.merge!(includes: { posts_with_comments: :comments }).find(author_id) } # find the author, then find the posts, then find the comments
+    author = assert_queries_count(3) { Author.all.merge!(includes: { posts_with_comments: :comments }).find(author_id) } # find the author, then find the posts, then find the comments
     author.posts_with_comments.each do |post_with_comments|
       assert_equal post_with_comments.comments.length, post_with_comments.comments.count
       assert_nil post_with_comments.comments.to_a.uniq!
@@ -315,7 +315,7 @@ class EagerAssociationTest < ActiveRecord::TestCase
     author = authors(:david)
     post = author.post_about_thinking_with_last_comment
     last_comment = post.last_comment
-    author = assert_queries(3) { Author.all.merge!(includes: { post_about_thinking_with_last_comment: :last_comment }).find(author.id) } # find the author, then find the posts, then find the comments
+    author = assert_queries_count(3) { Author.all.merge!(includes: { post_about_thinking_with_last_comment: :last_comment }).find(author.id) } # find the author, then find the posts, then find the comments
     assert_no_queries do
       assert_equal post, author.post_about_thinking_with_last_comment
       assert_equal last_comment, author.post_about_thinking_with_last_comment.last_comment
@@ -326,7 +326,7 @@ class EagerAssociationTest < ActiveRecord::TestCase
     post = posts(:welcome)
     author = post.author
     author_address = author.author_address
-    post = assert_queries(3) { Post.all.merge!(includes: { author_with_address: :author_address }).find(post.id) } # find the post, then find the author, then find the address
+    post = assert_queries_count(3) { Post.all.merge!(includes: { author_with_address: :author_address }).find(post.id) } # find the post, then find the author, then find the address
     assert_no_queries do
       assert_equal author, post.author_with_address
       assert_equal author_address, post.author_with_address.author_address
@@ -336,7 +336,7 @@ class EagerAssociationTest < ActiveRecord::TestCase
   def test_finding_with_includes_on_null_belongs_to_association_with_same_include_includes_only_once
     post = posts(:welcome)
     post.update!(author: nil)
-    post = assert_queries(1) { Post.all.merge!(includes: { author_with_address: :author_address }).find(post.id) }
+    post = assert_queries_count(1) { Post.all.merge!(includes: { author_with_address: :author_address }).find(post.id) }
     # find the post, then find the author which is null so no query for the author or address
     assert_no_queries do
       assert_nil post.author_with_address
@@ -346,7 +346,7 @@ class EagerAssociationTest < ActiveRecord::TestCase
   def test_finding_with_includes_on_null_belongs_to_polymorphic_association
     sponsor = sponsors(:moustache_club_sponsor_for_groucho)
     sponsor.update!(sponsorable: nil)
-    sponsor = assert_queries(1) { Sponsor.all.merge!(includes: :sponsorable).find(sponsor.id) }
+    sponsor = assert_queries_count(1) { Sponsor.all.merge!(includes: :sponsorable).find(sponsor.id) }
     assert_no_queries do
       assert_nil sponsor.sponsorable
     end
@@ -355,7 +355,7 @@ class EagerAssociationTest < ActiveRecord::TestCase
   def test_finding_with_includes_on_empty_polymorphic_type_column
     sponsor = sponsors(:moustache_club_sponsor_for_groucho)
     sponsor.update!(sponsorable_type: "", sponsorable_id: nil) # sponsorable_type column might be declared NOT NULL
-    sponsor = assert_queries(1) do
+    sponsor = assert_queries_count(1) do
       assert_nothing_raised { Sponsor.all.merge!(includes: :sponsorable).find(sponsor.id) }
     end
     assert_no_queries do
@@ -704,7 +704,7 @@ class EagerAssociationTest < ActiveRecord::TestCase
   end
 
   def test_eager_with_has_many_and_limit_and_high_offset_and_multiple_array_conditions
-    assert_queries(1) do
+    assert_queries_count(1) do
       posts = Post.references(:authors, :comments).
         merge(includes: [ :author, :comments ], limit: 2, offset: 10,
           where: [ "authors.name = ? and comments.body = ?", "David", "go wild" ]).to_a
@@ -713,7 +713,7 @@ class EagerAssociationTest < ActiveRecord::TestCase
   end
 
   def test_eager_with_has_many_and_limit_and_high_offset_and_multiple_hash_conditions
-    assert_queries(1) do
+    assert_queries_count(1) do
       posts = Post.all.merge!(includes: [ :author, :comments ], limit: 2, offset: 10,
         where: { "authors.name" => "David", "comments.body" => "go wild" }).to_a
       assert_equal 0, posts.size
@@ -1091,7 +1091,7 @@ class EagerAssociationTest < ActiveRecord::TestCase
   end
 
   def test_eager_with_floating_point_numbers
-    assert_queries(2) do
+    assert_queries_count(2) do
       # Before changes, the floating-point numbers will be interpreted as table names and will cause this to run in one query
       Comment.all.merge!(where: "123.456 = 123.456", includes: :post).to_a
     end
@@ -1182,7 +1182,7 @@ class EagerAssociationTest < ActiveRecord::TestCase
   end
 
   def test_load_with_sti_sharing_association
-    assert_queries(2) do # should not do 1 query per subclass
+    assert_queries_count(2) do # should not do 1 query per subclass
       Comment.includes(:post).to_a
     end
   end
@@ -1202,7 +1202,7 @@ class EagerAssociationTest < ActiveRecord::TestCase
   end
 
   def test_eager_loading_with_order_on_joined_table_preloads
-    posts = assert_queries(2) do
+    posts = assert_queries_count(2) do
       Post.all.merge!(joins: :comments, includes: :author, order: "comments.id DESC").to_a
     end
     assert_equal posts(:eager_other), posts[2]
@@ -1210,18 +1210,18 @@ class EagerAssociationTest < ActiveRecord::TestCase
   end
 
   def test_eager_loading_with_conditions_on_joined_table_preloads
-    posts = assert_queries(2) do
+    posts = assert_queries_count(2) do
       Post.all.merge!(select: "distinct posts.*", includes: :author, joins: [:comments], where: "comments.body like 'Thank you%'", order: "posts.id").to_a
     end
     assert_equal [posts(:welcome)], posts
     assert_equal authors(:david), assert_no_queries { posts[0].author }
 
-    posts = assert_queries(2) do
+    posts = assert_queries_count(2) do
       Post.all.merge!(includes: :author, joins: { taggings: :tag }, where: "tags.name = 'General'", order: "posts.id").to_a
     end
     assert_equal posts(:welcome, :thinking), posts
 
-    posts = assert_queries(2) do
+    posts = assert_queries_count(2) do
       Post.all.merge!(includes: :author, joins: { taggings: { tag: :taggings } }, where: "taggings_tags.super_tag_id=2", order: "posts.id").to_a
     end
     assert_equal posts(:welcome, :thinking), posts
@@ -1240,13 +1240,13 @@ class EagerAssociationTest < ActiveRecord::TestCase
   end
 
   def test_eager_loading_with_conditions_on_string_joined_table_preloads
-    posts = assert_queries(2) do
+    posts = assert_queries_count(2) do
       Post.all.merge!(select: "distinct posts.*", includes: :author, joins: "INNER JOIN comments on comments.post_id = posts.id", where: "comments.body like 'Thank you%'", order: "posts.id").to_a
     end
     assert_equal [posts(:welcome)], posts
     assert_equal authors(:david), assert_no_queries { posts[0].author }
 
-    posts = assert_queries(2) do
+    posts = assert_queries_count(2) do
       Post.all.merge!(select: "distinct posts.*", includes: :author, joins: ["INNER JOIN comments on comments.post_id = posts.id"], where: "comments.body like 'Thank you%'", order: "posts.id").to_a
     end
     assert_equal [posts(:welcome)], posts
@@ -1254,7 +1254,7 @@ class EagerAssociationTest < ActiveRecord::TestCase
   end
 
   def test_eager_loading_with_select_on_joined_table_preloads
-    posts = assert_queries(2) do
+    posts = assert_queries_count(2) do
       Post.all.merge!(select: "posts.*, authors.name as author_name", includes: :comments, joins: :author, order: "posts.id").to_a
     end
     assert_equal "David", posts[0].author_name
@@ -1262,7 +1262,7 @@ class EagerAssociationTest < ActiveRecord::TestCase
   end
 
   def test_eager_loading_with_conditions_on_join_model_preloads
-    authors = assert_queries(2) do
+    authors = assert_queries_count(2) do
       Author.all.merge!(includes: :author_address, joins: :comments, where: "posts.title like 'Welcome%'").to_a
     end
     assert_equal authors(:david), authors[0]
@@ -1321,7 +1321,7 @@ class EagerAssociationTest < ActiveRecord::TestCase
   def test_preloading_empty_belongs_to
     c = Client.create!(name: "Foo", client_of: Company.maximum(:id) + 1)
 
-    client = assert_queries(2) { Client.preload(:firm).find(c.id) }
+    client = assert_queries_count(2) { Client.preload(:firm).find(c.id) }
     assert_no_queries { assert_nil client.firm }
     assert_equal c.client_of, client.client_of
   end
@@ -1329,7 +1329,7 @@ class EagerAssociationTest < ActiveRecord::TestCase
   def test_preloading_empty_belongs_to_polymorphic
     t = Tagging.create!(taggable_type: "Post", taggable_id: Post.maximum(:id) + 1, tag: tags(:general))
 
-    tagging = assert_queries(2) { Tagging.preload(:taggable).find(t.id) }
+    tagging = assert_queries_count(2) { Tagging.preload(:taggable).find(t.id) }
     assert_no_queries { assert_nil tagging.taggable }
     assert_equal t.taggable_id, tagging.taggable_id
   end
@@ -1337,7 +1337,7 @@ class EagerAssociationTest < ActiveRecord::TestCase
   def test_preloading_through_empty_belongs_to
     c = Client.create!(name: "Foo", client_of: Company.maximum(:id) + 1)
 
-    client = assert_queries(2) { Client.preload(:accounts).find(c.id) }
+    client = assert_queries_count(2) { Client.preload(:accounts).find(c.id) }
     assert_no_queries { assert_predicate client.accounts, :empty? }
   end
 
@@ -1369,14 +1369,14 @@ class EagerAssociationTest < ActiveRecord::TestCase
     sponsor = sponsors(:moustache_club_sponsor_for_groucho)
     groucho = members(:groucho)
 
-    sponsor = assert_queries(2) {
+    sponsor = assert_queries_count(2) {
       Sponsor.includes(:thing).where(id: sponsor.id).first
     }
     assert_no_queries { assert_equal groucho, sponsor.thing }
   end
 
   def test_joins_with_includes_should_preload_via_joins
-    post = assert_queries(1) { Post.includes(:comments).joins(:comments).order("posts.id desc").to_a.first }
+    post = assert_queries_count(1) { Post.includes(:comments).joins(:comments).order("posts.id desc").to_a.first }
 
     assert_no_queries do
       assert_not_equal 0, post.comments.to_a.count
@@ -1501,7 +1501,7 @@ class EagerAssociationTest < ActiveRecord::TestCase
   end
 
   test "preloading associations with string joins and order references" do
-    author = assert_queries(2) {
+    author = assert_queries_count(2) {
       Author.includes(:posts).joins("LEFT JOIN posts ON posts.author_id = authors.id").order("posts.title DESC").first
     }
     assert_no_queries {
@@ -1510,7 +1510,7 @@ class EagerAssociationTest < ActiveRecord::TestCase
   end
 
   test "including associations with where.not adds implicit references" do
-    author = assert_queries(2) {
+    author = assert_queries_count(2) {
       Author.includes(:posts).where.not(posts: { title: "Welcome to the weblog" }).last
     }
 
@@ -1651,22 +1651,22 @@ class EagerAssociationTest < ActiveRecord::TestCase
 
   test "preloading through a polymorphic association doesn't require the association to exist" do
     sponsors = []
-    assert_queries 5 do
+    assert_queries_count 5 do
       sponsors = Sponsor.where(sponsorable_id: 1).preload(sponsorable: [:post, :membership]).to_a
     end
     # check the preload worked
-    assert_queries 0 do
+    assert_queries_count 0 do
       sponsors.map(&:sponsorable).map { |s| s.respond_to?(:posts) ? s.post.author : s.membership }
     end
   end
 
   test "preloading a regular association through a polymorphic association doesn't require the association to exist on all types" do
     sponsors = []
-    assert_queries 6 do
+    assert_queries_count 6 do
       sponsors = Sponsor.where(sponsorable_id: 1).preload(sponsorable: [{ post: :first_comment }, :membership]).to_a
     end
     # check the preload worked
-    assert_queries 0 do
+    assert_queries_count 0 do
       sponsors.map(&:sponsorable).map { |s| s.respond_to?(:posts) ? s.post.author : s.membership }
     end
   end

--- a/activerecord/test/cases/associations/has_and_belongs_to_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_and_belongs_to_many_associations_test.rb
@@ -300,7 +300,7 @@ class HasAndBelongsToManyAssociationsTest < ActiveRecord::TestCase
   def test_build
     devel = Developer.find(1)
 
-    proj = assert_queries(0) { devel.projects.build("name" => "Projekt") }
+    proj = assert_queries_count(0) { devel.projects.build("name" => "Projekt") }
     assert_not_predicate devel.projects, :loaded?
 
     assert_equal devel.projects.last, proj
@@ -316,7 +316,7 @@ class HasAndBelongsToManyAssociationsTest < ActiveRecord::TestCase
   def test_new_aliased_to_build
     devel = Developer.find(1)
 
-    proj = assert_queries(0) { devel.projects.new("name" => "Projekt") }
+    proj = assert_queries_count(0) { devel.projects.new("name" => "Projekt") }
     assert_not_predicate devel.projects, :loaded?
 
     assert_equal devel.projects.last, proj
@@ -537,7 +537,7 @@ class HasAndBelongsToManyAssociationsTest < ActiveRecord::TestCase
 
     developer = project.developers.first
 
-    assert_queries(0) do
+    assert_queries_count(0) do
       assert_predicate project.developers, :loaded?
       assert_includes project.developers, developer
     end
@@ -549,7 +549,7 @@ class HasAndBelongsToManyAssociationsTest < ActiveRecord::TestCase
 
     project.reload
     assert_not_predicate project.developers, :loaded?
-    assert_queries(1) do
+    assert_queries_count(1) do
       assert_includes project.developers, developer
     end
     assert_not_predicate project.developers, :loaded?
@@ -739,7 +739,7 @@ class HasAndBelongsToManyAssociationsTest < ActiveRecord::TestCase
   def test_get_ids_for_loaded_associations
     developer = developers(:david)
     developer.projects.reload
-    assert_queries(0) do
+    assert_queries_count(0) do
       developer.project_ids
       developer.project_ids
     end
@@ -828,13 +828,13 @@ class HasAndBelongsToManyAssociationsTest < ActiveRecord::TestCase
     # clear cache possibly created by other tests
     david.projects.reset_column_information
 
-    assert_queries(:any) { david.projects.columns }
+    assert_queries_count(include_schema: true) { david.projects.columns }
     assert_no_queries { david.projects.columns }
 
     ## and again to verify that reset_column_information clears the cache correctly
     david.projects.reset_column_information
 
-    assert_queries(:any) { david.projects.columns }
+    assert_queries_count(include_schema: true) { david.projects.columns }
     assert_no_queries { david.projects.columns }
   end
 
@@ -867,7 +867,7 @@ class HasAndBelongsToManyAssociationsTest < ActiveRecord::TestCase
 
   def test_has_and_belongs_to_many_associations_on_new_records_use_null_relations
     projects = Developer.new.projects
-    assert_queries(0) do
+    assert_queries_count(0) do
       assert_equal [], projects
       assert_equal [], projects.where(title: "omg")
       assert_equal [], projects.pluck(:title)

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -63,7 +63,7 @@ class HasManyAssociationsTestPrimaryKeys < ActiveRecord::TestCase
     subscriber = Subscriber.new(nick: "webster132")
     assert_not_predicate subscriber.subscriptions, :loaded?
 
-    assert_queries 1 do
+    assert_queries_count 1 do
       assert_equal 2, subscriber.subscriptions.size
     end
 
@@ -74,7 +74,7 @@ class HasManyAssociationsTestPrimaryKeys < ActiveRecord::TestCase
     author = Author.new(name: "David")
     assert_not_predicate author.essays, :loaded?
 
-    assert_queries 1 do
+    assert_queries_count 1 do
       assert_equal 1, author.essays.size
     end
 
@@ -109,7 +109,7 @@ class HasManyAssociationsTestPrimaryKeys < ActiveRecord::TestCase
     author = Author.new
     assert_not_predicate author.essays, :loaded?
 
-    assert_queries 0 do
+    assert_queries_count 0 do
       assert_equal 0, author.essays.size
     end
   end
@@ -560,14 +560,14 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     company = companies(:first_firm)
     new_clients = []
 
-    assert_queries(0) do
+    assert_queries_count(0) do
       new_clients << company.clients_of_firm.build(name: "Another Client")
       new_clients << company.clients_of_firm.build(name: "Another Client II")
       new_clients << company.clients_of_firm.build(name: "Another Client III")
     end
 
     assert_not_predicate company.clients_of_firm, :loaded?
-    assert_queries(1) do
+    assert_queries_count(1) do
       assert_same new_clients[0], company.clients_of_firm.third
       assert_same new_clients[1], company.clients_of_firm.fourth
       assert_same new_clients[2], company.clients_of_firm.fifth
@@ -581,14 +581,14 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     company = companies(:first_firm)
     new_clients = []
 
-    assert_queries(0) do
+    assert_queries_count(0) do
       new_clients << company.clients_of_firm.build(name: "Another Client")
       new_clients << company.clients_of_firm.build(name: "Another Client II")
       new_clients << company.clients_of_firm.build(name: "Another Client III")
     end
 
     assert_not_predicate company.clients_of_firm, :loaded?
-    assert_queries(1) do
+    assert_queries_count(1) do
       assert_same new_clients[0], company.clients_of_firm.third!
       assert_same new_clients[1], company.clients_of_firm.fourth!
       assert_same new_clients[2], company.clients_of_firm.fifth!
@@ -834,7 +834,7 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
 
     assert_not_predicate firm.clients, :loaded?
 
-    assert_queries(4) do
+    assert_queries_count(4) do
       firm.clients.find_each(batch_size: 1) { |c| assert_equal firm.id, c.firm_id }
     end
 
@@ -844,7 +844,7 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
   def test_find_each_with_conditions
     firm = companies(:first_firm)
 
-    assert_queries(2) do
+    assert_queries_count(2) do
       firm.clients.where(name: "Microsoft").find_each(batch_size: 1) do |c|
         assert_equal firm.id, c.firm_id
         assert_equal "Microsoft", c.name
@@ -859,7 +859,7 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
 
     assert_not_predicate firm.clients, :loaded?
 
-    assert_queries(2) do
+    assert_queries_count(2) do
       firm.clients.find_in_batches(batch_size: 2) do |clients|
         clients.each { |c| assert_equal firm.id, c.firm_id }
       end
@@ -937,9 +937,9 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     assert_equal 2, connection.query_cache.size
 
     # Clear the cache and fetch the clients again, populating the cache with a query
-    assert_queries(1) { firm.clients.reload }
+    assert_queries_count(1) { firm.clients.reload }
     # This query is cached, so it shouldn't make a real SQL query
-    assert_queries(0) { firm.clients.load }
+    assert_queries_count(0) { firm.clients.load }
 
     assert_equal 1, connection.query_cache.size
   ensure
@@ -1106,14 +1106,14 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
 
   def test_transactions_when_adding_to_new_record
     firm = Firm.new
-    assert_queries(0) do
+    assert_queries_count(0) do
       firm.clients_of_firm.concat(Client.new("name" => "Natural Company"))
     end
   end
 
   def test_inverse_on_before_validate
     firm = companies(:first_firm)
-    assert_queries(1) do
+    assert_queries_count(3) do
       firm.clients_of_firm << Client.new("name" => "Natural Company")
     end
   end
@@ -1121,7 +1121,7 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
   def test_new_aliased_to_build
     company = companies(:first_firm)
 
-    new_client = assert_queries(0) { company.clients_of_firm.new("name" => "Another Client") }
+    new_client = assert_queries_count(0) { company.clients_of_firm.new("name" => "Another Client") }
     assert_not_predicate company.clients_of_firm, :loaded?
 
     assert_equal "Another Client", new_client.name
@@ -1132,7 +1132,7 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
   def test_build
     company = companies(:first_firm)
 
-    new_client = assert_queries(0) { company.clients_of_firm.build("name" => "Another Client") }
+    new_client = assert_queries_count(0) { company.clients_of_firm.build("name" => "Another Client") }
     assert_not_predicate company.clients_of_firm, :loaded?
 
     assert_equal "Another Client", new_client.name
@@ -1190,7 +1190,7 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
   def test_build_many
     company = companies(:first_firm)
 
-    new_clients = assert_queries(0) { company.clients_of_firm.build([{ "name" => "Another Client" }, { "name" => "Another Client II" }]) }
+    new_clients = assert_queries_count(0) { company.clients_of_firm.build([{ "name" => "Another Client" }, { "name" => "Another Client II" }]) }
     assert_equal 2, new_clients.size
   end
 
@@ -1205,7 +1205,7 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
 
     assert_equal 1, first_topic.replies.length
 
-    assert_queries(0) do
+    assert_queries_count(0) do
       first_topic.replies.build(title: "Not saved", content: "Superstars")
       assert_equal 2, first_topic.replies.size
     end
@@ -1216,7 +1216,7 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
   def test_build_via_block
     company = companies(:first_firm)
 
-    new_client = assert_queries(0) { company.clients_of_firm.build { |client| client.name = "Another Client" } }
+    new_client = assert_queries_count(0) { company.clients_of_firm.build { |client| client.name = "Another Client" } }
     assert_not_predicate company.clients_of_firm, :loaded?
 
     assert_equal "Another Client", new_client.name
@@ -1227,7 +1227,7 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
   def test_build_many_via_block
     company = companies(:first_firm)
 
-    new_clients = assert_queries(0) do
+    new_clients = assert_queries_count(0) do
       company.clients_of_firm.build([{ "name" => "Another Client" }, { "name" => "Another Client II" }]) do |client|
         client.name = "changed"
       end
@@ -1244,7 +1244,7 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     assert_equal 2, first_firm.clients_of_firm.size
     first_firm.clients_of_firm.reset
 
-    assert_queries(1) do
+    assert_queries_count(3) do
       first_firm.clients_of_firm.create(name: "Superstars")
     end
 
@@ -1323,7 +1323,7 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     query_constraints = /#{blog_id} = .* AND #{id} = .*/
     expectation = /DELETE.*WHERE.* \(#{query_constraints} OR #{query_constraints}\)/
 
-    assert_match(expectation, sql.first)
+    assert_match(expectation, sql.second)
 
     blog_post.reload
 
@@ -1396,7 +1396,7 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     reply1 = Reply.create!(title: "re: zoom", content: "speedy quick!")
     reply2 = Reply.create!(title: "re: zoom 2", content: "OMG lol!")
 
-    assert_queries(4) do
+    assert_queries_count(6) do
       topic.replies << [reply1, reply2]
     end
 
@@ -1429,7 +1429,7 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     categorization1 = Categorization.create!
     categorization2 = Categorization.create!
 
-    assert_queries(4) do
+    assert_queries_count(6) do
       category.categorizations << [categorization1, categorization2]
     end
 
@@ -1591,7 +1591,7 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
 
   def test_transaction_when_deleting_new_record
     firm = Firm.new
-    assert_queries(0) do
+    assert_queries_count(0) do
       client = Client.new("name" => "New Client")
       firm.clients_of_firm << client
       firm.clients_of_firm.destroy(client)
@@ -2107,7 +2107,7 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
 
   def test_transactions_when_replacing_on_new_record
     firm = Firm.new
-    assert_queries(0) do
+    assert_queries_count(0) do
       firm.clients_of_firm = [Client.new("name" => "New Client")]
     end
   end
@@ -2162,7 +2162,7 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
 
   def test_get_ids_for_association_on_new_record_does_not_try_to_find_records
     company = Company.new
-    assert_queries(0) do
+    assert_queries_count(0) do
       company.contract_ids
     end
 
@@ -2243,7 +2243,7 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
 
     firm.reload
     assert_not_predicate firm.clients, :loaded?
-    assert_queries(1) do
+    assert_queries_count(1) do
       assert_equal true, firm.clients.include?(client)
     end
     assert_not_predicate firm.clients, :loaded?
@@ -2283,7 +2283,7 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     firm.clients.build(name: "Foo")
     assert_not_predicate firm.clients, :loaded?
 
-    assert_queries 1 do
+    assert_queries_count 1 do
       firm.clients.first
       firm.clients.second
       firm.clients.last
@@ -2299,7 +2299,7 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
 
     assert_not_predicate author.topics_without_type, :loaded?
 
-    assert_queries(1) do
+    assert_queries_count(1) do
       if current_adapter?(:Mysql2Adapter, :TrilogyAdapter, :SQLite3Adapter)
         assert_equal fourth, author.topics_without_type.first
         assert_equal third, author.topics_without_type.second
@@ -2315,7 +2315,7 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     firm.clients.create(name: "Foo")
     assert_not_predicate firm.clients, :loaded?
 
-    assert_queries 3 do
+    assert_queries_count 3 do
       firm.clients.first
       firm.clients.second
       firm.clients.last
@@ -2339,7 +2339,7 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     firm.clients.create(name: "Foo")
     assert_not_predicate firm.clients, :loaded?
 
-    assert_queries 2 do
+    assert_queries_count 2 do
       firm.clients.first(2)
       firm.clients.last(2)
     end
@@ -2349,7 +2349,7 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
 
   def test_calling_many_should_count_instead_of_loading_association
     firm = companies(:first_firm)
-    assert_queries(1) do
+    assert_queries_count(1) do
       firm.clients.many?  # use count query
     end
     assert_not_predicate firm.clients, :loaded?
@@ -2363,7 +2363,7 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
 
   def test_subsequent_calls_to_many_should_use_query
     firm = companies(:first_firm)
-    assert_queries(2) do
+    assert_queries_count(2) do
       firm.clients.many?
       firm.clients.many?
     end
@@ -2371,7 +2371,7 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
 
   def test_calling_many_should_defer_to_collection_if_using_a_block
     firm = companies(:first_firm)
-    assert_queries(1) do
+    assert_queries_count(1) do
       assert_not_called(firm.clients, :size) do
         firm.clients.many? { true }
       end
@@ -2397,7 +2397,7 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
 
   def test_calling_none_should_count_instead_of_loading_association
     firm = companies(:first_firm)
-    assert_queries(1) do
+    assert_queries_count(1) do
       firm.clients.none?  # use count query
     end
     assert_not_predicate firm.clients, :loaded?
@@ -2411,7 +2411,7 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
 
   def test_calling_none_should_defer_to_collection_if_using_a_block
     firm = companies(:first_firm)
-    assert_queries(1) do
+    assert_queries_count(1) do
       assert_not_called(firm.clients, :size) do
         firm.clients.none? { true }
       end
@@ -2433,7 +2433,7 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
 
   def test_calling_one_should_count_instead_of_loading_association
     firm = companies(:first_firm)
-    assert_queries(1) do
+    assert_queries_count(1) do
       firm.clients.one?  # use count query
     end
     assert_not_predicate firm.clients, :loaded?
@@ -2447,7 +2447,7 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
 
   def test_subsequent_calls_to_one_should_use_query
     firm = companies(:first_firm)
-    assert_queries(2) do
+    assert_queries_count(2) do
       firm.clients.one?
       firm.clients.one?
     end
@@ -2455,7 +2455,7 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
 
   def test_calling_one_should_defer_to_collection_if_using_a_block
     firm = companies(:first_firm)
-    assert_queries(1) do
+    assert_queries_count(1) do
       assert_not_called(firm.clients, :size) do
         firm.clients.one? { true }
       end
@@ -2748,7 +2748,7 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     assert_not_predicate post.taggings_with_delete_all, :loaded?
 
     # 2 queries: one DELETE and another to update the counter cache
-    assert_queries(2) do
+    assert_queries_count(2) do
       post.taggings_with_delete_all.delete_all
     end
   end
@@ -3034,11 +3034,11 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
 
     car_two = Car.create!
 
-    assert_queries(1) do
+    assert_queries_count(1) do
       assert_equal 1, car.bulbs.size
     end
 
-    assert_queries(1) do
+    assert_queries_count(1) do
       assert_equal 0, car_two.bulbs.size
     end
   end
@@ -3066,11 +3066,11 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
 
     car_two = Car.create!
 
-    assert_queries(1) do
+    assert_queries_count(1) do
       assert_not_empty car.bulbs
     end
 
-    assert_queries(1) do
+    assert_queries_count(1) do
       assert_empty car_two.bulbs
     end
   end

--- a/activerecord/test/cases/associations/has_many_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_through_associations_test.rb
@@ -221,11 +221,11 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
     post   = posts(:thinking)
     person = people(:david)
 
-    assert_queries(1) do
+    assert_queries_count(3) do
       post.people << person
     end
 
-    assert_queries(1) do
+    assert_queries_count(1) do
       assert_includes post.people, person
     end
 
@@ -318,20 +318,20 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
   end
 
   def test_associating_new
-    assert_queries(1) { posts(:thinking) }
+    assert_queries_count(1) { posts(:thinking) }
     new_person = nil # so block binding catches it
 
-    assert_queries(0) do
+    assert_queries_count(0) do
       new_person = Person.new first_name: "bob"
     end
 
     # Associating new records always saves them
     # Thus, 1 query for the new person record, 1 query for the new join table record
-    assert_queries(2) do
+    assert_queries_count(4) do
       posts(:thinking).people << new_person
     end
 
-    assert_queries(1) do
+    assert_queries_count(1) do
       assert_includes posts(:thinking).people, new_person
     end
 
@@ -339,15 +339,15 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
   end
 
   def test_associate_new_by_building
-    assert_queries(1) { posts(:thinking) }
+    assert_queries_count(1) { posts(:thinking) }
 
-    assert_queries(0) do
+    assert_queries_count(0) do
       posts(:thinking).people.build(first_name: "Bob")
       posts(:thinking).people.new(first_name: "Ted")
     end
 
     # Should only need to load the association once
-    assert_queries(1) do
+    assert_queries_count(1) do
       assert_includes posts(:thinking).people.collect(&:first_name), "Bob"
       assert_includes posts(:thinking).people.collect(&:first_name), "Ted"
     end
@@ -355,7 +355,7 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
     # 2 queries for each new record (1 to save the record itself, 1 for the join model)
     #    * 2 new records = 4
     # + 1 query to save the actual post = 5
-    assert_queries(5) do
+    assert_queries_count(7) do
       posts(:thinking).body += "-changed"
       posts(:thinking).save
     end
@@ -407,13 +407,13 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
   end
 
   def test_delete_association
-    assert_queries(2) { posts(:welcome); people(:michael) }
+    assert_queries_count(2) { posts(:welcome); people(:michael) }
 
-    assert_queries(1) do
+    assert_queries_count(3) do
       posts(:welcome).people.delete(people(:michael))
     end
 
-    assert_queries(1) do
+    assert_queries_count(1) do
       assert_empty posts(:welcome).people
     end
 
@@ -659,11 +659,11 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
   end
 
   def test_replace_association
-    assert_queries(4) { posts(:welcome); people(:david); people(:michael); posts(:welcome).people.reload }
+    assert_queries_count(4) { posts(:welcome); people(:david); people(:michael); posts(:welcome).people.reload }
 
     # 1 query to delete the existing reader (michael)
     # 1 query to associate the new reader (david)
-    assert_queries(2) do
+    assert_queries_count(4) do
       posts(:welcome).people = [people(:david)]
     end
 
@@ -709,16 +709,16 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
   end
 
   def test_associate_with_create
-    assert_queries(1) { posts(:thinking) }
+    assert_queries_count(1) { posts(:thinking) }
 
     # 1 query for the new record, 1 for the join table record
     # No need to update the actual collection yet!
-    assert_queries(2) do
+    assert_queries_count(4) do
       posts(:thinking).people.create(first_name: "Jeb")
     end
 
     # *Now* we actually need the collection so it's loaded
-    assert_queries(1) do
+    assert_queries_count(1) do
       assert_includes posts(:thinking).people.collect(&:first_name), "Jeb"
     end
 
@@ -804,9 +804,9 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
   end
 
   def test_clear_associations
-    assert_queries(2) { posts(:welcome); posts(:welcome).people.reload }
+    assert_queries_count(2) { posts(:welcome); posts(:welcome).people.reload }
 
-    assert_queries(1) do
+    assert_queries_count(1) do
       posts(:welcome).people.clear
     end
 

--- a/activerecord/test/cases/associations/has_many_through_disable_joins_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_through_disable_joins_associations_test.rb
@@ -34,120 +34,120 @@ class HasManyThroughDisableJoinsAssociationsTest < ActiveRecord::TestCase
 
   def test_counting_on_disable_joins_through
     assert_equal @author.comments.count, @author.no_joins_comments.count
-    assert_queries(2) { @author.no_joins_comments.count }
-    assert_queries(1) { @author.comments.count }
+    assert_queries_count(2) { @author.no_joins_comments.count }
+    assert_queries_count(1) { @author.comments.count }
   end
 
   def test_counting_on_disable_joins_through_using_custom_foreign_key
     assert_equal @author.comments_with_foreign_key.count, @author.no_joins_comments_with_foreign_key.count
-    assert_queries(2) { @author.no_joins_comments_with_foreign_key.count }
-    assert_queries(1) { @author.comments_with_foreign_key.count }
+    assert_queries_count(2) { @author.no_joins_comments_with_foreign_key.count }
+    assert_queries_count(1) { @author.comments_with_foreign_key.count }
   end
 
   def test_pluck_on_disable_joins_through
     assert_equal @author.comments.pluck(:id).sort, @author.no_joins_comments.pluck(:id).sort
-    assert_queries(2) { @author.no_joins_comments.pluck(:id) }
-    assert_queries(1) { @author.comments.pluck(:id) }
+    assert_queries_count(2) { @author.no_joins_comments.pluck(:id) }
+    assert_queries_count(1) { @author.comments.pluck(:id) }
   end
 
   def test_pluck_on_disable_joins_through_using_custom_foreign_key
     assert_equal @author.comments_with_foreign_key.pluck(:id).sort, @author.no_joins_comments_with_foreign_key.pluck(:id).sort
-    assert_queries(2) { @author.no_joins_comments_with_foreign_key.pluck(:id) }
-    assert_queries(1) { @author.comments_with_foreign_key.pluck(:id) }
+    assert_queries_count(2) { @author.no_joins_comments_with_foreign_key.pluck(:id) }
+    assert_queries_count(1) { @author.comments_with_foreign_key.pluck(:id) }
   end
 
   def test_fetching_on_disable_joins_through
     assert_equal @author.comments.first.id, @author.no_joins_comments.first.id
-    assert_queries(2) { @author.no_joins_comments.first.id }
-    assert_queries(1) { @author.comments.first.id }
+    assert_queries_count(2) { @author.no_joins_comments.first.id }
+    assert_queries_count(1) { @author.comments.first.id }
   end
 
   def test_fetching_on_disable_joins_through_using_custom_foreign_key
     assert_equal @author.comments_with_foreign_key.first.id, @author.no_joins_comments_with_foreign_key.first.id
-    assert_queries(2) { @author.no_joins_comments_with_foreign_key.first.id }
-    assert_queries(1) { @author.comments_with_foreign_key.first.id }
+    assert_queries_count(2) { @author.no_joins_comments_with_foreign_key.first.id }
+    assert_queries_count(1) { @author.comments_with_foreign_key.first.id }
   end
 
   def test_to_a_on_disable_joins_through
     assert_equal @author.comments.sort_by(&:id), @author.no_joins_comments.sort_by(&:id)
     @author.reload
-    assert_queries(2) { @author.no_joins_comments.to_a }
-    assert_queries(1) { @author.comments.to_a }
+    assert_queries_count(2) { @author.no_joins_comments.to_a }
+    assert_queries_count(1) { @author.comments.to_a }
   end
 
   def test_appending_on_disable_joins_through
     assert_difference(->() { @author.no_joins_comments.reload.size }) do
       @post.comments.create(body: "text")
     end
-    assert_queries(2) { @author.no_joins_comments.reload.size }
-    assert_queries(1) { @author.comments.reload.size }
+    assert_queries_count(2) { @author.no_joins_comments.reload.size }
+    assert_queries_count(1) { @author.comments.reload.size }
   end
 
   def test_appending_on_disable_joins_through_using_custom_foreign_key
     assert_difference(->() { @author.no_joins_comments_with_foreign_key.reload.size }) do
       @post.comments.create(body: "text")
     end
-    assert_queries(2) { @author.no_joins_comments_with_foreign_key.reload.size }
-    assert_queries(1) { @author.comments_with_foreign_key.reload.size }
+    assert_queries_count(2) { @author.no_joins_comments_with_foreign_key.reload.size }
+    assert_queries_count(1) { @author.comments_with_foreign_key.reload.size }
   end
 
   def test_empty_on_disable_joins_through
     empty_author = authors(:bob)
-    assert_equal [], assert_queries(0) { empty_author.comments.all }
-    assert_equal [], assert_queries(1) { empty_author.no_joins_comments.all }
+    assert_equal [], assert_queries_count(0) { empty_author.comments.all }
+    assert_equal [], assert_queries_count(1) { empty_author.no_joins_comments.all }
   end
 
   def test_empty_on_disable_joins_through_using_custom_foreign_key
     empty_author = authors(:bob)
-    assert_equal [], assert_queries(0) { empty_author.comments_with_foreign_key.all }
-    assert_equal [], assert_queries(1) { empty_author.no_joins_comments_with_foreign_key.all }
+    assert_equal [], assert_queries_count(0) { empty_author.comments_with_foreign_key.all }
+    assert_equal [], assert_queries_count(1) { empty_author.no_joins_comments_with_foreign_key.all }
   end
 
   def test_pluck_on_disable_joins_through_a_through
     rating_ids = Rating.where(comment: @comment).pluck(:id).sort
-    assert_equal rating_ids, assert_queries(1) { @author.ratings.pluck(:id).sort }
-    assert_equal rating_ids, assert_queries(3) { @author.no_joins_ratings.pluck(:id).sort }
+    assert_equal rating_ids, assert_queries_count(1) { @author.ratings.pluck(:id).sort }
+    assert_equal rating_ids, assert_queries_count(3) { @author.no_joins_ratings.pluck(:id).sort }
   end
 
   def test_count_on_disable_joins_through_a_through
     ratings_count = Rating.where(comment: @comment).count
-    assert_equal ratings_count, assert_queries(1) { @author.ratings.count }
-    assert_equal ratings_count, assert_queries(3) { @author.no_joins_ratings.count }
+    assert_equal ratings_count, assert_queries_count(1) { @author.ratings.count }
+    assert_equal ratings_count, assert_queries_count(3) { @author.no_joins_ratings.count }
   end
 
   def test_count_on_disable_joins_using_relation_with_scope
-    assert_equal 2, assert_queries(1) { @author.good_ratings.count }
-    assert_equal 2, assert_queries(3) { @author.no_joins_good_ratings.count }
+    assert_equal 2, assert_queries_count(1) { @author.good_ratings.count }
+    assert_equal 2, assert_queries_count(3) { @author.no_joins_good_ratings.count }
   end
 
   def test_to_a_on_disable_joins_with_multiple_scopes
-    assert_equal [@rating1, @rating2], assert_queries(1) { @author.good_ratings.to_a }
-    assert_equal [@rating1, @rating2], assert_queries(3) { @author.no_joins_good_ratings.to_a }
+    assert_equal [@rating1, @rating2], assert_queries_count(1) { @author.good_ratings.to_a }
+    assert_equal [@rating1, @rating2], assert_queries_count(3) { @author.no_joins_good_ratings.to_a }
   end
 
   def test_preloading_has_many_through_disable_joins
-    assert_queries(3) { Author.all.preload(:good_ratings).map(&:good_ratings) }
-    assert_queries(4) { Author.all.preload(:no_joins_good_ratings).map(&:good_ratings) }
+    assert_queries_count(3) { Author.all.preload(:good_ratings).map(&:good_ratings) }
+    assert_queries_count(4) { Author.all.preload(:no_joins_good_ratings).map(&:good_ratings) }
   end
 
   def test_polymophic_disable_joins_through_counting
-    assert_equal 2, assert_queries(1) { @author.ordered_members.count }
-    assert_equal 2, assert_queries(3) { @author.no_joins_ordered_members.count }
+    assert_equal 2, assert_queries_count(1) { @author.ordered_members.count }
+    assert_equal 2, assert_queries_count(3) { @author.no_joins_ordered_members.count }
   end
 
   def test_polymophic_disable_joins_through_ordering
-    assert_equal [@member2, @member], assert_queries(1) { @author.ordered_members.to_a }
-    assert_equal [@member2, @member], assert_queries(3) { @author.no_joins_ordered_members.to_a }
+    assert_equal [@member2, @member], assert_queries_count(1) { @author.ordered_members.to_a }
+    assert_equal [@member2, @member], assert_queries_count(3) { @author.no_joins_ordered_members.to_a }
   end
 
   def test_polymorphic_disable_joins_through_reordering
-    assert_equal [@member, @member2], assert_queries(1) { @author.ordered_members.reorder(id: :asc).to_a }
-    assert_equal [@member, @member2], assert_queries(3) { @author.no_joins_ordered_members.reorder(id: :asc).to_a }
+    assert_equal [@member, @member2], assert_queries_count(1) { @author.ordered_members.reorder(id: :asc).to_a }
+    assert_equal [@member, @member2], assert_queries_count(3) { @author.no_joins_ordered_members.reorder(id: :asc).to_a }
   end
 
   def test_polymorphic_disable_joins_through_ordered_scopes
-    assert_equal [@member2, @member], assert_queries(1) { @author.ordered_members.unnamed.to_a }
-    assert_equal [@member2, @member], assert_queries(3) { @author.no_joins_ordered_members.unnamed.to_a }
+    assert_equal [@member2, @member], assert_queries_count(1) { @author.ordered_members.unnamed.to_a }
+    assert_equal [@member2, @member], assert_queries_count(3) { @author.no_joins_ordered_members.unnamed.to_a }
   end
 
   def test_polymorphic_disable_joins_through_ordered_chained_scopes
@@ -156,28 +156,28 @@ class HasManyThroughDisableJoinsAssociationsTest < ActiveRecord::TestCase
     @post2.comments.create(body: "text", origin: member3)
     @post2.comments.create(body: "text", origin: member4)
 
-    assert_equal [member3, @member2, @member], assert_queries(1) { @author.ordered_members.unnamed.with_member_type_id(@member_type.id).to_a }
-    assert_equal [member3, @member2, @member], assert_queries(3) { @author.no_joins_ordered_members.unnamed.with_member_type_id(@member_type.id).to_a }
+    assert_equal [member3, @member2, @member], assert_queries_count(1) { @author.ordered_members.unnamed.with_member_type_id(@member_type.id).to_a }
+    assert_equal [member3, @member2, @member], assert_queries_count(3) { @author.no_joins_ordered_members.unnamed.with_member_type_id(@member_type.id).to_a }
   end
 
   def test_polymorphic_disable_joins_through_ordered_scope_limits
-    assert_equal [@member2], assert_queries(1) { @author.ordered_members.unnamed.limit(1).to_a }
-    assert_equal [@member2], assert_queries(3) { @author.no_joins_ordered_members.unnamed.limit(1).to_a }
+    assert_equal [@member2], assert_queries_count(1) { @author.ordered_members.unnamed.limit(1).to_a }
+    assert_equal [@member2], assert_queries_count(3) { @author.no_joins_ordered_members.unnamed.limit(1).to_a }
   end
 
   def test_polymorphic_disable_joins_through_ordered_scope_first
-    assert_equal @member2, assert_queries(1) { @author.ordered_members.unnamed.first }
-    assert_equal @member2, assert_queries(3) { @author.no_joins_ordered_members.unnamed.first }
+    assert_equal @member2, assert_queries_count(1) { @author.ordered_members.unnamed.first }
+    assert_equal @member2, assert_queries_count(3) { @author.no_joins_ordered_members.unnamed.first }
   end
 
   def test_order_applied_in_double_join
-    assert_equal [@member2, @member], assert_queries(1) { @author.members.to_a }
-    assert_equal [@member2, @member], assert_queries(3) { @author.no_joins_members.to_a }
+    assert_equal [@member2, @member], assert_queries_count(1) { @author.members.to_a }
+    assert_equal [@member2, @member], assert_queries_count(3) { @author.no_joins_members.to_a }
   end
 
   def test_first_and_scope_applied_in_double_join
-    assert_equal @member2, assert_queries(1) { @author.members.unnamed.first }
-    assert_equal @member2, assert_queries(3) { @author.no_joins_members.unnamed.first }
+    assert_equal @member2, assert_queries_count(1) { @author.members.unnamed.first }
+    assert_equal @member2, assert_queries_count(3) { @author.no_joins_members.unnamed.first }
   end
 
   def test_first_and_scope_in_double_join_applies_order_in_memory
@@ -186,8 +186,8 @@ class HasManyThroughDisableJoinsAssociationsTest < ActiveRecord::TestCase
   end
 
   def test_limit_and_scope_applied_in_double_join
-    assert_equal [@member2], assert_queries(1) { @author.members.unnamed.limit(1).to_a }
-    assert_equal [@member2], assert_queries(3) { @author.no_joins_members.unnamed.limit(1) }
+    assert_equal [@member2], assert_queries_count(1) { @author.members.unnamed.limit(1).to_a }
+    assert_equal [@member2], assert_queries_count(3) { @author.no_joins_members.unnamed.limit(1) }
   end
 
   def test_limit_and_scope_in_double_join_applies_limit_in_memory

--- a/activerecord/test/cases/associations/has_one_associations_test.rb
+++ b/activerecord/test/cases/associations/has_one_associations_test.rb
@@ -33,7 +33,7 @@ class HasOneAssociationsTest < ActiveRecord::TestCase
   def test_has_one
     firm = companies(:first_firm)
     first_account = Account.find(1)
-    assert_sql(/LIMIT|ROWNUM <=|FETCH FIRST/) do
+    assert_queries_match(/LIMIT|ROWNUM <=|FETCH FIRST/) do
       assert_equal first_account, firm.account
       assert_equal first_account.credit_limit, firm.account.credit_limit
     end
@@ -46,7 +46,7 @@ class HasOneAssociationsTest < ActiveRecord::TestCase
 
   def test_has_one_cache_nils
     firm = companies(:another_firm)
-    assert_queries(1) { assert_nil firm.account }
+    assert_queries_count(1) { assert_nil firm.account }
     assert_no_queries { assert_nil firm.account }
 
     firms = Firm.includes(:account).to_a
@@ -268,7 +268,7 @@ class HasOneAssociationsTest < ActiveRecord::TestCase
 
   def test_build_association_dont_create_transaction
     firm = Firm.new
-    assert_queries(0) do
+    assert_queries_count(0) do
       firm.build_account
     end
   end
@@ -377,7 +377,7 @@ class HasOneAssociationsTest < ActiveRecord::TestCase
     Account.where(id: odegy.account.id).update_all(credit_limit: 80)
     assert_equal 53, odegy.account.credit_limit
 
-    assert_queries(1) { odegy.reload_account }
+    assert_queries_count(1) { odegy.reload_account }
     assert_no_queries { odegy.account }
     assert_equal 80, odegy.account.credit_limit
   end
@@ -397,10 +397,10 @@ class HasOneAssociationsTest < ActiveRecord::TestCase
     assert_equal 2, connection.query_cache.size
 
     # Clear the cache and fetch the account again, populating the cache with a query
-    assert_queries(1) { odegy.reload_account }
+    assert_queries_count(1) { odegy.reload_account }
 
     # This query is not cached anymore, so it should make a real SQL query
-    assert_queries(1) { Company.find(odegy_id) }
+    assert_queries_count(1) { Company.find(odegy_id) }
   ensure
     ActiveRecord::Base.connection.disable_query_cache!
   end
@@ -414,7 +414,7 @@ class HasOneAssociationsTest < ActiveRecord::TestCase
 
     assert_no_queries { odegy.reset_account }
 
-    assert_queries(1) { odegy.account }
+    assert_queries_count(1) { odegy.account }
     assert_equal 80, odegy.account.credit_limit
   end
 
@@ -669,7 +669,7 @@ class HasOneAssociationsTest < ActiveRecord::TestCase
     company.account = nil
     assert_no_queries { company.account = nil }
     account = Account.find(2)
-    assert_queries { company.account = account }
+    assert_queries_count(3) { company.account = account }
 
     assert_no_queries { Firm.new.account = account }
   end
@@ -681,7 +681,7 @@ class HasOneAssociationsTest < ActiveRecord::TestCase
 
     ship.name = "new name"
     assert_predicate ship, :changed?
-    assert_queries(1) do
+    assert_queries_count(3) do
       # One query for updating name, not triggering query for updating pirate_id
       pirate.ship = ship
     end
@@ -695,7 +695,7 @@ class HasOneAssociationsTest < ActiveRecord::TestCase
     ship.save!
 
     new_ship = Ship.create(name: "new name")
-    assert_queries(2) do
+    assert_queries_count(4) do
       # One query to nullify the old ship, one query to update the new ship
       pirate.ship = new_ship
     end
@@ -751,13 +751,13 @@ class HasOneAssociationsTest < ActiveRecord::TestCase
   end
 
   def test_has_one_with_touch_option_on_create
-    assert_queries(3) {
+    assert_queries_count(5) {
       Club.create(name: "1000 Oaks", membership_attributes: { favorite: true })
     }
   end
 
   def test_polymorphic_has_one_with_touch_option_on_create_wont_cache_association_so_fetching_after_transaction_commit_works
-    assert_queries(4) {
+    assert_queries_count(6) {
       chef = Chef.create(employable: DrinkDesignerWithPolymorphicTouchChef.new)
       employable = chef.employable
 
@@ -769,7 +769,7 @@ class HasOneAssociationsTest < ActiveRecord::TestCase
     DrinkDesignerWithPolymorphicTouchChef.create(chef: Chef.new)
     designer = DrinkDesignerWithPolymorphicTouchChef.last
 
-    assert_queries(3) {
+    assert_queries_count(5) {
       designer.update(name: "foo")
     }
   end
@@ -778,21 +778,21 @@ class HasOneAssociationsTest < ActiveRecord::TestCase
     new_club = Club.create(name: "1000 Oaks")
     new_club.create_membership
 
-    assert_queries(2) { new_club.update(name: "Effingut") }
+    assert_queries_count(4) { new_club.update(name: "Effingut") }
   end
 
   def test_has_one_with_touch_option_on_touch
     new_club = Club.create(name: "1000 Oaks")
     new_club.create_membership
 
-    assert_queries(1) { new_club.touch }
+    assert_queries_count(3) { new_club.touch }
   end
 
   def test_has_one_with_touch_option_on_destroy
     new_club = Club.create(name: "1000 Oaks")
     new_club.create_membership
 
-    assert_queries(2) { new_club.destroy }
+    assert_queries_count(4) { new_club.destroy }
   end
 
   def test_has_one_with_touch_option_on_empty_update
@@ -910,7 +910,7 @@ class HasOneAssociationsTest < ActiveRecord::TestCase
 
   def test_has_one_with_touch_option_on_nonpersisted_built_associations_doesnt_update_parent
     car = SpecialCar.create(name: "honda")
-    assert_queries(1) do
+    assert_queries_count(1) do
       car.build_special_bulb
       car.build_special_bulb
     end

--- a/activerecord/test/cases/associations/has_one_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_one_through_associations_test.rb
@@ -38,7 +38,7 @@ class HasOneThroughAssociationsTest < ActiveRecord::TestCase
 
   def test_has_one_through_executes_limited_query
     boring_club = clubs(:boring_club)
-    assert_sql(/LIMIT|ROWNUM <=|FETCH FIRST/) do
+    assert_queries_match(/LIMIT|ROWNUM <=|FETCH FIRST/) do
       assert_equal boring_club, @member.general_club
     end
   end
@@ -165,7 +165,7 @@ class HasOneThroughAssociationsTest < ActiveRecord::TestCase
   end
 
   def test_has_one_through_eager_loading
-    members = assert_queries(3) do # base table, through table, clubs table
+    members = assert_queries_count(3) do # base table, through table, clubs table
       Member.all.merge!(includes: :club, where: ["name = ?", "Groucho Marx"]).to_a
     end
     assert_equal 1, members.size
@@ -173,7 +173,7 @@ class HasOneThroughAssociationsTest < ActiveRecord::TestCase
   end
 
   def test_has_one_through_eager_loading_through_polymorphic
-    members = assert_queries(3) do # base table, through table, clubs table
+    members = assert_queries_count(3) do # base table, through table, clubs table
       Member.all.merge!(includes: :sponsor_club, where: ["name = ?", "Groucho Marx"]).to_a
     end
     assert_equal 1, members.size
@@ -203,7 +203,7 @@ class HasOneThroughAssociationsTest < ActiveRecord::TestCase
   end
 
   def test_has_one_through_nonpreload_eagerloading
-    members = assert_queries(1) do
+    members = assert_queries_count(1) do
       Member.all.merge!(includes: :club, where: ["members.name = ?", "Groucho Marx"], order: "clubs.name").to_a # force fallback
     end
     assert_equal 1, members.size
@@ -211,7 +211,7 @@ class HasOneThroughAssociationsTest < ActiveRecord::TestCase
   end
 
   def test_has_one_through_nonpreload_eager_loading_through_polymorphic
-    members = assert_queries(1) do
+    members = assert_queries_count(1) do
       Member.all.merge!(includes: :sponsor_club, where: ["members.name = ?", "Groucho Marx"], order: "clubs.name").to_a # force fallback
     end
     assert_equal 1, members.size
@@ -220,7 +220,7 @@ class HasOneThroughAssociationsTest < ActiveRecord::TestCase
 
   def test_has_one_through_nonpreload_eager_loading_through_polymorphic_with_more_than_one_through_record
     Sponsor.new(sponsor_club: clubs(:outrageous_club), sponsorable: members(:groucho)).save!
-    members = assert_queries(1) do
+    members = assert_queries_count(1) do
       Member.all.merge!(includes: :sponsor_club, where: ["members.name = ?", "Groucho Marx"], order: "clubs.name DESC").to_a # force fallback
     end
     assert_equal 1, members.size
@@ -290,7 +290,7 @@ class HasOneThroughAssociationsTest < ActiveRecord::TestCase
     @member_detail = MemberDetail.new
     @member.member_detail = @member_detail
     @member.organization = @organization
-    @member_details = assert_queries(3) do
+    @member_details = assert_queries_count(3) do
       MemberDetail.all.merge!(includes: :member_type).to_a
     end
     @new_detail = @member_details[0]
@@ -322,13 +322,13 @@ class HasOneThroughAssociationsTest < ActiveRecord::TestCase
 
     assert_not_nil @member_detail.member_type
     @member_detail.destroy
-    assert_queries(1) do
+    assert_queries_count(1) do
       @member_detail.association(:member_type).reload
       assert_not_nil @member_detail.member_type
     end
 
     @member_detail.member.destroy
-    assert_queries(1) do
+    assert_queries_count(1) do
       @member_detail.association(:member_type).reload
       assert_nil @member_detail.member_type
     end

--- a/activerecord/test/cases/associations/has_one_through_disable_joins_associations_test.rb
+++ b/activerecord/test/cases/associations/has_one_through_disable_joins_associations_test.rb
@@ -37,8 +37,8 @@ class HasOneThroughDisableJoinsAssociationsTest < ActiveRecord::TestCase
 
   def test_nil_on_disable_joins_through
     member = members(:blarpy_winkup)
-    assert_nil assert_queries(1) { member.organization }
-    assert_nil assert_queries(1) { member.organization_without_joins }
+    assert_nil assert_queries_count(1) { member.organization }
+    assert_nil assert_queries_count(1) { member.organization_without_joins }
   end
 
   def test_preload_on_disable_joins_through

--- a/activerecord/test/cases/associations/inner_join_association_test.rb
+++ b/activerecord/test/cases/associations/inner_join_association_test.rb
@@ -43,7 +43,7 @@ class InnerJoinAssociationTest < ActiveRecord::TestCase
     SQL
 
     expected = people(:susan)
-    assert_sql(/agents_people_2/i) do
+    assert_queries_match(/agents_people_2/i) do
       assert_equal [expected], Person.joins(:agents).joins(string_join)
     end
   end
@@ -54,7 +54,7 @@ class InnerJoinAssociationTest < ActiveRecord::TestCase
     constraint = agents[:primary_contact_id].eq(agents_2[:id]).and(agents[:id].gt(agents_2[:id]))
 
     expected = people(:susan)
-    assert_sql(/agents_people_2/i) do
+    assert_queries_match(/agents_people_2/i) do
       assert_equal [expected], Person.joins(:agents).joins(agents.create_join(agents, agents.create_on(constraint)))
     end
   end

--- a/activerecord/test/cases/associations/join_model_test.rb
+++ b/activerecord/test/cases/associations/join_model_test.rb
@@ -45,9 +45,9 @@ class AssociationsJoinModelTest < ActiveRecord::TestCase
   def test_has_many_distinct_through_count
     author = authors(:mary)
     assert_not_predicate authors(:mary).unique_categorized_posts, :loaded?
-    assert_queries(1) { assert_equal 1, author.unique_categorized_posts.count }
-    assert_queries(1) { assert_equal 1, author.unique_categorized_posts.count(:title) }
-    assert_queries(1) { assert_equal 0, author.unique_categorized_posts.where(title: nil).count(:title) }
+    assert_queries_count(1) { assert_equal 1, author.unique_categorized_posts.count }
+    assert_queries_count(1) { assert_equal 1, author.unique_categorized_posts.count(:title) }
+    assert_queries_count(1) { assert_equal 0, author.unique_categorized_posts.where(title: nil).count(:title) }
     assert_not_predicate authors(:mary).unique_categorized_posts, :loaded?
   end
 
@@ -732,7 +732,7 @@ class AssociationsJoinModelTest < ActiveRecord::TestCase
 
     david.reload
     assert_not_predicate david.categories, :loaded?
-    assert_queries(1) do
+    assert_queries_count(1) do
       assert_includes david.categories, category
     end
     assert_not_predicate david.categories, :loaded?

--- a/activerecord/test/cases/associations/nested_through_associations_test.rb
+++ b/activerecord/test/cases/associations/nested_through_associations_test.rb
@@ -62,7 +62,7 @@ class NestedThroughAssociationsTest < ActiveRecord::TestCase
   end
 
   def test_has_many_through_has_many_with_has_many_through_source_reflection_preload
-    author = assert_queries(5) { Author.includes(:tags).first }
+    author = assert_queries_count(5) { Author.includes(:tags).first }
     general = tags(:general)
 
     assert_no_queries do
@@ -77,7 +77,7 @@ class NestedThroughAssociationsTest < ActiveRecord::TestCase
     assert_not taggings_reflection.scope
 
     with_automatic_scope_inversing(tag_reflection, taggings_reflection) do
-      assert_queries(4) { Author.includes(:tags).first }
+      assert_queries_count(4) { Author.includes(:tags).first }
     end
   end
 
@@ -102,7 +102,7 @@ class NestedThroughAssociationsTest < ActiveRecord::TestCase
 
   def test_has_many_through_has_many_through_with_has_many_source_reflection_preload
     luke, david = subscribers(:first), subscribers(:second)
-    author = assert_queries(4) { Author.includes(:subscribers).first }
+    author = assert_queries_count(4) { Author.includes(:subscribers).first }
     assert_no_queries do
       assert_equal [luke, david, david], author.subscribers.sort_by(&:nick)
     end
@@ -124,7 +124,7 @@ class NestedThroughAssociationsTest < ActiveRecord::TestCase
   end
 
   def test_has_many_through_has_one_with_has_one_through_source_reflection_preload
-    member = assert_queries(4) { Member.includes(:nested_member_types).first }
+    member = assert_queries_count(4) { Member.includes(:nested_member_types).first }
     founding = member_types(:founding)
     assert_no_queries do
       assert_equal [founding], member.nested_member_types
@@ -146,7 +146,7 @@ class NestedThroughAssociationsTest < ActiveRecord::TestCase
   end
 
   def test_has_many_through_has_one_through_with_has_one_source_reflection_preload
-    member = assert_queries(4) { Member.includes(:nested_sponsors).first }
+    member = assert_queries_count(4) { Member.includes(:nested_sponsors).first }
     mustache = sponsors(:moustache_club_sponsor_for_groucho)
     assert_no_queries do
       assert_equal [mustache], member.nested_sponsors
@@ -172,7 +172,7 @@ class NestedThroughAssociationsTest < ActiveRecord::TestCase
 
   def test_has_many_through_has_one_with_has_many_through_source_reflection_preload
     ActiveRecord::Base.connection.table_alias_length  # preheat cache
-    member = assert_queries(4) { Member.includes(:organization_member_details).first }
+    member = assert_queries_count(4) { Member.includes(:organization_member_details).first }
     groucho_details, other_details = member_details(:groucho), member_details(:some_other_guy)
 
     assert_no_queries do
@@ -201,7 +201,7 @@ class NestedThroughAssociationsTest < ActiveRecord::TestCase
   end
 
   def test_has_many_through_has_one_through_with_has_many_source_reflection_preload
-    member = assert_queries(4) { Member.includes(:organization_member_details_2).first }
+    member = assert_queries_count(4) { Member.includes(:organization_member_details_2).first }
     groucho_details, other_details = member_details(:groucho), member_details(:some_other_guy)
 
     # postgresql test if randomly executed then executes "SHOW max_identifier_length". Hence
@@ -231,7 +231,7 @@ class NestedThroughAssociationsTest < ActiveRecord::TestCase
   end
 
   def test_has_many_through_has_many_with_has_and_belongs_to_many_source_reflection_preload
-    author = assert_queries(4) { Author.includes(:post_categories).third }
+    author = assert_queries_count(4) { Author.includes(:post_categories).third }
     general, cooking = categories(:general), categories(:cooking)
 
     assert_no_queries do
@@ -260,7 +260,7 @@ class NestedThroughAssociationsTest < ActiveRecord::TestCase
 
   def test_has_many_through_has_and_belongs_to_many_with_has_many_source_reflection_preload
     Category.includes(:post_comments).to_a # preheat cache
-    category = assert_queries(4) { Category.includes(:post_comments).second }
+    category = assert_queries_count(4) { Category.includes(:post_comments).second }
     greetings, more = comments(:greetings), comments(:more_greetings)
 
     assert_no_queries do
@@ -288,7 +288,7 @@ class NestedThroughAssociationsTest < ActiveRecord::TestCase
   end
 
   def test_has_many_through_has_many_with_has_many_through_habtm_source_reflection_preload
-    author = assert_queries(6) { Author.includes(:category_post_comments).third }
+    author = assert_queries_count(6) { Author.includes(:category_post_comments).third }
     greetings, more = comments(:greetings), comments(:more_greetings)
 
     assert_no_queries do
@@ -314,7 +314,7 @@ class NestedThroughAssociationsTest < ActiveRecord::TestCase
   end
 
   def test_has_many_through_has_many_through_with_belongs_to_source_reflection_preload
-    author = assert_queries(5) { Author.includes(:tagging_tags).first }
+    author = assert_queries_count(5) { Author.includes(:tagging_tags).first }
     general = tags(:general)
 
     assert_no_queries do
@@ -329,7 +329,7 @@ class NestedThroughAssociationsTest < ActiveRecord::TestCase
     assert_not taggings_reflection.scope
 
     with_automatic_scope_inversing(tag_reflection, taggings_reflection) do
-      assert_queries(4) { Author.includes(:tagging_tags).first }
+      assert_queries_count(4) { Author.includes(:tagging_tags).first }
     end
   end
 
@@ -351,7 +351,7 @@ class NestedThroughAssociationsTest < ActiveRecord::TestCase
   end
 
   def test_has_many_through_belongs_to_with_has_many_through_source_reflection_preload
-    categorization = assert_queries(4) { Categorization.includes(:post_taggings).first }
+    categorization = assert_queries_count(4) { Categorization.includes(:post_taggings).first }
     welcome_general, thinking_general = taggings(:welcome_general), taggings(:thinking_general)
 
     assert_no_queries do
@@ -374,7 +374,7 @@ class NestedThroughAssociationsTest < ActiveRecord::TestCase
   end
 
   def test_has_one_through_has_one_with_has_one_through_source_reflection_preload
-    member = assert_queries(4) { Member.includes(:nested_member_type).first }
+    member = assert_queries_count(4) { Member.includes(:nested_member_type).first }
     founding = member_types(:founding)
 
     assert_no_queries do
@@ -408,7 +408,7 @@ class NestedThroughAssociationsTest < ActiveRecord::TestCase
   end
 
   def test_has_one_through_has_one_through_with_belongs_to_source_reflection_preload
-    member = assert_queries(4) { Member.includes(:club_category).first }
+    member = assert_queries_count(4) { Member.includes(:club_category).first }
     general = categories(:general)
 
     assert_no_queries do
@@ -539,7 +539,7 @@ class NestedThroughAssociationsTest < ActiveRecord::TestCase
   def test_nested_has_many_through_with_conditions_on_through_associations_preload
     assert_empty Author.where("tags.id" => 100).joins(:misc_post_first_blue_tags)
 
-    author = assert_queries(2) { Author.includes(:misc_post_first_blue_tags).third }
+    author = assert_queries_count(2) { Author.includes(:misc_post_first_blue_tags).third }
     blue = tags(:blue)
 
     assert_no_queries do
@@ -560,7 +560,7 @@ class NestedThroughAssociationsTest < ActiveRecord::TestCase
   end
 
   def test_nested_has_many_through_with_conditions_on_source_associations_preload
-    author = assert_queries(2) { Author.includes(:misc_post_first_blue_tags_2).third }
+    author = assert_queries_count(2) { Author.includes(:misc_post_first_blue_tags_2).third }
     blue = tags(:blue)
 
     assert_no_queries do
@@ -649,10 +649,10 @@ class NestedThroughAssociationsTest < ActiveRecord::TestCase
     def assert_includes_and_joins_equal(query, expected, association)
       query = query.order(:id)
 
-      actual = assert_queries(1) { query.joins(association).to_a.uniq }
+      actual = assert_queries_count(1) { query.joins(association).to_a.uniq }
       assert_equal expected, actual
 
-      actual = assert_queries(1) { query.includes(association).to_a.uniq }
+      actual = assert_queries_count(1) { query.includes(association).to_a.uniq }
       assert_equal expected, actual
     end
 end

--- a/activerecord/test/cases/associations_test.rb
+++ b/activerecord/test/cases/associations_test.rb
@@ -594,7 +594,7 @@ class AssociationProxyTest < ActiveRecord::TestCase
 
     human = Human.find(human.id)
 
-    assert_queries(1) do
+    assert_queries_count(1) do
       assert_equal human, human.interests.where("1=1").first.human
     end
   end
@@ -788,7 +788,7 @@ class PreloaderTest < ActiveRecord::TestCase
   def test_preload_makes_correct_number_of_queries_on_array
     post = posts(:welcome)
 
-    assert_queries(1) do
+    assert_queries_count(1) do
       preloader = ActiveRecord::Associations::Preloader.new(records: [post], associations: :comments)
       preloader.call
     end
@@ -798,7 +798,7 @@ class PreloaderTest < ActiveRecord::TestCase
     post = posts(:welcome)
     relation = Post.where(id: post.id)
 
-    assert_queries(2) do
+    assert_queries_count(2) do
       preloader = ActiveRecord::Associations::Preloader.new(records: relation, associations: :comments)
       preloader.call
     end
@@ -831,7 +831,7 @@ class PreloaderTest < ActiveRecord::TestCase
     book = books(:awdr)
     post = posts(:welcome)
 
-    assert_queries(1) do
+    assert_queries_count(1) do
       preloader = ActiveRecord::Associations::Preloader.new(records: [book, post], associations: :author)
       preloader.call
     end
@@ -860,7 +860,7 @@ class PreloaderTest < ActiveRecord::TestCase
       comments(:eager_sti_on_associations_s_comment2),
     ]
 
-    assert_queries(2) do
+    assert_queries_count(2) do
       ActiveRecord::Associations::Preloader.new(records: comments, associations: [:author, :ordinary_post]).call
     end
   end
@@ -868,7 +868,7 @@ class PreloaderTest < ActiveRecord::TestCase
   def test_preload_grouped_queries_of_through_records
     author = authors(:david)
 
-    assert_queries(3) do
+    assert_queries_count(3) do
       ActiveRecord::Associations::Preloader.new(records: [author], associations: [:hello_post_comments, :comments]).call
     end
   end
@@ -879,7 +879,7 @@ class PreloaderTest < ActiveRecord::TestCase
 
     member.reload.organization # load through record
 
-    assert_queries(1) do
+    assert_queries_count(1) do
       ActiveRecord::Associations::Preloader.new(records: [member], associations: :organization_member_details_2).call
     end
 
@@ -903,7 +903,7 @@ class PreloaderTest < ActiveRecord::TestCase
       body: "this post is also about David"
     )
 
-    assert_queries(2) do
+    assert_queries_count(2) do
       preloader = ActiveRecord::Associations::Preloader.new(records: [david, david2, bob], associations: :posts_mentioning_author)
       preloader.call
     end
@@ -924,7 +924,7 @@ class PreloaderTest < ActiveRecord::TestCase
     comment1 = david.posts.first.comments.create!(body: "Hi David!")
     comment2 = david.posts.first.comments.create!(body: "This comment mentions david")
 
-    assert_queries(2) do
+    assert_queries_count(2) do
       preloader = ActiveRecord::Associations::Preloader.new(records: [david, david2, bob], associations: :comments_mentioning_author)
       preloader.call
     end
@@ -961,7 +961,7 @@ class PreloaderTest < ActiveRecord::TestCase
     comment2 = post.comments.create!(body: "hello!")
     comment3 = post3.comments.create!(body: "HI BOB!")
 
-    assert_queries(3) do
+    assert_queries_count(3) do
       preloader = ActiveRecord::Associations::Preloader.new(records: [david, david2, bob], associations: :comments_on_posts_mentioning_author)
       preloader.call
     end
@@ -996,7 +996,7 @@ class PreloaderTest < ActiveRecord::TestCase
     # SELECT "line_item_discount_applications".* FROM "line_item_discount_applications" WHERE "line_item_discount_applications"."line_item_id" = ?
     # SELECT "shipping_line_discount_applications".* FROM "shipping_line_discount_applications" WHERE "shipping_line_discount_applications"."shipping_line_id" = ?
     # SELECT "discounts".* FROM "discounts" WHERE "discounts"."id" IN (?, ?).
-    assert_queries(5) do
+    assert_queries_count(5) do
       preloader = ActiveRecord::Associations::Preloader.new(records: [invoice], associations: [
         line_items: { discount_applications: :discount },
         shipping_lines: { discount_applications: :discount },
@@ -1015,7 +1015,7 @@ class PreloaderTest < ActiveRecord::TestCase
     # SELECT "shipping_lines".* FROM shipping_lines WHERE "shipping_lines"."invoice_id" = ?
     # SELECT "shipping_line_discount_applications".* FROM "shipping_line_discount_applications" WHERE "shipping_line_discount_applications"."shipping_line_id" = ?
     # SELECT "discounts".* FROM "discounts" WHERE "discounts"."id" = ?.
-    assert_queries(3) do
+    assert_queries_count(3) do
       preloader = ActiveRecord::Associations::Preloader.new(records: [invoice], associations: [
         line_items: { discount_applications: :discount },
         shipping_lines: { discount_applications: :discount },
@@ -1035,7 +1035,7 @@ class PreloaderTest < ActiveRecord::TestCase
       comments(:eager_sti_on_associations_s_comment2),
     ]
 
-    assert_queries(2) do
+    assert_queries_count(2) do
       preloader = ActiveRecord::Associations::Preloader.new(records: comments, associations: [:author, :post])
       preloader.call
     end
@@ -1053,7 +1053,7 @@ class PreloaderTest < ActiveRecord::TestCase
     #   SELECT FROM posts ... (thinking)
     #   SELECT FROM posts ... (welcome)
     #   SELECT FROM comments ... (comments for both welcome and thinking)
-    assert_queries(4) do
+    assert_queries_count(4) do
       author = Author
         .where(name: "David")
         .includes(thinking_posts: :comments, welcome_posts: :comments)
@@ -1074,7 +1074,7 @@ class PreloaderTest < ActiveRecord::TestCase
     #   SELECT FROM posts ... (thinking)
     #   SELECT FROM posts ... (welcome)
     #   SELECT FROM comments ... (comments for both welcome and thinking)
-    assert_queries(4) do
+    assert_queries_count(4) do
       author = Author
         .where(name: "David")
         .includes(thinking_posts: :comments, welcome_posts: :comments_with_extending)
@@ -1094,7 +1094,7 @@ class PreloaderTest < ActiveRecord::TestCase
     AuthorFavorite.create!(author: mary, favorite_author: bob)
     favorites = AuthorFavorite.all.load
 
-    assert_queries(1) do
+    assert_queries_count(1) do
       preloader = ActiveRecord::Associations::Preloader.new(records: favorites, associations: [:author, :favorite_author])
       preloader.call
     end
@@ -1111,7 +1111,7 @@ class PreloaderTest < ActiveRecord::TestCase
 
     AuthorFavorite.create!(author: mary, favorite_author: bob)
 
-    assert_queries(3) do
+    assert_queries_count(3) do
       preloader = ActiveRecord::Associations::Preloader.new(records: [mary], associations: [:posts, favorite_authors: :posts])
       preloader.call
     end
@@ -1130,7 +1130,7 @@ class PreloaderTest < ActiveRecord::TestCase
 
     associations = { similar_posts: :comments, favorite_authors: { similar_posts: :comments } }
 
-    assert_queries(9) do
+    assert_queries_count(9) do
       preloader = ActiveRecord::Associations::Preloader.new(records: [mary], associations: associations)
       preloader.call
     end
@@ -1150,7 +1150,7 @@ class PreloaderTest < ActiveRecord::TestCase
     with_automatic_scope_inversing(tag_reflection, taggings_reflection) do
       mary.reload
 
-      assert_queries(8) do
+      assert_queries_count(8) do
         preloader = ActiveRecord::Associations::Preloader.new(records: [mary], associations: associations)
         preloader.call
       end
@@ -1165,7 +1165,7 @@ class PreloaderTest < ActiveRecord::TestCase
     # When the scopes differ in the generated SQL:
     # SELECT "authors".* FROM "authors" WHERE (name LIKE '%a%') AND "authors"."id" = ?
     # SELECT "authors".* FROM "authors" WHERE "authors"."id" = ?.
-    assert_queries(2) do
+    assert_queries_count(2) do
       preloader = ActiveRecord::Associations::Preloader.new(records: [post, postesque], associations: :author_with_the_letter_a)
       preloader.call
     end
@@ -1179,7 +1179,7 @@ class PreloaderTest < ActiveRecord::TestCase
     postesque.reload
 
     # When the generated SQL is identical, but one scope has preload values.
-    assert_queries(3) do
+    assert_queries_count(3) do
       preloader = ActiveRecord::Associations::Preloader.new(records: [post, postesque], associations: :author_with_address)
       preloader.call
     end
@@ -1195,7 +1195,7 @@ class PreloaderTest < ActiveRecord::TestCase
     postesque = Postesque.create(author: Author.last)
     postesque.reload
 
-    assert_queries(2) do
+    assert_queries_count(2) do
       preloader = ActiveRecord::Associations::Preloader.new(records: [post, postesque], associations: :author)
       preloader.call
     end
@@ -1241,7 +1241,7 @@ class PreloaderTest < ActiveRecord::TestCase
     bob = authors(:bob)
     mary = authors(:mary)
 
-    assert_queries(1) do
+    assert_queries_count(1) do
       ActiveRecord::Associations::Preloader.new(records: [bob_post, mary_post], associations: :author, available_records: [bob]).call
     end
 
@@ -1260,7 +1260,7 @@ class PreloaderTest < ActiveRecord::TestCase
     assert_predicate bob_post.association(:author), :loaded?
     assert_not mary_post.association(:author).loaded?
 
-    assert_queries(1) do
+    assert_queries_count(1) do
       ActiveRecord::Associations::Preloader.new(records: [bob_post, mary_post], associations: :author).call
     end
 
@@ -1274,7 +1274,7 @@ class PreloaderTest < ActiveRecord::TestCase
     author = authors(:david)
     categories = Category.all.to_a
 
-    assert_queries(1) do
+    assert_queries_count(1) do
       # One query to get the middle records (i.e. essays)
       ActiveRecord::Associations::Preloader.new(records: [author], associations: :essay_category, available_records: categories).call
     end
@@ -1292,7 +1292,7 @@ class PreloaderTest < ActiveRecord::TestCase
     dave = authors(:david)
     dave_category = categories(:general)
 
-    assert_queries(2) do
+    assert_queries_count(2) do
       ActiveRecord::Associations::Preloader.new(records: [mary, dave], associations: :essay_category, available_records: [mary_category]).call
     end
 
@@ -1321,7 +1321,7 @@ class PreloaderTest < ActiveRecord::TestCase
     post = posts(:welcome)
     david = authors(:david)
 
-    assert_queries(1) do
+    assert_queries_count(1) do
       ActiveRecord::Associations::Preloader.new(records: [post], associations: :author, scope: Author.where(name: "David"), available_records: [david]).call
     end
 
@@ -1333,7 +1333,7 @@ class PreloaderTest < ActiveRecord::TestCase
     post = posts(:welcome)
     comments = Comment.all.to_a
 
-    assert_queries(1) do
+    assert_queries_count(1) do
       ActiveRecord::Associations::Preloader.new(records: [post], associations: :comments, available_records: comments).call
     end
 
@@ -1346,7 +1346,7 @@ class PreloaderTest < ActiveRecord::TestCase
     bob = authors(:bob)
     david = authors(:david)
 
-    assert_queries(1) do
+    assert_queries_count(1) do
       ActiveRecord::Associations::Preloader.new(records: [post], associations: :author, available_records: [bob]).call
     end
 
@@ -1496,7 +1496,7 @@ class PreloaderTest < ActiveRecord::TestCase
     post = posts(:welcome)
     comment = post.comments.build
 
-    assert_queries(1) do
+    assert_queries_count(1) do
       ActiveRecord::Associations::Preloader.new(records: [post], associations: :comments).call
 
       assert_includes post.comments.to_a, comment
@@ -1570,7 +1570,7 @@ class WithAnnotationsTest < ActiveRecord::TestCase
     assert_not_predicate log, :empty?
     assert_predicate log.select { |query| query.match?(%r{/\*}) }, :empty?
 
-    assert_sql(%r{/\* that tells jokes \*/}) do
+    assert_queries_match(%r{/\* that tells jokes \*/}) do
       pirate.parrot_with_annotation
     end
   end
@@ -1585,7 +1585,7 @@ class WithAnnotationsTest < ActiveRecord::TestCase
     assert_not_predicate log, :empty?
     assert_predicate log.select { |query| query.match?(%r{/\*}) }, :empty?
 
-    assert_sql(%r{/\* that are very colorful \*/}) do
+    assert_queries_match(%r{/\* that are very colorful \*/}) do
       pirate.parrots_with_annotation.first
     end
   end
@@ -1600,7 +1600,7 @@ class WithAnnotationsTest < ActiveRecord::TestCase
     assert_not_predicate log, :empty?
     assert_predicate log.select { |query| query.match?(%r{/\*}) }, :empty?
 
-    assert_sql(%r{/\* that is a rocket \*/}) do
+    assert_queries_match(%r{/\* that is a rocket \*/}) do
       pirate.ship_with_annotation
     end
   end
@@ -1615,7 +1615,7 @@ class WithAnnotationsTest < ActiveRecord::TestCase
     assert_not_predicate log, :empty?
     assert_predicate log.select { |query| query.match?(%r{/\*}) }, :empty?
 
-    assert_sql(%r{/\* that are also parrots \*/}) do
+    assert_queries_match(%r{/\* that are also parrots \*/}) do
       pirate.birds_with_annotation.first
     end
   end
@@ -1630,7 +1630,7 @@ class WithAnnotationsTest < ActiveRecord::TestCase
     assert_not_predicate log, :empty?
     assert_predicate log.select { |query| query.match?(%r{/\*}) }, :empty?
 
-    assert_sql(%r{/\* yarrr \*/}) do
+    assert_queries_match(%r{/\* yarrr \*/}) do
       pirate.treasure_estimates_with_annotation.first
     end
   end
@@ -1645,7 +1645,7 @@ class WithAnnotationsTest < ActiveRecord::TestCase
     assert_not_predicate log, :empty?
     assert_predicate log.select { |query| query.match?(%r{/\*}) }, :empty?
 
-    assert_sql(%r{/\* yarrr \*/}) do
+    assert_queries_match(%r{/\* yarrr \*/}) do
       SpacePirate.includes(:treasure_estimates_with_annotation, :treasures).first
     end
   end

--- a/activerecord/test/cases/autosave_association_test.rb
+++ b/activerecord/test/cases/autosave_association_test.rb
@@ -269,19 +269,19 @@ class TestDefaultAutosaveAssociationOnAHasOneAssociation < ActiveRecord::TestCas
   def test_not_resaved_when_unchanged
     firm = Firm.all.merge!(includes: :account).first
     firm.name += "-changed"
-    assert_queries(1) { firm.save! }
+    assert_queries_count(3) { firm.save! }
 
     firm = Firm.first
     firm.account = Account.first
-    assert_queries(Firm.partial_updates? ? 0 : 1) { firm.save! }
+    assert_queries_count(Firm.partial_updates? ? 0 : 1) { firm.save! }
 
     firm = Firm.first.dup
     firm.account = Account.first
-    assert_queries(2) { firm.save! }
+    assert_queries_count(4) { firm.save! }
 
     firm = Firm.first.dup
     firm.account = Account.first.dup
-    assert_queries(2) { firm.save! }
+    assert_queries_count(4) { firm.save! }
   end
 
   def test_callbacks_firing_order_on_create
@@ -916,11 +916,11 @@ class TestDefaultAutosaveAssociationOnAHasManyAssociation < ActiveRecord::TestCa
   def test_build_before_save
     company = companies(:first_firm)
 
-    new_client = assert_queries(0) { company.clients_of_firm.build("name" => "Another Client") }
+    new_client = assert_queries_count(0) { company.clients_of_firm.build("name" => "Another Client") }
     assert_not_predicate company.clients_of_firm, :loaded?
 
     company.name += "-changed"
-    assert_queries(2) { assert company.save }
+    assert_queries_count(4) { assert company.save }
     assert_predicate new_client, :persisted?
     assert_equal 3, company.clients_of_firm.reload.size
   end
@@ -928,21 +928,21 @@ class TestDefaultAutosaveAssociationOnAHasManyAssociation < ActiveRecord::TestCa
   def test_build_many_before_save
     company = companies(:first_firm)
 
-    assert_queries(0) { company.clients_of_firm.build([{ "name" => "Another Client" }, { "name" => "Another Client II" }]) }
+    assert_queries_count(0) { company.clients_of_firm.build([{ "name" => "Another Client" }, { "name" => "Another Client II" }]) }
 
     company.name += "-changed"
-    assert_queries(3) { assert company.save }
+    assert_queries_count(5) { assert company.save }
     assert_equal 4, company.clients_of_firm.reload.size
   end
 
   def test_build_via_block_before_save
     company = companies(:first_firm)
 
-    new_client = assert_queries(0) { company.clients_of_firm.build { |client| client.name = "Another Client" } }
+    new_client = assert_queries_count(0) { company.clients_of_firm.build { |client| client.name = "Another Client" } }
     assert_not_predicate company.clients_of_firm, :loaded?
 
     company.name += "-changed"
-    assert_queries(2) { assert company.save }
+    assert_queries_count(4) { assert company.save }
     assert_predicate new_client, :persisted?
     assert_equal 3, company.clients_of_firm.reload.size
   end
@@ -950,14 +950,14 @@ class TestDefaultAutosaveAssociationOnAHasManyAssociation < ActiveRecord::TestCa
   def test_build_many_via_block_before_save
     company = companies(:first_firm)
 
-    assert_queries(0) do
+    assert_queries_count(0) do
       company.clients_of_firm.build([{ "name" => "Another Client" }, { "name" => "Another Client II" }]) do |client|
         client.name = "changed"
       end
     end
 
     company.name += "-changed"
-    assert_queries(3) { assert company.save }
+    assert_queries_count(5) { assert company.save }
     assert_equal 4, company.clients_of_firm.reload.size
   end
 
@@ -1494,7 +1494,7 @@ class TestAutosaveAssociationOnAHasOneAssociation < ActiveRecord::TestCase
 
     @parrot = @pirate.parrots.create(name: "some_name")
     @parrot.name = "changed_name"
-    assert_queries(1) { @ship.save! }
+    assert_queries_count(3) { @ship.save! }
     assert_no_queries { @ship.save! }
   end
 
@@ -1598,7 +1598,7 @@ class TestAutosaveAssociationOnAHasOneAssociation < ActiveRecord::TestCase
   end
 
   def test_should_not_load_the_associated_model
-    assert_queries(1) { @pirate.catchphrase = "Arr"; @pirate.save! }
+    assert_queries_count(3) { @pirate.catchphrase = "Arr"; @pirate.save! }
   end
 
   def test_mark_for_destruction_is_ignored_without_autosave_true
@@ -1770,7 +1770,7 @@ class TestAutosaveAssociationOnABelongsToAssociation < ActiveRecord::TestCase
   end
 
   def test_should_not_load_the_associated_model
-    assert_queries(1) { @ship.name = "The Vile Serpent"; @ship.save! }
+    assert_queries_count(3) { @ship.name = "The Vile Serpent"; @ship.save! }
   end
 
   def test_should_save_with_non_nullable_foreign_keys
@@ -1938,11 +1938,11 @@ module AutosaveAssociationOnACollectionAssociationTests
   end
 
   def test_should_not_load_the_associated_models_if_they_were_not_loaded_yet
-    assert_queries(1) { @pirate.catchphrase = "Arr"; @pirate.save! }
+    assert_queries_count(3) { @pirate.catchphrase = "Arr"; @pirate.save! }
 
     @pirate.public_send(@association_name).load_target
 
-    assert_queries(3) do
+    assert_queries_count(5) do
       @pirate.catchphrase = "Yarr"
       new_names = ["Grace OMalley", "Privateers Greed"]
       @pirate.public_send(@association_name).each_with_index { |child, i| child.name = new_names[i] }

--- a/activerecord/test/cases/base_prevent_writes_test.rb
+++ b/activerecord/test/cases/base_prevent_writes_test.rb
@@ -51,13 +51,13 @@ class BasePreventWritesTest < ActiveRecord::TestCase
       Bird.create!(name: "Bluejay")
 
       ActiveRecord::Base.while_preventing_writes do
-        assert_queries(2) { Bird.where(name: "Bluejay").explain }
+        assert_queries_count(2) { Bird.where(name: "Bluejay").explain }
       end
     end
 
     test "an empty transaction does not raise if preventing writes" do
       ActiveRecord::Base.while_preventing_writes do
-        assert_queries(2, ignore_none: true) do
+        assert_queries_count(2, include_schema: true) do
           Bird.transaction do
             ActiveRecord::Base.connection.materialize_transactions
           end

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -1450,10 +1450,10 @@ class BasicsTest < ActiveRecord::TestCase
     end
   end
 
-  def test_assert_queries
+  def test_assert_queries_count
     query = lambda { ActiveRecord::Base.connection.execute "select count(*) from developers" }
-    assert_queries(2) { 2.times { query.call } }
-    assert_queries 1, &query
+    assert_queries_count(2) { 2.times { query.call } }
+    assert_queries_count 1, &query
     assert_no_queries { assert true }
   end
 

--- a/activerecord/test/cases/bind_parameter_test.rb
+++ b/activerecord/test/cases/bind_parameter_test.rb
@@ -214,7 +214,7 @@ if ActiveRecord::Base.connection.prepared_statements
 
           authors = Author.where(id: [1, 2, 3, nil])
           assert_equal sql, @connection.to_sql(authors.arel)
-          assert_sql(sql) { assert_equal 3, authors.length }
+          assert_queries_match(sql) { assert_equal 3, authors.length }
 
           # prepared_statements: true
           #
@@ -228,7 +228,7 @@ if ActiveRecord::Base.connection.prepared_statements
 
           authors = Author.where(id: [1, 2, 3, 9223372036854775808])
           assert_equal sql, @connection.to_sql(authors.arel)
-          assert_sql(sql) { assert_equal 3, authors.length }
+          assert_queries_match(sql) { assert_equal 3, authors.length }
 
           # prepared_statements: true
           #
@@ -242,7 +242,7 @@ if ActiveRecord::Base.connection.prepared_statements
 
           arel_node = Arel.sql("SELECT #{table}.* FROM #{table} WHERE #{pk} IN (?)", [1, 2, 3])
           assert_equal sql, @connection.to_sql(arel_node)
-          assert_sql(sql) { assert_equal 3, @connection.select_all(arel_node).length }
+          assert_queries_match(sql) { assert_equal 3, @connection.select_all(arel_node).length }
         end
 
         def bind_params(ids)

--- a/activerecord/test/cases/collection_cache_key_test.rb
+++ b/activerecord/test/cases/collection_cache_key_test.rb
@@ -152,7 +152,7 @@ module ActiveRecord
     test "it triggers at most one query" do
       developers = Developer.where(name: "David")
 
-      assert_queries(1) { developers.cache_key }
+      assert_queries_count(1) { developers.cache_key }
       assert_no_queries { developers.cache_key }
     end
 

--- a/activerecord/test/cases/connection_adapters/schema_cache_test.rb
+++ b/activerecord/test/cases/connection_adapters/schema_cache_test.rb
@@ -132,7 +132,7 @@ module ActiveRecord
       def test_yaml_loads_5_1_dump_without_indexes_still_queries_for_indexes
         cache = load_bound_reflection(schema_dump_path)
 
-        assert_queries :any, ignore_none: true do
+        assert_queries_count(include_schema: true) do
           assert_equal 1, cache.indexes("courses").size
         end
       end

--- a/activerecord/test/cases/counter_cache_test.rb
+++ b/activerecord/test/cases/counter_cache_test.rb
@@ -132,7 +132,7 @@ class CounterCacheTest < ActiveRecord::TestCase
 
     # SELECT "topics".* FROM "topics" WHERE "topics"."id" = ? LIMIT ?
     # SELECT COUNT(*) FROM "topics" WHERE "topics"."type" IN (?, ?, ?, ?, ?) AND "topics"."parent_id" = ?
-    assert_queries(2) do
+    assert_queries_count(2) do
       Topic.reset_counters(@topic.id, :replies_count)
     end
   end
@@ -143,7 +143,7 @@ class CounterCacheTest < ActiveRecord::TestCase
     # SELECT "topics".* FROM "topics" WHERE "topics"."id" = ? LIMIT ?
     # SELECT COUNT(*) FROM "topics" WHERE "topics"."type" IN (?, ?, ?, ?, ?) AND "topics"."parent_id" = ?
     # UPDATE "topics" SET "updated_at" = ? WHERE "topics"."id" = ?
-    assert_queries(3) do
+    assert_queries_count(3) do
       Topic.reset_counters(@topic.id, :replies_count, touch: true)
     end
   end

--- a/activerecord/test/cases/custom_locking_test.rb
+++ b/activerecord/test/cases/custom_locking_test.rb
@@ -10,7 +10,7 @@ module ActiveRecord
     def test_custom_lock
       if current_adapter?(:Mysql2Adapter, :TrilogyAdapter)
         assert_match "SHARE MODE", Person.lock("LOCK IN SHARE MODE").to_sql
-        assert_sql(/LOCK IN SHARE MODE/) do
+        assert_queries_match(/LOCK IN SHARE MODE/) do
           Person.all.merge!(lock: "LOCK IN SHARE MODE").find(1)
         end
       end

--- a/activerecord/test/cases/excluding_test.rb
+++ b/activerecord/test/cases/excluding_test.rb
@@ -25,7 +25,7 @@ class ExcludingTest < ActiveRecord::TestCase
   def test_result_set_does_not_include_collection_of_excluded_records_from_a_query
     query = Post.where(id: @post)
 
-    assert_sql(/SELECT #{Regexp.escape Post.connection.quote_table_name("posts.id")} FROM/) do
+    assert_queries_match(/SELECT #{Regexp.escape Post.connection.quote_table_name("posts.id")} FROM/) do
       records = Post.excluding(query).to_a
 
       assert_not_includes records, @post
@@ -35,7 +35,7 @@ class ExcludingTest < ActiveRecord::TestCase
   def test_result_set_does_not_include_collection_of_excluded_records_from_a_loaded_query
     query = Post.where(id: @post).load
 
-    records = assert_queries 1 do
+    records = assert_queries_count 1 do
       Post.excluding(query).to_a
     end
 
@@ -45,7 +45,7 @@ class ExcludingTest < ActiveRecord::TestCase
   def test_result_set_does_not_include_collection_of_excluded_records_and_queries
     thinking = posts(:thinking)
 
-    records = assert_queries 2 do
+    records = assert_queries_count 2 do
       Post.excluding(@post, Post.where(id: thinking)).to_a
     end
 
@@ -72,7 +72,7 @@ class ExcludingTest < ActiveRecord::TestCase
   def test_result_set_through_association_does_not_include_collection_of_excluded_records_from_a_relation
     relation = @post.comments
 
-    assert_sql(/SELECT #{Regexp.escape Comment.connection.quote_table_name("comments.id")} FROM/) do
+    assert_queries_match(/SELECT #{Regexp.escape Comment.connection.quote_table_name("comments.id")} FROM/) do
       records = Comment.excluding(relation).to_a
 
       assert_not_empty records
@@ -84,7 +84,7 @@ class ExcludingTest < ActiveRecord::TestCase
   def test_result_set_through_association_does_not_include_collection_of_excluded_records_from_a_loaded_relation
     relation = @post.comments.load
 
-    records = assert_queries 1 do
+    records = assert_queries_count 1 do
       Comment.excluding(relation).to_a
     end
 

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -276,7 +276,7 @@ class FinderTest < ActiveRecord::TestCase
 
   def test_exists_does_not_select_columns_without_alias
     c = Topic.connection
-    assert_sql(/SELECT 1 AS one FROM #{Regexp.escape(c.quote_table_name("topics"))}/i) do
+    assert_queries_match(/SELECT 1 AS one FROM #{Regexp.escape(c.quote_table_name("topics"))}/i) do
       Topic.exists?
     end
   end
@@ -366,26 +366,26 @@ class FinderTest < ActiveRecord::TestCase
 
   def test_exists_with_includes_limit_and_empty_result
     assert_no_queries { assert_equal false, Topic.includes(:replies).limit(0).exists? }
-    assert_queries(1) { assert_equal false, Topic.includes(:replies).limit(1).where("0 = 1").exists? }
+    assert_queries_count(1) { assert_equal false, Topic.includes(:replies).limit(1).where("0 = 1").exists? }
   end
 
   def test_exists_with_distinct_association_includes_and_limit
     author = Author.first
     unique_categorized_posts = author.unique_categorized_posts.includes(:special_comments)
     assert_no_queries { assert_equal false, unique_categorized_posts.limit(0).exists? }
-    assert_queries(1) { assert_equal true, unique_categorized_posts.limit(1).exists? }
+    assert_queries_count(1) { assert_equal true, unique_categorized_posts.limit(1).exists? }
   end
 
   def test_exists_with_distinct_association_includes_limit_and_order
     author = Author.first
     unique_categorized_posts = author.unique_categorized_posts.includes(:special_comments).order("comments.tags_count DESC")
     assert_no_queries { assert_equal false, unique_categorized_posts.limit(0).exists? }
-    assert_queries(1) { assert_equal true, unique_categorized_posts.limit(1).exists? }
+    assert_queries_count(1) { assert_equal true, unique_categorized_posts.limit(1).exists? }
   end
 
   def test_exists_should_reference_correct_aliases_while_joining_tables_of_has_many_through_association
     ratings = developers(:david).ratings.includes(comment: :post).where(posts: { id: 1 })
-    assert_queries(1) { assert_not_predicate ratings.limit(1), :exists? }
+    assert_queries_count(1) { assert_not_predicate ratings.limit(1), :exists? }
   end
 
   def test_exists_with_empty_table_and_no_args_given
@@ -440,13 +440,13 @@ class FinderTest < ActiveRecord::TestCase
   end
 
   def test_include_on_unloaded_relation_with_match
-    assert_sql(/1 AS one.*LIMIT/) do
+    assert_queries_match(/1 AS one.*LIMIT/) do
       assert_equal true, Customer.where(name: "David").include?(customers(:david))
     end
   end
 
   def test_include_on_unloaded_relation_without_match
-    assert_sql(/1 AS one.*LIMIT/) do
+    assert_queries_match(/1 AS one.*LIMIT/) do
       assert_equal false, Customer.where(name: "David").include?(customers(:mary))
     end
   end
@@ -461,7 +461,7 @@ class FinderTest < ActiveRecord::TestCase
   end
 
   def test_include_on_unloaded_relation_with_offset
-    assert_sql(/ORDER BY name ASC/) do
+    assert_queries_match(/ORDER BY name ASC/) do
       assert_equal true, Customer.offset(1).order("name ASC").include?(customers(:mary))
     end
   end
@@ -504,7 +504,7 @@ class FinderTest < ActiveRecord::TestCase
   end
 
   def test_include_on_unloaded_relation_with_composite_primary_key
-    assert_sql(/1 AS one.*LIMIT/) do
+    assert_queries_match(/1 AS one.*LIMIT/) do
       book = cpk_books(:cpk_great_author_first_book)
       assert Cpk::Book.where(title: "The first book").include?(book)
     end
@@ -520,13 +520,13 @@ class FinderTest < ActiveRecord::TestCase
   end
 
   def test_member_on_unloaded_relation_with_match
-    assert_sql(/1 AS one.*LIMIT/) do
+    assert_queries_match(/1 AS one.*LIMIT/) do
       assert_equal true, Customer.where(name: "David").member?(customers(:david))
     end
   end
 
   def test_member_on_unloaded_relation_without_match
-    assert_sql(/1 AS one.*LIMIT/) do
+    assert_queries_match(/1 AS one.*LIMIT/) do
       assert_equal false, Customer.where(name: "David").member?(customers(:mary))
     end
   end
@@ -541,7 +541,7 @@ class FinderTest < ActiveRecord::TestCase
   end
 
   def test_member_on_unloaded_relation_with_offset
-    assert_sql(/ORDER BY name ASC/) do
+    assert_queries_match(/ORDER BY name ASC/) do
       assert_equal true, Customer.offset(1).order("name ASC").member?(customers(:mary))
     end
   end
@@ -575,7 +575,7 @@ class FinderTest < ActiveRecord::TestCase
   end
 
   def test_member_on_unloaded_relation_with_composite_primary_key
-    assert_sql(/1 AS one.*LIMIT/) do
+    assert_queries_match(/1 AS one.*LIMIT/) do
       book = cpk_books(:cpk_great_author_first_book)
       assert Cpk::Book.where(title: "The first book").member?(book)
     end
@@ -617,19 +617,19 @@ class FinderTest < ActiveRecord::TestCase
   end
 
   def test_find_with_large_number
-    assert_queries(0) do
+    assert_queries_count(0) do
       assert_raises(ActiveRecord::RecordNotFound) { Topic.find("9999999999999999999999999999999") }
     end
   end
 
   def test_find_by_with_large_number
-    assert_queries(0) do
+    assert_queries_count(0) do
       assert_nil Topic.find_by(id: "9999999999999999999999999999999")
     end
   end
 
   def test_find_by_id_with_large_number
-    assert_queries(0) do
+    assert_queries_count(0) do
       assert_nil Topic.find_by_id("9999999999999999999999999999999")
     end
   end
@@ -661,7 +661,7 @@ class FinderTest < ActiveRecord::TestCase
   end
 
   def test_find_doesnt_have_implicit_ordering
-    assert_sql(/^((?!ORDER).)*$/) { Topic.find(1) }
+    assert_queries_match(/^((?!ORDER).)*$/) { Topic.find(1) }
   end
 
   def test_find_by_ids_missing_one
@@ -949,11 +949,11 @@ class FinderTest < ActiveRecord::TestCase
 
   def test_nth_to_last_with_order_uses_limit
     c = Topic.connection
-    assert_sql(/ORDER BY #{Regexp.escape(c.quote_table_name("topics.id"))} DESC LIMIT/i) do
+    assert_queries_match(/ORDER BY #{Regexp.escape(c.quote_table_name("topics.id"))} DESC LIMIT/i) do
       Topic.second_to_last
     end
 
-    assert_sql(/ORDER BY #{Regexp.escape(c.quote_table_name("topics.updated_at"))} DESC LIMIT/i) do
+    assert_queries_match(/ORDER BY #{Regexp.escape(c.quote_table_name("topics.updated_at"))} DESC LIMIT/i) do
       Topic.order(:updated_at).second_to_last
     end
   end
@@ -979,9 +979,9 @@ class FinderTest < ActiveRecord::TestCase
   end
 
   def test_take_and_first_and_last_with_integer_should_use_sql_limit
-    assert_sql(/LIMIT|ROWNUM <=|FETCH FIRST/) { Topic.take(3).entries }
-    assert_sql(/LIMIT|ROWNUM <=|FETCH FIRST/) { Topic.first(2).entries }
-    assert_sql(/LIMIT|ROWNUM <=|FETCH FIRST/) { Topic.last(5).entries }
+    assert_queries_match(/LIMIT|ROWNUM <=|FETCH FIRST/) { Topic.take(3).entries }
+    assert_queries_match(/LIMIT|ROWNUM <=|FETCH FIRST/) { Topic.first(2).entries }
+    assert_queries_match(/LIMIT|ROWNUM <=|FETCH FIRST/) { Topic.last(5).entries }
   end
 
   def test_last_with_integer_and_order_should_keep_the_order
@@ -990,13 +990,13 @@ class FinderTest < ActiveRecord::TestCase
 
   def test_last_with_integer_and_order_should_use_sql_limit
     relation = Topic.order("title")
-    assert_queries(1) { relation.last(5) }
+    assert_queries_count(1) { relation.last(5) }
     assert_not_predicate relation, :loaded?
   end
 
   def test_last_with_integer_and_reorder_should_use_sql_limit
     relation = Topic.reorder("title")
-    assert_queries(1) { relation.last(5) }
+    assert_queries_count(1) { relation.last(5) }
     assert_not_predicate relation, :loaded?
   end
 
@@ -1067,7 +1067,7 @@ class FinderTest < ActiveRecord::TestCase
     assert_equal topics(:third), Topic.last
 
     c = Topic.connection
-    assert_sql(/ORDER BY #{Regexp.escape(c.quote_table_name("topics.title"))} DESC, #{Regexp.escape(c.quote_table_name("topics.id"))} DESC LIMIT/i) {
+    assert_queries_match(/ORDER BY #{Regexp.escape(c.quote_table_name("topics.title"))} DESC, #{Regexp.escape(c.quote_table_name("topics.id"))} DESC LIMIT/i) {
       Topic.last
     }
   ensure
@@ -1079,7 +1079,7 @@ class FinderTest < ActiveRecord::TestCase
     Topic.implicit_order_column = "id"
 
     c = Topic.connection
-    assert_sql(/ORDER BY #{Regexp.escape(c.quote_table_name("topics.id"))} DESC LIMIT/i) {
+    assert_queries_match(/ORDER BY #{Regexp.escape(c.quote_table_name("topics.id"))} DESC LIMIT/i) {
       Topic.last
     }
   ensure
@@ -1091,7 +1091,7 @@ class FinderTest < ActiveRecord::TestCase
     NonPrimaryKey.implicit_order_column = "created_at"
 
     c = NonPrimaryKey.connection
-    assert_sql(/ORDER BY #{Regexp.escape(c.quote_table_name("non_primary_keys.created_at"))} DESC LIMIT/i) {
+    assert_queries_match(/ORDER BY #{Regexp.escape(c.quote_table_name("non_primary_keys.created_at"))} DESC LIMIT/i) {
       NonPrimaryKey.last
     }
   ensure
@@ -1104,7 +1104,7 @@ class FinderTest < ActiveRecord::TestCase
     quoted_type = Regexp.escape(c.quote_table_name("clothing_items.clothing_type"))
     quoted_color = Regexp.escape(c.quote_table_name("clothing_items.color"))
 
-    assert_sql(/ORDER BY #{quoted_color} ASC, #{quoted_type} ASC LIMIT/i) do
+    assert_queries_match(/ORDER BY #{quoted_color} ASC, #{quoted_type} ASC LIMIT/i) do
       assert_kind_of ClothingItem, ClothingItem.first
     end
   ensure
@@ -1118,7 +1118,7 @@ class FinderTest < ActiveRecord::TestCase
     quoted_color = Regexp.escape(c.quote_table_name("clothing_items.color"))
     quoted_descrption = Regexp.escape(c.quote_table_name("clothing_items.description"))
 
-    assert_sql(/ORDER BY #{quoted_descrption} ASC, #{quoted_type} ASC, #{quoted_color} ASC LIMIT/i) do
+    assert_queries_match(/ORDER BY #{quoted_descrption} ASC, #{quoted_type} ASC, #{quoted_color} ASC LIMIT/i) do
       assert_kind_of ClothingItem, ClothingItem.first
     end
   ensure
@@ -1748,7 +1748,7 @@ class FinderTest < ActiveRecord::TestCase
   end
 
   test "find_by doesn't have implicit ordering" do
-    assert_sql(/^((?!ORDER).)*$/) { Post.find_by(id: posts(:eager_other).id) }
+    assert_queries_match(/^((?!ORDER).)*$/) { Post.find_by(id: posts(:eager_other).id) }
   end
 
   test "find_by! with hash conditions returns the first matching record" do
@@ -1764,7 +1764,7 @@ class FinderTest < ActiveRecord::TestCase
   end
 
   test "find_by! doesn't have implicit ordering" do
-    assert_sql(/^((?!ORDER).)*$/) { Post.find_by!(id: posts(:eager_other).id) }
+    assert_queries_match(/^((?!ORDER).)*$/) { Post.find_by!(id: posts(:eager_other).id) }
   end
 
   test "find_by! raises RecordNotFound if the record is missing" do
@@ -1797,12 +1797,12 @@ class FinderTest < ActiveRecord::TestCase
 
   test "#skip_query_cache! for #exists?" do
     Topic.cache do
-      assert_queries(1) do
+      assert_queries_count(1) do
         Topic.exists?
         Topic.exists?
       end
 
-      assert_queries(2) do
+      assert_queries_count(2) do
         Topic.all.skip_query_cache!.exists?
         Topic.all.skip_query_cache!.exists?
       end
@@ -1811,12 +1811,12 @@ class FinderTest < ActiveRecord::TestCase
 
   test "#skip_query_cache! for #exists? with a limited eager load" do
     Topic.cache do
-      assert_queries(1) do
+      assert_queries_count(1) do
         Topic.eager_load(:replies).limit(1).exists?
         Topic.eager_load(:replies).limit(1).exists?
       end
 
-      assert_queries(2) do
+      assert_queries_count(2) do
         Topic.eager_load(:replies).limit(1).skip_query_cache!.exists?
         Topic.eager_load(:replies).limit(1).skip_query_cache!.exists?
       end
@@ -1828,7 +1828,7 @@ class FinderTest < ActiveRecord::TestCase
     quoted_type = Regexp.escape(c.quote_table_name("clothing_items.clothing_type"))
     quoted_color = Regexp.escape(c.quote_table_name("clothing_items.color"))
 
-    assert_sql(/ORDER BY #{quoted_type} DESC, #{quoted_color} DESC LIMIT/i) do
+    assert_queries_match(/ORDER BY #{quoted_type} DESC, #{quoted_color} DESC LIMIT/i) do
       assert_kind_of ClothingItem, ClothingItem.last
     end
   end
@@ -1838,7 +1838,7 @@ class FinderTest < ActiveRecord::TestCase
     quoted_type = Regexp.escape(c.quote_table_name("clothing_items.clothing_type"))
     quoted_color = Regexp.escape(c.quote_table_name("clothing_items.color"))
 
-    assert_sql(/ORDER BY #{quoted_type} ASC, #{quoted_color} ASC LIMIT/i) do
+    assert_queries_match(/ORDER BY #{quoted_type} ASC, #{quoted_color} ASC LIMIT/i) do
       assert_kind_of ClothingItem, ClothingItem.first
     end
   end

--- a/activerecord/test/cases/inheritance_test.rb
+++ b/activerecord/test/cases/inheritance_test.rb
@@ -479,7 +479,7 @@ class InheritanceTest < ActiveRecord::TestCase
   def test_eager_load_belongs_to_primary_key_quoting
     c = Account.connection
     bind_param = Arel::Nodes::BindParam.new(nil)
-    assert_sql(/#{Regexp.escape(c.quote_table_name("companies.id"))} = (?:#{Regexp.escape(bind_param.to_sql)}|1)/i) do
+    assert_queries_match(/#{Regexp.escape(c.quote_table_name("companies.id"))} = (?:#{Regexp.escape(bind_param.to_sql)}|1)/i) do
       Account.all.merge!(includes: :firm).find(1)
     end
   end

--- a/activerecord/test/cases/insert_all_test.rb
+++ b/activerecord/test/cases/insert_all_test.rb
@@ -133,7 +133,7 @@ class InsertAllTest < ActiveRecord::TestCase
     def test_insert_all_generates_correct_sql
       skip unless supports_insert_on_duplicate_skip?
 
-      assert_sql(/ON DUPLICATE KEY UPDATE/) do
+      assert_queries_match(/ON DUPLICATE KEY UPDATE/) do
         Book.insert_all [{ id: 1, name: "Agile Web Development with Rails" }]
       end
     end

--- a/activerecord/test/cases/locking_test.rb
+++ b/activerecord/test/cases/locking_test.rb
@@ -382,7 +382,7 @@ class OptimisticLockingTest < ActiveRecord::TestCase
     assert_equal "title1", t1.title
     assert_equal 0, t1.lock_version
 
-    assert_queries(1) { t1.update(title: "title2") }
+    assert_queries_count(3) { t1.update(title: "title2") }
 
     t1.reload
     assert_equal "title2", t1.title
@@ -390,7 +390,7 @@ class OptimisticLockingTest < ActiveRecord::TestCase
 
     t2 = LockWithoutDefault.new(title: "title1")
 
-    assert_queries(1) { t2.save! }
+    assert_queries_count(3) { t2.save! }
 
     t2.reload
     assert_equal "title1", t2.title
@@ -439,7 +439,7 @@ class OptimisticLockingTest < ActiveRecord::TestCase
     assert_equal "title1", t1.title
     assert_equal 0, t1.custom_lock_version
 
-    assert_queries(1) { t1.update(title: "title2") }
+    assert_queries_count(3) { t1.update(title: "title2") }
 
     t1.reload
     assert_equal "title2", t1.title
@@ -447,7 +447,7 @@ class OptimisticLockingTest < ActiveRecord::TestCase
 
     t2 = LockWithCustomColumnWithoutDefault.new(title: "title1")
 
-    assert_queries(1) { t2.save! }
+    assert_queries_count(3) { t2.save! }
 
     t2.reload
     assert_equal "title1", t2.title
@@ -761,7 +761,7 @@ class PessimisticLockingTest < ActiveRecord::TestCase
       def test_lock_sending_custom_lock_statement
         Person.transaction do
           person = Person.find(1)
-          assert_sql(/LIMIT \$?\d FOR SHARE NOWAIT/) do
+          assert_queries_match(/LIMIT \$?\d FOR SHARE NOWAIT/) do
             person.lock!("FOR SHARE NOWAIT")
           end
         end
@@ -777,7 +777,7 @@ class PessimisticLockingTest < ActiveRecord::TestCase
 
       def test_with_lock_locks_with_no_args
         person = Person.find 1
-        assert_sql(/LIMIT \$?\d FOR UPDATE/i) do
+        assert_queries_match(/LIMIT \$?\d FOR UPDATE/i) do
           person.with_lock do
           end
         end

--- a/activerecord/test/cases/migration/columns_test.rb
+++ b/activerecord/test/cases/migration/columns_test.rb
@@ -394,8 +394,8 @@ module ActiveRecord
         # SQLite3's ALTER TABLE statement has several limitations. To manage
         # this, the adapter creates a temporary table, copies the data, drops
         # the old table, creates the new table, then copies the data back.
-        expected_query_count = current_adapter?(:SQLite3Adapter) ? 12 : 1
-        assert_queries(expected_query_count) do
+        expected_query_count = current_adapter?(:SQLite3Adapter) ? 14 : 1
+        assert_queries_count(expected_query_count) do
           connection.remove_columns("my_table", "col_one", "col_two")
         end
 
@@ -411,8 +411,8 @@ module ActiveRecord
         # SQLite3's ALTER TABLE statement has several limitations. To manage
         # this, the adapter creates a temporary table, copies the data, drops
         # the old table, creates the new table, then copies the data back.
-        expected_query_count = current_adapter?(:SQLite3Adapter) ? 12 : 1
-        assert_queries(expected_query_count) do
+        expected_query_count = current_adapter?(:SQLite3Adapter) ? 14 : 1
+        assert_queries_count(expected_query_count) do
           connection.add_timestamps("my_table")
         end
 

--- a/activerecord/test/cases/migration/references_foreign_key_test.rb
+++ b/activerecord/test/cases/migration/references_foreign_key_test.rb
@@ -35,7 +35,7 @@ if ActiveRecord::Base.connection.supports_foreign_keys?
         end
 
         test "foreign keys can be created in one query when index is not added" do
-          assert_queries(1) do
+          assert_queries_count(1) do
             @connection.create_table :testings do |t|
               t.references :testing_parent, foreign_key: true, index: false
             end

--- a/activerecord/test/cases/migration_test.rb
+++ b/activerecord/test/cases/migration_test.rb
@@ -1238,7 +1238,7 @@ if ActiveRecord::Base.connection.supports_bulk_alter?
         raise "need an expected query count for #{classname}"
       }
 
-      assert_queries(expected_query_count) do
+      assert_queries_count(expected_query_count) do
         with_bulk_change_table do |t|
           t.column :name, :string
           t.string :qualification, :experience
@@ -1278,7 +1278,7 @@ if ActiveRecord::Base.connection.supports_bulk_alter?
 
       [:qualification, :experience].each { |c| assert column(c) }
 
-      assert_queries(1) do
+      assert_queries_count(1) do
         with_bulk_change_table do |t|
           t.remove :qualification, :experience
           t.string :qualification_experience
@@ -1296,7 +1296,7 @@ if ActiveRecord::Base.connection.supports_bulk_alter?
 
       assert column(:title)
 
-      assert_queries(1) do
+      assert_queries_count(1) do
         with_bulk_change_table do |t|
           t.timestamps
           t.remove :title
@@ -1314,7 +1314,7 @@ if ActiveRecord::Base.connection.supports_bulk_alter?
 
       [:created_at, :updated_at].each { |c| assert column(c) }
 
-      assert_queries(1) do
+      assert_queries_count(1) do
         with_bulk_change_table do |t|
           t.remove_timestamps
           t.string :title
@@ -1341,7 +1341,7 @@ if ActiveRecord::Base.connection.supports_bulk_alter?
         raise "need an expected query count for #{classname}"
       }
 
-      assert_queries(expected_query_count) do
+      assert_queries_count(expected_query_count) do
         with_bulk_change_table do |t|
           t.index :username, unique: true, name: :awesome_username_index
           t.index [:name, :age], comment: "This is a comment"
@@ -1375,7 +1375,7 @@ if ActiveRecord::Base.connection.supports_bulk_alter?
         raise "need an expected query count for #{classname}"
       }
 
-      assert_queries(expected_query_count) do
+      assert_queries_count(expected_query_count) do
         with_bulk_change_table do |t|
           t.remove_index :name
           t.index :name, name: :new_name_index, unique: true
@@ -1406,7 +1406,7 @@ if ActiveRecord::Base.connection.supports_bulk_alter?
         raise "need an expected query count for #{classname}"
       }
 
-      assert_queries(expected_query_count, ignore_none: true) do
+      assert_queries_count(expected_query_count, include_schema: true) do
         with_bulk_change_table do |t|
           t.change :name, :string, default: "NONAME"
           t.change :birthdate, :datetime, comment: "This is a comment"
@@ -1437,7 +1437,7 @@ if ActiveRecord::Base.connection.supports_bulk_alter?
         raise "need an expected query count for #{classname}"
       }
 
-      assert_queries(expected_query_count, ignore_none: true) do
+      assert_queries_count(expected_query_count, include_schema: true) do
         with_bulk_change_table do |t|
           t.change :name, :string, default: "NONAME"
           t.change :birthdate, :datetime
@@ -1508,7 +1508,7 @@ if ActiveRecord::Base.connection.supports_bulk_alter?
         raise "need an expected query count for #{classname}"
       }
 
-      assert_queries(expected_query_count) do
+      assert_queries_count(expected_query_count) do
         with_bulk_change_table do |t|
           t.remove_index name: :username_index
           t.index :username, name: :username_index, unique: true
@@ -1576,7 +1576,7 @@ if ActiveRecord::Base.connection.supports_bulk_alter?
         end
       }.new
 
-      assert_queries(1) do
+      assert_queries_count(1) do
         migration.migrate(:down)
       end
 

--- a/activerecord/test/cases/nested_attributes_test.rb
+++ b/activerecord/test/cases/nested_attributes_test.rb
@@ -1096,7 +1096,7 @@ class TestHasManyAutosaveAssociationWhichItselfHasAutosaveAssociations < ActiveR
     part = ship.parts.build(name: "Stern")
     ship.treasures.build(looter: part)
 
-    assert_queries 3 do
+    assert_queries_count(5) do
       ship.save!
     end
   end

--- a/activerecord/test/cases/null_relation_test.rb
+++ b/activerecord/test/cases/null_relation_test.rb
@@ -20,7 +20,7 @@ class NullRelationTest < ActiveRecord::TestCase
   end
 
   def test_none_chainable
-    assert_queries(0) do
+    assert_queries_count(0) do
       assert_equal [], Developer.none.where(name: "David")
     end
   end
@@ -38,7 +38,7 @@ class NullRelationTest < ActiveRecord::TestCase
   end
 
   def test_none_chained_to_methods_firing_queries_straight_to_db
-    assert_no_queries(ignore_none: false) do
+    assert_no_queries do
       assert_equal [],    Developer.none.pluck(:id, :name)
       assert_equal 0,     Developer.none.delete_all
       assert_equal 0,     Developer.none.update_all(name: "David")

--- a/activerecord/test/cases/persistence_test.rb
+++ b/activerecord/test/cases/persistence_test.rb
@@ -1523,7 +1523,7 @@ class PersistenceTest < ActiveRecord::TestCase
 
   def test_update_uses_query_constraints_config
     clothing_item = clothing_items(:green_t_shirt)
-    sql = capture_sql { clothing_item.update(description: "Lovely green t-shirt")  }.first
+    sql = capture_sql { clothing_item.update(description: "Lovely green t-shirt")  }.second
     assert_match(/WHERE .*clothing_type/, sql)
     assert_match(/WHERE .*color/, sql)
   end
@@ -1531,7 +1531,7 @@ class PersistenceTest < ActiveRecord::TestCase
   def test_save_uses_query_constraints_config
     clothing_item = clothing_items(:green_t_shirt)
     clothing_item.description = "Lovely green t-shirt"
-    sql = capture_sql { clothing_item.save }.first
+    sql = capture_sql { clothing_item.save }.second
     assert_match(/WHERE .*clothing_type/, sql)
     assert_match(/WHERE .*color/, sql)
   end
@@ -1545,7 +1545,7 @@ class PersistenceTest < ActiveRecord::TestCase
 
   def test_destroy_uses_query_constraints_config
     clothing_item = clothing_items(:green_t_shirt)
-    sql = capture_sql { clothing_item.destroy }.first
+    sql = capture_sql { clothing_item.destroy }.second
     assert_match(/WHERE .*clothing_type/, sql)
     assert_match(/WHERE .*color/, sql)
   end
@@ -1559,7 +1559,7 @@ class PersistenceTest < ActiveRecord::TestCase
 
   def test_update_attribute_uses_query_constraints_config
     clothing_item = clothing_items(:green_t_shirt)
-    sql = capture_sql { clothing_item.update_attribute(:description, "Lovely green t-shirt") }.first
+    sql = capture_sql { clothing_item.update_attribute(:description, "Lovely green t-shirt") }.second
     assert_match(/WHERE .*clothing_type/, sql)
     assert_match(/WHERE .*color/, sql)
   end
@@ -1568,7 +1568,7 @@ class PersistenceTest < ActiveRecord::TestCase
     clothing_item = clothing_items(:green_t_shirt)
     clothing_item.color = "blue"
     clothing_item.description = "Now it's a blue t-shirt"
-    sql = capture_sql { clothing_item.save }.first
+    sql = capture_sql { clothing_item.save }.second
     assert_match(/WHERE .*clothing_type/, sql)
     assert_match(/WHERE .*color/, sql)
 

--- a/activerecord/test/cases/primary_keys_test.rb
+++ b/activerecord/test/cases/primary_keys_test.rb
@@ -250,7 +250,7 @@ class PrimaryKeysTest < ActiveRecord::TestCase
       self.table_name = "dashboards"
     end
     klass.create! # warmup schema cache
-    assert_queries(3, ignore_none: true) { klass.create! }
+    assert_queries_count(3, include_schema: true) { klass.create! }
   end
 
   def test_assign_id_raises_error_if_primary_key_doesnt_exist

--- a/activerecord/test/cases/query_cache_test.rb
+++ b/activerecord/test/cases/query_cache_test.rb
@@ -295,25 +295,25 @@ class QueryCacheTest < ActiveRecord::TestCase
   end
 
   def test_find_queries
-    assert_queries(2) { Task.find(1); Task.find(1) }
+    assert_queries_count(2) { Task.find(1); Task.find(1) }
   end
 
   def test_find_queries_with_cache
     Task.cache do
-      assert_queries(1) { Task.find(1); Task.find(1) }
+      assert_queries_count(1) { Task.find(1); Task.find(1) }
     end
   end
 
   def test_find_queries_with_cache_multi_record
     Task.cache do
-      assert_queries(2) { Task.find(1); Task.find(1); Task.find(2) }
+      assert_queries_count(2) { Task.find(1); Task.find(1); Task.find(2) }
     end
   end
 
   def test_find_queries_with_multi_cache_blocks
     Task.cache do
       Task.cache do
-        assert_queries(2) { Task.find(1); Task.find(2) }
+        assert_queries_count(2) { Task.find(1); Task.find(2) }
       end
       assert_no_queries { Task.find(1); Task.find(1); Task.find(2) }
     end
@@ -321,19 +321,19 @@ class QueryCacheTest < ActiveRecord::TestCase
 
   def test_count_queries_with_cache
     Task.cache do
-      assert_queries(1) { Task.count; Task.count }
+      assert_queries_count(1) { Task.count; Task.count }
     end
   end
 
   def test_exists_queries_with_cache
     Post.cache do
-      assert_queries(1) { Post.exists?; Post.exists? }
+      assert_queries_count(1) { Post.exists?; Post.exists? }
     end
   end
 
   def test_select_all_with_cache
     Post.cache do
-      assert_queries(1) do
+      assert_queries_count(1) do
         2.times { Post.connection.select_all(Post.all) }
       end
     end
@@ -341,7 +341,7 @@ class QueryCacheTest < ActiveRecord::TestCase
 
   def test_select_one_with_cache
     Post.cache do
-      assert_queries(1) do
+      assert_queries_count(1) do
         2.times { Post.connection.select_one(Post.all) }
       end
     end
@@ -349,7 +349,7 @@ class QueryCacheTest < ActiveRecord::TestCase
 
   def test_select_value_with_cache
     Post.cache do
-      assert_queries(1) do
+      assert_queries_count(1) do
         2.times { Post.connection.select_value(Post.all) }
       end
     end
@@ -357,7 +357,7 @@ class QueryCacheTest < ActiveRecord::TestCase
 
   def test_select_values_with_cache
     Post.cache do
-      assert_queries(1) do
+      assert_queries_count(1) do
         2.times { Post.connection.select_values(Post.all) }
       end
     end
@@ -365,7 +365,7 @@ class QueryCacheTest < ActiveRecord::TestCase
 
   def test_select_rows_with_cache
     Post.cache do
-      assert_queries(1) do
+      assert_queries_count(1) do
         2.times { Post.connection.select_rows(Post.all) }
       end
     end
@@ -407,7 +407,7 @@ class QueryCacheTest < ActiveRecord::TestCase
     subscriber = ActiveSupport::Notifications.subscribe "sql.active_record", logger
 
     ActiveRecord::Base.cache do
-      assert_queries(1) { Task.find(1); Task.find(1) }
+      assert_queries_count(1) { Task.find(1); Task.find(1) }
     end
 
     assert_not_predicate logger, :exception?
@@ -421,7 +421,7 @@ class QueryCacheTest < ActiveRecord::TestCase
     end
 
     ActiveRecord::Base.cache do
-      assert_queries(1) do
+      assert_queries_count(1) do
         assert_raises FrozenError do
           Task.find(1)
         end
@@ -433,11 +433,11 @@ class QueryCacheTest < ActiveRecord::TestCase
 
   def test_cache_is_flat
     Task.cache do
-      assert_queries(1) { Topic.find(1); Topic.find(1) }
+      assert_queries_count(1) { Topic.find(1); Topic.find(1) }
     end
 
     ActiveRecord::Base.cache do
-      assert_queries(1) { Task.find(1); Task.find(1) }
+      assert_queries_count(1) { Task.find(1); Task.find(1) }
     end
   end
 
@@ -451,7 +451,7 @@ class QueryCacheTest < ActiveRecord::TestCase
     task = Task.find 1
 
     Task.cache do
-      assert_queries(2) { task.lock!; task.lock! }
+      assert_queries_count(2) { task.lock!; task.lock! }
     end
   end
 
@@ -460,7 +460,7 @@ class QueryCacheTest < ActiveRecord::TestCase
 
     ActiveRecord::Base.configurations = {}
     Task.cache do
-      assert_queries(1) { Task.find(1); Task.find(1) }
+      assert_queries_count(1) { Task.find(1); Task.find(1) }
     end
   ensure
     ActiveRecord::Base.configurations = conf
@@ -475,7 +475,7 @@ class QueryCacheTest < ActiveRecord::TestCase
     assert_not_predicate Task, :connected?
 
     Task.cache do
-      assert_queries(1) { Task.find(1); Task.find(1) }
+      assert_queries_count(1) { Task.find(1); Task.find(1) }
     ensure
       ActiveRecord::Base.establish_connection(original_connection)
     end
@@ -485,7 +485,7 @@ class QueryCacheTest < ActiveRecord::TestCase
     ActiveRecord::Base.connection.enable_query_cache!
 
     # Warm up the cache by running the query
-    assert_queries(1) do
+    assert_queries_count(1) do
       assert_equal 0, Post.where(title: "test").to_a.count
     end
 
@@ -496,7 +496,7 @@ class QueryCacheTest < ActiveRecord::TestCase
 
     ActiveRecord::Base.connection.uncached do
       # Check that new query is executed, avoiding the cache
-      assert_queries(1) do
+      assert_queries_count(1) do
         assert_equal 0, Post.where(title: "test").to_a.count
       end
     end
@@ -902,13 +902,13 @@ class QueryCacheExpiryTest < ActiveRecord::TestCase
     connection.pool.db_config.stub(:query_cache, 2) do
       connection.send(:configure_query_cache!)
       Post.cache do
-        assert_queries(2) do
+        assert_queries_count(2) do
           connection.select_all("SELECT 1")
           connection.select_all("SELECT 2")
           connection.select_all("SELECT 1")
         end
 
-        assert_queries(1) do
+        assert_queries_count(1) do
           connection.select_all("SELECT 3")
           connection.select_all("SELECT 3")
         end
@@ -917,7 +917,7 @@ class QueryCacheExpiryTest < ActiveRecord::TestCase
           connection.select_all("SELECT 1")
         end
 
-        assert_queries(1) do
+        assert_queries_count(1) do
           connection.select_all("SELECT 2")
         end
       end

--- a/activerecord/test/cases/relation/load_async_test.rb
+++ b/activerecord/test/cases/relation/load_async_test.rb
@@ -196,7 +196,7 @@ module ActiveRecord
       end
 
       assert_equal expected_records, deferred_posts.to_a
-      assert_queries(0) do
+      assert_queries_count(0) do
         deferred_posts.each(&:comments)
       end
       assert_equal Post.connection.supports_concurrent_connections?, status[:async]
@@ -205,7 +205,7 @@ module ActiveRecord
     end
 
     def test_contradiction
-      assert_queries(0) do
+      assert_queries_count(0) do
         assert_equal [], Post.where(id: []).load_async.to_a
       end
 
@@ -315,7 +315,7 @@ module ActiveRecord
         assert_not_predicate deferred_posts, :scheduled?
 
         assert_equal expected_records, deferred_posts.to_a
-        assert_queries(0) do
+        assert_queries_count(0) do
           deferred_posts.each(&:comments)
         end
 
@@ -326,7 +326,7 @@ module ActiveRecord
       end
 
       def test_contradiction
-        assert_queries(0) do
+        assert_queries_count(0) do
           assert_equal [], Post.where(id: []).load_async.to_a
         end
 
@@ -458,7 +458,7 @@ module ActiveRecord
         assert_predicate deferred_posts, :scheduled?
 
         assert_equal expected_records, deferred_posts.to_a
-        assert_queries(0) do
+        assert_queries_count(0) do
           deferred_posts.each(&:comments)
         end
         assert_equal Post.connection.supports_concurrent_connections?, status[:async]
@@ -467,7 +467,7 @@ module ActiveRecord
       end
 
       def test_contradiction
-        assert_queries(0) do
+        assert_queries_count(0) do
           assert_equal [], Post.where(id: []).load_async.to_a
         end
 

--- a/activerecord/test/cases/relation/update_all_test.rb
+++ b/activerecord/test/cases/relation/update_all_test.rb
@@ -322,7 +322,7 @@ class UpdateAllTest < ActiveRecord::TestCase
         assert_not test_update_with_order_succeeds.call("id ASC")
       else
         # test that we're failing because the current Arel's engine doesn't support UPDATE ORDER BY queries is using subselects instead
-        assert_sql(/\AUPDATE .+ \(SELECT .* ORDER BY id DESC\)\z/i) do
+        assert_queries_match(/\AUPDATE .+ \(SELECT .* ORDER BY id DESC\)\z/i) do
           test_update_with_order_succeeds.call("id DESC")
         end
       end

--- a/activerecord/test/cases/relation/where_test.rb
+++ b/activerecord/test/cases/relation/where_test.rb
@@ -418,7 +418,7 @@ module ActiveRecord
     def test_where_on_association_with_relation_performs_subselect_not_two_queries
       author = authors(:david)
 
-      assert_queries(1) do
+      assert_queries_count(1) do
         Essay.where(writer: Author.where(id: author.id)).to_a
       end
     end

--- a/activerecord/test/cases/relation_test.rb
+++ b/activerecord/test/cases/relation_test.rb
@@ -331,14 +331,14 @@ module ActiveRecord
 
     def test_relation_with_annotation_includes_comment_in_sql
       post_with_annotation = Post.where(id: 1).annotate("foo")
-      assert_sql(%r{/\* foo \*/}) do
+      assert_queries_match(%r{/\* foo \*/}) do
         assert post_with_annotation.first, "record should be found"
       end
     end
 
     def test_relation_with_annotation_chains_sql_comments
       post_with_annotation = Post.where(id: 1).annotate("foo").annotate("bar")
-      assert_sql(%r{/\* foo \*/ /\* bar \*/}) do
+      assert_queries_match(%r{/\* foo \*/ /\* bar \*/}) do
         assert post_with_annotation.first, "record should be found"
       end
     end
@@ -351,7 +351,7 @@ module ActiveRecord
     def test_relation_with_annotation_includes_comment_in_count_query
       post_with_annotation = Post.annotate("foo")
       all_count = Post.all.to_a.count
-      assert_sql(%r{/\* foo \*/}) do
+      assert_queries_match(%r{/\* foo \*/}) do
         assert_equal all_count, post_with_annotation.count
       end
     end
@@ -421,25 +421,25 @@ module ActiveRecord
     end
 
     test "no queries on empty IN" do
-      assert_queries(0) do
+      assert_queries_count(0) do
         Post.where(id: []).load
       end
     end
 
     test "can unscope empty IN" do
-      assert_queries(1) do
+      assert_queries_count(1) do
         Post.where(id: []).unscope(where: :id).load
       end
     end
 
     test "no queries on empty relation exists?" do
-      assert_queries(0) do
+      assert_queries_count(0) do
         Post.where(id: []).exists?(123)
       end
     end
 
     test "no queries on empty condition exists?" do
-      assert_queries(0) do
+      assert_queries_count(0) do
         Post.all.exists?(id: [])
       end
     end

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -98,7 +98,7 @@ class RelationTest < ActiveRecord::TestCase
     assert_not_predicate topics, :loaded?
     assert_not_predicate topics, :loaded
 
-    assert_queries(1) do
+    assert_queries_count(1) do
       2.times { assert_equal 5, topics.to_a.size }
     end
 
@@ -109,7 +109,7 @@ class RelationTest < ActiveRecord::TestCase
   def test_scoped_first
     topics = Topic.all.order("id ASC")
 
-    assert_queries(1) do
+    assert_queries_count(1) do
       2.times { assert_equal "The First Topic", topics.first.title }
     end
 
@@ -153,7 +153,7 @@ class RelationTest < ActiveRecord::TestCase
   def test_reload
     topics = Topic.all
 
-    assert_queries(1) do
+    assert_queries_count(1) do
       2.times { topics.to_a }
     end
 
@@ -162,7 +162,7 @@ class RelationTest < ActiveRecord::TestCase
     original_size = topics.to_a.size
     Topic.create! title: "fake"
 
-    assert_queries(1) { topics.reload }
+    assert_queries_count(1) { topics.reload }
     assert_equal original_size + 1, topics.size
     assert_predicate topics, :loaded?
   end
@@ -614,27 +614,27 @@ class RelationTest < ActiveRecord::TestCase
   end
 
   def test_find_with_preloaded_associations
-    assert_queries(2) do
+    assert_queries_count(2) do
       posts = Post.preload(:comments).order("posts.id")
       assert posts.first.comments.first
     end
 
-    assert_queries(2) do
+    assert_queries_count(2) do
       posts = Post.preload(:comments).order("posts.id")
       assert posts.first.comments.first
     end
 
-    assert_queries(2) do
+    assert_queries_count(2) do
       posts = Post.preload(:author).order("posts.id")
       assert posts.first.author
     end
 
-    assert_queries(2) do
+    assert_queries_count(2) do
       posts = Post.preload(:author).order("posts.id")
       assert posts.first.author
     end
 
-    assert_queries(3) do
+    assert_queries_count(3) do
       posts = Post.preload(:author, :comments).order("posts.id")
       assert posts.first.author
       assert posts.first.comments.first
@@ -642,36 +642,36 @@ class RelationTest < ActiveRecord::TestCase
   end
 
   def test_preload_applies_to_all_chained_preloaded_scopes
-    assert_queries(3) do
+    assert_queries_count(3) do
       post = Post.with_comments.with_tags.first
       assert post
     end
   end
 
   def test_extracted_association
-    relation_authors = assert_queries(2) { Post.all.extract_associated(:author) }
-    root_authors = assert_queries(2) { Post.extract_associated(:author) }
+    relation_authors = assert_queries_count(2) { Post.all.extract_associated(:author) }
+    root_authors = assert_queries_count(2) { Post.extract_associated(:author) }
     assert_equal relation_authors, root_authors
     assert_equal Post.all.collect(&:author), relation_authors
   end
 
   def test_find_with_included_associations
-    assert_queries(2) do
+    assert_queries_count(2) do
       posts = Post.includes(:comments).order("posts.id")
       assert posts.first.comments.first
     end
 
-    assert_queries(2) do
+    assert_queries_count(2) do
       posts = Post.all.includes(:comments).order("posts.id")
       assert posts.first.comments.first
     end
 
-    assert_queries(2) do
+    assert_queries_count(2) do
       posts = Post.includes(:author).order("posts.id")
       assert posts.first.author
     end
 
-    assert_queries(3) do
+    assert_queries_count(3) do
       posts = Post.includes(:author, :comments).order("posts.id")
       assert posts.first.author
       assert posts.first.comments.first
@@ -902,17 +902,17 @@ class RelationTest < ActiveRecord::TestCase
 
   def test_find_all_using_where_with_relation
     david = authors(:david)
-    assert_queries(1) {
+    assert_queries_count(1) {
       relation = Author.where(id: Author.where(id: david.id))
       assert_equal [david], relation.to_a
     }
 
-    assert_queries(1) {
+    assert_queries_count(1) {
       relation = Author.where("id in (?)", Author.where(id: david).select(:id))
       assert_equal [david], relation.to_a
     }
 
-    assert_queries(1) do
+    assert_queries_count(1) do
       relation = Author.where("id in (:author_ids)", author_ids: Author.where(id: david).select(:id))
       assert_equal [david], relation.to_a
     end
@@ -922,17 +922,17 @@ class RelationTest < ActiveRecord::TestCase
     david = authors(:david)
     davids_posts = david.posts.order(:id).to_a
 
-    assert_queries(1) do
+    assert_queries_count(1) do
       relation = Post.where(id: david.posts.select(:id))
       assert_equal davids_posts, relation.order(:id).to_a
     end
 
-    assert_queries(1) do
+    assert_queries_count(1) do
       relation = Post.where("id in (?)", david.posts.select(:id))
       assert_equal davids_posts, relation.order(:id).to_a, "should process Relation as bind variables"
     end
 
-    assert_queries(1) do
+    assert_queries_count(1) do
       relation = Post.where("id in (:post_ids)", post_ids: david.posts.select(:id))
       assert_equal davids_posts, relation.order(:id).to_a, "should process Relation as named bind variables"
     end
@@ -940,7 +940,7 @@ class RelationTest < ActiveRecord::TestCase
 
   def test_find_all_using_where_with_relation_and_alternate_primary_key
     cool_first = minivans(:cool_first)
-    assert_queries(1) {
+    assert_queries_count(1) {
       relation = Minivan.where(minivan_id: Minivan.where(name: cool_first.name))
       assert_equal [cool_first], relation.to_a
     }
@@ -966,7 +966,7 @@ class RelationTest < ActiveRecord::TestCase
 
     subquery = Author.where(id: david.id)
 
-    assert_queries(1) {
+    assert_queries_count(1) {
       relation = Author.where(id: subquery)
       assert_equal [david], relation.to_a
     }
@@ -976,7 +976,7 @@ class RelationTest < ActiveRecord::TestCase
 
   def test_find_all_using_where_with_relation_with_joins
     david = authors(:david)
-    assert_queries(1) {
+    assert_queries_count(1) {
       relation = Author.where(id: Author.joins(:posts).where(id: david.id))
       assert_equal [david], relation.to_a
     }
@@ -984,7 +984,7 @@ class RelationTest < ActiveRecord::TestCase
 
   def test_find_all_using_where_with_relation_with_select_to_build_subquery
     david = authors(:david)
-    assert_queries(1) {
+    assert_queries_count(1) {
       relation = Author.where(name: Author.where(id: david.id).select(:name))
       assert_equal [david], relation.to_a
     }
@@ -1059,33 +1059,33 @@ class RelationTest < ActiveRecord::TestCase
 
   def test_size_with_distinct
     posts = Post.distinct.select(:author_id, :comments_count)
-    assert_queries(1) { assert_equal 8, posts.size }
-    assert_queries(1) { assert_equal 8, posts.load.size }
+    assert_queries_count(1) { assert_equal 8, posts.size }
+    assert_queries_count(1) { assert_equal 8, posts.load.size }
   end
 
   def test_size_with_eager_loading_and_custom_order
     posts = Post.includes(:comments).order("comments.id")
-    assert_queries(1) { assert_equal 11, posts.size }
-    assert_queries(1) { assert_equal 11, posts.load.size }
+    assert_queries_count(1) { assert_equal 11, posts.size }
+    assert_queries_count(1) { assert_equal 11, posts.load.size }
   end
 
   def test_size_with_eager_loading_and_custom_select_and_order
     posts = Post.includes(:comments).order("comments.id").select(:type)
-    assert_queries(1) { assert_equal 11, posts.size }
-    assert_queries(1) { assert_equal 11, posts.load.size }
+    assert_queries_count(1) { assert_equal 11, posts.size }
+    assert_queries_count(1) { assert_equal 11, posts.load.size }
   end
 
   def test_size_with_eager_loading_and_custom_order_and_distinct
     posts = Post.includes(:comments).order("comments.id").distinct
-    assert_queries(1) { assert_equal 11, posts.size }
-    assert_queries(1) { assert_equal 11, posts.load.size }
+    assert_queries_count(1) { assert_equal 11, posts.size }
+    assert_queries_count(1) { assert_equal 11, posts.load.size }
   end
 
   def test_size_with_eager_loading_and_manual_distinct_select_and_custom_order
     accounts = Account.select("DISTINCT accounts.firm_id").order("accounts.firm_id")
 
-    assert_queries(1) { assert_equal 5, accounts.size }
-    assert_queries(1) { assert_equal 5, accounts.load.size }
+    assert_queries_count(1) { assert_equal 5, accounts.size }
+    assert_queries_count(1) { assert_equal 5, accounts.load.size }
   end
 
   def test_count_explicit_columns
@@ -1110,7 +1110,7 @@ class RelationTest < ActiveRecord::TestCase
   def test_size
     posts = Post.all
 
-    assert_queries(1) { assert_equal 11, posts.size }
+    assert_queries_count(1) { assert_equal 11, posts.size }
     assert_not_predicate posts, :loaded?
 
     best_posts = posts.where(comments_count: 0)
@@ -1121,7 +1121,7 @@ class RelationTest < ActiveRecord::TestCase
   def test_size_with_limit
     posts = Post.limit(10)
 
-    assert_queries(1) { assert_equal 10, posts.size }
+    assert_queries_count(1) { assert_equal 10, posts.size }
     assert_not_predicate posts, :loaded?
 
     best_posts = posts.where(comments_count: 0)
@@ -1156,11 +1156,11 @@ class RelationTest < ActiveRecord::TestCase
   def test_empty
     posts = Post.all
 
-    assert_queries(1) { assert_equal false, posts.empty? }
+    assert_queries_count(1) { assert_equal false, posts.empty? }
     assert_not_predicate posts, :loaded?
 
     no_posts = posts.where(title: "")
-    assert_queries(1) { assert_equal true, no_posts.empty? }
+    assert_queries_count(1) { assert_equal true, no_posts.empty? }
     assert_not_predicate no_posts, :loaded?
 
     best_posts = posts.where(comments_count: 0)
@@ -1171,18 +1171,18 @@ class RelationTest < ActiveRecord::TestCase
   def test_empty_complex_chained_relations
     posts = Post.select("comments_count").where("id is not null").group("author_id").where("legacy_comments_count > 0")
 
-    assert_queries(1) { assert_equal false, posts.empty? }
+    assert_queries_count(1) { assert_equal false, posts.empty? }
     assert_not_predicate posts, :loaded?
 
     no_posts = posts.where(title: "")
-    assert_queries(1) { assert_equal true, no_posts.empty? }
+    assert_queries_count(1) { assert_equal true, no_posts.empty? }
     assert_not_predicate no_posts, :loaded?
   end
 
   def test_any
     posts = Post.all
 
-    assert_queries(3) do
+    assert_queries_count(3) do
       assert_predicate posts, :any? # Uses COUNT()
       assert_not_predicate posts.where(id: nil), :any?
 
@@ -1199,7 +1199,7 @@ class RelationTest < ActiveRecord::TestCase
   def test_many
     posts = Post.all
 
-    assert_queries(2) do
+    assert_queries_count(2) do
       assert_predicate posts, :many? # Uses COUNT()
       assert posts.many? { |p| p.id > 0 }
       assert_not posts.many? { |p| p.id < 2 }
@@ -1221,13 +1221,13 @@ class RelationTest < ActiveRecord::TestCase
 
   def test_none?
     posts = Post.all
-    assert_queries(1) do
+    assert_queries_count(1) do
       assert_not posts.none? # Uses COUNT()
     end
 
     assert_not_predicate posts, :loaded?
 
-    assert_queries(1) do
+    assert_queries_count(1) do
       assert posts.none? { |p| p.id < 0 }
       assert_not posts.none? { |p| p.id == 1 }
 
@@ -1240,13 +1240,13 @@ class RelationTest < ActiveRecord::TestCase
 
   def test_one
     posts = Post.all
-    assert_queries(1) do
+    assert_queries_count(1) do
       assert_not posts.one? # Uses COUNT()
     end
 
     assert_not_predicate posts, :loaded?
 
-    assert_queries(1) do
+    assert_queries_count(1) do
       assert_not posts.one? { |p| p.id < 3 }
       assert posts.one? { |p| p.id == 1 }
 
@@ -1259,7 +1259,7 @@ class RelationTest < ActiveRecord::TestCase
 
   def test_one_with_destroy
     posts = Post.all
-    assert_queries(1) do
+    assert_queries_count(1) do
       assert_not posts.one?
     end
 
@@ -1786,10 +1786,10 @@ class RelationTest < ActiveRecord::TestCase
     query = Tag.select(:name).where(id: [tag1.id, tag2.id])
 
     assert_equal ["Foo", "Foo"], query.map(&:name)
-    assert_sql(/DISTINCT/) do
+    assert_queries_match(/DISTINCT/) do
       assert_equal ["Foo"], query.distinct.map(&:name)
     end
-    assert_sql(/DISTINCT/) do
+    assert_queries_match(/DISTINCT/) do
       assert_equal ["Foo"], query.distinct(true).map(&:name)
     end
     assert_equal ["Foo", "Foo"], query.distinct(true).distinct(false).map(&:name)
@@ -1973,7 +1973,7 @@ class RelationTest < ActiveRecord::TestCase
     topics = Topic.all
 
     # the first query is triggered because there are no topics yet.
-    assert_queries(1) { assert_predicate topics, :present? }
+    assert_queries_count(1) { assert_predicate topics, :present? }
 
     # checking if there are topics is used before you actually display them,
     # thus it shouldn't invoke an extra count query.
@@ -1986,7 +1986,7 @@ class RelationTest < ActiveRecord::TestCase
     assert_no_queries { topics.each }
 
     # count always trigger the COUNT query.
-    assert_queries(1) { topics.count }
+    assert_queries_count(1) { topics.count }
 
     assert_predicate topics, :loaded?
   end
@@ -2026,7 +2026,7 @@ class RelationTest < ActiveRecord::TestCase
   end
 
   test "find_by doesn't have implicit ordering" do
-    assert_sql(/^((?!ORDER).)*$/) { Post.all.find_by(author_id: 2) }
+    assert_queries_match(/^((?!ORDER).)*$/) { Post.all.find_by(author_id: 2) }
   end
 
   test "find_by requires at least one argument" do
@@ -2046,7 +2046,7 @@ class RelationTest < ActiveRecord::TestCase
   end
 
   test "find_by! doesn't have implicit ordering" do
-    assert_sql(/^((?!ORDER).)*$/) { Post.all.find_by!(author_id: 2) }
+    assert_queries_match(/^((?!ORDER).)*$/) { Post.all.find_by!(author_id: 2) }
   end
 
   test "find_by! raises RecordNotFound if the record is missing" do
@@ -2114,13 +2114,13 @@ class RelationTest < ActiveRecord::TestCase
   end
 
   test "relations don't load all records in #inspect" do
-    assert_sql(/LIMIT|ROWNUM <=|FETCH FIRST/) do
+    assert_queries_match(/LIMIT|ROWNUM <=|FETCH FIRST/) do
       Post.all.inspect
     end
   end
 
   test "loading query is annotated in #inspect" do
-    assert_sql(%r(/\* loading for inspect \*/)) do
+    assert_queries_match(%r(/\* loading for inspect \*/)) do
       Post.all.inspect
     end
   end
@@ -2145,13 +2145,13 @@ class RelationTest < ActiveRecord::TestCase
   end
 
   test "relations don't load all records in #pretty_print" do
-    assert_sql(/LIMIT|ROWNUM <=|FETCH FIRST/) do
+    assert_queries_match(/LIMIT|ROWNUM <=|FETCH FIRST/) do
       PP.pp Post.all, StringIO.new # avoid outputting.
     end
   end
 
   test "loading query is annotated in #pretty_print" do
-    assert_sql(%r(/\* loading for pp \*/)) do
+    assert_queries_match(%r(/\* loading for pp \*/)) do
       PP.pp Post.all, StringIO.new # avoid outputting.
     end
   end
@@ -2187,7 +2187,7 @@ class RelationTest < ActiveRecord::TestCase
 
   test "#load" do
     relation = Post.all
-    assert_queries(1) do
+    assert_queries_count(1) do
       assert_equal relation, relation.load
     end
     assert_no_queries { relation.to_a }
@@ -2393,12 +2393,12 @@ class RelationTest < ActiveRecord::TestCase
 
   test "#skip_query_cache!" do
     Post.cache do
-      assert_queries(1) do
+      assert_queries_count(1) do
         Post.all.load
         Post.all.load
       end
 
-      assert_queries(2) do
+      assert_queries_count(2) do
         Post.all.skip_query_cache!.load
         Post.all.skip_query_cache!.load
       end
@@ -2407,12 +2407,12 @@ class RelationTest < ActiveRecord::TestCase
 
   test "#skip_query_cache! with an eager load" do
     Post.cache do
-      assert_queries(1) do
+      assert_queries_count(1) do
         Post.eager_load(:comments).load
         Post.eager_load(:comments).load
       end
 
-      assert_queries(2) do
+      assert_queries_count(2) do
         Post.eager_load(:comments).skip_query_cache!.load
         Post.eager_load(:comments).skip_query_cache!.load
       end
@@ -2421,12 +2421,12 @@ class RelationTest < ActiveRecord::TestCase
 
   test "#skip_query_cache! with a preload" do
     Post.cache do
-      assert_queries(2) do
+      assert_queries_count(2) do
         Post.preload(:comments).load
         Post.preload(:comments).load
       end
 
-      assert_queries(4) do
+      assert_queries_count(4) do
         Post.preload(:comments).skip_query_cache!.load
         Post.preload(:comments).skip_query_cache!.load
       end

--- a/activerecord/test/cases/sanitize_test.rb
+++ b/activerecord/test/cases/sanitize_test.rb
@@ -91,11 +91,11 @@ class SanitizeTest < ActiveRecord::TestCase
       }
     end
 
-    assert_sql(/LIKE '20!% !_reduction!_!!'/) do
+    assert_queries_match(/LIKE '20!% !_reduction!_!!'/) do
       searchable_post.search_as_method("20% _reduction_!").to_a
     end
 
-    assert_sql(/LIKE '20!% !_reduction!_!!'/) do
+    assert_queries_match(/LIKE '20!% !_reduction!_!!'/) do
       searchable_post.search_as_scope("20% _reduction_!").to_a
     end
   end

--- a/activerecord/test/cases/scoping/default_scoping_test.rb
+++ b/activerecord/test/cases/scoping/default_scoping_test.rb
@@ -84,14 +84,14 @@ class DefaultScopingTest < ActiveRecord::TestCase
     Mentor.create!
     klass = DeveloperWithIncludedMentorDefaultScopeNotAllQueriesAndDefaultScopeFirmWithAllQueries
 
-    create_sql = capture_sql { klass.create!(name: "Steve") }.first
+    create_sql = capture_sql { klass.create!(name: "Steve") }.second
 
     assert_match(/mentor_id/, create_sql)
     assert_match(/firm_id/, create_sql)
 
     developer = klass.find_by!(name: "Steve")
 
-    update_sql = capture_sql { developer.update(name: "Stephen") }.first
+    update_sql = capture_sql { developer.update(name: "Stephen") }.second
 
     assert_no_match(/mentor_id/, update_sql)
     assert_match(/firm_id/, update_sql)
@@ -99,14 +99,14 @@ class DefaultScopingTest < ActiveRecord::TestCase
 
   def test_default_scope_runs_on_create
     Mentor.create!
-    create_sql = capture_sql { DeveloperwithDefaultMentorScopeNot.create!(name: "Eileen") }.first
+    create_sql = capture_sql { DeveloperwithDefaultMentorScopeNot.create!(name: "Eileen") }.second
 
     assert_match(/mentor_id/, create_sql)
   end
 
   def test_default_scope_with_all_queries_runs_on_create
     Mentor.create!
-    create_sql = capture_sql { DeveloperWithDefaultMentorScopeAllQueries.create!(name: "Eileen") }.first
+    create_sql = capture_sql { DeveloperWithDefaultMentorScopeAllQueries.create!(name: "Eileen") }.second
 
     assert_match(/mentor_id/, create_sql)
   end
@@ -151,7 +151,7 @@ class DefaultScopingTest < ActiveRecord::TestCase
   def test_default_scope_with_all_queries_runs_on_update
     Mentor.create!
     dev = DeveloperWithDefaultMentorScopeAllQueries.create!(name: "Eileen")
-    update_sql = capture_sql { dev.update!(name: "Not Eileen") }.first
+    update_sql = capture_sql { dev.update!(name: "Not Eileen") }.second
 
     assert_match(/mentor_id/, update_sql)
   end
@@ -197,7 +197,7 @@ class DefaultScopingTest < ActiveRecord::TestCase
   def test_default_scope_with_all_queries_runs_on_destroy
     Mentor.create!
     dev = DeveloperWithDefaultMentorScopeAllQueries.create!(name: "Eileen")
-    destroy_sql = capture_sql { dev.destroy }.first
+    destroy_sql = capture_sql { dev.destroy }.second
 
     assert_match(/mentor_id/, destroy_sql)
   end

--- a/activerecord/test/cases/scoping/named_scoping_test.rb
+++ b/activerecord/test/cases/scoping/named_scoping_test.rb
@@ -24,7 +24,7 @@ class NamedScopingTest < ActiveRecord::TestCase
   def test_found_items_are_cached
     all_posts = Topic.base
 
-    assert_queries(1) do
+    assert_queries_count(1) do
       all_posts.collect { true }
       all_posts.collect { true }
     end
@@ -227,7 +227,7 @@ class NamedScopingTest < ActiveRecord::TestCase
 
   def test_empty_should_not_load_results
     topics = Topic.base
-    assert_queries(2) do
+    assert_queries_count(2) do
       topics.empty?  # use count query
       topics.load    # force load
       topics.empty?  # use loaded (no query)
@@ -236,7 +236,7 @@ class NamedScopingTest < ActiveRecord::TestCase
 
   def test_any_should_not_load_results
     topics = Topic.base
-    assert_queries(2) do
+    assert_queries_count(2) do
       topics.any?    # use count query
       topics.load    # force load
       topics.any?    # use loaded (no query)
@@ -245,7 +245,7 @@ class NamedScopingTest < ActiveRecord::TestCase
 
   def test_any_should_call_proxy_found_if_using_a_block
     topics = Topic.base
-    assert_queries(1) do
+    assert_queries_count(1) do
       assert_not_called(topics, :empty?) do
         topics.any? { true }
       end
@@ -266,7 +266,7 @@ class NamedScopingTest < ActiveRecord::TestCase
 
   def test_many_should_not_load_results
     topics = Topic.base
-    assert_queries(2) do
+    assert_queries_count(2) do
       topics.many?   # use count query
       topics.load    # force load
       topics.many?   # use loaded (no query)
@@ -275,7 +275,7 @@ class NamedScopingTest < ActiveRecord::TestCase
 
   def test_many_should_call_proxy_found_if_using_a_block
     topics = Topic.base
-    assert_queries(1) do
+    assert_queries_count(1) do
       assert_not_called(topics, :size) do
         topics.many? { true }
       end
@@ -428,8 +428,8 @@ class NamedScopingTest < ActiveRecord::TestCase
 
   def test_size_should_use_count_when_results_are_not_loaded
     topics = Topic.base
-    assert_queries(1) do
-      assert_sql(/COUNT/i) { topics.size }
+    assert_queries_count(1) do
+      assert_queries_match(/COUNT/i) { topics.size }
     end
   end
 
@@ -495,11 +495,11 @@ class NamedScopingTest < ActiveRecord::TestCase
   def test_scopes_batch_finders
     assert_equal 4, Topic.approved.count
 
-    assert_queries(5) do
+    assert_queries_count(5) do
       Topic.approved.find_each(batch_size: 1) { |t| assert_predicate t, :approved? }
     end
 
-    assert_queries(3) do
+    assert_queries_count(3) do
       Topic.approved.find_in_batches(batch_size: 2) do |group|
         group.each { |t| assert_predicate t, :approved? }
       end
@@ -528,7 +528,7 @@ class NamedScopingTest < ActiveRecord::TestCase
   end
 
   def test_nested_scopes_queries_size
-    assert_queries(1) do
+    assert_queries_count(1) do
       Topic.approved.by_lifo.replied.written_before(Time.now).to_a
     end
   end
@@ -540,7 +540,7 @@ class NamedScopingTest < ActiveRecord::TestCase
     post = posts(:welcome)
 
     Post.cache do
-      assert_queries(1) { post.comments.containing_the_letter_e.to_a }
+      assert_queries_count(1) { post.comments.containing_the_letter_e.to_a }
       assert_no_queries { post.comments.containing_the_letter_e.to_a }
     end
   end
@@ -549,10 +549,10 @@ class NamedScopingTest < ActiveRecord::TestCase
     post = posts(:welcome)
 
     Post.cache do
-      one = assert_queries(1) { post.comments.limit_by(1).to_a }
+      one = assert_queries_count(1) { post.comments.limit_by(1).to_a }
       assert_equal 1, one.size
 
-      two = assert_queries(1) { post.comments.limit_by(2).to_a }
+      two = assert_queries_count(1) { post.comments.limit_by(2).to_a }
       assert_equal 2, two.size
 
       assert_no_queries { post.comments.limit_by(1).to_a }
@@ -622,7 +622,7 @@ class NamedScopingTest < ActiveRecord::TestCase
       scope :including_annotate_in_scope, Proc.new { annotate("from-scope") }
     end
 
-    assert_sql(%r{/\* from-scope \*/}) do
+    assert_queries_match(%r{/\* from-scope \*/}) do
       assert_equal Topic.including_annotate_in_scope.to_a, Topic.all.to_a
     end
   end

--- a/activerecord/test/cases/scoping/relation_scoping_test.rb
+++ b/activerecord/test/cases/scoping/relation_scoping_test.rb
@@ -156,7 +156,7 @@ class RelationScopingTest < ActiveRecord::TestCase
   def test_scoped_find_with_annotation
     Developer.annotate("scoped").scoping do
       developer = nil
-      assert_sql(%r{/\* scoped \*/}) do
+      assert_queries_match(%r{/\* scoped \*/}) do
         developer = Developer.where("name = 'David'").first
       end
       assert_equal "David", developer.name
@@ -370,7 +370,7 @@ class RelationScopingTest < ActiveRecord::TestCase
     end
 
     Author.where(organization_id: 1).scoping(all_queries: true) do
-      update_scoped_sql = capture_sql { dev.update(name: "Not Eileen") }.first
+      update_scoped_sql = capture_sql { dev.update(name: "Not Eileen") }.second
       assert_match(/organization_id/, update_scoped_sql)
     end
   end

--- a/activerecord/test/cases/validations/uniqueness_validation_test.rb
+++ b/activerecord/test/cases/validations/uniqueness_validation_test.rb
@@ -654,7 +654,7 @@ class UniquenessValidationWithIndexTest < ActiveRecord::TestCase
     @connection.add_index(:topics, :title, unique: true, name: :topics_index)
 
     t = Topic.new(title: "abc")
-    assert_queries(1) do
+    assert_queries_count(1) do
       t.valid?
     end
   end
@@ -665,7 +665,7 @@ class UniquenessValidationWithIndexTest < ActiveRecord::TestCase
 
     t = Topic.create!(title: "abc")
     t.author_name = "John"
-    assert_no_queries(ignore_none: false) do
+    assert_no_queries do
       t.valid?
     end
   end
@@ -676,7 +676,7 @@ class UniquenessValidationWithIndexTest < ActiveRecord::TestCase
 
     t = Topic.create!(title: "abc")
     t.title = "abc v2"
-    assert_queries(1) do
+    assert_queries_count(1) do
       t.valid?
     end
   end
@@ -688,7 +688,7 @@ class UniquenessValidationWithIndexTest < ActiveRecord::TestCase
     t = Topic.create!
     assert_nil t.title
     t.author_name = "John"
-    assert_queries(1) do
+    assert_queries_count(1) do
       t.valid?
     end
   end
@@ -699,7 +699,7 @@ class UniquenessValidationWithIndexTest < ActiveRecord::TestCase
 
     t = Topic.create!(title: "abc")
     t.title = "abc v2"
-    assert_queries(1) do
+    assert_queries_count(1) do
       t.valid?
     end
   end
@@ -710,7 +710,7 @@ class UniquenessValidationWithIndexTest < ActiveRecord::TestCase
 
     t = Topic.create!(title: "abc")
     t.title = "abc v2"
-    assert_queries(1) do
+    assert_queries_count(1) do
       t.valid?
     end
   end
@@ -723,7 +723,7 @@ class UniquenessValidationWithIndexTest < ActiveRecord::TestCase
 
     t = Topic.create!(title: "abc")
     t.author_name = "John"
-    assert_queries(1) do
+    assert_queries_count(1) do
       t.valid?
     end
   end
@@ -734,7 +734,7 @@ class UniquenessValidationWithIndexTest < ActiveRecord::TestCase
 
     t = Topic.create!(title: "abc")
     t.author_name = "John"
-    assert_queries(1) do
+    assert_queries_count(1) do
       t.valid?
     end
   end
@@ -745,12 +745,12 @@ class UniquenessValidationWithIndexTest < ActiveRecord::TestCase
 
     t = Topic.create!(title: "abc", author_name: "John")
     t.content = "hello world"
-    assert_no_queries(ignore_none: false) do
+    assert_no_queries do
       t.valid?
     end
 
     t.author_name = "Amy"
-    assert_queries(1) do
+    assert_queries_count(1) do
       t.valid?
     end
   end
@@ -764,12 +764,12 @@ class UniquenessValidationWithIndexTest < ActiveRecord::TestCase
     t = TopicWithEvent.create!(event: e1)
 
     t.content = "hello world"
-    assert_no_queries(ignore_none: false) do
+    assert_no_queries do
       t.valid?
     end
 
     t.event = e2
-    assert_queries(1) do
+    assert_queries_count(1) do
       t.valid?
     end
   ensure
@@ -792,12 +792,12 @@ class UniquenessValidationWithIndexTest < ActiveRecord::TestCase
 
     t = Topic.create!(title: "abc", author_name: "John")
     t.content = "hello world"
-    assert_no_queries(ignore_none: false) do
+    assert_no_queries do
       t.valid?
     end
 
     t.author_name = "Amy"
-    assert_queries(1, ignore_none: false) do
+    assert_queries_count(1) do
       t.valid?
     end
   end
@@ -808,7 +808,7 @@ class UniquenessValidationWithIndexTest < ActiveRecord::TestCase
 
     t = Topic.create!(title: "abc", author_name: "John")
     t.content = "hello world"
-    assert_queries(1) do
+    assert_queries_count(1) do
       t.valid?
     end
   end
@@ -821,7 +821,7 @@ class UniquenessValidationWithIndexTest < ActiveRecord::TestCase
       t = Topic.create!(title: "abc", author_name: "John")
       t.content = "hello world"
 
-      assert_queries(1) do
+      assert_queries_count(1) do
         t.valid?
       end
     end

--- a/activestorage/test/models/variant_with_record_test.rb
+++ b/activestorage/test/models/variant_with_record_test.rb
@@ -85,7 +85,7 @@ class ActiveStorage::VariantWithRecordTest < ActiveSupport::TestCase
     users.reset
 
     assert_no_difference -> { ActiveStorage::VariantRecord.count } do
-      assert_queries(11) do
+      assert_queries_count(11) do
         # 11 queries:
         # users x 1
         # attachment (cover photo) x 2
@@ -105,9 +105,8 @@ class ActiveStorage::VariantWithRecordTest < ActiveSupport::TestCase
     users.reset
 
     assert_no_difference -> { ActiveStorage::VariantRecord.count } do
-      assert_queries(6) do
-        # 6 queries:
-        # users x 1
+      assert_queries_count(5) do
+        # 5 queries:
         # attachment (cover photos) x 1
         # blob for the cover photo x 1
         # variant record x 1
@@ -144,7 +143,7 @@ class ActiveStorage::VariantWithRecordTest < ActiveSupport::TestCase
     user.reload
 
     assert_no_difference -> { ActiveStorage::VariantRecord.count } do
-      assert_queries(9) do
+      assert_queries_count(9) do
         # 9 queries:
         # attachments (vlogs) x 1
         # blob x 2
@@ -163,7 +162,7 @@ class ActiveStorage::VariantWithRecordTest < ActiveSupport::TestCase
     user.reload
 
     assert_no_difference -> { ActiveStorage::VariantRecord.count } do
-      assert_queries(7) do
+      assert_queries_count(7) do
         # 7 queries:
         # attachments (vlogs) x 1
         # blob x 1
@@ -181,7 +180,7 @@ class ActiveStorage::VariantWithRecordTest < ActiveSupport::TestCase
     user.reload
 
     assert_no_difference -> { ActiveStorage::VariantRecord.count } do
-      assert_queries(5) do
+      assert_queries_count(5) do
         # 5 queries:
         # attachments (vlogs) x 1
         # blobs for the vlogs x 1
@@ -200,7 +199,7 @@ class ActiveStorage::VariantWithRecordTest < ActiveSupport::TestCase
     user.reload
 
     assert_no_difference -> { ActiveStorage::VariantRecord.count } do
-      assert_queries(5) do
+      assert_queries_count(5) do
         # 5 queries:
         # attachments (vlogs) x 1
         # blobs for the vlogs x 1
@@ -219,7 +218,7 @@ class ActiveStorage::VariantWithRecordTest < ActiveSupport::TestCase
     user.reload
 
     assert_no_difference -> { ActiveStorage::VariantRecord.count } do
-      assert_queries(6) do
+      assert_queries_count(6) do
         # 6 queries:
         # user x 1
         # attachments (vlogs) x 1
@@ -244,7 +243,7 @@ class ActiveStorage::VariantWithRecordTest < ActiveSupport::TestCase
       # More queries here because we are creating a different variant.
       # The second time we load this variant, we are back down to just 3 queries.
 
-      assert_queries(9, matcher: /SELECT/) do
+      assert_queries_match(/SELECT/i, count: 9) do
         # 9 queries:
         # attachments (vlogs) initial load x 1
         # blob x 1 (gets both records)
@@ -260,7 +259,7 @@ class ActiveStorage::VariantWithRecordTest < ActiveSupport::TestCase
 
       user.reload
 
-      assert_queries(5) do
+      assert_queries_count(5) do
         user.vlogs.with_all_variant_records.each do |vlog|
           rep = vlog.representation(resize_to_limit: [200, 200])
           rep.processed

--- a/guides/source/testing.md
+++ b/guides/source/testing.md
@@ -362,8 +362,10 @@ Rails adds some custom assertions of its own to the `minitest` framework:
 | [`assert_generates(expected_path, options, defaults={}, extras = {}, message=nil)`](https://api.rubyonrails.org/classes/ActionDispatch/Assertions/RoutingAssertions.html#method-i-assert_generates) | Asserts that the provided options can be used to generate the provided path. This is the inverse of assert_recognizes. The extras parameter is used to tell the request the names and values of additional request parameters that would be in a query string. The message parameter allows you to specify a custom error message for assertion failures.|
 | [`assert_response(type, message = nil)`](https://api.rubyonrails.org/classes/ActionDispatch/Assertions/ResponseAssertions.html#method-i-assert_response) | Asserts that the response comes with a specific status code. You can specify `:success` to indicate 200-299, `:redirect` to indicate 300-399, `:missing` to indicate 404, or `:error` to match the 500-599 range. You can also pass an explicit status number or its symbolic equivalent. For more information, see [full list of status codes](https://rubydoc.info/gems/rack/Rack/Utils#HTTP_STATUS_CODES-constant) and how their [mapping](https://rubydoc.info/gems/rack/Rack/Utils#SYMBOL_TO_STATUS_CODE-constant) works.|
 | [`assert_redirected_to(options = {}, message=nil)`](https://api.rubyonrails.org/classes/ActionDispatch/Assertions/ResponseAssertions.html#method-i-assert_redirected_to) | Asserts that the response is a redirect to a URL matching the given options. You can also pass named routes such as `assert_redirected_to root_path` and Active Record objects such as `assert_redirected_to @article`.|
-|`assert_queries(int, &block)` | Asserts that `&block` generates an `int` number of SQL queries.|
+|`assert_queries_count(int, &block)` | Asserts that `&block` generates an `int` number of SQL queries.|
 |`assert_no_queries(&block)` | Asserts that `&block` generates no SQL queries.|
+|`assert_queries_match(pattern, &block)` | Asserts that `&block` generates SQL queries that match the pattern.|
+|`assert_no_queries_match(pattern, &block)` | Asserts that `&block` generates no SQL queries that match the pattern.|
 
 You'll see the usage of some of these assertions in the next chapter.
 


### PR DESCRIPTION
Follow up to https://github.com/rails/rails/pull/50281.

The originally introduced (exposed) helpers are a bit limited. For example:
1. we must specify an exact number of queries we are expecting
2. only application related queries are considered, schema/transactions related queries are always skipped
3. only one matcher can be specified

These limitations work most of the time for regular users, but not when trying to test some lower behavior (for example, inside some gem's tests).

For example, it was not possible to test that an index and a foreign key are created when running some operation.
Now, this can be done via:
```ruby
assert_queries_match(/create index/i, include_schema: true) do
  do_something
end
```

cc @byroot @p8 
