### PR TITLE
Replace "Return" with "Returns" in API documentations

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -475,8 +475,7 @@ module ActiveRecord
         @available.num_waiting
       end
 
-      # Return connection pool's usage statistic
-      # Example:
+      # Returns the connection pool's usage statistic.
       #
       #    ActiveRecord::Base.connection_pool.stat # => { size: 15, connections: 1, busy: 1, dead: 0, idle: 0, waiting: 0, checkout_timeout: 5 }
       def stat

--- a/activerecord/lib/active_record/connection_handling.rb
+++ b/activerecord/lib/active_record/connection_handling.rb
@@ -256,7 +256,7 @@ module ActiveRecord
 
     attr_writer :connection_specification_name
 
-    # Return the connection specification name from the current class or its parent.
+    # Returns the connection specification name from the current class or its parent.
     def connection_specification_name
       if @connection_specification_name.nil?
         return self == Base ? Base.name : superclass.connection_specification_name


### PR DESCRIPTION
### Motivation / Background
The guidelines are explicit about how we should start sentences with "Returns" rather than "Return." So these instances should follow that way.

### Additional information
See also the enhancements made at https://github.com/rails/rails/pull/50595.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
