### PR TITLE
Add sqlite3 back to bug templates that need it

### DIFF
--- a/guides/bug_report_templates/action_mailbox.rb
+++ b/guides/bug_report_templates/action_mailbox.rb
@@ -10,6 +10,8 @@ gemfile(true) do
   gem "rails"
   # If you want to test against edge Rails replace the previous line with this:
   # gem "rails", github: "rails/rails", branch: "main"
+
+  gem "sqlite3"
 end
 
 require "active_record/railtie"

--- a/guides/bug_report_templates/active_record.rb
+++ b/guides/bug_report_templates/active_record.rb
@@ -10,6 +10,8 @@ gemfile(true) do
   gem "rails"
   # If you want to test against edge Rails replace the previous line with this:
   # gem "rails", github: "rails/rails", branch: "main"
+
+  gem "sqlite3"
 end
 
 require "active_record"

--- a/guides/bug_report_templates/active_record_migrations.rb
+++ b/guides/bug_report_templates/active_record_migrations.rb
@@ -10,6 +10,8 @@ gemfile(true) do
   gem "rails"
   # If you want to test against edge Rails replace the previous line with this:
   # gem "rails", github: "rails/rails", branch: "main"
+
+  gem "sqlite3"
 end
 
 require "active_record"

--- a/guides/bug_report_templates/active_storage.rb
+++ b/guides/bug_report_templates/active_storage.rb
@@ -10,6 +10,8 @@ gemfile(true) do
   gem "rails"
   # If you want to test against edge Rails replace the previous line with this:
   # gem "rails", github: "rails/rails", branch: "main"
+
+  gem "sqlite3"
 end
 
 require "active_record/railtie"


### PR DESCRIPTION
Ref #50317

The sqlite3 gem was removed during the merging of main and gem templates, but the resulting templates still depend on it.
