### PR TITLE
Fix a couple of typos [ci skip]

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/assume_ssl.rb
+++ b/actionpack/lib/action_dispatch/middleware/assume_ssl.rb
@@ -4,7 +4,7 @@ module ActionDispatch
   # = Action Dispatch \AssumeSSL
   #
   # When proxying through a load balancer that terminates SSL, the forwarded request will appear
-  # as though its HTTP instead of HTTPS to the application. This makes redirects and cookie
+  # as though it's HTTP instead of HTTPS to the application. This makes redirects and cookie
   # security target HTTP instead of HTTPS. This middleware makes the server assume that the
   # proxy already terminated SSL, and that the request really is HTTPS.
   class AssumeSSL

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -202,7 +202,7 @@ Sets the host for the assets. Useful when CDNs are used for hosting assets, or w
 
 #### `config.assume_ssl`
 
-Makes application believe that all requests are arriving over SSL. This is useful when proxying through a load balancer that terminates SSL, the forwarded request will appear as though its HTTP instead of HTTPS to the application. This makes redirects and cookie security target HTTP instead of HTTPS. This middleware makes the server assume that the proxy already terminated SSL, and that the request really is HTTPS.
+Makes application believe that all requests are arriving over SSL. This is useful when proxying through a load balancer that terminates SSL, the forwarded request will appear as though it's HTTP instead of HTTPS to the application. This makes redirects and cookie security target HTTP instead of HTTPS. This middleware makes the server assume that the proxy already terminated SSL, and that the request really is HTTPS.
 
 #### `config.autoflush_log`
 


### PR DESCRIPTION
Related to #47139. I stumbled upon these typos while reading through [This year in Rails, a summary of 2023](https://world.hey.com/this.week.in.rails/this-year-in-rails-a-summary-of-2023-f11c4b13).