### PR TITLE
Increase assert_output timeout for `FullStackConsoleTest` and `ApplicationTests::ServerTest`

### DIFF
--- a/railties/test/application/console_test.rb
+++ b/railties/test/application/console_test.rb
@@ -121,7 +121,7 @@ class FullStackConsoleTest < ActiveSupport::TestCase
   def write_prompt(command, expected_output = nil)
     @primary.puts command
     assert_output command, @primary
-    assert_output expected_output, @primary if expected_output
+    assert_output expected_output, @primary, 100 if expected_output
     assert_output "> ", @primary
   end
 

--- a/railties/test/application/server_test.rb
+++ b/railties/test/application/server_test.rb
@@ -29,12 +29,12 @@ module ApplicationTests
 
       Bundler.with_original_env do
         pid = Process.spawn("bin/rails server -b localhost -P tmp/dummy.pid", chdir: app_path, in: replica, out: replica, err: replica)
-        assert_output("Listening", primary)
+        assert_output("Listening", primary, 100)
 
         rails("restart")
 
-        assert_output("Restarting", primary)
-        assert_output("Listening", primary)
+        assert_output("Restarting", primary, 100)
+        assert_output("Listening", primary, 100)
       ensure
         kill(pid) if pid
       end
@@ -59,8 +59,8 @@ module ApplicationTests
 
       Bundler.with_original_env do
         pid = Process.spawn("bin/rails server -b localhost", chdir: app_path, in: replica, out: primary, err: replica)
-        assert_output("Hello world", primary)
-        assert_output("Listening", primary)
+        assert_output("Hello world", primary, 100)
+        assert_output("Listening", primary, 100)
       ensure
         kill(pid) if pid
       end


### PR DESCRIPTION
### Motivation / Background

This pull request addresses the following failures at Rails Nightly CI with assertion enabled Ruby. that has been built with `cppflags="-DENABLE_PATH_CHECK=0 -DRUBY_DEBUG=1" optflags="-O3 -fno-inline"`

https://buildkite.com/rails/rails-nightly/builds/191#018dc3d1-9032-4baa-ae8a-3c630889ab5f/1342-1348 https://buildkite.com/rails/rails-nightly/builds/191#018dc3d1-9033-4c0c-b61c-00f26d3a63fb/1198-1204

Related to #51140

### Detail
- Failures fixed by this commit:

```ruby
$ ruby -v
ruby 3.4.0dev (2024-02-20T11:52:09Z master c22cb960cf) [x86_64-linux]
$ bin/test test/application/console_test.rb -n test_sandbox
Run options: -n test_sandbox --seed 3666

F

Failure:
FullStackConsoleTest#test_sandbox [test/console_helpers.rb:19]:
"=> 0" expected, but got:

app-template(dev)> quapp-template(dev)> quiapp-template(dev)> quit.
Expected "\r\napp-template(dev)> quapp-template(dev)> quiapp-template(dev)> quit" to include "=> 0".

bin/test test/application/console_test.rb:142

Finished in 32.180314s, 0.0311 runs/s, 0.7458 assertions/s.
1 runs, 24 assertions, 1 failures, 0 errors, 0 skips
$
```

```ruby
$ bin/test test/application/server_test.rb
Run options: --seed 64559

F

Failure:
ApplicationTests::ServerTest#test_restart_rails_server_with_custom_pid_file_path [test/console_helpers.rb:19]:
"Listening" expected, but got:

.
Expected "" to include "Listening".

bin/test test/application/server_test.rb:19

F

Failure:
ApplicationTests::ServerTest#test_run_+server+_blocks_after_the_server_starts [test/console_helpers.rb:19]:
"Hello world" expected, but got:

.
Expected "" to include "Hello world".

bin/test test/application/server_test.rb:43

Finished in 2.117413s, 0.9445 runs/s, 1.8891 assertions/s.
2 runs, 4 assertions, 2 failures, 0 errors, 0 skips
$
```

### Additional information

Note: These failures depend on assert_timeout and test environment. If these failures do not reproduce locally, setting short timeout = 1 should reproduce them.
```diff
$ git diff
diff --git a/railties/test/console_helpers.rb b/railties/test/console_helpers.rb
index 10d3a54602..32d333ed99 100644
--- a/railties/test/console_helpers.rb
+++ b/railties/test/console_helpers.rb
@@ -6,7 +6,7 @@
 end

 module ConsoleHelpers
-  def assert_output(expected, io, timeout = 10)
+  def assert_output(expected, io, timeout = 1)
     timeout = Time.now + timeout

     output = +""
$
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
