### PR TITLE
Add parameter filter capability for redirect locations

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -90,4 +90,15 @@
 
     *Rafael Mendonça França*
 
+*   Add parameter filter capability for redirect locations.
+
+    It uses the `config.filter_parameters` to match what needs to be filtered.
+    The result would be like this:
+
+        Redirected to http://secret.foo.bar?username=roque&password=[FILTERED]
+
+    Fixes #14055.
+
+    *Roque Pinel*, *Trevor Turk*, *tonytonyjan*
+
 Please check [7-1-stable](https://github.com/rails/rails/blob/7-1-stable/actionpack/CHANGELOG.md) for previous changes.

--- a/actionpack/lib/action_dispatch/http/filter_redirect.rb
+++ b/actionpack/lib/action_dispatch/http/filter_redirect.rb
@@ -11,7 +11,7 @@ module ActionDispatch
         if location_filter_match?
           FILTERED
         else
-          location
+          parameter_filtered_location
         end
       end
 
@@ -32,6 +32,16 @@ module ActionDispatch
             location.match?(filter)
           end
         end
+      end
+
+      def parameter_filtered_location
+        uri = URI.parse(location)
+        unless uri.query.nil? || uri.query.empty?
+          uri.query.gsub!(FilterParameters::PAIR_RE) do
+            request.parameter_filter.filter($1 => $2).first.join("=")
+          end
+        end
+        uri.to_s
       end
     end
   end

--- a/guides/source/action_controller_overview.md
+++ b/guides/source/action_controller_overview.md
@@ -1210,7 +1210,8 @@ You can set it to a String, a Regexp, or an array of both.
 config.filter_redirect.concat ['s3.amazonaws.com', /private_path/]
 ```
 
-Matching URLs will be marked as '[FILTERED]'.
+Matching URLs will be replaced with '[FILTERED]'. However, if you only wish to filter the parameters, not the whole URLs,
+please take a look at [Parameters Filtering](#parameters-filtering).
 
 Rescue
 ------


### PR DESCRIPTION
### Motivation / Background

This PR aims to complete an accepted pull request #21045 submitted 8 years ago because the author seems have no time keep working on it.


### Detail

It uses the `config.filter_parameters` to match what needs to be filtered. The result would be like this:

```
Redirected to http://secret.foo.bar?username=roque&password=[FILTERED]
```

Also did rebase and improvement to make the code clearer.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
