### PR TITLE
Add `explain` support for calculation methods like `count`

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,19 @@
+*   Add `explain` support for calculation methods like `count`
+
+    Allow `explain` to take an operation and column name as argument:
+
+    ```ruby
+    User.all.explain(:count)
+    # EXPLAIN SELECT COUNT(*) FROM `users`
+    # ...
+
+    User.all.explain(:maximum, :id)
+    # EXPLAIN SELECT MAX(`users`.`id`) FROM `users`
+    # ...
+    ```
+
+    *Petrik de Heus*
+
 *   Add support for generated columns in SQLite3 adapter
 
     Generated columns (both stored and dynamic) are supported since version 3.31.0 of SQLite.

--- a/activerecord/test/cases/adapters/abstract_mysql_adapter/mysql_explain_test.rb
+++ b/activerecord/test/cases/adapters/abstract_mysql_adapter/mysql_explain_test.rb
@@ -22,17 +22,17 @@ class MySQLExplainTest < ActiveRecord::AbstractMysqlTestCase
   end
 
   def test_explain_with_options_as_symbol
-    explain = Author.where(id: 1).explain(explain_option)
+    explain = Author.where(id: 1).explain(options: [explain_option])
     assert_match %(#{expected_analyze_clause} SELECT `authors`.* FROM `authors` WHERE `authors`.`id` = 1), explain
   end
 
   def test_explain_with_options_as_strings
-    explain = Author.where(id: 1).explain(explain_option.to_s.upcase)
+    explain = Author.where(id: 1).explain(options: [explain_option.to_s.upcase])
     assert_match %(#{expected_analyze_clause} SELECT `authors`.* FROM `authors` WHERE `authors`.`id` = 1), explain
   end
 
   def test_explain_options_with_eager_loading
-    explain = Author.where(id: 1).includes(:posts).explain(explain_option)
+    explain = Author.where(id: 1).includes(:posts).explain(options: [explain_option])
     assert_match %(#{expected_analyze_clause} SELECT `authors`.* FROM `authors` WHERE `authors`.`id` = 1), explain
     assert_match %(#{expected_analyze_clause} SELECT `posts`.* FROM `posts` WHERE `posts`.`author_id` = 1), explain
   end

--- a/activerecord/test/cases/adapters/postgresql/explain_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/explain_test.rb
@@ -21,19 +21,19 @@ class PostgreSQLExplainTest < ActiveRecord::PostgreSQLTestCase
   end
 
   def test_explain_with_options_as_symbols
-    explain = Author.where(id: 1).explain(:analyze, :buffers)
+    explain = Author.where(id: 1).explain(options: [:analyze, :buffers])
     assert_match %r(EXPLAIN \(ANALYZE, BUFFERS\) SELECT "authors"\.\* FROM "authors" WHERE "authors"\."id" = (?:\$1 \[\["id", 1\]\]|1)), explain
     assert_match %(QUERY PLAN), explain
   end
 
   def test_explain_with_options_as_strings
-    explain = Author.where(id: 1).explain("VERBOSE", "ANALYZE", "FORMAT JSON")
+    explain = Author.where(id: 1).explain(options: ["VERBOSE", "ANALYZE", "FORMAT JSON"])
     assert_match %r(EXPLAIN \(VERBOSE, ANALYZE, FORMAT JSON\) SELECT "authors"\.\* FROM "authors" WHERE "authors"\."id" = (?:\$1 \[\["id", 1\]\]|1)), explain
     assert_match %(QUERY PLAN), explain
   end
 
   def test_explain_options_with_eager_loading
-    explain = Author.where(id: 1).includes(:posts).explain(:analyze)
+    explain = Author.where(id: 1).includes(:posts).explain(options: [:analyze])
     assert_match %(QUERY PLAN), explain
     assert_match %r(EXPLAIN \(ANALYZE\) SELECT "authors"\.\* FROM "authors" WHERE "authors"\."id" = (?:\$1 \[\["id", 1\]\]|1)), explain
     assert_match %r(EXPLAIN \(ANALYZE\) SELECT "posts"\.\* FROM "posts" WHERE "posts"\."author_id" = (?:\$1 \[\["author_id", 1\]\]|1)), explain

--- a/activerecord/test/cases/explain_test.rb
+++ b/activerecord/test/cases/explain_test.rb
@@ -35,6 +35,53 @@ if ActiveRecord::Base.connection.supports_explain?
       end
     end
 
+    def test_relation_explain_with_count
+      expected_query = capture_sql {
+        Car.count
+      }.first
+      message = Car.all.explain(:count)
+      assert_match("EXPLAIN #{expected_query}", message)
+    end
+
+    def test_relation_explain_with_count_and_column_name
+      expected_query = capture_sql {
+        Car.count(:id)
+      }.first
+      message = Car.all.explain(:count, :id)
+      assert_match("EXPLAIN #{expected_query}", message)
+    end
+
+    def test_relation_explain_with_minimum
+      expected_query = capture_sql {
+        Car.minimum(:id)
+      }.first
+      message = Car.all.explain(:minimum, :id)
+      assert_match("EXPLAIN #{expected_query}", message)
+    end
+
+    def test_relation_explain_with_maximum
+      expected_query = capture_sql {
+        Car.maximum(:id)
+      }.first
+      message = Car.all.explain(:maximum, :id)
+      assert_match("EXPLAIN #{expected_query}", message)
+    end
+
+    def test_relation_explain_with_sum
+      expected_query = capture_sql {
+        Car.sum(:id)
+      }.first
+      message = Car.all.explain(:sum, :id)
+      assert_match("EXPLAIN #{expected_query}", message)
+    end
+
+    def test_relation_explain_with_unsupported_method
+      error = assert_raise ArgumentError do
+        Car.all.explain(:last)
+      end
+      assert_equal "`last` is not a supported method argument for `explain`", error.message
+    end
+
     def test_exec_explain_with_no_binds
       sqls    = %w(foo bar)
       binds   = [[], []]


### PR DESCRIPTION
Allow `explain` to take an operation and column name as argument:

```ruby
User.all.explain(:count)
# => "EXPLAIN SELECT COUNT(*) FROM `users`"

User.all.explain(:maximum, :id)
# => "EXPLAIN SELECT MAX(`users`.`id`) FROM `users`"
```

This breaks passing options like `:analyze` and `:buffers` as arguments.
These can be passed as named argument instead:

```ruby
User.all.explain(options: [:analyze, :buffers])
# => "EXPLAIN ANALYZE BUFFERS SELECT ...
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
