### PR TITLE
[mysql] Fix primary key auto-population for models backed by views

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -325,6 +325,14 @@ module ActiveRecord
         SQL
       end
 
+      def return_value_after_insert?(column) # :nodoc:
+        if supports_insert_returning?
+          super
+        else
+          column.auto_increment?
+        end
+      end
+
       def change_table_comment(table_name, comment_or_changes) # :nodoc:
         comment = extract_new_comment_value(comment_or_changes)
         comment = "" if comment.nil?

--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -1257,7 +1257,7 @@ module ActiveRecord
       )
 
       returning_columns.zip(returning_values).each do |column, value|
-        _write_attribute(column, value) if !_read_attribute(column)
+        _write_attribute(column, value)
       end if returning_values
 
       @new_record = false

--- a/activerecord/test/cases/adapters/abstract_mysql_adapter/schema_test.rb
+++ b/activerecord/test/cases/adapters/abstract_mysql_adapter/schema_test.rb
@@ -125,4 +125,8 @@ class MysqlAnsiQuotesTest < ActiveRecord::AbstractMysqlTestCase
     assert_equal([["lessons_students", "students", :cascade]],
                  fks.map { |fk| [fk.from_table, fk.to_table, fk.on_delete] })
   end
+
+  def test_returning_column_names_list_only_contains_one_id_column_if_returning_is_not_supported
+    assert_equal ["id"], Post._returning_columns_for_insert
+  end unless supports_insert_returning?
 end

--- a/activerecord/test/cases/persistence_test.rb
+++ b/activerecord/test/cases/persistence_test.rb
@@ -1582,6 +1582,13 @@ class PersistenceTest < ActiveRecord::TestCase
     assert_not_nil record.id
     assert record.id > 0
   end if supports_insert_returning? && !current_adapter?(:SQLite3Adapter)
+
+  def test_columns_with_default_function_are_not_overridden_after_creation
+    freeze_time
+    post = Post.create!(title: "post", body: "body", published_at: 3.days.ago)
+    assert_equal 3.days.ago, post.published_at
+    assert_equal 3.days.ago, post.reload.published_at
+  end
 end
 
 class QueryConstraintsTest < ActiveRecord::TestCase

--- a/activerecord/test/cases/view_test.rb
+++ b/activerecord/test/cases/view_test.rb
@@ -197,7 +197,7 @@ if ActiveRecord::Base.connection.supports_views?
         book = PrintedBook.create! name: "Rails in Action", status: 0, format: "paperback"
         assert_not_nil book.id
         assert book.id > 0
-      end if current_adapter?(:PostgreSQLAdapter, :SQLite3Adapter) && supports_insert_returning?
+      end
 
       def test_update_record_to_fail_view_conditions
         book = PrintedBook.first

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -1010,6 +1010,13 @@ ActiveRecord::Schema.define do
     t.integer :indestructible_tags_count, default: 0
     t.integer :tags_with_destroy_count, default: 0
     t.integer :tags_with_nullify_count, default: 0
+    default_posted_at_function = if ActiveRecord::TestCase.current_adapter?(:SQLite3Adapter)
+      "datetime('now')"
+    else
+      "CURRENT_TIMESTAMP"
+    end
+
+    t.timestamp :published_at, default: -> { default_posted_at_function }
   end
 
   create_table :postesques, force: true do |t|


### PR DESCRIPTION
Fixes https://github.com/rails/rails/issues/49950 but for mysql

This commit addresses the same issue fixed by c2c861f98ae25d0daa177898db48f12de1065cf6 but for MySQL. The main fix is the removal of unnecessary `!_read_attribute(column)` check which was preventing the auto-generated PK value from being set on the record.

This change also revealed an issue with the `_returning_columns_for_insert` list built when using one of the MySQL adapters. The list had excessive number of column names even though MySQL is only capable of returning one column value, which is the last inserted ID. This commit overrides the `return_value_after_insert?` for mysql adapters to only return `true` for `auto_increment?` column unless database supports `RETURNING` statement.
