### PR TITLE
Fix VideoAnalyzerTest#test_analyzing_a_rotated_HDR_video failure with ffmpeg < 5.0

### DIFF
--- a/activestorage/test/analyzer/video_analyzer_test.rb
+++ b/activestorage/test/analyzer/video_analyzer_test.rb
@@ -35,7 +35,7 @@ class ActiveStorage::Analyzer::VideoAnalyzerTest < ActiveSupport::TestCase
 
     assert_equal 1080.0, metadata[:width]
     assert_equal 1920.0, metadata[:height]
-    assert_equal(-90, metadata[:angle])
+    assert_includes [90, -90], metadata[:angle]
   end
 
   test "analyzing a video with rectangular samples" do


### PR DESCRIPTION
### Background

Fixes https://github.com/rails/rails/issues/50924

### Detail

Big thanks to @yahonda for explaining the anomaly with `ffprobe` `v4.2.2` versus `v6.0.6`. This change ensures the test works with both versions, similar to how we handle it in `test_analyzing_a_rotated_video`.