### PR TITLE
Add customized prompt for Rails console

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,18 @@
+*   Rails console now indicates the current Rails environment:
+
+    ```txt
+    dev:001> # for RAILS_ENV=development
+    test:001> # for RAILS_ENV=test
+    prod:001> # for RAILS_ENV=production
+    my_env:001> # for RAILS_ENV=my_env
+    ```
+
+    The environment name will also be colorized when the environment is
+    `development` (green), `test` (green), or `production` (red), if your
+    terminal supports it.
+
+    *Stan Lo*
+
 *   `bin/rails` now prints its help message when given an unrecognized bare
     option.
 

--- a/railties/test/commands/console_test.rb
+++ b/railties/test/commands/console_test.rb
@@ -99,6 +99,25 @@ class Rails::ConsoleTest < ActiveSupport::TestCase
     ENV["IRB_USE_AUTOCOMPLETE"] = original_use_autocomplete
   end
 
+  def test_prompt_env_colorization
+    irb_console = Rails::Console::IRBConsole.new
+    red = "\e[31m"
+    green = "\e[32m"
+    clear = "\e[0m"
+
+    Rails.env = "development"
+    assert_equal("#{green}dev#{clear}", irb_console.colorized_env)
+
+    Rails.env = "test"
+    assert_equal("#{green}test#{clear}", irb_console.colorized_env)
+
+    Rails.env = "production"
+    assert_equal("#{red}prod#{clear}", irb_console.colorized_env)
+
+    Rails.env = "custom_env"
+    assert_equal("custom_env", irb_console.colorized_env)
+  end
+
   def test_default_environment_with_no_rails_env
     with_rails_env nil do
       start


### PR DESCRIPTION

**Update**

There were 2 more follow up PRs on this:

- https://github.com/rails/rails/pull/50825
- https://github.com/rails/rails/pull/50855

So the resulted prompt now looks like this instead:

![Screenshot 2024-01-26 at 23 00 56](https://github.com/rails/rails/assets/5079556/36359953-e0dc-4f76-aa97-e27a914be721)

### Motivation / Background

As discussed in #50770, Rails console's prompt is not easily distinguishable from normal IRB console. It also doesn't provide Rails-specific information to assist developers.

Closes #50770 

### Detail

- A new IRB prompt called `RAILS_PROMPT` is added, which looks like:
    - `dev:001>` in development
    - `prod:001>` in production
    - `test:001>` in test
- The `RAILS_PROMPT` is only selected when the user doesn't specify another custom prompt.

### Additional information

<!-- Provide additional information such as benchmarks, reference to other repositories or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
