### PR TITLE
Document apply_rubocop_autocorrect_after_generate! in configuration guide [skip ci]

### DIFF
--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -697,6 +697,7 @@ The full set of methods that can be used in this block are as follows:
 * `scaffold_controller` different from `resource_controller`, defines which generator to use for generating a _scaffolded_ controller when using `bin/rails generate scaffold`. Defaults to `:scaffold_controller`.
 * `test_framework` defines which test framework to use. Defaults to `false` and will use minitest by default.
 * `template_engine` defines which template engine to use, such as ERB or Haml. Defaults to `:erb`.
+* `apply_rubocop_autocorrect_after_generate!` applies RuboCop's autocorrect feature after Rails generators are run.
 
 ### Configuring Middleware
 


### PR DESCRIPTION
### Motivation / Background

https://github.com/rails/rails/pull/50506 Added a new configuration method `apply_rubocop_autocorrect_after_generate!` for applying the rubocop autocorrection on files generated by `bin/rails generate`.

### Detail

This Pull Request adds the document ` apply_rubocop_autocorrect_after_generate!` in the configuration guide.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
