### PR TITLE
Fix assertion method call

### DIFF
--- a/activerecord/test/cases/associations_test.rb
+++ b/activerecord/test/cases/associations_test.rb
@@ -1228,7 +1228,7 @@ class PreloaderTest < ActiveRecord::TestCase
     # Expected
     #   SELECT FROM dogs ... (Dog)
     #   SELECT FROM dogs ... (OtherDog)
-    assert_queries(2) do
+    assert_queries_count(2) do
       preloader = ActiveRecord::Associations::Preloader.new(records: [dog_comment, other_dog_comment], associations: :origin)
       preloader.call
     end


### PR DESCRIPTION
Follow up to #50382.

`assert_queries` was renamed to `assert_queries_count` in #50373.
