### PR TITLE
Action View: Fallback to existing partial when possible

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,33 @@
+*   Fallback to rendering partial without controller namespace prefix when available
+
+    When `config.action_view.prefix_partial_path_with_controller_namespace =
+    true` and a root-level partial exists, fallback to rendering the partial:
+
+    ```erb
+    <%# app/views/articles/_article.html.erb %>
+    Rendered
+    ```
+
+    ```ruby
+    # app/controllers/articles_controller.rb
+    class ArticlesController < ApplicationController
+      def show
+        render partial: Article.find(params[:id])
+        # => "Rendered"
+      end
+    end
+
+    # app/controllers/scoped/articles_controller.rb
+    class Scoped::ArticlesController < ApplicationController
+      def show
+        render partial: Article.find(params[:id])
+        # => "Rendered"
+      end
+    end
+    ```
+
+    *Sean Doyle*
+
 *   Extract `current_page?`, `button_to`, and `link_to` methods to
     `ActionView::Helpers::NavigationHelper`
 

--- a/actionview/lib/action_view/path_set.rb
+++ b/actionview/lib/action_view/path_set.rb
@@ -60,7 +60,13 @@ module ActionView # :nodoc:
 
     private
       def search_combinations(prefixes)
-        prefixes = Array(prefixes)
+        prefixes = Array(prefixes).flat_map do |prefix|
+          nested_prefixes = prefix.chars.filter_map.with_index do |char, index|
+            prefix[index + 1..] if char == "/"
+          end
+
+          [prefix, *nested_prefixes]
+        end
         prefixes.each do |prefix|
           paths.each do |resolver|
             yield resolver, prefix

--- a/actionview/test/actionpack/controller/render_test.rb
+++ b/actionview/test/actionpack/controller/render_test.rb
@@ -23,7 +23,26 @@ module Quiz
   end
 end
 
+module ActiveStorage
+  Attachment = Struct.new(:filename) do
+    extend ActiveModel::Naming
+    include ActiveModel::Conversion
+  end
+end
+
+module Namespaced
+  Article = Struct.new(:file) do
+    extend ActiveModel::Naming
+    include ActiveModel::Conversion
+  end
+end
+
 module Fun
+  Article = Struct.new(:file) do
+    extend ActiveModel::Naming
+    include ActiveModel::Conversion
+  end
+
   class GamesController < ActionController::Base
     def hello_world; end
 
@@ -1090,6 +1109,51 @@ class RenderTest < ActionController::TestCase
   def test_render_to_string_inline
     get :render_to_string_with_inline_and_render
     assert_equal "Hello world!", @response.body
+  end
+
+  def test_unnested_rendering_with_fallback
+    @controller = Fun::GamesController.new
+    def @controller.hello_world
+      render partial: ::Customer.new("Rendered"), locals: { greeting: "Hello" }
+    end
+
+    get :hello_world
+    assert_equal "Hello: Rendered", @response.body
+  end
+
+  def test_rendering_with_multiple_namespaces
+    @controller = Fun::GamesController.new
+    def @controller.hello_world
+      file = ::ActiveStorage::Attachment.new("file.txt")
+      fun_article = ::Fun::Article.new(file)
+      render partial: fun_article
+    end
+
+    get :hello_world
+    assert_equal "Rendered attachment: file.txt", @response.body
+  end
+
+  def test_rendering_with_different_namespaces
+    @controller = Fun::GamesController.new
+    def @controller.hello_world
+      file = ::ActiveStorage::Attachment.new("file.txt")
+      namespaced_article = ::Namespaced::Article.new(file)
+      render partial: namespaced_article
+    end
+
+    get :hello_world
+    assert_equal "Rendered attachment: file.txt", @response.body
+  end
+
+  def test_unnested_rendering_without_fallback
+    @controller = Fun::GamesController.new
+    def @controller.hello_world
+      render partial: Post.new
+    end
+
+    assert_raises ActionView::MissingTemplate, match: "Missing partial fun/posts/_post" do
+      get :hello_world
+    end
   end
 
   # :ported:

--- a/actionview/test/fixtures/actionpack/active_storage/attachments/_attachment.html.erb
+++ b/actionview/test/fixtures/actionpack/active_storage/attachments/_attachment.html.erb
@@ -1,0 +1,1 @@
+Rendered attachment: <%= attachment.filename -%>

--- a/actionview/test/fixtures/actionpack/fun/articles/_article.html.erb
+++ b/actionview/test/fixtures/actionpack/fun/articles/_article.html.erb
@@ -1,0 +1,1 @@
+<%= render article.file -%>

--- a/actionview/test/fixtures/actionpack/namespaced/articles/_article.html.erb
+++ b/actionview/test/fixtures/actionpack/namespaced/articles/_article.html.erb
@@ -1,0 +1,1 @@
+<%= render article.file -%>


### PR DESCRIPTION
Closes [#50844][]

Motivation / Background
---

A controller declared in the top-level module can render a top-level Active Model instance whose partial is declared in the root view directory (like `articles/_article.html.erb`).

A controller scoped within a module can render an Active Model instance whose partial is similarly scoped within view directory (like `scoped/articles/_article.html.erb`).

A controller scoped within a module cannot render an Active Model instance whose partial is declared in the root view directory (like `articles/_article.html.erb`), despite the absence of a similarly scoped partial.

This is intended behavior that's powered by
[`config.action_view.prefix_partial_path_with_controller_namespace = true`][prefix_partial_path_with_controller_namespace] (`true` by default).

This change was introduced in March of 2012 as part of [#5625][].

Detail
---

As a consumer of Action View, my intuition is that the lookup would fallback, in the same way that a controller that inherits from `ApplicationController` could define its own view, then rely on fallback to render an `app/views/application` partial.

This commit modifies the behavior to gracefully fall back to the root-level view partial.

Checklist
---

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.

[#50844]: https://github.com/rails/rails/issues/50844
[prefix_partial_path_with_controller_namespace]: https://guides.rubyonrails.org/configuring.html#config-action-view-prefix-partial-path-with-controller-namespace
[#5625]: https://github.com/rails/rails/pull/5625
