### PR TITLE
Fix linting error for generated system test case.

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/test/application_system_test_case.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/test/application_system_test_case.rb.tt
@@ -9,7 +9,7 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
 
     driven_by :selenium, using: :headless_chrome, screen_size: [ 1400, 1400 ], options: {
       browser: :remote,
-      url: "http://#{ENV["SELENIUM_HOST"]}:4444",
+      url: "http://#{ENV["SELENIUM_HOST"]}:4444"
     }
   else
     driven_by :selenium, using: :headless_chrome, screen_size: [ 1400, 1400 ]


### PR DESCRIPTION
Fixes:

```
Offenses:

test/application_system_test_case.rb:9:49: C: [Correctable] Style/TrailingCommaInHashLiteral: Avoid comma after the last item of a hash.
      url: "http://#{ENV["SELENIUM_HOST"]}:4444",
```
