### PR TITLE
Fix NFD for add_autoload_paths_to_load_path

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_7_1.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_7_1.rb.tt
@@ -15,8 +15,9 @@
 #
 # This will reduce the size of the load path, making `require` faster if you don't use bootsnap, or reduce the size
 # of the bootsnap cache if you use it.
-#++
-# Rails.application.config.add_autoload_paths_to_load_path = false
+#
+# To set this configuration, add the following line to `config/application.rb` (NOT this file):
+#   config.add_autoload_paths_to_load_path = false
 
 ###
 # Remove the default X-Download-Options headers since it is used only by Internet Explorer.
@@ -38,7 +39,7 @@
 
 ###
 # Active Record Encryption now uses SHA-256 as its hash digest algorithm.
-# 
+#
 # There are 3 scenarios to consider.
 #
 # 1. If you have data encrypted with previous Rails versions, and you have


### PR DESCRIPTION
### Motivation / Background

Previously, this value was listed as a regular configuration that could be applied by uncommenting a line in new_framework_defaults. However, the autoloader is configured before initializers run so configuring this value here will have no effect.

### Detail

This commit fixes the issue by suggesting to add the configuration to config/application.rb instead of new_framework_defaults.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
