### PR TITLE
Delegate `ActionText::Content#deconstruct` to Nokogiri

### DIFF
--- a/actiontext/CHANGELOG.md
+++ b/actiontext/CHANGELOG.md
@@ -1,3 +1,20 @@
+*   Delegate `ActionText::Content#deconstruct` to `Nokogiri::XML::DocumentFragment#elements`
+
+    ```ruby
+    content = ActionText::Content.new <<~HTML
+      <h1>Hello, world</h1>
+
+      <div>The body</div>
+    HTML
+
+    content => [h1, div]
+
+    assert_pattern { h1 => { content: "Hello, world" } }
+    assert_pattern { div => { content: "The body" } }
+    ```
+
+    *Sean Doyle*
+
 *   Fix all Action Text database related models to respect
     `ActiveRecord::Base.table_name_prefix` configuration.
 

--- a/actiontext/lib/action_text/content.rb
+++ b/actiontext/lib/action_text/content.rb
@@ -24,6 +24,7 @@ module ActionText
 
     attr_reader :fragment
 
+    delegate :deconstruct, to: :fragment
     delegate :blank?, :empty?, :html_safe, :present?, to: :to_html # Delegating to to_html to avoid including the layout
 
     class << self

--- a/actiontext/lib/action_text/fragment.rb
+++ b/actiontext/lib/action_text/fragment.rb
@@ -21,6 +21,8 @@ module ActionText
 
     attr_reader :source
 
+    delegate :deconstruct, to: "source.elements"
+
     def initialize(source)
       @source = source
     end

--- a/actiontext/test/unit/content_test.rb
+++ b/actiontext/test/unit/content_test.rb
@@ -210,3 +210,7 @@ class ActionText::ContentTest < ActiveSupport::TestCase
       ActionText::Attachment.tag_name = previous_tag_name
     end
 end
+
+if RUBY_VERSION >= "3.1"
+  require_relative "./content_test/pattern_matching_test_cases"
+end

--- a/actiontext/test/unit/content_test/pattern_matching_test_cases.rb
+++ b/actiontext/test/unit/content_test/pattern_matching_test_cases.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class ActionText::PatternMatchingTestCases < ActiveSupport::TestCase
+  test "delegates pattern matching to Nokogiri" do
+    content = ActionText::Content.new <<~HTML
+      <h1 id="hello-world">Hello, world</h1>
+
+      <div>The body</div>
+    HTML
+
+    # rubocop:disable Lint/Syntax
+    content => [h1, div]
+
+    assert_pattern { h1 => { name: "h1", content: "Hello, world", attributes: [{ name: "id", value: "hello-world" }] } }
+    refute_pattern { h1 => { name: "h1", content: "Goodbye, world" } }
+    assert_pattern { div => { content: "The body" } }
+    # rubocop:enable Lint/Syntax
+  end
+end

--- a/actionview/test/template/test_case_test/pattern_matching_test_cases.rb
+++ b/actionview/test/template/test_case_test/pattern_matching_test_cases.rb
@@ -9,6 +9,7 @@ class ActionView::PatternMatchingTestCases < ActionView::TestCase
     # rubocop:disable Lint/Syntax
     assert_pattern { document_root_element.at("h1") => { content: "Eloy", attributes: [{ name: "id", value: "name" }] } }
     refute_pattern { document_root_element.at("h1") => { content: "Not Eloy" } }
+    # rubocop:enable Lint/Syntax
   end
 
   test "rendered.html integrates with pattern matching" do


### PR DESCRIPTION
### Motivation / Background

Since `ActionText::Content` wraps an `ActionText::Fragment`, and `ActionText::Fragment` wraps a `Nokogiri::XML::DocumentFragment`, then `ActionText::Content` should be able to rely on the newer Ruby pattern matching introduced by [nokogiri@1.16.0][] (mainly the [DocumentFragment#deconstruct][] method):

```ruby
action_text_content = ActionText::Content.new <<~HTML
  <h1>Hello, world</h1>

  <div>The body</div>
HTML

action_text_content => [h1, div]

assert_pattern { h1 => { content: "Hello, world" } }
assert_pattern { div => { content: "The body" } }
```

### Detail

The implementation change relies on delegating from `Content` to `Fragment`, and from `Fragment` to `DocumentFragment#elements` (to deliberately exclude text nodes).

[nokogiri@1.16.0]: https://nokogiri.org/CHANGELOG.html?h=pattern
[DocumentFragment#deconstruct]: https://nokogiri.org/rdoc/Nokogiri/XML/DocumentFragment.html?h=deconstruct#method-i-deconstruct

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
