### PR TITLE
Fix predicate builder for polymorphic models referencing models with composite primary keys

### DIFF
--- a/activerecord/lib/active_record/relation/predicate_builder/polymorphic_array_value.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder/polymorphic_array_value.rb
@@ -43,7 +43,12 @@ module ActiveRecord
 
         def convert_to_id(value)
           if value.is_a?(Base)
-            value._read_attribute(primary_key(value))
+            primary_key = primary_key(value)
+            if primary_key.is_a?(Array)
+              primary_key.map { |column| value._read_attribute(column) }
+            else
+              value._read_attribute(primary_key)
+            end
           elsif value.is_a?(Relation)
             value.select(primary_key(value))
           else

--- a/activerecord/test/cases/associations/belongs_to_associations_test.rb
+++ b/activerecord/test/cases/associations/belongs_to_associations_test.rb
@@ -63,6 +63,12 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
     assert_empty Comment.where(author: [])
   end
 
+  def test_where_on_polymorphic_association_with_cpk
+    post = Cpk::Post.create!(title: "Welcome", author: "Mary")
+    post.comments << Cpk::Comment.create!
+    assert_equal 1, Cpk::Comment.where(commentable: post).count
+  end
+
   def test_assigning_belongs_to_on_destroyed_object
     client = Client.create!(name: "Client")
     client.destroy!


### PR DESCRIPTION
This is backport of #50319 to `7-1-stable`.

cc @eileencodes 