### PR TITLE
Fix NoMethodErrors in Active Record after backport [7-1-stable]

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
@@ -131,7 +131,7 @@ module ActiveRecord
       #++
 
       def active?
-        connected? && @lock.synchronize { @raw_connection&.ping } || false
+        !(@raw_connection.nil? || @raw_connection.closed?) && @lock.synchronize { @raw_connection&.ping } || false
       end
 
       alias :reset! :reconnect!

--- a/activerecord/lib/active_record/connection_adapters/trilogy_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/trilogy_adapter.rb
@@ -140,7 +140,7 @@ module ActiveRecord
       end
 
       def active?
-        connected? && @lock.synchronize { @raw_connection&.ping } || false
+        !(@raw_connection.nil? || @raw_connection.closed?) && @lock.synchronize { @raw_connection&.ping } || false
       rescue ::Trilogy::Error
         false
       end

--- a/activerecord/lib/active_record/counter_cache.rb
+++ b/activerecord/lib/active_record/counter_cache.rb
@@ -199,8 +199,7 @@ module ActiveRecord
 
         if affected_rows > 0
           each_counter_cached_associations do |association|
-            foreign_key = association.reflection.foreign_key.to_sym
-            unless destroyed_by_association && _foreign_keys_equal?(destroyed_by_association.foreign_key, foreign_key)
+            unless destroyed_by_association && _foreign_keys_equal?(destroyed_by_association.foreign_key, association.reflection.foreign_key)
               association.decrement_counters
             end
           end


### PR DESCRIPTION
Ref #51012

connected? only exists on main, but was included in a [backport][1]

[1]: https://github.com/rails/rails/commit/eb760da85898017a1ea300a8f08c32d0412879d3

cc @byroot 