### PR TITLE
Browser blocking for Rails 8

### DIFF
--- a/actionpack/actionpack.gemspec
+++ b/actionpack/actionpack.gemspec
@@ -43,6 +43,7 @@ Gem::Specification.new do |s|
   s.add_dependency "rails-html-sanitizer", "~> 1.6"
   s.add_dependency "rails-dom-testing", "~> 2.2"
   s.add_dependency "actionview", version
+  s.add_dependency "useragent", ">= 0.16.10"
 
   s.add_development_dependency "activemodel", version
 end

--- a/actionpack/lib/action_dispatch.rb
+++ b/actionpack/lib/action_dispatch.rb
@@ -52,6 +52,7 @@ module ActionDispatch
   eager_autoload do
     autoload_under "http" do
       autoload :ContentSecurityPolicy
+      autoload :BrowserGuard
       autoload :PermissionsPolicy
       autoload :Request
       autoload :Response

--- a/actionpack/lib/action_dispatch/http/browser_guard.rb
+++ b/actionpack/lib/action_dispatch/http/browser_guard.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+require "active_support/core_ext/object/deep_dup"
+require "active_support/core_ext/array/wrap"
+require "useragent"
+
+module ActionDispatch # :nodoc:
+  # = Browser Guard
+  # Rails.application.configure do
+  #   config.browser_guard do |guard|
+  #     guard.require_at_least :chrome, 110
+  #   end
+
+  #   # Handler get's called for all browsers that don't match the requirement, e.g. for reporting or logging
+  #   config.browser_guard_error_handler = ->(request) { Rails.logger.info("#{request.user_agent} is unsupported!") }
+  # end
+  class BrowserGuard
+    module Request
+      BROWSER_GUARD = "action_dispatch.browser_guard"
+      BROWSER_GUARD_ERROR_HANDLER = "action_dispatch.browser_guard_error_handler"
+
+      def browser_guard
+        get_header(BROWSER_GUARD)
+      end
+
+      def browser_guard=(config)
+        set_header(BROWSER_GUARD, config)
+      end
+
+      def browser_guard_error_handler
+        get_header(BROWSER_GUARD_ERROR_HANDLER)
+      end
+
+      def browser_guard_error_handler=(handler)
+        set_header(BROWSER_GUARD_ERROR_HANDLER, handler)
+      end
+    end
+
+    Browser = Struct.new(:browser, :version)
+
+    class Middleware
+      def initialize(app)
+        @app = app
+      end
+
+      def call(env)
+        request = ActionDispatch::Request.new env
+        @browser_guard_config = request.browser_guard
+
+        user_agent = UserAgent.parse(request.user_agent)
+        if app_supports?(user_agent)
+          @app.call(env)
+        else
+          request.browser_guard_error_handler.call(request)
+          body = File.read(Rails.public_path.join("browser_support.html"))
+          [
+            403,
+            {
+              Rack::CONTENT_LENGTH => body.bytesize.to_s,
+            },
+            [body]
+          ]
+        end
+      end
+
+      private
+        def app_supports?(user_agent)
+          if min_version = @browser_guard_config.min_versions_for_browsers[user_agent.browser]
+            user_agent >= Browser.new(user_agent.browser, min_version)
+          else
+            # we did not find any config for the current browser, therefore we pass
+            # I think this could also be a configuration.
+            true
+          end
+        end
+    end
+
+    attr_reader :min_versions_for_browsers
+    def initialize
+      @min_versions_for_browsers = {} # by default every browser in every version is valid
+      yield self if block_given?
+    end
+
+    SYMBOL_TO_BROWSER_MAPPING = {
+      chrome: "Chrome",
+      safari: "Safari",
+      firefox: "Firefox",
+      edge: "Edge",
+      internet_explorer: "Internet Explorer",
+      opera: "Opera",
+      vivaldi: "Vivaldi"
+    }
+
+    def require_at_least(vendor, version)
+      browser_name = SYMBOL_TO_BROWSER_MAPPING.fetch(vendor)
+      @min_versions_for_browsers[browser_name] = version.to_s
+    end
+  end
+end

--- a/actionpack/lib/action_dispatch/http/request.rb
+++ b/actionpack/lib/action_dispatch/http/request.rb
@@ -24,6 +24,7 @@ module ActionDispatch
     include ActionDispatch::Http::URL
     include ActionDispatch::ContentSecurityPolicy::Request
     include ActionDispatch::PermissionsPolicy::Request
+    include ActionDispatch::BrowserGuard::Request
     include Rack::Request::Env
 
     autoload :Session, "action_dispatch/request/session"

--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -327,6 +327,8 @@ module Rails
           "action_dispatch.content_security_policy_nonce_generator" => config.content_security_policy_nonce_generator,
           "action_dispatch.content_security_policy_nonce_directives" => config.content_security_policy_nonce_directives,
           "action_dispatch.permissions_policy" => config.permissions_policy,
+          "action_dispatch.browser_guard" => config.browser_guard,
+          "action_dispatch.browser_guard_error_handler" => config.browser_guard_error_handler,
         )
     end
 

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -21,6 +21,7 @@ module Rails
                     :beginning_of_week, :filter_redirect, :x,
                     :read_encrypted_secrets, :log_level, :content_security_policy_report_only,
                     :content_security_policy_nonce_generator, :content_security_policy_nonce_directives,
+                    :browser_guard_error_handler,
                     :require_master_key, :credentials, :disable_sandbox, :sandbox_by_default,
                     :add_autoload_paths_to_load_path, :rake_eager_load, :server_timing, :log_file_size,
                     :dom_testing_default_html_version
@@ -83,6 +84,8 @@ module Rails
         @rake_eager_load                         = false
         @server_timing                           = false
         @dom_testing_default_html_version        = :html4
+        @browser_guard                           = nil
+        @browser_guard_error_handler             = nil
       end
 
       # Loads default configuration values for a target version. This includes
@@ -533,6 +536,15 @@ module Rails
           @content_security_policy = ActionDispatch::ContentSecurityPolicy.new(&block)
         else
           @content_security_policy
+        end
+      end
+
+      # Configures the ActionDispatch::BrowserGuard.
+      def browser_guard(&block)
+        if block_given?
+          @browser_guard = ActionDispatch::BrowserGuard.new(&block)
+        else
+          @browser_guard
         end
       end
 

--- a/railties/lib/rails/application/default_middleware_stack.rb
+++ b/railties/lib/rails/application/default_middleware_stack.rb
@@ -80,6 +80,7 @@ module Rails
             middleware.use ::ActionDispatch::Flash
             middleware.use ::ActionDispatch::ContentSecurityPolicy::Middleware
             middleware.use ::ActionDispatch::PermissionsPolicy::Middleware
+            middleware.use ::ActionDispatch::BrowserGuard::Middleware
           end
 
           middleware.use ::Rack::Head

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/browser_guard.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/browser_guard.rb.tt
@@ -1,0 +1,19 @@
+# Be sure to restart your server when you modify this file.
+
+# Defines which browser versions your app supports. Unsupported browsers will see an error message.
+# By default all browsers are allowed, only browsers with a specific version specified will receive errors.
+
+# Rails.application.configure do
+#   config.browser_guard do |guard|
+#     guard.require_at_least :chrome, 63
+#     guard.require_at_least :safari, 16.7
+#     guard.require_at_least :edge, 89
+#     guard.require_at_least :firefox, 108
+#     guard.require_at_least :opera, 76
+#   end
+# 
+#   # Handler get's called for all browsers that don't match the requirement
+#   config.browser_guard_error_handler = ->(request) { 
+#     Rails.logger.info("#{request.user_agent} blocked from application")
+#   }
+# end

--- a/railties/lib/rails/generators/rails/app/templates/public/browser_support.html
+++ b/railties/lib/rails/generators/rails/app/templates/public/browser_support.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Your browser is not supported.</title>
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <style>
+  .rails-default-error-page {
+    background-color: #EFEFEF;
+    color: #2E2F30;
+    text-align: center;
+    font-family: arial, sans-serif;
+    margin: 0;
+  }
+
+  .rails-default-error-page div.dialog {
+    width: 95%;
+    max-width: 33em;
+    margin: 4em auto 0;
+  }
+
+  .rails-default-error-page div.dialog > div {
+    border: 1px solid #CCC;
+    border-right-color: #999;
+    border-left-color: #999;
+    border-bottom-color: #BBB;
+    border-top: #B00100 solid 4px;
+    border-top-left-radius: 9px;
+    border-top-right-radius: 9px;
+    background-color: white;
+    padding: 7px 12% 0;
+    box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
+  }
+
+  .rails-default-error-page h1 {
+    font-size: 100%;
+    color: #730E15;
+    line-height: 1.5em;
+  }
+
+  .rails-default-error-page div.dialog > p {
+    margin: 0 0 1em;
+    padding: 1em;
+    background-color: #F7F7F7;
+    border: 1px solid #CCC;
+    border-right-color: #999;
+    border-left-color: #999;
+    border-bottom-color: #999;
+    border-bottom-left-radius: 4px;
+    border-bottom-right-radius: 4px;
+    border-top-color: #DADADA;
+    color: #666;
+    box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
+  }
+  </style>
+</head>
+
+<body class="rails-default-error-page">
+  <!-- This file lives in public/browser_support.html -->
+  <div class="dialog">
+    <div>
+      <h1>Your browser is not supported.</h1>
+    </div>
+    <p>Please consider upgrading your browser to a newer version.</p>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
This Pull Request has been created because of https://github.com/rails/rails/issues/50445#issuecomment-1870716582 and to better collaborate on a public API.

### Detail

This Pull Request implements a first draft for a potential unsupported browser blocking middleware for Rails 8.

Once the public API is defined more clearly, I can add tests, docs, change the internal implementation etc.

Things I'd like to add:

```ruby
config.browser_guard do |guard|
  guard.report_only # Don't block actual browsers but call the error handler to report unsupported UAs
end
```

A mechanism to just block certain browsers:

```ruby
config.browser_guard do |guard|
  guard.block_browser(:internet_explorer) # blocks all versions of internet explorer
end
```

@dhh I could not assign you on PR creation (I guess because of missing permissions), I'm pinging you instead. Thank you for taking a look 👍 