### PR TITLE
Refactor SchemaCache to hold a ConnectionPool

### DIFF
--- a/activerecord/lib/active_record/attribute_methods/primary_key.rb
+++ b/activerecord/lib/active_record/attribute_methods/primary_key.rb
@@ -109,7 +109,7 @@ module ActiveRecord
             elsif base_name && primary_key_prefix_type == :table_name_with_underscore
               base_name.foreign_key
             elsif ActiveRecord::Base != self && table_exists?
-              connection.schema_cache.primary_keys(table_name)
+              schema_cache.primary_keys(table_name)
             else
               "id"
             end

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -50,7 +50,9 @@ module ActiveRecord
         @schema_cache = nil
         @pool = value
 
-        @pool.schema_reflection.load!(self) if ActiveRecord.lazily_load_schema_cache
+        if @pool && ActiveRecord.lazily_load_schema_cache
+          @pool.schema_reflection.load!(@pool)
+        end
       end
 
       set_callback :checkin, :after, :enable_lazy_transactions!
@@ -321,7 +323,7 @@ module ActiveRecord
       end
 
       def schema_cache
-        @schema_cache ||= BoundSchemaReflection.new(@pool.schema_reflection, self)
+        @pool.schema_cache || (@schema_cache ||= BoundSchemaReflection.for_lone_connection(@pool.schema_reflection, self))
       end
 
       # this method must only be called while holding connection pool's mutex

--- a/activerecord/lib/active_record/connection_handling.rb
+++ b/activerecord/lib/active_record/connection_handling.rb
@@ -319,8 +319,12 @@ module ActiveRecord
       connection_handler.remove_connection_pool(name, role: current_role, shard: current_shard)
     end
 
+    def schema_cache # :nodoc:
+      connection_pool.schema_cache
+    end
+
     def clear_cache! # :nodoc:
-      connection.schema_cache.clear!
+      connection_pool.schema_cache.clear!
     end
 
     def clear_active_connections!(role = nil)

--- a/activerecord/lib/active_record/insert_all.rb
+++ b/activerecord/lib/active_record/insert_all.rb
@@ -52,9 +52,8 @@ module ActiveRecord
     end
 
     def primary_keys
-      Array(connection.schema_cache.primary_keys(model.table_name))
+      Array(@model.schema_cache.primary_keys(model.table_name))
     end
-
 
     def skip_duplicates?
       on_duplicate == :skip
@@ -163,9 +162,8 @@ module ActiveRecord
       end
 
       def unique_indexes
-        connection.schema_cache.indexes(model.table_name).select(&:unique)
+        @model.schema_cache.indexes(model.table_name).select(&:unique)
       end
-
 
       def ensure_valid_options_for_connection!
         if returning && !connection.supports_insert_returning?
@@ -301,7 +299,7 @@ module ActiveRecord
           end
 
           def extract_types_from_columns_on(table_name, keys:)
-            columns = connection.schema_cache.columns_hash(table_name)
+            columns = @model.schema_cache.columns_hash(table_name)
 
             unknown_column = (keys - columns.keys).first
             raise UnknownAttributeError.new(model.new, unknown_column) if unknown_column

--- a/activerecord/lib/active_record/internal_metadata.rb
+++ b/activerecord/lib/active_record/internal_metadata.rb
@@ -91,7 +91,7 @@ module ActiveRecord
     end
 
     def table_exists?
-      connection.schema_cache.data_source_exists?(table_name)
+      @connection.schema_cache.data_source_exists?(table_name)
     end
 
     private

--- a/activerecord/lib/active_record/model_schema.rb
+++ b/activerecord/lib/active_record/model_schema.rb
@@ -410,7 +410,7 @@ module ActiveRecord
 
       # Indicates whether the table associated with this class exists
       def table_exists?
-        connection.schema_cache.data_source_exists?(table_name)
+        schema_cache.data_source_exists?(table_name)
       end
 
       def attributes_builder # :nodoc:
@@ -520,7 +520,7 @@ module ActiveRecord
       def reset_column_information
         connection.clear_cache!
         ([self] + descendants).each(&:undefine_attribute_methods)
-        connection.schema_cache.clear_data_source_cache!(table_name)
+        schema_cache.clear_data_source_cache!(table_name)
 
         reload_schema_from_cache
         initialize_find_by_cache
@@ -584,7 +584,7 @@ module ActiveRecord
             raise ActiveRecord::TableNotSpecified, "#{self} has no table configured. Set one with #{self}.table_name="
           end
 
-          columns_hash = connection.schema_cache.columns_hash(table_name)
+          columns_hash = schema_cache.columns_hash(table_name)
           columns_hash = columns_hash.except(*ignored_columns) unless ignored_columns.empty?
           @columns_hash = columns_hash.freeze
         end

--- a/activerecord/lib/active_record/type_caster/connection.rb
+++ b/activerecord/lib/active_record/type_caster/connection.rb
@@ -14,17 +14,17 @@ module ActiveRecord
       end
 
       def type_for_attribute(attr_name)
-        schema_cache = connection.schema_cache
+        schema_cache = @klass.schema_cache
 
         if schema_cache.data_source_exists?(table_name)
           column = schema_cache.columns_hash(table_name)[attr_name.to_s]
-          type = connection.lookup_cast_type_from_column(column) if column
+          if column
+            type = @klass.connection.lookup_cast_type_from_column(column)
+          end
         end
 
         type || Type.default_value
       end
-
-      delegate :connection, to: :@klass, private: true
 
       private
         attr_reader :table_name

--- a/activerecord/lib/active_record/validations/uniqueness.rb
+++ b/activerecord/lib/active_record/validations/uniqueness.rb
@@ -84,7 +84,7 @@ module ActiveRecord
           attributes = scope + [attr]
           attributes = resolve_attributes(record, attributes)
 
-          klass.connection.schema_cache.indexes(klass.table_name).any? do |index|
+          klass.schema_cache.indexes(klass.table_name).any? do |index|
             index.unique &&
               index.where.nil? &&
               (Array(index.columns) - attributes).empty?

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -128,7 +128,7 @@ class BasicsTest < ActiveRecord::TestCase
 
     Topic.reset_column_information
 
-    Topic.connection.stub(:schema_cache, -> { raise "Some Error" }) do
+    Topic.connection_pool.stub(:schema_cache, -> { raise "Some Error" }) do
       assert_raises RuntimeError do
         Topic.columns_hash
       end
@@ -1485,14 +1485,14 @@ class BasicsTest < ActiveRecord::TestCase
 
   def test_clear_cache!
     # preheat cache
-    c1 = Post.connection.schema_cache.columns("posts")
-    assert_not_equal 0, Post.connection.schema_cache.size
+    c1 = Post.schema_cache.columns("posts")
+    assert_not_equal 0, Post.schema_cache.size
 
     ActiveRecord::Base.clear_cache!
-    assert_equal 0, Post.connection.schema_cache.size
+    assert_equal 0, Post.schema_cache.size
 
-    c2 = Post.connection.schema_cache.columns("posts")
-    assert_not_equal 0, Post.connection.schema_cache.size
+    c2 = Post.schema_cache.columns("posts")
+    assert_not_equal 0, Post.schema_cache.size
 
     assert_equal c1, c2
   end
@@ -1761,7 +1761,7 @@ class BasicsTest < ActiveRecord::TestCase
   end
 
   test "ignored columns are not present in columns_hash" do
-    cache_columns = Developer.connection.schema_cache.columns_hash(Developer.table_name)
+    cache_columns = Developer.schema_cache.columns_hash(Developer.table_name)
     assert_includes cache_columns.keys, "first_name"
     assert_not_includes Developer.columns_hash.keys, "first_name"
     assert_not_includes SubDeveloper.columns_hash.keys, "first_name"

--- a/activerecord/test/cases/connection_adapters/connection_handler_test.rb
+++ b/activerecord/test/cases/connection_adapters/connection_handler_test.rb
@@ -446,7 +446,7 @@ module ActiveRecord
         end
 
         def test_retrieve_connection_pool_copies_schema_cache_from_ancestor_pool
-          @pool.connection.schema_cache.add("posts")
+          @pool.schema_cache.add("posts")
 
           rd, wr = IO.pipe
           rd.binmode
@@ -455,7 +455,7 @@ module ActiveRecord
           pid = fork {
             rd.close
             pool = @handler.retrieve_connection_pool(@connection_name)
-            wr.write Marshal.dump pool.connection.schema_cache.size
+            wr.write Marshal.dump pool.schema_cache.size
             wr.close
             exit!
           }
@@ -463,7 +463,7 @@ module ActiveRecord
           wr.close
 
           Process.waitpid pid
-          assert_equal @pool.connection.schema_cache.size, Marshal.load(rd.read)
+          assert_equal @pool.schema_cache.size, Marshal.load(rd.read)
           rd.close
         end
 

--- a/activerecord/test/cases/connection_adapters/schema_cache_test.rb
+++ b/activerecord/test/cases/connection_adapters/schema_cache_test.rb
@@ -8,6 +8,7 @@ module ActiveRecord
       self.use_transactional_tests = false
 
       def setup
+        @pool = ARUnit2Model.connection_pool
         @connection = ARUnit2Model.connection
         @cache = new_bound_reflection
         @check_schema_cache_dump_version_was = SchemaReflection.check_schema_cache_dump_version
@@ -17,12 +18,12 @@ module ActiveRecord
         SchemaReflection.check_schema_cache_dump_version = @check_schema_cache_dump_version_was
       end
 
-      def new_bound_reflection(connection = @connection)
-        BoundSchemaReflection.new(SchemaReflection.new(nil), connection)
+      def new_bound_reflection(pool = @pool)
+        BoundSchemaReflection.new(SchemaReflection.new(nil), pool)
       end
 
-      def load_bound_reflection(filename, connection = @connection)
-        BoundSchemaReflection.new(SchemaReflection.new(filename), connection).tap do |cache|
+      def load_bound_reflection(filename, pool = @pool)
+        BoundSchemaReflection.new(SchemaReflection.new(filename), pool).tap do |cache|
           cache.load!
         end
       end
@@ -47,7 +48,7 @@ module ActiveRecord
         SchemaReflection.check_schema_cache_dump_version = false
         assert reflection.cached?("courses")
 
-        cache = BoundSchemaReflection.new(reflection, :__unused_connection__)
+        cache = BoundSchemaReflection.new(reflection, :__unused_pool__)
         assert cache.cached?("courses")
       end
 
@@ -352,28 +353,29 @@ module ActiveRecord
           ActiveRecord::Base.establish_connection(new_config)
 
           # cache starts empty
-          assert_nil ActiveRecord::Base.connection.pool.schema_reflection.instance_variable_get(:@cache)
+          assert_nil ActiveRecord::Base.connection_pool.schema_reflection.instance_variable_get(:@cache)
 
           # now we access the cache, causing it to load
-          assert_not_nil ActiveRecord::Base.connection.schema_cache.version
+          assert_not_nil ActiveRecord::Base.schema_cache.version
 
           assert File.exist?(tempfile)
-          assert_not_nil ActiveRecord::Base.connection.pool.schema_reflection.instance_variable_get(:@cache)
+          assert_not_nil ActiveRecord::Base.connection_pool.schema_reflection.instance_variable_get(:@cache)
 
           # assert cache is still empty on new connection (precondition for the
           # following to show it is loading because of the config change)
           ActiveRecord::Base.establish_connection(new_config)
 
           assert File.exist?(tempfile)
-          assert_nil ActiveRecord::Base.connection.pool.schema_reflection.instance_variable_get(:@cache)
+          assert_nil ActiveRecord::Base.connection_pool.schema_reflection.instance_variable_get(:@cache)
 
           # cache is loaded upon connection when lazily loading is on
           old_config = ActiveRecord.lazily_load_schema_cache
           ActiveRecord.lazily_load_schema_cache = true
           ActiveRecord::Base.establish_connection(new_config)
+          ActiveRecord::Base.connection_pool.connection.verify!
 
           assert File.exist?(tempfile)
-          assert_not_nil ActiveRecord::Base.connection.pool.schema_reflection.instance_variable_get(:@cache)
+          assert_not_nil ActiveRecord::Base.connection_pool.schema_reflection.instance_variable_get(:@cache)
         ensure
           ActiveRecord.lazily_load_schema_cache = old_config
           ActiveRecord::Base.establish_connection(:arunit)

--- a/activerecord/test/cases/connection_pool_test.rb
+++ b/activerecord/test/cases/connection_pool_test.rb
@@ -595,8 +595,8 @@ module ActiveRecord
       end
 
       def test_pool_sets_connection_schema_cache
+        pool.schema_cache.add(:posts)
         connection = pool.checkout
-        connection.schema_cache.add(:posts)
 
         pool.with_connection do |conn|
           # We've retrieved a second, distinct, connection from the pool

--- a/activerecord/test/cases/instrumentation_test.rb
+++ b/activerecord/test/cases/instrumentation_test.rb
@@ -6,7 +6,7 @@ require "models/book"
 module ActiveRecord
   class InstrumentationTest < ActiveRecord::TestCase
     def setup
-      ActiveRecord::Base.connection.schema_cache.add(Book.table_name)
+      ActiveRecord::Base.schema_cache.add(Book.table_name)
     end
 
     def test_payload_name_on_load

--- a/activerecord/test/cases/migration_test.rb
+++ b/activerecord/test/cases/migration_test.rb
@@ -46,7 +46,7 @@ class MigrationTest < ActiveRecord::TestCase
     @verbose_was, ActiveRecord::Migration.verbose = ActiveRecord::Migration.verbose, false
     @schema_migration = ActiveRecord::Base.connection.schema_migration
     @internal_metadata = ActiveRecord::Base.connection.internal_metadata
-    ActiveRecord::Base.connection.schema_cache.clear!
+    ActiveRecord::Base.schema_cache.clear!
   end
 
   teardown do
@@ -1809,7 +1809,7 @@ class CopyMigrationsTest < ActiveRecord::TestCase
       @internal_metadata = ActiveRecord::Base.connection.internal_metadata
       @active_record_validate_timestamps_was = ActiveRecord.validate_migration_timestamps
       ActiveRecord.validate_migration_timestamps = true
-      ActiveRecord::Base.connection.schema_cache.clear!
+      ActiveRecord::Base.schema_cache.clear!
 
       @migrations_path = MIGRATIONS_ROOT + "/temp"
       @migrator = ActiveRecord::MigrationContext.new(@migrations_path, @schema_migration, @internal_metadata)

--- a/activerecord/test/cases/primary_keys_test.rb
+++ b/activerecord/test/cases/primary_keys_test.rb
@@ -373,8 +373,8 @@ class CompositePrimaryKeyTest < ActiveRecord::TestCase
   fixtures :cpk_books, :cpk_orders
 
   def setup
+    ActiveRecord::Base.schema_cache.clear!
     @connection = ActiveRecord::Base.connection
-    @connection.schema_cache.clear!
     @connection.create_table(:uber_barcodes, primary_key: ["region", "code"], force: true) do |t|
       t.string :region
       t.integer :code

--- a/activerecord/test/cases/tasks/database_tasks_test.rb
+++ b/activerecord/test/cases/tasks/database_tasks_test.rb
@@ -1330,7 +1330,7 @@ module ActiveRecord
     end
 
     def test_migrate_clears_schema_cache_afterward
-      assert_called(ActiveRecord::Base.connection.schema_cache, :clear!) do
+      assert_called(ActiveRecord::Base.schema_cache, :clear!) do
         ActiveRecord::Tasks::DatabaseTasks.migrate
       end
     end

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -433,7 +433,7 @@ module ApplicationTests
       RUBY
 
       app_file "config/initializers/schema_cache.rb", <<-RUBY
-      ActiveRecord::Base.connection.schema_cache.add("posts")
+      ActiveRecord::Base.schema_cache.add("posts")
       RUBY
 
       app "production"
@@ -464,7 +464,7 @@ module ApplicationTests
       RUBY
 
       app_file "config/initializers/schema_cache.rb", <<-RUBY
-      ActiveRecord::Base.connection.schema_cache.add("posts")
+      ActiveRecord::Base.schema_cache.add("posts")
       RUBY
 
       app "production"
@@ -3844,7 +3844,7 @@ module ApplicationTests
           end
         end
 
-        ActiveRecord::Base.connection.schema_cache.add("posts")
+        ActiveRecord::Base.schema_cache.add("posts")
       RUBY
 
       app_file "app/models/post.rb", <<-RUBY
@@ -3884,7 +3884,7 @@ module ApplicationTests
           end
         end
 
-        ActiveRecord::Base.connection.schema_cache.add("posts")
+        ActiveRecord::Base.schema_cache.add("posts")
       RUBY
 
       app "production"

--- a/railties/test/application/initializers/frameworks_test.rb
+++ b/railties/test/application/initializers/frameworks_test.rb
@@ -235,7 +235,7 @@ module ApplicationTests
       Dir.chdir(app_path) do
         app("development")
 
-        assert ActiveRecord::Base.connection.schema_cache.data_sources("posts")
+        assert ActiveRecord::Base.schema_cache.data_sources("posts")
       end
     ensure
       ActiveRecord::Base.connection.drop_table("posts", if_exists: true) # force drop posts table for test.
@@ -253,7 +253,7 @@ module ApplicationTests
         app("development")
 
         _, error = capture_io do
-          assert_not ActiveRecord::Base.connection.schema_cache.data_sources("posts")
+          assert_not ActiveRecord::Base.schema_cache.data_sources("posts")
         end
 
         assert_match(/Ignoring db\/schema_cache\.yml because it has expired/, error)
@@ -278,7 +278,7 @@ module ApplicationTests
 
           _, error = capture_io do
             assert_raises ActiveRecord::ConnectionNotEstablished do
-              ActiveRecord::Base.connection.schema_cache.columns("posts")
+              ActiveRecord::Base.schema_cache.columns("posts")
             end
           end
 

--- a/railties/test/application/rake/dbs_test.rb
+++ b/railties/test/application/rake/dbs_test.rb
@@ -403,8 +403,8 @@ module ApplicationTests
         Dir.chdir(app_path) do
           rails "db:schema:cache:dump"
 
-          cache_size = lambda { rails("runner", "p ActiveRecord::Base.connection.schema_cache.size").strip }
-          cache_tables = lambda { rails("runner", "p ActiveRecord::Base.connection.schema_cache.columns('books')").strip }
+          cache_size = lambda { rails("runner", "p ActiveRecord::Base.schema_cache.size").strip }
+          cache_tables = lambda { rails("runner", "p ActiveRecord::Base.schema_cache.columns('books')").strip }
 
           assert_equal "12", cache_size[]
           assert_includes cache_tables[], "id", "expected cache_tables to include an id entry"
@@ -479,7 +479,7 @@ module ApplicationTests
 
           rails "db:schema:cache:dump"
 
-          virtual_column_exists = rails("runner", "p ActiveRecord::Base.connection.schema_cache.columns('books')[2].virtual?").strip
+          virtual_column_exists = rails("runner", "p ActiveRecord::Base.schema_cache.columns('books')[2].virtual?").strip
           assert_equal "true", virtual_column_exists
         end
       end
@@ -492,7 +492,7 @@ module ApplicationTests
           rails "db:migrate"
 
           expired_warning = capture(:stderr) do
-            cache_size = rails("runner", "p ActiveRecord::Base.connection.schema_cache.size", stderr: true).strip
+            cache_size = rails("runner", "p ActiveRecord::Base.schema_cache.size", stderr: true).strip
             assert_equal "0", cache_size
           end
           assert_match(/Ignoring .*\.yml because it has expired/, expired_warning)

--- a/railties/test/application/rake/multi_dbs_test.rb
+++ b/railties/test/application/rake/multi_dbs_test.rb
@@ -817,16 +817,16 @@ module ApplicationTests
         require "#{app_path}/config/environment"
         db_migrate_and_schema_cache_dump
 
-        cache_size_a = rails("runner", "p ActiveRecord::Base.connection.schema_cache.size").strip
+        cache_size_a = rails("runner", "p ActiveRecord::Base.schema_cache.size").strip
         assert_equal "12", cache_size_a
 
-        cache_tables_a = rails("runner", "p ActiveRecord::Base.connection.schema_cache.columns('books')").strip
+        cache_tables_a = rails("runner", "p ActiveRecord::Base.schema_cache.columns('books')").strip
         assert_includes cache_tables_a, "title", "expected cache_tables_a to include a title entry"
 
-        cache_size_b = rails("runner", "p AnimalsBase.connection.schema_cache.size", stderr: true).strip
+        cache_size_b = rails("runner", "p AnimalsBase.schema_cache.size", stderr: true).strip
         assert_equal "12", cache_size_b, "expected the cache size for animals to be valid since it was dumped"
 
-        cache_tables_b = rails("runner", "p AnimalsBase.connection.schema_cache.columns('dogs')").strip
+        cache_tables_b = rails("runner", "p AnimalsBase.schema_cache.columns('dogs')").strip
         assert_includes cache_tables_b, "name", "expected cache_tables_b to include a name entry"
       end
 


### PR DESCRIPTION
Another refactoring in relation to https://github.com/rails/rails/pull/50793 but it makes sense even without it.

Also ref: https://github.com/rails/rails/pull/48716

Rather than each connection having its own `BoundSchemaReflection`, we can instead have `BoundSchemaReflection` hold a `ConnectionPool`, from which it can checkout a connection to perform queries when needed.

If the current thread already leased a connection, it will be used.

This simplifies the interface quite a bit.
