### PR TITLE
Add ERB Lint

### DIFF
--- a/guides/source/command_line.md
+++ b/guides/source/command_line.md
@@ -67,6 +67,7 @@ If you wish to skip some files from being generated or skip some libraries, you 
 | `--skip-bootsnap`       | Skip bootsnap gem                                           |
 | `--skip-dev-gems`       | Skip adding development gems                                |
 | `--skip-rubocop`        | Skip RuboCop setup                                          |
+| `--skip-erb-lint`       | Skip ERB Lint setup                                         |
 
 These are just some of the options that `rails new` accepts. For a full list of options, type `rails new --help`.
 

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add ERBLint to the default Gemfile to lint ERB templates. Skip with --skip-erb-lint.
+
+    *Igor Alexandrov*
+
 *   Set `config.action_view.annotate_rendered_view_with_filenames` to `true` in the
     development environment.
 

--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -103,6 +103,9 @@ module Rails
         class_option :skip_rubocop,        type: :boolean, default: nil,
                                            desc: "Skip RuboCop setup"
 
+        class_option :skip_erb_lint,       type: :boolean, default: nil,
+                                           desc: "Skip ERB Lint setup"
+
         class_option :skip_brakeman,       type: :boolean, default: nil,
                                            desc: "Skip brakeman setup"
 
@@ -390,6 +393,10 @@ module Rails
 
       def skip_rubocop?
         options[:skip_rubocop]
+      end
+
+      def skip_erb_lint?
+        options[:skip_erb_lint]
       end
 
       def skip_brakeman?

--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -92,6 +92,10 @@ module Rails
       template "rubocop.yml", ".rubocop.yml"
     end
 
+    def erb_lint
+      template "erb-lint.yml", ".erb-lint.yml"
+    end
+
     def version_control
       if !options[:skip_git] && !options[:pretend]
         run git_init_command, capture: options[:quiet], abort_on_failure: false
@@ -108,7 +112,7 @@ module Rails
     end
 
     def bin
-      exclude_pattern = Regexp.union([(/rubocop/ if skip_rubocop?), (/brakeman/ if skip_brakeman?)].compact)
+      exclude_pattern = Regexp.union([(/rubocop/ if skip_rubocop?), (/brakeman/ if skip_brakeman?), (/erblint/ if skip_erb_lint?)].compact)
       directory "bin", { exclude_pattern: exclude_pattern } do |content|
         "#{shebang}\n" + content
       end
@@ -381,6 +385,11 @@ module Rails
       def create_rubocop_file
         return if skip_rubocop?
         build(:rubocop)
+      end
+
+      def create_erb_lint_file
+        return if skip_erb_lint?
+        build(:erb_lint)
       end
 
       def create_cifiles

--- a/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
@@ -46,6 +46,10 @@ group :development, :test do
   # Omakase Ruby styling [https://github.com/rails/rubocop-rails-omakase/]
   gem "rubocop-rails-omakase", require: false
 <%- end -%>
+<%- unless options.skip_erb_lint? -%>
+
+  gem "erb_lint", require: false
+<%- end -%>
 end
 <% end -%>
 

--- a/railties/lib/rails/generators/rails/app/templates/bin/erblint.tt
+++ b/railties/lib/rails/generators/rails/app/templates/bin/erblint.tt
@@ -1,0 +1,8 @@
+require "rubygems"
+require "bundler/setup"
+
+# explicit ERB Lint config and files to lint
+ARGV.unshift("--config", File.expand_path("../.erb-lint.yml", __dir__))
+ARGV.unshift("--lint-all")
+
+load Gem.bin_path("erb_lint", "erblint")

--- a/railties/lib/rails/generators/rails/app/templates/erb-lint.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/erb-lint.yml.tt
@@ -1,0 +1,16 @@
+---
+EnableDefaultLinters: true
+linters:
+  SelfClosingTag:
+    enabled: false
+    enforced_style: 'always'
+
+<%- unless options.skip_rubocop? -%>
+  Rubocop:
+    enabled: true
+    only: [Style/StringLiterals]
+    rubocop_config:
+      Style/StringLiterals:
+        Enabled: true
+        EnforcedStyle: double_quotes
+<%- end -%>

--- a/railties/lib/rails/generators/rails/app/templates/github/ci.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/github/ci.yml.tt
@@ -73,7 +73,7 @@ jobs:
           bundler-cache: true
 
       - name: Lint templates for consistent style
-        run: bin/erblint ./app/**/*.erb
+        run: bin/erblint
 <% end -%>
 
   test:

--- a/railties/lib/rails/generators/rails/app/templates/github/ci.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/github/ci.yml.tt
@@ -43,7 +43,7 @@ jobs:
 <% end -%>
 <%- unless skip_rubocop? -%>
 
-  lint:
+  lint_code:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -57,6 +57,23 @@ jobs:
 
       - name: Lint code for consistent style
         run: bin/rubocop -f github
+<% end -%>
+<%- unless skip_erb_lint? -%>
+
+  lint_templates:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: .ruby-version
+          bundler-cache: true
+
+      - name: Lint templates for consistent style
+        run: bin/erblint ./app/**/*.erb
 <% end -%>
 
   test:

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -11,6 +11,7 @@ DEFAULT_APP_FILES = %w(
   .gitignore
   .dockerignore
   .rubocop.yml
+  .erb-lint.yml
   .ruby-version
   README.md
   Gemfile
@@ -44,6 +45,7 @@ DEFAULT_APP_FILES = %w(
   bin/rails
   bin/rake
   bin/rubocop
+  bin/erblint
   bin/setup
   config/application.rb
   config/boot.rb
@@ -657,10 +659,23 @@ class AppGeneratorTest < Rails::Generators::TestCase
     assert_no_file "bin/brakeman"
   end
 
-  def test_both_brakeman_and_rubocop_binstubs_are_skipped_if_required
-    run_generator [destination_root, "--skip-brakeman", "--skip-rubocop"]
+  def test_inclusion_of_erb_lint
+    run_generator
+    assert_gem "erb_lint"
+  end
+
+  def test_erb_lint_is_skipped_if_required
+    run_generator [destination_root, "--skip-erb-lint"]
+
+    assert_no_gem "erb_lint"
+    assert_no_file "bin/erblint"
+  end
+
+  def test_brakeman_rubocop_and_erblint_binstubs_are_skipped_if_required
+    run_generator [destination_root, "--skip-brakeman", "--skip-rubocop", "--skip-erb-lint"]
 
     assert_no_file "bin/rubocop"
+    assert_no_file "bin/erblint"
     assert_no_file "bin/brakeman"
   end
 


### PR DESCRIPTION
Since now Rails has a default Rubocop config I decided that ERB templates should also have a linter out of the box.

Default setup is very basic and light, it includes:

- Default ERB Lint configuration
- Enforce quoted strings to match [rubocop-rails-omakase](https://github.com/rails/rubocop-rails-omakase)

It can be skipped with the `--skip-erb-lint` flag. 

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
