### PR TITLE
Fix calculation of SQL runtime

### DIFF
--- a/activerecord/lib/active_record/runtime_registry.rb
+++ b/activerecord/lib/active_record/runtime_registry.rb
@@ -34,7 +34,8 @@ module ActiveRecord
 end
 
 ActiveSupport::Notifications.monotonic_subscribe("sql.active_record") do |name, start, finish, id, payload|
-  runtime = finish - start
+  runtime = (finish - start) * 1_000.0
+
   if payload[:async]
     ActiveRecord::RuntimeRegistry.async_sql_runtime += (runtime - payload[:lock_wait])
   end


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because [this other PR](https://github.com/rails/rails/pull/50493) seems to have introduced a bug in the `db_runtime` emitted as part of `sql.active_record` notification.

The time is calculated using `ActiveSupport::Notifications.monotonic_subscribe` which uses [Process.clock_gettime(Process::CLOCK_MONOTONIC)](https://github.com/rails/rails/blob/main/activesupport/lib/active_support/notifications/fanout.rb#L142) with the default unit (seconds).

This being run in a Rails console prints 1.

```ruby
ActiveSupport::Notifications.monotonic_subscribe("test_event") do |_name, start, finish, _id, payload|
  puts finish - start
end

ActiveSupport::Notifications.instrument("test_event") do
  sleep 1.second
end
```

Also, when an `ActiveSupport::Notifications::Event` is used, [it needs to multiply start and ending](https://github.com/rails/rails/blob/main/activesupport/lib/active_support/notifications/instrumenter.rb#L113) by `1_000.0` same as we are proposing here.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.