### PR TITLE
Add safe navigation to named_routes in RoutingAssertions#method_missing

### DIFF
--- a/actionpack/lib/action_dispatch/testing/assertions/routing.rb
+++ b/actionpack/lib/action_dispatch/testing/assertions/routing.rb
@@ -248,7 +248,7 @@ module ActionDispatch
 
       # ROUTES TODO: These assertions should really work in an integration context
       def method_missing(selector, ...)
-        if @controller && @routes&.named_routes.route_defined?(selector)
+        if @controller && @routes&.named_routes&.route_defined?(selector)
           @controller.public_send(selector, ...)
         else
           super


### PR DESCRIPTION
### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

Follow up to https://github.com/rails/rails/pull/50597/commits/27140247c21c3925ee971ca4437e9a7f6fe198a3, from the cleanup of `defined?`, if `@routes` is nil in `RoutingAssertions#method_missing`, a NoMethodError will raise saying that there's an undefined method route_defined? for nil.

```
NoMethodError: undefined method `route_defined?' for nil
```

### Detail

Adds safe navigation to `named_routes` as well.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
