### PR TITLE
Fix multi-database polymorphic preloading with equivalent table names

### DIFF
--- a/activerecord/lib/active_record/associations/preloader/association.rb
+++ b/activerecord/lib/active_record/associations/preloader/association.rb
@@ -16,12 +16,12 @@ module ActiveRecord
 
           def eql?(other)
             association_key_name == other.association_key_name &&
-              scope.table_name == other.scope.table_name &&
+              scope.name == other.scope.name &&
               scope.values_for_queries == other.scope.values_for_queries
           end
 
           def hash
-            [association_key_name, scope.table_name, scope.values_for_queries].hash
+            [association_key_name, scope.name, scope.values_for_queries].hash
           end
 
           def records_for(loaders)

--- a/activerecord/lib/active_record/associations/preloader/association.rb
+++ b/activerecord/lib/active_record/associations/preloader/association.rb
@@ -16,12 +16,13 @@ module ActiveRecord
 
           def eql?(other)
             association_key_name == other.association_key_name &&
-              scope.name == other.scope.name &&
+              scope.table_name == other.scope.table_name &&
+              scope.connection_specification_name == other.scope.connection_specification_name &&
               scope.values_for_queries == other.scope.values_for_queries
           end
 
           def hash
-            [association_key_name, scope.name, scope.values_for_queries].hash
+            [association_key_name, scope.table_name, scope.connection_specification_name, scope.values_for_queries].hash
           end
 
           def records_for(loaders)

--- a/activerecord/test/cases/associations_test.rb
+++ b/activerecord/test/cases/associations_test.rb
@@ -1220,6 +1220,14 @@ class PreloaderTest < ActiveRecord::TestCase
     other_dog_comment.origin_type = other_dog.class.name
     other_dog_comment.origin_id = other_dog.id
 
+    # Both Dog and OtherDog are backed by a table named `dogs`,
+    # however they are stored in different databases and should
+    # therefore result in two separate queries rather than be batched
+    # together.
+    #
+    # Expected
+    #   SELECT FROM dogs ... (Dog)
+    #   SELECT FROM dogs ... (OtherDog)
     assert_queries(2) do
       preloader = ActiveRecord::Associations::Preloader.new(records: [dog_comment, other_dog_comment], associations: :origin)
       preloader.call

--- a/activerecord/test/cases/associations_test.rb
+++ b/activerecord/test/cases/associations_test.rb
@@ -39,6 +39,8 @@ require "models/sharded"
 require "models/cpk"
 require "models/member_detail"
 require "models/organization"
+require "models/dog"
+require "models/other_dog"
 
 
 class AssociationsTest < ActiveRecord::TestCase
@@ -773,7 +775,8 @@ end
 class PreloaderTest < ActiveRecord::TestCase
   fixtures :posts, :comments, :books, :authors, :tags, :taggings, :essays, :categories, :author_addresses,
            :sharded_blog_posts, :sharded_comments, :sharded_blog_posts_tags, :sharded_tags,
-           :members, :member_details, :organizations, :cpk_orders, :cpk_order_agreements
+           :members, :member_details, :organizations, :cpk_orders, :cpk_order_agreements,
+           :dogs, :other_dogs
 
   def test_preload_with_scope
     post = posts(:welcome)
@@ -1203,6 +1206,23 @@ class PreloaderTest < ActiveRecord::TestCase
     assert_no_queries do
       post.author
       postesque.author
+    end
+  end
+
+  def test_multi_database_polymorphic_preload_with_same_table_name
+    dog = dogs(:sophie)
+    dog_comment = comments(:greetings)
+    dog_comment.origin_type = dog.class.name
+    dog_comment.origin_id = dog.id
+
+    other_dog = other_dogs(:lassie)
+    other_dog_comment = comments(:more_greetings)
+    other_dog_comment.origin_type = other_dog.class.name
+    other_dog_comment.origin_id = other_dog.id
+
+    assert_queries(2) do
+      preloader = ActiveRecord::Associations::Preloader.new(records: [dog_comment, other_dog_comment], associations: :origin)
+      preloader.call
     end
   end
 


### PR DESCRIPTION
### Motivation / Background
I work with an application that utilizes a polymorphic association that spans multiple databases. A basic example would be something like this, where `Notification#notifiable` could reference `Comment` or `OtherNamespace::Comment`, which exist on two separate databases but happen to have the same table name:

```ruby
# app/models/notification.rb
class Notification < ApplicationRecord
  belongs_to :notifiable, polymorphic: true
end

# app/models/comment.rb
class Comment < ApplicationRecord
  self.table_name = "comments"
end

# app/models/application_record.rb
class ApplicationRecord < ActiveRecord::Base
  self.abstract_class = true

  connects_to database: { writing: :primary }
end

# app/models/other_namespace/comment.rb
module OtherNamespace
  class Comment < OtherNamespace::Base
    self.table_name = "comments"
  end
end

# app/models/other_namespace/base.rb
module OtherNamespace
  class Base < ApplicationRecord
    self.abstract_class = true

    connects_to database: { writing: :other_namespace }
  end
end
```

Prior to upgrading to Rails 7.0, the following would preload both `Comment`s and `OtherNamespace::Comment`s:

```ruby
comment = Comment.create
other_namespace_comment = OtherNamespace::Comment.create

Notification.create(notifiable: comment)
Notification.create(notifiable: other_namespace_comment)

# Prior to Rails 7.0, this would preload the related `Comment`s and `OtherNamespace::Comment`s
Notification.all.includes(:notifiable)
```

After upgrading to Rails 7.0, we noticed that only `Comment`s were being preloading and `OtherNamespace::Comment`s were not. 

After some digging, I tracked the difference in behavior down to [PR #41385](https://github.com/rails/rails/pull/41385). In this PR there were some optimizations made to combine association preloading into less queries when possible. This was later optimized a bit further in [PR #41597](https://github.com/rails/rails/pull/41597). 

From what I can tell [`ActiveRecord::Associations::Preloader::Batch#group_and_load_similar`](https://github.com/rails/rails/blob/a7f1d63a3bf92e5c07400afefd6016cdf48208a2/activerecord/lib/active_record/associations/preloader/batch.rb#L40), queries are being grouped and loaded. That comparison is being done based on [`ActiveRecord::Associations::Preloader::Association::LoaderQuery#eql?`](https://github.com/rails/rails/blob/a7f1d63a3bf92e5c07400afefd6016cdf48208a2/activerecord/lib/active_record/associations/preloader/association.rb#L17), which is the following:

```ruby
  def eql?(other)
    association_key_name == other.association_key_name &&
      scope.table_name == other.scope.table_name &&
      scope.values_for_queries == other.scope.values_for_queries
  end
```

As you can see, in the polymorphic use case shown above the loaders for `OtherNamespace::Comment` and `Comment` would be considered equivalent since they have the same `association_key_name` (`notifiable` in this case), `table_name` (`comments` in this case), and `values_for_queries` (`id` in this case). By comparing them this way it results in  `OtherNamespace::Comment` not being preloaded after the Rails 7.0 upgrade.  

### Detail
Using the existing models and relationships in the test suite, I was able to generate a failing test case. I've also included a proposed fix which adds a loader comparison on `scope.connection_specification_name`. The idea is to prevent two tables with the same name on two separate databases from being considered equivalent when preloading associations.

Another idea would be to replace the `table_name` comparison with `name` (the class name). I tried this and all tests pass, but I'm unsure if this could be problematic in other cases, such as when using single table inheritance. If there's another way of achieving the desired result with a different comparison, I'm happy to change the logic!

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.

Happy to add a Changelog entry if it's needed.