### PR TITLE
Enable `Minitest/NonExecutableTestMethod` cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -367,6 +367,9 @@ Minitest/AssertWithExpectedArgument:
 Minitest/LiteralAsActualArgument:
   Enabled: true
 
+Minitest/NonExecutableTestMethod:
+  Enabled: true
+
 Minitest/SkipEnsure:
   Enabled: true
 


### PR DESCRIPTION
### Motivation / Background

This pull request enables `Minitest/NonExecutableTestMethod` cop to find non-executed test that is out of `ActiveSupport::TestCase` and its subclasses.

This cop is based on the request since there was a test that is not executed found at https://github.com/rails/rails/pull/50334#issuecomment-1851411434 and implemented to RuboCop Minitest 0.34.0 via https://github.com/rubocop/rubocop-minitest/issues/279

### Detail

This cop works as follows.
As of right now, there is no offenses by reverting the merge commit via #50334

```ruby
$ git revert -m 1 9517841
$ bundle exec rubocop
Inspecting 3254 files
... snip ...

Offenses:

activerecord/test/cases/assertions/query_assertions_test.rb:27:5: W: Minitest/NonExecutableTestMethod: Test method should be defined inside a test class to ensure execution.
    def test_assert_no_queries ...
    ^^^^^^^^^^^^^^^^^^^^^^^^^^

3254 files inspected, 1 offense detected
$
```

### Additional information

<!-- Provide additional information such as benchmarks, reference to other repositories or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.


