### PR TITLE
Improve `after_enqueue` example

### DIFF
--- a/activejob/lib/active_job/callbacks.rb
+++ b/activejob/lib/active_job/callbacks.rb
@@ -132,7 +132,8 @@ module ActiveJob
       #     queue_as :default
       #
       #     after_enqueue do |job|
-      #       $statsd.increment "enqueue-video-job.success"
+      #       result = job.successfully_enqueued? ? "success" : "failure"
+      #       $statsd.increment "enqueue-video-job.#{result}"
       #     end
       #
       #     def perform(video_id)


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because the current example suggests that `after_enqueue` is only called if the enqueue is successful, which is not always true.

### Detail

This Pull Request changes the example to highlight the [introspection methods](https://github.com/rails/rails/commit/ee60ce5606cda9e17b76406aea004b9250bf3655) added in Rails 7.0.

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [X] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
