### PR TITLE
Allow named variants to evaluate dynamic transformation options

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,2 +1,5 @@
+*   Add ability to define named variant transformations dynamically.
+
+    *Carlos Palhares*
 
 Please check [7-2-stable](https://github.com/rails/rails/blob/7-2-stable/activestorage/CHANGELOG.md) for previous changes.

--- a/activestorage/app/models/active_storage/attachment.rb
+++ b/activestorage/app/models/active_storage/attachment.rb
@@ -166,7 +166,7 @@ class ActiveStorage::Attachment < ActiveStorage::Record
         named_variants.fetch(variant_name) do
           record_model_name = record.to_model.model_name.name
           raise ArgumentError, "Cannot find variant :#{variant_name} for #{record_model_name}##{name}"
-        end.transformations
+        end.transformations_for(record)
       else
         transformations
       end

--- a/activestorage/app/models/active_storage/named_variant.rb
+++ b/activestorage/app/models/active_storage/named_variant.rb
@@ -9,13 +9,23 @@ class ActiveStorage::NamedVariant # :nodoc:
   end
 
   def preprocessed?(record)
-    case preprocessed
-    when Symbol
-      record.send(preprocessed)
-    when Proc
-      preprocessed.call(record)
-    else
-      preprocessed
-    end
+    callable_value(record, preprocessed)
   end
+
+  def transformations_for(record)
+    callable = method(:callable_value).curry.call(record)
+    transformations.transform_values(&callable)
+  end
+
+  private
+    def callable_value(record, method_or_value)
+      case method_or_value
+      when Symbol
+        record.send(method_or_value)
+      when Proc
+        method_or_value.call(record)
+      else
+        method_or_value
+      end
+    end
 end

--- a/activestorage/test/models/attached/many_test.rb
+++ b/activestorage/test/models/attached/many_test.rb
@@ -866,6 +866,36 @@ class ActiveStorage::ManyAttachedTest < ActiveSupport::TestCase
     assert_equal 67, image.height
   end
 
+  test "creating variation with dynamic variation method" do
+    john = User.create!(name: "John")
+
+    assert_no_enqueued_jobs only: ActiveStorage::TransformJob do
+      @user.highlights_with_dynamic.attach fixture_file_upload("racecar.jpg")
+      john.highlights_with_dynamic.attach fixture_file_upload("racecar.jpg")
+    end
+
+    josh_variation = @user.highlights_with_dynamic.first.variant(:thumb).variation
+    john_variation = john.highlights_with_dynamic.first.variant(:thumb).variation
+
+    assert_equal({ format: "jpg", resize_to_limit: [100, 100] }, josh_variation.transformations)
+    assert_equal({ format: "jpg", resize_to_limit: [200, 200] }, john_variation.transformations)
+  end
+
+  test "creating variation with dynamic variation proc" do
+    john = User.create!(name: "John")
+
+    assert_no_enqueued_jobs only: ActiveStorage::TransformJob do
+      @user.highlights_with_dynamic.attach fixture_file_upload("racecar.jpg")
+      john.highlights_with_dynamic.attach fixture_file_upload("racecar.jpg")
+    end
+
+    josh_variation = @user.highlights_with_dynamic.first.variant(:thumb_proc).variation
+    john_variation = john.highlights_with_dynamic.first.variant(:thumb_proc).variation
+
+    assert_equal({ format: "jpg", resize_to_limit: [100, 100] }, josh_variation.transformations)
+    assert_equal({ format: "jpg", resize_to_limit: [200, 200] }, john_variation.transformations)
+  end
+
   test "raises error when unknown variant name is used to generate variant" do
     @user.highlights_with_variants.attach fixture_file_upload("racecar.jpg")
 

--- a/activestorage/test/models/attached/one_test.rb
+++ b/activestorage/test/models/attached/one_test.rb
@@ -806,6 +806,21 @@ class ActiveStorage::OneAttachedTest < ActiveSupport::TestCase
     assert_equal 67, image.height
   end
 
+  test "creating variation with dynamic variation" do
+    john = User.create!(name: "John")
+
+    assert_no_enqueued_jobs only: ActiveStorage::TransformJob do
+      @user.avatar_with_dynamic.attach fixture_file_upload("racecar.jpg")
+      john.avatar_with_dynamic.attach fixture_file_upload("racecar.jpg")
+    end
+
+    josh_variation = @user.avatar_with_dynamic.variant(:thumb).variation
+    john_variation = john.avatar_with_dynamic.variant(:thumb).variation
+
+    assert_equal({ format: "jpg", resize_to_limit: [100, 100] }, josh_variation.transformations)
+    assert_equal({ format: "jpg", resize_to_limit: [200, 200] }, john_variation.transformations)
+  end
+
   test "raises error when unknown variant name is used to generate variant" do
     @user.avatar_with_variants.attach fixture_file_upload("racecar.jpg")
 

--- a/activestorage/test/models/reflection_test.rb
+++ b/activestorage/test/models/reflection_test.rb
@@ -39,8 +39,8 @@ class ActiveStorage::ReflectionTest < ActiveSupport::TestCase
   test "reflecting on all attachments" do
     reflections = User.reflect_on_all_attachments.sort_by(&:name)
     assert_equal [ User ], reflections.collect(&:active_record).uniq
-    assert_equal %i[ avatar avatar_with_conditional_preprocessed avatar_with_preprocessed avatar_with_variants cover_photo highlights highlights_with_conditional_preprocessed highlights_with_preprocessed highlights_with_variants intro_video name_pronunciation_audio resume resume_with_preprocessing vlogs ], reflections.collect(&:name)
-    assert_equal %i[ has_one_attached has_one_attached has_one_attached has_one_attached has_one_attached has_many_attached has_many_attached has_many_attached has_many_attached has_one_attached has_one_attached has_one_attached has_one_attached has_many_attached ], reflections.collect(&:macro)
-    assert_equal [ :purge_later, :purge_later, :purge_later, :purge_later, false, :purge_later, :purge_later, :purge_later, :purge_later, :purge_later, :purge_later, :purge_later, :purge_later, false ], reflections.collect { |reflection| reflection.options[:dependent] }
+    assert_equal %i[ avatar avatar_with_conditional_preprocessed avatar_with_dynamic avatar_with_preprocessed avatar_with_variants cover_photo highlights highlights_with_conditional_preprocessed highlights_with_preprocessed highlights_with_variants intro_video name_pronunciation_audio resume resume_with_preprocessing vlogs ], reflections.collect(&:name)
+    assert_equal %i[ has_one_attached has_one_attached has_one_attached has_one_attached has_one_attached has_one_attached has_many_attached has_many_attached has_many_attached has_many_attached has_many_attached has_one_attached has_one_attached has_one_attached has_one_attached has_many_attached ], reflections.collect(&:macro)
+    assert_equal [ :purge_later, :purge_later, :purge_later, :purge_later, :purge_later, false, :purge_later, :purge_later, :purge_later, :purge_later, :purge_later, :purge_later, :purge_later, :purge_later, :purge_later, false ], reflections.collect { |reflection| reflection.options[:dependent] }
   end
 end

--- a/activestorage/test/test_helper.rb
+++ b/activestorage/test/test_helper.rb
@@ -131,6 +131,10 @@ class User < ActiveRecord::Base
 
   has_one_attached :avatar
   has_one_attached :cover_photo, dependent: false, service: :local
+  has_one_attached :avatar_with_dynamic do |attachable|
+    attachable.variant :thumb, resize_to_limit: :thumb_size
+    attachable.variant :thumb_proc, resize_to_limit: ->(model) { model.thumb_size }
+  end
   has_one_attached :avatar_with_variants do |attachable|
     attachable.variant :thumb, resize_to_limit: [100, 100]
   end
@@ -150,6 +154,10 @@ class User < ActiveRecord::Base
   has_many_attached :vlogs, dependent: false, service: :local
   has_many_attached :highlights_with_variants do |attachable|
     attachable.variant :thumb, resize_to_limit: [100, 100]
+  end
+  has_many_attached :highlights_with_dynamic do |attachable|
+    attachable.variant :thumb, resize_to_limit: :thumb_size
+    attachable.variant :thumb_proc, resize_to_limit: ->(model) { model.thumb_size }
   end
   has_many_attached :highlights_with_preprocessed do |attachable|
     attachable.variant :bool, resize_to_limit: [1, 1], preprocessed: true
@@ -171,6 +179,12 @@ class User < ActiveRecord::Base
 
   def should_preprocessed?
     name == "transform via method"
+  end
+
+  def thumb_size
+    return [200, 200] if name == "John"
+
+    [100, 100]
   end
 end
 


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

Sometimes you want to build a transformation based on the user input, or information persisted in the database (i.e.: add a watermark to a picture, crop based on user input)

### Detail

This PR allow the transformations to be built based on user input:

```ruby
class User < ApplicationRecord
  has_one_attached :photo do |attachable|
    attachable.variant :default, crop: ->(user) { user.crop_positions }
    attachable.variant :thumb, crop: :crop_positions,
                               resize_to_limit: [100, 100]
  end

  def crop_positions
    [crop_x1, crop_y1, crop_x2, crop_y2]
  end
end
```

### Checklist

Before submitting the PR make sure the following are checked:

- [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
- [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
- [x] Tests are added or updated if you fix a bug or add a feature.
- [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
