### PR TITLE
Add silenced? for Action View Start subscriber

### DIFF
--- a/actionview/lib/action_view/log_subscriber.rb
+++ b/actionview/lib/action_view/log_subscriber.rb
@@ -96,6 +96,10 @@ module ActionView
 
       def finish(name, id, payload)
       end
+
+      def silenced?(_)
+        logger.nil? || !logger.debug?
+      end
     end
 
     def self.attach_to(*)


### PR DESCRIPTION
### Motivation / Background

Ref #45796 

Previously, the `render_template.action_view` and `render_layout.action_view` events would always be handled as if they had subscribers even if the log level of its subscribers result in nothing being logged. For regular `LogSubscriber`s, `subscribe_log_level` could be used to optimize these cases but the Start subscriber is not a subclass of `LogSubscriber`.

### Detail

This commit implements a `#silenced?` method for the Start subscriber so that it can also benefit from the `subscribe_log_level` optimization.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
