### PR TITLE
Don't require an active connection for table and column quoting

### DIFF
--- a/activerecord/lib/active_record/attribute_methods/primary_key.rb
+++ b/activerecord/lib/active_record/attribute_methods/primary_key.rb
@@ -92,7 +92,7 @@ module ActiveRecord
           # Returns a quoted version of the primary key name, used to construct
           # SQL statements.
           def quoted_primary_key
-            @quoted_primary_key ||= connection.quote_column_name(primary_key)
+            @quoted_primary_key ||= adapter_class.quote_column_name(primary_key)
           end
 
           def reset_primary_key # :nodoc:

--- a/activerecord/lib/active_record/connection_adapters/mysql/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/quoting.rb
@@ -6,8 +6,51 @@ module ActiveRecord
   module ConnectionAdapters
     module MySQL
       module Quoting # :nodoc:
+        extend ActiveSupport::Concern
+
         QUOTED_COLUMN_NAMES = Concurrent::Map.new # :nodoc:
         QUOTED_TABLE_NAMES = Concurrent::Map.new # :nodoc:
+
+        module ClassMethods # :nodoc:
+          def column_name_matcher
+            /
+              \A
+              (
+                (?:
+                  # `table_name`.`column_name` | function(one or no argument)
+                  ((?:\w+\.|`\w+`\.)?(?:\w+|`\w+`) | \w+\((?:|\g<2>)\))
+                )
+                (?:(?:\s+AS)?\s+(?:\w+|`\w+`))?
+              )
+              (?:\s*,\s*\g<1>)*
+              \z
+            /ix
+          end
+
+          def column_name_with_order_matcher
+            /
+              \A
+              (
+                (?:
+                  # `table_name`.`column_name` | function(one or no argument)
+                  ((?:\w+\.|`\w+`\.)?(?:\w+|`\w+`) | \w+\((?:|\g<2>)\))
+                )
+                (?:\s+COLLATE\s+(?:\w+|"\w+"))?
+                (?:\s+ASC|\s+DESC)?
+              )
+              (?:\s*,\s*\g<1>)*
+              \z
+            /ix
+          end
+
+          def quote_column_name(name)
+            QUOTED_COLUMN_NAMES[name] ||= "`#{name.to_s.gsub('`', '``')}`".freeze
+          end
+
+          def quote_table_name(name)
+            QUOTED_TABLE_NAMES[name] ||= "`#{name.to_s.gsub('`', '``').gsub(".", "`.`")}`".freeze
+          end
+        end
 
         def cast_bound_value(value)
           case value
@@ -24,14 +67,6 @@ module ActiveRecord
           else
             value
           end
-        end
-
-        def quote_column_name(name)
-          QUOTED_COLUMN_NAMES[name] ||= "`#{super.gsub('`', '``')}`".freeze
-        end
-
-        def quote_table_name(name)
-          QUOTED_TABLE_NAMES[name] ||= -super.gsub(".", "`.`").freeze
         end
 
         def unquoted_true
@@ -81,43 +116,6 @@ module ActiveRecord
             super
           end
         end
-
-        def column_name_matcher
-          COLUMN_NAME
-        end
-
-        def column_name_with_order_matcher
-          COLUMN_NAME_WITH_ORDER
-        end
-
-        COLUMN_NAME = /
-          \A
-          (
-            (?:
-              # `table_name`.`column_name` | function(one or no argument)
-              ((?:\w+\.|`\w+`\.)?(?:\w+|`\w+`) | \w+\((?:|\g<2>)\))
-            )
-            (?:(?:\s+AS)?\s+(?:\w+|`\w+`))?
-          )
-          (?:\s*,\s*\g<1>)*
-          \z
-        /ix
-
-        COLUMN_NAME_WITH_ORDER = /
-          \A
-          (
-            (?:
-              # `table_name`.`column_name` | function(one or no argument)
-              ((?:\w+\.|`\w+`\.)?(?:\w+|`\w+`) | \w+\((?:|\g<2>)\))
-            )
-            (?:\s+COLLATE\s+(?:\w+|"\w+"))?
-            (?:\s+ASC|\s+DESC)?
-          )
-          (?:\s*,\s*\g<1>)*
-          \z
-        /ix
-
-        private_constant :COLUMN_NAME, :COLUMN_NAME_WITH_ORDER
       end
     end
   end

--- a/activerecord/lib/active_record/connection_adapters/sqlite3/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3/quoting.rb
@@ -4,8 +4,51 @@ module ActiveRecord
   module ConnectionAdapters
     module SQLite3
       module Quoting # :nodoc:
+        extend ActiveSupport::Concern
+
         QUOTED_COLUMN_NAMES = Concurrent::Map.new # :nodoc:
         QUOTED_TABLE_NAMES = Concurrent::Map.new # :nodoc:
+
+        module ClassMethods # :nodoc:
+          def column_name_matcher
+            /
+              \A
+              (
+                (?:
+                  # "table_name"."column_name" | function(one or no argument)
+                  ((?:\w+\.|"\w+"\.)?(?:\w+|"\w+") | \w+\((?:|\g<2>)\))
+                )
+                (?:(?:\s+AS)?\s+(?:\w+|"\w+"))?
+              )
+              (?:\s*,\s*\g<1>)*
+              \z
+            /ix
+          end
+
+          def column_name_with_order_matcher
+            /
+              \A
+              (
+                (?:
+                  # "table_name"."column_name" | function(one or no argument)
+                  ((?:\w+\.|"\w+"\.)?(?:\w+|"\w+") | \w+\((?:|\g<2>)\))
+                )
+                (?:\s+COLLATE\s+(?:\w+|"\w+"))?
+                (?:\s+ASC|\s+DESC)?
+              )
+              (?:\s*,\s*\g<1>)*
+              \z
+            /ix
+          end
+
+          def quote_column_name(name)
+            QUOTED_COLUMN_NAMES[name] ||= %Q("#{name.to_s.gsub('"', '""')}").freeze
+          end
+
+          def quote_table_name(name)
+            QUOTED_TABLE_NAMES[name] ||= %Q("#{name.to_s.gsub('"', '""').gsub(".", "\".\"")}").freeze
+          end
+        end
 
         def quote_string(s)
           ::SQLite3::Database.quote(s)
@@ -13,14 +56,6 @@ module ActiveRecord
 
         def quote_table_name_for_assignment(table, attr)
           quote_column_name(attr)
-        end
-
-        def quote_table_name(name)
-          QUOTED_TABLE_NAMES[name] ||= -super.gsub(".", "\".\"").freeze
-        end
-
-        def quote_column_name(name)
-          QUOTED_COLUMN_NAMES[name] ||= %Q("#{super.gsub('"', '""')}").freeze
         end
 
         def quoted_time(value)
@@ -75,43 +110,6 @@ module ActiveRecord
             super
           end
         end
-
-        def column_name_matcher
-          COLUMN_NAME
-        end
-
-        def column_name_with_order_matcher
-          COLUMN_NAME_WITH_ORDER
-        end
-
-        COLUMN_NAME = /
-          \A
-          (
-            (?:
-              # "table_name"."column_name" | function(one or no argument)
-              ((?:\w+\.|"\w+"\.)?(?:\w+|"\w+") | \w+\((?:|\g<2>)\))
-            )
-            (?:(?:\s+AS)?\s+(?:\w+|"\w+"))?
-          )
-          (?:\s*,\s*\g<1>)*
-          \z
-        /ix
-
-        COLUMN_NAME_WITH_ORDER = /
-          \A
-          (
-            (?:
-              # "table_name"."column_name" | function(one or no argument)
-              ((?:\w+\.|"\w+"\.)?(?:\w+|"\w+") | \w+\((?:|\g<2>)\))
-            )
-            (?:\s+COLLATE\s+(?:\w+|"\w+"))?
-            (?:\s+ASC|\s+DESC)?
-          )
-          (?:\s*,\s*\g<1>)*
-          \z
-        /ix
-
-        private_constant :COLUMN_NAME, :COLUMN_NAME_WITH_ORDER
       end
     end
   end

--- a/activerecord/lib/active_record/connection_handling.rb
+++ b/activerecord/lib/active_record/connection_handling.rb
@@ -286,6 +286,10 @@ module ActiveRecord
       connection_pool.db_config
     end
 
+    def adapter_class # :nodoc:
+      connection_pool.db_config.adapter_class
+    end
+
     def connection_pool
       connection_handler.retrieve_connection_pool(connection_specification_name, role: current_role, shard: current_shard, strict: true)
     end

--- a/activerecord/lib/active_record/model_schema.rb
+++ b/activerecord/lib/active_record/model_schema.rb
@@ -279,7 +279,7 @@ module ActiveRecord
 
       # Returns a quoted version of the table name, used to construct SQL statements.
       def quoted_table_name
-        @quoted_table_name ||= connection.quote_table_name(table_name)
+        @quoted_table_name ||= adapter_class.quote_table_name(table_name)
       end
 
       # Computes the table name, (re)sets it internally, and returns it.

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -469,7 +469,7 @@ module ActiveRecord
         collection = eager_loading? ? apply_join_dependency : self
 
         column = connection.visitor.compile(table[timestamp_column])
-        select_values = "COUNT(*) AS #{connection.quote_column_name("size")}, MAX(%s) AS timestamp"
+        select_values = "COUNT(*) AS #{adapter_class.quote_column_name("size")}, MAX(%s) AS timestamp"
 
         if collection.has_limit_or_offset?
           query = collection.select("#{column} AS collection_cache_key_timestamp")

--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -511,13 +511,13 @@ module ActiveRecord
         column = aggregate_column(column_name)
         column_alias = column_alias_tracker.alias_for("#{operation} #{column_name.to_s.downcase}")
         select_value = operation_over_aggregate_column(column, operation, distinct)
-        select_value.as(connection.quote_column_name(column_alias))
+        select_value.as(adapter_class.quote_column_name(column_alias))
 
         select_values = [select_value]
         select_values += self.select_values unless having_clause.empty?
 
         select_values.concat group_columns.map { |aliaz, field|
-          aliaz = connection.quote_column_name(aliaz)
+          aliaz = adapter_class.quote_column_name(aliaz)
           if field.respond_to?(:as)
             field.as(aliaz)
           else

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -634,7 +634,7 @@ module ActiveRecord
     #   #   END ASC
     #
     def in_order_of(column, values)
-      klass.disallow_raw_sql!([column], permit: connection.column_name_with_order_matcher)
+      klass.disallow_raw_sql!([column], permit: model.adapter_class.column_name_with_order_matcher)
       return spawn.none! if values.empty?
 
       references = column_references([column])
@@ -1848,7 +1848,7 @@ module ActiveRecord
           case field
           when Symbol
             arel_column(field.to_s) do |attr_name|
-              connection.quote_table_name(attr_name)
+              adapter_class.quote_table_name(attr_name)
             end
           when String
             arel_column(field, &:itself)
@@ -1878,7 +1878,7 @@ module ActiveRecord
 
       def table_name_matches?(from)
         table_name = Regexp.escape(table.name)
-        quoted_table_name = Regexp.escape(connection.quote_table_name(table.name))
+        quoted_table_name = Regexp.escape(adapter_class.quote_table_name(table.name))
         /(?:\A|(?<!FROM)\s)(?:\b#{table_name}\b|#{quoted_table_name})(?!\.)/i.match?(from.to_s)
       end
 
@@ -1951,7 +1951,7 @@ module ActiveRecord
       def preprocess_order_args(order_args)
         @klass.disallow_raw_sql!(
           flattened_args(order_args),
-          permit: connection.column_name_with_order_matcher
+          permit: model.adapter_class.column_name_with_order_matcher
         )
 
         validate_order_args(order_args)
@@ -2013,7 +2013,7 @@ module ActiveRecord
           if attr_name == "count" && !group_values.empty?
             table[attr_name]
           else
-            Arel.sql(connection.quote_table_name(attr_name))
+            Arel.sql(adapter_class.quote_table_name(attr_name))
           end
         end
       end

--- a/activerecord/lib/active_record/sanitization.rb
+++ b/activerecord/lib/active_record/sanitization.rb
@@ -85,7 +85,7 @@ module ActiveRecord
         if condition.is_a?(Array) && condition.first.to_s.include?("?")
           disallow_raw_sql!(
             [condition.first],
-            permit: connection.column_name_with_order_matcher
+            permit: adapter_class.column_name_with_order_matcher
           )
 
           # Ensure we aren't dealing with a subclass of String that might
@@ -173,7 +173,7 @@ module ActiveRecord
         end
       end
 
-      def disallow_raw_sql!(args, permit: connection.column_name_matcher) # :nodoc:
+      def disallow_raw_sql!(args, permit: adapter_class.column_name_matcher) # :nodoc:
         unexpected = nil
         args.each do |arg|
           next if arg.is_a?(Symbol) || Arel.arel_node?(arg) || permit.match?(arg.to_s.strip)

--- a/activerecord/test/cases/adapters/abstract_mysql_adapter/quoting_test.rb
+++ b/activerecord/test/cases/adapters/abstract_mysql_adapter/quoting_test.rb
@@ -27,4 +27,23 @@ class QuotingTest < ActiveRecord::AbstractMysqlTestCase
   def test_cast_bound_false
     assert_equal "0", @conn.cast_bound_value(false)
   end
+
+  def test_quote_string
+    assert_equal "\\'", @conn.quote_string("'")
+  end
+
+  def test_quote_column_name
+    [@conn, @conn.class].each do |adapter|
+      assert_equal "`foo`", adapter.quote_column_name("foo")
+      assert_equal '`hel"lo`', adapter.quote_column_name(%{hel"lo})
+    end
+  end
+
+  def test_quote_table_name
+    [@conn, @conn.class].each do |adapter|
+      assert_equal "`foo`", adapter.quote_table_name("foo")
+      assert_equal "`foo`.`bar`", adapter.quote_table_name("foo.bar")
+      assert_equal '`hel"lo.wol\\d`', adapter.quote_column_name('hel"lo.wol\\d')
+    end
+  end
 end

--- a/activerecord/test/cases/adapters/postgresql/quoting_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/quoting_test.rb
@@ -46,6 +46,25 @@ module ActiveRecord
           assert_equal "\"user posts\"", @conn.quote_table_name(value)
         end
 
+        def test_quote_string
+          assert_equal "''", @conn.quote_string("'")
+        end
+
+        def test_quote_column_name
+          [@conn, @conn.class].each do |adapter|
+            assert_equal '"foo"', adapter.quote_column_name("foo")
+            assert_equal '"hel""lo"', adapter.quote_column_name(%{hel"lo})
+          end
+        end
+
+        def test_quote_table_name
+          [@conn, @conn.class].each do |adapter|
+            assert_equal '"foo"', adapter.quote_table_name("foo")
+            assert_equal '"foo"."bar"', adapter.quote_table_name("foo.bar")
+            assert_equal '"hel""lo.wol\\d"', adapter.quote_column_name('hel"lo.wol\\d')
+          end
+        end
+
         def test_raise_when_int_is_wider_than_64bit
           value = 9223372036854775807 + 1
           assert_raise ActiveRecord::ConnectionAdapters::PostgreSQL::Quoting::IntegerOutOf64BitRange do

--- a/activerecord/test/cases/adapters/sqlite3/quoting_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/quoting_test.rb
@@ -10,6 +10,25 @@ class SQLite3QuotingTest < ActiveRecord::SQLite3TestCase
     @conn = ActiveRecord::Base.connection
   end
 
+  def test_quote_string
+    assert_equal "''", @conn.quote_string("'")
+  end
+
+  def test_quote_column_name
+    [@conn, @conn.class].each do |adapter|
+      assert_equal '"foo"', adapter.quote_column_name("foo")
+      assert_equal '"hel""lo"', adapter.quote_column_name(%{hel"lo})
+    end
+  end
+
+  def test_quote_table_name
+    [@conn, @conn.class].each do |adapter|
+      assert_equal '"foo"', adapter.quote_table_name("foo")
+      assert_equal '"foo"."bar"', adapter.quote_table_name("foo.bar")
+      assert_equal '"hel""lo.wol\\d"', adapter.quote_column_name('hel"lo.wol\\d')
+    end
+  end
+
   def test_type_cast_binary_encoding_without_logger
     @conn.extend(Module.new { def logger; end })
     binary = SecureRandom.hex

--- a/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
@@ -497,10 +497,6 @@ module ActiveRecord
         end
       end
 
-      def test_quote_string
-        assert_equal "''", @conn.quote_string("'")
-      end
-
       def test_insert_logged
         with_example_table do
           sql = "INSERT INTO ex (number) VALUES (10)"

--- a/activerecord/test/cases/column_definition_test.rb
+++ b/activerecord/test/cases/column_definition_test.rb
@@ -5,11 +5,24 @@ require "cases/helper"
 module ActiveRecord
   module ConnectionAdapters
     class ColumnDefinitionTest < ActiveRecord::TestCase
-      def setup
-        @adapter = AbstractAdapter.new(nil)
-        def @adapter.native_database_types
+      class DummyAdapter < AbstractAdapter
+        class << self
+          def quote_table_name(table_name)
+            table_name.to_s
+          end
+
+          def quote_column_name(column_name)
+            column_name.to_s
+          end
+        end
+
+        def native_database_types
           { string: "varchar" }
         end
+      end
+
+      def setup
+        @adapter = DummyAdapter.new(nil)
         @viz = @adapter.send(:schema_creation)
       end
 

--- a/activerecord/test/cases/quoting_test.rb
+++ b/activerecord/test/cases/quoting_test.rb
@@ -24,15 +24,19 @@ module ActiveRecord
       end
 
       def test_quote_column_name
-        assert_equal "foo", @quoter.quote_column_name("foo")
+        assert_raises NotImplementedError do
+          @quoter.quote_column_name("foo")
+        end
       end
 
       def test_quote_table_name
-        assert_equal "foo", @quoter.quote_table_name("foo")
+        assert_raises NotImplementedError do
+          @quoter.quote_table_name("foo")
+        end
       end
 
       def test_quote_table_name_calls_quote_column_name
-        @quoter.extend(Module.new {
+        @quoter.class.extend(Module.new {
           def quote_column_name(string)
             "lol"
           end

--- a/activerecord/test/models/post.rb
+++ b/activerecord/test/models/post.rb
@@ -337,6 +337,10 @@ class FakeKlass
       ActiveRecord::Scoping::ScopeRegistry.instance
     end
 
+    def adapter_class
+      Post.adapter_class
+    end
+
     def connection
       Post.connection
     end


### PR DESCRIPTION
Extracted from: https://github.com/rails/rails/pull/50793

Right now quoting table or column names requires a leased Adapter instance, even though none of the implementations actually requires an active connection.

The idea here is to move these methods to the class so that the quoting can be done without leasing a connection or even needing the connection to ever have been established.

I also checked `activerecord-sqlserver-adapter` (FYI @aidanharan) and `oracle-enhanced` (FYI @yahonda) gems, and neither need an active connection.

Also FYI @matthewd as you may have opinions. I'm a bit on the fence about moving these to the class, an alternative could be to move them to a different object, but I'm think this keeps the `Adapter` interface simpler.