### PR TITLE
Fix error raised when running `db:schema:load:#{name}` and test DB config is missing

### DIFF
--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -584,7 +584,7 @@ db_namespace = namespace :db do
         task name => %w(load_config check_protected_environments) do
           ActiveRecord::Tasks::DatabaseTasks.with_temporary_connection_for_each(env: "test", name: name) do |conn|
             db_config = conn.pool.db_config
-            ActiveRecord::Tasks::DatabaseTasks.purge(db_config)
+            ActiveRecord::Tasks::DatabaseTasks.purge(db_config) if db_config
           end
         end
       end

--- a/activerecord/lib/active_record/tasks/database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/database_tasks.rb
@@ -500,6 +500,7 @@ module ActiveRecord
       def with_temporary_connection_for_each(env: ActiveRecord::Tasks::DatabaseTasks.env, name: nil, clobber: false, &block) # :nodoc:
         if name
           db_config = ActiveRecord::Base.configurations.configs_for(env_name: env, name: name)
+          return unless db_config
           with_temporary_connection(db_config, clobber: clobber, &block)
         else
           ActiveRecord::Base.configurations.configs_for(env_name: env, name: name).each do |db_config|

--- a/railties/test/application/rake/dbs_test.rb
+++ b/railties/test/application/rake/dbs_test.rb
@@ -559,6 +559,23 @@ module ApplicationTests
         assert_equal 2, Admin::Book.count
       end
 
+      test "db:schema:load does not raise when test DB config is missing" do
+        app_file "config/database.yml", <<-YAML
+          development:
+            one:
+              adapter: sqlite3
+              database: storage/development_one.sqlite3
+            two:
+              adapter: sqlite3
+              database: storage/development_two.sqlite3
+        YAML
+
+        rails "db:create", "db:migrate"
+        rails "db:schema:load:one"
+      ensure
+        rails "db:drop" rescue nil
+      end
+
       test "db:schema:load does not purge the existing database" do
         rails "runner", "ActiveRecord::Base.connection.create_table(:posts) {|t| t.string :title }"
 


### PR DESCRIPTION
### Motivation / Background

Fixes #50672

### Detail

The task `db:schema:load:#{name}` depends on `db:test:purge:#{name}` since adb64db which requires the DB config to be present, otherwise an error is raised.

```
$ bin/rails db:schema:load:one --trace
** Invoke db:schema:load:one (first_time)
** Invoke db:test:purge:one (first_time)
** Invoke db:load_config (first_time)
** Invoke environment (first_time)
** Execute environment
** Execute db:load_config
** Invoke db:check_protected_environments (first_time) ** Invoke db:load_config
** Execute db:check_protected_environments
** Execute db:test:purge:one
** Execute db:schema:load:one
```

This commit fixes the problem by returning early when the DB config is indeed missing.

### Additional information

The task `db:schema:load` may need to be updated to depend on `db:test:purge` too, to keep it consistent with `db:schema:load:#{name}`.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
