### PR TITLE
Add note about `params` hash in Action Controller Overview [ci skip] 

### DIFF
--- a/guides/source/action_controller_overview.md
+++ b/guides/source/action_controller_overview.md
@@ -110,7 +110,10 @@ class ClientsController < ApplicationController
 end
 ```
 
+NOTE: The `params` hash is not a plain old Ruby Hash; instead, it is an [`ActionController::Parameters`][] object. While it behaves like Hash, it does not inherit from Hash.
+
 [`params`]: https://api.rubyonrails.org/classes/ActionController/StrongParameters.html#method-i-params
+[`ActionController::Parameters`]: https://api.rubyonrails.org/classes/ActionController/Parameters.html
 
 ### Hash and Array Parameters
 


### PR DESCRIPTION
### Motivation / Background

Newbies tend to misunderstand `params` hash is a plain old Hash. So I added a note that `params` hash is ActionController::Parameters.

### Detail

This Pull Request changes "4 Parameters" in Action Controller Overview.

![Screenshot 2024-01-18 at 10 31 55](https://github.com/rails/rails/assets/1148320/de0dc860-35d1-4d3b-b209-ab4abbac5a17)

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.

