### PR TITLE
Remove workaround for `mail` gem dependencies

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -32,19 +32,13 @@ PATH
       activerecord (= 7.2.0.alpha)
       activestorage (= 7.2.0.alpha)
       activesupport (= 7.2.0.alpha)
-      mail (>= 2.7.1)
-      net-imap
-      net-pop
-      net-smtp
+      mail (>= 2.8.0)
     actionmailer (7.2.0.alpha)
       actionpack (= 7.2.0.alpha)
       actionview (= 7.2.0.alpha)
       activejob (= 7.2.0.alpha)
       activesupport (= 7.2.0.alpha)
-      mail (~> 2.5, >= 2.5.4)
-      net-imap
-      net-pop
-      net-smtp
+      mail (~> 2.5, >= 2.8.0)
       rails-dom-testing (~> 2.2)
     actionpack (7.2.0.alpha)
       actionview (= 7.2.0.alpha)

--- a/actionmailbox/actionmailbox.gemspec
+++ b/actionmailbox/actionmailbox.gemspec
@@ -38,8 +38,5 @@ Gem::Specification.new do |s|
   s.add_dependency "activejob",     version
   s.add_dependency "actionpack",    version
 
-  s.add_dependency "mail", ">= 2.7.1"
-  s.add_dependency "net-imap"
-  s.add_dependency "net-pop"
-  s.add_dependency "net-smtp"
+  s.add_dependency "mail", ">= 2.8.0"
 end

--- a/actionmailer/actionmailer.gemspec
+++ b/actionmailer/actionmailer.gemspec
@@ -38,9 +38,6 @@ Gem::Specification.new do |s|
   s.add_dependency "actionview", version
   s.add_dependency "activejob", version
 
-  s.add_dependency "mail", ["~> 2.5", ">= 2.5.4"]
-  s.add_dependency "net-imap"
-  s.add_dependency "net-pop"
-  s.add_dependency "net-smtp"
+  s.add_dependency "mail", ["~> 2.5", ">= 2.8.0"]
   s.add_dependency "rails-dom-testing", "~> 2.2"
 end

--- a/actionmailer/lib/action_mailer/delivery_methods.rb
+++ b/actionmailer/lib/action_mailer/delivery_methods.rb
@@ -32,8 +32,7 @@ module ActionMailer
 
       add_delivery_method :sendmail, Mail::Sendmail,
         location:  "/usr/sbin/sendmail",
-        # See breaking change in the mail gem - https://github.com/mikel/mail/commit/7e1196bd29815a0901d7290c82a332c0959b163a
-        arguments: Gem::Version.new(Mail::VERSION.version) >= Gem::Version.new("2.8.0") ? %w[-i] : "-i"
+        arguments: %w[-i]
 
       add_delivery_method :test, Mail::TestMailer
     end


### PR DESCRIPTION
#44083 introduced a workaround with the `mail` gem for Ruby 3.1 support. Since then, the gem itself has solved this issue: https://github.com/mikel/mail/commit/d9d8dcc6bae1774a033ad488cea6217db3a3ebf3.

Since `mail` 2.8.0 is the first version to properly support 3.1 and rails itself doesn't support anything below 3.1 on main the workaround can be removed and the required mail version bumped.