### PR TITLE
Set ActiveRecord::RecordNotFound#id when raised from a call to #reload a deleted record

### DIFF
--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -412,6 +412,7 @@ module ActiveRecord
     # argument.
     def raise_record_not_found_exception!(ids = nil, result_size = nil, expected_size = nil, key = primary_key, not_found_ids = nil) # :nodoc:
       conditions = " [#{arel.where_sql(klass)}]" unless where_clause.empty?
+      ids ||= where_clause.to_h[key]
 
       name = @klass.name
 

--- a/activerecord/test/cases/relation/delete_all_test.rb
+++ b/activerecord/test/cases/relation/delete_all_test.rb
@@ -64,7 +64,9 @@ class DeleteAllTest < ActiveRecord::TestCase
     end
 
     posts_to_be_deleted.each do |deleted_post|
-      assert_raise(ActiveRecord::RecordNotFound) { deleted_post.reload }
+      exception = assert_raise(ActiveRecord::RecordNotFound) { deleted_post.reload }
+
+      assert_equal deleted_post.id, exception.id
     end
   end
 


### PR DESCRIPTION
### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created because I am writing some tests for my app around records being deleted by calling `reload`, and there was no easy way to assert that the record raising the `ActiveRecord::RecordNotFound` exception was the record I was expecting

### Detail

This Pull Request changes `raise_record_not_found_exception!` to find IDs based on the primary key from the where condition, if no IDs are explicitly passed

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
