### PR TITLE
Change skeleton test to assert exact file output

### DIFF
--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -257,8 +257,6 @@ module Rails
     def tmp
       empty_directory_with_keep_file "tmp"
       empty_directory_with_keep_file "tmp/pids"
-      empty_directory "tmp/cache"
-      empty_directory "tmp/cache/assets"
     end
 
     def vendor
@@ -461,7 +459,6 @@ module Rails
         if options[:api]
           remove_dir "app/assets"
           remove_dir "lib/assets"
-          remove_dir "tmp/cache/assets"
         end
       end
 

--- a/railties/lib/rails/generators/rails/plugin/plugin_generator.rb
+++ b/railties/lib/rails/generators/rails/plugin/plugin_generator.rb
@@ -112,9 +112,12 @@ module Rails
     def generate_test_dummy(force = false)
       opts = options.transform_keys(&:to_sym).except(*DUMMY_IGNORE_OPTIONS)
       opts[:force] = force
+      opts[:skip_brakeman] = true
       opts[:skip_bundle] = true
+      opts[:skip_ci] = true
       opts[:skip_git] = true
       opts[:skip_hotwire] = true
+      opts[:skip_rubocop] = true
       opts[:dummy_app] = true
 
       invoke Rails::Generators::AppGenerator,
@@ -144,7 +147,7 @@ module Rails
     def test_dummy_clean
       inside dummy_path do
         remove_file ".ruby-version"
-        remove_file "db/seeds.rb"
+        remove_dir "db"
         remove_file "Gemfile"
         remove_file "lib/tasks"
         remove_file "public/robots.txt"

--- a/railties/lib/rails/tasks/tmp.rake
+++ b/railties/lib/rails/tasks/tmp.rake
@@ -7,7 +7,7 @@ namespace :tmp do
   tmp_dirs = [ "tmp/cache",
                "tmp/sockets",
                "tmp/pids",
-               "tmp/cache/assets" ]
+             ]
 
   tmp_dirs.each { |d| directory d }
 

--- a/railties/test/generators/api_app_generator_test.rb
+++ b/railties/test/generators/api_app_generator_test.rb
@@ -177,7 +177,6 @@ class ApiAppGeneratorTest < Rails::Generators::TestCase
          config/initializers/permissions_policy.rb
          lib/assets
          test/helpers
-         tmp/cache/assets
          public/404.html
          public/422.html
          public/426.html

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -5,90 +5,88 @@ require "rails/generators/rails/app/app_generator"
 require "generators/shared_generator_tests"
 
 DEFAULT_APP_FILES = %w(
+  .dockerignore
+  .git
   .gitattributes
   .github/dependabot.yml
   .github/workflows/ci.yml
   .gitignore
-  .dockerignore
   .rubocop.yml
   .ruby-version
-  README.md
-  Gemfile
-  Rakefile
   Dockerfile
-  config.ru
+  Gemfile
+  README.md
+  Rakefile
   app/assets/config/manifest.js
-  app/assets/images
-  app/assets/stylesheets
+  app/assets/images/.keep
   app/assets/stylesheets/application.css
   app/channels/application_cable/channel.rb
   app/channels/application_cable/connection.rb
-  app/controllers
   app/controllers/application_controller.rb
-  app/controllers/concerns
-  app/helpers
+  app/controllers/concerns/.keep
   app/helpers/application_helper.rb
-  app/mailers
-  app/mailers/application_mailer.rb
-  app/models
-  app/models/application_record.rb
-  app/models/concerns
-  app/jobs
   app/jobs/application_job.rb
-  app/views/layouts
+  app/mailers/application_mailer.rb
+  app/models/application_record.rb
+  app/models/concerns/.keep
   app/views/layouts/application.html.erb
   app/views/layouts/mailer.html.erb
   app/views/layouts/mailer.text.erb
-  bin/docker-entrypoint
+  app/views/pwa/manifest.json.erb
+  app/views/pwa/service-worker.js
   bin/brakeman
+  bin/docker-entrypoint
   bin/rails
   bin/rake
   bin/rubocop
   bin/setup
+  config.ru
   config/application.rb
   config/boot.rb
   config/cable.yml
+  config/credentials.yml.enc
+  config/database.yml
   config/environment.rb
-  config/environments
   config/environments/development.rb
   config/environments/production.rb
   config/environments/test.rb
-  config/initializers
   config/initializers/assets.rb
   config/initializers/content_security_policy.rb
   config/initializers/enable_yjit.rb
   config/initializers/filter_parameter_logging.rb
   config/initializers/inflections.rb
-  config/locales
+  config/initializers/permissions_policy.rb
   config/locales/en.yml
+  config/master.key
   config/puma.rb
   config/routes.rb
-  config/credentials.yml.enc
   config/storage.yml
-  db
   db/seeds.rb
-  lib
-  lib/tasks
-  lib/assets
-  log
-  public
-  storage
+  lib/assets/.keep
+  lib/tasks/.keep
+  log/.keep
+  public/404.html
+  public/422.html
+  public/426.html
+  public/500.html
+  public/icon.png
+  public/icon.svg
+  public/robots.txt
+  storage/.keep
   test/application_system_test_case.rb
-  test/test_helper.rb
-  test/fixtures
-  test/fixtures/files
   test/channels/application_cable/connection_test.rb
-  test/controllers
-  test/models
-  test/helpers
-  test/mailers
-  test/integration
-  test/system
-  vendor
-  tmp
-  tmp/cache
-  tmp/cache/assets
-  tmp/storage
+  test/controllers/.keep
+  test/fixtures/files/.keep
+  test/helpers/.keep
+  test/integration/.keep
+  test/mailers/.keep
+  test/models/.keep
+  test/system/.keep
+  test/test_helper.rb
+  tmp/.keep
+  tmp/pids/.keep
+  tmp/storage/.keep
+  vendor/.keep
 )
 
 class AppGeneratorTest < Rails::Generators::TestCase
@@ -111,12 +109,6 @@ class AppGeneratorTest < Rails::Generators::TestCase
     assert_file "Gemfile"
   end
 
-  def test_assets
-    run_generator
-
-    assert_file("app/assets/stylesheets/application.css")
-  end
-
   def test_invalid_javascript_option_raises_an_error
     content = capture(:stderr) { run_generator([destination_root, "-j", "unknown"]) }
     assert_match(/Expected '--javascript' to be one of/, content)
@@ -130,11 +122,6 @@ class AppGeneratorTest < Rails::Generators::TestCase
   def test_invalid_css_option_raises_an_error
     content = capture(:stderr) { run_generator([destination_root, "-c", "unknown"]) }
     assert_match(/Expected '--css' to be one of/, content)
-  end
-
-  def test_application_job_file_present
-    run_generator
-    assert_file("app/jobs/application_job.rb")
   end
 
   def test_invalid_application_name_raises_an_error
@@ -181,17 +168,6 @@ class AppGeneratorTest < Rails::Generators::TestCase
     run_app_update(app_moved_root)
 
     assert_file "#{app_moved_root}/config/environment.rb", /Rails\.application\.initialize!/
-  end
-
-  def test_new_application_not_include_api_initializers
-    run_generator
-
-    assert_no_file "config/initializers/cors.rb"
-  end
-
-  def test_new_application_doesnt_need_defaults
-    run_generator
-    assert_empty Dir.glob("config/initializers/new_framework_defaults_*.rb", base: destination_root)
   end
 
   def test_new_application_load_defaults

--- a/railties/test/generators/plugin_generator_test.rb
+++ b/railties/test/generators/plugin_generator_test.rb
@@ -7,19 +7,70 @@ require "generators/shared_generator_tests"
 require "rails/engine/updater"
 
 DEFAULT_PLUGIN_FILES = %w(
+  .git
   .gitignore
   Gemfile
-  Rakefile
-  README.md
-  bukkits.gemspec
   MIT-LICENSE
-  lib
+  README.md
+  Rakefile
+  bin/test
+  bukkits.gemspec
   lib/bukkits.rb
-  lib/tasks/bukkits_tasks.rake
+  lib/bukkits/railtie.rb
   lib/bukkits/version.rb
+  lib/tasks/bukkits_tasks.rake
   test/bukkits_test.rb
+  test/dummy/Rakefile
+  test/dummy/app/assets/images/.keep
+  test/dummy/app/assets/stylesheets/application.css
+  test/dummy/app/channels/application_cable/channel.rb
+  test/dummy/app/channels/application_cable/connection.rb
+  test/dummy/app/controllers/application_controller.rb
+  test/dummy/app/controllers/concerns/.keep
+  test/dummy/app/helpers/application_helper.rb
+  test/dummy/app/jobs/application_job.rb
+  test/dummy/app/mailers/application_mailer.rb
+  test/dummy/app/models/application_record.rb
+  test/dummy/app/models/concerns/.keep
+  test/dummy/app/views/layouts/application.html.erb
+  test/dummy/app/views/layouts/mailer.html.erb
+  test/dummy/app/views/layouts/mailer.text.erb
+  test/dummy/app/views/pwa/manifest.json.erb
+  test/dummy/app/views/pwa/service-worker.js
+  test/dummy/bin/rails
+  test/dummy/bin/rake
+  test/dummy/bin/setup
+  test/dummy/config.ru
+  test/dummy/config/application.rb
+  test/dummy/config/boot.rb
+  test/dummy/config/cable.yml
+  test/dummy/config/database.yml
+  test/dummy/config/environment.rb
+  test/dummy/config/environments/development.rb
+  test/dummy/config/environments/production.rb
+  test/dummy/config/environments/test.rb
+  test/dummy/config/initializers/content_security_policy.rb
+  test/dummy/config/initializers/enable_yjit.rb
+  test/dummy/config/initializers/filter_parameter_logging.rb
+  test/dummy/config/initializers/inflections.rb
+  test/dummy/config/initializers/permissions_policy.rb
+  test/dummy/config/locales/en.yml
+  test/dummy/config/puma.rb
+  test/dummy/config/routes.rb
+  test/dummy/config/storage.yml
+  test/dummy/lib/assets/.keep
+  test/dummy/log/.keep
+  test/dummy/public/404.html
+  test/dummy/public/422.html
+  test/dummy/public/426.html
+  test/dummy/public/500.html
+  test/dummy/public/icon.png
+  test/dummy/public/icon.svg
+  test/dummy/storage/.keep
+  test/dummy/tmp/.keep
+  test/dummy/tmp/pids/.keep
+  test/dummy/tmp/storage/.keep
   test/test_helper.rb
-  test/dummy
 )
 
 class PluginGeneratorTest < Rails::Generators::TestCase
@@ -68,8 +119,6 @@ class PluginGeneratorTest < Rails::Generators::TestCase
   def test_generating_without_options
     run_generator
     assert_file "README.md", /Bukkits/
-    assert_no_file "config/routes.rb"
-    assert_no_file "app/assets/config/bukkits_manifest.js"
     assert_file "test/test_helper.rb" do |content|
       assert_match(/require_relative.+test\/dummy\/config\/environment/, content)
       assert_match(/ActiveRecord::Migrator\.migrations_paths.+test\/dummy\/db\/migrate/, content)
@@ -83,13 +132,6 @@ class PluginGeneratorTest < Rails::Generators::TestCase
       assert_match(/class BukkitsTest < ActiveSupport::TestCase/, content)
       assert_match(/assert Bukkits::VERSION/, content)
     end
-    assert_file "bin/test"
-    assert_no_file "bin/rails"
-  end
-
-  def test_initializes_git_repo
-    run_generator
-    assert_directory ".git"
   end
 
   def test_initializes_git_repo_with_main_branch_without_user_default
@@ -174,12 +216,6 @@ class PluginGeneratorTest < Rails::Generators::TestCase
     run_generator [destination_root, "-T", "--mountable", "--dummy-path", "my_dummy_app"]
     assert_file "Rakefile", /APP_RAKEFILE/
     assert_file "bin/rails", /APP_PATH/
-  end
-
-  def test_generating_adds_dummy_app_without_javascript_and_assets_deps
-    run_generator
-
-    assert_file "test/dummy/app/assets/stylesheets/application.css"
   end
 
   def test_ensure_that_plugin_options_are_not_passed_to_app_generator
@@ -606,24 +642,6 @@ class PluginGeneratorTest < Rails::Generators::TestCase
     assert_file ".gitignore" do |contents|
       assert_match(/spec\/dummy/, contents)
     end
-  end
-
-  def test_unnecessary_files_are_not_generated_in_dummy_application
-    run_generator
-    assert_no_file "test/dummy/.gitignore"
-    assert_no_file "test/dummy/.ruby-version"
-    assert_no_file "test/dummy/db/seeds.rb"
-    assert_no_file "test/dummy/Gemfile"
-    assert_no_file "test/dummy/public/robots.txt"
-    assert_no_file "test/dummy/README.md"
-    assert_no_file "test/dummy/config/master.key"
-    assert_no_file "test/dummy/config/credentials.yml.enc"
-    assert_no_file "test/dummy/Dockerfile"
-    assert_no_file "test/dummy/.dockerignore"
-    assert_no_directory "test/dummy/lib/tasks"
-    assert_no_directory "test/dummy/test"
-    assert_no_directory "test/dummy/vendor"
-    assert_no_directory "test/dummy/.git"
   end
 
   def test_skipping_test_files


### PR DESCRIPTION
Previously, the skeleton test would assert that every file in the `default_files` list existed. However, since there is no requirement that a file is added to this list when added to the generator the list can (and has) become out of sync with the exact generated output.

This commit refactors the skeleton test to gather the full list of files created by the generator so that it can be compared exactly to the list of `default_files`. This ensures the generated file list must be updated when any file is added or removed from the generator. Additionally, by using array equality the sorting of the `default_files` list is enforced (it was previously _mostly_ alphabetical, but not fully).

The new skeleton test assertion was written to only assert files instead of folders for a few reasons:
- asserting that folders exist is redundant if a file exists within a folder (and the `default_files` list would be significantly longer with all folders)
- any folder generated without any files inside it will not be tracked by Git, so other code cannot assume these empty folders exist

Because of these reasons, this patch also includes a change to no longer generate the `tmp/cache/assets` folder by default. The folder is an implementation detail of Sprockets and doesn't need any special treatment in Rails. The `Sprockets::Cache::FileStore` will create the directory if it does not exist (which it usually won't since `tmp/cache` is excluded from Git by the `.gitignore`), and the `tmp:cache:clear` task already clears all subdirectories of `tmp/cache`.

Finally, some tests making assertions about the default output of the app generator were removed as they have been made redundant by the improvements to the skeleton test.

---

[Assert exact file output for plugins too](https://github.com/rails/rails/pull/50903/commits/c278684ae180302b073c8190d2fb50f3a359528c)

In a [previous commit][1], the App Generator skeleton test was updated to verify the exact file output when generating a new application. This commit applies the same change to the Plugin Generator.

At first, I was hesitant to add the list of dummy app files to the `default_files` for the Plugin Generator test, however it quickly became apparent that it was a good idea. Making this change exposed that recent file additions to the App Generator were added to the plugin's dummy app as well. Things like CI files, rubocop configuration, and a brakeman command should not be created for a dummy app, and are now properly excluded.

Similar to the App Generator commit, this change also removes tests that are now redundant due to the skeleton test verifying the exact list of files generated.

[1]: https://github.com/rails/rails/commit/e5e4b801046bceb1067ffb316edd1ad704b6596d
