### PR TITLE
Fix skipped rubocop test typo

### DIFF
--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -636,7 +636,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
   def test_rubocop_is_skipped_if_required
     run_generator [destination_root, "--skip-rubocop"]
 
-    assert_no_gem "rubocop"
+    assert_no_gem "rubocop-rails-omakase"
     assert_no_file "bin/rubocop"
     assert_no_file ".rubocop.yml"
   end


### PR DESCRIPTION
The test should be assert with `rubocop-rails-omakase` instead of `rubocop`.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.

\cc @zzak 