### PR TITLE
Gracefully handle transactional fixtures leaks

### DIFF
--- a/activerecord/test/cases/active_record_test.rb
+++ b/activerecord/test/cases/active_record_test.rb
@@ -4,9 +4,11 @@ require "cases/helper"
 require "rack"
 
 class ActiveRecordTest < ActiveRecord::TestCase
+  self.use_transactional_tests = false
+
   unless in_memory_db?
     test ".disconnect_all! closes all connections" do
-      ActiveRecord::Base.connection.active?
+      ActiveRecord::Base.connection.connect!
       assert_predicate ActiveRecord::Base, :connected?
 
       ActiveRecord.disconnect_all!

--- a/activerecord/test/cases/adapters/abstract_mysql_adapter/connection_test.rb
+++ b/activerecord/test/cases/adapters/abstract_mysql_adapter/connection_test.rb
@@ -37,7 +37,7 @@ class ConnectionTest < ActiveRecord::AbstractMysqlTestCase
     assert_not_predicate @connection, :active?
   ensure
     # Repair all fixture connections so other tests won't break.
-    @fixture_connections.each(&:verify!)
+    @fixture_connections.each_key(&:verify!)
   end
 
   def test_successful_reconnection_after_timeout_with_manual_reconnect

--- a/activerecord/test/cases/adapters/postgresql/connection_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/connection_test.rb
@@ -145,7 +145,7 @@ module ActiveRecord
       assert_predicate @connection, :active?
     ensure
       # Repair all fixture connections so other tests won't break.
-      @fixture_connections.each(&:verify!)
+      @fixture_connections.each_key(&:verify!)
     end
 
     def test_set_session_variable_true

--- a/activerecord/test/cases/connection_adapters/connection_handler_test.rb
+++ b/activerecord/test/cases/connection_adapters/connection_handler_test.rb
@@ -6,6 +6,8 @@ require "models/person"
 module ActiveRecord
   module ConnectionAdapters
     class ConnectionHandlerTest < ActiveRecord::TestCase
+      self.use_transactional_tests = false
+
       fixtures :people
 
       def setup
@@ -93,6 +95,8 @@ module ActiveRecord
           connection_handler = ActiveRecord::Base.connection_handler
           ActiveRecord::Base.connection_handler = ActiveRecord::ConnectionAdapters::ConnectionHandler.new
 
+          setup_transactional_fixtures
+
           assert_nothing_raised do
             ActiveRecord::Base.connects_to(database: { reading: :arunit, writing: :arunit })
           end
@@ -101,6 +105,8 @@ module ActiveRecord
           ro_conn = ActiveRecord::Base.connection_handler.retrieve_connection("ActiveRecord::Base", role: :reading)
 
           assert_equal rw_conn, ro_conn
+
+          teardown_transactional_fixtures
         ensure
           ActiveRecord::Base.connection_handler = connection_handler
         end

--- a/activerecord/test/cases/connection_adapters/schema_cache_test.rb
+++ b/activerecord/test/cases/connection_adapters/schema_cache_test.rb
@@ -5,6 +5,8 @@ require "cases/helper"
 module ActiveRecord
   module ConnectionAdapters
     class SchemaCacheTest < ActiveRecord::TestCase
+      self.use_transactional_tests = false
+
       def setup
         @connection = ARUnit2Model.connection
         @cache = new_bound_reflection

--- a/activerecord/test/cases/primary_class_test.rb
+++ b/activerecord/test/cases/primary_class_test.rb
@@ -3,6 +3,8 @@
 require "cases/helper"
 
 class PrimaryClassTest < ActiveRecord::TestCase
+  self.use_transactional_tests = false
+
   def teardown
     clean_up_connection_handler
   end


### PR DESCRIPTION
Extracted from: https://github.com/rails/rails/pull/50999

Some tests may use the connections in ways that cause the fixtures transaction to be committed or rolled back. The typical case being doing schema change query in MySQL, which automatically commits the transaction. But ther eare more subtle cases.

The general idea here is to ensure our transaction is correctly rolling back during teardown. If it fails, then we assume something might have mutated some of the inserted fixtures, so we invalidate the cache to ensure the next test will reset them.

This issue is particularly common in Active Record's own test suite since transaction fixtures are enabled by default but we have many tests create tables and such.

We could treat this case as an error, but since we can gracefully recover from it, I don't think it's worth it.
