### PR TITLE
Update 7.0 release notes re inflections and the once autoloader

### DIFF
--- a/guides/source/upgrading_ruby_on_rails.md
+++ b/guides/source/upgrading_ruby_on_rails.md
@@ -477,6 +477,20 @@ to be an error condition in future versions of Rails.
 
 If you still get this warning in the logs, please check the section about autoloading when the application boots in the [autoloading guide](https://guides.rubyonrails.org/v7.0/autoloading_and_reloading_constants.html#autoloading-when-the-application-boots). You'd get a `NameError` in Rails 7 otherwise.
 
+Constants managed by the `once` autoloader can be autoloaded during initialization, and they can be used normally, no need for a `to_prepare` block. However, the `once` autoloader is now set up earlier to support that. If the application has custom inflections, and the `once` autoloader should be aware of them, you need to move the code in `config/initializers/inflections.rb` to the body of the application class definition in `config/application.rb`:
+
+```ruby
+module MyApp
+  class Application < Rails::Application
+    # ...
+
+    ActiveSupport::Inflector.inflections(:en) do |inflect|
+      inflect.acronym "HTML"
+    end
+  end
+end
+```
+
 ### Ability to configure `config.autoload_once_paths`
 
 [`config.autoload_once_paths`][] can be set in the body of the application class defined in `config/application.rb` or in the configuration for environments in `config/environments/*`.


### PR DESCRIPTION
I realized this while chatting with @zenspider about a poltergeist he had upgrading an app.

The workaround is suboptimal. In Rails 8 the plan is that new applications will have inflections generated in a different place, and loaded earlier, so users won't need to think about this.

This patch will be backported to 7-1-stable and 7-0-stable.
