### PR TITLE
Add format constraints for generated pwa routes

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/routes.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/routes.rb.tt
@@ -6,8 +6,8 @@ Rails.application.routes.draw do
   get "up" => "rails/health#show", as: :rails_health_check
 
   # Render dynamic PWA files from app/views/pwa/*
-  get "service-worker" => "rails/pwa#service_worker", as: :pwa_service_worker
-  get "manifest" => "rails/pwa#manifest", as: :pwa_manifest
+  get "service-worker" => "rails/pwa#service_worker", as: :pwa_service_worker, constraints: {format: "js"}
+  get "manifest" => "rails/pwa#manifest", as: :pwa_manifest, constraints: {format: "json"}
 
   # Defines the root path route ("/")
   # root "posts#index"


### PR DESCRIPTION
### Motivation / Background

As a followup to #50528, which added default pwa manifest and service worker routes and files to the new app generator, I'd like to associate the new routes with the expected mime types.

### Detail

We expect the `pwa#manifest` request to be limited to json, i.e. `manifest.json` and we expect the `pwa#service_worker` request to be limited to js, i.e. `service-worker.js`. This change adds format constraints to the generated routes.

### Additional information

I didn't see associated tests with the previous change but would be open to adding some if desired.

### Checklist

Before submitting the PR make sure the following are checked:

* [ ] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [ ] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
