### PR TITLE
Stop repeating the Ruby version

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-ruby <%= "\"#{gem_ruby_version}\"" -%>
+ruby File.read(".ruby-version").strip
 
 <% gemfile_entries.each do |gemfile_entry| %>
 <%= gemfile_entry %>


### PR DESCRIPTION
.ruby-version should ideally be the only place you need to change.

Would be nice if there was a simple way to inject the .ruby-version into the default Dockerfile, but haven't found one yet.