### PR TITLE
Fix deprecated `enum` syntax in tests

### DIFF
--- a/activerecord/test/cases/adapters/abstract_mysql_adapter/mysql_enum_test.rb
+++ b/activerecord/test/cases/adapters/abstract_mysql_adapter/mysql_enum_test.rb
@@ -11,7 +11,7 @@ class MySQLEnumTest < ActiveRecord::AbstractMysqlTestCase
   class EnumTest < ActiveRecord::Base
     attribute :state, :integer
 
-    enum state: {
+    enum :state, {
       start: 0,
       middle: 1,
       finish: 2

--- a/activerecord/test/cases/adapters/postgresql/enum_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/enum_test.rb
@@ -11,12 +11,12 @@ class PostgresqlEnumTest < ActiveRecord::PostgreSQLTestCase
   class PostgresqlEnum < ActiveRecord::Base
     self.table_name = "postgresql_enums"
 
-    enum current_mood: {
+    enum :current_mood, {
       sad: "sad",
       okay: "ok", # different spelling
       happy: "happy",
       aliased_field: "happy"
-    }, _prefix: true
+    }, prefix: true
   end
 
   def setup


### PR DESCRIPTION
Follow up to https://github.com/rails/rails/pull/50987.
https://buildkite.com/rails/rails/builds/104740#018d90a5-2b0e-4ef7-a44f-8deb7c9158f5/1175-1181

cc @skipkayhil 