### PR TITLE
Prevent `CurrentAttributes` defaults from leaking

### DIFF
--- a/activesupport/test/current_attributes_test.rb
+++ b/activesupport/test/current_attributes_test.rb
@@ -214,6 +214,13 @@ class CurrentAttributesTest < ActiveSupport::TestCase
     assert_equal true, Current.respond_to?("respond_to_test")
   end
 
+  test "CurrentAttributes defaults do not leak between classes" do
+    Class.new(ActiveSupport::CurrentAttributes) { attribute :counter_integer, default: 100 }
+    Current.reset
+
+    assert_equal 0, Current.counter_integer
+  end
+
   test "CurrentAttributes use fiber-local variables" do
     previous_level = ActiveSupport::IsolatedExecutionState.isolation_level
     ActiveSupport::IsolatedExecutionState.isolation_level = :fiber


### PR DESCRIPTION
Follow-up to #50677.

Prior to this commit, all `ActiveSupport::CurrentAttributes` subclasses stored their default values in the same `Hash`, causing default values to leak between classes.  This commit ensures each subclass maintains a separate `Hash`.

This commit also simplifies the resolution of default values, replacing the `merge_defaults!` method with `resolve_defaults`.
