### PR TITLE
Use `includes` instead of `eager_load` for `with_all_rich_text`

### DIFF
--- a/actiontext/CHANGELOG.md
+++ b/actiontext/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Use `includes` instead of `eager_load` for `with_all_rich_text`.
+
+    *Petrik de Heus*
+
 *   Delegate `ActionText::Content#deconstruct` to `Nokogiri::XML::DocumentFragment#elements`
 
     ```ruby

--- a/actiontext/lib/action_text/attribute.rb
+++ b/actiontext/lib/action_text/attribute.rb
@@ -65,7 +65,7 @@ module ActionText
 
       # Eager load all dependent RichText models in bulk.
       def with_all_rich_text
-        eager_load(rich_text_association_names)
+        includes(rich_text_association_names)
       end
 
       def rich_text_association_names

--- a/actiontext/test/unit/model_test.rb
+++ b/actiontext/test/unit/model_test.rb
@@ -106,9 +106,18 @@ class ActionText::ModelTest < ActiveSupport::TestCase
   end
 
   test "eager loading all rich text" do
-    Message.create!(subject: "Subject", content: "<h1>Content</h1>", body: "<h2>Body</h2>")
+    2.times do
+      Message.create!(subject: "Subject", content: "<h1>Content</h1>", body: "<h2>Body</h2>")
+    end
 
-    message = assert_queries_count(1) { Message.with_all_rich_text.last }
+    message = assert_queries_count(3) do
+      # 3 queries:
+      # messages x 1
+      # action texts (content) x 1
+      # action texts (body) x 1
+      Message.with_all_rich_text.to_a.last
+    end
+
     assert_no_queries do
       assert_equal "Content", message.content.to_plain_text
       assert_equal "Body", message.body.to_plain_text


### PR DESCRIPTION
### Motivation / Background

`eager_load` performs a single query using a `LEFT OUTER JOIN` to load the associations. Loading the associations in a join can result in many rows that contain redundant data and it performs poorly at scale.

With `includes` a separate query is performed for each association, unless a join is required by conditions.

`includes` is also used by similar methods in Active Storage like `with_attached_*`.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
