### PR TITLE
Handle alternative base classes in `define_attribute_methods`

### DIFF
--- a/activemodel/lib/active_model/attribute_methods.rb
+++ b/activemodel/lib/active_model/attribute_methods.rb
@@ -365,6 +365,8 @@ module ActiveModel
           super
           base.class_eval do
             @attribute_method_patterns_cache = nil
+            @aliases_by_attribute_name = nil
+            @generated_attribute_methods = nil
           end
         end
 

--- a/activerecord/lib/active_record/attribute_methods/primary_key.rb
+++ b/activerecord/lib/active_record/attribute_methods/primary_key.rb
@@ -152,11 +152,6 @@ module ActiveRecord
                 @attributes_builder = nil
               end
             end
-
-            def load_schema! # :nodoc:
-              super
-              alias_attribute :id_value, :id if @columns_hash.key?("id")
-            end
         end
     end
   end

--- a/activerecord/test/cases/attribute_methods_test.rb
+++ b/activerecord/test/cases/attribute_methods_test.rb
@@ -37,6 +37,7 @@ class AttributeMethodsTest < ActiveRecord::TestCase
       self.table_name = "topics"
     end
 
+    new_topic_model.define_attribute_methods
     assert_includes new_topic_model.attribute_names, "id"
     assert_includes new_topic_model.attribute_aliases, "id_value"
   end


### PR DESCRIPTION
Ref: https://github.com/rails/rails/commit/d429bfb3b6fd2794f0d859b68e5dee24578d405f#r136670440

cc @ghiculescu @rafaelfranca 

Before merging, I'd like a repro, so I can include a test case though.