### PR TITLE
Implement `CurrentAttributes#set` in terms of `Object#with`

### DIFF
--- a/activesupport/lib/active_support/current_attributes.rb
+++ b/activesupport/lib/active_support/current_attributes.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "active_support/callbacks"
+require "active_support/core_ext/object/with"
 require "active_support/core_ext/enumerable"
 require "active_support/core_ext/module/delegation"
 
@@ -207,12 +208,8 @@ module ActiveSupport
     #       end
     #     end
     #   end
-    def set(set_attributes)
-      old_attributes = compute_attributes(set_attributes.keys)
-      assign_attributes(set_attributes)
-      yield
-    ensure
-      assign_attributes(old_attributes)
+    def set(attributes, &block)
+      with(**attributes, &block)
     end
 
     # Reset all attributes. Should be called before and after actions, when used as a per-request singleton.
@@ -221,14 +218,5 @@ module ActiveSupport
         self.attributes = {}
       end
     end
-
-    private
-      def assign_attributes(new_attributes)
-        new_attributes.each { |key, value| public_send("#{key}=", value) }
-      end
-
-      def compute_attributes(keys)
-        keys.index_with { |key| public_send(key) }
-      end
   end
 end

--- a/activesupport/test/current_attributes_test.rb
+++ b/activesupport/test/current_attributes_test.rb
@@ -144,6 +144,12 @@ class CurrentAttributesTest < ActiveSupport::TestCase
 
     assert_equal "world/1", Current.world
     assert_equal "account/1", Current.account
+
+    hash = { world: "world/2", account: "account/2" }
+    Current.set(hash) do
+      assert_equal "world/2", Current.world
+      assert_equal "account/2", Current.account
+    end
   end
 
   test "using keyword arguments" do


### PR DESCRIPTION
### Motivation / Background

`CurrentAttributes` supports block-scoped overrides for its attributes through the `#set` method. The introduction of [CurrentAttributes#set][] predates the introduction of [Object#with][] by 6 years.

### Detail

This commit changes the implementation of `#set` to delegate to `#with`. Through that delegation, the private `#assign_attributes` and `#compute_attributes` methods are no longer necessary.

[CurrentAttributes#set]: https://github.com/rails/rails/blame/2d6b02bad6b02bf1d26c26461406bda710181244/activesupport/lib/active_support/current_attributes.rb#L210
[Object#with]: https://github.com/rails/rails/blame/2d6b02bad6b02bf1d26c26461406bda710181244/activesupport/lib/active_support/core_ext/object/with.rb#L26

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
