### PR TITLE
Do not automatically require minitest-bisect (6-1-stable)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -120,7 +120,7 @@ local_gemfile = File.expand_path(".Gemfile", __dir__)
 instance_eval File.read local_gemfile if File.exist? local_gemfile
 
 group :test do
-  gem "minitest-bisect"
+  gem "minitest-bisect", require: false
   gem "minitest-retry"
   gem "minitest-reporters"
 


### PR DESCRIPTION
Ref #50656 

This is currently causing an issue in 6-1-stable CI due to a chain of dependencies: minitest-bisect -> minitest-server -> drb. The last working version of Drb for Ruby 2.5 and 2.6 includes usage of ruby2_keywords but does not declare a dependency on the shim gem (meaning that version of Drb actual does not work on those Ruby versions).

ruby2_keywords was [added][1] to the 6-1-stable Active Support gemspec to address the issue with Drb, but this only fixes cases where Drb is required by Rails. However, there are still failing tests on 6-1-stable due to Drb being loaded in integration tests where a dummy Rails application calls Bundler.require and the above dependency chain is required.

To address those test failures, this commit prevents minitest-bisect from being automatically required when the whole bundle is required. It is not strictly necessary for main or any stable branches other than 6-1-stable, but it seems more correct since minitest_bisect is ran as an external command anyways.

[1]: 5a54e2f36aa91e32ac9a4b7af7e605f876cc3cfa
