### PR TITLE
Enable `Lint/SafeNavigationChain` rubocop cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -272,6 +272,9 @@ Lint/InterpolationCheck:
   Exclude:
     - '**/test/**/*'
 
+Lint/SafeNavigationChain:
+  Enabled: true
+
 Style/EvalWithLocation:
   Enabled: true
   Exclude:

--- a/activerecord/lib/active_record/encryption/encryptable_record.rb
+++ b/activerecord/lib/active_record/encryption/encryptable_record.rb
@@ -221,7 +221,7 @@ module ActiveRecord
         end
 
         def cant_modify_encrypted_attributes_when_frozen
-          self.class&.encrypted_attributes.each do |attribute|
+          self.class.encrypted_attributes.each do |attribute|
             errors.add(attribute.to_sym, "can't be modified because it is encrypted") if changed_attributes.include?(attribute)
           end
         end


### PR DESCRIPTION
#50597 introduced code that doesn't properly extend the safe navigation to the entire expression, which in turn was fixed in #50638. If this cop would have been enabled the issue would have been caught before being merged into main.

The single current offense being changed is safe since it is always called after `has_encrypted_attributes?` which calls `self.class.encrypted_attributes.present?` without any safe navigation. I'm not even sure if class could ever be nil in any context.