### PR TITLE
Improve `dom_id` uniqueness in guides

### DIFF
--- a/guides/rails_guides/generator.rb
+++ b/guides/rails_guides/generator.rb
@@ -177,7 +177,7 @@ module RailsGuides
         anchors = Set.new
         html.scan(/<h\d\s+id="([^"]+)/).flatten.each do |anchor|
           if anchors.member?(anchor)
-            puts "*** DUPLICATE ID: #{anchor}, please make sure that there are no headings with the same name at the same level."
+            puts "*** DUPLICATE ID: '#{anchor}', please make sure that there are no headings with the same name at the same level."
           else
             anchors << anchor
           end

--- a/guides/rails_guides/markdown.rb
+++ b/guides/rails_guides/markdown.rb
@@ -35,16 +35,15 @@ module RailsGuides
       def dom_id(nodes)
         dom_id = dom_id_text(nodes.last.text)
 
-        # Fix duplicate node by prefix with its parent node
+        # Fix duplicate dom_ids by prefixing the parent node dom_id
         if @node_ids[dom_id]
           if @node_ids[dom_id].size > 1
             duplicate_nodes = @node_ids.delete(dom_id)
-            new_node_id = "#{duplicate_nodes[-2][:id]}-#{duplicate_nodes.last[:id]}"
+            new_node_id = dom_id_with_parent_node(dom_id, duplicate_nodes[-2])
             duplicate_nodes.last[:id] = new_node_id
             @node_ids[new_node_id] = duplicate_nodes
           end
-
-          dom_id = "#{nodes[-2][:id]}-#{dom_id}"
+          dom_id = dom_id_with_parent_node(dom_id, nodes[-2])
         end
 
         @node_ids[dom_id] = nodes
@@ -58,6 +57,14 @@ module RailsGuides
                      .gsub(/!/, "-bang")
                      .gsub(/[#{escaped_chars}]+/, " ").strip
                      .gsub(/\s+/, "-")
+      end
+
+      def dom_id_with_parent_node(dom_id, parent_node)
+        if parent_node
+          [parent_node[:id], dom_id].join("-")
+        else
+          dom_id
+        end
       end
 
       def engine


### PR DESCRIPTION
All headers in a guide get a unique `dom_id` to make anchor links work.
If a header is already present we would prefix it (and it's duplicate) with the `dom_id` of the parent node.
This would raise an error for headers without parent nodes:

```
../rails/guides/rails_guides/markdown.rb:47:in `dom_id': undefined method `[]' for nil:NilClass (NoMethodError)

          dom_id = "#{nodes[-2][:id]}-#{dom_id}"
```

This commit simplifies the `dom_id` uniqueness by only prepending the
parent node if it exists. This can still result in duplicates at the
same level, but for these we already show a warning:

    *** DUPLICATE ID: "some_id", please make sure that there are no headings with the same name at the same level.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
