### PR TITLE
docs: fix ImageMagick package name on fedora [ci-skip]

### DIFF
--- a/guides/source/development_dependencies_install.md
+++ b/guides/source/development_dependencies_install.md
@@ -139,7 +139,7 @@ $ sudo npm install --global yarn
 To install all run:
 
 ```bash
-$ sudo dnf install sqlite-devel sqlite-libs mysql-server mysql-devel postgresql-server postgresql-devel redis memcached imagemagick ffmpeg mupdf libxml2-devel vips poppler-utils
+$ sudo dnf install sqlite-devel sqlite-libs mysql-server mysql-devel postgresql-server postgresql-devel redis memcached ImageMagick ffmpeg mupdf libxml2-devel vips poppler-utils
 
 # Install Yarn
 # Use this command if you do not have Node.js installed


### PR DESCRIPTION
### Motivation / Background

This PR corrects the name of the ImageMagick package when installing project dependencies on Fedora (from `imagemagick` to `ImageMagick`).

Reference: https://packages.fedoraproject.org/pkgs/ImageMagick/ImageMagick/

### Detail

```
$ sudo dnf install imagemagick

No match for argument: imagemagick
  * Maybe you meant: ImageMagick
Error: Unable to find a match: imagemagick
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] ~Tests are added or updated if you fix a bug or add a feature.~ (n/a)
* [x] ~CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.~ (n/a)
