### PR TITLE
Do not generate pidfile in production environments

### DIFF
--- a/actionmailbox/test/dummy/config/puma.rb
+++ b/actionmailbox/test/dummy/config/puma.rb
@@ -28,7 +28,11 @@ port ENV.fetch("PORT") { 3000 }
 environment ENV.fetch("RAILS_ENV") { "development" }
 
 # Specifies the `pidfile` that Puma will use.
-pidfile ENV.fetch("PIDFILE") { "tmp/pids/server.pid" } if ENV.fetch("RAILS_ENV", "development") == "development"
+if ENV["PIDFILE"]
+  pidfile ENV["PIDFILE"]
+else
+  pidfile "tmp/pids/server.pid" if ENV.fetch("RAILS_ENV", "development") == "development"
+end
 
 # Allow puma to be restarted by `bin/rails restart` command.
 plugin :tmp_restart

--- a/actionmailbox/test/dummy/config/puma.rb
+++ b/actionmailbox/test/dummy/config/puma.rb
@@ -28,7 +28,7 @@ port ENV.fetch("PORT") { 3000 }
 environment ENV.fetch("RAILS_ENV") { "development" }
 
 # Specifies the `pidfile` that Puma will use.
-pidfile ENV.fetch("PIDFILE") { "tmp/pids/server.pid" }
+pidfile ENV.fetch("PIDFILE") { "tmp/pids/server.pid" } if ENV.fetch("RAILS_ENV", "development") == "development"
 
 # Allow puma to be restarted by `bin/rails restart` command.
 plugin :tmp_restart

--- a/actiontext/test/dummy/config/puma.rb
+++ b/actiontext/test/dummy/config/puma.rb
@@ -28,7 +28,11 @@ port ENV.fetch("PORT") { 3000 }
 environment ENV.fetch("RAILS_ENV") { "development" }
 
 # Specifies the `pidfile` that Puma will use.
-pidfile ENV.fetch("PIDFILE") { "tmp/pids/server.pid" } if ENV.fetch("RAILS_ENV", "development") == "development"
+if ENV["PIDFILE"]
+  pidfile ENV["PIDFILE"]
+else
+  pidfile "tmp/pids/server.pid" if ENV.fetch("RAILS_ENV", "development") == "development"
+end
 
 # Allow puma to be restarted by `bin/rails restart` command.
 plugin :tmp_restart

--- a/actiontext/test/dummy/config/puma.rb
+++ b/actiontext/test/dummy/config/puma.rb
@@ -28,7 +28,7 @@ port ENV.fetch("PORT") { 3000 }
 environment ENV.fetch("RAILS_ENV") { "development" }
 
 # Specifies the `pidfile` that Puma will use.
-pidfile ENV.fetch("PIDFILE") { "tmp/pids/server.pid" }
+pidfile ENV.fetch("PIDFILE") { "tmp/pids/server.pid" } if ENV.fetch("RAILS_ENV", "development") == "development"
 
 # Allow puma to be restarted by `bin/rails restart` command.
 plugin :tmp_restart

--- a/activestorage/test/dummy/config/puma.rb
+++ b/activestorage/test/dummy/config/puma.rb
@@ -28,7 +28,11 @@ port ENV.fetch("PORT") { 3000 }
 environment ENV.fetch("RAILS_ENV") { "development" }
 
 # Specifies the `pidfile` that Puma will use.
-pidfile ENV.fetch("PIDFILE") { "tmp/pids/server.pid" } if ENV.fetch("RAILS_ENV", "development") == "development"
+if ENV["PIDFILE"]
+  pidfile ENV["PIDFILE"]
+else
+  pidfile tmp/pids/server.pid" if ENV.fetch("RAILS_ENV", "development") == "development"
+end
 
 # Allow puma to be restarted by `bin/rails restart` command.
 plugin :tmp_restart

--- a/activestorage/test/dummy/config/puma.rb
+++ b/activestorage/test/dummy/config/puma.rb
@@ -28,7 +28,7 @@ port ENV.fetch("PORT") { 3000 }
 environment ENV.fetch("RAILS_ENV") { "development" }
 
 # Specifies the `pidfile` that Puma will use.
-pidfile ENV.fetch("PIDFILE") { "tmp/pids/server.pid" }
+pidfile ENV.fetch("PIDFILE") { "tmp/pids/server.pid" } if ENV.fetch("RAILS_ENV", "development") == "development"
 
 # Allow puma to be restarted by `bin/rails restart` command.
 plugin :tmp_restart

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Disable `pidfile` generation in production environment.
+
+    *Hans Schnedlitz*
+
 *   Set `config.action_view.annotate_rendered_view_with_filenames` to `true` in the
     development environment.
 

--- a/railties/lib/rails/commands/server/server_command.rb
+++ b/railties/lib/rails/commands/server/server_command.rb
@@ -114,7 +114,7 @@ module Rails
       class_option :using, aliases: "-u", type: :string,
         desc: "Specify the Rack server used to run the application (thin/puma/webrick).", banner: :name
       class_option :pid, aliases: "-P", type: :string,
-        desc: "Specify the PID file - defaults to #{DEFAULT_PIDFILE}."
+        desc: "Specify the PID file. Defaults to #{DEFAULT_PIDFILE} in development."
       class_option :dev_caching, aliases: "-C", type: :boolean, default: nil,
         desc: "Specify whether to perform caching in development."
       class_option :restart, type: :boolean, default: nil, hide: true
@@ -243,11 +243,13 @@ module Rails
         end
 
         def pid
-          File.expand_path(options[:pid] || ENV.fetch("PIDFILE", DEFAULT_PIDFILE))
+          default_pidfile = environment == "development" ? DEFAULT_PIDFILE : nil
+          pid = options[:pid] || ENV["PIDFILE"] || default_pidfile
+          File.expand_path(pid) if pid
         end
 
         def prepare_restart
-          FileUtils.rm_f(pid) if options[:restart]
+          FileUtils.rm_f(pid) if pid && options[:restart]
         end
 
         def rack_server_suggestion(server)

--- a/railties/lib/rails/generators/rails/app/templates/config/puma.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/puma.rb.tt
@@ -29,7 +29,7 @@ port ENV.fetch("PORT") { 3000 }
 environment ENV.fetch("RAILS_ENV") { "development" }
 
 # Specifies the `pidfile` that Puma will use.
-pidfile ENV.fetch("PIDFILE") { "tmp/pids/server.pid" }
+pidfile ENV.fetch("PIDFILE") { "tmp/pids/server.pid" } if ENV.fetch("RAILS_ENV", "development") == "development"
 
 # Allow puma to be restarted by `bin/rails restart` command.
 plugin :tmp_restart

--- a/railties/lib/rails/generators/rails/app/templates/config/puma.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/puma.rb.tt
@@ -29,7 +29,11 @@ port ENV.fetch("PORT") { 3000 }
 environment ENV.fetch("RAILS_ENV") { "development" }
 
 # Specifies the `pidfile` that Puma will use.
-pidfile ENV.fetch("PIDFILE") { "tmp/pids/server.pid" } if ENV.fetch("RAILS_ENV", "development") == "development"
+if ENV["PIDFILE"]
+  pidfile ENV["PIDFILE"]
+else
+  pidfile "tmp/pids/server.pid" if ENV.fetch("RAILS_ENV", "development") == "development"
+end
 
 # Allow puma to be restarted by `bin/rails restart` command.
 plugin :tmp_restart


### PR DESCRIPTION
### Motivation / Background

This is a follow-up to #50628. 

When running Rails applications with Docker containers may fail to restart if they crashed (e.g. because of OOM). This is because the `/rails/tmp/pids/server.pid` file is already present. 

Such failed containers will require manual intervention (e.g. remove the faulty container) to get up and running again. To allow containers to restart the server.pid file must be deleted on container start. As suggested in #50628, rather than removing the file in the `docker-entrypoint`, the default for new Rails applications should be not to create PIDs in the first place in production.

This Pull Request has been created to not create pidfiles in production.

### Detail

This makes the `pidfile` instruction from the default `puma.tt` template conditional. The puma files in the respective dummy / test apps have been updated for consistency. The default path for the pidfile in the server command has also been made conditional. 

### Additional information

I opted for making pidfile generation conditional rather than removing it outright as it has its uses in development (e.g. when not running with Docker per default). Might be though that this conditional behaviour ends up causing some confusion. Thoughts? 