### PR TITLE
Use new rake task `test:all`

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/github/ci.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/github/ci.yml.tt
@@ -119,7 +119,7 @@ jobs:
           DATABASE_URL: postgres://postgres:postgres@localhost:5432
           <%- end -%>
           # REDIS_URL: redis://localhost:6379/0
-        run: bin/rails db:setup test test:system
+        run: bin/rails db:setup test:all
 
       - name: Keep screenshots from failed system tests
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
I think we can use [test:all](https://github.com/rails/rails/pull/39221) for the default CI config