### PR TITLE
Fix ActiveStorage::Blob inverse association:

### DIFF
--- a/activestorage/app/models/active_storage/attachment.rb
+++ b/activestorage/app/models/active_storage/attachment.rb
@@ -28,7 +28,7 @@ class ActiveStorage::Attachment < ActiveStorage::Record
   # :method:
   #
   # Returns the associated ActiveStorage::Blob.
-  belongs_to :blob, class_name: "ActiveStorage::Blob", autosave: true
+  belongs_to :blob, class_name: "ActiveStorage::Blob", autosave: true, inverse_of: :attachments
 
   delegate_missing_to :blob
   delegate :signed_id, to: :blob

--- a/activestorage/lib/active_storage/attached/changes/create_one_of_many.rb
+++ b/activestorage/lib/active_storage/attached/changes/create_one_of_many.rb
@@ -4,7 +4,11 @@ module ActiveStorage
   class Attached::Changes::CreateOneOfMany < Attached::Changes::CreateOne # :nodoc:
     private
       def find_attachment
-        record.public_send("#{name}_attachments").detect { |attachment| attachment.blob_id == blob.id }
+        if blob.persisted?
+          record.public_send("#{name}_attachments").detect { |attachment| attachment.blob_id == blob.id }
+        else
+          blob.attachments.find { |attachment| attachment.record == record }
+        end
       end
   end
 end


### PR DESCRIPTION
### Motivation / Background

This is a fix needed to unblock https://github.com/rails/rails/pull/50284, because Active Storage relies on a Active Record bug.

### Detail

The problem is best understood with a small snippet:

```ruby
blob = ActiveStorage::Blob.new

ActiveStorage::Attachment.new(blob: blob)
ActiveStorage::Attachment.new(blob: blob)

# Currently:
p blob.attachments #=> #<ActiveRecord::Associations::CollectionProxy []>

# Once the Active Record bug is fixed:
p blob.attachments #=> #<ActiveRecord::Associations::CollectionProxy [#<ActiveStorage::Attachment id: nil, name: nil, record_type: nil, record_id: nil, blob_id: nil, created_at: nil>, #<ActiveStorage::Attachment id: nil, name: nil, record_type: nil, record_id: nil, blob_id: nil, created_at: nil>]>

# Saving the blob would result in trying to create 2 attachments which
# fails because of unique constraints.
```

### Additional information

The real code path that does what the snippet above does is located here:

https://github.com/rails/rails/blob/9c3ffab47c3bf59320ba08e9dafdb0275cf91a5a/activestorage/lib/active_storage/attached/many.rb#L52

It's basically doing this:

```ruby
user.images.attach "photo1.png"
# Initialize a Blob record and an Attachment

user.images.attach "photo2.png"
# Get the Blob from above, create another Attachment
# Initialize a new Blob record and an new Attachment

# Rinse and repeat every time `attach` is called
```

### Solution

- Explicitly set the `inverse_of`, so that it behaves as if #50284 is shipped
- Don't build a new attachment for blob already having one.

### Tests

I didn't add tests, the test suite is already well covered, adding the `inverse_of`
without any changes breaks the test suite already. You can try by running
for instance the `activestorage/test/models/attached/many_test.rb`.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
