### PR TITLE
Fix flaky `multi_db_migrator_test.rb` test

### DIFF
--- a/activerecord/test/cases/multi_db_migrator_test.rb
+++ b/activerecord/test/cases/multi_db_migrator_test.rb
@@ -160,6 +160,7 @@ class MultiDbMigratorTest < ActiveRecord::TestCase
     assert_not @pool_a.connection.table_exists?("schema_migrations")
     migrator.migrate(1)
     assert @pool_a.connection.table_exists?("schema_migrations")
+    migrator.rollback
 
     _, migrator = migrator_class(3)
     migrator = migrator.new(@path_b, @schema_migration_b, @internal_metadata_b)
@@ -168,6 +169,7 @@ class MultiDbMigratorTest < ActiveRecord::TestCase
     assert_not @pool_b.connection.table_exists?("schema_migrations")
     migrator.migrate(1)
     assert @pool_b.connection.table_exists?("schema_migrations")
+    migrator.rollback
   end
 
   def test_migrator_forward


### PR DESCRIPTION
Fixes #51172.

In the touched in this PR test case migrations were not properly reverted, and so this migration from the failing test case was not running https://github.com/rails/rails/blob/b6285e98f01373ddd4114735e6548592128c32a8/activerecord/test/cases/migration/compatibility_test.rb#L740-L744 because we already have a migration with `version=1` migrated.

cc @yahonda 