### PR TITLE
Add default svg icon in generated application layout

### DIFF
--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -489,6 +489,7 @@ module Rails
           remove_file "public/426.html"
           remove_file "public/500.html"
           remove_file "public/icon.png"
+          remove_file "public/icon.svg"
         end
       end
 

--- a/railties/lib/rails/generators/rails/app/templates/app/views/layouts/application.html.erb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/app/views/layouts/application.html.erb.tt
@@ -12,7 +12,7 @@
     <link rel="manifest" href="/manifest.json">
     <link rel="icon" href="/icon.png" type="image/png">
     <link rel="icon" href="/icon.svg" type="image/svg+xml">
-    <link rel="apple-touch-icon" href="/icon.png" sizes="512x512">
+    <link rel="apple-touch-icon" href="/icon.png">
     <%- if options[:skip_hotwire] || options[:skip_javascript] -%>
     <%%= stylesheet_link_tag "application" %>
     <%- else -%>

--- a/railties/lib/rails/generators/rails/app/templates/app/views/layouts/application.html.erb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/app/views/layouts/application.html.erb.tt
@@ -11,6 +11,7 @@
 
     <link rel="manifest" href="/manifest.json">
     <link rel="icon" href="/icon.png" type="image/png">
+    <link rel="icon" href="/icon.svg" type="image/svg+xml">
     <link rel="apple-touch-icon" href="/icon.png" sizes="512x512">
     <%- if options[:skip_hotwire] || options[:skip_javascript] -%>
     <%%= stylesheet_link_tag "application" %>

--- a/railties/lib/rails/generators/rails/app/templates/public/icon.svg
+++ b/railties/lib/rails/generators/rails/app/templates/public/icon.svg
@@ -1,0 +1,3 @@
+<svg width="100" height="100" xmlns="http://www.w3.org/2000/svg">
+  <rect width="100%" height="100%" fill="red"/>
+</svg>

--- a/railties/test/generators/api_app_generator_test.rb
+++ b/railties/test/generators/api_app_generator_test.rb
@@ -183,6 +183,7 @@ class ApiAppGeneratorTest < Rails::Generators::TestCase
          public/426.html
          public/500.html
          public/icon.png
+         public/icon.svg
       )
     end
 end


### PR DESCRIPTION
SVG icon is supported by Chrome/Firefox. So prefer that over PNG. That'll give new applications the full recommended set of options.