### PR TITLE
Workaround a Ruby bug that can cause a VM crash

### DIFF
--- a/activesupport/lib/active_support/tagged_logging.rb
+++ b/activesupport/lib/active_support/tagged_logging.rb
@@ -119,6 +119,10 @@ module ActiveSupport
 
       if logger.formatter
         logger.formatter = logger.formatter.clone
+
+        # Workaround for https://bugs.ruby-lang.org/issues/20250
+        # Can be removed when Ruby 3.4 is the least supported version.
+        logger.formatter.object_id if logger.formatter.is_a?(Proc)
       else
         # Ensure we set a default formatter so we aren't extending nil!
         logger.formatter = ActiveSupport::Logger::SimpleFormatter.new


### PR DESCRIPTION
See: https://bugs.ruby-lang.org/issues/20250

The bug exist all the way since Ruby 2.7, if you `clone` a `Proc` object on which you already accessed `object_id`, when its clone is GCed Ruby will crash.

By accessing the clone's `object_id` right away, we prevent the crash.
