### PR TITLE
Move where errors are reported to ensure they are reported in production

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/debug_exceptions.rb
+++ b/actionpack/lib/action_dispatch/middleware/debug_exceptions.rb
@@ -40,6 +40,7 @@ module ActionDispatch
       wrapper = ExceptionWrapper.new(backtrace_cleaner, exception)
 
       invoke_interceptors(request, exception, wrapper)
+      Rails.error.report(exception, handled: false, source: "application.action_dispatch")
       raise exception unless wrapper.show?(request)
       render_exception(request, exception, wrapper)
     end

--- a/actionpack/lib/action_dispatch/middleware/executor.rb
+++ b/actionpack/lib/action_dispatch/middleware/executor.rb
@@ -13,9 +13,6 @@ module ActionDispatch
       begin
         response = @app.call(env)
         returned = response << ::Rack::BodyProxy.new(response.pop) { state.complete! }
-      rescue => error
-        @executor.error_reporter.report(error, handled: false, source: "application.action_dispatch")
-        raise
       ensure
         state.complete! unless returned
       end


### PR DESCRIPTION
### Motivation / Background

As reported in https://github.com/rails/rails/issues/51002#issuecomment-1936054456 the Rails error reporter is not reporting errors in production. 

Fixes #51002

### Detail

This moves the reporting to inside the DebugExceptions middleware which is always hit in prod and development and removes the reporting from the Executor middleware. Moving it here also ensures they are reported in development. Initially i had wanted it in ShowExceptions but in development DebugExceptions swallows it first. 

### Additional information

<!-- Provide additional information such as benchmarks, reference to other repositories or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
