### PR TITLE
Ensure only directories exist in Rails default load paths

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,17 @@
+*   Ensure only directories exist in Rails default load paths
+
+    Previously, some files put under `app` directory would contaminate the load paths.
+    This commit removes files from the default load paths set up by the Rails framework.
+
+    Now, only directories are included as default in the following paths:
+
+    * autoload_paths
+    * autoload_once_paths
+    * eager_load_paths
+    * load_paths
+
+    *Takumasa Ochi*
+
 *   Prevent unnecessary application reloads in development.
 
     Previously, some files outside autoload paths triggered unnecessary reloads.

--- a/railties/lib/rails/paths.rb
+++ b/railties/lib/rails/paths.rb
@@ -105,8 +105,8 @@ module Rails
     private
       def filter_by(&block)
         all_paths.find_all(&block).flat_map { |path|
-          paths = path.existent
-          paths - path.children.flat_map { |p| yield(p) ? [] : p.existent }
+          paths = path.existent_directories
+          paths - path.children.flat_map { |p| yield(p) ? [] : p.existent_directories }
         }.uniq
       end
     end


### PR DESCRIPTION
### Motivation / Background

As commented at https://github.com/rails/rails/issues/37011#issuecomment-1322560651,
files such as `app/README.md` should not be in the autoload paths.

### Detail

This PR removes files from the default load paths set up by the Rails framework.

### Additional information

Although `File.stub(:exist?, true)` in existing test has been changed to `File.stub(:directory?, true)`,
it is obvious that this does not break the objectives of the test.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
