### PR TITLE
Fix t.references validating options on Rails < 7.1

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,5 +1,5 @@
 *   Fix Migrations with versions older than 7.1 validating options given to
-    `add_reference`.
+    `add_reference` and `t.references`.
 
     *Hartley McGuire*
 

--- a/activerecord/lib/active_record/migration/compatibility.rb
+++ b/activerecord/lib/active_record/migration/compatibility.rb
@@ -82,6 +82,11 @@ module ActiveRecord
             super
           end
 
+          def references(*args, **options)
+            options[:_skip_validate_options] = true
+            super
+          end
+
           private
             def raise_on_if_exist_options(options)
             end

--- a/activerecord/test/cases/migration/compatibility_test.rb
+++ b/activerecord/test/cases/migration/compatibility_test.rb
@@ -673,6 +673,7 @@ module NoOptionValidationTestCases
         change_table :tests do |t|
           t.change :some_id, :float, null: false, wrong_index: true
           t.integer :another_id, wrong_unique: true
+          t.references :yet_another_table, bad: :option
         end
       end
     }.new


### PR DESCRIPTION
### Motivation / Background

Option validation was [added][1] for 7.1+ Migration classes, and a compatibility layer was added to ensure that previous Migration versions do not have their options validated. However, the `t.references` method was missing in the compatibility layer which results in pre 7.1 Migrations validating options passed to `t.references`.

### Detail

This commit fixes the issue by adding t.references to the compatibility layer.

See also a [similar fix][2] for `add_reference`

[1]: https://github.com/rails/rails/commit/e6da3ebd6c65af23d134a9e01145f26600912008
[2]: https://github.com/rails/rails/commit/71b4e223018d180b7c96915c0df1c28afbf7cc53

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
