### PR TITLE
Add support for MSSQLServer on the CI

### DIFF
--- a/railties/lib/rails/generators/database.rb
+++ b/railties/lib/rails/generators/database.rb
@@ -61,8 +61,9 @@ module Rails
 
       def build_package_for_database(database = options[:database])
         case database
-        when "mysql" then "default-libmysqlclient-dev"
+        when "mysql"      then "default-libmysqlclient-dev"
         when "postgresql" then "libpq-dev"
+        when "sqlserver"  then "freetds-dev"
         else nil
         end
       end

--- a/railties/lib/rails/generators/rails/app/templates/github/ci.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/github/ci.yml.tt
@@ -88,6 +88,14 @@ jobs:
         ports:
           - 5432:5432
         options: --health-cmd="pg_isready" --health-interval=10s --health-timeout=5s --health-retries=3
+      <%- elsif options[:database] == "sqlserver" -%>
+      sqlserver:
+        image: mcr.microsoft.com/mssql/server:2022-latest
+        env:
+          ACCEPT_EULA: Y
+          MSSQL_SA_PASSWORD: SecurePass1!
+        ports:
+          - 1433:1433
       <%- end -%>
 
       # redis:
@@ -117,6 +125,8 @@ jobs:
           DATABASE_URL: mysql2://127.0.0.1:3306
           <%- elsif options[:database] == "postgresql" -%>
           DATABASE_URL: postgres://postgres:postgres@localhost:5432
+          <%- elsif options[:database] == "sqlserver" -%>
+          DATABASE_URL: "sqlserver://sa:SecurePass1!@localhost:1433"
           <%- end -%>
           # REDIS_URL: redis://localhost:6379/0
         run: bin/rails db:setup test test:system


### PR DESCRIPTION
If app uses MSSQL Server we can configure Github CI to use sql server for the tests.
Here is the [link to working CI](https://github.com/dixpac/demo_ms/actions/runs/7433034257) that uses same config
