### PR TITLE
dump schema: ignore tables from any postgres schema

### DIFF
--- a/activerecord/lib/active_record/tasks/postgresql_database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/postgresql_database_tasks.rb
@@ -68,7 +68,7 @@ module ActiveRecord
         ignore_tables = ActiveRecord::SchemaDumper.ignore_tables
         if ignore_tables.any?
           ignore_tables = connection.data_sources.select { |table| ignore_tables.any? { |pattern| pattern === table } }
-          args += ignore_tables.flat_map { |table| ["-T", table] }
+          args += ignore_tables.flat_map { |table| ["-T", "*.#{table}"] }
         end
 
         args << db_config.database

--- a/activerecord/test/cases/adapters/postgresql/postgresql_rake_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/postgresql_rake_test.rb
@@ -412,7 +412,7 @@ module ActiveRecord
           assert_called_with(
             Kernel,
             :system,
-            [{}, "pg_dump", "--schema-only", "--no-privileges", "--no-owner", "--file", @filename, "-T", "prefix_foo", "-T", "ignored_foo", "my-app-db"],
+            [{}, "pg_dump", "--schema-only", "--no-privileges", "--no-owner", "--file", @filename, "-T", "*.prefix_foo", "-T", "*.ignored_foo", "my-app-db"],
             returns: true
           ) do
             ActiveRecord::Tasks::DatabaseTasks.structure_dump(@configuration, @filename)


### PR DESCRIPTION
### Motivation / Background

this pull request improve the current implementation of ignoring table during the schema dump by allowing to ignore tables from other postgres schema than "public".

### Detail

This Pull Request changes [REPLACE ME]

### Additional information

the proposed implementation lack the ability to specify exactly from which schema, the table is ignored but I think that even do, it's better than the current implementation.

- [pg_dump documentation](https://www.postgresql.org/docs/current/app-pgdump.html)
- [pattern documentation](https://www.postgresql.org/docs/current/app-psql.html#APP-PSQL-PATTERNS

#### my specific use-case that need to exclude tables

In my specific case, I use pg_partman (extension to ease table partitioning in PostgreSQL) that is installed in his own schema and generate a table for each week/month/... so that mean that depending when we dump the schema we will not have the same partition (new weeks will exist in the future). But as they are handle by that extension, we don't need to include them in the structure, the extension will generate them on demand.

so I will just to add the following to ignore them
```ruby
ActiveRecord::SchemaDumper.ignore_tables += [
  /my_partitioned_table_/ # partition autogenerated table by partman on partman schema
]
```

### Checklist

* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.

I feel that the code change is too small to request updating CHANGELOG or writing new tests