### PR TITLE
Get rid of EnvHelpers at Minitest::RailsPluginTest

### DIFF
--- a/railties/test/minitest/rails_plugin_test.rb
+++ b/railties/test/minitest/rails_plugin_test.rb
@@ -1,11 +1,8 @@
 # frozen_string_literal: true
 
 require "abstract_unit"
-require "env_helpers"
 
 class Minitest::RailsPluginTest < ActiveSupport::TestCase
-  include EnvHelpers
-
   setup do
     @output = StringIO.new("".encode("UTF-8"))
   end


### PR DESCRIPTION
### Motivation / Background
In https://github.com/rails/rails/pull/50563 the test case which used to require EnvHelpers has moved to a separate file. Consequently this file no longer needs to include nor require EnvHelpers.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
