### PR TITLE
Respect raise_on_missing_translations in controller's translations

### DIFF
--- a/actionpack/lib/abstract_controller/translation.rb
+++ b/actionpack/lib/abstract_controller/translation.rb
@@ -30,18 +30,7 @@ module AbstractController
         end
       end
 
-      if options[:raise].nil?
-        options[:default] = [] unless options[:default]
-        options[:default] << MISSING_TRANSLATION
-      end
-
-      result = ActiveSupport::HtmlSafeTranslation.translate(key, **options)
-
-      if result == MISSING_TRANSLATION
-        +"translation missing: #{key}"
-      else
-        result
-      end
+      ActiveSupport::HtmlSafeTranslation.translate(key, **options)
     end
     alias :t :translate
 
@@ -50,9 +39,5 @@ module AbstractController
       I18n.localize(object, **options)
     end
     alias :l :localize
-
-    private
-      MISSING_TRANSLATION = -(2**60)
-      private_constant :MISSING_TRANSLATION
   end
 end

--- a/actionpack/test/abstract/translation_test.rb
+++ b/actionpack/test/abstract/translation_test.rb
@@ -146,15 +146,19 @@ module AbstractController
       def test_translate_marks_translation_with_missing_html_key_as_safe_html
         @controller.stub :action_name, :index do
           translation = @controller.t("<tag>.html")
-          assert_equal "translation missing: <tag>.html", translation
           assert_equal false, translation.html_safe?
+          assert_equal "Translation missing: en.<tag>.html", translation
         end
       end
       def test_translate_marks_translation_with_missing_nested_html_key_as_safe_html
         @controller.stub :action_name, :index do
           translation = @controller.t(".<tag>.html")
-          assert_equal "translation missing: abstract_controller.testing.translation.index.<tag>.html", translation
           assert_equal false, translation.html_safe?
+          assert_equal(<<~MSG.strip, translation)
+            Translation missing. Options considered were:
+            - en.abstract_controller.testing.translation.index.<tag>.html
+            - en.abstract_controller.testing.translation.<tag>.html
+          MSG
         end
       end
     end

--- a/activesupport/lib/active_support/html_safe_translation.rb
+++ b/activesupport/lib/active_support/html_safe_translation.rb
@@ -7,8 +7,18 @@ module ActiveSupport
     def translate(key, **options)
       if html_safe_translation_key?(key)
         html_safe_options = html_escape_translation_options(options)
-        translation = I18n.translate(key, **html_safe_options)
-        html_safe_translation(translation)
+
+        exception = false
+        exception_handler = ->(*args) do
+          exception = true
+          I18n.exception_handler.call(*args)
+        end
+        translation = I18n.translate(key, **html_safe_options, exception_handler: exception_handler)
+        if exception
+          translation
+        else
+          html_safe_translation(translation)
+        end
       else
         I18n.translate(key, **options)
       end


### PR DESCRIPTION
Previously raise_on_missing_translations was not being respected in a controller. This commit brings back the correct behaviour.

This will be backported to 7-1-stable and 7-0-stable