### PR TITLE
Backport 48963 to 6-1-stable

### DIFF
--- a/activesupport/test/core_ext/numeric_ext_test.rb
+++ b/activesupport/test/core_ext/numeric_ext_test.rb
@@ -401,7 +401,7 @@ class NumericExtFormattingTest < ActiveSupport::TestCase
     assert_equal "1010110101111000111010111100010110101100011000100000000000000000000", (100**10).to_s(2)
 
     assert_equal "1000010.0", BigDecimal("1000010").to_s
-    assert_equal "10000 10.0", BigDecimal("1000010").to_s("5F")
+    assert_equal "0.10000 1", BigDecimal("0.100001").to_s("5F")
 
     assert_raises TypeError do
       1.to_s({})


### PR DESCRIPTION
Backport #48963 to 6-1-stable

To fix failures in CI: https://buildkite.com/rails/rails/builds/103600#018cea9c-a408-44e7-906c-982f78089200