### PR TITLE
Support options for ActionMailer delivery callbacks

### DIFF
--- a/actionmailer/lib/action_mailer/base.rb
+++ b/actionmailer/lib/action_mailer/base.rb
@@ -474,7 +474,6 @@ module ActionMailer
   # * <tt>deliver_later_queue_name</tt> - The queue name used by <tt>deliver_later</tt> with the default
   #   <tt>delivery_job</tt>. Mailers can set this to use a custom queue name.
   class Base < AbstractController::Base
-    include Callbacks
     include DeliveryMethods
     include QueuedDelivery
     include Rescuable
@@ -492,6 +491,8 @@ module ActionMailer
     include AbstractController::AssetPaths
     include AbstractController::Callbacks
     include AbstractController::Caching
+
+    include Callbacks
 
     include ActionView::Layouts
 

--- a/actionmailer/lib/action_mailer/callbacks.rb
+++ b/actionmailer/lib/action_mailer/callbacks.rb
@@ -5,26 +5,16 @@ module ActionMailer
     extend ActiveSupport::Concern
 
     included do
-      include ActiveSupport::Callbacks
       define_callbacks :deliver, skip_after_callbacks_if_terminated: true
     end
 
     module ClassMethods
-      # Defines a callback that will get called right before the
-      # message is sent to the delivery method.
-      def before_deliver(*filters, &blk)
-        set_callback(:deliver, :before, *filters, &blk)
-      end
-
-      # Defines a callback that will get called right after the
-      # message's delivery method is finished.
-      def after_deliver(*filters, &blk)
-        set_callback(:deliver, :after, *filters, &blk)
-      end
-
-      # Defines a callback that will get called around the message's deliver method.
-      def around_deliver(*filters, &blk)
-        set_callback(:deliver, :around, *filters, &blk)
+      [:before, :after, :around].each do |callback|
+        define_method "#{callback}_deliver" do |*names, &blk|
+          _insert_callbacks(names, blk) do |name, options|
+            set_callback(:deliver, callback, name, options)
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
Closes https://github.com/rails/rails/issues/50830.

The code works, but docs/tests etc are currently missing. I want to validate the approach before proceeding.

Inside action mailer I am reusing private methods from the implementation of callbacks from the action controller, see https://github.com/rails/rails/blob/main/actionpack/lib/abstract_controller/callbacks.rb.

The questions to consider are:
1. Should the mailer callbacks really depend on the internals of controller callbacks, considering that it already includes it https://github.com/rails/rails/blob/776626ff987a96201b0bdbd86d716ca6698fa8b3/actionmailer/lib/action_mailer/base.rb#L493
2. Controllers callbacks have a `raise_on_missing_callbacks_action`, see https://github.com/rails/rails/blob/776626ff987a96201b0bdbd86d716ca6698fa8b3/actionpack/lib/abstract_controller/callbacks.rb#L36 which can be set via `config.action_controller. raise_on_missing_callbacks_action`. This kinda makes sense for action mailer too, so should we introduce `config.action_mailer.raise_on_missing_callbacks_action` config? 
3. Controller callbacks use the word `"controller"`, see https://github.com/rails/rails/blob/776626ff987a96201b0bdbd86d716ca6698fa8b3/actionpack/lib/abstract_controller/callbacks.rb#L54, while for mailer we should use the `"mailer"` word or should we make the message text more generic? 

cc @bensheldon 