### PR TITLE
Remove workaround for Ruby 2.7 at ActiveSupport::Cache#lookup_store

### DIFF
--- a/activesupport/lib/active_support/cache.rb
+++ b/activesupport/lib/active_support/cache.rb
@@ -86,13 +86,7 @@ module ActiveSupport
         case store
         when Symbol
           options = parameters.extract_options!
-          # clean this up once Ruby 2.7 support is dropped
-          # see https://github.com/rails/rails/pull/41522#discussion_r581186602
-          if options.empty?
-            retrieve_store_class(store).new(*parameters)
-          else
-            retrieve_store_class(store).new(*parameters, **options)
-          end
+          retrieve_store_class(store).new(*parameters, **options)
         when Array
           lookup_store(*store)
         when nil


### PR DESCRIPTION
### Motivation / Background
With the minimum required version 3.1, this 2.7-specific comment and condition can be got rid of.

### Additional information
Follow-up to https://github.com/rails/rails/pull/41522. cc: @ghiculescu @kamipo 

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
