### PR TITLE
Share already loaded fixtures across test classes

### DIFF
--- a/activerecord/test/cases/fixtures_test.rb
+++ b/activerecord/test/cases/fixtures_test.rb
@@ -783,7 +783,7 @@ class MultipleFixturesTest < ActiveRecord::TestCase
   fixtures :developers, :accounts
 
   def test_fixture_table_names
-    assert_equal %w(topics developers accounts), fixture_table_names
+    assert_equal %w(accounts developers topics), fixture_table_names
   end
 end
 
@@ -815,7 +815,7 @@ class OverlappingFixturesTest < ActiveRecord::TestCase
   fixtures :developers, :accounts
 
   def test_fixture_table_names
-    assert_equal %w(topics developers accounts), fixture_table_names
+    assert_equal %w(accounts developers topics), fixture_table_names
   end
 end
 
@@ -1162,6 +1162,8 @@ class FixturesBrokenRollbackTest < ActiveRecord::TestCase
   alias_method :ar_teardown_fixtures, :teardown_fixtures
   alias_method :teardown_fixtures, :blank_teardown
   alias_method :teardown, :blank_teardown
+
+  fixtures rand.to_s # bypass fixtures cache
 
   def test_no_rollback_in_teardown_unless_transaction_active
     assert_equal 0, ActiveRecord::Base.connection.open_transactions

--- a/activerecord/test/cases/view_test.rb
+++ b/activerecord/test/cases/view_test.rb
@@ -101,6 +101,8 @@ if ActiveRecord::Base.connection.supports_views?
 
   class ViewWithoutPrimaryKeyTest < ActiveRecord::TestCase
     include SchemaDumpingHelper
+
+    self.use_transactional_tests = false
     fixtures :books
 
     class Paperback < ActiveRecord::Base; end


### PR DESCRIPTION
`self.class` is a fairly narrow cache key, so it doesn't hit that much, but more importantly, since nothing clears that cache, on large test suites it keeps growing extremely large.

~~Using the list of fixtures as a cache key doesn't strictly solve the growth issue, but most classes actually load all fixtures so this should shrink the cache size considerably.~~

Instead we can use the parameters of `load_fixtures` as a cache key, and clear the entire cache when changes, this both improve the hit rate and solves a memory leak.

cc @ChrisBr 