### PR TITLE
Eagerly load preview images (N+1)

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Fix N+1 query when fetching preview images for non-image assets
+
+    *Aaron Patterson & Justin Searls*
+
 *   Fix all Active Storage database related models to respect
     `ActiveRecord::Base.table_name_prefix` configuration.
 

--- a/activestorage/app/models/active_storage/attachment.rb
+++ b/activestorage/app/models/active_storage/attachment.rb
@@ -42,7 +42,10 @@ class ActiveStorage::Attachment < ActiveStorage::Record
   # Eager load all variant records on an attachment at once.
   #
   #   User.first.avatars.with_all_variant_records
-  scope :with_all_variant_records, -> { includes(blob: { variant_records: { image_attachment: :blob } }) }
+  scope :with_all_variant_records, -> { includes(blob: {
+    variant_records: { image_attachment: :blob },
+    preview_image_attachment: { blob: { variant_records: { image_attachment: :blob } } }
+  }) }
 
   # Synchronously deletes the attachment and {purges the blob}[rdoc-ref:ActiveStorage::Blob#purge].
   def purge

--- a/activestorage/lib/active_storage/attached/model.rb
+++ b/activestorage/lib/active_storage/attached/model.rb
@@ -126,7 +126,10 @@ module ActiveStorage
 
         scope :"with_attached_#{name}", -> {
           if ActiveStorage.track_variants
-            includes("#{name}_attachment": { blob: { variant_records: { image_attachment: :blob } } })
+            includes("#{name}_attachment": { blob: {
+              variant_records: { image_attachment: :blob },
+              preview_image_attachment: { blob: { variant_records: { image_attachment: :blob } } }
+            } })
           else
             includes("#{name}_attachment": :blob)
           end
@@ -223,7 +226,10 @@ module ActiveStorage
 
         scope :"with_attached_#{name}", -> {
           if ActiveStorage.track_variants
-            includes("#{name}_attachments": { blob: { variant_records: { image_attachment: :blob } } })
+            includes("#{name}_attachments": { blob: {
+              variant_records: { image_attachment: :blob },
+              preview_image_attachment: { blob: { variant_records: { image_attachment: :blob } } }
+            } })
           else
             includes("#{name}_attachments": :blob)
           end

--- a/activestorage/test/models/variant_with_record_test.rb
+++ b/activestorage/test/models/variant_with_record_test.rb
@@ -106,7 +106,7 @@ class ActiveStorage::VariantWithRecordTest < ActiveSupport::TestCase
 
     assert_no_difference -> { ActiveStorage::VariantRecord.count } do
       assert_queries_count(6) do
-        # 5 queries:
+        # 6 queries:
         # attachment (cover photos) x 1
         # blob for the cover photo x 1
         # variant record x 1

--- a/activestorage/test/models/variant_with_record_test.rb
+++ b/activestorage/test/models/variant_with_record_test.rb
@@ -122,6 +122,36 @@ class ActiveStorage::VariantWithRecordTest < ActiveSupport::TestCase
     end
   end
 
+  def find_keys_for_representation(filename)
+    user = User.create!(name: "Justin")
+
+    10.times do
+      blob = directly_upload_file_blob(filename: filename)
+      user.highlights_with_variants.attach(blob)
+    end
+
+    # Force the processing
+    user.highlights_with_variants.each do |highlight|
+      highlight.representation(:thumb).processed.key
+    end
+
+    highlights = User.with_attached_highlights_with_variants.find_by(name: "Justin").highlights_with_variants.to_a
+
+    assert_queries_count(0) do
+      highlights.each do |highlight|
+        highlight.representation(:thumb).key
+      end
+    end
+  end
+
+  def test_with_attached_image_variant_no_n_plus_1
+    find_keys_for_representation "racecar.jpg"
+  end
+
+  def test_with_attached_video_variant_no_n_plus_1
+    find_keys_for_representation "video.mp4"
+  end
+
   test "eager loading has_many_attached records" do
     user = User.create!(name: "Josh")
 

--- a/activestorage/test/models/variant_with_record_test.rb
+++ b/activestorage/test/models/variant_with_record_test.rb
@@ -105,11 +105,12 @@ class ActiveStorage::VariantWithRecordTest < ActiveSupport::TestCase
     users.reset
 
     assert_no_difference -> { ActiveStorage::VariantRecord.count } do
-      assert_queries_count(5) do
+      assert_queries_count(6) do
         # 5 queries:
         # attachment (cover photos) x 1
         # blob for the cover photo x 1
         # variant record x 1
+        # preview_image_attachments for non-images
         # attachment x 1
         # variant record x 1
         users.with_attached_cover_photo.each do |u|
@@ -248,12 +249,13 @@ class ActiveStorage::VariantWithRecordTest < ActiveSupport::TestCase
     user.reload
 
     assert_no_difference -> { ActiveStorage::VariantRecord.count } do
-      assert_queries_count(6) do
-        # 6 queries:
+      assert_queries_count(7) do
+        # 7 queries:
         # user x 1
         # attachments (vlogs) x 1
         # blobs for the vlogs x 1
         # variant records for the blobs x 1
+        # preview_image_attachments for non-images
         # attachments for the variant records x 1
         # blobs for the attachments for the variant records x 1
         User.where(id: user.id).with_attached_vlogs.each do |u|

--- a/railties/test/application/test_runner_test.rb
+++ b/railties/test/application/test_runner_test.rb
@@ -799,7 +799,7 @@ module ApplicationTests
 
       assert_match %r{Interrupt}, @error_output
       assert_equal 1, matches[3].to_i
-      assert matches[1].to_i < 11
+      assert_operator matches[1].to_i, :<, 11
     end
 
     def test_run_in_parallel_with_processes


### PR DESCRIPTION
For non-image attachments (like videos), generated representations are
created as a preview_image_attachment instead of as normal variants, and
as a result aren't included in the `with_attached_` scopes. This adds
those preview image attachments to the `includes` of these scopes to
avoid an N+1 when iterating over a collection of attachments and
fetching the key of their representation (variants).

Fixes #50560