### PR TITLE
Rails test command suggests similar test files when the given file is not found

### DIFF
--- a/railties/lib/rails/commands/test/test_command.rb
+++ b/railties/lib/rails/commands/test/test_command.rb
@@ -31,6 +31,8 @@ module Rails
         Rails::TestUnit::Runner.parse_options(args)
         run_prepare_task if self.args.none?(EXACT_TEST_ARGUMENT_PATTERN)
         Rails::TestUnit::Runner.run(args)
+      rescue Rails::TestUnit::InvalidTestError => error
+        say error.message
       end
 
       # Define Thor tasks to avoid going through Rake and booting twice when using bin/rails test:*

--- a/railties/test/application/test_runner_test.rb
+++ b/railties/test/application/test_runner_test.rb
@@ -964,6 +964,14 @@ module ApplicationTests
       assert_match(%r{cannot load such file.+test/not_exists\.rb}, error)
     end
 
+    def test_did_you_mean_when_specified_file_name_is_close
+      create_test_file :models, "account"
+      output = run_test_command("test/models/accnt.rb")
+
+      assert_match(%r{Could not load test file.+test/models/accnt\.rb}, output)
+      assert_match(%r{Did you mean?.+test/models/account_test\.rb}, output)
+    end
+
     def test_pass_TEST_env_on_rake_test
       create_test_file :models, "account"
       create_test_file :models, "post", pass: false


### PR DESCRIPTION
For example, if you run `rails test test/models/usr_tsst.rb` and the file does not exist, Rails will suggest `test/models/users_test.rb` as a possible file.

```
Could not load test file: test/models/usr_tsst.rb. Did you mean? test/models/user_test.rb
```

After investigating #50978, I was inspired to add this feature to Rails.

Credit to @tenderlove for the minitest implementation.