### PR TITLE
Add flexibility to argument check in docker entrypoint

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/docker-entrypoint.tt
+++ b/railties/lib/rails/generators/rails/app/templates/docker-entrypoint.tt
@@ -2,7 +2,7 @@
 
 <% unless skip_active_record? -%>
 # If running the rails server then create or migrate existing database
-if [ "${1}" == "./bin/rails" ] && [ "${2}" == "server" ]; then
+if echo "$@" | grep -Eq "(rails s|rails server)"; then
   ./bin/rails db:prepare
 fi
 


### PR DESCRIPTION
This allows prepending commands to `./bin/rails server` as the Docker CMD when running this container, e.g. `some-binary-or-script -- ./bin/rails server -b 0.0.0.0`.

### Motivation / Background

This Pull Request has been created because I wanted to prepend the `bin/rails server` command with another binary `dotenvx run --` but have it still run `db:prepare` as expected.

```
# Dockerfile
...
CMD ["dotenvx", "run", "--debug", "--", "./bin/rails", "server"]
```

### Detail

This Pull Request changes the docker entrypoint, so `bin/rails server` (or `bin/rails s`) can be found at any location in the run `CMD` for checking if we should run the db:prepare step.

### Additional information

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* N/A Tests are added or updated if you fix a bug or add a feature.
* N/A CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
