### PR TITLE
Pool disabled query cache handling

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Only clear the query cache if either the connection pool or the connection itself has the query cache enabled.
+
+    *Donal McBreen*
+
 *   Make `ActiveRecord::Encryption::Encryptor` agnostic of the serialization format used for encrypted data.
 
     Previously, the encryptor instance only allowed an encrypted value serialized as a `String` to be passed to the message serializer.

--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -43,6 +43,9 @@ module ActiveRecord
       def db_config
         NULL_CONFIG
       end
+      def query_cache_enabled
+        false
+      end
     end
 
     # = Active Record Connection Pool

--- a/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb
@@ -21,7 +21,9 @@ module ActiveRecord
           method_names.each do |method_name|
             base.class_eval <<-end_code, __FILE__, __LINE__ + 1
               def #{method_name}(...)
-                ActiveRecord::Base.clear_query_caches_for_current_thread
+                if query_cache_enabled || pool.query_cache_enabled
+                  ActiveRecord::Base.clear_query_caches_for_current_thread
+                end
                 super
               end
             end_code

--- a/activerecord/test/cases/query_cache_test.rb
+++ b/activerecord/test/cases/query_cache_test.rb
@@ -650,6 +650,19 @@ class QueryCacheTest < ActiveRecord::TestCase
     ActiveRecord::Base.connection_pool.lock_thread = false
   end
 
+  def test_writes_to_a_pool_and_connection_with_the_query_cache_disabled_do_not_clear_other_pools
+    middleware { |env|
+      assert_cache :clean
+      Post.first
+      assert_cache :dirty
+
+      Professor.connection_pool.disable_query_cache!
+      Professor.create!(name: "Plum")
+
+      assert_cache :dirty
+    }.call({})
+  end
+
   private
     def with_temporary_connection_pool(&block)
       pool_config = ActiveRecord::Base.connection.pool.pool_config


### PR DESCRIPTION
### Motivation / Background

For [Solid Cache](https://github.com/rails/solid_cache), we want to be able to read and write from the cache database without using the query cache. 

We also don't want to expire the query cache on other connection pools when we write. Writing to the Rails cache shouldn't invalidate the main query cache.

This is an alternative to https://github.com/rails/rails/pull/50695, based on @byroot's [suggestion here](https://github.com/rails/rails/pull/50695#issuecomment-1885312807).

### Detail

After a database write we clear the query cache on all connection pools. The change here is that we will now only do that if either the connection pool or the connection itself has the query cache enabled.

The query cache is [enabled on all connection pools](https://github.com/rails/rails/blob/cff2eb1be11cb729382b3674e3caa2bd198ec55e/activerecord/lib/active_record/query_cache.rb#L28-L42) by the executor hooks, so to take advantage of this we'll need to add another executor hook that disables the query cache on the Solid Cache connection pool (but only when it has a dedicated pool). 

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
