### PR TITLE
Add new middleware to ensure errors are always reported to the AS error reporter

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add new middleware to ensure errors are always reported to the ActiveSupport::ErrorReporter
+
+    *Nick Pezza*
+
 *   Add `allow_browser` to set minimum browser versions for the application.
 
     A browser that's blocked will by default be served the file in `public/426.html` with a HTTP status code of "426 Upgrade Required".

--- a/actionpack/lib/action_dispatch.rb
+++ b/actionpack/lib/action_dispatch.rb
@@ -66,6 +66,7 @@ module ActionDispatch
     autoload :Cookies
     autoload :ActionableExceptions
     autoload :DebugExceptions
+    autoload :ReportErrors
     autoload :DebugLocks
     autoload :DebugView
     autoload :ExceptionWrapper

--- a/actionpack/lib/action_dispatch/middleware/executor.rb
+++ b/actionpack/lib/action_dispatch/middleware/executor.rb
@@ -13,9 +13,6 @@ module ActionDispatch
       begin
         response = @app.call(env)
         returned = response << ::Rack::BodyProxy.new(response.pop) { state.complete! }
-      rescue => error
-        @executor.error_reporter.report(error, handled: false, source: "application.action_dispatch")
-        raise
       ensure
         state.complete! unless returned
       end

--- a/actionpack/lib/action_dispatch/middleware/report_errors.rb
+++ b/actionpack/lib/action_dispatch/middleware/report_errors.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module ActionDispatch
+  # = Action Dispatch \ReportErrors
+  #
+  # This middleware is responsible for reporting exceptions through
+  # the Active Support Error Reporter
+  class ReportErrors
+    def initialize(app, executor)
+      @app, @executor = app, executor
+    end
+
+    def call(env)
+      begin
+        @app.call(env)
+      rescue => error
+        @executor.error_reporter.report(error, handled: false, source: "application.action_dispatch")
+        raise
+      end
+    end
+  end
+end

--- a/actionpack/test/dispatch/report_errors_test.rb
+++ b/actionpack/test/dispatch/report_errors_test.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require "abstract_unit"
+
+class ReportErrorsTest < ActionDispatch::IntegrationTest
+  class ErrorSubscriber
+    def report(error, handled:, severity:, context:, source: nil)
+    end
+  end
+
+  class TestApp
+    def call(env)
+      req = ActionDispatch::Request.new(env)
+      raise StandardError.new("ruh roh")
+    end
+  end
+
+  def setup
+    @app = build_app
+    executor.error_reporter.subscribe(ErrorSubscriber.new)
+  end
+
+  test "reports error" do
+    report = assert_error_reported(StandardError) do
+      begin
+        get "/"
+      rescue StandardError
+      end
+    end
+
+    assert_equal "ruh roh", report.error.message
+    assert_equal :error, report.severity
+    assert_equal "application.action_dispatch", report.source
+  end
+
+  test "reports error with production like middleware" do
+    stack = ActionDispatch::MiddlewareStack.new
+    stack.use ActionDispatch::Executor, executor
+    stack.use ActionDispatch::ShowExceptions, ActionDispatch::PublicExceptions.new("/public")
+    stack.use ActionDispatch::DebugExceptions, Rack::Lint.new([]), "html"
+    stack.use ActionDispatch::ReportErrors, executor
+
+    app = Rack::Lint.new(
+      stack.build(Rack::Lint.new(proc { |env| raise StandardError.new("ruh roh") }))
+    )
+
+    env = Rack::MockRequest.env_for("", {})
+    report = assert_error_reported(StandardError) do
+      begin
+        app.call(env)
+      rescue StandardError
+      end
+    end
+    assert_equal "ruh roh", report.error.message
+  end
+
+  private
+
+    def executor
+      @executor ||= Class.new(ActiveSupport::Executor)
+    end
+
+    def build_app(exceptions_app = nil)
+      Rack::Lint.new(ActionDispatch::ReportErrors.new(Rack::Lint.new(TestApp.new), executor))
+    end
+end

--- a/railties/lib/rails/application/default_middleware_stack.rb
+++ b/railties/lib/rails/application/default_middleware_stack.rb
@@ -57,6 +57,7 @@ module Rails
           middleware.use ::Rails::Rack::Logger, config.log_tags
           middleware.use ::ActionDispatch::ShowExceptions, show_exceptions_app
           middleware.use ::ActionDispatch::DebugExceptions, app, config.debug_exception_response_format
+          middleware.use ::ActionDispatch::ReportErrors, app.executor
 
           if config.consider_all_requests_local
             middleware.use ::ActionDispatch::ActionableExceptions


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because it was reported in https://github.com/rails/rails/issues/51002#issuecomment-1936054456 that the Rails error reporter is not reporting errors in production.

Fixes #51002
### Detail

This moves the reporting to inside a new middleware, ReportErrors, which is always hit in prod and development and removes the reporting from the Executor middleware. Moving it here ensures errors are always reported regardless of the environment. 

### Additional information

<!-- Provide additional information such as benchmarks, reference to other repositories or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
