### PR TITLE
Enhanced ActiveStorage variant tracking control

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Added the option to pass the `track` option when generating a variant to allow
+    for finer control of tracking.
+
+    *Jace Bayless*
+
 *   Fix N+1 query when fetching preview images for non-image assets
 
     *Aaron Patterson & Justin Searls*

--- a/activestorage/app/models/active_storage/blob/representable.rb
+++ b/activestorage/app/models/active_storage/blob/representable.rb
@@ -31,9 +31,9 @@ module ActiveStorage::Blob::Representable
   # Raises ActiveStorage::InvariableError if the variant processor cannot
   # transform the blob. To determine whether a blob is variable, call
   # ActiveStorage::Blob#variable?.
-  def variant(transformations)
+  def variant(variation = nil, track: ActiveStorage.track_variants, **transformations)
     if variable?
-      variant_class.new(self, ActiveStorage::Variation.wrap(transformations).default_to(default_variant_transformations))
+      variant_class(track).new(self, ActiveStorage::Variation.wrap(variation || transformations).default_to(default_variant_transformations))
     else
       raise ActiveStorage::InvariableError
     end
@@ -123,7 +123,7 @@ module ActiveStorage::Blob::Representable
       end
     end
 
-    def variant_class
-      ActiveStorage.track_variants ? ActiveStorage::VariantWithRecord : ActiveStorage::Variant
+    def variant_class(track)
+      track ? ActiveStorage::VariantWithRecord : ActiveStorage::Variant
     end
 end

--- a/activestorage/app/models/active_storage/variant_with_record.rb
+++ b/activestorage/app/models/active_storage/variant_with_record.rb
@@ -3,7 +3,8 @@
 # = Active Storage \Variant With Record
 #
 # Like an ActiveStorage::Variant, but keeps detail about the variant in the database as an
-# ActiveStorage::VariantRecord. This is only used if +ActiveStorage.track_variants+ is enabled.
+# ActiveStorage::VariantRecord. This is only used if +ActiveStorage.track_variants+ is enabled
+# or the variant is generated with the option of +track: true+.
 class ActiveStorage::VariantWithRecord
   include ActiveStorage::Blob::Servable
 

--- a/activestorage/test/models/variant_test.rb
+++ b/activestorage/test/models/variant_test.rb
@@ -197,6 +197,24 @@ class ActiveStorage::VariantTest < ActiveSupport::TestCase
     end
   end
 
+  test "tracking is determined by the default config when no option is passed" do
+    result = create_file_blob.variant(resize_to_limit: [100, 100]).processed
+
+    assert_instance_of ActiveStorage::Variant, result
+  end
+
+  test "creates a VariantWithRecord when told to track" do
+    result = create_file_blob.variant(track: true, resize_to_limit: [100, 100]).processed
+
+    assert_instance_of ActiveStorage::VariantWithRecord, result
+  end
+
+  test "creates a Variant (without record) when told to not track" do
+    result = create_file_blob.variant(track: false, resize_to_limit: [100, 100]).processed
+
+    assert_instance_of ActiveStorage::Variant, result
+  end
+
   test "content_type not recognized by marcel isn't included as variable" do
     blob = create_file_blob(filename: "racecar.jpg")
 


### PR DESCRIPTION
### Motivation / Background

#### My Specific Use Case

In my project, where `ActiveStorage.track_variants = true`, I needed to generate a variant of an image (a thumbnail for a room on a floorplan) but did not want to create a variant record of the original image record. This is because I intended to save the variant on a child relation, separate from the original image record.

#### The Challenge
With `ActiveStorage.track_variants = true` every variant generated through `ActiveStorage` is automatically tracked in the database to the original record. There are cases in this application where we **do** want to track these variant records so I was unable to change the default configuration. This meant to properly generate my variant I had to use `ImageProcessing::Vips` directly to not generate the variant record. This worked but generated two concerns for me:

1. This specific code is dependent on `ImageProcessing::Vips` and if we were to ever migrate to another image processor we would have to remember to update this code as well instead of just relying on the `ActiveStorage` default processor.
2. It strays enough from the standard pattern when generating `ActiveStorage` variants that without good documentation it can become confusing to maintain.

### Detail

This pull request adds the `track` option to the `variant` method which allows for overriding of the `ActiveStorage.track_variants`. This is useful when in cases where you want to stray from the application's standard configuration.

```ruby
ActiveSupport.track_variants
# => true
user.avatar.variant(track: false, resize_to_limit: [100, 100])
# => #<ActiveStorage::Variant:0x00007f4e0004ffb0> 
```
and
```ruby
ActiveSupport.track_variants
# => false
user.avatar.variant(track: true, resize_to_limit: [100, 100])
# => #<ActiveStorage::VariantWithRecord:0x00007f4e0004ffb0> 
```

### Additional information

This is my first time contributing to Rails and I appreciate anyone who takes the time to read all this. I tried my best to follow all conventions and to keep all current functionality, but in the case that I missed something I'd be happy to discuss and fix whatever is needed.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
