### PR TITLE
Replace usage of `Array#&` with `Array#intersect?` for efficiency

### DIFF
--- a/actionview/lib/action_view/layouts.rb
+++ b/actionview/lib/action_view/layouts.rb
@@ -428,7 +428,7 @@ module ActionView
     end
 
     def _include_layout?(options)
-      (options.keys & [:body, :plain, :html, :inline, :partial]).empty? || options.key?(:layout)
+      !options.keys.intersect?([:body, :plain, :html, :inline, :partial]) || options.key?(:layout)
     end
   end
 end

--- a/actionview/lib/action_view/render_parser/prism_render_parser.rb
+++ b/actionview/lib/action_view/render_parser/prism_render_parser.rb
@@ -84,7 +84,7 @@ module ActionView
 
           # Here we validate that the options have the keys we expect.
           keys = options.keys
-          return if (keys & RENDER_TYPE_KEYS).empty?
+          return if !keys.intersect?(RENDER_TYPE_KEYS)
           return if (keys - ALL_KNOWN_KEYS).any?
 
           # Finally, we can return a valid set of options.

--- a/actionview/lib/action_view/rendering.rb
+++ b/actionview/lib/action_view/rendering.rb
@@ -179,7 +179,7 @@ module ActionView
           options[:partial] = action_name
         end
 
-        if (options.keys & [:partial, :file, :template]).empty?
+        if !options.keys.intersect?([:partial, :file, :template])
           options[:prefixes] ||= _prefixes
         end
 

--- a/activemodel/lib/active_model/validations/callbacks.rb
+++ b/activemodel/lib/active_model/validations/callbacks.rb
@@ -101,7 +101,7 @@ module ActiveModel
               options[:on] = Array(options[:on])
               options[:if] = [
                 ->(o) {
-                  !(options[:on] & Array(o.validation_context)).empty?
+                  options[:on].intersect?(Array(o.validation_context))
                 },
                 *options[:if]
               ]

--- a/activemodel/lib/active_model/validations/comparison.rb
+++ b/activemodel/lib/active_model/validations/comparison.rb
@@ -10,7 +10,7 @@ module ActiveModel
       include ResolveValue
 
       def check_validity!
-        unless (options.keys & COMPARE_CHECKS.keys).any?
+        unless options.keys.intersect?(COMPARE_CHECKS.keys)
           raise ArgumentError, "Expected one of :greater_than, :greater_than_or_equal_to, "\
           ":equal_to, :less_than, :less_than_or_equal_to, or :other_than option to be supplied."
         end

--- a/activesupport/lib/active_support/core_ext/module/delegation.rb
+++ b/activesupport/lib/active_support/core_ext/module/delegation.rb
@@ -227,7 +227,7 @@ class Module
           if method_object
             parameters = method_object.parameters
 
-            if (parameters.map(&:first) & [:opt, :rest, :keyreq, :key, :keyrest]).any?
+            if parameters.map(&:first).intersect?([:opt, :rest, :keyreq, :key, :keyrest])
               "..."
             else
               defn = parameters.filter_map { |type, arg| arg if type == :req }

--- a/activesupport/lib/active_support/core_ext/string/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/string/conversions.rb
@@ -22,7 +22,7 @@ class String
   def to_time(form = :local)
     parts = Date._parse(self, false)
     used_keys = %i(year mon mday hour min sec sec_fraction offset)
-    return if (parts.keys & used_keys).empty?
+    return if !parts.keys.intersect?(used_keys)
 
     now = Time.now
     time = Time.new(

--- a/activesupport/lib/active_support/duration/iso8601_parser.rb
+++ b/activesupport/lib/active_support/duration/iso8601_parser.rb
@@ -102,12 +102,12 @@ module ActiveSupport
           raise_parsing_error("is empty duration") if parts.empty?
 
           # Mixing any of Y, M, D with W is invalid.
-          if parts.key?(:weeks) && (parts.keys & DATE_COMPONENTS).any?
+          if parts.key?(:weeks) && parts.keys.intersect?(DATE_COMPONENTS)
             raise_parsing_error("mixing weeks with other date parts not allowed")
           end
 
           # Specifying an empty T part is invalid.
-          if mode == :time && (parts.keys & TIME_COMPONENTS).empty?
+          if mode == :time && !parts.keys.intersect?(TIME_COMPONENTS)
             raise_parsing_error("time part marker is present but time part is empty")
           end
 

--- a/activesupport/lib/active_support/duration/iso8601_serializer.rb
+++ b/activesupport/lib/active_support/duration/iso8601_serializer.rb
@@ -50,7 +50,7 @@ module ActiveSupport
         end
 
         def week_mixed_with_date?(parts)
-          parts.key?(:weeks) && (parts.keys & DATE_COMPONENTS).any?
+          parts.key?(:weeks) && parts.keys.intersect?(DATE_COMPONENTS)
         end
 
         def format_seconds(seconds)

--- a/activesupport/lib/active_support/logger.rb
+++ b/activesupport/lib/active_support/logger.rb
@@ -23,7 +23,7 @@ module ActiveSupport
       logdevs = loggers.map { |logger| logger.instance_variable_get(:@logdev) }
       logger_sources = logdevs.filter_map { |logdev| logdev.dev if logdev.respond_to?(:dev) }
 
-      (sources & logger_sources).any?
+      sources.intersect?(logger_sources)
     end
 
     def initialize(*args, **kwargs)


### PR DESCRIPTION
### Motivation / Background

`Array#intersect?` was introduced in Ruby 3.1.0 and it's more efficient and useful when the result of the intersection is not needed as the benchmarks in the next sections show. It's also better for clarity and readability.

https://bugs.ruby-lang.org/issues/15198

### Detail
`Array#intersect?` is equivalent to `!(a1 & a2).empty?`, this PR replaces cases like this and other similar ones where the result is only a predicate.

### Additional information

Benchmark:

```ruby
require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"

  git_source(:github) { |repo| "https://github.com/#{repo}.git" }

  gem "rails", path: "./"
  # If you want to test against edge Rails replace the previous line with this:
  # gem "rails", github: "rails/rails", branch: "main"
  gem "benchmark-ips"
end

require "active_support"

SCENARIOS = [
  [(1..100).to_a, (90..200).to_a],    # Case 1
  [("a".."m").to_a, ("j".."z").to_a], # Case 2
  [(1..100).to_a, (101..200).to_a],   # Case 3
]

SCENARIOS.each_with_index do |values, n|
  puts
  puts " Case #{n + 1} ".center(80, "=")
  puts
  Benchmark.ips do |x|
    x.report("Array#?") { !(values[0] & values[1]).empty? }
    x.report("Array#intersect?") { values[0].intersect?(values[1]) }
    x.compare!
  end
end
```

Results:

```
==================================== Case 1 ====================================

ruby 3.2.2 (2023-03-30 revision e51014f9c0) [arm64-darwin21]
Warming up --------------------------------------
             Array#?    34.221k i/100ms
    Array#intersect?    62.035k i/100ms
Calculating -------------------------------------
             Array#?    343.119k (± 1.1%) i/s -      1.745M in   5.087078s
    Array#intersect?    615.394k (± 1.1%) i/s -      3.102M in   5.040838s

Comparison:
    Array#intersect?:   615393.7 i/s
             Array#?:   343119.4 i/s - 1.79x  slower

==================================== Case 2 ====================================

ruby 3.2.2 (2023-03-30 revision e51014f9c0) [arm64-darwin21]
Warming up --------------------------------------
             Array#?   103.256k i/100ms
    Array#intersect?   185.104k i/100ms
Calculating -------------------------------------
             Array#?      1.039M (± 1.3%) i/s -      5.266M in   5.066847s
    Array#intersect?      1.873M (± 1.6%) i/s -      9.440M in   5.041740s

Comparison:
    Array#intersect?:  1872932.7 i/s
             Array#?:  1039482.4 i/s - 1.80x  slower

==================================== Case 3 ====================================

ruby 3.2.2 (2023-03-30 revision e51014f9c0) [arm64-darwin21]
Warming up --------------------------------------
             Array#?    37.070k i/100ms
    Array#intersect?    41.438k i/100ms
Calculating -------------------------------------
             Array#?    370.902k (± 0.8%) i/s -      1.891M in   5.097584s
    Array#intersect?    409.902k (± 1.0%) i/s -      2.072M in   5.055185s

Comparison:
    Array#intersect?:   409901.8 i/s
             Array#?:   370902.3 i/s - 1.11x  slower
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
