### PR TITLE
Don't forcefully clear temporarily disabled query caches

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb
@@ -29,18 +29,13 @@ module ActiveRecord
       end
 
       class Store # :nodoc:
-        attr_reader :enabled
+        attr_accessor :enabled
         alias_method :enabled?, :enabled
 
         def initialize(max_size)
           @map = {}
           @max_size = max_size
           @enabled = false
-        end
-
-        def enabled=(enabled)
-          clear if @enabled && !enabled
-          @enabled = enabled
         end
 
         def size


### PR DESCRIPTION
Followup: https://github.com/rails/rails/pull/50938

The behavior changed to always clear the query cache as soon as it's disabled, on the assumption that once queries have been performed without it, all bets are off.

However that isn't quite true, we can apply the same clearing logic than when it's enabled. If you perform read only queries without the cache, there is no reason to clear it.

