### PR TITLE
Don't force controller or integration tests to load

### DIFF
--- a/railties/lib/rails/test_help.rb
+++ b/railties/lib/rails/test_help.rb
@@ -7,9 +7,6 @@
 abort("Abort testing: Your Rails environment is running in production mode!") if Rails.env.production?
 
 require "active_support/test_case"
-require "action_controller"
-require "action_controller/test_case"
-require "action_dispatch/testing/integration"
 require "rails/generators/test_case"
 require "active_support/testing/autorun"
 


### PR DESCRIPTION
https://github.com/rails/rails/pull/32776 replaced references to `ActionController::TestCase` and `ActionDispatch::IntegrationTest` in this file with lazy load hooks to avoid loading them prematurely, but these requires meant that they were still loaded anyway.

Aside from the direct benefit of loading as little as possible until necessary, this will allow users of https://github.com/amatsuda/routes_lazy_routes to run e.g. a model test without loading the application's routes, which can reduce boot time significantly for large applications.