### PR TITLE
Fix `bin/rails -T` when no default task is defined

### DIFF
--- a/guides/source/active_record_multiple_databases.md
+++ b/guides/source/active_record_multiple_databases.md
@@ -160,39 +160,41 @@ multiply the number of connections you have since Rails uses the model class nam
 connection specification name.
 
 Now that we have the `database.yml` and the new model set up, it's time to create the databases.
-Rails 6.0 ships with all the rails tasks you need to use multiple databases in Rails.
+Rails ships with all the commands you need to use multiple databases.
 
-You can run `bin/rails -T` to see all the commands you're able to run. You should see the following:
+You can run `bin/rails --help` to see all the commands you're able to run. You should see the following:
 
 ```bash
-$ bin/rails -T
-bin/rails db:create                          # Create the database from DATABASE_URL or config/database.yml for the ...
-bin/rails db:create:animals                  # Create animals database for current environment
-bin/rails db:create:primary                  # Create primary database for current environment
-bin/rails db:drop                            # Drop the database from DATABASE_URL or config/database.yml for the cu...
-bin/rails db:drop:animals                    # Drop animals database for current environment
-bin/rails db:drop:primary                    # Drop primary database for current environment
-bin/rails db:migrate                         # Migrate the database (options: VERSION=x, VERBOSE=false, SCOPE=blog)
-bin/rails db:migrate:animals                 # Migrate animals database for current environment
-bin/rails db:migrate:primary                 # Migrate primary database for current environment
-bin/rails db:migrate:status                  # Display status of migrations
-bin/rails db:migrate:status:animals          # Display status of migrations for animals database
-bin/rails db:migrate:status:primary          # Display status of migrations for primary database
-bin/rails db:reset                           # Drop and recreates all databases from their schema for the current environment and loads the seeds
-bin/rails db:reset:animals                   # Drop and recreates the animals database from its schema for the current environment and loads the seeds
-bin/rails db:reset:primary                   # Drop and recreates the primary database from its schema for the current environment and loads the seeds
-bin/rails db:rollback                        # Roll the schema back to the previous version (specify steps w/ STEP=n)
-bin/rails db:rollback:animals                # Rollback animals database for current environment (specify steps w/ STEP=n)
-bin/rails db:rollback:primary                # Rollback primary database for current environment (specify steps w/ STEP=n)
-bin/rails db:schema:dump                     # Create a database schema file (either db/schema.rb or db/structure.sql  ...
-bin/rails db:schema:dump:animals             # Create a database schema file (either db/schema.rb or db/structure.sql  ...
-bin/rails db:schema:dump:primary             # Create a db/schema.rb file that is portable against any DB supported  ...
-bin/rails db:schema:load                     # Load a database schema file (either db/schema.rb or db/structure.sql  ...
-bin/rails db:schema:load:animals             # Load a database schema file (either db/schema.rb or db/structure.sql  ...
-bin/rails db:schema:load:primary             # Load a database schema file (either db/schema.rb or db/structure.sql  ...
-bin/rails db:setup                           # Create all databases, loads all schemas, and initializes with the seed data (use db:reset to also drop all databases first)
-bin/rails db:setup:animals                   # Create the animals database, loads the schema, and initializes with the seed data (use db:reset:animals to also drop the database first)
-bin/rails db:setup:primary                   # Create the primary database, loads the schema, and initializes with the seed data (use db:reset:primary to also drop the database first)
+$ bin/rails --help
+...
+db:create                          # Create the database from DATABASE_URL or config/database.yml for the ...
+db:create:animals                  # Create animals database for current environment
+db:create:primary                  # Create primary database for current environment
+db:drop                            # Drop the database from DATABASE_URL or config/database.yml for the cu...
+db:drop:animals                    # Drop animals database for current environment
+db:drop:primary                    # Drop primary database for current environment
+db:migrate                         # Migrate the database (options: VERSION=x, VERBOSE=false, SCOPE=blog)
+db:migrate:animals                 # Migrate animals database for current environment
+db:migrate:primary                 # Migrate primary database for current environment
+db:migrate:status                  # Display status of migrations
+db:migrate:status:animals          # Display status of migrations for animals database
+db:migrate:status:primary          # Display status of migrations for primary database
+db:reset                           # Drop and recreates all databases from their schema for the current environment and loads the seeds
+db:reset:animals                   # Drop and recreates the animals database from its schema for the current environment and loads the seeds
+db:reset:primary                   # Drop and recreates the primary database from its schema for the current environment and loads the seeds
+db:rollback                        # Roll the schema back to the previous version (specify steps w/ STEP=n)
+db:rollback:animals                # Rollback animals database for current environment (specify steps w/ STEP=n)
+db:rollback:primary                # Rollback primary database for current environment (specify steps w/ STEP=n)
+db:schema:dump                     # Create a database schema file (either db/schema.rb or db/structure.sql  ...
+db:schema:dump:animals             # Create a database schema file (either db/schema.rb or db/structure.sql  ...
+db:schema:dump:primary             # Create a db/schema.rb file that is portable against any DB supported  ...
+db:schema:load                     # Load a database schema file (either db/schema.rb or db/structure.sql  ...
+db:schema:load:animals             # Load a database schema file (either db/schema.rb or db/structure.sql  ...
+db:schema:load:primary             # Load a database schema file (either db/schema.rb or db/structure.sql  ...
+db:setup                           # Create all databases, loads all schemas, and initializes with the seed data (use db:reset to also drop all databases first)
+db:setup:animals                   # Create the animals database, loads the schema, and initializes with the seed data (use db:reset:animals to also drop the database first)
+db:setup:primary                   # Create the primary database, loads the schema, and initializes with the seed data (use db:reset:primary to also drop the database first)
+...
 ```
 
 Running a command like `bin/rails db:create` will create both the primary and animals databases.

--- a/railties/lib/rails/commands/rake/rake_command.rb
+++ b/railties/lib/rails/commands/rake/rake_command.rb
@@ -18,7 +18,7 @@ module Rails
 
         def perform(task, args, config)
           with_rake(task, *args) do |rake|
-            if unrecognized_task = rake.top_level_tasks.find { |task| !rake.lookup(task[/[^\[]+/]) }
+            if unrecognized_task = (rake.top_level_tasks - ["default"]).find { |task| !rake.lookup(task[/[^\[]+/]) }
               @rake_tasks = rake.tasks
               raise UnrecognizedCommandError.new(unrecognized_task)
             end

--- a/railties/test/command/help_integration_test.rb
+++ b/railties/test/command/help_integration_test.rb
@@ -40,6 +40,8 @@ class Rails::Command::HelpIntegrationTest < ActiveSupport::TestCase
 
   test "prints Rake tasks on --tasks / -T option" do
     app_file "lib/tasks/my_task.rake", <<~RUBY
+      Rake.application.clear
+
       desc "my_task"
       task :my_task
     RUBY


### PR DESCRIPTION
When Rake parses an argument string with no tasks, it sets the top-level task as "default".  Prior to this commit, if no default task was defined (for example, if an app was generated with `--skip-test` and didn't define its own default task), `Rails::Command::RakeCommand` would raise `UnrecognizedCommandError`, preventing Rake from displaying the task list.

This commit changes `Rails::Command::RakeCommand` to let Rake handle the "default" task.

Fixes #50700.
