### PR TITLE
Refactor some Active Record tests

### DIFF
--- a/activerecord/test/cases/adapter_test.rb
+++ b/activerecord/test/cases/adapter_test.rb
@@ -736,7 +736,7 @@ module ActiveRecord
       end
 
       test "#execute is retryable" do
-        conn_id = case @connection.class::ADAPTER_NAME
+        conn_id = case @connection.adapter_name
                   when "Mysql2"
                     @connection.execute("SELECT CONNECTION_ID()").to_a[0][0]
                   when "Trilogy"
@@ -754,7 +754,7 @@ module ActiveRecord
 
       private
         def raw_transaction_open?(connection)
-          case connection.class::ADAPTER_NAME
+          case connection.adapter_name
           when "PostgreSQL"
             connection.instance_variable_get(:@raw_connection).transaction_status == ::PG::PQTRANS_INTRANS
           when "Mysql2", "Trilogy"
@@ -779,7 +779,7 @@ module ActiveRecord
         end
 
         def remote_disconnect(connection)
-          case connection.class::ADAPTER_NAME
+          case connection.adapter_name
           when "PostgreSQL"
             unless connection.instance_variable_get(:@raw_connection).transaction_status == ::PG::PQTRANS_INTRANS
               connection.instance_variable_get(:@raw_connection).async_exec("begin")
@@ -796,7 +796,7 @@ module ActiveRecord
 
         def kill_connection_from_server(connection_id)
           conn = @connection.pool.checkout
-          case conn.class::ADAPTER_NAME
+          case conn.adapter_name
           when "Mysql2", "Trilogy"
             conn.execute("KILL #{connection_id}")
           when "PostgreSQL"

--- a/activerecord/test/cases/adapters/sqlite3/copy_table_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/copy_table_test.rb
@@ -7,9 +7,6 @@ class CopyTableTest < ActiveRecord::SQLite3TestCase
 
   def setup
     @connection = ActiveRecord::Base.connection
-    class << @connection
-      public :copy_table, :table_structure, :indexes
-    end
   end
 
   def test_copy_table(from = "customers", to = "customers2", options = {})
@@ -90,11 +87,11 @@ class CopyTableTest < ActiveRecord::SQLite3TestCase
 
 private
   def copy_table(from, to, options = {})
-    @connection.copy_table(from, to, { temporary: true }.merge(options))
+    @connection.send(:copy_table, from, to, { temporary: true }.merge(options))
   end
 
   def column_names(table)
-    @connection.table_structure(table).map { |column| column["name"] }
+    @connection.send(:table_structure, table).map { |column| column["name"] }
   end
 
   def column_values(table, column)

--- a/activerecord/test/cases/adapters/trilogy/trilogy_adapter_test.rb
+++ b/activerecord/test/cases/adapters/trilogy/trilogy_adapter_test.rb
@@ -167,6 +167,8 @@ class TrilogyAdapterTest < ActiveRecord::TrilogyTestCase
     @conn.cache do
       event_fired = false
       subscription = ->(name, start, finish, id, payload) {
+        next if payload[:name] == "SCHEMA"
+
         event_fired = true
 
         # First, we test keys that are defined by default by the AbstractAdapter
@@ -198,6 +200,8 @@ class TrilogyAdapterTest < ActiveRecord::TrilogyTestCase
 
       event_fired = false
       subscription = ->(name, start, finish, id, payload) {
+        next if payload[:name] == "SCHEMA"
+
         event_fired = true
 
         # First, we test keys that are defined by default by the AbstractAdapter

--- a/activerecord/test/cases/fixtures_test.rb
+++ b/activerecord/test/cases/fixtures_test.rb
@@ -148,9 +148,9 @@ class FixturesTest < ActiveRecord::TestCase
 
   if current_adapter?(:Mysql2Adapter, :TrilogyAdapter)
     def test_bulk_insert_with_multi_statements_enabled
-      orig_connection_class = ActiveRecord::Base.connection.class
+      adapter_name = ActiveRecord::Base.connection.adapter_name
       run_without_connection do |orig_connection|
-        case orig_connection_class::ADAPTER_NAME
+        case adapter_name
         when "Trilogy"
           ActiveRecord::Base.establish_connection(
             orig_connection.merge(multi_statement: true)
@@ -170,7 +170,7 @@ class FixturesTest < ActiveRecord::TestCase
         assert_nothing_raised do
           conn = ActiveRecord::Base.connection
           conn.execute("SELECT 1; SELECT 2;")
-          case orig_connection_class::ADAPTER_NAME
+          case adapter_name
           when "Trilogy"
             conn.raw_connection.next_result while conn.raw_connection.more_results_exist?
           else
@@ -190,7 +190,7 @@ class FixturesTest < ActiveRecord::TestCase
         assert_nothing_raised do
           conn = ActiveRecord::Base.connection
           conn.execute("SELECT 1; SELECT 2;")
-          case orig_connection_class::ADAPTER_NAME
+          case adapter_name
           when "Trilogy"
             conn.raw_connection.next_result while conn.raw_connection.more_results_exist?
           else
@@ -201,9 +201,9 @@ class FixturesTest < ActiveRecord::TestCase
     end
 
     def test_bulk_insert_with_multi_statements_disabled
-      orig_connection_class = ActiveRecord::Base.connection.class
+      adapter_name = ActiveRecord::Base.connection.adapter_name
       run_without_connection do |orig_connection|
-        case orig_connection_class::ADAPTER_NAME
+        case adapter_name
         when "Trilogy"
           ActiveRecord::Base.establish_connection(
             orig_connection.merge(multi_statement: false)
@@ -223,7 +223,7 @@ class FixturesTest < ActiveRecord::TestCase
         assert_raises(ActiveRecord::StatementInvalid) do
           conn = ActiveRecord::Base.connection
           conn.execute("SELECT 1; SELECT 2;")
-          case orig_connection_class::ADAPTER_NAME
+          case adapter_name
           when "Trilogy"
             conn.raw_connection.next_result while conn.raw_connection.more_results_exist?
           else
@@ -239,7 +239,7 @@ class FixturesTest < ActiveRecord::TestCase
         assert_raises(ActiveRecord::StatementInvalid) do
           conn = ActiveRecord::Base.connection
           conn.execute("SELECT 1; SELECT 2;")
-          case orig_connection_class::ADAPTER_NAME
+          case adapter_name
           when "Trilogy"
             conn.raw_connection.next_result while conn.raw_connection.more_results_exist?
           else

--- a/activerecord/test/cases/pooled_connections_test.rb
+++ b/activerecord/test/cases/pooled_connections_test.rb
@@ -9,45 +9,12 @@ class PooledConnectionsTest < ActiveRecord::TestCase
     self.use_transactional_tests = false
 
     def setup
-      @per_test_teardown = []
       @connection = ActiveRecord::Base.remove_connection.configuration_hash
     end
 
-    teardown do
+    def teardown
       ActiveRecord::Base.connection_handler.clear_all_connections!(:all)
       ActiveRecord::Base.establish_connection(@connection)
-      @per_test_teardown.each(&:call)
-    end
-
-    # Will deadlock due to lack of Monitor timeouts in 1.9
-    def checkout_checkin_connections(pool_size, threads)
-      ActiveRecord::Base.establish_connection(@connection.merge(pool: pool_size, checkout_timeout: 0.5))
-      @connection_count = 0
-      @timed_out = 0
-      threads.times do
-        Thread.new do
-          conn = ActiveRecord::Base.connection_pool.checkout
-          sleep 0.1
-          ActiveRecord::Base.connection_pool.checkin conn
-          @connection_count += 1
-        rescue ActiveRecord::ConnectionTimeoutError
-          @timed_out += 1
-        end.join
-      end
-    end
-
-    def checkout_checkin_connections_loop(pool_size, loops)
-      ActiveRecord::Base.establish_connection(@connection.merge(pool: pool_size, checkout_timeout: 0.5))
-      @connection_count = 0
-      @timed_out = 0
-      loops.times do
-        conn = ActiveRecord::Base.connection_pool.checkout
-        ActiveRecord::Base.connection_pool.checkin conn
-        @connection_count += 1
-        ActiveRecord::Base.connection.data_sources
-      rescue ActiveRecord::ConnectionTimeoutError
-        @timed_out += 1
-      end
     end
 
     def test_pooled_connection_checkin_one
@@ -71,5 +38,37 @@ class PooledConnectionsTest < ActiveRecord::TestCase
       ActiveRecord::Base.connection_pool.remove(extra_connection)
       assert_equal ActiveRecord::Base.connection, old_connection
     end
+
+    private
+      # Will deadlock due to lack of Monitor timeouts in 1.9
+      def checkout_checkin_connections(pool_size, threads)
+        ActiveRecord::Base.establish_connection(@connection.merge(pool: pool_size, checkout_timeout: 0.5))
+        @connection_count = 0
+        @timed_out = 0
+        threads.times do
+          Thread.new do
+            conn = ActiveRecord::Base.connection_pool.checkout
+            sleep 0.1
+            ActiveRecord::Base.connection_pool.checkin conn
+            @connection_count += 1
+          rescue ActiveRecord::ConnectionTimeoutError
+            @timed_out += 1
+          end.join
+        end
+      end
+
+      def checkout_checkin_connections_loop(pool_size, loops)
+        ActiveRecord::Base.establish_connection(@connection.merge(pool: pool_size, checkout_timeout: 0.5))
+        @connection_count = 0
+        @timed_out = 0
+        loops.times do
+          conn = ActiveRecord::Base.connection_pool.checkout
+          ActiveRecord::Base.connection_pool.checkin conn
+          @connection_count += 1
+          ActiveRecord::Base.connection.data_sources
+        rescue ActiveRecord::ConnectionTimeoutError
+          @timed_out += 1
+        end
+      end
   end
 end


### PR DESCRIPTION
Mostly extracted from: https://github.com/rails/rails/pull/50793

- Use `#adapter_name` instead of `#class::ADAPTER_NAME`
- Avoid monkey patching some connection instances
- Ignore SCHEMA queries in some asssertions
