### PR TITLE
Handle all false args in `config.x` error check

### DIFF
--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -569,14 +569,12 @@ module Rails
         def method_missing(method, *args)
           if method.end_with?("=")
             @configurations[:"#{method[0..-2]}"] = args.first
-          elsif args.none?
+          elsif args.empty?
             @configurations.fetch(method) {
               @configurations[method] = ActiveSupport::OrderedOptions.new
             }
           else
-            arguments = args.map(&:inspect)
-
-            raise ArgumentError.new("unexpected arguments (%s) while reading `%s` configuration" % [arguments.join(", "), method])
+            raise ArgumentError, "wrong number of arguments (given #{args.length}, expected 0) when reading configuration `#{method}`"
           end
         end
 

--- a/railties/test/application/configuration/custom_test.rb
+++ b/railties/test/application/configuration/custom_test.rb
@@ -37,8 +37,8 @@ module ApplicationTests
         assert_kind_of Method, x.method(:i_do_not_exist)
         assert_kind_of ActiveSupport::OrderedOptions, x.i_do_not_exist
 
-        assert_raises ArgumentError, match: "unexpected arguments (true, false) while reading `i_do_not_exist` configuration" do
-          x.i_do_not_exist(true, false)
+        assert_raises ArgumentError, match: "wrong number of arguments (given 1, expected 0) when reading configuration `i_do_not_exist`" do
+          x.i_do_not_exist(false)
         end
       end
 


### PR DESCRIPTION
Follow-up to #50050.

Using `args.none?` does not catch the case when all args are `false` or `nil`.  Therefore, this commit changes the condition to `args.empty?`.

This commit also changes the error message to more closely match Ruby's error messages when trying to pass an arg to a getter method:

  ```ruby
  Rails.configuration.x(false)
  # => wrong number of arguments (given 1, expected 0) (ArgumentError)

  Rails.configuration.x.i_do_not_exist(false)
  # => wrong number of arguments (given 1, expected 0) when reading configuration `i_do_not_exist` (ArgumentError)
  ```
