### PR TITLE
Fix AllowBrowser versions

### DIFF
--- a/actionpack/lib/action_controller/metal/allow_browser.rb
+++ b/actionpack/lib/action_controller/metal/allow_browser.rb
@@ -20,7 +20,7 @@ module ActionController # :nodoc:
       # In addition to specifically named browser versions, you can also pass
       # `:modern` as the set to restrict support to browsers natively supporting webp
       # images, web push, badges, import maps, CSS nesting, and CSS :has. This
-      # includes Safari 17.2+, Chrome 119+, Firefox 121+, Opera 104+.
+      # includes Safari 17.2+, Chrome 120+, Firefox 121+, Opera 106+.
       #
       # You can use https://caniuse.com to check for browser versions supporting the
       # features you use.
@@ -31,7 +31,7 @@ module ActionController # :nodoc:
       # Examples:
       #
       #     class ApplicationController < ActionController::Base
-      #       # Allow only browsers natively supporting webp images, web push, badges, import maps, CSS nesting + :has
+      #       # Allow only browsers natively supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has
       #       allow_browser versions: :modern
       #     end
       #
@@ -62,7 +62,7 @@ module ActionController # :nodoc:
 
       class BrowserBlocker
         SETS = {
-          modern: { safari: 17.2, chrome: 119, firefox: 121, opera: 104, ie: false }
+          modern: { safari: 17.2, chrome: 120, firefox: 121, opera: 106, ie: false }
         }
 
         attr_reader :request, :versions

--- a/actionpack/test/controller/allow_browser_test.rb
+++ b/actionpack/test/controller/allow_browser_test.rb
@@ -3,7 +3,7 @@
 require "abstract_unit"
 
 class AllowBrowserController < ActionController::Base
-  allow_browser versions: { safari: "16.4", chrome: "119", firefox: "123", opera: "104", ie: false }, block: -> { head :upgrade_required }, only: :hello
+  allow_browser versions: { safari: "16.4", chrome: "119", firefox: "123", opera: "106", ie: false }, block: -> { head :upgrade_required }, only: :hello
   def hello
     head :ok
   end
@@ -22,7 +22,7 @@ class AllowBrowserTest < ActionController::TestCase
   SAFARI_17_2_0 = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.2.0 Safari/605.1.15"
   FIREFOX_114   = "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:109.0) Gecko/20100101 Firefox/114.0"
   IE_11         = "Mozilla/5.0 (Windows NT 10.0; WOW64; Trident/7.0; rv:11.0) like Gecko"
-  OPERA_104     = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/95.0.4638.69 Safari/537.36 OPR/104.0.4638.54"
+  OPERA_106     = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36 OPR/106.0.0.0"
 
   test "blocked browser below version limit" do
     get_with_agent :hello, FIREFOX_114
@@ -41,7 +41,7 @@ class AllowBrowserTest < ActionController::TestCase
     get_with_agent :hello, CHROME_120
     assert_response :ok
 
-    get_with_agent :hello, OPERA_104
+    get_with_agent :hello, OPERA_106
     assert_response :ok
   end
 
@@ -55,7 +55,7 @@ class AllowBrowserTest < ActionController::TestCase
     get_with_agent :modern, CHROME_120
     assert_response :ok
 
-    get_with_agent :modern, OPERA_104
+    get_with_agent :modern, OPERA_106
     assert_response :ok
   end
 


### PR DESCRIPTION
### Motivation / Background

The new AllowBrowser feature was added in #50505 . It permits setting minimum browser versions for an application, defines and documents a `:modern` version-set as requiring a list of certain features, and adds that option to the default config for new apps.

This PR has been created to make two minor corrections to `:modern`, one to its versions, one to its documentation.

### Detail

1. In 24264baeae1d57743aa87b4fcb88e55a42cc850a, adjust the `:modern` browser versions to match the description of required features. Specifically, CSS nesting isn't supported by Chrome until 120, Opera until 106 ([1](https://caniuse.com/css-nesting), [2](https://developer.mozilla.org/en-US/docs/Web/CSS/Nesting_selector#browser_compatibility)).
2. In ff0291291a2c93f40c92a306f4fc3025bd8bdbc0, remove badging from the documentation's list of required features, because it's still a [spec](https://www.w3.org/TR/badging/) that isn't fully implemented by any current browser ([1](https://caniuse.com/mdn-api_notification_badge), [2](https://developer.mozilla.org/en-US/docs/Web/API/Badging_API#browser_compatibility)).

### Additional information

Personally I'm not convinced this feature will be a good default for new apps, but if it's going to be offered, it should be correct for its stated purpose.

For fun, I benchmarked `UserAgent.parse.browser` on my laptop and it runs in about 40 microseconds, which is faster than I'd expected. But the runtime `require "useragent"` added 30 milliseconds to the first request.

The `useragent` gem was [last updated](https://github.com/gshutler/useragent) five years ago, and its browser recognition code is all [7 to 9 years old](https://github.com/gshutler/useragent/tree/master/lib/user_agent/browsers). It seems inappropriate to have a `:modern` default that doesn't recognize Edge (2015). There's a [fork by art19](https://github.com/art19/useragent) that recognizes Edge, but it adds 54 other browsers too, so it has 4x the LoC, and its `require` is 90 milliseconds. Something in-between might be nice.

I made a [google spreadsheet](https://docs.google.com/spreadsheets/d/13hz5ndUBDeTqAKwYCv5CyAMGpcCVkc5hwJ7Is7BG0qo/edit#gid=0) listing browser versions that support each of the `:modern` features listed. The tl;dr is that badges and css nesting are the most-restrictive requirement for every major browser except Firefox (which was late to support css :has).