### PR TITLE
[RF DOCS] Action Mailbox Documention [ci-skip]

### DIFF
--- a/guides/source/action_mailbox_basics.md
+++ b/guides/source/action_mailbox_basics.md
@@ -342,7 +342,7 @@ If the email is marked either `delivered`, `failed`, or `bounced` it's considere
 
 Here is an example of an Action Mailbox that processes emails to create 'forwards' for the user's project.
 
-The `before_processing` callback is used to ensure that certain conditions are met before `process` method is called. In this case, `before_processing` checks that the user has at least on project. Other supported [Action Mailbox callbacks](https://api.rubyonrails.org/classes/ActionMailbox/Callbacks.html) are `after_processing` and `around_processing`.
+The `before_processing` callback is used to ensure that certain conditions are met before `process` method is called. In this case, `before_processing` checks that the user has at least one project. Other supported [Action Mailbox callbacks](https://api.rubyonrails.org/classes/ActionMailbox/Callbacks.html) are `after_processing` and `around_processing`.
 
 The email can be bounced using `bounced_with` if the 'forwarder' has no projects. The 'forwarder' is a `User` with the same email as `mail.from`.
 

--- a/guides/source/action_mailbox_basics.md
+++ b/guides/source/action_mailbox_basics.md
@@ -298,6 +298,27 @@ This creates a `ForwardsMailbox` class with a `process` method.
 
 **Process email**
 
+When processing an `InboundEmail`, you can get the parsed version of the email as a [`Mail`][] object with `InboundEmail#mail`. You can also access the raw source directly using the `#source` method. Some relevant fields:
+
+- mail.to
+- mail.date
+- mail.subject
+- mail.decoded
+
+Once an email has been routed to the matching Mailbox and processed, Action Mailbox updates the email status stored in `action_mailbox_inbound_emails` table with one of the following values:
+
+- Pending: Just received by one of the ingress controllers and scheduled for routing.
+- Processing: During active processing, while a specific mailbox is running its process method.
+- Delivered: Successfully processed by the specific mailbox.
+- Failed: An exception was raised during the specific mailbox’s execution of the #process method.
+- Bounced: Rejected processing by the specific mailbox and bounced to sender.
+
+If the email is marked either `delivered`, `failed`, or `bounced` it's considered 'processed' and marked for incineration.
+
+[`Mail`]: https://github.com/mikel/mail
+
+## Example
+
 ```ruby
 # app/mailboxes/forwards_mailbox.rb
 class ForwardsMailbox < ApplicationMailbox

--- a/guides/source/action_mailbox_basics.md
+++ b/guides/source/action_mailbox_basics.md
@@ -284,7 +284,7 @@ Before you can start processing incoming emails, you'll need to setup Action Mai
 
 ### Configure Routing
 
-After an incoming email is received via the configured ingress, it needs to be forwarded to a mailbox for actual processing by your application. Much like the [Rails router](routing.html) that dispatches URLs to controllers, routing in Action Mailbox defines which emails go to which mailboxes for processing. Routes are added to the `application_mailbox.rb` file using regular expression:
+After an incoming email is received via the configured ingress, it needs to be forwarded to a mailbox for actual processing by your application. Much like the [Rails router](routing.html) that dispatches URLs to controllers, routing in Action Mailbox defines which emails go to which mailboxes for processing. Routes are added to the `application_mailbox.rb` file using regular expressions:
 
 ```ruby
 # app/mailboxes/application_mailbox.rb

--- a/guides/source/action_mailbox_basics.md
+++ b/guides/source/action_mailbox_basics.md
@@ -1,5 +1,4 @@
-**DO NOT READ THIS FILE ON GITHUB, GUIDES ARE PUBLISHED ON
-https://guides.rubyonrails.org.**
+**DO NOT READ THIS FILE ON GITHUB, GUIDES ARE PUBLISHED ON https://guides.rubyonrails.org.**
 
 Action Mailbox Basics
 =====================

--- a/guides/source/action_mailbox_basics.md
+++ b/guides/source/action_mailbox_basics.md
@@ -309,7 +309,7 @@ This creates `app/mailboxes/forwards_mailbox.rb`, with a `ForwardsMailbox` class
 
 ### Process Email
 
-When processing an `InboundEmail`, you can get the parsed version of the email as a [`Mail`](https://github.com/mikel/mail) object with `InboundEmail#mail`. You can also get the raw source directly using the `#source` method. With `Mail` object, you can access the relevant fields, such as `mail.to`, `mail.body.decoded`, etc.
+When processing an `InboundEmail`, you can get the parsed version of the email as a [`Mail`](https://github.com/mikel/mail) object with `InboundEmail#mail`. You can also get the raw source directly using the `#source` method. With the `Mail` object, you can access the relevant fields, such as `mail.to`, `mail.body.decoded`, etc.
 
 ```bash
 $ mail

--- a/guides/source/action_mailbox_basics.md
+++ b/guides/source/action_mailbox_basics.md
@@ -429,7 +429,7 @@ Please refer to the [ActionMailbox::TestHelper API](https://api.rubyonrails.org/
 
 ## Incineration of InboundEmails
 
-By default, an `InboundEmail` that has been processed will be incinerated after 30 days. The InboundEmail is considered as processed when its status changes to `delivered`, `failed`, or `bounced`.
+By default, an `InboundEmail` that has been processed will be incinerated after 30 days. The `InboundEmail` is considered as processed when its status changes to `delivered`, `failed`, or `bounced`.
 
 The actual incineration is done via the [`IncinerationJob`](https://api.rubyonrails.org/classes/ActionMailbox/IncinerationJob.html) that's scheduled to run after [`config.action_mailbox.incinerate_after`](configuring.html#config-action-mailbox-incinerate-after) time. This value is set to `30.days` by default, but you can change it in your production.rb configuration. (Note that this far-future incineration scheduling relies on your job queue being able to hold jobs for that long.)
 

--- a/guides/source/action_mailbox_basics.md
+++ b/guides/source/action_mailbox_basics.md
@@ -294,7 +294,9 @@ class ApplicationMailbox < ActionMailbox::Base
 end
 ```
 
-The regular expression matches the incoming email's `to` field. For example, the above will match any email sent to `save@` to a 'forwards' mailbox, which we will need to create.
+The regular expression matches the incoming email's `to`, `cc`, or `bcc` fields. For example, the above will match any email sent to `save@` to a 'forwards' mailbox. There are other ways to route an email, see [`ActionMailbox::Base API`](https://api.rubyonrails.org/classes/ActionMailbox/Base.html) for more.  
+
+We need to create that 'forwards' mailbox next.
 
 ### Create a Mailbox
 

--- a/guides/source/action_mailbox_basics.md
+++ b/guides/source/action_mailbox_basics.md
@@ -44,7 +44,7 @@ $ bin/rails db:migrate
 
 This will run the Action Mailbox and Active Storage migrations.
 
-The Action Mailbox table `action_mailbox_inbound_emails` stores incoming messages and their processing 'status'.
+The Action Mailbox table `action_mailbox_inbound_emails` stores incoming messages and their processing status.
 
 At this point you can start your rails server and check out `http://localhost:3000/rails/conductor/action_mailbox/inbound_emails`. See [Local Development and Testing](#local-development-and-testing) for more.
 

--- a/guides/source/action_mailbox_basics.md
+++ b/guides/source/action_mailbox_basics.md
@@ -24,7 +24,7 @@ The inbound emails are routed asynchronously using [Active Job](https://guides.r
 
 `InboundEmail` records also provide lifecycle tracking, storage of the original email via [Active Storage](https://guides.rubyonrails.org/active_storage_overview.html), and responsible data handling with on-by-default [incineration](#incineration-of-inboundemails).
 
-Action Mailbox ships with ingresses for external email providers such as Mailgun, Mandrill, Postmark, and SendGrid. You can also handle inbound mails directly via the built-in Exim, Postfix, and Qmail ingresses.
+Action Mailbox ships with ingresses which enable your application to receive emails from external email providers such as Mailgun, Mandrill, Postmark, and SendGrid. You can also handle inbound mails directly via the built-in Exim, Postfix, and Qmail ingresses.
 
 ## Setup
 
@@ -46,13 +46,13 @@ This will run the Action Mailbox and Active Storage migrations.
 
 The Action Mailbox table `action_mailbox_inbound_emails` stores incoming messages and their processing 'status'.
 
-At this point you can start your rails server and check out `http://localhost:3000/rails/conductor/action_mailbox/inbound_emails`.
+At this point you can start your rails server and check out `http://localhost:3000/rails/conductor/action_mailbox/inbound_emails`. See [Local Development and Testing](#local-development-and-testing) for more.
 
 The next step is to configure an ingress in your Rails application to specify how incoming emails should be received.
 
 ## Ingress Configuration
 
-Configuring ingress involves setting up credentials and endpoint information for the chosen email service. Here are the steps for each of the supported ingress.
+Configuring ingress involves setting up credentials and endpoint information for the chosen email service. Here are the steps for each of the supported ingresses.
 
 ### Exim
 

--- a/guides/source/action_mailbox_basics.md
+++ b/guides/source/action_mailbox_basics.md
@@ -341,7 +341,7 @@ If the email is marked either `delivered`, `failed`, or `bounced` it's considere
 
 Here is an example of an Action Mailbox that processes emails to create 'forwards' for the user's project.
 
-The `before_processing` callback is used to ensure that certain conditions are met before `process` method is called. In this case, `before_processing` checks that the user has at least on project. Other [Action Mailbox callbacks](https://api.rubyonrails.org/classes/ActionMailbox/Callbacks.html) are `after_processing` and `around_processing`.
+The `before_processing` callback is used to ensure that certain conditions are met before `process` method is called. In this case, `before_processing` checks that the user has at least on project. Other supported [Action Mailbox callbacks](https://api.rubyonrails.org/classes/ActionMailbox/Callbacks.html) are `after_processing` and `around_processing`.
 
 The email can be bounced using `bounced_with` if the 'forwarder' has no projects. The 'forwarder' is a `User` with the same email as `mail.from`.
 

--- a/guides/source/action_mailbox_basics.md
+++ b/guides/source/action_mailbox_basics.md
@@ -267,13 +267,13 @@ https://actionmailbox:PASSWORD@example.com/rails/action_mailbox/sendgrid/inbound
 
 NOTE: When configuring your SendGrid Inbound Parse webhook, be sure to check the box labeled **“Post the raw, full MIME message.”** Action Mailbox needs the raw MIME message to work.
 
-## Process Incoming Email
+## Processing Incoming Email
 
 Processing incoming emails usually entails using the email content to create models, update views, queue background work, etc. in your Rails application.
 
 Before you can start processing incoming emails, you'll need to setup Action Mailbox routing and create mailboxes.
 
-**Configure mailbox routing**
+### Configure mailbox routing
 
 Routes for Action Mailbox are added to the `application_mailbox.rb` file. The regular expression matches the incoming email's `to` field.
 
@@ -287,7 +287,7 @@ end
 
 For example, the above will match any email sent to `save@` to a 'forwards' mailbox. Which we need to create.
 
-**Create a mailbox**
+### Create a mailbox
 
 ```bash
 # Generate new mailbox
@@ -296,14 +296,27 @@ $ bin/rails generate mailbox forwards
 
 This creates a `ForwardsMailbox` class with a `process` method.
 
-**Process email**
+### Process email
 
-When processing an `InboundEmail`, you can get the parsed version of the email as a [`Mail`][] object with `InboundEmail#mail`. You can also access the raw source directly using the `#source` method. Some relevant fields:
+When processing an `InboundEmail`, you can get the parsed version of the email as a [`Mail`][] object with `InboundEmail#mail`. You can also get the raw source directly using the `#source` method. With `Mail` object, you can access the relevant fields, such as `mail.to`, `mail.body.decoded`, etc.
 
-- mail.to
-- mail.date
-- mail.subject
-- mail.decoded
+```bash
+$ mail
+#<Mail::Message:33780, Multipart: false, Headers: <Date: Wed, 31 Jan 2024 22:18:40 -0600>, <From: someone@hey.com>, <To: save@example.com>, <Message-ID: <65bb1ba066830_50303a70397e@Bhumis-MacBook-Pro.local.mail>>, <In-Reply-To: >, <Subject: Hello Action Mailbox>, <Mime-Version: 1.0>, <Content-Type: text/plain; charset=UTF-8>, <Content-Transfer-Encoding: 7bit>, <x-original-to: >>
+$ mail.to
+["save@example.com"]
+$ mail.from
+["someone@hey.com"]
+$ mail.date
+Wed, 31 Jan 2024 22:18:40 -0600
+$ mail.subject
+"Hello Action Mailbox"
+$ mail.body
+#<Mail::Body:0x00007fc74cbf46c0 @boundary=nil, @preamble=nil, @epilogue=nil, @charset="US-ASCII", @part_sort_order=["text/plain", "text/enriched", "text/html", "multipart/alternative"], @parts=[], @raw_source="This is the body of the email message.", @ascii_only=true, @encoding="7bit">
+$ mail.body.decoded
+"This is the body of the email message."
+```
+### Inbound Email Status
 
 Once an email has been routed to the matching Mailbox and processed, Action Mailbox updates the email status stored in `action_mailbox_inbound_emails` table with one of the following values:
 

--- a/guides/source/action_mailbox_basics.md
+++ b/guides/source/action_mailbox_basics.md
@@ -326,7 +326,7 @@ $ mail.body
 #<Mail::Body:0x00007fc74cbf46c0 @boundary=nil, @preamble=nil, @epilogue=nil, @charset="US-ASCII", @part_sort_order=["text/plain", "text/enriched", "text/html", "multipart/alternative"], @parts=[], @raw_source="This is the body of the email message.", @ascii_only=true, @encoding="7bit">
 $ mail.body.decoded
 "This is the body of the email message."
-# mail.decode, a shorthand for mail.body.decoded, also works
+# mail.decoded, a shorthand for mail.body.decoded, also works
 $ mail.decoded
 "This is the body of the email message."
 ```

--- a/guides/source/action_mailbox_basics.md
+++ b/guides/source/action_mailbox_basics.md
@@ -24,7 +24,7 @@ The inbound emails are routed asynchronously using [Active Job](active_job_basic
 
 `InboundEmail` records also provide lifecycle tracking, storage of the original email via [Active Storage](active_storage_overview.html), and responsible data handling with on-by-default [incineration](#incineration-of-inboundemails).
 
-Action Mailbox ships with ingresses which enable your application to receive emails from external email providers such as Mailgun, Mandrill, Postmark, and SendGrid. You can also handle inbound mails directly via the built-in Exim, Postfix, and Qmail ingresses.
+Action Mailbox ships with ingresses which enable your application to receive emails from external email providers such as Mailgun, Mandrill, Postmark, and SendGrid. You can also handle inbound emails directly via the built-in Exim, Postfix, and Qmail ingresses.
 
 ## Setup
 
@@ -284,7 +284,7 @@ Before you can start processing incoming emails, you'll need to setup Action Mai
 
 ### Configure Routing
 
-After an incoming email is received via the configured ingress, it needs to be forwarded to a mailbox for actual processing by your application. Much like the [Rails router](https://guides.rubyonrails.org/routing.html) that dispatches URLs to controllers, routing in Action Mailbox defines which emails go to which mailboxes for processing. Routes are added to the `application_mailbox.rb` file using regular expression, which matches the incoming email's `to` field:
+After an incoming email is received via the configured ingress, it needs to be forwarded to a mailbox for actual processing by your application. Much like the [Rails router](https://guides.rubyonrails.org/routing.html) that dispatches URLs to controllers, routing in Action Mailbox defines which emails go to which mailboxes for processing. Routes are added to the `application_mailbox.rb` file using regular expression:
 
 ```ruby
 # app/mailboxes/application_mailbox.rb
@@ -294,7 +294,7 @@ class ApplicationMailbox < ActionMailbox::Base
 end
 ```
 
-For example, the above will match any email sent to `save@` to a 'forwards' mailbox, which we will need to create.
+The regular expression matches the incoming email's `to` field. For example, the above will match any email sent to `save@` to a 'forwards' mailbox, which we will need to create.
 
 ### Create a Mailbox
 
@@ -327,7 +327,7 @@ $ mail.body.decoded
 ```
 ### Inbound Email Status
 
-Once an email has been routed to the matching Mailbox and processed, Action Mailbox updates the email status stored in `action_mailbox_inbound_emails` table with one of the following values:
+Once an email has been routed to a matching mailbox and processed, Action Mailbox updates the email status stored in `action_mailbox_inbound_emails` table with one of the following values:
 
 - Pending: Just received by one of the ingress controllers and scheduled for routing.
 - Processing: During active processing, while a specific mailbox is running its `process` method.

--- a/guides/source/action_mailbox_basics.md
+++ b/guides/source/action_mailbox_basics.md
@@ -426,7 +426,7 @@ Please refer to the [ActionMailbox::TestHelper API](https://api.rubyonrails.org/
 
 ## Incineration of InboundEmails
 
-By default, an `InboundEmail` that has been processed will be incinerated after 30 days. The InboundEmail is considered as processed when its status changes to `delivered`, `failed` or `bounced`.
+By default, an `InboundEmail` that has been processed will be incinerated after 30 days. The InboundEmail is considered as processed when its status changes to `delivered`, `failed`, or `bounced`.
 
 The actual incineration is done via the [`IncinerationJob`](https://api.rubyonrails.org/classes/ActionMailbox/IncinerationJob.html) that's scheduled to run after [`config.action_mailbox.incinerate_after`](configuring.html#config-action-mailbox-incinerate-after) time. This value is set to `30.days` by default, but you can change it in your production.rb configuration. (Note that this far-future incineration scheduling relies on your job queue being able to hold jobs for that long.)
 

--- a/guides/source/action_mailbox_basics.md
+++ b/guides/source/action_mailbox_basics.md
@@ -311,24 +311,24 @@ This creates `app/mailboxes/forwards_mailbox.rb`, with a `ForwardsMailbox` class
 
 When processing an `InboundEmail`, you can get the parsed version of the email as a [`Mail`](https://github.com/mikel/mail) object with `InboundEmail#mail`. You can also get the raw source directly using the `#source` method. With the `Mail` object, you can access the relevant fields, such as `mail.to`, `mail.body.decoded`, etc.
 
-```bash
-$ mail
-#<Mail::Message:33780, Multipart: false, Headers: <Date: Wed, 31 Jan 2024 22:18:40 -0600>, <From: someone@hey.com>, <To: save@example.com>, <Message-ID: <65bb1ba066830_50303a70397e@Bhumis-MacBook-Pro.local.mail>>, <In-Reply-To: >, <Subject: Hello Action Mailbox>, <Mime-Version: 1.0>, <Content-Type: text/plain; charset=UTF-8>, <Content-Transfer-Encoding: 7bit>, <x-original-to: >>
-$ mail.to
-["save@example.com"]
-$ mail.from
-["someone@hey.com"]
-$ mail.date
-Wed, 31 Jan 2024 22:18:40 -0600
-$ mail.subject
-"Hello Action Mailbox"
-$ mail.body
-#<Mail::Body:0x00007fc74cbf46c0 @boundary=nil, @preamble=nil, @epilogue=nil, @charset="US-ASCII", @part_sort_order=["text/plain", "text/enriched", "text/html", "multipart/alternative"], @parts=[], @raw_source="This is the body of the email message.", @ascii_only=true, @encoding="7bit">
-$ mail.body.decoded
-"This is the body of the email message."
+```irb
+irb> mail
+=> #<Mail::Message:33780, Multipart: false, Headers: <Date: Wed, 31 Jan 2024 22:18:40 -0600>, <From: someone@hey.com>, <To: save@example.com>, <Message-ID: <65bb1ba066830_50303a70397e@Bhumis-MacBook-Pro.local.mail>>, <In-Reply-To: >, <Subject: Hello Action Mailbox>, <Mime-Version: 1.0>, <Content-Type: text/plain; charset=UTF-8>, <Content-Transfer-Encoding: 7bit>, <x-original-to: >>
+irb> mail.to
+=> ["save@example.com"]
+irb> mail.from
+=> ["someone@hey.com"]
+irb> mail.date
+=> Wed, 31 Jan 2024 22:18:40 -0600
+irb> mail.subject
+=> "Hello Action Mailbox"
+irb> mail.body
+=> #<Mail::Body:0x00007fc74cbf46c0 @boundary=nil, @preamble=nil, @epilogue=nil, @charset="US-ASCII", @part_sort_order=["text/plain", "text/enriched", "text/html", "multipart/alternative"], @parts=[], @raw_source="This is the body of the email message.", @ascii_only=true, @encoding="7bit">
+irb> mail.body.decoded
+=> "This is the body of the email message."
 # mail.decoded, a shorthand for mail.body.decoded, also works
-$ mail.decoded
-"This is the body of the email message."
+irb> mail.decoded
+=> "This is the body of the email message."
 ```
 
 ### Inbound Email Status

--- a/guides/source/action_mailbox_basics.md
+++ b/guides/source/action_mailbox_basics.md
@@ -378,7 +378,7 @@ class ForwardsMailbox < ApplicationMailbox
     end
 
     def record_forward
-      forwarder.forwards.create subject: mail.subject, content: mail.body.decoded
+      forwarder.forwards.create subject: mail.subject, content: mail.decoded
     end
 
     def request_forwarding_project

--- a/guides/source/action_mailbox_basics.md
+++ b/guides/source/action_mailbox_basics.md
@@ -284,7 +284,7 @@ Before you can start processing incoming emails, you'll need to setup Action Mai
 
 ### Configure Routing
 
-Routes for Action Mailbox are added to the `application_mailbox.rb` file. The regular expression matches the incoming email's `to` field.
+After an incoming email is received via the configured ingress, it needs to be forwarded to a mailbox for actual processing by your application. Much like the [Rails router that dispatches URLs to controllers](https://guides.rubyonrails.org/routing.html), routing in Action Mailbox defines which emails go to which mailboxes for processing. They are added to the `application_mailbox.rb` file. The regular expression matches the incoming email's `to` field:
 
 ```ruby
 # app/mailboxes/application_mailbox.rb

--- a/guides/source/action_mailbox_basics.md
+++ b/guides/source/action_mailbox_basics.md
@@ -18,11 +18,11 @@ After reading this guide, you will know:
 What is Action Mailbox?
 -----------------------
 
-Action Mailbox routes incoming emails to controller-like mailboxes for processing in your Rails application. Action Mailbox is for receiving email, while [Action Mailer](https://guides.rubyonrails.org/action_mailer_basics.html) is for *sending* them.
+Action Mailbox routes incoming emails to controller-like mailboxes for processing in your Rails application. Action Mailbox is for receiving email, while [Action Mailer](action_mailer_basics.html) is for *sending* them.
 
-The inbound emails are routed asynchronously using [Active Job](https://guides.rubyonrails.org/active_job_basics.html) to one or several dedicated mailboxes. These emails are turned into [`InboundEmail`](https://api.rubyonrails.org/classes/ActionMailbox/InboundEmail.html) records using [Active Record](https://guides.rubyonrails.org/active_record_basics.html), which are capable of interacting directly with the rest of your domain model.
+The inbound emails are routed asynchronously using [Active Job](active_job_basics.html) to one or several dedicated mailboxes. These emails are turned into [`InboundEmail`](https://api.rubyonrails.org/classes/ActionMailbox/InboundEmail.html) records using [Active Record](active_record_basics.html), which are capable of interacting directly with the rest of your domain model.
 
-`InboundEmail` records also provide lifecycle tracking, storage of the original email via [Active Storage](https://guides.rubyonrails.org/active_storage_overview.html), and responsible data handling with on-by-default [incineration](#incineration-of-inboundemails).
+`InboundEmail` records also provide lifecycle tracking, storage of the original email via [Active Storage](active_storage_overview.html), and responsible data handling with on-by-default [incineration](#incineration-of-inboundemails).
 
 Action Mailbox ships with ingresses which enable your application to receive emails from external email providers such as Mailgun, Mandrill, Postmark, and SendGrid. You can also handle inbound mails directly via the built-in Exim, Postfix, and Qmail ingresses.
 

--- a/guides/source/action_mailbox_basics.md
+++ b/guides/source/action_mailbox_basics.md
@@ -18,11 +18,11 @@ After reading this guide, you will know:
 What is Action Mailbox?
 -----------------------
 
-Action Mailbox routes incoming emails to controller-like mailboxes for processing in your Rails application. Action Mailbox is for receiving inbound email, while [Action Mailer](https://guides.rubyonrails.org/action_mailer_basics.html) is for *sending* emails from your Rails application.
+Action Mailbox routes incoming emails to controller-like mailboxes for processing in your Rails application. Action Mailbox is for receiving email, while [Action Mailer](https://guides.rubyonrails.org/action_mailer_basics.html) is for *sending* them.
 
-The inbound emails are routed asynchronously using Active Job to one or several dedicated mailboxes. These emails are turned into `InboundEmail` records using Active Record, which are capable of interacting directly with the rest of your domain model.
+The inbound emails are routed asynchronously using [Active Job](https://guides.rubyonrails.org/active_job_basics.html) to one or several dedicated mailboxes. These emails are turned into [`InboundEmail`](https://api.rubyonrails.org/classes/ActionMailbox/InboundEmail.html) records using [Active Record](https://guides.rubyonrails.org/active_record_basics.html), which are capable of interacting directly with the rest of your domain model.
 
-`InboundEmail` records also provide lifecycle tracking, storage of the original email via Active Storage, and responsible data handling with on-by-default incineration.
+`InboundEmail` records also provide lifecycle tracking, storage of the original email via [Active Storage](https://guides.rubyonrails.org/active_storage_overview.html), and responsible data handling with on-by-default [incineration](#incineration-of-inboundemails).
 
 Action Mailbox ships with ingresses for external email providers such as Mailgun, Mandrill, Postmark, and SendGrid. You can also handle inbound mails directly via the built-in Exim, Postfix, and Qmail ingresses.
 
@@ -347,7 +347,6 @@ Here is an example of an Action Mailbox that processes emails to create 'forward
 
 If the 'forwarder' does have at least one project, the `record_forward` method creates an Active Record model in the application using the email data `mail.subject` and `mail.content`. Otherwise it sends an email, using Action Mailer, requesting the 'forwarder' to choose a project.
 
-
 ```ruby
 # app/mailboxes/forwards_mailbox.rb
 class ForwardsMailbox < ApplicationMailbox
@@ -424,7 +423,7 @@ Please refer to the [ActionMailbox::TestHelper API](https://api.rubyonrails.org/
 
 ## Incineration of InboundEmails
 
-By default, an [`InboundEmail`][] that has been processed will be incinerated after 30 days. The InboundEmail is considered as processed when its status changes to `delivered`, `failed` or `bounced`.
+By default, an `InboundEmail` that has been processed will be incinerated after 30 days. The InboundEmail is considered as processed when its status changes to `delivered`, `failed` or `bounced`.
 
 The actual incineration is done via the `IncinerationJob` that's scheduled to run after [`config.action_mailbox.incinerate_after`][] time. This value is set to `30.days` by default, but you can change it in your production.rb configuration. (Note that this far-future incineration scheduling relies on your job queue being able to hold jobs for that long.)
 
@@ -432,5 +431,4 @@ Default data incineration ensures that you're not holding on to people's data un
 
 The intention with Action Mailbox processing is that as you process an email, you should extract all the data you need from the email and persist into domain models in your application. The `InboundEmail` simply stays in the system for the extra time to allow for debugging and forensic and then will be deleted.
 
-[`InboundEmail`]: https://api.rubyonrails.org/classes/ActionMailbox/InboundEmail.html
 [`config.action_mailbox.incinerate_after`]: configuring.html#config-action-mailbox-incinerate-after

--- a/guides/source/action_mailbox_basics.md
+++ b/guides/source/action_mailbox_basics.md
@@ -389,7 +389,7 @@ irb> mail.body
 
 ### Inbound Email Status
 
-Once an email has been routed to a matching mailbox and processed, Action
+While the email is being routed to a matching mailbox and processed, Action
 Mailbox updates the email status stored in `action_mailbox_inbound_emails` table
 with one of the following values:
 

--- a/guides/source/action_mailbox_basics.md
+++ b/guides/source/action_mailbox_basics.md
@@ -338,21 +338,13 @@ end
 
 ## Incineration of InboundEmails
 
-By default, an [`InboundEmail`][] that has been processed will be
-incinerated after 30 days. The InboundEmail is considered as processed
-when its status changes to delivered, failed or bounced.
-This ensures you're not holding on to people's data willy-nilly
-after they may have canceled their accounts or deleted their
-content. The intention is that after you've processed an email, you should have
-extracted all the data you needed and turned it into domain models and content
-on your side of the application. The InboundEmail simply stays in the system
-for the extra time to provide debugging and forensics options.
+By default, an [`InboundEmail`][] that has been processed will be incinerated after 30 days. The InboundEmail is considered as processed when its status changes to `delivered`, `failed` or `bounced`.
 
-The actual incineration is done via the `IncinerationJob` that's scheduled
-to run after [`config.action_mailbox.incinerate_after`][] time. This value is
-by default set to `30.days`, but you can change it in your production.rb
-configuration. (Note that this far-future incineration scheduling relies on
-your job queue being able to hold jobs for that long.)
+The actual incineration is done via the `IncinerationJob` that's scheduled to run after [`config.action_mailbox.incinerate_after`][] time. This value is set to `30.days` by default, but you can change it in your production.rb configuration. (Note that this far-future incineration scheduling relies on your job queue being able to hold jobs for that long.)
+
+Default data incineration ensures that you're not holding on to people's data unnecessarily after they may have canceled their accounts or deleted their content.
+
+The intention with Action Mailbox processing is that as you process an email, you should extract all the data you need from the email and persist into domain models in your application. The `InboundEmail` simply stays in the system for the extra time to allow for debugging and forensic and then will be deleted.
 
 [`InboundEmail`]: https://api.rubyonrails.org/classes/ActionMailbox/InboundEmail.html
 [`config.action_mailbox.incinerate_after`]: configuring.html#config-action-mailbox-incinerate-after

--- a/guides/source/action_mailbox_basics.md
+++ b/guides/source/action_mailbox_basics.md
@@ -20,26 +20,30 @@ What is Action Mailbox?
 
 Action Mailbox routes incoming emails to controller-like mailboxes for processing in your Rails application. Action Mailbox is for receiving inbound email, while [Action Mailer](https://guides.rubyonrails.org/action_mailer_basics.html) is for *sending* emails from your Rails application.
 
-These inbound emails are routed asynchronously using Active Job to one or several dedicated mailboxes, which are capable of interacting directly with the rest of your domain model.
+The inbound emails are routed asynchronously using Active Job to one or several dedicated mailboxes. These emails are turned into `InboundEmail` records using Active Record, which are capable of interacting directly with the rest of your domain model.
 
-The inbound emails are turned into `InboundEmail` records using Active Record and feature lifecycle tracking, storage of the original email on cloud storage via Active Storage, and responsible data handling with on-by-default incineration.
+`InboundEmail` records also provide lifecycle tracking, storage of the original email via Active Storage, and responsible data handling with on-by-default incineration.
 
 Action Mailbox ships with ingresses for external email providers such as Mailgun, Mandrill, Postmark, and SendGrid. You can also handle inbound mails directly via the built-in Exim, Postfix, and Qmail ingresses.
 
-Action Mailbox has a number of moving parts. You will first need to install Action Mailbox. Then configure a chosen ingress for handling incoming email. You then configure Action Mailbox routing, create mailboxes and process incoming emails.
-
-Processing incoming emails usually entails using the email content to create models and update views in your Rails application. Some example use cases are [todo]
-
 ## Setup
 
-Install migrations needed for `InboundEmail` and ensure Active Storage is set up:
+Action Mailbox has a few moving parts. First you'll run the Action Mailbox installer. Then configure a chosen ingress for handling incoming email. You're then ready to add Action Mailbox routing, create mailboxes and start processing incoming emails.
 
-```bash
-$ bin/rails action_mailbox:install
-$ bin/rails db:migrate
-```
+To start let's install Action Mailbox:
 
-## Configuration
+1. `bin/rails action_mailbox:install` - this will create an `application_mailbox.rb` file and copy over migrations.
+2. `bin/rails db:migrate` - this will run the Action Mailbox and Active Storage migrations.
+
+The Action Mailbox table `action_mailbox_inbound_emails` stores incoming message and their processing 'status'.
+
+At this point you can start your rails server and check out `http://localhost:3000/rails/conductor/action_mailbox/inbound_emails`.
+
+The next step is to configure an ingress in your Rails application to specify how incoming emails should be received.
+
+## Ingress Configuration
+
+Configuring ingress involves setting up credentials and endpoint information for the chosen email service. Here are the steps for each of the supported ingress.
 
 ### Exim
 

--- a/guides/source/action_mailbox_basics.md
+++ b/guides/source/action_mailbox_basics.md
@@ -332,7 +332,7 @@ $ mail.body.decoded
 
 Once an email has been routed to a matching mailbox and processed, Action Mailbox updates the email status stored in `action_mailbox_inbound_emails` table with one of the following values:
 
-- `pending`: Just received by one of the ingress controllers and scheduled for routing.
+- `pending`: Received by one of the ingress controllers and scheduled for routing.
 - `processing`: During active processing, while a specific mailbox is running its `process` method.
 - `delivered`: Successfully processed by the specific mailbox.
 - `failed`: An exception was raised during the specific mailbox’s execution of the `process` method.

--- a/guides/source/action_mailbox_basics.md
+++ b/guides/source/action_mailbox_basics.md
@@ -420,7 +420,7 @@ class ForwardsMailboxTest < ActionMailbox::TestCase
     recording = people(:david).buckets.first.recordings.last
     assert_equal people(:david), recording.creator
     assert_equal "Status update?", recording.forward.subject
-    assert_match "What's the status?", recording.forward.decoded.to_s
+    assert_match "What's the status?", recording.forward.content.to_s
   end
 end
 ```

--- a/guides/source/action_mailbox_basics.md
+++ b/guides/source/action_mailbox_basics.md
@@ -267,9 +267,15 @@ https://actionmailbox:PASSWORD@example.com/rails/action_mailbox/sendgrid/inbound
 
 NOTE: When configuring your SendGrid Inbound Parse webhook, be sure to check the box labeled **“Post the raw, full MIME message.”** Action Mailbox needs the raw MIME message to work.
 
-## Examples
+## Process Incoming Email
 
-Configure basic routing:
+Processing incoming emails usually entails using the email content to create models, update views, queue background work, etc. in your Rails application.
+
+Before you can start processing incoming emails, you'll need to setup Action Mailbox routing and create mailboxes.
+
+**Configure mailbox routing**
+
+Routes for Action Mailbox are added to the `application_mailbox.rb` file. The regular expression matches the incoming email's `to` field.
 
 ```ruby
 # app/mailboxes/application_mailbox.rb
@@ -279,12 +285,18 @@ class ApplicationMailbox < ActionMailbox::Base
 end
 ```
 
-Then set up a mailbox:
+For example, the above will match any email sent to `save@` to a 'forwards' mailbox. Which we need to create.
+
+**Create a mailbox**
 
 ```bash
 # Generate new mailbox
 $ bin/rails generate mailbox forwards
 ```
+
+This creates a `ForwardsMailbox` class with a `process` method.
+
+**Process email**
 
 ```ruby
 # app/mailboxes/forwards_mailbox.rb

--- a/guides/source/action_mailbox_basics.md
+++ b/guides/source/action_mailbox_basics.md
@@ -1,10 +1,11 @@
-**DO NOT READ THIS FILE ON GITHUB, GUIDES ARE PUBLISHED ON https://guides.rubyonrails.org.**
+**DO NOT READ THIS FILE ON GITHUB, GUIDES ARE PUBLISHED ON
+https://guides.rubyonrails.org.**
 
 Action Mailbox Basics
 =====================
 
-This guide provides you with all you need to get started in receiving
-emails to your application.
+This guide provides you with all you need to get started in receiving emails to
+your application.
 
 After reading this guide, you will know:
 
@@ -18,17 +19,32 @@ After reading this guide, you will know:
 What is Action Mailbox?
 -----------------------
 
-Action Mailbox routes incoming emails to controller-like mailboxes for processing in your Rails application. Action Mailbox is for receiving email, while [Action Mailer](action_mailer_basics.html) is for *sending* them.
+Action Mailbox routes incoming emails to controller-like mailboxes for
+processing in your Rails application. Action Mailbox is for receiving email,
+while [Action Mailer](action_mailer_basics.html) is for *sending* them.
 
-The inbound emails are routed asynchronously using [Active Job](active_job_basics.html) to one or several dedicated mailboxes. These emails are turned into [`InboundEmail`](https://api.rubyonrails.org/classes/ActionMailbox/InboundEmail.html) records using [Active Record](active_record_basics.html), which are capable of interacting directly with the rest of your domain model.
+The inbound emails are routed asynchronously using [Active
+Job](active_job_basics.html) to one or several dedicated mailboxes. These emails
+are turned into
+[`InboundEmail`](https://api.rubyonrails.org/classes/ActionMailbox/InboundEmail.html)
+records using [Active Record](active_record_basics.html), which are capable of
+interacting directly with the rest of your domain model.
 
-`InboundEmail` records also provide lifecycle tracking, storage of the original email via [Active Storage](active_storage_overview.html), and responsible data handling with on-by-default [incineration](#incineration-of-inboundemails).
+`InboundEmail` records also provide lifecycle tracking, storage of the original
+email via [Active Storage](active_storage_overview.html), and responsible data
+handling with on-by-default [incineration](#incineration-of-inboundemails).
 
-Action Mailbox ships with ingresses which enable your application to receive emails from external email providers such as Mailgun, Mandrill, Postmark, and SendGrid. You can also handle inbound emails directly via the built-in Exim, Postfix, and Qmail ingresses.
+Action Mailbox ships with ingresses which enable your application to receive
+emails from external email providers such as Mailgun, Mandrill, Postmark, and
+SendGrid. You can also handle inbound emails directly via the built-in Exim,
+Postfix, and Qmail ingresses.
 
 ## Setup
 
-Action Mailbox has a few moving parts. First, you'll run the installer. Next, you'll choose and configure an ingress for handling incoming email. You're then ready to add Action Mailbox routing, create mailboxes, and start processing incoming emails.
+Action Mailbox has a few moving parts. First, you'll run the installer. Next,
+you'll choose and configure an ingress for handling incoming email. You're then
+ready to add Action Mailbox routing, create mailboxes, and start processing
+incoming emails.
 
 To start, let's install Action Mailbox:
 
@@ -44,15 +60,21 @@ $ bin/rails db:migrate
 
 This will run the Action Mailbox and Active Storage migrations.
 
-The Action Mailbox table `action_mailbox_inbound_emails` stores incoming messages and their processing status.
+The Action Mailbox table `action_mailbox_inbound_emails` stores incoming
+messages and their processing status.
 
-At this point, you can start your Rails server and check out `http://localhost:3000/rails/conductor/action_mailbox/inbound_emails`. See [Local Development and Testing](#local-development-and-testing) for more.
+At this point, you can start your Rails server and check out
+`http://localhost:3000/rails/conductor/action_mailbox/inbound_emails`. See
+[Local Development and Testing](#local-development-and-testing) for more.
 
-The next step is to configure an ingress in your Rails application to specify how incoming emails should be received.
+The next step is to configure an ingress in your Rails application to specify
+how incoming emails should be received.
 
 ## Ingress Configuration
 
-Configuring ingress involves setting up credentials and endpoint information for the chosen email service. Here are the steps for each of the supported ingresses.
+Configuring ingress involves setting up credentials and endpoint information for
+the chosen email service. Here are the steps for each of the supported
+ingresses.
 
 ### Exim
 
@@ -63,22 +85,25 @@ Tell Action Mailbox to accept emails from an SMTP relay:
 config.action_mailbox.ingress = :relay
 ```
 
-Generate a strong password that Action Mailbox can use to authenticate requests to the relay ingress.
+Generate a strong password that Action Mailbox can use to authenticate requests
+to the relay ingress.
 
-Use `bin/rails credentials:edit` to add the password to your application's encrypted credentials under
-`action_mailbox.ingress_password`, where Action Mailbox will automatically find it:
+Use `bin/rails credentials:edit` to add the password to your application's
+encrypted credentials under `action_mailbox.ingress_password`, where Action
+Mailbox will automatically find it:
 
 ```yaml
 action_mailbox:
   ingress_password: ...
 ```
 
-Alternatively, provide the password in the `RAILS_INBOUND_EMAIL_PASSWORD` environment variable.
+Alternatively, provide the password in the `RAILS_INBOUND_EMAIL_PASSWORD`
+environment variable.
 
-Configure Exim to pipe inbound emails to `bin/rails action_mailbox:ingress:exim`,
-providing the `URL` of the relay ingress and the `INGRESS_PASSWORD` you
-previously generated. If your application lived at `https://example.com`, the
-full command would look like this:
+Configure Exim to pipe inbound emails to `bin/rails
+action_mailbox:ingress:exim`, providing the `URL` of the relay ingress and the
+`INGRESS_PASSWORD` you previously generated. If your application lived at
+`https://example.com`, the full command would look like this:
 
 ```bash
 $ bin/rails action_mailbox:ingress:exim URL=https://example.com/rails/action_mailbox/relay/inbound_emails INGRESS_PASSWORD=...
@@ -86,21 +111,21 @@ $ bin/rails action_mailbox:ingress:exim URL=https://example.com/rails/action_mai
 
 ### Mailgun
 
-Give Action Mailbox your
-Mailgun Signing key (which you can find under Settings -> Security & Users -> API security in Mailgun),
-so it can authenticate requests to the Mailgun ingress.
+Give Action Mailbox your Mailgun Signing key (which you can find under Settings
+-> Security & Users -> API security in Mailgun), so it can authenticate requests
+to the Mailgun ingress.
 
 Use `bin/rails credentials:edit` to add your Signing key to your application's
-encrypted credentials under `action_mailbox.mailgun_signing_key`,
-where Action Mailbox will automatically find it:
+encrypted credentials under `action_mailbox.mailgun_signing_key`, where Action
+Mailbox will automatically find it:
 
 ```yaml
 action_mailbox:
   mailgun_signing_key: ...
 ```
 
-Alternatively, provide your Signing key in the `MAILGUN_INGRESS_SIGNING_KEY` environment
-variable.
+Alternatively, provide your Signing key in the `MAILGUN_INGRESS_SIGNING_KEY`
+environment variable.
 
 Tell Action Mailbox to accept emails from Mailgun:
 
@@ -109,10 +134,12 @@ Tell Action Mailbox to accept emails from Mailgun:
 config.action_mailbox.ingress = :mailgun
 ```
 
-[Configure Mailgun](https://documentation.mailgun.com/en/latest/user_manual.html#receiving-forwarding-and-storing-messages)
-to forward inbound emails to `/rails/action_mailbox/mailgun/inbound_emails/mime`.
-If your application lived at `https://example.com`, you would specify the
-fully-qualified URL `https://example.com/rails/action_mailbox/mailgun/inbound_emails/mime`.
+[Configure
+Mailgun](https://documentation.mailgun.com/en/latest/user_manual.html#receiving-forwarding-and-storing-messages)
+to forward inbound emails to
+`/rails/action_mailbox/mailgun/inbound_emails/mime`. If your application lived
+at `https://example.com`, you would specify the fully-qualified URL
+`https://example.com/rails/action_mailbox/mailgun/inbound_emails/mime`.
 
 ### Mandrill
 
@@ -120,8 +147,8 @@ Give Action Mailbox your Mandrill API key, so it can authenticate requests to
 the Mandrill ingress.
 
 Use `bin/rails credentials:edit` to add your API key to your application's
-encrypted credentials under `action_mailbox.mandrill_api_key`,
-where Action Mailbox will automatically find it:
+encrypted credentials under `action_mailbox.mandrill_api_key`, where Action
+Mailbox will automatically find it:
 
 ```yaml
 action_mailbox:
@@ -138,10 +165,12 @@ Tell Action Mailbox to accept emails from Mandrill:
 config.action_mailbox.ingress = :mandrill
 ```
 
-[Configure Mandrill](https://mandrill.zendesk.com/hc/en-us/articles/205583197-Inbound-Email-Processing-Overview)
-to route inbound emails to `/rails/action_mailbox/mandrill/inbound_emails`.
-If your application lived at `https://example.com`, you would specify
-the fully-qualified URL `https://example.com/rails/action_mailbox/mandrill/inbound_emails`.
+[Configure
+Mandrill](https://mandrill.zendesk.com/hc/en-us/articles/205583197-Inbound-Email-Processing-Overview)
+to route inbound emails to `/rails/action_mailbox/mandrill/inbound_emails`. If
+your application lived at `https://example.com`, you would specify the
+fully-qualified URL
+`https://example.com/rails/action_mailbox/mandrill/inbound_emails`.
 
 ### Postfix
 
@@ -152,19 +181,23 @@ Tell Action Mailbox to accept emails from an SMTP relay:
 config.action_mailbox.ingress = :relay
 ```
 
-Generate a strong password that Action Mailbox can use to authenticate requests to the relay ingress.
+Generate a strong password that Action Mailbox can use to authenticate requests
+to the relay ingress.
 
-Use `bin/rails credentials:edit` to add the password to your application's encrypted credentials under
-`action_mailbox.ingress_password`, where Action Mailbox will automatically find it:
+Use `bin/rails credentials:edit` to add the password to your application's
+encrypted credentials under `action_mailbox.ingress_password`, where Action
+Mailbox will automatically find it:
 
 ```yaml
 action_mailbox:
   ingress_password: ...
 ```
 
-Alternatively, provide the password in the `RAILS_INBOUND_EMAIL_PASSWORD` environment variable.
+Alternatively, provide the password in the `RAILS_INBOUND_EMAIL_PASSWORD`
+environment variable.
 
-[Configure Postfix](https://serverfault.com/questions/258469/how-to-configure-postfix-to-pipe-all-incoming-email-to-a-script)
+[Configure
+Postfix](https://serverfault.com/questions/258469/how-to-configure-postfix-to-pipe-all-incoming-email-to-a-script)
 to pipe inbound emails to `bin/rails action_mailbox:ingress:postfix`, providing
 the `URL` of the Postfix ingress and the `INGRESS_PASSWORD` you previously
 generated. If your application lived at `https://example.com`, the full command
@@ -183,12 +216,12 @@ Tell Action Mailbox to accept emails from Postmark:
 config.action_mailbox.ingress = :postmark
 ```
 
-Generate a strong password that Action Mailbox can use to authenticate
-requests to the Postmark ingress.
+Generate a strong password that Action Mailbox can use to authenticate requests
+to the Postmark ingress.
 
 Use `bin/rails credentials:edit` to add the password to your application's
-encrypted credentials under `action_mailbox.ingress_password`,
-where Action Mailbox will automatically find it:
+encrypted credentials under `action_mailbox.ingress_password`, where Action
+Mailbox will automatically find it:
 
 ```yaml
 action_mailbox:
@@ -198,17 +231,20 @@ action_mailbox:
 Alternatively, provide the password in the `RAILS_INBOUND_EMAIL_PASSWORD`
 environment variable.
 
-[Configure Postmark inbound webhook](https://postmarkapp.com/manual#configure-your-inbound-webhook-url)
-to forward inbound emails to `/rails/action_mailbox/postmark/inbound_emails` with the username `actionmailbox`
-and the password you previously generated. If your application lived at `https://example.com`, you would
-configure Postmark with the following fully-qualified URL:
+[Configure Postmark inbound
+webhook](https://postmarkapp.com/manual#configure-your-inbound-webhook-url) to
+forward inbound emails to `/rails/action_mailbox/postmark/inbound_emails` with
+the username `actionmailbox` and the password you previously generated. If your
+application lived at `https://example.com`, you would configure Postmark with
+the following fully-qualified URL:
 
 ```
 https://actionmailbox:PASSWORD@example.com/rails/action_mailbox/postmark/inbound_emails
 ```
 
-NOTE: When configuring your Postmark inbound webhook, be sure to check the box labeled **"Include raw email content in JSON payload"**.
-Action Mailbox needs the raw email content to work.
+NOTE: When configuring your Postmark inbound webhook, be sure to check the box
+labeled **"Include raw email content in JSON payload"**. Action Mailbox needs
+the raw email content to work.
 
 ### Qmail
 
@@ -219,22 +255,25 @@ Tell Action Mailbox to accept emails from an SMTP relay:
 config.action_mailbox.ingress = :relay
 ```
 
-Generate a strong password that Action Mailbox can use to authenticate requests to the relay ingress.
+Generate a strong password that Action Mailbox can use to authenticate requests
+to the relay ingress.
 
-Use `bin/rails credentials:edit` to add the password to your application's encrypted credentials under
-`action_mailbox.ingress_password`, where Action Mailbox will automatically find it:
+Use `bin/rails credentials:edit` to add the password to your application's
+encrypted credentials under `action_mailbox.ingress_password`, where Action
+Mailbox will automatically find it:
 
 ```yaml
 action_mailbox:
   ingress_password: ...
 ```
 
-Alternatively, provide the password in the `RAILS_INBOUND_EMAIL_PASSWORD` environment variable.
+Alternatively, provide the password in the `RAILS_INBOUND_EMAIL_PASSWORD`
+environment variable.
 
-Configure Qmail to pipe inbound emails to `bin/rails action_mailbox:ingress:qmail`,
-providing the `URL` of the relay ingress and the `INGRESS_PASSWORD` you
-previously generated. If your application lived at `https://example.com`, the
-full command would look like this:
+Configure Qmail to pipe inbound emails to `bin/rails
+action_mailbox:ingress:qmail`, providing the `URL` of the relay ingress and the
+`INGRESS_PASSWORD` you previously generated. If your application lived at
+`https://example.com`, the full command would look like this:
 
 ```bash
 $ bin/rails action_mailbox:ingress:qmail URL=https://example.com/rails/action_mailbox/relay/inbound_emails INGRESS_PASSWORD=...
@@ -249,12 +288,12 @@ Tell Action Mailbox to accept emails from SendGrid:
 config.action_mailbox.ingress = :sendgrid
 ```
 
-Generate a strong password that Action Mailbox can use to authenticate
-requests to the SendGrid ingress.
+Generate a strong password that Action Mailbox can use to authenticate requests
+to the SendGrid ingress.
 
 Use `bin/rails credentials:edit` to add the password to your application's
-encrypted credentials under `action_mailbox.ingress_password`,
-where Action Mailbox will automatically find it:
+encrypted credentials under `action_mailbox.ingress_password`, where Action
+Mailbox will automatically find it:
 
 ```yaml
 action_mailbox:
@@ -264,27 +303,36 @@ action_mailbox:
 Alternatively, provide the password in the `RAILS_INBOUND_EMAIL_PASSWORD`
 environment variable.
 
-[Configure SendGrid Inbound Parse](https://sendgrid.com/docs/for-developers/parsing-email/setting-up-the-inbound-parse-webhook/)
-to forward inbound emails to
-`/rails/action_mailbox/sendgrid/inbound_emails` with the username `actionmailbox`
-and the password you previously generated. If your application lived at `https://example.com`,
-you would configure SendGrid with the following URL:
+[Configure SendGrid Inbound
+Parse](https://sendgrid.com/docs/for-developers/parsing-email/setting-up-the-inbound-parse-webhook/)
+to forward inbound emails to `/rails/action_mailbox/sendgrid/inbound_emails`
+with the username `actionmailbox` and the password you previously generated. If
+your application lived at `https://example.com`, you would configure SendGrid
+with the following URL:
 
 ```
 https://actionmailbox:PASSWORD@example.com/rails/action_mailbox/sendgrid/inbound_emails
 ```
 
-NOTE: When configuring your SendGrid Inbound Parse webhook, be sure to check the box labeled **“Post the raw, full MIME message.”** Action Mailbox needs the raw MIME message to work.
+NOTE: When configuring your SendGrid Inbound Parse webhook, be sure to check the
+box labeled **“Post the raw, full MIME message.”** Action Mailbox needs the raw
+MIME message to work.
 
 ## Processing Incoming Email
 
-Processing incoming emails usually entails using the email content to create models, update views, queue background work, etc. in your Rails application.
+Processing incoming emails usually entails using the email content to create
+models, update views, queue background work, etc. in your Rails application.
 
-Before you can start processing incoming emails, you'll need to setup Action Mailbox routing and create mailboxes.
+Before you can start processing incoming emails, you'll need to setup Action
+Mailbox routing and create mailboxes.
 
 ### Configure Routing
 
-After an incoming email is received via the configured ingress, it needs to be forwarded to a mailbox for actual processing by your application. Much like the [Rails router](routing.html) that dispatches URLs to controllers, routing in Action Mailbox defines which emails go to which mailboxes for processing. Routes are added to the `application_mailbox.rb` file using regular expressions:
+After an incoming email is received via the configured ingress, it needs to be
+forwarded to a mailbox for actual processing by your application. Much like the
+[Rails router](routing.html) that dispatches URLs to controllers, routing in
+Action Mailbox defines which emails go to which mailboxes for processing. Routes
+are added to the `application_mailbox.rb` file using regular expressions:
 
 ```ruby
 # app/mailboxes/application_mailbox.rb
@@ -294,7 +342,10 @@ class ApplicationMailbox < ActionMailbox::Base
 end
 ```
 
-The regular expression matches the incoming email's `to`, `cc`, or `bcc` fields. For example, the above will match any email sent to `save@` to a "forwards" mailbox. There are other ways to route an email, see [`ActionMailbox::Base API`](https://api.rubyonrails.org/classes/ActionMailbox/Base.html) for more.
+The regular expression matches the incoming email's `to`, `cc`, or `bcc` fields.
+For example, the above will match any email sent to `save@` to a "forwards"
+mailbox. There are other ways to route an email, see [`ActionMailbox::Base
+API`](https://api.rubyonrails.org/classes/ActionMailbox/Base.html) for more.
 
 We need to create that "forwards" mailbox next.
 
@@ -305,11 +356,16 @@ We need to create that "forwards" mailbox next.
 $ bin/rails generate mailbox forwards
 ```
 
-This creates `app/mailboxes/forwards_mailbox.rb`, with a `ForwardsMailbox` class and a `process` method.
+This creates `app/mailboxes/forwards_mailbox.rb`, with a `ForwardsMailbox` class
+and a `process` method.
 
 ### Process Email
 
-When processing an `InboundEmail`, you can get the parsed version of the email as a [`Mail`](https://github.com/mikel/mail) object with `InboundEmail#mail`. You can also get the raw source directly using the `#source` method. With the `Mail` object, you can access the relevant fields, such as `mail.to`, `mail.body.decoded`, etc.
+When processing an `InboundEmail`, you can get the parsed version of the email
+as a [`Mail`](https://github.com/mikel/mail) object with `InboundEmail#mail`.
+You can also get the raw source directly using the `#source` method. With the
+`Mail` object, you can access the relevant fields, such as `mail.to`,
+`mail.body.decoded`, etc.
 
 ```irb
 irb> mail
@@ -322,36 +378,52 @@ irb> mail.date
 => Wed, 31 Jan 2024 22:18:40 -0600
 irb> mail.subject
 => "Hello Action Mailbox"
-irb> mail.body
-=> #<Mail::Body:0x00007fc74cbf46c0 @boundary=nil, @preamble=nil, @epilogue=nil, @charset="US-ASCII", @part_sort_order=["text/plain", "text/enriched", "text/html", "multipart/alternative"], @parts=[], @raw_source="This is the body of the email message.", @ascii_only=true, @encoding="7bit">
 irb> mail.body.decoded
 => "This is the body of the email message."
 # mail.decoded, a shorthand for mail.body.decoded, also works
 irb> mail.decoded
 => "This is the body of the email message."
+irb> mail.body
+=> <Mail::Body:0x00007fc74cbf46c0 @boundary=nil, @preamble=nil, @epilogue=nil, @charset="US-ASCII", @part_sort_order=["text/plain", "text/enriched", "text/html", "multipart/alternative"], @parts=[], @raw_source="This is the body of the email message.", @ascii_only=true, @encoding="7bit">
 ```
 
 ### Inbound Email Status
 
-Once an email has been routed to a matching mailbox and processed, Action Mailbox updates the email status stored in `action_mailbox_inbound_emails` table with one of the following values:
+Once an email has been routed to a matching mailbox and processed, Action
+Mailbox updates the email status stored in `action_mailbox_inbound_emails` table
+with one of the following values:
 
-- `pending`: Received by one of the ingress controllers and scheduled for routing.
-- `processing`: During active processing, while a specific mailbox is running its `process` method.
+- `pending`: Received by one of the ingress controllers and scheduled for
+  routing.
+- `processing`: During active processing, while a specific mailbox is running
+  its `process` method.
 - `delivered`: Successfully processed by the specific mailbox.
-- `failed`: An exception was raised during the specific mailbox’s execution of the `process` method.
+- `failed`: An exception was raised during the specific mailbox’s execution of
+  the `process` method.
 - `bounced`: Rejected processing by the specific mailbox and bounced to sender.
 
-If the email is marked either `delivered`, `failed`, or `bounced` it's considered "processed" and marked for [incineration](#incineration-of-inboundemails).
+If the email is marked either `delivered`, `failed`, or `bounced` it's
+considered "processed" and marked for
+[incineration](#incineration-of-inboundemails).
 
 ## Example
 
-Here is an example of an Action Mailbox that processes emails to create "forwards" for the user's project.
+Here is an example of an Action Mailbox that processes emails to create
+"forwards" for the user's project.
 
-The `before_processing` callback is used to ensure that certain conditions are met before `process` method is called. In this case, `before_processing` checks that the user has at least one project. Other supported [Action Mailbox callbacks](https://api.rubyonrails.org/classes/ActionMailbox/Callbacks.html) are `after_processing` and `around_processing`.
+The `before_processing` callback is used to ensure that certain conditions are
+met before `process` method is called. In this case, `before_processing` checks
+that the user has at least one project. Other supported [Action Mailbox
+callbacks](https://api.rubyonrails.org/classes/ActionMailbox/Callbacks.html) are
+`after_processing` and `around_processing`.
 
-The email can be bounced using `bounced_with` if the "forwarder" has no projects. The "forwarder" is a `User` with the same email as `mail.from`.
+The email can be bounced using `bounced_with` if the "forwarder" has no
+projects. The "forwarder" is a `User` with the same email as `mail.from`.
 
-If the "forwarder" does have at least one project, the `record_forward` method creates an Active Record model in the application using the email data `mail.subject` and `mail.decoded`. Otherwise, it sends an email, using Action Mailer, requesting the "forwarder" to choose a project.
+If the "forwarder" does have at least one project, the `record_forward` method
+creates an Active Record model in the application using the email data
+`mail.subject` and `mail.decoded`. Otherwise, it sends an email, using Action
+Mailer, requesting the "forwarder" to choose a project.
 
 ```ruby
 # app/mailboxes/forwards_mailbox.rb
@@ -395,9 +467,9 @@ end
 
 It's helpful to be able to test incoming emails in development without actually
 sending and receiving real emails. To accomplish this, there's a conductor
-controller mounted at `/rails/conductor/action_mailbox/inbound_emails`,
-which gives you an index of all the InboundEmails in the system, their
-state of processing, and a form to create a new InboundEmail as well.
+controller mounted at `/rails/conductor/action_mailbox/inbound_emails`, which
+gives you an index of all the InboundEmails in the system, their state of
+processing, and a form to create a new InboundEmail as well.
 
 Here is and example of testing an inbound email with Action Mailbox TestHelpers.
 
@@ -425,14 +497,30 @@ class ForwardsMailboxTest < ActionMailbox::TestCase
 end
 ```
 
-Please refer to the [ActionMailbox::TestHelper API](https://api.rubyonrails.org/classes/ActionMailbox/TestHelper.html) for further test helper methods.
+Please refer to the [ActionMailbox::TestHelper
+API](https://api.rubyonrails.org/classes/ActionMailbox/TestHelper.html) for
+further test helper methods.
 
 ## Incineration of InboundEmails
 
-By default, an `InboundEmail` that has been processed will be incinerated after 30 days. The `InboundEmail` is considered as processed when its status changes to `delivered`, `failed`, or `bounced`.
+By default, an `InboundEmail` that has been processed will be incinerated after
+30 days. The `InboundEmail` is considered as processed when its status changes
+to `delivered`, `failed`, or `bounced`.
 
-The actual incineration is done via the [`IncinerationJob`](https://api.rubyonrails.org/classes/ActionMailbox/IncinerationJob.html) that's scheduled to run after [`config.action_mailbox.incinerate_after`](configuring.html#config-action-mailbox-incinerate-after) time. This value is set to `30.days` by default, but you can change it in your production.rb configuration. (Note that this far-future incineration scheduling relies on your job queue being able to hold jobs for that long.)
+The actual incineration is done via the
+[`IncinerationJob`](https://api.rubyonrails.org/classes/ActionMailbox/IncinerationJob.html)
+that's scheduled to run after
+[`config.action_mailbox.incinerate_after`](configuring.html#config-action-mailbox-incinerate-after)
+time. This value is set to `30.days` by default, but you can change it in your
+production.rb configuration. (Note that this far-future incineration scheduling
+relies on your job queue being able to hold jobs for that long.)
 
-Default data incineration ensures that you're not holding on to people's data unnecessarily after they may have canceled their accounts or deleted their content.
+Default data incineration ensures that you're not holding on to people's data
+unnecessarily after they may have canceled their accounts or deleted their
+content.
 
-The intention with Action Mailbox processing is that as you process an email, you should extract all the data you need from the email and persist it into domain models in your application. The `InboundEmail` stays in the system for the configured time to allow for debugging and forensics and then will be deleted.
+The intention with Action Mailbox processing is that as you process an email,
+you should extract all the data you need from the email and persist it into
+domain models in your application. The `InboundEmail` stays in the system for
+the configured time to allow for debugging and forensics and then will be
+deleted.

--- a/guides/source/action_mailbox_basics.md
+++ b/guides/source/action_mailbox_basics.md
@@ -273,7 +273,7 @@ Processing incoming emails usually entails using the email content to create mod
 
 Before you can start processing incoming emails, you'll need to setup Action Mailbox routing and create mailboxes.
 
-### Configure routing
+### Configure Routing
 
 Routes for Action Mailbox are added to the `application_mailbox.rb` file. The regular expression matches the incoming email's `to` field.
 

--- a/guides/source/action_mailbox_basics.md
+++ b/guides/source/action_mailbox_basics.md
@@ -351,7 +351,7 @@ The `before_processing` callback is used to ensure that certain conditions are m
 
 The email can be bounced using `bounced_with` if the "forwarder" has no projects. The "forwarder" is a `User` with the same email as `mail.from`.
 
-If the "forwarder" does have at least one project, the `record_forward` method creates an Active Record model in the application using the email data `mail.subject` and `mail.body.decoded`. Otherwise, it sends an email, using Action Mailer, requesting the "forwarder" to choose a project.
+If the "forwarder" does have at least one project, the `record_forward` method creates an Active Record model in the application using the email data `mail.subject` and `mail.decoded`. Otherwise, it sends an email, using Action Mailer, requesting the "forwarder" to choose a project.
 
 ```ruby
 # app/mailboxes/forwards_mailbox.rb

--- a/guides/source/action_mailbox_basics.md
+++ b/guides/source/action_mailbox_basics.md
@@ -284,7 +284,7 @@ Before you can start processing incoming emails, you'll need to setup Action Mai
 
 ### Configure Routing
 
-After an incoming email is received via the configured ingress, it needs to be forwarded to a mailbox for actual processing by your application. Much like the [Rails router](https://guides.rubyonrails.org/routing.html) that dispatches URLs to controllers, routing in Action Mailbox defines which emails go to which mailboxes for processing. Routes are added to the `application_mailbox.rb` file using regular expression:
+After an incoming email is received via the configured ingress, it needs to be forwarded to a mailbox for actual processing by your application. Much like the [Rails router](routing.html) that dispatches URLs to controllers, routing in Action Mailbox defines which emails go to which mailboxes for processing. Routes are added to the `application_mailbox.rb` file using regular expression:
 
 ```ruby
 # app/mailboxes/application_mailbox.rb

--- a/guides/source/action_mailbox_basics.md
+++ b/guides/source/action_mailbox_basics.md
@@ -432,4 +432,4 @@ The actual incineration is done via the [`IncinerationJob`](https://api.rubyonra
 
 Default data incineration ensures that you're not holding on to people's data unnecessarily after they may have canceled their accounts or deleted their content.
 
-The intention with Action Mailbox processing is that as you process an email, you should extract all the data you need from the email and persist into domain models in your application. The `InboundEmail` simply stays in the system for the extra time to allow for debugging and forensic and then will be deleted.
+The intention with Action Mailbox processing is that as you process an email, you should extract all the data you need from the email and persist it into domain models in your application. The `InboundEmail` stays in the system for the configured time to allow for debugging and forensics and then will be deleted.

--- a/guides/source/action_mailbox_basics.md
+++ b/guides/source/action_mailbox_basics.md
@@ -294,9 +294,9 @@ class ApplicationMailbox < ActionMailbox::Base
 end
 ```
 
-The regular expression matches the incoming email's `to`, `cc`, or `bcc` fields. For example, the above will match any email sent to `save@` to a 'forwards' mailbox. There are other ways to route an email, see [`ActionMailbox::Base API`](https://api.rubyonrails.org/classes/ActionMailbox/Base.html) for more.
+The regular expression matches the incoming email's `to`, `cc`, or `bcc` fields. For example, the above will match any email sent to `save@` to a "forwards" mailbox. There are other ways to route an email, see [`ActionMailbox::Base API`](https://api.rubyonrails.org/classes/ActionMailbox/Base.html) for more.
 
-We need to create that 'forwards' mailbox next.
+We need to create that "forwards" mailbox next.
 
 ### Create a Mailbox
 
@@ -341,17 +341,17 @@ Once an email has been routed to a matching mailbox and processed, Action Mailbo
 - `failed`: An exception was raised during the specific mailbox’s execution of the `process` method.
 - `bounced`: Rejected processing by the specific mailbox and bounced to sender.
 
-If the email is marked either `delivered`, `failed`, or `bounced` it's considered 'processed' and marked for [incineration](#incineration-of-inboundemails).
+If the email is marked either `delivered`, `failed`, or `bounced` it's considered "processed" and marked for [incineration](#incineration-of-inboundemails).
 
 ## Example
 
-Here is an example of an Action Mailbox that processes emails to create 'forwards' for the user's project.
+Here is an example of an Action Mailbox that processes emails to create "forwards" for the user's project.
 
 The `before_processing` callback is used to ensure that certain conditions are met before `process` method is called. In this case, `before_processing` checks that the user has at least one project. Other supported [Action Mailbox callbacks](https://api.rubyonrails.org/classes/ActionMailbox/Callbacks.html) are `after_processing` and `around_processing`.
 
-The email can be bounced using `bounced_with` if the 'forwarder' has no projects. The 'forwarder' is a `User` with the same email as `mail.from`.
+The email can be bounced using `bounced_with` if the "forwarder" has no projects. The "forwarder" is a `User` with the same email as `mail.from`.
 
-If the 'forwarder' does have at least one project, the `record_forward` method creates an Active Record model in the application using the email data `mail.subject` and `mail.body.decoded`. Otherwise, it sends an email, using Action Mailer, requesting the 'forwarder' to choose a project.
+If the "forwarder" does have at least one project, the `record_forward` method creates an Active Record model in the application using the email data `mail.subject` and `mail.body.decoded`. Otherwise, it sends an email, using Action Mailer, requesting the "forwarder" to choose a project.
 
 ```ruby
 # app/mailboxes/forwards_mailbox.rb

--- a/guides/source/action_mailbox_basics.md
+++ b/guides/source/action_mailbox_basics.md
@@ -325,6 +325,7 @@ $ mail.body
 $ mail.body.decoded
 "This is the body of the email message."
 ```
+
 ### Inbound Email Status
 
 Once an email has been routed to a matching mailbox and processed, Action Mailbox updates the email status stored in `action_mailbox_inbound_emails` table with one of the following values:

--- a/guides/source/action_mailbox_basics.md
+++ b/guides/source/action_mailbox_basics.md
@@ -285,7 +285,7 @@ class ApplicationMailbox < ActionMailbox::Base
 end
 ```
 
-For example, the above will match any email sent to `save@` to a 'forwards' mailbox. Which we need to create.
+For example, the above will match any email sent to `save@` to a 'forwards' mailbox, which we will need to create.
 
 ### Create a mailbox
 

--- a/guides/source/action_mailbox_basics.md
+++ b/guides/source/action_mailbox_basics.md
@@ -284,7 +284,7 @@ Before you can start processing incoming emails, you'll need to setup Action Mai
 
 ### Configure Routing
 
-After an incoming email is received via the configured ingress, it needs to be forwarded to a mailbox for actual processing by your application. Much like the [Rails router that dispatches URLs to controllers](https://guides.rubyonrails.org/routing.html), routing in Action Mailbox defines which emails go to which mailboxes for processing. They are added to the `application_mailbox.rb` file. The regular expression matches the incoming email's `to` field:
+After an incoming email is received via the configured ingress, it needs to be forwarded to a mailbox for actual processing by your application. Much like the [Rails router](https://guides.rubyonrails.org/routing.html) that dispatches URLs to controllers, routing in Action Mailbox defines which emails go to which mailboxes for processing. Routes are added to the `application_mailbox.rb` file using regular expression, which matches the incoming email's `to` field:
 
 ```ruby
 # app/mailboxes/application_mailbox.rb
@@ -307,7 +307,7 @@ This creates `app/mailboxes/forwards_mailbox.rb`, with a `ForwardsMailbox` class
 
 ### Process Email
 
-When processing an `InboundEmail`, you can get the parsed version of the email as a [`Mail`][] object with `InboundEmail#mail`. You can also get the raw source directly using the `#source` method. With `Mail` object, you can access the relevant fields, such as `mail.to`, `mail.body.decoded`, etc.
+When processing an `InboundEmail`, you can get the parsed version of the email as a [`Mail`](https://github.com/mikel/mail) object with `InboundEmail#mail`. You can also get the raw source directly using the `#source` method. With `Mail` object, you can access the relevant fields, such as `mail.to`, `mail.body.decoded`, etc.
 
 ```bash
 $ mail
@@ -335,9 +335,7 @@ Once an email has been routed to the matching Mailbox and processed, Action Mail
 - Failed: An exception was raised during the specific mailbox’s execution of the #process method.
 - Bounced: Rejected processing by the specific mailbox and bounced to sender.
 
-If the email is marked either `delivered`, `failed`, or `bounced` it's considered 'processed' and marked for incineration.
-
-[`Mail`]: https://github.com/mikel/mail
+If the email is marked either `delivered`, `failed`, or `bounced` it's considered 'processed' and marked for [incineration](#incineration-of-inboundemails).
 
 ## Example
 
@@ -425,10 +423,8 @@ Please refer to the [ActionMailbox::TestHelper API](https://api.rubyonrails.org/
 
 By default, an `InboundEmail` that has been processed will be incinerated after 30 days. The InboundEmail is considered as processed when its status changes to `delivered`, `failed` or `bounced`.
 
-The actual incineration is done via the `IncinerationJob` that's scheduled to run after [`config.action_mailbox.incinerate_after`][] time. This value is set to `30.days` by default, but you can change it in your production.rb configuration. (Note that this far-future incineration scheduling relies on your job queue being able to hold jobs for that long.)
+The actual incineration is done via the [`IncinerationJob`](https://api.rubyonrails.org/classes/ActionMailbox/IncinerationJob.html) that's scheduled to run after [`config.action_mailbox.incinerate_after`](configuring.html#config-action-mailbox-incinerate-after) time. This value is set to `30.days` by default, but you can change it in your production.rb configuration. (Note that this far-future incineration scheduling relies on your job queue being able to hold jobs for that long.)
 
 Default data incineration ensures that you're not holding on to people's data unnecessarily after they may have canceled their accounts or deleted their content.
 
 The intention with Action Mailbox processing is that as you process an email, you should extract all the data you need from the email and persist into domain models in your application. The `InboundEmail` simply stays in the system for the extra time to allow for debugging and forensic and then will be deleted.
-
-[`config.action_mailbox.incinerate_after`]: configuring.html#config-action-mailbox-incinerate-after

--- a/guides/source/action_mailbox_basics.md
+++ b/guides/source/action_mailbox_basics.md
@@ -341,7 +341,9 @@ If the email is marked either `delivered`, `failed`, or `bounced` it's considere
 
 Here is an example of an Action Mailbox that processes emails to create 'forwards' for the user's project.
 
-`before_processing` callback is used to ensure that certain conditions are met before `process` is called. In this case, the email is bounced using `bounced_with` if the 'forwarder' has no projects. The 'forwarder' is a `User` with the same email as `mail.from`.
+The `before_processing` callback is used to ensure that certain conditions are met before `process` method is called. In this case, `before_processing` checks that the user has at least on project. Other [Action Mailbox callbacks](https://api.rubyonrails.org/classes/ActionMailbox/Callbacks.html) are `after_processing` and `around_processing`.
+
+The email can be bounced using `bounced_with` if the 'forwarder' has no projects. The 'forwarder' is a `User` with the same email as `mail.from`.
 
 If the 'forwarder' does have at least one project, the `record_forward` method creates an Active Record model in the application using the email data `mail.subject` and `mail.content`. Otherwise it sends an email, using Action Mailer, requesting the 'forwarder' to choose a project.
 

--- a/guides/source/action_mailbox_basics.md
+++ b/guides/source/action_mailbox_basics.md
@@ -330,11 +330,11 @@ $ mail.body.decoded
 
 Once an email has been routed to a matching mailbox and processed, Action Mailbox updates the email status stored in `action_mailbox_inbound_emails` table with one of the following values:
 
-- Pending: Just received by one of the ingress controllers and scheduled for routing.
-- Processing: During active processing, while a specific mailbox is running its `process` method.
-- Delivered: Successfully processed by the specific mailbox.
-- Failed: An exception was raised during the specific mailbox’s execution of the `process` method.
-- Bounced: Rejected processing by the specific mailbox and bounced to sender.
+- `pending`: Just received by one of the ingress controllers and scheduled for routing.
+- `processing`: During active processing, while a specific mailbox is running its `process` method.
+- `delivered`: Successfully processed by the specific mailbox.
+- `failed`: An exception was raised during the specific mailbox’s execution of the `process` method.
+- `bounced`: Rejected processing by the specific mailbox and bounced to sender.
 
 If the email is marked either `delivered`, `failed`, or `bounced` it's considered 'processed' and marked for [incineration](#incineration-of-inboundemails).
 

--- a/guides/source/action_mailbox_basics.md
+++ b/guides/source/action_mailbox_basics.md
@@ -35,7 +35,7 @@ To start let's install Action Mailbox:
 1. `bin/rails action_mailbox:install` - this will create an `application_mailbox.rb` file and copy over migrations.
 2. `bin/rails db:migrate` - this will run the Action Mailbox and Active Storage migrations.
 
-The Action Mailbox table `action_mailbox_inbound_emails` stores incoming message and their processing 'status'.
+The Action Mailbox table `action_mailbox_inbound_emails` stores incoming messages and their processing 'status'.
 
 At this point you can start your rails server and check out `http://localhost:3000/rails/conductor/action_mailbox/inbound_emails`.
 

--- a/guides/source/action_mailbox_basics.md
+++ b/guides/source/action_mailbox_basics.md
@@ -326,6 +326,9 @@ $ mail.body
 #<Mail::Body:0x00007fc74cbf46c0 @boundary=nil, @preamble=nil, @epilogue=nil, @charset="US-ASCII", @part_sort_order=["text/plain", "text/enriched", "text/html", "multipart/alternative"], @parts=[], @raw_source="This is the body of the email message.", @ascii_only=true, @encoding="7bit">
 $ mail.body.decoded
 "This is the body of the email message."
+# mail.decode, a shorthand for mail.body.decoded, also works
+$ mail.decoded
+"This is the body of the email message."
 ```
 
 ### Inbound Email Status
@@ -348,7 +351,7 @@ The `before_processing` callback is used to ensure that certain conditions are m
 
 The email can be bounced using `bounced_with` if the 'forwarder' has no projects. The 'forwarder' is a `User` with the same email as `mail.from`.
 
-If the 'forwarder' does have at least one project, the `record_forward` method creates an Active Record model in the application using the email data `mail.subject` and `mail.content`. Otherwise it sends an email, using Action Mailer, requesting the 'forwarder' to choose a project.
+If the 'forwarder' does have at least one project, the `record_forward` method creates an Active Record model in the application using the email data `mail.subject` and `mail.body.decoded`. Otherwise, it sends an email, using Action Mailer, requesting the 'forwarder' to choose a project.
 
 ```ruby
 # app/mailboxes/forwards_mailbox.rb
@@ -375,7 +378,7 @@ class ForwardsMailbox < ApplicationMailbox
     end
 
     def record_forward
-      forwarder.forwards.create subject: mail.subject, content: mail.content
+      forwarder.forwards.create subject: mail.subject, content: mail.body.decoded
     end
 
     def request_forwarding_project
@@ -417,7 +420,7 @@ class ForwardsMailboxTest < ActionMailbox::TestCase
     recording = people(:david).buckets.first.recordings.last
     assert_equal people(:david), recording.creator
     assert_equal "Status update?", recording.forward.subject
-    assert_match "What's the status?", recording.forward.content.to_s
+    assert_match "What's the status?", recording.forward.decoded.to_s
   end
 end
 ```

--- a/guides/source/action_mailbox_basics.md
+++ b/guides/source/action_mailbox_basics.md
@@ -46,7 +46,7 @@ This will run the Action Mailbox and Active Storage migrations.
 
 The Action Mailbox table `action_mailbox_inbound_emails` stores incoming messages and their processing status.
 
-At this point you can start your rails server and check out `http://localhost:3000/rails/conductor/action_mailbox/inbound_emails`. See [Local Development and Testing](#local-development-and-testing) for more.
+At this point, you can start your Rails server and check out `http://localhost:3000/rails/conductor/action_mailbox/inbound_emails`. See [Local Development and Testing](#local-development-and-testing) for more.
 
 The next step is to configure an ingress in your Rails application to specify how incoming emails should be received.
 

--- a/guides/source/action_mailbox_basics.md
+++ b/guides/source/action_mailbox_basics.md
@@ -28,7 +28,7 @@ Action Mailbox ships with ingresses which enable your application to receive ema
 
 ## Setup
 
-Action Mailbox has a few moving parts. First you'll run the Action Mailbox installer. Then configure a chosen ingress for handling incoming email. You're then ready to add Action Mailbox routing, create mailboxes and start processing incoming emails.
+Action Mailbox has a few moving parts. First you'll run the installer. Then configure a chosen ingress for handling incoming email. You're then ready to add Action Mailbox routing, create mailboxes and start processing incoming emails.
 
 To start let's install Action Mailbox:
 

--- a/guides/source/action_mailbox_basics.md
+++ b/guides/source/action_mailbox_basics.md
@@ -18,19 +18,17 @@ After reading this guide, you will know:
 What is Action Mailbox?
 -----------------------
 
-Action Mailbox routes incoming emails to controller-like mailboxes for
-processing in Rails. It ships with ingresses for Mailgun, Mandrill, Postmark,
-and SendGrid. You can also handle inbound mails directly via the built-in Exim,
-Postfix, and Qmail ingresses.
+Action Mailbox routes incoming emails to controller-like mailboxes for processing in your Rails application. Action Mailbox is for receiving inbound email, while [Action Mailer](https://guides.rubyonrails.org/action_mailer_basics.html) is for *sending* emails from your Rails application.
 
-The inbound emails are turned into `InboundEmail` records using Active Record
-and feature lifecycle tracking, storage of the original email on cloud storage
-via Active Storage, and responsible data handling with
-on-by-default incineration.
+These inbound emails are routed asynchronously using Active Job to one or several dedicated mailboxes, which are capable of interacting directly with the rest of your domain model.
 
-These inbound emails are routed asynchronously using Active Job to one or
-several dedicated mailboxes, which are capable of interacting directly
-with the rest of your domain model.
+The inbound emails are turned into `InboundEmail` records using Active Record and feature lifecycle tracking, storage of the original email on cloud storage via Active Storage, and responsible data handling with on-by-default incineration.
+
+Action Mailbox ships with ingresses for external email providers such as Mailgun, Mandrill, Postmark, and SendGrid. You can also handle inbound mails directly via the built-in Exim, Postfix, and Qmail ingresses.
+
+Action Mailbox has a number of moving parts. You will first need to install Action Mailbox. Then configure a chosen ingress for handling incoming email. You then configure Action Mailbox routing, create mailboxes and process incoming emails.
+
+Processing incoming emails usually entails using the email content to create models and update views in your Rails application. Some example use cases are [todo]
 
 ## Setup
 

--- a/guides/source/action_mailbox_basics.md
+++ b/guides/source/action_mailbox_basics.md
@@ -273,7 +273,7 @@ Processing incoming emails usually entails using the email content to create mod
 
 Before you can start processing incoming emails, you'll need to setup Action Mailbox routing and create mailboxes.
 
-### Configure mailbox routing
+### Configure routing
 
 Routes for Action Mailbox are added to the `application_mailbox.rb` file. The regular expression matches the incoming email's `to` field.
 

--- a/guides/source/action_mailbox_basics.md
+++ b/guides/source/action_mailbox_basics.md
@@ -294,7 +294,7 @@ class ApplicationMailbox < ActionMailbox::Base
 end
 ```
 
-The regular expression matches the incoming email's `to`, `cc`, or `bcc` fields. For example, the above will match any email sent to `save@` to a 'forwards' mailbox. There are other ways to route an email, see [`ActionMailbox::Base API`](https://api.rubyonrails.org/classes/ActionMailbox/Base.html) for more.  
+The regular expression matches the incoming email's `to`, `cc`, or `bcc` fields. For example, the above will match any email sent to `save@` to a 'forwards' mailbox. There are other ways to route an email, see [`ActionMailbox::Base API`](https://api.rubyonrails.org/classes/ActionMailbox/Base.html) for more.
 
 We need to create that 'forwards' mailbox next.
 

--- a/guides/source/action_mailbox_basics.md
+++ b/guides/source/action_mailbox_basics.md
@@ -344,8 +344,9 @@ end
 
 The regular expression matches the incoming email's `to`, `cc`, or `bcc` fields.
 For example, the above will match any email sent to `save@` to a "forwards"
-mailbox. There are other ways to route an email, see [`ActionMailbox::Base
-API`](https://api.rubyonrails.org/classes/ActionMailbox/Base.html) for more.
+mailbox. There are other ways to route an email, see
+[`ActionMailbox::Base`](https://api.rubyonrails.org/classes/ActionMailbox/Base.html)
+for more.
 
 We need to create that "forwards" mailbox next.
 

--- a/guides/source/action_mailbox_basics.md
+++ b/guides/source/action_mailbox_basics.md
@@ -303,7 +303,7 @@ For example, the above will match any email sent to `save@` to a 'forwards' mail
 $ bin/rails generate mailbox forwards
 ```
 
-This creates a `ForwardsMailbox` class with a `process` method.
+This creates `app/mailboxes/forwards_mailbox.rb`, with a `ForwardsMailbox` class and a `process` method.
 
 ### Process Email
 

--- a/guides/source/action_mailbox_basics.md
+++ b/guides/source/action_mailbox_basics.md
@@ -333,7 +333,7 @@ Once an email has been routed to a matching mailbox and processed, Action Mailbo
 - Pending: Just received by one of the ingress controllers and scheduled for routing.
 - Processing: During active processing, while a specific mailbox is running its `process` method.
 - Delivered: Successfully processed by the specific mailbox.
-- Failed: An exception was raised during the specific mailbox’s execution of the #process method.
+- Failed: An exception was raised during the specific mailbox’s execution of the `process` method.
 - Bounced: Rejected processing by the specific mailbox and bounced to sender.
 
 If the email is marked either `delivered`, `failed`, or `bounced` it's considered 'processed' and marked for [incineration](#incineration-of-inboundemails).

--- a/guides/source/action_mailbox_basics.md
+++ b/guides/source/action_mailbox_basics.md
@@ -30,7 +30,7 @@ Action Mailbox ships with ingresses which enable your application to receive ema
 
 Action Mailbox has a few moving parts. First, you'll run the installer. Next, you'll choose and configure an ingress for handling incoming email. You're then ready to add Action Mailbox routing, create mailboxes, and start processing incoming emails.
 
-To start let's install Action Mailbox:
+To start, let's install Action Mailbox:
 
 ```bash
 $ bin/rails action_mailbox:install

--- a/guides/source/action_mailbox_basics.md
+++ b/guides/source/action_mailbox_basics.md
@@ -319,6 +319,13 @@ If the email is marked either `delivered`, `failed`, or `bounced` it's considere
 
 ## Example
 
+Here is an example of an Action Mailbox that processes emails to create 'forwards' for the user's project.
+
+`before_processing` callback is used to ensure that certain conditions are met before `process` is called. In this case, the email is bounced using `bounced_with` if the 'forwarder' has no projects. The 'forwarder' is a `User` with the same email as `mail.from`.
+
+If the 'forwarder' does have at least one project, the `record_forward` method creates an Active Record model in the application using the email data `mail.subject` and `mail.content`. Otherwise it sends an email, using Action Mailer, requesting the 'forwarder' to choose a project.
+
+
 ```ruby
 # app/mailboxes/forwards_mailbox.rb
 class ForwardsMailbox < ApplicationMailbox
@@ -357,20 +364,7 @@ class ForwardsMailbox < ApplicationMailbox
 end
 ```
 
-## Incineration of InboundEmails
-
-By default, an [`InboundEmail`][] that has been processed will be incinerated after 30 days. The InboundEmail is considered as processed when its status changes to `delivered`, `failed` or `bounced`.
-
-The actual incineration is done via the `IncinerationJob` that's scheduled to run after [`config.action_mailbox.incinerate_after`][] time. This value is set to `30.days` by default, but you can change it in your production.rb configuration. (Note that this far-future incineration scheduling relies on your job queue being able to hold jobs for that long.)
-
-Default data incineration ensures that you're not holding on to people's data unnecessarily after they may have canceled their accounts or deleted their content.
-
-The intention with Action Mailbox processing is that as you process an email, you should extract all the data you need from the email and persist into domain models in your application. The `InboundEmail` simply stays in the system for the extra time to allow for debugging and forensic and then will be deleted.
-
-[`InboundEmail`]: https://api.rubyonrails.org/classes/ActionMailbox/InboundEmail.html
-[`config.action_mailbox.incinerate_after`]: configuring.html#config-action-mailbox-incinerate-after
-
-## Working with Action Mailbox in Development
+## Local Development and Testing
 
 It's helpful to be able to test incoming emails in development without actually
 sending and receiving real emails. To accomplish this, there's a conductor
@@ -378,9 +372,7 @@ controller mounted at `/rails/conductor/action_mailbox/inbound_emails`,
 which gives you an index of all the InboundEmails in the system, their
 state of processing, and a form to create a new InboundEmail as well.
 
-## Testing Mailboxes
-
-Example:
+Here is and example of testing an inbound email with Action Mailbox TestHelpers.
 
 ```ruby
 class ForwardsMailboxTest < ActionMailbox::TestCase
@@ -407,3 +399,16 @@ end
 ```
 
 Please refer to the [ActionMailbox::TestHelper API](https://api.rubyonrails.org/classes/ActionMailbox/TestHelper.html) for further test helper methods.
+
+## Incineration of InboundEmails
+
+By default, an [`InboundEmail`][] that has been processed will be incinerated after 30 days. The InboundEmail is considered as processed when its status changes to `delivered`, `failed` or `bounced`.
+
+The actual incineration is done via the `IncinerationJob` that's scheduled to run after [`config.action_mailbox.incinerate_after`][] time. This value is set to `30.days` by default, but you can change it in your production.rb configuration. (Note that this far-future incineration scheduling relies on your job queue being able to hold jobs for that long.)
+
+Default data incineration ensures that you're not holding on to people's data unnecessarily after they may have canceled their accounts or deleted their content.
+
+The intention with Action Mailbox processing is that as you process an email, you should extract all the data you need from the email and persist into domain models in your application. The `InboundEmail` simply stays in the system for the extra time to allow for debugging and forensic and then will be deleted.
+
+[`InboundEmail`]: https://api.rubyonrails.org/classes/ActionMailbox/InboundEmail.html
+[`config.action_mailbox.incinerate_after`]: configuring.html#config-action-mailbox-incinerate-after

--- a/guides/source/action_mailbox_basics.md
+++ b/guides/source/action_mailbox_basics.md
@@ -32,8 +32,17 @@ Action Mailbox has a few moving parts. First you'll run the Action Mailbox insta
 
 To start let's install Action Mailbox:
 
-1. `bin/rails action_mailbox:install` - this will create an `application_mailbox.rb` file and copy over migrations.
-2. `bin/rails db:migrate` - this will run the Action Mailbox and Active Storage migrations.
+```bash
+$ bin/rails action_mailbox:install
+```
+
+This will create an `application_mailbox.rb` file and copy over migrations.
+
+```bash
+$ bin/rails db:migrate
+```
+
+This will run the Action Mailbox and Active Storage migrations.
 
 The Action Mailbox table `action_mailbox_inbound_emails` stores incoming messages and their processing 'status'.
 

--- a/guides/source/action_mailbox_basics.md
+++ b/guides/source/action_mailbox_basics.md
@@ -28,7 +28,7 @@ Action Mailbox ships with ingresses which enable your application to receive ema
 
 ## Setup
 
-Action Mailbox has a few moving parts. First you'll run the installer. Then configure a chosen ingress for handling incoming email. You're then ready to add Action Mailbox routing, create mailboxes and start processing incoming emails.
+Action Mailbox has a few moving parts. First, you'll run the installer. Next, you'll choose and configure an ingress for handling incoming email. You're then ready to add Action Mailbox routing, create mailboxes, and start processing incoming emails.
 
 To start let's install Action Mailbox:
 

--- a/guides/source/action_mailbox_basics.md
+++ b/guides/source/action_mailbox_basics.md
@@ -321,7 +321,7 @@ $ mail.body.decoded
 Once an email has been routed to the matching Mailbox and processed, Action Mailbox updates the email status stored in `action_mailbox_inbound_emails` table with one of the following values:
 
 - Pending: Just received by one of the ingress controllers and scheduled for routing.
-- Processing: During active processing, while a specific mailbox is running its process method.
+- Processing: During active processing, while a specific mailbox is running its `process` method.
 - Delivered: Successfully processed by the specific mailbox.
 - Failed: An exception was raised during the specific mailbox’s execution of the #process method.
 - Bounced: Rejected processing by the specific mailbox and bounced to sender.

--- a/guides/source/action_mailbox_basics.md
+++ b/guides/source/action_mailbox_basics.md
@@ -296,7 +296,7 @@ $ bin/rails generate mailbox forwards
 
 This creates a `ForwardsMailbox` class with a `process` method.
 
-### Process email
+### Process Email
 
 When processing an `InboundEmail`, you can get the parsed version of the email as a [`Mail`][] object with `InboundEmail#mail`. You can also get the raw source directly using the `#source` method. With `Mail` object, you can access the relevant fields, such as `mail.to`, `mail.body.decoded`, etc.
 

--- a/guides/source/action_mailbox_basics.md
+++ b/guides/source/action_mailbox_basics.md
@@ -287,7 +287,7 @@ end
 
 For example, the above will match any email sent to `save@` to a 'forwards' mailbox, which we will need to create.
 
-### Create a mailbox
+### Create a Mailbox
 
 ```bash
 # Generate new mailbox


### PR DESCRIPTION
## Overview

Action Mailbox is a pretty useful / interesting sub-framework of Rails, that more apps probably could benefit from. It does have a number of moving parts so I focused on explaining the flow of how things work. I did a lot of 'in-app testing' of the docs by implementing its features in a rails app and exploring what's missing in the docs.

## New sections

Here are the new things I added, in addition to clarifying the existing text.

- Processing Incoming Email - more of a step by step of the flow
- Mail object and it's fields
- List of Inbound Email 'status' values
- ActiveJobs that are part of Action Mailbox - Routing and Incineration

## Testing

In addition to testing the Action Mailbox features in-app, I also ran `guides:generate` and `guides:validate` locally. I perused the generated html locally as well.

I also tested the instructions for one 'real' ingress Postmark (locally with ngrok).
