### PR TITLE
Prevent vendorizing gems fixtures in dot directories (like .bundle) from loading when running tests

### DIFF
--- a/railties/lib/rails/engine.rb
+++ b/railties/lib/rails/engine.rb
@@ -738,7 +738,7 @@ module Rails
       def fixtures_in_root_and_not_in_vendor_or_dot_dir?(fixtures)
         fixtures.exist? && fixtures.to_s.start_with?(Rails.root.to_s) &&
           !fixtures.to_s.start_with?(Rails.root.join("vendor").to_s) &&
-          !fixtures.to_s.start_with?(Rails.root.join(".").to_s)
+          !fixtures.to_s.start_with?("#{Rails.root}/.".to_s)
       end
 
       def build_request(env)

--- a/railties/lib/rails/engine.rb
+++ b/railties/lib/rails/engine.rb
@@ -627,7 +627,7 @@ module Rails
       next if is_a?(Rails::Application)
 
       fixtures = config.root.join("test", "fixtures")
-      if fixtures_in_root_and_not_in_vendor?(fixtures)
+      if fixtures_in_root_and_not_in_vendor_or_dot_dir?(fixtures)
         ActiveSupport.on_load(:active_record_fixtures) { self.fixture_paths |= ["#{fixtures}/"] }
       end
     end
@@ -735,9 +735,10 @@ module Rails
         end
       end
 
-      def fixtures_in_root_and_not_in_vendor?(fixtures)
+      def fixtures_in_root_and_not_in_vendor_or_dot_dir?(fixtures)
         fixtures.exist? && fixtures.to_s.start_with?(Rails.root.to_s) &&
-          !fixtures.to_s.start_with?(Rails.root.join("vendor").to_s)
+          !fixtures.to_s.start_with?(Rails.root.join("vendor").to_s) &&
+          !fixtures.to_s.start_with?(Rails.root.join(".").to_s)
       end
 
       def build_request(env)


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because I ran a fresh rails application off the main branch and testing failed. I used asdf as my ruby version manage, which put the gems in .bundle instead of vendor (not sure if that is the default of bundler or an asdf behavior). I wish to fix this behavior so I do not need to find any racecar.jpg image to place in my fixtures file 😆 🚗 💨 .

 All joking beside, the behavior for the fixture autoloading appears to be for gems not in the default install path. This was the fix recommended by @rafaelfranca  in [48933](https://github.com/rails/rails/pull/48933). I did spend a little bit of time seeing if I could change the bundle config to just place gems in vendor, but I was worried about breaking installs with various managers (rvm in the dev container seemed to work differently than typical bundler - but I could be wrong). It did seem like this was the least risky solution, so I stuck with it.  

### Detail

This Pull Request changes the text fixture autoloading to ignore any fixtures in dot directories. 

### Additional information

Potentially resolves [48933](https://github.com/rails/rails/pull/48933)

Relates to:

- [48287](https://github.com/rails/rails/pull/48287) introduced auto loading fixtures in engines. All engines present in the root folder of the rails app would have their fixtures auto loaded. This caused tests to fail when gems were vendorized, because fixtures from the internal rails test suite would be loaded.
- [48323](https://github.com/rails/rails/pull/48323)  Added a check to exclude the vendor folder.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
