### PR TITLE
Support encrypting binary columns

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Add support for encrypting binary columns
+
+    Ensure encryption and decryption pass `Type::Binary::Data` around for binary data.
+
+    Previously encrypting binary columns with the `ActiveRecord::Encryption::MessageSerializer`
+    incidentally worked for MySQL and SQLite, but not PostgreSQL.
+
+    *Donal McBreen*
+
 *   Deprecated `ENV["SCHEMA_CACHE"]` in favor of `schema_cache_path` in the database configuration.
 
     *Rafael Mendonça França*

--- a/activerecord/lib/active_record/encryption/encrypted_attribute_type.rb
+++ b/activerecord/lib/active_record/encryption/encrypted_attribute_type.rb
@@ -81,17 +81,15 @@ module ActiveRecord
           @previous_type
         end
 
-        def decrypt(value)
+        def decrypt_as_text(value)
           with_context do
             unless value.nil?
               if @default && @default == value
-                decrypted_value = value
+                value
               else
-                decrypted_value = encryptor.decrypt(value, **decryption_options)
+                encryptor.decrypt(value, **decryption_options)
               end
             end
-
-            reserialize(decrypted_value)
           end
         rescue ActiveRecord::Encryption::Errors::Base => error
           if previous_types_without_clean_text.blank?
@@ -99,6 +97,10 @@ module ActiveRecord
           else
             try_to_deserialize_with_previous_encrypted_types(value)
           end
+        end
+
+        def decrypt(value)
+          reserialize decrypt_as_text(value)
         end
 
         def try_to_deserialize_with_previous_encrypted_types(value)
@@ -131,10 +133,14 @@ module ActiveRecord
           encrypt(casted_value.to_s) unless casted_value.nil?
         end
 
-        def encrypt(value)
+        def encrypt_as_text(value)
           with_context do
-            reserialize(encryptor.encrypt(value, **encryption_options))
+            encryptor.encrypt(value, **encryption_options)
           end
+        end
+
+        def encrypt(value)
+          reserialize encrypt_as_text(value)
         end
 
         def encryptor

--- a/activerecord/lib/active_record/encryption/encrypted_attribute_type.rb
+++ b/activerecord/lib/active_record/encryption/encrypted_attribute_type.rb
@@ -100,7 +100,7 @@ module ActiveRecord
         end
 
         def decrypt(value)
-          reserialize decrypt_as_text(value)
+          text_to_database_type decrypt_as_text(value)
         end
 
         def try_to_deserialize_with_previous_encrypted_types(value)
@@ -140,7 +140,7 @@ module ActiveRecord
         end
 
         def encrypt(value)
-          reserialize encrypt_as_text(value)
+          text_to_database_type encrypt_as_text(value)
         end
 
         def encryptor
@@ -159,9 +159,9 @@ module ActiveRecord
           @clean_text_scheme ||= ActiveRecord::Encryption::Scheme.new(downcase: downcase?, encryptor: ActiveRecord::Encryption::NullEncryptor.new)
         end
 
-        def reserialize(value)
-          if cast_type.binary?
-            cast_type.serialize(value)
+        def text_to_database_type(value)
+          if value && cast_type.binary?
+            ActiveModel::Type::Binary::Data.new(value)
           else
             value
           end

--- a/activerecord/test/cases/encryption/encryptable_record_test.rb
+++ b/activerecord/test/cases/encryption/encryptable_record_test.rb
@@ -397,6 +397,8 @@ class ActiveRecord::Encryption::EncryptableRecordTest < ActiveRecord::Encryption
   test "binary data can be encrypted" do
     all_bytes = (0..255).map(&:chr).join
     assert_equal all_bytes, EncryptedBookWithBinary.create!(logo: all_bytes).logo
+    assert_nil EncryptedBookWithBinary.create!(logo: nil).logo
+    assert_equal "", EncryptedBookWithBinary.create!(logo: "").logo
   end
 
   test "binary data can be encrypted uncompressed" do
@@ -404,6 +406,11 @@ class ActiveRecord::Encryption::EncryptableRecordTest < ActiveRecord::Encryption
     high_bytes = (128..255).map(&:chr).join
     assert_equal low_bytes, EncryptedBookWithBinary.create!(logo: low_bytes).logo
     assert_equal high_bytes, EncryptedBookWithBinary.create!(logo: high_bytes).logo
+  end
+
+  test "serialized binary data can be encrypted" do
+    json_bytes = (32..127).map(&:chr)
+    assert_equal json_bytes, EncryptedBookWithSerializedBinary.create!(logo: json_bytes).logo
   end
 
   private

--- a/activerecord/test/cases/encryption/encryptable_record_test.rb
+++ b/activerecord/test/cases/encryption/encryptable_record_test.rb
@@ -394,6 +394,18 @@ class ActiveRecord::Encryption::EncryptableRecordTest < ActiveRecord::Encryption
     assert_predicate OtherEncryptedPost.type_for_attribute(:title).scheme.previous_schemes, :one?
   end
 
+  test "binary data can be encrypted" do
+    all_bytes = (0..255).map(&:chr).join
+    assert_equal all_bytes, EncryptedBookWithBinary.create!(logo: all_bytes).logo
+  end
+
+  test "binary data can be encrypted uncompressed" do
+    low_bytes = (0..127).map(&:chr).join
+    high_bytes = (128..255).map(&:chr).join
+    assert_equal low_bytes, EncryptedBookWithBinary.create!(logo: low_bytes).logo
+    assert_equal high_bytes, EncryptedBookWithBinary.create!(logo: high_bytes).logo
+  end
+
   private
     def build_derived_key_provider_with(hash_digest_class)
       ActiveRecord::Encryption.with_encryption_context(key_generator: ActiveRecord::Encryption::KeyGenerator.new(hash_digest_class: hash_digest_class)) do

--- a/activerecord/test/models/book_encrypted.rb
+++ b/activerecord/test/models/book_encrypted.rb
@@ -43,3 +43,9 @@ class EncryptedBookWithUnencryptedDataOptedIn < ActiveRecord::Base
   validates :name, uniqueness: true
   encrypts :name, deterministic: true, support_unencrypted_data: true
 end
+
+class EncryptedBookWithBinary < ActiveRecord::Base
+  self.table_name = "encrypted_books"
+
+  encrypts :logo
+end

--- a/activerecord/test/models/book_encrypted.rb
+++ b/activerecord/test/models/book_encrypted.rb
@@ -49,3 +49,10 @@ class EncryptedBookWithBinary < ActiveRecord::Base
 
   encrypts :logo
 end
+
+class EncryptedBookWithSerializedBinary < ActiveRecord::Base
+  self.table_name = "encrypted_books"
+
+  serialize :logo, coder: JSON
+  encrypts :logo
+end

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -163,6 +163,7 @@ ActiveRecord::Schema.define do
     t.string :format
     t.column :name, :string, default: "<untitled>"
     t.column :original_name, :string
+    t.column :logo, :binary
 
     t.datetime :created_at
     t.datetime :updated_at


### PR DESCRIPTION

### Motivation / Background

ActiveRecord Encryption doesn't prevent you from encrypting binary columns but it doesn't have proper support for it either.

When the data is fed through encrypt/decrypt it is converted to a String. This means that the the encryption layer is not transparent to binary data - which should be passed as Type::Binary::Data.

As a result the data is not properly escaped in the SQL queries or deserialized correctly after decryption.

However it just happens to work fine for MySQL and SQLite because the MessageSerializer doesn't use any characters that need to be encoded. However if you try to use a custom serializer that does then it breaks.

PostgreSQL on the other hand does not work - because the Bytea type is passed a String rather than a Type::Binary::Data to deserialize, it attempts to unescape the data and either mangles it or raises an error if it contains null bytes.

### Detail

The commit fixes the issue, by reserializing the data after encryption and decryption. For text data that's a no-op, but for binary data we'll convert it back to a Type::Binary::Data.
