### PR TITLE
Remove codespell from contribution guide [skip ci]

### DIFF
--- a/guides/source/contributing_to_ruby_on_rails.md
+++ b/guides/source/contributing_to_ruby_on_rails.md
@@ -288,16 +288,6 @@ Inspecting 1 file
 
 For `rails-ujs` CoffeeScript and JavaScript files, you can run `npm run lint` in `actionview` folder.
 
-#### Spell Checking
-
-We run [codespell](https://github.com/codespell-project/codespell) with GitHub Actions to check spelling and
-[codespell](https://pypi.org/project/codespell/) runs against a [small custom dictionary](https://github.com/rails/rails/blob/main/codespell.txt).
-`codespell` is written in [Python](https://www.python.org/) and you can run it with:
-
-```bash
-$ codespell --ignore-words=codespell.txt
-```
-
 ### Benchmark Your Code
 
 For changes that might have an impact on performance, please benchmark your


### PR DESCRIPTION
Backport https://github.com/rails/rails/pull/50972 to `7-1-stable` as we already removed codespell from `7-1-stable` as well https://github.com/rails/rails/pull/50746

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
