### PR TITLE
Raise error for Trilogy when `prepared_statements` is `true`

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/trilogy_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/trilogy_adapter.rb
@@ -83,6 +83,10 @@ module ActiveRecord
         # matched rather than number of rows updated.
         config[:found_rows] = true
 
+        if config[:prepared_statements]
+          raise ArgumentError, "Trilogy currently doesn't support prepared statements. Remove `prepared_statements: true` from your database configuration."
+        end
+
         super
       end
 

--- a/activerecord/test/cases/adapter_test.rb
+++ b/activerecord/test/cases/adapter_test.rb
@@ -158,7 +158,7 @@ module ActiveRecord
       end
     end
 
-    unless in_memory_db?
+    unless in_memory_db? || current_adapter?(:TrilogyAdapter)
       def test_disable_prepared_statements
         original_prepared_statements = ActiveRecord.disable_prepared_statements
         db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", name: "primary")

--- a/activerecord/test/cases/adapters/trilogy/trilogy_adapter_test.rb
+++ b/activerecord/test/cases/adapters/trilogy/trilogy_adapter_test.rb
@@ -390,6 +390,12 @@ class TrilogyAdapterTest < ActiveRecord::TrilogyTestCase
     end
   end
 
+  test "setting prepared_statements to true raises" do
+    assert_raises ArgumentError do
+      ActiveRecord::ConnectionAdapters::TrilogyAdapter.new(prepared_statements: true).connect!
+    end
+  end
+
   # Create a temporary subscription to verify notification is sent.
   # Optionally verify the notification payload includes expected types.
   def assert_notification(notification, expected_payload = {}, &block)


### PR DESCRIPTION
Trilogy doesn't currently support prepared statements. The error that applications would see is a `StatementInvalid` error. This doesn't quite point you to the fact this isn't supported. So raise a more appropriate error pointing to what to change.