### PR TITLE
Read `ActionText::Attachment.tag_name` in Action Text Fixtures

### DIFF
--- a/actiontext/lib/action_text/fixture_set.rb
+++ b/actiontext/lib/action_text/fixture_set.rb
@@ -62,7 +62,7 @@ module ActionText
       signed_global_id = ActiveRecord::FixtureSet.signed_global_id fixture_set_name, label,
         column_type: column_type, for: ActionText::Attachable::LOCATOR_NAME
 
-      %(<action-text-attachment sgid="#{signed_global_id}"></action-text-attachment>)
+      %(<#{Attachment.tag_name} sgid="#{signed_global_id}"></#{Attachment.tag_name}>)
     end
   end
 end

--- a/actiontext/test/fixtures/action_text/rich_texts.yml
+++ b/actiontext/test/fixtures/action_text/rich_texts.yml
@@ -1,9 +1,9 @@
 hello_alice_message_content:
   record: hello_alice (Message)
   name: content
-  body: <p>Hello, <%= ActionText::FixtureSet.attachment("people", :alice) %></p>
+  body: <div>Hello, <%= ActionText::FixtureSet.attachment("people", :alice) %></div>
 
 hello_world_review_content:
   record: hello_world (Review)
   name: content
-  body: <p><%= ActionText::FixtureSet.attachment("messages", :hello_world) %> is great!</p>
+  body: <div><%= ActionText::FixtureSet.attachment("messages", :hello_world) %> is great!</div>


### PR DESCRIPTION
### Motivation / Background

Utilizing the [ActionText::FixtureSet.attachment][] method in consumer application's test suites relies on a hard-coded
`action-text-attachment` element tag name. While it's uncommon for that value to change, it _is_ possible to configure it with the `config.action_text.attachment_tag_name` configuration.

### Detail

This commit replaces the hard-coded name by interpolating `ActionText::Attachment.tag_name`.

Internal to the Rails test suite, Action Text's fixtures use HTML with `<p>` elements to wrap new blocks of text. Trix uses `<div>` elements by default for line breaking (and for [other historical reasons][]). This change is internal to this codebase, and will not affect users.

### Additional information

[ActionText::FixtureSet.attachment]: https://edgeapi.rubyonrails.org/classes/ActionText/FixtureSet.html#method-c-attachment
[other historical reasons]: https://github.com/basecamp/trix/issues/202#issuecomment-461166895

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
