### PR TITLE
`Rails::Generators::GeneratedAttribute#to_s`

### DIFF
--- a/railties/lib/rails/generators/generated_attribute.rb
+++ b/railties/lib/rails/generators/generated_attribute.rb
@@ -239,6 +239,31 @@ module Rails
           end
         end
       end
+
+      def to_s
+        if has_uniq_index?
+          "#{name}:#{type}#{print_attribute_options}:uniq"
+        elsif has_index?
+          "#{name}:#{type}#{print_attribute_options}:index"
+        else
+          "#{name}:#{type}#{print_attribute_options}"
+        end
+      end
+
+      private
+        def print_attribute_options
+          if attr_options.empty?
+            ""
+          elsif attr_options[:size]
+            "{#{attr_options[:size]}}"
+          elsif attr_options[:limit]
+            "{#{attr_options[:limit]}}"
+          elsif attr_options[:precision] && attr_options[:scale]
+            "{#{attr_options[:precision]},#{attr_options[:scale]}}"
+          else
+            "{#{attr_options.keys.join(",")}}"
+          end
+        end
     end
   end
 end

--- a/railties/test/generators/generated_attribute_test.rb
+++ b/railties/test/generators/generated_attribute_test.rb
@@ -228,4 +228,39 @@ class GeneratedAttributeTest < Rails::Generators::TestCase
     att = Rails::Generators::GeneratedAttribute.parse("supplier:references:index")
     assert_not_predicate att, :required?
   end
+
+  def test_generated_attribute_to_s
+    att = Rails::Generators::GeneratedAttribute.parse("name")
+    assert_equal "name:string", att.to_s
+  end
+
+  def test_generated_attribute_to_s_with_index
+    att = Rails::Generators::GeneratedAttribute.parse("name:index")
+    assert_equal "name:string:index", att.to_s
+  end
+
+  def test_generated_attribute_to_s_with_uniq_index
+    att = Rails::Generators::GeneratedAttribute.parse("name:uniq")
+    assert_equal "name:string:uniq", att.to_s
+  end
+
+  def test_generated_attribute_to_s_with_limit
+    att = Rails::Generators::GeneratedAttribute.parse("name:text{140}")
+    assert_equal "name:text{140}", att.to_s
+  end
+
+  def test_generated_attribute_to_s_with_size
+    att = Rails::Generators::GeneratedAttribute.parse("name:text{medium}")
+    assert_equal "name:text{medium}", att.to_s
+  end
+
+  def test_generated_attribute_to_s_with_precision_and_scale
+    att = Rails::Generators::GeneratedAttribute.parse("name:decimal{1,2}")
+    assert_equal "name:decimal{1,2}", att.to_s
+  end
+
+  def test_generated_attribute_to_s_with_polymorphic
+    att = Rails::Generators::GeneratedAttribute.parse("name:references{polymorphic}")
+    assert_equal "name:references{polymorphic}", att.to_s
+  end
 end


### PR DESCRIPTION
### Motivation / Background

I'm writing my own generator (concept) and would like to easily call the model generator

This Pull Request has been created because it wasn't easy to convert a generated attribute (options passed to the generator) to a string to be passed to another generator

### Detail

This Pull Request changes `Rails::Generators::GeneratedAttribute#to_s`

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
