### PR TITLE
Don't pop logger tags in Rails::Rack::Logger until request is finished

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Ensure logger tags configured with `config.log_tags` are still active in `request.action_dispatch` handlers
+
+    *KJ Tsanaktsidis*
+
 *   Setup jemalloc in the default Dockerfile for memory optimization.
 
     *Matt Almeida*, *Jean Boussier*

--- a/railties/lib/rails/rack/logger.rb
+++ b/railties/lib/rails/rack/logger.rb
@@ -20,22 +20,23 @@ module Rails
       def call(env)
         request = ActionDispatch::Request.new(env)
 
-        if logger.respond_to?(:tagged)
-          logger.tagged(*compute_tags(request)) { call_app(request, env) }
+        logger_tag_pop_count = if logger.respond_to?(:push_tags)
+          logger.push_tags(*compute_tags(request)).size
         else
-          call_app(request, env)
+          0
         end
+        call_app(request, env, logger_tag_pop_count)
       end
 
       private
-        def call_app(request, env) # :doc:
+        def call_app(request, env, logger_tag_pop_count) # :doc:
           instrumenter = ActiveSupport::Notifications.instrumenter
           handle = instrumenter.build_handle("request.action_dispatch", { request: request })
           handle.start
 
           logger.info { started_request_message(request) }
           status, headers, body = response = @app.call(env)
-          body = ::Rack::BodyProxy.new(body) { finish_request_instrumentation(handle) }
+          body = ::Rack::BodyProxy.new(body) { finish_request_instrumentation(handle, logger_tag_pop_count) }
 
           if response.frozen?
             [status, headers, body]
@@ -44,7 +45,7 @@ module Rails
             response
           end
         rescue Exception
-          finish_request_instrumentation(handle)
+          finish_request_instrumentation(handle, logger_tag_pop_count)
           raise
         end
 
@@ -74,8 +75,9 @@ module Rails
           Rails.logger
         end
 
-        def finish_request_instrumentation(handle)
+        def finish_request_instrumentation(handle, logger_tag_pop_count)
           handle.finish
+          logger.pop_tags(logger_tag_pop_count) if logger.respond_to?(:pop_tags) && logger_tag_pop_count > 0
           ActiveSupport::LogSubscriber.flush_all!
         end
     end


### PR DESCRIPTION


<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

At the moment, Rails::Rack::Logger tags the logger (if it's `ActiveSupport::TaggedLogging`) for the duration of the `@app.call`, but only fires the request.action_dispatch event later, on body close. That means anything logged in `request.action_dispatch` handlers won't have the same tags as the rest of the request.

### Detail

Fix this by deferring the popping of tags into `finish_request_instrumentation`, in the same way that finishing the instrumentation handle is deferred.


### Additional information

There didn't seem to be any test case related to request log taggers, so I added one. Also, I don't know if this is important enough for a changelog entry, but it seemed harmless enough to add a one-liner in there.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
