### PR TITLE
Introduce predicate definition when defining scopes

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,29 @@
+*   Introduce predicate definition when defining scopes
+
+    Creates parity between scopes and instances of records, similar to how
+    `enums` automatically create instance methods that query whether the model
+    belongs to that scope.
+
+    ```ruby
+    class Book < ApplicationRecord
+      scope :out_of_print, -> { where(out_of_print: true) }, predicate: true
+      # Creates instance method named `within_out_of_print?`
+
+      scope :in_print, -> { where(out_of_print: false) }, predicate: :in_print
+      # Creates instance method named `in_print?`
+    end
+    ```
+
+    ```irb
+    irb> Book.out_of_print.first.within_out_of_print?
+    => true
+
+    irb> Book.in_print.first.in_print?
+    => true
+    ```
+
+    *Steve Polito*
+
 *   Add support for generated columns in SQLite3 adapter
 
     Generated columns (both stored and dynamic) are supported since version 3.31.0 of SQLite.

--- a/activerecord/lib/active_record/scoping/named.rb
+++ b/activerecord/lib/active_record/scoping/named.rb
@@ -206,10 +206,9 @@ module ActiveRecord
           end
 
           if predicate
-            method_name = case predicate
-            when Symbol, String
+            method_name = if predicate.is_a?(Symbol) || predicate.is_a?(String)
               predicate.to_sym
-            when true
+            elsif predicate == true
               :"within_#{name}"
             else
               raise ArgumentError,

--- a/activerecord/lib/active_record/scoping/named.rb
+++ b/activerecord/lib/active_record/scoping/named.rb
@@ -207,15 +207,15 @@ module ActiveRecord
 
           if predicate
             method_name = case predicate
-                          when Symbol, String
-                            predicate.to_sym
-                          when true
-                            :"within_#{name}"
-                          else
-                            raise ArgumentError,
-                              "Invalid value for 'predicate'. Expected a Symbol, " \
-                              "a String, or true, but received #{predicate.inspect}"
-                          end
+            when Symbol, String
+              predicate.to_sym
+            when true
+              :"within_#{name}"
+            else
+              raise ArgumentError,
+                "Invalid value for 'predicate'. Expected a Symbol, " \
+                "a String, or true, but received #{predicate.inspect}"
+            end
 
             define_method("#{method_name}?") do
               self.class.send(name).exists?(id)

--- a/guides/source/active_record_querying.md
+++ b/guides/source/active_record_querying.md
@@ -2054,6 +2054,32 @@ SELECT books.* FROM books WHERE books.out_of_print = true
 
 [`unscoped`]: https://api.rubyonrails.org/classes/ActiveRecord/Scoping/Default/ClassMethods.html#method-i-unscoped
 
+### Defining Predicate Methods
+
+To create parity between scopes and instances of records, use the `predicate`
+option.
+
+This is similar to how [enums](#enums) automatically create instance methods
+that query whether the model belongs to that scope.
+
+```ruby
+class Book < ApplicationRecord
+  scope :out_of_print, -> { where(out_of_print: true) }, predicate: true
+  # Creates instance method named `within_out_of_print?`
+
+  scope :in_print, -> { where(out_of_print: false) }, predicate: :in_print
+  # Creates instance method named `in_print?`
+end
+```
+
+```irb
+irb> Book.out_of_print.first.within_out_of_print?
+=> true
+
+irb> Book.in_print.first.in_print?
+=> true
+```
+
 Dynamic Finders
 ---------------
 


### PR DESCRIPTION
### Motivation / Background

Creates parity between scopes and instances of records, similar to how [enums](https://guides.rubyonrails.org/active_record_querying.html#enums) automatically create instance methods that query whether the model belongs to that scope.

```ruby
class Book < ApplicationRecord
  scope :out_of_print, -> { where(out_of_print: true) }, predicate: true
  # Creates instance method named `within_out_of_print?`

  scope :in_print, -> { where(out_of_print: false) }, predicate: :in_print
  # Creates instance method named `in_print?`
end
```

```irb
irb> Book.out_of_print.first.within_out_of_print?
=> true

irb> Book.in_print.first.in_print?
=> true
```

### Detail

Adds `**options` argument to `scope` definition, allowing caller to optionally pass `predicate: true` or `predicate: :desired_predicate_name`.

The goal is to keep this feature opt-in to avoid automatically creating a method for each and every scope.

Additionally, we default to `within_<scope_name>` as to not conflict with the instance methods generated by [enums](https://guides.rubyonrails.org/active_record_querying.html#enums)

### Additional information

This should be compatible with [Composite Primary Keys](https://guides.rubyonrails.org/active_record_composite_primary_keys.html), but existing fixtures did not exist (as far as I could tell).

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
