### PR TITLE
Document correct usage of named routes [skip ci]

### DIFF
--- a/actionpack/lib/action_dispatch/routing.rb
+++ b/actionpack/lib/action_dispatch/routing.rb
@@ -120,9 +120,9 @@ module ActionDispatch
   #
   #   # In config/routes.rb
   #   controller :blog do
-  #     get 'blog/show',    to: :list
-  #     get 'blog/delete',  to: :delete
-  #     get 'blog/edit',    to: :edit
+  #     get 'blog/show'    => :list
+  #     get 'blog/delete'  => :delete
+  #     get 'blog/edit'    => :edit
   #   end
   #
   #   # provides named routes for show, delete, and edit


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because [Using symbols when using 'to:' in routes.rb results in NoMethodError on startup #50465](https://github.com/rails/rails/issues/50465)

### Detail

This Pull Request changes actionpack/lib/action_dispatch/routing.rb (documentation only).

### Additional information

Correct usage:

```ruby
	controller :blog do
	  get 'blog/show',    to: 'blog#list'
	end    
```

## Documentation Verification

Rails app routes.rb:

```ruby
Rails.application.routes.draw do
  # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html

  # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
  # Can be used by load balancers and uptime monitors to verify that the app is live.
  get "up" => "rails/health#show", as: :rails_health_check

  controller :blog do
    get 'blog/show',    to: 'blog#list'
    get 'blog/delete',  to: 'blog#delete'
    get 'blog/edit',    to: 'blog#edit'
  end      

  # Defines the root path route ("/")
  # root "posts#index"
end
```

Output:

```
$ rails routes | grep blog

blog_show GET  /blog/show(.:format)                      blog#list
blog_delete GET  /blog/delete(.:format)                  blog#delete
blog_edit GET  /blog/edit(.:format)                       blog#edit
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
