### PR TITLE
Improve Action Text System Test coverage

### DIFF
--- a/actiontext/test/system/rich_text_editor_test.rb
+++ b/actiontext/test/system/rich_text_editor_test.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require "application_system_test_case"
+
+class ActionText::RichTextEditorTest < ApplicationSystemTestCase
+  test "attaches and uploads image file" do
+    image_file = file_fixture("racecar.jpg")
+
+    visit new_message_url
+    attach_file image_file do
+      click_button "Attach Files"
+    end
+    within :rich_text_area do
+      assert_selector :element, "img", src: %r{/rails/active_storage/blobs/redirect/.*/#{image_file.basename}\Z}
+    end
+    click_button "Create Message"
+
+    within class: "trix-content" do
+      assert_selector :element, "img", src: %r{/rails/active_storage/representations/redirect/.*/#{image_file.basename}\Z}
+    end
+  end
+end

--- a/actiontext/test/system/system_test_helper_test.rb
+++ b/actiontext/test/system/system_test_helper_test.rb
@@ -8,31 +8,31 @@ class ActionText::SystemTestHelperTest < ApplicationSystemTestCase
   end
 
   test "filling in a rich-text area by ID" do
-    assert_selector "trix-editor#message_content"
+    assert_selector :element, "trix-editor", id: "message_content"
     fill_in_rich_textarea "message_content", with: "Hello world!"
     assert_selector :field, "message[content]", with: /Hello world!/, type: "hidden"
   end
 
   test "filling in a rich-text area by placeholder" do
-    assert_selector "trix-editor[placeholder='Your message here']"
+    assert_selector :element, "trix-editor", placeholder: "Your message here"
     fill_in_rich_textarea "Your message here", with: "Hello world!"
     assert_selector :field, "message[content]", with: /Hello world!/, type: "hidden"
   end
 
   test "filling in a rich-text area by aria-label" do
-    assert_selector "trix-editor[aria-label='Message content aria-label']"
+    assert_selector :element, "trix-editor", "aria-label": "Message content aria-label"
     fill_in_rich_textarea "Message content aria-label", with: "Hello world!"
     assert_selector :field, "message[content]", with: /Hello world!/, type: "hidden"
   end
 
   test "filling in a rich-text area by label" do
-    assert_selector "label", text: "Message content label"
+    assert_selector :label, "Message content label", for: "message_content"
     fill_in_rich_textarea "Message content label", with: "Hello world!"
     assert_selector :field, "message[content]", with: /Hello world!/, type: "hidden"
   end
 
   test "filling in a rich-text area by input name" do
-    assert_selector "trix-editor[input]"
+    assert_selector :element, "trix-editor", input: true
     fill_in_rich_textarea "message[content]", with: "Hello world!"
     assert_selector :field, "message[content]", with: /Hello world!/, type: "hidden"
   end


### PR DESCRIPTION
### Motivation / Background

Introduce the `ActionText::RichTextEditorTest` to exercise Action Text's integration with Active Storage. First, assert that Action Text renders an Active Storage blob preview of the image within the `<trix-editor>` element prior to persisting the rich-text record. Next, assert that Active Storage renders the uploaded file within the rendered rich-text content.

### Detail

In addition to expanding System Test coverage, this commit also alters the existing `ActionText::SystemTestHelperTest` coverage to utilize Capybara's built-in [:element][] selector as an alternative to CSS. The `:element` selector supports arbitrary keyword arguments as HTML attribute filters. For example, `input: true` as a filter translates to asserting the presence of any `[input]` attribute. Similarly, it enables assertions with Ruby strings instead of interpolating Ruby strings **into** CSS selectors.

[:element]: https://rubydoc.info/github/teamcapybara/capybara/master/Capybara/Selector

### Additional information

Related to https://github.com/rails/rails/pull/49527 and https://github.com/rails/rails/pull/46807.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
