### PR TITLE
Define AR migration-generator-default-database config

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,7 +1,9 @@
 *   Define generators default database configuration
 
-    By default, migrations / models will get generated for the primary database.
-    Users can modify this behaviour in order to point to another database instead.
+    By default, migrations will be generated in the `db/migrate` directory and models
+    will get generated for the first database defined in the `database.yml` configuration.
+
+    Users can modify this behavior with a different default database configuration.
 
     *Sinclert Pérez*
 

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Define generators default database configuration
+
+    By default, migrations / models will get generated for the primary database.
+    Users can modify this behaviour in order to point to another database instead.
+
+    *Sinclert Pérez*
+
 *   Remove deprecated behavior that would rollback a transaction block when exited using `return`, `break` or `throw`.
 
     *Rafael Mendonça França*

--- a/activerecord/lib/active_record.rb
+++ b/activerecord/lib/active_record.rb
@@ -406,6 +406,12 @@ module ActiveRecord
   self.migration_strategy = Migration::DefaultStrategy
 
   ##
+  # :singleton-method: default_database_for_generators
+  # Specify the default database to generate migrations for.
+  singleton_class.attr_accessor :default_database_for_generators
+  self.default_database_for_generators = nil
+
+  ##
   # :singleton-method: dump_schema_after_migration
   # Specify whether schema dump should happen at the end of the
   # bin/rails db:migrate command. This is true by default, which is useful for the

--- a/activerecord/lib/active_record.rb
+++ b/activerecord/lib/active_record.rb
@@ -407,7 +407,7 @@ module ActiveRecord
 
   ##
   # :singleton-method: default_database_for_generators
-  # Specify the default database to generate migrations for.
+  # Specify the database that the generators will use by default.
   singleton_class.attr_accessor :default_database_for_generators
   self.default_database_for_generators = nil
 

--- a/activerecord/lib/rails/generators/active_record/migration.rb
+++ b/activerecord/lib/rails/generators/active_record/migration.rb
@@ -40,7 +40,7 @@ module ActiveRecord
         end
 
         def configured_migrate_path
-          return unless database = options[:database]
+          return unless database
 
           config = ActiveRecord::Base.configurations.configs_for(
             env_name: Rails.env,
@@ -48,6 +48,10 @@ module ActiveRecord
           )
 
           Array(config&.migrations_paths).first
+        end
+
+        def database
+          options.fetch(:database, ActiveRecord.default_database_for_generators)
         end
     end
   end

--- a/activerecord/lib/rails/generators/active_record/model/model_generator.rb
+++ b/activerecord/lib/rails/generators/active_record/model/model_generator.rb
@@ -75,7 +75,7 @@ module ActiveRecord
         end
 
         def database
-          options[:database]
+          options.fetch(:database, ActiveRecord.default_database_for_generators)
         end
 
         def parent

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -1122,6 +1122,11 @@ end
 config.active_record.migration_strategy = CustomMigrationStrategy
 ```
 
+#### `config.active_record.default_database_for_generators`
+
+Controls the default database for which new migrations / models get created when using the generator.
+The default value is `nil`.
+
 #### `config.active_record.lock_optimistically`
 
 Controls whether Active Record will use optimistic locking and is `true` by default.

--- a/railties/test/generators/generators_test_helper.rb
+++ b/railties/test/generators/generators_test_helper.rb
@@ -60,6 +60,13 @@ module GeneratorsTestHelper
     ActiveRecord::Base.configurations = original_configurations
   end
 
+  def with_default_database_for_generators(database_name = "secondary")
+    Rails.application.config.active_record.default_database_for_generators = database_name
+    yield
+  ensure
+    Rails.application.config.active_record.default_database_for_generators = nil
+  end
+
   def copy_routes
     routes = File.expand_path("../../lib/rails/generators/rails/app/templates/config/routes.rb.tt", __dir__)
     destination = File.join(destination_root, "config")

--- a/railties/test/generators/migration_generator_test.rb
+++ b/railties/test/generators/migration_generator_test.rb
@@ -327,6 +327,22 @@ class MigrationGeneratorTest < Rails::Generators::TestCase
     end
   end
 
+  def test_database_puts_migrations_in_configured_migrations_paths
+    default_database = "random"
+
+    with_default_database_for_generators(default_database) do
+      with_database_configuration(default_database) do
+        run_generator ["create_books"]
+
+        assert_migration "db/#{default_database}_migrate/create_books.rb" do |content|
+          assert_method :change, content do |change|
+            assert_match(/create_table :books/, change)
+          end
+        end
+      end
+    end
+  end
+
   def test_should_create_empty_migrations_if_name_not_start_with_add_or_remove_or_create
     migration = "delete_books"
     run_generator [migration, "title:string", "content:text"]

--- a/railties/test/generators/model_generator_test.rb
+++ b/railties/test/generators/model_generator_test.rb
@@ -154,6 +154,20 @@ class ModelGeneratorTest < Rails::Generators::TestCase
     assert_file "app/models/admin/account.rb", /class Admin::Account < ApplicationRecord/
   end
 
+  def test_model_with_custom_default_database
+    default_database = "random"
+
+    with_default_database_for_generators(default_database) do
+      with_database_configuration(default_database) do
+        run_generator
+
+        assert_file "app/models/random_record.rb", /class RandomRecord < ApplicationRecord/
+        assert_file "app/models/account.rb", /class Account < RandomRecord/
+        assert_migration "db/#{default_database}_migrate/create_accounts.rb", /class CreateAccounts < ActiveRecord::Migration\[[0-9.]+\]/
+      end
+    end
+  end
+
   def test_migration
     run_generator
     assert_migration "db/migrate/create_accounts.rb", /class CreateAccounts < ActiveRecord::Migration\[[0-9.]+\]/


### PR DESCRIPTION
### Motivation / Background

This PR defines a new Active Record configuration, to tune the default database that gets used when generating migrations.

Applications that have sharded DBs, usually define a _primary_ database where most of the metadata / routing tables are, while keeping most of the data in the sharded DB instances. In these scenarios, most if not all of the schema-changes are created to target the sharded DB schemas, not the _primary_ one.

Making the default database migrations point to, configurable, simplifies developer experience.

### Additional information

The lack of this configuration option is making Shopify to monkey patch the `MigrationGenerator` class.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
