### PR TITLE
Fix `guides/active_record_migrations.rb` template to use the current migrations version

### DIFF
--- a/guides/bug_report_templates/active_record_migrations.rb
+++ b/guides/bug_report_templates/active_record_migrations.rb
@@ -31,7 +31,7 @@ end
 class Payment < ActiveRecord::Base
 end
 
-class ChangeAmountToAddScale < ActiveRecord::Migration[7.2]
+class ChangeAmountToAddScale < ActiveRecord::Migration::Current # or use a specific version via `Migration[number]`
   def change
     reversible do |dir|
       dir.up do


### PR DESCRIPTION
Fixes https://github.com/rails/rails/issues/50380.

The regression was introduced in https://github.com/rails/rails/pull/50317/files#diff-6353d2979a5ebdafe8f7d31056f091de3e47b9bfafe5503630e5b0da951d8d3dR10-R12

cc @zzak @yahonda 