### PR TITLE
Print `bin/rails` help on unrecognized bare options

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,53 @@
+*   `bin/rails` now prints its help message when given an unrecognized bare
+    option.
+
+    __Before__
+
+      ```console
+      $ bin/rails -v
+      Rails 7.2.0.alpha
+
+      $ bin/rails -V
+      rake, version 13.0.6
+
+      $ bin/rails -s
+      Running 0 tests in a single process (parallelization threshold is 50)
+      ...
+
+      $ bin/rails -S
+      invalid option: -S
+      ```
+
+    __After__
+
+      ```console
+      $ bin/rails -v
+      Rails 7.2.0.alpha
+
+      $ bin/rails -V
+      Usage:
+        bin/rails COMMAND [options]
+
+      You must specify a command. The most common commands are:
+      ...
+
+      $ bin/rails -s
+      Usage:
+        bin/rails COMMAND [options]
+
+      You must specify a command. The most common commands are:
+      ...
+
+      $ bin/rails -S
+      Usage:
+        bin/rails COMMAND [options]
+
+      You must specify a command. The most common commands are:
+      ...
+      ```
+
+    *Jonathan Hefner*
+
 *   Ensure `autoload_paths`, `autoload_once_paths`, `eager_load_paths`, and
     `load_paths` only have directories when initialized from engine defaults.
     Previously, files under the `app` directory could end up there too.

--- a/railties/lib/rails/command.rb
+++ b/railties/lib/rails/command.rb
@@ -130,14 +130,16 @@ module Rails
 
         def split_namespace(namespace)
           case namespace
-          when /^(.+):(\w+)$/
-            [$1, $2]
-          when ""
-            ["help", "help"]
           when HELP_MAPPINGS, "help"
             ["help", "help_extended"]
           when VERSION_MAPPINGS
             ["version", "version"]
+          when "--tasks", "-T"
+            ["", ""]
+          when /^-/, ""
+            ["help", "help"]
+          when /^(.+):(\w+)$/
+            [$1, $2]
           else
             [namespace, namespace]
           end

--- a/railties/test/command/help_integration_test.rb
+++ b/railties/test/command/help_integration_test.rb
@@ -7,6 +7,11 @@ class Rails::Command::HelpIntegrationTest < ActiveSupport::TestCase
   setup :build_app
   teardown :teardown_app
 
+  test "prints help on unrecognized bare option" do
+    assert_match "You must specify a command.", rails("--zzz")
+    assert_match "You must specify a command.", rails("-z")
+  end
+
   test "prints helpful error on unrecognized command" do
     output = rails "vershen", allow_failure: true
 
@@ -33,7 +38,17 @@ class Rails::Command::HelpIntegrationTest < ActiveSupport::TestCase
     assert_equal help, output
   end
 
-  test "excludes application Rake tasks from command listing" do
+  test "prints Rake tasks on --tasks / -T option" do
+    app_file "lib/tasks/my_task.rake", <<~RUBY
+      desc "my_task"
+      task :my_task
+    RUBY
+
+    assert_match "my_task", rails("--tasks")
+    assert_match "my_task", rails("-T")
+  end
+
+  test "excludes application Rake tasks from command list via --help" do
     app_file "Rakefile", <<~RUBY, "a"
       desc "my_task"
       task :my_task_1


### PR DESCRIPTION
Prior to this commit, `bin/rails` would pass unrecognized bare options on to Rake:

  ```console
  $ bin/rails -v
  Rails 7.2.0.alpha

  $ bin/rails -V
  rake, version 13.0.6

  $ bin/rails -s
  Running 0 tests in a single process (parallelization threshold is 50)
  ...

  $ bin/rails -S
  invalid option: -S
  ```

This commit changes `bin/rails` to print its help message when given an unrecognized bare option:

  ```console
  $ bin/rails -v
  Rails 7.2.0.alpha

  $ bin/rails -V
  Usage:
    bin/rails COMMAND [options]

  You must specify a command. The most common commands are:
  ...

  $ bin/rails -s
  Usage:
    bin/rails COMMAND [options]

  You must specify a command. The most common commands are:
  ...

  $ bin/rails -S
  Usage:
    bin/rails COMMAND [options]

  You must specify a command. The most common commands are:
  ...
  ```

However, for backward compatibility, an exception has been made for the `-T` / `--tasks` option:

  ```console
  $ bin/rails -T
  # Prints list of Rake tasks...
  ```

Addresses #50712.
