### PR TITLE
Make `group`/`regroup` inside `merge` be applied to the merged relation

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,19 @@
+*   Make `group`/`regroup` inside `merge` be applied to the merged relation instead of the outermost relation.
+
+    ```ruby
+    Product.joins(:items).group(:id).merge(Item.group(:id))
+    # SELECT "products".* FROM "products"
+    # INNER JOIN "items" ON "items"."product_id" = "products"."id"
+    # GROUP BY "products"."id", "items"."id"
+
+    Product.joins(:items).group(:id).merge(Item.group(:title).regroup(:id))
+    # SELECT "products".* FROM "products"
+    # INNER JOIN "items" ON "items"."product_id" = "products"."id"
+    # GROUP BY "products"."id", "items"."id"
+    ```
+
+    *João Marcos S B de Moraes*
+
 *   Fix single quote escapes on default generated MySQL columns
 
     MySQL 5.7.5+ supports generated columns, which can be used to create a column that is computed from an expression.

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -54,7 +54,7 @@ module ActiveRecord
     MULTI_VALUE_METHODS  = [:includes, :eager_load, :preload, :select, :group,
                             :order, :joins, :left_outer_joins, :references,
                             :extending, :unscope, :optimizer_hints, :annotate,
-                            :with]
+                            :with, :raw_group]
 
     SINGLE_VALUE_METHODS = [:limit, :offset, :lock, :readonly, :reordering, :strict_loading,
                             :reverse_order, :distinct, :create_with, :skip_query_cache]
@@ -589,9 +589,8 @@ module ActiveRecord
       arel = eager_loading? ? apply_join_dependency.arel : build_arel
       arel.source.left = table
 
-      group_values_arel_columns = arel_columns(group_values.uniq)
       having_clause_ast = having_clause.ast unless having_clause.empty?
-      stmt = arel.compile_update(values, table[primary_key], having_clause_ast, group_values_arel_columns)
+      stmt = arel.compile_update(values, table[primary_key], having_clause_ast, group_values)
       klass.connection.update(stmt, "#{klass} Update All").tap { reset }
     end
 
@@ -722,9 +721,8 @@ module ActiveRecord
       arel = eager_loading? ? apply_join_dependency.arel : build_arel
       arel.source.left = table
 
-      group_values_arel_columns = arel_columns(group_values.uniq)
       having_clause_ast = having_clause.ast unless having_clause.empty?
-      stmt = arel.compile_delete(table[primary_key], having_clause_ast, group_values_arel_columns)
+      stmt = arel.compile_delete(table[primary_key], having_clause_ast, group_values)
 
       klass.connection.delete(stmt, "#{klass} Delete All").tap { reset }
     end

--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -490,7 +490,7 @@ module ActiveRecord
       end
 
       def execute_grouped_calculation(operation, column_name, distinct) # :nodoc:
-        group_fields = group_values
+        group_fields = raw_group_values
         group_fields = group_fields.uniq if group_fields.size > 1
 
         if group_fields.size == 1 && group_fields.first.respond_to?(:to_sym)
@@ -526,7 +526,7 @@ module ActiveRecord
         }
 
         relation = except(:group).distinct!(false)
-        relation.group_values  = group_fields
+        relation.group_values  = associated ? group_fields : group_values
         relation.select_values = select_values
 
         result = skip_query_cache_if_necessary { @klass.connection.select_all(relation.arel, "#{@klass.name} #{operation.capitalize}", async: @async) }

--- a/activerecord/lib/active_record/relation/merger.rb
+++ b/activerecord/lib/active_record/relation/merger.rb
@@ -54,7 +54,8 @@ module ActiveRecord
       NORMAL_VALUES = Relation::VALUE_METHODS - Relation::CLAUSE_METHODS -
                       [
                         :select, :includes, :preload, :joins, :left_outer_joins,
-                        :order, :reverse_order, :lock, :create_with, :reordering
+                        :order, :reverse_order, :lock, :create_with, :reordering,
+                        :group, :raw_group
                       ]
 
       def merge
@@ -161,6 +162,11 @@ module ActiveRecord
           elsif other.order_values.any?
             # merge in order_values from relation
             relation.order!(*other.order_values)
+          end
+
+          if other.group_values.any?
+            relation.only_group!(*other.group_values)
+            relation.raw_group!(*other.raw_group_values) if other.raw_group_values.any?
           end
 
           extensions = other.extensions - relation.extensions

--- a/activerecord/test/cases/calculations_test.rb
+++ b/activerecord/test/cases/calculations_test.rb
@@ -207,6 +207,40 @@ class CalculationsTest < ActiveRecord::TestCase
     assert_equal expected, accounts.merge!(accounts).minimum(:credit_limit)
   end
 
+  def test_regroup_by_multiple_same_field
+    accounts = Account.regroup(:firm_id)
+
+    expected = {
+      nil => 50,
+      1 => 50,
+      2 => 60,
+      6 => 105,
+      9 => 53
+    }
+    assert_equal expected, accounts.sum(:credit_limit)
+    assert_equal expected, accounts.merge!(accounts).uniq!(:regroup).sum(:credit_limit)
+
+    expected = {
+      nil => 50,
+      1 => 50,
+      2 => 60,
+      6 => 55,
+      9 => 53
+    }
+
+    assert_equal expected, accounts.merge!(accounts).maximum(:credit_limit)
+
+    expected = {
+      nil => 50,
+      1 => 50,
+      2 => 60,
+      6 => 50,
+      9 => 53
+    }
+
+    assert_equal expected, accounts.merge!(accounts).minimum(:credit_limit)
+  end
+
   def test_should_generate_valid_sql_with_joins_and_group
     assert_nothing_raised do
       AuditLog.joins(:developer).group(:id).count

--- a/activerecord/test/cases/relation/mutation_test.rb
+++ b/activerecord/test/cases/relation/mutation_test.rb
@@ -5,7 +5,7 @@ require "models/post"
 
 module ActiveRecord
   class RelationMutationTest < ActiveRecord::TestCase
-    (Relation::MULTI_VALUE_METHODS - [:extending, :order, :unscope, :select]).each do |method|
+    (Relation::MULTI_VALUE_METHODS - [:extending, :order, :unscope, :select, :group, :raw_group]).each do |method|
       test "##{method}!" do
         assert relation.public_send("#{method}!", :foo).equal?(relation)
         assert_equal [:foo], relation.public_send("#{method}_values")

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -2446,7 +2446,7 @@ class RelationTest < ActiveRecord::TestCase
     assert_empty authors
   end
 
-  (ActiveRecord::Relation::MULTI_VALUE_METHODS - [:extending, :with]).each do |method|
+  (ActiveRecord::Relation::MULTI_VALUE_METHODS - [:extending, :with, :raw_group]).each do |method|
     test "#{method} with blank value" do
       authors = Author.public_send(method, [""])
       assert_empty authors.public_send(:"#{method}_values")


### PR DESCRIPTION
### Motivation / Background

When using `group` inside `merge`, the `group` is applied to the outermost relation instead of the merged relation, which is unexpected. The same is true for `regroup`.

### Detail

Now, `group` inside `merge` is applied to the merged relation, as intended. The behavior was changed for `regroup` as well, and documented.

Before:

```rb
Product.joins(:items).group(:id).merge(Item.group(:title))
# SELECT "products".* FROM "products"
# INNER JOIN "items" ON "items"."product_id" = "products"."id"
# GROUP BY "products"."id", "products"."title"

Product.joins(:items).group(:id).merge(Item.group(:title).regroup(:id))
# SELECT "products".* FROM "products"
# INNER JOIN "items" ON "items"."product_id" = "products"."id"
# GROUP BY "products"."id"

Product.joins(:items).group(:id).merge(Item.group(:title).regroup(:id)).regroup(:title)
# SELECT "products".* FROM "products"
# INNER JOIN "items" ON "items"."product_id" = "products"."id"
# GROUP BY "products"."title"
```

After:
```rb
Product.joins(:items).group(:id).merge(Item.group(:title))
# SELECT "products".* FROM "products"
# INNER JOIN "items" ON "items"."product_id" = "products"."id"
# GROUP BY "products"."id", "items"."title"

Product.joins(:items).group(:id).merge(Item.group(:title).regroup(:id))
# SELECT "products".* FROM "products"
# INNER JOIN "items" ON "items"."product_id" = "products"."id"
# GROUP BY "products"."id", "items"."id"

Product.joins(:items).group(:id).merge(Item.group(:title).regroup(:id)).regroup(:title)
# SELECT "products".* FROM "products"
# INNER JOIN "items" ON "items"."product_id" = "products"."id"
# GROUP BY "products"."title"
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
