### PR TITLE
Fix issue with regression in integration tests when providing as: :html

### DIFF
--- a/actionpack/lib/action_dispatch/testing/request_encoder.rb
+++ b/actionpack/lib/action_dispatch/testing/request_encoder.rb
@@ -52,7 +52,10 @@ module ActionDispatch
       @encoders[mime_name] = new(mime_name, param_encoder, response_parser)
     end
 
-    register_encoder :html, response_parser: -> body { Rails::Dom::Testing.html_document.parse(body) }
+    register_encoder :html,
+    response_parser: ->(body) { Rails::Dom::Testing.html_document.parse(body) },
+    param_encoder: ->(params) { params }
+
     register_encoder :json, response_parser: -> body { JSON.parse(body, object_class: ActiveSupport::HashWithIndifferentAccess) }
   end
 end

--- a/actionpack/test/dispatch/content_type_test.rb
+++ b/actionpack/test/dispatch/content_type_test.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require "bundler/inline"
+require "action_controller/railtie"
+require "minitest/autorun"
+require "rack/test"
+
+class ContentTest < ActionDispatch::IntegrationTest
+  class CharactersController < ActionController::Base
+    def create
+      render head: :no_content
+    end
+  end
+
+  def test_params_without_content_type
+    post "/characters", params: { name: "Muad'Dib" }
+  end
+
+  def test_params_with_html_content_type
+    post "/users", as: :html, params: { name: "Muad'Dib" }
+  end
+end


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created in order to fix issue #50345. 

### Detail

This Pull Request solves the problem in Rails 7.1 where providing as: :html in the integration test for ActionDispatch causes a "undefined method to_html" error to be thrown.

To solve this issue, this Pull Request registers a param_encoder in addition to a HTML encoder in order to perform the request to the controller. 

As a result, both the new tests provided in content_type_test.rb as well as the original tests for ActionDispatch are working.

### Additional information

<!-- Provide additional information such as benchmarks, reference to other repositories or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
