### PR TITLE
[ci skip] [docs] make increment requirement explicit

### DIFF
--- a/activesupport/lib/active_support/cache.rb
+++ b/activesupport/lib/active_support/cache.rb
@@ -725,7 +725,11 @@ module ActiveSupport
 
       # Increments an integer value in the cache.
       #
-      # Options are passed to the underlying cache implementation.
+      # * +:expires_in+ - Sets a relative expiration time for the cache entry,
+      #   specified in seconds, when the entry is created (first incremented).
+      #   This option is ignored when incrementing existing, non-expired entries.
+      #
+      # Other options are passed to the underlying cache implementation.
       #
       # Some implementations may not support this method.
       def increment(name, amount = 1, options = nil)


### PR DESCRIPTION
### Motivation / Background

As of December, [ActionController::Metal::RateLimiting](https://github.com/rails/rails/blob/main/actionpack/lib/action_controller/metal/rate_limiting.rb) provides rate limiting through the `increment` method of any cache store. RateLimiting relies on a feature of the underlying store. This feature needs to be documented, so that it remains supported, and so alternative stores know to support it.

This PR has been created to document this behavior.

### Detail

The feature is that `increment`, when passed `expires_in`, will set expiration time when the key is first created, and ignore that option if the key already exists.

That functionality is already tested [here](https://github.com/rails/rails/blob/cf26c5482924babca573e6c01594d77e3321ae58/activesupport/test/cache/behaviors/cache_increment_decrement_behavior.rb#L34), in the `CacheIncrementDecrementBehavior` test module.

This Pull Request changes the documentation of `ActiveSupport::Cache::Store.increment` to reflect a now-required feature of existing stores.