### PR TITLE
Correct guidance on where to put partial tests

### DIFF
--- a/guides/source/testing.md
+++ b/guides/source/testing.md
@@ -1718,7 +1718,7 @@ Testing View Partials
 
 Partial templates - usually called "partials" - are another device for breaking the rendering process into more manageable chunks. With partials, you can extract pieces of code from your templates to separate files and reuse them throughout your templates.
 
-View tests provide an opportunity to test that partials render content the way you expect. View partial tests reside in `test/views/` and inherit from `ActionView::TestCase`.
+View tests provide an opportunity to test that partials render content the way you expect. View partial tests reside in `test/controllers/` and inherit from `ActionView::TestCase`.
 
 To render a partial, call `render` like you would in a template. The content is
 available through the test-local `#rendered` method:


### PR DESCRIPTION
Discussion in https://github.com/rails/rails/pull/50422 exposed that the Guides tell people to put tests for partials in a location that is not tracked by Stats and is not created by Rails by default.

Correcting the guide to not send code to this non-canonical location.

@dhh since you were just looking at this.