### PR TITLE
Bump libxml-ruby

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -310,7 +310,7 @@ GEM
       activesupport (>= 6.0.0)
       redis (>= 4.2, < 6)
     language_server-protocol (3.17.0.3)
-    libxml-ruby (4.1.2)
+    libxml-ruby (5.0.0)
     listen (3.8.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)


### PR DESCRIPTION
This fixes bundle install when using libxml2 2.12.0

<details><summary>Sample installation log</summary>
<p>

```
Installing libxml-ruby 4.1.2 with native extensions
Gem::Ext::BuildError: ERROR: Failed to build gem native extension.

    current directory: /home/user/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/libxml-ruby-4.1.2/ext/libxml
/home/user/.rbenv/versions/3.2.2/bin/ruby extconf.rb
checking for libxml/xmlversion.h in
/opt/include/libxml2,/opt/local/include/libxml2,/opt/homebrew/opt/libxml2/include/libxml2,/usr/local/include/libxml2,/usr/include/libxml2,/usr/local/include,/usr/local/opt/libxml2/include/libxml2...
yes
checking for xmlParseDoc() in -lxml2... yes
creating extconf.h
creating Makefile

current directory: /home/user/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/libxml-ruby-4.1.2/ext/libxml
make DESTDIR\= sitearchdir\=./.gem.20240108-14058-stfou5 sitelibdir\=./.gem.20240108-14058-stfou5 clean

current directory: /home/user/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/libxml-ruby-4.1.2/ext/libxml
make DESTDIR\= sitearchdir\=./.gem.20240108-14058-stfou5 sitelibdir\=./.gem.20240108-14058-stfou5
compiling libxml.c
In file included from ruby_libxml.h:13,
                 from libxml.c:1:
ruby_xml_encoding.h:12:27: error: unknown type name ‘xmlChar’
   12 | VALUE rxml_new_cstr(const xmlChar* xstr, const xmlChar* xencoding);
      |                           ^~~~~~~
ruby_xml_encoding.h:12:48: error: unknown type name ‘xmlChar’
   12 | VALUE rxml_new_cstr(const xmlChar* xstr, const xmlChar* xencoding);
      |                                                ^~~~~~~
ruby_xml_encoding.h:13:31: error: unknown type name ‘xmlChar’
   13 | VALUE rxml_new_cstr_len(const xmlChar* xstr, const long length, const xmlChar* xencoding);
      |                               ^~~~~~~
ruby_xml_encoding.h:13:71: error: unknown type name ‘xmlChar’
   13 | VALUE rxml_new_cstr_len(const xmlChar* xstr, const long length, const xmlChar* xencoding);
      |                                                                       ^~~~~~~
ruby_xml_encoding.h:15:60: error: unknown type name ‘xmlCharEncoding’
   15 | rb_encoding* rxml_xml_encoding_to_rb_encoding(VALUE klass, xmlCharEncoding xmlEncoding);
      |                                                            ^~~~~~~~~~~~~~~
ruby_xml_encoding.h:16:41: error: unknown type name ‘xmlChar’
   16 | rb_encoding* rxml_figure_encoding(const xmlChar* xencoding);
      |                                         ^~~~~~~
In file included from ruby_libxml.h:14:
ruby_xml_attributes.h:9:27: error: unknown type name ‘xmlNodePtr’
    9 | VALUE rxml_attributes_new(xmlNodePtr xnode);
      |                           ^~~~~~~~~~
In file included from ruby_libxml.h:15:
ruby_xml_attr.h:9:22: error: unknown type name ‘xmlAttrPtr’
    9 | VALUE rxml_attr_wrap(xmlAttrPtr xattr);
      |                      ^~~~~~~~~~
In file included from ruby_libxml.h:16:
ruby_xml_attr_decl.h:9:27: error: unknown type name ‘xmlAttributePtr’
    9 | VALUE rxml_attr_decl_wrap(xmlAttributePtr xattribute);
      |                           ^~~~~~~~~~~~~~~
In file included from ruby_libxml.h:17:
ruby_xml_document.h:8:26: error: unknown type name ‘xmlDocPtr’; did you mean ‘xmlErrorPtr’?
    8 | VALUE rxml_document_wrap(xmlDocPtr xnode);
      |                          ^~~~~~~~~
      |                          xmlErrorPtr
ruby_xml_document.h:10:9: error: unknown type name ‘xmlChar’
   10 | typedef xmlChar * xmlCharPtr;
      |         ^~~~~~~
In file included from ruby_libxml.h:18:
ruby_xml_node.h:9:21: error: unknown type name ‘xmlNodePtr’
    9 | void rxml_node_mark(xmlNodePtr xnode);
      |                     ^~~~~~~~~~
ruby_xml_node.h:10:22: error: unknown type name ‘xmlNodePtr’
   10 | VALUE rxml_node_wrap(xmlNodePtr xnode);
      |                      ^~~~~~~~~~
ruby_xml_node.h:11:23: error: unknown type name ‘xmlNodePtr’
   11 | void rxml_node_manage(xmlNodePtr xnode, VALUE node);
      |                       ^~~~~~~~~~
ruby_xml_node.h:12:25: error: unknown type name ‘xmlNodePtr’
   12 | void rxml_node_unmanage(xmlNodePtr xnode, VALUE node);
      |                         ^~~~~~~~~~
In file included from ruby_libxml.h:19:
ruby_xml_namespace.h:9:27: error: unknown type name ‘xmlNsPtr’; did you mean ‘xmlCharPtr’?
    9 | VALUE rxml_namespace_wrap(xmlNsPtr xns);
      |                           ^~~~~~~~
      |                           xmlCharPtr
In file included from ruby_libxml.h:29:
ruby_xml_sax2_handler.h:6:8: error: unknown type name ‘xmlSAXHandler’
    6 | extern xmlSAXHandler rxml_sax_handler;
      |        ^~~~~~~~~~~~~
cc1: note: unrecognized command-line option ‘-Wno-self-assign’ may have been intended to silence earlier diagnostics
cc1: note: unrecognized command-line option ‘-Wno-parentheses-equality’ may have been intended to silence earlier diagnostics
cc1: note: unrecognized command-line option ‘-Wno-constant-logical-operand’ may have been intended to silence earlier diagnostics
make: *** [Makefile:248: libxml.o] Error 1

make failed, exit code 2

```
</p>
</details> 

The latest release fixes this, see https://github.com/xml4r/libxml-ruby/blob/master/HISTORY

It dropped support for ruby 2.7 but that not a problem on main anymore (yay), ~~but backporting if desired seems a bit more complicated.~~ The gemspec still says 2.5 so it's all good.
