### PR TITLE
Preserve `--asset-pipeline propshaft` when running `app:update`

### DIFF
--- a/railties/lib/rails/app_updater.rb
+++ b/railties/lib/rails/app_updater.rb
@@ -31,9 +31,21 @@ module Rails
           options[:skip_action_cable]   = !defined?(ActionCable::Engine)
           options[:skip_test]           = !defined?(Rails::TestUnitRailtie)
           options[:skip_system_test]    = Rails.application.config.generators.system_tests.nil?
-          options[:skip_asset_pipeline] = !defined?(Sprockets::Railtie) && !defined?(Propshaft::Railtie)
+          options[:asset_pipeline]      = asset_pipeline
+          options[:skip_asset_pipeline] = asset_pipeline.nil?
           options[:skip_bootsnap]       = !defined?(Bootsnap)
           options
+        end
+
+        def asset_pipeline
+          case
+          when defined?(Sprockets::Railtie)
+            "sprockets"
+          when defined?(Propshaft::Railtie)
+            "propshaft"
+          else
+            nil
+          end
         end
     end
   end

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -316,6 +316,17 @@ class AppGeneratorTest < Rails::Generators::TestCase
     end
   end
 
+  def test_app_update_preserves_propshaft
+    run_generator [destination_root, "-a", "propshaft"]
+
+    FileUtils.cd(destination_root) do
+      config = "config/environments/production.rb"
+      assert_no_changes -> { File.readlines(config).grep(/config\.assets/) } do
+        run_app_update
+      end
+    end
+  end
+
   def test_gem_for_active_storage
     run_generator
     assert_file "Gemfile", /^# gem "image_processing"/


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because `skip_sprockets?` wasn't being preserved when running `app:update` in a project using `propshaft`. Helpful when #50444 lands.

### Detail

This Pull Request sets `options[:asset_pipeline]` in `AppUpdater` based on whether Sprockets/Propshaft Railtie is defined.

Without this change, `app:update` will suggest injecting sprocket configuration in a propshaft project.