### PR TITLE
Retry `ActionableError`s when running tests

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,32 @@
+*   Allow Actionable Errors encountered when running tests to be retried.
+
+    ```txt
+    Migrations are pending. To resolve this issue, run:
+
+            bin/rails db:migrate
+
+    You have 1 pending migration:
+
+    db/migrate/20240201213806_add_a_to_b.rb
+    Run pending migrations? [Yn] Y
+    == 20240201213806 AddAToB: migrating =========================================
+    == 20240201213806 AddAToB: migrated (0.0000s) ================================
+
+    Running 7 tests in a single process (parallelization threshold is 50)
+    Run options: --seed 22200
+
+    # Running:
+
+    .......
+
+    Finished in 0.243394s, 28.7600 runs/s, 45.1942 assertions/s.
+    7 runs, 11 assertions, 0 failures, 0 errors, 0 skips
+    ```
+
+    This feature will only be present on interactive terminals.
+
+    *Andrew Novoselac & Gannon McGibbon*
+
 *   Skip generating a `test` job in ci.yml when a new application is generated with the
     `--skip-test` option.
 

--- a/railties/lib/rails/commands/test/test_command.rb
+++ b/railties/lib/rails/commands/test/test_command.rb
@@ -30,7 +30,9 @@ module Rails
 
         Rails::TestUnit::Runner.parse_options(args)
         run_prepare_task if self.args.none?(EXACT_TEST_ARGUMENT_PATTERN)
-        Rails::TestUnit::Runner.run(args)
+        with_actionable_errors_retried do
+          Rails::TestUnit::Runner.run(args)
+        end
       rescue Rails::TestUnit::InvalidTestError => error
         say error.message
       end

--- a/railties/lib/rails/testing/maintain_test_schema.rb
+++ b/railties/lib/rails/testing/maintain_test_schema.rb
@@ -1,12 +1,8 @@
 # frozen_string_literal: true
 
 if defined?(ActiveRecord::Base)
-  begin
-    ActiveRecord::Migration.maintain_test_schema!
-  rescue ActiveRecord::PendingMigrationError => e
-    puts e.to_s.strip
-    exit 1
-  end
+
+  ActiveRecord::Migration.maintain_test_schema!
 
   if Rails.configuration.eager_load
     ActiveRecord::Base.descendants.each do |model|

--- a/railties/test/application/test_test.rb
+++ b/railties/test/application/test_test.rb
@@ -345,6 +345,45 @@ Expected: ["id", "name"]
       assert_unsuccessful_run "models/user_test.rb", "SCHEMA LOADED!"
     end
 
+    def test_actionable_command_line_error_with_tty
+      rails "generate", "scaffold", "user", "name:string"
+      app_file "config/initializers/thor_yes.rb", <<-RUBY
+        Rails::Command::Base.class_eval <<-INITIALIZER
+          def yes?(statement, color = nil)
+            raise ArgumentError unless statement == "Run pending migrations? [Yn]"
+            true
+          end
+
+          def tty?
+            true
+          end
+        INITIALIZER
+      RUBY
+
+      run_test_file("models/user_test.rb").tap do |output|
+        assert_match "Migrations are pending. To resolve this issue, run:", output
+        assert_match "CreateUsers: migrating", output
+        assert_match "0 runs, 0 assertions, 0 failures, 0 errors, 0 skips", output
+      end
+    end
+
+    def test_actionable_command_line_without_tty
+      rails "generate", "scaffold", "user", "name:string"
+      app_file "config/initializers/thor_yes.rb", <<-RUBY
+        Rails::Command::Base.class_eval <<-INITIALIZER
+          def tty?
+            false
+          end
+        INITIALIZER
+      RUBY
+
+      run_test_file("models/user_test.rb").tap do |output|
+        assert_match "Migrations are pending. To resolve this issue, run:", output
+        assert_no_match "CreateUsers: migrating", output
+        assert_no_match "0 runs, 0 assertions, 0 failures, 0 errors, 0 skips", output
+      end
+    end
+
     private
       def assert_unsuccessful_run(name, message)
         result = run_test_file(name)


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because I want to make it easier to retry actionable errors that occur when running tests. Rails already knows how to recover these errors, so lets make it possible for the user to recover from them and run their tests without exiting the process.

### Detail

Allow Actionable Errors encountered when running tests to be retried. 

    
    Migrations are pending. To resolve this issue, run:
    
            bin/rails db:migrate
    
    You have 1 pending migration:
    
    db/migrate/20240201213806_add_a_to_b.rb
    Run pending migrations? [Yn] Y
    == 20240201213806 AddAToB: migrating =========================================
    == 20240201213806 AddAToB: migrated (0.0000s) ================================
    
    Running 7 tests in a single process (parallelization threshold is 50)
    Run options: --seed 22200
    
    # Running:
    
    .......
    
    Finished in 0.243394s, 28.7600 runs/s, 45.1942 assertions/s.
    7 runs, 11 assertions, 0 failures, 0 errors, 0 skips
    
This feature is only available in an interactive terminal.

### Additional information

Right now this is only implemented in the Test Runner, but I'd also like to follow up with a similar implementation for `Rails::Command::CorrectableNameError`s.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
