### PR TITLE
Update Guides: AR querying english text to match code behavior [ci-skip]

### DIFF
--- a/guides/source/active_record_querying.md
+++ b/guides/source/active_record_querying.md
@@ -1459,7 +1459,7 @@ SELECT books.* FROM books
   INNER JOIN reviews ON reviews.book_id = books.id
 ```
 
-Or, in English: "return all books with their author that have at least one review". Note again that books with multiple reviews will show up multiple times.
+Or, in English: "return all books that have an author and at least one review". Note again that books with multiple reviews will show up multiple times.
 
 ##### Joining Nested Associations (Single Level)
 


### PR DESCRIPTION
### Motivation / Background

From Active Record Querying docs:

> [12.1.3 Joining Multiple Associations](https://guides.rubyonrails.org/active_record_querying.html#joining-multiple-associations)
> 
> Book.joins(:author, :reviews)
>
> This produces:
> .....
> Or, in English: "return all books with their author ..."

The English statement is wrong. English text implies it returns the book **and** the author.

However, The code will return books only and the join means the returned books will have an author with at least 1 review.

Changing the text to imply it returns books **with an** author instead of books and the author.

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [X] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
