### PR TITLE
Use logical core count for test parallelization

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Use logical core count instead of physical core count to determine the
+    default number of workers when parallelizing tests.
+
+    *Jonathan Hefner*
+
 *   Fix `Time.now/DateTime.now/Date.today' to return results in a system timezone after `#travel_to'.
 
     There is a bug in the current implementation of #travel_to:

--- a/activesupport/lib/active_support/test_case.rb
+++ b/activesupport/lib/active_support/test_case.rb
@@ -78,7 +78,7 @@ module ActiveSupport
       # number of tests to run is above the +threshold+ param. The default value is
       # 50, and it's configurable via +config.active_support.test_parallelization_threshold+.
       def parallelize(workers: :number_of_processors, with: :processes, threshold: ActiveSupport.test_parallelization_threshold)
-        workers = Concurrent.physical_processor_count if workers == :number_of_processors
+        workers = Concurrent.processor_count if workers == :number_of_processors
         workers = ENV["PARALLEL_WORKERS"].to_i if ENV["PARALLEL_WORKERS"]
 
         Minitest.parallel_executor = ActiveSupport::Testing::ParallelizeExecutor.new(size: workers, with: with, threshold: threshold)

--- a/railties/lib/rails/generators/rails/app/templates/github/ci.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/github/ci.yml.tt
@@ -110,9 +110,6 @@ jobs:
           ruby-version: .ruby-version
           bundler-cache: true
 
-      - name: Configure parallelization
-        run: echo "PARALLEL_WORKERS=$(nproc)" >> $GITHUB_ENV
-
       - name: Run tests
         env:
           RAILS_ENV: test


### PR DESCRIPTION
This changes the default number of workers when parallelizing tests to be based on logical core count instead of physical core count.  This may provide a performance boost for parallelized tests.

This also reverts #50545 in favor of using the default worker count.
