### PR TITLE
Fix `ActiveSupport::Notifications.publish_event` to preserve units

### DIFF
--- a/activesupport/lib/active_support/notifications/instrumenter.rb
+++ b/activesupport/lib/active_support/notifications/instrumenter.rb
@@ -104,7 +104,7 @@ module ActiveSupport
     end
 
     class Event
-      attr_reader :name, :time, :end, :transaction_id
+      attr_reader :name, :transaction_id
       attr_accessor :payload
 
       def initialize(name, start, ending, transaction_id, payload)
@@ -119,7 +119,15 @@ module ActiveSupport
         @allocation_count_finish = 0
       end
 
-      def record
+      def time
+        @time / 1000.0 if @time
+      end
+
+      def end
+        @end / 1000.0 if @end
+      end
+
+      def record # :nodoc:
         start!
         begin
           yield payload if block_given?
@@ -195,7 +203,7 @@ module ActiveSupport
       #
       #   @event.duration # => 1000.138
       def duration
-        self.end - time
+        @end - @time
       end
 
       private


### PR DESCRIPTION
Ref: https://github.com/rails/rails/pull/43502
Fix: https://github.com/rails/rails/pull/50767
Fix: https://github.com/rails/rails/pull/50493

When republishing a an event into a `start, finish` tuple, we need to convert the timestamps back into seconds.

cc @fatkodima @rporrasluc 

To be backported in 7.1 and 7.0