### PR TITLE
Move singleton require

### DIFF
--- a/activejob/lib/active_job/serializers/object_serializer.rb
+++ b/activejob/lib/active_job/serializers/object_serializer.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "singleton"
+
 module ActiveJob
   module Serializers
     # Base class for serializing and deserializing custom objects.

--- a/activesupport/lib/active_support/deprecation.rb
+++ b/activesupport/lib/active_support/deprecation.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "singleton"
-
 module ActiveSupport
   # = Active Support \Deprecation
   #


### PR DESCRIPTION
ActiveSupport::Deprecation used to `include Singleton` which is why the require is here, but it was removed in 9812641891f1c9ba4c3f8ffb8549ec26fc2668c4 (June 5 2023). Leaving the require seems to have been an oversight.

However, module ActiveJob::Serializers::ObjectSerializer does require Singleton and was relying on AS:Deprecation to require it. This PR just moves the require to the place it's actually used, this is way less confusing.

The case for moving it is that it's confusing where it is, and it requires additional code that isn't needed if people are just requiring activesupport. The require where it was may also have prevented activejob from being required independently.

The danger is that people have code running out there that uses Singleton but are leaning on the require in activesupport to load it, and removing the require will break that code. They /shouldn't/ be doing this, but it's possible.