### PR TITLE
Fixes ActionView::Template::Error when pasting images via Trix

### DIFF
--- a/actiontext/app/views/action_text/attachables/_remote_image.html.erb
+++ b/actiontext/app/views/action_text/attachables/_remote_image.html.erb
@@ -1,5 +1,5 @@
 <figure class="attachment attachment--preview">
-  <%= image_tag(remote_image.url, width: remote_image.width, height: remote_image.height) %>
+  <%= image_tag(remote_image.url, width: remote_image.width, height: remote_image.height, skip_pipeline: true) %>
   <% if caption = remote_image.try(:caption) %>
     <figcaption class="attachment__caption">
       <%= caption %>


### PR DESCRIPTION
The asset pipeline really shouldn't be checked for remote images regardless, but this also happens to fix an issue with images pasted into Trix that get serialized as action-text-attachments with "blob:" urls.
