### PR TITLE
Remove add_autoload_paths_to_load_path docs from autoloading guide

### DIFF
--- a/guides/source/autoloading_and_reloading_constants.md
+++ b/guides/source/autoloading_and_reloading_constants.md
@@ -228,19 +228,6 @@ module MyApp
 end
 ```
 
-$LOAD_PATH{#load_path}
-----------
-
-Autoload paths are added to `$LOAD_PATH` by default. However, Zeitwerk uses absolute file names internally, and your application should not issue `require` calls for autoloadable files, so those directories are actually not needed there. You can opt out with this flag:
-
-```ruby
-config.add_autoload_paths_to_load_path = false
-```
-
-That may speed up legitimate `require` calls a bit since there are fewer lookups. Also, if your application uses [Bootsnap](https://github.com/Shopify/bootsnap), that saves the library from building unnecessary indexes, leading to lower memory usage.
-
-The `lib` directory is not affected by this flag, it is added to `$LOAD_PATH` always.
-
 Reloading
 ---------
 


### PR DESCRIPTION
I'd suggest to deemphasize `add_autoload_paths_to_load_path` in the docs, by removing its section from the autoloading guide.

As [we say](https://github.com/rails/rails/blob/main/guides/source/upgrading_ruby_on_rails.md#autoloaded-paths-are-no-longer-in-load_path) in the upgrading guide for 7.1:

> we discourage [enabling this], classes and modules in the autoload paths are meant to be autoloaded. That is, just reference them.

If we document that you can toggle this in the autoloading guide, we should follow with something like: "this would make sense for example if...", and I don't see a use case. The upgrading guide is right. You're not supposed to issue `require` calls for stuff in the autoload paths, therefore there should be no API for that.

So, I would just remove these docs. If someone finds this in their code base, the configuration guide documents it.

I'd also backport this to `7-1-stable`, whose autoloading guide [is incorrect right now](https://github.com/rails/rails/blob/20c58a4ea2e721cea9548cc9bbf720e882b1619d/guides/source/autoloading_and_reloading_constants.md#load_pathload_path) (it says this is `true` by default).

@byroot what do you think? Could we even perhaps consider this flag to be a transition aid that could be deprecated and later deleted?

/cc @siaw23 