### PR TITLE
Update API-only guide to remove specific app name [ci skip] 

### DIFF
--- a/guides/source/api_app.md
+++ b/guides/source/api_app.md
@@ -450,7 +450,7 @@ built (like `config/application.rb`) and pass them to your preferred middleware,
 
 ```ruby
 # This also configures session_options for use below
-config.session_store :cookie_store, key: '_interslice_session'
+config.session_store :cookie_store, key: '_your_app_session'
 
 # Required for all session management (regardless of session_store)
 config.middleware.use ActionDispatch::Cookies


### PR DESCRIPTION
The API-only guide talks about configuring a session store and uses `_interslice_session` as the key for the cookie store. I think this was an errant paste from someone's specific configuration, and should be `_your_app_session` to match the rest of Rails' guides.


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
