### PR TITLE
Ensure migrations installed by ActiveStorage/ActionText comply with `rubocop-rails-omakase`

### DIFF
--- a/actiontext/db/migrate/20180528164100_create_action_text_tables.rb
+++ b/actiontext/db/migrate/20180528164100_create_action_text_tables.rb
@@ -20,6 +20,6 @@ class CreateActionTextTables < ActiveRecord::Migration[6.0]
       setting = config.options[config.orm][:primary_key_type]
       primary_key_type = setting || :primary_key
       foreign_key_type = setting || :bigint
-      [primary_key_type, foreign_key_type]
+      [ primary_key_type, foreign_key_type ]
     end
 end

--- a/activestorage/db/migrate/20170806125915_create_active_storage_tables.rb
+++ b/activestorage/db/migrate/20170806125915_create_active_storage_tables.rb
@@ -51,6 +51,6 @@ class CreateActiveStorageTables < ActiveRecord::Migration[7.0]
       setting = config.options[config.orm][:primary_key_type]
       primary_key_type = setting || :primary_key
       foreign_key_type = setting || :bigint
-      [primary_key_type, foreign_key_type]
+      [ primary_key_type, foreign_key_type ]
     end
 end


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because `rubocop-rails-omakase` is offended by migrations installed by ActiveStorage and ActionText.

I noticed when a newly created project was failing GitHub CI (added in #50508).

### Detail

This Pull Request adds space inside array literal brackets in ActiveStorage/ActionText migrations.

### Additional information

The simplest reproduction is

```sh
> rails new --main blog 
> cd blog
> bin/rails action_text:install
> bin/rubocop
Inspecting 31 files
.........................CC....

Offenses:
db/migrate/20240104075942_create_active_storage_tables.active_storage.rb:55:7: C: [Correctable] Layout/SpaceInsideArrayLiteralBrackets: Use space inside array brackets.
      [primary_key_type, foreign_key_type]
      ^
db/migrate/20240104075942_create_active_storage_tables.active_storage.rb:55:42: C: Layout/SpaceInsideArrayLiteralBrackets: Use space inside array brackets.
      [primary_key_type, foreign_key_type]
                                         ^
db/migrate/20240104075943_create_action_text_tables.action_text.rb:24:7: C: [Correctable] Layout/SpaceInsideArrayLiteralBrackets: Use space inside array brackets.
      [primary_key_type, foreign_key_type]
      ^
db/migrate/20240104075943_create_action_text_tables.action_text.rb:24:42: C: Layout/SpaceInsideArrayLiteralBrackets: Use space inside array brackets.
      [primary_key_type, foreign_key_type]
                                         ^

31 files inspected, 4 offenses detected, 2 offenses autocorrectable
```