### PR TITLE
Don't clear the local cache on each requests with `with_local_cache`:

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,20 @@
+*   `ActiveSupport::Cache#with_local_cache` now prevents the local cache
+    from being cleared after each requests.
+
+    This is most useful for testing purposes to assert the state
+    of the cache without to temporary change the cache strategy.
+    For example:
+
+    ```ruby
+      Rails.cache.with_local_cache do
+        get "/customers"
+
+        assert_equal("", Rails.cache.read("cache_key"))
+      end
+    ```
+
+    *Edouard Chin*
+
 *   Include `IPAddr#prefix` when serializing an `IPAddr` using the
     `ActiveSupport::MessagePack` serializer. This change is backward and forward
     compatible — old payloads can still be read, and new payloads will be

--- a/activesupport/lib/active_support/cache/strategy/local_cache.rb
+++ b/activesupport/lib/active_support/cache/strategy/local_cache.rb
@@ -65,7 +65,12 @@ module ActiveSupport
 
         # Use a local cache for the duration of block.
         def with_local_cache(&block)
+          clear_cache = middleware.clear_cache?
+          middleware.clear_cache = false
+
           use_temporary_local_cache(LocalStore.new, &block)
+        ensure
+          middleware.clear_cache = clear_cache
         end
 
         # Middleware class can be inserted as a Rack handler to be local cache for the

--- a/activesupport/test/cache/local_cache_middleware_test.rb
+++ b/activesupport/test/cache/local_cache_middleware_test.rb
@@ -56,6 +56,43 @@ module ActiveSupport
             assert_throws(:warden) { middleware.call({}) }
             assert_nil LocalCacheRegistry.cache_for(key)
           end
+
+          def test_local_cache_not_cleared_on_close_when_clear_cache_is_false
+            key = "super awesome key"
+            assert_nil LocalCacheRegistry.cache_for key
+            middleware = Middleware.new("<3", key).new(->(env) {
+              assert LocalCacheRegistry.cache_for(key), "should have a cache"
+              [200, {}, []]
+            })
+            _, _, body = middleware.call({})
+            assert LocalCacheRegistry.cache_for(key), "should still have a cache"
+            body.each { }
+            assert LocalCacheRegistry.cache_for(key), "should still have a cache"
+
+            clear_cache = middleware.clear_cache?
+            middleware.clear_cache = false
+            body.close
+            assert LocalCacheRegistry.cache_for(key), "should still have a cache"
+          ensure
+            LocalCacheRegistry.set_cache_for(key, nil)
+            middleware.clear_cache = clear_cache
+          end
+
+          def test_local_cache_no_cleared_on_exception_when_clear_cache_is_false
+            key = "super awesome key"
+            assert_nil LocalCacheRegistry.cache_for key
+            middleware = Middleware.new("<3", key).new(->(env) {
+              assert LocalCacheRegistry.cache_for(key), "should have a cache"
+              raise
+            })
+            clear_cache = middleware.clear_cache?
+            middleware.clear_cache = false
+            assert_raises(RuntimeError) { middleware.call({}) }
+            assert LocalCacheRegistry.cache_for(key), "should still have a cache"
+          ensure
+            LocalCacheRegistry.set_cache_for(key, nil)
+            middleware.clear_cache = clear_cache
+          end
         end
       end
     end

--- a/railties/test/application/integration_test_case_test.rb
+++ b/railties/test/application/integration_test_case_test.rb
@@ -73,4 +73,79 @@ module ApplicationTests
       assert_match(/0 failures, 0 errors/, output)
     end
   end
+
+  class LocalCacheTest < ActiveSupport::TestCase
+    include ActiveSupport::Testing::Isolation, EnvHelpers
+
+    setup :build_app
+    teardown :teardown_app
+
+    test "with_local_cache isn't cleared between requests" do
+      app_file "config/routes.rb", <<-RUBY
+        Rails.application.routes.draw do
+          get :customer, to: "customer#show"
+          get :cached_customer, to: "customer#show_with_cache"
+        end
+      RUBY
+
+      app_file "app/controllers/customer_controller.rb", <<-RUBY
+        class CustomerController < ApplicationController
+          def show
+            Rails.cache.fetch("customer") { "David" }
+            head(:ok)
+          end
+
+          def show_with_cache
+            if customer = Rails.cache.read("customer")
+              render(plain: customer, status: :ok)
+            else
+              render(plain: "Cache miss", status: :bad_request)
+            end
+          end
+        end
+      RUBY
+
+      app_file "test/integration/customer_integration_test.rb", <<-RUBY
+        require "test_helper"
+
+        class CustomerIntegrationTest < ActionDispatch::IntegrationTest
+          def test_cache_is_cleared_on_each_request
+            get("/customer")
+
+            assert_response(:ok)
+            assert_nil(Rails.cache.read("customer"), "The cache was not cleared")
+          end
+
+          def test_cache_is_not_cleared_after_the_request
+            Rails.cache.with_local_cache do
+              get("/customer")
+
+              assert_response(:ok)
+              assert_equal("David", Rails.cache.read("customer"))
+            end
+
+            assert_nil(Rails.cache.read("customer"), "The cache was not cleared")
+          end
+
+          def test_cache_is_hit
+            Rails.cache.with_local_cache do
+              get("/customer")
+              assert_response(:ok)
+              assert_equal("David", Rails.cache.read("customer"))
+
+              get("/cached_customer")
+              assert_response(:ok)
+              assert_equal("David", response.body)
+            end
+
+            assert_nil(Rails.cache.read("customer"), "The cache was not cleared")
+          end
+        end
+      RUBY
+
+      with_rails_env("test") { rails("db:migrate") }
+      output = rails("test")
+      assert_match(/3 runs, 10 assertions, 0 failures, 0 errors/, output)
+    end
+  end
 end


### PR DESCRIPTION
### Motivation / Background

The `ActiveSupport::LocalCache::Middleware` clears the local cache after each requests, but when using the `with_local_cache` method, this could be counter intuitive as this method is supposed to use a local cache for the duration of the block:

```ruby
Rails.cache.with_local_cache do
  get "/" 
  # Before this patch: Cache is cleared here
end
# After this patch: Cache is cleared here
```

Asserting on the state of the cache in an integration test isn't possible (by default in test environment the store is a NullStore), unless the cache strategy is temporary changed.
This patch makes it easier to check the cache after a request but also allow make subsequent requests to hit the cache.

```ruby
Rails.cache.with_local_cache
  get "/"
  get "/"
  assert_no_cache_miss
end
```

This Pull Request has been created because [REPLACE ME]

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
