### PR TITLE
Add `BACKTRACE` env variable to turn off backtrace

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   Support `BACKTRACE` ENV variable to turn off backtrace cleaning.
+
+    Useful for debugging framework code:
+
+    ```sh
+    BACKTRACE=1 ./bin/rails server
+    ```
+
+    *Alex Ghiculescu*
+
 *   Raise `ArgumentError` when reading `config.x.something` with arguments
 
     ```ruby

--- a/railties/lib/minitest/rails_plugin.rb
+++ b/railties/lib/minitest/rails_plugin.rb
@@ -109,7 +109,7 @@ module Minitest
   # Owes great inspiration to test runner trailblazers like RSpec,
   # minitest-reporters, maxitest, and others.
   def self.plugin_rails_init(options)
-    unless options[:full_backtrace] || ENV["BACKTRACE"]
+    unless options[:full_backtrace]
       # Plugin can run without Rails loaded, check before filtering.
       if ::Rails.respond_to?(:backtrace_cleaner)
         Minitest.backtrace_filter = BacktraceFilterWithFallback.new(::Rails.backtrace_cleaner, Minitest.backtrace_filter)

--- a/railties/lib/rails/application/bootstrap.rb
+++ b/railties/lib/rails/application/bootstrap.rb
@@ -71,6 +71,10 @@ module Rails
         end
       end
 
+      initializer :configure_backtrace_cleaner, group: :all do
+        Rails.backtrace_cleaner.remove_silencers! if ENV["BACKTRACE"]
+      end
+
       # Initialize cache early in the stack so railties can make use of it.
       initializer :initialize_cache, group: :all do
         cache_format_version = config.active_support.delete(:cache_format_version)

--- a/railties/test/application/backtrace_cleaner_test.rb
+++ b/railties/test/application/backtrace_cleaner_test.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require "isolation/abstract_unit"
+require "rack/test"
+require "env_helpers"
+
+module ApplicationTests
+  class RoutingTest < ActiveSupport::TestCase
+    include ActiveSupport::Testing::Isolation
+    include Rack::Test::Methods
+    include EnvHelpers
+
+    def teardown
+      teardown_app
+    end
+
+    test "backtrace is cleaned" do
+      setup_app
+
+      app("development")
+      get "/"
+      assert_includes last_response.body, "app/app/controllers/foo_controller.rb:4:in `index'"
+      assert_not_includes last_response.body, "rails/railties/test/env_helpers.rb"
+    end
+
+    test "backtrace is not cleaned" do
+      switch_env("BACKTRACE", "1") do
+        setup_app
+
+        app("development")
+        get "/"
+        assert_includes last_response.body, "app/app/controllers/foo_controller.rb:4:in `index'"
+        assert_includes last_response.body, "rails/railties/test/env_helpers.rb"
+      end
+    end
+
+    private
+      def setup_app
+        build_app
+
+        controller :foo, <<-RUBY
+          class FooController < ApplicationController
+            def index
+              begin
+                raise "ERROR"
+              rescue StandardError => e
+                render plain: e.backtrace.join("\n")
+              end
+            end
+          end
+        RUBY
+
+        app_file "config/routes.rb", <<-RUBY
+          Rails.application.routes.draw do
+            root to: "foo#index"
+          end
+        RUBY
+      end
+  end
+end

--- a/railties/test/minitest/rails_plugin_test.rb
+++ b/railties/test/minitest/rails_plugin_test.rb
@@ -46,16 +46,6 @@ class Minitest::RailsPluginTest < ActiveSupport::TestCase
     end
   end
 
-  test "does not replace backtrace filter when BACKTRACE environment variable is set" do
-    backtrace_filter = baseline_backtrace_filter
-
-    switch_env "BACKTRACE", "true" do
-      with_plugin(initial_backtrace_filter: backtrace_filter) do
-        assert_same backtrace_filter, Minitest.backtrace_filter
-      end
-    end
-  end
-
   test "replaces Minitest::SummaryReporter reporter" do
     with_plugin do
       assert_empty Minitest.reporter.reporters.select { |reporter| reporter.instance_of? Minitest::SummaryReporter }


### PR DESCRIPTION
Fixes https://github.com/rails/rails/issues/50440

Do `BACKTRACE=1 bin/rails server` to run the Rails server without the backtrace cleaner, so you can more easily debug framework code.

Prior art: https://github.com/rails/rails/commit/f4c9d0b014e3c1c27c3d5db73dbf42c48733a1b6