### PR TITLE
[ci skip] Fix strong param example typo

### DIFF
--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -507,7 +507,7 @@ module ActionController
     # but take into account that at some point those ones have to be permitted:
     #
     #   def person_params
-    #     params.require(:person).permit(:name).tap do |person_params|
+    #     params.require(:person).tap do |person_params|
     #       person_params.require(:name) # SAFER
     #     end
     #   end


### PR DESCRIPTION
Fixes a typo in the Strong Parameters an example of the documentation