### PR TITLE
Ensure required version of Bundler to be installed in the container

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/Dockerfile.tt
+++ b/railties/lib/rails/generators/rails/app/templates/Dockerfile.tt
@@ -41,6 +41,7 @@ RUN curl -fsSL https://bun.sh/install | bash -s -- "bun-v${BUN_VERSION}"
 <% end -%>
 # Install application gems
 COPY Gemfile Gemfile.lock ./
+RUN gem install bundler -v "$(grep -A 1 "BUNDLED WITH" Gemfile.lock | tail -n 1)"
 RUN bundle install && \
     rm -rf ~/.bundle/ "${BUNDLE_PATH}"/ruby/*/cache "${BUNDLE_PATH}"/ruby/*/bundler/gems/*/.git<% if depend_on_bootsnap? -%> && \
     bundle exec bootsnap precompile --gemfile<% end %>


### PR DESCRIPTION
PR enforces `bundler` version from Gemfile.lock to be installed.

When using bundler different from the version that is installed by default in your Ruby version, you may experience an error.

```
To install the version of bundler this project requires, run `gem install bundler -v '~> 2.5'`
Activating bundler (~> 2.5) failed:
Could not find 'bundler' (~> 2.5) - did find: [bundler-2.4.19]
Checked in 'GEM_PATH=/rails/.local/share/gem/ruby/3.2.0:/usr/local/lib/ruby/gems/3.2.0:/usr/local/bundle' , execute `gem env` for more information
```

PR is based on the Bundler documentation and it will be a default behaviour for the future versions of the Bundler.

* https://bundler.io/blog/2019/05/14/solutions-for-cant-find-gem-bundler-with-executable-bundle.html