### PR TITLE
Allow customization to console prompt's format

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -14,7 +14,14 @@
     `development` (blue), `test` (blue), or `production` (red), if your
     terminal supports it.
 
-    *Stan Lo*
+    Additionally, you can customize the prompt with `RAILS_PROMPT_PREFIX` in case of having
+    multiple environments (e.g. different regions like "eu-west-1", "us-north-1") but all using
+    the same `Rails.env` as `production`.
+
+    Also the color can be overriden with `RAILS_PROMPT_COLOR` if set to one of the following colors
+    `BLUE`, `CYAN`, `GREEN`, `MAGENTA`, `RED`.
+
+    *Stan Lo*, *Nathan Samson*
 
 *   Ensure `autoload_paths`, `autoload_once_paths`, `eager_load_paths`, and
     `load_paths` only have directories when initialized from engine defaults.

--- a/railties/lib/rails/commands/console/console_command.rb
+++ b/railties/lib/rails/commands/console/console_command.rb
@@ -51,6 +51,17 @@ module Rails
       end
 
       def colorized_env
+        rails_prompt_prefix = ENV.fetch("RAILS_PROMPT_PREFIX", nil)
+        return colorized_env_from_rails_env unless rails_prompt_prefix
+
+        rails_prompt_color = ENV.fetch("RAILS_PROMPT_COLOR", color_from_rails_env)
+        return rails_prompt_prefix unless rails_prompt_color &&
+                                          rails_prompt_color.to_sym.in?([:BLUE, :CYAN, :GREEN, :MAGENTA, :RED])
+
+        IRB::Color.colorize(rails_prompt_prefix, [rails_prompt_color.to_sym])
+      end
+
+      def colorized_env_from_rails_env
         case Rails.env
         when "development"
           IRB::Color.colorize("dev", [:BLUE])
@@ -60,6 +71,14 @@ module Rails
           IRB::Color.colorize("prod", [:RED])
         else
           Rails.env
+        end
+      end
+
+      def color_from_rails_env
+        if Rails.env.production?
+          :RED
+        elsif Rails.env.local?
+          :BLUE
         end
       end
     end

--- a/railties/test/application/console_test.rb
+++ b/railties/test/application/console_test.rb
@@ -233,6 +233,23 @@ class FullStackConsoleTest < ActiveSupport::TestCase
     write_prompt "123", "app-template(test)> 123"
   end
 
+  def test_custom_console_prompt
+    options = "-e production"
+    spawn_console(options, env: { "RAILS_PROMPT_PREFIX" => "custom-env" })
+
+    write_prompt "123", "app-template(custom-env)> 123"
+  end
+
+  def test_custom_with_color_console_prompt
+    options = "-e production"
+    spawn_console(options, env: {
+      "RAILS_PROMPT_PREFIX" => "custom-env",
+      "RAILS_PROMPT_COLOR" => "BLUE",
+    })
+
+    write_prompt "123", "app-template(custom-env)> 123"
+  end
+
   def test_console_respects_user_defined_prompt_mode
     irbrc = Tempfile.new("irbrc")
     irbrc.write <<-RUBY


### PR DESCRIPTION
Allows more customization of the new console prompts instead of only looking at the `Rails.env` with newly introduced environment variables.

`RAILS_PROMPT_PREFIX` will replace the dev/test/prod wording regardless the env. This can be useful in case of multiple production environments or staging environments that also use the `production` rails env.

`RAILS_PROMPT_COLOR` can be used to override the colour. This can be usefully to differentiate between a real production environment and a staging / QA environment that runs in `production` mode.

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created because we often work with different "production" like environments.
eg they all use the same settings in `production`; but are for different cases. Eg one could be a staging environment, or even multiple production environments eg different installations for different tenants.
In this case we still want to color the environment (eg red for all actual production environments, but cyan for staging environments) + correctly name them.

### Detail

This Pull Request changes https://github.com/rails/rails/pull/50796

### Additional information

I took the liberty to change the last ChangeLog entry (and add my name) instead of creating a new changelog entry, as the changes relate to the latest change anyway.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
