### PR TITLE
Accept Tempfile as ActiveStorage attachable

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   Accept Tempfile as ActiveStorage attachable.
+
+    ```ruby
+    tempfile = Tempfile.open(["users", ".csv"])
+    write_csv_to(tempfile)
+    export.csv.attach(tempfile)
+    ```
+
+    *Shouichi Kamiya*
+
 *   Require image processing backend upfront when Active Storage is being loaded.
 
     This removes extra overhead when processing first variant after deploy and improves copy-on-write for preforking web servers.

--- a/activestorage/lib/active_storage/attached/changes/create_one.rb
+++ b/activestorage/lib/active_storage/attached/changes/create_one.rb
@@ -89,7 +89,7 @@ module ActiveStorage
           )
         when String
           ActiveStorage::Blob.find_signed!(attachable, record: record)
-        when File
+        when File, Tempfile
           ActiveStorage::Blob.build_after_unfurling(
             io: attachable,
             filename: File.basename(attachable),
@@ -155,7 +155,7 @@ module ActiveStorage
           attachable.respond_to?(:open) ? attachable.open : attachable
         when Hash
           attachable.fetch(:io)
-        when File
+        when File, Tempfile
           attachable
         when Pathname
           attachable.open

--- a/activestorage/test/models/attached/one_test.rb
+++ b/activestorage/test/models/attached/one_test.rb
@@ -29,6 +29,23 @@ class ActiveStorage::OneAttachedTest < ActiveSupport::TestCase
     assert_nothing_raised { @user.avatar.download }
   end
 
+  test "creating a record with a Tempfile as attachable attribute" do
+    Tempfile.open("active-storage-test") do |tempfile|
+      @user = User.create!(name: "Dorian", avatar: tempfile)
+
+      assert @user.avatar.filename.to_s.start_with?("active-storage-test")
+      assert_not_nil @user.avatar_attachment
+      assert_not_nil @user.avatar_blob
+    end
+  end
+
+  test "uploads the tempfile when passing a Tempfile as attachable attribute" do
+    Tempfile.open("active-storage-test") do |tempfile|
+      @user = User.create!(name: "Dorian", avatar: tempfile)
+      assert_nothing_raised { @user.avatar.download }
+    end
+  end
+
   test "creating a record with a Pathname as attachable attribute" do
     @user = User.create!(name: "Dorian", avatar: file_fixture("image.gif"))
 


### PR DESCRIPTION
`File` is already accepted as an attachable, so why not?