### PR TITLE
Revert "Lock `bigdecimal` version to 3.1.4 or lower"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -86,7 +86,7 @@ PATH
       marcel (~> 1.0)
     activesupport (7.2.0.alpha)
       base64
-      bigdecimal (< 3.1.5)
+      bigdecimal
       concurrent-ruby (~> 1.0, >= 1.0.2)
       connection_pool (>= 2.2.5)
       drb

--- a/activesupport/activesupport.gemspec
+++ b/activesupport/activesupport.gemspec
@@ -41,5 +41,5 @@ Gem::Specification.new do |s|
   s.add_dependency "minitest",        ">= 5.1"
   s.add_dependency "base64"
   s.add_dependency "drb"
-  s.add_dependency "bigdecimal",      "< 3.1.5"
+  s.add_dependency "bigdecimal"
 end


### PR DESCRIPTION
Reverts rails/rails#50331

Since `bigdecimal` 3.1.5 has been released https://rubygems.org/gems/bigdecimal/versions/3.1.5 we no longer need to pin the bigdecimal version to 3.1.4 or lower.

Refer to the background information for this change.
https://github.com/ruby/ruby/pull/9163#issuecomment-1846994447