### PR TITLE
Improve title tag for new apps

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/app/views/layouts/application.html.erb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/app/views/layouts/application.html.erb.tt
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title><%%= content_for(:title) || "<%= camelized %>" %></title>
+    <title><%%= content_for(:title) || "<%= app_name.titleize %>" %></title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <%%= csrf_meta_tags %>

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -421,7 +421,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
 
   def test_application_name_is_normalized_in_config
     run_generator [File.join(destination_root, "MyWebSite"), "-d", "postgresql"]
-    assert_file "MyWebSite/app/views/layouts/application.html.erb", /<title><%= content_for(:title) || "MyWebSite" %><\/title>/
+    assert_file "MyWebSite/app/views/layouts/application.html.erb", /content_for\(:title\) \|\| "MyWebSite"/
     assert_file "MyWebSite/config/database.yml", /my_web_site_production/
   end
 

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -421,7 +421,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
 
   def test_application_name_is_normalized_in_config
     run_generator [File.join(destination_root, "MyWebSite"), "-d", "postgresql"]
-    assert_file "MyWebSite/app/views/layouts/application.html.erb", /content_for\(:title\) \|\| "MyWebSite"/
+    assert_file "MyWebSite/app/views/layouts/application.html.erb", /content_for\(:title\) \|\| "My Web Site"/
     assert_file "MyWebSite/config/database.yml", /my_web_site_production/
   end
 


### PR DESCRIPTION
### Motivation / Background

This Pull Request aims to a common pattern observed where developers frequently modify the title in new projects for better readability. A similar initiative was discussed and implemented in [PR #49702](https://github.com/rails/rails/pull/49702), which underscores the value of making the application name more user-friendly in the generated HTML.

This modification results in more human-readable titles for new applications. For example, an application generated with `rails new club_invoces` would have a title of `Club Invoces` instead of the less readable `ClubInvoces`.

### Detail

To address this, the proposed change involves modifying the title generation logic to replace camel casing with spaces, thus improving the readability of the application name in the title tag.

### Additional information

This change is straightforward and focuses solely on improving the default user experience with minimal impact on the existing codebase. It aligns with Rails' philosophy, providing sensible defaults that meet the expectations of the majority of developers.

Also, I fixed the regex introduced in [PR #49702](https://github.com/rails/rails/pull/49702), as it was not testing what it should test: `title` tag only.

### Checklist

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.