### PR TITLE
Add `default:` support for `ActiveSupport::CurrentAttributes.attribute`

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   Add `default:` support for `ActiveSupport::CurrentAttributes.attribute`
+
+    ```ruby
+    class Current < ActiveSupport::CurrentAttributes
+      attribute :counter, default: 0
+    end
+    ```
+
+    *Sean Doyle*
+
 *   Yield instance to `Object#with` block
 
     ```ruby

--- a/activesupport/test/current_attributes_test.rb
+++ b/activesupport/test/current_attributes_test.rb
@@ -11,6 +11,8 @@ class CurrentAttributesTest < ActiveSupport::TestCase
   Person = Struct.new(:id, :name, :time_zone)
 
   class Current < ActiveSupport::CurrentAttributes
+    attribute :counter_integer, default: 0
+    attribute :counter_callable, default: -> { 0 }
     attribute :world, :account, :person, :request
     delegate :time_zone, to: :person
 
@@ -84,6 +86,30 @@ class CurrentAttributesTest < ActiveSupport::TestCase
   test "read and write attribute" do
     Current.world = "world/1"
     assert_equal "world/1", Current.world
+  end
+
+  test "read and write attribute with default value" do
+    assert_equal 0, Current.counter_integer
+
+    Current.counter_integer += 1
+
+    assert_equal 1, Current.counter_integer
+
+    Current.reset
+
+    assert_equal 0, Current.counter_integer
+  end
+
+  test "read attribute with default callable" do
+    assert_equal 0, Current.counter_callable
+
+    Current.counter_callable += 1
+
+    assert_equal 1, Current.counter_callable
+
+    Current.reset
+
+    assert_equal 0, Current.counter_callable
   end
 
   test "read overwritten attribute method" do


### PR DESCRIPTION
### Detail

Extend the `.attribute` class method to accept a `:default` option for its list of attributes:

```ruby
class Current < ActiveSupport::CurrentAttributes
  attribute :counter, default: 0
end
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
