### PR TITLE
Fix issue with destroy after RestartParentTransaction and SavepointTransaction rollback

### DIFF
--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -782,7 +782,11 @@ module ActiveRecord
     def destroy
       _raise_readonly_record_error if readonly?
       destroy_associations
-      @_trigger_destroy_callback ||= persisted? && destroy_row > 0
+      if @_trigger_destroy_callback
+        destroy_row
+      else
+        @_trigger_destroy_callback = persisted? && destroy_row > 0
+      end
       @destroyed = true
       @previously_new_record = false
       freeze

--- a/activerecord/test/cases/persistence_test.rb
+++ b/activerecord/test/cases/persistence_test.rb
@@ -25,6 +25,7 @@ require "models/cpk"
 require "models/chat_message"
 require "models/default"
 require "models/post_with_prefetched_pk"
+require "models/mypost"
 
 class PersistenceTest < ActiveRecord::TestCase
   fixtures :topics, :companies, :developers, :accounts, :minimalistics, :authors, :author_addresses,
@@ -872,6 +873,22 @@ class PersistenceTest < ActiveRecord::TestCase
       book.destroy!
     end
   end
+
+  def test_destroy_after_restart_parent_transaction_rollback
+    MyPost.create!
+    assert_equal 1, MyPost.count
+    MyPost.test_restart_parent_transaction
+    assert_equal 0, MyPost.count
+  end
+
+  def test_destroy_after_savepoint_transaction_rollback
+    MyPost.create!
+    assert_equal 1, MyPost.count
+    MyPost.test_savepoint_transaction
+    assert_equal 0, MyPost.count
+  end
+
+
 
   def test_find_raises_record_not_found_exception
     assert_raise(ActiveRecord::RecordNotFound) { Topic.find(99999) }

--- a/activerecord/test/models/mypost.rb
+++ b/activerecord/test/models/mypost.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+class MyPost < ActiveRecord::Base
+  self.table_name = "my_posts"
+  has_many :comments
+  def self.test_restart_parent_transaction
+    post = self.first
+    ActiveRecord::Base.transaction do
+      ActiveRecord::Base.transaction(requires_new: true) do
+        post.destroy
+        raise "Rollback"
+      end
+    end
+  rescue
+    post.destroy
+  end
+  def self.test_savepoint_transaction
+    post = nil
+    ActiveRecord::Base.transaction do
+        post = self.first
+        ActiveRecord::Base.transaction(requires_new: true) do
+          post.destroy
+          raise "Rollback"
+        end
+      end
+  rescue
+    post.destroy
+  end
+end

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -832,6 +832,10 @@ ActiveRecord::Schema.define do
     t.string      :name
   end
 
+  create_table :my_posts, force: true do |t|
+    t.string      :name
+  end
+
   create_table :notifications, force: true do |t|
     t.string :message
   end


### PR DESCRIPTION


<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created in order to fix issue #50338.

### Detail

This Pull Request provides a working solution for the destroy function for the cases of RestartParentTransaction and SavepointTransaction. 

Previously, the destroy function was not properly removing entries from the database for the RestartParentTransaction and SavepointTransaction. If @_trigger_destroy_callback is true at the beginning of the destroy function, destroy_row would never be invoked.

This Pull Request will ensure destroy_row is invoked when @_trigger_destroy_callback is true at the beginning of the destroy function. This will remove the corresponding row from the database. Otherwise, if @_trigger_destroy_callback is false, destroy_row is only invoked if persisted? is true.

### Additional information

<!-- Provide additional information such as benchmarks, reference to other repositories or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
