### PR TITLE
Add missing super in prune_thread_cache method

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb
@@ -135,6 +135,7 @@ module ActiveRecord
 
         private
           def prune_thread_cache
+            super
             dead_threads = @thread_query_caches.keys.reject(&:alive?)
             dead_threads.each do |dead_thread|
               @thread_query_caches.delete(dead_thread)


### PR DESCRIPTION
Followup to https://github.com/rails/rails/pull/50938.

~QueryCache::ConnectionPoolConfiguration is prepended to ConnectionPool and its `prune_thread_cache` method doesn't call super, so this method was never called. It's also unnecessary: reaped connections are already removed from `@thread_cached_conns` by the `remove_connection_from_thread_cache` call in `steal!`.~