### PR TITLE
doc: Fix upgrade guide (7.1 AR hash_digest_class) [ci skip]

### DIFF
--- a/guides/source/upgrading_ruby_on_rails.md
+++ b/guides/source/upgrading_ruby_on_rails.md
@@ -324,14 +324,14 @@ Active Record Encryption now uses SHA-256 as its hash digest algorithm. If you h
 versions, there are two scenarios to consider:
 
 1. If you have `config.active_support.key_generator_hash_digest_class` configured as SHA-1 (the default
-   before Rails 7.0), you need to configure SHA-1 for Active Record Encryption too:
+   before Rails 7.1), you need to configure SHA-1 for Active Record Encryption too:
 
     ```ruby
     config.active_record.encryption.hash_digest_class = OpenSSL::Digest::SHA1
     ```
 
 2. If you have `config.active_support.key_generator_hash_digest_class` configured as SHA-256 (the new default
-   in 7.0), then you need to configure SHA-256 for Active Record Encryption:
+   in 7.1), then you need to configure SHA-256 for Active Record Encryption:
 
     ```ruby
     config.active_record.encryption.hash_digest_class = OpenSSL::Digest::SHA256


### PR DESCRIPTION
### Motivation / Background

While the configuration guide for `config.active_record.encryption.hash_digest_class` is correct regarding the starting version in which this configuration is defaulted to SHA256, the upgrade guide says that the starting version is 7.0, which is incorrect. This can cause someone upgrading an app that was created with Rails 7.0 to 7.1 to think that they are "safe" because they are already using SHA256, when they are not.

### Detail

This Pull Request changes the upgrade guide (`guides/source/upgrading_ruby_on_rails.md`) by mentioning that SHA-1 was the default `config.active_record.encryption.hash_digest_class` before Rails 7.1, not Rails 7.0.

### Additional information

See https://edgeguides.rubyonrails.org/configuring.html#config-active-record-encryption-hash-digest-class . This configuration guide is correct. We just needed to fix the upgrade guide to make it match with it.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] ~Tests are added or updated if you fix a bug or add a feature.~
* [x] ~CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.~
