### PR TITLE
Enhance database config templates for flexible env connections

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/databases/jdbc.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/jdbc.yml.tt
@@ -41,6 +41,7 @@ default: &default
   pool: <%%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
   username: <%= app_name %>
   password:
+  host: <%%= ENV.fetch("DB_HOST") { "localhost" } %>
   driver:
 
 development:

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/jdbcmysql.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/jdbcmysql.yml.tt
@@ -14,7 +14,7 @@ default: &default
   pool: <%%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
   username: root
   password:
-  host: localhost
+  host: <%%= ENV.fetch("DB_HOST") { "localhost" } %>
 
 development:
   <<: *default

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/mysql.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/mysql.yml.tt
@@ -18,7 +18,7 @@ default: &default
 <% if mysql_socket -%>
   socket: <%= mysql_socket %>
 <% else -%>
-  host: localhost
+  host: <%%= ENV.fetch("DB_HOST") { "localhost" } %>
 <% end -%>
 
 development:

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/oracle.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/oracle.yml.tt
@@ -21,6 +21,7 @@ default: &default
   pool: <%%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
   username: <%= app_name %>
   password:
+  host: <%%= ENV.fetch("DB_HOST") { "localhost" } %>
 
 development:
   <<: *default

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/postgresql.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/postgresql.yml.tt
@@ -23,15 +23,15 @@ default: &default
   # To create additional roles in PostgreSQL see `$ createuser --help`.
   # When left blank, PostgreSQL will use the default role. This is
   # the same name as the operating system user running Rails.
-  username: <%%= ENV.fetch("<%= app_name.upcase %>_DATABASE_USER") { "postgres" } %>
+  username: postgres
 
   # The password associated with the PostgreSQL role (username).
-  password: <%%= ENV.fetch("<%= app_name.upcase %>_DATABASE_PASSWORD") { "postgres" } %>
+  password: postgres
 
   # Connect on a TCP socket. Omitted by default since the client uses a
   # domain socket that doesn't need configuration. Windows does not have
   # domain sockets, so uncomment these lines.
-  host: <%%= ENV.fetch("<%= app_name.upcase %>_DATABASE_HOST") { "localhost" } %>
+  host: <%%= ENV.fetch("DB_HOST") { "localhost" } %>
 
   # The TCP port the server listens on. Defaults to 5432.
   # If your server runs on a different port number, change accordingly.

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/postgresql.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/postgresql.yml.tt
@@ -23,7 +23,7 @@ default: &default
   # To create additional roles in PostgreSQL see `$ createuser --help`.
   # When left blank, PostgreSQL will use the default role. This is
   # the same name as the operating system user running Rails.
-  username: postgres
+  # username: postgres
 
   # The password associated with the PostgreSQL role (username).
   password: postgres

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/postgresql.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/postgresql.yml.tt
@@ -19,27 +19,27 @@ default: &default
   # https://guides.rubyonrails.org/configuring.html#database-pooling
   pool: <%%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
 
-development:
-  <<: *default
-  database: <%= app_name %>_development
-
   # The specified database role being used to connect to PostgreSQL.
   # To create additional roles in PostgreSQL see `$ createuser --help`.
   # When left blank, PostgreSQL will use the default role. This is
   # the same name as the operating system user running Rails.
-  #username: <%= app_name %>
+  username: <%%= ENV.fetch("<%= app_name.upcase %>_DATABASE_USER") { "postgres" } %>
 
   # The password associated with the PostgreSQL role (username).
-  #password:
+  password: <%%= ENV.fetch("<%= app_name.upcase %>_DATABASE_PASSWORD") { "postgres" } %>
 
   # Connect on a TCP socket. Omitted by default since the client uses a
   # domain socket that doesn't need configuration. Windows does not have
   # domain sockets, so uncomment these lines.
-  #host: localhost
+  host: <%%= ENV.fetch("<%= app_name.upcase %>_DATABASE_HOST") { "localhost" } %>
 
   # The TCP port the server listens on. Defaults to 5432.
   # If your server runs on a different port number, change accordingly.
   #port: 5432
+
+development:
+  <<: *default
+  database: <%= app_name %>_development
 
   # Schema search path. The server defaults to $user,public
   #schema_search_path: myapp,sharedapp,public

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/sqlserver.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/sqlserver.yml.tt
@@ -13,7 +13,7 @@ default: &default
   encoding: utf8
   username: sa
   password: <%%= ENV["SA_PASSWORD"] %>
-  host: localhost
+  host: <%%= ENV.fetch("DB_HOST") { "localhost" } %>
 
 development:
   <<: *default

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/trilogy.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/trilogy.yml.tt
@@ -18,7 +18,7 @@ default: &default
 <% if mysql_socket -%>
   socket: <%= mysql_socket %>
 <% else -%>
-  host: localhost
+  host: <%%= ENV.fetch("DB_HOST") { "localhost" } %>
 <% end -%>
 
 development:


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created to enhance the flexibility and usability of the Rails `database.yml` configuration for PostgreSQL databases. Currently, Rails applications default to connecting to PostgreSQL through a local Unix socket for development environments. This setup works well for local development but becomes cumbersome when developers use Dockerized PostgreSQL instances or switch between local and Docker environments. 

```bash
> rails db:prepare
bin/rails aborted!
ActiveRecord::ConnectionNotEstablished: connection to server on socket "/tmp/.s.PGSQL.5432" failed: No such file or directory (ActiveRecord::ConnectionNotEstablished)
	Is the server running locally and accepting connections on that socket?

Caused by:
PG::ConnectionBad: connection to server on socket "/tmp/.s.PGSQL.5432" failed: No such file or directory (PG::ConnectionBad)
	Is the server running locally and accepting connections on that socket?
```

By facilitating easy switching between these environments without the need to manually edit the `database.yml` file, this PR aims to streamline the development workflow, making it more efficient and less error-prone.

### Detail

This Pull Request changes the PostgreSQL database configuration template (`postgresql.yml.tt`) by introducing dynamic environment variable support for the `host`, `username`, and, `password` settings in the default configuration. Specifically, it allows these settings to be overridden via environment variables, with defaults provided for local development. This approach enables developers to easily switch between a local PostgreSQL server and a Dockerized PostgreSQL instance by simply setting or unsetting environment variables, without the need for manual configuration file edits.

### Additional information

This approach supports the idea in https://github.com/rails/rails/pull/50914#discussion_r1478343297.

~~I do not like to use `"<%= app_name.upcase %>_..." in variable names, but I followed the naming in https://github.com/rails/rails/blob/2c5fe6fa7aba4a10d56ff4ee54d26511e58dda3b/railties/lib/rails/generators/rails/app/templates/config/databases/postgresql.yml.tt#L84.~~

~~As suggested in https://github.com/rails/rails/pull/50914#discussion_r1478855943, I would rather use `DATABASE_URL`, `POSTGRES_USER`, and `POSTGRES_PASSWORD`.~~

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.

I am not able to run the tests in Dev Container or locally on macOS (it crashes 👎🏼).  Of course, I would love to add or fix tests, need more tome to set up the local environment.

But I could create a new app from local branch, which includes correct generated Postgres database config (https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#running-an-application-against-your-local-branch).