### PR TITLE
Use `httpclient` to run "Daily build with Ruby head"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -127,6 +127,7 @@ end
 # Action Mailbox
 gem "aws-sdk-sns", require: false
 gem "webmock"
+gem "httpclient", github: "nahi/httpclient", branch: "master", require: false
 
 # Add your own local bundler stuff.
 local_gemfile = File.expand_path(".Gemfile", __dir__)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,6 +8,13 @@ GIT
       websocket
 
 GIT
+  remote: https://github.com/nahi/httpclient.git
+  revision: d57cc6d5ffee1b566b5c189fe6dc8cc89570b812
+  branch: master
+  specs:
+    httpclient (2.8.3)
+
+GIT
   remote: https://github.com/rails/sdoc.git
   revision: e9bb867eba81f48c402a129e688e810ec1fa387c
   branch: main
@@ -273,7 +280,6 @@ GEM
       os (>= 0.9, < 2.0)
       signet (>= 0.16, < 2.a)
     hashdiff (1.1.0)
-    httpclient (2.8.3)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
     image_processing (1.12.2)
@@ -603,6 +609,7 @@ DEPENDENCIES
   delayed_job
   delayed_job_active_record
   google-cloud-storage (~> 1.11)
+  httpclient!
   image_processing (~> 1.2)
   importmap-rails (>= 1.2.3)
   jbuilder


### PR DESCRIPTION
### Motivation / Background

This pull request addresses "Daily build with Ruby head" failure https://buildkite.com/rails/rails-nightly/builds/101#018d5285-b4de-4072-b7d3-61c19f21347a

### Detail

Action Mailbox needs `webmock` which depends on `httpclient`. `httpclient` master branch that added `mutex_m` as a dependency via https://github.com/nahi/httpclient/pull/455 to support Ruby 3.4.0dev.

#### Steps to reproduce
```ruby
cd actionmailbox
bundle exec rake test
```

#### Without this commit
```ruby
... snip ...
/home/yahonda/.rbenv/versions/ruby-dev/lib/ruby/gems/3.4.0+0/gems/webmock-3.19.1/lib/webmock/http_lib_adapters/httpclient_adapter.rb:234:in `alias_method': undefined method `do_get_block' for class `WebMockHTTPClient' (NameError)

    alias_method :do_get_block_without_webmock, :do_get_block
    ^^^^^^^^^^^^
        from /home/yahonda/.rbenv/versions/ruby-dev/lib/ruby/gems/3.4.0+0/gems/webmock-3.19.1/lib/webmock/http_lib_adapters/httpclient_adapter.rb:234:in `<class:WebMockHTTPClient>'
        from /home/yahonda/.rbenv/versions/ruby-dev/lib/ruby/gems/3.4.0+0/gems/webmock-3.19.1/lib/webmock/http_lib_adapters/httpclient_adapter.rb:233:in `<top (required)>'
        from /home/yahonda/.rbenv/versions/ruby-dev/lib/ruby/gems/3.4.0+0/gems/webmock-3.19.1/lib/webmock.rb:52:in `require_relative'
        from /home/yahonda/.rbenv/versions/ruby-dev/lib/ruby/gems/3.4.0+0/gems/webmock-3.19.1/lib/webmock.rb:52:in `<top (required)>'
        from <internal:/home/yahonda/.rbenv/versions/ruby-dev/lib/ruby/3.4.0+0/rubygems/core_ext/kernel_require.rb>:37:in `require'
        from <internal:/home/yahonda/.rbenv/versions/ruby-dev/lib/ruby/3.4.0+0/rubygems/core_ext/kernel_require.rb>:37:in `require'
        from /home/yahonda/.rbenv/versions/ruby-dev/lib/ruby/3.4.0+0/bundled_gems.rb:74:in `block (2 levels) in replace_require'
        from /home/yahonda/.rbenv/versions/ruby-dev/lib/ruby/gems/3.4.0+0/gems/zeitwerk-2.6.12/lib/zeitwerk/kernel.rb:38:in `require'
        from /home/yahonda/.rbenv/versions/ruby-dev/lib/ruby/3.4.0+0/bundler/runtime.rb:60:in `block (2 levels) in require'
        from <internal:array>:52:in `each'
        from /home/yahonda/.rbenv/versions/ruby-dev/lib/ruby/3.4.0+0/bundler/runtime.rb:55:in `block in require'
        from <internal:array>:52:in `each'
        from /home/yahonda/.rbenv/versions/ruby-dev/lib/ruby/3.4.0+0/bundler/runtime.rb:44:in `require'
        from /home/yahonda/.rbenv/versions/ruby-dev/lib/ruby/3.4.0+0/bundler.rb:187:in `require'
        from /home/yahonda/src/github.com/rails/rails/actionmailbox/test/dummy/config/application.rb:7:in `<top (required)>'
        from /home/yahonda/src/github.com/rails/rails/actionmailbox/test/dummy/config/environment.rb:2:in `require_relative'
        from /home/yahonda/src/github.com/rails/rails/actionmailbox/test/dummy/config/environment.rb:2:in `<top (required)>'
        from /home/yahonda/src/github.com/rails/rails/actionmailbox/test/test_helper.rb:8:in `require_relative'
        from /home/yahonda/src/github.com/rails/rails/actionmailbox/test/test_helper.rb:8:in `<top (required)>'
        from /home/yahonda/.rbenv/versions/ruby-dev/lib/ruby/3.4.0+0/bundled_gems.rb:74:in `require'
        from /home/yahonda/.rbenv/versions/ruby-dev/lib/ruby/3.4.0+0/bundled_gems.rb:74:in `block (2 levels) in replace_require'
        from /home/yahonda/src/github.com/rails/rails/actionmailbox/test/controllers/ingresses/mailgun/inbound_emails_controller_test.rb:3:in `<top (required)>'
        from /home/yahonda/.rbenv/versions/ruby-dev/lib/ruby/3.4.0+0/bundled_gems.rb:74:in `require'
        from /home/yahonda/.rbenv/versions/ruby-dev/lib/ruby/3.4.0+0/bundled_gems.rb:74:in `block (2 levels) in replace_require'
        from /home/yahonda/.rbenv/versions/ruby-dev/lib/ruby/gems/3.4.0+0/gems/rake-13.1.0/lib/rake/rake_test_loader.rb:21:in `block in <main>'
        from /home/yahonda/.rbenv/versions/ruby-dev/lib/ruby/gems/3.4.0+0/gems/rake-13.1.0/lib/rake/rake_test_loader.rb:6:in `select'
        from /home/yahonda/.rbenv/versions/ruby-dev/lib/ruby/gems/3.4.0+0/gems/rake-13.1.0/lib/rake/rake_test_loader.rb:6:in `<main>'
rake aborted!
Command failed with status (1): [ruby -w -I"lib:test" /home/yahonda/.rbenv/versions/ruby-dev/lib/ruby/gems/3.4.0+0/gems/rake-13.1.0/lib/rake/rake_test_loader.rb "test/controllers/ingresses/mailgun/inbound_emails_controller_test.rb" "test/controllers/ingresses/mandrill/inbound_emails_controller_test.rb" "test/controllers/ingresses/postmark/inbound_emails_controller_test.rb" "test/controllers/ingresses/relay/inbound_emails_controller_test.rb" "test/controllers/ingresses/sendgrid/inbound_emails_controller_test.rb" "test/controllers/rails/action_mailbox/inbound_emails_controller_test.rb" "test/generators/mailbox_generator_test.rb" "test/jobs/incineration_job_test.rb" "test/migrations_test.rb" "test/models/table_name_test.rb" "test/unit/inbound_email/incineration_test.rb" "test/unit/inbound_email/message_id_test.rb" "test/unit/inbound_email_test.rb" "test/unit/mail_ext/address_equality_test.rb" "test/unit/mail_ext/address_wrapping_test.rb" "test/unit/mail_ext/addresses_test.rb" "test/unit/mailbox/bouncing_test.rb" "test/unit/mailbox/callbacks_test.rb" "test/unit/mailbox/notifications_test.rb" "test/unit/mailbox/routing_test.rb" "test/unit/mailbox/state_test.rb" "test/unit/relayer_test.rb" "test/unit/router_test.rb" "test/unit/test_helper_test.rb" ]
<internal:array>:52:in `each'
<internal:array>:52:in `each'
/home/yahonda/.rbenv/versions/ruby-dev/bin/bundle:25:in `load'
/home/yahonda/.rbenv/versions/ruby-dev/bin/bundle:25:in `<main>'
Tasks: TOP => test
(See full trace by running task with --trace)
$
```

### Additional information

`httpclient` gem that includes  https://github.com/nahi/httpclient/pull/455  has not been released to rubygems.org yet. In the meantime I want to make "Daily build with Ruby head" green. Once the newer versions of http client is released this commit can be reverted.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.

