### PR TITLE
Parse `ActionView::TestCase#rendered` as DocumentFragment

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Parse `ActionView::TestCase#rendered` HTML content as `Nokogiri::XML::DocumentFragment` instead of `Nokogiri::XML::Document`
+
+    *Sean Doyle*
+
 *   Rename `ActionView::TestCase::Behavior::{Content,RenderedViewContent}`
 
     *Sean Doyle*

--- a/actionview/lib/action_view/test_case.rb
+++ b/actionview/lib/action_view/test_case.rb
@@ -202,7 +202,7 @@ module ActionView
 
         setup :setup_with_controller
 
-        register_parser :html, -> rendered { Rails::Dom::Testing.html_document.parse(rendered).root }
+        register_parser :html, -> rendered { Rails::Dom::Testing.html_document_fragment.parse(rendered) }
         register_parser :json, -> rendered { JSON.parse(rendered, object_class: ActiveSupport::HashWithIndifferentAccess) }
 
         ActiveSupport.run_load_hooks(:action_view_test_case, self)

--- a/actionview/test/template/test_case_test.rb
+++ b/actionview/test/template/test_case_test.rb
@@ -397,12 +397,13 @@ module ActionView
   end
 
   class HTMLParserTest < ActionView::TestCase
-    test "rendered.html is a Nokogiri::XML::Element" do
+    test "rendered.html is a Nokogiri::XML::DocumentFragment" do
       developer = DeveloperStruct.new("Eloy")
 
       render "developers/developer", developer: developer
 
-      assert_kind_of Nokogiri::XML::Element, rendered.html
+      assert_kind_of Nokogiri::XML::DocumentFragment, rendered.html
+      assert_equal rendered.to_s, rendered.html.to_s
       assert_equal developer.name, document_root_element.text
     end
 
@@ -425,6 +426,7 @@ module ActionView
       render formats: :json, partial: "developers/developer", locals: { developer: developer }
 
       assert_kind_of ActiveSupport::HashWithIndifferentAccess, rendered.json
+      assert_equal rendered.to_s, rendered.json.to_json
       assert_equal developer.name, rendered.json[:name]
     end
   end


### PR DESCRIPTION
### Motivation / Background

To integrate with [rails-dom-testing][] and its selector assertions, `ActionView::TestCase` [defines a `#document_root_element` method][document_root_element] that parses the HTML into a fully valid HTML document and returns the "root".

In the case of most Action View partials rendered with `render partial: "..."`, the resulting document would be invalid, so its constituent parts (its `<html>`, `<head>`, and `<body>` elements) are synthesized during the parsing process. This results in a document whose _contents_ are equivalent to the original HTML string, but whose structure is not.

To share a concrete example:

  ```ruby
  irb(main):002:0> rendered = "<h1>Hello world</h1><h2>Goodbye world</h2>"
  => "<h1>Hello world</h1><h2>Goodbye world</h2>"
  irb(main):003:0> root = Rails::Dom::Testing.html_document.parse(rendered).root
  =>
  #(Element:0x57080 {
  ...
  irb(main):004:0> rendered.to_s
  => "<h1>Hello world</h1><h2>Goodbye world</h2>"
  irb(main):005:0> root.to_s
  => "<html><head></head><body><h1>Hello world</h1><h2>Goodbye world</h2></body></html>"
  irb(main):006:0> rendered.to_s == root.to_s
  => false
  ```

Prior to this commit, the parsed HTML content returned from calling `rendered.html` relied on the same mechanisms as
`#document_root_element`, and parsed the HTML fragment into a full document, with a synthesized `<html>` element as its root. The `rendered.html` value should reflect the content that was **rendered** by the partial, and should not behave the same as
`#document_root_element`.

When the parsing class is changed from [Nokogiri::XML::Document][] to [Nokogiri::XML::DocumentFragment][], the returned value reflects the same **exact** content as what was rendered.

To elaborate on the previous example:

  ```ruby
  irb(main):007:0> fragment = Rails::Dom::Testing.html_document_fragment.parse(rendered)
  =>
  #(DocumentFragment:0x62ee4 {
  ...
  irb(main):008:0> fragment.to_s
  => "<h1>Hello world</h1><h2>Goodbye world</h2>"
  irb(main):009:0> rendered.to_s == fragment.to_s
  => true
  ```

### Detail

This commit changes the default `rendered.html` behavior to rely on `Nokogiri::XML::DocumentFragment` instead of `Nokogiri::XML::Document`.

[rails-dom-testing]: https://github.com/rails/rails-dom-testing
[Nokogiri::XML::Document]: https://nokogiri.org/rdoc/Nokogiri/XML/Document.html
[Nokogiri::XML::DocumentFragment]: https://nokogiri.org/rdoc/Nokogiri/XML/DocumentFragment.html
[document_root_element]: https://github.com/rails/rails-dom-testing/blob/v2.2.0/lib/rails/dom/testing/assertions/selector_assertions.rb#L75

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
