### PR TITLE
Address `Defining enums with keyword arguments` warning in Action Mai…

### DIFF
--- a/actionmailbox/app/models/action_mailbox/inbound_email.rb
+++ b/actionmailbox/app/models/action_mailbox/inbound_email.rb
@@ -28,7 +28,7 @@ module ActionMailbox
     include Incineratable, MessageId, Routable
 
     has_one_attached :raw_email, service: ActionMailbox.storage_service
-    enum status: %i[ pending processing delivered failed bounced ]
+    enum :status, %i[ pending processing delivered failed bounced ]
 
     def mail
       @mail ||= Mail.from_source(source)


### PR DESCRIPTION
### Motivation / Background

This commit addresses `DEPRECATION WARNING: Defining enums with keyword arguments is deprecated and will be removed` warning in Action Mailbox.

### Detail

* Steps to reproduce
```ruby
git clone https://github.com/rails/rails
cd rails/actionmailbox
bundle install
bin/test test/unit/router_test.rb
```

* Without this commit
```ruby
$ bin/test test/unit/router_test.rb
... snip ..
DEPRECATION WARNING: Defining enums with keyword arguments is deprecated and will be removed
in Rails 7.3. Positional arguments should be used instead:

enum :status, [:pending, :processing, :delivered, :failed, :bounced]
 (called from <class:InboundEmail> at /home/yahonda/src/github.com/rails/rails/actionmailbox/app/models/action_mailbox/inbound_email.rb:31)
Run options: --seed 65254

...............

Finished in 0.230357s, 65.1163 runs/s, 108.5271 assertions/s.
15 runs, 25 assertions, 0 failures, 0 errors, 0 skips
$
```

### Additional information
Follow up https://github.com/rails/rails/pull/50987
Refer to https://github.com/rails/rails/pull/51037

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.



