### PR TITLE
Add `permitted_columns` to ActiveRecord, inverse of `ignored_columns`

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Add `permitted_columns` to ActiveRecord::ModelSchema
+
+    Adds `permitted_columns` getter and setter, which acts as an inverse of `ignored_columns`.
+    When set on a model, only columns specified in `permitted_columns` will be referenced.
+
+    *Scott Hudson*
+
 *   Add ActiveRecord::Encryption::MessagePackMessageSerializer
 
     Serialize data to the MessagePack format, for efficient storage in binary columns.

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -1734,7 +1734,7 @@ module ActiveRecord
       def build_select(arel)
         if select_values.any?
           arel.project(*arel_columns(select_values))
-        elsif klass.ignored_columns.any? || klass.enumerate_columns_in_select_statements
+        elsif klass.ignored_columns.any? || klass.permitted_columns.any? || klass.enumerate_columns_in_select_statements
           arel.project(*klass.column_names.map { |field| table[field] })
         else
           arel.project(table[Arel.star])

--- a/activerecord/test/models/developer.rb
+++ b/activerecord/test/models/developer.rb
@@ -129,6 +129,13 @@ class SymbolIgnoredDeveloper < ActiveRecord::Base
   attribute :last_name
 end
 
+class SymbolPermittedDeveloper < ActiveRecord::Base
+  self.table_name = "developers"
+  self.permitted_columns = [:created_at, :updated_at]
+
+  attribute :last_name
+end
+
 class AuditLog < ActiveRecord::Base
   belongs_to :developer, validate: true
   belongs_to :unvalidated_developer, class_name: "Developer"
@@ -360,6 +367,12 @@ class DeveloperName < ActiveRecord::Type::String
   end
 end
 
+class SubDeveloperWithPermittedColumns < Developer
+  attribute :name, DeveloperName.new
+
+  self.permitted_columns = ["id", "last_name", "salary"]
+end
+
 class AttributedDeveloper < ActiveRecord::Base
   self.table_name = "developers"
 
@@ -371,4 +384,21 @@ end
 class ColumnNamesCachedDeveloper < ActiveRecord::Base
   self.table_name = "developers"
   self.ignored_columns += ["name"] if column_names.include?("name")
+end
+
+class DeveloperWithPermittedColumns < ActiveRecord::Base
+  self.table_name = "developers"
+
+  attribute :name, DeveloperName.new
+
+  self.permitted_columns = ["created_at", "updated_at", "last_name"]
+end
+
+class DeveloperWithPermittedAndIgnoredColumns < ActiveRecord::Base
+  self.table_name = "developers"
+
+  attribute :name, DeveloperName.new
+
+  self.permitted_columns += ["first_name"] if column_names.include?("first_name")
+  self.ignored_columns += ["first_name"] if column_names.include?("first_name")
 end


### PR DESCRIPTION
### Motivation / Background

Currently, columns that are marked for removal from the database must first be added to the `ignored_columns` list, lest we suffer a failed deploy that requires manual intervention. This critical step can be overlooked because it's an additive change in a situation where code is typically being removed from a codebase, and trying to prevent this situation with linters and automated tests is tricky.

It would be great to be able to lean in the opposite direction by explicitly defining which columns the model has access to, similar to how we define strong params. When it's time to remove a column from the db, the column name is removed from `permitted_columns` and all of its references are removed from the model, eliminating the need to modify `ignored_columns`.

### Detail

This Pull Request adds `permitted_columns` and `permitted_columns=` to `ActiveRecord::ModelSchema`, which acts as an inverse to `ignored_columns`. When set, only columns specified in `permitted_columns` will be referenced by the model.  If a column name is specified in both `permitted_columns` and `ignored_columns`, then it is ignored. 

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
