### PR TITLE
Document --skip-rubocop rails command [skip ci]

### DIFF
--- a/guides/source/command_line.md
+++ b/guides/source/command_line.md
@@ -66,6 +66,7 @@ If you wish to skip some files from being generated or skip some libraries, you 
 | `--skip-system-test`    | Skip system test files                                      |
 | `--skip-bootsnap`       | Skip bootsnap gem                                           |
 | `--skip-dev-gems`       | Skip adding development gems                                |
+| `--skip-rubocop`        | Skip RuboCop setup                                          |
 
 These are just some of the options that `rails new` accepts. For a full list of options, type `rails new --help`.
 


### PR DESCRIPTION
Followup: https://github.com/rails/rails/pull/50486

### Motivation / Background

In https://github.com/rails/rails/pull/50486, we've added the default rubocop config for all the new rails applications. And added a command for skipping the configuration.

### Detail

This Pull Request documents `--skip-rubocop` rails command.


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.

cc\ @zzak 
