### PR TITLE
Add ".[key]" to the abstract namespaces [ci skip]

### DIFF
--- a/guides/source/i18n.md
+++ b/guides/source/i18n.md
@@ -918,11 +918,11 @@ end
 The key for the error message in this case is `:blank`. Active Record will look up this key in the namespaces:
 
 ```
-activerecord.errors.models.[model_name].attributes.[attribute_name]
-activerecord.errors.models.[model_name]
-activerecord.errors.messages
-errors.attributes.[attribute_name]
-errors.messages
+activerecord.errors.models.[model_name].attributes.[attribute_name].[key]
+activerecord.errors.models.[model_name].[key]
+activerecord.errors.messages.[key]
+errors.attributes.[attribute_name].[key]
+errors.messages.[key]
 ```
 
 Thus, in our example it will try the following keys in this order and return the first result:

--- a/guides/source/i18n.md
+++ b/guides/source/i18n.md
@@ -915,7 +915,17 @@ class User < ApplicationRecord
 end
 ```
 
-The key for the error message in this case is `:blank`. Active Record will look up this key in the namespaces:
+The key for the error message in this case is `:blank`. Thus, in our example it will try the following keys in this order and return the first result:
+
+```
+activerecord.errors.models.user.attributes.name.blank
+activerecord.errors.models.user.blank
+activerecord.errors.messages.blank
+errors.attributes.name.blank
+errors.messages.blank
+```
+
+To explain it more abstractly, it returns the first key that matches in the order of the following list.
 
 ```
 activerecord.errors.models.[model_name].attributes.[attribute_name].[key]
@@ -925,15 +935,6 @@ errors.attributes.[attribute_name].[key]
 errors.messages.[key]
 ```
 
-Thus, in our example it will try the following keys in this order and return the first result:
-
-```
-activerecord.errors.models.user.attributes.name.blank
-activerecord.errors.models.user.blank
-activerecord.errors.messages.blank
-errors.attributes.name.blank
-errors.messages.blank
-```
 
 When your models are additionally using inheritance then the messages are looked up in the inheritance chain.
 


### PR DESCRIPTION
### Motivation / Background

The section "Error Message Scopes" describes how the Rails look up the namespaces for a validation error message with code snippets. The first code snippet shows abstract namespaces like `errors.attributes.[attribute_name]` while the second one demonstrates the materialized one like `errors.attributes.name.blank`. The first code snippet lacks the validation error "key." My team member was confused and created a translation without "key", so I think it would be helpful to add ".[key]" to the abstract namespaces.


### Checklist

Before submitting the PR make sure the following are checked:

* ~[ ] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.~
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* ~[ ] Tests are added or updated if you fix a bug or add a feature.~
* ~[ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.~
