### PR TITLE
[docs] Add more examples to `#in_order_of` [ci-skip]

### DIFF
--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -606,8 +606,8 @@ module ActiveRecord
       self
     end
 
-    # Allows to specify an <code>ORDER BY</code> clause to a query based on a given +column+,
-    # ordered and filtered by the specific set of +values+.
+    # Applies an <tt>ORDER BY</tt> clause based on a given +column+,
+    # ordered and filtered by a specific set of +values+.
     #
     #   User.in_order_of(:id, [1, 5, 3])
     #   # SELECT "users".* FROM "users"
@@ -625,7 +625,7 @@ module ActiveRecord
     #     enum :status, [ :active, :archived ]
     #   end
     #
-    #   Conversation.in_order_of(:status, %w(archived active))
+    #   Conversation.in_order_of(:status, [:archived, :active])
     #   # SELECT "conversations".* FROM "conversations"
     #   #   WHERE "conversations"."status" IN (1, 0)
     #   #   ORDER BY CASE
@@ -635,7 +635,7 @@ module ActiveRecord
     #
     # +values+ can also include +nil+.
     #
-    #   Conversation.in_order_of(:status, %w(nil archived active))
+    #   Conversation.in_order_of(:status, [nil, :archived, :active])
     #   # SELECT "conversations".* FROM "conversations"
     #   #   WHERE ("conversations"."status" IN (1, 0) OR "conversations"."status" IS NULL)
     #   #   ORDER BY CASE

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -606,7 +606,8 @@ module ActiveRecord
       self
     end
 
-    # Allows to specify an order by a specific set of values.
+    # Allows to specify an <code>ORDER BY</code> clause to a query based on a given +column+,
+    # ordered and filtered by the specific set of +values+.
     #
     #   User.in_order_of(:id, [1, 5, 3])
     #   # SELECT "users".* FROM "users"
@@ -615,6 +616,32 @@ module ActiveRecord
     #   #     WHEN "users"."id" = 1 THEN 1
     #   #     WHEN "users"."id" = 5 THEN 2
     #   #     WHEN "users"."id" = 3 THEN 3
+    #   #   END ASC
+    #
+    # +column+ can point to an enum column; the actual query generated may be different depending
+    # on the database adapter and the column definition.
+    #
+    #   class Conversation < ActiveRecord::Base
+    #     enum :status, [ :active, :archived ]
+    #   end
+    #
+    #   Conversation.in_order_of(:status, %w(archived active))
+    #   # SELECT "conversations".* FROM "conversations"
+    #   #   WHERE "conversations"."status" IN (1, 0)
+    #   #   ORDER BY CASE
+    #   #     WHEN "conversations"."status" = 1 THEN 1
+    #   #     WHEN "conversations"."status" = 0 THEN 2
+    #   #   END ASC
+    #
+    # +values+ can also include +nil+.
+    #
+    #   Conversation.in_order_of(:status, %w(nil archived active))
+    #   # SELECT "conversations".* FROM "conversations"
+    #   #   WHERE ("conversations"."status" IN (1, 0) OR "conversations"."status" IS NULL)
+    #   #   ORDER BY CASE
+    #   #     WHEN "conversations"."status" IS NULL THEN 1
+    #   #     WHEN "conversations"."status" = 1 THEN 2
+    #   #     WHEN "conversations"."status" = 0 THEN 3
     #   #   END ASC
     #
     def in_order_of(column, values)


### PR DESCRIPTION
### Motivation / Background

`#in_order_of` is an excellent method and makes ordering enum columns easier, and many complex order case/when queries can be refactored to use it.

This PR was created because I believe having more examples would help people understand this method a bit better.

Also, I think it's useful to document that this method will order results, but also FILTER them, excluding rows in which the column doesn't match any of the given values.

So I expanded the description and added these examples:
- what happens when dealing with `enum` +columns+
- what happens when passing `nil` as a +value+ for nullable columns

Here's a gist with some tests: https://gist.github.com/thdaraujo/7d9aa5ffd1b61bf57604ded14535e357

I'd be happy to add other examples for other usecases you think are relevant, just let me know!

### Detail

This Pull Request expands the documentation for [in_order_of](https://api.rubyonrails.org/classes/ActiveRecord/QueryMethods.html#method-i-in_order_of)

### Additional information

n/a

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* ~[ ] Tests are added or updated if you fix a bug or add a feature.~ not applicable
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
