### PR TITLE
Fix `db:test:prepare` when using sharding and test primary config is named differently than development primary config

### DIFF
--- a/activerecord/lib/active_record/database_configurations.rb
+++ b/activerecord/lib/active_record/database_configurations.rb
@@ -139,10 +139,10 @@ module ActiveRecord
     # when the application needs to treat one configuration differently. For
     # example, when Rails dumps the schema, the primary configuration's schema
     # file will be named `schema.rb` instead of `primary_schema.rb`.
-    def primary?(name) # :nodoc:
+    def primary?(name, env: default_env) # :nodoc:
       return true if name == "primary"
 
-      first_config = find_db_config(default_env)
+      first_config = find_db_config(env)
       first_config && name == first_config.name
     end
 

--- a/activerecord/lib/active_record/database_configurations/hash_config.rb
+++ b/activerecord/lib/active_record/database_configurations/hash_config.rb
@@ -127,7 +127,7 @@ module ActiveRecord
       end
 
       def primary? # :nodoc:
-        Base.configurations.primary?(name)
+        Base.configurations.primary?(name, env: env_name)
       end
 
       # Determines whether to dump the schema/structure files and the filename that

--- a/railties/test/application/rake/multi_dbs_test.rb
+++ b/railties/test/application/rake/multi_dbs_test.rb
@@ -1170,6 +1170,35 @@ module ApplicationTests
         end
       end
 
+      test "db:test:prepare loads default schema file for primary database configuration when it is named differently than in development" do
+        app_file "config/database.yml", <<~EOS
+          development:
+            primary:
+              adapter: sqlite3
+              database: dev_db
+            secondary:
+              adapter: sqlite3
+              database: secondary_dev_db
+              schema_dump: false
+          test:
+            primary_test: # note the different name
+              adapter: sqlite3
+              database: test_db
+            secondary_test:
+              adapter: sqlite3
+              database: secondary_test_db
+              schema_dump: false
+        EOS
+
+        Dir.chdir(app_path) do
+          rails "generate", "model", "book"
+          rails "db:migrate"
+
+          output = rails("db:test:prepare", "--trace")
+          assert_match(/Execute db:test:prepare/, output)
+        end
+      end
+
       test "db:create and db:drop don't raise errors when loading YAML containing multiple ERB statements on the same line" do
         app_file "config/database.yml", <<-YAML
           development:


### PR DESCRIPTION
When using sharding and the `test` primary config is named differently than `development` primary config, like
```yml
development:
  primary: # can be any name, not necessary 'primary'
    adapter: sqlite3
    database: dev_db
  secondary:
    adapter: sqlite3
    database: secondary_dev_db
    schema_dump: false
test:
  primary_test: # note the different name
    adapter: sqlite3
    database: test_db
  secondary_test:
    adapter: sqlite3
    database: secondary_test_db
    schema_dump: false
```

 rails is unable to use the default `schema.rb` file when running `rails db:test:prepare`. It generates the following error:
```
app/db/shard_one_test_schema.rb doesn't exist yet. Run `bin/rails db:migrate` to create it, then try again. 
If you do not intend to use a database, you should instead alter app/config/application.rb to limit the 
frameworks that will be loaded.
```

When they both are named the same, rails just "erroneously" uses the one from the `development` configuration and it succeeds.