### PR TITLE
Move "English" and "Oxford Comma" sections under "Wording" [ci-skip]

### DIFF
--- a/guides/source/api_documentation_guidelines.md
+++ b/guides/source/api_documentation_guidelines.md
@@ -98,13 +98,11 @@ used. Instead of:
 * his or hers... use theirs.
 * himself or herself... use themselves.
 
-English
--------
+### American English
 
 Please use American English (*color*, *center*, *modularize*, etc). See [a list of American and British English spelling differences here](https://en.wikipedia.org/wiki/American_and_British_English_spelling_differences).
 
-Oxford Comma
-------------
+### Oxford Comma
 
 Please use the [Oxford comma](https://en.wikipedia.org/wiki/Serial_comma)
 ("red, white, and blue", instead of "red, white and blue").


### PR DESCRIPTION
The "English" and "Oxford Comma" sections currently have 1 or 2 sentences, which makes it difficult to justify their own top sections.

Moving the "English" section under the "Wording" section makes sense, as we already have a "Naming" section.
As the "Wording" section also mentions punctuation, we can move the "Oxford Comma" section there as well.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
