### PR TITLE
Fix: #50293 Bump ActiveSupport::Cache.format_version to 7.1

### DIFF
--- a/activesupport/lib/active_support/cache.rb
+++ b/activesupport/lib/active_support/cache.rb
@@ -52,7 +52,7 @@ module ActiveSupport
       autoload :LocalCache, "active_support/cache/strategy/local_cache"
     end
 
-    @format_version = 6.1
+    @format_version = 7.1
 
     class << self
       attr_accessor :format_version

--- a/activesupport/test/cache/cache_coder_test.rb
+++ b/activesupport/test/cache/cache_coder_test.rb
@@ -8,6 +8,10 @@ class CacheCoderTest < ActiveSupport::TestCase
     @coder = ActiveSupport::Cache::Coder.new(Serializer, Compressor)
   end
 
+  test "default format version" do
+    assert_equal(7.1, ActiveSupport::Cache.format_version)
+  end
+
   test "roundtrips entry" do
     ENTRIES.each do |entry|
       assert_entry entry, @coder.load(@coder.dump(entry))

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -4329,12 +4329,12 @@ module ApplicationTests
       assert_equal 7.1, ActiveSupport::Cache.format_version
     end
 
-    test "ActiveSupport::Cache.format_version is 6.1 by default for upgraded apps" do
+    test "ActiveSupport::Cache.format_version is 7.1 by default for upgraded apps" do
       remove_from_config '.*config\.load_defaults.*\n'
 
       app "development"
 
-      assert_equal 6.1, ActiveSupport::Cache.format_version
+      assert_equal 7.1, ActiveSupport::Cache.format_version
     end
 
     test "ActiveSupport::Cache.format_version can be configured via config.active_support.cache_format_version" do
@@ -4360,18 +4360,6 @@ module ApplicationTests
       assert_equal \
         Marshal.dump(ActiveSupport::Cache::NullStore.new.instance_variable_get(:@coder)),
         Marshal.dump(Rails.cache.instance_variable_get(:@coder))
-    end
-
-    test "ActiveSupport::Cache.format_version 6.1 is deprecated" do
-      remove_from_config '.*config\.load_defaults.*\n'
-
-      app "development"
-
-      assert_equal 6.1, ActiveSupport::Cache.format_version
-
-      assert_deprecated(ActiveSupport.deprecator) do
-        ActiveSupport::Cache::Store.new
-      end
     end
 
     test "raise_on_invalid_cache_expiration_time is false with 7.0 defaults" do


### PR DESCRIPTION
### Motivation / Background
This pull request fixed the issue https://github.com/rails/rails/issues/50293 

The issue was:
```bash
% rails server
DEPRECATION WARNING: Support for `config.active_support.cache_format_version = 6.1` has been deprecated and will be removed in Rails 7.2.

Check the Rails upgrade guide at https://guides.rubyonrails.org/upgrading_ruby_on_rails.html#new-activesupport-cache-serialization-format
for more information on how to upgrade.
```

As per the message itself the `ActiveSupport::Cache.format_version` should not have the version 6.1. But the actual version is still 6.1. So this pull request bumped the format version to the latest 7.1. This pull request also ensured a test coverage to check the current version to 7.1 as well. 


<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created because `ActiveSupport::Cache.format_version` was assigned to 6.1 with rails 7.2 which is not not expected from 7.2.

### Detail

This Pull Request changes `ActiveSupport::Cache.format_version` from 6.1 to 7.1

### Additional information

<!-- Provide additional information such as benchmarks, reference to other repositories or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [ ] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [ ] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
