### PR TITLE
Refactor `Rails::Rack::Logger` to avoid adding a new param to `call_app`

### DIFF
--- a/railties/lib/rails/rack/logger.rb
+++ b/railties/lib/rails/rack/logger.rb
@@ -20,16 +20,19 @@ module Rails
       def call(env)
         request = ActionDispatch::Request.new(env)
 
-        logger_tag_pop_count = if logger.respond_to?(:push_tags)
+        env["rails.rack_logger_tag_count"] = if logger.respond_to?(:push_tags)
           logger.push_tags(*compute_tags(request)).size
         else
           0
         end
-        call_app(request, env, logger_tag_pop_count)
+
+        call_app(request, env)
       end
 
       private
-        def call_app(request, env, logger_tag_pop_count) # :doc:
+        def call_app(request, env) # :doc:
+          logger_tag_pop_count = env["rails.rack_logger_tag_count"]
+
           instrumenter = ActiveSupport::Notifications.instrumenter
           handle = instrumenter.build_handle("request.action_dispatch", { request: request })
           handle.start


### PR DESCRIPTION
ref: https://github.com/rails/rails/pull/50992#issuecomment-1939865460

This refactors the implementation from that PR so that we don't need a new param on the `call_app` method. This means we don't break any gems or apps that have overridden it.

cc @KJTsanaktsidis @rafaelfranca 
