### PR TITLE
Prevent unnecessary application reloads in development

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Prevent unnecessary application reloads in development.
+
+    Previously, some files outside autoload paths triggered unnecessary reloads.
+    With this fix, application reloads according to `Rails.autoloaders.main.dirs`,
+    thereby preventing unnecessary reloads.
+
+    *Takumasa Ochi*
+
 *   Use `oven-sh/setup-bun` in GitHub CI when generating an app with bun
 
     *TangRufus*

--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -412,8 +412,8 @@ module Rails
     def watchable_args # :nodoc:
       files, dirs = config.watchable_files.dup, config.watchable_dirs.dup
 
-      ActiveSupport::Dependencies.autoload_paths.each do |path|
-        File.file?(path) ? files << path.to_s : dirs[path.to_s] = [:rb]
+      Rails.autoloaders.main.dirs.each do |path|
+        dirs[path.to_s] = [:rb]
       end
 
       [files, dirs]

--- a/railties/test/application/watcher_test.rb
+++ b/railties/test/application/watcher_test.rb
@@ -13,7 +13,7 @@ module ApplicationTests
       @app ||= Rails.application
     end
 
-    test "watchable_args classifies files included in autoload path" do
+    test "watchable_args does NOT include files in autoload path" do
       add_to_config <<-RUBY
         config.file_watcher = ActiveSupport::EventedFileUpdateChecker
       RUBY
@@ -22,7 +22,23 @@ module ApplicationTests
       require "#{rails_root}/config/environment"
 
       files, _ = Rails.application.watchable_args
-      assert_includes files, "#{rails_root}/app/README.md"
+      assert_not_includes files, "#{rails_root}/app/README.md"
+    end
+
+    test "watchable_args does include dirs in autoload path" do
+      add_to_config <<-RUBY
+        config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+        config.autoload_paths += %W(#{rails_root}/manually-specified-path)
+      RUBY
+      app_dir "app/automatically-specified-path"
+      app_dir "manually-specified-path"
+
+      require "#{rails_root}/config/environment"
+
+      _, dirs = Rails.application.watchable_args
+
+      assert_includes dirs, "#{rails_root}/app/automatically-specified-path"
+      assert_includes dirs, "#{rails_root}/manually-specified-path"
     end
   end
 end


### PR DESCRIPTION
### Motivation / Background

As commented in https://github.com/rails/rails/issues/37011#issuecomment-1322560651,
previously, changes in some files outside the autoload paths triggered reloading application.

For instance, editing `app/README.md` would trigger a reload,
even though the reloaded classes and modules, which were under autoload paths,
were identical to those loaded previously.

### Detail

This PR fixes this issue by ensuring the application reloads correctly
according to `Rails.autoloaders.main.dirs`, thereby preventing unnecessary reloads.

### Additional information

I have fixed the issue according to the above comment.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
