### PR TITLE
Ensure RuboCop and Brakeman are always available in CI

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
@@ -36,10 +36,6 @@ gem "bootsnap", require: false
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri <%= bundler_windows_platforms %> ]
-end
-<% end -%>
-
-group :development do
 <%- unless options.skip_brakeman? -%>
   # Static analysis for security vulnerabilities [https://brakemanscanner.org/]
   gem "brakeman", require: false
@@ -50,6 +46,10 @@ group :development do
   gem "rubocop-rails-omakase", require: false
 
 <%- end -%>
+end
+<% end -%>
+
+group :development do
 <%- unless options.api? || options.skip_dev_gems? -%>
   # Use console on exceptions pages [https://github.com/rails/web-console]
   gem "web-console"


### PR DESCRIPTION
In CI, it's common to exclude gems in the `development` group, usually through `BUNDLE_WITHOUT`, so that we don't spend time installing unnecessary gems. For example:

https://github.com/diaspora/diaspora/blob/389b1870d3a59d17e5239a0168f69a6d84d13982/.github/workflows/ci.yml#L30

This PR changes the `Gemfile` template so that `rubocop-rails-omakase` and `brakeman` are available in both the `test` and `development` groups.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
