### PR TITLE
Address `ActiveStorage::VariantTest#test_resized_variation_of_WEBP_blob` failure at Rails Nightly CI

### DIFF
--- a/activestorage/test/models/variant_test.rb
+++ b/activestorage/test/models/variant_test.rb
@@ -122,7 +122,7 @@ class ActiveStorage::VariantTest < ActiveSupport::TestCase
     image = read_image(variant)
     assert_equal "WEBP", image.type
     assert_equal 50, image.width
-    assert_equal 33, image.height
+    assert_includes [33, 34], image.height
   end
 
   test "optimized variation of GIF blob" do


### PR DESCRIPTION
### Motivation / Background

Managed to reproduce Rails Nightly CI failure
at https://buildkite.com/rails/rails-nightly/builds/149#018d9052-1b2d-48fa-9d74-a39df3f3f1d6/1251-1291

This commit allows both 33 and 34 as its height because this issue is isolated that the difference comes from libvips and/or ruby-vips behavior differences, not Active Storage.

### Detail
- Steps to reproduce, Run this test on Ubuntu 22.04. It should not reproduce on Ubuntu 23.10.

```ruby
git clone https://github.com/rails/rails
cd rails
rm Gemfile.lock
cd activestorage
bin/test test/models/variant_test.rb -n test_resized_variation_of_WEBP_blob
```

* Expected behavior It should pass.

* Actual behavior It fails because the height of the thumbnail is 34.

```ruby
$ bin/test test/models/variant_test.rb -n test_resized_variation_of_WEBP_blob
F

Failure:
ActiveStorage::VariantTest#test_resized_variation_of_WEBP_blob [test/models/variant_test.rb:125]:
Expected: 33
  Actual: 34

bin/test test/models/variant_test.rb:117
```

### Additional information
Refer to https://github.com/libvips/ruby-vips/issues/383

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
