### PR TITLE
Ensure that LogSubscriber.flush_all! is called after LogSubscribers run

### DIFF
--- a/railties/test/rack_logger_test.rb
+++ b/railties/test/rack_logger_test.rb
@@ -5,10 +5,13 @@ require "active_support/testing/autorun"
 require "active_support/test_case"
 require "rails/rack/logger"
 require "logger"
+require "active_support/log_subscriber/test_helper"
 
 module Rails
   module Rack
     class LoggerTest < ActiveSupport::TestCase
+      include ActiveSupport::LogSubscriber::TestHelper
+
       class TestLogger < Rails::Rack::Logger
         NULL = ::Logger.new File::NULL
 
@@ -43,16 +46,16 @@ module Rails
         end
       end
 
-      attr_reader :subscriber, :notifier
+      attr_reader :subscriber
 
       def setup
+        super
         @subscriber = Subscriber.new
-        @notifier = ActiveSupport::Notifications.notifier
-        @subscription = notifier.subscribe "request.action_dispatch", subscriber
+        @subscription = ActiveSupport::Notifications.notifier.subscribe "request.action_dispatch", subscriber
       end
 
       def teardown
-        notifier.unsubscribe @subscription
+        ActiveSupport::Notifications.notifier.unsubscribe @subscription
       end
 
       def test_notification
@@ -89,6 +92,32 @@ module Rails
             logger.call("REQUEST_METHOD" => "GET")
           end
         end
+      end
+
+      def test_logger_is_flushed_after_request_finished
+        logger_middleware = TestLogger.new { }
+
+        flush_count_in_request_event = nil
+        block_sub = @notifier.subscribe "request.action_dispatch" do |_event|
+          flush_count_in_request_event = ActiveSupport::LogSubscriber.logger.flush_count
+        end
+
+        # Assert that we don't get a logger flush when we finish the response headers
+        response_body = nil
+        assert_no_difference("ActiveSupport::LogSubscriber.logger.flush_count") do
+          response_body = logger_middleware.call("REQUEST_METHOD" => "GET").last
+        end
+
+        # Assert that we _do_ get a logger flush when we finish the response body
+        assert_difference("ActiveSupport::LogSubscriber.logger.flush_count") do
+          response_body.close
+        end
+
+        # And that the flush happens _after_ any LogSubscribers etc get run.
+        flush_count = ActiveSupport::LogSubscriber.logger.flush_count
+        assert_equal(1, flush_count - flush_count_in_request_event, "flush_all! should happen after event")
+      ensure
+        @notifier.unsubscribe block_sub
       end
     end
   end


### PR DESCRIPTION

<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

The `Rails::Rack::Logger` middleware defers finishing the request.action_dispatch notification until the body is written. However, it calls `ActiveSupport::LogSubscriber.flush_all!` immediately once the headers are written, before the body is closed.

This means that if you have a custom `ActiveSupport::LogSubscriber` attached to `request.action_dispatch`, any logs you write there are NOT flushed until the _next_ request finishes (or something else calls `Rails.logger.flush` or some such).

I mostly care about this because I'm experimenting with a custom `Rails.logger` implementation which buffers all logs for a request into a single object, which can be sent to our structured logging platform as one log entry. I was hoping to use `#flush` as the signal to write out that completed event, but because it happens too early in Rack, I can't (I have to define `#flush` as a no-op on my custom logger, and implement a `#real_flush` which is called from a `request.action_dispatch` handler).

But even outside exotic logger implementations like this, I think "flush" should happen after `request.action_dispatch` is done. 

### Detail

This PR fixes the issue by simply ensuring that `ActiveSupport::LogSubscriber.flush_all!` is called in the same circumstances as `handle.finish` is in the `Rails::Rack::Logger` middleware.

### Additional information

<!-- Provide additional information such as benchmarks, reference to other repositories or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
