### PR TITLE
[FIX] For Sqlite3 db:drop command output

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/sqlite3/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3/schema_statements.rb
@@ -129,6 +129,12 @@ module ActiveRecord
           SQLite3::SchemaCreation.new(self)
         end
 
+        def create_database
+          mode = ::SQLite3::Constants::Open::READWRITE | ::SQLite3::Constants::Open::CREATE
+          config = @connection_parameters.merge(flags: mode)
+          ::SQLite3::Database.new(config[:database].to_s, config)
+        end
+
         private
           def valid_table_definition_options
             super + [:rename]

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -30,12 +30,8 @@ module ActiveRecord
       class << self
         def new_client(config)
           ::SQLite3::Database.new(config[:database].to_s, config)
-        rescue Errno::ENOENT => error
-          if error.message.include?("No such file or directory")
-            raise ActiveRecord::NoDatabaseError
-          else
-            raise
-          end
+        rescue ::SQLite3::CantOpenException => _error
+          raise ActiveRecord::NoDatabaseError
         end
 
         def dbconsole(config, options = {})
@@ -114,6 +110,7 @@ module ActiveRecord
           end
         end
 
+        @config[:flags] = ::SQLite3::Constants::Open::READWRITE if @config[:flags].nil? && !@config[:readonly]
         @config[:strict] = ConnectionAdapters::SQLite3Adapter.strict_strings_by_default unless @config.key?(:strict)
         @connection_parameters = @config.merge(database: @config[:database].to_s, results_as_hash: true)
         @use_insert_returning = @config.key?(:insert_returning) ? self.class.type_cast_config_to_boolean(@config[:insert_returning]) : true

--- a/activerecord/lib/active_record/tasks/database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/database_tasks.rb
@@ -375,6 +375,7 @@ module ActiveRecord
         return true unless file && File.exist?(file)
 
         with_temporary_connection(db_config) do |connection|
+          connection.create_database
           return false unless connection.internal_metadata.enabled?
           return false unless connection.internal_metadata.table_exists?
 

--- a/activerecord/lib/active_record/tasks/sqlite_database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/sqlite_database_tasks.rb
@@ -16,6 +16,7 @@ module ActiveRecord
         raise DatabaseAlreadyExists if File.exist?(db_config.database)
 
         establish_connection
+        connection.create_database
         connection
       end
 
@@ -71,7 +72,6 @@ module ActiveRecord
 
         def establish_connection(config = db_config)
           ActiveRecord::Base.establish_connection(config)
-          connection.connect!
         end
 
         def run_cmd(cmd, args, out)

--- a/activerecord/test/cases/adapters/sqlite3/sqlite3_create_folder_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/sqlite3_create_folder_test.rb
@@ -14,6 +14,7 @@ module ActiveRecord
             adapter: "sqlite3",
             timeout: 100,
           )
+          @conn.create_database
           @conn.connect!
 
           assert Dir.exist? dir.join("db")

--- a/activerecord/test/cases/fixtures_test.rb
+++ b/activerecord/test/cases/fixtures_test.rb
@@ -1599,6 +1599,7 @@ class MultipleFixtureConnectionsTest < ActiveRecord::TestCase
       handler = ActiveRecord::ConnectionAdapters::ConnectionHandler.new
       ActiveRecord::Base.connection_handler = handler
       handler.establish_connection(db_config)
+      ActiveRecord::Base.connection.create_database
 
       ActiveRecord::Base.connects_to(database: { writing: :default, reading: :readonly })
 

--- a/activerecord/test/cases/migration/pending_migrations_test.rb
+++ b/activerecord/test/cases/migration/pending_migrations_test.rb
@@ -14,7 +14,10 @@ module ActiveRecord
 
           @original_configurations = ActiveRecord::Base.configurations
           ActiveRecord::Base.configurations = base_config
-          ActiveRecord::Base.establish_connection(:primary)
+          pool_secondary = ActiveRecord::Base.establish_connection(:secondary)
+          pool_secondary.connection.create_database
+          pool_primary = ActiveRecord::Base.establish_connection(:primary)
+          pool_primary.connection.create_database
         end
 
         teardown do

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -190,6 +190,7 @@ module ApplicationTests
       app "development"
 
       begin
+        ActiveRecord::Base.connection.create_database
         ActiveRecord::Migrator.migrations_paths = ["#{app_path}/db/migrate"]
 
         get "/foo"

--- a/railties/test/application/integration_test_case_test.rb
+++ b/railties/test/application/integration_test_case_test.rb
@@ -40,7 +40,10 @@ module ApplicationTests
         end
       RUBY
 
-      with_rails_env("test") { rails("db:migrate") }
+      with_rails_env("test") do
+        rails("db:create")
+        rails("db:migrate") 
+      end
       output = rails("test")
       assert_match(/0 failures, 0 errors/, output)
     end
@@ -68,7 +71,10 @@ module ApplicationTests
         end
       RUBY
 
-      with_rails_env("test") { rails("db:migrate") }
+      with_rails_env("test") do
+        rails("db:create")
+        rails("db:migrate")
+      end
       output = rails("test")
       assert_match(/0 failures, 0 errors/, output)
     end

--- a/railties/test/application/integration_test_case_test.rb
+++ b/railties/test/application/integration_test_case_test.rb
@@ -42,7 +42,7 @@ module ApplicationTests
 
       with_rails_env("test") do
         rails("db:create")
-        rails("db:migrate") 
+        rails("db:migrate")
       end
       output = rails("test")
       assert_match(/0 failures, 0 errors/, output)

--- a/railties/test/application/rake/migrations_test.rb
+++ b/railties/test/application/rake/migrations_test.rb
@@ -7,6 +7,7 @@ module ApplicationTests
     class RakeMigrationsTest < ActiveSupport::TestCase
       def setup
         build_app
+        rails("db:create")
         FileUtils.rm_rf("#{app_path}/config/environments")
       end
 
@@ -437,6 +438,7 @@ module ApplicationTests
 
         Dir.chdir(app_path) do
           rails "generate", "model", "book", "title:string"
+          rails "db:create"
           rails "db:migrate"
 
           assert File.exist?("db/schema_file.rb"), "should dump schema when configured to"
@@ -455,6 +457,7 @@ module ApplicationTests
 
         Dir.chdir(app_path) do
           rails "generate", "model", "book", "title:string"
+          rails "db:create"
           rails "db:migrate"
 
           assert_not File.exist?("db/schema.rb"), "should not dump schema when configured not to"

--- a/railties/test/application/rake/multi_dbs_test.rb
+++ b/railties/test/application/rake/multi_dbs_test.rb
@@ -57,6 +57,7 @@ module ApplicationTests
       def db_migrate_and_migrate_status
         Dir.chdir(app_path) do
           generate_models_for_animals
+          rails "db:create"
           rails "db:migrate"
           output = rails "db:migrate:status"
           assert_match(/up     \d+  Create books/, output)
@@ -67,6 +68,7 @@ module ApplicationTests
       def db_migrate_and_schema_cache_dump
         Dir.chdir(app_path) do
           generate_models_for_animals
+          rails "db:create"
           rails "db:migrate", "--trace"
           rails "db:schema:cache:dump", "--trace"
           assert File.exist?("db/schema_cache.yml")
@@ -77,6 +79,7 @@ module ApplicationTests
       def db_migrate_and_schema_cache_dump_and_schema_cache_clear
         Dir.chdir(app_path) do
           generate_models_for_animals
+          rails "db:create"
           rails "db:migrate"
           rails "db:schema:cache:dump"
           rails "db:schema:cache:clear"

--- a/railties/test/application/test_runner_test.rb
+++ b/railties/test/application/test_runner_test.rb
@@ -830,7 +830,6 @@ module ApplicationTests
         exercise_parallelization_regardless_of_machine_core_count(with: :processes)
 
         rails "generate", "scaffold", "User", "name:string"
-        rails "db:create"
         rails "db:migrate"
 
         output = rails "test"
@@ -1057,6 +1056,7 @@ module ApplicationTests
 
     def test_rake_db_and_test_tasks_parses_args_correctly
       create_test_file :models, "account"
+      create_database
       output = Dir.chdir(app_path) { `bin/rake db:migrate test:models TESTOPTS='-v' && echo ".tables" | rails dbconsole` }
       assert_match "AccountTest#test_truth", output
       assert_match "ar_internal_metadata", output
@@ -1258,6 +1258,7 @@ module ApplicationTests
             name: Tsubasa Hanekawa
         YAML
 
+        create_database
         run_migration
       end
 
@@ -1425,6 +1426,7 @@ module ApplicationTests
       def create_scaffold
         rails "generate", "scaffold", "user", "name:string"
         assert File.exist?("#{app_path}/app/models/user.rb")
+        create_database
         run_migration
       end
 
@@ -1434,6 +1436,10 @@ module ApplicationTests
 
       def run_migration
         rails "db:migrate"
+      end
+
+      def create_database
+        rails "db:create"
       end
   end
 end

--- a/railties/test/application/view_reloading_test.rb
+++ b/railties/test/application/view_reloading_test.rb
@@ -10,7 +10,7 @@ module ApplicationTests
 
     def setup
       build_app
-
+      rails("db:create")
       app_file "config/routes.rb", <<-RUBY
         Rails.application.routes.draw do
           get 'pages/:id', to: 'pages#show'
@@ -38,7 +38,6 @@ module ApplicationTests
 
       ENV["RAILS_ENV"] = "development"
       require "#{app_path}/config/environment"
-
       get "/pages/foo"
       get "/pages/foo"
       assert_equal 200, last_response.status, last_response.body


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

Fixes #50391 

Whille executing command, in case when database already dosen't exist.

```shell
bin/rails db:drop
Dropped database 'storage/development.sqlite3'
Database 'storage/test.sqlite3' does not exist
```

It is observed that for the non-existing database `storage/development.sqlite3` on the disk, the command output displays `Dropped database 'storage/development.sqlite3'`. Instead, it should state `Database 'storage/development.sqlite3' does not exist`.

---
In the ActiveRecord SQLite3 adapter code at 

https://github.com/rails/rails/blob/462e8e8b1c74d46a78e7077c5b07bfbc6fab08b0/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb#L31-L39

It appears that every time a new connection to SQLite3 is established, an attempt is made to create a database due to the default configuration settings.

This behavior is defined in the SQLite3 Ruby gem code, specifically at 

https://github.com/sparklemotion/sqlite3-ruby/blob/302e9c0328bff2bb04e1d4a54614140ca06f3648/lib/sqlite3/database.rb#L91-L101

You can also refer to the relevant documentation [here](https://rubydoc.info/gems/sqlite3/SQLite3%2FDatabase:initialize), which outlines supported permission options.

Each time a new connection to the database is established (used for dropping the database or executing other commands), the connection first attempts to create a database and then proceeds to drop it.

An issue arises when an exception is raised in the code snippet below, as it doesn't work as intended. The SQLite3 database is created with the default mode of `READWRITE | CREATE`. Consequently, a new database is created every time, even if it already exists. 

```ruby
rescue Errno::ENOENT => error 
   if error.message.include?("No such file or directory") 
     raise ActiveRecord::NoDatabaseError 
   else 
     raise 
   end 
 end 
```

### Detail

In this PR, I have made a modification to the default mode of SQLite3 from `READWRITE|CREATE` to just `READWRITE`. Consequently, if the database does not exist, it will now raise an exception `SQLite3::CantOpenException`.

This adjustment aligns with a similar approach used for MySQL and Postgres. Specifically, when establishing a connection, the database is not created automatically; instead, it is handled separately to ensure consistent behavior across different database systems.

### Additional information

<!-- Provide additional information such as benchmarks, reference to other repositories or alternative solutions. -->
1. Default Mode in Sqlite3: https://rubydoc.info/gems/sqlite3/SQLite3%2FDatabase:initialize
2. Why Sqlite3 have not made it READWRITE as default mode?: https://github.com/sparklemotion/sqlite3-ruby/pull/174

### Checklist

Before submitting the PR make sure the following are checked:

* [ ] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [ ] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #50391 50391]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
