### PR TITLE
Freeze and dedup `quote_column_name` and `quote_table_name` caches

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/mysql/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/quoting.rb
@@ -30,11 +30,11 @@ module ActiveRecord
         end
 
         def quote_column_name(name)
-          QUOTED_COLUMN_NAMES[name] ||= "`#{super.gsub('`', '``')}`"
+          QUOTED_COLUMN_NAMES[name] ||= "`#{super.gsub('`', '``')}`".freeze
         end
 
         def quote_table_name(name)
-          QUOTED_TABLE_NAMES[name] ||= super.gsub(".", "`.`").freeze
+          QUOTED_TABLE_NAMES[name] ||= -super.gsub(".", "`.`").freeze
         end
 
         def unquoted_true

--- a/activerecord/lib/active_record/connection_adapters/postgresql/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/quoting.rb
@@ -86,12 +86,7 @@ module ActiveRecord
         # - "schema.name".table_name
         # - "schema.name"."table.name"
         def quote_table_name(name) # :nodoc:
-          QUOTED_TABLE_NAMES[name] ||= Utils.extract_schema_qualified_name(name.to_s).quoted.freeze
-        end
-
-        # Quotes schema names for use in SQL queries.
-        def quote_schema_name(name)
-          PG::Connection.quote_ident(name)
+          QUOTED_TABLE_NAMES[name] ||= -Utils.extract_schema_qualified_name(name.to_s).quoted.freeze
         end
 
         def quote_table_name_for_assignment(table, attr)
@@ -102,6 +97,9 @@ module ActiveRecord
         def quote_column_name(name) # :nodoc:
           QUOTED_COLUMN_NAMES[name] ||= PG::Connection.quote_ident(super).freeze
         end
+
+        # Quotes schema names for use in SQL queries.
+        alias_method :quote_schema_name, :quote_column_name
 
         # Quote date/time values for use in SQL input.
         def quoted_date(value) # :nodoc:

--- a/activerecord/lib/active_record/connection_adapters/sqlite3/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3/quoting.rb
@@ -16,11 +16,11 @@ module ActiveRecord
         end
 
         def quote_table_name(name)
-          QUOTED_TABLE_NAMES[name] ||= super.gsub(".", "\".\"").freeze
+          QUOTED_TABLE_NAMES[name] ||= -super.gsub(".", "\".\"").freeze
         end
 
         def quote_column_name(name)
-          QUOTED_COLUMN_NAMES[name] ||= %Q("#{super.gsub('"', '""')}")
+          QUOTED_COLUMN_NAMES[name] ||= %Q("#{super.gsub('"', '""')}").freeze
         end
 
         def quoted_time(value)


### PR DESCRIPTION
Ref: https://github.com/rails/rails/pull/48773#discussion_r1453812580

Avoid corrupting the cache by mutating the return value, and also sligthly reduce memory usage when the quoting format often return an unmodified string.

FYI: @dkubb 