### PR TITLE
Fix a race condition in FutureResult#instrument

### DIFF
--- a/activerecord/lib/active_record/future_result.rb
+++ b/activerecord/lib/active_record/future_result.rb
@@ -32,8 +32,11 @@ module ActiveRecord
 
       def instrument(name, payload = {}, &block)
         event = @instrumenter.new_event(name, payload)
-        @events << event
-        event.record(&block)
+        begin
+          event.record(&block)
+        ensure
+          @events << event
+        end
       end
 
       def flush


### PR DESCRIPTION
We must wait until the event is fully recorded before adding it to the list, otherwise it might be flushed while incomplete.
