### PR TITLE
Fix eager loading of composite primary key associations

### DIFF
--- a/activerecord/lib/active_record/associations/join_dependency.rb
+++ b/activerecord/lib/active_record/associations/join_dependency.rb
@@ -254,10 +254,10 @@ module ActiveRecord
 
             if node.primary_key
               keys = Array(node.primary_key).map { |column| aliases.column_alias(node, column) }
-              ids = keys.map { |key| row[key] }
+              id = keys.map { |key| row[key] }
             else
               keys = Array(node.reflection.join_primary_key).map { |column| aliases.column_alias(node, column.to_s) }
-              ids = keys.map { nil } # Avoid id-based model caching.
+              id = keys.map { nil } # Avoid id-based model caching.
             end
 
             if keys.any? { |key| row[key].nil? }
@@ -266,11 +266,9 @@ module ActiveRecord
               next
             end
 
-            ids.each do |id|
-              unless model = seen[ar_parent][node][id]
-                model = construct_model(ar_parent, node, row, model_cache, id, strict_loading_value)
-                seen[ar_parent][node][id] = model if id
-              end
+            unless model = seen[ar_parent][node][id]
+              model = construct_model(ar_parent, node, row, model_cache, id, strict_loading_value)
+              seen[ar_parent][node][id] = model if id
             end
 
             construct(model, node, row, seen, model_cache, strict_loading_value)

--- a/activerecord/test/cases/associations/eager_test.rb
+++ b/activerecord/test/cases/associations/eager_test.rb
@@ -1729,6 +1729,26 @@ class EagerAssociationTest < ActiveRecord::TestCase
     assert_equal(expected_tag_ids.sort, blog_post.tags.map(&:id).sort)
   end
 
+  test "preloading belongs_to CPK model with one of the keys being shared between models" do
+    post1 = Cpk::Post.create!(title: "post1", author: "the_same_author")
+    Cpk::Comment.create!(post: post1, text: "great post1!")
+
+    post2 = Cpk::Post.create!(title: "post2", author: "the_same_author")
+    Cpk::Comment.create!(post: post2, text: "great post2!")
+
+    comments = Cpk::Comment.eager_load(:post).to_a
+    expected = {
+      "great post1!" => "post1",
+      "great post2!" => "post2"
+    }
+
+    actual = comments.each_with_object({}) do |comment, hash|
+      hash[comment.text] = comment.post.title
+    end
+
+    assert_equal expected, actual
+  end
+
   test "preloading belongs_to with cpk" do
     order = Cpk::Order.create!(shop_id: 2)
     order_agreement = Cpk::OrderAgreement.create!(order: order)

--- a/activerecord/test/models/cpk/comment.rb
+++ b/activerecord/test/models/cpk/comment.rb
@@ -4,5 +4,6 @@ module Cpk
   class Comment < ActiveRecord::Base
     self.table_name = :cpk_comments
     belongs_to :commentable, class_name: "Cpk::Post", query_constraints: %i[commentable_title commentable_author], polymorphic: true
+    belongs_to :post, class_name: "Cpk::Post", query_constraints: %i[commentable_title commentable_author]
   end
 end

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -270,6 +270,7 @@ ActiveRecord::Schema.define do
     t.string :commentable_title
     t.string :commentable_author
     t.string :commentable_type
+    t.text :text
   end
 
   create_table :cpk_reviews, force: true do |t|


### PR DESCRIPTION
Follow-up for https://github.com/rails/rails/pull/48490/
Fixes https://github.com/rails/rails/issues/50857

Previous code wrongly assumed that `keys.map { |key| row[key] }` returns an array of ids while it actually returns an identifier of a single model. For a single-column PK models it will return an array with 1 element and for a composite primary key model it will return an array of N elements where N is the number of composite primary key columns.

It lead to a bug where the constructed objects were wrongly populated in the cache due to cache key collision. For example `posts` records with composite keys like `["post1", "the_same_author"]` and `["post2", "the_same_author"]` end up sharing the same cache entry under the `the_same_author` key.

This commit fixes the issue by using full composite primary key values as a whole identifier.