### PR TITLE
Add a default yield :head to layouts/application.html.erb

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/app/views/layouts/application.html.erb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/app/views/layouts/application.html.erb.tt
@@ -6,9 +6,12 @@
     <%%= csrf_meta_tags %>
     <%%= csp_meta_tag %>
 
+    <%%= yield :head %>
     <%- if options[:skip_hotwire] || options[:skip_javascript] -%>
+
     <%%= stylesheet_link_tag "application" %>
     <%- else -%>
+
     <%%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%- end -%>
   </head>

--- a/railties/test/application/rake_test.rb
+++ b/railties/test/application/rake_test.rb
@@ -182,7 +182,7 @@ module ApplicationTests
     end
 
     def test_code_statistics
-      assert_match /Code LOC: \d+\s+Test LOC: \d+\s+ Code to Test Ratio: 1:\w+/, rails("stats")
+      assert_match(/Code LOC: \d+\s+Test LOC: \d+\s+ Code to Test Ratio: 1:\w+/, rails("stats"))
     end
 
     def test_loading_specific_fixtures

--- a/railties/test/application/rake_test.rb
+++ b/railties/test/application/rake_test.rb
@@ -182,8 +182,7 @@ module ApplicationTests
     end
 
     def test_code_statistics
-      assert_match "Code LOC: 63     Test LOC: 5     Code to Test Ratio: 1:0.1",
-        rails("stats")
+      assert_match /Code LOC: \d+\s+Test LOC: \d+\s+ Code to Test Ratio: 1:\w+/, rails("stats")
     end
 
     def test_loading_specific_fixtures


### PR DESCRIPTION
Good pattern that most applications should be using. It allows templates rendered inside of the application layout to add tags to the head. Like additional meta tags. Used by turbo-rails, for example.