### PR TITLE
Simplify `CurrentAttribute.instance` delegation

### DIFF
--- a/activesupport/lib/active_support/current_attributes.rb
+++ b/activesupport/lib/active_support/current_attributes.rb
@@ -125,22 +125,7 @@ module ActiveSupport
           end
         end
 
-        ActiveSupport::CodeGenerator.batch(singleton_class, __FILE__, __LINE__) do |owner|
-          names.each do |name|
-            owner.define_cached_method(name, namespace: :current_attributes_delegation) do |batch|
-              batch <<
-                "def #{name}" <<
-                "instance.#{name}" <<
-                "end"
-            end
-            owner.define_cached_method("#{name}=", namespace: :current_attributes_delegation) do |batch|
-              batch <<
-                "def #{name}=(value)" <<
-                "instance.#{name} = value" <<
-                "end"
-            end
-          end
-        end
+        singleton_class.delegate(*names.flat_map { |name| [name, "#{name}="] }, to: :instance, as: self)
       end
 
       # Calls this callback before #reset is called on the instance. Used for resetting external collaborators that depend on current values.


### PR DESCRIPTION
### Motivation / Background

Follow-up to [#50676][]

### Detail

Instead of relying on code generation, call a corresponding [delegate][] method on the `.singleton_class`.

[#50676]: https://github.com/rails/rails/pull/50676
[delegate]: https://edgeapi.rubyonrails.org/classes/Module.html#method-i-delegate