### PR TITLE
Tiny update to callbacks docs [ci skip]

### DIFF
--- a/actionpack/lib/abstract_controller/callbacks.rb
+++ b/actionpack/lib/abstract_controller/callbacks.rb
@@ -18,9 +18,6 @@ module AbstractController
   # * <tt>skip_after_action</tt>
   # * <tt>skip_around_action</tt>
   # * <tt>skip_before_action</tt>
-  #
-  # NOTE: Calling the same callback multiple times will overwrite previous callback definitions.
-  #
   module Callbacks
     extend ActiveSupport::Concern
 

--- a/activejob/lib/active_job/callbacks.rb
+++ b/activejob/lib/active_job/callbacks.rb
@@ -15,9 +15,6 @@ module ActiveJob
   # * <tt>before_perform</tt>
   # * <tt>around_perform</tt>
   # * <tt>after_perform</tt>
-  #
-  # NOTE: Calling the same callback multiple times will overwrite previous callback definitions.
-  #
   module Callbacks
     extend  ActiveSupport::Concern
     include ActiveSupport::Callbacks

--- a/activemodel/lib/active_model/callbacks.rb
+++ b/activemodel/lib/active_model/callbacks.rb
@@ -60,7 +60,7 @@ module ActiveModel
   # Would only create the +after_create+ and +before_create+ callback methods in
   # your class.
   #
-  # NOTE: Calling the same callback multiple times will overwrite previous callback definitions.
+  # NOTE: Defining the same callback multiple times will overwrite previous callback definitions.
   #
   module Callbacks
     def self.extended(base) # :nodoc:


### PR DESCRIPTION
### Motivation / Background

The following was added to the `ActiveJob::Callbacks`, `ActiveModel::Callbacks` and `AbstractController:Callbacks` docs in #29072:

> NOTE: Calling the same callback multiple times will overwrite previous callback definitions.

The comment refers to "calling" callbacks but seems to be about defining callbacks, as mentioned in the PR description.

In the ActiveJob and AbstractController docs, I believe this will be misinterpreted as referring to setting callbacks, which, as far as I can tell, does not have such a restriction.

In the ActiveModel docs, I believe it would be slightly clearer to replace "calling" with "defining".

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
