### PR TITLE
support dumping PostgreSQL inheritance & partitioning options to `schema.rb`

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add support for dumping table inheritance and native partitioning table definitions for PostgeSQL adapter
+
+    *Justin Talbott*
+
 *   Deserialize database values before decryption
 
     PostgreSQL binary values (`ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Bytea`)

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -284,6 +284,10 @@ module ActiveRecord
         database_version >= 15_00_00 # >= 15.0
       end
 
+      def supports_native_partitioning? # :nodoc:
+        database_version >= 10_00_00 # >= 10.0
+      end
+
       def index_algorithms
         { concurrently: "CONCURRENTLY" }
       end

--- a/activerecord/test/cases/adapters/postgresql/schema_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/schema_test.rb
@@ -861,3 +861,90 @@ class SchemaIndexNullsNotDistinctTest < ActiveRecord::PostgreSQLTestCase
     assert_no_match(/nulls_not_distinct/, output)
   end
 end
+
+class SchemaCreateTableOptionsTest < ActiveRecord::PostgreSQLTestCase
+  include SchemaDumpingHelper
+
+  setup do
+    @connection = ActiveRecord::Base.connection
+  end
+
+  teardown do
+    @connection.drop_table "trains", if_exists: true
+    @connection.drop_table "transportation_modes", if_exists: true
+    @connection.drop_table "vehicles", if_exists: true
+  end
+
+  def test_list_partition_options_is_dumped
+    skip("current adapter doesn't support native partitioning") unless supports_native_partitioning?
+
+    options = "PARTITION BY LIST (kind)"
+
+    @connection.create_table "trains", id: false, options: options do |t|
+      t.string :name
+      t.string :kind
+    end
+
+    output = dump_table_schema "trains"
+
+    assert_match("options: \"#{options}\"", output)
+  end
+
+  def test_range_partition_options_is_dumped
+    skip("current adapter doesn't support native partitioning") unless supports_native_partitioning?
+
+    options = "PARTITION BY RANGE (created_at)"
+
+    @connection.create_table "trains", id: false, options: options do |t|
+      t.string :name
+      t.datetime :created_at, null: false
+    end
+
+    output = dump_table_schema "trains"
+
+    assert_match("options: \"#{options}\"", output)
+  end
+
+  def test_inherited_table_options_is_dumped
+    @connection.create_table "transportation_modes" do |t|
+      t.string :name
+      t.string :kind
+    end
+
+    options = "INHERITS (transportation_modes)"
+
+    @connection.create_table "trains", options: options
+
+    output = dump_table_schema "trains"
+
+    assert_match("options: \"#{options}\"", output)
+  end
+
+  def test_multiple_inherited_table_options_is_dumped
+    @connection.create_table "vehicles" do |t|
+      t.string :name
+    end
+
+    @connection.create_table "transportation_modes" do |t|
+      t.string :kind
+    end
+
+    options = "INHERITS (transportation_modes, vehicles)"
+
+    @connection.create_table "trains", options: options
+
+    output = dump_table_schema "trains"
+
+    assert_match("options: \"#{options}\"", output)
+  end
+
+  def test_no_partition_options_are_dumped
+    @connection.create_table "trains" do |t|
+      t.string :name
+    end
+
+    output = dump_table_schema "trains"
+
+    assert_no_match("options:", output)
+  end
+end

--- a/activerecord/test/support/adapter_helper.rb
+++ b/activerecord/test/support/adapter_helper.rb
@@ -60,6 +60,7 @@ module AdapterHelper
     supports_nulls_not_distinct?
     supports_identity_columns?
     supports_virtual_columns?
+    supports_native_partitioning?
   ].each do |method_name|
     define_method method_name do
       ActiveRecord::Base.lease_connection.public_send(method_name)


### PR DESCRIPTION
### Motivation / Background & Detail

[`create_table`](https://api.rubyonrails.org/v7.1.2/classes/ActiveRecord/ConnectionAdapters/SchemaStatements.html#method-i-create_table) provides an `options:` key that allows you to append options to your table definition. One of the things you can do this way with PostgreSQL 10+ is use [native partitioning](https://www.postgresql.org/docs/current/ddl-partitioning.html) to declare partitioning definitions:

```
create_table :events, id: false, options: "PARTITION BY LIST (account_id)" do |t|
  t.bigint :account_id, null: false
  t.integer :kind, null: false
  t.datetime :occurred_at, null: false
end
```

Adding this to a migration and running it will properly create the partitioned table in development, but the dumped schema will not persist the specified partitioning options. Therefore, if you run your test suite which loads from `schema.rb`, your test database's table won't be properly partitioned.

This PR extends the PostgeSQL adapter's schema statements so that it can dump this partitioning definition as defined in the relevant system tables. 

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
