### PR TITLE
add linestring and multilinestring for mysql

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -11,6 +11,8 @@ require "active_record/connection_adapters/mysql/schema_definitions"
 require "active_record/connection_adapters/mysql/schema_dumper"
 require "active_record/connection_adapters/mysql/schema_statements"
 require "active_record/connection_adapters/mysql/type_metadata"
+require "active_record/connection_adapters/mysql/type/linestring"
+require "active_record/connection_adapters/mysql/type/multilinestring"
 
 module ActiveRecord
   module ConnectionAdapters
@@ -30,20 +32,22 @@ module ActiveRecord
 
       NATIVE_DATABASE_TYPES = {
         primary_key: "bigint auto_increment PRIMARY KEY",
-        string:      { name: "varchar", limit: 255 },
-        text:        { name: "text" },
-        integer:     { name: "int", limit: 4 },
-        bigint:      { name: "bigint" },
-        float:       { name: "float", limit: 24 },
-        decimal:     { name: "decimal" },
-        datetime:    { name: "datetime" },
-        timestamp:   { name: "timestamp" },
-        time:        { name: "time" },
-        date:        { name: "date" },
-        binary:      { name: "blob" },
-        blob:        { name: "blob" },
-        boolean:     { name: "tinyint", limit: 1 },
-        json:        { name: "json" },
+        string:           { name: "varchar", limit: 255 },
+        text:             { name: "text" },
+        integer:          { name: "int", limit: 4 },
+        bigint:           { name: "bigint" },
+        float:            { name: "float", limit: 24 },
+        decimal:          { name: "decimal" },
+        datetime:         { name: "datetime" },
+        timestamp:        { name: "timestamp" },
+        time:             { name: "time" },
+        date:             { name: "date" },
+        binary:           { name: "blob" },
+        blob:             { name: "blob" },
+        boolean:          { name: "tinyint", limit: 1 },
+        json:             { name: "json" },
+        linestring:       { name: "linestring" },
+        multilinestring:  { name: "multilinestring" },
       }
 
       class StatementPool < ConnectionAdapters::StatementPool # :nodoc:

--- a/activerecord/lib/active_record/connection_adapters/mysql/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/schema_definitions.rb
@@ -50,10 +50,18 @@ module ActiveRecord
         # :method: unsigned_decimal
         # :call-seq: unsigned_decimal(*names, **options)
 
+        ##
+        # :method: linestring
+        # :call-seq: linestring(*names, **options)
+
+        ##
+        # :method: multilinestring
+        # :call-seq: multilinestring(*names, **options)
+
         included do
           define_column_methods :blob, :tinyblob, :mediumblob, :longblob,
             :tinytext, :mediumtext, :longtext, :unsigned_integer, :unsigned_bigint,
-            :unsigned_float, :unsigned_decimal
+            :unsigned_float, :unsigned_decimal, :linestring, :multilinestring
         end
       end
 

--- a/activerecord/lib/active_record/connection_adapters/mysql/type/linestring.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/type/linestring.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module ActiveRecord
+  module ConnectionAdapters
+    module MySQL
+      module Type # :nodoc:
+        class Linestring < ActiveModel::Type::String
+          def type
+            :linestring
+          end
+        end
+      end
+    end
+  end
+end

--- a/activerecord/lib/active_record/connection_adapters/mysql/type/multilinestring.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/type/multilinestring.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module ActiveRecord
+  module ConnectionAdapters
+    module MySQL
+      module Type # :nodoc:
+        class Multilinestring < ActiveModel::Type::String
+          def type
+            :multilinestring
+          end
+        end
+      end
+    end
+  end
+end

--- a/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
@@ -47,6 +47,8 @@ module ActiveRecord
 
             m.register_type %r(^enum)i, Type.lookup(:string, adapter: :mysql2)
             m.register_type %r(^set)i,  Type.lookup(:string, adapter: :mysql2)
+            m.register_type("linestring", MySQL::Type::Linestring.new)
+            m.register_type("multilinestring", MySQL::Type::Multilinestring.new)
           end
       end
 
@@ -196,6 +198,8 @@ module ActiveRecord
         end
 
         ActiveRecord::Type.register(:unsigned_integer, Type::UnsignedInteger, adapter: :mysql2)
+        ActiveRecord::Type.register(:linestring, MySQL::Type::Linestring, adapter: :mysql2)
+        ActiveRecord::Type.register(:multilinestring, MySQL::Type::Multilinestring, adapter: :mysql2)
     end
 
     ActiveSupport.run_load_hooks(:active_record_mysql2adapter, Mysql2Adapter)


### PR DESCRIPTION
### Motivation / Background

In mysql, there are two column data types: linestring and multilinestring. At the moment, we cannot create those two using

```rb
t.column :test_col, :linestring
t.column :test_mcol, :multilinestring
```

When run `db:migrate`, it will print to `schema.rb`

```rb
# Could not dump table "tests" because of following StandardError
#   Unknown type 'linestring' for column 'ls'
```

Test repo: https://github.com/zgid123/test-mysql-data-type

### Detail

I followed this PR: https://github.com/rails/rails/pull/49842 to add those two types. I still not know how to write unit test for this case. Please help me this one.

### Additional information

Here the result after the fix

```rb
ActiveRecord::Schema[7.2].define(version: 2024_02_25_192506) do
  create_table "tests", charset: "utf8mb3", force: :cascade do |t|
    t.string "name"
    t.decimal "number", precision: 10
    t.linestring "ls"
    t.multilinestring "mls"
    t.datetime "created_at", null: false
    t.datetime "updated_at", null: false
  end
end
```

<img width="1159" alt="image" src="https://github.com/rails/rails/assets/15771072/8bb7d5cb-c1d9-4028-92e3-ce4438b8b1fc">


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
