### PR TITLE
Fix `Relation#transaction` to not apply a default scope

### DIFF
--- a/activerecord/lib/active_record/relation/delegation.rb
+++ b/activerecord/lib/active_record/relation/delegation.rb
@@ -101,7 +101,7 @@ module ActiveRecord
              :to_sentence, :to_fs, :to_formatted_s, :as_json,
              :shuffle, :split, :slice, :index, :rindex, to: :records
 
-    delegate :primary_key, :connection, to: :klass
+    delegate :primary_key, :connection, :transaction, to: :klass
 
     module ClassSpecificRelation # :nodoc:
       extend ActiveSupport::Concern

--- a/activerecord/test/cases/transactions_test.rb
+++ b/activerecord/test/cases/transactions_test.rb
@@ -36,6 +36,14 @@ class TransactionTest < ActiveRecord::TestCase
     assert_equal title_change, topic.changes["title"]
   end
 
+  def test_transaction_does_not_apply_default_scope
+    # Regression test for https://github.com/rails/rails/issues/50368
+    topic = topics(:fifth)
+    Topic.where.not(id: topic.id).transaction do
+      assert_not_nil Topic.find(topic.id)
+    end
+  end
+
   if !in_memory_db?
     def test_rollback_dirty_changes_even_with_raise_during_rollback_removes_from_pool
       topic = topics(:fifth)


### PR DESCRIPTION
Fix: https://github.com/rails/rails/issues/50368

When called on a scope it would go through the default scoping delegator that applies a default scope, which make no sense.
