### PR TITLE
Remove redundant `parent` method from RESTRICTED_CLASS_METHODS

### DIFF
--- a/activerecord/lib/active_record/attribute_methods.rb
+++ b/activerecord/lib/active_record/attribute_methods.rb
@@ -20,7 +20,7 @@ module ActiveRecord
       include Serialization
     end
 
-    RESTRICTED_CLASS_METHODS = %w(private public protected allocate new name parent superclass)
+    RESTRICTED_CLASS_METHODS = %w(private public protected allocate new name superclass)
 
     class GeneratedAttributeMethods < Module # :nodoc:
       LOCK = Monitor.new

--- a/activerecord/test/cases/enum_test.rb
+++ b/activerecord/test/cases/enum_test.rb
@@ -535,7 +535,7 @@ class EnumTest < ActiveRecord::TestCase
       :save,     # generates #save!, which conflicts with an AR method
       :proposed, # same value as an existing enum
       :public, :private, :protected, # some important methods on Module and Class
-      :name, :parent, :superclass,
+      :name, :superclass,
       :id        # conflicts with AR querying
     ]
 

--- a/activerecord/test/cases/scoping/named_scoping_test.rb
+++ b/activerecord/test/cases/scoping/named_scoping_test.rb
@@ -363,7 +363,6 @@ class NamedScopingTest < ActiveRecord::TestCase
       :protected,
       :private,
       :name,
-      :parent,
       :superclass
     ]
 


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

Previously, `parent` was added as one of ActiveRecord's `RESTRICTED_CLASS_METHODS` as part of a commit (94b7328b08) in 2014 that stopped Rails `enum`s from being able to redefine important class methods.

At the time, Rails monkey-patched `Module` with a `parent` class method that returned a module's containing module if it was nested.

However, in October 2020 (167b4153ca) in Rails 6.1, this method was deprecated in favour of a renamed method `module_parent`. As such, the `parent` method doesn't need to be a restricted class method any more, but this was never cleaned up inside `AttributeMethods`.

### Detail

This Pull Request removes `parent` from the list of restricted class methods.

### Additional information

Arguably it means that the replacement module methods `module_parent`, as well as `module_parents` and `module_parent_name` should be introduced as restricted class methods, but I notice that `parents` and `parent_name` were never added to this list, so I'm making the assumption that actually they aren't that important to protect any more. I'm very happy to try and make this list more correct if that's what's needed here.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.

Since the original PR didn't add a CHANGELOG entry when it introduced this restricted method, I haven't added one for removing it.