### PR TITLE
Deprecate config.active_record.warn_on_records_fetched_greater_than

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Deprecate config.active_record.warn_on_records_fetched_greater_than now that sql.active_record
+    notification includes row_count field
+
+    *Jason Nochlin*
+
 *   Fix an issue where `ActiveRecord::Encryption` configurations are not ready before the loading
     of Active Record models, when an application is eager loaded. As a result, encrypted attributes
     could be misconfigured in some cases.

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,5 +1,5 @@
-*   Deprecate config.active_record.warn_on_records_fetched_greater_than now that sql.active_record
-    notification includes row_count field
+*   Deprecate `config.active_record.warn_on_records_fetched_greater_than` now that `sql.active_record`
+    notification includes `:row_count` field.
 
     *Jason Nochlin*
 

--- a/activerecord/lib/active_record/railtie.rb
+++ b/activerecord/lib/active_record/railtie.rb
@@ -225,8 +225,8 @@ To keep using the current cache store, you can turn off cache versioning entirel
       if config.active_record.warn_on_records_fetched_greater_than
         ActiveRecord.deprecator.warn <<~MSG.squish
           `config.active_record.warn_on_records_fetched_greater_than` is deprecated and will be
-          removed in Rails 7.2.
-          Please subscribe to sql.active_record notifications and access the row count field to
+          removed in Rails 7.3.
+          Please subscribe to `sql.active_record` notifications and access the row count field to
           detect large result set sizes.
         MSG
         ActiveSupport.on_load(:active_record) do

--- a/activerecord/lib/active_record/railtie.rb
+++ b/activerecord/lib/active_record/railtie.rb
@@ -223,6 +223,12 @@ To keep using the current cache store, you can turn off cache versioning entirel
 
     initializer "active_record.warn_on_records_fetched_greater_than" do
       if config.active_record.warn_on_records_fetched_greater_than
+        ActiveRecord.deprecator.warn <<~MSG.squish
+          `config.active_record.warn_on_records_fetched_greater_than` is deprecated and will be
+          removed in Rails 7.2.
+          Please subscribe to sql.active_record notifications and access the row count field to
+          detect large result set sizes.
+        MSG
         ActiveSupport.on_load(:active_record) do
           require "active_record/relation/record_fetch_warning"
         end

--- a/activerecord/lib/active_record/relation/record_fetch_warning.rb
+++ b/activerecord/lib/active_record/relation/record_fetch_warning.rb
@@ -3,6 +3,9 @@
 module ActiveRecord
   class Relation
     module RecordFetchWarning
+      # Deprecated: subscribe to sql.active_record notifications and
+      # access the row count field to detect large result set sizes.
+      #
       # When this module is prepended to ActiveRecord::Relation and
       # +config.active_record.warn_on_records_fetched_greater_than+ is
       # set to an integer, if the number of records a query returns is


### PR DESCRIPTION
Deprecate config.active_record.warn_on_records_fetched_greater_than setting in favor of #50887.

The same functionality (and more) can now be achieved by subscribing to sql.active_record notifications:

![image](https://github.com/rails/rails/assets/91577/b6501bca-405c-417c-864d-b016b2db0abc)


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
