### PR TITLE
Disambiguate language around when controller code stops re: `redirect_to` [ci skip]

### DIFF
--- a/guides/source/layouts_and_rendering.md
+++ b/guides/source/layouts_and_rendering.md
@@ -714,7 +714,14 @@ Just like the `:status` option for `render`, `:status` for `redirect_to` accepts
 
 #### The Difference Between `render` and `redirect_to`
 
-Sometimes inexperienced developers think of `redirect_to` as a sort of `goto` command, moving execution from one place to another in your Rails code. This is _not_ correct. Your code stops running and waits for a new request from the browser. It just happens that you've told the browser what request it should make next, by sending back an HTTP 302 status code.
+Sometimes inexperienced developers think of `redirect_to` as a sort of `goto`
+command, moving execution from one place to another in your Rails code. This is
+_not_ correct.
+
+The current action will complete, returning a response to the browser. After
+this your code stops running and waits for a new request, it just happens that
+you've told the browser what request it should make next by sending back an
+HTTP 302 status code.
 
 Consider these actions to see the difference:
 


### PR DESCRIPTION
### Motivation / Background / Description

Changes to: [Layouts and Rendering: 2.3.2 The Difference Between render and redirect_to](https://guides.rubyonrails.org/layouts_and_rendering.html#the-difference-between-render-and-redirect-to)

The changed paragraph tends to cause confustion with Rails developers who have just learned the correct control flow of `redirect_to` and `render`.

A phrase above it in the "Avoiding Double Render Errors" section clears up a common misunderstanding that `render` will stop execution within a controller action. That misunderstanding is further clarified with a following phrase.

> But this will _not_ stop the rest of the code in the `show` action from running

This section is often enough to get the point across for newer developers who might often be running into double render errors, but soon after the phrase which attempts the same illustration of `redirect_to`'s execution confuses the matter by using the same language as the earlier statement to mean the opposite.

> Sometimes inexperienced developers think of `redirect_to` as a sort of `goto` command, moving execution from one place to another in your Rails code. This is _not_ correct. Your code stops running and waits for a new request from the browser.

Here "Your code stops running" means that the action **_will_** run to completion and not jump to another site in controller code, where the other phrase "stop the rest of the code ... from running" is used to illustrate the misunderstanding and means the action **_will not_** run to completion. This often re-confuses the concept they've just learned and undermines their understanding. By being more specific in the second phrase, we can reinforce the concept instead.

### The change

Open to feedback around the particular phrasing or formatting, the important part is changing the re-use of the "stops ... running" terminology.


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
