### PR TITLE
Update shims for older rubies

### DIFF
--- a/activesupport/lib/active_support/core_ext/range/overlap.rb
+++ b/activesupport/lib/active_support/core_ext/range/overlap.rb
@@ -4,7 +4,7 @@ class Range
   # Compare two ranges and see if they overlap each other
   #  (1..5).overlap?(4..6) # => true
   #  (1..5).overlap?(7..9) # => false
-  unless Range.method_defined?(:overlap?)
+  unless Range.method_defined?(:overlap?) # Ruby 3.3+
     def overlap?(other)
       raise TypeError unless other.is_a? Range
 

--- a/activesupport/lib/active_support/core_ext/time/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/time/calculations.rb
@@ -108,12 +108,6 @@ class Time
     subsec
   end
 
-  unless Time.method_defined?(:floor)
-    def floor(precision = 0)
-      change(nsec: 0) + subsec.floor(precision)
-    end
-  end
-
   # Returns a new Time where one or more of the elements have been changed according
   # to the +options+ parameter. The time options (<tt>:hour</tt>, <tt>:min</tt>,
   # <tt>:sec</tt>, <tt>:usec</tt>, <tt>:nsec</tt>) reset cascadingly, so if only

--- a/activesupport/lib/active_support/hash_with_indifferent_access.rb
+++ b/activesupport/lib/active_support/hash_with_indifferent_access.rb
@@ -392,14 +392,8 @@ module ActiveSupport
     end
 
     private
-      if Symbol.method_defined?(:name)
-        def convert_key(key)
-          key.kind_of?(Symbol) ? key.name : key
-        end
-      else
-        def convert_key(key)
-          key.kind_of?(Symbol) ? key.to_s : key
-        end
+      def convert_key(key)
+        key.kind_of?(Symbol) ? key.name : key
       end
 
       def convert_value(value, conversion: nil)

--- a/railties/lib/rails/command.rb
+++ b/railties/lib/rails/command.rb
@@ -23,7 +23,7 @@ module Rails
         super(message)
       end
 
-      if !Exception.method_defined?(:detailed_message)
+      if !Exception.method_defined?(:detailed_message) # Ruby 3.2+
         def detailed_message(...)
           message
         end


### PR DESCRIPTION
`Symbol#name` and `Time#floor` are now present on the minimum required version.
