### PR TITLE
Document `upsert`/`upsert_all` `on_duplicate: :skip` option

### DIFF
--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -869,7 +869,9 @@ module ActiveRecord
     # Active Record's schema_cache.
     #
     # [:on_duplicate]
-    #   Configure the SQL update sentence that will be used in case of conflict.
+    #   Configure the behavior that will be used in case of conflict. Use `:skip`
+    #   to ignore any conflicts or provide a safe SQL fragment wrapped with
+    #   `Arel.sql`.
     #
     #   NOTE: If you use this option you must provide all the columns you want to update
     #   by yourself.

--- a/activerecord/test/cases/insert_all_test.rb
+++ b/activerecord/test/cases/insert_all_test.rb
@@ -893,6 +893,20 @@ class InsertAllTest < ActiveRecord::TestCase
     assert_equal "published", book.reload.status
   end
 
+  def test_upsert_all_does_nothing_with_on_duplicate_skip
+    skip unless supports_insert_on_duplicate_update? && supports_insert_conflict_target?
+
+    book = books(:rfr)
+    assert_equal "proposed", book.status
+
+    Book.upsert_all(
+      [{ name: book.name, author_id: book.author_id, status: "published" }],
+      unique_by: [:name, :author_id],
+      on_duplicate: :skip
+    )
+    assert_equal "proposed", book.reload.status
+  end
+
   def test_upsert_all_with_unique_by_fails_cleanly_for_adapters_not_supporting_insert_conflict_target
     skip if supports_insert_conflict_target?
 


### PR DESCRIPTION
### Detail

I've stumbled on this when writing an `upsert` call that must produce a `ON CONFLICT () DO NOTHING` fragment.

Using `update_only: []` didn't worked as it does update all columns on the table, but reading `InsertAll` I noticed the use of `:skip` internally that worked for this scenario, but it isn't mentioned on the public docs.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
