### PR TITLE
Change Default Variant Format from PNG to WEBP

### DIFF
--- a/activestorage/app/models/active_storage/blob/representable.rb
+++ b/activestorage/app/models/active_storage/blob/representable.rb
@@ -117,9 +117,9 @@ module ActiveStorage::Blob::Representable
 
     def default_variant_format
       if web_image?
-        format || :png
+        format || :webp
       else
-        :png
+        :webp
       end
     end
 

--- a/activestorage/test/models/variant_test.rb
+++ b/activestorage/test/models/variant_test.rb
@@ -73,10 +73,10 @@ class ActiveStorage::VariantTest < ActiveSupport::TestCase
   test "resized variation of PSD blob" do
     blob = create_file_blob(filename: "icon.psd", content_type: "image/vnd.adobe.photoshop")
     variant = blob.variant(resize_to_limit: [20, 20]).processed
-    assert_match(/icon\.png/, variant.url)
+    assert_match(/icon\.webp/, variant.url)
 
     image = read_image(variant)
-    assert_equal "PNG", image.type
+    assert_equal "WEBP", image.type
     assert_equal 20, image.width
     assert_equal 20, image.height
   end
@@ -84,10 +84,10 @@ class ActiveStorage::VariantTest < ActiveSupport::TestCase
   test "resized variation of ICO blob" do
     blob = create_file_blob(filename: "favicon.ico", content_type: "image/vnd.microsoft.icon")
     variant = blob.variant(resize_to_limit: [20, 20]).processed
-    assert_match(/icon\.png/, variant.url)
+    assert_match(/icon\.webp/, variant.url)
 
     image = read_image(variant)
-    assert_equal "PNG", image.type
+    assert_equal "WEBP", image.type
     assert_equal 20, image.width
     assert_equal 20, image.height
   end
@@ -95,10 +95,10 @@ class ActiveStorage::VariantTest < ActiveSupport::TestCase
   test "resized variation of TIFF blob" do
     blob = create_file_blob(filename: "racecar.tif")
     variant = blob.variant(resize_to_limit: [50, 50]).processed
-    assert_match(/racecar\.png/, variant.url)
+    assert_match(/racecar\.webp/, variant.url)
 
     image = read_image(variant)
-    assert_equal "PNG", image.type
+    assert_equal "WEBP", image.type
     assert_equal 50, image.width
     assert_equal 33, image.height
   end
@@ -106,10 +106,10 @@ class ActiveStorage::VariantTest < ActiveSupport::TestCase
   test "resized variation of BMP blob" do
     blob = create_file_blob(filename: "colors.bmp", content_type: "image/bmp")
     variant = blob.variant(resize_to_limit: [15, 15]).processed
-    assert_match(/colors\.png/, variant.url)
+    assert_match(/colors\.webp/, variant.url)
 
     image = read_image(variant)
-    assert_equal "PNG", image.type
+    assert_equal "WEBP", image.type
     assert_equal 15, image.width
     assert_equal 8, image.height
   end
@@ -141,20 +141,20 @@ class ActiveStorage::VariantTest < ActiveSupport::TestCase
     end
   end
 
-  test "PNG variation of JPEG blob with lowercase format" do
+  test "WEBP variation of JPEG blob with lowercase format" do
     blob = create_file_blob(filename: "racecar.jpg")
-    variant = blob.variant(format: :png).processed
-    assert_equal "racecar.png", variant.filename.to_s
-    assert_equal "image/png", variant.content_type
-    assert_equal "PNG", read_image(variant).type
+    variant = blob.variant(format: :webp).processed
+    assert_equal "racecar.webp", variant.filename.to_s
+    assert_equal "image/webp", variant.content_type
+    assert_equal "WEBP", read_image(variant).type
   end
 
-  test "PNG variation of JPEG blob with uppercase format" do
+  test "WEBP variation of JPEG blob with uppercase format" do
     blob = create_file_blob(filename: "racecar.jpg")
-    variant = blob.variant(format: "PNG").processed
-    assert_equal "racecar.png", variant.filename.to_s
-    assert_equal "image/png", variant.content_type
-    assert_equal "PNG", read_image(variant).type
+    variant = blob.variant(format: "WEBP").processed
+    assert_equal "racecar.webp", variant.filename.to_s
+    assert_equal "image/webp", variant.content_type
+    assert_equal "WEBP", read_image(variant).type
   end
 
   test "variation of invariable blob" do
@@ -219,7 +219,7 @@ class ActiveStorage::VariantTest < ActiveSupport::TestCase
     end
 
     assert_nil blob.send(:format)
-    assert_equal :png, blob.send(:default_variant_format)
+    assert_equal :webp, blob.send(:default_variant_format)
   end
 
   test "variations with dangerous argument string raise UnsupportedImageProcessingArgument" do


### PR DESCRIPTION
# Use WEBP as the default format for representations

This pull request updates the `default_variant_format` method in the `representable.rb` file. Previously, the default image format was PNG. With this change, the default image format is now WEBP.

This change is made to improve the performance of our web pages, as [all major browsers support WEBP images](https://caniuse.com/webp), which are generally smaller in size compared to PNG images, without any significant loss in image quality. This will help in faster loading of images and improve the overall user experience.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
