### PR TITLE
Use ActiveSupport::TestCase for Tracker tests

### DIFF
--- a/actionview/test/template/dependency_tracker_test.rb
+++ b/actionview/test/template/dependency_tracker_test.rb
@@ -225,7 +225,7 @@ module SharedTrackerTests
   end
 end
 
-class ERBTrackerTest < Minitest::Test
+class ERBTrackerTest < ActiveSupport::TestCase
   include SharedTrackerTests
 
   def make_tracker(name, template)
@@ -266,7 +266,7 @@ module RubyTrackerTests
   end
 end
 
-class RipperRubyTrackerTest < Minitest::Test
+class RipperRubyTrackerTest < ActiveSupport::TestCase
   include SharedTrackerTests
   include RubyTrackerTests
 
@@ -275,7 +275,7 @@ class RipperRubyTrackerTest < Minitest::Test
   end
 end
 
-class PrismRubyTrackerTest < Minitest::Test
+class PrismRubyTrackerTest < ActiveSupport::TestCase
   include SharedTrackerTests
   include RubyTrackerTests
 


### PR DESCRIPTION
Minitest::Test does not support all of the same options as ActiveSupport::TestCase, such as running bin/test <filename>:<lineno> and -n /regex/. Trying to use these options on this file would just run all of the Minitest::Tests no matter what options were passed.

This commit fixes the ability to use those options by using ActiveSupport::TestCase (like every other test in the repo).

Before:

```
$ bin/test test/template/dependency_tracker_test.rb:217
Running 59 tests in parallel using 8 processes
Run options: --seed 42725

.........................................................

Finished in 0.322759s, 176.6024 runs/s, 176.6024 assertions/s.
57 runs, 57 assertions, 0 failures, 0 errors, 0 skips
```

After:

```
$ bin/test test/template/dependency_tracker_test.rb:217
Running 59 tests in parallel using 8 processes
Run options: --seed 15213

...

Finished in 0.359162s, 8.3528 runs/s, 8.3528 assertions/s.
3 runs, 3 assertions, 0 failures, 0 errors, 0 skips
```
