### PR TITLE
Fix $LOAD_PATH to correctly require files

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,9 +1,14 @@
 # frozen_string_literal: true
 
+require "bundler/setup"
 require "net/http"
 
-$:.unshift __dir__
+$LOAD_PATH.unshift __dir__
+
 require "tasks/release"
+
+$LOAD_PATH.unshift(*FRAMEWORKS.map { |framework| File.join(__dir__, framework, "lib") })
+
 require "railties/lib/rails/api/task"
 
 desc "Build gem files for all projects"


### PR DESCRIPTION
Other I would get errors like:

LoadError: cannot load such file -- rails/api/generator (LoadError)

We were loading the installed rails gem and not the current subdirectories

This can be reproduced by doing `bundle clean --force` then `rake`

Fixes #50739