### PR TITLE
Fix IPAddr prefix information missing when write to cache in msgpack serializer

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Include `IPAddr#prefix` when serializing an `IPAddr` using the
+    `ActiveSupport::MessagePack` serializer. This change is backward and forward
+    compatible — old payloads can still be read, and new payloads will be
+    readable by older versions of Rails.
+
+    *Taiki Komaba*
+
 *   Add `default:` support for `ActiveSupport::CurrentAttributes.attribute`
 
     ```ruby

--- a/activesupport/lib/active_support/message_pack/extensions.rb
+++ b/activesupport/lib/active_support/message_pack/extensions.rb
@@ -86,8 +86,9 @@ module ActiveSupport
           unpacker: URI.method(:parse)
 
         registry.register_type 14, IPAddr,
-          packer: :to_s,
-          unpacker: :new
+          packer: method(:write_ipaddr),
+          unpacker: method(:read_ipaddr),
+          recursive: true
 
         registry.register_type 15, Pathname,
           packer: :to_s,
@@ -219,6 +220,18 @@ module ActiveSupport
 
       def read_set(unpacker)
         Set.new(unpacker.read)
+      end
+
+      def write_ipaddr(ipaddr, packer)
+        if ipaddr.prefix < 32 || (ipaddr.ipv6? && ipaddr.prefix < 128)
+          packer.write("#{ipaddr}/#{ipaddr.prefix}")
+        else
+          packer.write(ipaddr.to_s)
+        end
+      end
+
+      def read_ipaddr(unpacker)
+        IPAddr.new(unpacker.read)
       end
 
       def write_hash_with_indifferent_access(hwia, packer)

--- a/activesupport/test/message_pack/shared_serializer_tests.rb
+++ b/activesupport/test/message_pack/shared_serializer_tests.rb
@@ -127,6 +127,12 @@ module MessagePackSharedSerializerTests
 
     test "roundtrips IPAddr" do
       assert_roundtrip IPAddr.new("127.0.0.1")
+      assert_roundtrip IPAddr.new("1.1.1.1/16")
+      assert_equal 16, load(dump(IPAddr.new("1.1.1.1/16"))).prefix
+
+      assert_roundtrip IPAddr.new("::1")
+      assert_roundtrip IPAddr.new("1:1:1:1:1:1:1:1/64")
+      assert_equal 64, load(dump(IPAddr.new("1:1:1:1:1:1:1:1/64"))).prefix
     end
 
     test "roundtrips Pathname" do


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created because we notice the msgpack serializer missing the prefix(netmask) data of IPAddr object when dump.

### Detail

This Pull Request fixed the missing prefix(netmask) data of IPAddr object when dumping by msgpack serializer.

### Additional information

#### `to_s` is not contains prefix(netmask) data.

```ruby
 IPAddr.new('192.168.0.1/24').to_s
=> "192.168.0.0"
```

So `to_s` missing the prefix(netmask) data when dump/load by msgpack serializer.

```ruby
irb(main):032> serializer = ActiveSupport::MessagePack::CacheSerializer
irb(main):033> serializer.load(serializer.dump(IPAddr.new('192.168.0.1/24')))
=> #<IPAddr: IPv4:192.168.0.0/255.255.255.255>
```

<!-- Provide additional information such as benchmarks, reference to other repositories or alternative solutions. -->

#### IPAddr object assertion
IPAddr instance equal assertion is not accurate to assert same data. This is reason why I use `inspect` for test.

```ruby
IPAddr.new('192.168.0.1/24') == IPAddr.new('192.168.0.0/32')
=> true
irb(main):027> IPAddr.new('192.168.0.1/24').inspect == IPAddr.new('192.168.0.0').inspect
=> false
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
