### PR TITLE
Active Storage can be configured by STORAGE_URL

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -2,6 +2,18 @@
 
     *zzak*
 
+*   Active Storage can be configured by `STORAGE_URL` environment variable
+
+    The following cases are currently supported:
+
+    ```
+    disk://my/root/path
+    s3://access_key_id:secret_access_key@us-east-1/your-bucket
+    gcs://path/to/gcs.keyfile@your_project/your-bucket
+    ```
+
+    *zzak*
+
 *   Improve `ActiveStorage::Filename#sanitized` method to handle special characters more effectively.
     Replace the characters `"*?<>` with `-` if they exist in the Filename to match the Filename convention of Win OS.
 

--- a/activestorage/lib/active_storage/service.rb
+++ b/activestorage/lib/active_storage/service.rb
@@ -43,6 +43,7 @@ module ActiveStorage
   class Service
     extend ActiveSupport::Autoload
     autoload :Configurator
+    autoload :UrlConfig
     attr_accessor :name
 
     class << self
@@ -59,10 +60,18 @@ module ActiveStorage
       # Passes the configurator and all of the service's config as keyword args.
       #
       # See MirrorService for an example.
-      def build(configurator:, name:, service: nil, **service_config) # :nodoc:
+      def build(configurator:, name:, service: nil, url_config: nil, **service_config) # :nodoc:
+        if url_config
+          service_config = options_from_url(url_config)
+        end
+
         new(**service_config).tap do |service_instance|
           service_instance.name = name
         end
+      end
+
+      def options_from_url(url_config) # :nodoc:
+        raise NotImplementedError
       end
     end
 

--- a/activestorage/lib/active_storage/service/configurator.rb
+++ b/activestorage/lib/active_storage/service/configurator.rb
@@ -9,14 +9,12 @@ module ActiveStorage
     end
 
     def initialize(configurations)
-      @configurations = configurations.deep_symbolize_keys
+      @configurations = build_configurations(configurations)
     end
 
     def build(service_name)
-      config = config_for(service_name.to_sym)
-      resolve(config.fetch(:service)).build(
-        **config, configurator: self, name: service_name
-      )
+      configurations.is_a?(ActiveStorage::Service::UrlConfig) ?
+        build_url_service(service_name) : build_service(service_name)
     end
 
     private
@@ -29,8 +27,36 @@ module ActiveStorage
       def resolve(class_name)
         require "active_storage/service/#{class_name.to_s.underscore}_service"
         ActiveStorage::Service.const_get(:"#{class_name.camelize}Service")
+      rescue NameError
+        ActiveStorage::Service.const_get(:"#{class_name.upcase}Service")
       rescue LoadError
         raise "Missing service adapter for #{class_name.inspect}"
+      end
+
+      def build_configurations(configurations)
+        configurations_from_url || configurations.deep_symbolize_keys
+      end
+
+      def configurations_from_url
+        if storage_url = ENV["STORAGE_URL"]
+          uri = URI.parse(storage_url)
+          if uri.scheme
+            return ActiveStorage::Service::UrlConfig.new(uri)
+          end
+        end
+      end
+
+      def build_url_service(service_name)
+        resolve(configurations.fetch(:service)).build(
+          configurator: self, url_config: configurations, name: service_name
+        )
+      end
+
+      def build_service(service_name)
+        config = config_for(service_name.to_sym)
+        resolve(config.fetch(:service)).build(
+          **config, configurator: self, name: service_name
+        )
       end
   end
 end

--- a/activestorage/lib/active_storage/service/disk_service.rb
+++ b/activestorage/lib/active_storage/service/disk_service.rb
@@ -13,6 +13,10 @@ module ActiveStorage
   class Service::DiskService < Service
     attr_accessor :root
 
+    def self.options_from_url(url_config) # :nodoc:
+      { root: url_config.host + url_config.path, **url_config.params }
+    end
+
     def initialize(root:, public: false, **options)
       @root = root
       @public = public

--- a/activestorage/lib/active_storage/service/gcs_service.rb
+++ b/activestorage/lib/active_storage/service/gcs_service.rb
@@ -13,6 +13,13 @@ module ActiveStorage
     class MetadataServerError < ActiveStorage::Error; end
     class MetadataServerNotFoundError < ActiveStorage::Error; end
 
+    def self.options_from_url(url_config) # :nodoc:
+      pattern = %r{^gcs://(?<credentials>[^@]+)@(?<project>[^/]+)/(?<bucket>[^?]+)}
+      match = url_config.fetch(:uri).to_s.match(pattern)
+
+      { bucket: match[:bucket], project: match[:project], credentials: match[:credentials], **url_config.params }
+    end
+
     def initialize(public: false, **config)
       @config = config
       @public = public

--- a/activestorage/lib/active_storage/service/s3_service.rb
+++ b/activestorage/lib/active_storage/service/s3_service.rb
@@ -14,6 +14,16 @@ module ActiveStorage
     attr_reader :client, :bucket
     attr_reader :multipart_upload_threshold, :upload_options
 
+    def self.options_from_url(url_config) # :nodoc:
+      {
+        bucket: url_config.path.gsub(%r{^/}, ""),
+        region: url_config.host,
+        access_key_id: url_config.user,
+        secret_access_key: url_config.password,
+        **url_config.params
+      }
+    end
+
     def initialize(bucket:, upload: {}, public: false, **options)
       @client = Aws::S3::Resource.new(**options)
       @bucket = @client.bucket(bucket)

--- a/activestorage/lib/active_storage/service/url_config.rb
+++ b/activestorage/lib/active_storage/service/url_config.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module ActiveStorage
+  class Service::UrlConfig # :nodoc:
+    delegate :host, :path, :user, :password, to: :uri
+
+    def initialize(uri)
+      @uri = uri
+      @configuration_hash = build_url_hash.freeze
+    end
+
+    def fetch(key)
+      @configuration_hash.fetch(:url).fetch(key)
+    end
+
+    def params
+      fetch(:params)
+    end
+
+    private
+      attr_reader :uri
+
+      def build_url_hash
+        service = uri.scheme && uri.scheme.tr("-", "_")
+        params = Hash[(uri.query || "").split("&").map { |pair| pair.split("=", 2) }].symbolize_keys
+
+        {
+          url: {
+            params: params,
+            service: service,
+            uri: uri
+          }
+        }
+      end
+  end
+end

--- a/activestorage/test/service/configurator_test.rb
+++ b/activestorage/test/service/configurator_test.rb
@@ -38,4 +38,62 @@ class ActiveStorage::Service::ConfiguratorTest < ActiveSupport::TestCase
       })
     end
   end
+
+  test "builds correct service given STORAGE_URL environment variable" do
+    @before_storage_url = ENV["STORAGE_URL"]
+    ENV["STORAGE_URL"] = "disk://tmp/storage"
+
+    service = ActiveStorage::Service::Configurator.build(:env, {})
+    assert_instance_of ActiveStorage::Service::DiskService, service
+    assert_equal "tmp/storage", service.root
+  ensure
+    ENV["STORAGE_URL"] = @before_storage_url
+  end
+
+  test "STORAGE_URL env var with disk service root path" do
+    @before_storage_url = ENV["STORAGE_URL"]
+    ENV["STORAGE_URL"] = "disk:///root/storage"
+
+    service = ActiveStorage::Service::Configurator.build(:env, {})
+    assert_instance_of ActiveStorage::Service::DiskService, service
+    assert_equal "/root/storage", service.root
+  ensure
+    ENV["STORAGE_URL"] = @before_storage_url
+  end
+
+  test "STORAGE_URL env var for s3" do
+    @before_storage_url = ENV["STORAGE_URL"]
+    ENV["STORAGE_URL"] = "s3://access_key_id:secret_access_key@us-east-1/your-bucket"
+
+    service = ActiveStorage::Service::Configurator.build(:env, {})
+    assert_instance_of ActiveStorage::Service::S3Service, service
+    assert_equal "your-bucket", service.bucket.name
+
+    assert_equal "us-east-1", service.client.client.config.region
+    assert_equal "access_key_id", service.client.client.config.access_key_id
+    assert_equal "secret_access_key", service.client.client.config.secret_access_key
+  ensure
+    ENV["STORAGE_URL"] = @before_storage_url
+  end
+
+  test "STORAGE_URL env var for gcs" do
+    @before_storage_url = ENV["STORAGE_URL"]
+    ENV["STORAGE_URL"] = "gcs://path/to/gcs.keyfile@your_project/your-bucket"
+
+    service = ActiveStorage::Service::Configurator.build(:env, {})
+    assert_instance_of ActiveStorage::Service::GCSService, service
+  ensure
+    ENV["STORAGE_URL"] = @before_storage_url
+  end
+
+  test "STORAGE_URL env var for gcs with query hash" do
+    @before_storage_url = ENV["STORAGE_URL"]
+    ENV["STORAGE_URL"] = "gcs://path/to/gcs.keyfile@your_project/your-bucket?public=true"
+
+    service = ActiveStorage::Service::Configurator.build(:env, {})
+    assert_instance_of ActiveStorage::Service::GCSService, service
+    assert_predicate service, :public? # public only has to be truthy to set acl to public-read
+  ensure
+    ENV["STORAGE_URL"] = @before_storage_url
+  end
 end

--- a/activestorage/test/service/disk_service_test.rb
+++ b/activestorage/test/service/disk_service_test.rb
@@ -2,68 +2,76 @@
 
 require "service/shared_service_tests"
 
+module ActiveStorage::Service::SharedDiskServiceTests
+  extend ActiveSupport::Concern
+
+  included do
+    include ActiveStorage::Service::SharedServiceTests
+
+    test "url_for_direct_upload" do
+      original_url_options = Rails.application.routes.default_url_options.dup
+      Rails.application.routes.default_url_options.merge!(protocol: "http", host: "test.example.com", port: 3001)
+
+      key      = SecureRandom.base58(24)
+      data     = "Something else entirely!"
+      checksum = Digest::MD5.base64digest(data)
+
+      begin
+        assert_match(/^https:\/\/example.com\/rails\/active_storage\/disk\/.*$/,
+          @service.url_for_direct_upload(key, expires_in: 5.minutes, content_type: "text/plain", content_length: data.size, checksum: checksum))
+      ensure
+        Rails.application.routes.default_url_options = original_url_options
+      end
+    end
+
+    test "URL generation" do
+      original_url_options = Rails.application.routes.default_url_options.dup
+      Rails.application.routes.default_url_options.merge!(protocol: "http", host: "test.example.com", port: 3001)
+      begin
+        assert_match(/^https:\/\/example.com\/rails\/active_storage\/disk\/.*\/avatar\.png$/,
+          @service.url(@key, expires_in: 5.minutes, disposition: :inline, filename: ActiveStorage::Filename.new("avatar.png"), content_type: "image/png"))
+      ensure
+        Rails.application.routes.default_url_options = original_url_options
+      end
+    end
+
+    test "URL generation without ActiveStorage::Current.url_options set" do
+      ActiveStorage::Current.url_options = nil
+
+      error = assert_raises ArgumentError do
+        @service.url(@key, expires_in: 5.minutes, disposition: :inline, filename: ActiveStorage::Filename.new("avatar.png"), content_type: "image/png")
+      end
+
+      assert_equal("Cannot generate URL for avatar.png using Disk service, please set ActiveStorage::Current.url_options.", error.message)
+    end
+
+    test "URL generation keeps working with ActiveStorage::Current.host set" do
+      ActiveStorage::Current.url_options = { host: "https://example.com" }
+
+      original_url_options = Rails.application.routes.default_url_options.dup
+      Rails.application.routes.default_url_options.merge!(protocol: "http", host: "test.example.com", port: 3001)
+      begin
+        assert_match(/^http:\/\/example.com:3001\/rails\/active_storage\/disk\/.*\/avatar\.png$/,
+          @service.url(@key, expires_in: 5.minutes, disposition: :inline, filename: ActiveStorage::Filename.new("avatar.png"), content_type: "image/png"))
+      ensure
+        Rails.application.routes.default_url_options = original_url_options
+      end
+    end
+
+    test "headers_for_direct_upload generation" do
+      assert_equal({ "Content-Type" => "application/json" }, @service.headers_for_direct_upload(@key, content_type: "application/json"))
+    end
+  end
+end
+
 class ActiveStorage::Service::DiskServiceTest < ActiveSupport::TestCase
+  include ActiveStorage::Service::SharedDiskServiceTests
+
   tmp_config = { tmp: { service: "Disk", root: File.join(Dir.tmpdir, "active_storage") } }
   SERVICE = ActiveStorage::Service.configure(:tmp, tmp_config)
 
-  include ActiveStorage::Service::SharedServiceTests
-
   test "name" do
     assert_equal :tmp, @service.name
-  end
-
-  test "url_for_direct_upload" do
-    original_url_options = Rails.application.routes.default_url_options.dup
-    Rails.application.routes.default_url_options.merge!(protocol: "http", host: "test.example.com", port: 3001)
-
-    key      = SecureRandom.base58(24)
-    data     = "Something else entirely!"
-    checksum = Digest::MD5.base64digest(data)
-
-    begin
-      assert_match(/^https:\/\/example.com\/rails\/active_storage\/disk\/.*$/,
-        @service.url_for_direct_upload(key, expires_in: 5.minutes, content_type: "text/plain", content_length: data.size, checksum: checksum))
-    ensure
-      Rails.application.routes.default_url_options = original_url_options
-    end
-  end
-
-  test "URL generation" do
-    original_url_options = Rails.application.routes.default_url_options.dup
-    Rails.application.routes.default_url_options.merge!(protocol: "http", host: "test.example.com", port: 3001)
-    begin
-      assert_match(/^https:\/\/example.com\/rails\/active_storage\/disk\/.*\/avatar\.png$/,
-        @service.url(@key, expires_in: 5.minutes, disposition: :inline, filename: ActiveStorage::Filename.new("avatar.png"), content_type: "image/png"))
-    ensure
-      Rails.application.routes.default_url_options = original_url_options
-    end
-  end
-
-  test "URL generation without ActiveStorage::Current.url_options set" do
-    ActiveStorage::Current.url_options = nil
-
-    error = assert_raises ArgumentError do
-      @service.url(@key, expires_in: 5.minutes, disposition: :inline, filename: ActiveStorage::Filename.new("avatar.png"), content_type: "image/png")
-    end
-
-    assert_equal("Cannot generate URL for avatar.png using Disk service, please set ActiveStorage::Current.url_options.", error.message)
-  end
-
-  test "URL generation keeps working with ActiveStorage::Current.host set" do
-    ActiveStorage::Current.url_options = { host: "https://example.com" }
-
-    original_url_options = Rails.application.routes.default_url_options.dup
-    Rails.application.routes.default_url_options.merge!(protocol: "http", host: "test.example.com", port: 3001)
-    begin
-      assert_match(/^http:\/\/example.com:3001\/rails\/active_storage\/disk\/.*\/avatar\.png$/,
-        @service.url(@key, expires_in: 5.minutes, disposition: :inline, filename: ActiveStorage::Filename.new("avatar.png"), content_type: "image/png"))
-    ensure
-      Rails.application.routes.default_url_options = original_url_options
-    end
-  end
-
-  test "headers_for_direct_upload generation" do
-    assert_equal({ "Content-Type" => "application/json" }, @service.headers_for_direct_upload(@key, content_type: "application/json"))
   end
 
   test "root" do
@@ -77,5 +85,60 @@ class ActiveStorage::Service::DiskServiceTest < ActiveSupport::TestCase
     assert_equal tmp_path_2, @service.root
   ensure
     @service.root = tmp_config.dig(:tmp, :root)
+  end
+end
+
+class ActiveStorage::Service::DiskServiceEnvTest < ActiveSupport::TestCase
+  include ActiveStorage::Service::SharedDiskServiceTests
+
+  tmp_config = { tmp: { service: "Disk", root: File.join(Dir.tmpdir, "active_storage") } }
+  SERVICE = ActiveStorage::Service.configure(:tmp, tmp_config)
+
+  setup do
+    @tmp_dir = File.join(Dir.tmpdir, "active_storage")
+    @before_env_storage_url = ENV["STORAGE_URL"]
+    ENV["STORAGE_URL"] = "disk://#{@tmp_dir}"
+    @service = ActiveStorage::Service.configure(:env, {})
+  end
+
+  teardown do
+    ENV["STORAGE_URL"] = @before_env_storage_url
+  end
+
+  test "name" do
+    assert_equal :env, @service.name
+  end
+
+  test "root" do
+    assert_equal @tmp_dir, @service.root
+  end
+
+  test "can change root" do
+    tmp_path_2 = File.join(Dir.tmpdir, "active_storage_2")
+    @service.root = tmp_path_2
+
+    assert_equal tmp_path_2, @service.root
+  ensure
+    @service.root = @tmp_dir
+  end
+end
+
+class ActiveStorage::Service::DiskServiceOptionsTest < ActiveSupport::TestCase
+  test "root path" do
+    uri = URI.parse("disk://tmp/storage")
+    url = ActiveStorage::Service::UrlConfig.new(uri)
+    options = ActiveStorage::Service::DiskService.options_from_url(url)
+    assert_equal "tmp/storage", options[:root]
+
+    uri = URI.parse("disk:///root/storage")
+    url = ActiveStorage::Service::UrlConfig.new(uri)
+    options = ActiveStorage::Service::DiskService.options_from_url(url)
+    assert_equal "/root/storage", options[:root]
+
+    uri = URI.parse("disk://storage?splat=true")
+    url = ActiveStorage::Service::UrlConfig.new(uri)
+    options = ActiveStorage::Service::DiskService.options_from_url(url)
+    assert_equal "storage", options[:root]
+    assert_equal "true", options[:splat]
   end
 end

--- a/activestorage/test/service/url_config_test.rb
+++ b/activestorage/test/service/url_config_test.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class ActiveStorage::Service::UrlConfigTest < ActiveSupport::TestCase
+  def test_fetch_url
+    uri = URI.parse("disk://tmp/storage")
+    config = ActiveStorage::Service::UrlConfig.new(uri)
+    assert_equal "disk", config.fetch(:service)
+
+    uri = URI.parse("disk://tmp/storage?default=false")
+    config = ActiveStorage::Service::UrlConfig.new(uri)
+    assert_equal "false", config.fetch(:params)[:default]
+
+    uri = URI.parse("disk://tmp/storage?cache_control=public,max-age=31536000&read_only=true")
+    config = ActiveStorage::Service::UrlConfig.new(uri)
+    assert_equal "public,max-age=31536000", config.params[:cache_control]
+    assert_equal "true", config.params[:read_only]
+  end
+end


### PR DESCRIPTION
Fixes #50448

The following cases are currently supported:

```
disk://my/root/path
s3://access_key_id:secret_access_key@us-east-1/your-bucket
gcs://path/to/gcs.keyfile@your_project/your-bucket
```

Based roughly on ActiveRecord::DatabaseConfigurations and how it deals with URLs from environment variables.