### PR TITLE
Backport #50640 to 7-1-stable (Bump libxml-ruby)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -291,7 +291,7 @@ GEM
       rexml
     kramdown-parser-gfm (1.1.0)
       kramdown (~> 2.0)
-    libxml-ruby (4.0.0)
+    libxml-ruby (5.0.0)
     listen (3.8.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)


### PR DESCRIPTION
#50640. Allows doing bundle install without manual intervention when using libxml2 >= 2.12.0

Note: As per the [changelog](https://github.com/xml4r/libxml-ruby/blob/master/HISTORY) for 5.0.0:
> Remove support for Ruby 2.7.* (gem should still work but is no longer tested)