### PR TITLE
Do not report rendered errors except 500

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/executor.rb
+++ b/actionpack/lib/action_dispatch/middleware/executor.rb
@@ -14,9 +14,12 @@ module ActionDispatch
       state = @executor.run!(reset: true)
       begin
         response = @app.call(env)
-        if rendered_error = env["action_dispatch.exception"]
-          @executor.error_reporter.report(rendered_error, handled: false, source: "application.action_dispatch")
+
+        if env["action_dispatch.report_exception"]
+          error = env["action_dispatch.exception"]
+          @executor.error_reporter.report(error, handled: false, source: "application.action_dispatch")
         end
+
         returned = response << ::Rack::BodyProxy.new(response.pop) { state.complete! }
       rescue => error
         @executor.error_reporter.report(error, handled: false, source: "application.action_dispatch")

--- a/actionpack/lib/action_dispatch/middleware/show_exceptions.rb
+++ b/actionpack/lib/action_dispatch/middleware/show_exceptions.rb
@@ -35,6 +35,7 @@ module ActionDispatch
       backtrace_cleaner = request.get_header("action_dispatch.backtrace_cleaner")
       wrapper = ExceptionWrapper.new(backtrace_cleaner, exception)
       request.set_header "action_dispatch.exception", wrapper.unwrapped_exception
+      request.set_header "action_dispatch.report_exception", !wrapper.rescue_response?
 
       if wrapper.show?(request)
         render_exception(request.dup, wrapper)

--- a/actionpack/test/dispatch/executor_test.rb
+++ b/actionpack/test/dispatch/executor_test.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "abstract_unit"
+require "active_support/core_ext/object/with"
 
 class ExecutorTest < ActiveSupport::TestCase
   class MyBody < Array
@@ -145,6 +146,28 @@ class ExecutorTest < ActiveSupport::TestCase
       middleware.call(env)
     end
     assert_instance_of TypeError, error_report.error
+  end
+
+  class BusinessAsUsual < StandardError; end
+
+  def test_handled_error_is_not_reported
+    middleware = Rack::Lint.new(
+      ActionDispatch::Executor.new(
+        ActionDispatch::ShowExceptions.new(
+          Rack::Lint.new(->(_env) { raise BusinessAsUsual }),
+          ->(env) { [418, {}, ["I'm a teapot"]] },
+        ),
+        executor,
+      )
+    )
+
+    env = Rack::MockRequest.env_for("", {})
+    ActionDispatch::ExceptionWrapper.with(rescue_responses: { BusinessAsUsual.name => 418 }) do
+      assert_no_error_reported do
+        response = middleware.call(env)
+        assert_equal 418, response[0]
+      end
+    end
   end
 
   private


### PR DESCRIPTION
### TLDR Context

https://github.com/rails/rails/pull/51050 change results in error tracking service being polluted with `ActionController::RoutingError` which are not actionable and we don't want them there


### Context
In https://github.com/rails/rails/pull/51050/commits/4067c9565a5da78a72e375a2d959000147f02c34 `ActionDispatch::Executor` started to report all errors, even the ones that were "handled" by the application. This leads to errors like `ActionController::RoutingError` polluting error trackers while not being actionable since they do not represent an exceptional situation.

This commit changes the behavior to only report errors that are not considered "handled" based on the `ActionDispatch::ExceptionWrapper.rescue_responses` list.


### Alternative solution
What I have considered and what might actually be a better solution for the long-term is to report "handled" exceptions as `handled: true`. This way subscribers can decide how they want to proceed reporting something that has already been handled. Example: While I strongly believe that `ActionController::RoutingError` should not be presented on the error tracker in the same way as something like `raise "boom"`, I can see that some applications may want to soft-report them in a way that doesn't trigger any alerts and doesn't require any attention. For example It's totally expected to have `ActionController::RoutingError` exceptions but if the number of `ActionController::RoutingError` spikes it may indicate that either some link that used to be accessible became unaccessible or a wrong link was posted/rendered somewhere which makes such event actionable and worth reporting. 


But regardless, `ActionController::RoutingError` (and similar) exceptions should not suddenly be reported as part of a patch version upgrade. It should be a major change with perhaps a configuration option to allow applications to adapt and make a decision on how to proceed. 

I'm open for the discussion and eager to learn what are yours expectations on this behavior! 