### PR TITLE
Document missing `:using` and `:where` options for `add_exclusion_constraint` [skip ci]

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -690,6 +690,10 @@ module ActiveRecord
         #   The constraint name. Defaults to <tt>excl_rails_<identifier></tt>.
         # [<tt>:deferrable</tt>]
         #   Specify whether or not the exclusion constraint should be deferrable. Valid values are +false+ or +:immediate+ or +:deferred+ to specify the default behavior. Defaults to +false+.
+        # [<tt>:using</tt>]
+        #   Specify which index method to use when creating this exclusion constraint (e.g. +:btree+, +:gist+ etc).
+        # [<tt>:where</tt>]
+        #   Specify an exclusion constraint on a subset of the table (internally PostgreSQL creates a partial index for this).
         def add_exclusion_constraint(table_name, expression, **options)
           options = exclusion_constraint_options(table_name, expression, options)
           at = create_alter_table(table_name)


### PR DESCRIPTION
Exclusion constraints were added in https://github.com/rails/rails/pull/40224. 
`add_exclusion_constraint` supports `:using` and `:where` options, but these were missing from the documentation.