### PR TITLE
Remove python setup from CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -26,11 +26,6 @@ jobs:
     - name: mdl
       run: bundle exec rake -f guides/Rakefile guides:lint
 
-    - name: Set up Python
-      uses: actions/setup-python@v3
-      with:
-        python-version: "3.10"
-
     - run: tools/railspect changelogs .
     - run: tools/railspect configuration .
 


### PR DESCRIPTION
We recently removed codespell from the CI https://github.com/rails/rails/pull/50657, python was configured for running the codespell. 