### PR TITLE
Yield instance to `Object#with` block

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   Yield instance to `Object#with` block
+
+    ```ruby
+    client.with(timeout: 5_000) do |c|
+      c.get("/commits")
+    end
+    ```
+
+    *Sean Doyle*
+
 *   Use logical core count instead of physical core count to determine the
     default number of workers when parallelizing tests.
 

--- a/activesupport/lib/active_support/core_ext/object/with.rb
+++ b/activesupport/lib/active_support/core_ext/object/with.rb
@@ -4,10 +4,12 @@ class Object
   # Set and restore public attributes around a block.
   #
   #   client.timeout # => 5
-  #   client.with(timeout: 1) do
-  #     client.timeout # => 1
+  #   client.with(timeout: 1) do |c|
+  #     c.timeout # => 1
   #   end
   #   client.timeout # => 5
+  #
+  # The receiver is yielded to the provided block.
   #
   # This method is a shorthand for the common begin/ensure pattern:
   #
@@ -28,7 +30,7 @@ class Object
         old_values[key] = public_send(key)
         public_send("#{key}=", value)
       end
-      yield
+      yield self
     ensure
       old_values.each do |key, old_value|
         public_send("#{key}=", old_value)

--- a/activesupport/test/core_ext/object/with_test.rb
+++ b/activesupport/test/core_ext/object/with_test.rb
@@ -88,6 +88,10 @@ class WithTest < ActiveSupport::TestCase
     assert_equal :mixed, @object.mixed_attr
   end
 
+  test "yields the instance to the block" do
+    assert_equal "1", @object.with(public_attr: "1", &:public_attr)
+  end
+
   test "basic immediates don't respond to #with" do
     assert_not_respond_to nil, :with
     assert_not_respond_to true, :with


### PR DESCRIPTION
### Detail

The introduction of the block argument means that `Object#with` can now accept a `Symbol#to_proc` as the block argument:

```ruby
client.with(timeout: 5_000, &:ping)
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
