### PR TITLE
Remove memoization to accept `key_provider` overridden by `with_encryption_context`

### DIFF
--- a/activerecord/lib/active_record/encryption/encrypted_attribute_type.rb
+++ b/activerecord/lib/active_record/encryption/encrypted_attribute_type.rb
@@ -140,11 +140,11 @@ module ActiveRecord
         end
 
         def encryption_options
-          @encryption_options ||= { key_provider: key_provider, cipher_options: { deterministic: deterministic? } }.compact
+          { key_provider: key_provider, cipher_options: { deterministic: deterministic? } }.compact
         end
 
         def decryption_options
-          @decryption_options ||= { key_provider: key_provider }.compact
+          { key_provider: key_provider }.compact
         end
 
         def clean_text_scheme

--- a/activerecord/lib/active_record/encryption/scheme.rb
+++ b/activerecord/lib/active_record/encryption/scheme.rb
@@ -50,7 +50,7 @@ module ActiveRecord
       end
 
       def key_provider
-        @key_provider ||= @key_provider_param || build_key_provider || default_key_provider
+        @key_provider_param || build_key_provider || default_key_provider
       end
 
       def merge(other_scheme)


### PR DESCRIPTION
Somewhat similar to #48923 (but with a different cause), as of 7.1 we weren't correctly observing `key_provider` when overridden with `with_encryption_context`. I believe this regressed in #44540 (though it feels possible in some cases there would have been a memoization problem beforehand).

Reported by @kstevens715. Thank you!

I'll also backport this to 7-1-stable