### PR TITLE
Backport 45837 to 6-1-stable

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Fix retrieving rotation value from FFmpeg on version 5.0+.
+
+    In FFmpeg version 5.0+ the rotation value has been removed from tags.
+    Instead the value can be found in side_data_list. Along with
+    this update it's possible to have values of -90, -270 to denote the video
+    has been rotated.
+
+    *Haroon Ahmed*
+
 ## Rails 6.1.7.6 (August 22, 2023) ##
 
 *   No changes.

--- a/activestorage/test/analyzer/video_analyzer_test.rb
+++ b/activestorage/test/analyzer/video_analyzer_test.rb
@@ -24,7 +24,7 @@ class ActiveStorage::Analyzer::VideoAnalyzerTest < ActiveSupport::TestCase
     assert_equal 480, metadata[:width]
     assert_equal 640, metadata[:height]
     assert_equal [4, 3], metadata[:display_aspect_ratio]
-    assert_equal 90, metadata[:angle]
+    assert_includes [90, -90], metadata[:angle]
   end
 
   test "analyzing a video with rectangular samples" do


### PR DESCRIPTION
Backport #45837 to `6-1-stable`

To fix failing Active Storage tests: https://buildkite.com/rails/rails/builds/103644#018cece2-9c4a-4988-ba46-754af5dfa47c