### PR TITLE
clear_query_caches_for_current_thread: avoid pinning all connections

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb
@@ -133,6 +133,10 @@ module ActiveRecord
           query_cache.enabled
         end
 
+        def clear_query_cache
+          query_cache.clear
+        end
+
         private
           def prune_thread_cache
             super
@@ -185,9 +189,7 @@ module ActiveRecord
       # the same SQL query and repeatedly return the same result each time, silently
       # undermining the randomness you were expecting.
       def clear_query_cache
-        @lock.synchronize do
-          @query_cache&.clear
-        end
+        pool.clear_query_cache
       end
 
       def select_all(arel, name = nil, binds = [], preparable: nil, async: false) # :nodoc:

--- a/activerecord/lib/active_record/connection_handling.rb
+++ b/activerecord/lib/active_record/connection_handling.rb
@@ -243,7 +243,7 @@ module ActiveRecord
     # Clears the query cache for all connections associated with the current thread.
     def clear_query_caches_for_current_thread
       connection_handler.each_connection_pool do |pool|
-        pool.connection.clear_query_cache
+        pool.clear_query_cache
       end
     end
 


### PR DESCRIPTION
Ref: https://github.com/rails/rails/pull/51083#discussion_r1496720821

Now that the query_cache is owned by the pool, we can clear it without having to checkout a connection.

cc @matthewd @bensheldon 