### PR TITLE
Fix `load_async` to work with query cache

### DIFF
--- a/activerecord/lib/active_record/future_result.rb
+++ b/activerecord/lib/active_record/future_result.rb
@@ -48,6 +48,7 @@ module ActiveRecord
     Canceled = Class.new(ActiveRecordError)
 
     delegate :empty?, :to_a, to: :result
+    delegate_missing_to :result
 
     attr_reader :lock_wait
 

--- a/activerecord/test/cases/relation/load_async_test.rb
+++ b/activerecord/test/cases/relation/load_async_test.rb
@@ -232,6 +232,13 @@ module ActiveRecord
       assert_equal false, deferred_posts.empty?
       assert_predicate deferred_posts, :loaded?
     end
+
+    def test_load_async_with_query_cache
+      titles = Post.where(author_id: 1).pluck(:title)
+      Post.cache do
+        assert_equal titles, Post.where(author_id: 1).load_async.pluck(:title)
+      end
+    end
   end
 
   class LoadAsyncNullExecutorTest < ActiveRecord::TestCase


### PR DESCRIPTION
After the #50410 merge, now `load_async` is not working.
For simple `@users = User.all.load_async` int the controller and `@users.each` in the view I got 
```
undefined method `column_types' for #<ActiveRecord::FutureResult::SelectAll:0x000000010b18abf8
``` 

cc @byroot 