### PR TITLE
Use the article "an" for "SQL"

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb
@@ -247,7 +247,7 @@ module ActiveRecord
 
         def warn_quote_duration_deprecated
           ActiveRecord.deprecator.warn(<<~MSG)
-            Using ActiveSupport::Duration as an interpolated bind parameter in a SQL
+            Using ActiveSupport::Duration as an interpolated bind parameter in an SQL
             string template is deprecated. To avoid this warning, you should explicitly
             convert the duration to a more specific database type. For example, if you
             want to use a duration as an integer number of seconds:

--- a/activerecord/lib/active_record/sanitization.rb
+++ b/activerecord/lib/active_record/sanitization.rb
@@ -17,7 +17,7 @@ module ActiveRecord
       #   sanitize_sql_for_conditions(["name='%s' and group_id='%s'", "foo'bar", 4])
       #   # => "name='foo''bar' and group_id='4'"
       #
-      # This method will NOT sanitize a SQL string since it won't contain
+      # This method will NOT sanitize an SQL string since it won't contain
       # any conditions in it and will return the string as is.
       #
       #   sanitize_sql_for_conditions("name='foo''bar' and group_id='4'")
@@ -52,7 +52,7 @@ module ActiveRecord
       #   Post.sanitize_sql_for_assignment({ name: nil, group_id: 4 })
       #   # => "`posts`.`name` = NULL, `posts`.`group_id` = 4"
       #
-      # This method will NOT sanitize a SQL string since it won't contain
+      # This method will NOT sanitize an SQL string since it won't contain
       # any conditions in it and will return the string as is.
       #
       #   sanitize_sql_for_assignment("name=NULL and group_id='4'")

--- a/guides/source/7_1_release_notes.md
+++ b/guides/source/7_1_release_notes.md
@@ -649,7 +649,7 @@ Please refer to the [Changelog][active-record] for detailed changes.
 
 *   Deprecate `config.active_record.suppress_multiple_database_warning`.
 
-*   Deprecate using `ActiveSupport::Duration` as an interpolated bind parameter in a SQL
+*   Deprecate using `ActiveSupport::Duration` as an interpolated bind parameter in an SQL
     string template.
 
 *   Deprecate `all_connection_pools` and make `connection_pool_list` more explicit.

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -1050,7 +1050,7 @@ Controls whether migrations are numbered with serial integers or with timestamps
 
 #### `config.active_record.db_warnings_action`
 
-Controls the action to be taken when a SQL query produces a warning. The following options are available:
+Controls the action to be taken when an SQL query produces a warning. The following options are available:
 
   * `:ignore` - Database warnings will be ignored. This is the default.
 

--- a/guides/source/security.md
+++ b/guides/source/security.md
@@ -674,7 +674,7 @@ Instead of passing a string, you can use positional handlers to sanitize tainted
 Model.where("zip_code = ? AND quantity >= ?", entered_zip_code, entered_quantity).first
 ```
 
-The first parameter is a SQL fragment with question marks. The second and third
+The first parameter is an SQL fragment with question marks. The second and third
 parameter will replace the question marks with the value of the variables.
 
 You can also use named handlers, the values will be taken from the hash used:
@@ -708,7 +708,7 @@ The most common entry points are message posts, user comments, and guest books, 
 
 XSS attacks work like this: An attacker injects some code, the web application saves it and displays it on a page, later presented to a victim. Most XSS examples simply display an alert box, but it is more powerful than that. XSS can steal the cookie, hijack the session, redirect the victim to a fake website, display advertisements for the benefit of the attacker, change elements on the website to get confidential information or install malicious software through security holes in the web browser.
 
-During the second half of 2007, there were 88 vulnerabilities reported in Mozilla browsers, 22 in Safari, 18 in IE, and 12 in Opera. The Symantec Global Internet Security threat report also documented 239 browser plug-in vulnerabilities in the last six months of 2007. [Mpack](https://www.pandasecurity.com/en/mediacenter/malware/mpack-uncovered/) is a very active and up-to-date attack framework which exploits these vulnerabilities. For criminal hackers, it is very attractive to exploit a SQL-Injection vulnerability in a web application framework and insert malicious code in every textual table column. In April 2008 more than 510,000 sites were hacked like this, among them the British government, United Nations, and many more high profile targets.
+During the second half of 2007, there were 88 vulnerabilities reported in Mozilla browsers, 22 in Safari, 18 in IE, and 12 in Opera. The Symantec Global Internet Security threat report also documented 239 browser plug-in vulnerabilities in the last six months of 2007. [Mpack](https://www.pandasecurity.com/en/mediacenter/malware/mpack-uncovered/) is a very active and up-to-date attack framework which exploits these vulnerabilities. For criminal hackers, it is very attractive to exploit an SQL-Injection vulnerability in a web application framework and insert malicious code in every textual table column. In April 2008 more than 510,000 sites were hacked like this, among them the British government, United Nations, and many more high profile targets.
 
 #### HTML/JavaScript Injection
 


### PR DESCRIPTION
### Motivation / Background
This Pull Request has been created because  the documentation guidelines favor the use of "an" for "SQL" and there are a handful of instances which go against it.

### Detail
> Use the article "an" for "SQL", as in "an SQL statement". Also "an SQLite database".

https://guides.rubyonrails.org/api_documentation_guidelines.html.

So I followed it.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
