### PR TITLE
allow dom_id method to accept an array of records_or_classes

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   allow dom_id method to accept an array of records_or_classes
+
+    Works similarly to `cache` helper from ActionView.
+
+    *Justin Wilson*
+
 *   Add the `nonce: true` option for `stylesheet_link_tag` helper to support automatic nonce generation for Content Security Policy.
     Works the same way as `javascript_include_tag nonce: true` does.
 

--- a/actionview/lib/action_view/record_identifier.rb
+++ b/actionview/lib/action_view/record_identifier.rb
@@ -90,9 +90,25 @@ module ActionView
     #
     #   dom_id(Post.find(45), :edit) # => "edit_post_45"
     #   dom_id(Post, :custom)        # => "custom_post"
-    def dom_id(record_or_class, prefix = nil)
-      raise ArgumentError, "dom_id must be passed a record_or_class as the first argument, you passed #{record_or_class.inspect}" unless record_or_class
+    #
+    # Providing an array of records or classes will join the singular dom_ids together
+    #
+    #   dom_id([Author.find(20), Post.find(45)])             # => "author_20_post_45"
+    #   dom_id([Author.find(20), Post.find(45)], :dashboard) # => "dashboard_author_20_post_45"
+    def dom_id(records_or_classes, prefix = nil)
+      raise ArgumentError, "dom_id must be passed records_or_classes as the first argument, you passed #{records_or_classes.inspect}" unless records_or_classes
 
+      if records_or_classes.is_a?(Array)
+        parts = records_or_classes.map { |object| singular_dom_id(object) }
+        ([prefix] + parts).compact.join(JOIN)
+      else
+        singular_dom_id(records_or_classes, prefix)
+      end
+    end
+
+  private
+    # Returns a string representation of a single record or class
+    def singular_dom_id(record_or_class, prefix = nil)
       record_id = record_key_for_dom_id(record_or_class) unless record_or_class.is_a?(Class)
       if record_id
         "#{dom_class(record_or_class, prefix)}#{JOIN}#{record_id}"
@@ -101,7 +117,6 @@ module ActionView
       end
     end
 
-  private
     # Returns a string representation of the key attribute(s) that is suitable for use in an HTML DOM id.
     # This can be overwritten to customize the default generated string representation if desired.
     # If you need to read back a key from a dom_id in order to query for the underlying database record,
@@ -112,7 +127,7 @@ module ActionView
     # make sure yourself that your dom ids are valid, in case you override this method.
     def record_key_for_dom_id(record) # :doc:
       key = convert_to_model(record).to_key
-      key && key.all? ? key.join(JOIN) : nil
+      (key && key.all?) ? key.join(JOIN) : nil
     end
   end
 end

--- a/actionview/test/template/record_identifier_test.rb
+++ b/actionview/test/template/record_identifier_test.rb
@@ -30,6 +30,20 @@ class RecordIdentifierTest < ActiveSupport::TestCase
     assert_equal "#{@singular}_1", dom_id(@record)
   end
 
+  def test_dom_id_with_two_saved_records
+    @record.save
+    @second_record = Tag.new
+    @second_record.save
+    assert_equal "#{@singular}_1_tag_1", dom_id([@record, @second_record])
+  end
+
+  def test_dom_id_with_two_saved_records_and_prefix
+    @record.save
+    @second_record = Tag.new
+    @second_record.save
+    assert_equal "my_prefix_#{@singular}_1_tag_1", dom_id([@record, @second_record], "my_prefix")
+  end
+
   def test_dom_id_with_composite_primary_key_record
     record = Cpk::Book.new(id: [1, 123])
     assert_equal("cpk_book_1_123", dom_id(record))


### PR DESCRIPTION
# Context

See also: https://github.com/hotwired/turbo-rails/pull/476

[hotwired/turbo-rails/pull/476](https://github.com/hotwired/turbo-rails/pull/476) removed the ability to pass multiple ids/models to the `turbo_frame_tag` helper method. In that PR it was suggested by @skipkayhil that this ability be passed down to the `dom_id` method (which is a part of rails core) method rather than the `turbo_frame_tag` helper (which is a part of turbo-rails).

ref: https://discuss.rubyonrails.org/t/allow-dom-id-method-to-accept-multiple-ids-models/84408

# Changes

If the first argument of the `dom_id` is an array, this change will loop through each value and form a singular dom ID, then join the parts together. This change will allow turbo frame tags to accept multiple models (similar to the `cache` helper from ActionView).

```
<%= turbo_frame_tag [customer, field] do %>
  <!-- code -->
<% end %>
```

***

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.