### PR TITLE
Deprecate defining enums with keywords args

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,19 @@
+*   Deprecate defining an `enum` with keyword arguments.
+
+    ```ruby
+    class Function > ApplicationRecord
+      # BAD
+      enum color: [:red, :blue],
+           type: [:instance, :class]
+
+      # GOOD
+      enum :color, [:red, :blue]
+      enum :type, [:instance, :class]
+    end
+    ```
+
+    *Hartley McGuire*
+
 *   Add `active_record.config.validate_migration_timestamps` option for validating migration timestamps.
 
     When set, validates that the timestamp prefix for a migration is no more than a day ahead of

--- a/activerecord/lib/active_record/enum.rb
+++ b/activerecord/lib/active_record/enum.rb
@@ -223,6 +223,13 @@ module ActiveRecord
       options.transform_keys! { |key| :"#{key[1..-1]}" }
 
       definitions.each { |name, values| _enum(name, values, **options) }
+
+      ActiveRecord.deprecator.warn(<<~MSG)
+        Defining enums with keyword arguments is deprecated and will be removed
+        in Rails 7.3. Positional arguments should be used instead:
+
+        #{definitions.map { |name, values| "enum :#{name}, #{values}" }.join("\n")}
+      MSG
     end
 
     private

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -486,7 +486,7 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     self.table_name = "books"
 
     belongs_to :author
-    enum last_read: { unread: 0, reading: 2, read: 3, forgotten: nil }
+    enum :last_read, { unread: 0, reading: 2, read: 3, forgotten: nil }
   end
 
   def test_association_enum_works_properly

--- a/activerecord/test/cases/associations/has_one_associations_test.rb
+++ b/activerecord/test/cases/associations/has_one_associations_test.rb
@@ -807,7 +807,7 @@ class HasOneAssociationsTest < ActiveRecord::TestCase
     belongs_to :author, class_name: "SpecialAuthor"
     has_one :subscription, class_name: "SpecialSubscription", foreign_key: "subscriber_id"
 
-    enum status: [:proposed, :written, :published]
+    enum :status, [:proposed, :written, :published]
   end
 
   class SpecialAuthor < ActiveRecord::Base

--- a/activerecord/test/cases/attribute_methods_test.rb
+++ b/activerecord/test/cases/attribute_methods_test.rb
@@ -1381,7 +1381,8 @@ class AttributeMethodsTest < ActiveRecord::TestCase
     self.table_name = "books"
 
     attribute :status, :string
-    enum status: {
+
+    enum :status, {
       pending: "0",
       completed: "1",
     }

--- a/activerecord/test/cases/enum_test.rb
+++ b/activerecord/test/cases/enum_test.rb
@@ -504,9 +504,11 @@ class EnumTest < ActiveRecord::TestCase
   end
 
   test "reserved enum names" do
-    klass = Class.new(ActiveRecord::Base) do
-      self.table_name = "books"
-      enum status: [:proposed, :written, :published]
+    klass = assert_deprecated(ActiveRecord.deprecator) do
+      Class.new(ActiveRecord::Base) do
+        self.table_name = "books"
+        enum status: [:proposed, :written, :published]
+      end
     end
 
     conflicts = [
@@ -524,9 +526,11 @@ class EnumTest < ActiveRecord::TestCase
   end
 
   test "reserved enum values" do
-    klass = Class.new(ActiveRecord::Base) do
-      self.table_name = "books"
-      enum status: [:proposed, :written, :published]
+    klass = assert_deprecated(ActiveRecord.deprecator) do
+      Class.new(ActiveRecord::Base) do
+        self.table_name = "books"
+        enum status: [:proposed, :written, :published]
+      end
     end
 
     conflicts = [
@@ -548,7 +552,7 @@ class EnumTest < ActiveRecord::TestCase
   end
 
   test "can use id as a value with a prefix or suffix" do
-    assert_nothing_raised do
+    assert_deprecated(ActiveRecord.deprecator) do
       Class.new(ActiveRecord::Base) do
         self.table_name = "books"
         enum status_1: [:id], _prefix: true
@@ -576,7 +580,7 @@ class EnumTest < ActiveRecord::TestCase
   end
 
   test "overriding enum method should not raise" do
-    assert_nothing_raised do
+    assert_deprecated(ActiveRecord.deprecator) do
       Class.new(ActiveRecord::Base) do
         self.table_name = "books"
 
@@ -596,10 +600,12 @@ class EnumTest < ActiveRecord::TestCase
   end
 
   test "validate uniqueness" do
-    klass = Class.new(ActiveRecord::Base) do
-      def self.name; "Book"; end
-      enum status: [:proposed, :written]
-      validates_uniqueness_of :status
+    klass = assert_deprecated(ActiveRecord.deprecator) do
+      Class.new(ActiveRecord::Base) do
+        def self.name; "Book"; end
+        enum status: [:proposed, :written]
+        validates_uniqueness_of :status
+      end
     end
     klass.delete_all
     klass.create!(status: "proposed")
@@ -610,10 +616,12 @@ class EnumTest < ActiveRecord::TestCase
   end
 
   test "validate inclusion of value in array" do
-    klass = Class.new(ActiveRecord::Base) do
-      def self.name; "Book"; end
-      enum status: [:proposed, :written]
-      validates_inclusion_of :status, in: ["written"]
+    klass = assert_deprecated(ActiveRecord.deprecator) do
+      Class.new(ActiveRecord::Base) do
+        def self.name; "Book"; end
+        enum status: [:proposed, :written]
+        validates_inclusion_of :status, in: ["written"]
+      end
     end
     invalid_book = klass.new(status: "proposed")
     assert_not_predicate invalid_book, :valid?
@@ -622,14 +630,18 @@ class EnumTest < ActiveRecord::TestCase
   end
 
   test "enums are distinct per class" do
-    klass1 = Class.new(ActiveRecord::Base) do
-      self.table_name = "books"
-      enum status: [:proposed, :written]
+    klass1 = assert_deprecated(ActiveRecord.deprecator) do
+      Class.new(ActiveRecord::Base) do
+        self.table_name = "books"
+        enum status: [:proposed, :written]
+      end
     end
 
-    klass2 = Class.new(ActiveRecord::Base) do
-      self.table_name = "books"
-      enum status: [:drafted, :uploaded]
+    klass2 = assert_deprecated(ActiveRecord.deprecator) do
+      Class.new(ActiveRecord::Base) do
+        self.table_name = "books"
+        enum status: [:drafted, :uploaded]
+      end
     end
 
     book1 = klass1.proposed.create!
@@ -644,8 +656,10 @@ class EnumTest < ActiveRecord::TestCase
   test "enums are inheritable" do
     subklass1 = Class.new(Book)
 
-    subklass2 = Class.new(Book) do
-      enum status: [:drafted, :uploaded]
+    subklass2 = assert_deprecated(ActiveRecord.deprecator) do
+      Class.new(Book) do
+        enum status: [:drafted, :uploaded]
+      end
     end
 
     book1 = subklass1.proposed.create!
@@ -672,10 +686,12 @@ class EnumTest < ActiveRecord::TestCase
   end
 
   test "declare multiple enums at a time" do
-    klass = Class.new(ActiveRecord::Base) do
-      self.table_name = "books"
-      enum status: [:proposed, :written, :published],
-           nullable_status: [:single, :married]
+    klass = assert_deprecated(ActiveRecord.deprecator) do
+      Class.new(ActiveRecord::Base) do
+        self.table_name = "books"
+        enum status: [:proposed, :written, :published],
+             nullable_status: [:single, :married]
+      end
     end
 
     book1 = klass.proposed.create!
@@ -686,14 +702,16 @@ class EnumTest < ActiveRecord::TestCase
   end
 
   test "declare multiple enums with { _prefix: true }" do
-    klass = Class.new(ActiveRecord::Base) do
-      self.table_name = "books"
+    klass = assert_deprecated(ActiveRecord.deprecator) do
+      Class.new(ActiveRecord::Base) do
+        self.table_name = "books"
 
-      enum(
-        status: [:value_1],
-        last_read: [:value_1],
-        _prefix: true
-      )
+        enum(
+          status: [:value_1],
+          last_read: [:value_1],
+          _prefix: true
+        )
+      end
     end
 
     instance = klass.new
@@ -702,14 +720,16 @@ class EnumTest < ActiveRecord::TestCase
   end
 
   test "declare multiple enums with { _suffix: true }" do
-    klass = Class.new(ActiveRecord::Base) do
-      self.table_name = "books"
+    klass = assert_deprecated(ActiveRecord.deprecator) do
+      Class.new(ActiveRecord::Base) do
+        self.table_name = "books"
 
-      enum(
-        status: [:value_1],
-        last_read: [:value_1],
-        _suffix: true
-      )
+        enum(
+          status: [:value_1],
+          last_read: [:value_1],
+          _suffix: true
+        )
+      end
     end
 
     instance = klass.new
@@ -718,10 +738,12 @@ class EnumTest < ActiveRecord::TestCase
   end
 
   test "enum with alias_attribute" do
-    klass = Class.new(ActiveRecord::Base) do
-      self.table_name = "books"
-      alias_attribute :aliased_status, :status
-      enum aliased_status: [:proposed, :written, :published]
+    klass = assert_deprecated(ActiveRecord.deprecator) do
+      Class.new(ActiveRecord::Base) do
+        self.table_name = "books"
+        alias_attribute :aliased_status, :status
+        enum aliased_status: [:proposed, :written, :published]
+      end
     end
 
     book = klass.proposed.create!
@@ -804,28 +826,34 @@ class EnumTest < ActiveRecord::TestCase
   end
 
   test "enum on custom attribute with default" do
-    klass = Class.new(ActiveRecord::Base) do
-      self.table_name = "books"
-      attribute :status, default: 2
-      enum status: [:proposed, :written, :published]
+    klass = assert_deprecated(ActiveRecord.deprecator) do
+      Class.new(ActiveRecord::Base) do
+        self.table_name = "books"
+        attribute :status, default: 2
+        enum status: [:proposed, :written, :published]
+      end
     end
 
     assert_equal "published", klass.new.status
   end
 
   test "overloaded default by :_default" do
-    klass = Class.new(ActiveRecord::Base) do
-      self.table_name = "books"
-      enum status: [:proposed, :written, :published], _default: :published
+    klass = assert_deprecated(ActiveRecord.deprecator) do
+      Class.new(ActiveRecord::Base) do
+        self.table_name = "books"
+        enum status: [:proposed, :written, :published], _default: :published
+      end
     end
 
     assert_equal "published", klass.new.status
   end
 
   test "scopes can be disabled by :_scopes" do
-    klass = Class.new(ActiveRecord::Base) do
-      self.table_name = "books"
-      enum status: [:proposed, :written], _scopes: false
+    klass = assert_deprecated(ActiveRecord.deprecator) do
+      Class.new(ActiveRecord::Base) do
+        self.table_name = "books"
+        enum status: [:proposed, :written], _scopes: false
+      end
     end
 
     assert_raises(NoMethodError) { klass.proposed }
@@ -887,9 +915,11 @@ class EnumTest < ActiveRecord::TestCase
   end
 
   test "scopes are named like methods" do
-    klass = Class.new(ActiveRecord::Base) do
-      self.table_name = "cats"
-      enum breed: { "American Bobtail" => 0, "Balinese-Javanese" => 1 }
+    klass = assert_deprecated(ActiveRecord.deprecator) do
+      Class.new(ActiveRecord::Base) do
+        self.table_name = "cats"
+        enum breed: { "American Bobtail" => 0, "Balinese-Javanese" => 1 }
+      end
     end
 
     assert_respond_to klass, :American_Bobtail
@@ -897,9 +927,11 @@ class EnumTest < ActiveRecord::TestCase
   end
 
   test "capital characters for enum names" do
-    klass = Class.new(ActiveRecord::Base) do
-      self.table_name = "computers"
-      enum extendedWarranty: [:extendedSilver, :extendedGold]
+    klass = assert_deprecated(ActiveRecord.deprecator) do
+      Class.new(ActiveRecord::Base) do
+        self.table_name = "computers"
+        enum extendedWarranty: [:extendedSilver, :extendedGold]
+      end
     end
 
     computer = klass.extendedSilver.build
@@ -908,9 +940,11 @@ class EnumTest < ActiveRecord::TestCase
   end
 
   test "unicode characters for enum names" do
-    klass = Class.new(ActiveRecord::Base) do
-      self.table_name = "books"
-      enum language: [:🇺🇸, :🇪🇸, :🇫🇷]
+    klass = assert_deprecated(ActiveRecord.deprecator) do
+      Class.new(ActiveRecord::Base) do
+        self.table_name = "books"
+        enum language: [:🇺🇸, :🇪🇸, :🇫🇷]
+      end
     end
 
     book = klass.🇺🇸.build
@@ -919,9 +953,11 @@ class EnumTest < ActiveRecord::TestCase
   end
 
   test "mangling collision for enum names" do
-    klass = Class.new(ActiveRecord::Base) do
-      self.table_name = "computers"
-      enum timezone: [:"Etc/GMT+1", :"Etc/GMT-1"]
+    klass = assert_deprecated(ActiveRecord.deprecator) do
+      Class.new(ActiveRecord::Base) do
+        self.table_name = "computers"
+        enum timezone: [:"Etc/GMT+1", :"Etc/GMT-1"]
+      end
     end
 
     computer = klass.public_send(:"Etc/GMT+1").build
@@ -932,9 +968,11 @@ class EnumTest < ActiveRecord::TestCase
   test "deserialize enum value to original hash key" do
     proposed = Struct.new(:to_s).new("proposed")
     written = Struct.new(:to_s).new("written")
-    klass = Class.new(ActiveRecord::Base) do
-      self.table_name = "books"
-      enum status: { proposed => 0, written => 1 }
+    klass = assert_deprecated(ActiveRecord.deprecator) do
+      Class.new(ActiveRecord::Base) do
+        self.table_name = "books"
+        enum status: { proposed => 0, written => 1 }
+      end
     end
 
     book = klass.create!(status: 0)
@@ -977,12 +1015,14 @@ class EnumTest < ActiveRecord::TestCase
       " This has caused a conflict with auto generated negative scopes."\
       " Avoid using enum elements starting with 'not' where the positive form is also an element."
 
-    Class.new(ActiveRecord::Base) do
-      def self.name
-        "Book"
-      end
-      silence_warnings do
-        enum status: [:sent, :not_sent]
+    assert_deprecated(ActiveRecord.deprecator) do
+      Class.new(ActiveRecord::Base) do
+        def self.name
+          "Book"
+        end
+        silence_warnings do
+          enum status: [:sent, :not_sent]
+        end
       end
     end
 
@@ -1001,12 +1041,14 @@ class EnumTest < ActiveRecord::TestCase
       " This has caused a conflict with auto generated negative scopes."\
       " Avoid using enum elements starting with 'not' where the positive form is also an element."
 
-    Class.new(ActiveRecord::Base) do
-      def self.name
-        "Book"
-      end
-      silence_warnings do
-        enum status: [:not_sent, :sent]
+    assert_deprecated(ActiveRecord.deprecator) do
+      Class.new(ActiveRecord::Base) do
+        def self.name
+          "Book"
+        end
+        silence_warnings do
+          enum status: [:not_sent, :sent]
+        end
       end
     end
 
@@ -1021,12 +1063,14 @@ class EnumTest < ActiveRecord::TestCase
 
     ActiveRecord::Base.logger = logger
 
-    Class.new(ActiveRecord::Base) do
-      def self.name
-        "Book"
-      end
-      silence_warnings do
-        enum status: [:not_sent]
+    assert_deprecated(ActiveRecord.deprecator) do
+      Class.new(ActiveRecord::Base) do
+        def self.name
+          "Book"
+        end
+        silence_warnings do
+          enum status: [:not_sent]
+        end
       end
     end
 
@@ -1041,12 +1085,14 @@ class EnumTest < ActiveRecord::TestCase
 
     ActiveRecord::Base.logger = logger
 
-    Class.new(ActiveRecord::Base) do
-      def self.name
-        "Book"
-      end
-      silence_warnings do
-        enum status: [:not_sent, :sent], _scopes: false
+    assert_deprecated(ActiveRecord.deprecator) do
+      Class.new(ActiveRecord::Base) do
+        def self.name
+          "Book"
+        end
+        silence_warnings do
+          enum status: [:not_sent, :sent], _scopes: false
+        end
       end
     end
 
@@ -1056,9 +1102,11 @@ class EnumTest < ActiveRecord::TestCase
   end
 
   test "raises for attributes with undeclared type" do
-    klass = Class.new(Book) do
-      def self.name; "Book"; end
-      enum typeless_genre: [:adventure, :comic]
+    klass = assert_deprecated(ActiveRecord.deprecator) do
+      Class.new(Book) do
+        def self.name; "Book"; end
+        enum typeless_genre: [:adventure, :comic]
+      end
     end
 
     error = assert_raises(RuntimeError) do
@@ -1068,18 +1116,22 @@ class EnumTest < ActiveRecord::TestCase
   end
 
   test "supports attributes declared with a explicit type" do
-    klass = Class.new(Book) do
-      attribute :my_genre, :integer
-      enum my_genre: [:adventure, :comic]
+    klass = assert_deprecated(ActiveRecord.deprecator) do
+      Class.new(Book) do
+        attribute :my_genre, :integer
+        enum my_genre: [:adventure, :comic]
+      end
     end
 
     assert_equal :integer, klass.type_for_attribute(:my_genre).type
   end
 
   test "default methods can be disabled by :_instance_methods" do
-    klass = Class.new(ActiveRecord::Base) do
-      self.table_name = "books"
-      enum status: [:proposed, :written], _instance_methods: false
+    klass = assert_deprecated(ActiveRecord.deprecator) do
+      Class.new(ActiveRecord::Base) do
+        self.table_name = "books"
+        enum status: [:proposed, :written], _instance_methods: false
+      end
     end
 
     instance = klass.new

--- a/activerecord/test/models/book.rb
+++ b/activerecord/test/models/book.rb
@@ -14,16 +14,16 @@ class Book < ActiveRecord::Base
 
   alias_attribute :title, :name
 
-  enum status: [:proposed, :written, :published]
-  enum last_read: { unread: 0, reading: 2, read: 3, forgotten: nil }
-  enum nullable_status: [:single, :married]
-  enum language: [:english, :spanish, :french], _prefix: :in
-  enum author_visibility: [:visible, :invisible], _prefix: true
-  enum illustrator_visibility: [:visible, :invisible], _prefix: true
-  enum font_size: [:small, :medium, :large], _prefix: :with, _suffix: true
-  enum difficulty: [:easy, :medium, :hard], _suffix: :to_read
-  enum cover: { hard: "hard", soft: "soft" }
-  enum boolean_status: { enabled: true, disabled: false }
+  enum :status, [:proposed, :written, :published]
+  enum :last_read, { unread: 0, reading: 2, read: 3, forgotten: nil }
+  enum :nullable_status, [:single, :married]
+  enum :language, [:english, :spanish, :french], prefix: :in
+  enum :author_visibility, [:visible, :invisible], prefix: true
+  enum :illustrator_visibility, [:visible, :invisible], prefix: true
+  enum :font_size, [:small, :medium, :large], prefix: :with, suffix: true
+  enum :difficulty, [:easy, :medium, :hard], suffix: :to_read
+  enum :cover, { hard: "hard", soft: "soft" }
+  enum :boolean_status, { enabled: true, disabled: false }
 
   def published!
     super

--- a/activerecord/test/models/book_destroy_async.rb
+++ b/activerecord/test/models/book_destroy_async.rb
@@ -8,7 +8,7 @@ class BookDestroyAsync < ActiveRecord::Base
   has_many :essays, dependent: :destroy_async, class_name: "EssayDestroyAsync", foreign_key: "book_id"
   has_one :content, dependent: :destroy_async
 
-  enum status: [:proposed, :written, :published]
+  enum :status, [:proposed, :written, :published]
 
   def published!
     super

--- a/activerecord/test/models/cat.rb
+++ b/activerecord/test/models/cat.rb
@@ -3,7 +3,7 @@
 class Cat < ActiveRecord::Base
   self.abstract_class = true
 
-  enum gender: [:female, :male]
+  enum :gender, [:female, :male]
 
   default_scope -> { where(is_vegetarian: false) }
 end

--- a/activerecord/test/models/comment.rb
+++ b/activerecord/test/models/comment.rb
@@ -28,7 +28,7 @@ class Comment < ActiveRecord::Base
   has_many :children, class_name: "Comment", inverse_of: :parent
   belongs_to :parent, class_name: "Comment", counter_cache: :children_count, inverse_of: :children
 
-  enum label: [:default, :child]
+  enum :label, [:default, :child]
 
   class ::OopsError < RuntimeError; end
 

--- a/activerecord/test/models/membership.rb
+++ b/activerecord/test/models/membership.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Membership < ActiveRecord::Base
-  enum type: %i(Membership CurrentMembership SuperMembership SelectedMembership TenantMembership)
+  enum :type, %i(Membership CurrentMembership SuperMembership SelectedMembership TenantMembership)
   belongs_to :member
   belongs_to :club
 end

--- a/activerecord/test/models/parrot.rb
+++ b/activerecord/test/models/parrot.rb
@@ -29,7 +29,7 @@ class Parrot < ActiveRecord::Base
 end
 
 class LiveParrot < Parrot
-  enum breed: { african: 0, australian: 1 }
+  enum :breed, { african: 0, australian: 1 }
 end
 
 class DeadParrot < Parrot


### PR DESCRIPTION
### Motivation / Background

Enums have historically been defined using keyword arguments:

```ruby
class Function > ApplicationRecord
  enum color: [:red, :blue],
       type: [:instance, :class],
       _scopes: false
```

This has the advantage of being able to define multiple enums at once with the same options. However, it also has a downside that enum options must be prefixed with an underscore to separate them from the enum definitions (to enable models to have enums with the same name as an option).

In Rails 7, a new syntax was [introduced][1] to instead define enums with positional arguments:

```ruby
class Function > ApplicationRecord
  enum :color, [:red, :blue], scopes: false
  enum :type, [:instance, :class], scopes: false
```

This new syntax eliminates the need to prefix options with an underscore, and the docs were updated to recommend this new syntax.

However, both versions of the API have been supported since, and it has started to cause some problems:

The first issue is that the available options have drifted. In Rails 7.1, an option was added to make assigning an invalid enum value use validation errors instead of runtime errors. However, the equivalent underscored prefix option was not added for the original enum syntax

Articles have been created that describe the new option in Rails 7.1, but the examples in the articles use un-prefixed options with the old syntax. This confusion has also lead to issues opened asking why that incorrect syntax is not working.

Additionally, the presence of underscored options is just generally confusing because it tends to imply an option is for internal use.

### Detail

This commit aims to fix all of these issues by deprecating the old enum syntax. With only one way to define enums, options cannot drift and there will be less confusion around how enums should be defined.

[1]: https://github.com/rails/rails/commit/0618d2d84a501aea93c898aec504ff9a0e09d6f2

### Additional information

Closes #50333

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
