### PR TITLE
Refactor QueryCache to be owned by the pool

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -113,7 +113,7 @@ module ActiveRecord
     #   are now explicitly documented
     class ConnectionPool
       include MonitorMixin
-      include QueryCache::ConnectionPoolConfiguration
+      prepend QueryCache::ConnectionPoolConfiguration
       include ConnectionAdapters::AbstractPool
 
       attr_accessor :automatic_reconnect, :checkout_timeout

--- a/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb
@@ -134,8 +134,15 @@ module ActiveRecord
         end
 
         private
+          def prune_thread_cache
+            dead_threads = @thread_query_caches.keys.reject(&:alive?)
+            dead_threads.each do |dead_thread|
+              @thread_query_caches.delete(dead_thread)
+            end
+          end
+
           def query_cache
-            @thread_query_caches.compute_if_absent(connection_cache_key(ActiveSupport::IsolatedExecutionState.context)) do
+            @thread_query_caches.compute_if_absent(ActiveSupport::IsolatedExecutionState.context) do
               Store.new(@query_cache_max_size)
             end
           end

--- a/activerecord/lib/active_record/query_cache.rb
+++ b/activerecord/lib/active_record/query_cache.rb
@@ -8,7 +8,7 @@ module ActiveRecord
       # If it's not, it will execute the given block.
       def cache(&block)
         if connected? || !configurations.empty?
-          connection.cache(&block)
+          connection_pool.enable_query_cache(&block)
         else
           yield
         end
@@ -18,7 +18,7 @@ module ActiveRecord
       # If it's not, it will execute the given block.
       def uncached(&block)
         if connected? || !configurations.empty?
-          connection.uncached(&block)
+          connection_pool.disable_query_cache(&block)
         else
           yield
         end
@@ -26,11 +26,11 @@ module ActiveRecord
     end
 
     def self.run
-      ActiveRecord::Base.connection_handler.each_connection_pool.reject { |p| p.query_cache_enabled }.each { |p| p.enable_query_cache! }
+      ActiveRecord::Base.connection_handler.each_connection_pool.reject(&:query_cache_enabled).each(&:enable_query_cache!)
     end
 
     def self.complete(pools)
-      pools.each { |pool| pool.disable_query_cache! }
+      pools.each(&:disable_query_cache!)
 
       ActiveRecord::Base.connection_handler.each_connection_pool do |pool|
         pool.release_connection if pool.active_connection? && !pool.connection.transaction_open?

--- a/activerecord/test/cases/query_cache_test.rb
+++ b/activerecord/test/cases/query_cache_test.rb
@@ -808,7 +808,7 @@ class QueryCacheExpiryTest < ActiveRecord::TestCase
   end
 
   def test_find
-    assert_called(Task.connection.query_cache, :clear) do
+    assert_called(Task.connection.query_cache, :clear, times: 2) do
       assert_not Task.connection.query_cache_enabled
       Task.cache do
         assert Task.connection.query_cache_enabled
@@ -922,9 +922,12 @@ class QueryCacheExpiryTest < ActiveRecord::TestCase
   end
 
   def test_query_cache_lru_eviction
+    store = ActiveRecord::ConnectionAdapters::QueryCache::Store.new(2)
+    store.enabled = true
+
     connection = Post.connection
-    connection.pool.db_config.stub(:query_cache, 2) do
-      connection.send(:configure_query_cache!)
+    old_store, connection.query_cache = connection.query_cache, store
+    begin
       Post.cache do
         assert_queries_count(2) do
           connection.select_all("SELECT 1")
@@ -945,9 +948,9 @@ class QueryCacheExpiryTest < ActiveRecord::TestCase
           connection.select_all("SELECT 2")
         end
       end
+    ensure
+      connection.query_cache = old_store
     end
-  ensure
-    connection.send(:configure_query_cache!)
   end
 
   test "threads use the same connection" do


### PR DESCRIPTION
Ref: https://github.com/rails/rails/pull/50793

If we want to stop caching the checked out connections, then we must persist the cache in the pool, and assign it to the connection when it's checked out.

The pool become responsible for managing the cache lifecycle.

This also open the door to sharing the cache between multiple connections, which is valuable for read replicas, etc.

This change only really make sense if we go through with no longer caching checked out connections. Otherwise it's just extra complexity.
