### PR TITLE
Fix calculation of Active Record :db_runtime metric

### DIFF
--- a/activerecord/lib/active_record/runtime_registry.rb
+++ b/activerecord/lib/active_record/runtime_registry.rb
@@ -25,5 +25,5 @@ module ActiveRecord
 end
 
 ActiveSupport::Notifications.monotonic_subscribe("sql.active_record") do |name, start, finish, id, payload|
-  ActiveRecord::RuntimeRegistry.sql_runtime += (finish - start) * 1_000.0
+  ActiveRecord::RuntimeRegistry.sql_runtime += (finish - start)
 end


### PR DESCRIPTION
When using async queries inside controllers, I noticed too large db runtime values and negative view runtime values in the logs, something like:
```
Completed 200 OK in 133ms (Views: -25271.4ms | ActiveRecord: 25329.3ms | Allocations: 29036)
```

Turned out, that the problem is in a recent change from https://github.com/rails/rails/commit/f56b4187be56304857b57ec7159a8e2dc2b91dea#diff-fc921d14f4dc8556c4b8cd785f350ec728fe07c8b884fbc3a0b4cbc9ec5eafffR28
There is no need to multiply by `1000`, because the values are already in milliseconds.

cc @byroot 