### PR TITLE
Remove unnecessary to_a conversion for readonly_attributes method call

### DIFF
--- a/activerecord/lib/active_record/insert_all.rb
+++ b/activerecord/lib/active_record/insert_all.rb
@@ -198,7 +198,7 @@ module ActiveRecord
 
 
       def readonly_columns
-        primary_keys + model.readonly_attributes.to_a
+        primary_keys + model.readonly_attributes
       end
 
       def unique_by_columns


### PR DESCRIPTION
### Motivation / Background

In Rails 7.0 despite api documention, `readonly_attributes` returned a set:
https://github.com/rails/rails/blob/7-0-stable/activerecord/lib/active_record/readonly_attributes.rb#L26

This was fixed in 7.1:
https://github.com/rails/rails/blob/7-1-stable/activerecord/lib/active_record/readonly_attributes.rb#L31

However the usage of `readonly_attributes` was guarded with a .to_a which is now no longer needed https://github.com/rails/rails/blob/590a675c4ecfaa9b7b06787a30adeb0136524879/activerecord/lib/active_record/insert_all.rb#L195

### Detail

This Pull Request changes an unnecessary to_a call

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`

NA:
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
