### PR TITLE
Default to creating GitHub CI files

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add GitHub CI files for dependabot, brakeman, rubocop, and running tests by default. Can be skipped with --skip-ci.
+
+    *DHH*
+
 *   Add brakeman gem by default for static analysis of security vulnerabilities. Allow skipping with --skip-brakeman option.
 
     *vipulnsward*

--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -106,6 +106,9 @@ module Rails
         class_option :skip_brakeman,       type: :boolean, default: nil,
                                            desc: "Skip brakeman setup"
 
+        class_option :skip_ci,             type: :boolean, default: nil,
+                                           desc: "Skip GitHub CI files"
+
         class_option :dev,                 type: :boolean, default: nil,
                                            desc: "Set up the #{name} with Gemfile pointing to your Rails checkout"
 
@@ -391,6 +394,10 @@ module Rails
 
       def skip_brakeman?
         options[:skip_brakeman]
+      end
+
+      def skip_ci?
+        options[:skip_ci]
       end
 
       class GemfileEntry < Struct.new(:name, :version, :comment, :options, :commented_out)

--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -82,6 +82,12 @@ module Rails
       chmod "bin/docker-entrypoint", 0755 & ~File.umask, verbose: false
     end
 
+    def cifiles
+      empty_directory ".github/workflows"
+      template "github/ci.yml", ".github/workflows/ci.yaml"
+      template "github/dependabot.yml", ".github/dependabot.yaml"
+    end
+
     def rubocop
       template "rubocop.yml", ".rubocop.yml"
     end
@@ -375,6 +381,11 @@ module Rails
       def create_rubocop_file
         return if skip_rubocop?
         build(:rubocop)
+      end
+
+      def create_cifiles
+        return if skip_ci?
+        build(:cifiles)
       end
 
       def create_config_files

--- a/railties/lib/rails/generators/rails/app/templates/github/ci.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/github/ci.yml.tt
@@ -46,14 +46,12 @@ jobs:
     runs-on: ubuntu-latest
 
     <%- if options[:database] == "sqlite3" -%>
-    # Enable when using Redis
     # services:
-    #   redis:
-    #     image: redis
-    #     ports:
-    #       - 6379:6379
-    #     options: --health-cmd "redis-cli ping" --health-interval 10s --health-timeout 5s --health-retries 5
-
+    #  redis:
+    #    image: redis
+    #    ports:
+    #      - 6379:6379
+    #    options: --health-cmd "redis-cli ping" --health-interval 10s --health-timeout 5s --health-retries 5
     <%- else -%>
     services:
       <%- if options[:database] == "mysql" || options[:database] == "trilogy" -%>
@@ -75,13 +73,13 @@ jobs:
         options: --health-cmd="pg_isready" --health-interval=10s --health-timeout=5s --health-retries=3
       <%- end -%>
 
-    <%- end -%>
       # redis:
       #   image: redis
       #   ports:
       #     - 6379:6379
       #   options: --health-cmd "redis-cli ping" --health-interval 10s --health-timeout 5s --health-retries 5
 
+    <%- end -%>
     steps:
       - name: Install packages
         run: sudo apt-get update && sudo apt-get install --no-install-recommends -y google-chrome-stable <%= (dockerfile_deploy_packages + [build_package_for_database]).join(" ") %>

--- a/railties/lib/rails/generators/rails/app/templates/github/ci.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/github/ci.yml.tt
@@ -55,7 +55,7 @@ jobs:
 
     steps:
       - name: Install packages
-        run: sudo apt-get update && sudo apt-get install --no-install-recommends -y <%= dockerfile_deploy_packages.join(" ") %>
+        run: sudo apt-get update && sudo apt-get install --no-install-recommends -y google-chrome-stable <%= (dockerfile_deploy_packages + [build_package_for_database]).join(" ") %>
 
       - name: Checkout code
         uses: actions/checkout@v4

--- a/railties/lib/rails/generators/rails/app/templates/github/ci.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/github/ci.yml.tt
@@ -74,8 +74,8 @@ jobs:
       postgres:
         image: postgres
         env:
-          POSTGRES_USER: root
-          POSTGRES_PASSWORD:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
         ports:
           - 5432:5432
         options: --health-cmd="pg_isready" --health-interval=10s --health-timeout=5s --health-retries=3
@@ -101,7 +101,7 @@ jobs:
           <%- if options[:database] == "mysql" || options[:database] == "trilogy" -%>
           DATABASE_URL: mysql2://127.0.0.1:3306
           <%- elsif options[:database] == "postgresql" -%>
-          DATABASE_URL: postgres://127.0.0.1:3306
+          DATABASE_URL: postgres://postgres:postgres@localhost:5432
           <%- end -%>
           # REDIS_URL: redis://localhost:6379/0
         run: bin/rails db:setup test test:system

--- a/railties/lib/rails/generators/rails/app/templates/github/ci.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/github/ci.yml.tt
@@ -62,9 +62,6 @@ jobs:
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
-        # Enable when using Redis
-        # env:
-        #   REDIS_URL: redis://localhost:6379/0
         with:
           ruby-version: .ruby-version
           bundler-cache: true

--- a/railties/lib/rails/generators/rails/app/templates/github/ci.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/github/ci.yml.tt
@@ -1,0 +1,73 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+<%- unless skip_brakeman? -%>
+  scan:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: .ruby-version
+          bundler-cache: true
+
+      - name: Scan for security vulnerabilities
+        run: bin/brakeman
+<% end -%>
+<%- unless skip_rubocop? -%>
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: .ruby-version
+          bundler-cache: true
+
+      - name: Lint code for consistent style
+        run: bin/rubocop
+<% end -%>
+
+  test:
+    runs-on: ubuntu-latest
+
+    # Enable when using Redis
+    # services:
+    #   redis:
+    #     image: redis
+    #     ports:
+    #       - 6379:6379
+    #     options: --health-cmd "redis-cli ping" --health-interval 10s --health-timeout 5s --health-retries 5
+
+    steps:
+      - name: Install packages
+        run: sudo apt-get update && sudo apt-get install --no-install-recommends -y <%= dockerfile_deploy_packages.join(" ") %>
+
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        # Enable when using Redis
+        # env:
+        #   REDIS_URL: redis://localhost:6379/0
+        with:
+          ruby-version: .ruby-version
+          bundler-cache: true
+
+      - name: Run Tests
+        run: bin/rails test:all

--- a/railties/lib/rails/generators/rails/app/templates/github/ci.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/github/ci.yml.tt
@@ -56,12 +56,6 @@ jobs:
 
     <%- else -%>
     services:
-      # Enable when using Redis
-      #   redis:
-      #     image: redis
-      #     ports:
-      #       - 6379:6379
-      #     options: --health-cmd "redis-cli ping" --health-interval 10s --health-timeout 5s --health-retries 5
       <%- if options[:database] == "mysql" || options[:database] == "trilogy" -%>
       mysql:
         image: mysql
@@ -82,6 +76,12 @@ jobs:
       <%- end -%>
 
     <%- end -%>
+      # redis:
+      #   image: redis
+      #   ports:
+      #     - 6379:6379
+      #   options: --health-cmd "redis-cli ping" --health-interval 10s --health-timeout 5s --health-retries 5
+
     steps:
       - name: Install packages
         run: sudo apt-get update && sudo apt-get install --no-install-recommends -y google-chrome-stable <%= (dockerfile_deploy_packages + [build_package_for_database]).join(" ") %>

--- a/railties/lib/rails/generators/rails/app/templates/github/ci.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/github/ci.yml.tt
@@ -45,6 +45,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
 
+    <%- if options[:database] == "sqlite3" -%>
     # Enable when using Redis
     # services:
     #   redis:
@@ -53,6 +54,34 @@ jobs:
     #       - 6379:6379
     #     options: --health-cmd "redis-cli ping" --health-interval 10s --health-timeout 5s --health-retries 5
 
+    <%- else -%>
+    services:
+      # Enable when using Redis
+      #   redis:
+      #     image: redis
+      #     ports:
+      #       - 6379:6379
+      #     options: --health-cmd "redis-cli ping" --health-interval 10s --health-timeout 5s --health-retries 5
+      <%- if options[:database] == "mysql" || options[:database] == "trilogy" -%>
+      mysql:
+        image: mysql
+        env:
+          MYSQL_ALLOW_EMPTY_PASSWORD: true
+        ports:
+          - 3306:3306
+        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+      <%- elsif options[:database] == "postgresql" -%>
+      postgres:
+        image: postgres
+        env:
+          POSTGRES_USER: root
+          POSTGRES_PASSWORD:
+        ports:
+          - 5432:5432
+        options: --health-cmd="pg_isready" --health-interval=10s --health-timeout=5s --health-retries=3
+      <%- end -%>
+
+    <%- end -%>
     steps:
       - name: Install packages
         run: sudo apt-get update && sudo apt-get install --no-install-recommends -y google-chrome-stable <%= (dockerfile_deploy_packages + [build_package_for_database]).join(" ") %>
@@ -67,4 +96,12 @@ jobs:
           bundler-cache: true
 
       - name: Run Tests
-        run: bin/rails test:all
+        env:
+          RAILS_ENV: test
+          <%- if options[:database] == "mysql" || options[:database] == "trilogy" -%>
+          DATABASE_URL: mysql2://127.0.0.1:3306
+          <%- elsif options[:database] == "postgresql" -%>
+          DATABASE_URL: postgres://127.0.0.1:3306
+          <%- end -%>
+          # REDIS_URL: redis://localhost:6379/0
+        run: bin/rails db:setup test test:system

--- a/railties/lib/rails/generators/rails/app/templates/github/dependabot.yml
+++ b/railties/lib/rails/generators/rails/app/templates/github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+- package-ecosystem: bundler
+  directory: "/"
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 10

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -653,11 +653,23 @@ class AppGeneratorTest < Rails::Generators::TestCase
   end
 
   def test_both_brakeman_and_rubocop_binstubs_are_skipped_if_required
-    puts destination_root
     run_generator [destination_root, "--skip-brakeman", "--skip-rubocop"]
 
     assert_no_file "bin/rubocop"
     assert_no_file "bin/brakeman"
+  end
+
+  def test_inclusion_of_ci_files
+    run_generator
+    assert_file ".github/workflows/ci.yml"
+    assert_file ".github/dependabot.yml"
+  end
+
+  def test_ci_files_are_skipped_if_required
+    run_generator [destination_root, "--skip-ci"]
+
+    assert_no_file ".github/workflows/ci.yml"
+    assert_no_file ".github/dependabot.yml"
   end
 
   def test_usage_read_from_file


### PR DESCRIPTION
Now that we have rubocop and brakeman by default, it makes sense to add a default GitHub CI workflow file for new applications. This will get especially newcomers off to a good start with automated scanning, linting, and testing. That's a natural continuation for the modern age of what we've done since the start with unit tests.

So we'll add `.github/workflows/ci.yml` and `.github/dependabot.yml` with good defaults.

This can be avoided with `--skip-ci`.

- [x] Setup database service if the application is setup for MySQL or PostgreSQL