### PR TITLE
Backport 47457 to 6-1-stable

### DIFF
--- a/actionview/test/template/render_test.rb
+++ b/actionview/test/template/render_test.rb
@@ -310,7 +310,7 @@ module RenderTestCases
 
   def test_undefined_method_error_references_named_class
     e = assert_raises(ActionView::Template::Error) { @view.render(inline: "<%= undefined %>") }
-    assert_match(/`undefined' for #<ActionView::Base:0x[0-9a-f]+>/, e.message)
+    assert_match(/undefined local variable or method `undefined'/, e.message)
   end
 
   def test_render_renderable_object

--- a/activesupport/test/core_ext/time_with_zone_test.rb
+++ b/activesupport/test/core_ext/time_with_zone_test.rb
@@ -1069,7 +1069,7 @@ class TimeWithZoneTest < ActiveSupport::TestCase
     e = assert_raises(NoMethodError) {
       @twz.this_method_does_not_exist
     }
-    assert_match "undefined method `this_method_does_not_exist' for Fri, 31 Dec 1999 19:00:00.000000000 EST -05:00:Time", e.message
+    assert_match(/undefined method `this_method_does_not_exist' for.*Time/, e.message)
     assert_no_match "rescue", e.backtrace.first
   end
 end


### PR DESCRIPTION
Backport #47457 to fix some Ruby 3.3 tests