### PR TITLE
Refactor InternalMetadata, MigrationContext to belong to the pool

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -173,6 +173,22 @@ module ActiveRecord
         @reaper.run
       end
 
+      def migration_context # :nodoc:
+        MigrationContext.new(migrations_paths, schema_migration, internal_metadata)
+      end
+
+      def migrations_paths # :nodoc:
+        db_config.migrations_paths || Migrator.migrations_paths
+      end
+
+      def schema_migration # :nodoc:
+        SchemaMigration.new(self)
+      end
+
+      def internal_metadata # :nodoc:
+        InternalMetadata.new(self)
+      end
+
       # Retrieve the connection associated with the current thread, or call
       # #checkout to obtain one if necessary.
       #

--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -214,7 +214,7 @@ module ActiveRecord
       end
 
       def truncate_tables(*table_names) # :nodoc:
-        table_names -= [schema_migration.table_name, internal_metadata.table_name]
+        table_names -= [pool.schema_migration.table_name, pool.internal_metadata.table_name]
 
         return if table_names.empty?
 

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -1317,7 +1317,7 @@ module ActiveRecord
       end
 
       def dump_schema_information # :nodoc:
-        versions = schema_migration.versions
+        versions = pool.schema_migration.versions
         insert_versions_sql(versions) if versions.any?
       end
 
@@ -1327,8 +1327,9 @@ module ActiveRecord
 
       def assume_migrated_upto_version(version)
         version = version.to_i
-        sm_table = quote_table_name(schema_migration.table_name)
+        sm_table = quote_table_name(pool.schema_migration.table_name)
 
+        migration_context = pool.migration_context
         migrated = migration_context.get_all_versions
         versions = migration_context.migrations.map(&:version)
 
@@ -1838,7 +1839,7 @@ module ActiveRecord
         end
 
         def insert_versions_sql(versions)
-          sm_table = quote_table_name(schema_migration.table_name)
+          sm_table = quote_table_name(pool.schema_migration.table_name)
 
           if versions.is_a?(Array)
             sql = +"INSERT INTO #{sm_table} (version) VALUES\n"

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -211,10 +211,6 @@ module ActiveRecord
         @config[:replica] || false
       end
 
-      def use_metadata_table?
-        @config.fetch(:use_metadata_table, true)
-      end
-
       def connection_retries
         (@config[:connection_retries] || 1).to_i
       end
@@ -240,22 +236,6 @@ module ActiveRecord
         return false if connection_class.nil?
 
         connection_class.current_preventing_writes
-      end
-
-      def migrations_paths # :nodoc:
-        @config[:migrations_paths] || Migrator.migrations_paths
-      end
-
-      def migration_context # :nodoc:
-        MigrationContext.new(migrations_paths, schema_migration, internal_metadata)
-      end
-
-      def schema_migration # :nodoc:
-        SchemaMigration.new(self)
-      end
-
-      def internal_metadata # :nodoc:
-        InternalMetadata.new(self)
       end
 
       def prepared_statements?
@@ -872,7 +852,7 @@ module ActiveRecord
       # numbered migration that has been executed, or 0 if no schema
       # information is present / the database is empty.
       def schema_version
-        migration_context.current_version
+        pool.migration_context.current_version
       end
 
       class << self

--- a/activerecord/lib/active_record/database_configurations/database_config.rb
+++ b/activerecord/lib/active_record/database_configurations/database_config.rb
@@ -91,6 +91,10 @@ module ActiveRecord
       def schema_cache_path
         raise NotImplementedError
       end
+
+      def use_metadata_table?
+        raise NotImplementedError
+      end
     end
   end
 end

--- a/activerecord/lib/active_record/database_configurations/hash_config.rb
+++ b/activerecord/lib/active_record/database_configurations/hash_config.rb
@@ -154,6 +154,10 @@ module ActiveRecord
         !replica? && !!configuration_hash.fetch(:database_tasks, true)
       end
 
+      def use_metadata_table? # :nodoc:
+        configuration_hash.fetch(:use_metadata_table, true)
+      end
+
       private
         def schema_file_type(format)
           case format

--- a/activerecord/lib/active_record/migration/pending_migration_connection.rb
+++ b/activerecord/lib/active_record/migration/pending_migration_connection.rb
@@ -2,10 +2,10 @@
 
 module ActiveRecord
   class PendingMigrationConnection # :nodoc:
-    def self.establish_temporary_connection(db_config, &block)
+    def self.with_temporary_pool(db_config, &block)
       pool = ActiveRecord::Base.connection_handler.establish_connection(db_config, owner_name: self)
 
-      yield pool.connection
+      yield pool
     ensure
       ActiveRecord::Base.connection_handler.remove_connection_pool(self.name)
     end

--- a/activerecord/lib/active_record/schema.rb
+++ b/activerecord/lib/active_record/schema.rb
@@ -52,14 +52,16 @@ module ActiveRecord
       end
 
       def define(info, &block) # :nodoc:
-        instance_eval(&block)
+        connection_pool.with_connection do |connection|
+          instance_eval(&block)
 
-        connection.schema_migration.create_table
-        if info[:version].present?
-          connection.assume_migrated_upto_version(info[:version])
+          connection_pool.schema_migration.create_table
+          if info[:version].present?
+            connection.assume_migrated_upto_version(info[:version])
+          end
+
+          connection_pool.internal_metadata.create_table_and_set_flags(connection_pool.migration_context.current_environment)
         end
-
-        connection.internal_metadata.create_table_and_set_flags(connection.migration_context.current_environment)
       end
     end
 

--- a/activerecord/test/cases/active_record_schema_test.rb
+++ b/activerecord/test/cases/active_record_schema_test.rb
@@ -9,7 +9,8 @@ class ActiveRecordSchemaTest < ActiveRecord::TestCase
     @original_verbose = ActiveRecord::Migration.verbose
     ActiveRecord::Migration.verbose = false
     @connection = ActiveRecord::Base.connection
-    @schema_migration = @connection.schema_migration
+    @pool = ActiveRecord::Base.connection_pool
+    @schema_migration = @pool.schema_migration
     @schema_migration.delete_all_versions
   end
 
@@ -72,7 +73,7 @@ class ActiveRecordSchemaTest < ActiveRecord::TestCase
         t.column :flavor, :string
       end
     end
-    assert_equal 7, @connection.migration_context.current_version
+    assert_equal 7, @pool.migration_context.current_version
   ensure
     ActiveRecord::Base.table_name_prefix = old_table_name_prefix
     @connection.drop_table :nep_fruits

--- a/activerecord/test/cases/adapters/abstract_mysql_adapter/schema_migrations_test.rb
+++ b/activerecord/test/cases/adapters/abstract_mysql_adapter/schema_migrations_test.rb
@@ -4,7 +4,8 @@ require "cases/helper"
 
 class SchemaMigrationsTest < ActiveRecord::AbstractMysqlTestCase
   def setup
-    @schema_migration = ActiveRecord::Base.connection.schema_migration
+    @pool = ActiveRecord::Base.connection_pool
+    @schema_migration = @pool.schema_migration
   end
 
   def test_renaming_index_on_foreign_key
@@ -30,7 +31,7 @@ class SchemaMigrationsTest < ActiveRecord::AbstractMysqlTestCase
 
   def test_initializes_internal_metadata_for_encoding_utf8mb4
     with_encoding_utf8mb4 do
-      internal_metadata = connection.internal_metadata
+      internal_metadata = @pool.internal_metadata
       table_name = internal_metadata.table_name
       connection.drop_table table_name, if_exists: true
 
@@ -39,7 +40,7 @@ class SchemaMigrationsTest < ActiveRecord::AbstractMysqlTestCase
       assert connection.column_exists?(table_name, :key, :string)
     end
   ensure
-    connection.internal_metadata[:environment] = connection.migration_context.current_environment
+    @pool.internal_metadata[:environment] = @pool.migration_context.current_environment
   end
 
   private

--- a/activerecord/test/cases/adapters/abstract_mysql_adapter/table_options_test.rb
+++ b/activerecord/test/cases/adapters/abstract_mysql_adapter/table_options_test.rb
@@ -93,7 +93,7 @@ class DefaultEngineOptionTest < ActiveRecord::AbstractMysqlTestCase
     ActiveRecord::Base.logger       = @logger_was
     ActiveRecord::Migration.verbose = @verbose_was
     ActiveRecord::Base.connection.drop_table "mysql_table_options", if_exists: true
-    ActiveRecord::Base.connection.schema_migration.delete_all_versions rescue nil
+    ActiveRecord::Base.connection_pool.schema_migration.delete_all_versions rescue nil
   end
 
   test "new migrations do not contain default ENGINE=InnoDB option" do
@@ -113,8 +113,8 @@ class DefaultEngineOptionTest < ActiveRecord::AbstractMysqlTestCase
       end
     end.new
 
-    connection = ActiveRecord::Base.connection
-    ActiveRecord::Migrator.new(:up, [migration], connection.schema_migration, connection.internal_metadata).migrate
+    pool = ActiveRecord::Base.connection_pool
+    ActiveRecord::Migrator.new(:up, [migration], pool.schema_migration, pool.internal_metadata).migrate
 
     assert_match %r{ENGINE=InnoDB}, @log.string
 

--- a/activerecord/test/cases/adapters/postgresql/extension_migration_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/extension_migration_test.rb
@@ -27,6 +27,7 @@ class PostgresqlExtensionMigrationTest < ActiveRecord::PostgreSQLTestCase
     super
 
     @connection = ActiveRecord::Base.connection
+    @pool = ActiveRecord::Base.connection_pool
 
     @old_table_name_prefix = ActiveRecord::Base.table_name_prefix
     @old_table_name_suffix = ActiveRecord::Base.table_name_suffix
@@ -34,12 +35,12 @@ class PostgresqlExtensionMigrationTest < ActiveRecord::PostgreSQLTestCase
     ActiveRecord::Base.table_name_prefix = "p_"
     ActiveRecord::Base.table_name_suffix = "_s"
 
-    @connection.schema_migration.delete_all_versions rescue nil
+    @pool.schema_migration.delete_all_versions rescue nil
     ActiveRecord::Migration.verbose = false
   end
 
   def teardown
-    @connection.schema_migration.delete_all_versions rescue nil
+    @pool.schema_migration.delete_all_versions rescue nil
     ActiveRecord::Migration.verbose = true
 
     ActiveRecord::Base.table_name_prefix = @old_table_name_prefix
@@ -52,7 +53,7 @@ class PostgresqlExtensionMigrationTest < ActiveRecord::PostgreSQLTestCase
     @connection.disable_extension("hstore")
 
     migrations = [EnableHstore.new(nil, 1)]
-    ActiveRecord::Migrator.new(:up, migrations, @connection.schema_migration, @connection.internal_metadata).migrate
+    ActiveRecord::Migrator.new(:up, migrations, @pool.schema_migration, @pool.internal_metadata).migrate
     assert @connection.extension_enabled?("hstore"), "extension hstore should be enabled"
   end
 
@@ -61,7 +62,7 @@ class PostgresqlExtensionMigrationTest < ActiveRecord::PostgreSQLTestCase
     @connection.create_schema "other_schema"
 
     migrations = [EnableHstoreInSchema.new(nil, 1)]
-    ActiveRecord::Migrator.new(:up, migrations, @connection.schema_migration, @connection.internal_metadata).migrate
+    ActiveRecord::Migrator.new(:up, migrations, @pool.schema_migration, @pool.internal_metadata).migrate
 
     assert @connection.extension_enabled?("hstore"), "extension hstore should be enabled"
   ensure
@@ -73,7 +74,7 @@ class PostgresqlExtensionMigrationTest < ActiveRecord::PostgreSQLTestCase
     @connection.enable_extension("hstore")
 
     migrations = [DisableHstore.new(nil, 1)]
-    ActiveRecord::Migrator.new(:up, migrations, @connection.schema_migration, @connection.internal_metadata).migrate
+    ActiveRecord::Migrator.new(:up, migrations, @pool.schema_migration, @pool.internal_metadata).migrate
     assert_not @connection.extension_enabled?("hstore"), "extension hstore should not be enabled"
   end
 

--- a/activerecord/test/cases/adapters/postgresql/uuid_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/uuid_test.rb
@@ -304,15 +304,15 @@ class PostgresqlUUIDGenerationTest < ActiveRecord::PostgreSQLTestCase
       end
     end.new
 
-    connection = ActiveRecord::Base.connection
-    ActiveRecord::Migrator.new(:up, [migration], connection.schema_migration, connection.internal_metadata).migrate
+    pool = ActiveRecord::Base.connection_pool
+    ActiveRecord::Migrator.new(:up, [migration], pool.schema_migration, pool.internal_metadata).migrate
 
     schema = dump_table_schema "pg_uuids_4"
     assert_match(/\bcreate_table "pg_uuids_4", id: :uuid, default: -> { "uuid_generate_v4\(\)" }/, schema)
   ensure
     drop_table "pg_uuids_4"
     ActiveRecord::Migration.verbose = @verbose_was
-    ActiveRecord::Base.connection.schema_migration.delete_all_versions
+    ActiveRecord::Base.connection_pool.schema_migration.delete_all_versions
   end
   uses_transaction :test_schema_dumper_for_uuid_primary_key_default_in_legacy_migration
 end
@@ -356,15 +356,15 @@ class PostgresqlUUIDTestNilDefault < ActiveRecord::PostgreSQLTestCase
       end
     end.new
 
-    connection = ActiveRecord::Base.connection
-    ActiveRecord::Migrator.new(:up, [migration], connection.schema_migration, connection.internal_metadata).migrate
+    pool = ActiveRecord::Base.connection_pool
+    ActiveRecord::Migrator.new(:up, [migration], pool.schema_migration, pool.internal_metadata).migrate
 
     schema = dump_table_schema "pg_uuids_4"
     assert_match(/\bcreate_table "pg_uuids_4", id: :uuid, default: nil/, schema)
   ensure
     drop_table "pg_uuids_4"
     ActiveRecord::Migration.verbose = @verbose_was
-    ActiveRecord::Base.connection.schema_migration.delete_all_versions
+    ActiveRecord::Base.connection_pool.schema_migration.delete_all_versions
   end
   uses_transaction :test_schema_dumper_for_uuid_primary_key_with_default_nil_in_legacy_migration
 end

--- a/activerecord/test/cases/migration/compatibility_test.rb
+++ b/activerecord/test/cases/migration/compatibility_test.rb
@@ -16,8 +16,9 @@ module ActiveRecord
       def setup
         super
         @connection = ActiveRecord::Base.connection
-        @schema_migration = @connection.schema_migration
-        @internal_metadata = @connection.internal_metadata
+        @pool = ActiveRecord::Base.connection_pool
+        @schema_migration = @pool.schema_migration
+        @internal_metadata = @pool.internal_metadata
         @verbose_was = ActiveRecord::Migration.verbose
         ActiveRecord::Migration.verbose = false
 
@@ -828,8 +829,9 @@ class BaseCompatibilityTest < ActiveRecord::TestCase
 
   def setup
     @connection = ActiveRecord::Base.connection
-    @schema_migration = @connection.schema_migration
-    @internal_metadata = @connection.internal_metadata
+    @pool = ActiveRecord::Base.connection_pool
+    @schema_migration = @pool.schema_migration
+    @internal_metadata = @pool.internal_metadata
 
     @verbose_was = ActiveRecord::Migration.verbose
     ActiveRecord::Migration.verbose = false
@@ -916,8 +918,9 @@ module LegacyPolymorphicReferenceIndexTestCases
 
   def setup
     @connection = ActiveRecord::Base.connection
-    @schema_migration = @connection.schema_migration
-    @internal_metadata = @connection.internal_metadata
+    @pool = ActiveRecord::Base.connection_pool
+    @schema_migration = @pool.schema_migration
+    @internal_metadata = @pool.internal_metadata
     @verbose_was = ActiveRecord::Migration.verbose
     ActiveRecord::Migration.verbose = false
 
@@ -1055,7 +1058,7 @@ module LegacyPrimaryKeyTestCases
     def teardown
       @migration.migrate(:down) if @migration
       ActiveRecord::Migration.verbose = @verbose_was
-      ActiveRecord::Base.connection.schema_migration.delete_all_versions rescue nil
+      ActiveRecord::Base.connection_pool.schema_migration.delete_all_versions rescue nil
       LegacyPrimaryKey.reset_column_information
     end
 

--- a/activerecord/test/cases/migration/logger_test.rb
+++ b/activerecord/test/cases/migration/logger_test.rb
@@ -17,14 +17,14 @@ module ActiveRecord
 
       def setup
         super
-        @schema_migration = ActiveRecord::Base.connection.schema_migration
+        @schema_migration = ActiveRecord::Base.connection_pool.schema_migration
         @schema_migration.create_table
         @schema_migration.delete_all_versions
-        @internal_metadata = ActiveRecord::Base.connection.internal_metadata
+        @internal_metadata = ActiveRecord::Base.connection_pool.internal_metadata
       end
 
       teardown do
-        @schema_migration.delete_all_versions
+        @schema_migration&.delete_all_versions
       end
 
       def test_migration_should_be_run_without_logger

--- a/activerecord/test/cases/migration/pending_migrations_test.rb
+++ b/activerecord/test/cases/migration/pending_migrations_test.rb
@@ -24,7 +24,7 @@ module ActiveRecord
         end
 
         def run_migrations
-          migrator = Base.connection.migration_context
+          migrator = Base.connection_pool.migration_context
           capture(:stdout) { migrator.migrate }
         end
 

--- a/activerecord/test/cases/migration_test.rb
+++ b/activerecord/test/cases/migration_test.rb
@@ -44,8 +44,9 @@ class MigrationTest < ActiveRecord::TestCase
     end
     Reminder.reset_column_information
     @verbose_was, ActiveRecord::Migration.verbose = ActiveRecord::Migration.verbose, false
-    @schema_migration = ActiveRecord::Base.connection.schema_migration
-    @internal_metadata = ActiveRecord::Base.connection.internal_metadata
+    @pool = ActiveRecord::Base.connection_pool
+    @schema_migration = @pool.schema_migration
+    @internal_metadata = @pool.internal_metadata
     ActiveRecord::Base.schema_cache.clear!
   end
 
@@ -675,7 +676,7 @@ class MigrationTest < ActiveRecord::TestCase
   end
 
   def test_internal_metadata_stores_environment
-    current_env     = env_name(@internal_metadata.connection)
+    current_env     = env_name(@pool)
     migrations_path = MIGRATIONS_ROOT + "/valid"
     migrator = ActiveRecord::MigrationContext.new(migrations_path, @schema_migration, @internal_metadata)
 
@@ -685,7 +686,7 @@ class MigrationTest < ActiveRecord::TestCase
 
   def test_internal_metadata_stores_environment_when_migration_fails
     @internal_metadata.delete_all_entries
-    current_env = env_name(@internal_metadata.connection)
+    current_env = env_name(@pool)
 
     migration = Class.new(ActiveRecord::Migration::Current) {
       def version; 101 end
@@ -703,7 +704,7 @@ class MigrationTest < ActiveRecord::TestCase
     @internal_metadata.delete_all_entries
     @internal_metadata[:foo] = "bar"
 
-    current_env     = env_name(@internal_metadata.connection)
+    current_env = env_name(@pool)
     migrations_path = MIGRATIONS_ROOT + "/valid"
 
     migrator = ActiveRecord::MigrationContext.new(migrations_path, @schema_migration, @internal_metadata)
@@ -714,10 +715,9 @@ class MigrationTest < ActiveRecord::TestCase
 
   def test_internal_metadata_not_used_when_not_enabled
     @internal_metadata.drop_table
-    original_config = ActiveRecord::Base.connection.instance_variable_get("@config")
+    original_config = @pool.db_config.instance_variable_get(:@configuration_hash)
     modified_config = original_config.dup.merge(use_metadata_table: false)
-
-    ActiveRecord::Base.connection.instance_variable_set("@config", modified_config)
+    @pool.db_config.instance_variable_set(:@configuration_hash, modified_config)
 
     assert_not @internal_metadata.enabled?
     assert_not @internal_metadata.table_exists?
@@ -729,7 +729,7 @@ class MigrationTest < ActiveRecord::TestCase
     assert_not @internal_metadata[:environment]
     assert_not @internal_metadata.table_exists?
   ensure
-    ActiveRecord::Base.connection.instance_variable_set("@config", original_config)
+    @pool.db_config.instance_variable_set(:@configuration_hash, original_config)
     @internal_metadata.create_table
   end
 
@@ -742,18 +742,18 @@ class MigrationTest < ActiveRecord::TestCase
 
   def test_updating_an_existing_entry_into_internal_metadata
     @internal_metadata[:version] = "foo"
-    updated_at = @internal_metadata.send(:select_entry, :version)["updated_at"]
+    updated_at = @internal_metadata.send(:select_entry, @pool.connection, :version)["updated_at"]
     assert_equal "foo", @internal_metadata[:version]
 
     # same version doesn't update timestamps
     @internal_metadata[:version] = "foo"
     assert_equal "foo", @internal_metadata[:version]
-    assert_equal updated_at, @internal_metadata.send(:select_entry, :version)["updated_at"]
+    assert_equal updated_at, @internal_metadata.send(:select_entry, @pool.connection, :version)["updated_at"]
 
     # updated version updates timestamps
     @internal_metadata[:version] = "not_foo"
     assert_equal "not_foo", @internal_metadata[:version]
-    assert_not_equal updated_at, @internal_metadata.send(:select_entry, :version)["updated_at"]
+    assert_not_equal updated_at, @internal_metadata.send(:select_entry, @pool.connection, :version)["updated_at"]
   ensure
     @internal_metadata.delete_all_entries
   end
@@ -762,22 +762,24 @@ class MigrationTest < ActiveRecord::TestCase
     @internal_metadata.drop_table
     assert_not_predicate @internal_metadata, :table_exists?
 
-    @internal_metadata.connection.transaction do
-      @internal_metadata.create_table
-      assert_predicate @internal_metadata, :table_exists?
+    @pool.with_connection do |connection|
+      connection.transaction do
+        @internal_metadata.create_table
+        assert_predicate @internal_metadata, :table_exists?
 
-      @internal_metadata[:version] = "foo"
-      assert_equal "foo", @internal_metadata[:version]
-      raise ActiveRecord::Rollback
-    end
+        @internal_metadata[:version] = "foo"
+        assert_equal "foo", @internal_metadata[:version]
+        raise ActiveRecord::Rollback
+      end
 
-    @internal_metadata.connection.transaction do
-      @internal_metadata.create_table
-      assert_predicate @internal_metadata, :table_exists?
+      connection.transaction do
+        @internal_metadata.create_table
+        assert_predicate @internal_metadata, :table_exists?
 
-      @internal_metadata[:version] = "bar"
-      assert_equal "bar", @internal_metadata[:version]
-      raise ActiveRecord::Rollback
+        @internal_metadata[:version] = "bar"
+        assert_equal "bar", @internal_metadata[:version]
+        raise ActiveRecord::Rollback
+      end
     end
   ensure
     @internal_metadata.create_table
@@ -787,20 +789,22 @@ class MigrationTest < ActiveRecord::TestCase
     @schema_migration.drop_table
     assert_not_predicate @schema_migration, :table_exists?
 
-    @schema_migration.connection.transaction do
-      @schema_migration.create_table
-      assert_predicate @schema_migration, :table_exists?
+    @pool.with_connection do |connection|
+      connection.transaction do
+        @schema_migration.create_table
+        assert_predicate @schema_migration, :table_exists?
 
-      assert_equal "foo", @schema_migration.create_version("foo")
-      raise ActiveRecord::Rollback
-    end
+        assert_equal "foo", @schema_migration.create_version("foo")
+        raise ActiveRecord::Rollback
+      end
 
-    @schema_migration.connection.transaction do
-      @schema_migration.create_table
-      assert_predicate @schema_migration, :table_exists?
+      connection.transaction do
+        @schema_migration.create_table
+        assert_predicate @schema_migration, :table_exists?
 
-      assert_equal "bar", @schema_migration.create_version("bar")
-      raise ActiveRecord::Rollback
+        assert_equal "bar", @schema_migration.create_version("bar")
+        raise ActiveRecord::Rollback
+      end
     end
   ensure
     @schema_migration.create_table
@@ -1142,8 +1146,8 @@ class MigrationTest < ActiveRecord::TestCase
       other_process.join
     end
 
-    def env_name(connection)
-      connection.pool.db_config.env_name
+    def env_name(pool)
+      pool.db_config.env_name
     end
 end
 
@@ -1789,8 +1793,8 @@ class CopyMigrationsTest < ActiveRecord::TestCase
   class MigrationValidationTest < ActiveRecord::TestCase
     def setup
       @verbose_was, ActiveRecord::Migration.verbose = ActiveRecord::Migration.verbose, false
-      @schema_migration = ActiveRecord::Base.connection.schema_migration
-      @internal_metadata = ActiveRecord::Base.connection.internal_metadata
+      @schema_migration = ActiveRecord::Base.connection_pool.schema_migration
+      @internal_metadata = ActiveRecord::Base.connection_pool.internal_metadata
       @active_record_validate_timestamps_was = ActiveRecord.validate_migration_timestamps
       ActiveRecord.validate_migration_timestamps = true
       ActiveRecord::Base.schema_cache.clear!

--- a/activerecord/test/cases/migrator_test.rb
+++ b/activerecord/test/cases/migrator_test.rb
@@ -21,10 +21,11 @@ class MigratorTest < ActiveRecord::TestCase
 
   def setup
     super
-    @schema_migration = ActiveRecord::Base.connection.schema_migration
+    @pool = ActiveRecord::Base.connection_pool
+    @schema_migration = @pool.schema_migration
     @schema_migration.create_table
     @schema_migration.delete_all_versions rescue nil
-    @internal_metadata = ActiveRecord::Base.connection.internal_metadata
+    @internal_metadata = @pool.internal_metadata
     @verbose_was = ActiveRecord::Migration.verbose
     ActiveRecord::Migration.message_count = 0
     ActiveRecord::Migration.class_eval do
@@ -89,9 +90,7 @@ class MigratorTest < ActiveRecord::TestCase
   end
 
   def test_finds_migrations
-    schema_migration = ActiveRecord::Base.connection.schema_migration
-    internal_metadata = ActiveRecord::Base.connection.internal_metadata
-    migrations = ActiveRecord::MigrationContext.new(MIGRATIONS_ROOT + "/valid", schema_migration, internal_metadata).migrations
+    migrations = ActiveRecord::MigrationContext.new(MIGRATIONS_ROOT + "/valid", @schema_migration, @internal_metadata).migrations
 
     [[1, "ValidPeopleHaveLastNames"], [2, "WeNeedReminders"], [3, "InnocentJointable"]].each_with_index do |pair, i|
       assert_equal migrations[i].version, pair.first
@@ -100,9 +99,7 @@ class MigratorTest < ActiveRecord::TestCase
   end
 
   def test_finds_migrations_in_subdirectories
-    schema_migration = ActiveRecord::Base.connection.schema_migration
-    internal_metadata = ActiveRecord::Base.connection.internal_metadata
-    migrations = ActiveRecord::MigrationContext.new(MIGRATIONS_ROOT + "/valid_with_subdirectories", schema_migration, internal_metadata).migrations
+    migrations = ActiveRecord::MigrationContext.new(MIGRATIONS_ROOT + "/valid_with_subdirectories", @schema_migration, @internal_metadata).migrations
 
     [[1, "ValidPeopleHaveLastNames"], [2, "WeNeedReminders"], [3, "InnocentJointable"]].each_with_index do |pair, i|
       assert_equal migrations[i].version, pair.first
@@ -111,10 +108,8 @@ class MigratorTest < ActiveRecord::TestCase
   end
 
   def test_finds_migrations_from_two_directories
-    schema_migration = ActiveRecord::Base.connection.schema_migration
-    internal_metadata = ActiveRecord::Base.connection.internal_metadata
     directories = [MIGRATIONS_ROOT + "/valid_with_timestamps", MIGRATIONS_ROOT + "/to_copy_with_timestamps"]
-    migrations = ActiveRecord::MigrationContext.new(directories, schema_migration, internal_metadata).migrations
+    migrations = ActiveRecord::MigrationContext.new(directories, @schema_migration, @internal_metadata).migrations
 
     [[20090101010101, "PeopleHaveHobbies"],
      [20090101010202, "PeopleHaveDescriptions"],
@@ -127,18 +122,14 @@ class MigratorTest < ActiveRecord::TestCase
   end
 
   def test_finds_migrations_in_numbered_directory
-    schema_migration = ActiveRecord::Base.connection.schema_migration
-    internal_metadata = ActiveRecord::Base.connection.internal_metadata
-    migrations = ActiveRecord::MigrationContext.new(MIGRATIONS_ROOT + "/10_urban", schema_migration, internal_metadata).migrations
+    migrations = ActiveRecord::MigrationContext.new(MIGRATIONS_ROOT + "/10_urban", @schema_migration, @internal_metadata).migrations
     assert_equal 9, migrations[0].version
     assert_equal "AddExpressions", migrations[0].name
   end
 
   def test_relative_migrations
-    schema_migration = ActiveRecord::Base.connection.schema_migration
-    internal_metadata = ActiveRecord::Base.connection.internal_metadata
     list = Dir.chdir(MIGRATIONS_ROOT) do
-      ActiveRecord::MigrationContext.new("valid", schema_migration, internal_metadata).migrations
+      ActiveRecord::MigrationContext.new("valid", @schema_migration, @internal_metadata).migrations
     end
 
     migration_proxy = list.find { |item|
@@ -158,8 +149,6 @@ class MigratorTest < ActiveRecord::TestCase
 
   def test_migrations_status
     path = MIGRATIONS_ROOT + "/valid"
-    schema_migration = ActiveRecord::Base.connection.schema_migration
-    internal_metadata = ActiveRecord::Base.connection.internal_metadata
 
     @schema_migration.create_version(2)
     @schema_migration.create_version(10)
@@ -169,14 +158,11 @@ class MigratorTest < ActiveRecord::TestCase
       ["up",   "002", "We need reminders"],
       ["down", "003", "Innocent jointable"],
       ["up",   "010", "********** NO FILE **********"],
-    ], ActiveRecord::MigrationContext.new(path, schema_migration, internal_metadata).migrations_status
+    ], ActiveRecord::MigrationContext.new(path, @schema_migration, @internal_metadata).migrations_status
   end
 
   def test_migrations_status_order_new_and_old_version
     path = MIGRATIONS_ROOT + "/old_and_new_versions"
-    schema_migration = ActiveRecord::Base.connection.schema_migration
-    internal_metadata = ActiveRecord::Base.connection.internal_metadata
-
     @schema_migration.create_version(230)
     @schema_migration.create_version(231)
     @schema_migration.create_version(20210716122844)
@@ -187,13 +173,11 @@ class MigratorTest < ActiveRecord::TestCase
       ["up", "231", "Add people last name"],
       ["up", "20210716122844", "Add people description"],
       ["up", "20210716123013", "Add people number of legs"],
-    ], ActiveRecord::MigrationContext.new(path, schema_migration, internal_metadata).migrations_status
+    ], ActiveRecord::MigrationContext.new(path, @schema_migration, @internal_metadata).migrations_status
   end
 
   def test_migrations_status_order_new_and_old_version_applied_out_of_order
     path = MIGRATIONS_ROOT + "/old_and_new_versions"
-    schema_migration = ActiveRecord::Base.connection.schema_migration
-    internal_metadata = ActiveRecord::Base.connection.internal_metadata
 
     @schema_migration.create_version(230)
     @schema_migration.create_version(231)
@@ -209,13 +193,11 @@ class MigratorTest < ActiveRecord::TestCase
       ["up", "231", "Add people last name"],
       ["down", "20210716122844", "Add people description"],
       ["up", "20210716123013", "Add people number of legs"],
-    ], ActiveRecord::MigrationContext.new(path, schema_migration, internal_metadata).migrations_status
+    ], ActiveRecord::MigrationContext.new(path, @schema_migration, @internal_metadata).migrations_status
   end
 
   def test_migrations_status_in_subdirectories
     path = MIGRATIONS_ROOT + "/valid_with_subdirectories"
-    schema_migration = ActiveRecord::Base.connection.schema_migration
-    internal_metadata = ActiveRecord::Base.connection.internal_metadata
 
     @schema_migration.create_version(2)
     @schema_migration.create_version(10)
@@ -225,14 +207,12 @@ class MigratorTest < ActiveRecord::TestCase
       ["up",   "002", "We need reminders"],
       ["down", "003", "Innocent jointable"],
       ["up",   "010", "********** NO FILE **********"],
-    ], ActiveRecord::MigrationContext.new(path, schema_migration, internal_metadata).migrations_status
+    ], ActiveRecord::MigrationContext.new(path, @schema_migration, @internal_metadata).migrations_status
   end
 
   def test_migrations_status_with_schema_define_in_subdirectories
     path = MIGRATIONS_ROOT + "/valid_with_subdirectories"
     prev_paths = ActiveRecord::Migrator.migrations_paths
-    schema_migration = ActiveRecord::Base.connection.schema_migration
-    internal_metadata = ActiveRecord::Base.connection.internal_metadata
     ActiveRecord::Migrator.migrations_paths = path
 
     ActiveRecord::Schema.define(version: 3) do
@@ -242,15 +222,13 @@ class MigratorTest < ActiveRecord::TestCase
       ["up", "001", "Valid people have last names"],
       ["up", "002", "We need reminders"],
       ["up", "003", "Innocent jointable"],
-    ], ActiveRecord::MigrationContext.new(path, schema_migration, internal_metadata).migrations_status
+    ], ActiveRecord::MigrationContext.new(path, @schema_migration, @internal_metadata).migrations_status
   ensure
     ActiveRecord::Migrator.migrations_paths = prev_paths
   end
 
   def test_migrations_status_from_two_directories
     paths = [MIGRATIONS_ROOT + "/valid_with_timestamps", MIGRATIONS_ROOT + "/to_copy_with_timestamps"]
-    schema_migration = ActiveRecord::Base.connection.schema_migration
-    internal_metadata = ActiveRecord::Base.connection.internal_metadata
 
     @schema_migration.create_version("20100101010101")
     @schema_migration.create_version("20160528010101")
@@ -262,7 +240,7 @@ class MigratorTest < ActiveRecord::TestCase
       ["down", "20100201010101", "Valid with timestamps we need reminders"],
       ["down", "20100301010101", "Valid with timestamps innocent jointable"],
       ["up",   "20160528010101", "********** NO FILE **********"],
-    ], ActiveRecord::MigrationContext.new(paths, schema_migration, internal_metadata).migrations_status
+    ], ActiveRecord::MigrationContext.new(paths, @schema_migration, @internal_metadata).migrations_status
   end
 
   def test_migrator_interleaved_migrations
@@ -310,8 +288,8 @@ class MigratorTest < ActiveRecord::TestCase
 
   def test_current_version
     @schema_migration.create_version("1000")
-    schema_migration = ActiveRecord::Base.connection.schema_migration
-    internal_metadata = ActiveRecord::Base.connection.internal_metadata
+    schema_migration = ActiveRecord::Base.connection_pool.schema_migration
+    internal_metadata = ActiveRecord::Base.connection_pool.internal_metadata
     migrator = ActiveRecord::MigrationContext.new("db/migrate", schema_migration, internal_metadata)
     assert_equal 1000, migrator.current_version
   end
@@ -426,7 +404,7 @@ class MigratorTest < ActiveRecord::TestCase
   end
 
   def test_migrator_going_down_due_to_version_target
-    schema_migration = ActiveRecord::Base.connection.schema_migration
+    schema_migration = ActiveRecord::Base.connection_pool.schema_migration
     calls, migrator = migrator_class(3)
     migrator = migrator.new("valid", schema_migration)
 
@@ -443,7 +421,7 @@ class MigratorTest < ActiveRecord::TestCase
   end
 
   def test_migrator_output_when_running_multiple_migrations
-    schema_migration = ActiveRecord::Base.connection.schema_migration
+    schema_migration = ActiveRecord::Base.connection_pool.schema_migration
     _, migrator = migrator_class(3)
     migrator = migrator.new("valid", schema_migration)
 
@@ -459,7 +437,7 @@ class MigratorTest < ActiveRecord::TestCase
   end
 
   def test_migrator_output_when_running_single_migration
-    schema_migration = ActiveRecord::Base.connection.schema_migration
+    schema_migration = ActiveRecord::Base.connection_pool.schema_migration
     _, migrator = migrator_class(1)
     migrator = migrator.new("valid", schema_migration)
 
@@ -469,7 +447,7 @@ class MigratorTest < ActiveRecord::TestCase
   end
 
   def test_migrator_rollback
-    schema_migration = ActiveRecord::Base.connection.schema_migration
+    schema_migration = ActiveRecord::Base.connection_pool.schema_migration
     _, migrator = migrator_class(3)
     migrator = migrator.new("valid", schema_migration)
 
@@ -490,7 +468,7 @@ class MigratorTest < ActiveRecord::TestCase
   end
 
   def test_migrator_db_has_no_schema_migrations_table
-    schema_migration = ActiveRecord::Base.connection.schema_migration
+    schema_migration = ActiveRecord::Base.connection_pool.schema_migration
     _, migrator = migrator_class(3)
     migrator = migrator.new("valid", schema_migration)
 
@@ -501,7 +479,7 @@ class MigratorTest < ActiveRecord::TestCase
   end
 
   def test_migrator_forward
-    schema_migration = ActiveRecord::Base.connection.schema_migration
+    schema_migration = ActiveRecord::Base.connection_pool.schema_migration
     _, migrator = migrator_class(3)
     migrator = migrator.new("/valid", schema_migration)
     migrator.migrate(1)
@@ -518,7 +496,7 @@ class MigratorTest < ActiveRecord::TestCase
     # migrate up to 1
     @schema_migration.create_version("1")
 
-    schema_migration = ActiveRecord::Base.connection.schema_migration
+    schema_migration = ActiveRecord::Base.connection_pool.schema_migration
     calls, migrator = migrator_class(3)
     migrator = migrator.new("valid", schema_migration)
     migrator.migrate
@@ -527,7 +505,7 @@ class MigratorTest < ActiveRecord::TestCase
   end
 
   def test_get_all_versions
-    schema_migration = ActiveRecord::Base.connection.schema_migration
+    schema_migration = ActiveRecord::Base.connection_pool.schema_migration
     _, migrator = migrator_class(3)
     migrator = migrator.new("valid", schema_migration)
 

--- a/activerecord/test/cases/schema_dumper_test.rb
+++ b/activerecord/test/cases/schema_dumper_test.rb
@@ -8,10 +8,10 @@ class SchemaDumperTest < ActiveRecord::TestCase
   self.use_transactional_tests = false
 
   setup do
-    @schema_migration = ActiveRecord::Base.connection.schema_migration
+    @schema_migration = ActiveRecord::Base.connection_pool.schema_migration
     @schema_migration.create_table
 
-    ARUnit2Model.connection.schema_migration.create_table
+    ARUnit2Model.connection_pool.schema_migration.create_table
   end
 
   def standard_dump
@@ -160,7 +160,7 @@ class SchemaDumperTest < ActiveRecord::TestCase
   end
 
   def test_schema_dump_with_regexp_ignored_table
-    output = dump_all_table_schema([/^courses/], connection: ARUnit2Model.connection)
+    output = dump_all_table_schema([/^courses/], pool: ARUnit2Model.connection_pool)
     assert_no_match %r{create_table "courses"}, output
     assert_match %r{create_table "colleges"}, output
     assert_no_match %r{create_table "schema_migrations"}, output
@@ -566,7 +566,7 @@ class SchemaDumperTest < ActiveRecord::TestCase
     migration.migrate(:up)
 
     stream = StringIO.new
-    output = ActiveRecord::SchemaDumper.dump(ActiveRecord::Base.connection, stream).string
+    output = ActiveRecord::SchemaDumper.dump(ActiveRecord::Base.connection_pool, stream).string
 
     assert_match %r{create_table "omg_cats"}, output
     assert_no_match %r{create_table "cats"}, output

--- a/activerecord/test/support/schema_dumping_helper.rb
+++ b/activerecord/test/support/schema_dumping_helper.rb
@@ -2,22 +2,22 @@
 
 module SchemaDumpingHelper
   def dump_table_schema(*tables)
-    connection = ActiveRecord::Base.connection
+    pool = ActiveRecord::Base.connection_pool
     old_ignore_tables = ActiveRecord::SchemaDumper.ignore_tables
-    ActiveRecord::SchemaDumper.ignore_tables = connection.data_sources - tables
+    ActiveRecord::SchemaDumper.ignore_tables = pool.connection.data_sources - tables
 
     output, = capture_io do
-      ActiveRecord::SchemaDumper.dump(connection)
+      ActiveRecord::SchemaDumper.dump(pool)
     end
     output
   ensure
     ActiveRecord::SchemaDumper.ignore_tables = old_ignore_tables
   end
 
-  def dump_all_table_schema(ignore_tables = [], connection: ActiveRecord::Base.connection)
+  def dump_all_table_schema(ignore_tables = [], pool: ActiveRecord::Base.connection_pool)
     old_ignore_tables, ActiveRecord::SchemaDumper.ignore_tables = ActiveRecord::SchemaDumper.ignore_tables, ignore_tables
     output, = capture_io do
-      ActiveRecord::SchemaDumper.dump(connection)
+      ActiveRecord::SchemaDumper.dump(pool)
     end
     output
   ensure

--- a/activestorage/test/database/setup.rb
+++ b/activestorage/test/database/setup.rb
@@ -5,6 +5,6 @@ require_relative "create_groups_migration"
 
 # Writing and reading roles are required for the "previewing on the writer DB" test
 ActiveRecord::Base.connects_to(database: { writing: :primary, reading: :replica })
-ActiveRecord::Base.connection.migration_context.migrate
+ActiveRecord::Base.connection_pool.migration_context.migrate
 ActiveStorageCreateUsers.migrate(:up)
 ActiveStorageCreateGroups.migrate(:up)

--- a/railties/lib/rails/info.rb
+++ b/railties/lib/rails/info.rb
@@ -95,11 +95,11 @@ module Rails
 
     # The name of the database adapter for the current environment.
     property "Database adapter" do
-      ActiveRecord::Base.connection.pool.db_config.adapter
+      ActiveRecord::Base.connection_pool.db_config.adapter
     end
 
     property "Database schema version" do
-      ActiveRecord::Base.connection.migration_context.current_version rescue nil
+      ActiveRecord::Base.connection_pool.migration_context.current_version rescue nil
     end
   end
 end

--- a/railties/test/application/rake/dbs_test.rb
+++ b/railties/test/application/rake/dbs_test.rb
@@ -616,8 +616,8 @@ module ApplicationTests
         app_file "db/schema.rb", ""
         rails "db:setup"
 
-        test_environment = lambda { rails("runner", "-e", "test", "puts ActiveRecord::Base.connection.internal_metadata[:environment]").strip }
-        development_environment = lambda { rails("runner", "puts ActiveRecord::Base.connection.internal_metadata[:environment]").strip }
+        test_environment = lambda { rails("runner", "-e", "test", "puts ActiveRecord::Base.connection_pool.internal_metadata[:environment]").strip }
+        development_environment = lambda { rails("runner", "puts ActiveRecord::Base.connection_pool.internal_metadata[:environment]").strip }
 
         assert_equal "test", test_environment.call
         assert_equal "development", development_environment.call
@@ -637,7 +637,7 @@ module ApplicationTests
         app_file "db/schema.rb", ""
         rails "db:test:prepare"
 
-        test_environment = lambda { rails("runner", "-e", "test", "puts ActiveRecord::Base.connection.internal_metadata[:environment]").strip }
+        test_environment = lambda { rails("runner", "-e", "test", "puts ActiveRecord::Base.connection_pool.internal_metadata[:environment]").strip }
 
         assert_equal "test", test_environment.call
 
@@ -739,8 +739,8 @@ module ApplicationTests
           tables = rails("runner", "p ActiveRecord::Base.connection.tables.sort").strip
           assert_equal('["ar_internal_metadata", "books", "recipes", "schema_migrations"]', tables)
 
-          test_environment = lambda { rails("runner", "-e", "test", "puts ActiveRecord::Base.connection.internal_metadata[:environment]").strip }
-          development_environment = lambda { rails("runner", "puts ActiveRecord::Base.connection.internal_metadata[:environment]").strip }
+          test_environment = lambda { rails("runner", "-e", "test", "puts ActiveRecord::Base.connection_pool.internal_metadata[:environment]").strip }
+          development_environment = lambda { rails("runner", "puts ActiveRecord::Base.connection_pool.internal_metadata[:environment]").strip }
 
           assert_equal "development", development_environment.call
           assert_equal "test", test_environment.call


### PR DESCRIPTION
Extracted from: https://github.com/rails/rails/pull/50793

Similar to the recent refactoring of schema caches, rather than to directly hold a connection, they now hold a pool and checkout a connection when needed.

~~NB: I did spot one leaky failure, to investigate: `bin/test --seed 26440`.~~