### PR TITLE
Remove initializer that was eager loading the schema cache dump

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Deprecated `ENV["SCHEMA_CACHE"]` in favor of `schema_cache_path` in the database configuration.
+
+    *Rafael Mendonça França*
+
 *   Add `ActiveRecord::Base.with_connection` as a shortcut for leasing a connection for a short duration.
 
     The leased connection is yielded, and for the duration of the block, any call to `ActiveRecord::Base.connection`

--- a/activerecord/lib/active_record/connection_adapters/schema_cache.rb
+++ b/activerecord/lib/active_record/connection_adapters/schema_cache.rb
@@ -18,10 +18,6 @@ module ActiveRecord
         @cache_path = cache_path
       end
 
-      def set_schema_cache(cache)
-        @cache = cache
-      end
-
       def clear!
         @cache = empty_cache
 

--- a/activerecord/lib/active_record/railtie.rb
+++ b/activerecord/lib/active_record/railtie.rb
@@ -134,49 +134,11 @@ To keep using the current cache store, you can turn off cache versioning entirel
       end
     end
 
-    initializer "active_record.use_schema_cache_dump" do
-      ActiveRecord::ConnectionAdapters::SchemaReflection.use_schema_cache_dump = config.active_record.use_schema_cache_dump
-    end
+    initializer "active_record.copy_schema_cache_config" do
+      active_record_config = config.active_record
 
-    initializer "active_record.check_schema_cache_dump" do
-      check_schema_cache_dump_version = config.active_record.check_schema_cache_dump_version
-
-      ActiveRecord::ConnectionAdapters::SchemaReflection.check_schema_cache_dump_version = check_schema_cache_dump_version
-
-      if config.active_record.use_schema_cache_dump && !config.active_record.lazily_load_schema_cache
-        config.after_initialize do |app|
-          ActiveSupport.on_load(:active_record) do
-            db_config = ActiveRecord::Base.configurations.configs_for(env_name: Rails.env).first
-            next if db_config.nil?
-
-            filename = ActiveRecord::Tasks::DatabaseTasks.cache_dump_filename(db_config)
-
-            cache = ActiveRecord::ConnectionAdapters::SchemaCache._load_from(filename)
-            next if cache.nil?
-
-            if check_schema_cache_dump_version
-              current_version = begin
-                ActiveRecord::Migrator.current_version
-              rescue ActiveRecordError => error
-                warn "Failed to validate the schema cache because of #{error.class}: #{error.message}"
-                nil
-              end
-
-              if current_version.nil?
-                connection_pool.schema_reflection.clear!
-                next
-              elsif cache.schema_version != current_version
-                warn "Ignoring #{filename} because it has expired. The current schema version is #{current_version}, but the one in the schema cache file is #{cache.schema_version}."
-                connection_pool.schema_reflection.clear!
-                next
-              end
-            end
-
-            Rails.logger.info("Using schema cache file #{filename}")
-            connection_pool.schema_reflection.set_schema_cache(cache)
-          end
-        end
-      end
+      ActiveRecord::ConnectionAdapters::SchemaReflection.use_schema_cache_dump = active_record_config.use_schema_cache_dump
+      ActiveRecord::ConnectionAdapters::SchemaReflection.check_schema_cache_dump_version = active_record_config.check_schema_cache_dump_version
     end
 
     initializer "active_record.define_attribute_methods" do |app|

--- a/activerecord/lib/active_record/tasks/database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/database_tasks.rb
@@ -441,7 +441,7 @@ module ActiveRecord
         if db_config_or_name.is_a?(DatabaseConfigurations::DatabaseConfig)
           schema_cache_path ||
             db_config_or_name.schema_cache_path ||
-            ENV["SCHEMA_CACHE"] ||
+            schema_cache_env ||
             db_config_or_name.default_schema_cache_path(ActiveRecord::Tasks::DatabaseTasks.db_dir)
         else
           ActiveRecord.deprecator.warn(<<~MSG.squish)
@@ -455,7 +455,7 @@ module ActiveRecord
             "#{db_config_or_name}_schema_cache.yml"
           end
 
-          schema_cache_path || ENV["SCHEMA_CACHE"] || File.join(ActiveRecord::Tasks::DatabaseTasks.db_dir, filename)
+          schema_cache_path || schema_cache_env || File.join(ActiveRecord::Tasks::DatabaseTasks.db_dir, filename)
         end
       end
 
@@ -523,6 +523,17 @@ module ActiveRecord
       end
 
       private
+        def schema_cache_env
+          if ENV["SCHEMA_CACHE"]
+            ActiveRecord.deprecator.warn(<<~MSG.squish)
+              Setting `ENV["SCHEMA_CACHE"]` is deprecated and will be removed in Rails 7.3.
+              Configure the `:schema_cache_path` in the database configuration instead.
+            MSG
+
+            nil
+          end
+        end
+
         def with_temporary_pool(db_config, clobber: false)
           original_db_config = migration_class.connection_db_config
           pool = migration_class.connection_handler.establish_connection(db_config, clobber: clobber)

--- a/activerecord/lib/active_record/tasks/database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/database_tasks.rb
@@ -444,7 +444,7 @@ module ActiveRecord
             ENV["SCHEMA_CACHE"] ||
             db_config_or_name.default_schema_cache_path(ActiveRecord::Tasks::DatabaseTasks.db_dir)
         else
-          ActiveRecord.deprecator.deprecation_warning(<<~MSG.squish)
+          ActiveRecord.deprecator.warn(<<~MSG.squish)
             Passing a database name to `cache_dump_filename` is deprecated and will be removed in Rails 7.3. Pass a
             `ActiveRecord::DatabaseConfigurations::DatabaseConfig` object instead.
           MSG

--- a/activerecord/test/cases/tasks/database_tasks_test.rb
+++ b/activerecord/test/cases/tasks/database_tasks_test.rb
@@ -388,8 +388,10 @@ module ActiveRecord
       config = DatabaseConfigurations::HashConfig.new("development", "primary", {})
 
       ActiveRecord::Tasks::DatabaseTasks.stub(:db_dir, "db") do
-        path = ActiveRecord::Tasks::DatabaseTasks.cache_dump_filename(config)
-        assert_equal "tmp/something.yml", path
+        path = assert_deprecated(/Setting `ENV\["SCHEMA_CACHE"\]` is deprecated and will be removed in Rails 7\.3\. Configure the `:schema_cache_path` in the database configuration instead\. \(/, ActiveRecord.deprecator) do
+          ActiveRecord::Tasks::DatabaseTasks.cache_dump_filename(config)
+        end
+        assert_equal "db/schema_cache.yml", path
       end
     ensure
       ENV["SCHEMA_CACHE"] = old_path
@@ -403,7 +405,7 @@ module ActiveRecord
         path = assert_deprecated(/Passing a database name to `cache_dump_filename` is deprecated and will be removed in Rails 7\.3\. Pass a `ActiveRecord::DatabaseConfigurations::DatabaseConfig` object instead\. \(/, ActiveRecord.deprecator) do
           ActiveRecord::Tasks::DatabaseTasks.cache_dump_filename("primary")
         end
-        assert_equal "tmp/something.yml", path
+        assert_equal "db/schema_cache.yml", path
       end
     ensure
       ENV["SCHEMA_CACHE"] = old_path

--- a/activerecord/test/cases/tasks/database_tasks_test.rb
+++ b/activerecord/test/cases/tasks/database_tasks_test.rb
@@ -400,7 +400,7 @@ module ActiveRecord
       ENV["SCHEMA_CACHE"] = "tmp/something.yml"
 
       ActiveRecord::Tasks::DatabaseTasks.stub(:db_dir, "db") do
-        path = assert_deprecated(ActiveRecord.deprecator) do
+        path = assert_deprecated(/Passing a database name to `cache_dump_filename` is deprecated and will be removed in Rails 7\.3\. Pass a `ActiveRecord::DatabaseConfigurations::DatabaseConfig` object instead\. \(/, ActiveRecord.deprecator) do
           ActiveRecord::Tasks::DatabaseTasks.cache_dump_filename("primary")
         end
         assert_equal "tmp/something.yml", path

--- a/railties/test/application/initializers/frameworks_test.rb
+++ b/railties/test/application/initializers/frameworks_test.rb
@@ -25,7 +25,7 @@ module ApplicationTests
         RUBY
 
         use_frameworks []
-        require "#{app_path}/config/environment"
+        app("development")
       end
     end
 
@@ -34,7 +34,7 @@ module ApplicationTests
         config.root = "#{app_path}"
       RUBY
 
-      require "#{app_path}/config/environment"
+      app("development")
 
       expanded_path = File.expand_path("app/views", app_path)
       assert_equal expanded_path, ActionController::Base.view_paths[0].to_s
@@ -48,7 +48,7 @@ module ApplicationTests
         end
       RUBY
 
-      require "#{app_path}/config/environment"
+      app("development")
       assert_equal "test.rails", ActionMailer::Base.default_url_options[:host]
     end
 
@@ -66,7 +66,7 @@ module ApplicationTests
         end
       RUBY
 
-      require "#{app_path}/config/environment"
+      app("development")
       assert Foo.method_defined?(:foo_url)
       assert Foo.method_defined?(:main_app)
     end
@@ -163,14 +163,14 @@ module ApplicationTests
     # AD
     test "action_dispatch extensions are applied to ActionDispatch" do
       add_to_config "config.action_dispatch.tld_length = 2"
-      require "#{app_path}/config/environment"
+      app("development")
       assert_equal 2, ActionDispatch::Http::URL.tld_length
     end
 
     test "assignment config.encoding to default_charset" do
       charset = "Shift_JIS"
       add_to_config "config.encoding = '#{charset}'"
-      require "#{app_path}/config/environment"
+      app("development")
       assert_equal charset, ActionDispatch::Response.default_charset
     end
 
@@ -181,14 +181,14 @@ module ApplicationTests
         end
       RUBY
 
-      require "#{app_path}/config/environment"
+      app("development")
       assert_equal true, ActionDispatch::Http::URL.secure_protocol
     end
 
     # AS
     test "if there's no config.active_support.bare, all of ActiveSupport is required" do
       use_frameworks []
-      require "#{app_path}/config/environment"
+      app("development")
       assert_nothing_raised { [1, 2, 3].sample }
     end
 
@@ -198,7 +198,7 @@ module ApplicationTests
       use_frameworks []
 
       Dir.chdir("#{app_path}/app") do
-        require "#{app_path}/config/environment"
+        app("development")
         assert_raises(NoMethodError) { "hello".exclude? "lo" }
       end
     end
@@ -206,13 +206,13 @@ module ApplicationTests
     # AR
     test "active_record extensions are applied to ActiveRecord" do
       add_to_config "config.active_record.table_name_prefix = 'tbl_'"
-      require "#{app_path}/config/environment"
+      app("development")
       assert_equal "tbl_", ActiveRecord::Base.table_name_prefix
     end
 
     test "database middleware doesn't initialize when activerecord is not in frameworks" do
       use_frameworks []
-      require "#{app_path}/config/environment"
+      app("development")
       assert !defined?(ActiveRecord::Base) || ActiveRecord.autoload?(:Base)
     end
 
@@ -220,7 +220,7 @@ module ApplicationTests
       rails %w(generate model post title:string)
 
       with_unhealthy_database do
-        require "#{app_path}/config/environment"
+        app("development")
       end
     end
 
@@ -232,7 +232,7 @@ module ApplicationTests
         config.eager_load = true
       RUBY
 
-      require "#{app_path}/config/environment"
+      app("development")
 
       assert ActiveRecord::Base.connection.schema_cache.data_sources("posts")
     ensure
@@ -252,7 +252,7 @@ module ApplicationTests
       RUBY
 
       assert_nothing_raised do
-        require "#{app_path}/config/environment"
+        app("development")
       end
     end
 
@@ -265,7 +265,7 @@ module ApplicationTests
       RUBY
 
       silence_warnings do
-        require "#{app_path}/config/environment"
+        app("development")
       end
       assert_not ActiveRecord::Base.connection.schema_cache.data_sources("posts")
     end
@@ -280,7 +280,7 @@ module ApplicationTests
 
       with_unhealthy_database do
         silence_warnings do
-          require "#{app_path}/config/environment"
+          app("development")
         end
 
         assert_not_nil ActiveRecord::Base.connection_pool.schema_reflection.instance_variable_get(:@cache)
@@ -304,7 +304,7 @@ module ApplicationTests
         config.active_record.check_schema_cache_dump_version = false
       RUBY
 
-      require "#{app_path}/config/environment"
+      app("development")
       assert ActiveRecord::Base.connection_pool.schema_reflection.data_sources(:__unused__, "posts")
     end
 
@@ -318,7 +318,7 @@ module ApplicationTests
       RUBY
 
       with_unhealthy_database do
-        require "#{app_path}/config/environment"
+        app("development")
 
         assert ActiveRecord::Base.connection_pool.schema_reflection.data_sources(:__unused__, "posts")
         assert_raises ActiveRecord::ConnectionNotEstablished do
@@ -344,7 +344,7 @@ module ApplicationTests
     end
 
     test "active record establish_connection uses Rails.env if DATABASE_URL is not set" do
-      require "#{app_path}/config/environment"
+      app("development")
       orig_database_url = ENV.delete("DATABASE_URL")
       orig_rails_env, Rails.env = Rails.env, "development"
       ActiveRecord::Base.establish_connection
@@ -359,7 +359,7 @@ module ApplicationTests
     end
 
     test "active record establish_connection uses DATABASE_URL even if Rails.env is set" do
-      require "#{app_path}/config/environment"
+      app("development")
       orig_database_url = ENV.delete("DATABASE_URL")
       orig_rails_env, Rails.env = Rails.env, "development"
       database_url_db_name = "db/database_url_db.sqlite3"
@@ -377,7 +377,7 @@ module ApplicationTests
       app_file "config/initializers/active_record.rb", <<-RUBY
         ActiveRecord::Base.connection
       RUBY
-      require "#{app_path}/config/environment"
+      app("development")
       assert_not_predicate ActiveRecord::Base.connection_pool, :active_connection?
     end
 
@@ -399,7 +399,7 @@ module ApplicationTests
         end
       RUBY
 
-      require "#{app_path}/config/environment"
+      app("development")
 
       assert A
       assert M
@@ -421,7 +421,7 @@ module ApplicationTests
         end
       RUBY
 
-      require "#{app_path}/config/environment"
+      app("development")
 
       assert Post
       filter_parameters = Rails.application.config.filter_parameters.dup
@@ -440,7 +440,7 @@ module ApplicationTests
         config.cache_store = :file_store, #{app_path("tmp/cache").inspect}, { serializer: :message_pack }
       RUBY
 
-      require "#{app_path}/config/environment"
+      app("development")
 
       post = Post.create!(title: "Hello World")
       Rails.cache.write("hello", post)

--- a/railties/test/application/initializers/frameworks_test.rb
+++ b/railties/test/application/initializers/frameworks_test.rb
@@ -327,6 +327,22 @@ module ApplicationTests
       end
     end
 
+    test "define attribute methods when schema cache is present and check_schema_cache_dump_version is false" do
+      rails %w(generate model post title:string)
+      rails %w(db:migrate db:schema:cache:dump)
+
+      add_to_config <<-RUBY
+        config.eager_load = true
+        config.active_record.check_schema_cache_dump_version = false
+      RUBY
+
+      Dir.chdir(app_path) do
+        app
+
+        assert_predicate Post, :attribute_methods_generated?
+      end
+    end
+
     test "active record establish_connection uses Rails.env if DATABASE_URL is not set" do
       require "#{app_path}/config/environment"
       orig_database_url = ENV.delete("DATABASE_URL")

--- a/railties/test/application/rake/dbs_test.rb
+++ b/railties/test/application/rake/dbs_test.rb
@@ -510,22 +510,6 @@ module ApplicationTests
         end
       end
 
-      test "db:schema:cache:dump ignores validation errors" do
-        Dir.chdir(app_path) do
-          rails "generate", "model", "book", "title:string"
-          rails "db:migrate"
-          rails "db:schema:cache:dump"
-
-          ActiveRecord::Migrator.stub(:current_version, -> { raise ActiveRecord::ActiveRecordError, "stubbed error" }) do
-            validation_warning = capture(:stderr) do
-              cache_tables = rails("runner", "p ActiveRecord::Base.connection.schema_cache.columns('books')", stderr: true).strip
-              assert_includes cache_tables, "title", "expected cache_tables to include a title entry"
-            end
-            assert_match(/Failed to validate the schema cache because of ActiveRecord::ActiveRecordError: stubbed error/, validation_warning)
-          end
-        end
-      end
-
       def db_fixtures_load(expected_database)
         Dir.chdir(app_path) do
           rails "generate", "model", "book", "title:string"

--- a/railties/test/application/rake/dbs_test.rb
+++ b/railties/test/application/rake/dbs_test.rb
@@ -439,17 +439,6 @@ module ApplicationTests
         db_schema_cache_dump
       end
 
-      test "db:schema:cache:dump custom env" do
-        @old_schema_cache_env = ENV["SCHEMA_CACHE"]
-        filename = "db/special_schema_cache.yml"
-        ENV["SCHEMA_CACHE"] = filename
-
-        db_schema_dump
-        db_schema_cache_dump
-      ensure
-        ENV["SCHEMA_CACHE"] = @old_schema_cache_env
-      end
-
       test "db:schema:cache:dump first config wins" do
         Dir.chdir(app_path) do
           File.open("#{app_path}/config/database.yml", "w") do |f|


### PR DESCRIPTION
This will be eager loaded by the `define_attribute_methods` initializer now that the schema cache can be automatically loaded for all connection if the file is present on disk after https://github.com/rails/rails/pull/48716.