### PR TITLE
Support IN queries on array columns

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Support `IN` queries of array columns.
+
+    Use `where(tags: [["tag1"], ["tag2"]])` to produce an `tags IN ({'tag1'}, {'tag2'})`,
+    similarly to how it works with non-array columns.
+
+    *Greg Navis*
+
 *   Add ActiveRecord::Encryption::MessagePackMessageSerializer
 
     Serialize data to the MessagePack format, for efficient storage in binary columns.

--- a/activerecord/lib/active_record/connection_adapters/postgresql/oid/array.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/oid/array.rb
@@ -73,7 +73,7 @@ module ActiveRecord
           end
 
           def force_equality?(value)
-            value.is_a?(::Array)
+            value.is_a?(::Array) && !value.first.is_a?(::Array)
           end
 
           private

--- a/activerecord/test/cases/adapters/postgresql/array_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/array_test.rb
@@ -347,6 +347,12 @@ class PostgresqlArrayTest < ActiveRecord::PostgreSQLTestCase
     assert_equal record, PgArray.where(tags: tags).take
   end
 
+  def test_where_by_attribute_with_array_of_arrays
+    PgArray.create!(tags: ["black"])
+    PgArray.create!(tags: ["blue"])
+    assert_equal 2, PgArray.where(tags: [["black"], ["blue"]]).count
+  end
+
   def test_uniqueness_validation
     klass = Class.new(PgArray) do
       validates_uniqueness_of :tags


### PR DESCRIPTION
### Motivation / Background

A non-array column can be queried via `where(name: [value1, value2])` which is automatically converted to `name IN (value1, value2)` in SQL. An array column would treat that array as the value to search for, so it'd be natural to expect an array of arrays would result in an `IN` query. Unfortunately, that wasn't the case as `where(name: [[value1], [value2]])` would return `name = {{value1}, {value2}}` in SQL, instead of `name IN ({value1}, {value2})`.

### Detail

That behavior stemmed from the fact that Active Record would force equality comparison for array columns if the value was an array. In order to allow `IN` queries this check was change to check whether it's a **one-dimensional** array by checking that the first item of is not an array.

After these changes the following logic applies for querying array columns:

1. Using a one-dimensional array results in an ordinary equality query.
2. Using a two-dimensional array produces an `IN` query.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
