### PR TITLE
Action View Test Case `rendered` memoization

### DIFF
--- a/actionview/lib/action_view/test_case.rb
+++ b/actionview/lib/action_view/test_case.rb
@@ -60,7 +60,7 @@ module ActionView
       include ActiveSupport::Testing::ConstantLookup
 
       delegate :lookup_context, to: :controller
-      attr_accessor :controller, :request, :output_buffer
+      attr_accessor :controller, :request, :output_buffer, :rendered
 
       module ClassMethods
         def inherited(descendant) # :nodoc:
@@ -223,7 +223,7 @@ module ActionView
         @request = @controller.request
         @view_flow = ActionView::OutputFlow.new
         @output_buffer = ActionView::OutputBuffer.new
-        @rendered = +""
+        @rendered = self.class.content_class.new(+"")
 
         test_case_instance = self
         controller_class.define_method(:_test_case) { test_case_instance }
@@ -243,6 +243,9 @@ module ActionView
         @_rendered_views ||= RenderedViewsCollection.new
       end
 
+      ##
+      # :method: rendered
+      #
       # Returns the content rendered by the last +render+ call.
       #
       # The returned object behaves like a string but also exposes a number of methods
@@ -290,9 +293,6 @@ module ActionView
       #
       #     assert_pattern { rendered.json => { title: "Hello, world" } }
       #   end
-      def rendered
-        @_rendered ||= self.class.content_class.new(@rendered)
-      end
 
       def _routes
         @controller._routes if @controller.respond_to?(:_routes)

--- a/actionview/test/template/test_case_test.rb
+++ b/actionview/test/template/test_case_test.rb
@@ -394,6 +394,26 @@ module ActionView
       assert_match(/#{developer.name}/, rendered)
       assert_includes rendered, developer.name
     end
+
+    test "#rendered resets after each render" do
+      render "developers/developer", developer: DeveloperStruct.new("first")
+
+      assert_includes rendered, "first"
+      assert_not_includes rendered, "second"
+      assert_not_includes rendered, "third"
+
+      render "developers/developer", developer: DeveloperStruct.new("second")
+
+      assert_includes rendered, "first"
+      assert_includes rendered, "second"
+      assert_not_includes rendered, "third"
+
+      render "developers/developer", developer: DeveloperStruct.new("third")
+
+      assert_includes rendered, "first"
+      assert_includes rendered, "second"
+      assert_includes rendered, "third"
+    end
   end
 
   class HTMLParserTest < ActionView::TestCase

--- a/guides/source/upgrading_ruby_on_rails.md
+++ b/guides/source/upgrading_ruby_on_rails.md
@@ -283,30 +283,6 @@ const fileInputSelector = Rails.fileInputSelector
 Rails.fileInputSelector(...)
 ```
 
-### `ActionView::TestCase#rendered` no longer returns a `String`
-
-Starting from Rails 7.1, `ActionView::TestCase#rendered` returns an object that
-responds to various format methods (for example, `rendered.html` and
-`rendered.json`). To preserve backward compatibility, the object returned from
-`rendered` will delegate missing methods to the `String` rendered during the
-test. For example, the following [assert_match][] assertion will pass:
-
-```ruby
-assert_match(/some content/i, rendered)
-```
-
-However, if your tests rely on `ActionView::TestCase#rendered` returning an
-instance of `String`, they will fail. To restore the original behavior, you can
-override the `#rendered` method to read from the `@rendered` instance variable:
-
-```ruby
-# config/initializers/action_view.rb
-
-ActiveSupport.on_load :action_view_test_case do
-  attr_reader :rendered
-end
-```
-
 ### `Rails.logger` now returns an `ActiveSupport::BroadcastLogger` instance
 
 The `ActiveSupport::BroadcastLogger` class is a new logger that allows to broadcast logs to different sinks (STDOUT, a log file...) in an easy way.


### PR DESCRIPTION
### Motivation / Background

The introduction of memoization as an optimization posed a backwards incompatible change to View tests that call `render` multiple times.

### Detail

Follow-up to [49856][]
Follow-up to [49194][]

This commit changes the `@rendered` instance variable from a `String` to an instance of the `RenderedViewContent` specialized `String` subclass.
    
The end result is that there is no memoization to reset, and the memoization optimization side-effect is preserved after rendering for test cases where `rendered` (or parser methods like `rendered.html`) might be invoked more than once.

[49856]: https://github.com/rails/rails/pull/49856#issuecomment-1945039015
[49194]: https://github.com/rails/rails/pull/49194/files#diff-ce84a807f3491121a5230d37bd40454bb1407fcca71179e1a2fa76d4c0ddfa2aR293

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
