### PR TITLE
Add `explain` support for methods like `last`, `pluck` and `count`

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,19 @@
+*   Add `explain` support for `last`, `pluck` and `count`
+
+    Let `explain` return a proxy that delegates these methods:
+
+    ```ruby
+    User.all.explain.count
+    # EXPLAIN SELECT COUNT(*) FROM `users`
+    # ...
+
+    User.all.explain.maximum(:id)
+    # EXPLAIN SELECT MAX(`users`.`id`) FROM `users`
+    # ...
+    ```
+
+    *Petrik de Heus*
+
 *   Validate using `:on` option when using `validates_associated`
 
     Fixes an issue where `validates_associated` `:on`  option wasn't respected

--- a/activerecord/test/cases/adapters/abstract_mysql_adapter/mysql_explain_test.rb
+++ b/activerecord/test/cases/adapters/abstract_mysql_adapter/mysql_explain_test.rb
@@ -8,13 +8,13 @@ class MySQLExplainTest < ActiveRecord::AbstractMysqlTestCase
   fixtures :authors, :author_addresses
 
   def test_explain_for_one_query
-    explain = Author.where(id: 1).explain
+    explain = Author.where(id: 1).explain.inspect
     assert_match %(EXPLAIN SELECT `authors`.* FROM `authors` WHERE `authors`.`id` = 1), explain
     assert_match %r(authors |.* const), explain
   end
 
   def test_explain_with_eager_loading
-    explain = Author.where(id: 1).includes(:posts).explain
+    explain = Author.where(id: 1).includes(:posts).explain.inspect
     assert_match %(EXPLAIN SELECT `authors`.* FROM `authors` WHERE `authors`.`id` = 1), explain
     assert_match %r(authors |.* const), explain
     assert_match %(EXPLAIN SELECT `posts`.* FROM `posts` WHERE `posts`.`author_id` = 1), explain
@@ -22,17 +22,17 @@ class MySQLExplainTest < ActiveRecord::AbstractMysqlTestCase
   end
 
   def test_explain_with_options_as_symbol
-    explain = Author.where(id: 1).explain(explain_option)
+    explain = Author.where(id: 1).explain(explain_option).inspect
     assert_match %(#{expected_analyze_clause} SELECT `authors`.* FROM `authors` WHERE `authors`.`id` = 1), explain
   end
 
   def test_explain_with_options_as_strings
-    explain = Author.where(id: 1).explain(explain_option.to_s.upcase)
+    explain = Author.where(id: 1).explain(explain_option.to_s.upcase).inspect
     assert_match %(#{expected_analyze_clause} SELECT `authors`.* FROM `authors` WHERE `authors`.`id` = 1), explain
   end
 
   def test_explain_options_with_eager_loading
-    explain = Author.where(id: 1).includes(:posts).explain(explain_option)
+    explain = Author.where(id: 1).includes(:posts).explain(explain_option).inspect
     assert_match %(#{expected_analyze_clause} SELECT `authors`.* FROM `authors` WHERE `authors`.`id` = 1), explain
     assert_match %(#{expected_analyze_clause} SELECT `posts`.* FROM `posts` WHERE `posts`.`author_id` = 1), explain
   end

--- a/activerecord/test/cases/adapters/abstract_mysql_adapter/optimizer_hints_test.rb
+++ b/activerecord/test/cases/adapters/abstract_mysql_adapter/optimizer_hints_test.rb
@@ -11,7 +11,7 @@ class OptimizerHintsTest < ActiveRecord::AbstractMysqlTestCase
       assert_queries_match(%r{\ASELECT /\*\+ NO_RANGE_OPTIMIZATION\(posts index_posts_on_author_id\) \*/}) do
         posts = Post.optimizer_hints("NO_RANGE_OPTIMIZATION(posts index_posts_on_author_id)")
         posts = posts.select(:id).where(author_id: [0, 1])
-        assert_includes posts.explain, "| index | index_posts_on_author_id | index_posts_on_author_id |"
+        assert_includes posts.explain.inspect, "| index | index_posts_on_author_id | index_posts_on_author_id |"
       end
     end
 
@@ -27,7 +27,7 @@ class OptimizerHintsTest < ActiveRecord::AbstractMysqlTestCase
       assert_queries_match(%r{\ASELECT /\*\+ NO_RANGE_OPTIMIZATION\(posts index_posts_on_author_id\) \*/}) do
         posts = Post.optimizer_hints("/*+ NO_RANGE_OPTIMIZATION(posts index_posts_on_author_id) */")
         posts = posts.select(:id).where(author_id: [0, 1])
-        assert_includes posts.explain, "| index | index_posts_on_author_id | index_posts_on_author_id |"
+        assert_includes posts.explain.inspect, "| index | index_posts_on_author_id | index_posts_on_author_id |"
       end
 
       assert_queries_match(%r{\ASELECT /\*\+ \*\* // `posts`\.\*, // \*\* \*/}) do

--- a/activerecord/test/cases/adapters/postgresql/explain_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/explain_test.rb
@@ -8,32 +8,32 @@ class PostgreSQLExplainTest < ActiveRecord::PostgreSQLTestCase
   fixtures :authors, :author_addresses
 
   def test_explain_for_one_query
-    explain = Author.where(id: 1).explain
+    explain = Author.where(id: 1).explain.inspect
     assert_match %r(EXPLAIN SELECT "authors"\.\* FROM "authors" WHERE "authors"\."id" = (?:\$1 \[\["id", 1\]\]|1)), explain
     assert_match %(QUERY PLAN), explain
   end
 
   def test_explain_with_eager_loading
-    explain = Author.where(id: 1).includes(:posts).explain
+    explain = Author.where(id: 1).includes(:posts).explain.inspect
     assert_match %(QUERY PLAN), explain
     assert_match %r(EXPLAIN SELECT "authors"\.\* FROM "authors" WHERE "authors"\."id" = (?:\$1 \[\["id", 1\]\]|1)), explain
     assert_match %r(EXPLAIN SELECT "posts"\.\* FROM "posts" WHERE "posts"\."author_id" = (?:\$1 \[\["author_id", 1\]\]|1)), explain
   end
 
   def test_explain_with_options_as_symbols
-    explain = Author.where(id: 1).explain(:analyze, :buffers)
+    explain = Author.where(id: 1).explain(:analyze, :buffers).inspect
     assert_match %r(EXPLAIN \(ANALYZE, BUFFERS\) SELECT "authors"\.\* FROM "authors" WHERE "authors"\."id" = (?:\$1 \[\["id", 1\]\]|1)), explain
     assert_match %(QUERY PLAN), explain
   end
 
   def test_explain_with_options_as_strings
-    explain = Author.where(id: 1).explain("VERBOSE", "ANALYZE", "FORMAT JSON")
+    explain = Author.where(id: 1).explain("VERBOSE", "ANALYZE", "FORMAT JSON").inspect
     assert_match %r(EXPLAIN \(VERBOSE, ANALYZE, FORMAT JSON\) SELECT "authors"\.\* FROM "authors" WHERE "authors"\."id" = (?:\$1 \[\["id", 1\]\]|1)), explain
     assert_match %(QUERY PLAN), explain
   end
 
   def test_explain_options_with_eager_loading
-    explain = Author.where(id: 1).includes(:posts).explain(:analyze)
+    explain = Author.where(id: 1).includes(:posts).explain(:analyze).inspect
     assert_match %(QUERY PLAN), explain
     assert_match %r(EXPLAIN \(ANALYZE\) SELECT "authors"\.\* FROM "authors" WHERE "authors"\."id" = (?:\$1 \[\["id", 1\]\]|1)), explain
     assert_match %r(EXPLAIN \(ANALYZE\) SELECT "posts"\.\* FROM "posts" WHERE "posts"\."author_id" = (?:\$1 \[\["author_id", 1\]\]|1)), explain

--- a/activerecord/test/cases/adapters/sqlite3/explain_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/explain_test.rb
@@ -8,13 +8,13 @@ class SQLite3ExplainTest < ActiveRecord::SQLite3TestCase
   fixtures :authors, :author_addresses
 
   def test_explain_for_one_query
-    explain = Author.where(id: 1).explain
+    explain = Author.where(id: 1).explain.inspect
     assert_match %r(EXPLAIN for: SELECT "authors"\.\* FROM "authors" WHERE "authors"\."id" = (?:\? \[\["id", 1\]\]|1)), explain
     assert_match(/(SEARCH )?(TABLE )?authors USING (INTEGER )?PRIMARY KEY/, explain)
   end
 
   def test_explain_with_eager_loading
-    explain = Author.where(id: 1).includes(:posts).explain
+    explain = Author.where(id: 1).includes(:posts).explain.inspect
     assert_match %r(EXPLAIN for: SELECT "authors"\.\* FROM "authors" WHERE "authors"\."id" = (?:\? \[\["id", 1\]\]|1)), explain
     assert_match(/(SEARCH )?(TABLE )?authors USING (INTEGER )?PRIMARY KEY/, explain)
     assert_match %r(EXPLAIN for: SELECT "posts"\.\* FROM "posts" WHERE "posts"\."author_id" = (?:\? \[\["author_id", 1\]\]|1)), explain

--- a/activerecord/test/cases/base_prevent_writes_test.rb
+++ b/activerecord/test/cases/base_prevent_writes_test.rb
@@ -51,7 +51,7 @@ class BasePreventWritesTest < ActiveRecord::TestCase
       Bird.create!(name: "Bluejay")
 
       ActiveRecord::Base.while_preventing_writes do
-        assert_queries_count(2) { Bird.where(name: "Bluejay").explain }
+        assert_queries_count(2) { Bird.where(name: "Bluejay").explain.inspect }
       end
     end
 

--- a/activerecord/test/cases/explain_test.rb
+++ b/activerecord/test/cases/explain_test.rb
@@ -16,7 +16,7 @@ if ActiveRecord::Base.connection.supports_explain?
     end
 
     def test_relation_explain
-      message = Car.where(name: "honda").explain
+      message = Car.where(name: "honda").explain.inspect
       assert_match(/^EXPLAIN/, message)
     end
 
@@ -33,6 +33,96 @@ if ActiveRecord::Base.connection.supports_explain?
       else
         assert_match "honda", sql
       end
+    end
+
+    def test_relation_explain_with_average
+      expected_query = capture_sql {
+        Car.average(:id)
+      }.first
+      message = Car.all.explain.average(:id)
+      assert_match(/^EXPLAIN/, message)
+      assert_match(expected_query, message)
+    end
+
+    def test_relation_explain_with_count
+      expected_query = capture_sql {
+        Car.count
+      }.first
+      message = Car.all.explain.count
+      assert_match(/^EXPLAIN/, message)
+      assert_match(expected_query, message)
+    end
+
+    def test_relation_explain_with_count_and_argument
+      expected_query = capture_sql {
+        Car.count(:id)
+      }.first
+      message = Car.all.explain.count(:id)
+      assert_match(/^EXPLAIN/, message)
+      assert_match(expected_query, message)
+    end
+
+    def test_relation_explain_with_minimum
+      expected_query = capture_sql {
+        Car.minimum(:id)
+      }.first
+      message = Car.all.explain.minimum(:id)
+      assert_match(/^EXPLAIN/, message)
+      assert_match(expected_query, message)
+    end
+
+    def test_relation_explain_with_maximum
+      expected_query = capture_sql {
+        Car.maximum(:id)
+      }.first
+      message = Car.all.explain.maximum(:id)
+      assert_match(/^EXPLAIN/, message)
+      assert_match(expected_query, message)
+    end
+
+    def test_relation_explain_with_sum
+      expected_query = capture_sql {
+        Car.sum(:id)
+      }.first
+      message = Car.all.explain.sum(:id)
+      assert_match(/^EXPLAIN/, message)
+      assert_match(expected_query, message)
+    end
+
+    def test_relation_explain_with_first
+      expected_query = capture_sql {
+        Car.all.first
+      }.first
+      message = Car.all.explain.first
+      assert_match(/^EXPLAIN/, message)
+      assert_match(expected_query, message)
+    end
+
+    def test_relation_explain_with_last
+      expected_query = capture_sql {
+        Car.all.last
+      }.first
+      message = Car.all.explain.last
+      assert_match(/^EXPLAIN/, message)
+      assert_match(expected_query, message)
+    end
+
+    def test_relation_explain_with_pluck
+      expected_query = capture_sql {
+        Car.all.pluck
+      }.first
+      message = Car.all.explain.pluck
+      assert_match(/^EXPLAIN/, message)
+      assert_match(expected_query, message)
+    end
+
+    def test_relation_explain_with_pluck_with_args
+      expected_query = capture_sql {
+        Car.all.pluck(:id, :name)
+      }.first
+      message = Car.all.explain.pluck(:id, :name)
+      assert_match(/^EXPLAIN/, message)
+      assert_match(expected_query, message)
     end
 
     def test_exec_explain_with_no_binds


### PR DESCRIPTION
### Motivation / Background

`explain` can be called on a relation to explain how the database would execute a query.
Currently `explain` doesn't work for queries using `last`, `pluck` or `count`, as these return the actual result instead of a relation. This makes it difficult to optimize these queries.

By letting `explain` return a proxy instead, we can support these methods.

### Detail

```ruby
User.all.explain.count
# => "EXPLAIN SELECT COUNT(*) FROM `users`"

User.all.explain.maximum(:id)
# => "EXPLAIN SELECT MAX(`users`.`id`) FROM `users`"
```

This breaks the existing behaviour in that it requires calling inspect after explain.

```ruby
User.all.explain.inspect
# => "EXPLAIN SELECT `users`.* FROM `users`"
```

However, as `explain` is mostly used from the commandline, this won't be a problem as inspect is called automatically in IRB.

### Additional information

This is a variation of https://github.com/rails/rails/pull/50424 which used arguments instead of a proxy and method calls.

Another variation could be passing a block instead. This would not break the current behaviour, but it's a bit more verbose:
```ruby
User.all.explain do |relation|
   relation.count
end
```

With a symbol-to-proc it becomes a bit terser:
```ruby
User.all.explain(&:count)
```

Unlike the proxy solution, this notation could also be applied to `to_sql`:
```ruby
User.all.to_sql(&:count)
```

Or we could use method name variations, but that would break with the arguments that can be passed to `explain`, like `explain(:analyze, :buffers)`:
```ruby
User.all.explain_count
User.all.explain_maximum(:id)
```
### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
