### PR TITLE
Remove `ActionView::Renderer#render_template`

### DIFF
--- a/actionview/lib/action_view/renderer/renderer.rb
+++ b/actionview/lib/action_view/renderer/renderer.rb
@@ -45,12 +45,6 @@ module ActionView
       end
     end
 
-    # Direct access to template rendering.
-    def render_template(context, options) # :nodoc:
-      render_template_to_object(context, options).body
-    end
-
-    # Direct access to partial rendering.
     def render_partial(context, options, &block) # :nodoc:
       render_partial_to_object(context, options, &block).body
     end


### PR DESCRIPTION
### Motivation / Background
This seems to be making a pair with `#render_partial` but in reality it's no longer referred to from anywhere. Since it is marked with nodoc, I propose to get rid of it.

### Additional information
As far as I can tell from my non-comprehensive research, this method was introduced in the commit b735761,
became practically private in f984907 and unused in 1bc0a59.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
