### PR TITLE
Fix links to master branches renamed to main [ci-skip]

### DIFF
--- a/actionpack/lib/action_dispatch/http/permissions_policy.rb
+++ b/actionpack/lib/action_dispatch/http/permissions_policy.rb
@@ -85,7 +85,7 @@ module ActionDispatch # :nodoc:
     }.freeze
 
     # List of available permissions can be found at
-    # https://github.com/w3c/webappsec-permissions-policy/blob/master/features.md#policy-controlled-features
+    # https://github.com/w3c/webappsec-permissions-policy/blob/main/features.md#policy-controlled-features
     DIRECTIVES = {
       accelerometer:        "accelerometer",
       ambient_light_sensor: "ambient-light-sensor",

--- a/guides/source/4_1_release_notes.md
+++ b/guides/source/4_1_release_notes.md
@@ -66,7 +66,7 @@ Spring is running:
 ```
 
 Have a look at the
-[Spring README](https://github.com/rails/spring/blob/master/README.md) to
+[Spring README](https://github.com/rails/spring/blob/main/README.md) to
 see all available features.
 
 See the [Upgrading Ruby on Rails](upgrading_ruby_on_rails.html#spring)

--- a/guides/source/active_storage_overview.md
+++ b/guides/source/active_storage_overview.md
@@ -290,7 +290,7 @@ google:
   gsa_email: "foobar@baz.iam.gserviceaccount.com"
 ```
 
-Add the [`google-cloud-storage`](https://github.com/GoogleCloudPlatform/google-cloud-ruby/tree/master/google-cloud-storage) gem to your `Gemfile`:
+Add the [`google-cloud-storage`](https://github.com/GoogleCloudPlatform/google-cloud-ruby/tree/main/google-cloud-storage) gem to your `Gemfile`:
 
 ```ruby
 gem "google-cloud-storage", "~> 1.11", require: false

--- a/guides/source/asset_pipeline.md
+++ b/guides/source/asset_pipeline.md
@@ -1023,7 +1023,7 @@ Making Your Library or Gem a Pre-Processor
 
 Sprockets uses Processors, Transformers, Compressors, and Exporters to extend
 Sprockets functionality. Have a look at
-[Extending Sprockets](https://github.com/rails/sprockets/blob/master/guides/extending_sprockets.md)
+[Extending Sprockets](https://github.com/rails/sprockets/blob/main/guides/extending_sprockets.md)
 to learn more. Here we registered a preprocessor to add a comment to the end
 of text/css (`.css`) files.
 

--- a/guides/source/testing.md
+++ b/guides/source/testing.md
@@ -1693,7 +1693,7 @@ assert_select "ol" do
 end
 ```
 
-This assertion is quite powerful. For more advanced usage, refer to its [documentation](https://github.com/rails/rails-dom-testing/blob/master/lib/rails/dom/testing/assertions/selector_assertions.rb).
+This assertion is quite powerful. For more advanced usage, refer to its [documentation](https://github.com/rails/rails-dom-testing/blob/main/lib/rails/dom/testing/assertions/selector_assertions.rb).
 
 ### Additional View-Based Assertions
 


### PR DESCRIPTION
We recently had [two][1] [PRs][2] to update these types of links, so this commit does all of the rest (remaining links to master branches were checked and still exist).

[1]: https://github.com/rails/rails/commit/e76c52a939dd7312fb9fd22b08e13496dc5c961e
[2]: https://github.com/rails/rails/commit/71fefdfae552fc642b2decb97864f6f5ca16ba00