### PR TITLE
add bundler-audit to new Rails applications

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add bundler-audit gem by default for vulnerable dependencies check. Allow skipping with --skip-bundler-audit option.
+
+    *gregmolnar*
+
 *   Updated system tests to now use headless Chrome by default for the new applications.
 
     *DHH*

--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -104,7 +104,10 @@ module Rails
                                            desc: "Skip RuboCop setup"
 
         class_option :skip_brakeman,       type: :boolean, default: nil,
-                                           desc: "Skip brakeman setup"
+                                           desc: "skip brakeman setup"
+
+        class_option :skip_bundler_audit,  type: :boolean, default: nil,
+                                           desc: "skip bundler audit setup"
 
         class_option :skip_ci,             type: :boolean, default: nil,
                                            desc: "Skip GitHub CI files"
@@ -394,6 +397,10 @@ module Rails
 
       def skip_brakeman?
         options[:skip_brakeman]
+      end
+
+      def skip_bundler_audit?
+        options[:skip_bundler_audit]
       end
 
       def skip_ci?

--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -108,7 +108,7 @@ module Rails
     end
 
     def bin
-      exclude_pattern = Regexp.union([(/rubocop/ if skip_rubocop?), (/brakeman/ if skip_brakeman?)].compact)
+      exclude_pattern = Regexp.union([(/rubocop/ if skip_rubocop?), (/brakeman/ if skip_brakeman?), (/bundler-audit/ if skip_bundler_audit?)].compact)
       directory "bin", { exclude_pattern: exclude_pattern } do |content|
         "#{shebang}\n" + content
       end

--- a/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
@@ -45,6 +45,11 @@ group :development do
   gem "brakeman", require: false
 
 <%- end -%>
+<%- unless options.skip_bundler_audit? -%>
+  # Check for vulnerable dependencies [https://github.com/rubysec/bundler-audit]
+  gem "bundler-audit", require: false
+
+<%- end -%>
 <%- unless options.skip_rubocop? -%>
   # Omakase Ruby styling [https://github.com/rails/rubocop-rails-omakase/]
   gem "rubocop-rails-omakase", require: false

--- a/railties/lib/rails/generators/rails/app/templates/bin/bundler-audit.tt
+++ b/railties/lib/rails/generators/rails/app/templates/bin/bundler-audit.tt
@@ -1,0 +1,4 @@
+require "rubygems"
+require "bundler/setup"
+
+load Gem.bin_path("bundler-audit", "bundler-audit")

--- a/railties/lib/rails/generators/rails/app/templates/github/ci.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/github/ci.yml.tt
@@ -20,10 +20,27 @@ jobs:
         with:
           ruby-version: .ruby-version
           bundler-cache: true
-
       - name: Scan for security vulnerabilities
         run: bin/brakeman
 <% end -%>
+
+<%- unless skip_bundler_audit? -%>
+  scan:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: .ruby-version
+          bundler-cache: true
+      - name: Scan for vulnerable dependencies
+        run: bin/bundle-audit --update
+<% end -%>
+
 <%- unless skip_rubocop? -%>
 
   lint:

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -41,6 +41,7 @@ DEFAULT_APP_FILES = %w(
   app/views/layouts/mailer.text.erb
   bin/docker-entrypoint
   bin/brakeman
+  bin/bundler-audit
   bin/rails
   bin/rake
   bin/rubocop
@@ -662,6 +663,19 @@ class AppGeneratorTest < Rails::Generators::TestCase
 
     assert_no_file "bin/rubocop"
     assert_no_file "bin/brakeman"
+  end
+
+  def test_inclusion_of_bundler_audit
+    run_generator
+    assert_gem "bundler-audit"
+    assert_file "bin/bundler-audit"
+  end
+
+  def test_bundler_audit_is_skipped_if_required
+    run_generator [destination_root, "--skip-bundler-audit"]
+
+    assert_no_gem "bundler-audit"
+    assert_no_file "bin/bundler-audit"
   end
 
   def test_inclusion_of_ci_files


### PR DESCRIPTION
### Motivation / Background

In #50507 brakeman was added as a default gem for new Rails apps and adding bundler-audit as well would cover the minimal automated security scans a Rails app should have.

/cc @dhh 

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
