### PR TITLE
Add standardrb for new rails apps

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,7 +24,7 @@ jobs:
       run: |
         bundle exec railties/exe/rails new dev/devrails --dev
         cd dev/devrails
-        bundle exec standardrb
+        bundle exec standardrb --verbose-version
 
     - name: mdl
       run: bundle exec rake -f guides/Rakefile guides:lint

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,6 +20,12 @@ jobs:
         ruby-version: 3.2
         bundler-cache: true
 
+    - name: standard rails new
+      run: |
+        bundle exec railties/exe/rails new dev/devrails --dev
+        cd dev/devrails
+        bundle exec standardrb
+
     - name: mdl
       run: bundle exec rake -f guides/Rakefile guides:lint
 

--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -88,6 +88,9 @@ module Rails
         class_option :skip_jbuilder,       type: :boolean, default: nil,
                                            desc: "Skip jbuilder gem"
 
+        class_option :skip_linter,         type: :boolean, aliases: ["-L", "--skip-standard"], default: false,
+                                           desc: "Skip standard Ruby linting"
+
         class_option :skip_test,           type: :boolean, aliases: "-T", default: nil,
                                            desc: "Skip test files"
 
@@ -141,6 +144,7 @@ module Rails
           css_gemfile_entry,
           jbuilder_gemfile_entry,
           cable_gemfile_entry,
+          linter_gemfile_entry,
         ].flatten.compact.select(&@gem_filter)
       end
 
@@ -475,6 +479,12 @@ module Rails
           GemfileEntry.floats "stimulus-rails", "Hotwire's modest JavaScript framework [https://stimulus.hotwired.dev]"
 
         [ turbo_rails_entry, stimulus_rails_entry ]
+      end
+
+      def linter_gemfile_entry
+        return if options[:skip_linter]
+
+        GemfileEntry.floats "standard", "Standard is a Ruby code formatter and linter [https://github.com/standardrb/standard]"
       end
 
       def using_js_runtime?

--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -144,7 +144,6 @@ module Rails
           css_gemfile_entry,
           jbuilder_gemfile_entry,
           cable_gemfile_entry,
-          linter_gemfile_entry,
         ].flatten.compact.select(&@gem_filter)
       end
 
@@ -479,12 +478,6 @@ module Rails
           GemfileEntry.floats "stimulus-rails", "Hotwire's modest JavaScript framework [https://stimulus.hotwired.dev]"
 
         [ turbo_rails_entry, stimulus_rails_entry ]
-      end
-
-      def linter_gemfile_entry
-        return if options[:skip_linter]
-
-        GemfileEntry.floats "standard", "Standard is a Ruby code formatter and linter [https://github.com/standardrb/standard]"
       end
 
       def using_js_runtime?

--- a/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
@@ -15,7 +15,7 @@ ruby <%= "\"#{gem_ruby_version}\"" -%>
 <% end -%>
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
-gem "tzinfo-data", platforms: %i[ <%= bundler_windows_platforms %> jruby ]
+gem "tzinfo-data", platforms: %i[<%= bundler_windows_platforms %> jruby]
 <% if depend_on_bootsnap? -%>
 
 # Reduces boot times through caching; required in config/boot.rb
@@ -35,7 +35,7 @@ gem "bootsnap", require: false
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
-  gem "debug", platforms: %i[ mri <%= bundler_windows_platforms %> ]
+  gem "debug", platforms: %i[mri <%= bundler_windows_platforms %>]
 end
 <% end -%>
 

--- a/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
@@ -48,6 +48,11 @@ group :development do
   # gem "rack-mini-profiler"
 
 <%- end -%>
+<%- unless options.skip_linter? -%>
+  # Standard is a Ruby code formatter and linter [https://github.com/standardrb/standard]
+  gem "standard"
+
+<%- end -%>
   # Speed up commands on slow machines / big apps [https://github.com/rails/spring]
   # gem "spring"
 <%- if RUBY_VERSION >= "3.1" && RUBY_VERSION < "3.2" -%>

--- a/railties/lib/rails/generators/rails/app/templates/config/application.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/application.rb.tt
@@ -18,7 +18,7 @@ module <%= app_const_base %>
     # Please, add to the `ignore` list any other `lib` subdirectories that do
     # not contain `.rb` files, or that should not be reloaded or eager loaded.
     # Common ones are `templates`, `generators`, or `middleware`, for example.
-    config.autoload_lib(ignore: %w(assets tasks))
+    config.autoload_lib(ignore: %w[assets tasks])
 
     # Configuration for the application, engines, and railties goes here.
     #

--- a/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
@@ -59,13 +59,13 @@ Rails.application.configure do
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   config.force_ssl = true
 
-  # Log to STDOUT by default
-  config.logger = ActiveSupport::Logger.new(STDOUT)
-    .tap  { |logger| logger.formatter = ::Logger::Formatter.new }
+  # Log to $stdout by default
+  config.logger = ActiveSupport::Logger.new($stdout)
+    .tap { |logger| logger.formatter = ::Logger::Formatter.new }
     .then { |logger| ActiveSupport::TaggedLogging.new(logger) }
 
   # Prepend all log lines with the following tags.
-  config.log_tags = [ :request_id ]
+  config.log_tags = [:request_id]
 
   # "info" includes generic and useful information about system operation, but avoids logging too much
   # information to avoid inadvertent exposure of personally identifiable information (PII). If you

--- a/railties/lib/rails/generators/rails/app/templates/config/routes.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/routes.rb.tt
@@ -3,7 +3,7 @@ Rails.application.routes.draw do
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
   # Can be used by load balancers and uptime monitors to verify that the app is live.
-  get "up" => "rails/health#show", as: :rails_health_check
+  get "up" => "rails/health#show", :as => :rails_health_check
 
   # Defines the root path route ("/")
   # root "posts#index"

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -609,6 +609,17 @@ class AppGeneratorTest < Rails::Generators::TestCase
     end
   end
 
+  def test_inclusion_of_linter
+    run_generator
+    assert_gem "standard"
+  end
+
+  def test_linter_is_skipped_if_required
+    run_generator [destination_root, "--skip-linter"]
+
+    assert_no_gem "standard"
+  end
+
   def test_inclusion_of_jbuilder
     run_generator
     assert_gem "jbuilder"


### PR DESCRIPTION
Fixes #50456

This is a very simple approach to adding a linter to `rails new` applications, the linter option is not configurable, it can only be disabled.

Formatting issues for any files with the default options were auto-fixed, this doesn't take into account any other scenarios where particular flags or other generators (migrations, etc) may introduce new lint errors. I think we should have a way to automatically test those to ensure they don't break -- this is not a invitation to go fix all of the existing generated code to match standardrb style. Any changes should be backed by a test, otherwise there is no point IMO.

I'm happy to squash and add a changelog, docs,  if this approach makes sense.

Any feedback welcome :bow: