### PR TITLE
[7-1-stable] Fix Active Storage test configurations for CI

### DIFF
--- a/activestorage/Rakefile
+++ b/activestorage/Rakefile
@@ -13,11 +13,13 @@ Rake::TestTask.new do |t|
 end
 
 if ENV["encrypted_0fb9444d0374_key"] && ENV["encrypted_0fb9444d0374_iv"]
-  file "test/service/configurations.yml" do
-    system "openssl aes-256-cbc -K $encrypted_0fb9444d0374_key -iv $encrypted_0fb9444d0374_iv -in test/service/configurations.yml.enc -out test/service/configurations.yml -d"
+  _file = "test/service/configurations.yml"
+  file _file do
+    puts "Generating #{_file} for Active Storage tests..."
+    system "openssl aes-256-cbc -K $encrypted_0fb9444d0374_key -iv $encrypted_0fb9444d0374_iv -in #{_file}.enc -out #{_file} -d"
   end
 
-  task test: "test/service/configurations.yml"
+  task test: _file
 end
 
 task :package

--- a/activestorage/test/controllers/direct_uploads_controller_test.rb
+++ b/activestorage/test/controllers/direct_uploads_controller_test.rb
@@ -35,7 +35,7 @@ if SERVICE_CONFIGURATIONS[:s3] && SERVICE_CONFIGURATIONS[:s3][:access_key_id].pr
         assert_equal "hello.txt", details["filename"]
         assert_equal 6, details["byte_size"]
         assert_equal checksum, details["checksum"]
-        assert_equal metadata, details["metadata"].deep_transform_keys(&:to_sym)
+        assert_equal metadata.deep_stringify_keys, details["metadata"].deep_stringify_keys
         assert_equal "text/plain", details["content_type"]
         assert_match SERVICE_CONFIGURATIONS[:s3][:bucket], details["direct_upload"]["url"]
         assert_match(/s3(-[-a-z0-9]+)?\.(\S+)?amazonaws\.com/, details["direct_upload"]["url"])
@@ -81,7 +81,7 @@ if SERVICE_CONFIGURATIONS[:gcs]
         assert_equal "hello.txt", details["filename"]
         assert_equal 6, details["byte_size"]
         assert_equal checksum, details["checksum"]
-        assert_equal metadata, details["metadata"].deep_transform_keys(&:to_sym)
+        assert_equal metadata.deep_stringify_keys, details["metadata"].deep_stringify_keys
         assert_equal "text/plain", details["content_type"]
         assert_match %r{storage\.googleapis\.com/#{@config[:bucket]}}, details["direct_upload"]["url"]
         assert_equal({ "Content-MD5" => checksum, "Content-Disposition" => "inline; filename=\"hello.txt\"; filename*=UTF-8''hello.txt", "x-goog-meta-my_key_3" => "my_value_3" }, details["direct_upload"]["headers"])

--- a/activestorage/test/dummy/config/environments/test.rb
+++ b/activestorage/test/dummy/config/environments/test.rb
@@ -41,11 +41,7 @@ Rails.application.configure do
     _file = Rails.root.join("../service/configurations.yml")
     ActiveSupport::ConfigurationFile.parse(_file).deep_symbolize_keys
   rescue Errno::ENOENT
-    msg = "Missing service configuration file in #{_file}"
-    if ENV["CI"]
-      raise msg
-    end
-    puts msg
+    puts "Missing service configuration file in #{_file}"
     {}
   end
   # Azure service tests are currently failing on the main branch.

--- a/activestorage/test/dummy/config/environments/test.rb
+++ b/activestorage/test/dummy/config/environments/test.rb
@@ -38,9 +38,14 @@ Rails.application.configure do
   config.active_storage.service = :local
 
   SERVICE_CONFIGURATIONS = begin
-    ActiveSupport::ConfigurationFile.parse(File.expand_path("service/configurations.yml", __dir__)).deep_symbolize_keys
+    _file = Rails.root.join("../service/configurations.yml")
+    ActiveSupport::ConfigurationFile.parse(_file).deep_symbolize_keys
   rescue Errno::ENOENT
-    puts "Missing service configuration file in test/service/configurations.yml"
+    msg = "Missing service configuration file in #{_file}"
+    if ENV["CI"]
+      raise msg
+    end
+    puts msg
     {}
   end
   # Azure service tests are currently failing on the main branch.


### PR DESCRIPTION
This is a resubmission of #50786 on an upstream branch to test the integration (secrets are not available in forks).

---

While investigating #50427, I found that the service configurations were missing, I think due to #47259.

We should expect the S3 and GCS tests to run here, like in 7-0-stable:
https://buildkite.com/rails/rails/builds/104036#018d1779-6305-41bb-82d1-b262123dcab4

```
Skipping Azure Storage Direct Upload tests because no Azure Storage configuration was supplied
Skipping Azure Storage Public Service tests because no Azure configuration was supplied
Skipping Azure Storage Service tests because no Azure configuration was supplied
Skipping GCS Public Service tests because no GCS configuration was supplied
/usr/local/bundle/gems/googleauth-1.9.1/lib/googleauth/helpers/connection.rb:27: warning: attribute accessor as module_function
/usr/local/bundle/gems/google-apis-core-0.11.3/lib/google/apis/core/base_service.rb:228: warning: method redefined; discarding old client
Skipping S3 Public Service tests because no S3 configuration was supplied
/usr/local/bundle/gems/aws-sdk-s3-1.142.0/lib/aws-sdk-s3/endpoint_provider.rb:22: warning: assigned but unused variable - key
/usr/local/bundle/gems/aws-sdk-s3-1.142.0/lib/aws-sdk-s3/endpoint_provider.rb:23: warning: assigned but unused variable - prefix
```

However, you can see in the build from that PR that all services are skipped:
https://buildkite.com/rails/rails/builds/93948#018666ba-a8de-47d3-877d-26788ab11fcd/1010-1083

```
Skipping S3 Direct Upload tests because no S3 configuration was supplied
Skipping GCS Direct Upload tests because no GCS configuration was supplied
Skipping Azure Storage Direct Upload tests because no Azure Storage configuration was supplied
Skipping Azure Storage Public Service tests because no Azure configuration was supplied
Skipping Azure Storage Service tests because no Azure configuration was supplied
Skipping GCS Public Service tests because no GCS configuration was supplied
Skipping GCS Service tests because no GCS configuration was supplied
Skipping S3 Public Service tests because no S3 configuration was supplied
Skipping S3 Service tests because no S3 configuration was supplied
```

I wasn't able to find a previous build (on 7-1-stable branch) older than that, so going on a hunch here.

Going to see if this at least gets the tests running in CI for this branch first, since the work to remove the dummy application is probably not going to be backported.