### PR TITLE
Link to framework main page instead of README in API docs [ci-skip]

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,12 +15,12 @@ application into three layers: Model, View, and Controller, each with a specific
 The _**Model layer**_ represents the domain model (such as Account, Product,
 Person, Post, etc.) and encapsulates the business logic specific to
 your application. In Rails, database-backed model classes are derived from
-`ActiveRecord::Base`. [Active Record](activerecord/README.rdoc) allows you to present the data from
+`ActiveRecord::Base`. [Active Record](https://api.rubyonrails.org/classes/ActiveRecord.html) allows you to present the data from
 database rows as objects and embellish these data objects with business logic
 methods.
 Although most Rails models are backed by a database, models can also be ordinary
 Ruby classes, or Ruby classes that implement a set of interfaces as provided by
-the [Active Model](activemodel/README.rdoc) module.
+the [Active Model](https://api.rubyonrails.org/classes/ActiveModel.html) module.
 
 ## View layer
 
@@ -28,7 +28,7 @@ The _**View layer**_ is composed of "templates" that are responsible for providi
 appropriate representations of your application's resources. Templates can
 come in a variety of formats, but most view templates are HTML with embedded
 Ruby code (ERB files). Views are typically rendered to generate a controller response
-or to generate the body of an email. In Rails, View generation is handled by [Action View](actionview/README.rdoc).
+or to generate the body of an email. In Rails, View generation is handled by [Action View](https://api.rubyonrails.org/classes/ActionView.html).
 
 ## Controller layer
 
@@ -42,17 +42,17 @@ are bundled together in [Action Pack](actionpack/README.rdoc).
 
 ## Frameworks and libraries
 
-[Active Record](activerecord/README.rdoc), [Active Model](activemodel/README.rdoc), [Action Pack](actionpack/README.rdoc), and [Action View](actionview/README.rdoc) can each be used independently outside Rails.
+[Active Record](https://api.rubyonrails.org/classes/ActiveRecord.html), [Active Model](https://api.rubyonrails.org/classes/ActiveModel.html), [Action Pack](actionpack/README.rdoc), and [Action View](https://api.rubyonrails.org/classes/ActionView.html) can each be used independently outside Rails.
 
 In addition to that, Rails also comes with:
 
-- [Action Mailer](actionmailer/README.rdoc), a library to generate and send emails
-- [Action Mailbox](actionmailbox/README.md), a library to receive emails within a Rails application
-- [Active Job](activejob/README.md), a framework for declaring jobs and making them run on a variety of queuing backends
-- [Action Cable](actioncable/README.md), a framework to integrate WebSockets with a Rails application
-- [Active Storage](activestorage/README.md), a library to attach cloud and local files to Rails applications
-- [Action Text](actiontext/README.md), a library to handle rich text content
-- [Active Support](activesupport/README.rdoc), a collection of utility classes and standard library extensions that are useful for Rails, and may also be used independently outside Rails
+- [Action Mailer](https://api.rubyonrails.org/classes/ActionMailer.html), a library to generate and send emails
+- [Action Mailbox](https://api.rubyonrails.org/classes/ActionMailbox.html), a library to receive emails within a Rails application
+- [Active Job](https://api.rubyonrails.org/classes/ActiveJob.html), a framework for declaring jobs and making them run on a variety of queuing backends
+- [Action Cable](https://api.rubyonrails.org/classes/ActionCable.html), a framework to integrate WebSockets with a Rails application
+- [Active Storage](https://api.rubyonrails.org/classes/ActiveStorage.html), a library to attach cloud and local files to Rails applications
+- [Action Text](https://api.rubyonrails.org/classes/ActionText.html), a library to handle rich text content
+- [Active Support](https://api.rubyonrails.org/classes/ActiveSupport.html), a collection of utility classes and standard library extensions that are useful for Rails, and may also be used independently outside Rails
 
 ## Getting Started
 

--- a/railties/RDOC_MAIN.md
+++ b/railties/RDOC_MAIN.md
@@ -15,12 +15,12 @@ application into three layers: Model, View, and Controller, each with a specific
 The _**Model layer**_ represents the domain model (such as Account, Product,
 Person, Post, etc.) and encapsulates the business logic specific to
 your application. In \Rails, database-backed model classes are derived from
-`ActiveRecord::Base`. [Active Record](files/activerecord/README.rdoc) allows you to present the data from
+`ActiveRecord::Base`. [Active Record](https://api.rubyonrails.org/classes/ActiveRecord.html) allows you to present the data from
 database rows as objects and embellish these data objects with business logic
 methods.
 Although most \Rails models are backed by a database, models can also be ordinary
 Ruby classes, or Ruby classes that implement a set of interfaces as provided by
-the [Active Model](files/activemodel/README.rdoc) module.
+the [Active Model](https://api.rubyonrails.org/classes/ActiveModel.html) module.
 
 ## View layer
 
@@ -28,7 +28,7 @@ The _**View layer**_ is composed of "templates" that are responsible for providi
 appropriate representations of your application's resources. Templates can
 come in a variety of formats, but most view templates are HTML with embedded
 Ruby code (\ERB files). Views are typically rendered to generate a controller response
-or to generate the body of an email. In \Rails, View generation is handled by [Action View](files/actionview/README.rdoc).
+or to generate the body of an email. In \Rails, View generation is handled by [Action View](https://api.rubyonrails.org/classes/ActionView.html).
 
 ## Controller layer
 
@@ -42,17 +42,17 @@ are bundled together in [Action Pack](files/actionpack/README.rdoc).
 
 ## Frameworks and libraries
 
-[Active Record](files/activerecord/README.rdoc), [Active Model](files/activemodel/README.rdoc), [Action Pack](files/actionpack/README.rdoc), and [Action View](files/actionview/README.rdoc) can each be used independently outside \Rails.
+[Active Record](https://api.rubyonrails.org/classes/ActiveRecord.html), [Active Model](https://api.rubyonrails.org/classes/ActiveModel.html), [Action Pack](files/actionpack/README.rdoc), and [Action View](https://api.rubyonrails.org/classes/ActionView.html) can each be used independently outside \Rails.
 
 In addition to that, \Rails also comes with:
 
-- [Action Mailer](files/actionmailer/README.rdoc), a library to generate and send emails
-- [Action Mailbox](files/actionmailbox/README.md), a library to receive emails within a \Rails application
-- [Active Job](files/activejob/README.md), a framework for declaring jobs and making them run on a variety of queuing backends
-- [Action Cable](files/actioncable/README.md), a framework to integrate WebSockets with a \Rails application
-- [Active Storage](files/activestorage/README.md), a library to attach cloud and local files to \Rails applications
-- [Action Text](files/actiontext/README.md), a library to handle rich text content
-- [Active Support](files/activesupport/README.rdoc), a collection of utility classes and standard library extensions that are useful for \Rails, and may also be used independently outside \Rails
+- [Action Mailer](https://api.rubyonrails.org/classes/ActionMailer.html), a library to generate and send emails
+- [Action Mailbox](https://api.rubyonrails.org/classes/ActionMailbox.html), a library to receive emails within a \Rails application
+- [Active Job](https://api.rubyonrails.org/classes/ActiveJob.html), a framework for declaring jobs and making them run on a variety of queuing backends
+- [Action Cable](https://api.rubyonrails.org/classes/ActionCable.html), a framework to integrate WebSockets with a \Rails application
+- [Active Storage](https://api.rubyonrails.org/classes/ActiveStorage.html), a library to attach cloud and local files to \Rails applications
+- [Action Text](https://api.rubyonrails.org/classes/ActionText.html), a library to handle rich text content
+- [Active Support](https://api.rubyonrails.org/classes/ActiveSupport.html), a collection of utility classes and standard library extensions that are useful for \Rails, and may also be used independently outside \Rails
 
 ## Getting Started
 


### PR DESCRIPTION
The Rails README that is shown as the homepage of https://api.rubyonrails.org/ has links to the different frameworks. However, these links link to the framework README's instead of the framework main page, which results in a page that misses links to the framework methods and namespaces.

For example, clicking on "ActionView" results in the following page, which misses any navigation to methods and namespaces.
https://api.rubyonrails.org/v7.1/files/actionview/README_rdoc.html

By linking to the framework main page the navigation is present:
https://api.rubyonrails.org/v7.1/classes/ActionView.html

### Additional information

The README's files are included in the docs in the `/files` directory. These can now probably be removed when generating the docs as the content of the README is already inlined in the framework homepage.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
