### PR TITLE
Don't fail for uploads with content-type parameters in the ActiveStorage::DiskController

### DIFF
--- a/actionpack/lib/action_dispatch/http/mime_type.rb
+++ b/actionpack/lib/action_dispatch/http/mime_type.rb
@@ -163,7 +163,7 @@ module Mime
 
       def lookup(string)
         # fallback to the media-type without parameters if it was not found
-        LOOKUP[string] || LOOKUP[string.split(";", 2)[0]&.rstrip] || Type.new(string)
+        LOOKUP[string] || LOOKUP[string&.split(";", 2)&.first&.rstrip] || Type.new(string)
       end
 
       def lookup_by_extension(extension)

--- a/actionpack/test/dispatch/mime_type_test.rb
+++ b/actionpack/test/dispatch/mime_type_test.rb
@@ -254,6 +254,10 @@ class MimeTypeTest < ActiveSupport::TestCase
     end
 
     assert_raises Mime::Type::InvalidMimeType do
+      Mime::Type.lookup(nil)
+    end
+
+    assert_raises Mime::Type::InvalidMimeType do
       Timeout.timeout(1) do # Shouldn't take more than 1s
         Mime::Type.new("text/html ;0 ;0 ;0 ;0 ;0 ;0 ;0 ;0 ;0 ;0 ;0 ;0 ;0 ;0 ;0 ;0 ;0 ;0;")
       end

--- a/activestorage/app/controllers/active_storage/disk_controller.rb
+++ b/activestorage/app/controllers/active_storage/disk_controller.rb
@@ -30,7 +30,7 @@ class ActiveStorage::DiskController < ActiveStorage::BaseController
     else
       head :not_found
     end
-  rescue ActiveStorage::IntegrityError
+  rescue ActiveStorage::IntegrityError, Mime::Type::InvalidMimeType
     head :unprocessable_entity
   end
 
@@ -52,6 +52,6 @@ class ActiveStorage::DiskController < ActiveStorage::BaseController
     end
 
     def acceptable_content?(token)
-      token[:content_type] == request.content_mime_type && token[:content_length] == request.content_length
+      Mime::Type.lookup(token[:content_type]) == request.content_mime_type && token[:content_length] == request.content_length
     end
 end


### PR DESCRIPTION
Fixes #50600 by parsing the string content-type before comparing it to the `Mime::Type`. This comparison will ignore the parameters.

@alexandergitter I added you as co-author for the reproduction test case.