### PR TITLE
Add `::` to namespace the module we delegate "to"

### DIFF
--- a/activesupport/lib/active_support/delegation.rb
+++ b/activesupport/lib/active_support/delegation.rb
@@ -39,7 +39,19 @@ module ActiveSupport
         location ||= caller_locations(1, 1).first
         file, line = location.path, location.lineno
 
-        receiver = to.to_s
+        receiver = if to.is_a?(Module)
+          if to.name.nil?
+            raise ArgumentError, "Can't delegate to anonymous class or module: #{to}"
+          end
+
+          unless Inflector.safe_constantize(to.name).equal?(to)
+            raise ArgumentError, "Can't delegate to detached class or module: #{to.name}"
+          end
+
+          "::#{to.name}"
+        else
+          to.to_s
+        end
         receiver = "self.#{receiver}" if RESERVED_METHOD_NAMES.include?(receiver)
 
         explicit_receiver = false

--- a/activesupport/test/core_ext/module_test.rb
+++ b/activesupport/test/core_ext/module_test.rb
@@ -586,6 +586,33 @@ class ModuleTest < ActiveSupport::TestCase
       location.delegate(:street, :city, to: :@place, prefix: :the, private: true)
   end
 
+  def test_module_nesting_is_empty
+    # Ensure constant resolution is done from top level namespace and not ActiveSupport
+    require "json"
+    c = Class.new do
+      singleton_class.delegate :parse, to: ::JSON
+    end
+    assert_equal [1], c.parse("[1]")
+  end
+
+  def test_delegation_unreacheable_module
+    anonymous_class = Class.new
+    error = assert_raises ArgumentError do
+      Class.new do
+        delegate :something, to: anonymous_class
+      end
+    end
+    assert_includes error.message, "Can't delegate to anonymous class or module"
+
+    anonymous_class.singleton_class.define_method(:name) { "FakeName" }
+    error = assert_raises ArgumentError do
+      Class.new do
+        delegate :something, to: anonymous_class
+      end
+    end
+    assert_includes error.message, "Can't delegate to detached class or module: FakeName"
+  end
+
   def test_delegation_arity_to_module
     c = Class.new do
       delegate :zero, :one, :two, to: ArityTester


### PR DESCRIPTION
## What are you trying to accomplish?
We should add `::` to namespace the module we delegate to when the caller is a module. Without the `::`, Ruby will perform relative name resolution which can lead to unexpected behaviour if there are nested constants with the same name.

@gmcgibbon helped create a code snippet that demonstrates the problem:

<details><summary>Current (bugged) behaviour `B.a` </summary>

```ruby
module A
  module Delegation
    def self.call(owner)
      owner.module_eval("def a; B.a; end", __FILE__, __LINE__)
    end
  end

  module B
    def self.a
      raise "Don't call this."
    end
  end
end

module B
  def self.a
    raise "This should be called."
  end
end

class C
  A::Delegation.(self)
end

C.new.a
```

```
> C.new.a
(irb):10:in `a': Don't call this. (RuntimeError)
```

</details> 

<details><summary>With this change `::B.a` </summary>

```ruby
module A
  module Delegation
    def self.call(owner)
      owner.module_eval("def a; ::B.a; end", __FILE__, __LINE__)
    end
  end

  module B
    def self.a
      raise "Don't call this."
    end
  end
end

module B
  def self.a
    raise "This should be called."
  end
end

class C
  A::Delegation.(self)
end

C.new.a
```

```
C.new.a
(irb):17:in `a': This should be called. (RuntimeError)
```

</details> 
