### PR TITLE
Fix override existing join types in the query in the `where.associated` method

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -3,6 +3,22 @@
 
     *Jason Nochlin*
 
+*   The fix ensures that the association is joined using the appropriate join type
+    (either inner join or left outer join) based on the existing joins in the scope.
+
+    This prevents unintentional overrides of existing join types and ensures consistency in the generated SQL queries.
+
+    Example:
+
+
+
+    ```ruby
+    # `associated` will use `LEFT JOIN` instead of using `JOIN`
+    Post.left_joins(:author).where.associated(:author)
+    ```
+
+    *Saleh Alhaddad*
+
 *   Fix an issue where `ActiveRecord::Encryption` configurations are not ready before the loading
     of Active Record models, when an application is eager loaded. As a result, encrypted attributes
     could be misconfigured in some cases.

--- a/activerecord/test/cases/relation/where_chain_test.rb
+++ b/activerecord/test/cases/relation/where_chain_test.rb
@@ -92,6 +92,27 @@ module ActiveRecord
       assert_equal Author.find(2), Author.order(id: :desc).joins(:reading_listing).where.associated(:reading_listing).extending(Author::NamedExtension).first
     end
 
+    def test_associated_with_add_joins_before
+      Comment.joins(:children).where.associated(:children).tap do |relation|
+        assert_includes     relation, comments(:greetings)
+        assert_not_includes relation, comments(:more_greetings)
+      end
+    end
+
+    def test_associated_with_add_left_joins_before
+      Comment.left_joins(:children).where.associated(:children).tap do |relation|
+        assert_includes     relation, comments(:greetings)
+        assert_not_includes relation, comments(:more_greetings)
+      end
+    end
+
+    def test_associated_with_add_left_outer_joins_before
+      Comment.left_outer_joins(:children).where.associated(:children).tap do |relation|
+        assert_includes     relation, comments(:greetings)
+        assert_not_includes relation, comments(:more_greetings)
+      end
+    end
+
     def test_missing_with_association
       assert_predicate posts(:authorless).author, :blank?
       assert_equal [posts(:authorless)], Post.where.missing(:author).to_a


### PR DESCRIPTION
**Motivation / Background**

Currently, the `where.associated` method in Rails only allows filtering associated records with an `inner join`, which can potentially override existing join types in the query. The fix ensures that the association is joined using the appropriate join type (either inner join or left outer join) based on the existing joins in the scope. This prevents unintentional overrides of existing join types and ensures consistency in the generated SQL queries.

Example:

```ruby
 User.left_outer_joins(:orders).where.associated(:orders).count
```
Old query
```sql
SELECT COUNT(*) FROM "users" INNER JOIN "orders" ON "orders"."user_id" = "users"."id" WHERE "orders"."id" IS NOT NULL
```
after fixing the issue, the query:
New Query
```sql
SELECT COUNT(*) FROM "users" LEFT OUTER JOIN "orders" ON "orders"."user_id" = "users"."id" WHERE "orders"."id" IS NOT NULL
```

This enhancement empowers developers with greater flexibility in querying associated data, facilitating scenarios such as:

- Retrieving posts with authors, even if some posts lack an assigned author (utilizing left_joins).
- Obtaining comments associated with specific users, encompassing orphaned comments without a user (employing multiple joins with varied types).

**Detail**

The pivotal improvement in this Pull Request is the inclusion of a check ensuring that associations are joined using the appropriate join type (either inner join or left outer join) based on existing joins within the scope. This safeguards against unintentional overrides of existing join types and fosters consistency in the generated SQL queries.

**Additional Information**

This refinement is informed by common requirements articulated by Rails developers in various forums and discussions. Analogous functionality is prevalent in certain popular ORM extensions, underscoring its utility. The implementation is crafted to preserve clarity and coherence within the existing codebase.

Note: This is a draft description and should be adapted to your specific implementation details and the project's context.

FYI: After merging this PR, I will check the `missing` method and fix this issue in a separate PR alternative same PR.

**Performance:**

- Benchmark Before the fix:

```
Benchmark.ips do |x| 
  x.report('joins') { User.joins(:comments, :orders).where.associated(:orders) }
  x.report('left_joins') { User.left_joins(:comments, :orders).where.associated(:orders) }
  x.report('left_outer_joins') { User.left_outer_joins(:comments, :orders).where.associated(:orders) }
  x.report('with out joins') { User.where.associated(:orders) }
end
```

```info
Warming up --------------------------------------
  joins                        3.260k i/100ms
  left_joins                3.261k i/100ms
  left_outer_joins     3.234k i/100ms
  with out joins         3.518k i/100ms
Calculating -------------------------------------
  joins                         32.610k (± 0.7%) i/s -    166.260k in   5.098730s
  left_joins                 32.240k (± 1.1%) i/s -    163.050k in   5.058117s
  left_outer_joins      32.395k (± 0.5%) i/s -    164.934k in   5.091447s
  with out joins          35.337k (± 0.6%) i/s -    179.418k in   5.077489s
```


- Benchmark After the fix:

```
Benchmark.ips do |x| 
  x.report('joins') { User.joins(:comments, :orders).where.associated(:orders) }
  x.report('left_joins') { User.left_joins(:comments, :orders).where.associated(:orders) }
  x.report('left_outer_joins') { User.left_outer_joins(:comments, :orders).where.associated(:orders) }
  x.report('with out joins') { User.where.associated(:orders) }
end

```

```
Warming up --------------------------------------
  joins                          3.278k i/100ms
  left_joins                  3.264k i/100ms
  left_outer_joins       3.245k i/100ms
  with out joins           3.434k i/100ms
Calculating -------------------------------------
  joins                           31.688k (± 3.8%) i/s -    160.622k in   5.076856s
  left_joins                   32.432k (± 1.1%) i/s -    163.200k in   5.032760s
  left_outer_joins        32.398k (± 1.4%) i/s -    162.250k in   5.009054s
  with out joins            34.698k (± 1.3%) i/s -    175.134k in   5.048274s
```


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
