### PR TITLE
Ignore warnings like `warning: net-smtp which is not part of the default gems since Ruby 3.1.0.`

### DIFF
--- a/railties/test/application/bin_setup_test.rb
+++ b/railties/test/application/bin_setup_test.rb
@@ -46,7 +46,7 @@ module ApplicationTests
         output.sub!(/^\[.*?\] Resolving packages\.\.\.$/, "[1/4] Resolving packages...")
         output.sub!(/^Done in \d+\.\d+s\.\n/, "Done in 0.00s.\n")
         # Ignore warnings such as `Psych.safe_load is deprecated`
-        output.gsub!(/^warning:\s.*\n/, "")
+        output.gsub!(/^.*warning:\s.*\n/, "")
 
         assert_equal(<<~OUTPUT, output)
           == Installing dependencies ==


### PR DESCRIPTION
### Motivation / Background

This commit addresses the CI failure against Ruby master branch. https://buildkite.com/rails/rails/builds/102575#018c4147-8760-48ac-812c-4e63fbe242fa

### Detail
* Steps to reproduce

Install `ruby 3.3.0dev`
```ruby
git clone https://github.com/rails/rails
cd rails/railties
rm ../Gemfile.lock
bundle
bin/test test/application/bin_setup_test.rb -n test_bin_setup_output
```

* Without this commit

```ruby
$ ruby -v
ruby 3.3.0dev (2023-12-16T21:45:33Z master d7d10f3ee8) [x86_64-linux]
$ rm ../Gemfile.lock ; bundle ; bin/test test/application/bin_setup_test.rb -n test_bin_setup_output
... snip ...
F

Failure:
ApplicationTests::BinSetupTest#test_bin_setup_output [/home/yahonda/src/github.com/rails/rails/railties/test/application/bin_setup_test.rb:51]:
--- expected
+++ actual
@@ -2,10 +2,12 @@
 The Gemfile's dependencies are satisfied

 == Preparing database ==
+/home/yahonda/.rbenv/versions/trunk/lib/ruby/gems/3.3.0+0/gems/zeitwerk-2.6.12/lib/zeitwerk/kernel.rb:38: warning: mutex_m was loaded from the standard library, but will no longer be part of the default gems since Ruby 3.4.0. Add mutex_m to your Gemfile or gemspec.
 Created database 'app_development'
 Created database 'app_test'

 == Removing old logs and tempfiles ==
+/home/yahonda/.rbenv/versions/trunk/lib/ruby/gems/3.3.0+0/gems/zeitwerk-2.6.12/lib/zeitwerk/kernel.rb:38: warning: mutex_m was loaded from the standard library, but will no longer be part of the default gems since Ruby 3.4.0. Add mutex_m to your Gemfile or gemspec.

 == Restarting application server ==
 "

bin/test test/application/bin_setup_test.rb:30

Finished in 12.553516s, 0.0797 runs/s, 0.0797 assertions/s.
1 runs, 1 assertions, 1 failures, 0 errors, 0 skips
$
```

### Additional information

This failure reproduces since this commit: 
https://github.com/ruby/ruby/commit/d411d8f5fe80b9c8f741ee03f91a670d5620917c


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.


