### PR TITLE
Remove ruby2_keywords dependency from `6-1-stable`

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -99,7 +99,6 @@ PATH
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       mutex_m
-      ruby2_keywords
       tzinfo (~> 2.0)
       zeitwerk (~> 2.3)
     rails (6.1.7.6)

--- a/activesupport/activesupport.gemspec
+++ b/activesupport/activesupport.gemspec
@@ -43,5 +43,4 @@ Gem::Specification.new do |s|
   s.add_dependency "drb"
   s.add_dependency "mutex_m"
   s.add_dependency "bigdecimal"
-  s.add_dependency "ruby2_keywords"
 end


### PR DESCRIPTION
### Motivation / Background

cc @skipkayhil

Followed up https://github.com/rails/rails/pull/50567

### Detail

`drb-2.0.6` has `ruby2_keywords` dependency itself. We don't need to add it to `activesupport`.

see https://rubygems.org/gems/drb/versions/2.0.6