### PR TITLE
More efficiently reset inspect implementation

### DIFF
--- a/activerecord/lib/active_record/normalization.rb
+++ b/activerecord/lib/active_record/normalization.rb
@@ -152,9 +152,7 @@ module ActiveRecord # :nodoc:
           [self.class, cast_type, normalizer, normalize_nil?].hash
         end
 
-        def inspect
-          Kernel.instance_method(:inspect).bind_call(self)
-        end
+        define_method(:inspect, Kernel.instance_method(:inspect))
 
         private
           def normalize(value)

--- a/activerecord/lib/active_record/type/serialized.rb
+++ b/activerecord/lib/active_record/type/serialized.rb
@@ -30,9 +30,7 @@ module ActiveRecord
         end
       end
 
-      def inspect
-        Kernel.instance_method(:inspect).bind_call(self)
-      end
+      define_method(:inspect, Kernel.instance_method(:inspect))
 
       def changed_in_place?(raw_old_value, value)
         return false if value.nil?


### PR DESCRIPTION
Not that `inspect` is anywhere close to be a hostspot, but just to not allow a less defficient pattern.

Instead of allocating an UnboundMethod and bind_call it, we can directly replace the method.
