### PR TITLE
Copy over .ruby-version prior to initial bundle in generated Dockerfile

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Copy over .ruby-version prior to initial bundle in generated Dockerfile
+
+    *Rob Zolkos*
+
 *   Setup jemalloc in the default Dockerfile for memory optimization.
 
     *Matt Almeida*, *Jean Boussier*

--- a/railties/lib/rails/generators/rails/app/templates/Dockerfile.tt
+++ b/railties/lib/rails/generators/rails/app/templates/Dockerfile.tt
@@ -40,7 +40,7 @@ RUN curl -fsSL https://bun.sh/install | bash -s -- "bun-v${BUN_VERSION}"
 
 <% end -%>
 # Install application gems
-COPY Gemfile Gemfile.lock ./
+COPY Gemfile Gemfile.lock .ruby-version ./
 RUN bundle install && \
     rm -rf ~/.bundle/ "${BUNDLE_PATH}"/ruby/*/cache "${BUNDLE_PATH}"/ruby/*/bundler/gems/*/.git<% if depend_on_bootsnap? -%> && \
     bundle exec bootsnap precompile --gemfile<% end %>

--- a/railties/test/fixtures/Dockerfile.test
+++ b/railties/test/fixtures/Dockerfile.test
@@ -24,7 +24,7 @@ RUN apt-get update -qq && \
 
 
 # Install application gems
-COPY Gemfile Gemfile.lock ./
+COPY Gemfile Gemfile.lock .ruby-version ./
 RUN bundle install && \
     rm -rf ~/.bundle/ "${BUNDLE_PATH}"/ruby/*/cache "${BUNDLE_PATH}"/ruby/*/bundler/gems/*/.git && \
     bundle exec bootsnap precompile --gemfile


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because the default Dockerfile will fail to build when it attempts to bundle gems, when there is no `.ruby-version` file for it to refer to if developers have updated the Gemfile ruby reference in a certain (but valid) way.  Bundler [2.4.19](https://github.com/rubygems/rubygems/blob/master/bundler/CHANGELOG.md#2419-august-17-2023) [introduced](https://github.com/rubygems/rubygems/pull/6876) the ability to read in the version of Ruby from the `.ruby-version` file.

`ruby file: '.ruby-version'`

Rails doesn't currently use this pattern, setting the Ruby version in both the `.ruby-version` file and the `Gemfile`.

However, some developers _will_ update the Gemfile to use the new `file:` syntax, as it is a perfectly valid way of referencing the ruby version.  
### Detail

This Pull Request changes the generated Dockerfile so that it copies over the `.ruby-version` file at the same time as the `Gemfile` and `Gemfile.lock` so bundler has everything it needs to bundle regardless of which method developers have chosen to specify the Ruby version in the Gemfile. 
### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
