### PR TITLE
Document autosave validation behavior for ActiveRecord associations [ci skip]

### DIFF
--- a/activerecord/lib/active_record/associations.rb
+++ b/activerecord/lib/active_record/associations.rb
@@ -1662,9 +1662,9 @@ module ActiveRecord
         #   If you want to ensure associated objects are revalidated on every update, use +validates_associated+.
         # [+:autosave+]
         #   If +true+, always saves the associated object or destroys it if marked for destruction,
-        #   when saving the parent object. If +false+, never save or destroy the associated object. 
+        #   when saving the parent object. If +false+, never save or destroy the associated object.
         #   By default, only saves the associated object if it's a new record. Setting this option
-        #   to +true+ also enables validations on the associated object unless explicitly disabled 
+        #   to +true+ also enables validations on the associated object unless explicitly disabled
         #   with <tt>validate: false</tt>. This is because saving an object with invalid associated
         #   objects would fail, so any associated objects will go through validation checks.
         #

--- a/activerecord/lib/active_record/associations.rb
+++ b/activerecord/lib/active_record/associations.rb
@@ -1661,9 +1661,12 @@ module ActiveRecord
         #   When set to +true+, validates new objects added to association when saving the parent object. +false+ by default.
         #   If you want to ensure associated objects are revalidated on every update, use +validates_associated+.
         # [+:autosave+]
-        #   If true, always save the associated object or destroy it if marked for destruction,
-        #   when saving the parent object. If false, never save or destroy the associated object.
-        #   By default, only save the associated object if it's a new record.
+        #   If +true+, always saves the associated object or destroys it if marked for destruction,
+        #   when saving the parent object. If +false+, never save or destroy the associated object. 
+        #   By default, only saves the associated object if it's a new record. Setting this option
+        #   to +true+ also enables validations on the associated object unless explicitly disabled 
+        #   with <tt>validate: false</tt>. This is because saving an object with invalid associated
+        #   objects would fail, so any associated objects will go through validation checks.
         #
         #   Note that NestedAttributes::ClassMethods#accepts_nested_attributes_for sets
         #   <tt>:autosave</tt> to <tt>true</tt>.


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
This Pull Request needs to be merged to document the behavior of autosave: true enabling validations for belongs_to and has_one associations in ActiveRecord. Currently, this behavior is implemented in the code but not mentioned in the official documentation. This can lead to confusion for developers who rely on the Rails guides for accurate information on how ActiveRecord associations work. Including this information will improve the clarity and comprehensiveness of the Rails documentation.
-->

### Detail

This Pull Request adds documentation comments to the belongs_to and has_one methods in ActiveRecord::Associations to explain that autosave: true also enables validations by default. This is to reflect the actual behavior of these methods, as described in the source code and observed in application behavior.

### Additional information

Reference to the issue discussed in Rails: Undocumented - validations enabled by autosave #50807
Inline gemfile with bundler example -
``` ruby
require "bundler/inline"

gemfile do
  source "https://rubygems.org"
  gem "rails", "7.1.3"
  gem "sqlite3"
end

require "active_record"
require "minitest/autorun"
require "logger"

# This connection will do for database-independent bug reports.
ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")
ActiveRecord::Base.logger = Logger.new(STDOUT)

ActiveRecord::Schema.define do
  create_table :authors do |t|
    t.string :name
  end

  create_table :books do |t|
    t.belongs_to :author
    t.string :title
  end
end

class Author < ActiveRecord::Base
  has_one :book, autosave: true
end

class Book < ActiveRecord::Base
  belongs_to :author
  validates :title, presence: true
end

class BugTest < Minitest::Test
  def test_autosave_with_validations
    author = Author.new(name: "J.K. Rowling")
    author.build_book # Not setting a title to trigger validation failure

    refute author.save, "Author should not be saved due to book validation failure"
    assert author.book.errors.full_messages.include?("Title can't be blank"), "Book should contain error on title"
  end
end

```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change, specifically the addition of documentation for autosave: true behavior.
* [x] Commit message includes a detailed description of the changes, for example: [Doc #50807] Document autosave validation behavior for associations.
* [x] Tests are not required as this is a documentation update.
* [x] CHANGELOG is not updated since this is a minor documentation change and does not affect library behavior.
