### PR TITLE
Display dev & test env in console prompt in blue instead of green

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -11,7 +11,7 @@
     For example, `MyApp` will displayed as `my-app` in the prompt.
 
     Additionally, the environment name will be colorized when the environment is
-    `development` (green), `test` (green), or `production` (red), if your
+    `development` (blue), `test` (blue), or `production` (red), if your
     terminal supports it.
 
     *Stan Lo*

--- a/railties/lib/rails/commands/console/console_command.rb
+++ b/railties/lib/rails/commands/console/console_command.rb
@@ -53,9 +53,9 @@ module Rails
       def colorized_env
         case Rails.env
         when "development"
-          IRB::Color.colorize("dev", [:GREEN])
+          IRB::Color.colorize("dev", [:BLUE])
         when "test"
-          IRB::Color.colorize("test", [:GREEN])
+          IRB::Color.colorize("test", [:BLUE])
         when "production"
           IRB::Color.colorize("prod", [:RED])
         else

--- a/railties/test/commands/console_test.rb
+++ b/railties/test/commands/console_test.rb
@@ -62,14 +62,14 @@ class Rails::ConsoleTest < ActiveSupport::TestCase
     app = build_app(nil)
     irb_console = Rails::Console.new(app).console
     red = "\e[31m"
-    green = "\e[32m"
+    blue = "\e[34m"
     clear = "\e[0m"
 
     Rails.env = "development"
-    assert_equal("#{green}dev#{clear}", irb_console.colorized_env)
+    assert_equal("#{blue}dev#{clear}", irb_console.colorized_env)
 
     Rails.env = "test"
-    assert_equal("#{green}test#{clear}", irb_console.colorized_env)
+    assert_equal("#{blue}test#{clear}", irb_console.colorized_env)
 
     Rails.env = "production"
     assert_equal("#{red}prod#{clear}", irb_console.colorized_env)

--- a/railties/test/commands/console_test.rb
+++ b/railties/test/commands/console_test.rb
@@ -59,7 +59,8 @@ class Rails::ConsoleTest < ActiveSupport::TestCase
   end
 
   def test_prompt_env_colorization
-    irb_console = Rails::Console::IRBConsole.new(app)
+    app = build_app(nil)
+    irb_console = Rails::Console.new(app).console
     red = "\e[31m"
     green = "\e[32m"
     clear = "\e[0m"


### PR DESCRIPTION
### Motivation / Background

The combination of red and blue is more color-blind friendly than red and green.

Discussion: https://github.com/rails/rails/pull/50796#discussion_r1463670198

### Detail

### Additional information

<!-- Provide additional information such as benchmarks, reference to other repositories or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
