### PR TITLE
Fix a flaky test in `query_assertions_test.rb`

### DIFF
--- a/activerecord/test/cases/assertions/query_assertions_test.rb
+++ b/activerecord/test/cases/assertions/query_assertions_test.rb
@@ -90,27 +90,25 @@ module ActiveRecord
       if current_adapter?(:PostgreSQLAdapter)
         def test_assert_queries_count_include_schema
           Post.columns # load columns
-          assert_raises(Minitest::Assertion, match: "0 instead of 1 queries were executed") do
-            assert_queries_count(1, include_schema: true) { Post.columns }
+          assert_raises(Minitest::Assertion, match: "1 or more queries expected") do
+            assert_queries_count(include_schema: true) { Post.columns }
           end
 
           Post.reset_column_information
-          assert_queries_count(1, include_schema: true) { Post.columns }
+          assert_queries_count(include_schema: true) { Post.columns }
         end
 
         def test_assert_no_queries_include_schema
           assert_no_queries { Post.none }
 
-          error = assert_raises(Minitest::Assertion) {
+          assert_raises(Minitest::Assertion, match: /\d instead of 0/) {
             assert_no_queries { Post.first }
           }
-          assert_match(/1 instead of 0/, error.message)
 
           Post.reset_column_information
-          error = assert_raises(Minitest::Assertion) {
+          assert_raises(Minitest::Assertion, match: /\d instead of 0/) {
             assert_no_queries(include_schema: true) { Post.columns }
           }
-          assert_match(/1 instead of 0/, error.message)
         end
 
         def test_assert_queries_match_include_schema


### PR DESCRIPTION
Fixes a flaky test from https://buildkite.com/rails/rails/builds/103104#018cbef2-ddda-4c0d-b30d-70d5d55cff93

To reproduce:
```
$ rake test:postgresql SEED=64665
```

I wasn't able to reduce it and to find the exact preceding test case that makes this test to fail. Seems like somewhere the connection is reset/etc and so is reestablished in this test case and thus generates extra queries. 

Changing this test case to be less strict makes it pass. 