### PR TITLE
Update minitest to include fix for test run filter

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@
 source "https://rubygems.org"
 gemspec
 
-gem "minitest", ">= 5.15.0", "< 5.22.0"
+gem "minitest", ">= 5.15.0"
 
 # We need a newish Rake since Active Job sets its test tasks' descriptions.
 gem "rake", ">= 13"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -328,7 +328,7 @@ GEM
     mini_magick (4.12.0)
     mini_mime (1.1.5)
     mini_portile2 (2.8.5)
-    minitest (5.21.1)
+    minitest (5.22.1)
     minitest-bisect (1.7.0)
       minitest-server (~> 1.0)
       path_expander (~> 1.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -93,7 +93,7 @@ PATH
       connection_pool (>= 2.2.5)
       drb
       i18n (>= 1.6, < 2)
-      minitest (>= 5.1, < 5.22.0)
+      minitest (>= 5.1)
       tzinfo (~> 2.0, >= 2.0.5)
     rails (7.2.0.alpha)
       actioncable (= 7.2.0.alpha)
@@ -616,7 +616,7 @@ DEPENDENCIES
   libxml-ruby
   listen (~> 3.3)
   mdl (!= 0.13.0)
-  minitest (>= 5.15.0, < 5.22.0)
+  minitest (>= 5.15.0)
   minitest-bisect
   minitest-ci
   minitest-retry

--- a/activesupport/activesupport.gemspec
+++ b/activesupport/activesupport.gemspec
@@ -38,7 +38,7 @@ Gem::Specification.new do |s|
   s.add_dependency "tzinfo",          "~> 2.0", ">= 2.0.5"
   s.add_dependency "concurrent-ruby", "~> 1.0", ">= 1.0.2"
   s.add_dependency "connection_pool", ">= 2.2.5"
-  s.add_dependency "minitest",        ">= 5.1", "< 5.22.0"
+  s.add_dependency "minitest",        ">= 5.1"
   s.add_dependency "base64"
   s.add_dependency "drb"
   s.add_dependency "bigdecimal"


### PR DESCRIPTION
This PR reverts #50978 and bumps the version of minitest in our Gemfile.lock