### PR TITLE
Add `activesupport` bug report template

### DIFF
--- a/guides/bug_report_templates/active_support.rb
+++ b/guides/bug_report_templates/active_support.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "bundler/inline"
+
+gemfile(true) do
+  source "https://rubygems.org"
+
+  git_source(:github) { |repo| "https://github.com/#{repo}.git" }
+
+  gem "activesupport"
+  # If you want to test against edge Rails replace the previous line with this:
+  # gem "activesupport", github: "rails/rails", branch: "main"
+end
+
+require "active_support/core_ext/object/blank"
+require "minitest/autorun"
+
+class BugTest < Minitest::Test
+  def test_stuff
+    assert_predicate "zomg", :present?
+    refute_predicate "zomg", :blank?
+
+    refute_predicate "", :present?
+    assert_predicate "", :blank?
+  end
+end

--- a/guides/source/contributing_to_ruby_on_rails.md
+++ b/guides/source/contributing_to_ruby_on_rails.md
@@ -47,6 +47,7 @@ Having a way to reproduce your issue will help people confirm, investigate, and 
 * Template for Active Storage issues: [link](https://github.com/rails/rails/blob/main/guides/bug_report_templates/active_storage.rb)
 * Template for Action Mailer issues: [link](https://github.com/rails/rails/blob/main/guides/bug_report_templates/action_mailer.rb)
 * Template for Action Mailbox issues: [link](https://github.com/rails/rails/blob/main/guides/bug_report_templates/action_mailbox.rb)
+* Template for Active Support issues: [link](https://github.com/rails/rails/blob/main/guides/bug_report_templates/active_support.rb)
 * Generic template for other issues: [link](https://github.com/rails/rails/blob/main/guides/bug_report_templates/generic.rb)
 
 These templates include the boilerplate code to set up a test case. Copy the content of the appropriate template into a `.rb` file and make the necessary changes to demonstrate the issue. You can execute it by running `ruby the_file.rb` in your terminal. If all goes well, you should see your test case failing.


### PR DESCRIPTION
Introduce Active Support bug report templates for contributors to reproduce issues with a failing `Minitest::Test`.