### PR TITLE
[7-1-stable] Pin minitest version to 5.21

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gemspec
 if RUBY_VERSION < "3"
   gem "minitest", ">= 5.15.0", "< 5.16"
 else
-  gem "minitest", ">= 5.15.0"
+  gem "minitest", ">= 5.15.0", "< 5.22.0"
 end
 
 # We need a newish Rake since Active Job sets its test tasks' descriptions.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -81,7 +81,7 @@ PATH
       connection_pool (>= 2.2.5)
       drb
       i18n (>= 1.6, < 2)
-      minitest (>= 5.1)
+      minitest (>= 5.1, < 5.22.0)
       mutex_m
       tzinfo (~> 2.0)
     rails (7.1.3)
@@ -587,7 +587,7 @@ DEPENDENCIES
   libxml-ruby
   listen (~> 3.3)
   mdl
-  minitest (>= 5.15.0)
+  minitest (>= 5.15.0, < 5.22.0)
   minitest-bisect
   minitest-ci
   minitest-retry

--- a/activesupport/activesupport.gemspec
+++ b/activesupport/activesupport.gemspec
@@ -38,7 +38,7 @@ Gem::Specification.new do |s|
   s.add_dependency "tzinfo",          "~> 2.0"
   s.add_dependency "concurrent-ruby", "~> 1.0", ">= 1.0.2"
   s.add_dependency "connection_pool", ">= 2.2.5"
-  s.add_dependency "minitest",        ">= 5.1"
+  s.add_dependency "minitest",        ">= 5.1", "< 5.22.0"
   s.add_dependency "base64"
   s.add_dependency "drb"
   s.add_dependency "mutex_m"


### PR DESCRIPTION
Backport #50978 to `7-1-stable`, while I'm not so sure this qualifies as backport material it is a major problem that none of the tests are running.

Original description:

---

Managed to reproduce CI failure at https://buildkite.com/rails/rails-nightly/builds/133#018d7bb8-8a32-4978-8e36-d7cb9b067813/1196-1204 . It would also reproduce against the released versions of Ruby because this is triggered by minitest v5.22.0 change. https://github.com/minitest/minitest/commit/ebb468c81c0eea069234127bd6a101c84e955872

To avoid all of railties CI failures, pin minitest version to 5.21 tentatively.

* Steps to reproduce
```ruby
git clone https://github.com/rails/rails
cd rails
rm Gemfile.lock
bundle install
cd railties
bin/test test/application/test_runner_test.rb -n test_system_tests_are_not_run_with_the_default_test_command
```

* Expected behavior It should pass.

* Actual behavior
```ruby
$ bin/test test/application/test_runner_test.rb -n test_system_tests_are_not_run_with_the_default_test_command
Run options: -n test_system_tests_are_not_run_with_the_default_test_command --seed 14574

F

Failure:
ApplicationTests::TestRunnerTest#test_system_tests_are_not_run_with_the_default_test_command [test/application/test_runner_test.rb:1191]:
Expected /0\ runs,\ 0\ assertions,\ 0\ failures,\ 0\ errors,\ 0\ skips/ to match "Nothing ran for filter: \nRunning 0 tests in a single process (parallelization threshold is 50)\nRun options: --seed 45713\n\n# Running:\n\n".

bin/test test/application/test_runner_test.rb:1179

Finished in 9.982314s, 0.1002 runs/s, 0.2004 assertions/s.
1 runs, 2 assertions, 1 failures, 0 errors, 0 skips
$
```