### PR TITLE
Fix ensuring 7.2 defaults listed in configuring

### DIFF
--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -58,6 +58,8 @@ NOTE: If you need to apply configuration directly to a class, use a [lazy load h
 
 Below are the default values associated with each target version. In cases of conflicting values, newer versions take precedence over older versions.
 
+#### Default Values For Target Version 7.2
+
 #### Default Values for Target Version 7.1
 
 - [`config.action_dispatch.debug_exception_log_level`](#config-action-dispatch-debug-exception-log-level): `:error`

--- a/tools/rail_inspector/lib/rail_inspector/configuring/check/framework_defaults.rb
+++ b/tools/rail_inspector/lib/rail_inspector/configuring/check/framework_defaults.rb
@@ -68,7 +68,7 @@ module RailInspector
           end
 
           def check_defaults(defaults)
-            header, configs = defaults[0], defaults[2, defaults.length - 3]
+            header, _, *configs, _ = defaults
 
             version = header.match(/\d\.\d/)[0]
 


### PR DESCRIPTION
Previously, because the 7.2 header was missing from configuring.md, railspect was not checking that newly introduced 7.2 framework defaults are listed.

This commit adds the header to ensure they get checked, and then also fixes an issue that occurs if a versioned section has no defaults listed.
