### PR TITLE
Handle nil backtrace_locations in SyntaxErrorProxy

### DIFF
--- a/actionpack/test/dispatch/exception_wrapper_test.rb
+++ b/actionpack/test/dispatch/exception_wrapper_test.rb
@@ -83,6 +83,14 @@ module ActionDispatch
      end
     end
 
+    test "#source_extracts works with nil backtrace_locations" do
+      exception = begin eval "class Foo; yield; end"; rescue SyntaxError => ex; ex; end
+
+      wrapper = ExceptionWrapper.new(nil, exception)
+
+      assert_empty wrapper.source_extracts
+    end
+
     if defined?(ErrorHighlight) && Gem::Version.new(ErrorHighlight::VERSION) >= Gem::Version.new("0.4.0")
       test "#source_extracts works with error_highlight" do
         lineno = __LINE__

--- a/activesupport/lib/active_support/syntax_error_proxy.rb
+++ b/activesupport/lib/active_support/syntax_error_proxy.rb
@@ -32,6 +32,8 @@ module ActiveSupport
     end
 
     def backtrace_locations
+      return nil if super.nil?
+
       parse_message_for_trace.map { |trace|
         file, line = trace.match(/^(.+?):(\d+).*$/, &:captures) || trace
         BacktraceLocation.new(file, line.to_i, trace)


### PR DESCRIPTION
Some `SyntaxError`s do not have `backtrace_locations` set. Previously this would cause an error that would bubble up to the web server, e.g. with Puma:

```
Puma caught this error: undefined method `map' for nil:NilClass (NoMethodError)
/Users/eugene/lib/rails/activesupport/lib/active_support/syntax_error_proxy.rb:41:in `backtrace_locations'
/Users/eugene/lib/rails/actionpack/lib/action_dispatch/middleware/exception_wrapper.rb:268:in `build_backtrace'
/Users/eugene/lib/rails/actionpack/lib/action_dispatch/middleware/exception_wrapper.rb:56:in `initialize'
/Users/eugene/lib/rails/actionpack/lib/action_dispatch/middleware/exception_wrapper.rb:289:in `new'
/Users/eugene/lib/rails/actionpack/lib/action_dispatch/middleware/exception_wrapper.rb:289:in `block in wrapped_causes_for'
/Users/eugene/lib/rails/actionpack/lib/action_dispatch/middleware/exception_wrapper.rb:285:in `causes_for'
/Users/eugene/lib/rails/actionpack/lib/action_dispatch/middleware/exception_wrapper.rb:289:in `each'
/Users/eugene/lib/rails/actionpack/lib/action_dispatch/middleware/exception_wrapper.rb:289:in `map'
/Users/eugene/lib/rails/actionpack/lib/action_dispatch/middleware/exception_wrapper.rb:289:in `wrapped_causes_for'
/Users/eugene/lib/rails/actionpack/lib/action_dispatch/middleware/exception_wrapper.rb:51:in `initialize'
/Users/eugene/lib/rails/actionpack/lib/action_dispatch/middleware/show_exceptions.rb:35:in `new'
/Users/eugene/lib/rails/actionpack/lib/action_dispatch/middleware/show_exceptions.rb:35:in `rescue in call'
/Users/eugene/lib/rails/actionpack/lib/action_dispatch/middleware/show_exceptions.rb:30:in `call'
/Users/eugene/lib/rails/railties/lib/rails/rack/logger.rb:37:in `call_app'
/Users/eugene/lib/rails/railties/lib/rails/rack/logger.rb:24:in `block in call'
/Users/eugene/lib/rails/activesupport/lib/active_support/tagged_logging.rb:135:in `block in tagged'
/Users/eugene/lib/rails/activesupport/lib/active_support/tagged_logging.rb:39:in `tagged'
/Users/eugene/lib/rails/activesupport/lib/active_support/tagged_logging.rb:135:in `tagged'
/Users/eugene/lib/rails/activesupport/lib/active_support/broadcast_logger.rb:240:in `method_missing'
/Users/eugene/lib/rails/railties/lib/rails/rack/logger.rb:24:in `call'
/Users/eugene/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/sprockets-rails-3.4.2/lib/sprockets/rails/quiet_assets.rb:13:in `call'
/Users/eugene/lib/rails/actionpack/lib/action_dispatch/middleware/remote_ip.rb:92:in `call'
/Users/eugene/lib/rails/actionpack/lib/action_dispatch/middleware/request_id.rb:28:in `call'
/Users/eugene/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/rack-3.0.8/lib/rack/method_override.rb:28:in `call'
/Users/eugene/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/rack-3.0.8/lib/rack/runtime.rb:24:in `call'
/Users/eugene/lib/rails/activesupport/lib/active_support/cache/strategy/local_cache_middleware.rb:29:in `call'
/Users/eugene/lib/rails/actionpack/lib/action_dispatch/middleware/server_timing.rb:59:in `block in call'
/Users/eugene/lib/rails/actionpack/lib/action_dispatch/middleware/server_timing.rb:24:in `collect_events'
/Users/eugene/lib/rails/actionpack/lib/action_dispatch/middleware/server_timing.rb:58:in `call'
/Users/eugene/lib/rails/actionpack/lib/action_dispatch/middleware/executor.rb:14:in `call'
/Users/eugene/lib/rails/actionpack/lib/action_dispatch/middleware/static.rb:25:in `call'
/Users/eugene/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/rack-3.0.8/lib/rack/sendfile.rb:114:in `call'
/Users/eugene/lib/rails/actionpack/lib/action_dispatch/middleware/host_authorization.rb:141:in `call'
/Users/eugene/lib/rails/railties/lib/rails/engine.rb:536:in `call'
/Users/eugene/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/puma-6.4.1/lib/puma/configuration.rb:272:in `call'
/Users/eugene/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/puma-6.4.1/lib/puma/request.rb:100:in `block in handle_request'
/Users/eugene/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/puma-6.4.1/lib/puma/thread_pool.rb:378:in `with_force_shutdown'
/Users/eugene/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/puma-6.4.1/lib/puma/request.rb:99:in `handle_request'
/Users/eugene/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/puma-6.4.1/lib/puma/server.rb:464:in `process_client'
/Users/eugene/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/puma-6.4.1/lib/puma/server.rb:245:in `block in run'
/Users/eugene/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/puma-6.4.1/lib/puma/thread_pool.rb:155:in `block in spawn_thread'
```