### PR TITLE
Add negative_scopes option to ActiveRecord's enum method

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -288,4 +288,18 @@
 
     *Tristan Fellows*
 
+*   Add `negative_scopes` to the ActiveRecord::Enum.
+
+    To disable these auto-generated negative scopes in an enum, use the `negative_scopes: false` option as shown below:
+
+    ```ruby
+    class Post < ActiveRecord::Base
+      enum status: [:started, :not_started, :completed], negative_scopes: false
+    end
+    ```
+
+    With `negative_scopes: false`, Rails will not generate the typical negative scopes, thus avoiding conflicts.
+
+    *Jay Ang*
+
 Please check [7-1-stable](https://github.com/rails/rails/blob/7-1-stable/activerecord/CHANGELOG.md) for previous changes.

--- a/activerecord/test/cases/enum_test.rb
+++ b/activerecord/test/cases/enum_test.rb
@@ -89,6 +89,13 @@ class EnumTest < ActiveRecord::TestCase
     assert Book.not_proposed.include?(@book)
   end
 
+  test "find via explicit negative scope" do
+    book = Book.create!(explicit_negative_status: "not_started")
+
+    assert_equal 1, Book.not_started.count
+    assert_equal book, Book.not_started.first
+  end
+
   test "find via where with values" do
     published, written = Book.statuses[:published], Book.statuses[:written]
 
@@ -831,6 +838,15 @@ class EnumTest < ActiveRecord::TestCase
     assert_raises(NoMethodError) { klass.proposed }
   end
 
+  test "negative_scopes can be disabled by :_negative_scopes" do
+    klass = Class.new(ActiveRecord::Base) do
+      self.table_name = "books"
+      enum status: [:proposed, :written], _negative_scopes: false
+    end
+
+    assert_raises(NoMethodError) { klass.not_proposed }
+  end
+
   test "overloaded default by :default" do
     klass = Class.new(ActiveRecord::Base) do
       self.table_name = "books"
@@ -847,6 +863,15 @@ class EnumTest < ActiveRecord::TestCase
     end
 
     assert_raises(NoMethodError) { klass.proposed }
+  end
+
+  test "negative_scopes can be disabled by :negative_scopes" do
+    klass = Class.new(ActiveRecord::Base) do
+      self.table_name = "books"
+      enum :status, [:proposed, :written], negative_scopes: false
+    end
+
+    assert_raises(NoMethodError) { klass.not_proposed }
   end
 
   test "query state by predicate with :prefix" do
@@ -876,7 +901,7 @@ class EnumTest < ActiveRecord::TestCase
   test "option names can be used as label" do
     klass = Class.new(ActiveRecord::Base) do
       self.table_name = "books"
-      enum :status, default: 0, scopes: 1, prefix: 2, suffix: 3
+      enum :status, default: 0, scopes: 1, prefix: 2, suffix: 3, negative_scopes: 4
     end
 
     book = klass.new
@@ -884,6 +909,7 @@ class EnumTest < ActiveRecord::TestCase
     assert_not_predicate book, :scopes?
     assert_not_predicate book, :prefix?
     assert_not_predicate book, :suffix?
+    assert_not_predicate book, :negative_scopes?
   end
 
   test "scopes are named like methods" do
@@ -1047,6 +1073,26 @@ class EnumTest < ActiveRecord::TestCase
       end
       silence_warnings do
         enum status: [:not_sent, :sent], _scopes: false
+      end
+    end
+
+    assert_empty(logger.logged(:warn))
+  ensure
+    ActiveRecord::Base.logger = old_logger
+  end
+
+  test "enum doesn't log a warning if opting out of negative_scopes" do
+    old_logger = ActiveRecord::Base.logger
+    logger = ActiveSupport::LogSubscriber::TestHelper::MockLogger.new
+
+    ActiveRecord::Base.logger = logger
+
+    Class.new(ActiveRecord::Base) do
+      def self.name
+        "Book"
+      end
+      silence_warnings do
+        enum status: [:not_sent, :sent], _negative_scopes: false
       end
     end
 

--- a/activerecord/test/models/book.rb
+++ b/activerecord/test/models/book.rb
@@ -24,6 +24,7 @@ class Book < ActiveRecord::Base
   enum difficulty: [:easy, :medium, :hard], _suffix: :to_read
   enum cover: { hard: "hard", soft: "soft" }
   enum boolean_status: { enabled: true, disabled: false }
+  enum explicit_negative_status: [:unassigned, :not_started, :started, :completed], _negative_scopes: false
 
   def published!
     super

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -138,6 +138,7 @@ ActiveRecord::Schema.define do
     t.column :font_size, :integer, **default_zero
     t.column :difficulty, :integer, **default_zero
     t.column :cover, :string, default: "hard"
+    t.column :explicit_negative_status, :integer, **default_zero
     t.string :isbn
     t.string :external_id
     t.column :original_name, :string


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

In certain situation, we might need to store and query `negative` values. Having the option to bypass the auto-generated negative scopes can avoid the conflicts.

### Detail

Add `negative_scopes` option to `ActiveRecord::Enum#enum`, this offers the flexibility to optionally skip the creation of negative scopes.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
