### PR TITLE
Documentation: Expand documentation on has_one_attached method [ci-skip].

### DIFF
--- a/activestorage/lib/active_storage/attached/model.rb
+++ b/activestorage/lib/active_storage/attached/model.rb
@@ -74,8 +74,10 @@ module ActiveStorage
       # The system has been designed to having you go through the ActiveStorage::Attached::One
       # proxy that provides the dynamic proxy to the associations and factory methods, like +attach+.
       #
-      # If the +:dependent+ option isn't set, the attachment will be purged
-      # (i.e. destroyed) whenever the record is destroyed.
+      # The +:dependent+ option defaults to +:purge_later+. This means the attachment will be
+      # purged (i.e. destroyed) in the background whenever the record is destroyed.
+      # If an ActiveJob::Backend queue adapter is not set in the application set it to
+      # +purge+ instead.
       #
       # If you need the attachment to use a service which differs from the globally configured one,
       # pass the +:service+ option. For example:
@@ -172,8 +174,10 @@ module ActiveStorage
       # The system has been designed to having you go through the ActiveStorage::Attached::Many
       # proxy that provides the dynamic proxy to the associations and factory methods, like +#attach+.
       #
-      # If the +:dependent+ option isn't set, all the attachments will be purged
-      # (i.e. destroyed) whenever the record is destroyed.
+      # The +:dependent+ option defaults to +:purge_later+. This means the attachments will be
+      # purged (i.e. destroyed) in the background whenever the record is destroyed.
+      # If an ActiveJob::Backend queue adapter is not set in the application set it to
+      # +purge+ instead.
       #
       # If you need the attachment to use a service which differs from the globally configured one,
       # pass the +:service+ option. For example:


### PR DESCRIPTION
### Motivation / Background

Give further context about the requirements for using the has_one_attached method. 

I have an application that does not have an ActiveJob::Backend queue adapter. When I tried to destroy a record, it raised an error that I needed a queue adapter. There is a dependency between the has_one_attached method and a queue adapter. 

That is why adding more context about the functionality and requirements about using the has_one_attached method is important. 

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [X] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
