### PR TITLE
Introduce `ActiveSupport::TestCase.around`

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,18 @@
+*   Introduce `ActiveSupport::TestCase.around`
+
+    Add a callback, which runs between `TestCase#setup` and `TestCase#teardown`.
+    Yields the test class instance and the test case to the block:
+
+    ```ruby
+    class ClientTest < ActiveSupport::TestCase
+      around do |test_case, block|
+        Client.with(stubbed: true, &block)
+      end
+    end
+    ```
+
+    *Sean Doyle*
+
 *   Add `prepend: true` option to `ActiveSupport::Notifications.subscribe`.
 
       When `prepend: true` is passed, the subscriber is added to the front of

--- a/activesupport/lib/active_support/testing/setup_and_teardown.rb
+++ b/activesupport/lib/active_support/testing/setup_and_teardown.rb
@@ -20,19 +20,61 @@ module ActiveSupport
     module SetupAndTeardown
       def self.prepended(klass)
         klass.include ActiveSupport::Callbacks
-        klass.define_callbacks :setup, :teardown
+        klass.define_callbacks :setup, :test, :teardown
         klass.extend ClassMethods
       end
 
       module ClassMethods
         # Add a callback, which runs before <tt>TestCase#setup</tt>.
+        #
+        #   class ClientTest < ActiveSupport::TestCase
+        #     setup do
+        #       # do client setup
+        #     end
+        #   end
         def setup(*args, &block)
           set_callback(:setup, :before, *args, &block)
         end
 
         # Add a callback, which runs after <tt>TestCase#teardown</tt>.
+        #
+        #   class ClientTest < ActiveSupport::TestCase
+        #     teardown do
+        #       # do client teardown
+        #     end
+        #   end
         def teardown(*args, &block)
           set_callback(:teardown, :after, *args, &block)
+        end
+
+        # Add a callback, which runs between the <tt>TestCase#setup</tt> callbacks and the <tt>TestCase#teardown</tt> callbacks.
+        # Yields the test class instance and the test case to the block:
+        #
+        #   class ClientTest < ActiveSupport::TestCase
+        #     around do |test_case, block|
+        #       # do client setup
+        #       block.call
+        #       # do client teardown
+        #     end
+        #   end
+        #
+        # Code after a failing test yielded by the block argument will still be executed.
+        def around(*args, &block)
+          set_callback(:test, :around, *args, &block)
+
+          include AroundCallbackSupport unless self < AroundCallbackSupport
+        end
+      end
+
+      module AroundCallbackSupport # :nodoc:
+        def send(name, ...) # :nodoc:
+          if name.start_with?("test_")
+            run_callbacks :test do
+              capture_exceptions { super }
+            end
+          else
+            super
+          end
         end
       end
 

--- a/activesupport/test/testing/around_callback_test.rb
+++ b/activesupport/test/testing/around_callback_test.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require_relative "../abstract_unit"
+
+class CallbackTest < ActiveSupport::TestCase
+  test "does not override #send" do
+    assert_not_includes self.class.ancestors, ActiveSupport::Testing::SetupAndTeardown::AroundCallbackSupport
+  end
+end
+
+class AroundCallbackTest < ActiveSupport::TestCase
+  class Client
+    class_attribute :stubbed, default: false
+  end
+
+  around do |test, block|
+    assert_not Client.stubbed
+
+    Client.stubbed = true
+    block.call
+    Client.stubbed = false
+
+    assert_not Client.stubbed
+  end
+
+  test "overrides #send for around callback support" do
+    assert_includes self.class.ancestors, ActiveSupport::Testing::SetupAndTeardown::AroundCallbackSupport
+  end
+
+  test "changes from around hook are present" do
+    assert Client.stubbed
+  end
+
+  test "around block when a test fails" do
+    failing_test = Class.new(ActiveSupport::TestCase) do
+      attr_reader :witness
+
+      around do |_, test|
+        test.call
+
+        @witness = true
+      end
+
+      def self.name
+        "FailingTest"
+      end
+
+      def test_fails
+        flunk
+      end
+    end.new("test_fails")
+
+    assert_nil failing_test.witness
+    result = failing_test.run
+
+    assert_not_predicate result, :passed?
+    assert failing_test.witness
+  end
+end


### PR DESCRIPTION
### Motivation / Background

When discussing testing frameworks for new projects, the absence of `around` hooks is usually a focal point of the conversation that pushes consensus toward alternative test harnesses.

Minitest itself [will not support built-in `around` hooks](https://github.com/minitest/minitest/issues/892). While the [minitest-hooks](https://github.com/jeremyevans/minitest-hooks) gem provides support for `around`, Active Support's callback system makes adding `around` hooks fairly trivial, and is guaranteed to be implemented in the same way as all other callbacks (Controller, Jobs, Mailers, etc.).


### Detail

Add a callback, which runs around `TestCase#setup`, the `test` block, and `TestCase#teardown`. Yields the test class instance and the test case to the block:

```ruby
class Test < ActiveSupport::TestCase
  around do |test_case, &block|
    Client.with(stubbed: true, &block)
  end
end
```

### Additional Information

To support this change, rename the `activesupport/test/testing/after_teardown_test.rb` file to `activesupport/test/testing/callbacks_test.rb`.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
