### PR TITLE
Allow `schema_dump` database config to be set via DATABASE_URL

### DIFF
--- a/activerecord/lib/active_record/database_configurations/url_config.rb
+++ b/activerecord/lib/active_record/database_configurations/url_config.rb
@@ -44,6 +44,13 @@ module ActiveRecord
         @configuration_hash = @configuration_hash.merge(build_url_hash).freeze
       end
 
+      def schema_dump(format = ActiveRecord.schema_format)
+        schema_dump_config = super(format)
+        return nil if schema_dump_config == "false"
+
+        schema_dump_config
+      end
+
       private
         # Return a Hash that can be merged into the main config that represents
         # the passed in url

--- a/activerecord/test/cases/database_configurations/url_config_test.rb
+++ b/activerecord/test/cases/database_configurations/url_config_test.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+
+module ActiveRecord
+  class DatabaseConfigurations
+    class UrlConfigTest < ActiveRecord::TestCase
+      def test_schema_dump_set_to_false
+        config = UrlConfig.new("default_env", "primary", "postges://localhost/foo?schema_dump=false", {})
+        assert_nil config.schema_dump
+      end
+
+      def test_schema_dump_set_to_path
+        config = UrlConfig.new("default_env", "primary", "postges://localhost/foo?schema_dump=db/foo_schema.rb", {})
+        assert_equal "db/foo_schema.rb", config.schema_dump
+      end
+
+      def test_schema_dump_unset
+        config = UrlConfig.new("default_env", "primary", "postges://localhost/foo", {})
+        assert_equal "schema.rb", config.schema_dump
+      end
+    end
+  end
+end


### PR DESCRIPTION
In `database.yml`, `schema_dump` can currently be set to `false`, `nil` or a file path.

I found that if you configure your database via DATABASE_URL, the false value does not work because it comes through as a string.

This change allows `?schema_dump=false` to disable the dump via database_url.

### Additional information

Original PR for `schema_dump` https://github.com/rails/rails/pull/42804

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
