### PR TITLE
Bump `psych` gem to 5.1.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -377,7 +377,7 @@ GEM
       activesupport (>= 7.0.0)
       rack
       railties (>= 7.0.0)
-    psych (5.1.1.1)
+    psych (5.1.2)
       stringio
     public_suffix (5.0.1)
     puma (6.3.0)


### PR DESCRIPTION
This fixes the following [error](https://buildkite.com/rails/rails/builds/102870#018c8481-6fcf-4984-9633-0cc0a426a4f7/1188-1253) for the guides build:

  ```
  Traceback (most recent call last):
    13: from bug_report_templates/action_controller.rb:5:in `<main>'
    12: from /usr/local/bundle/gems/bundler-2.4.22/lib/bundler/inline.rb:42:in `gemfile'
    11: from /usr/local/bundle/gems/bundler-2.4.22/lib/bundler.rb:403:in `with_unbundled_env'
    10: from /usr/local/bundle/gems/bundler-2.4.22/lib/bundler.rb:649:in `with_env'
     9: from /usr/local/bundle/gems/bundler-2.4.22/lib/bundler.rb:403:in `block in with_unbundled_env'
     8: from /usr/local/bundle/gems/bundler-2.4.22/lib/bundler/inline.rb:51:in `block in gemfile'
     7: from /usr/local/bundle/gems/bundler-2.4.22/lib/bundler/settings.rb:142:in `temporary'
     6: from /usr/local/bundle/gems/bundler-2.4.22/lib/bundler/inline.rb:66:in `block (2 levels) in gemfile'
     5: from /usr/local/bundle/gems/bundler-2.4.22/lib/bundler/runtime.rb:24:in `setup'
     4: from /usr/local/bundle/gems/bundler-2.4.22/lib/bundler/runtime.rb:24:in `map'
     3: from /usr/local/bundle/gems/bundler-2.4.22/lib/bundler/spec_set.rb:165:in `each'
     2: from /usr/local/bundle/gems/bundler-2.4.22/lib/bundler/spec_set.rb:165:in `each'
     1: from /usr/local/bundle/gems/bundler-2.4.22/lib/bundler/runtime.rb:25:in `block in setup'
  /usr/local/bundle/gems/bundler-2.4.22/lib/bundler/runtime.rb:304:in `check_for_activated_spec!': You have already activated psych 5.1.1.1, but your Gemfile requires psych 5.1.2. Prepending `bundle exec` to your command may solve this. (Gem::LoadError)
  ```

This is similar to #45052.  Eventually, this should be fixed permanently by either rubygems/rubygems#5529 or rubygems/rubygems#5535.
