### PR TITLE
Make various minor fixes to the Active Record test suite

### DIFF
--- a/activerecord/test/cases/adapter_test.rb
+++ b/activerecord/test/cases/adapter_test.rb
@@ -820,19 +820,21 @@ module ActiveRecord
       @threads.each(&:kill)
     end
 
-    test "#active? is synchronized" do
-      threads(2, 25) { @connection.select_all("SELECT 1") }
-      threads(2, 25) { @connection.verify! }
-      threads(2, 25) { @connection.disconnect! }
+    unless in_memory_db?
+      test "#active? is synchronized" do
+        threads(2, 25) { @connection.select_all("SELECT 1") }
+        threads(2, 25) { @connection.verify! }
+        threads(2, 25) { @connection.disconnect! }
 
-      join
-    end
+        join
+      end
 
-    test "#verify! is synchronized" do
-      threads(2, 25) { @connection.verify! }
-      threads(2, 25) { @connection.disconnect! }
+      test "#verify! is synchronized" do
+        threads(2, 25) { @connection.verify! }
+        threads(2, 25) { @connection.disconnect! }
 
-      join
+        join
+      end
     end
 
     private

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -1555,6 +1555,7 @@ class BasicsTest < ActiveRecord::TestCase
         post.comments.build
         wr.write Marshal.dump(post)
         wr.close
+        exit!(0)
       end
 
       wr.close

--- a/activerecord/test/cases/connection_pool_test.rb
+++ b/activerecord/test/cases/connection_pool_test.rb
@@ -6,6 +6,11 @@ require "concurrent/atomic/count_down_latch"
 module ActiveRecord
   module ConnectionAdapters
     module ConnectionPoolTests
+      def self.included(test)
+        super
+        test.use_transactional_tests = false
+      end
+
       attr_reader :pool
 
       def setup

--- a/activerecord/test/cases/migration/foreign_key_test.rb
+++ b/activerecord/test/cases/migration/foreign_key_test.rb
@@ -674,20 +674,30 @@ if ActiveRecord::Base.connection.supports_foreign_keys?
         end
 
         def test_add_foreign_key_is_reversible
+          @connection.drop_table("cities", if_exists: true)
+          @connection.drop_table("houses", if_exists: true)
+
           migration = CreateCitiesAndHousesMigration.new
           silence_stream($stdout) { migration.migrate(:up) }
           assert_equal 1, @connection.foreign_keys("houses").size
-        ensure
           silence_stream($stdout) { migration.migrate(:down) }
+        ensure
+          @connection.drop_table("cities", if_exists: true)
+          @connection.drop_table("houses", if_exists: true)
         end
 
         def test_foreign_key_constraint_is_not_cached_incorrectly
+          @connection.drop_table("cities", if_exists: true)
+          @connection.drop_table("houses", if_exists: true)
+
           migration = CreateCitiesAndHousesMigration.new
           silence_stream($stdout) { migration.migrate(:up) }
           output = dump_table_schema "houses"
           assert_match %r{\s+add_foreign_key "houses",.+on_delete: :cascade$}, output
-        ensure
           silence_stream($stdout) { migration.migrate(:down) }
+        ensure
+          @connection.drop_table("cities", if_exists: true)
+          @connection.drop_table("houses", if_exists: true)
         end
 
         class CreateSchoolsAndClassesMigration < ActiveRecord::Migration::Current

--- a/activerecord/test/cases/test_fixtures_test.rb
+++ b/activerecord/test/cases/test_fixtures_test.rb
@@ -6,6 +6,8 @@ require "fileutils"
 require "models/zine"
 
 class TestFixturesTest < ActiveRecord::TestCase
+  self.use_transactional_tests = false
+
   setup do
     @klass = Class.new
     @klass.include(ActiveRecord::TestFixtures)


### PR DESCRIPTION
Extracted from: https://github.com/rails/rails/pull/50999

- Make fixtures setup and teardown methods private.
- Don't run adapter thread safety tests with sqlite3_mem
- Make foreign_key_tests more resilient to leaked state
- Use `exit!` in fork to avoid `at_exit` side effects.
- Disable transactional fixtures in tests that do a lot of low level assertions on connections or connection pools.
