### PR TITLE
Don't load `*_test.rb` file from the "fixtures" folder:

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   `bin/rails test` will no longer load files named `*_test.rb` if they are located in the `fixtures` folder.
+
+    *Edouard Chin*
+
 *   Ensure logger tags configured with `config.log_tags` are still active in `request.action_dispatch` handlers
 
     *KJ Tsanaktsidis*

--- a/railties/lib/rails/test_unit/runner.rb
+++ b/railties/lib/rails/test_unit/runner.rb
@@ -87,7 +87,7 @@ module Rails
           end
 
           def default_test_exclude_glob
-            ENV["DEFAULT_TEST_EXCLUDE"] || "test/{system,dummy}/**/*_test.rb"
+            ENV["DEFAULT_TEST_EXCLUDE"] || "test/{system,dummy,fixtures}/**/*_test.rb"
           end
 
           def regexp_filter?(arg)

--- a/railties/test/application/test_runner_test.rb
+++ b/railties/test/application/test_runner_test.rb
@@ -1223,6 +1223,12 @@ module ApplicationTests
       assert_match "1 runs, 1 assertions, 0 failures, 0 errors, 0 skips", output
     end
 
+    def test_run_does_not_load_file_from_the_fixture_folder
+      create_test_file "fixtures", "smoke_foo"
+
+      assert_match "0 runs, 0 assertions, 0 failures, 0 errors, 0 skips", run_test_command("")
+    end
+
     def test_can_exclude_files_from_being_tested_via_default_rails_command_by_setting_DEFAULT_TEST_EXCLUDE_env_var
       create_test_file "smoke", "smoke_foo"
 


### PR DESCRIPTION
### Motivation / Background

Don't load `*_test.rb` files from the "fixtures" folder.


### Detail

If an application has files named `*_test.rb` in the "fixtures/files" folder, they were picked up to be loaded. In most cases this would result in a LoadError as its likely those files include code that can't be loaded.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
