### PR TITLE
Add syntax sugar as inverted exists? method

### DIFF
--- a/activerecord/lib/active_record/encryption/extended_deterministic_queries.rb
+++ b/activerecord/lib/active_record/encryption/extended_deterministic_queries.rb
@@ -101,6 +101,10 @@ module ActiveRecord
           super(*EncryptedQuery.process_arguments(self, args, true))
         end
 
+        def missing?(*args)
+          !exists?(args)
+        end
+
         def scope_for_create
           return super unless klass.deterministic_encrypted_attributes&.any?
 


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because we have so many syntax sugar, like for `present?` method we have `blank?`, and so on, so, that's would be really nice to add opposite method for a `exists?` instead of writing always `!`, or using unless

### Detail

This Pull Request changes adds just an inverted `exists?` method called `missing?`. So, it's really simple, but powerful change

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
