### PR TITLE
Add class name to enum validation exception message

### DIFF
--- a/activerecord/lib/active_record/enum.rb
+++ b/activerecord/lib/active_record/enum.rb
@@ -249,7 +249,7 @@ module ActiveRecord
 
         decorate_attributes([name]) do |_name, subtype|
           if subtype == ActiveModel::Type.default_value
-            raise "Undeclared attribute type for enum '#{name}'. Enums must be" \
+            raise "Undeclared attribute type for enum '#{name}' in #{self.name}. Enums must be" \
               " backed by a database column or declared with an explicit type" \
               " via `attribute`."
           end

--- a/activerecord/test/cases/enum_test.rb
+++ b/activerecord/test/cases/enum_test.rb
@@ -1057,13 +1057,14 @@ class EnumTest < ActiveRecord::TestCase
 
   test "raises for attributes with undeclared type" do
     klass = Class.new(Book) do
+      def self.name; "Book"; end
       enum typeless_genre: [:adventure, :comic]
     end
 
     error = assert_raises(RuntimeError) do
       klass.type_for_attribute(:typeless_genre)
     end
-    assert_match "Undeclared attribute type for enum 'typeless_genre'", error.message
+    assert_match "Undeclared attribute type for enum 'typeless_genre' in Book", error.message
   end
 
   test "supports attributes declared with a explicit type" do


### PR DESCRIPTION
### Motivation / Background

In general validation errors should include more information on where it has happened.

### Detail

This PR updates `activerecord/lib/active_record/enum.rb` validation exception message and just adds class name.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
