### PR TITLE
[ci skip] Utilize new `enum` syntax in PostgreSQL guide

### DIFF
--- a/guides/source/active_record_postgresql.md
+++ b/guides/source/active_record_postgresql.md
@@ -292,9 +292,9 @@ Declaring an enum attribute in the model adds helper methods and prevents invali
 ```ruby
 # app/models/article.rb
 class Article < ApplicationRecord
-  enum status: {
+  enum :status, {
     draft: "draft", published: "published", archived: "archived"
-  }, _prefix: true
+  }, prefix: true
 end
 ```
 


### PR DESCRIPTION
Utilize new `enum` syntax in this guide to avoid confusion with the old one.

### Motivation / Background

This Pull Request was made because the guide currently employs the outdated enum syntax.

### Detail

The Pull Request modifies the enum syntax to align the example with the most recent version of Rails.

### Additional information

https://github.com/rails/rails/pull/41328
https://guides.rubyonrails.org/active_record_querying.html#enums

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [X] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
