### PR TITLE
Add custom ArgumentError for invalid to: values

### DIFF
--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -216,14 +216,23 @@ module ActionDispatch
 
             if to.respond_to?(:action) || to.respond_to?(:call)
               options
-            else
-              to_endpoint = split_to to
-              controller  = to_endpoint[0] || default_controller
-              action      = to_endpoint[1] || default_action
+            elsif to.nil?
+              controller = default_controller
+              action = default_action
 
               controller = add_controller_module(controller, modyoule)
 
               options.merge! check_controller_and_action(path_params, controller, action)
+            elsif to.is_a?(String) && to.include?("#")
+              to_endpoint = to.split("#").map!(&:-@)
+              controller  = to_endpoint[0]
+              action      = to_endpoint[1]
+
+              controller = add_controller_module(controller, modyoule)
+
+              options.merge! check_controller_and_action(path_params, controller, action)
+            else
+              raise ArgumentError, ":to must respond_to? :action or :call, or it must be a String that includes '#'"
             end
           end
 
@@ -306,14 +315,6 @@ module ActionDispatch
               end
             end
             hash
-          end
-
-          def split_to(to)
-            if to&.include?("#")
-              to.split("#").map!(&:-@)
-            else
-              []
-            end
           end
 
           def add_controller_module(controller, modyoule)

--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -216,23 +216,21 @@ module ActionDispatch
 
             if to.respond_to?(:action) || to.respond_to?(:call)
               options
-            elsif to.nil?
-              controller = default_controller
-              action = default_action
-
-              controller = add_controller_module(controller, modyoule)
-
-              options.merge! check_controller_and_action(path_params, controller, action)
-            elsif to.is_a?(String) && to.include?("#")
-              to_endpoint = to.split("#").map!(&:-@)
-              controller  = to_endpoint[0]
-              action      = to_endpoint[1]
-
-              controller = add_controller_module(controller, modyoule)
-
-              options.merge! check_controller_and_action(path_params, controller, action)
             else
-              raise ArgumentError, ":to must respond_to? :action or :call, or it must be a String that includes '#'"
+              if to.nil?
+                controller = default_controller
+                action = default_action
+              elsif to.is_a?(String) && to.include?("#")
+                to_endpoint = to.split("#").map!(&:-@)
+                controller  = to_endpoint[0]
+                action      = to_endpoint[1]
+              else
+                raise ArgumentError, ":to must respond to `action` or `call`, or it must be a String that includes '#'"
+              end
+
+              controller = add_controller_module(controller, modyoule)
+
+              options.merge! check_controller_and_action(path_params, controller, action)
             end
           end
 

--- a/actionpack/test/dispatch/routing_test.rb
+++ b/actionpack/test/dispatch/routing_test.rb
@@ -4054,7 +4054,7 @@ class TestNamespaceWithControllerOption < ActionDispatch::IntegrationTest
         get "/foo/bar", to: "foo"
       end
     }
-    assert_match(/:to must respond_to/, ex.message)
+    assert_match(/:to must respond to/, ex.message)
   end
 
   def test_to_is_a_symbol
@@ -4063,7 +4063,7 @@ class TestNamespaceWithControllerOption < ActionDispatch::IntegrationTest
         get "/foo/bar", to: :foo
       end
     }
-    assert_match(/:to must respond_to/, ex.message)
+    assert_match(/:to must respond to/, ex.message)
   end
 
   def test_missing_action_on_hash

--- a/actionpack/test/dispatch/routing_test.rb
+++ b/actionpack/test/dispatch/routing_test.rb
@@ -4054,7 +4054,16 @@ class TestNamespaceWithControllerOption < ActionDispatch::IntegrationTest
         get "/foo/bar", to: "foo"
       end
     }
-    assert_match(/Missing :controller/, ex.message)
+    assert_match(/:to must respond_to/, ex.message)
+  end
+
+  def test_to_is_a_symbol
+    ex = assert_raises(ArgumentError) {
+      draw do
+        get "/foo/bar", to: :foo
+      end
+    }
+    assert_match(/:to must respond_to/, ex.message)
   end
 
   def test_missing_action_on_hash


### PR DESCRIPTION
### Motivation / Background

Ref #50465 

Previously, it was theoretically possible to define a route with a Symbol as a `to:` value (or at least, it would not raise a `NoMethodError`). However, passing a Symbol broke when `/#/.match?(to)` was [replaced][1] with `to&.include?("#")` with the assumption that `to` was always a String.

### Detail

~This commit fixes the issue by calling `to_s` on the `to:` value before calling `includes?` to prevent the `NoMethodError`.~

Instead of restoring the previous error, this commit improves how the `to:` value is checked so that it raises an `ArgumentError` for any invalid values. The extra strictness will specifically improve the error when a Symbol or String that doesn't include a "#" are passed since they were effectively equivalent to passing a `nil` value, or not specifying `to:` at all.

[1]: https://github.com/rails/rails/commit/5726b1d1d7665c33830ad114f45258ecf772b7b6

### Additional information

~I considered writing a test but testing that a symbol is allowed seems wrong when it doesn't actually work (it tries to split the symbol into controller/action, and returns nil for both if symbol). Maybe alternatively we proactively raise an `ArgumentError` if the `to` value isn't a `String` (after the `respond_to?` checks)?~

~If accepted, this should be backported to `7-1-stable`~ Is this still backport worthy?

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
