### PR TITLE
Setup jemalloc in default Dockerfile to optimize memory allocation

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Setup jemalloc in the default Dockerfile for memory optimization.
+
+    *Matt Almeida*, *Jean Boussier*
+
 *   Commented out lines in .railsrc file should not be treated as arguments when using
     rails new generator command. Update ARGVScrubber to ignore text after # symbols.
 

--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -595,6 +595,9 @@ module Rails
         # ActiveStorage preview support
         packages << "libvips" unless skip_active_storage?
 
+        # jemalloc for memory optimization
+        packages << "libjemalloc2"
+
         packages.compact.sort
       end
 

--- a/railties/lib/rails/generators/rails/app/templates/docker-entrypoint.tt
+++ b/railties/lib/rails/generators/rails/app/templates/docker-entrypoint.tt
@@ -1,5 +1,10 @@
 #!/bin/bash -e
 
+# Enable jemalloc for reduced memory usage and reduce latency.
+if [ -f /usr/lib/*/libjemalloc.so.2 ]; then
+  LD_PRELOAD="$(echo /usr/lib/*/libjemalloc.so.2) $LD_PRELOAD"
+fi
+
 <% unless skip_active_record? -%>
 # If running the rails server then create or migrate existing database
 if [ "${1}" == "./bin/rails" ] && [ "${2}" == "server" ]; then


### PR DESCRIPTION
[Ruby's use of `malloc` can create memory fragmentation problems, especially when using multiple threads](https://www.speedshop.co/2017/12/04/malloc-doubles-ruby-memory.html) like Puma does. Switching to an allocator that uses different patterns to avoid fragmentation can decrease memory usage by a substantial margin.