### PR TITLE
Use uniform spacing in 7.1 new framework defaults

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_7_1.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_7_1.rb.tt
@@ -241,7 +241,6 @@
 # this file):
 #   config.active_support.cache_format_version = 7.1
 
-
 ###
 # Configure Action View to use HTML5 standards-compliant sanitizers when they are supported on your
 # platform.
@@ -252,7 +251,6 @@
 # In previous versions of Rails, Action View always used `Rails::HTML4::Sanitizer` as its vendor.
 #++
 # Rails.application.config.action_view.sanitizer_vendor = Rails::HTML::Sanitizer.best_supported_vendor
-
 
 ###
 # Configure Action Text to use an HTML5 standards-compliant sanitizer when it is supported on your
@@ -265,13 +263,11 @@
 #++
 # Rails.application.config.action_text.sanitizer_vendor = Rails::HTML::Sanitizer.best_supported_vendor
 
-
 ###
 # Configure the log level used by the DebugExceptions middleware when logging
 # uncaught exceptions during requests.
 #++
 # Rails.application.config.action_dispatch.debug_exception_log_level = :error
-
 
 ###
 # Configure the test helpers in Action View, Action Dispatch, and rails-dom-testing to use HTML5


### PR DESCRIPTION
Only the last five entries have two newlines between them and I can't see a good reason for that, see #49546.

In addition to being inconsistent this trips RuboCop with `Layout/EmptyLines` which is enabled by default.