### PR TITLE
Raise `ArgumentError` when calling `assert_redirected_to` with invalid `:status`

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Raise `ArgumentError` when `assert_redirected_to` called with status that is not a redirect
+
+    ```ruby
+    assert_redirected_to "/", status: 302
+    assert_redirected_to "/", status: 200 # raises ArgumentError
+    ```
+
+    *Sean Doyle*
+
 *   Add `allow_browser` to set minimum browser versions for the application.
 
     A browser that's blocked will by default be served the file in `public/426.html` with a HTTP status code of "426 Upgrade Required".

--- a/actionpack/lib/action_dispatch/testing/assertions/response.rb
+++ b/actionpack/lib/action_dispatch/testing/assertions/response.rb
@@ -56,8 +56,12 @@ module ActionDispatch
       #   assert_redirected_to "/some/path", status: :moved_permanently
       def assert_redirected_to(url_options = {}, options = {}, message = nil)
         options, message = {}, options unless options.is_a?(Hash)
-
         status = options[:status] || :redirect
+
+        unless AssertionResponse.new(status).code.to_s.match?(/\A3..\z/)
+          raise ArgumentError, "Expected :status to be for a redirect, but was #{status}"
+        end
+
         assert_response(status, message)
         return true if url_options === @response.location
 

--- a/actionpack/test/controller/action_pack_assertions_test.rb
+++ b/actionpack/test/controller/action_pack_assertions_test.rb
@@ -470,6 +470,25 @@ class ActionPackAssertionsControllerTest < ActionController::TestCase
     end
   end
 
+  def test_assert_redirection_with_status_outside_3XX_range
+    Rack::Utils::HTTP_STATUS_CODES.keys.each do |status|
+      if status < 300 || status > 399
+        assert_raise ArgumentError, match: "Expected :status to be for a redirect, but was #{status}" do
+          assert_redirected_to("http://test.host/some/path", status: status)
+        end
+      end
+    end
+
+    ActionDispatch::AssertionResponse::GENERIC_RESPONSE_CODES.except(:redirect).each do |status, pseudostatus|
+      assert_raise ArgumentError, match: "Expected :status to be for a redirect, but was #{status}" do
+        assert_redirected_to("http://test.host/some/path", status: status)
+      end
+      assert_raise ArgumentError, match: "Expected :status to be for a redirect, but was #{pseudostatus}" do
+        assert_redirected_to("http://test.host/some/path", status: pseudostatus)
+      end
+    end
+  end
+
   def test_redirected_to_with_nested_controller
     @controller = Admin::InnerModuleController.new
     get :redirect_to_absolute_controller


### PR DESCRIPTION
### Motivation / Background

Prior to this commit, it was possible for test suites to misuse the `assert_redirected_to` assertion by passing a `:status` option for codes outside the `3XX` range.

### Detail

This change raises an `ArgumentError` to guide callers toward a redirect code.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
