### PR TITLE
Fix failing test due to the relative path output of minitest at v5.21.0

### DIFF
--- a/railties/test/generators/plugin_test_runner_test.rb
+++ b/railties/test/generators/plugin_test_runner_test.rb
@@ -73,7 +73,7 @@ class PluginTestRunnerTest < ActiveSupport::TestCase
     create_test_file "post", pass: false
 
     output = run_test_command("test/post_test.rb")
-    expect = %r{Running:\n\nPostTest\nF\n\nFailure:\nPostTest#test_truth \[[^\]]+test/post_test.rb:6\]:\nwups!\n\nbin/test (/private)?#{plugin_path}/test/post_test.rb:4}
+    expect = %r{Running:\n\nPostTest\nF\n\nFailure:\nPostTest#test_truth \[.*?test/post_test.rb:6\]:\nwups!\n\nbin/test (/private)?#{plugin_path}/test/post_test.rb:4}
     assert_match expect, output
   end
 

--- a/railties/test/generators/test_runner_in_engine_test.rb
+++ b/railties/test/generators/test_runner_in_engine_test.rb
@@ -27,7 +27,7 @@ class TestRunnerInEngineTest < ActiveSupport::TestCase
     create_test_file "post", pass: false
 
     output = run_test_command("test/post_test.rb")
-    expect = %r{Running:\n\nPostTest\nF\n\nFailure:\nPostTest#test_truth \[[^\]]+test/post_test\.rb:6\]:\nwups!\n\nbin/rails test test/post_test\.rb:4}
+    expect = %r{Running:\n\nPostTest\nF\n\nFailure:\nPostTest#test_truth \[.*?test/post_test\.rb:6\]:\nwups!\n\nbin/rails test test/post_test\.rb:4}
     assert_match expect, output
   end
 


### PR DESCRIPTION
This patch fixes failing test to pass regardless of minitest versions.

### Motivation / Background

minitest has been updated to output relative paths for failures at v5.21.0
https://github.com/minitest/minitest/commit/e410bade1723478cffb234faedd725cb0a599ec0

This causes test failures of `test/generators/plugin_test_runner_test.rb:72`

### Detail

This patch fixes the regular expression to run regardless of minitest versions.

### Additional information

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
