### PR TITLE
Update rails console prompt

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,13 +1,16 @@
-*   Rails console now indicates the current Rails environment:
+*   Rails console now indicates application name and the current Rails environment:
 
     ```txt
-    dev:001> # for RAILS_ENV=development
-    test:001> # for RAILS_ENV=test
-    prod:001> # for RAILS_ENV=production
-    my_env:001> # for RAILS_ENV=my_env
+    my-app(dev)> # for RAILS_ENV=development
+    my-app(test)> # for RAILS_ENV=test
+    my-app(prod)> # for RAILS_ENV=production
+    my-app(my_env)> # for RAILS_ENV=my_env
     ```
 
-    The environment name will also be colorized when the environment is
+    The application name is derived from the application's module name from `config/application.rb`.
+    For example, `MyApp` will displayed as `my-app` in the prompt.
+
+    Additionally, the environment name will be colorized when the environment is
     `development` (green), `test` (green), or `production` (red), if your
     terminal supports it.
 

--- a/railties/lib/rails/commands/console/console_command.rb
+++ b/railties/lib/rails/commands/console/console_command.rb
@@ -13,7 +13,9 @@ module Rails
     end
 
     class IRBConsole
-      def initialize
+      def initialize(app)
+        @app = app
+
         require "irb"
         require "irb/completion"
 
@@ -33,11 +35,13 @@ module Rails
         end
 
         env = colorized_env
+        app_name = @app.class.module_parent_name.underscore.dasherize
+        prompt_prefix = "#{app_name}(#{env})"
 
         IRB.conf[:PROMPT][:RAILS_PROMPT] = {
-          PROMPT_I: "#{env}:%03n> ",
-          PROMPT_S: "#{env}:%03n%l ",
-          PROMPT_C: "#{env}:%03n* ",
+          PROMPT_I: "#{prompt_prefix}> ",
+          PROMPT_S: "#{prompt_prefix}%l ",
+          PROMPT_C: "#{prompt_prefix}* ",
           RETURN: "=> %s\n"
         }
 
@@ -79,7 +83,7 @@ module Rails
 
       app.load_console
 
-      @console = app.config.console || IRBConsole.new
+      @console = app.config.console || IRBConsole.new(app)
     end
 
     def sandbox?

--- a/railties/test/application/console_test.rb
+++ b/railties/test/application/console_test.rb
@@ -216,21 +216,21 @@ class FullStackConsoleTest < ActiveSupport::TestCase
     options = "-e production"
     spawn_console(options)
 
-    write_prompt "123", "prod:001> 123"
+    write_prompt "123", "app-template(prod)> 123"
   end
 
   def test_development_console_prompt
     options = "-e development"
     spawn_console(options)
 
-    write_prompt "123", "dev:001> 123"
+    write_prompt "123", "app-template(dev)> 123"
   end
 
   def test_test_console_prompt
     options = "-e test"
     spawn_console(options)
 
-    write_prompt "123", "test:001> 123"
+    write_prompt "123", "app-template(test)> 123"
   end
 
   def test_console_respects_user_defined_prompt_mode

--- a/railties/test/commands/console_test.rb
+++ b/railties/test/commands/console_test.rb
@@ -59,7 +59,7 @@ class Rails::ConsoleTest < ActiveSupport::TestCase
   end
 
   def test_prompt_env_colorization
-    irb_console = Rails::Console::IRBConsole.new
+    irb_console = Rails::Console::IRBConsole.new(app)
     red = "\e[31m"
     green = "\e[32m"
     clear = "\e[0m"


### PR DESCRIPTION
### Motivation / Background

This PR adopts the follow up suggestion in https://github.com/rails/rails/issues/50770 around Rails console's prompt.

### Detail

Instead of displaying `[env]:[line-number]>` as the prompt, showing `[app-name]([env])>` will provide more value to users.

For example, if the app's top-level module is `MyApp`, its development prompt would be:

```
my-app(dev)>
```

### Additional information

<!-- Provide additional information such as benchmarks, reference to other repositories or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
