### PR TITLE
Fix typo in ActiveSupport changelog

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -23,7 +23,7 @@
 
     *Jonathan Hefner*
 
-*   Fix `Time.now/DateTime.now/Date.today' to return results in a system timezone after `#travel_to'.
+*   Fix `Time.now/DateTime.now/Date.today` to return results in a system timezone after `#travel_to`.
 
     There is a bug in the current implementation of #travel_to:
     it remembers a timezone of its argument, and all stubbed methods start


### PR DESCRIPTION
Backport to 7.1 as well because https://github.com/rails/rails/commit/f06d5838a476c6cb8ed27084f29e61f1e949257e

cc @907th for #50292 which contains this for 7.0 but hasn't been merged yet.