### PR TITLE
Add test for not purging non referenced files

### DIFF
--- a/actiontext/test/integration/purge_later_test.rb
+++ b/actiontext/test/integration/purge_later_test.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class ActionText::PurgeLaterTest < ActiveJob::TestCase
+  test "doesn't delete the files" do
+    blob = create_file_blob(filename: "racecar.jpg", content_type: "image/jpeg")
+    message = Message.create!(content: ActionText::Content.new.append_attachables(blob))
+    assert_equal 1, message.content.body.attachables.size
+    assert_equal 1, message.content.embeds.size
+    message.update!(content: "")
+    perform_enqueued_jobs
+    assert_equal 0, message.content.body.attachables.size
+    assert_equal 1, message.content.embeds.size
+    assert_nothing_raised { blob.download }
+  end
+end


### PR DESCRIPTION
This was probably fixed between Rails 7.1 and Rails c6ef89824 (current main)

We encountered this problem on Rails 7.1

### Motivation / Background

We had a change in signed ids that affected our action text rich text (mentions and files). So I edited the rich text content but it deleted some files

### Detail

I wanted to fix this on rails main but I noticed it was already fixed, not sure when or by who

### Additional information

See https://github.com/rails/rails/issues/50707

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
