### PR TITLE
Update docker-entrypoint template to avoid failing container restarts

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/docker-entrypoint.tt
+++ b/railties/lib/rails/generators/rails/app/templates/docker-entrypoint.tt
@@ -1,5 +1,8 @@
 #!/bin/bash -e
 
+# Remove PID in case of restart after container crash
+rm -f /rails/tmp/pids/server.pid
+
 <% unless skip_active_record? -%>
 # If running the rails server then create or migrate existing database
 if [ "${1}" == "./bin/rails" ] && [ "${2}" == "server" ]; then


### PR DESCRIPTION

### Motivation / Background

Rails provides great templates for running applications with Docker. However, when running Rails apps with the default `docker-entrypoint`, containers may fail to restart if they crashed (e.g. because of OOM). This is becuase the `/rails/tmp/pids/server.pid` file is already present. 

Such failed containers will require manual intervention (e.g. remove the faulty container) to get up-and-running again. To allow containers to restart the server.pid file must be removed on container start. 

This Pull Request has been created to incorporate this improvement into the default `docker-entrypoint` template.   

### Detail

This Pull Request changes the `docker-entrypoint` template used when generating a new Rails application. A new line to remove any existing server PID files has been added. 
```bash
rm -f /rails/tmp/pids/server.pid
```
The `-f` flag is required to avoid failing the command if the file is not present (as should be the case for any new container).

### Additional information

The abovementioned issue can be reproduced by running a Rails application container, killing it, and trying to start the same container again. I'd be happy to create a separate bug report if additional details or reproduction steps are required.

```bash
# Start container
docker run -p 3000:3000 --name rails-demo -e RAILS_ENV=production -e RAILS_MASTER_KEY=key rails-demo:latest
# Kill from separate terminal
docker kill --signal=9 rails-demo
# Try restarting the container
docker start -a rails-demo
W, [2024-01-07T13:22:14.105941 #7]  WARN -- : You are running SQLite in production, this is generally not recommended. You can disable this warning by setting "config.active_record.sqlite3_production_warning=false".
=> Booting Puma
=> Rails 7.1.2 application starting in production
=> Run `bin/rails server --help` for more startup options
Exiting
A server is already running (pid: 1, file: /rails/tmp/pids/server.pid).
```

There is no alternative solution that I know of. I can't think of any side effects caused by removing the server.pid file if its present either. After all, containers are _supposed_ to be ephermal, and the file should actually never be there in the first place.

The fix proposed in this PR is commonplace see for example [GitHub discussion](https://github.com/docker/compose/issues/1393) or [the Entrypoint for httpd default image](https://github.com/docker-library/httpd/blob/7ef8528047b6d344b32009572b9b61285c30e73a/2.4/httpd-foreground#L5).
