### PR TITLE
ActionView: Raise on invalid format

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Raise `ArgumentError` if `:formats` are not all valid (e.g., `[:txt, :html]` instead of `[:text, :html]`)
+
+    *Riccardo Odone*
+
 *   Raise `ArgumentError` if `:renderable` object does not respond to `#render_in`
 
     *Sean Doyle*

--- a/actionview/lib/action_view/path_set.rb
+++ b/actionview/lib/action_view/path_set.rb
@@ -43,6 +43,8 @@ module ActionView # :nodoc:
     end
 
     def find_all(path, prefixes, partial, details, details_key, locals)
+      ensure_valid_formats!(details.fetch(:formats))
+
       search_combinations(prefixes) do |resolver, prefix|
         templates = resolver.find_all(path, prefix, partial, details, details_key, locals)
         return templates unless templates.empty?
@@ -55,6 +57,13 @@ module ActionView # :nodoc:
     end
 
     private
+      def ensure_valid_formats!(candidates)
+        return if Template::Types.valid_symbols?(candidates)
+
+        invalid_formats = candidates - Template::Types.symbols
+        raise ArgumentError, "Invalid formats: #{invalid_formats.map(&:inspect).join(", ")}"
+      end
+
       def search_combinations(prefixes)
         prefixes = Array(prefixes)
         prefixes.each do |prefix|

--- a/actionview/test/path_set_test.rb
+++ b/actionview/test/path_set_test.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require "abstract_unit"
+
+class PathSetTest < ActiveSupport::TestCase
+  setup do
+    @path_set = ActionView::PathSet.new
+  end
+
+  test "find_all with invalid format raises" do
+    details = { formats: [:txt] }
+    ex = assert_raises(ArgumentError) do
+      @path_set.find_all(nil, nil, nil, details, nil, nil)
+    end
+    assert_equal "Invalid formats: :txt", ex.message
+  end
+
+  test "find_all with invalid formats raises" do
+    details = { formats: [:txt, :text, :htm, :html] }
+    ex = assert_raises(ArgumentError) do
+      @path_set.find_all(nil, nil, nil, details, nil, nil)
+    end
+    assert_equal "Invalid formats: :txt, :htm", ex.message
+  end
+
+  test "exists? with invalid format raises" do
+    details = { formats: [:txt] }
+    ex = assert_raises(ArgumentError) do
+      @path_set.exists?(nil, nil, nil, details, nil, nil)
+    end
+    assert_equal "Invalid formats: :txt", ex.message
+  end
+
+  test "find with invalid format raises" do
+    details = { formats: [:txt] }
+    ex = assert_raises(ArgumentError) do
+      @path_set.find(nil, nil, nil, details, nil, nil)
+    end
+    assert_equal "Invalid formats: :txt", ex.message
+  end
+end


### PR DESCRIPTION
### Motivation / Background

Fixes #45636 

### Detail

This Pull Request adds a check in `ActionView::PathSet#find_all` to ensure all passed formats are valid.

Since `#find_all` is used by `#exists?` and `#find`, the check is extended to all the public methods in the class that search templates.

### Additional information

.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
