### PR TITLE
Handle empty array value in query builder's tuple syntax

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Handle empty array value in query builder's tuple syntax
+
+    Interpret `.where([:col1, :col2] => [])` as a reqeust to fetch an empty relation,
+    similar to `where(col: [])`.
+
+    *Dmytro Soltys*
+
 *   Fix `has_one` association autosave setting the foreign key attribute when it is unchanged.
 
     This behaviour is also inconsistent with autosaving `belongs_to` and can have unintended side effects like raising

--- a/activerecord/lib/active_record/relation/predicate_builder.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder.rb
@@ -2,6 +2,8 @@
 
 module ActiveRecord
   class PredicateBuilder # :nodoc:
+    EMPTY_RELATION_QUERY = ["1=0"]
+
     require "active_record/relation/predicate_builder/array_handler"
     require "active_record/relation/predicate_builder/basic_object_handler"
     require "active_record/relation/predicate_builder/range_handler"
@@ -74,11 +76,12 @@ module ActiveRecord
 
     protected
       def expand_from_hash(attributes, &block)
-        return ["1=0"] if attributes.empty?
+        return EMPTY_RELATION_QUERY if attributes.empty?
 
         attributes.flat_map do |key, value|
           if key.is_a?(Array)
-            queries = Array(value).map do |ids_set|
+            values = Array(value).presence || [Array.new(key.length) { [] }]
+            queries = values.map do |ids_set|
               raise ArgumentError, "Expected corresponding value for #{key} to be an Array" unless ids_set.is_a?(Array)
               expand_from_hash(key.zip(ids_set).to_h)
             end

--- a/activerecord/test/cases/relation/where_test.rb
+++ b/activerecord/test/cases/relation/where_test.rb
@@ -107,6 +107,10 @@ module ActiveRecord
       assert_equal [first_topic, third_topic].sort, Topic.where(key => conditions).sort
     end
 
+    def test_where_with_tuple_syntax_and_empty_array
+      assert_empty Topic.where([:id] => [])
+    end
+
     def test_where_with_tuple_syntax_on_composite_models
       book_one = Cpk::Book.create!(id: [1, 2])
       book_two = Cpk::Book.create!(id: [3, 4])

--- a/activerecord/test/cases/relation_test.rb
+++ b/activerecord/test/cases/relation_test.rb
@@ -420,9 +420,31 @@ module ActiveRecord
       end
     end
 
+    test "no queries on impossible condition" do
+      assert_queries_count(0) do
+        Post.excluding(Post.where(id: [])).invert_where.load
+      end
+
+      assert_queries_count(0) do
+        Post.where(id: []).and(Post.where(author_id: [])).load
+      end
+
+      assert_queries_count(0) do
+        Post.where(id: 999999999999999999999999999999999999999).load
+      end
+
+      assert_queries_count(0) do
+        Post.where(id: 1).and(Post.where(author_id: [])).load
+      end
+    end
+
     test "no queries on empty IN" do
       assert_queries_count(0) do
         Post.where(id: []).load
+      end
+
+      assert_queries_count(0) do
+        Post.where([:id, :author_id] => []).load
       end
     end
 
@@ -430,17 +452,29 @@ module ActiveRecord
       assert_queries_count(1) do
         Post.where(id: []).unscope(where: :id).load
       end
+
+      assert_queries_count(1) do
+        Post.where([:id, :author_id] => []).unscope(where: [:id, :author_id]).load
+      end
     end
 
     test "no queries on empty relation exists?" do
       assert_queries_count(0) do
         Post.where(id: []).exists?(123)
       end
+
+      assert_queries_count(0) do
+        Post.where([:id, :author_id] => []).exists?(123)
+      end
     end
 
     test "no queries on empty condition exists?" do
       assert_queries_count(0) do
         Post.all.exists?(id: [])
+      end
+
+      assert_queries_count(0) do
+        Post.all.exists?([:id] => [])
       end
     end
 


### PR DESCRIPTION
Specifically, `.where([:id] => [])` is now equivalent to `where(:id => [])`.

### Motivation / Background

This behaviour fixes `#collection_singular_ids=` for relations with composite query constraints when used in forms, as `ids_writer` compacts blank values before looking up matching records, efectively calling `.where(primary_key => [])` when, for example, all checkboxes were deselected by a user on a form.

The error indicative of the behaviour that this commit attempts to fix: `Arel::Visitors::UnsupportedVisitError: Unsupported argument type: NilClass. Construct an Arel node instead.`

### Detail

`#reduce` returns `nil` when operating on empty collections. This commit adds a separate branch for handling an empty query set in `PredicateBuilder#grouping_queries`.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.