### PR TITLE
Revert "Use Ruby 3.3 for github workflows"

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,10 +14,10 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: Set up Ruby 3.3
+    - name: Set up Ruby 3.2
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 3.3
+        ruby-version: 3.2
         bundler-cache: true
 
     - name: mdl

--- a/.github/workflows/rail_inspector.yml
+++ b/.github/workflows/rail_inspector.yml
@@ -17,9 +17,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Ruby 3.3
-        uses: ruby/setup-ruby@v1
+      - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.3
+          ruby-version: 3.2
           bundler-cache: true
       - run: cd tools/rail_inspector && bundle exec rake

--- a/.github/workflows/rails-new-docker.yml
+++ b/.github/workflows/rails-new-docker.yml
@@ -15,10 +15,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Ruby 3.3
-      uses: ruby/setup-ruby@v1
+    - uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 3.3
+        ruby-version: '3.2'
         bundler-cache: true
     - name: Generate --dev app
       run: |

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -14,10 +14,10 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: Set up Ruby 3.3
+    - name: Set up Ruby 3.2
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 3.3
+        ruby-version: 3.2
         bundler-cache: true
 
     - name: Run RuboCop


### PR DESCRIPTION
Reverts rails/rails#50625

`google-protobuf` currently does not build on Ruby 3.3

cc @rafaelfranca 