### PR TITLE
removes deprecated yarn check in bin/setup

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/bin/setup.tt
+++ b/railties/lib/rails/generators/rails/app/templates/bin/setup.tt
@@ -18,7 +18,7 @@ FileUtils.chdir APP_ROOT do
 <% if using_node? -%>
 
   # Install JavaScript dependencies
-  system("yarn check --check-files") || system!("yarn install")
+  system("yarn install --check-files")
 <% elsif using_bun? -%>
 
   # Install JavaScript dependencies


### PR DESCRIPTION
### Motivation / Background

While running a fresh Rails install I got a bunch of warnings from the command `yarn check --check-files` and dig a bit into [the documentation](https://classic.yarnpkg.com/lang/en/docs/cli/check/#toc-yarn-check)

This Pull Request has been created because it appears the `check` command is deprecated and will be removed in [Yarn 2.0](https://github.com/yarnpkg/rfcs/pull/106)


### Detail

This Pull Request changes the generator to replace 
```
system("yarn check --check-files") || system!("yarn install") 
``` 

by the recommended command

```
system("yarn install--check-files")
``` 

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
