### PR TITLE
Eager load the Rails default controllers used in production

### DIFF
--- a/railties/lib/rails.rb
+++ b/railties/lib/rails.rb
@@ -27,12 +27,15 @@ module Rails
   extend ActiveSupport::Autoload
   extend ActiveSupport::Benchmarkable
 
-  autoload :HealthController
   autoload :Info
   autoload :InfoController
   autoload :MailersController
-  autoload :PwaController
   autoload :WelcomeController
+
+  eager_autoload do
+    autoload :HealthController
+    autoload :PwaController
+  end
 
   class << self
     @application = @app_class = nil

--- a/railties/lib/rails/application/finisher.rb
+++ b/railties/lib/rails/application/finisher.rb
@@ -78,6 +78,7 @@ module Rails
         if config.eager_load
           ActiveSupport.run_load_hooks(:before_eager_load, self)
           Zeitwerk::Loader.eager_load_all
+          Rails.eager_load!
           config.eager_load_namespaces.each(&:eager_load!)
 
           if config.reloading_enabled?


### PR DESCRIPTION
Since those controller can be used in production we need to eager load them to better copy-on-write and avoid tread-safety issues.

Related to #50528