### PR TITLE
Fix JSON-encoding ActiveStorage::Filename

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Fix JSON-encoding of `ActiveStorage::Filename` instances.
+
+    *Jonathan del Strother*
+
 *   Fix N+1 query when fetching preview images for non-image assets
 
     *Aaron Patterson & Justin Searls*

--- a/activestorage/app/models/active_storage/filename.rb
+++ b/activestorage/app/models/active_storage/filename.rb
@@ -69,10 +69,6 @@ class ActiveStorage::Filename
     to_s
   end
 
-  def to_json
-    to_s
-  end
-
   def <=>(other)
     to_s.downcase <=> other.to_s.downcase
   end

--- a/activestorage/test/models/filename_test.rb
+++ b/activestorage/test/models/filename_test.rb
@@ -53,4 +53,10 @@ class ActiveStorage::FilenameTest < ActiveSupport::TestCase
   test "compare sanitized" do
     assert_operator ActiveStorage::Filename.new("foo-bar.pdf"), :==, ActiveStorage::Filename.new("foo\tbar.pdf")
   end
+
+  test "encoding to json" do
+    assert_equal '"foo.pdf"', ActiveStorage::Filename.new("foo.pdf").to_json
+    assert_equal '{"filename":"foo.pdf"}', { filename: ActiveStorage::Filename.new("foo.pdf") }.to_json
+    assert_equal '{"filename":"foo.pdf"}', JSON.generate(filename: ActiveStorage::Filename.new("foo.pdf"))
+  end
 end


### PR DESCRIPTION
### Motivation / Background

ActiveStorage::Filename was missing quotes when encoded, generating invalid json like this -

```ruby
JSON.generate(foo: ActiveStorage::Filename.new("bar.pdf") # => '{"foo":bar.pdf}'
```

### Detail

Delete `to_json` and rely on the implementation from ActiveSupport::ToJsonWithActiveSupportEncoder

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
