### PR TITLE
Implement `Object#absence_in` ActiveSupport core extension method

### DIFF
--- a/activesupport/lib/active_support/core_ext/object/inclusion.rb
+++ b/activesupport/lib/active_support/core_ext/object/inclusion.rb
@@ -34,4 +34,17 @@ class Object
   def presence_in(another_object)
     in?(another_object) ? self : nil
   end
+
+  # Returns the receiver if it's not included in the argument otherwise returns +nil+.
+  # Argument must be any object which responds to +#include?+. Usage:
+  #
+  #   params[:bucket_type].absence_in %w( main private )
+  #
+  # This will throw an +ArgumentError+ if the argument doesn't respond to +#include?+.
+  #
+  # @return [Object]
+
+  def absence_in(another_object)
+    in?(another_object) ? nil : self
+  end
 end

--- a/activesupport/test/core_ext/object/inclusion_test.rb
+++ b/activesupport/test/core_ext/object/inclusion_test.rb
@@ -63,4 +63,10 @@ class InTest < ActiveSupport::TestCase
     assert_nil "stuff".presence_in(%w( lots of crap ))
     assert_raise(ArgumentError) { 1.presence_in(1) }
   end
+
+  def test_absence_in
+    assert_nil "stuff".absence_in(%w( lots of stuff ))
+    assert_equal "stuff", "stuff".absence_in(%w( lots of crap ))
+    assert_raise(ArgumentError) { 1.absence_in(1) }
+  end
 end


### PR DESCRIPTION
Method `absence_in` complements existing `presence_in` and can be used to check for absence on the blacklist .

<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

Existing method `Object#presence_in` can be used for whilelisting:

```ruby
def page_title
  params[:page_title].presence_in(%w[photos videos]) || "photos"
end
```

However, sometimes sometimes it is important to check for absence on the blacklist rather than whilelist inclusion:

```ruby
def page_title
  params[:page_title].absence_in(%w[default hidden]) || "photos"
end
```

Seems like this method does not add any additional complexity. I also wasn't able to come up with a clean, short and good-looking alternative based on existing methods (tell me if I'm missing something!).
  
### Detail

This PR adds implementation for `Object#absence_in` ActiveSupport core extension.

### Checklist

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
