### PR TITLE
Introduce today_or_future? method

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Introduce `today_or_future?` method to both `ActiveSupport::TimeWithZone` &
+    `DateAndTime::Calculations`
+
+    *Olivier Simart*
+
 *   Include `IPAddr#prefix` when serializing an `IPAddr` using the
     `ActiveSupport::MessagePack` serializer. This change is backward and forward
     compatible — old payloads can still be read, and new payloads will be

--- a/activesupport/lib/active_support/core_ext/date_and_time/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/date_and_time/calculations.rb
@@ -53,6 +53,11 @@ module DateAndTime
       self > self.class.current
     end
 
+    # Returns true if the date/time is today or in the future.
+    def today_or_future?
+      to_date == ::Date.current || self > self.class.current
+    end
+
     # Returns true if the date/time falls on a Saturday or Sunday.
     def on_weekend?
       WEEKEND_DAYS.include?(wday)

--- a/activesupport/lib/active_support/time_with_zone.rb
+++ b/activesupport/lib/active_support/time_with_zone.rb
@@ -271,6 +271,12 @@ module ActiveSupport
       utc.future?
     end
 
+    # Returns true if the current object's time falls within
+    # the current day or is in the future.
+    def today_or_future?
+      time.today? || time.future?
+    end
+
     # Returns +true+ if +other+ is equal to current object.
     def eql?(other)
       other.eql?(utc)


### PR DESCRIPTION
### Motivation / Background

This Pull Request introduces a convenient helper to check if a date/time is either today or in the future.

Drawing inspiration from https://github.com/rails/rails/pull/46786 which introduces `.local?` helper for environment check.

### Detail

This Pull Request changes:
- `ActiveSupport::TimeWithZone`
-  `DateAndTime::Calculations`

### Additional information

<!-- Provide additional information such as benchmarks, reference to other repositories or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
