### PR TITLE
Upgrade minitest from 5.20.0 to 5.21.1 to fix mutex_m deprecation

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -327,7 +327,7 @@ GEM
     mini_magick (4.12.0)
     mini_mime (1.1.5)
     mini_portile2 (2.8.5)
-    minitest (5.20.0)
+    minitest (5.21.1)
     minitest-bisect (1.7.0)
       minitest-server (~> 1.0)
       path_expander (~> 1.1)


### PR DESCRIPTION
When running any test on the rails test suite, e.g. even doing `rake` a warning would show with:

```
/Users/dorianmariefr/.asdf/installs/ruby/3.3.0/lib/ruby/gems/3.3.0/gems/minitest-5.20.0/lib/minitest.rb:3: warning: mutex_m was loaded from the standard library, but will no longer be part of the default gems since Ruby 3.4.0. Add mutex_m to your Gemfile or gemspec. Also contact author of minitest-5.20.0 to add mutex_m into its gemspec.
```

This is fixed in the last version of minitest

- https://github.com/minitest/minitest/issues/969
- https://github.com/minitest/minitest/blob/master/History.rdoc
- https://github.com/minitest/minitest/commit/5f5c2111f36658fd2636b108b8327ce4b2f3cf8d