### PR TITLE
[DOCS] Warn against uniqueness validator when create_or_find_by is used [ci-skip]

### DIFF
--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -255,6 +255,8 @@ module ActiveRecord
     #   the problem of running out of integers, if the underlying table is still stuck on a primary
     #   key of type int (note: All \Rails apps since 5.1+ have defaulted to bigint, which is not liable
     #   to this problem).
+    # * Columns with unique database constraints should not have uniqueness validations defined,
+    #   otherwise #create will fail due to validation errors and #find_by will never be called.
     #
     # This method will return a record if all given attributes are covered by unique constraints
     # (unless the INSERT -> DELETE -> SELECT race condition is triggered), but if creation was attempted


### PR DESCRIPTION
### Motivation / Background

It can be really confusing when use you have `uniqueness` validator and try to use `create_by_find_by` eg. https://github.com/rails/rails/issues/36027. 

### Checklist

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
