### PR TITLE
Parse tests with prism

### DIFF
--- a/railties/test/test_unit/test_parser_test.rb
+++ b/railties/test/test_unit/test_parser_test.rb
@@ -5,55 +5,61 @@ require "active_support/test_case"
 require "active_support/testing/autorun"
 require "rails/test_unit/test_parser"
 
+class TestParserTestFixture < ActiveSupport::TestCase
+  def test_method
+    assert true
+
+    assert true
+  end
+
+  def test_oneline; assert true; end
+
+  test "declarative" do
+    assert true
+
+    assert true
+  end
+
+  test("declarative w/parens") do
+    assert true
+  end
+
+  self.test "declarative explicit receiver" do
+    assert true
+
+    assert true
+  end
+
+  test("declarative oneline") { assert true }
+
+  test("declarative oneline do") do assert true end
+
+  test("declarative multiline w/ braces") {
+    assert true
+    assert_not false
+  }
+end
+
 class TestParserTest < ActiveSupport::TestCase
   def test_parser
-    example_test = <<~RUBY
-      require "test_helper"
+    actual =
+      TestParserTestFixture
+        .instance_methods(false)
+        .map { |method| TestParserTestFixture.instance_method(method) }
+        .sort_by { |method| method.source_location[1] }
+        .map { |method| [method.name, *Rails::TestUnit::TestParser.definition_for(method)] }
 
-      class ExampleTest < ActiveSupport::TestCase
-        def test_method
-          assert true
+    expected = [
+      [:test_method, __FILE__, 9..13],
+      [:test_oneline, __FILE__, 15..15],
+      [:test_declarative, __FILE__, 17..21],
+      [:"test_declarative_w/parens", __FILE__, 23..25],
+      [:test_declarative_explicit_receiver, __FILE__, 27..31],
+      [:test_declarative_oneline, __FILE__, 33..33],
+      [:test_declarative_oneline_do, __FILE__, 35..35],
+      [:"test_declarative_multiline_w/_braces", __FILE__, 37..40]
+    ]
 
-
-        end
-
-        def test_oneline; assert true; end
-
-        test "declarative" do
-          assert true
-        end
-
-        test("declarative w/parens") do
-          assert true
-
-        end
-
-        self.test "declarative explicit receiver" do
-          assert true
-        end
-
-        test("declarative oneline") { assert true }
-
-        test("declarative oneline do") do assert true end
-
-        test("declarative multiline w/ braces") {
-          assert true
-          refute false
-        }
-      end
-    RUBY
-
-    actual_map = Rails::TestUnit::TestParser.definitions_for(example_test, "example_test.rb")
-    expected_map = {
-      4 => 8,   # test_method
-      10 => 10, # test_oneline
-      12 => 14, # declarative
-      16 => 19, # declarative w/parens
-      21 => 23, # declarative explicit receiver
-      25 => 25, # declarative oneline
-      27 => 27, # declarative oneilne do
-      29 => 32  # declarative multiline w/braces
-    }
-    assert_equal expected_map, actual_map
+    assert_equal expected, actual
   end
 end

--- a/railties/test/test_unit/test_parser_test.rb
+++ b/railties/test/test_unit/test_parser_test.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "active_support/deprecator"
 require "active_support/test_case"
 require "active_support/testing/autorun"
 require "rails/test_unit/test_parser"
@@ -42,7 +43,7 @@ class TestParserTest < ActiveSupport::TestCase
       end
     RUBY
 
-    parser = Rails::TestUnit::TestParser.new(example_test, "example_test.rb")
+    actual_map = Rails::TestUnit::TestParser.definitions_for(example_test, "example_test.rb")
     expected_map = {
       4 => 8,   # test_method
       10 => 10, # test_oneline
@@ -53,6 +54,6 @@ class TestParserTest < ActiveSupport::TestCase
       27 => 27, # declarative oneilne do
       29 => 32  # declarative multiline w/braces
     }
-    assert_equal expected_map, parser.parse
+    assert_equal expected_map, actual_map
   end
 end


### PR DESCRIPTION
### Motivation / Background

This is a refactor PR to change TestParser to parse using the prism parser if it is available instead of the ripper library.

### Detail

Prism provides a simpler interface with consistent field names, so it should be easier to maintain going forward. It also has a guaranteed stable API, as opposed to ripper which can change between patch versions of Ruby. It also results in less code.

### Additional information

I benchmarked this change, and it appears to have no visible difference (it's within the margin of error). My benchmark script is below.

<details>
<summary>Benchmark</summary>

```ruby
# frozen_string_literal: true

require "active_support/test_case"
require "prism"
require "ripper"
require "benchmark/ips"

class PrismParser
  def self.definition_for(method)
    filepath, start_line = method.source_location
    queue = [Prism.parse_file(filepath).value]

    while (node = queue.shift)
      case node.type
      when :def_node
        if node.name.start_with?("test") && node.location.start_line == start_line
          return [filepath, start_line..node.location.end_line]
        end
      when :call_node
        if node.name == :test && node.location.start_line == start_line
          return [filepath, start_line..node.location.end_line]
        end
      end

      queue.concat(node.compact_child_nodes)
    end

    nil
  end
end

class RipperParser < Ripper
  def self.definition_for(method_obj)
    path, begin_line = method_obj.source_location
    begins_to_ends = new(File.read(path), path).parse
    return unless end_line = begins_to_ends[begin_line]
    [path, (begin_line..end_line)]
  end

  def initialize(*)
    # A hash mapping the 1-indexed line numbers that tests start on to where they end.
    @begins_to_ends = {}
    super
  end

  def parse
    super
    @begins_to_ends
  end

  def on_def(begin_line, *)
    @begins_to_ends[begin_line] = lineno
  end

  def on_method_add_block(begin_line, end_line)
    if begin_line && end_line
      @begins_to_ends[begin_line] = end_line
    end
  end

  def on_command_call(*, begin_lineno, _args)
    begin_lineno
  end

  def first_arg(arg, *)
    arg
  end

  def just_lineno(*)
    lineno
  end

  alias on_method_add_arg first_arg
  alias on_command first_arg
  alias on_stmts_add first_arg
  alias on_arg_paren first_arg
  alias on_bodystmt first_arg

  alias on_ident just_lineno
  alias on_do_block just_lineno
  alias on_stmts_new just_lineno
  alias on_brace_block just_lineno

  def on_args_new
    []
  end

  def on_args_add(parts, part)
    parts << part
  end

  def on_args_add_block(args, *rest)
    args.first
  end
end

class ExampleTest < ActiveSupport::TestCase
  def test_method
    assert true


  end

  def test_oneline; assert true; end

  test "declarative" do
    assert true
  end

  test("declarative w/parens") do
    assert true

  end

  self.test "declarative explicit receiver" do
    assert true
  end

  test("declarative oneline") { assert true }

  test("declarative oneline do") do assert true end

  test("declarative multiline w/ braces") {
    assert true
    refute false
  }
end

methods = ExampleTest.instance_methods.grep(/^test_/).map { |method| ExampleTest.instance_method(method) }

Benchmark.ips do |x|
  x.report("Prism") { methods.each { |method| PrismParser.definition_for(method) } }
  x.report("Ripper") { methods.each { |method| RipperParser.definition_for(method) } }
  x.compare!
end
```

</details>

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
