### PR TITLE
BacktraceCleaner silence core internal methods by default

### DIFF
--- a/activesupport/lib/active_support/backtrace_cleaner.rb
+++ b/activesupport/lib/active_support/backtrace_cleaner.rb
@@ -34,6 +34,7 @@ module ActiveSupport
   class BacktraceCleaner
     def initialize
       @filters, @silencers = [], []
+      add_core_silencer
       add_gem_filter
       add_gem_silencer
       add_stdlib_silencer
@@ -116,6 +117,10 @@ module ActiveSupport
         gems_regexp = %r{\A(#{gems_paths.join('|')})/(bundler/)?gems/([^/]+)-([\w.]+)/(.*)}
         gems_result = '\3 (\4) \5'
         add_filter { |line| line.sub(gems_regexp, gems_result) }
+      end
+
+      def add_core_silencer
+        add_silencer { |line| line.include?("<internal:") }
       end
 
       def add_gem_silencer


### PR DESCRIPTION
Ref: https://bugs.ruby-lang.org/issues/20227

In recent Ruby versions some pure C functions have been moved into some semi-ruby code and now have an `<internal:something>` location.

They should be silenced like stdlib etc.

cc @yahonda 