### PR TITLE
PoC: Add an option to disable connection checkout caching

### DIFF
--- a/activerecord/lib/active_record.rb
+++ b/activerecord/lib/active_record.rb
@@ -300,6 +300,14 @@ module ActiveRecord
     @global_executor_concurrency ||= nil
   end
 
+  ##
+  # :singleton-method:
+  #
+  # Specifies whether the `ActiveRecord::Base.connection` acquires a permanent
+  # connection lease. Defaults to true.
+  singleton_class.attr_accessor :cache_connection_checkout
+  self.cache_connection_checkout = true
+
   singleton_class.attr_accessor :index_nested_attribute_errors
   self.index_nested_attribute_errors = false
 

--- a/activerecord/lib/active_record/connection_handling.rb
+++ b/activerecord/lib/active_record/connection_handling.rb
@@ -256,11 +256,17 @@ module ActiveRecord
       connection_pool.lease_connection
     end
 
-    alias_method :connection, :lease_connection
+    def connection
+      if ActiveRecord.cache_connection_checkout
+        connection_pool.lease_connection
+      else
+        connection_pool.active_connection
+      end
+    end
 
     # Return the currently leased connection into the pool
     def release_connection
-      connection.release_connection
+      connection_pool.release_connection
     end
 
     # Checkouts a connection from the pool, yield it and then check it back in.

--- a/activerecord/test/cases/connection_checkout_caching_test.rb
+++ b/activerecord/test/cases/connection_checkout_caching_test.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+
+module ActiveRecord
+  class ConnectionCheckoutCachingTest < ActiveRecord::TestCase
+    setup do
+      @_cache_connection_checkout_was = ActiveRecord.cache_connection_checkout
+      ActiveRecord::Base.release_connection
+      ActiveRecord.cache_connection_checkout = false
+    end
+
+    teardown do
+      ActiveRecord.cache_connection_checkout = @_cache_connection_checkout_was
+    end
+
+    test ".connection leases a connection if cache_connection_checkout is true" do
+      ActiveRecord.cache_connection_checkout = true
+
+      assert_not_predicate ActiveRecord::Base.connection_pool, :active_connection?
+      ActiveRecord::Base.deprecated_connection
+      assert_predicate ActiveRecord::Base.connection_pool, :active_connection?
+    end
+
+    test ".connection doesn't lease a connection by itself if cache_connection_checkout is false" do
+      assert_not_predicate ActiveRecord::Base.connection_pool, :active_connection?
+      ActiveRecord::Base.deprecated_connection
+      assert_not_predicate ActiveRecord::Base.connection_pool, :active_connection?
+    end
+
+    test "performing a query doesn't permanently lease a connection" do
+      conn = ActiveRecord::Base.deprecated_connection
+      assert_not_predicate ActiveRecord::Base.connection_pool, :active_connection?
+
+      assert_equal [[1]], conn.select_all("SELECT 1").rows
+      assert_not_predicate ActiveRecord::Base.connection_pool, :active_connection?
+    end
+  end
+end

--- a/activerecord/test/cases/helper.rb
+++ b/activerecord/test/cases/helper.rb
@@ -24,6 +24,7 @@ ActiveRecord.deprecator.debug = true
 
 # ActiveRecord::Base.connection is only soft deprecated but we remove it
 # in the test suite to ensure we're not using it internally.
+ActiveRecord::ConnectionHandling.alias_method(:deprecated_connection, :connection)
 ActiveRecord::ConnectionHandling.remove_method(:connection)
 
 # Disable available locale checks to avoid warnings running the test suite.


### PR DESCRIPTION
### Context

In part for performance and simplicity reasons, and in part because of its historical lack of threading support, Active Record rely quite heavily on `ActiveRecord::Base.connection` checking out and holding a connection inside a thread of fiber local variable.

Concretly, every request or job lazily checkout connections when it needs to perform a database operations, and then holds onto it until the request or job completes, at which point the `Executor` hook automatically check it back in the pool.

For the overwhelming majority of Rails application, which don't do enough IOs to benefit from more than a handful of threads, it's a perfectly adequate solution, as it pretty much remove connection management as a concern.

However for applications that spent most of their time on IOs others than the database (e.g. 3rd party APIs), and would benefit from much higher levels of concurrency, this strategy is problematic because it requires about as many database connections as there is threads or fibers, even though most connections are idle but can't be used because they checked out of the pool and held by another thead or fiber.

### Goal

I believe the current model is still preferable for the vast majority of Rails users, and changing the way `ActiveRecord::Base.connection` behaves would break a ton of code anyway. So I believe it should remain the default.

However I think we could support an alternative mode, in which `ActiveRecord::Base.connection` doesn't hold onto the connection until the end of the request cycle, but instead immediately check it back in, allowing it to be re-used immediately.

### Implementation

First, nothing changes unless you disable `ActiveRecord.cache_connection_checkout`.

Then, since a lot of code in Rails itself, in third party libraries, and in private Rails applications do rely on `Model.connection.something()`, we must make it work without caching the connection.

To solve this, when caching is disabled, `Model.connection` returns a proxy object, that delegates the methods it receive to a freshly checked out connection, and then check it back in. See `LazyConnectionProxy` in `connection_pool.rb` for the details.

That is the key to permitting this feature while retaining backward compatibility. It's not perfect, as code might assume that subsequent calls to `Model.connection` will return the same connection instance, but in most case it's not necessary.

Also, while the proxy holds the connection, it caches in on the thread or fiber, so subsequent calls to `Model.connection` will return the same connection until it's checked back in. This solves most of the statefulness issues, like opening a transaction etc, as long as the APIs are blocked based.

### Status

This is a proof of concept, it's nowhere near ready to merge, it's mostly to explore whether it's doable with some work, or just not possible.

Most of the Active Record test suite passes against Sqlite3, except for 3 tests that do disconnect and reconnect. In general all the tests had to be opted out of the feature, I still need to dig into why exactly.

I also had to disable the feature for a few test suites that rely too much on the caching, and would need a bit of refactoring to pass without, but at first glance it doesn't look like a fundamental incompatibility.

### Concerns

There is a number of Active Record methods that currently cause more than one checkout/checkin cycle and would benefit from a strategically placed `with_connection do` call to optimize that. But that is mostly a performance concern, not a fundamental incompatibility.

One more major concern is the query cache. As it stand it's pretty much useless when checkout caching is disabled, because when we check the connection back in, we have to clear the cache, so it's pretty much always empty. To make it usable again, we need a substantial refactoring. At first glance it looks possible, just not trivial.

### Conclusion

I'm a bit on the fence about this. I think we can make it work, but I already spent most of one day on just the proof of concept, and would need substantially more work to iron out all the issues.

The actual code changes needed in Active Record itself are relatively small, it's really all the test suite and 3rd party code that would need to be updated to properly work with this option that is the big can of worm I'm worried about.
