### PR TITLE
Do not mask `NoMethodError` from within `render_in`

### DIFF
--- a/actionview/lib/action_view/template/renderable.rb
+++ b/actionview/lib/action_view/template/renderable.rb
@@ -14,8 +14,12 @@ module ActionView
 
       def render(context, *args)
         @renderable.render_in(context)
-      rescue NoMethodError
-        raise ArgumentError, "'#{@renderable.inspect}' is not a renderable object. It must implement #render_in."
+      rescue NoMethodError => error
+        if error.name == :render_in
+          raise ArgumentError, "'#{@renderable.inspect}' is not a renderable object. It must implement #render_in."
+        else
+          raise
+        end
       end
 
       def format

--- a/actionview/test/template/render_test.rb
+++ b/actionview/test/template/render_test.rb
@@ -312,6 +312,15 @@ module RenderTestCases
     end
   end
 
+  def test_render_renderable_does_not_mask_nomethoderror_from_within_render_in
+    renderable = Object.new
+    renderable.define_singleton_method(:render_in) { |*| nil.foo }
+
+    assert_raises NoMethodError, match: "undefined method `foo' for nil" do
+      @view.render renderable: renderable
+    end
+  end
+
   def test_render_partial_starting_with_a_capital
     assert_nothing_raised { @view.render(partial: "test/FooBar") }
   end


### PR DESCRIPTION
Follow-up to #50665.

Unconditionally converting `NoMethodError` to `ArgumentError` can mask a legitimate `NoMethodError` from within the `render_in` method.  This commit adds a check to prevent that.
