### PR TITLE
Cleanup usage of ruby2_keywords

### DIFF
--- a/actionmailer/lib/action_mailer/base.rb
+++ b/actionmailer/lib/action_mailer/base.rb
@@ -625,17 +625,16 @@ module ActionMailer
         payload[:perform_deliveries] = mail.perform_deliveries
       end
 
-      def method_missing(method_name, *args)
-        if action_methods.include?(method_name.to_s)
-          MessageDelivery.new(self, method_name, *args)
+      def method_missing(method_name, ...)
+        if action_methods.include?(method_name.name)
+          MessageDelivery.new(self, method_name, ...)
         else
           super
         end
       end
-      ruby2_keywords(:method_missing)
 
       def respond_to_missing?(method, include_all = false)
-        action_methods.include?(method.to_s) || super
+        action_methods.include?(method.name) || super
       end
     end
 

--- a/actionmailer/lib/action_mailer/parameterized.rb
+++ b/actionmailer/lib/action_mailer/parameterized.rb
@@ -114,14 +114,13 @@ module ActionMailer
       end
 
       private
-        def method_missing(method_name, *args)
-          if @mailer.action_methods.include?(method_name.to_s)
-            ActionMailer::Parameterized::MessageDelivery.new(@mailer, method_name, @params, *args)
+        def method_missing(method_name, ...)
+          if @mailer.action_methods.include?(method_name.name)
+            ActionMailer::Parameterized::MessageDelivery.new(@mailer, method_name, @params, ...)
           else
             super
           end
         end
-        ruby2_keywords(:method_missing)
 
         def respond_to_missing?(method, include_all = false)
           @mailer.respond_to?(method, include_all)
@@ -129,11 +128,10 @@ module ActionMailer
     end
 
     class MessageDelivery < ActionMailer::MessageDelivery # :nodoc:
-      def initialize(mailer_class, action, params, *args)
-        super(mailer_class, action, *args)
+      def initialize(mailer_class, action, params, ...)
+        super(mailer_class, action, ...)
         @params = params
       end
-      ruby2_keywords(:initialize)
 
       private
         def processed_mailer

--- a/actionpack/lib/abstract_controller/base.rb
+++ b/actionpack/lib/abstract_controller/base.rb
@@ -148,7 +148,7 @@ module AbstractController
     #
     # ==== Returns
     # * <tt>self</tt>
-    def process(action, *args)
+    def process(action, ...)
       @_action_name = action.to_s
 
       unless action_name = _find_action_name(@_action_name)
@@ -157,9 +157,8 @@ module AbstractController
 
       @_response_body = nil
 
-      process_action(action_name, *args)
+      process_action(action_name, ...)
     end
-    ruby2_keywords(:process)
 
     # Delegates to the class's ::controller_path.
     def controller_path

--- a/actionpack/lib/abstract_controller/collector.rb
+++ b/actionpack/lib/abstract_controller/collector.rb
@@ -7,10 +7,9 @@ module AbstractController
     def self.generate_method_for_mime(mime)
       sym = mime.is_a?(Symbol) ? mime : mime.to_sym
       class_eval <<-RUBY, __FILE__, __LINE__ + 1
-        def #{sym}(*args, &block)
-          custom(Mime[:#{sym}], *args, &block)
+        def #{sym}(...)
+          custom(Mime[:#{sym}], ...)
         end
-        ruby2_keywords(:#{sym})
       RUBY
     end
 
@@ -23,7 +22,7 @@ module AbstractController
     end
 
   private
-    def method_missing(symbol, *args, &block)
+    def method_missing(symbol, ...)
       unless mime_constant = Mime[symbol]
         raise NoMethodError, "To respond to a custom format, register it as a MIME type first: " \
           "https://guides.rubyonrails.org/action_controller_overview.html#restful-downloads. " \
@@ -34,11 +33,10 @@ module AbstractController
 
       if Mime::SET.include?(mime_constant)
         AbstractController::Collector.generate_method_for_mime(mime_constant)
-        public_send(symbol, *args, &block)
+        public_send(symbol, ...)
       else
         super
       end
     end
-    ruby2_keywords(:method_missing)
   end
 end

--- a/actionpack/lib/abstract_controller/helpers.rb
+++ b/actionpack/lib/abstract_controller/helpers.rb
@@ -131,10 +131,9 @@ module AbstractController
           #   controller.send(:'current_user', *args, &block)
           # end
           _helpers_for_modification.class_eval <<~ruby_eval.lines.map(&:strip).join(";"), file, line
-            def #{method}(*args, &block)
-              controller.send(:'#{method}', *args, &block)
+            def #{method}(...)
+              controller.send(:'#{method}', ...)
             end
-            ruby2_keywords(:'#{method}')
           ruby_eval
         end
       end

--- a/actionpack/lib/action_dispatch/testing/assertions/routing.rb
+++ b/actionpack/lib/action_dispatch/testing/assertions/routing.rb
@@ -247,14 +247,13 @@ module ActionDispatch
       end
 
       # ROUTES TODO: These assertions should really work in an integration context
-      def method_missing(selector, *args, &block)
+      def method_missing(selector, ...)
         if defined?(@controller) && @controller && defined?(@routes) && @routes && @routes.named_routes.route_defined?(selector)
-          @controller.public_send(selector, *args, &block)
+          @controller.public_send(selector, ...)
         else
           super
         end
       end
-      ruby2_keywords(:method_missing)
 
       private
         def create_routes

--- a/actionpack/lib/action_dispatch/testing/integration.rb
+++ b/actionpack/lib/action_dispatch/testing/integration.rb
@@ -431,16 +431,15 @@ module ActionDispatch
       end
 
       # Delegate unhandled messages to the current session instance.
-      def method_missing(method, *args, &block)
+      def method_missing(method, ...)
         if integration_session.respond_to?(method)
-          integration_session.public_send(method, *args, &block).tap do
+          integration_session.public_send(method, ...).tap do
             copy_session_variables!
           end
         else
           super
         end
       end
-      ruby2_keywords(:method_missing)
     end
   end
 

--- a/actionview/lib/action_view/test_case.rb
+++ b/actionview/lib/action_view/test_case.rb
@@ -171,10 +171,9 @@ module ActionView
           # Almost a duplicate from ActionController::Helpers
           methods.flatten.each do |method|
             _helpers_for_modification.module_eval <<~end_eval, __FILE__, __LINE__ + 1
-              def #{method}(*args, &block)                    # def current_user(*args, &block)
-                _test_case.send(:'#{method}', *args, &block)  #   _test_case.send(:'current_user', *args, &block)
-              end                                             # end
-              ruby2_keywords(:'#{method}')
+              def #{method}(...)                    # def current_user(*args, &block)
+                _test_case.send(:'#{method}', ...)  #   _test_case.send(:'current_user', *args, &block)
+              end                                   # end
             end_eval
           end
         end
@@ -416,7 +415,7 @@ module ActionView
         end]
       end
 
-      def method_missing(selector, *args)
+      def method_missing(selector, ...)
         begin
           routes = @controller.respond_to?(:_routes) && @controller._routes
         rescue
@@ -426,12 +425,11 @@ module ActionView
         if routes &&
            (routes.named_routes.route_defined?(selector) ||
              routes.mounted_helpers.method_defined?(selector))
-          @controller.__send__(selector, *args)
+          @controller.__send__(selector, ...)
         else
           super
         end
       end
-      ruby2_keywords(:method_missing)
 
       def respond_to_missing?(name, include_private = false)
         begin

--- a/activemodel/lib/active_model/attribute_methods.rb
+++ b/activemodel/lib/active_model/attribute_methods.rb
@@ -66,7 +66,6 @@ module ActiveModel
 
     NAME_COMPILABLE_REGEXP = /\A[a-zA-Z_]\w*[!?=]?\z/
     CALL_COMPILABLE_REGEXP = /\A[a-zA-Z_]\w*[!?]?\z/
-    FORWARD_PARAMETERS = "*args"
 
     included do
       class_attribute :attribute_aliases, instance_writer: false, default: {}
@@ -432,10 +431,8 @@ module ActiveModel
               "send(#{call_args.join(", ")})"
             end
 
-            modifier = parameters == FORWARD_PARAMETERS ? "ruby2_keywords " : ""
-
             batch <<
-              "#{modifier}def #{mangled_name}(#{parameters || ''})" <<
+              "def #{mangled_name}(#{parameters || ''})" <<
               body <<
               "end"
           end
@@ -449,7 +446,7 @@ module ActiveModel
           def initialize(prefix: "", suffix: "", parameters: nil)
             @prefix = prefix
             @suffix = suffix
-            @parameters = parameters.nil? ? FORWARD_PARAMETERS : parameters
+            @parameters = parameters.nil? ? "..." : parameters
             @regex = /\A(?:#{Regexp.escape(@prefix)})(.*)(?:#{Regexp.escape(@suffix)})\z/
             @proxy_target = "#{@prefix}attribute#{@suffix}"
             @method_name = "#{prefix}%s#{suffix}"
@@ -477,24 +474,22 @@ module ActiveModel
     # It's also possible to instantiate related objects, so a <tt>Client</tt>
     # class belonging to the +clients+ table with a +master_id+ foreign key
     # can instantiate master through <tt>Client#master</tt>.
-    def method_missing(method, *args, &block)
+    def method_missing(method, ...)
       if respond_to_without_attributes?(method, true)
         super
       else
-        match = matched_attribute_method(method.to_s)
-        match ? attribute_missing(match, *args, &block) : super
+        match = matched_attribute_method(method.name)
+        match ? attribute_missing(match, ...) : super
       end
     end
-    ruby2_keywords(:method_missing)
 
     # +attribute_missing+ is like +method_missing+, but for attributes. When
     # +method_missing+ is called we check to see if there is a matching
     # attribute method. If so, we tell +attribute_missing+ to dispatch the
     # attribute. This method can be overloaded to customize the behavior.
-    def attribute_missing(match, *args, &block)
-      __send__(match.proxy_target, match.attr_name, *args, &block)
+    def attribute_missing(match, ...)
+      __send__(match.proxy_target, match.attr_name, ...)
     end
-    ruby2_keywords(:attribute_missing)
 
     # A +Person+ instance with a +name+ attribute can ask
     # <tt>person.respond_to?(:name)</tt>, <tt>person.respond_to?(:name=)</tt>,

--- a/activemodel/lib/active_model/type/registry.rb
+++ b/activemodel/lib/active_model/type/registry.rb
@@ -20,16 +20,15 @@ module ActiveModel
         registrations[type_name] = block
       end
 
-      def lookup(symbol, *args)
+      def lookup(symbol, ...)
         registration = registrations[symbol]
 
         if registration
-          registration.call(symbol, *args)
+          registration.call(symbol, ...)
         else
           raise ArgumentError, "Unknown type #{symbol.inspect}"
         end
       end
-      ruby2_keywords(:lookup)
 
       private
         attr_reader :registrations

--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -730,10 +730,9 @@ module ActiveRecord
         end
       end
 
-      def method_missing(name, *args, &block) # :nodoc:
-        nearest_delegate.send(name, *args, &block)
+      def method_missing(name, ...) # :nodoc:
+        nearest_delegate.send(name, ...)
       end
-      ruby2_keywords(:method_missing)
 
       def migrate(direction)
         new.migrate direction

--- a/activerecord/lib/active_record/migration/command_recorder.rb
+++ b/activerecord/lib/active_record/migration/command_recorder.rb
@@ -377,14 +377,13 @@ module ActiveRecord
         end
 
         # Forwards any missing method call to the \target.
-        def method_missing(method, *args, &block)
+        def method_missing(method, ...)
           if delegate.respond_to?(method)
-            delegate.public_send(method, *args, &block)
+            delegate.public_send(method, ...)
           else
             super
           end
         end
-        ruby2_keywords(:method_missing)
     end
   end
 end

--- a/activerecord/lib/active_record/migration/default_strategy.rb
+++ b/activerecord/lib/active_record/migration/default_strategy.rb
@@ -6,13 +6,12 @@ module ActiveRecord
     # to the connection adapter.
     class DefaultStrategy < ExecutionStrategy # :nodoc:
       private
-        def method_missing(method, *arguments, &block)
-          connection.send(method, *arguments, &block)
+        def method_missing(method, ...)
+          connection.send(method, ...)
         end
-        ruby2_keywords(:method_missing)
 
-        def respond_to_missing?(method, *)
-          connection.respond_to?(method) || super
+        def respond_to_missing?(method, include_private = false)
+          connection.respond_to?(method, include_private) || super
         end
 
         def connection

--- a/activerecord/lib/active_record/relation/delegation.rb
+++ b/activerecord/lib/active_record/relation/delegation.rb
@@ -79,10 +79,9 @@ module ActiveRecord
               end
             RUBY
           else
-            define_method(method) do |*args, &block|
-              scoping { klass.public_send(method, *args, &block) }
+            define_method(method) do |*args, **kwargs, &block|
+              scoping { klass.public_send(method, *args, **kwargs, &block) }
             end
-            ruby2_keywords(method)
           end
         end
       end
@@ -113,17 +112,16 @@ module ActiveRecord
       end
 
       private
-        def method_missing(method, *args, &block)
+        def method_missing(method, ...)
           if @klass.respond_to?(method)
             unless Delegation.uncacheable_methods.include?(method)
               @klass.generate_relation_method(method)
             end
-            scoping { @klass.public_send(method, *args, &block) }
+            scoping { @klass.public_send(method, ...) }
           else
             super
           end
         end
-        ruby2_keywords(:method_missing)
     end
 
     module ClassMethods # :nodoc:

--- a/activesupport/lib/active_support/core_ext/module/delegation.rb
+++ b/activesupport/lib/active_support/core_ext/module/delegation.rb
@@ -336,9 +336,9 @@ class Module
         #{target}.respond_to?(name) || super
       end
 
-      def method_missing(method, *args, &block)
+      def method_missing(method, ...)
         if #{target}.respond_to?(method)
-          #{target}.public_send(method, *args, &block)
+          #{target}.public_send(method, ...)
         else
           begin
             super
@@ -355,7 +355,6 @@ class Module
           end
         end
       end
-      ruby2_keywords(:method_missing)
     RUBY
   end
 end

--- a/activesupport/lib/active_support/current_attributes.rb
+++ b/activesupport/lib/active_support/current_attributes.rb
@@ -177,15 +177,14 @@ module ActiveSupport
           @current_instances_key ||= name.to_sym
         end
 
-        def method_missing(name, *args, &block)
+        def method_missing(name, ...)
           # Caches the method definition as a singleton method of the receiver.
           #
           # By letting #delegate handle it, we avoid an enclosure that'll capture args.
           singleton_class.delegate name, to: :instance
 
-          send(name, *args, &block)
+          send(name, ...)
         end
-        ruby2_keywords(:method_missing)
 
         def respond_to_missing?(name, _)
           super || instance.respond_to?(name)

--- a/activesupport/lib/active_support/testing/strict_warnings.rb
+++ b/activesupport/lib/active_support/testing/strict_warnings.rb
@@ -21,7 +21,7 @@ module ActiveSupport
       %r{/lib/mail/parsers/.*assigned but unused variable - testEof}
     )
 
-    def warn(message, *)
+    def warn(message, ...)
       return if SUPPRESSED_WARNINGS.match?(message)
 
       super
@@ -32,7 +32,6 @@ module ActiveSupport
 
       raise message
     end
-    ruby2_keywords :warn if respond_to?(:ruby2_keywords, true)
   end
 end
 

--- a/railties/lib/rails/railtie.rb
+++ b/railties/lib/rails/railtie.rb
@@ -221,14 +221,13 @@ module Rails
 
         # If the class method does not have a method, then send the method call
         # to the Railtie instance.
-        def method_missing(name, *args, &block)
+        def method_missing(name, ...)
           if !abstract_railtie? && instance.respond_to?(name)
-            instance.public_send(name, *args, &block)
+            instance.public_send(name, ...)
           else
             super
           end
         end
-        ruby2_keywords(:method_missing)
 
         # receives an instance variable identifier, set the variable value if is
         # blank and append given block to value, which will be used later in


### PR DESCRIPTION
Now that we no longer support Ruby 2.7, many `ruby2_keyword` calls can be eliminated.

The ones that are left could be eliminated but would end up substantially slower or more complicated so I left them for now.
