### PR TITLE
Move server shutdown translation to abstract mysql adapter

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -776,6 +776,7 @@ module ActiveRecord
         ER_DB_CREATE_EXISTS     = 1007
         ER_FILSORT_ABORT        = 1028
         ER_DUP_ENTRY            = 1062
+        ER_SERVER_SHUTDOWN      = 1053
         ER_NOT_NULL_VIOLATION   = 1048
         ER_NO_REFERENCED_ROW    = 1216
         ER_ROW_IS_REFERENCED    = 1217
@@ -804,7 +805,7 @@ module ActiveRecord
             else
               super
             end
-          when ER_CONNECTION_KILLED, CR_SERVER_GONE_ERROR, CR_SERVER_LOST, ER_CLIENT_INTERACTION_TIMEOUT
+          when ER_CONNECTION_KILLED, ER_SERVER_SHUTDOWN, CR_SERVER_GONE_ERROR, CR_SERVER_LOST, ER_CLIENT_INTERACTION_TIMEOUT
             ConnectionFailed.new(message, sql: sql, binds: binds, connection_pool: @pool)
           when ER_DB_CREATE_EXISTS
             DatabaseAlreadyExists.new(message, sql: sql, binds: binds, connection_pool: @pool)

--- a/activerecord/lib/active_record/connection_adapters/trilogy_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/trilogy_adapter.rb
@@ -13,7 +13,6 @@ module ActiveRecord
       ER_BAD_DB_ERROR = 1049
       ER_DBACCESS_DENIED_ERROR = 1044
       ER_ACCESS_DENIED_ERROR = 1045
-      ER_SERVER_SHUTDOWN = 1053
 
       ADAPTER_NAME = "Trilogy"
 
@@ -200,12 +199,6 @@ module ActiveRecord
         def translate_exception(exception, message:, sql:, binds:)
           if exception.is_a?(::Trilogy::TimeoutError) && !exception.error_code
             return ActiveRecord::AdapterTimeout.new(message, sql: sql, binds: binds, connection_pool: @pool)
-          end
-          error_code = exception.error_code if exception.respond_to?(:error_code)
-
-          case error_code
-          when ER_SERVER_SHUTDOWN
-            return ConnectionFailed.new(message, connection_pool: @pool)
           end
 
           case exception


### PR DESCRIPTION
1053 is the server shutdown error code. We see these fairly often at GitHub when, for example, shutting down Vitess vtage processes for maintenance. Translating the error to `ConnectionFailed` allows us to treat these as retryable connection errors, so we can reconnect and hit a new vtage process.

This is all true regardless of whether the adapter is trilogy or mysql2 or whatever, so this commit moves the translation out into the abstract mysql adapter.