### PR TITLE
Add cost argument to has_secure_password

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Added optional `cost` argument to `has_secure_password` to set a custom
+    cost value for the generated password hash.
+
+    *Tony Drake*
+
 *   Add a default token generator for password reset tokens when using `has_secure_password`.
 
     ```ruby

--- a/activemodel/lib/active_model/secure_password.rb
+++ b/activemodel/lib/active_model/secure_password.rb
@@ -39,6 +39,11 @@ module ActiveModel
       # <tt>validations: false</tt> as an argument. This allows complete
       # customizability of validation behavior.
       #
+      # You may specify the cost used when generating the password with the
+      # <tt>cost:</tt> argument. If not provided, +BCrypt::Engine.cost+ is used.
+      # Note that a higher cost increases the algorithm will spend more time to
+      # generate the hash. If set, this attribute should be between 4 and 31.
+      #
       # Finally, a password reset token that's valid for 15 minutes after issue
       # is automatically configured when +reset_token+ is set to true (which it is by default)
       # and the object reponds to +generates_token_for+ (which Active Records do).
@@ -113,7 +118,7 @@ module ActiveModel
       #
       #   # raises ActiveSupport::MessageVerifier::InvalidSignature since the token is expired
       #   User.find_by_password_reset_token!(token)
-      def has_secure_password(attribute = :password, validations: true, reset_token: true)
+      def has_secure_password(attribute = :password, validations: true, reset_token: true, cost: nil)
         # Load bcrypt gem only when has_secure_password is used.
         # This is to avoid ActiveModel (and by extension the entire framework)
         # being dependent on a binary library.
@@ -124,7 +129,7 @@ module ActiveModel
           raise
         end
 
-        include InstanceMethodsOnActivation.new(attribute, reset_token: reset_token)
+        include InstanceMethodsOnActivation.new(attribute, reset_token: reset_token, cost: cost)
 
         if validations
           include ActiveModel::Validations
@@ -180,7 +185,11 @@ module ActiveModel
     end
 
     class InstanceMethodsOnActivation < Module
-      def initialize(attribute, reset_token:)
+      def initialize(attribute, reset_token:, cost: nil)
+        if cost && !cost.to_i.between?(BCrypt::Engine::MIN_COST, BCrypt::Engine::MAX_COST)
+          raise ArgumentError, "Invalid BCrypt cost #{cost}. This should be between #{BCrypt::Engine::MIN_COST} and #{BCrypt::Engine::MAX_COST}"
+        end
+
         attr_reader attribute
 
         define_method("#{attribute}=") do |unencrypted_password|
@@ -189,8 +198,9 @@ module ActiveModel
             self.public_send("#{attribute}_digest=", nil)
           elsif !unencrypted_password.empty?
             instance_variable_set("@#{attribute}", unencrypted_password)
-            cost = ActiveModel::SecurePassword.min_cost ? BCrypt::Engine::MIN_COST : BCrypt::Engine.cost
-            self.public_send("#{attribute}_digest=", BCrypt::Password.create(unencrypted_password, cost: cost))
+            password_cost = cost.to_i if cost
+            password_cost ||= ActiveModel::SecurePassword.min_cost ? BCrypt::Engine::MIN_COST : BCrypt::Engine.cost
+            self.public_send("#{attribute}_digest=", BCrypt::Password.create(unencrypted_password, cost: password_cost))
           end
         end
 
@@ -215,6 +225,12 @@ module ActiveModel
         define_method("#{attribute}_salt") do
           attribute_digest = public_send("#{attribute}_digest")
           attribute_digest.present? ? BCrypt::Password.new(attribute_digest).salt : nil
+        end
+
+        # Returns the cost, the number of cycles to use in the algorithm to generate the password.
+        define_method("#{attribute}_cost") do
+          attribute_digest = public_send("#{attribute}_digest")
+          attribute_digest.present? ? BCrypt::Password.new(attribute_digest).cost : nil
         end
 
         alias_method :authenticate, :authenticate_password if attribute == :password

--- a/activemodel/test/cases/secure_password_test.rb
+++ b/activemodel/test/cases/secure_password_test.rb
@@ -292,6 +292,36 @@ class SecurePasswordTest < ActiveModel::TestCase
     assert_nil @user.password_salt
   end
 
+  test "password_cost" do
+    @user.password = "secret"
+    assert_equal @user.password_cost, BCrypt::Engine::MIN_COST
+  end
+
+  test "custom_cost_password_cost should return the configured custom cost" do
+    @user.custom_cost_password = "secret"
+    assert_equal @user.custom_cost_password_cost, BCrypt::Engine::MIN_COST + 1
+  end
+
+  test "password_cost should return nil when password is nil" do
+    @user.password = nil
+    assert_nil @user.password_cost
+  end
+
+  test "password_cost should return nil when password digest is nil" do
+    @user.password_digest = nil
+    assert_nil @user.password_cost
+  end
+
+  test "custom password cost should be between bcrypt min and max costs" do
+    assert_raises ArgumentError do
+      User::InstanceMethodsOnActivation.new(:bad_password_cost, reset_token: false, cost: BCrypt::Engine::MIN_COST - 1)
+    end
+
+    assert_raises ArgumentError do
+      User::InstanceMethodsOnActivation.new(:bad_password_cost, reset_token: false, cost: BCrypt::Engine::MAX_COST + 1)
+    end
+  end
+
   test "Password digest cost defaults to bcrypt default cost when min_cost is false" do
     ActiveModel::SecurePassword.min_cost = false
 

--- a/activemodel/test/models/user.rb
+++ b/activemodel/test/models/user.rb
@@ -14,6 +14,9 @@ class User
   attribute :recovery_password_digest
   has_secure_password :recovery_password, validations: false
 
+  attribute :custom_cost_password_digest
+  has_secure_password :custom_cost_password, cost: BCrypt::Engine::MIN_COST + 1, validations: false
+
   attr_accessor :password_called
 
   def password=(unencrypted_password)


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

There may be instances where a developer is working in an environment where a higher cost than the default (12) for BCrypt is required either due to arbitrary security requirements or the recommended minimum changes and the version of bcrypt used isn't updated.

### Detail

This change adds a `cost:` argument to `has_secure_password`. If provided, it will use that value for the password cost. Its value is validated to make sure it's between `BCrypt::Engine::MIN_COST` and `BCrypt::Engine::MAX_COST`.

Additionally `[password attribute]_cost` is exposed as a convenience method to determine the cost used for the set password hash. This can be used to review the current costs from a user record and either transparently upgrade the user's password or force a password reset.

### Additional information

I'm not 100% married to using `cost` as the argument name as it affects only new passwords created for the record going forward.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
