### PR TITLE
Add `exclusion_constraint_exists?` and `unique_constraint_exists?` helpers

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add `exclusion_constraint_exists?` and `unique_constraint_exists?` helpers
+
+    *fatkodima*
+
 *   Add `enforced:` option to `add_foreign_key` and `change_foreign_key` for PostgreSQL 18.4+.
 
     `NOT ENFORCED` foreign keys are available since PostgreSQL 18.0, but `DEFERRABLE`

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_definitions.rb
@@ -196,6 +196,11 @@ module ActiveRecord
         def export_name_on_schema_dump?
           !ActiveRecord::SchemaDumper.excl_ignore_pattern.match?(name) if name
         end
+
+        def defined_for?(name:, expression: nil, **options)
+          self.name == name.to_s &&
+            options.all? { |k, v| self.options[k].to_s == v.to_s }
+        end
       end
 
       UniqueConstraintDefinition = Struct.new(:table_name, :column, :options) do
@@ -308,6 +313,17 @@ module ActiveRecord
           @base.remove_exclusion_constraint(name, ...)
         end
 
+        # Checks if an exclusion constraint exists on a table.
+        #
+        #  unless t.exclusion_constraint_exists?(name: "invoices_date_overlap")
+        #    t.exclusion_constraint("daterange(start_date, end_date) WITH &&", using: :gist, name: "invoices_date_overlap")
+        #  end
+        #
+        # See {connection.exclusion_constraint_exists?}[rdoc-ref:SchemaStatements#exclusion_constraint_exists?]
+        def exclusion_constraint_exists?(*args, **options)
+          @base.exclusion_constraint_exists?(name, *args, **options)
+        end
+
         # Adds a unique constraint.
         #
         #  t.unique_constraint(:position, name: 'unique_position', deferrable: :deferred, nulls_not_distinct: true)
@@ -344,6 +360,17 @@ module ActiveRecord
         # See {connection.validate_check_constraint}[rdoc-ref:SchemaStatements#validate_check_constraint]
         def validate_check_constraint(...)
           @base.validate_check_constraint(name, ...)
+        end
+
+        # Checks if a unique constraint exists on a table.
+        #
+        #  unless t.unique_constraint_exists?(name: "unique_position")
+        #    t.unique_constraint(:position, name: "unique_position", deferrable: :deferred)
+        #  end
+        #
+        # See {connection.unique_constraint_exists?}[rdoc-ref:SchemaStatements#unique_constraint_exists?]
+        def unique_constraint_exists?(*args, **options)
+          @base.unique_constraint_exists?(name, *args, **options)
         end
       end
 

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -962,6 +962,17 @@ module ActiveRecord
           remove_constraint(table_name, excl_name_to_delete)
         end
 
+        # Checks to see if an exclusion constraint exists on a table for a given exclusion constraint definition.
+        #
+        #   exclusion_constraint_exists?(:invoices, name: "invoices_date_overlap")
+        #
+        def exclusion_constraint_exists?(table_name, **options)
+          if !options.key?(:name) && !options.key?(:expression)
+            raise ArgumentError, "At least one of :name or :expression must be supplied"
+          end
+          exclusion_constraint_for(table_name, **options).present?
+        end
+
         # Adds a new unique constraint to the table.
         #
         #   add_unique_constraint :sections, [:position], deferrable: :deferred, name: "unique_position", nulls_not_distinct: true
@@ -1015,6 +1026,17 @@ module ActiveRecord
           unique_name_to_delete = unique_constraint_for!(table_name, column: column_name, **options).name
 
           remove_constraint(table_name, unique_name_to_delete)
+        end
+
+        # Checks to see if a unique constraint exists on a table for a given unique constraint definition.
+        #
+        #   unique_constraint_exists?(:sections, name: "unique_position")
+        #
+        def unique_constraint_exists?(table_name, **options)
+          if !options.key?(:name) && !options.key?(:expression)
+            raise ArgumentError, "At least one of :name or :expression must be supplied"
+          end
+          unique_constraint_for(table_name, **options).present?
         end
 
         # Maps logical Rails types to PostgreSQL-specific data types.
@@ -1325,7 +1347,7 @@ module ActiveRecord
 
           def exclusion_constraint_for(table_name, **options)
             excl_name = exclusion_constraint_name(table_name, **options)
-            exclusion_constraints(table_name).detect { |excl| excl.name == excl_name }
+            exclusion_constraints(table_name).detect { |excl| excl.defined_for?(name: excl_name, **options) }
           end
 
           def exclusion_constraint_for!(table_name, expression: nil, **options)

--- a/activerecord/test/cases/migration/change_table_test.rb
+++ b/activerecord/test/cases/migration/change_table_test.rb
@@ -170,6 +170,13 @@ module ActiveRecord
           end
         end
 
+        def test_exclusion_constraint_exists
+          with_change_table do |t|
+            expect :exclusion_constraint_exists?, nil, [:delete_me], name: "date_overlap"
+            assert_not t.exclusion_constraint_exists?(name: "date_overlap")
+          end
+        end
+
         def test_remove_exclusion_constraint_removes_exclusion_constraint
           with_change_table do |t|
             expect :remove_exclusion_constraint, nil, [:delete_me], name: "date_overlap"
@@ -181,6 +188,13 @@ module ActiveRecord
           with_change_table do |t|
             expect :add_unique_constraint, nil, [:delete_me, :foo], deferrable: :deferred, name: "unique_constraint"
             t.unique_constraint :foo, deferrable: :deferred, name: "unique_constraint"
+          end
+        end
+
+        def test_unique_constraint_exists
+          with_change_table do |t|
+            expect :unique_constraint_exists?, nil, [:delete_me], name: "unique_constraint"
+            assert_not t.unique_constraint_exists?(name: "unique_constraint")
           end
         end
 

--- a/activerecord/test/cases/migration/exclusion_constraint_test.rb
+++ b/activerecord/test/cases/migration/exclusion_constraint_test.rb
@@ -172,6 +172,16 @@ if ActiveRecord::Base.lease_connection.supports_exclusion_constraints?
           end
         end
 
+        def test_exclusion_constraint_exists
+          @connection.add_exclusion_constraint :invoices, "daterange(start_date, end_date) WITH &&", using: :gist, name: "invoices_date_overlap", deferrable: :deferred
+
+          assert @connection.exclusion_constraint_exists?(:invoices, name: "invoices_date_overlap")
+          assert @connection.exclusion_constraint_exists?(:invoices, name: "invoices_date_overlap", deferrable: :deferred)
+          assert_not @connection.exclusion_constraint_exists?(:non_invoices, name: "invoices_date_overlap")
+          assert_not @connection.exclusion_constraint_exists?(:invoices, name: "other_check")
+          assert_not @connection.exclusion_constraint_exists?(:invoices, name: "invoices_date_overlap", deferrable: :immediate)
+        end
+
         def test_remove_exclusion_constraint
           assert_equal 0, @connection.exclusion_constraints("invoices").size
 

--- a/activerecord/test/cases/migration/unique_constraint_test.rb
+++ b/activerecord/test/cases/migration/unique_constraint_test.rb
@@ -197,6 +197,15 @@ if ActiveRecord::Base.lease_connection.supports_unique_constraints?
           end
         end
 
+        def test_unique_constraint_exists
+          @connection.add_unique_constraint :sections, :position, name: "unique_constraint"
+
+          assert @connection.unique_constraint_exists?(:sections, name: "unique_constraint")
+          assert_not @connection.unique_constraint_exists?(:non_sections, name: "unique_constraint")
+          assert_not @connection.unique_constraint_exists?(:sections, column: :non_position, name: "unique_constraint")
+          assert_not @connection.unique_constraint_exists?(:sections, name: "other_check")
+        end
+
         def test_remove_unique_constraint
           @connection.add_unique_constraint :sections, [:position], name: :unique_section_position
           assert_equal 1, @connection.unique_constraints("sections").size


### PR DESCRIPTION
Exclusion constraints were added in https://github.com/rails/rails/pull/40224 and unique constraints were added in https://github.com/rails/rails/pull/46192.

Both lacks an ability to check if the constraint already exists, to make, for example, adding constraints idempotent. 
This ability already exists for check constraints, for example (same for foreign keys, indexes etc).