### PR TITLE
Add minimum size to connection pool

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Add an option to `ActiveRecord::ConnectionAdapters::ConnectionPool` and
+    `ActiveRecord::DatabaseConfigurations::HashConfig` to specify a minimum number
+    of connections to keep alive in the database connection pool.
+
+    *Chris AtLee*
+
 *   Support `:source_location` tag option for query log tags
 
     ```ruby

--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool/reaper.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool/reaper.rb
@@ -55,6 +55,7 @@ module ActiveRecord
                     @pools[frequency].each do |p|
                       p.reap
                       p.flush
+                      p.ensure_minimum_connections
                     rescue WeakRef::RefError
                     end
 

--- a/activerecord/lib/active_record/database_configurations/hash_config.rb
+++ b/activerecord/lib/active_record/database_configurations/hash_config.rb
@@ -73,6 +73,10 @@ module ActiveRecord
         (configuration_hash[:pool] || 5).to_i
       end
 
+      def min_size
+        (configuration_hash[:min_size] || 0).to_i
+      end
+
       def min_threads
         (configuration_hash[:min_threads] || 0).to_i
       end

--- a/activerecord/test/cases/asynchronous_queries_test.rb
+++ b/activerecord/test/cases/asynchronous_queries_test.rb
@@ -178,12 +178,12 @@ class AsynchronousExecutorTypeTest < ActiveRecord::TestCase
     assert async_pool1.is_a?(Concurrent::ThreadPoolExecutor)
     assert async_pool2.is_a?(Concurrent::ThreadPoolExecutor)
 
-    assert_equal 4, async_pool1.min_length
+    assert_equal 0, async_pool1.min_length
     assert_equal 4, async_pool1.max_length
     assert_equal 16, async_pool1.max_queue
     assert_equal :caller_runs, async_pool1.fallback_policy
 
-    assert_equal 4, async_pool2.min_length
+    assert_equal 0, async_pool2.min_length
     assert_equal 4, async_pool2.max_length
     assert_equal 16, async_pool2.max_queue
     assert_equal :caller_runs, async_pool2.fallback_policy
@@ -215,12 +215,12 @@ class AsynchronousExecutorTypeTest < ActiveRecord::TestCase
     assert async_pool1.is_a?(Concurrent::ThreadPoolExecutor)
     assert async_pool2.is_a?(Concurrent::ThreadPoolExecutor)
 
-    assert_equal 8, async_pool1.min_length
+    assert_equal 0, async_pool1.min_length
     assert_equal 8, async_pool1.max_length
     assert_equal 32, async_pool1.max_queue
     assert_equal :caller_runs, async_pool1.fallback_policy
 
-    assert_equal 8, async_pool2.min_length
+    assert_equal 0, async_pool2.min_length
     assert_equal 8, async_pool2.max_length
     assert_equal 32, async_pool2.max_queue
     assert_equal :caller_runs, async_pool2.fallback_policy

--- a/activerecord/test/cases/asynchronous_queries_test.rb
+++ b/activerecord/test/cases/asynchronous_queries_test.rb
@@ -178,12 +178,12 @@ class AsynchronousExecutorTypeTest < ActiveRecord::TestCase
     assert async_pool1.is_a?(Concurrent::ThreadPoolExecutor)
     assert async_pool2.is_a?(Concurrent::ThreadPoolExecutor)
 
-    assert_equal 0, async_pool1.min_length
+    assert_equal 4, async_pool1.min_length
     assert_equal 4, async_pool1.max_length
     assert_equal 16, async_pool1.max_queue
     assert_equal :caller_runs, async_pool1.fallback_policy
 
-    assert_equal 0, async_pool2.min_length
+    assert_equal 4, async_pool2.min_length
     assert_equal 4, async_pool2.max_length
     assert_equal 16, async_pool2.max_queue
     assert_equal :caller_runs, async_pool2.fallback_policy
@@ -215,12 +215,12 @@ class AsynchronousExecutorTypeTest < ActiveRecord::TestCase
     assert async_pool1.is_a?(Concurrent::ThreadPoolExecutor)
     assert async_pool2.is_a?(Concurrent::ThreadPoolExecutor)
 
-    assert_equal 0, async_pool1.min_length
+    assert_equal 8, async_pool1.min_length
     assert_equal 8, async_pool1.max_length
     assert_equal 32, async_pool1.max_queue
     assert_equal :caller_runs, async_pool1.fallback_policy
 
-    assert_equal 0, async_pool2.min_length
+    assert_equal 8, async_pool2.min_length
     assert_equal 8, async_pool2.max_length
     assert_equal 32, async_pool2.max_queue
     assert_equal :caller_runs, async_pool2.fallback_policy

--- a/activerecord/test/cases/connection_pool_test.rb
+++ b/activerecord/test/cases/connection_pool_test.rb
@@ -226,7 +226,7 @@ module ActiveRecord
 
       def test_inactive_are_returned_from_dead_thread
         ready = Concurrent::CountDownLatch.new
-        @pool.instance_variable_set(:@size, 1)
+        @pool.instance_variable_set(:@max_size, 1)
 
         child = new_thread do
           @pool.checkout
@@ -269,7 +269,7 @@ module ActiveRecord
 
         idle_conn.instance_variable_set(
           :@idle_since,
-          Process.clock_gettime(Process::CLOCK_MONOTONIC) - 0.02
+          Process.clock_gettime(Process::CLOCK_MONOTONIC) - 0.03
         )
 
         @pool.flush
@@ -313,7 +313,7 @@ module ActiveRecord
         connections.each do |conn|
           conn.instance_variable_set(
             :@idle_since,
-            Process.clock_gettime(Process::CLOCK_MONOTONIC) - 0.02
+            Process.clock_gettime(Process::CLOCK_MONOTONIC) - 0.03
           )
         end
 

--- a/activerecord/test/cases/connection_pool_test.rb
+++ b/activerecord/test/cases/connection_pool_test.rb
@@ -139,7 +139,7 @@ module ActiveRecord
 
       def test_full_pool_blocking_shares_load_interlock
         skip_fiber_testing
-        @pool.instance_variable_set(:@size, 1)
+        @pool.instance_variable_set(:@max_size, 1)
 
         load_interlock_latch = Concurrent::CountDownLatch.new
         connection_latch = Concurrent::CountDownLatch.new
@@ -416,7 +416,7 @@ module ActiveRecord
       def test_checkout_fairness
         skip_fiber_testing
 
-        @pool.instance_variable_set(:@size, 10)
+        @pool.instance_variable_set(:@max_size, 10)
         expected = (1..@pool.size).to_a.freeze
         # check out all connections so our threads start out waiting
         conns = expected.map { @pool.checkout }
@@ -463,7 +463,7 @@ module ActiveRecord
       def test_checkout_fairness_by_group
         skip_fiber_testing
 
-        @pool.instance_variable_set(:@size, 10)
+        @pool.instance_variable_set(:@max_size, 10)
         # take all the connections
         conns = (1..10).map { @pool.checkout }
         mutex = Mutex.new

--- a/activerecord/test/cases/reaper_test.rb
+++ b/activerecord/test/cases/reaper_test.rb
@@ -29,6 +29,9 @@ module ActiveRecord
         def discarded?
           @discarded
         end
+
+        def ensure_minimum_connections
+        end
       end
 
       # A reaper with nil time should never reap connections


### PR DESCRIPTION
### Motivation / Background

This PR implements the minimum connection pool size idea described in #50989.

The primary motivation with this is to ensure that we always have at least _N_ connections established to the DB so that we don't need to spend time connecting to the DB during the handling of a request.

Fixes #50989

### Detail

In `ConnectionPool`, rename `:size` to `:max_size`, and add `:min_size` as a configuration option. `:min_size` is initialized from `db_config.min_size`, where I've also added a new configuration option.

`ConnectionPool#initialize` calls a new method, `ensure_minimum_connections` when `min_size` is > 0.

In `ConnectionPool#flush`, we need to pay attention to the minimum pool size, and make sure that we don't close too many connections.

Finally, `ConnectionPool::Reaper` also calls into `ensure_minimum_connections` after reaping/flushing to ensure that we always have the desired number of established connections active.

### Additional information

<!-- Provide additional information such as benchmarks, reference to other repositories or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
