### PR TITLE
Add `to_sql` support for calculation methods like `count`

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,16 @@
+*   Add `to_sql` support for calculation methods like `count`
+
+    Allow `to_sql` to take an operation and column name as argument:
+
+    ```ruby
+    User.all.to_sql(:count)
+    # => "SELECT COUNT(*) FROM `users`"
+
+    User.all.to_sql(:maximum, :id)
+    # => "SELECT MAX(`users`.`id`) FROM `users`"
+    ```
+    *Petrik de Heus*
+
 *   Add support for generated columns in SQLite3 adapter
 
     Generated columns (both stored and dynamic) are supported since version 3.31.0 of SQLite.

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -765,6 +765,61 @@ class RelationTest < ActiveRecord::TestCase
     assert_not auth.posts.to_sql.include?("1=1")
   end
 
+  def test_to_sql_with_count
+    expected = capture_sql {
+      Post.count
+    }.first
+    actual = Post.all.to_sql(:count)
+    assert_equal expected, actual
+  end
+
+  def test_to_sql_with_distinct_and_count
+    expected = capture_sql {
+      Post.distinct.count
+    }.first
+    actual = Post.distinct.to_sql(:count)
+    assert_equal expected, actual
+  end
+
+  def test_to_sql_with_group_and_count
+    error = assert_raise do
+      Post.group(:id).to_sql(:count)
+    end
+    assert_equal "Calling `to_sql(:count)` with a `group` is not supported", error.message
+  end
+
+  def test_to_sql_with_minimum
+    expected = capture_sql {
+      Post.minimum(:id)
+    }.first
+    actual = Post.all.to_sql(:minimum, :id)
+    assert_equal expected, actual
+  end
+
+  def test_to_sql_with_maximum
+    expected = capture_sql {
+      Post.maximum(:id)
+    }.first
+    actual = Post.all.to_sql(:maximum, :id)
+    assert_equal expected, actual
+  end
+
+  def test_to_sql_with_sum
+    expected = capture_sql {
+      Post.sum(:id)
+    }.first
+    actual = Post.all.to_sql(:sum, :id)
+    assert_equal expected, actual
+  end
+
+  def test_to_sql_on_eager_join_with_minimum
+    expected = capture_sql {
+      Post.eager_load(:last_comment).order("comments.id DESC").minimum(:id)
+    }.first
+    actual = Post.eager_load(:last_comment).order("comments.id DESC").to_sql(:minimum, :id)
+    assert_equal expected, actual
+  end
+
   def test_loading_with_one_association_with_non_preload
     posts = Post.eager_load(:last_comment).order("comments.id DESC")
     post = posts.find { |p| p.id == 1 }


### PR DESCRIPTION
### Motivation / Background

As the calculation methods directly return a result, it's not possible to call `to_sql` on the query.

By allowing `to_sql` to take an operation and column name as argument we can return the SQL:

```ruby
User.all.to_sql(:count)
# => "SELECT COUNT(*) FROM `users`"

User.all.to_sql(:maximum, :id)
# => "SELECT MAX(`users`.`id`) FROM `users`"
```

### Additional information

Combining `count` with a `group` is not yet supported.
I'd like to add the same functionality to `explain`.
Related issue adding `:delete_all`: https://github.com/rails/rails/pull/37975

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
