### PR TITLE
Add warning for non-existent directories in autoload paths for Zeitwerk

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add warning for non-existent directories in `config.autoload_paths` and `config.autoload_once_paths` for Zeitwerk
+
+    *Takumasa Ochi*
+
 *   Prevent unnecessary application reloads in development.
 
     Previously, some files outside autoload paths triggered unnecessary reloads.

--- a/railties/lib/rails/application/bootstrap.rb
+++ b/railties/lib/rails/application/bootstrap.rb
@@ -105,7 +105,13 @@ module Rails
         ActiveSupport::Dependencies.autoload_once_paths.freeze
         ActiveSupport::Dependencies.autoload_once_paths.uniq.each do |path|
           # Zeitwerk only accepts existing directories in `push_dir`.
-          next unless File.directory?(path)
+          unless File.directory?(path)
+            warn <<~INFO
+              config.autoload_once_paths must be existing directories.
+              '#{path}' is not an existing directory.
+            INFO
+            next
+          end
           next if already_configured_dirs.member?(path.to_s)
 
           autoloader.push_dir(path)

--- a/railties/lib/rails/application/finisher.rb
+++ b/railties/lib/rails/application/finisher.rb
@@ -25,7 +25,13 @@ module Rails
         ActiveSupport::Dependencies.autoload_paths.freeze
         ActiveSupport::Dependencies.autoload_paths.uniq.each do |path|
           # Zeitwerk only accepts existing directories in `push_dir`.
-          next unless File.directory?(path)
+          unless File.directory?(path)
+            warn <<~INFO
+              config.autoload_paths must be existing directories.
+              '#{path}' is not an existing directory.
+            INFO
+            next
+          end
           next if already_configured_dirs.member?(path.to_s)
 
           autoloader.push_dir(path)


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because I noticed that Rails does not warn the user when they specify a non-existing directory in the `config.autoload_paths` or `config.autoload_once_paths` settings. This can lead to confusion and hard-to-debug errors when the user expects some files to be loaded but they are not.

### Detail

This Pull Request add a warning message when specified paths for `config.autoload_paths` and `config.autoload_once_paths` are not existing directories.
Below is the example message:

```
config.autoload_paths must be existing directories.
'/wrong/path/to/load' is not an existing directory.
```

### Additional information

Since this PR does not change the behavior itself, I believe existing tests cover this PR.

The warning message has been inspired by the following code.
https://github.com/rails/rails/blob/91968e5a185927b8216b82c860a48b6367285456/railties/lib/rails/application/bootstrap.rb#L23-L30

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
