### PR TITLE
`#render_template_to_object` and `#render_partial_to_object` are private

### DIFF
--- a/actionview/lib/action_view/renderer/renderer.rb
+++ b/actionview/lib/action_view/renderer/renderer.rb
@@ -59,46 +59,46 @@ module ActionView
       @cache_hits ||= {}
     end
 
-    def render_template_to_object(context, options) # :nodoc:
-      TemplateRenderer.new(@lookup_context).render(context, options)
-    end
+    private
+      def render_template_to_object(context, options)
+        TemplateRenderer.new(@lookup_context).render(context, options)
+      end
 
-    def render_partial_to_object(context, options, &block) # :nodoc:
-      partial = options[:partial]
-      if String === partial
-        collection = collection_from_options(options)
+      def render_partial_to_object(context, options, &block)
+        partial = options[:partial]
+        if String === partial
+          collection = collection_from_options(options)
 
-        if collection
-          # Collection + Partial
-          renderer = CollectionRenderer.new(@lookup_context, options)
-          renderer.render_collection_with_partial(collection, partial, context, block)
-        else
-          if options.key?(:object)
-            # Object + Partial
-            renderer = ObjectRenderer.new(@lookup_context, options)
-            renderer.render_object_with_partial(options[:object], partial, context, block)
+          if collection
+            # Collection + Partial
+            renderer = CollectionRenderer.new(@lookup_context, options)
+            renderer.render_collection_with_partial(collection, partial, context, block)
           else
-            # Partial
-            renderer = PartialRenderer.new(@lookup_context, options)
-            renderer.render(partial, context, block)
+            if options.key?(:object)
+              # Object + Partial
+              renderer = ObjectRenderer.new(@lookup_context, options)
+              renderer.render_object_with_partial(options[:object], partial, context, block)
+            else
+              # Partial
+              renderer = PartialRenderer.new(@lookup_context, options)
+              renderer.render(partial, context, block)
+            end
+          end
+        else
+          collection = collection_from_object(partial) || collection_from_options(options)
+
+          if collection
+            # Collection + Derived Partial
+            renderer = CollectionRenderer.new(@lookup_context, options)
+            renderer.render_collection_derive_partial(collection, context, block)
+          else
+            # Object + Derived Partial
+            renderer = ObjectRenderer.new(@lookup_context, options)
+            renderer.render_object_derive_partial(partial, context, block)
           end
         end
-      else
-        collection = collection_from_object(partial) || collection_from_options(options)
-
-        if collection
-          # Collection + Derived Partial
-          renderer = CollectionRenderer.new(@lookup_context, options)
-          renderer.render_collection_derive_partial(collection, context, block)
-        else
-          # Object + Derived Partial
-          renderer = ObjectRenderer.new(@lookup_context, options)
-          renderer.render_object_derive_partial(partial, context, block)
-        end
       end
-    end
 
-    private
       def collection_from_options(options)
         if options.key?(:collection)
           collection = options[:collection]


### PR DESCRIPTION
### Motivation / Background
Apparently it had not been clear what visibility they should assume when they were initially created at https://github.com/rails/rails/pull/35265, then a big refactoring took place at https://github.com/rails/rails/pull/38594 after which they remain intact.

So after a couple of years I think they can now become properly private as they are nodoc and not refered to but from within the same class.

### Detail
This Pull Request changes the visibility of `ActionView::Renderer`'s `#render_template_to_object` and `#render_partial_to_object`.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.

I'm not sure if this should be counted as a behavior change when it's an internal change. Leaving the last one unchecked means that I would like to seek guidance here. Thanks!
