### PR TITLE
Improve documentation of ActiveRecord::Core.configurations

### DIFF
--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -73,7 +73,29 @@ module ActiveRecord
       end
       self.configurations = {}
 
-      # Returns a fully resolved ActiveRecord::DatabaseConfigurations object.
+      ##
+      # Contains the database configuration - as is typically stored in
+      # config/database.yml - as an ActiveRecord::DatabaseConfigurations
+      # object.
+      #
+      # For example, the following database.yml...
+      #
+      #   development:
+      #     adapter: sqlite3
+      #     database: storage/development.sqlite3
+      #
+      #   production:
+      #     adapter: sqlite3
+      #     database: storage/production.sqlite3
+      #
+      # ...would result in ActiveRecord::Base.configurations to look like this:
+      #
+      #   #<ActiveRecord::DatabaseConfigurations:0x00007fd1acbdf800 @configurations=[
+      #     #<ActiveRecord::DatabaseConfigurations::HashConfig:0x00007fd1acbded10 @env_name="development",
+      #       @name="primary", @config={adapter: "sqlite3", database: "storage/development.sqlite3"}>,
+      #     #<ActiveRecord::DatabaseConfigurations::HashConfig:0x00007fd1acbdea90 @env_name="production",
+      #       @name="primary", @config={adapter: "sqlite3", database: "storage/production.sqlite3"}>
+      #   ]>
       def self.configurations
         @@configurations
       end

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -47,27 +47,11 @@ module ActiveRecord
       class_attribute :destroy_association_async_batch_size, instance_writer: false, instance_predicate: false, default: nil
 
       ##
-      # Contains the database configuration - as is typically stored in config/database.yml -
-      # as an ActiveRecord::DatabaseConfigurations object.
+      # Sets the database configuration:
       #
-      # For example, the following database.yml...
-      #
-      #   development:
-      #     adapter: sqlite3
-      #     database: storage/development.sqlite3
-      #
-      #   production:
-      #     adapter: sqlite3
-      #     database: storage/production.sqlite3
-      #
-      # ...would result in ActiveRecord::Base.configurations to look like this:
-      #
-      #   #<ActiveRecord::DatabaseConfigurations:0x00007fd1acbdf800 @configurations=[
-      #     #<ActiveRecord::DatabaseConfigurations::HashConfig:0x00007fd1acbded10 @env_name="development",
-      #       @name="primary", @config={adapter: "sqlite3", database: "storage/development.sqlite3"}>,
-      #     #<ActiveRecord::DatabaseConfigurations::HashConfig:0x00007fd1acbdea90 @env_name="production",
-      #       @name="primary", @config={adapter: "sqlite3", database: "storage/production.sqlite3"}>
-      #   ]>
+      #   ActiveRecord::Base.configurations = {
+      #     "development" => { "adapter" => "abstract", "database" => "dev-db" }
+      #   }
       def self.configurations=(config)
         @@configurations = ActiveRecord::DatabaseConfigurations.new(config)
       end


### PR DESCRIPTION
### Motivation / Background

The documenation of `ActiveRecord::Core.configurations=` [reads](https://edgeapi.rubyonrails.org/classes/ActiveRecord/Core.html#method-c-configurations-3D) like the documentation for the getter instead of the setter.
It should not describe what is returned, but what arguments are expected.

This changes moves the documentation of the setter to the getter and adds a new comment to the setter.

This commit has 2 separate commits to make sure the diffs only apply to documentation and not the code.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
