### PR TITLE
Require 'uri' explicitly to address `NameError: uninitialized constant ToQueryTest::URI`

### DIFF
--- a/activesupport/test/core_ext/object/to_query_test.rb
+++ b/activesupport/test/core_ext/object/to_query_test.rb
@@ -3,6 +3,7 @@
 require_relative "../../abstract_unit"
 require "active_support/core_ext/object/to_query"
 require "active_support/core_ext/string/output_safety"
+require "uri"
 
 class ToQueryTest < ActiveSupport::TestCase
   def test_simple_conversion


### PR DESCRIPTION
### Motivation / Background

This commit addresses CI failure at https://buildkite.com/rails/rails-nightly/builds/108#018d57ac-4f2a-45f1-86b9-9015a7b0a463/1165-2002


### Detail

This commit addresses the following `NameError: uninitialized constant ToQueryTest::URI`.

```ruby
$ ruby -v
ruby 3.4.0dev (2024-01-30T10:19:23Z master 86547fd69d) [x86_64-linux]
$ rm Gemfile.lock
$ bundle install
$ cd activesupport
$ bin/test test/core_ext/object/to_query_test.rb -n test_hash_not_sorted_lexicographically_for_nested_structure
... snip ...

E

Error:
ToQueryTest#test_hash_not_sorted_lexicographically_for_nested_structure:
NameError: uninitialized constant ToQueryTest::URI
    test/core_ext/object/to_query_test.rb:90:in `test_hash_not_sorted_lexicographically_for_nested_structure'

bin/test test/core_ext/object/to_query_test.rb:79

Finished in 0.000385s, 2597.3082 runs/s, 0.0000 assertions/s.
1 runs, 0 assertions, 0 failures, 1 errors, 0 skips
$
```

### Additional information

This behavior has been introduced since Ruby 3.4.0dev vendors URI from top level to `Gem::URI` via https://github.com/ruby/ruby/commit/d64d0b54231208c7bec899a7fe8c3b98ec2e9a1b . Here is the original one that explains some reason why https://github.com/rubygems/rubygems/pull/7386

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
