### PR TITLE
Rename `#assert_not_has_stream` `#assert_has_no_stream`

### DIFF
--- a/actioncable/CHANGELOG.md
+++ b/actioncable/CHANGELOG.md
@@ -1,13 +1,13 @@
-*   Add two new assertion methods for ActionCable test cases: `assert_not_has_stream`
-    and `assert_not_has_stream_for`. These methods can be used to assert that a
+*   Add two new assertion methods for ActionCable test cases: `assert_has_no_stream`
+    and `assert_has_no_stream_for`. These methods can be used to assert that a
     stream has been stopped, e.g. via `stop_stream` or `stop_stream_for`. They complement
     the already existing `assert_has_stream` and `assert_has_stream_for` methods.
 
     ```ruby
-    assert_not_has_stream "messages"
-    assert_not_has_stream_for User.find(42)
+    assert_has_no_stream "messages"
+    assert_has_no_stream_for User.find(42)
     ```
 
-    *Sebastian Pöll*
+    *Sebastian Pöll*, *Junichi Sato*
 
 Please check [7-1-stable](https://github.com/rails/rails/blob/7-1-stable/actioncable/CHANGELOG.md) for previous changes.

--- a/actioncable/lib/action_cable/channel/test_case.rb
+++ b/actioncable/lib/action_cable/channel/test_case.rb
@@ -314,24 +314,24 @@ module ActionCable
 
         # Asserts that the specified stream has not been started.
         #
-        #   def test_assert_not_started_stream
+        #   def test_assert_no_started_stream
         #     subscribe
-        #     assert_not_has_stream 'messages'
+        #     assert_has_no_stream 'messages'
         #   end
         #
-        def assert_not_has_stream(stream)
+        def assert_has_no_stream(stream)
           assert subscription.streams.exclude?(stream), "Stream #{stream} has been started"
         end
 
         # Asserts that the specified stream for a model has not started.
         #
-        #   def test_assert_not_started_stream_for
+        #   def test_assert_no_started_stream_for
         #     subscribe id: 41
-        #     assert_not_has_stream_for User.find(42)
+        #     assert_has_no_stream_for User.find(42)
         #   end
         #
-        def assert_not_has_stream_for(object)
-          assert_not_has_stream(broadcasting_for(object))
+        def assert_has_no_stream_for(object)
+          assert_has_no_stream(broadcasting_for(object))
         end
 
         private

--- a/actioncable/test/channel/test_case_test.rb
+++ b/actioncable/test/channel/test_case_test.rb
@@ -111,14 +111,14 @@ class StreamsTestChannelTest < ActionCable::Channel::TestCase
     subscribe
     unsubscribe
 
-    assert_not_has_stream "test_0"
+    assert_has_no_stream "test_0"
   end
 
   def test_not_stream_with_params
     subscribe id: 42
     perform :unsubscribed, id: 42
 
-    assert_not_has_stream "test_42"
+    assert_has_no_stream "test_42"
   end
 
   def test_unsubscribe_from_stream
@@ -150,7 +150,7 @@ class StreamsForTestChannelTest < ActionCable::Channel::TestCase
     subscribe id: 42
     perform :unsubscribed, id: 42
 
-    assert_not_has_stream_for User.new(42)
+    assert_has_no_stream_for User.new(42)
   end
 end
 


### PR DESCRIPTION
### Motivation / Background
I propose to provide smoother reading experiences with the two methods introduced in https://github.com/rails/rails/pull/50585: `#assert_not_has_stream` and `#assert_not_has_stream_for`.

### Detail
Replaced `#assert_not_has_stream` with `#assert_has_no_stream`, and `#assert_not_has_stream_for` with `#assert_has_no_stream_for`.

### Additional information
How does it sound to you @SebastianPoell?

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
