### PR TITLE
Modernize method missing implementations

### DIFF
--- a/actionmailer/lib/action_mailer/base.rb
+++ b/actionmailer/lib/action_mailer/base.rb
@@ -668,7 +668,7 @@ module ActionMailer
         true
       end
 
-      def method_missing(*args)
+      def method_missing(...)
         nil
       end
     end

--- a/actionpack/lib/action_controller/metal/mime_responds.rb
+++ b/actionpack/lib/action_controller/metal/mime_responds.rb
@@ -306,7 +306,7 @@ module ActionController # :nodoc:
         end
         alias :all :any
 
-        def method_missing(name, *args, &block)
+        def method_missing(name, *, &block)
           @variants[name] = block if block_given?
         end
 

--- a/actionpack/lib/action_dispatch/http/mime_type.rb
+++ b/actionpack/lib/action_dispatch/http/mime_type.rb
@@ -326,7 +326,7 @@ module Mime
       def to_ary; end
       def to_a; end
 
-      def method_missing(method, *args)
+      def method_missing(method, ...)
         if method.end_with?("?")
           method[0..-2].downcase.to_sym == to_sym
         else
@@ -373,7 +373,7 @@ module Mime
         method.end_with?("?")
       end
 
-      def method_missing(method, *args)
+      def method_missing(method, ...)
         false if method.end_with?("?")
       end
   end

--- a/actionpack/lib/action_dispatch/system_test_case.rb
+++ b/actionpack/lib/action_dispatch/system_test_case.rb
@@ -178,9 +178,9 @@ module ActionDispatch
           end
       end
 
-      def method_missing(name, *args, &block)
+      def method_missing(name, ...)
         if url_helpers.respond_to?(name)
-          url_helpers.public_send(name, *args, &block)
+          url_helpers.public_send(name, ...)
         else
           super
         end

--- a/actionpack/test/controller/integration_test.rb
+++ b/actionpack/test/controller/integration_test.rb
@@ -151,8 +151,8 @@ class IntegrationTestTest < ActiveSupport::TestCase
   # try to delegate these methods to the session object.
   def test_does_not_prevent_method_missing_passing_up_to_ancestors
     mixin = Module.new do
-      def method_missing(name, *args)
-        name.to_s == "foo" ? "pass" : super
+      def method_missing(name, ...)
+        name == :foo ? "pass" : super
       end
     end
     @test.class.superclass.include(mixin)

--- a/actionpack/test/dispatch/routing_test.rb
+++ b/actionpack/test/dispatch/routing_test.rb
@@ -3895,9 +3895,9 @@ private
     @app.routes.url_helpers.url_for(options)
   end
 
-  def method_missing(method, *args, &block)
-    if method.to_s.match?(/_(path|url)$/)
-      @app.routes.url_helpers.send(method, *args, &block)
+  def method_missing(method, ...)
+    if method.match?(/_(path|url)$/)
+      @app.routes.url_helpers.send(method, ...)
     else
       super
     end

--- a/actionview/lib/action_view/helpers/tag_helper.rb
+++ b/actionview/lib/action_view/helpers/tag_helper.rb
@@ -334,12 +334,12 @@ module ActionView
             true
           end
 
-          def method_missing(called, *args, **options, &block)
-            name = called.to_s.dasherize
+          def method_missing(called, ...)
+            name = called.name.dasherize
 
             TagHelper.ensure_valid_html5_tag_name(name)
 
-            tag_string(name, *args, **options, &block)
+            tag_string(name, ...)
           end
       end
 

--- a/activemodel/test/cases/naming_test.rb
+++ b/activemodel/test/cases/naming_test.rb
@@ -279,8 +279,8 @@ class NamingHelpersTest < ActiveModel::TestCase
   end
 
   private
-    def method_missing(method, *args)
-      ActiveModel::Naming.public_send(method, *args)
+    def method_missing(method, ...)
+      ActiveModel::Naming.public_send(method, ...)
     end
 end
 

--- a/activemodel/test/cases/serialization_test.rb
+++ b/activemodel/test/cases/serialization_test.rb
@@ -18,7 +18,7 @@ class SerializationTest < ActiveModel::TestCase
       instance_values.except("address", "friends")
     end
 
-    def method_missing(method_name, *args)
+    def method_missing(method_name, ...)
       if method_name == :bar
         "i_am_bar"
       else

--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -16,7 +16,7 @@ module ActiveRecord
       include ConnectionAdapters::AbstractPool
 
       class NullConfig # :nodoc:
-        def method_missing(*)
+        def method_missing(...)
           nil
         end
       end

--- a/activerecord/lib/active_record/dynamic_matchers.rb
+++ b/activerecord/lib/active_record/dynamic_matchers.rb
@@ -12,12 +12,12 @@ module ActiveRecord
         end
       end
 
-      def method_missing(name, *arguments, &block)
+      def method_missing(name, ...)
         match = Method.match(self, name)
 
         if match && match.valid?
           match.define
-          send(name, *arguments, &block)
+          send(name, ...)
         else
           super
         end

--- a/activerecord/lib/active_record/test_fixtures.rb
+++ b/activerecord/lib/active_record/test_fixtures.rb
@@ -272,16 +272,16 @@ module ActiveRecord
         use_instantiated_fixtures != :no_instances
       end
 
-      def method_missing(name, *args, **kwargs, &block)
-        if fs_name = fixture_sets[name.to_s]
-          access_fixture(fs_name, *args, **kwargs, &block)
+      def method_missing(method, ...)
+        if fs_name = fixture_sets[method.name]
+          access_fixture(fs_name, ...)
         else
           super
         end
       end
 
-      def respond_to_missing?(name, include_private = false)
-        if include_private && fixture_sets.key?(name.to_s)
+      def respond_to_missing?(method, include_private = false)
+        if include_private && fixture_sets.key?(method.name)
           true
         else
           super

--- a/activerecord/test/cases/relation/where_test.rb
+++ b/activerecord/test/cases/relation/where_test.rb
@@ -309,8 +309,8 @@ module ActiveRecord
           model.is_a?(klass)
         end
 
-        def method_missing(method, *args, &block)
-          model.send(method, *args, &block)
+        def method_missing(...)
+          model.send(...)
         end
       end
 

--- a/activesupport/lib/active_support/array_inquirer.rb
+++ b/activesupport/lib/active_support/array_inquirer.rb
@@ -39,7 +39,7 @@ module ActiveSupport
         name.end_with?("?") || super
       end
 
-      def method_missing(name, *args)
+      def method_missing(name, ...)
         if name.end_with?("?")
           any?(name[0..-2])
         else

--- a/activesupport/lib/active_support/broadcast_logger.rb
+++ b/activesupport/lib/active_support/broadcast_logger.rb
@@ -231,15 +231,15 @@ module ActiveSupport
         @broadcasts.each { |logger| block.call(logger) }
       end
 
-      def method_missing(name, *args, **kwargs, &block)
+      def method_missing(name, ...)
         loggers = @broadcasts.select { |logger| logger.respond_to?(name) }
 
         if loggers.none?
-          super(name, *args, **kwargs, &block)
+          super
         elsif loggers.one?
-          loggers.first.send(name, *args, **kwargs, &block)
+          loggers.first.send(name, ...)
         else
-          loggers.map { |logger| logger.send(name, *args, **kwargs, &block) }
+          loggers.map { |logger| logger.send(name, ...) }
         end
       end
 

--- a/activesupport/lib/active_support/deprecation/proxy_wrappers.rb
+++ b/activesupport/lib/active_support/deprecation/proxy_wrappers.rb
@@ -183,9 +183,9 @@ module ActiveSupport
           target.const_get(name)
         end
 
-        def method_missing(called, *args, &block)
+        def method_missing(...)
           @deprecator.warn(@message, caller_locations)
-          target.__send__(called, *args, &block)
+          target.__send__(...)
         end
     end
   end

--- a/activesupport/lib/active_support/duration.rb
+++ b/activesupport/lib/active_support/duration.rb
@@ -506,8 +506,8 @@ module ActiveSupport
         value.respond_to?(method)
       end
 
-      def method_missing(method, *args, &block)
-        value.public_send(method, *args, &block)
+      def method_missing(...)
+        value.public_send(...)
       end
 
       def raise_type_error(other)

--- a/activesupport/lib/active_support/multibyte/chars.rb
+++ b/activesupport/lib/active_support/multibyte/chars.rb
@@ -59,8 +59,8 @@ module ActiveSupport # :nodoc:
       end
 
       # Forward all undefined methods to the wrapped string.
-      def method_missing(method, *args, &block)
-        result = @wrapped_string.__send__(method, *args, &block)
+      def method_missing(method, ...)
+        result = @wrapped_string.__send__(method, ...)
         if method.end_with?("!")
           self if result
         else

--- a/activesupport/lib/active_support/option_merger.rb
+++ b/activesupport/lib/active_support/option_merger.rb
@@ -31,8 +31,8 @@ module ActiveSupport
         end
       end
 
-      def respond_to_missing?(*arguments)
-        @context.respond_to?(*arguments)
+      def respond_to_missing?(...)
+        @context.respond_to?(...)
       end
   end
 end

--- a/activesupport/lib/active_support/ordered_options.rb
+++ b/activesupport/lib/active_support/ordered_options.rb
@@ -46,18 +46,14 @@ module ActiveSupport
       super(key.to_sym, *identifiers)
     end
 
-    def method_missing(name, *args)
-      name_string = +name.to_s
-      if name_string.chomp!("=")
-        self[name_string] = args.first
+    def method_missing(method, *args)
+      if method.end_with?("=")
+        self[method.name.chomp("=")] = args.first
+      elsif method.end_with?("!")
+        name_string = method.name.chomp("!")
+        self[name_string].presence || raise(KeyError.new(":#{name_string} is blank"))
       else
-        bangs = name_string.chomp!("!")
-
-        if bangs
-          self[name_string].presence || raise(KeyError.new(":#{name_string} is blank"))
-        else
-          self[name_string]
-        end
+        self[method.name]
       end
     end
 

--- a/activesupport/lib/active_support/string_inquirer.rb
+++ b/activesupport/lib/active_support/string_inquirer.rb
@@ -24,7 +24,7 @@ module ActiveSupport
         method_name.end_with?("?") || super
       end
 
-      def method_missing(method_name, *arguments)
+      def method_missing(method_name, ...)
         if method_name.end_with?("?")
           self == method_name[0..-2]
         else

--- a/activesupport/test/callbacks_test.rb
+++ b/activesupport/test/callbacks_test.rb
@@ -235,7 +235,7 @@ module CallbacksTest
     def no; false; end
     def yes; true; end
 
-    def method_missing(sym, *)
+    def method_missing(sym, ...)
       case sym
       when /^log_(.*)/
         @history << $1

--- a/activesupport/test/core_ext/array/wrap_test.rb
+++ b/activesupport/test/core_ext/array/wrap_test.rb
@@ -12,7 +12,7 @@ class WrapTest < ActiveSupport::TestCase
 
   class Proxy
     def initialize(target) @target = target end
-    def method_missing(*a) @target.public_send(*a) end
+    def method_missing(...) @target.public_send(...) end
   end
 
   class DoubtfulToAry

--- a/activesupport/test/core_ext/module_test.rb
+++ b/activesupport/test/core_ext/module_test.rb
@@ -76,7 +76,7 @@ Product = Struct.new(:name) do
 end
 
 module ExtraMissing
-  def method_missing(sym, *args)
+  def method_missing(sym, ...)
     if sym == :extra_missing
       42
     else

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -585,7 +585,7 @@ module Rails
           end
         end
 
-        def respond_to_missing?(symbol, *)
+        def respond_to_missing?(symbol, _)
           true
         end
       end

--- a/railties/lib/rails/application/dummy_config.rb
+++ b/railties/lib/rails/application/dummy_config.rb
@@ -9,9 +9,9 @@ class DummyConfig # :nodoc:
     "DummyConfig"
   end
 
-  def method_missing(selector, *args, &blk)
+  def method_missing(selector, ...)
     if @config.respond_to?(selector)
-      @config.send(selector, *args, &blk)
+      @config.send(selector, ...)
     else
       self
     end

--- a/railties/lib/rails/configuration.rb
+++ b/railties/lib/rails/configuration.rb
@@ -141,7 +141,7 @@ module Rails
       end
 
       def method_missing(method, *args)
-        method = method.to_s.delete_suffix("=").to_sym
+        method = method.name.delete_suffix("=").to_sym
 
         if args.empty?
           if method == :rails

--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -15,8 +15,8 @@ module Rails
       %w(template copy_file directory empty_directory inside
          empty_directory_with_keep_file create_file chmod shebang).each do |method|
         class_eval <<-RUBY, __FILE__, __LINE__ + 1
-          def #{method}(*args, &block)
-            @generator.send(:#{method}, *args, &block)
+          def #{method}(...)
+            @generator.send(:#{method}, ...)
           end
         RUBY
       end

--- a/railties/lib/rails/railtie/configurable.rb
+++ b/railties/lib/rails/railtie/configurable.rb
@@ -27,8 +27,8 @@ module Rails
         end
 
         private
-          def method_missing(*args, &block)
-            instance.send(*args, &block)
+          def method_missing(...)
+            instance.send(...)
           end
       end
     end


### PR DESCRIPTION
`...` is both simpler an more correct since the keyword argument separation.
