### PR TITLE
Fix extra blank line when adding rubocop-rails-omakase and brakeman

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
@@ -37,14 +37,14 @@ group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri <%= bundler_windows_platforms %> ]
 <%- unless options.skip_brakeman? -%>
+
   # Static analysis for security vulnerabilities [https://brakemanscanner.org/]
   gem "brakeman", require: false
-
 <%- end -%>
 <%- unless options.skip_rubocop? -%>
+
   # Omakase Ruby styling [https://github.com/rails/rubocop-rails-omakase/]
   gem "rubocop-rails-omakase", require: false
-
 <%- end -%>
 end
 <% end -%>


### PR DESCRIPTION
### Motivation / Background

An extra blank line is creating in gemfile, when adding `rubocop-rails-omakase` and `brakeman` gem by default for new rails applications.

![Screenshot 2024-01-07 at 12 56 17 PM](https://github.com/rails/rails/assets/22231095/2a87c3e7-e2e3-4be3-a589-0ffbe7d544a5)

### Detail

This Pull Request removes the extra blank lines from gemfile, when creating new rails applications.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
