### PR TITLE
Use relative includes of README's in documentation [ci-skip]

### DIFF
--- a/actioncable/lib/action_cable.rb
+++ b/actioncable/lib/action_cable.rb
@@ -44,7 +44,7 @@ Zeitwerk::Loader.for_gem.tap do |loader|
 end.setup
 
 # :markup: markdown
-# :include: actioncable/README.md
+# :include: ../README.md
 module ActionCable
   require_relative "action_cable/version"
   require_relative "action_cable/deprecator"

--- a/actionmailbox/lib/action_mailbox.rb
+++ b/actionmailbox/lib/action_mailbox.rb
@@ -9,7 +9,7 @@ require "action_mailbox/deprecator"
 require "action_mailbox/mail_ext"
 
 # :markup: markdown
-# :include: actionmailbox/README.md
+# :include: ../README.md
 module ActionMailbox
   extend ActiveSupport::Autoload
 

--- a/actionmailer/lib/action_mailer.rb
+++ b/actionmailer/lib/action_mailer.rb
@@ -35,7 +35,7 @@ require "active_support/core_ext/module/attr_internal"
 require "active_support/core_ext/string/inflections"
 require "active_support/lazy_load_hooks"
 
-# :include: actionmailer/README.rdoc
+# :include: ../README.rdoc
 module ActionMailer
   extend ::ActiveSupport::Autoload
 

--- a/actiontext/lib/action_text.rb
+++ b/actiontext/lib/action_text.rb
@@ -9,7 +9,7 @@ require "action_text/deprecator"
 require "nokogiri"
 
 # :markup: markdown
-# :include: actiontext/README.md
+# :include: ../README.md
 module ActionText
   extend ActiveSupport::Autoload
 

--- a/actionview/lib/action_view.rb
+++ b/actionview/lib/action_view.rb
@@ -28,7 +28,7 @@ require "active_support/rails"
 require "action_view/version"
 require "action_view/deprecator"
 
-# :include: actionview/README.rdoc
+# :include: ../README.rdoc
 module ActionView
   extend ActiveSupport::Autoload
 

--- a/activejob/lib/active_job.rb
+++ b/activejob/lib/active_job.rb
@@ -30,7 +30,7 @@ require "active_job/deprecator"
 require "global_id"
 
 # :markup: markdown
-# :include: activejob/README.md
+# :include: ../README.md
 module ActiveJob
   extend ActiveSupport::Autoload
 

--- a/activemodel/lib/active_model.rb
+++ b/activemodel/lib/active_model.rb
@@ -28,7 +28,7 @@ require "active_support/rails"
 require "active_model/version"
 require "active_model/deprecator"
 
-# :include: activemodel/README.rdoc
+# :include: ../README.rdoc
 module ActiveModel
   extend ActiveSupport::Autoload
 

--- a/activerecord/lib/active_record.rb
+++ b/activerecord/lib/active_record.rb
@@ -35,7 +35,7 @@ require "active_record/deprecator"
 require "active_model/attribute_set"
 require "active_record/errors"
 
-# :include: activerecord/README.rdoc
+# :include: ../README.rdoc
 module ActiveRecord
   extend ActiveSupport::Autoload
 

--- a/activestorage/lib/active_storage.rb
+++ b/activestorage/lib/active_storage.rb
@@ -35,7 +35,7 @@ require "active_storage/errors"
 require "marcel"
 
 # :markup: markdown
-# :include: activestorage/README.md
+# :include: ../README.md
 module ActiveStorage
   extend ActiveSupport::Autoload
 

--- a/activesupport/lib/active_support.rb
+++ b/activesupport/lib/active_support.rb
@@ -32,7 +32,7 @@ require "active_support/broadcast_logger"
 require "active_support/lazy_load_hooks"
 require "active_support/core_ext/date_and_time/compatibility"
 
-# :include: activesupport/README.rdoc
+# :include: ../README.rdoc
 module ActiveSupport
   extend ActiveSupport::Autoload
 

--- a/railties/lib/rails.rb
+++ b/railties/lib/rails.rb
@@ -22,7 +22,7 @@ silence_warnings do
   Encoding.default_internal = Encoding::UTF_8
 end
 
-# :include: railties/README.rdoc
+# :include: ../README.rdoc
 module Rails
   extend ActiveSupport::Autoload
   extend ActiveSupport::Benchmarkable


### PR DESCRIPTION
The Rails documentation uses the `:include:` directive to inline the README of the framework into the main documentation page. As the README's aren't in the root directory from where SDoc is run we need to add the framework path to the include:

    # :include: activesupport/README.md

This results in a warning when installing the gems as generating the rdoc for the gem is run from the gem/framework root:

    Couldn't find file to include 'activesupport/README.rdoc' from lib/active_support.rb

The `:include:` RDoc directive supports includes relative to the current file as well:

    # :include: ../README.md

This makes sure it works for the Rails API docs and the separate gems.

### Additional information

Fixes: https://github.com/rails/rails/issues/49524

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
