### PR TITLE
Add assertions for stopped ActionCable streams

### DIFF
--- a/actioncable/CHANGELOG.md
+++ b/actioncable/CHANGELOG.md
@@ -1,2 +1,13 @@
+*   Add two new assertion methods for ActionCable test cases: `assert_not_has_stream`
+    and `assert_not_has_stream_for`. These methods can be used to assert that a
+    stream has been stopped, e.g. via `stop_stream` or `stop_stream_for`. They complement
+    the already existing `assert_has_stream` and `assert_has_stream_for` methods.
+
+    ```ruby
+    assert_not_has_stream "messages"
+    assert_not_has_stream_for User.find(42)
+    ```
+
+    *Sebastian Pöll*
 
 Please check [7-1-stable](https://github.com/rails/rails/blob/7-1-stable/actioncable/CHANGELOG.md) for previous changes.

--- a/actioncable/lib/action_cable/channel/test_case.rb
+++ b/actioncable/lib/action_cable/channel/test_case.rb
@@ -312,6 +312,28 @@ module ActionCable
           assert_has_stream(broadcasting_for(object))
         end
 
+        # Asserts that the specified stream has not been started.
+        #
+        #   def test_assert_not_started_stream
+        #     subscribe
+        #     assert_not_has_stream 'messages'
+        #   end
+        #
+        def assert_not_has_stream(stream)
+          assert subscription.streams.exclude?(stream), "Stream #{stream} has been started"
+        end
+
+        # Asserts that the specified stream for a model has not started.
+        #
+        #   def test_assert_not_started_stream_for
+        #     subscribe id: 41
+        #     assert_not_has_stream_for User.find(42)
+        #   end
+        #
+        def assert_not_has_stream_for(object)
+          assert_not_has_stream(broadcasting_for(object))
+        end
+
         private
           def check_subscribed!
             raise "Must be subscribed!" if subscription.nil? || subscription.rejected?

--- a/actioncable/test/channel/test_case_test.rb
+++ b/actioncable/test/channel/test_case_test.rb
@@ -107,6 +107,20 @@ class StreamsTestChannelTest < ActionCable::Channel::TestCase
     assert_has_stream "test_42"
   end
 
+  def test_not_stream_without_params
+    subscribe
+    unsubscribe
+
+    assert_not_has_stream "test_0"
+  end
+
+  def test_not_stream_with_params
+    subscribe id: 42
+    perform :unsubscribed, id: 42
+
+    assert_not_has_stream "test_42"
+  end
+
   def test_unsubscribe_from_stream
     subscribe
     unsubscribe
@@ -119,6 +133,10 @@ class StreamsForTestChannel < ActionCable::Channel::Base
   def subscribed
     stream_for User.new(params[:id])
   end
+
+  def unsubscribed
+    stop_stream_for User.new(params[:id])
+  end
 end
 
 class StreamsForTestChannelTest < ActionCable::Channel::TestCase
@@ -126,6 +144,13 @@ class StreamsForTestChannelTest < ActionCable::Channel::TestCase
     subscribe id: 42
 
     assert_has_stream_for User.new(42)
+  end
+
+  def test_not_stream_with_params
+    subscribe id: 42
+    perform :unsubscribed, id: 42
+
+    assert_not_has_stream_for User.new(42)
   end
 end
 


### PR DESCRIPTION
### Motivation / Background

When writing tests for ActionCable channels, we currently have the methods `assert_has_stream` and `assert_has_stream_for` but nothing to assert the opposite. Being able to assert that a stream indeed has been stopped  after calling `stop_stream` or `stop_stream_for`  would increase testability IMHO. A toy example:

```ruby
class SomeChannel < ApplicationCable::Channel

  def subscribed
    stream_from "stream_1"
    stream_from "stream_2"
  end

  def stop_some_stream
    stop_stream_from "stream_1"
  end
end 
```

When writing a test case for `stop_some_stream`, we want to assert that we don't receive "stream_1" anymore. To assert this correctly, the only way I can think of currently would be to use the special method `subscription.streams` as a workaround.

### Detail

I'd like to propose two new assertion methods: `assert_not_has_stream` and `assert_not_has_stream_for` to complement the existing methods.

Naming them like that would follow the convention of other assertions: `assert_not_nil`, `assert_not_empty`, `assert_not_predicate`, `assert_not_instance_of`, ...

A test case for the above `stop_some_stream` might then look like this:

```ruby
class SomeChannelTest < ActionCable::Channel::TestCase

  test "stop some stream" do
    subscribe
    assert_has_stream "stream_1"

    perform :stop_some_stream
    
    # This is new
    assert_not_has_stream "stream_1"
  end
end
```

### Additional information

This small PR was actually extracted from my own SaaS platform, which heavily relies on web sockets (and thus really benefits from this kind of detailed testing). Thx, for considering :)

> ### Checklist
> 
> Before submitting the PR make sure the following are checked:
> 
> * [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
> * [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
> * [x] Tests are added or updated if you fix a bug or add a feature.
> * [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
