### PR TITLE
Fix SQLite table definition parsing bug to handle commas in default function definitions

### DIFF
--- a/activerecord/test/cases/adapters/sqlite3/virtual_column_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/virtual_column_test.rb
@@ -17,6 +17,7 @@ if ActiveRecord::Base.lease_connection.supports_virtual_columns?
         t.virtual :upper_name, type: :string, as: "UPPER(name)", stored: true
         t.virtual :lower_name, type: :string, as: "LOWER(name)", stored: false
         t.virtual :octet_name, type: :integer, as: "LENGTH(name)"
+        t.virtual :mutated_name, type: :string, as: "REPLACE(name, 'l', 'L')"
         t.integer :column1
       end
       VirtualColumn.create(name: "Rails", column1: 10)
@@ -56,6 +57,14 @@ if ActiveRecord::Base.lease_connection.supports_virtual_columns?
       assert_predicate column, :virtual?
       assert_not_predicate column, :virtual_stored?
       assert_equal 5, VirtualColumn.take.octet_name
+    end
+
+    def test_virtual_column_with_comma_in_definition
+      column = VirtualColumn.columns_hash["mutated_name"]
+      assert_predicate column, :virtual?
+      assert_not_predicate column, :virtual_stored?
+      assert_not_nil column.default_function
+      assert_equal "RaiLs", VirtualColumn.take.mutated_name
     end
 
     def test_change_table_with_stored_generated_column


### PR DESCRIPTION
### Motivation / Background

This Pull Request fixes a bug in the low-level SQLite adapter introspection logic. I came across the bug when working with virtual columns and JSON, but there are many possible cases where this would cause problems. Here is one reproducible bug script though:

```ruby
# frozen_string_literal: true

require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"

  git_source(:github) { |repo| "https://github.com/#{repo}.git" }

  gem "rails", github: "rails/rails", branch: "main"
  gem "sqlite3"
end

require "active_record"
require "minitest/autorun"
require "logger"

ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:");
ActiveRecord::Base.logger = Logger.new(STDOUT)

ActiveRecord::Schema.define do
  create_table :posts, force: true do |t|
    t.json :payload, null: false, default: {}
    t.virtual :external_id, type: :string, as: "JSON_EXTRACT(payload, '$.id')", stored: true, null: false, index: true
  end
end

class Post < ActiveRecord::Base; end

class BugTest < Minitest::Test
  def test_virtual_column_with_comma_in_definition_is_autopopulated
    post = Post.create!(payload: { id: 'pst_1' })

    assert_equal 'pst_1', post.external_id
  end
end
```

### Detail

This Pull Request more intelligently parses the SQL string description of the table to ensure that we only split by commas that mark a new column definition. In order to accomplish this, the table parsing method needs the list of column names for the table. When `table_structure_sql` is called by `table_structure_with_collation`, these can be supplied as they are already present; when it is called by `foreign_keys`, however, they are not present and thus must be fetched.

I also added a simple regression test as a part of the virtual column test case.

### Additional information

This bug has existed for a long time, but I most recently touched the relevant code in https://github.com/rails/rails/pull/49376.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.

cc: @byroot (this is related to #49346), @tenderlove (this is related to https://github.com/rails/rails/pull/49290), @yahonda (this is related to https://github.com/rails/rails/pull/49376)
