### PR TITLE
Map enums using array to the correct column type

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,19 @@
+*   Auto-detect the column type for enums defined with the array syntax.
+
+    Previously enums defined using an array were always mapped to integers
+    and indexed by position, now it is converted based on the column type,
+    it works for strings and database enums as well.
+
+    ```ruby
+    # Before
+    enum :status, { proposed: "proposed", written: "written", published: "published" }
+
+    # After
+    enum :status, [:proposed, :written, :published]
+    ```
+
+    *Lázaro Nixon*
+
 *   Remove deprecated behavior that would rollback a transaction block when exited using `return`, `break` or `throw`.
 
     *Rafael Mendonça França*

--- a/activerecord/lib/active_record/errors.rb
+++ b/activerecord/lib/active_record/errors.rb
@@ -455,6 +455,10 @@ module ActiveRecord
     end
   end
 
+  # Raised when enums are not backed by a database column or not declared with an explicit type via `attribute`.
+  class UndeclaredAttributeTypeForEnumError < ActiveRecordError
+  end
+
   # Raised when a relation cannot be mutated because it's already loaded.
   #
   #   class Task < ActiveRecord::Base

--- a/activerecord/test/cases/adapters/abstract_mysql_adapter/mysql_enum_test.rb
+++ b/activerecord/test/cases/adapters/abstract_mysql_adapter/mysql_enum_test.rb
@@ -44,4 +44,13 @@ class MySQLEnumTest < ActiveRecord::AbstractMysqlTestCase
     enum_test = EnumTest.create!(state: :middle)
     assert_equal "middle", enum_test.state
   end
+
+  def test_enum_with_array_arguments
+    klass = Class.new(ActiveRecord::Base) do
+      self.table_name = "enum_tests"
+      enum :enum_column, [:text, :blob, :tiny, :medium, :long, :unsigned, :bigint]
+    end
+
+    assert_equal "tiny", klass.create!(enum_column: :tiny).enum_column
+  end
 end

--- a/activerecord/test/cases/adapters/postgresql/enum_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/enum_test.rb
@@ -98,6 +98,15 @@ class PostgresqlEnumTest < ActiveRecord::PostgreSQLTestCase
     assert_nil model.reload.current_mood
   end
 
+  def test_enum_with_array_arguments
+    klass = Class.new(ActiveRecord::Base) do
+      self.table_name = "postgresql_enums"
+      enum :current_mood, [:sad, :ok, :happy]
+    end
+
+    assert_equal "happy", klass.create!(current_mood: :happy).current_mood
+  end
+
   def test_schema_dump
     @connection.add_column "postgresql_enums", "good_mood", :mood, default: "happy", null: false
 

--- a/activerecord/test/cases/enum_test.rb
+++ b/activerecord/test/cases/enum_test.rb
@@ -313,6 +313,26 @@ class EnumTest < ActiveRecord::TestCase
     assert_equal "'unknown' is not a valid status", e.message
   end
 
+  test "enum with array arguments and integer columns" do
+    klass = Class.new(ActiveRecord::Base) do
+      self.table_name = "books"
+      enum :status, [:proposed, :written]
+    end
+
+    assert_equal 0, klass.create!(status: :proposed).status_for_database
+    assert_equal 1, klass.create!(status: :written).status_for_database
+  end
+
+  test "enum with array arguments and string columns" do
+    klass = Class.new(ActiveRecord::Base) do
+      self.table_name = "books"
+      enum :cover, [:hard, :soft]
+    end
+
+    assert_equal "hard", klass.create!(cover: :hard).cover_for_database
+    assert_equal "soft", klass.create!(cover: :soft).cover_for_database
+  end
+
   test "validation with 'validate: true' option" do
     klass = Class.new(ActiveRecord::Base) do
       def self.name; "Book"; end
@@ -1109,7 +1129,7 @@ class EnumTest < ActiveRecord::TestCase
       end
     end
 
-    error = assert_raises(RuntimeError) do
+    error = assert_raises(ActiveRecord::UndeclaredAttributeTypeForEnumError) do
       klass.type_for_attribute(:typeless_genre)
     end
     assert_match "Undeclared attribute type for enum 'typeless_genre' in Book", error.message


### PR DESCRIPTION
### Motivation / Background


Previously enums without keywords were always mapped to integers and indexed by position, now it is converted based on the column type, it works for strings and database enums as well.

```ruby
# Before
enum status: { proposed: "proposed", written: "written", published: "published" }

# After
enum status: [:proposed, :written, :published]
```

### Detail

This Pull Request closes #47278

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
