### PR TITLE
Allow raw CTEs in with query method

### DIFF
--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -1745,9 +1745,12 @@ module ActiveRecord
         return if with_values.empty?
 
         with_statements = with_values.map do |with_value|
-          raise ArgumentError, "Unsupported argument type: #{with_value} #{with_value.class}" unless with_value.is_a?(Hash)
-
-          build_with_value_from_hash(with_value)
+          case with_value
+          when Hash then build_with_value_from_hash(with_value)
+          when Arel::Nodes::Cte then with_value
+          else
+            raise ArgumentError, "Unsupported argument type: #{with_value} #{with_value.class}"
+          end
         end
 
         arel.with(with_statements)

--- a/activerecord/test/cases/relation/with_test.rb
+++ b/activerecord/test/cases/relation/with_test.rb
@@ -24,6 +24,17 @@ module ActiveRecord
         assert_equal POSTS_WITH_COMMENTS, relation.order(:id).pluck(:id)
       end
 
+      def test_with_when_cte_is_passed_as_an_argument
+        relation = Post
+          .with(Arel::Nodes::Cte.new(
+             Arel.sql("post_ids(id)"),
+             Arel::Nodes::Grouping.new(Arel::Nodes::ValuesList.new([[5], [4], [1]]))
+           ))
+          .from("post_ids AS posts")
+
+        assert_equal [1, 4, 5], relation.order(:id).pluck(:id)
+      end
+
       def test_with_when_hash_with_multiple_elements_of_different_type_is_passed_as_an_argument
         cte_options = {
           posts_with_tags: Post.arel_table.project(Arel.star).where(Post.arel_table[:tags_count].gt(0)),


### PR DESCRIPTION
### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created because I've found the `.with()` method to be a little overly restrictive - in particular, I would like to be able to name the columns of the CTE, which would allow me to use expressions without column names (e.g. `VALUES`).

### Detail

Support for the `.with` query method was added in https://github.com/rails/rails/pull/37944

The hash based syntax added in that PR supports Relations, Arel SelectManagers, and SqlLiterals as expressions, but only allows simple names for the CTEs.

In some circumstances, it's useful to be able to name the columns of the CTE as well as the table.

For example, if the expression is a ValuesList:

    WITH magic(a, b, c) AS (VALUES (2, 6, 7), (9, 5, 1), (4, 3, 8))
    SELECT a + b + c FROM magic;

... we need to be able to name the columns in order to reference them later.

One use case for having this supported in ActiveRecord's with query method is joining the results from a previous query to a subsequent one. For example, if you were walking through an org chart, but you couldn't use recursive CTEs, you could use this approach to keep information about the management path:

    big_bosses = Employee.where(manager: nil).pluck(id)

    first_level = Employee.with(Arel::Nodes::Cte.new(
        Arel.sql("bosses(id)"),
        Arel::Nodes::Grouping.new(Arel::Nodes::ValuesList.new(big_bosses))
      )
      .joins("INNER JOIN employees ON emplooyees.manager = bosses.id")
      .pluck("employees.id", "bosses.id")

    second_level = Employee.with(Arel::Nodes::Cte.new(
        Arel.sql("bosses(id, grand_boss_id)"),
        Arel::Nodes::Grouping.new(Arel::Nodes::ValuesList.new(first_level))
      )
      .joins("INNER JOIN employees ON emplooyees.manager = bosses.id")
      .pluck("employees.id", "bosses.id", "bosses.grand_boss_id")

    ... and so on ... (not tested)

I'm not sure about this use case particularly, but I imagine there are a few other situations where it's useful to have more control over the name of the CTE than we currently have.

### Additional information

- https://github.com/rails/rails/pull/37944 (original PR to add the `.with()` query method)

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
