### PR TITLE
Fix single quote escapes on default generated MySQL columns

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,15 @@
+*   Fix single quote escapes on default generated MySQL columns
+
+    MySQL 5.7.5+ supports generated columns, which can be used to create a column that is computed from an expression.
+
+    Previously, the schema dump would output a string with double escapes for generated columns with single quotes in the default expression.
+
+    This would result in issues when importing the schema on a fresh instance of a MySQL database.
+
+    Now, the string will not be escaped and will be valid Ruby upon importing of the schema.
+
+    *Yash Kapadia*
+
 *   Fix Migrations with versions older than 7.1 validating options given to
     `add_reference` and `t.references`.
 

--- a/activerecord/lib/active_record/connection_adapters/mysql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/schema_statements.rb
@@ -185,6 +185,7 @@ module ActiveRecord
               default, default_function = nil, default
             elsif type_metadata.extra == "DEFAULT_GENERATED"
               default = +"(#{default})" unless default.start_with?("(")
+              default = default.gsub("\\'", "'")
               default, default_function = nil, default
             elsif type_metadata.type == :text && default&.start_with?("'")
               # strip and unescape quotes

--- a/activerecord/test/cases/defaults_test.rb
+++ b/activerecord/test/cases/defaults_test.rb
@@ -175,6 +175,13 @@ class MysqlDefaultExpressionTest < ActiveRecord::TestCase
         output = dump_table_schema("defaults")
         assert_match %r/t\.binary\s+"uuid",\s+limit: 36,\s+default: -> { "\(?uuid\(\)\)?" }/i, output
       end
+
+      if current_adapter?(:Mysql2Adapter)
+        test "schema dump includes default expression with single quotes reflected correctly" do
+          output = dump_table_schema("defaults")
+          assert_match %r/t\.string\s+"char2_concatenated",\s+default: -> { "\(?concat\(`char2`,(_utf8mb4)?'-'\)\)?" }/i, output
+        end
+      end
     end
 
     if supports_datetime_with_precision?

--- a/activerecord/test/schema/mysql2_specific_schema.rb
+++ b/activerecord/test/schema/mysql2_specific_schema.rb
@@ -23,6 +23,7 @@ ActiveRecord::Schema.define do
     t.string :char2, limit: 50, default: "a varchar field"
     if ActiveRecord::TestCase.supports_default_expression?
       t.binary :uuid, limit: 36, default: -> { "(uuid())" }
+      t.string :char2_concatenated, default: -> { "(concat(`char2`, '-'))" }
     end
   end
 


### PR DESCRIPTION
Closes https://github.com/rails/rails/issues/50732

### Motivation / Background

MySQL 5.7.5+ supports generated columns, which can be used to create a column that is computed from an expression. If single quotes are used in the definition of a default generated column, the schema dump will escape the quotes twice.

In a scenario such as the following:

```ruby
create_table :people, force: true do |t|
  t.string :first_name
  t.string :last_name
  t.string :full_name, default: -> { "(concat(`first_name`,_utf8mb4'-',`last_name`))" }
end
```

We want the schema dump to look like this:

```ruby
t.string "full_name", default: -> { "(concat(`first_name`,_utf8mb4'-',`last_name`))" }
```

And not this, which is how it is today:

```ruby
t.string "full_name", default: -> { "(concat(`first_name`,_utf8mb4\\'-\\',`last_name`))" }
```

See the related issue for more.

### Details

This pull request changes the schema statement generator under the `elsif` block for a column with `DEFAULT_GENERATED` in the metadata. In the changes, we simply `gsub` the escapes as we do in other parts of the class.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message.
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
