### PR TITLE
Add `oven-sh/setup-bun` to GitHub CI when generating an app with bun

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Use `oven-sh/setup-bun` in GitHub CI when generating an app with bun
+
+    *TangRufus*
+
 *   Disable `pidfile` generation in production environment.
 
     *Hans Schnedlitz*

--- a/railties/lib/rails/generators/rails/app/templates/github/ci.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/github/ci.yml.tt
@@ -109,6 +109,12 @@ jobs:
         with:
           ruby-version: .ruby-version
           bundler-cache: true
+      <%- if using_bun? -%>
+
+      - uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: <%= dockerfile_bun_version %>
+      <%- end -%>
 
       - name: Run tests
         env:


### PR DESCRIPTION
### Motivation / Background

When generating an app with bun, GitHub CI test fails with `Command install failed, ensure bun is installed`.

### Detail

This Pull Request adds `oven-sh/setup-bun` to `ci.yml` when generating an app with bun.

### Additional information

See also: 

- https://bun.sh/guides/runtime/cicd
- https://github.com/rails/rails/issues/50502

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
