### PR TITLE
Update link for creating a gem [ci-skip]

### DIFF
--- a/guides/source/plugins.md
+++ b/guides/source/plugins.md
@@ -524,6 +524,6 @@ $ bundle exec rake rdoc
 
 ### References
 
-* [Developing a RubyGem using Bundler](https://github.com/radar/guides/blob/master/gem-development.md)
+* [Developing a RubyGem using Bundler](https://bundler.io/guides/creating_gem.html)
 * [Using .gemspecs as Intended](https://yehudakatz.com/2010/04/02/using-gemspecs-as-intended/)
 * [Gemspec Reference](https://guides.rubygems.org/specification-reference/)


### PR DESCRIPTION
[The old link points to this new page][1]

[1]: https://github.com/radar/guides/commit/eaaf139b440fd2d54ad54a3dc1732942ff8b22c0
