### PR TITLE
Support `:source_location` tag option for query log tags

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,15 @@
+*   Support `:source_location` tag option for query log tags
+
+    ```ruby
+    config.active_record.query_log_tags << :source_location
+    ```
+
+    Calculating the caller location is a costly operation and should be used primarily in development
+    (note, there is also a `config.active_record.verbose_query_logs` that serves the same purpose)
+    or occasionally on production for debugging purposes.
+
+    *fatkodima*
+
 *   Add an option to `ActiveRecord::Encryption::Encryptor` to disable compression
 
     Allow compression to be disabled by setting `compress: false`

--- a/activerecord/lib/active_record/railtie.rb
+++ b/activerecord/lib/active_record/railtie.rb
@@ -415,7 +415,8 @@ To keep using the current cache store, you can turn off cache versioning entirel
             pid:          -> { Process.pid.to_s },
             socket:       ->(context) { context[:connection].pool.db_config.socket },
             db_host:      ->(context) { context[:connection].pool.db_config.host },
-            database:     ->(context) { context[:connection].pool.db_config.database }
+            database:     ->(context) { context[:connection].pool.db_config.database },
+            source_location: -> { QueryLogs.query_source_location }
           )
           ActiveRecord.disable_prepared_statements = true
 

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -1411,9 +1411,9 @@ NOTE: When this is set to `true` database prepared statements will be automatica
 
 #### `config.active_record.query_log_tags`
 
-Define an `Array` specifying the key/value tags to be inserted in an SQL
-comment. Defaults to `[ :application ]`, a predefined tag returning the
-application name.
+Define an `Array` specifying the key/value tags to be inserted in an SQL comment. Defaults to
+`[ :application, :controller, :action, :job ]`. The available tags are: `:application`, `:controller`,
+`:namespaced_controller`, `:action`, `:job`, and `:source_location`.
 
 #### `config.active_record.query_log_tags_format`
 

--- a/railties/test/application/query_logs_test.rb
+++ b/railties/test/application/query_logs_test.rb
@@ -149,6 +149,23 @@ module ApplicationTests
       assert_equal("/*action='index',controller='users',database='storage%2Fproduction_animals.sqlite3'*/", comment)
     end
 
+    test "source_location information is added if enabled" do
+      add_to_config <<~RUBY
+        config.active_record.query_log_tags_enabled = true
+        config.active_record.query_log_tags = [ :source_location ]
+
+        # Remove silencers, so we won't get all backtrace lines filtered.
+        Rails.backtrace_cleaner.remove_silencers!
+      RUBY
+
+      boot_app
+
+      get "/", {}, { "HTTPS" => "on" }
+      comment = last_response.body.strip
+
+      assert_match(/source_location='.*'/, comment)
+    end
+
     test "controller tags are not doubled up if already configured" do
       add_to_config "config.active_record.query_log_tags_enabled = true"
       add_to_config "config.active_record.query_log_tags = [ :action, :job, :controller, :pid ]"


### PR DESCRIPTION
Follow up to #42240 (as discussed in https://github.com/rails/rails/pull/42240#issuecomment-1926446571).

We lost the ability to use the `:line` option with QueryLogs (https://github.com/rails/rails/pull/42240#issuecomment-898668464), while there is one in the marginalia. It was costly to use it before in the gem, but we made it fast (https://github.com/basecamp/marginalia/pull/138), so it is not *that* costly and people deliberately decide if they want to use it.

I would like to have the `:line` option (upd: decided to name it as `:source_location`), it is very much useful. Without it, if we have a slow db query log, for example, it is very hard to know from which part of the codebase the query was generated. Even having an `:action` component, you need to investigate the unfamiliar codebase to find out where the query was triggered.

cc @byroot 