### PR TITLE
Improve documentation of ActiveSupport::TimeZone.create [ci-skip]

### DIFF
--- a/activesupport/lib/active_support/values/time_zone.rb
+++ b/activesupport/lib/active_support/values/time_zone.rb
@@ -208,7 +208,9 @@ module ActiveSupport
         TZInfo::Timezone.get(MAPPING[name] || name)
       end
 
+      # :stopdoc:
       alias_method :create, :new
+      # :startdoc:
 
       # Returns a TimeZone instance with the given name, or +nil+ if no
       # such TimeZone instance exists. (This exists to support the use of
@@ -296,15 +298,22 @@ module ActiveSupport
     attr_reader :name
     attr_reader :tzinfo
 
+    ##
+    # :singleton-method: create
+    # :call-seq: create(name, utc_offset = nil, tzinfo = nil)
+    #
     # Create a new TimeZone object with the given name and offset. The
     # offset is the number of seconds that this time zone is offset from UTC
     # (GMT). Seconds were chosen as the offset unit because that is the unit
     # that Ruby uses to represent time zone offsets (see Time#utc_offset).
+
+    # :stopdoc:
     def initialize(name, utc_offset = nil, tzinfo = nil)
       @name = name
       @utc_offset = utc_offset
       @tzinfo = tzinfo || TimeZone.find_tzinfo(name)
     end
+    # :startdoc:
 
     # Returns the offset of this time zone from UTC in seconds.
     def utc_offset


### PR DESCRIPTION
The `create` method is currently marked as an alias of `new`. However, because `new` is later overridden, it's no longer an alias.

This requires wrapping the `alias_method` with stopdoc/startdoc, as the method is still marked as an alias otherwise (adding `:nodoc:` to `alias_method` [doesn't work yet](https://github.com/ruby/rdoc/pull/1090)). 

The `initialize` method has to be wrapped with stopdoc/startdoc as well, as the `new` method will still be documented for the initialized. Adding a `:nodoc:` instead will remove documentation for all following methods.

### Before

<img width="1003" alt="image" src="https://github.com/rails/rails/assets/28561/d3e2419d-b1e9-41ed-869d-fdc544e2aff3">

### After

<img width="995" alt="image" src="https://github.com/rails/rails/assets/28561/d85a2a89-398c-4ce6-8edc-a7d445cfe0dc">

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
