### PR TITLE
Scaffold view templates using Strict Locals

### DIFF
--- a/actiontext/app/views/active_storage/blobs/_blob.html.erb
+++ b/actiontext/app/views/active_storage/blobs/_blob.html.erb
@@ -1,6 +1,8 @@
+<%# locals: (blob:, in_gallery: false) %>
+
 <figure class="attachment attachment--<%= blob.representable? ? "preview" : "file" %> attachment--<%= blob.filename.extension %>">
   <% if blob.representable? %>
-    <%= image_tag blob.representation(resize_to_limit: local_assigns[:in_gallery] ? [ 800, 600 ] : [ 1024, 768 ]) %>
+    <%= image_tag blob.representation(resize_to_limit: in_gallery ? [ 800, 600 ] : [ 1024, 768 ]) %>
   <% end %>
 
   <figcaption class="attachment__caption">

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Scaffold template files using strict locals
+
+    *Sean Doyle*
+
 *   Rails console now indicates application name and the current Rails environment:
 
     ```txt

--- a/railties/lib/rails/generators/erb/scaffold/templates/_form.html.erb.tt
+++ b/railties/lib/rails/generators/erb/scaffold/templates/_form.html.erb.tt
@@ -1,3 +1,5 @@
+<%%# locals: (<%= model_resource_name %>:) %>
+
 <%%= form_with(model: <%= model_resource_name %>) do |form| %>
   <%% if <%= singular_table_name %>.errors.any? %>
     <div style="color: red">

--- a/railties/lib/rails/generators/erb/scaffold/templates/partial.html.erb.tt
+++ b/railties/lib/rails/generators/erb/scaffold/templates/partial.html.erb.tt
@@ -1,3 +1,5 @@
+<%%# locals: (<%= singular_name %>:) %>
+
 <div id="<%%= dom_id <%= singular_name %> %>">
 <% attributes.reject(&:password_digest?).each do |attribute| -%>
   <p>

--- a/railties/test/generators/scaffold_generator_test.rb
+++ b/railties/test/generators/scaffold_generator_test.rb
@@ -88,6 +88,7 @@ class ScaffoldGeneratorTest < Rails::Generators::TestCase
     end
 
     assert_file "app/views/product_lines/_form.html.erb" do |test|
+      assert_match "<%# locals: (product_line:) %>", test
       assert_match "product_line", test
       assert_no_match "@product_line", test
     end
@@ -286,6 +287,7 @@ class ScaffoldGeneratorTest < Rails::Generators::TestCase
     end
 
     assert_file "app/views/admin/roles/_role.html.erb" do |content|
+      assert_match "<%# locals: (role:) %>", content
       assert_match "role", content
       assert_no_match "admin_role", content
     end


### PR DESCRIPTION
### Motivation / Background

Strict template locals were introduced as part of the [7.1 Release][].

### Detail

To encourage their use within new applications and files, this commit changes scaffolded (for example, `_form.html.erb` and `_$MODEL.html.erb`) templates to use [Strict Locals][].

In addition to scaffolds, this commit includes
`app/views/active_storage/blobs/_blob.html.erb`, since it's copied into host applications as part of `rails actiontext:install`.

[7.1 Release]: https://edgeguides.rubyonrails.org/7_1_release_notes.html#allow-templates-to-set-strict-locals
[Strict Locals]: https://guides.rubyonrails.org/v7.1.0/action_view_overview.html#strict-locals

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
