### PR TITLE
Backport: Define missing attribute methods from `method_missing`

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Handle records being loaded with Marshal without triggering schema load
+
+    When using the old marshalling format for Active Record and loading
+    a serialized instance, it didn't trigger loading the schema and defining
+    attribute methods.
+
+    *Jean Boussier*
+
 *   Prevent some constant redefinition warnings when defining `inherited` on models.
 
     *Adrian Hirt*

--- a/activerecord/test/cases/attribute_methods/read_test.rb
+++ b/activerecord/test/cases/attribute_methods/read_test.rb
@@ -14,11 +14,17 @@ module ActiveRecord
         @klass = Class.new(Class.new { def self.initialize_generated_modules; end }) do
           def self.superclass; Base; end
           def self.base_class?; true; end
+          def self.abstract_class?; false; end
+          def self.load_schema; end
 
           include ActiveRecord::AttributeMethods
 
           def self.attribute_names
             %w{ one two three }
+          end
+
+          def self.attribute_types
+            {}
           end
 
           def self.primary_key

--- a/activerecord/test/cases/attribute_methods_test.rb
+++ b/activerecord/test/cases/attribute_methods_test.rb
@@ -1032,11 +1032,16 @@ class AttributeMethodsTest < ActiveRecord::TestCase
 
     topic = topic_class.new(title: "New topic")
     assert_equal("New topic", topic.subject_to_be_undefined)
+    assert_equal true, topic_class.method_defined?(:subject_to_be_undefined)
     topic_class.undefine_attribute_methods
+    assert_equal false, topic_class.method_defined?(:subject_to_be_undefined)
 
-    assert_raises(NoMethodError, match: /undefined method `subject_to_be_undefined'/) do
-      topic.subject_to_be_undefined
-    end
+    topic.subject_to_be_undefined
+    assert_equal true, topic_class.method_defined?(:subject_to_be_undefined)
+
+    topic_class.undefine_attribute_methods
+    assert_equal true, topic.respond_to?(:subject_to_be_undefined)
+    assert_equal true, topic_class.method_defined?(:subject_to_be_undefined)
   end
 
   test "#define_attribute_methods brings back undefined aliases" do
@@ -1050,11 +1055,11 @@ class AttributeMethodsTest < ActiveRecord::TestCase
     assert_equal("New topic", topic.title_alias_to_be_undefined)
     topic_class.undefine_attribute_methods
 
-    assert_not_respond_to topic, :title_alias_to_be_undefined
+    assert_equal false, topic_class.method_defined?(:title_alias_to_be_undefined)
 
     topic_class.define_attribute_methods
 
-    assert_respond_to topic, :title_alias_to_be_undefined
+    assert_equal true, topic_class.method_defined?(:title_alias_to_be_undefined)
     assert_equal "New topic", topic.title_alias_to_be_undefined
   end
 


### PR DESCRIPTION
Fix: https://github.com/rails/rails/issues/52295
Ref: https://github.com/rails/rails/pull/50594

Opening a PR because the backport is non-trivial, so I want CI coverage. Also @ghiculescu pointed a possible issue in https://github.com/rails/rails/commit/d429bfb3b6fd2794f0d859b68e5dee24578d405f so I'd like to get to the bottom of that before merging the backport.

cc @rafaelfranca 