### PR TITLE
Action Cable `assert_broadcasts` API docs [ci skip]

### DIFF
--- a/actioncable/lib/action_cable/test_helper.rb
+++ b/actioncable/lib/action_cable/test_helper.rb
@@ -32,21 +32,17 @@ module ActionCable
     #     end
     #
     # If a block is passed, that block should cause the specified number of messages
-    # to be broadcasted. It returns the messages that were broadcasted.
+    # to be broadcasted.
     #
     #     def test_broadcasts_again
-    #       message = assert_broadcasts('messages', 1) do
+    #       assert_broadcasts('messages', 1) do
     #         ActionCable.server.broadcast 'messages', { text: 'hello' }
     #       end
-    #       assert_equal({ text: 'hello' }, message)
     #
-    #       messages = assert_broadcasts('messages', 2) do
+    #       assert_broadcasts('messages', 2) do
     #         ActionCable.server.broadcast 'messages', { text: 'hi' }
     #         ActionCable.server.broadcast 'messages', { text: 'how are you?' }
     #       end
-    #       assert_equal 2, messages.length
-    #       assert_equal({ text: 'hi' }, messages.first)
-    #       assert_equal({ text: 'how are you?' }, messages.last)
     #     end
     #
     def assert_broadcasts(stream, number, &block)


### PR DESCRIPTION
### Motivation / Background

Follow-up to [#48798][]
Reverts [#47837][]


### Detail

The `capture_broadcasts` helper was introduced in [#48798][] to remove the return value from the `assert_broadcasts` call. The behavior was changed, but the corresponding documentation for the `assert_broadcasts` method did not revert the changes added in [#47837][].

### Additional information

This change should probably also get backported to `7-1-0-stable`.

[#47837]: https://github.com/rails/rails/pull/47837
[#48798]: https://github.com/rails/rails/pull/48798