### PR TITLE
[7-1-stable] Fix Active Storage test configurations for CI

### DIFF
--- a/activestorage/Rakefile
+++ b/activestorage/Rakefile
@@ -13,13 +13,13 @@ Rake::TestTask.new do |t|
 end
 
 if ENV["encrypted_0fb9444d0374_key"] && ENV["encrypted_0fb9444d0374_iv"]
-  _file = "test/service/configurations.yml"
-  file _file do
-    puts "Generating #{_file} for Active Storage tests..."
-    system "openssl aes-256-cbc -K $encrypted_0fb9444d0374_key -iv $encrypted_0fb9444d0374_iv -in #{_file}.enc -out #{_file} -d"
+  config_file = "test/service/configurations.yml"
+  file config_file do
+    puts "Generating #{config_file} for Active Storage tests..."
+    system "openssl aes-256-cbc -K $encrypted_0fb9444d0374_key -iv $encrypted_0fb9444d0374_iv -in #{config_file}.enc -out #{config_file} -d"
   end
 
-  task test: _file
+  task test: config_file
 end
 
 task :package

--- a/activestorage/test/controllers/direct_uploads_controller_test.rb
+++ b/activestorage/test/controllers/direct_uploads_controller_test.rb
@@ -17,13 +17,13 @@ if SERVICE_CONFIGURATIONS[:s3] && SERVICE_CONFIGURATIONS[:s3][:access_key_id].pr
     test "creating new direct upload" do
       checksum = OpenSSL::Digest::MD5.base64digest("Hello")
       metadata = {
-        "foo": "bar",
-        "my_key_1": "my_value_1",
-        "my_key_2": "my_value_2",
-        "platform": "my_platform",
-        "library_ID": "12345",
-        "custom": {
-          "my_key_3": "my_value_3"
+        "foo" => "bar",
+        "my_key_1" => "my_value_1",
+        "my_key_2" => "my_value_2",
+        "platform" => "my_platform",
+        "library_ID" => "12345",
+        "custom" => {
+          "my_key_3" => "my_value_3"
         }
       }
 
@@ -35,7 +35,7 @@ if SERVICE_CONFIGURATIONS[:s3] && SERVICE_CONFIGURATIONS[:s3][:access_key_id].pr
         assert_equal "hello.txt", details["filename"]
         assert_equal 6, details["byte_size"]
         assert_equal checksum, details["checksum"]
-        assert_equal metadata.deep_stringify_keys, details["metadata"].deep_stringify_keys
+        assert_equal metadata, details["metadata"]
         assert_equal "text/plain", details["content_type"]
         assert_match SERVICE_CONFIGURATIONS[:s3][:bucket], details["direct_upload"]["url"]
         assert_match(/s3(-[-a-z0-9]+)?\.(\S+)?amazonaws\.com/, details["direct_upload"]["url"])
@@ -63,25 +63,25 @@ if SERVICE_CONFIGURATIONS[:gcs]
     test "creating new direct upload" do
       checksum = OpenSSL::Digest::MD5.base64digest("Hello")
       metadata = {
-        "foo": "bar",
-        "my_key_1": "my_value_1",
-        "my_key_2": "my_value_2",
-        "platform": "my_platform",
-        "library_ID": "12345",
-        "custom": {
-          "my_key_3": "my_value_3"
+        "foo" => "bar",
+        "my_key_1" => "my_value_1",
+        "my_key_2" => "my_value_2",
+        "platform" => "my_platform",
+        "library_ID" => "12345",
+        "custom" => {
+          "my_key_3" => "my_value_3"
         }
       }
 
       post rails_direct_uploads_url, params: { blob: {
         filename: "hello.txt", byte_size: 6, checksum: checksum, content_type: "text/plain", metadata: metadata } }
 
-      @response.parsed_body.tap do |details|
+      response.parsed_body.tap do |details|
         assert_equal ActiveStorage::Blob.find(details["id"]), ActiveStorage::Blob.find_signed!(details["signed_id"])
         assert_equal "hello.txt", details["filename"]
         assert_equal 6, details["byte_size"]
         assert_equal checksum, details["checksum"]
-        assert_equal metadata.deep_stringify_keys, details["metadata"].deep_stringify_keys
+        assert_equal metadata, details["metadata"]
         assert_equal "text/plain", details["content_type"]
         assert_match %r{storage\.googleapis\.com/#{@config[:bucket]}}, details["direct_upload"]["url"]
         assert_equal({ "Content-MD5" => checksum, "Content-Disposition" => "inline; filename=\"hello.txt\"; filename*=UTF-8''hello.txt", "x-goog-meta-my_key_3" => "my_value_3" }, details["direct_upload"]["headers"])
@@ -108,22 +108,22 @@ if SERVICE_CONFIGURATIONS[:azure]
     test "creating new direct upload" do
       checksum = OpenSSL::Digest::MD5.base64digest("Hello")
       metadata = {
-        "foo": "bar",
-        "my_key_1": "my_value_1",
-        "my_key_2": "my_value_2",
-        "platform": "my_platform",
-        "library_ID": "12345"
+        "foo" => "bar",
+        "my_key_1" => "my_value_1",
+        "my_key_2" => "my_value_2",
+        "platform" => "my_platform",
+        "library_ID" => "12345"
       }
 
       post rails_direct_uploads_url, params: { blob: {
         filename: "hello.txt", byte_size: 6, checksum: checksum, content_type: "text/plain", metadata: metadata } }
 
-      @response.parsed_body.tap do |details|
+      response.parsed_body.tap do |details|
         assert_equal ActiveStorage::Blob.find(details["id"]), ActiveStorage::Blob.find_signed!(details["signed_id"])
         assert_equal "hello.txt", details["filename"]
         assert_equal 6, details["byte_size"]
         assert_equal checksum, details["checksum"]
-        assert_equal metadata, details["metadata"].deep_transform_keys(&:to_sym)
+        assert_equal metadata, details["metadata"]
         assert_equal "text/plain", details["content_type"]
         assert_match %r{#{@config[:storage_account_name]}\.blob\.core\.windows\.net/#{@config[:container]}}, details["direct_upload"]["url"]
         assert_equal({ "Content-Type" => "text/plain", "Content-MD5" => checksum, "x-ms-blob-content-disposition" => "inline; filename=\"hello.txt\"; filename*=UTF-8''hello.txt", "x-ms-blob-type" => "BlockBlob" }, details["direct_upload"]["headers"])
@@ -148,7 +148,7 @@ class ActiveStorage::DiskDirectUploadsControllerTest < ActionDispatch::Integrati
     post rails_direct_uploads_url, params: { blob: {
       filename: "hello.txt", byte_size: 6, checksum: checksum, content_type: "text/plain", metadata: metadata } }
 
-    @response.parsed_body.tap do |details|
+    response.parsed_body.tap do |details|
       assert_equal ActiveStorage::Blob.find(details["id"]), ActiveStorage::Blob.find_signed!(details["signed_id"])
       assert_equal "hello.txt", details["filename"]
       assert_equal 6, details["byte_size"]
@@ -163,11 +163,11 @@ class ActiveStorage::DiskDirectUploadsControllerTest < ActionDispatch::Integrati
   test "creating new direct upload does not include root in json" do
     checksum = OpenSSL::Digest::MD5.base64digest("Hello")
     metadata = {
-      "foo": "bar",
-      "my_key_1": "my_value_1",
-      "my_key_2": "my_value_2",
-      "platform": "my_platform",
-      "library_ID": "12345"
+      "foo" => "bar",
+      "my_key_1" => "my_value_1",
+      "my_key_2" => "my_value_2",
+      "platform" => "my_platform",
+      "library_ID" => "12345"
     }
 
     set_include_root_in_json(true) do
@@ -175,7 +175,7 @@ class ActiveStorage::DiskDirectUploadsControllerTest < ActionDispatch::Integrati
         filename: "hello.txt", byte_size: 6, checksum: checksum, content_type: "text/plain", metadata: metadata } }
     end
 
-    @response.parsed_body.tap do |details|
+    response.parsed_body.tap do |details|
       assert_nil details["blob"]
       assert_not_nil details["id"]
     end

--- a/activestorage/test/dummy/config/environments/test.rb
+++ b/activestorage/test/dummy/config/environments/test.rb
@@ -38,10 +38,10 @@ Rails.application.configure do
   config.active_storage.service = :local
 
   SERVICE_CONFIGURATIONS = begin
-    _file = Rails.root.join("../service/configurations.yml")
-    ActiveSupport::ConfigurationFile.parse(_file).deep_symbolize_keys
+    config_file = Rails.root.join("../service/configurations.yml")
+    ActiveSupport::ConfigurationFile.parse(config_file, symbolize_names: true)
   rescue Errno::ENOENT
-    puts "Missing service configuration file in #{_file}"
+    puts "Missing service configuration file in #{config_file}"
     {}
   end
   # Azure service tests are currently failing on the main branch.


### PR DESCRIPTION
Apply #50967 to 7-1-stable, to simplify the tests for metadata and corrects the test configuration path with improvements to the readability.

This change improves upon #50787 in that it removes the need to stringify or symbolize any keys, since we are comparing the metadata with string keys. This is a follow up to #43705.

Sorry this took me 2 PRs! :bow: