### PR TITLE
Set `action_mailer.default_url_options` values in `development` and `test`

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Set `action_mailer.default_url_options` values in `development` and `test`.
+
+    Prior to this commit, new Rails applications would raise `ActionView::Template::Error`
+    if a mailer included a url built with a `*_path` helper.
+
+    *Steve Polito*
+
 *   Introduce `Rails::Generators::Testing::Assertions#assert_initializer`
 
     Compliments the existing `initializer` generator action.

--- a/railties/lib/rails/generators/rails/app/templates/config/environments/development.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/development.rb.tt
@@ -43,6 +43,8 @@ Rails.application.configure do
   config.action_mailer.raise_delivery_errors = false
 
   config.action_mailer.perform_caching = false
+
+  config.action_mailer.define_url_options = { host: "localhost", port: 3000 }
   <%- end -%>
 
   # Print deprecation notices to the Rails logger.

--- a/railties/lib/rails/generators/rails/app/templates/config/environments/development.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/development.rb.tt
@@ -44,7 +44,7 @@ Rails.application.configure do
 
   config.action_mailer.perform_caching = false
 
-  config.action_mailer.define_url_options = { host: "localhost", port: 3000 }
+  config.action_mailer.default_url_options = { host: "localhost", port: 3000 }
   <%- end -%>
 
   # Print deprecation notices to the Rails logger.

--- a/railties/lib/rails/generators/rails/app/templates/config/environments/test.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/test.rb.tt
@@ -44,6 +44,10 @@ Rails.application.configure do
   # ActionMailer::Base.deliveries array.
   config.action_mailer.delivery_method = :test
 
+  # Unlike controllers, the mailer instance doesn't have any context about the
+  # incoming request so you'll need to provide the :host parameter yourself.
+  config.action_mailer.default_url_options = { host: "www.example.com" }
+
   <%- end -%>
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr


### PR DESCRIPTION
### Motivation / Background

Prior to this commit, new Rails applications would raise `ActionView::Template::Error` if a mailer included a url built with a `*_path` helper.

Since we already know [new apps will be served on `localhost:3000`][new apps], we set this as the value in `development`.

In an effort to remain consistent with existing patters, we set the `host` to `www.example.com` in `test`.

[new apps]: https://github.com/rails/rails/blob/47300002db11d67d7b35103f5c429dad7dacdacd/README.md?plain=1#L81

### Additional information

If we feel this is not the right solution, how do we feel about at least adding these values, but commented out?

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
