### PR TITLE
Suggest `bin/rails action_text:install` from error page

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/templates/rescues/invalid_statement.html.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/rescues/invalid_statement.html.erb
@@ -11,6 +11,9 @@
 <main role="main" id="container">
   <h2>
     <%= h @exception.message %>
+    <% if defined?(ActionText) && @exception.message.match?(%r{#{ActionText::RichText.table_name}}) %>
+      <br />To resolve this issue run: bin/rails action_text:install
+    <% end %>
     <% if defined?(ActiveStorage) && @exception.message.match?(%r{#{ActiveStorage::Blob.table_name}|#{ActiveStorage::Attachment.table_name}}) %>
       <br />To resolve this issue run: bin/rails active_storage:install
     <% end %>

--- a/actionpack/lib/action_dispatch/middleware/templates/rescues/invalid_statement.text.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/rescues/invalid_statement.text.erb
@@ -4,6 +4,9 @@
 <% end %>
 
 <%= @exception.message %>
+<% if defined?(ActionText) && @exception.message.match?(%r{#{ActionText::RichText.table_name}}) %>
+To resolve this issue run: bin/rails action_text:install
+<% end %>
 <% if defined?(ActiveStorage) && @exception.message.match?(%r{#{ActiveStorage::Blob.table_name}|#{ActiveStorage::Attachment.table_name}}) %>
 To resolve this issue run: bin/rails active_storage:install
 <% end %>

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Suggest `bin/rails action_text:install` from Action Dispatch error page
+
+    *Sean Doyle*
+
 *   Remove deprecated `STATS_DIRECTORIES`.
 
     *Rafael Mendonça França*

--- a/railties/test/application/action_text/installation_integration_test.rb
+++ b/railties/test/application/action_text/installation_integration_test.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require "isolation/abstract_unit"
+require "rack/test"
+
+module ApplicationTests
+  class InstallationIntegrationTest < ActiveSupport::TestCase
+    include ActiveSupport::Testing::Isolation
+    include Rack::Test::Methods
+
+    def setup
+      build_app
+    end
+
+    def teardown
+      teardown_app
+    end
+
+    def test_renders_actionable_exception_page_when_action_text_not_installed
+      app "development"
+      app_file "config/routes.rb", <<~RUBY
+        Rails.application.routes.draw do
+          post "/rich_texts" => "rich_texts#create"
+        end
+      RUBY
+      app_file "app/controllers/rich_texts_controller.rb", <<~RUBY
+        class RichTextsController < ActionController::Base
+          def create
+            ActionText::RichText.create!
+          end
+        end
+      RUBY
+
+      post "/rich_texts"
+
+      assert_equal 500, last_response.status
+      assert_match "To resolve this issue run: bin/rails action_text:install", last_response.body
+    end
+  end
+end


### PR DESCRIPTION
### Detail

Mirror Active Storage's encouragement to execute the
`active_storage:install` task from Action Dispatch error pages by adding
similar instructions for the `rails action_text:install` task when the
error is related to missing Action Text tables.