### PR TITLE
Optimize TagBuilder tag generation

### DIFF
--- a/actionview/lib/action_view/helpers/tag_helper.rb
+++ b/actionview/lib/action_view/helpers/tag_helper.rb
@@ -52,7 +52,7 @@ module ActionView
           code_generator.define_cached_method(method_name, namespace: :tag_builder) do |batch|
             batch.push(<<~RUBY) unless instance_methods.include?(method_name.to_sym)
               def #{method_name}(content = nil, escape: true, **options, &block)
-                tag_string(#{name.inspect}, content, escape: escape, **options, &block)
+                tag_string("#{name}", content, options, escape: escape, &block)
               end
             RUBY
           end
@@ -70,7 +70,7 @@ module ActionView
                     positional argument will raise, and using a block will have
                     no effect.
                   TEXT
-                  tag_string("#{name}", content, escape: escape, **options, &block)
+                  tag_string("#{name}", content, options, escape: escape, &block)
                 else
                   self_closing_tag_string("#{name}", options, escape, ">")
                 end
@@ -84,7 +84,7 @@ module ActionView
             batch.push(<<~RUBY)
               def #{method_name}(content = nil, escape: true, **options, &block)
                 if content || block
-                  tag_string("#{name}", content, escape: escape, **options, &block)
+                  tag_string("#{name}", content, options, escape: escape, &block)
                 else
                   self_closing_tag_string("#{name}", options, escape)
                 end
@@ -239,7 +239,7 @@ module ActionView
           tag_options(attributes.to_h).to_s.strip.html_safe
         end
 
-        def tag_string(name, content = nil, escape: true, **options, &block)
+        def tag_string(name, content = nil, options, escape: true, &block)
           content = @view_context.capture(self, &block) if block
 
           content_tag_string(name, content, options, escape)
@@ -252,7 +252,7 @@ module ActionView
         def content_tag_string(name, content, options, escape = true)
           tag_options = tag_options(options, escape) if options
 
-          if escape
+          if escape && content.present?
             content = ERB::Util.unwrapped_html_escape(content)
           end
           "<#{name}#{tag_options}>#{PRE_CONTENT_STRINGS[name]}#{content}</#{name}>".html_safe
@@ -334,12 +334,12 @@ module ActionView
             true
           end
 
-          def method_missing(called, ...)
+          def method_missing(called, *args, escape: true, **options, &block)
             name = called.name.dasherize
 
             TagHelper.ensure_valid_html5_tag_name(name)
 
-            tag_string(name, ...)
+            tag_string(name, *args, options, escape: escape, &block)
           end
       end
 

--- a/actionview/test/template/tag_helper_test.rb
+++ b/actionview/test/template/tag_helper_test.rb
@@ -45,7 +45,7 @@ class TagHelperTest < ActionView::TestCase
   end
 
   def test_tag_builder_self_closing_tag_with_content
-    assert_equal "<svg><circle><desc>A circle</desc></circle></svg>", tag.svg { tag.circle { tag.desc "A circle" } }
+    assert_equal "<svg><circle r=\"5\"><desc>A circle</desc></circle></svg>", tag.svg { tag.circle(r: "5") { tag.desc "A circle" } }
   end
 
   def test_tag_builder_defines_methods_to_build_html_elements


### PR DESCRIPTION
Currently there's about a 35% difference between tags generated using the `TagBuilder` and tags generated by passing a positional argument to `#tag`.

This commit optimizes `TagBuilder` to reduce that difference down to 13%.

The first change is to perform less hash allocations by not splatting the options twice in the `TagBuilder` (one at the `tag.a` invocation, and one at `tag_string`). The extra splat for `tag_string` was moved into `method_missing` since that is the only other caller of this private method.

The other change is to only escape the content in `tag_string` if it a non-empty.

Benchmark:

```
require "action_view"
require "benchmark/ips"

class Foo
  include ActionView::Helpers
end

helpers = Foo.new

Benchmark.ips do |x|
  x.report("tag") { helpers.tag("a", href: "foo") }
  x.report("tag_builder") { helpers.tag.a(href: "foo") }
  x.compare!
end
```

Before:

```
ruby 3.2.2 (2023-03-30 revision e51014f9c0) [arm64-darwin22]
Warming up --------------------------------------
                 tag    67.180k i/100ms
         tag_builder    50.267k i/100ms
Calculating -------------------------------------
                 tag    673.064k (± 0.4%) i/s -      3.426M in   5.090520s
         tag_builder    504.971k (± 0.4%) i/s -      2.564M in   5.076842s

Comparison:
                 tag:   673063.7 i/s
         tag_builder:   504971.4 i/s - 1.33x  slower
```

After:

```
ruby 3.2.2 (2023-03-30 revision e51014f9c0) [arm64-darwin22]
Warming up --------------------------------------
                 tag    67.374k i/100ms
         tag_builder    59.702k i/100ms
Calculating -------------------------------------
                 tag    670.837k (± 0.4%) i/s -      3.369M in   5.021714s
         tag_builder    592.727k (± 1.3%) i/s -      2.985M in   5.037088s

Comparison:
                 tag:   670836.6 i/s
         tag_builder:   592726.7 i/s - 1.13x  slower
```