### PR TITLE
Made Brakeman CI config stricter

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/bin/brakeman.tt
+++ b/railties/lib/rails/generators/rails/app/templates/bin/brakeman.tt
@@ -2,6 +2,5 @@ require "rubygems"
 require "bundler/setup"
 
 ARGV.unshift("--ensure-latest")
-ARGV.unshift("--no-pager")
 
 load Gem.bin_path("brakeman", "brakeman")

--- a/railties/lib/rails/generators/rails/app/templates/bin/brakeman.tt
+++ b/railties/lib/rails/generators/rails/app/templates/bin/brakeman.tt
@@ -1,4 +1,7 @@
 require "rubygems"
 require "bundler/setup"
 
+ARGV.unshift("--ensure-latest")
+ARGV.unshift("--no-pager")
+
 load Gem.bin_path("brakeman", "brakeman")

--- a/railties/lib/rails/generators/rails/app/templates/github/ci.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/github/ci.yml.tt
@@ -21,7 +21,7 @@ jobs:
           bundler-cache: true
 
       - name: Scan for security vulnerabilities in Ruby dependencies
-        run: bin/brakeman
+        run: bin/brakeman --no-pager
 <% end -%>
 <%- if options[:javascript] == "importmap" -%>
 


### PR DESCRIPTION
Made Brakeman execution stricter:

- `--ensure-latest` ensures that the latest version of Brakeman is used
- `--no-pager` is better for CI execution