### PR TITLE
Fix query references for non-hash association where clause values

### DIFF
--- a/activerecord/lib/active_record/relation/predicate_builder.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder.rb
@@ -25,9 +25,9 @@ module ActiveRecord
       expand_from_hash(attributes, &block)
     end
 
-    def self.references(attributes)
+    def self.references(attributes, associations: nil)
       attributes.each_with_object([]) do |(key, value), result|
-        if value.is_a?(Hash)
+        if value.is_a?(Hash) || associations&.key?(key)
           result << Arel.sql(key)
         elsif (idx = key.rindex("."))
           result << Arel.sql(key[0, idx])

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -1524,7 +1524,7 @@ module ActiveRecord
               klass.attribute_aliases[key] || key
             end
           end
-          references = PredicateBuilder.references(opts)
+          references = PredicateBuilder.references(opts, associations: klass.reflections)
           self.references_values |= references unless references.empty?
 
           parts = predicate_builder.build_from_hash(opts) do |table_name|

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -1866,19 +1866,49 @@ class RelationTest < ActiveRecord::TestCase
   end
 
   def test_automatically_added_where_references
+    post = Post.create!(title: "title", body: "body")
+    comment = Comment.create!(post: post, body: "body")
+
     scope = Post.where(comments: { body: "Bla" })
     assert_equal ["comments"], scope.references_values
 
     scope = Post.where("comments.body" => "Bla")
     assert_equal ["comments"], scope.references_values
+
+    scope = Post.where(comments: Comment.containing_the_letter_e)
+    assert_equal ["comments"], scope.references_values
+
+    scope = Post.where(comments: [comment])
+    assert_equal ["comments"], scope.references_values
+
+    scope = Comment.where(post: post)
+    assert_equal ["post"], scope.references_values
+
+    scope = Comment.where(post: post.id)
+    assert_equal ["post"], scope.references_values
   end
 
   def test_automatically_added_where_not_references
+    post = Post.create!(title: "title", body: "body")
+    comment = Comment.create!(post: post, body: "body")
+
     scope = Post.where.not(comments: { body: "Bla" })
     assert_equal ["comments"], scope.references_values
 
     scope = Post.where.not("comments.body" => "Bla")
     assert_equal ["comments"], scope.references_values
+
+    scope = Post.where.not(comments: Comment.containing_the_letter_e)
+    assert_equal ["comments"], scope.references_values
+
+    scope = Post.where.not(comments: [comment])
+    assert_equal ["comments"], scope.references_values
+
+    scope = Comment.where.not(post: post)
+    assert_equal ["post"], scope.references_values
+
+    scope = Comment.where.not(post: post.id)
+    assert_equal ["post"], scope.references_values
   end
 
   def test_automatically_added_having_references


### PR DESCRIPTION
### Detail

This PR fixes an issue where non-hash where-clause values for associations would not set `references_values`. This could (and often does) end up causing hard-to-debug SQL errors due to association name vs table name mismatch, e.g. querying on a singular association name while the actual join table is plural, or vice-versa due to a prior scope.

More detailed reproduction script:  https://gist.github.com/ezekg/5969735eb8c5092fb25198bd8fac4053

#### Before

```rb
scope = Comment.where(post: { id: post })
scope.references_values # => ["post"]

scope = Comment.where(post: post)
scope.references_values # => []
```

I'd expect these to be synonymous since [`#id` is called on `post`](https://github.com/ezekg/rails/blob/c37450b76b24cac7951032c4210db17a9c1b7f51/activerecord/lib/active_record/relation/predicate_builder.rb#L58) for the second case.

#### After

```rb
scope = Comment.where(post: { id: post })
scope.references_values # => ["post"]

scope = Comment.where(post: post)
scope.references_values # => ["post"]
```

With this patch, they're now more or less synonymous, both setting `references_values`.

Since this is likely a breaking change (it broke a few tests in [keygen-sh/keygen-api](https://github.com/keygen-sh/keygen-api) when testing against the patch), this may require some more thought. But it is worth noting that all broken tests were related to various workarounds for this particular bug.

Let me know what you guys think is the best course of action here.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
