### PR TITLE
Incorporate I18n.locale into Action Text Rich Text

### DIFF
--- a/actiontext/CHANGELOG.md
+++ b/actiontext/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Add `action_text_rich_texts.locale`
+
+    Store the locale when Rich Text content is created.
+
+    *Sean Doyle*
+
 *   Fix all Action Text database related models to respect
     `ActiveRecord::Base.table_name_prefix` configuration.
 

--- a/actiontext/app/models/action_text/rich_text.rb
+++ b/actiontext/app/models/action_text/rich_text.rb
@@ -39,8 +39,22 @@ module ActionText
     belongs_to :record, polymorphic: true, touch: true
     has_many_attached :embeds
 
+    after_initialize do
+      self.locale ||= I18n.locale
+    end
+
     before_save do
       self.embeds = body.attachables.grep(ActiveStorage::Blob).uniq if body.present?
+    end
+
+    def body=(value)
+      super
+
+      body.try(:locale=, locale)
+    end
+
+    def body
+      super.tap { |value| value.try(:locale=, locale) }
     end
 
     # Returns a plain-text version of the markup contained by the +body+ attribute,

--- a/actiontext/app/views/layouts/action_text/contents/_content.html.erb
+++ b/actiontext/app/views/layouts/action_text/contents/_content.html.erb
@@ -1,3 +1,3 @@
-<div class="trix-content">
+<div lang="<%= content.locale %>" class="trix-content">
   <%= yield -%>
 </div>

--- a/actiontext/db/update_migrate/20240103085247_add_locale_to_action_text_rich_texts.rb
+++ b/actiontext/db/update_migrate/20240103085247_add_locale_to_action_text_rich_texts.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class AddLocaleToActionTextRichTexts < ActiveRecord::Migration[6.0]
+  def change
+    return unless table_exists?(:action_text_rich_texts)
+
+    add_column :action_text_rich_texts, :locale, :string, null: true
+
+    if (locale = I18n.locale)
+      ActionText::RichText.unscoped.update_all(locale: locale)
+    end
+
+    change_column_null :action_text_rich_texts, :locale, false
+  end
+end

--- a/actiontext/lib/action_text/content.rb
+++ b/actiontext/lib/action_text/content.rb
@@ -22,6 +22,7 @@ module ActionText
   class Content
     include Rendering, Serialization
 
+    attr_accessor :locale
     attr_reader :fragment
 
     delegate :blank?, :empty?, :html_safe, :present?, to: :to_html # Delegating to to_html to avoid including the layout
@@ -35,7 +36,9 @@ module ActionText
     end
 
     def initialize(content = nil, options = {})
-      options.with_defaults! canonicalize: true
+      options.with_defaults! canonicalize: true, locale: I18n.locale
+
+      self.locale = options[:locale]
 
       if options[:canonicalize]
         @fragment = self.class.fragment_by_canonicalizing_content(content)

--- a/actiontext/lib/tasks/actiontext.rake
+++ b/actiontext/lib/tasks/actiontext.rake
@@ -4,3 +4,9 @@ desc "Copy over the migration, stylesheet, and JavaScript files"
 task "action_text:install" do
   Rails::Command.invoke :generate, ["action_text:install"]
 end
+
+task "action_text:update" do
+  ENV["MIGRATIONS_PATH"] = "db/update_migrate"
+
+  Rails::Command.invoke :generate, ["action_text:install"]
+end

--- a/actiontext/test/dummy/db/migrate/20240103151150_add_locale_to_action_text_rich_texts.action_text.rb
+++ b/actiontext/test/dummy/db/migrate/20240103151150_add_locale_to_action_text_rich_texts.action_text.rb
@@ -1,0 +1,14 @@
+# This migration comes from action_text (originally 20240103085247)
+class AddLocaleToActionTextRichTexts < ActiveRecord::Migration[6.0]
+  def change
+    return unless table_exists?(:action_text_rich_texts)
+
+    add_column :action_text_rich_texts, :locale, :string, null: true
+
+    if (locale = I18n.locale)
+      ActionText::RichText.unscoped.update_all(locale: locale)
+    end
+
+    change_column_null :action_text_rich_texts, :locale, false
+  end
+end

--- a/actiontext/test/dummy/db/schema.rb
+++ b/actiontext/test/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2019_03_17_200724) do
+ActiveRecord::Schema[7.2].define(version: 2024_01_03_151150) do
   create_table "action_text_rich_texts", force: :cascade do |t|
     t.string "name", null: false
     t.text "body"
@@ -18,6 +18,7 @@ ActiveRecord::Schema[7.2].define(version: 2019_03_17_200724) do
     t.integer "record_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "locale", null: false
     t.index ["record_type", "record_id", "name"], name: "index_action_text_rich_texts_uniqueness", unique: true
   end
 

--- a/actiontext/test/fixtures/action_text/rich_texts.yml
+++ b/actiontext/test/fixtures/action_text/rich_texts.yml
@@ -2,8 +2,10 @@ hello_alice_message_content:
   record: hello_alice (Message)
   name: content
   body: <p>Hello, <%= ActionText::FixtureSet.attachment("people", :alice) %></p>
+  locale: en
 
 hello_world_review_content:
   record: hello_world (Review)
   name: content
   body: <p><%= ActionText::FixtureSet.attachment("messages", :hello_world) %> is great!</p>
+  locale: en

--- a/actiontext/test/unit/content_test.rb
+++ b/actiontext/test/unit/content_test.rb
@@ -3,6 +3,26 @@
 require "test_helper"
 
 class ActionText::ContentTest < ActiveSupport::TestCase
+  test "#locale defaults to I18n.locale" do
+    assert_equal :en, ActionText::Content.new.locale
+
+    I18n.with_locale :es do
+      assert_equal :es, ActionText::Content.new.locale
+    end
+  end
+
+  test "#locale= sets the locale" do
+    english = ActionText::Content.new nil, locale: :en
+
+    assert_equal :en, english.locale
+
+    I18n.with_locale :en do
+      danish = ActionText::Content.new nil, locale: :dk
+
+      assert_equal :dk, danish.locale
+    end
+  end
+
   test "equality" do
     html = "<div>test</div>"
     content = content_from_html(html)
@@ -128,7 +148,7 @@ class ActionText::ContentTest < ActiveSupport::TestCase
     rendered = content_from_html(html).to_rendered_html_with_layout
 
     assert_includes rendered, html
-    assert_match %r/\A#{Regexp.escape '<div class="trix-content">'}/, rendered
+    assert_match %r/\A#{Regexp.escape '<div lang="en" class="trix-content">'}/, rendered
     assert_not defined?(::ApplicationController)
   end
 
@@ -164,7 +184,7 @@ class ActionText::ContentTest < ActiveSupport::TestCase
     Thread.new { rendered = content_from_html(html).to_rendered_html_with_layout }.join
 
     assert_includes rendered, html
-    assert_match %r/\A#{Regexp.escape '<div class="trix-content">'}/, rendered
+    assert_match %r/\A#{Regexp.escape '<div lang="en" class="trix-content">'}/, rendered
   end
 
   test "replace certain nodes" do

--- a/actiontext/test/unit/model_test.rb
+++ b/actiontext/test/unit/model_test.rb
@@ -7,7 +7,14 @@ class ActionText::ModelTest < ActiveSupport::TestCase
 
   test "html conversion" do
     message = Message.new(subject: "Greetings", content: "<h1>Hello world</h1>")
-    assert_equal %Q(<div class="trix-content">\n  <h1>Hello world</h1>\n</div>\n), "#{message.content}"
+    assert_equal %Q(<div lang="en" class="trix-content">\n  <h1>Hello world</h1>\n</div>\n), message.content.to_s
+  end
+
+  test "html conversion incorporates I18n.locale" do
+    I18n.with_locale "es" do
+      message = Message.new(subject: "Greetings", content: "<h1>Hola mundo</h1>")
+      assert_equal %Q(<div lang="es" class="trix-content">\n  <h1>Hola mundo</h1>\n</div>\n), message.content.to_s
+    end
   end
 
   test "plain text conversion" do

--- a/actiontext/test/unit/rich_text_test.rb
+++ b/actiontext/test/unit/rich_text_test.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class ActionText::RichTextTest < ActiveSupport::TestCase
+  test "defaults #locale to the I18n.locale after initialization" do
+    assert_equal "en", ActionText::RichText.new.locale
+
+    I18n.with_locale "es" do
+      assert_equal "es", ActionText::RichText.new.locale
+    end
+  end
+
+  test "does not override existing #locale after initialization" do
+    spanish = ActionText::RichText.new(locale: "es")
+
+    assert_equal "es", spanish.locale
+
+    I18n.with_locale "es" do
+      danish = ActionText::RichText.new(locale: "dk")
+
+      assert_equal "dk", danish.locale
+    end
+  end
+
+  test "#body= sets the locale for a String value" do
+    model = ActionText::RichText.new locale: "es"
+
+    model.body = "<h1>Hola mundo</h1>"
+
+    assert_equal "es", model.body.locale
+  end
+
+  test "#body= sets the locale for an ActionText::Content value" do
+    model = ActionText::RichText.new locale: "es"
+    content = ActionText::Content.new("<h1>Hola mundo</h1>")
+
+    model.body = content
+
+    assert_equal "es", model.body.locale
+    assert_equal I18n.locale, content.locale, "does not write to the instance"
+  end
+
+  test "#body= ignores the locale for a nil value" do
+    model = ActionText::RichText.new locale: "es"
+
+    model.body = nil
+
+    assert_nil model.body&.locale
+  end
+end

--- a/guides/source/action_text_overview.md
+++ b/guides/source/action_text_overview.md
@@ -106,6 +106,8 @@ class MessagesController < ApplicationController
 end
 ```
 
+Rich text content will be saved with the [current I18n.locale](./i18n.html#managing-the-locale-across-requests) value.
+
 NOTE: Since Action Text relies on polymorphic associations, and [polymorphic associations](./association_basics.html#polymorphic-associations) rely on storing class names in the database, that data must remain synchronized with the class name used by the Ruby code. When renaming classes that use `has_rich_text`, make sure to also update the class names in the `action_text_rich_texts.record_type` polymorphic type column of the corresponding rows.
 
 [`rich_text_area`]: https://api.rubyonrails.org/classes/ActionView/Helpers/FormHelper.html#method-i-rich_text_area
@@ -141,10 +143,12 @@ To customize the HTML container element that's rendered around rich text content
 ```html+erb
 <%# app/views/layouts/action_text/contents/_content.html.erb %>
 
-<div class="trix-content">
+<div lang="<%= content.locale %>" class="trix-content">
   <%= yield %>
 </div>
 ```
+
+If the application supports multiple languages, render the element with the [lang](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/lang) attribute set to reflect the source language of the content.
 
 To customize the HTML rendered for embedded images and other attachments (known as blobs), edit the `app/views/active_storage/blobs/_blob.html.erb` template created by the installer:
 

--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -366,6 +366,13 @@ module Rails
       end
       remove_task :update_bin_files
 
+      def update_action_text
+        unless skip_action_text?
+          rails_command "action_text:update", inline: true
+        end
+      end
+      remove_task :update_action_text
+
       def update_active_storage
         unless skip_active_storage?
           rails_command "active_storage:update", inline: true

--- a/railties/test/railties/engine_test.rb
+++ b/railties/test/railties/engine_test.rb
@@ -1805,6 +1805,33 @@ en:
       assert_equal "/fruits/2/bukkits/posts", last_response.body
     end
 
+    test "action_text:install task works within engine" do
+      @plugin.write "Rakefile", <<-RUBY
+        APP_RAKEFILE = '#{app_path}/Rakefile'
+        load "rails/tasks/engine.rake"
+      RUBY
+
+      Dir.chdir(@plugin.path) do
+        assert_command_succeeds("bundle exec rake app:action_text:install")
+
+        action_text_migration = migrations.detect { |migration| migration.name == "CreateActionTextTables" }
+        assert action_text_migration
+      end
+    end
+
+    test "action_text:update task works within engine" do
+      @plugin.write "Rakefile", <<-RUBY
+        APP_RAKEFILE = '#{app_path}/Rakefile'
+        load "rails/tasks/engine.rake"
+      RUBY
+
+      Dir.chdir(@plugin.path) do
+        assert_command_succeeds("bundle exec rake app:action_text:update")
+
+        assert migrations.detect { |migration| migration.name == "AddLocaleToActionTextRichTexts" }
+      end
+    end
+
     test "active_storage:install task works within engine" do
       @plugin.write "Rakefile", <<-RUBY
         APP_RAKEFILE = '#{app_path}/Rakefile'


### PR DESCRIPTION
### Motivation / Background

As described by MDN, the HTML [lang][] attribute:

> helps define the language of an element: the language that
> non-editable elements are written in

Since `ActionText::RichText` instances intend to capture and render user-sourced content, it's important to hint to browsers the language of that content.

### Detail

This commit introduces an `AddLocaleToActionTextRichTexts` migration to add an `action_text_rich_texts.locale` column to encode the locale when the row is created.

Once captured, that locale is incorporated into the wrapping `<div class="trix-content">` element as a `[lang]` attribute so that browsers can act accordingly (for example, offer translations when served in other locale browsing contexts).

To make that information available to the rendering context, the `ActionText::Content` class must be made aware of the `#locale` during column serialization, so this commit overrides the built-in `RichText#body=` and `RichText#body` attributes.

Upgrading applications can include the new migration by executing:

```bash
bin/rails action_text:update
```

[lang]: https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/lang

### Additional information

Related to https://github.com/rails/rails/pull/42404.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
