### PR TITLE
[Tests only] Expand trigger populated PK test case to run against more DBs

### DIFF
--- a/activerecord/test/cases/persistence_test.rb
+++ b/activerecord/test/cases/persistence_test.rb
@@ -1581,7 +1581,7 @@ class PersistenceTest < ActiveRecord::TestCase
 
     assert_not_nil record.id
     assert record.id > 0
-  end if current_adapter?(:PostgreSQLAdapter)
+  end if supports_insert_returning? && !current_adapter?(:SQLite3Adapter)
 end
 
 class QueryConstraintsTest < ActiveRecord::TestCase


### PR DESCRIPTION
Follow-up for https://github.com/rails/rails/pull/50783

I realized that I unnecessarily limited one of the tests to postgresql while the fix should be applicable to any database that supports `RETURNING` statement. 

Sadly I couldn't come up with a proper setup for sqlite since it looks like there is no way of updating `NEW` record columns before insert in a trigger. So if someone has ideas on how to setup an sqlite trigger to generate `id` column value before insert - the test case can be tested against sqlite. But for now it technically means we will be testing it on MariaDB in addition to postgresql 