### PR TITLE
Prevent rdoc task from excluding the main page

### DIFF
--- a/railties/lib/rails/api/task.rb
+++ b/railties/lib/rails/api/task.rb
@@ -146,8 +146,6 @@ module Rails
       end
 
       def configure_rdoc_files
-        rdoc_files.include(api_main)
-
         RDOC_FILES.each do |component, cfg|
           cdr = component_root_dir(component)
 
@@ -172,6 +170,9 @@ module Rails
           # Nothing to do
           exit(0) if rdoc_files.empty?
         end
+
+        # This must come after the mtime comparison to ensure the main page is not excluded.
+        rdoc_files.include(api_main)
       end
 
       # These variables are used by the sdoc template


### PR DESCRIPTION
### Motivation / Background
There was a bug where the main page becomes unable to be found and this change ensures that it does not happen.

Closes https://github.com/rails/rails/issues/50871.

### Checklist
Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
