### PR TITLE
Use rubocop github formatter on CI to display annotations in the UI

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/github/ci.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/github/ci.yml.tt
@@ -56,7 +56,7 @@ jobs:
           bundler-cache: true
 
       - name: Lint code for consistent style
-        run: bin/rubocop
+        run: bin/rubocop -f github
 <% end -%>
 
   test:


### PR DESCRIPTION
## Description

Now that Rails offers CI integration with GitHub Actions by default, it would be beneficial to utilize the RuboCop GitHub formatter. This would enable the display of linter errors as annotations in the GitHub UI.

Example:

<img width="1376" alt="Screenshot 2024-01-04 at 21 05 02" src="https://github.com/rails/rails/assets/16840674/74a890b3-4cbc-4c02-bab6-58f22e5f5f5b">
