### PR TITLE
Add methods to `ActiveRecord::Relation::FinderMethods` to determine if it contains exactly/more than/less than N records

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,15 @@
+*   Adds the following methods to `ActiveRecord::Relation::FinderMethods`:
+    * `exactly?` returns true if the relation contains exactly N records, false otherwise.
+    * `at_least?` returns true if the relation contains at least N records, false otherwise.
+    * `at_most?` returns true if the relation contains at most N records, false otherwise.
+    * `less_than?` returns true if the relation contains less than N records, false otherwise.
+    * `more_than?` returns true if the relation contains more than N records, false otherwise.
+
+    These methods will perform a `limit(N).count` on the relation which is more efficient
+    than doing `count`.
+
+    *Jordi Noguera*
+
 *   Consistently raise an `ArgumentError` when passing an invalid argument to a nested attributes association writer.
 
     Previously, this would only raise on collection associations and produce a generic error on singular associations.

--- a/activerecord/lib/active_record/querying.rb
+++ b/activerecord/lib/active_record/querying.rb
@@ -6,7 +6,7 @@ module ActiveRecord
       :find, :find_by, :find_by!, :take, :take!, :sole, :find_sole_by, :first, :first!, :last, :last!,
       :second, :second!, :third, :third!, :fourth, :fourth!, :fifth, :fifth!,
       :forty_two, :forty_two!, :third_to_last, :third_to_last!, :second_to_last, :second_to_last!,
-      :exists?, :any?, :many?, :none?, :one?,
+      :exists?, :any?, :many?, :none?, :one?, :exactly?, :at_least?, :at_most?, :less_than?, :more_than?,
       :first_or_create, :first_or_create!, :first_or_initialize,
       :find_or_create_by, :find_or_create_by!, :find_or_initialize_by,
       :create_or_find_by, :create_or_find_by!,

--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -402,6 +402,51 @@ module ActiveRecord
 
     alias :member? :include?
 
+    # Returns true if the relation has exactly N records (where N is the supplied parameter)
+    # or false otherwise
+    #
+    #   Person.exactly?(5)
+    #   Person.where(['name LIKE ?', "%#{query}%"]).exactly?(5)
+    def exactly?(expected)
+      limit(expected + 1).count == expected
+    end
+
+    # Returns true if the relation has at least N records (where N is the supplied parameter)
+    # or false otherwise
+    #
+    #   Person.at_least?(5)
+    #   Person.where(['name LIKE ?', "%#{query}%"]).at_least?(5)
+    def at_least?(expected)
+      limit(expected).count == expected
+    end
+
+    # Returns true if the relation has at most N records (where N is the supplied parameter)
+    # or false otherwise
+    #
+    #   Person.at_most?(5)
+    #   Person.where(['name LIKE ?', "%#{query}%"]).at_most?(5)
+    def at_most?(expected)
+      limit(expected + 1).count <= expected
+    end
+
+    # Returns true if the relation has less than N records (where N is the supplied parameter)
+    # or false otherwise
+    #
+    #   Person.less_than?(5)
+    #   Person.where(['name LIKE ?', "%#{query}%"]).less_than?(5)
+    def less_than?(expected)
+      limit(expected).count < expected
+    end
+
+    # Returns true if the relation has more than N records (where N is the supplied parameter)
+    # or false otherwise
+    #
+    #   Person.more_than?(5)
+    #   Person.where(['name LIKE ?', "%#{query}%"]).more_than?(5)
+    def more_than?(expected)
+      limit(expected + 1).count == expected + 1
+    end
+
     # This method is called whenever no records are found with either a single
     # id or multiple ids and raises an ActiveRecord::RecordNotFound exception.
     #

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -100,6 +100,38 @@ class FinderTest < ActiveRecord::TestCase
     assert_equal "The Fifth Topic of the day", records[2].title
   end
 
+  def test_exactly
+    count = Topic.count
+    assert Topic.exactly?(count)
+    assert_equal false, Topic.exactly?(count + 1)
+    assert_equal false, Topic.exactly?(count - 1)
+  end
+
+  def test_at_least
+    count = Topic.count
+    assert Topic.at_least?(count)
+    assert_equal false, Topic.at_least?(count + 1)
+  end
+
+  def test_at_most
+    count = Topic.count
+    assert Topic.at_most?(count)
+    assert Topic.at_most?(count + 1)
+    assert_equal false, Topic.at_most?(count - 1)
+  end
+
+  def test_less_than
+    count = Topic.count
+    assert Topic.less_than?(count + 1)
+    assert_equal false, Topic.less_than?(count)
+  end
+
+  def test_more_than
+    count = Topic.count
+    assert Topic.more_than?(count - 1)
+    assert_equal false, Topic.more_than?(count)
+  end
+
   def test_find_with_ids_and_order_clause
     # The order clause takes precedence over the informed ids
     records = Topic.order(:author_name).find([5, 3, 1])


### PR DESCRIPTION
### Motivation / Background

I've had to check in a few places if a relation had exactly or less than or more than N records. On top of that, if the collection contains a lot of records, counting on the entire collection not only is slower but also unnecessary and limiting the count the first N or N+1 records is sufficient and faster.

### Detail

Adds the following methods to `ActiveRecord::Relation::FinderMethods`:
  * `exactly?` returns true if the relation contains exactly N records, false otherwise.
  * `at_least?` returns true if the relation contains at least N records, false otherwise.
  * `at_most?` returns true if the relation contains at most N records, false otherwise.
  * `less_than?` returns true if the relation contains less than N records, false otherwise.
  * `more_than?` returns true if the relation contains more than N records, false otherwise.

These methods perform a `limit(M).count` (where M = N or N + 1) under the hood.

### Additional information

I think the naming of these methods is fine as is. Don't know if others would prefer to prefix these with `has_` or `contains_`, ie `has_exactly?` or `contains_exactly?`.

With regards to performance of doing the count with and without the limit. Without the limit when there are 8M records I get:

```sql
  Referral Count (135.2ms)  SELECT COUNT(*) FROM "referrals" WHERE "referrals"."company_id" = $1  [["company_id", "29f1dfa2-01d0-4e5d-b482-7aa1f3ba7535"]]
=> 8467786
```

With a limit of a 100:

```sql
  Referral Count (0.4ms)  SELECT COUNT(*) FROM (SELECT 1 AS one FROM "referrals" WHERE "referrals"."company_id" = $1 LIMIT $2) subquery_for_count  [["company_id","29f1dfa2-01d0-4e5d-b482-7aa1f3ba7535", ["LIMIT", 100]]
=> 100
```

So it's 300x faster even when doing an index only scan:

```sql
explain SELECT COUNT(*) FROM "referrals" WHERE "referrals"."company_id" ='29f1dfa2-01d0-4e5d-b482-7aa1f3ba7535';

                                                                          QUERY PLAN                                                                           
---------------------------------------------------------------------------------------------------------------------------------------------------------------
 Finalize Aggregate  (cost=136744.58..136744.59 rows=1 width=8)
   ->  Gather  (cost=136744.36..136744.57 rows=2 width=8)
         Workers Planned: 2
         ->  Partial Aggregate  (cost=135744.36..135744.37 rows=1 width=8)
               ->  Parallel Index Only Scan using index_referrals_on_company_id_and_conversion_state on referrals  (cost=0.56..127008.31 rows=3494420 width=0)
                     Index Cond: (company_id = '29f1dfa2-01d0-4e5d-b482-7aa1f3ba7535'::uuid)
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
