### PR TITLE
[Fix #50897] Autosaving `has_one` sets foreign key attribute when unchanged

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Fix `has_one` association autosave setting the foreign key attribute when it is unchanged.
+
+    This behaviour is also inconsistent with autosaving `belongs_to` and can have unintended side effects like raising
+    an `ActiveRecord::ReadOnlyAttributeError` when the foreign key attribute is marked as read-only.
+
+    *Joshua Young*
+
 *   Remove deprecated behavior that would rollback a transaction block when exited using `return`, `break` or `throw`.
 
     *Rafael Mendonça França*

--- a/activerecord/lib/active_record/autosave_association.rb
+++ b/activerecord/lib/active_record/autosave_association.rb
@@ -458,7 +458,8 @@ module ActiveRecord
                 primary_key_foreign_key_pairs = primary_key.zip(foreign_key)
 
                 primary_key_foreign_key_pairs.each do |primary_key, foreign_key|
-                  record[foreign_key] = _read_attribute(primary_key)
+                  association_id = _read_attribute(primary_key)
+                  record[foreign_key] = association_id unless record[foreign_key] == association_id
                 end
                 association.set_inverse_instance(record)
               end

--- a/activerecord/test/cases/autosave_association_test.rb
+++ b/activerecord/test/cases/autosave_association_test.rb
@@ -302,6 +302,13 @@ class TestDefaultAutosaveAssociationOnAHasOneAssociation < ActiveRecord::TestCas
     eye.update(iris_attributes: { color: "blue" })
     assert_equal [false, false, false, false], eye.after_save_callbacks_stack
   end
+
+  def test_foreign_key_attribute_is_not_set_unless_changed
+    eye = Eye.create!(iris_with_read_only_foreign_key_attributes: { color: "honey" })
+    assert_nothing_raised do
+      eye.update!(override_iris_with_read_only_foreign_key_color: true)
+    end
+  end
 end
 
 class TestDefaultAutosaveAssociationOnABelongsToAssociation < ActiveRecord::TestCase

--- a/activerecord/test/models/eye.rb
+++ b/activerecord/test/models/eye.rb
@@ -4,19 +4,20 @@ class Eye < ActiveRecord::Base
   attr_reader :after_create_callbacks_stack
   attr_reader :after_update_callbacks_stack
   attr_reader :after_save_callbacks_stack
+  attr_writer :override_iris_with_read_only_foreign_key_color
 
   # Callbacks configured before the ones has_one sets up.
-  after_create :trace_after_create
-  after_update :trace_after_update
-  after_save   :trace_after_save
+  after_create :trace_after_create, if: :iris
+  after_update :trace_after_update, if: :iris
+  after_save   :trace_after_save, if: :iris
 
   has_one :iris
   accepts_nested_attributes_for :iris
 
   # Callbacks configured after the ones has_one sets up.
-  after_create :trace_after_create2
-  after_update :trace_after_update2
-  after_save   :trace_after_save2
+  after_create :trace_after_create2, if: :iris
+  after_update :trace_after_update2, if: :iris
+  after_save   :trace_after_save2, if: :iris
 
   def trace_after_create
     (@after_create_callbacks_stack ||= []) << !iris.persisted?
@@ -32,8 +33,23 @@ class Eye < ActiveRecord::Base
     (@after_save_callbacks_stack ||= []) << iris.has_changes_to_save?
   end
   alias trace_after_save2 trace_after_save
+
+  has_one :iris_with_read_only_foreign_key, class_name: "IrisWithReadOnlyForeignKey", foreign_key: :eye_id
+  accepts_nested_attributes_for :iris_with_read_only_foreign_key
+
+  before_save :set_iris_with_read_only_foreign_key_color_to_blue, if: -> {
+    iris_with_read_only_foreign_key && @override_iris_with_read_only_foreign_key_color
+  }
+
+  def set_iris_with_read_only_foreign_key_color_to_blue
+    iris_with_read_only_foreign_key.color = "blue"
+  end
 end
 
 class Iris < ActiveRecord::Base
   belongs_to :eye
+end
+
+class IrisWithReadOnlyForeignKey < Iris
+  attr_readonly :eye_id
 end


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

Fixes https://github.com/rails/rails/issues/50897

Similar to https://github.com/rails/rails/pull/46759

### Detail

Updates `ActiveRecord::AutosaveAssociation#save_has_one_association` to only update the foreign key attribute on the child record if it has changed. This makes its behaviour consistent with `belongs_to` associations and ensures that `ActiveRecord::ReadOnlyAttributeError` isn't raised when no changes have been made to the attribute.

### Additional information

<!-- Provide additional information such as benchmarks, reference to other repositories or alternative solutions. -->

None.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
