### PR TITLE
Reset `@target` in subclasses

### DIFF
--- a/activerecord/lib/active_record/associations/association.rb
+++ b/activerecord/lib/active_record/associations/association.rb
@@ -52,7 +52,6 @@ module ActiveRecord
       # Resets the \loaded flag to +false+ and sets the \target to +nil+.
       def reset
         @loaded = false
-        @target = nil
         @stale_state = nil
       end
 

--- a/activerecord/lib/active_record/associations/singular_association.rb
+++ b/activerecord/lib/active_record/associations/singular_association.rb
@@ -14,6 +14,12 @@ module ActiveRecord
         target
       end
 
+      # Resets the \loaded flag to +false+ and sets the \target to +nil+.
+      def reset
+        super
+        @target = nil
+      end
+
       # Implements the writer method, e.g. foo.bar= for Foo.belongs_to :bar
       def writer(record)
         replace(record)


### PR DESCRIPTION
Collection associations point to an array target, where singular associations will point to a single object. An "empty" (or "reset") association has different meaning depending on whether it's single or a collection. This commit changes the reset method to be specific to the type of association.

This is related to #48671