### PR TITLE
Downcase the model name in the system scaffolds

### DIFF
--- a/railties/lib/rails/generators/test_unit/scaffold/templates/system_test.rb.tt
+++ b/railties/lib/rails/generators/test_unit/scaffold/templates/system_test.rb.tt
@@ -28,7 +28,7 @@ class <%= class_name.pluralize %>Test < ApplicationSystemTestCase
     click_on "Back"
   end
 
-  test "should update <%= human_name %>" do
+  test "should update <%= human_name.downcase %>" do
     visit <%= singular_table_name %>_url(@<%= singular_table_name %>)
     click_on "Edit this <%= human_name.downcase %>", match: :first
 
@@ -47,7 +47,7 @@ class <%= class_name.pluralize %>Test < ApplicationSystemTestCase
     click_on "Back"
   end
 
-  test "should destroy <%= human_name %>" do
+  test "should destroy <%= human_name.downcase %>" do
     visit <%= singular_table_name %>_url(@<%= singular_table_name %>)
     click_on "Destroy this <%= human_name.downcase %>", match: :first
 


### PR DESCRIPTION
### Motivation / Background

I noticed there is an inconsistency in the system test scaffold where the model name is sometimes capitalised. This fixes the two instances where the model name is humanised.

```rb
test "should create user"
test "should update User"
test "should destroy User"
```

Considering all the other scaffolds use lowercase text I think it's right these two are downcased in the same way.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
