### PR TITLE
Treat `as: :html` tests request params as `:url_encoded_form`

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,2 +1,5 @@
+*   Submit test requests using `as: :html` with `Content-Type: x-www-form-urlencoded`
+
+    *Sean Doyle*
 
 Please check [8-1-stable](https://github.com/rails/rails/blob/8-1-stable/actionpack/CHANGELOG.md) for previous changes.

--- a/actionpack/test/controller/integration_test.rb
+++ b/actionpack/test/controller/integration_test.rb
@@ -1098,6 +1098,12 @@ class IntegrationRequestEncodersTest < ActionDispatch::IntegrationTest
       render plain: "ok"
     end
 
+    def foos_html
+      render inline: <<~ERB
+        <code><%= params.permit(:foo) %></code>
+      ERB
+    end
+
     def foos_json
       render json: params.permit(:foo)
     end
@@ -1124,6 +1130,17 @@ class IntegrationRequestEncodersTest < ActionDispatch::IntegrationTest
 
       assert_response :success
       assert_equal({ "foo" => "fighters" }, response.parsed_body)
+    end
+  end
+
+  def test_encoding_as_html
+    post_to_foos as: :html do
+      assert_response :success
+      assert_equal "application/x-www-form-urlencoded", request.media_type
+      assert_equal "text/html", request.accepts.first.to_s
+      assert_equal :html, request.format.ref
+      assert_equal({ "foo" => "fighters" }, request.request_parameters)
+      assert_equal({ "foo" => "fighters" }.to_s, response.parsed_body.at("code").text)
     end
   end
 


### PR DESCRIPTION
### Motivation / Background

Closes [#50345][]

### Detail

First, handle the exception mentioned in [#50345][]:

```
BugTest#test_params_with_htm_content_type:
NoMethodError: undefined method `to_html' for {:name=>"Muad'Dib"}:Hash
    .../actionpack/lib/action_dispatch/testing/request_encoder.rb:39:in `encode_params'
    .../actionpack/lib/action_dispatch/testing/integration.rb:251:in `process'
```

Calls with `as: :html` result in a `NoMethodError` because
`Hash#to_html` does not exist.

Passing `as: :html` implies that the request parameters will come from a
`POST` body encoded as `text/html`. That isn't entirely true -- browsers
will encode `POST` parameters as with the `Content-Type:` header set to
either [application/x-www-form-urlencoded][] or [multipart/form-data][].
This commit skips setting the `CONTENT_TYPE` Rack header when processed
with `as: :html`.

To account for that, extend the `RequestEncoder` constructor to accept a
`content_type `argument to use when provided. When omitted, continue to
fall back to the provided MIME type. Extend the default `:html` encoder
configuration to default to submitting with `Content-Type:
x-www-form-urlencoded`.

[#50345]: https://github.com/rails/rails/issues/50345
[application/x-www-form-urlencoded]: https://developer.mozilla.org/en-US/docs/Learn/Forms/Sending_and_retrieving_form_data#the_post_method
[multipart/form-data]: https://developer.mozilla.org/en-US/docs/Learn/Forms/Sending_and_retrieving_form_data#the_enctype_attribute

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
