### PR TITLE
Include view tests in rake stats

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -83,4 +83,8 @@
 
     *Adrian Hirt*
 
+*   `rails stats` now includes `test/views` view tests in its output statistics.
+
+    *Noah Horton*
+
 Please check [7-1-stable](https://github.com/rails/rails/blob/7-1-stable/railties/CHANGELOG.md) for previous changes.

--- a/railties/lib/rails/tasks/statistics.rake
+++ b/railties/lib/rails/tasks/statistics.rake
@@ -24,6 +24,7 @@ STATS_DIRECTORIES ||= [
   %w(Mailer\ tests      test/mailers),
   %w(Mailbox\ tests     test/mailboxes),
   %w(Channel\ tests     test/channels),
+  %w(View\ tests        test/views),
   %w(Integration\ tests test/integration),
   %w(System\ tests      test/system),
 ]


### PR DESCRIPTION
### Motivation / Background
When View tests were added to rails, the directory containing them was not added to the list of directories that are analyzed by the `stats` task. This adds them to the list.

There are no tests covering the set of directories analyzed or such, so no additional tests are added in this.