### PR TITLE
[RF DOCS] Add documentation for `perform_all_later` to Active Job Basics guide [ci-skip]

### DIFF
--- a/guides/source/active_job_basics.md
+++ b/guides/source/active_job_basics.md
@@ -138,7 +138,7 @@ Here is an example calling `perform_all_later` with `GuestCleanupJob` instances:
 ```ruby
 # Create jobs to pass to `perform_all_later`.
 # The arguments to `new` are passed on to `perform`
-guest_cleanup_jobs = User.pluck(:id).map { |id| GuestsCleanupJob.new(guest_id: id) }
+guest_cleanup_jobs = Guest.all.map { |guest| GuestsCleanupJob.new(guest) }
 
 # Will enqueue a seperate job for each instance of `GuestCleanupJob`
 ActiveJob.perform_all_later(guest_cleanup_jobs)

--- a/guides/source/active_job_basics.md
+++ b/guides/source/active_job_basics.md
@@ -462,7 +462,7 @@ ActiveJob.perform_all_later(cleanup_job, export_job, notify_job)
 
 ### Bulk Enqueue Callbacks
 
-When enqueueing jobs in bulk using `perform_all_later`, callbacks such as `around_enqueue`, will not be triggered on the individual jobs. This behavior is in line with other Active Record bulk methods. Since callbacks run on individual jobs, they can't take advantage of the bulk nature of this method.
+When enqueuing jobs in bulk using `perform_all_later`, callbacks such as `around_enqueue`, will not be triggered on the individual jobs. This behavior is in line with other Active Record bulk methods. Since callbacks run on individual jobs, they can't take advantage of the bulk nature of this method.
 
 However, the `perform_all_later` method does fire an [`enqueue_all.active_job`](active_support_instrumentation.html#enqueue-all-active-job) event which you can subscribe to using `ActiveSupport::Notifications`.
 

--- a/guides/source/active_job_basics.md
+++ b/guides/source/active_job_basics.md
@@ -410,7 +410,7 @@ end
 [`around_perform`]: https://api.rubyonrails.org/classes/ActiveJob/Callbacks/ClassMethods.html#method-i-around_perform
 [`after_perform`]: https://api.rubyonrails.org/classes/ActiveJob/Callbacks/ClassMethods.html#method-i-after_perform
 
-Please note that When enqueueing jobs in bulk using `perform_all_later`, callbacks such as `around_enqueue`, will not be triggered on the individual jobs. See [Bulk Enqueuing Callbacks](#bulk-enqueue-callbacks).
+Please note that when enqueueing jobs in bulk using `perform_all_later`, callbacks such as `around_enqueue`, will not be triggered on the individual jobs. See [Bulk Enqueuing Callbacks](#bulk-enqueue-callbacks).
 
 Bulk Enqueuing
 --------------

--- a/guides/source/active_job_basics.md
+++ b/guides/source/active_job_basics.md
@@ -124,6 +124,29 @@ GuestsCleanupJob.perform_later(guest1, guest2, filter: 'some_filter')
 
 That's it!
 
+### Bulk Enqueuing
+
+You can Enqueue multiple jobs using perform_all_later.
+
+`perform_all_later` is a top-level api on ActiveJob. It accepts instantiated jobs as arguments (note that this is different from `perform_later`). `perform_all_later` does call `perform` under the hood. The arguments passed to `new` will be passed on to `perform` when it's eventually called.
+
+Here is an example calling `perform_all_later` with `GuestCleanupJob` instances:
+
+```ruby
+# Create jobs to pass to `perform_all_later`. The arguments to `new` are
+# passed on to `perform`
+job1 = GuestsCleanupJob.new("guest1")
+job2 = GuestsCleanupJob.new("guest2")
+job3 = GuestsCleanupJob.new("guest3")
+
+# Will enqueue a seperate job for each instance of `GuestCleanupJob`
+ActiveJob.perform_all_later(job1, job2, job3)
+```
+
+`perform_all_later` logs the number of jobs successfully enqueued, something like `Enqueued 3 jobs to Async (3 GuestsCleanupJob)`. 
+
+The return value is `nil`. Note that this may be enhance to return the number of successfully enqueued job in the future.
+
 [`perform_later`]: https://api.rubyonrails.org/classes/ActiveJob/Enqueuing/ClassMethods.html#method-i-perform_later
 [`set`]: https://api.rubyonrails.org/classes/ActiveJob/Core/ClassMethods.html#method-i-set
 

--- a/guides/source/active_job_basics.md
+++ b/guides/source/active_job_basics.md
@@ -178,7 +178,7 @@ Note that `perform_all_later` does not trigger callbacks on the individual jobs.
 
 For `perform_all_later`, bulk enqueuing needs to be backed by the queue backend.
 
-For example Sidekiq has a `push_bulk` method, which can push a large number of jobs to Redis and prevent the round trip network latency. GoodJob also supports bulk enqueuing with `GoodJob::Bulk.enqueue` method. The new queue backend [`Solid Queue`] has added support for bulk enqueuing as well.
+For example Sidekiq has a `push_bulk` method, which can push a large number of jobs to Redis and prevent the round trip network latency. GoodJob also supports bulk enqueuing with `GoodJob::Bulk.enqueue` method. The new queue backend [`Solid Queue`][] has added support for bulk enqueuing as well.
 
 If the queue backend does *not* support bulk enqueuing, `perform_all_later` will enqueue jobs one by one.
 

--- a/guides/source/active_job_basics.md
+++ b/guides/source/active_job_basics.md
@@ -124,6 +124,9 @@ GuestsCleanupJob.perform_later(guest1, guest2, filter: 'some_filter')
 
 That's it!
 
+[`perform_later`]: https://api.rubyonrails.org/classes/ActiveJob/Enqueuing/ClassMethods.html#method-i-perform_later
+[`set`]: https://api.rubyonrails.org/classes/ActiveJob/Core/ClassMethods.html#method-i-set
+
 ### Bulk Enqueuing
 
 You can Enqueue multiple jobs at once using [`perform_all_later`](https://api.rubyonrails.org/v7.1.3/classes/ActiveJob.html#method-c-perform_all_later). Bulk Enqueuing reduces the number of round trips to a queue data store like Redis.
@@ -182,9 +185,6 @@ For `perform_all_later`, bulk enqueuing needs to be backed by the queue backend.
 For example Sidekiq has a `push_bulk` method, which can push a large number of jobs to Redis and prevent the round trip network latency. GoodJob also supports bulk enqueuing with `GoodJob::Bulk.enqueue` method. The new queue backend [`Solid Queue`](https://github.com/basecamp/solid_queue/pull/93) has added support for bulk enqueuing as well.
 
 If the queue backend does *not* support bulk enqueuing, `perform_all_later` will enqueue jobs one by one.
-
-[`perform_later`]: https://api.rubyonrails.org/classes/ActiveJob/Enqueuing/ClassMethods.html#method-i-perform_later
-[`set`]: https://api.rubyonrails.org/classes/ActiveJob/Core/ClassMethods.html#method-i-set
 
 Job Execution
 -------------

--- a/guides/source/active_job_basics.md
+++ b/guides/source/active_job_basics.md
@@ -144,7 +144,7 @@ guest_cleanup_jobs = Guest.all.map { |guest| GuestsCleanupJob.new(guest) }
 ActiveJob.perform_all_later(guest_cleanup_jobs)
 ```
 
-`perform_all_later` logs the number of jobs successfully enqueued, for example if `User.pluck(:id).map` above resulted in 3 `guest_cleanup_jobs`, it would log `Enqueued 3 jobs to Async (3 GuestsCleanupJob)` (assuming all were enqueued).
+`perform_all_later` logs the number of jobs successfully enqueued, for example if `Guest.all.map` above resulted in 3 `guest_cleanup_jobs`, it would log `Enqueued 3 jobs to Async (3 GuestsCleanupJob)` (assuming all were enqueued).
 
 The return value of `perform_all_later` is `nil`. Note that this is different from `perform_later`, which returns the instance of the queued job class.
 

--- a/guides/source/active_job_basics.md
+++ b/guides/source/active_job_basics.md
@@ -174,7 +174,7 @@ notify_job = NotifyGuestsJob.new(guest)
 ApplicationJob.perform_all_later(cleanup_job, export_job, notify_job)
 ```
 
-#### Callbacks
+#### Bulk Enqueue Callbacks
 
 Note that `perform_all_later` does not trigger callbacks on the individual jobs. This is inline with other ActiveRecord bulk methods. Since callbacks run on individual jobs, they can't take advantage of the bulk nature of this method. Also there isn't a meaningful semantic for something like `around_enqueue` callback.
 

--- a/guides/source/active_job_basics.md
+++ b/guides/source/active_job_basics.md
@@ -436,7 +436,7 @@ The return value of `perform_all_later` is `nil`. Note that this is different fr
 
 ### Enqueue Multiple Active Job Classes
 
-With `perform_all_later` it's also possible to enqueue different Active Job class instances in the same call. For example
+With `perform_all_later`, it's also possible to enqueue different Active Job class instances in the same call. For example:
 
 ```ruby
 class ExportDataJob < ApplicationJob

--- a/guides/source/active_job_basics.md
+++ b/guides/source/active_job_basics.md
@@ -472,7 +472,7 @@ The method [`successfully_enqueued?`](https://api.rubyonrails.org/classes/Active
 
 For `perform_all_later`, bulk enqueuing needs to be backed by the [queue backend](#backends).
 
-For example Sidekiq has a `push_bulk` method, which can push a large number of jobs to Redis and prevent the round trip network latency. GoodJob also supports bulk enqueuing with `GoodJob::Bulk.enqueue` method. The new queue backend [`Solid Queue`](https://github.com/basecamp/solid_queue/pull/93) has added support for bulk enqueuing as well.
+For example, Sidekiq has a `push_bulk` method, which can push a large number of jobs to Redis and prevent the round trip network latency. GoodJob also supports bulk enqueuing with the `GoodJob::Bulk.enqueue` method. The new queue backend [`Solid Queue`](https://github.com/basecamp/solid_queue/pull/93) has added support for bulk enqueuing as well.
 
 If the queue backend does *not* support bulk enqueuing, `perform_all_later` will enqueue jobs one by one.
 

--- a/guides/source/active_job_basics.md
+++ b/guides/source/active_job_basics.md
@@ -40,7 +40,7 @@ jobs in the queue will be dropped upon restart.
 
 
 Create and Enqueue Jobs
---------------
+-----------------------
 
 This section will provide a step-by-step guide to creating a job and enqueuing it.
 
@@ -410,7 +410,7 @@ end
 [`around_perform`]: https://api.rubyonrails.org/classes/ActiveJob/Callbacks/ClassMethods.html#method-i-around_perform
 [`after_perform`]: https://api.rubyonrails.org/classes/ActiveJob/Callbacks/ClassMethods.html#method-i-after_perform
 
-Please note that when enqueuing jobs in bulk using `perform_all_later`, callbacks such as `around_enqueue`, will not be triggered on the individual jobs. See [Bulk Enqueuing Callbacks](#bulk-enqueue-callbacks).
+Please note that when enqueuing jobs in bulk using `perform_all_later`, callbacks such as `around_enqueue` will not be triggered on the individual jobs. See [Bulk Enqueuing Callbacks](#bulk-enqueue-callbacks).
 
 Bulk Enqueuing
 --------------

--- a/guides/source/active_job_basics.md
+++ b/guides/source/active_job_basics.md
@@ -129,7 +129,7 @@ That's it!
 
 ### Bulk Enqueuing
 
-You can enqueue multiple jobs at once using [`perform_all_later`](https://api.rubyonrails.org/classes/ActiveJob.html#method-c-perform_all_later). Bulk enqueuing reduces the number of round trips to a queue data store like Redis, making it a more performant operation than enqueueing the same jobs individually.
+You can enqueue multiple jobs at once using [`perform_all_later`](https://api.rubyonrails.org/classes/ActiveJob.html#method-c-perform_all_later). Bulk enqueuing reduces the number of round trips to the queue data store (like Redis or a database), making it a more performant operation than enqueueing the same jobs individually.
 
 `perform_all_later` is a top-level api on Active Job. It accepts instantiated jobs as arguments (note that this is different from `perform_later`). `perform_all_later` does call `perform` under the hood. The arguments passed to `new` will be passed on to `perform` when it's eventually called.
 

--- a/guides/source/active_job_basics.md
+++ b/guides/source/active_job_basics.md
@@ -145,7 +145,9 @@ ActiveJob.perform_all_later(guest_cleanup_jobs)
 
 The return value of `perform_all_later` is `nil`. Note that this is different from `perform_later`. This may be enhanced to return the number of successfully enqueued job in the future, but for now it's `nil`.
 
-With `perform_all_later` it's possible to enqueue different ActiveJob class instances in the same call. For example 
+#### Enqueue Multiple ActiveJob Classes
+
+With `perform_all_later` it's also possible to enqueue different ActiveJob class instances in the same call. For example 
 
 ```ruby
 class ExportDataJob < ApplicationJob
@@ -169,6 +171,9 @@ notify_job = NotifyGuestsJob.new(guest)
 ApplicationJob.perform_all_later(cleanup_job, export_job, notify_job)
 ```
 
+#### Queue Backend Support
+
+For `perform_all_later`, bulk enqueuing needs to be backed by the queue backend. For example sidekiq has a push_bulk method, which can push a large number of jobs to Redis and prevent the Redis round trip network latency. The new queue backend [`Solid Queue`] has also added support for bulk enqueuing. If the queue backend does not support bulk enqueuing, `perform_all_later` will enqueue jobs one by one.
 
 [`perform_later`]: https://api.rubyonrails.org/classes/ActiveJob/Enqueuing/ClassMethods.html#method-i-perform_later
 [`set`]: https://api.rubyonrails.org/classes/ActiveJob/Core/ClassMethods.html#method-i-set

--- a/guides/source/active_job_basics.md
+++ b/guides/source/active_job_basics.md
@@ -39,7 +39,7 @@ runs jobs with an in-process thread pool. Jobs will run asynchronously, but any
 jobs in the queue will be dropped upon restart.
 
 
-Creating a Job
+Create and Enqueue Jobs
 --------------
 
 This section will provide a step-by-step guide to creating a job and enqueuing it.
@@ -144,6 +144,31 @@ ActiveJob.perform_all_later(guest_cleanup_jobs)
 `perform_all_later` logs the number of jobs successfully enqueued, something like `Enqueued 3 jobs to Async (3 GuestsCleanupJob)` if it was called with `ActiveJob.perform_all_later(job1, job2, job3)`. 
 
 The return value of `perform_all_later` is `nil`. Note that this is different from `perform_later`. This may be enhanced to return the number of successfully enqueued job in the future, but for now it's `nil`.
+
+With `perform_all_later` it's possible to enqueue different ActiveJob class instances in the same call. For example 
+
+```ruby
+class ExportDataJob < ApplicationJob
+  def perform(*args)
+    # Export data
+  end
+end
+
+class NotifyGuestsJob < ApplicationJob
+  def perform(*guests)
+    # Email guests
+  end
+end
+
+# Instantiate job instances
+cleanup_job = GuestsCleanupJob.new(guest)
+export_job = ExportDataJob.new(data)
+notify_job = NotifyGuestsJob.new(guest)
+
+# Enqueues job instances from multiple classes at once 
+ApplicationJob.perform_all_later(cleanup_job, export_job, notify_job)
+```
+
 
 [`perform_later`]: https://api.rubyonrails.org/classes/ActiveJob/Enqueuing/ClassMethods.html#method-i-perform_later
 [`set`]: https://api.rubyonrails.org/classes/ActiveJob/Core/ClassMethods.html#method-i-set

--- a/guides/source/active_job_basics.md
+++ b/guides/source/active_job_basics.md
@@ -469,7 +469,7 @@ end
 
 When enqueueing jobs in bulk using `perform_all_later`, callbacks such as `around_enqueue`, will not be triggered on the individual jobs.
 
- However, the `perform_all_later` method does fire an [`enqueue_all.active_job`](active_support_instrumentation.html#enqueue-all-active-job) event which you can subscribe to using `ActiveSupport::Notifications`.
+However, the `perform_all_later` method does fire an [`enqueue_all.active_job`](active_support_instrumentation.html#enqueue-all-active-job) event which you can subscribe to using `ActiveSupport::Notifications`.
 
 The method [`successfully_enqueued?`](https://api.rubyonrails.org/classes/ActiveJob/Core.html#method-i-successfully_enqueued-3F) can be used to find out if a given job was successfully enqueued.
 

--- a/guides/source/active_job_basics.md
+++ b/guides/source/active_job_basics.md
@@ -417,7 +417,7 @@ Bulk Enqueuing
 
 You can enqueue multiple jobs at once using [`perform_all_later`](https://api.rubyonrails.org/classes/ActiveJob.html#method-c-perform_all_later). Bulk enqueuing reduces the number of round trips to the queue data store (like Redis or a database), making it a more performant operation than enqueueing the same jobs individually.
 
-`perform_all_later` is a top-level api on Active Job. It accepts instantiated jobs as arguments (note that this is different from `perform_later`). `perform_all_later` does call `perform` under the hood. The arguments passed to `new` will be passed on to `perform` when it's eventually called.
+`perform_all_later` is a top-level API on Active Job. It accepts instantiated jobs as arguments (note that this is different from `perform_later`). `perform_all_later` does call `perform` under the hood. The arguments passed to `new` will be passed on to `perform` when it's eventually called.
 
 Here is an example calling `perform_all_later` with `GuestCleanupJob` instances:
 

--- a/guides/source/active_job_basics.md
+++ b/guides/source/active_job_basics.md
@@ -135,17 +135,15 @@ Here is an example calling `perform_all_later` with `GuestCleanupJob` instances:
 ```ruby
 # Create jobs to pass to `perform_all_later`. The arguments to `new` are
 # passed on to `perform`
-job1 = GuestsCleanupJob.new("guest1")
-job2 = GuestsCleanupJob.new("guest2")
-job3 = GuestsCleanupJob.new("guest3")
+guest_cleanup_jobs = User.pluck(:id).map { |id| GuestsCleanupJob.new(guest_id: id) }
 
 # Will enqueue a seperate job for each instance of `GuestCleanupJob`
-ActiveJob.perform_all_later(job1, job2, job3)
+ActiveJob.perform_all_later(guest_cleanup_jobs)
 ```
 
-`perform_all_later` logs the number of jobs successfully enqueued, something like `Enqueued 3 jobs to Async (3 GuestsCleanupJob)`. 
+`perform_all_later` logs the number of jobs successfully enqueued, something like `Enqueued 3 jobs to Async (3 GuestsCleanupJob)` if it was called with `ActiveJob.perform_all_later(job1, job2, job3)`. 
 
-The return value is `nil`. Note that this may be enhance to return the number of successfully enqueued job in the future.
+The return value of `perform_all_later` is `nil`. Note that this is different from `perform_later`. This may be enhanced to return the number of successfully enqueued job in the future, but for now it's `nil`.
 
 [`perform_later`]: https://api.rubyonrails.org/classes/ActiveJob/Enqueuing/ClassMethods.html#method-i-perform_later
 [`set`]: https://api.rubyonrails.org/classes/ActiveJob/Core/ClassMethods.html#method-i-set

--- a/guides/source/active_job_basics.md
+++ b/guides/source/active_job_basics.md
@@ -129,7 +129,7 @@ That's it!
 
 ### Bulk Enqueuing
 
-You can enqueue multiple jobs at once using [`perform_all_later`](https://api.rubyonrails.org/v7.1.3/classes/ActiveJob.html#method-c-perform_all_later). Bulk enqueuing reduces the number of round trips to a queue data store like Redis, making it a more performant operation than enqueueing the same jobs individually.
+You can enqueue multiple jobs at once using [`perform_all_later`](https://api.rubyonrails.org/classes/ActiveJob.html#method-c-perform_all_later). Bulk enqueuing reduces the number of round trips to a queue data store like Redis, making it a more performant operation than enqueueing the same jobs individually.
 
 `perform_all_later` is a top-level api on Active Job. It accepts instantiated jobs as arguments (note that this is different from `perform_later`). `perform_all_later` does call `perform` under the hood. The arguments passed to `new` will be passed on to `perform` when it's eventually called.
 

--- a/guides/source/active_job_basics.md
+++ b/guides/source/active_job_basics.md
@@ -481,7 +481,7 @@ ActiveJob.perform_all_later(cleanup_job, export_job, notify_job)
 ### Bulk Enqueue Callbacks
 
 When enqueuing jobs in bulk using `perform_all_later`, callbacks such as
-`around_enqueue`, will not be triggered on the individual jobs. This behavior is
+`around_enqueue` will not be triggered on the individual jobs. This behavior is
 in line with other Active Record bulk methods. Since callbacks run on individual
 jobs, they can't take advantage of the bulk nature of this method.
 

--- a/guides/source/active_job_basics.md
+++ b/guides/source/active_job_basics.md
@@ -180,7 +180,7 @@ Note that `perform_all_later` does not trigger callbacks on the individual jobs.
 
 #### Queue Backend Support
 
-For `perform_all_later`, bulk enqueuing needs to be backed by the queue backend.
+For `perform_all_later`, bulk enqueuing needs to be backed by the [queue backend](#backends).
 
 For example Sidekiq has a `push_bulk` method, which can push a large number of jobs to Redis and prevent the round trip network latency. GoodJob also supports bulk enqueuing with `GoodJob::Bulk.enqueue` method. The new queue backend [`Solid Queue`](https://github.com/basecamp/solid_queue/pull/93) has added support for bulk enqueuing as well.
 
@@ -471,21 +471,7 @@ When enqueueing jobs in bulk using `perform_all_later`, callbacks such as `aroun
 
  However, the `perform_all_later` method does fire an [`enqueue_all.active_job`](active_support_instrumentation.html#enqueue-all-active-job) event which you can subscribe to using `ActiveSupport::Notifications`.
 
-The event payload contains the adapter name, enqueued jobs count, the list of job instances, etc. `successfully_enqueued?` can be used to find out if a given job was successfully enqueued.
-
-```ruby
-ActiveSupport::Notifications.subscribe "enqueue_all.active_job" do |event|
-  event.name      # => "enqueue_all.active_job"
-  event.duration  # => 30 (in milliseconds)
-  event.payload   # => {
-  :adapter=>some_adapter
-  :jobs=>[ #<JobInstance1:0x000000010ead96e8 …>, <#<JobInstance2:0x000000010ert96e8 …>]
-  :enqueued_count=>12
-  }
-
-  Rails.logger.info "Any successfully enqueued jobs? #{jobs.any?(&:successfully_enqueued?)}"
-end
-```
+The method `successfully_enqueued?` can be used to find out if a given job was successfully enqueued.
 
 Action Mailer
 ------------

--- a/guides/source/active_job_basics.md
+++ b/guides/source/active_job_basics.md
@@ -426,7 +426,7 @@ Here is an example calling `perform_all_later` with `GuestCleanupJob` instances:
 # The arguments to `new` are passed on to `perform`
 guest_cleanup_jobs = Guest.all.map { |guest| GuestsCleanupJob.new(guest) }
 
-# Will enqueue a seperate job for each instance of `GuestCleanupJob`
+# Will enqueue a separate job for each instance of `GuestCleanupJob`
 ActiveJob.perform_all_later(guest_cleanup_jobs)
 ```
 

--- a/guides/source/active_job_basics.md
+++ b/guides/source/active_job_basics.md
@@ -146,7 +146,7 @@ ActiveJob.perform_all_later(guest_cleanup_jobs)
 
 `perform_all_later` logs the number of jobs successfully enqueued, something like `Enqueued 3 jobs to Async (3 GuestsCleanupJob)` if it was called with `ActiveJob.perform_all_later(job1, job2, job3)`.
 
-The return value of `perform_all_later` is `nil`. Note that this is different from `perform_later`. This may be enhanced to return the number of successfully enqueued job in the future, but for now it's `nil`.
+The return value of `perform_all_later` is `nil`. Note that this is different from `perform_later`, which returns the instance of the queued job class.
 
 #### Enqueue Multiple ActiveJob Classes
 

--- a/guides/source/active_job_basics.md
+++ b/guides/source/active_job_basics.md
@@ -148,7 +148,7 @@ ActiveJob.perform_all_later(guest_cleanup_jobs)
 
 The return value of `perform_all_later` is `nil`. Note that this is different from `perform_later`, which returns the instance of the queued job class.
 
-#### Enqueue Multiple ActiveJob Classes
+#### Enqueue Multiple Active Job Classes
 
 With `perform_all_later` it's also possible to enqueue different ActiveJob class instances in the same call. For example
 

--- a/guides/source/active_job_basics.md
+++ b/guides/source/active_job_basics.md
@@ -437,6 +437,11 @@ guest_cleanup_jobs = Guest.all.map { |guest| GuestsCleanupJob.new(guest) }
 
 # Will enqueue a separate job for each instance of `GuestCleanupJob`
 ActiveJob.perform_all_later(guest_cleanup_jobs)
+
+# Can also use `set` method to configure options before bulk enqueuing jobs.
+guest_cleanup_jobs = Guest.all.map { |guest| GuestsCleanupJob.new(guest).set(wait: 1.day) }
+
+ActiveJob.perform_all_later(guest_cleanup_jobs)
 ```
 
 `perform_all_later` logs the number of jobs successfully enqueued, for example

--- a/guides/source/active_job_basics.md
+++ b/guides/source/active_job_basics.md
@@ -129,9 +129,9 @@ That's it!
 
 ### Bulk Enqueuing
 
-You can Enqueue multiple jobs at once using [`perform_all_later`](https://api.rubyonrails.org/v7.1.3/classes/ActiveJob.html#method-c-perform_all_later). Bulk Enqueuing reduces the number of round trips to a queue data store like Redis.
+You can enqueue multiple jobs at once using [`perform_all_later`](https://api.rubyonrails.org/v7.1.3/classes/ActiveJob.html#method-c-perform_all_later). Bulk enqueuing reduces the number of round trips to a queue data store like Redis, making it a more performant operation than enqueueing the same jobs individually.
 
-`perform_all_later` is a top-level api on ActiveJob. It accepts instantiated jobs as arguments (note that this is different from `perform_later`). `perform_all_later` does call `perform` under the hood. The arguments passed to `new` will be passed on to `perform` when it's eventually called.
+`perform_all_later` is a top-level api on Active Job. It accepts instantiated jobs as arguments (note that this is different from `perform_later`). `perform_all_later` does call `perform` under the hood. The arguments passed to `new` will be passed on to `perform` when it's eventually called.
 
 Here is an example calling `perform_all_later` with `GuestCleanupJob` instances:
 
@@ -144,13 +144,13 @@ guest_cleanup_jobs = User.pluck(:id).map { |id| GuestsCleanupJob.new(guest_id: i
 ActiveJob.perform_all_later(guest_cleanup_jobs)
 ```
 
-`perform_all_later` logs the number of jobs successfully enqueued, something like `Enqueued 3 jobs to Async (3 GuestsCleanupJob)` if it was called with `ActiveJob.perform_all_later(job1, job2, job3)`.
+`perform_all_later` logs the number of jobs successfully enqueued, for example if `User.pluck(:id).map` above resulted in 3 `guest_cleanup_jobs`, it would log `Enqueued 3 jobs to Async (3 GuestsCleanupJob)` (assuming all were enqueued).
 
 The return value of `perform_all_later` is `nil`. Note that this is different from `perform_later`, which returns the instance of the queued job class.
 
 #### Enqueue Multiple Active Job Classes
 
-With `perform_all_later` it's also possible to enqueue different ActiveJob class instances in the same call. For example
+With `perform_all_later` it's also possible to enqueue different Active Job class instances in the same call. For example
 
 ```ruby
 class ExportDataJob < ApplicationJob
@@ -471,7 +471,7 @@ When enqueueing jobs in bulk using `perform_all_later`, callbacks such as `aroun
 
  However, the `perform_all_later` method does fire an [`enqueue_all.active_job`](active_support_instrumentation.html#enqueue-all-active-job) event which you can subscribe to using `ActiveSupport::Notifications`.
 
-The method `successfully_enqueued?` can be used to find out if a given job was successfully enqueued.
+The method [`successfully_enqueued?`](https://api.rubyonrails.org/classes/ActiveJob/Core.html#method-i-successfully_enqueued-3F) can be used to find out if a given job was successfully enqueued.
 
 Action Mailer
 ------------

--- a/guides/source/active_job_basics.md
+++ b/guides/source/active_job_basics.md
@@ -415,7 +415,7 @@ Please note that when enqueuing jobs in bulk using `perform_all_later`, callback
 Bulk Enqueuing
 --------------
 
-You can enqueue multiple jobs at once using [`perform_all_later`](https://api.rubyonrails.org/classes/ActiveJob.html#method-c-perform_all_later). Bulk enqueuing reduces the number of round trips to the queue data store (like Redis or a database), making it a more performant operation than enqueueing the same jobs individually.
+You can enqueue multiple jobs at once using [`perform_all_later`](https://api.rubyonrails.org/classes/ActiveJob.html#method-c-perform_all_later). Bulk enqueuing reduces the number of round trips to the queue data store (like Redis or a database), making it a more performant operation than enqueuing the same jobs individually.
 
 `perform_all_later` is a top-level API on Active Job. It accepts instantiated jobs as arguments (note that this is different from `perform_later`). `perform_all_later` does call `perform` under the hood. The arguments passed to `new` will be passed on to `perform` when it's eventually called.
 

--- a/guides/source/active_job_basics.md
+++ b/guides/source/active_job_basics.md
@@ -126,7 +126,7 @@ That's it!
 
 ### Bulk Enqueuing
 
-You can Enqueue multiple jobs using perform_all_later.
+You can Enqueue multiple jobs at once using [`perform_all_later`][]. Bulk Enqueuing reduces the number of round trips to a queue data store like Redis.
 
 `perform_all_later` is a top-level api on ActiveJob. It accepts instantiated jobs as arguments (note that this is different from `perform_later`). `perform_all_later` does call `perform` under the hood. The arguments passed to `new` will be passed on to `perform` when it's eventually called.
 
@@ -172,6 +172,7 @@ ApplicationJob.perform_all_later(cleanup_job, export_job, notify_job)
 
 [`perform_later`]: https://api.rubyonrails.org/classes/ActiveJob/Enqueuing/ClassMethods.html#method-i-perform_later
 [`set`]: https://api.rubyonrails.org/classes/ActiveJob/Core/ClassMethods.html#method-i-set
+[`perform_all_later`]: https://api.rubyonrails.org/v7.1.3/classes/ActiveJob.html#method-c-perform_all_later
 
 Job Execution
 -------------

--- a/guides/source/active_job_basics.md
+++ b/guides/source/active_job_basics.md
@@ -176,7 +176,7 @@ ApplicationJob.perform_all_later(cleanup_job, export_job, notify_job)
 
 #### Bulk Enqueue Callbacks
 
-Note that `perform_all_later` does not trigger callbacks on the individual jobs. This behavior is in line with other Active Record bulk methods. Since callbacks run on individual jobs, they can't take advantage of the bulk nature of this method. Also there isn't a meaningful semantic for something like `around_enqueue` callback.
+Note that `perform_all_later` does not trigger [callbacks](#callbacks) on the individual jobs. This behavior is in line with other Active Record bulk methods. Since callbacks run on individual jobs, they can't take advantage of the bulk nature of this method. Also there isn't a meaningful semantic for something like `around_enqueue` callback.
 
 #### Queue Backend Support
 

--- a/guides/source/active_job_basics.md
+++ b/guides/source/active_job_basics.md
@@ -410,7 +410,7 @@ end
 [`around_perform`]: https://api.rubyonrails.org/classes/ActiveJob/Callbacks/ClassMethods.html#method-i-around_perform
 [`after_perform`]: https://api.rubyonrails.org/classes/ActiveJob/Callbacks/ClassMethods.html#method-i-after_perform
 
-Please note that when enqueueing jobs in bulk using `perform_all_later`, callbacks such as `around_enqueue`, will not be triggered on the individual jobs. See [Bulk Enqueuing Callbacks](#bulk-enqueue-callbacks).
+Please note that when enqueuing jobs in bulk using `perform_all_later`, callbacks such as `around_enqueue`, will not be triggered on the individual jobs. See [Bulk Enqueuing Callbacks](#bulk-enqueue-callbacks).
 
 Bulk Enqueuing
 --------------

--- a/guides/source/active_job_basics.md
+++ b/guides/source/active_job_basics.md
@@ -136,8 +136,8 @@ You can enqueue multiple jobs at once using [`perform_all_later`](https://api.ru
 Here is an example calling `perform_all_later` with `GuestCleanupJob` instances:
 
 ```ruby
-# Create jobs to pass to `perform_all_later`. The arguments to `new` are
-# passed on to `perform`
+# Create jobs to pass to `perform_all_later`.
+# The arguments to `new` are passed on to `perform`
 guest_cleanup_jobs = User.pluck(:id).map { |id| GuestsCleanupJob.new(guest_id: id) }
 
 # Will enqueue a seperate job for each instance of `GuestCleanupJob`

--- a/guides/source/active_job_basics.md
+++ b/guides/source/active_job_basics.md
@@ -171,7 +171,7 @@ export_job = ExportDataJob.new(data)
 notify_job = NotifyGuestsJob.new(guest)
 
 # Enqueues job instances from multiple classes at once
-ApplicationJob.perform_all_later(cleanup_job, export_job, notify_job)
+ActiveJob.perform_all_later(cleanup_job, export_job, notify_job)
 ```
 
 #### Bulk Enqueue Callbacks

--- a/guides/source/active_job_basics.md
+++ b/guides/source/active_job_basics.md
@@ -176,7 +176,7 @@ ApplicationJob.perform_all_later(cleanup_job, export_job, notify_job)
 
 #### Bulk Enqueue Callbacks
 
-Note that `perform_all_later` does not trigger callbacks on the individual jobs. This is inline with other ActiveRecord bulk methods. Since callbacks run on individual jobs, they can't take advantage of the bulk nature of this method. Also there isn't a meaningful semantic for something like `around_enqueue` callback.
+Note that `perform_all_later` does not trigger callbacks on the individual jobs. This behavior is in line with other Active Record bulk methods. Since callbacks run on individual jobs, they can't take advantage of the bulk nature of this method. Also there isn't a meaningful semantic for something like `around_enqueue` callback.
 
 #### Queue Backend Support
 

--- a/guides/source/active_job_basics.md
+++ b/guides/source/active_job_basics.md
@@ -126,7 +126,7 @@ That's it!
 
 ### Bulk Enqueuing
 
-You can Enqueue multiple jobs at once using [`perform_all_later`][]. Bulk Enqueuing reduces the number of round trips to a queue data store like Redis.
+You can Enqueue multiple jobs at once using [`perform_all_later`](https://api.rubyonrails.org/v7.1.3/classes/ActiveJob.html#method-c-perform_all_later). Bulk Enqueuing reduces the number of round trips to a queue data store like Redis.
 
 `perform_all_later` is a top-level api on ActiveJob. It accepts instantiated jobs as arguments (note that this is different from `perform_later`). `perform_all_later` does call `perform` under the hood. The arguments passed to `new` will be passed on to `perform` when it's eventually called.
 
@@ -141,13 +141,13 @@ guest_cleanup_jobs = User.pluck(:id).map { |id| GuestsCleanupJob.new(guest_id: i
 ActiveJob.perform_all_later(guest_cleanup_jobs)
 ```
 
-`perform_all_later` logs the number of jobs successfully enqueued, something like `Enqueued 3 jobs to Async (3 GuestsCleanupJob)` if it was called with `ActiveJob.perform_all_later(job1, job2, job3)`. 
+`perform_all_later` logs the number of jobs successfully enqueued, something like `Enqueued 3 jobs to Async (3 GuestsCleanupJob)` if it was called with `ActiveJob.perform_all_later(job1, job2, job3)`.
 
 The return value of `perform_all_later` is `nil`. Note that this is different from `perform_later`. This may be enhanced to return the number of successfully enqueued job in the future, but for now it's `nil`.
 
 #### Enqueue Multiple ActiveJob Classes
 
-With `perform_all_later` it's also possible to enqueue different ActiveJob class instances in the same call. For example 
+With `perform_all_later` it's also possible to enqueue different ActiveJob class instances in the same call. For example
 
 ```ruby
 class ExportDataJob < ApplicationJob
@@ -167,9 +167,10 @@ cleanup_job = GuestsCleanupJob.new(guest)
 export_job = ExportDataJob.new(data)
 notify_job = NotifyGuestsJob.new(guest)
 
-# Enqueues job instances from multiple classes at once 
+# Enqueues job instances from multiple classes at once
 ApplicationJob.perform_all_later(cleanup_job, export_job, notify_job)
 ```
+
 #### Callbacks
 
 Note that `perform_all_later` does not trigger callbacks on the individual jobs. This is inline with other ActiveRecord bulk methods. Since callbacks run on individual jobs, they can't take advantage of the bulk nature of this method. Also there isn't a meaningful semantic for something like `around_enqueue` callback.
@@ -178,14 +179,12 @@ Note that `perform_all_later` does not trigger callbacks on the individual jobs.
 
 For `perform_all_later`, bulk enqueuing needs to be backed by the queue backend.
 
-For example Sidekiq has a `push_bulk` method, which can push a large number of jobs to Redis and prevent the round trip network latency. GoodJob also supports bulk enqueuing with `GoodJob::Bulk.enqueue` method. The new queue backend [`Solid Queue`][] has added support for bulk enqueuing as well.
+For example Sidekiq has a `push_bulk` method, which can push a large number of jobs to Redis and prevent the round trip network latency. GoodJob also supports bulk enqueuing with `GoodJob::Bulk.enqueue` method. The new queue backend [`Solid Queue`](https://github.com/basecamp/solid_queue/pull/93) has added support for bulk enqueuing as well.
 
 If the queue backend does *not* support bulk enqueuing, `perform_all_later` will enqueue jobs one by one.
 
 [`perform_later`]: https://api.rubyonrails.org/classes/ActiveJob/Enqueuing/ClassMethods.html#method-i-perform_later
 [`set`]: https://api.rubyonrails.org/classes/ActiveJob/Core/ClassMethods.html#method-i-set
-[`perform_all_later`]: https://api.rubyonrails.org/v7.1.3/classes/ActiveJob.html#method-c-perform_all_later
-[`Solid Queue`]: https://github.com/basecamp/solid_queue/pull/93
 
 Job Execution
 -------------
@@ -470,9 +469,9 @@ end
 
 When enqueueing jobs in bulk using `perform_all_later`, callbacks such as `around_enqueue`, will not be triggered on the individual jobs.
 
- However, the `perform_all_later` method does fire an [`enqueue_all.active_job`][] event which you can subscribe to using `ActiveSupport::Notifications`. 
+ However, the `perform_all_later` method does fire an [`enqueue_all.active_job`](active_support_instrumentation.html#enqueue-all-active-job) event which you can subscribe to using `ActiveSupport::Notifications`.
 
-The event payload contains the adapter name, enqueued jobs count, the list of job instances, etc. `successfully_enqueued?` can be used to find out if a given job was successfully enqueued. 
+The event payload contains the adapter name, enqueued jobs count, the list of job instances, etc. `successfully_enqueued?` can be used to find out if a given job was successfully enqueued.
 
 ```ruby
 ActiveSupport::Notifications.subscribe "enqueue_all.active_job" do |event|
@@ -487,8 +486,6 @@ ActiveSupport::Notifications.subscribe "enqueue_all.active_job" do |event|
   Rails.logger.info "Any successfully enqueued jobs? #{jobs.any?(&:successfully_enqueued?)}"
 end
 ```
-
-[`enqueue_all.active_job`]: https://guides.rubyonrails.org/active_support_instrumentation.html#enqueue-all-active-job
 
 Action Mailer
 ------------

--- a/guides/source/active_job_basics.md
+++ b/guides/source/active_job_basics.md
@@ -410,14 +410,23 @@ end
 [`around_perform`]: https://api.rubyonrails.org/classes/ActiveJob/Callbacks/ClassMethods.html#method-i-around_perform
 [`after_perform`]: https://api.rubyonrails.org/classes/ActiveJob/Callbacks/ClassMethods.html#method-i-after_perform
 
-Please note that when enqueuing jobs in bulk using `perform_all_later`, callbacks such as `around_enqueue` will not be triggered on the individual jobs. See [Bulk Enqueuing Callbacks](#bulk-enqueue-callbacks).
+Please note that when enqueuing jobs in bulk using `perform_all_later`,
+callbacks such as `around_enqueue` will not be triggered on the individual jobs.
+See [Bulk Enqueuing Callbacks](#bulk-enqueue-callbacks).
 
 Bulk Enqueuing
 --------------
 
-You can enqueue multiple jobs at once using [`perform_all_later`](https://api.rubyonrails.org/classes/ActiveJob.html#method-c-perform_all_later). Bulk enqueuing reduces the number of round trips to the queue data store (like Redis or a database), making it a more performant operation than enqueuing the same jobs individually.
+You can enqueue multiple jobs at once using
+[`perform_all_later`](https://api.rubyonrails.org/classes/ActiveJob.html#method-c-perform_all_later).
+Bulk enqueuing reduces the number of round trips to the queue data store (like
+Redis or a database), making it a more performant operation than enqueuing the
+same jobs individually.
 
-`perform_all_later` is a top-level API on Active Job. It accepts instantiated jobs as arguments (note that this is different from `perform_later`). `perform_all_later` does call `perform` under the hood. The arguments passed to `new` will be passed on to `perform` when it's eventually called.
+`perform_all_later` is a top-level API on Active Job. It accepts instantiated
+jobs as arguments (note that this is different from `perform_later`).
+`perform_all_later` does call `perform` under the hood. The arguments passed to
+`new` will be passed on to `perform` when it's eventually called.
 
 Here is an example calling `perform_all_later` with `GuestCleanupJob` instances:
 
@@ -430,13 +439,17 @@ guest_cleanup_jobs = Guest.all.map { |guest| GuestsCleanupJob.new(guest) }
 ActiveJob.perform_all_later(guest_cleanup_jobs)
 ```
 
-`perform_all_later` logs the number of jobs successfully enqueued, for example if `Guest.all.map` above resulted in 3 `guest_cleanup_jobs`, it would log `Enqueued 3 jobs to Async (3 GuestsCleanupJob)` (assuming all were enqueued).
+`perform_all_later` logs the number of jobs successfully enqueued, for example
+if `Guest.all.map` above resulted in 3 `guest_cleanup_jobs`, it would log
+`Enqueued 3 jobs to Async (3 GuestsCleanupJob)` (assuming all were enqueued).
 
-The return value of `perform_all_later` is `nil`. Note that this is different from `perform_later`, which returns the instance of the queued job class.
+The return value of `perform_all_later` is `nil`. Note that this is different
+from `perform_later`, which returns the instance of the queued job class.
 
 ### Enqueue Multiple Active Job Classes
 
-With `perform_all_later`, it's also possible to enqueue different Active Job class instances in the same call. For example:
+With `perform_all_later`, it's also possible to enqueue different Active Job
+class instances in the same call. For example:
 
 ```ruby
 class ExportDataJob < ApplicationJob
@@ -462,19 +475,32 @@ ActiveJob.perform_all_later(cleanup_job, export_job, notify_job)
 
 ### Bulk Enqueue Callbacks
 
-When enqueuing jobs in bulk using `perform_all_later`, callbacks such as `around_enqueue`, will not be triggered on the individual jobs. This behavior is in line with other Active Record bulk methods. Since callbacks run on individual jobs, they can't take advantage of the bulk nature of this method.
+When enqueuing jobs in bulk using `perform_all_later`, callbacks such as
+`around_enqueue`, will not be triggered on the individual jobs. This behavior is
+in line with other Active Record bulk methods. Since callbacks run on individual
+jobs, they can't take advantage of the bulk nature of this method.
 
-However, the `perform_all_later` method does fire an [`enqueue_all.active_job`](active_support_instrumentation.html#enqueue-all-active-job) event which you can subscribe to using `ActiveSupport::Notifications`.
+However, the `perform_all_later` method does fire an
+[`enqueue_all.active_job`](active_support_instrumentation.html#enqueue-all-active-job)
+event which you can subscribe to using `ActiveSupport::Notifications`.
 
-The method [`successfully_enqueued?`](https://api.rubyonrails.org/classes/ActiveJob/Core.html#method-i-successfully_enqueued-3F) can be used to find out if a given job was successfully enqueued.
+The method
+[`successfully_enqueued?`](https://api.rubyonrails.org/classes/ActiveJob/Core.html#method-i-successfully_enqueued-3F)
+can be used to find out if a given job was successfully enqueued.
 
 ### Queue Backend Support
 
-For `perform_all_later`, bulk enqueuing needs to be backed by the [queue backend](#backends).
+For `perform_all_later`, bulk enqueuing needs to be backed by the [queue
+backend](#backends).
 
-For example, Sidekiq has a `push_bulk` method, which can push a large number of jobs to Redis and prevent the round trip network latency. GoodJob also supports bulk enqueuing with the `GoodJob::Bulk.enqueue` method. The new queue backend [`Solid Queue`](https://github.com/basecamp/solid_queue/pull/93) has added support for bulk enqueuing as well.
+For example, Sidekiq has a `push_bulk` method, which can push a large number of
+jobs to Redis and prevent the round trip network latency. GoodJob also supports
+bulk enqueuing with the `GoodJob::Bulk.enqueue` method. The new queue backend
+[`Solid Queue`](https://github.com/basecamp/solid_queue/pull/93) has added
+support for bulk enqueuing as well.
 
-If the queue backend does *not* support bulk enqueuing, `perform_all_later` will enqueue jobs one by one.
+If the queue backend does *not* support bulk enqueuing, `perform_all_later` will
+enqueue jobs one by one.
 
 Action Mailer
 ------------


### PR DESCRIPTION
## Overview

Add documentation related to `perform_all_later` for bulk enqueuing jobs.

## Testing

Tested the new method in-app using sidekiq locally. Also tested documentation by running `guides:generate`, `guides:validate` and `guides:lint` locally.