### PR TITLE
Set `lang` attribute in application layout

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/app/views/layouts/application.html.erb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/app/views/layouts/application.html.erb.tt
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="<%= I18n.locale %>">
   <head>
     <title><%= camelized %></title>
     <meta name="viewport" content="width=device-width,initial-scale=1">

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -441,6 +441,12 @@ class AppGeneratorTest < Rails::Generators::TestCase
     assert_file "MyWebSite/config/database.yml", /my_web_site_production/
   end
 
+  def test_html_language_attribute
+    run_generator
+
+    assert_file "app/views/layouts/application.html.erb", /<html lang="en">/
+  end
+
   def test_gemfile_has_no_whitespace_errors
     run_generator
     absolute = File.expand_path("Gemfile", destination_root)


### PR DESCRIPTION
### Motivation / Background

Leverage [I18n][] to set the [lang][] attribute on the `<html>` tag in the application layout in an effort to improve document semantics.

[I18n]: https://guides.rubyonrails.org/i18n.html#the-public-i18n-api
[lang]: https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/lang

### Additional information

Per the [guides](https://guides.rubyonrails.org/i18n.html#configure-the-i18n-module):

> The I18n library will use English as a default locale, i.e. if a different locale is not set, :en will be used for looking up translations.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
