### PR TITLE
Add `brakeman` as development dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -151,6 +151,9 @@ group :test do
   end
 
   gem "benchmark-ips"
+
+  # Needed for Railties tests because it is included in generated apps.
+  gem "brakeman"
 end
 
 platforms :ruby, :windows do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -163,6 +163,8 @@ GEM
     bindex (0.8.1)
     bootsnap (1.15.0)
       msgpack (~> 1.2)
+    brakeman (6.1.1)
+      racc
     builder (3.2.4)
     bunny (2.20.2)
       amq-protocol (~> 2.3, >= 2.3.1)
@@ -192,6 +194,8 @@ GEM
       railties (>= 6.0.0)
     date (3.3.3)
     debug (1.7.1)
+      irb (>= 1.5.0)
+      reline (>= 0.3.1)
     declarative (0.0.20)
     delayed_job (4.1.11)
       activesupport (>= 3.0, < 8.0)
@@ -588,6 +592,7 @@ DEPENDENCIES
   bcrypt (~> 3.1.11)
   benchmark-ips
   bootsnap (>= 1.4.4)
+  brakeman
   capybara (>= 3.39)
   cgi (>= 0.3.6)
   connection_pool


### PR DESCRIPTION
Follow-up to #50507.

Since `brakeman` is now included in generated apps by default, it must be installed before running Rails tests that invoke `bin/rails` for generated apps.

This fixes CI failures such as:

  ```
  Error:
  AppGeneratorTest#test_app_update_does_not_change_app_name_when_app_name_is_hyphenated_name:
  RuntimeError: Command failed with exit 1: yes | bin/rails app:update
      test/generators/app_generator_test.rb:1304:in `system'
      test/generators/app_generator_test.rb:1304:in `block (2 levels) in run_app_update'
      test/generators/app_generator_test.rb:1304:in `block in run_app_update'
      test/generators/app_generator_test.rb:1299:in `chdir'
      test/generators/app_generator_test.rb:1299:in `run_app_update'
      test/generators/app_generator_test.rb:430:in `test_app_update_does_not_change_app_name_when_app_name_is_hyphenated_name'
  ```
