### PR TITLE
ActionCable: allow to pass websocket.close args

### DIFF
--- a/actioncable/lib/action_cable/connection/web_socket.rb
+++ b/actioncable/lib/action_cable/connection/web_socket.rb
@@ -26,8 +26,8 @@ module ActionCable
         websocket.transmit data
       end
 
-      def close
-        websocket.close
+      def close(code = nil, reason = nil)
+        websocket.close code, reason
       end
 
       def protocol

--- a/actioncable/lib/action_cable/connection/web_socket.rb
+++ b/actioncable/lib/action_cable/connection/web_socket.rb
@@ -19,23 +19,23 @@ module ActionCable
       end
 
       def alive?
-        websocket && websocket.alive?
+        websocket&.alive?
       end
 
       def transmit(data)
-        websocket.transmit data
+        websocket&.transmit data
       end
 
       def close(code = nil, reason = nil)
-        websocket.close code, reason
+        websocket&.close code, reason
       end
 
       def protocol
-        websocket.protocol
+        websocket&.protocol
       end
 
       def rack_response
-        websocket.rack_response
+        websocket&.rack_response
       end
 
       private

--- a/actioncable/lib/action_cable/connection/web_socket.rb
+++ b/actioncable/lib/action_cable/connection/web_socket.rb
@@ -22,12 +22,12 @@ module ActionCable
         websocket&.alive?
       end
 
-      def transmit(data)
-        websocket&.transmit data
+      def transmit(...)
+        websocket&.transmit(...)
       end
 
-      def close(code = nil, reason = nil)
-        websocket&.close code, reason
+      def close(...)
+        websocket&.close(...)
       end
 
       def protocol


### PR DESCRIPTION
This PR allows you to set `code` and `reason` when closing a WebSocket connection.
It's very useful when hacking ActionCable.

In addition, I small refactor the file to avoid potential nil error, I can remove this change.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
