### PR TITLE
SQLite3 +returning+ documentation additions

### DIFF
--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -115,7 +115,7 @@ module ActiveRecord
       # ==== Options
       #
       # [:returning]
-      #   (PostgreSQL and MariaDB only) An array of attributes to return for all successfully
+      #   (PostgreSQL, SQLite3, and MariaDB only) An array of attributes to return for all successfully
       #   inserted records, which by default is the primary key.
       #   Pass <tt>returning: %w[ id name ]</tt> for both id and name
       #   or <tt>returning: false</tt> to omit the underlying <tt>RETURNING</tt> SQL
@@ -205,7 +205,7 @@ module ActiveRecord
       # ==== Options
       #
       # [:returning]
-      #   (PostgreSQL and MariaDB only) An array of attributes to return for all successfully
+      #   (PostgreSQL, SQLite3, and MariaDB only) An array of attributes to return for all successfully
       #   inserted records, which by default is the primary key.
       #   Pass <tt>returning: %w[ id name ]</tt> for both id and name
       #   or <tt>returning: false</tt> to omit the underlying <tt>RETURNING</tt> SQL
@@ -271,7 +271,7 @@ module ActiveRecord
       # ==== Options
       #
       # [:returning]
-      #   (PostgreSQL and MariaDB only) An array of attributes to return for all successfully
+      #   (PostgreSQL, SQLite3, and MariaDB only) An array of attributes to return for all successfully
       #   inserted records, which by default is the primary key.
       #   Pass <tt>returning: %w[ id name ]</tt> for both id and name
       #   or <tt>returning: false</tt> to omit the underlying <tt>RETURNING</tt> SQL


### PR DESCRIPTION
### Detail

In PR https://github.com/rails/rails/pull/49290 I failed to update the documentation of the `insert_all`, `insert_all!`, and `upsert_all` methods to note that the `returning` keyword argument works for the SQLite3 adapter now. 

### Additional information

This is the only detail from PR https://github.com/rails/rails/pull/42955 that is left unresolved. Thanks to @OuYangJinTing for reminding me of this detail. @nvasilevski, we can merge this PR and close that one.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
