### PR TITLE
Ignore the query cache in a block

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,20 @@
+*   Add `ActiveRecord::ConnectionAdapters::QueryCache#ignore_query_cache`
+
+    This entirely ignores the query cache within a block.
+
+    - Queries are not cached or read from the cache
+    - Writes do not clear the cache
+    - cached/uncached blocks do nothing
+
+    ```ruby
+      ActiveRecord::Base.connection.ignore_query_cache do
+        post = Post.find 1
+        post.touch
+      end
+    ```
+
+    *Donal McBreen*
+
 *   Make `ActiveRecord::Encryption::Encryptor` agnostic of the serialization format used for encrypted data.
 
     Previously, the encryptor instance only allowed an encrypted value serialized as a `String` to be passed to the message serializer.


### PR DESCRIPTION
### Motivation / Background

This PR allow the Query cache to be ignored in a block.

For Solid Cache queries we want to be able to completely disable the query cache (see https://github.com/rails/solid_cache/issues/123).

Solid Cache uses the database as the Rails cache so it gets the automatic query cache behaviour by default. 

We'd like to avoid this because the local cache already handles caching repeated reads and having Rails cache writes clear the AR query cache is not desirable.

`uncached` works for disabling reads doesn't disable clearing the cache for writes.

### Detail

We add a `ignore_query_cache` method to the connection. It takes a block and within that block:
- queries will not be cached in the query cache
- queries will not be read from the query cache
- writes will not clear the query cache
- cached/uncached blocks will be ignored

Example usage:

```ruby
ActiveRecord::Base.connection.ignore_query_cache do
  post = Post.find 1
  post.touch
end
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
