### PR TITLE
ConnectionPool: handle schema_reflection being re-assigned

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -118,9 +118,9 @@ module ActiveRecord
       include ConnectionAdapters::AbstractPool
 
       attr_accessor :automatic_reconnect, :checkout_timeout
-      attr_reader :db_config, :size, :reaper, :pool_config, :async_executor, :role, :shard, :schema_cache
+      attr_reader :db_config, :size, :reaper, :pool_config, :async_executor, :role, :shard
 
-      delegate :schema_reflection, :schema_reflection=, :server_version, to: :pool_config
+      delegate :schema_reflection, :server_version, to: :pool_config
 
       # Creates a new ConnectionPool object. +pool_config+ is a PoolConfig
       # object which describes database connection information (e.g. adapter,
@@ -167,10 +167,19 @@ module ActiveRecord
 
         @async_executor = build_async_executor
 
-        @schema_cache = BoundSchemaReflection.new(schema_reflection, self)
+        @schema_cache = nil
 
         @reaper = Reaper.new(self, db_config.reaping_frequency)
         @reaper.run
+      end
+
+      def schema_cache
+        @schema_cache ||= BoundSchemaReflection.new(schema_reflection, self)
+      end
+
+      def schema_reflection=(schema_reflection)
+        pool_config.schema_reflection = schema_reflection
+        @schema_cache = nil
       end
 
       def migration_context # :nodoc:

--- a/activerecord/test/cases/connection_pool_test.rb
+++ b/activerecord/test/cases/connection_pool_test.rb
@@ -594,6 +594,17 @@ module ActiveRecord
         ActiveSupport::Notifications.unsubscribe(subscription) if subscription
       end
 
+      def test_sets_pool_schema_reflection
+        pool.schema_cache.add(:posts)
+        assert pool.schema_cache.cached?(:posts)
+
+        pool.schema_reflection = SchemaReflection.new("does-not-exist")
+        assert_not pool.schema_cache.cached?(:posts)
+
+        pool.schema_cache.add(:posts)
+        assert pool.schema_cache.cached?(:posts)
+      end
+
       def test_pool_sets_connection_schema_cache
         pool.schema_cache.add(:posts)
         connection = pool.checkout


### PR DESCRIPTION
This fixes a regression recently introduced that a schema_reflection assignment from taking effect.

FYI @jenshenny 