### PR TITLE
Remove `t.verbose = true` from Rake test tasks

### DIFF
--- a/actioncable/Rakefile
+++ b/actioncable/Rakefile
@@ -14,7 +14,6 @@ Rake::TestTask.new do |t|
   t.libs << "test"
   t.test_files = FileList["#{__dir__}/test/**/*_test.rb"]
   t.warning = true
-  t.verbose = true
   t.ruby_opts = ["--dev"] if defined?(JRUBY_VERSION)
 end
 

--- a/actionmailbox/Rakefile
+++ b/actionmailbox/Rakefile
@@ -9,7 +9,6 @@ task :package
 Rake::TestTask.new do |t|
   t.libs << "test"
   t.pattern = "test/**/*_test.rb"
-  t.verbose = true
 end
 
 namespace :test do

--- a/actionmailer/Rakefile
+++ b/actionmailer/Rakefile
@@ -12,7 +12,6 @@ Rake::TestTask.new { |t|
   t.libs << "test"
   t.pattern = "test/**/*_test.rb"
   t.warning = true
-  t.verbose = true
   t.ruby_opts = ["--dev"] if defined?(JRUBY_VERSION)
 }
 

--- a/actionpack/Rakefile
+++ b/actionpack/Rakefile
@@ -15,7 +15,6 @@ Rake::TestTask.new do |t|
   t.test_files = test_files
 
   t.warning = true
-  t.verbose = true
   t.ruby_opts = ["--dev"] if defined?(JRUBY_VERSION)
 end
 

--- a/actiontext/Rakefile
+++ b/actiontext/Rakefile
@@ -9,13 +9,11 @@ task :package
 Rake::TestTask.new do |t|
   t.libs << "test"
   t.test_files = FileList["test/**/*_test.rb"].exclude("test/system/**/*", "test/dummy/**/*")
-  t.verbose = true
 end
 
 Rake::TestTask.new "test:system" do |t|
   t.libs << "test"
   t.test_files = FileList["test/system/**/*_test.rb"]
-  t.verbose = true
 end
 
 namespace :test do

--- a/actionview/Rakefile
+++ b/actionview/Rakefile
@@ -26,7 +26,6 @@ namespace :test do
     t.libs << "test"
     t.test_files = FileList["test/template/**/*_test.rb"]
     t.warning = true
-    t.verbose = true
     t.ruby_opts = ["--dev"] if defined?(JRUBY_VERSION)
   end
 
@@ -36,7 +35,6 @@ namespace :test do
       t.libs << "test"
       t.test_files = FileList["test/activerecord/*_test.rb"]
       t.warning = true
-      t.verbose = true
       t.ruby_opts = ["--dev"] if defined?(JRUBY_VERSION)
     end
 
@@ -45,7 +43,6 @@ namespace :test do
       t.libs << "test"
       t.test_files = FileList["test/actionpack/**/*_test.rb"]
       t.warning = true
-      t.verbose = true
       t.ruby_opts = ["--dev"] if defined?(JRUBY_VERSION)
     end
   end

--- a/activejob/Rakefile
+++ b/activejob/Rakefile
@@ -40,7 +40,6 @@ namespace :test do
         (x.include?("delayed_job") && adapter != "delayed_job") ||
           (x.include?("async") && adapter != "async")
       }
-      t.verbose = true
       t.warning = true
       t.ruby_opts = ["--dev"] if defined?(JRUBY_VERSION)
     end
@@ -61,7 +60,6 @@ namespace :test do
         t.description = "Run integration tests for #{adapter}"
         t.libs << "test"
         t.test_files = FileList["test/integration/**/*_test.rb"]
-        t.verbose = true
         t.warning = true
         t.ruby_opts = ["--dev"] if defined?(JRUBY_VERSION)
       end

--- a/activemodel/Rakefile
+++ b/activemodel/Rakefile
@@ -10,7 +10,6 @@ Rake::TestTask.new do |t|
   t.libs << "test"
   t.test_files = FileList["#{__dir__}/test/cases/**/*_test.rb"]
   t.warning = true
-  t.verbose = true
   t.ruby_opts = ["--dev"] if defined?(JRUBY_VERSION)
 end
 

--- a/activerecord/Rakefile
+++ b/activerecord/Rakefile
@@ -44,7 +44,6 @@ namespace :test do
     t.test_files = FileList["test/cases/arel/**/*_test.rb"]
 
     t.warning = true
-    t.verbose = true
   end
 end
 
@@ -68,7 +67,6 @@ end
 
       t.test_files = files
       t.warning = true
-      t.verbose = true
       t.ruby_opts = ["--dev"] if defined?(JRUBY_VERSION)
     end
 
@@ -79,7 +77,6 @@ end
           t.libs << "test"
           t.test_files = FileList["test/activejob/*_test.rb"]
           t.warning = true
-          t.verbose = true
           t.ruby_opts = ["--dev"] if defined?(JRUBY_VERSION)
         end
       end
@@ -185,7 +182,6 @@ end
           t.test_files = FileList["test/cases/encryption/performance/*_test.rb"]
 
           t.warning = true
-          t.verbose = true
           t.ruby_opts = ["--dev"] if defined?(JRUBY_VERSION)
         end
       end

--- a/activestorage/Rakefile
+++ b/activestorage/Rakefile
@@ -8,7 +8,6 @@ Rake::TestTask.new do |t|
   t.libs << "app/controllers"
   t.libs << "test"
   t.test_files = FileList["test/**/*_test.rb"]
-  t.verbose = true
   t.warning = true
 end
 

--- a/activesupport/Rakefile
+++ b/activesupport/Rakefile
@@ -9,7 +9,6 @@ task :package
 Rake::TestTask.new do |t|
   t.pattern = "test/**/*_test.rb"
   t.warning = true
-  t.verbose = true
   t.ruby_opts = ["--dev"] if defined?(JRUBY_VERSION)
 end
 

--- a/railties/Rakefile
+++ b/railties/Rakefile
@@ -142,6 +142,5 @@ Rake::TestTask.new("test:regular") do |t|
   t.libs << "test" << "#{__dir__}/../activesupport/lib"
   t.pattern = "test/**/*_test.rb"
   t.warning = true
-  t.verbose = true
   t.ruby_opts = ["--dev"] if defined?(JRUBY_VERSION)
 end


### PR DESCRIPTION
Here is an example of the output it generated:

```
/Users/dorianmariefr/.asdf/installs/ruby/3.3.0/bin/ruby -w -I"lib" /Users/dorianmariefr/.asdf/installs/ruby/3.3.0/lib/ruby/gems/3.3.0/gems/rake-13.1.0/lib/rake/rake_test_loader.rb "test/actionable_error_test.rb" "test/array_inquirer_test.rb" "test/autoload_test.rb" "test/benchmarkable_test.rb" "test/broadcast_logger_test.rb" "test/cache/cache_coder_test.rb" "test/cache/cache_entry_test.rb" "test/cache/cache_key_test.rb" "test/cache/cache_store_logger_test.rb" "test/cache/cache_store_namespace_test.rb" "test/cache/cache_store_setting_test.rb" "test/cache/local_cache_middleware_test.rb" "test/cache/serializer_with_fallback_test.rb" "test/cache/stores/file_store_test.rb" "test/cache/stores/mem_cache_store_test.rb" "test/cache/stores/memory_store_test.rb" "test/cache/stores/null_store_test.rb" "test/cache/stores/redis_cache_store_test.rb" "test/callback_inheritance_test.rb" "test/callbacks_test.rb" "test/clean_backtrace_test.rb" "test/clean_logger_test.rb" "test/concern_test.rb" "test/concurrency/load_interlock_aware_monitor_test.rb" "test/configurable_test.rb" "test/configuration_file_test.rb" "test/core_ext/array/access_test.rb" "test/core_ext/array/conversions_test.rb" "test/core_ext/array/extract_options_test.rb" "test/core_ext/array/extract_test.rb" "test/core_ext/array/grouping_test.rb" "test/core_ext/array/wrap_test.rb" "test/core_ext/bigdecimal_test.rb" "test/core_ext/class/attribute_test.rb" "test/core_ext/class_test.rb" "test/core_ext/date_and_time_compatibility_test.rb" "test/core_ext/date_ext_test.rb" "test/core_ext/date_time_ext_test.rb" "test/core_ext/digest/uuid_test.rb" "test/core_ext/duration_test.rb" "test/core_ext/enumerable_test.rb" "test/core_ext/erb_util_test.rb" "test/core_ext/file_test.rb" "test/core_ext/hash/transform_values_test.rb" "test/core_ext/hash_ext_test.rb" "test/core_ext/integer_ext_test.rb" "test/core_ext/kernel/concern_test.rb" "test/core_ext/kernel_test.rb" "test/core_ext/load_error_test.rb" "test/core_ext/module/anonymous_test.rb" "test/core_ext/module/attr_internal_test.rb" "test/core_ext/module/attribute_accessor_per_thread_test.rb" "test/core_ext/module/attribute_accessor_test.rb" "test/core_ext/module/attribute_aliasing_test.rb" "test/core_ext/module/concerning_test.rb" "test/core_ext/module/introspection_test.rb" "test/core_ext/module/remove_method_test.rb" "test/core_ext/module_test.rb" "test/core_ext/name_error_test.rb" "test/core_ext/numeric_ext_test.rb" "test/core_ext/object/acts_like_test.rb" "test/core_ext/object/blank_test.rb" "test/core_ext/object/deep_dup_test.rb" "test/core_ext/object/duplicable_test.rb" "test/core_ext/object/inclusion_test.rb" "test/core_ext/object/instance_variables_test.rb" "test/core_ext/object/json_cherry_pick_test.rb" "test/core_ext/object/json_gem_encoding_test.rb" "test/core_ext/object/to_param_test.rb" "test/core_ext/object/to_query_test.rb" "test/core_ext/object/try_test.rb" "test/core_ext/object/with_test.rb" "test/core_ext/pathname/blank_test.rb" "test/core_ext/pathname/existence_test.rb" "test/core_ext/range_ext_test.rb" "test/core_ext/regexp_ext_test.rb" "test/core_ext/secure_random_test.rb" "test/core_ext/string_ext_test.rb" "test/core_ext/symbol_ext_test.rb" "test/core_ext/time_ext_test.rb" "test/core_ext/time_with_zone_test.rb" "test/current_attributes_test.rb" "test/deep_mergeable_test.rb" "test/dependencies_test.rb" "test/deprecation/deprecators_test.rb" "test/deprecation/method_wrappers_test.rb" "test/deprecation/proxy_wrappers_test.rb" "test/deprecation_test.rb" "test/descendants_tracker_test.rb" "test/digest_test.rb" "test/encrypted_configuration_test.rb" "test/encrypted_file_test.rb" "test/environment_inquirer_test.rb" "test/error_reporter_test.rb" "test/evented_file_update_checker_test.rb" "test/execution_context_test.rb" "test/executor_test.rb" "test/file_update_checker_test.rb" "test/fork_tracker_test.rb" "test/gzip_test.rb" "test/hash_with_indifferent_access_test.rb" "test/i18n_test.rb" "test/inflector_test.rb" "test/isolated_execution_state_test.rb" "test/json/decoding_test.rb" "test/json/encoding_test.rb" "test/key_generator_test.rb" "test/lazy_load_hooks_test.rb" "test/log_subscriber_test.rb" "test/logger_test.rb" "test/message_encryptor_test.rb" "test/message_encryptors_test.rb" "test/message_pack/cache_serializer_test.rb" "test/message_pack/serializer_test.rb" "test/message_verifier_test.rb" "test/message_verifiers_test.rb" "test/messages/message_encryptor_metadata_test.rb" "test/messages/message_encryptor_rotator_test.rb" "test/messages/message_verifier_metadata_test.rb" "test/messages/message_verifier_rotator_test.rb" "test/messages/rotation_configuration_test.rb" "test/messages/serializer_with_fallback_test.rb" "test/multibyte_chars_test.rb" "test/multibyte_proxy_test.rb" "test/notifications/evented_notification_test.rb" "test/notifications/instrumenter_test.rb" "test/notifications_test.rb" "test/number_helper_i18n_test.rb" "test/number_helper_test.rb" "test/option_merger_test.rb" "test/ordered_hash_test.rb" "test/ordered_options_test.rb" "test/parameter_filter_test.rb" "test/reloader_test.rb" "test/rescuable_test.rb" "test/safe_buffer_test.rb" "test/secure_compare_rotator_test.rb" "test/security_utils_test.rb" "test/share_lock_test.rb" "test/silence_logger_test.rb" "test/string_inquirer_test.rb" "test/subscriber_test.rb" "test/tagged_logging_test.rb" "test/test_case_test.rb" "test/testing/after_teardown_test.rb" "test/testing/constant_lookup_test.rb" "test/testing/file_fixtures_test.rb" "test/testing/method_call_assertions_test.rb" "test/time_travel_test.rb" "test/time_zone_test.rb" "test/transliterate_test.rb" "test/xml_mini/jdom_engine_test.rb" "test/xml_mini/libxml_engine_test.rb" "test/xml_mini/libxmlsax_engine_test.rb" "test/xml_mini/nokogiri_engine_test.rb" "test/xml_mini/nokogirisax_engine_test.rb" "test/xml_mini/rexml_engine_test.rb" "test/xml_mini/xml_mini_engine_test.rb" "test/xml_mini_test.rb"
```