### PR TITLE
Add row_count field to sql.active_record notification

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Add row_count field to sql.active_record notification
+
+    This field returns the amount of rows returned by the query that emitted the notification.
+
+    This metric is useful in cases where one wants to detect queries with big result sets.
+
+    *Marvin Bitterlich*
+
 *   Consistently raise an `ArgumentError` when passing an invalid argument to a nested attributes association writer.
 
     Previously, this would only raise on collection associations and produce a generic error on singular associations.

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -1156,6 +1156,7 @@ module ActiveRecord
             statement_name:    statement_name,
             async:             async,
             connection:        self,
+            row_count:         0,
             &block
           )
         rescue ActiveRecord::StatementInvalid => ex

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -880,10 +880,11 @@ module ActiveRecord
           update_typemap_for_default_timezone
 
           type_casted_binds = type_casted_binds(binds)
-          log(sql, name, binds, type_casted_binds, async: async) do
+          log(sql, name, binds, type_casted_binds, async: async) do |notification_payload|
             with_raw_connection(allow_retry: false, materialize_transactions: materialize_transactions) do |conn|
               result = conn.exec_params(sql, type_casted_binds)
               verified!
+              notification_payload[:row_count] = result.count
               result
             end
           end
@@ -898,9 +899,10 @@ module ActiveRecord
             stmt_key = prepare_statement(sql, binds, conn)
             type_casted_binds = type_casted_binds(binds)
 
-            log(sql, name, binds, type_casted_binds, stmt_key, async: async) do
+            log(sql, name, binds, type_casted_binds, stmt_key, async: async) do |notification_payload|
               result = conn.exec_prepared(stmt_key, type_casted_binds)
               verified!
+              notification_payload[:row_count] = result.count
               result
             end
           end

--- a/activerecord/lib/active_record/connection_adapters/trilogy/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/trilogy/database_statements.rb
@@ -43,12 +43,13 @@ module ActiveRecord
 
         private
           def raw_execute(sql, name, async: false, allow_retry: false, materialize_transactions: true)
-            log(sql, name, async: async) do
+            log(sql, name, async: async) do |notification_payload|
               with_raw_connection(allow_retry: allow_retry, materialize_transactions: materialize_transactions) do |conn|
                 sync_timezone_changes(conn)
                 result = conn.query(sql)
                 verified!
                 handle_warnings(sql)
+                notification_payload[:row_count] = result.count
                 result
               end
             end

--- a/guides/source/active_support_instrumentation.md
+++ b/guides/source/active_support_instrumentation.md
@@ -365,6 +365,7 @@ The `:cache_hits` key is only included if the collection is rendered with `cache
 | `:statement_name`    | SQL Statement name                       |
 | `:async`             | `true` if query is loaded asynchronously |
 | `:cached`            | `true` is added when cached queries used |
+| `:row_count`         | Number of rows returned by the query     |
 
 Adapters may add their own data as well.
 
@@ -375,7 +376,8 @@ Adapters may add their own data as well.
   connection: <ActiveRecord::ConnectionAdapters::SQLite3Adapter:0x00007f9f7a838850>,
   binds: [<ActiveModel::Attribute::WithCastValue:0x00007fe19d15dc00>],
   type_casted_binds: [11],
-  statement_name: nil
+  statement_name: nil,
+  row_count: 5
 }
 ```
 


### PR DESCRIPTION
### Motivation / Background

In Intercom we are working on detecting queries with large result sets, as Vitess based databases (like in our case Planetscale) block queries that return more than (by default) 100k result set rows.

We have an internal patch for this that works well for us, but thought to contribute this upstream, so others can benefit

### Detail

This Pull Request changes `{*}Adapter.log`, which emits `sql.active_record` notifications.

Previously the instrument call only logs information that goes into a request, but allows the caller inside the block to modify the payload. We make use of this inside each adapter to add a new field to each `sql.active_record` notification with the number of result rows being returned in each query.

This allows consumers of this notification [(example)](https://github.com/DataDog/dd-trace-rb/blob/master/lib/datadog/tracing/contrib/active_record/events/sql.rb) to consume this metric. 

There is previous work in this regard with the [`RecordFetchWarning`](https://github.com/rails/rails/blob/main/activerecord/lib/active_record/relation/record_fetch_warning.rb) module that can be included, which demonstrates the need to monitor queries with large result sets. In our case these log lines weren't easy to integrate into our observability stack, and having a numerical value attached to each sql trace allowed us to use the full power of our observability suite. 

This pr also includes three tests in the instrumentation test suite that verify this working for model instanciation queries, direct value queries like `pluck` and raw `ActiveRecord::Base.connection.execute(sql)` queries.

### Performance

The change asks the resultset how many elements it has. Expectation was that that should be a constant lookup, and benchmarks suggest this to be true:

I have tested this change with `examples/performance` on adapters `sqlite3`, `mysql2` and `postgresql` with no measurable difference in performance (less than 0.1% when standard deviation was 1%).

### Additional information

I originally approached this inside `abstract_adapter` but it turns out every adapters Result uses a different method, so I moved the call into each adapters respective usage of `log` 

[`RecordFetchWarning`](https://github.com/rails/rails/blob/main/activerecord/lib/active_record/relation/record_fetch_warning.rb) works by patching `exec_queries`, so it aggregates the result set size of multiple queries into one, which is less helpful for this case, as the limits imposed by Vitess are per query. Additionally, this does not support the case of executing raw SQL on the connection, which is something that this patch captures.

As for the field name on the payload `row_count` seemed like a good name as it follows the same pattern as `result_count` does in https://guides.rubyonrails.org/active_support_instrumentation.html#instantiation-active-record

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
