### PR TITLE
Clean up trilogy error translation

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/trilogy_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/trilogy_adapter.rb
@@ -202,11 +202,10 @@ module ActiveRecord
           end
 
           case exception
-          when SocketError, IOError
+          when ::Trilogy::ConnectionClosed, ::Trilogy::EOFError
             return ConnectionFailed.new(message, connection_pool: @pool)
           when ::Trilogy::Error
-            if /TRILOGY_CLOSED_CONNECTION|TRILOGY_INVALID_SEQUENCE_ID|TRILOGY_UNEXPECTED_PACKET/.match?(exception.message) ||
-                exception.is_a?(SystemCallError)
+            if exception.is_a?(SystemCallError) || exception.message.include?("TRILOGY_INVALID_SEQUENCE_ID")
               return ConnectionFailed.new(message, connection_pool: @pool)
             end
           end


### PR DESCRIPTION
This commit makes a few changes to our trilogy error translation:

* https://github.com/trilogy-libraries/trilogy/pull/118 introduced `Trilogy::EOFError` which we can use instead of matching on `TRILOGY_CLOSED_CONNECTION`.
* https://github.com/trilogy-libraries/trilogy/pull/15 introduced `Trilogy::ConnectionClosed`, which inherits from `IOError` for backwards compatibility. As far as I can tell that's the only `IOError` trilogy can raise, so this commit rescues the trilogy-specific error instead.
* As far as I can tell Trilogy does not raise `SocketError`, so don't bother translating that
* Don't treat `TRILOGY_UNEXPECTED_PACKET` as a connection error. If we get this, it's probably a bug in trilogy that we should fix. I'd like to eventually get rid of `TRILOGY_INVALID_SEQUENCE_ID` too, but we're currently relying on it in a few tests (related to trilogy missing caching_sha2_password auth support, if I recall correctly)

I'm kinda hoping we'll eventually be able to simplify this to something like:

```rb
if exception.is_a?(Trilogy::ConnectionError)
  ConnectionFailed.new(message, connection_pool: @pool)
else
  super
end
```

but we'd need more changes to trilogy before that is possible.