### PR TITLE
Remove setting `migrations_paths` for replicas from the docs [skip ci]

### DIFF
--- a/guides/source/active_record_multiple_databases.md
+++ b/guides/source/active_record_multiple_databases.md
@@ -412,7 +412,6 @@ production:
     database: my_primary_shard_one
     adapter: mysql2
     replica: true
-    migrations_paths: db/migrate_shards
   primary_shard_two:
     database: my_primary_shard_two
     adapter: mysql2
@@ -421,7 +420,6 @@ production:
     database: my_primary_shard_two
     adapter: mysql2
     replica: true
-    migrations_paths: db/migrate_shards
 ```
 
 Models are then connected with the `connects_to` API via the `shards` key:


### PR DESCRIPTION
Migrations are not run on replicas, so there is no need to configure `migrations_paths` on them.