### PR TITLE
Put plural inverse association inference behind a configuration flag

### DIFF
--- a/activerecord/test/cases/associations/inverse_associations_test.rb
+++ b/activerecord/test/cases/associations/inverse_associations_test.rb
@@ -201,6 +201,8 @@ class AutomaticInverseFindingTests < ActiveRecord::TestCase
   end
 
   def test_belongs_to_should_find_inverse_has_many_automatically
+    assert_equal true, Subscription.automatically_invert_plural_associations
+
     book = Book.create!
     subscriber = book.subscribers.new nick: "Nickname"
 

--- a/activerecord/test/cases/helper.rb
+++ b/activerecord/test/cases/helper.rb
@@ -32,6 +32,8 @@ I18n.enforce_available_locales = false
 # Quote "type" if it's a reserved word for the current connection.
 QUOTED_TYPE = ActiveRecord::Base.lease_connection.quote_column_name("type")
 
+ActiveRecord::Base.automatically_invert_plural_associations = true
+
 ActiveRecord.raise_on_assign_to_attr_readonly = true
 ActiveRecord.belongs_to_required_validates_foreign_key = false
 

--- a/activerecord/test/models/subscriber.rb
+++ b/activerecord/test/models/subscriber.rb
@@ -2,6 +2,7 @@
 
 class Subscriber < ActiveRecord::Base
   self.primary_key = "nick"
+
   has_many :subscriptions
   has_many :books, through: :subscriptions
 end

--- a/activerecord/test/models/subscription.rb
+++ b/activerecord/test/models/subscription.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Subscription < ActiveRecord::Base
+  self.automatically_invert_plural_associations = true
+
   belongs_to :subscriber, counter_cache: :books_count
   belongs_to :book, -> { author_visibility_visible }
 

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -60,6 +60,7 @@ Below are the default values associated with each target version. In cases of co
 
 #### Default Values for Target Version 7.2
 
+- [`config.active_record.automatically_invert_plural_associations`](#config-active-record-automatically-invert-plural-associations): `true`
 - [`config.active_record.validate_migration_timestamps`](#config-active-record-validate-migration-timestamps): `true`
 - [`config.active_storage.web_image_content_types`](#config-active-storage-web-image-content-types): `%w[image/png image/jpeg image/gif image/webp]`
 
@@ -1050,6 +1051,49 @@ Specifies if an error should be raised if the order of a query is ignored during
 #### `config.active_record.timestamped_migrations`
 
 Controls whether migrations are numbered with serial integers or with timestamps. The default is `true`, to use timestamps, which are preferred if there are multiple developers working on the same application.
+
+#### `config.active_record.automatically_invert_plural_associations`
+
+Controls whether Active Record will automatically look for an inverse relations with a pluralized name.
+
+Example:
+
+```ruby
+class Post < ApplicationRecord
+  has_many :comments
+end
+
+class Comment < ApplicationRecord
+  belongs_to :post
+end
+```
+
+In the above case Active Record used to only look for a `:comment` (singular) association in `Post`, and won't find it.
+
+With this option enabled, it will also look for a `:comments` association. In the vast majority of cases
+having the inverse association discovered is beneficial as it can prevent some useless queries, but
+it may cause backward compatibility issues with legacy code that doesn't expect it.
+
+This behavior can be disable on a per-model basis:
+
+
+```ruby
+class Comment < ApplicationRecord
+  self.automatically_invert_plural_associations = false
+
+  belongs_to :post
+end
+```
+
+And on a per-association basis:
+
+```ruby
+class Comment < ApplicationRecord
+  self.automatically_invert_plural_associations = false
+
+  belongs_to :post, inverse_of: false
+end
+```
 
 #### `config.active_record.validate_migration_timestamps`
 

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -328,6 +328,7 @@ module Rails
 
           if respond_to?(:active_record)
             active_record.validate_migration_timestamps = true
+            active_record.automatically_invert_plural_associations = true
           end
         else
           raise "Unknown version #{target_version.to_s.inspect}"

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_7_2.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_7_2.rb.tt
@@ -27,3 +27,17 @@
 # expected format can disable validation by setting this config to `false`.
 #++
 # Rails.application.config.active_record.validate_migration_timestamps = true
+
+###
+# Controls whether Active Record will automatically look for an inverse relations
+# with a pluralized name.
+#
+# Example:
+#   class Comment < ActiveRecord::Base
+#     belongs_to :post
+#   end
+#
+# In the above case Active Record will now try to infer a `:comments` relation
+# on `Post`, while previously it would only look for `:comment`.
+#++
+# Rails.application.config.active_record.automatically_invert_plural_associations = true


### PR DESCRIPTION
Ref: https://github.com/rails/rails/pull/50284

While having the inverse association configured it generally positive as it avoid some extra queries etc, infering it may break legecy code, as evidenced by how it broke `ActiveStorage::Blob` in https://github.com/rails/rails/pull/50800

As such we can't just enable this behavior immediately, we need to provide and upgrade path for users.

At this stage this PR is just a quick draft to discuss how exactly we should gate this. We can just make it a regular framework default, but perhaps emitting a deprecation warning when we would have infered the inverse relation would help users upgrade?  cc @rafaelfranca as you generally have great insights on this kind of new framework default.

