### PR TITLE
Update the default Puma configuration

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/puma.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/puma.rb.tt
@@ -2,38 +2,57 @@
 # are invoked here are part of Puma's configuration DSL. For more information
 # about methods provided by the DSL, see https://puma.io/puma/Puma/DSL.html.
 
-# Puma can serve each request in a thread from an internal thread pool.
-# The `threads` method setting takes two numbers: a minimum and maximum.
-# Any libraries that use thread pools should be configured to match
-# the maximum value specified for Puma. Default is set to 5 threads for minimum
-# and maximum; this matches the default thread size of Active Record.
-max_threads_count = ENV.fetch("RAILS_MAX_THREADS") { 5 }
-min_threads_count = ENV.fetch("RAILS_MIN_THREADS") { max_threads_count }
-threads min_threads_count, max_threads_count
+rails_env = ENV.fetch("RAILS_ENV", "development")
 
-# Specifies that the worker count should equal the number of processors in production.
-if ENV["RAILS_ENV"] == "production"
-  require "concurrent-ruby"
-  worker_count = Integer(ENV.fetch("WEB_CONCURRENCY") { Concurrent.physical_processor_count })
-  workers worker_count if worker_count > 1
+# Puma starts a configurable number of processes (workers) and each process
+# serves each request in a thread from an internal thread pool.
+#
+# The ideal number of threads per worker depends both on how much time the
+# application spends waiting for IO operations and on how much you wish to
+# to prioritize throughput over latency.
+#
+# As a rule of thumb, increasing the number of threads will increase how much
+# traffic a given process can handle (throughput), but due to CRuby's
+# Global VM Lock (GVL) it has diminishing returns and will degrade the
+# response time (latency) of the application.
+#
+# The default is set to 3 threads as it's deemed a decent compromise between
+# throughput and latency for the average Rails application.
+#
+# Any libraries that use a connection pool or another resource pool should
+# be configured to provide at least as many connections as the number of
+# threads. This includes Active Record's `pool` parameter in `database.yml`.
+threads_count = ENV.fetch("RAILS_MAX_THREADS") { 3 }
+threads threads_count, threads_count
+
+if rails_env == "production"
+  # If you are running more than 1 thread per process, the workers count
+  # should be equal to the number of processors (CPU cores) in production.
+  #
+  # It defaults to 1 because it's impossible to reliably detect how many
+  # CPU cores are available. Make sure to set the `WEB_CONCURRENCY` environment
+  # variable to match the number of processors.
+  processors_count = Integer(ENV.fetch("WEB_CONCURRENCY") { 1 })
+  if processors_count > 1
+    workers worker_count
+  else
+    preload_app!
+  end
 end
-
-# Specifies the `worker_timeout` threshold that Puma will use to wait before
-# terminating a worker in development environments.
-worker_timeout 3600 if ENV.fetch("RAILS_ENV", "development") == "development"
 
 # Specifies the `port` that Puma will listen on to receive requests; default is 3000.
 port ENV.fetch("PORT") { 3000 }
 
 # Specifies the `environment` that Puma will run in.
-environment ENV.fetch("RAILS_ENV") { "development" }
-
-# Specifies the `pidfile` that Puma will use.
-if ENV["PIDFILE"]
-  pidfile ENV["PIDFILE"]
-else
-  pidfile "tmp/pids/server.pid" if ENV.fetch("RAILS_ENV", "development") == "development"
-end
+environment rails_env
 
 # Allow puma to be restarted by `bin/rails restart` command.
 plugin :tmp_restart
+
+pidfile ENV["PIDFILE"] if ENV["PIDFILE"]
+
+if rails_env == "development"
+  # Specifies a very generous `worker_timeout` so that the worker
+  # isn't killed by Puma when suspended by a debugger.
+  worker_timeout 3600
+end


### PR DESCRIPTION
Fix: https://github.com/rails/rails/issues/50450

The main change is the default number of threads
is reduced from 5 to 3 as discussed in https://github.com/rails/rails/issues/50450

Pending a potential future "Rails tuning" guide, I tried to include in comments the gist of the tradeoffs involved.

~~I also removed the pidfile except for development. It's useful to prevent booting the server twice there but I don't think it makes much sense in production, especially [since Puma no longer supports daemonization and instead recommend using a process
monitor](https://github.com/puma/puma/blob/99f83c50fbb712b0987667f3533cce4ea925b2da/docs/deployment.md#should-i-daemonize). And it makes even less sense in a PaaS or containerized world.~~
