### PR TITLE
Ensure all RubyTracker RenderParsers are tested

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,6 +36,8 @@ gem "json", ">= 2.0.0", "!=2.7.0"
 # Workaround until Ruby ships with cgi version 0.3.6 or higher.
 gem "cgi", ">= 0.3.6", require: false
 
+gem "prism"
+
 group :lint do
   gem "syntax_tree", "6.1.1", require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -370,6 +370,7 @@ GEM
     path_expander (1.1.1)
     pg (1.5.4)
     prettier_print (1.2.1)
+    prism (0.19.0)
     propshaft (0.8.0)
       actionpack (>= 7.0.0)
       activesupport (>= 7.0.0)
@@ -618,6 +619,7 @@ DEPENDENCIES
   mysql2 (~> 0.5)
   nokogiri (>= 1.8.1, != 1.11.0)
   pg (~> 1.3)
+  prism
   propshaft (>= 0.1.7)
   puma (>= 5.0.3)
   queue_classic (>= 4.0.0)

--- a/actionview/lib/action_view/dependency_tracker/ruby_tracker.rb
+++ b/actionview/lib/action_view/dependency_tracker/ruby_tracker.rb
@@ -17,8 +17,9 @@ module ActionView
         true
       end
 
-      def initialize(name, template, view_paths = nil)
+      def initialize(name, template, view_paths = nil, parser_class: RenderParser::Default)
         @name, @template, @view_paths = name, template, view_paths
+        @parser_class = parser_class
       end
 
       private
@@ -29,7 +30,7 @@ module ActionView
 
           compiled_source = template.handler.call(template, template.source)
 
-          RenderParser.new(@name, compiled_source).render_calls.filter_map do |render_call|
+          @parser_class.new(@name, compiled_source).render_calls.filter_map do |render_call|
             next if render_call.end_with?("/_")
             render_call.gsub(%r|/_|, "/")
           end

--- a/actionview/lib/action_view/render_parser.rb
+++ b/actionview/lib/action_view/render_parser.rb
@@ -31,14 +31,10 @@ module ActionView
     rescue LoadError
       require "ripper"
       require_relative "render_parser/ripper_render_parser"
-      Parser = RipperRenderParser
+      Default = RipperRenderParser
     else
       require_relative "render_parser/prism_render_parser"
-      Parser = PrismRenderParser
-    end
-
-    def self.new(name, code)
-      Parser.new(name, code)
+      Default = PrismRenderParser
     end
   end
 end

--- a/actionview/test/template/dependency_tracker_test.rb
+++ b/actionview/test/template/dependency_tracker_test.rb
@@ -3,6 +3,11 @@
 require "abstract_unit"
 require "action_view/dependency_tracker"
 
+require "action_view/render_parser/prism_render_parser"
+
+require "ripper"
+require "action_view/render_parser/ripper_render_parser"
+
 class NeckbeardTracker
   def self.call(name, template)
     ["foo/#{name}"]
@@ -228,11 +233,9 @@ class ERBTrackerTest < Minitest::Test
   end
 end
 
-class RubyTrackerTest < Minitest::Test
-  include SharedTrackerTests
-
+module RubyTrackerTests
   def make_tracker(name, template)
-    ActionView::DependencyTracker::RubyTracker.new(name, template)
+    ActionView::DependencyTracker::RubyTracker.new(name, template, parser_class: parser_class)
   end
 
   def test_dependencies_skip_unknown_options
@@ -260,5 +263,23 @@ class RubyTrackerTest < Minitest::Test
     tracker = make_tracker("messages/show", template)
 
     assert_equal [], tracker.dependencies
+  end
+end
+
+class RipperRubyTrackerTest < Minitest::Test
+  include SharedTrackerTests
+  include RubyTrackerTests
+
+  def parser_class
+    ActionView::RenderParser::RipperRenderParser
+  end
+end
+
+class PrismRubyTrackerTest < Minitest::Test
+  include SharedTrackerTests
+  include RubyTrackerTests
+
+  def parser_class
+    ActionView::RenderParser::PrismRenderParser
   end
 end


### PR DESCRIPTION
### Motivation / Background

Previously, only the PrismRenderParser or RipperRenderParser would be tested depending on if the Prism gem is available. This meant that PrismRenderParser was being tested on Ruby 3.3 and RipperRenderParser was tested on Ruby < 3.3. Additionally, if someone were to add prism to the rails/rails Gemfile because they wrote a tool that uses it then the RipperRenderParser would end up completely untested.

### Detail

This commit is a small refactor to enable testing both RenderParsers in all Ruby versions so that the prism gem can be added to the Gemfile.