### PR TITLE
Fix view runtime for controllers with async queries

### DIFF
--- a/activerecord/lib/active_record/railties/controller_runtime.rb
+++ b/activerecord/lib/active_record/railties/controller_runtime.rb
@@ -37,9 +37,10 @@ module ActiveRecord
             db_rt_before_render = ActiveRecord::RuntimeRegistry.reset
             self.db_runtime = (db_runtime || 0) + db_rt_before_render
             runtime = super
+            queries_rt = ActiveRecord::RuntimeRegistry.sql_runtime - ActiveRecord::RuntimeRegistry.async_sql_runtime
             db_rt_after_render = ActiveRecord::RuntimeRegistry.reset
             self.db_runtime += db_rt_after_render
-            runtime - db_rt_after_render
+            runtime - queries_rt
           else
             super
           end

--- a/activerecord/lib/active_record/runtime_registry.rb
+++ b/activerecord/lib/active_record/runtime_registry.rb
@@ -17,13 +17,26 @@ module ActiveRecord
       ActiveSupport::IsolatedExecutionState[:active_record_sql_runtime] = runtime
     end
 
+    def async_sql_runtime
+      ActiveSupport::IsolatedExecutionState[:active_record_async_sql_runtime] ||= 0.0
+    end
+
+    def async_sql_runtime=(runtime)
+      ActiveSupport::IsolatedExecutionState[:active_record_async_sql_runtime] = runtime
+    end
+
     def reset
       rt, self.sql_runtime = sql_runtime, 0.0
+      self.async_sql_runtime = 0.0
       rt
     end
   end
 end
 
 ActiveSupport::Notifications.monotonic_subscribe("sql.active_record") do |name, start, finish, id, payload|
-  ActiveRecord::RuntimeRegistry.sql_runtime += (finish - start)
+  runtime = finish - start
+  if payload[:async]
+    ActiveRecord::RuntimeRegistry.async_sql_runtime += (runtime - payload[:lock_wait])
+  end
+  ActiveRecord::RuntimeRegistry.sql_runtime += runtime
 end


### PR DESCRIPTION
Currently, when there are async queries inside the controller, we get a negative view runtime reported. Something like
```
Completed 200 OK in 1151ms (Views: -500.2ms | ActiveRecord: 1088.3ms | Allocations: 18532)
```

To reproduce, add something like this to the controller's action:
```ruby
@users = User.select("pg_sleep(1)").load_async
sleep(0.5)
```

That is because when a query is executed in a separate thread, we increment the db runtime for the query https://github.com/rails/rails/blob/7f341134caaba5def74ef30cc5fc646289cb3637/activerecord/lib/active_record/runtime_registry.rb#L27-L29 Even though the time spent inside the view for the query is less than that. 
This way, we get a db execution time larger than the view rendering time (even though that queries are executed as part of the view rendering) and when we subtract them to get just the view rendering time here https://github.com/rails/rails/blob/7f341134caaba5def74ef30cc5fc646289cb3637/activerecord/lib/active_record/railties/controller_runtime.rb#L42 we get a negative value.

In reality, we should subtract the time spent for queries inside the main thread, not the time spent executing the query inside the database.

cc @byroot (as implementor of async features)   