### PR TITLE
Improve ActionView::Helpers::UrlHelper button_to explanation [ci-skip]

### DIFF
--- a/actionview/lib/action_view/helpers/url_helper.rb
+++ b/actionview/lib/action_view/helpers/url_helper.rb
@@ -220,8 +220,9 @@ module ActionView
       # +:form_class+ option within +html_options+. It defaults to
       # <tt>"button_to"</tt> to allow styling of the form and its children.
       #
-      # The form submits a POST request by default. You can specify a different
-      # HTTP verb via the +:method+ option within +html_options+.
+      # The form submits a POST request by default if the object is not persisted;
+      # conversely, if the object is persisted, it will submit a PATCH request.
+      # To specify a different HTTP verb use the +:method+ option within +html_options+.
       #
       # If the HTML button generated from +button_to+ does not work with your layout, you can
       # consider using the +link_to+ method with the +data-turbo-method+


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because the current button_to method documentation in Rails API lacks clarity regarding its default HTTP request behavior based on the object's persistence. This update aims to explicitly differentiate between POST and PATCH requests in the method's documentation, providing clearer guidance for developers, especially when handling objects with different persistence states.


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
