### PR TITLE
Add a new option `early_expiration` to `ActiveSupport::Cache::Store#fetch` to avoid dog pile effect

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -57,4 +57,10 @@
 
     *Jason Kim*, *John Hawthorn*
 
+*   Add a new option `:early_expiration` to `ActiveSupport::Cache::Store` to allow for probabilistic early expiration of cache entries.
+
+    This option outperforms `:race_condition_ttl` if predictability is not a concern.
+
+    *tonytonyjan*
+
 Please check [7-2-stable](https://github.com/rails/rails/blob/7-2-stable/activesupport/CHANGELOG.md) for previous changes.

--- a/activesupport/lib/active_support/cache/entry.rb
+++ b/activesupport/lib/active_support/cache/entry.rb
@@ -18,16 +18,17 @@ module ActiveSupport
         end
       end
 
-      attr_reader :version
+      attr_reader :version, :generation_time
 
       # Creates a new cache entry for the specified value. Options supported are
       # +:compressed+, +:version+, +:expires_at+ and +:expires_in+.
-      def initialize(value, compressed: false, version: nil, expires_in: nil, expires_at: nil, **)
+      def initialize(value, compressed: false, version: nil, expires_in: nil, expires_at: nil, generation_time: 0.0, **)
         @value      = value
         @version    = version
         @created_at = 0.0
         @expires_in = expires_at&.to_f || expires_in && (expires_in.to_f + Time.now.to_f)
         @compressed = true if compressed
+        @generation_time = generation_time
       end
 
       def value
@@ -117,6 +118,10 @@ module ActiveSupport
         members = [value, expires_at, version]
         members.pop while !members.empty? && members.last.nil?
         members
+      end
+
+      def should_expire_early?(beta: 1)
+        Time.now.to_f - @generation_time * beta * Math.log(Kernel.rand) >= expires_at
       end
 
       private

--- a/activesupport/lib/active_support/cache/memory_store.rb
+++ b/activesupport/lib/active_support/cache/memory_store.rb
@@ -31,7 +31,12 @@ module ActiveSupport
 
         def dump(entry)
           if entry.value && entry.value != true && !entry.value.is_a?(Numeric)
-            Cache::Entry.new(dump_value(entry.value), expires_at: entry.expires_at, version: entry.version)
+            Cache::Entry.new(
+              dump_value(entry.value),
+              expires_at: entry.expires_at,
+              version: entry.version,
+              generation_time: entry.generation_time
+            )
           else
             entry
           end
@@ -44,7 +49,12 @@ module ActiveSupport
 
         def load(entry)
           if !entry.compressed? && entry.value.is_a?(String)
-            Cache::Entry.new(load_value(entry.value), expires_at: entry.expires_at, version: entry.version)
+            Cache::Entry.new(
+              load_value(entry.value),
+              expires_at: entry.expires_at,
+              version: entry.version,
+              generation_time: entry.generation_time
+            )
           else
             entry
           end

--- a/activesupport/test/cache/cache_entry_test.rb
+++ b/activesupport/test/cache/cache_entry_test.rb
@@ -19,4 +19,23 @@ class CacheEntryTest < ActiveSupport::TestCase
     clone = ActiveSupport::Cache::Entry.new("value", expires_at: entry.expires_at)
     assert_equal entry.expires_at, clone.expires_at
   end
+
+  def test_should_expire_early?
+    options = { current_time: 0.0, expired_at: 10.0, generation_time: 1.0 }
+    assert_early_expiration(true, random: 0, **options)
+    assert_early_expiration(true, random: Math::E**-10, **options)
+    assert_early_expiration(false, random: Math::E**-10 + 1e-4, **options)
+  end
+
+  private
+    def assert_early_expiration(expected, current_time:, expired_at:, generation_time:, random:)
+      entry = ActiveSupport::Cache::Entry.new(
+        "value", generation_time: generation_time, expires_at: expired_at
+      )
+      Time.stub(:now, current_time) do
+        Kernel.stub(:rand, random) do
+          assert_equal expected, entry.should_expire_early?
+        end
+      end
+    end
 end


### PR DESCRIPTION
### Motivation / Background

I encountered an issue that `:race_condition_ttl` can still suffer from dog pile effect in the use case of high intense services because during the period of extending expiration time, other process can still access the same entry and try to regenerate the cache at the same time.

While searching for solutions, I realized probabilistic early expiration approach might be a simpler and more efficient solution. It is a technique to avoid the dog pile effect (aka cache stampede) by expiring the cache before the TTL.

I implemented this method based on the paper[^1] which uses probabilistic decision with the exponential function `Exp(λ)` and demonstrates to be optimal.

[^1]: [Vattani, A.; Chierichetti, F.; Lowenstein, K. (2015), Optimal Probabilistic Cache Stampede Prevention, Proceedings of the VLDB Endowment, VLDB](https://cseweb.ucsd.edu/~avattani/papers/cache_stampede.pdf)

### Detail

1. Add new option `early_expiration` to `ActiveSupport::Cache::Store#fetch`.
2. Add new method `ActiveSupport::Cache::Entry#should_expire_early?(beta: 1)`.
4. Add new instance variable `@generation_time` to `ActiveSupport::Cache::Entry`.

Here is a simple implementation to illustrate the approach:

```ruby
def x_fetch(key, ttl, beta = 1)
  value, delta, expiry = read(key)
  if value.nil? || Time.now − delta * beta * Math.log(rand) ≥ expiry
    start = Time.now
    value = yield
    delta = Time.now – start
    write(key, value, delta, ttl)
  end
  return value
end
```

### Additional information

I created a stacked histogram comparing the stampede sizes between `:race_condition_ttl` (fetch) and `:early_expiration` (x_fetch):

![800k_histogram](https://github.com/rails/rails/assets/809410/01dc5a69-4206-458e-ad76-c52637f9f00b)

As the histogram shows, `:early_expiration` has smaller stampede size compared to `:race_condition_ttl`.

For the definition of "the stampede sizes", please refer to [the paper](https://cseweb.ucsd.edu/~avattani/papers/cache_stampede.pdf).

Note that the benchmark is generated using 16 threads. The difference could be more significant with higher number of threads.

For more information, please refer to the [benchmark repository](https://github.com/tonytonyjan/rails_cache_stampede_benchmark).

The benchmark repository: https://github.com/tonytonyjan/rails_cache_stampede_benchmark
The paper: https://cseweb.ucsd.edu/~avattani/papers/cache_stampede.pdf

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
