### PR TITLE
Action View Tests: Use `#with_routing` helper

### DIFF
--- a/actionview/test/actionpack/controller/view_paths_test.rb
+++ b/actionview/test/actionpack/controller/view_paths_test.rb
@@ -139,14 +139,16 @@ class ViewLoadPathsTest < ActionController::TestCase
 
   def test_view_paths_override_for_layouts_in_controllers_with_a_module
     @controller = Test::SubController.new
-    with_routes do
-      get :hello_world, to: "view_load_paths_test/test/sub#hello_world"
-    end
+    with_routing do |routes|
+      routes.draw do
+        get :hello_world, to: "view_load_paths_test/test/sub#hello_world"
+      end
 
-    Test::SubController.view_paths = [ "#{FIXTURE_LOAD_PATH}/override", FIXTURE_LOAD_PATH, "#{FIXTURE_LOAD_PATH}/override2" ]
-    get :hello_world
-    assert_response :success
-    assert_equal "layout: Hello overridden world!", @response.body
+      Test::SubController.view_paths = [ "#{FIXTURE_LOAD_PATH}/override", FIXTURE_LOAD_PATH, "#{FIXTURE_LOAD_PATH}/override2" ]
+      get :hello_world
+      assert_response :success
+      assert_equal "layout: Hello overridden world!", @response.body
+    end
   end
 
   def test_view_paths_override_at_request_time


### PR DESCRIPTION
### Motivation / Background

Follow-up to [#49819][]

### Detail

Since [#49819][] resolves an issue with
`ActionDispatch::IntegrationTest#with_routing` helper support, Action View's `test/abstract_unit.rb` file can rely on routing being reset within the block argument.

This means that the `RoutedRackApp` class and `.build_app` method is can be made unnecessary.

[#49819]: https://github.com/rails/rails/pull/49819
