### PR TITLE
Address `ApplicationTests::FrameworksTest` failure on Ubuntu 22.04

### DIFF
--- a/railties/test/application/initializers/frameworks_test.rb
+++ b/railties/test/application/initializers/frameworks_test.rb
@@ -282,7 +282,7 @@ module ApplicationTests
             end
           end
 
-          assert_match(/Failed to validate the schema cache because of ActiveRecord::ConnectionNotEstablished/, error)
+          assert_match(/Failed to validate the schema cache because of ActiveRecord::(ConnectionNotEstablished|DatabaseConnectionError)/, error)
         end
       end
     end


### PR DESCRIPTION
### Motivation / Background

This commit address Rails Nightly failure at https://buildkite.com/rails/rails-nightly/builds/191#018dc3d1-8fb2-4c35-ad1d-bd3891757361/1310-1318

### Detail

This issue reproduces when the `default-mysql-client` apt package installs `mysql-client-8.0` that raises `CR_CONN_HOST_ERROR` which is mapped to `ActiveRecord::DatabaseConnectionError` while `mariadb-client` raises `CR_CONNECTION_ERROR` error which is mapped to `ActiveRecord::ConnectionNotEstablished`.

In this test, whichever exception `ActiveRecord::ConnectionNotEstablished` or `DatabaseConnectionError` is fine as long as the connection is invalid.

- Steps to reproduce

Run this step at Linux box on Ubuntu Jammy or whatever `default-mysql-client` installs MySQL client, not MariaDB one.

```
git clone https://github.com/rails/rails
cd rails/railties
bundle install
bin/test test/application/initializers/frameworks_test.rb:285
```

- Failure fixed by this commit

```ruby
$ bin/test test/application/initializers/frameworks_test.rb:285
Run options: --seed 32832

F

Failure:
ApplicationTests::FrameworksTest#test_expire_schema_cache_dump_if_the_version_can't_be_checked_because_the_database_is_unhealthy [test/application/initializers/frameworks_test.rb:285]:
Expected /Failed to validate the schema cache because of ActiveRecord::ConnectionNotEstablished/ to match "Failed to validate the schema cache because of ActiveRecord::DatabaseConnectionError: There is an issue connecting with your hostname: 127.0.0.1.\n\nPlease check your database configuration and ensure there is a valid connection to your database.\n".

bin/test test/application/initializers/frameworks_test.rb:263

Finished in 6.299418s, 0.1587 runs/s, 0.6350 assertions/s.
1 runs, 4 assertions, 1 failures, 0 errors, 0 skips
```

### Additional information
- `default-mysql-client` package used by Rails CI
https://github.com/rails/buildkite-config/blob/3158d00b48da5a30f4319af1f7ac73f2b7094898/Dockerfile#L91
`default-mysql-client` installs different package per distribution, https://packages.ubuntu.com/jammy/default-mysql-client https://packages.debian.org/bookworm/default-mysql-client

- Each error message are defined in these lines by these commits: 
- MariaDB
https://github.com/MariaDB/server/blob/eeba940311ed17d160023280783fd2bbb64abef3/sql-common/errmsg.c#L32 https://github.com/MariaDB/server/commit/9075973dbf2ef69e95d427e3a979be23435692e3

- MySQL
https://github.com/mysql/mysql-server/blob/824e2b4064053f7daf17d7f3f84b7a3ed92e5fb4/libmysql/errmsg.cc#L39 https://github.com/mysql/mysql-server/commit/964d5fdb02659c8cd148b618f665957a1fbb3ce5

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
