### PR TITLE
Accept a `child_index` lambda on `fields_for` with an argument

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Accepts passing the association's child as an argument in a lambda as the `child_index` option in `fields_for`.
+
+    *Ryan Krug*, *Stefanni Brasil*, *Sean Doyle*, *Louis Antonopoulos*, *Aji Slater*
+
 *   Raise `ArgumentError` if `:renderable` object does not respond to `#render_in`
 
     *Sean Doyle*

--- a/actionview/lib/action_view/helpers/form_helper.rb
+++ b/actionview/lib/action_view/helpers/form_helper.rb
@@ -2723,11 +2723,12 @@ module ActionView
             association.each do |child|
               if explicit_child_index
                 if explicit_child_index.respond_to?(:call)
-                  if explicit_child_index.arity.zero?
-                    options[:child_index] = explicit_child_index.call
-                  else
-                    options[:child_index] = explicit_child_index.call(child)
-                  end
+                  options[:child_index] =
+                    if explicit_child_index.arity.zero?
+                      explicit_child_index.call
+                    else
+                      explicit_child_index.call(child)
+                    end
                 end
               else
                 options[:child_index] = nested_child_index(name)

--- a/actionview/lib/action_view/helpers/form_helper.rb
+++ b/actionview/lib/action_view/helpers/form_helper.rb
@@ -2722,7 +2722,13 @@ module ActionView
             output = ActiveSupport::SafeBuffer.new
             association.each do |child|
               if explicit_child_index
-                options[:child_index] = explicit_child_index.call if explicit_child_index.respond_to?(:call)
+                if explicit_child_index.respond_to?(:call)
+                  if explicit_child_index.arity.zero?
+                    options[:child_index] = explicit_child_index.call
+                  else
+                    options[:child_index] = explicit_child_index.call(child)
+                  end
+                end
               else
                 options[:child_index] = nested_child_index(name)
               end

--- a/actionview/test/template/form_helper/form_with_test.rb
+++ b/actionview/test/template/form_helper/form_with_test.rb
@@ -1858,6 +1858,23 @@ class FormWithActsLikeFormForTest < FormWithTest
     assert_dom_equal expected, @rendered
   end
 
+  def test_nested_fields_with_child_index_as_lambda_option_with_argument_override_on_a_nested_attributes_collection_association
+    @post.comments = []
+
+    form_with(model: @post) do |f|
+      concat f.fields(:comments, model: Comment.new(321), child_index: ->(comment) { comment.id }) { |cf|
+        concat cf.text_field(:name)
+      }
+    end
+
+    expected = whole_form("/posts/123", method: "patch") do
+      '<input name="post[comments_attributes][321][name]" type="text" value="comment #321" id="post_comments_attributes_321_name" />' \
+      '<input name="post[comments_attributes][321][id]" type="hidden" value="321" id="post_comments_attributes_321_id" autocomplete="off" />'
+    end
+
+    assert_dom_equal expected, @rendered
+  end
+
   class FakeAssociationProxy
     def to_ary
       [1, 2, 3]

--- a/actionview/test/template/form_helper_test.rb
+++ b/actionview/test/template/form_helper_test.rb
@@ -3492,6 +3492,23 @@ class FormHelperTest < ActionView::TestCase
     assert_dom_equal expected, @rendered
   end
 
+  def test_nested_fields_for_with_child_index_as_lambda_with_argument_option_override_on_a_nested_attributes_collection_association
+    @post.comments = []
+
+    form_for(@post) do |f|
+      concat f.fields_for(:comments, Comment.new(321), child_index: ->(comment) { comment.id }) { |cf|
+        concat cf.text_field(:name)
+      }
+    end
+
+    expected = whole_form("/posts/123", "edit_post_123", "edit_post", method: "patch") do
+      '<input id="post_comments_attributes_321_name" name="post[comments_attributes][321][name]" type="text" value="comment #321" />' \
+      '<input id="post_comments_attributes_321_id" name="post[comments_attributes][321][id]" type="hidden" value="321" autocomplete="off" />'
+    end
+
+    assert_dom_equal expected, @rendered
+  end
+
   class FakeAssociationProxy
     def to_ary
       [1, 2, 3]


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

While `fields_for` currently accepts a lambda as an argument for `child_index`, that lambda is called without any arguments. Being that we are enumerating the association on `fields_for` at the time the lambda is called, we have an opportunity to pass the child of the association down to the lambda.  This could simplify the case where you may want to use the `id` of an Active Record object as the index.  So with this change you could do something like this:

```html.erb
<%= author_form.fields_for :books, child_index: ->(book) { book.id } do |book_form| %>
  <%= book_form.text_field :name %>
<% end %>
```

Prior to this, you would have had to enumerate the association yourself:

```html.erb
<% author.books.each do |book| %>
  <%= author_form.fields_for :books, book, child_index: book.id do |book_form| %>
    <%= book_form.text_field :name %>
  <% end %>
<% end %>
```

### Detail

Accepts passing the association's child as an argument in a lambda as the `child_index` option in `fields_for`.

### Additional information

Used [PR 19661](https://github.com/rails/rails/pull/19661) as a guide when passing a lambda to `child_index` was originally introduced.



<!-- Provide additional information such as benchmarks, reference to other repositories or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
