### PR TITLE
Fix beginless and endless range comparisons

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,18 @@
+*   Fix `RangeError` in `Range#===` and `Range#include?` for endless and beginless ranges
+
+    ```ruby
+    (1..) === (2..)
+    => true
+    (2..) === (1..)
+    => false
+    (..1) === (..2)
+    => false
+    (..2) === (..1)
+    => true
+    ```
+
+    *Alex Mooney*
+
 *   `ActiveSupport::ErrorReporter#report` now assigns a backtrace to unraised exceptions.
 
     Previously reporting an un-raised exception would result in an error report without

--- a/activesupport/lib/active_support/core_ext/range/compare_range.rb
+++ b/activesupport/lib/active_support/core_ext/range/compare_range.rb
@@ -2,6 +2,41 @@
 
 module ActiveSupport
   module CompareWithRange
+    class << self
+      def compare(range, other, &block) # :nodoc:
+        return false if other_is_backwards?(other)
+
+        begin_includes_other_begin?(range, other, &block) && end_includes_other_end?(range, other)
+      end
+
+      private
+        def other_is_backwards?(other)
+          is_backwards_op = other.exclude_end? ? :>= : :>
+          other.begin && other.end && other.begin.public_send(is_backwards_op, other.end)
+        end
+
+        def begin_includes_other_begin?(range, other, &block)
+          # A beginless range always includes the other range's begin.
+          range.begin.nil? || block.call(other.begin)
+        end
+
+        def end_includes_other_end?(range, other)
+          # An endless range always includes the other range's end.
+          return true if range.end.nil?
+          # If the other range is endless, it's not included.
+          return false if other.end.nil?
+
+          # 1...10 includes 1..9 but it does not include 1..10.
+          # 1..10 includes 1...11 but it does not include 1...12.
+          # We can't simplify to `max >= other.max` since it raises TypeError for exclusive ranges with float end points.
+          range_exclude_end = range.exclude_end?
+          other_exclude_end = other.exclude_end?
+          operator = range_exclude_end && !other_exclude_end ? :< : :<=
+          value_max = !range_exclude_end && other_exclude_end ? other.max : other.last
+          value_max.public_send(operator, range.last)
+        end
+    end
+
     # Extends the default Range#=== to support range comparisons.
     #  (1..5) === (1..5)  # => true
     #  (1..5) === (2..3)  # => true
@@ -11,17 +46,9 @@ module ActiveSupport
     # The native Range#=== behavior is untouched.
     #  ('a'..'f') === ('c') # => true
     #  (5..9) === (11) # => false
-    #
-    # The given range must be fully bounded, with both start and end.
-    def ===(value)
-      if value.is_a?(::Range)
-        is_backwards_op = value.exclude_end? ? :>= : :>
-        return false if value.begin && value.end && value.begin.public_send(is_backwards_op, value.end)
-        # 1...10 includes 1..9 but it does not include 1..10.
-        # 1..10 includes 1...11 but it does not include 1...12.
-        operator = exclude_end? && !value.exclude_end? ? :< : :<=
-        value_max = !exclude_end? && value.exclude_end? ? value.max : value.last
-        super(value.first) && (self.end.nil? || value_max.public_send(operator, last))
+    def ===(other)
+      if other.is_a?(::Range)
+        CompareWithRange.compare(self, other) { |arg_for_comparison| super(arg_for_comparison) }
       else
         super
       end
@@ -36,17 +63,9 @@ module ActiveSupport
     # The native Range#include? behavior is untouched.
     #  ('a'..'f').include?('c') # => true
     #  (5..9).include?(11) # => false
-    #
-    # The given range must be fully bounded, with both start and end.
-    def include?(value)
-      if value.is_a?(::Range)
-        is_backwards_op = value.exclude_end? ? :>= : :>
-        return false if value.begin && value.end && value.begin.public_send(is_backwards_op, value.end)
-        # 1...10 includes 1..9 but it does not include 1..10.
-        # 1..10 includes 1...11 but it does not include 1...12.
-        operator = exclude_end? && !value.exclude_end? ? :< : :<=
-        value_max = !exclude_end? && value.exclude_end? ? value.max : value.last
-        super(value.first) && (self.end.nil? || value_max.public_send(operator, last))
+    def include?(other)
+      if other.is_a?(::Range)
+        CompareWithRange.compare(self, other) { |arg_for_comparison| super(arg_for_comparison) }
       else
         super
       end

--- a/activesupport/test/core_ext/range_ext_test.rb
+++ b/activesupport/test/core_ext/range_ext_test.rb
@@ -131,6 +131,13 @@ class RangeTest < ActiveSupport::TestCase
     assert_not_operator((...3), :overlap?, (3..))
   end
 
+  def test_include_uses_ruby_include
+    assert((1..3).include?(1.5))
+    assert(("a".."d").include?("c"))
+
+    assert_not(("a".."d").include?("cc")) # As opposed to `=== 'cc'` => `true`
+  end
+
   def test_should_include_identical_inclusive
     assert((1..10).include?(1..10))
   end
@@ -143,8 +150,10 @@ class RangeTest < ActiveSupport::TestCase
     assert((1..10).include?(1...11))
   end
 
-  def test_include_returns_false_for_backwards
+  def test_include_returns_false_for_backwards_ranges
     assert_not((1..10).include?(5..3))
+    assert_not((10..1).include?(3..5))
+    assert_not((10..1).include?(5..3))
   end
 
   # Match quirky plain-Ruby behavior
@@ -158,10 +167,12 @@ class RangeTest < ActiveSupport::TestCase
 
   def test_should_include_range_with_endless_range
     assert((1..).include?(2..4))
+    assert_not((2..4).include?(1..))
   end
 
   def test_should_not_include_range_with_endless_range
     assert_not((1..).include?(0..4))
+    assert_not((0..4).include?(1..))
   end
 
   def test_include_with_beginless_range
@@ -170,10 +181,20 @@ class RangeTest < ActiveSupport::TestCase
 
   def test_should_include_range_with_beginless_range
     assert((..2).include?(-1..1))
+    assert((..2).include?(..1))
   end
 
   def test_should_not_include_range_with_beginless_range
     assert_not((..2).include?(-1..3))
+    assert_not((..1).include?(..2))
+    assert_not((-1..1).include?(..2))
+  end
+
+  def test_case_equality_uses_ruby_case_equality
+    assert((1..3) === 1.5)
+    assert(("a".."d") === "c")
+
+    assert(("a".."d") === "cc") # As opposed to `.include?('cc')` => `false`
   end
 
   def test_should_compare_identical_inclusive
@@ -199,18 +220,25 @@ class RangeTest < ActiveSupport::TestCase
 
   def test_should_compare_range_with_endless_range
     assert((1..) === (2..4))
+    assert((1..) === (1..))
+    assert((1..) === (2..))
   end
 
   def test_should_not_compare_range_with_endless_range
     assert_not((1..) === (0..4))
+    assert_not((0..4) === (1..))
+    assert_not((2..) === (1..))
   end
 
   def test_should_compare_range_with_beginless_range
     assert((..2) === (-1..1))
+    assert((..2) === (..1))
   end
 
   def test_should_not_compare_range_with_beginless_range
     assert_not((..2) === (-1..3))
+    assert_not((..1) === (..2))
+    assert_not((-1..3) === (..2))
   end
 
   def test_exclusive_end_should_not_include_identical_with_inclusive_end


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created because some endless and beginless range comparisons raise `RangeError` due to `ActiveSupport::CompareWithRange`

### Detail

This Pull Request changes the `CompareWithRange#===` and `CompareWithRange#include?` methods to support begin and endless ranges on the left and right hand side of the comparison.

### Additional information

<!-- Provide additional information such as benchmarks, reference to other repositories or alternative solutions. -->

POR:
```ruby
> (1..) === (2..)
=> false
> (..1) === (..2)
=> false
```
Rails 7.1.3:
```ruby
> (1..) === (2..)
RangeError: cannot get the last element of endless range
from …/activesupport-7.1.3/lib/active_support/core_ext/range/compare_range.rb:23:in `last'
> (..1) === (..2)
RangeError: cannot get the first element of beginless range
from …/activesupport-7.1.3/lib/active_support/core_ext/range/compare_range.rb:24:in `first'
```
This PR:
```ruby
> (1..) === (2..)
=> true
> (2..) === (1..)
=> false
> (..1) === (..2)
=> false
> (..2) === (..1)
=> true
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
