### PR TITLE
Run tests with `--profile` on CI

### DIFF
--- a/actioncable/Rakefile
+++ b/actioncable/Rakefile
@@ -15,6 +15,7 @@ Rake::TestTask.new do |t|
   t.test_files = FileList["#{__dir__}/test/**/*_test.rb"]
   t.warning = true
   t.verbose = true
+  t.options = "--profile" if ENV["CI"]
   t.ruby_opts = ["--dev"] if defined?(JRUBY_VERSION)
 end
 

--- a/actionmailbox/Rakefile
+++ b/actionmailbox/Rakefile
@@ -10,6 +10,7 @@ Rake::TestTask.new do |t|
   t.libs << "test"
   t.pattern = "test/**/*_test.rb"
   t.verbose = true
+  t.options = "--profile" if ENV["CI"]
 end
 
 namespace :test do

--- a/actionmailer/Rakefile
+++ b/actionmailer/Rakefile
@@ -13,6 +13,7 @@ Rake::TestTask.new { |t|
   t.pattern = "test/**/*_test.rb"
   t.warning = true
   t.verbose = true
+  t.options = "--profile" if ENV["CI"]
   t.ruby_opts = ["--dev"] if defined?(JRUBY_VERSION)
 }
 

--- a/actionpack/Rakefile
+++ b/actionpack/Rakefile
@@ -16,6 +16,7 @@ Rake::TestTask.new do |t|
 
   t.warning = true
   t.verbose = true
+  t.options = "--profile" if ENV["CI"]
   t.ruby_opts = ["--dev"] if defined?(JRUBY_VERSION)
 end
 

--- a/actiontext/Rakefile
+++ b/actiontext/Rakefile
@@ -10,12 +10,14 @@ Rake::TestTask.new do |t|
   t.libs << "test"
   t.test_files = FileList["test/**/*_test.rb"].exclude("test/system/**/*", "test/dummy/**/*")
   t.verbose = true
+  t.options = "--profile" if ENV["CI"]
 end
 
 Rake::TestTask.new "test:system" do |t|
   t.libs << "test"
   t.test_files = FileList["test/system/**/*_test.rb"]
   t.verbose = true
+  t.options = "--profile" if ENV["CI"]
 end
 
 namespace :test do

--- a/actionview/Rakefile
+++ b/actionview/Rakefile
@@ -27,6 +27,7 @@ namespace :test do
     t.test_files = FileList["test/template/**/*_test.rb"]
     t.warning = true
     t.verbose = true
+    t.options = "--profile" if ENV["CI"]
     t.ruby_opts = ["--dev"] if defined?(JRUBY_VERSION)
   end
 
@@ -37,6 +38,7 @@ namespace :test do
       t.test_files = FileList["test/activerecord/*_test.rb"]
       t.warning = true
       t.verbose = true
+      t.options = "--profile" if ENV["CI"]
       t.ruby_opts = ["--dev"] if defined?(JRUBY_VERSION)
     end
 
@@ -46,6 +48,7 @@ namespace :test do
       t.test_files = FileList["test/actionpack/**/*_test.rb"]
       t.warning = true
       t.verbose = true
+      t.options = "--profile" if ENV["CI"]
       t.ruby_opts = ["--dev"] if defined?(JRUBY_VERSION)
     end
   end

--- a/activejob/Rakefile
+++ b/activejob/Rakefile
@@ -41,6 +41,7 @@ namespace :test do
           (x.include?("async") && adapter != "async")
       }
       t.verbose = true
+      t.options = "--profile" if ENV["CI"]
       t.warning = true
       t.ruby_opts = ["--dev"] if defined?(JRUBY_VERSION)
     end
@@ -62,6 +63,7 @@ namespace :test do
         t.libs << "test"
         t.test_files = FileList["test/integration/**/*_test.rb"]
         t.verbose = true
+        t.options = "--profile" if ENV["CI"]
         t.warning = true
         t.ruby_opts = ["--dev"] if defined?(JRUBY_VERSION)
       end

--- a/activemodel/Rakefile
+++ b/activemodel/Rakefile
@@ -11,6 +11,7 @@ Rake::TestTask.new do |t|
   t.test_files = FileList["#{__dir__}/test/cases/**/*_test.rb"]
   t.warning = true
   t.verbose = true
+  t.options = "--profile" if ENV["CI"]
   t.ruby_opts = ["--dev"] if defined?(JRUBY_VERSION)
 end
 

--- a/activerecord/Rakefile
+++ b/activerecord/Rakefile
@@ -45,6 +45,7 @@ namespace :test do
 
     t.warning = true
     t.verbose = true
+    t.options = "--profile" if ENV["CI"]
   end
 end
 
@@ -69,6 +70,7 @@ end
       t.test_files = files
       t.warning = true
       t.verbose = true
+      t.options = "--profile" if ENV["CI"]
       t.ruby_opts = ["--dev"] if defined?(JRUBY_VERSION)
     end
 
@@ -80,6 +82,7 @@ end
           t.test_files = FileList["test/activejob/*_test.rb"]
           t.warning = true
           t.verbose = true
+          t.options = "--profile" if ENV["CI"]
           t.ruby_opts = ["--dev"] if defined?(JRUBY_VERSION)
         end
       end
@@ -186,6 +189,7 @@ end
 
           t.warning = true
           t.verbose = true
+          t.options = "--profile" if ENV["CI"]
           t.ruby_opts = ["--dev"] if defined?(JRUBY_VERSION)
         end
       end

--- a/activestorage/Rakefile
+++ b/activestorage/Rakefile
@@ -9,6 +9,7 @@ Rake::TestTask.new do |t|
   t.libs << "test"
   t.test_files = FileList["test/**/*_test.rb"]
   t.verbose = true
+  t.options = "--profile" if ENV["CI"]
   t.warning = true
 end
 

--- a/activesupport/Rakefile
+++ b/activesupport/Rakefile
@@ -10,6 +10,7 @@ Rake::TestTask.new do |t|
   t.pattern = "test/**/*_test.rb"
   t.warning = true
   t.verbose = true
+  t.options = "--profile" if ENV["CI"]
   t.ruby_opts = ["--dev"] if defined?(JRUBY_VERSION)
 end
 

--- a/railties/Rakefile
+++ b/railties/Rakefile
@@ -71,6 +71,7 @@ namespace :test do
 
     dirs = (ENV["TEST_DIR"] || ENV["TEST_DIRS"] || "**").split(",")
     test_options = ENV["TESTOPTS"].to_s.split(/[\s]+/)
+    test_options << "--profile" if ENV["CI"]
 
     test_patterns = dirs.map { |dir| "test/#{dir}/*_test.rb" }
     test_files = Dir[*test_patterns].select do |file|
@@ -143,5 +144,6 @@ Rake::TestTask.new("test:regular") do |t|
   t.pattern = "test/**/*_test.rb"
   t.warning = true
   t.verbose = true
+  t.options = "--profile" if ENV["CI"]
   t.ruby_opts = ["--dev"] if defined?(JRUBY_VERSION)
 end

--- a/railties/lib/minitest/rails_plugin.rb
+++ b/railties/lib/minitest/rails_plugin.rb
@@ -36,6 +36,10 @@ module Minitest
       @results << result
     end
 
+    def passed?
+      true
+    end
+
     def report
       total_time = @results.sum(&:time)
 


### PR DESCRIPTION
~~Debugging why a CI job get stuck is particularly painful as the output doesn't contain any information whatsoever.~~

~~By enabling `--verbose` we ensure the last line of the CI job is the name of the test that got stuck, helping debug.~~

Similarly, it's hard to figure out why a particular job is slow, so enabling `--profile` would make it easy to spot some low hanging fruits to improve CI speed.

Edit: `--verbose` is a bit too much, so leaving it out for now.