### PR TITLE
Initialize ActiveRecord::Migrator.migrations_paths at application initialization

### DIFF
--- a/activerecord/lib/active_record/railtie.rb
+++ b/activerecord/lib/active_record/railtie.rb
@@ -308,6 +308,13 @@ To keep using the current cache store, you can turn off cache versioning entirel
       end
     end
 
+    # This configures the Migrator for general usage.
+    initializer "active_record.initialize_migrator" do
+      ActiveSupport.on_load(:active_record) do
+        ActiveRecord::Migrator.migrations_paths = ActiveRecord::Tasks::DatabaseTasks.migrations_paths
+      end
+    end
+
     # Expose database runtime for logging.
     initializer "active_record.log_runtime" do
       require "active_record/railties/controller_runtime"

--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -23,8 +23,6 @@ db_namespace = namespace :db do
     if ActiveRecord::Base.configurations.empty?
       ActiveRecord::Base.configurations = ActiveRecord::Tasks::DatabaseTasks.database_configuration
     end
-
-    ActiveRecord::Migrator.migrations_paths = ActiveRecord::Tasks::DatabaseTasks.migrations_paths
   end
 
   namespace :create do


### PR DESCRIPTION
This is already done in rake tasks in the `load_config` task. However, if migrations want to be manipulated/used by a non-rake program this initialization would miss any extra directories configured by the user.

We move the initialization to an initializer block. With this we can remove the rake config since it depends on `environment` anyway.

### Motivation / Background

In our app we use schema-based multitenancy which means we need to setup and migrate for each tenant. We have created
a few helpers to aid in this task. 
Recently, we began modularizing our app, and started moving our migrations into packs. 
Then we started facing issues with migrations that tried to run more than once.
We diagnosed the root cause that our tenant creation command was not invoking `db:load_config` before loading the schema.
This resulted in "packed" migrations not being recorded in the initial seed of the `schema_migrations` table. Then when we attempted to run migrations on that tenant those migrations would try to run and fail. 

This Pull Request has been created because a fix for this is to ensure whenever the app is loaded, the correct default paths
are loaded.

### Detail

This Pull Request changes the initialization from a rake task to the app initialization process.


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
