### PR TITLE
Add rubocop-rails-omakase as development dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,6 +56,9 @@ group :rubocop do
   gem "rubocop-performance", require: false
   gem "rubocop-rails", require: false
   gem "rubocop-md", require: false
+
+  # This gem is used in Railties tests so it must be a development dependency.
+  gem "rubocop-rails-omakase", require: false
 end
 
 group :mdl do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -465,6 +465,11 @@ GEM
       activesupport (>= 4.2.0)
       rack (>= 1.1)
       rubocop (>= 1.33.0, < 2.0)
+    rubocop-rails-omakase (1.0.0)
+      rubocop
+      rubocop-minitest
+      rubocop-performance
+      rubocop-rails
     ruby-progressbar (1.13.0)
     ruby-vips (2.1.4)
       ffi (~> 1.12)
@@ -627,6 +632,7 @@ DEPENDENCIES
   rubocop-packaging
   rubocop-performance
   rubocop-rails
+  rubocop-rails-omakase
   rubyzip (~> 2.0)
   sdoc!
   selenium-webdriver (>= 4.11.0)


### PR DESCRIPTION
Fixes CI:
https://buildkite.com/rails/rails/builds/103078

This gem is used in Railties tests so it must be a development dependency. Due to the fixture rails app tmp/rails/app_template faking Bundler and using the repo's Gemfile: https://github.com/rails/rails/blob/0fb5f67ac413d62df64b8b59094b4fe85999b5c1/railties/test/isolation/abstract_unit.rb#L618-L622

/cc @matthewd as you wrote e4b0488851
