### PR TITLE
Make sure attribute_aliases is consistent

### DIFF
--- a/activerecord/lib/active_record/attribute_methods.rb
+++ b/activerecord/lib/active_record/attribute_methods.rb
@@ -120,9 +120,6 @@ module ActiveRecord
           unless abstract_class?
             load_schema
             super(attribute_names)
-            if _has_attribute?("id")
-              alias_attribute(:id_value, :id)
-            end
           end
 
           ActiveSupport::CodeGenerator.batch(generated_attribute_methods, __FILE__, __LINE__) do |code_generator|

--- a/activerecord/lib/active_record/attribute_methods/primary_key.rb
+++ b/activerecord/lib/active_record/attribute_methods/primary_key.rb
@@ -152,6 +152,11 @@ module ActiveRecord
                 @attributes_builder = nil
               end
             end
+
+            def load_schema! # :nodoc:
+              super
+              alias_attribute :id_value, :id if @columns_hash.key?("id")
+            end
         end
     end
   end

--- a/activerecord/lib/active_record/model_schema.rb
+++ b/activerecord/lib/active_record/model_schema.rb
@@ -583,6 +583,7 @@ module ActiveRecord
           columns_hash = connection.schema_cache.columns_hash(table_name)
           columns_hash = columns_hash.except(*ignored_columns) unless ignored_columns.empty?
           @columns_hash = columns_hash.freeze
+          alias_attribute :id_value, :id if @columns_hash.key?("id")
         end
 
         # Guesses the table name, but does not decorate it with prefix and suffix information.

--- a/activerecord/lib/active_record/model_schema.rb
+++ b/activerecord/lib/active_record/model_schema.rb
@@ -583,7 +583,6 @@ module ActiveRecord
           columns_hash = connection.schema_cache.columns_hash(table_name)
           columns_hash = columns_hash.except(*ignored_columns) unless ignored_columns.empty?
           @columns_hash = columns_hash.freeze
-          alias_attribute :id_value, :id if @columns_hash.key?("id")
         end
 
         # Guesses the table name, but does not decorate it with prefix and suffix information.

--- a/activerecord/test/cases/attribute_methods_test.rb
+++ b/activerecord/test/cases/attribute_methods_test.rb
@@ -32,6 +32,15 @@ class AttributeMethodsTest < ActiveRecord::TestCase
     ActiveRecord::Base.send(:attribute_method_patterns).concat(@old_matchers)
   end
 
+  test "#id_value alias is defined if id column exist" do
+    new_topic_model = Class.new(ActiveRecord::Base) do
+      self.table_name = "topics"
+    end
+
+    assert_includes new_topic_model.attribute_names, "id"
+    assert_includes new_topic_model.attribute_aliases, "id_value"
+  end
+
   test "aliasing `id` attribute allows reading the column value" do
     topic = Topic.create(id: 123_456, title: "title").becomes(TitlePrimaryKeyTopic)
 


### PR DESCRIPTION
Before this change `attribute_aliases` would be empty if the model class didn't define any attribute yet.

This partially revert the changes made in #50158, but as you can notice the test wasn't removed, so moving the `alias_method` call wasn't necessary to fix the issue. I also run the test on #50154 to make sure the issue was fixed and I got all tests passing.