### PR TITLE
Get rid of `ForkTracker.check!`

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_handler.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_handler.rb
@@ -55,9 +55,6 @@ module ActiveRecord
     # about the model. The model needs to pass a connection specification name to the handler,
     # in order to look up the correct connection pool.
     class ConnectionHandler
-      FINALIZER = lambda { |_| ActiveSupport::ForkTracker.check! }
-      private_constant :FINALIZER
-
       class StringConnectionName # :nodoc:
         attr_reader :name
 
@@ -77,9 +74,6 @@ module ActiveRecord
       def initialize
         # These caches are keyed by pool_config.connection_name (PoolConfig#connection_name).
         @connection_name_to_pool_manager = Concurrent::Map.new(initial_capacity: 2)
-
-        # Backup finalizer: if the forked child skipped Kernel#fork the early discard has not occurred
-        ObjectSpace.define_finalizer self, FINALIZER
       end
 
       def prevent_writes # :nodoc:

--- a/activerecord/lib/active_record/connection_adapters/pool_config.rb
+++ b/activerecord/lib/active_record/connection_adapters/pool_config.rb
@@ -50,8 +50,6 @@ module ActiveRecord
       end
 
       def disconnect!(automatic_reconnect: false)
-        ActiveSupport::ForkTracker.check!
-
         return unless @pool
 
         synchronize do
@@ -65,8 +63,6 @@ module ActiveRecord
       end
 
       def pool
-        ActiveSupport::ForkTracker.check!
-
         @pool || synchronize { @pool ||= ConnectionAdapters::ConnectionPool.new(self) }
       end
 

--- a/activesupport/lib/active_support/fork_tracker.rb
+++ b/activesupport/lib/active_support/fork_tracker.rb
@@ -24,14 +24,6 @@ module ActiveSupport
         end
       end
 
-      if Process.respond_to?(:_fork) # Ruby 3.1+
-        def check!
-          # We trust the `_fork` callback
-        end
-      else
-        alias_method :check!, :after_fork_callback
-      end
-
       def hook!
         ::Process.singleton_class.prepend(CoreExt)
       end

--- a/activesupport/test/fork_tracker_test.rb
+++ b/activesupport/test/fork_tracker_test.rb
@@ -152,39 +152,6 @@ class ForkTrackerTest < ActiveSupport::TestCase
     ActiveSupport::ForkTracker.unregister(handler)
   end
 
-  def test_check
-    count = 0
-    handler = ActiveSupport::ForkTracker.after_fork { count += 1 }
-
-    assert_no_difference -> { count } do
-      3.times { ActiveSupport::ForkTracker.check! }
-    end
-
-    if Process.respond_to?(:_fork)
-      Process.stub(:pid, Process.pid + 1) do
-        assert_no_difference -> { count } do
-          3.times { ActiveSupport::ForkTracker.check! }
-        end
-
-        assert_no_difference -> { count } do
-          3.times { ActiveSupport::ForkTracker.check! }
-        end
-      end
-    else
-      Process.stub(:pid, Process.pid + 1) do
-        assert_difference -> { count }, +1 do
-          3.times { ActiveSupport::ForkTracker.check! }
-        end
-      end
-
-      assert_difference -> { count }, +1 do
-        3.times { ActiveSupport::ForkTracker.check! }
-      end
-    end
-  ensure
-    ActiveSupport::ForkTracker.unregister(handler)
-  end
-
   def test_basic_object_with_kernel_fork
     read, write = IO.pipe
     called = false


### PR DESCRIPTION
Now that we require Ruby 3.1, we can assume `Process._fork` is defined on MRI, hence we can trust that our decorator will reliably detect forks so we no longer need to check the if the pid changed in critical spots.
