### PR TITLE
Fix destroy of has_one with multiple belongs_to

### DIFF
--- a/activerecord/lib/active_record/callbacks.rb
+++ b/activerecord/lib/active_record/callbacks.rb
@@ -418,7 +418,7 @@ module ActiveRecord
 
     def destroy # :nodoc:
       @_destroy_callback_already_called ||= false
-      return if @_destroy_callback_already_called
+      return true if @_destroy_callback_already_called
       @_destroy_callback_already_called = true
       _run_destroy_callbacks { super }
     rescue RecordNotDestroyed => e

--- a/activerecord/test/cases/associations/has_one_associations_test.rb
+++ b/activerecord/test/cases/associations/has_one_associations_test.rb
@@ -20,6 +20,8 @@ require "models/club"
 require "models/membership"
 require "models/parrot"
 require "models/cpk"
+require "models/room"
+require "models/user"
 
 class HasOneAssociationsTest < ActiveRecord::TestCase
   self.use_transactional_tests = false unless supports_savepoints?
@@ -804,6 +806,28 @@ class HasOneAssociationsTest < ActiveRecord::TestCase
     new_club.create_membership
 
     assert_no_queries { new_club.save }
+  end
+
+  def test_has_one_double_belongs_to_destroys_both_from_either_end
+    landlord = User.create!
+    tenant = User.create!
+    room = Room.create!(landlord: landlord, tenant: tenant)
+
+    landlord.destroy!
+
+    assert_predicate(room, :destroyed?)
+    assert_predicate(landlord, :destroyed?)
+    assert_predicate(tenant, :destroyed?)
+
+    landlord = User.create!
+    tenant = User.create!
+    room = Room.create!(landlord: landlord, tenant: tenant)
+
+    tenant.destroy!
+
+    assert_predicate(room, :destroyed?)
+    assert_predicate(tenant, :destroyed?)
+    assert_predicate(landlord, :destroyed?)
   end
 
   class SpecialBook < ActiveRecord::Base

--- a/activerecord/test/cases/token_for_test.rb
+++ b/activerecord/test/cases/token_for_test.rb
@@ -4,6 +4,7 @@ require "cases/helper"
 require "models/matey"
 require "models/user"
 require "models/cpk"
+require "models/room"
 require "active_support/message_verifier"
 
 class TokenForTest < ActiveRecord::TestCase

--- a/activerecord/test/models/room.rb
+++ b/activerecord/test/models/room.rb
@@ -3,4 +3,7 @@
 class Room < ActiveRecord::Base
   belongs_to :user
   belongs_to :owner, class_name: "User"
+
+  belongs_to :landlord, class_name: "User", dependent: :destroy, inverse_of: :let_room
+  belongs_to :tenant, class_name: "User", dependent: :destroy, inverse_of: :rented_room
 end

--- a/activerecord/test/models/user.rb
+++ b/activerecord/test/models/user.rb
@@ -18,6 +18,9 @@ class User < ActiveRecord::Base
   has_one :family_tree, -> { where(token: nil) }, foreign_key: "member_id"
   has_one :family, through: :family_tree
   has_many :family_members, through: :family, source: :members
+
+  has_one :let_room, class_name: "Room", foreign_key: "landlord_id", dependent: :destroy
+  has_one :rented_room, class_name: "Room", foreign_key: "tenant_id", dependent: :destroy
 end
 
 class UserWithNotification < User

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -1070,6 +1070,8 @@ ActiveRecord::Schema.define do
   create_table :rooms, force: true do |t|
     t.references :user
     t.references :owner
+    t.references :landlord
+    t.references :tenant
   end
 
   disable_referential_integrity do


### PR DESCRIPTION
With a bi-directional has one through association, where the join model belongs to each parent with `dependent: :destroy`, destroying either parent should destroy the through record and the other parent.

    class Left < ActiveRecord::Base
      has_one :middle, dependent: :destroy
      has_one :right, through: :middle
    end

    class Middle < ActiveRecord::Base
      belongs_to :left, dependent: :destroy
      belongs_to :right, dependent: :destroy
    end

    class Right < ActiveRecord::Base
      has_one :middle, dependent: :destroy
      has_one :left, through: :middle
    end

However this only worked from one end.  When destroying the "non-working" end, the join model was correctly destroyed but the other end was not.

In the example above:

- `right.destroy` correctly destroys its `middle` and its `left`;
- `left.destroy` destroys its `middle` but not its `right`.

The end which worked depended on the order of `belongs_to` statements in the join model.

This commit ensures that the no matter which end you destroy, the far end is destroyed (along with the join record).

Fixes #50948.


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
