### PR TITLE
Specify RDoc method name for accessors defined on singleton_class

### DIFF
--- a/activejob/lib/active_job.rb
+++ b/activejob/lib/active_job.rb
@@ -58,7 +58,7 @@ module ActiveJob
   end
 
   ##
-  # :singleton-method:
+  # :singleton-method: verbose_enqueue_logs
   #
   # Specifies if the methods calling background job enqueue should be logged below
   # their relevant enqueue log lines. Defaults to false.

--- a/activerecord/lib/active_record.rb
+++ b/activerecord/lib/active_record.rb
@@ -180,12 +180,16 @@ module ActiveRecord
   singleton_class.attr_accessor :disable_prepared_statements
   self.disable_prepared_statements = false
 
+  ##
+  # :singleton-method: lazily_load_schema_cache
   # Lazily load the schema cache. This option will load the schema cache
   # when a connection is established rather than on boot. If set,
   # +config.active_record.use_schema_cache_dump+ will be set to false.
   singleton_class.attr_accessor :lazily_load_schema_cache
   self.lazily_load_schema_cache = false
 
+  ##
+  # :singleton-method: schema_cache_ignored_tables
   # A list of tables or regex's to match tables to ignore when
   # dumping the schema cache. For example if this is set to +[/^_/]+
   # the schema cache will not dump tables named with an underscore.
@@ -206,6 +210,8 @@ module ActiveRecord
 
   self.default_timezone = :utc
 
+  ##
+  # :singleton-method: db_warnings_action
   # The action to take when database query produces warning.
   # Must be one of :ignore, :log, :raise, :report, or a custom proc.
   # The default is :ignore.
@@ -235,6 +241,8 @@ module ActiveRecord
 
   self.db_warnings_action = :ignore
 
+  ##
+  # :singleton-method: db_warnings_ignore
   # Specify allowlist of database warnings.
   singleton_class.attr_accessor :db_warnings_ignore
   self.db_warnings_ignore = []
@@ -253,6 +261,8 @@ module ActiveRecord
     MSG
   end
 
+  ##
+  # :singleton-method: async_query_executor
   # Sets the async_query_executor for an application. By default the thread pool executor
   # set to +nil+ which will not run queries in the background. Applications must configure
   # a thread pool executor to use this feature. Options are:
@@ -294,7 +304,7 @@ module ActiveRecord
   self.index_nested_attribute_errors = false
 
   ##
-  # :singleton-method:
+  # :singleton-method: verbose_query_logs
   #
   # Specifies if the methods calling database queries should be logged below
   # their relevant queries. Defaults to false.
@@ -302,7 +312,7 @@ module ActiveRecord
   self.verbose_query_logs = false
 
   ##
-  # :singleton-method:
+  # :singleton-method: queues
   #
   # Specifies the names of the queues used by background jobs.
   singleton_class.attr_accessor :queues
@@ -327,7 +337,7 @@ module ActiveRecord
   self.commit_transaction_on_non_local_return = false
 
   ##
-  # :singleton-method:
+  # :singleton-method: warn_on_records_fetched_greater_than
   # Specify a threshold for the size of query result sets. If the number of
   # records in the set exceeds the threshold, a warning is logged. This can
   # be used to identify queries which load thousands of records and
@@ -339,14 +349,14 @@ module ActiveRecord
   self.application_record_class = nil
 
   ##
-  # :singleton-method:
+  # :singleton-method: action_on_strict_loading_violation
   # Set the application to log or raise when an association violates strict loading.
   # Defaults to :raise.
   singleton_class.attr_accessor :action_on_strict_loading_violation
   self.action_on_strict_loading_violation = :raise
 
   ##
-  # :singleton-method:
+  # :singleton-method: schema_format
   # Specifies the format to use when dumping the database schema with Rails'
   # Rakefile. If :sql, the schema is dumped as (potentially database-
   # specific) SQL statements. If :ruby, the schema is dumped as an
@@ -357,7 +367,7 @@ module ActiveRecord
   self.schema_format = :ruby
 
   ##
-  # :singleton-method:
+  # :singleton-method: error_on_ignored_order
   # Specifies if an error should be raised if the query has an order being
   # ignored when doing batch queries. Useful in applications where the
   # scope being ignored is error-worthy, rather than a warning.
@@ -365,19 +375,19 @@ module ActiveRecord
   self.error_on_ignored_order = false
 
   ##
-  # :singleton-method:
+  # :singleton-method: timestamped_migrations
   # Specify whether or not to use timestamps for migration versions
   singleton_class.attr_accessor :timestamped_migrations
   self.timestamped_migrations = true
 
   ##
-  # :singleton-method:
+  # :singleton-method: migration_strategy
   # Specify strategy to use for executing migrations.
   singleton_class.attr_accessor :migration_strategy
   self.migration_strategy = Migration::DefaultStrategy
 
   ##
-  # :singleton-method:
+  # :singleton-method: dump_schema_after_migration
   # Specify whether schema dump should happen at the end of the
   # bin/rails db:migrate command. This is true by default, which is useful for the
   # development environment. This should ideally be false in the production
@@ -386,7 +396,7 @@ module ActiveRecord
   self.dump_schema_after_migration = true
 
   ##
-  # :singleton-method:
+  # :singleton-method: dump_schemas
   # Specifies which database schemas to dump when calling db:schema:dump.
   # If the value is :schema_search_path (the default), any schemas listed in
   # schema_search_path are dumped. Use :all to dump all schemas regardless
@@ -410,7 +420,7 @@ module ActiveRecord
   end
 
   ##
-  # :singleton-method:
+  # :singleton-method: verify_foreign_keys_for_fixtures
   # If true, Rails will verify all foreign keys in the database after loading fixtures.
   # An error will be raised if there are any foreign key violations, indicating incorrectly
   # written fixtures.
@@ -419,7 +429,7 @@ module ActiveRecord
   self.verify_foreign_keys_for_fixtures = false
 
   ##
-  # :singleton-method:
+  # :singleton-method: allow_deprecated_singular_associations_name
   # If true, Rails will continue allowing plural association names in where clauses on singular associations
   # This behavior will be removed in Rails 7.2.
   singleton_class.attr_accessor :allow_deprecated_singular_associations_name
@@ -429,14 +439,14 @@ module ActiveRecord
   self.query_transformers = []
 
   ##
-  # :singleton-method:
+  # :singleton-method: use_yaml_unsafe_load
   # Application configurable boolean that instructs the YAML Coder to use
   # an unsafe load if set to true.
   singleton_class.attr_accessor :use_yaml_unsafe_load
   self.use_yaml_unsafe_load = false
 
   ##
-  # :singleton-method:
+  # :singleton-method: raise_int_wider_than_64bit
   # Application configurable boolean that denotes whether or not to raise
   # an exception when the PostgreSQLAdapter is provided with an integer that
   # is wider than signed 64bit representation
@@ -444,14 +454,14 @@ module ActiveRecord
   self.raise_int_wider_than_64bit = true
 
   ##
-  # :singleton-method:
+  # :singleton-method: yaml_column_permitted_classes
   # Application configurable array that provides additional permitted classes
   # to Psych safe_load in the YAML Coder
   singleton_class.attr_accessor :yaml_column_permitted_classes
   self.yaml_column_permitted_classes = [Symbol]
 
   ##
-  # :singleton-method:
+  # :singleton-method: generate_secure_token_on
   # Controls when to generate a value for <tt>has_secure_token</tt>
   # declarations. Defaults to <tt>:create</tt>.
   singleton_class.attr_accessor :generate_secure_token_on
@@ -466,7 +476,7 @@ module ActiveRecord
   end
 
   ##
-  # :singleton-method:
+  # :singleton-method: protocol_adapters
   # Provides a mapping between database protocols/DBMSs and the
   # underlying database adapter to be used. This is used only by the
   # <tt>DATABASE_URL</tt> environment variable.


### PR DESCRIPTION
RDoc can't extract the name of accessors defined with `singleton_class.attr_accessor`, resulting in methods called `unknown` in RDoc.

## Before

<img width="1033" alt="image" src="https://github.com/rails/rails/assets/28561/ef21546b-15de-41b6-94b8-f4b965b62fc0">

https://edgeapi.rubyonrails.org/classes/ActiveJob.html#method-c-unknown

## After

<img width="1010" alt="image" src="https://github.com/rails/rails/assets/28561/f749fb18-5818-4a87-8b7a-6269f2a45ba5">

### Additional Information

If the method can't be found RDoc will output a warning when the `verbose` option is set.
I'd would be nice if this would raise an error instead.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
