### PR TITLE
Handle bad URIs when filtering redirects

### DIFF
--- a/actionpack/lib/action_dispatch/http/filter_redirect.rb
+++ b/actionpack/lib/action_dispatch/http/filter_redirect.rb
@@ -42,6 +42,8 @@ module ActionDispatch
           end
         end
         uri.to_s
+      rescue URI::Error
+        FILTERED
       end
     end
   end

--- a/actionpack/test/controller/log_subscriber_test.rb
+++ b/actionpack/test/controller/log_subscriber_test.rb
@@ -36,6 +36,10 @@ module Another
       redirect_to "http://secret.foo.bar?username=repinel&password=1234"
     end
 
+    def filterable_redirector_bad_uri
+      redirect_to " s:/invalid-string0uri"
+    end
+
     def data_sender
       send_data "cool data", filename: "file.txt"
     end
@@ -294,6 +298,16 @@ class ACLogSubscriberTest < ActionController::TestCase
 
     assert_equal 3, logs.size
     assert_equal "Redirected to http://secret.foo.bar?username=repinel&password=[FILTERED]", logs[1]
+  end
+
+  def test_filter_redirect_bad_uri
+    @request.env["action_dispatch.parameter_filter"] = [/pass.+/]
+
+    get :filterable_redirector_bad_uri
+    wait
+
+    assert_equal 3, logs.size
+    assert_equal "Redirected to [FILTERED]", logs[1]
   end
 
   def test_send_data


### PR DESCRIPTION
### Motivation / Background

rails/rails#51131 introduced parameter filtering for redirects. We didn't account for invalid URIs though, and it changes the behaviour of redirect_to to raise URI errors when we try to filter a bad URI. Instead, we should fallback to filtering bad URIs entirely to preserve behaviour.

This Pull Request has been created because rails/rails#51131 changes the behaviour of redirection, and I'm concerned it will break applications.

### Detail

This Pull Request changes redirect filtering to fallback to filtering the entire URI when we can't parse the URI.

### Additional information

We seem to do this for permitted host checking etc, so I think this is the correct behaviour.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
