### PR TITLE
Make `.connection` always return a permanently leased connection

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb
@@ -89,7 +89,7 @@ module ActiveRecord
             end
         end
 
-        def checkout(...)
+        def lease_connection
           connection = super
           connection.query_cache ||= query_cache
           connection
@@ -141,7 +141,6 @@ module ActiveRecord
 
         private
           def prune_thread_cache
-            super
             dead_threads = @thread_query_caches.keys.reject(&:alive?)
             dead_threads.each do |dead_thread|
               @thread_query_caches.delete(dead_thread)

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -49,10 +49,6 @@ module ActiveRecord
         return if value.eql?(@pool)
         @schema_cache = nil
         @pool = value
-
-        if @pool && ActiveRecord.lazily_load_schema_cache
-          @pool.schema_reflection.load!(@pool)
-        end
       end
 
       set_callback :checkin, :after, :enable_lazy_transactions!

--- a/activerecord/lib/active_record/connection_handling.rb
+++ b/activerecord/lib/active_record/connection_handling.rb
@@ -250,8 +250,17 @@ module ActiveRecord
     # Returns the connection currently associated with the class. This can
     # also be used to "borrow" the connection to do database work unrelated
     # to any of the specific Active Records.
-    def connection
-      connection_pool.connection
+    # The connection will remain leased for the entire duration of the request
+    # or job, or until +#release_connection+ is called.
+    def lease_connection
+      connection_pool.lease_connection
+    end
+
+    alias_method :connection, :lease_connection
+
+    # Return the currently leased connection into the pool
+    def release_connection
+      connection.release_connection
     end
 
     # Checkouts a connection from the pool, yield it and then check it back in.

--- a/activerecord/test/cases/pooled_connections_test.rb
+++ b/activerecord/test/cases/pooled_connections_test.rb
@@ -36,7 +36,7 @@ class PooledConnectionsTest < ActiveRecord::TestCase
       old_connection = ActiveRecord::Base.connection
       extra_connection = ActiveRecord::Base.connection_pool.checkout
       ActiveRecord::Base.connection_pool.remove(extra_connection)
-      assert_equal ActiveRecord::Base.connection, old_connection
+      assert_equal ActiveRecord::Base.connection.object_id, old_connection.object_id
     end
 
     private


### PR DESCRIPTION
Ref: https://github.com/rails/rails/pull/51083
Redo of: https://github.com/rails/rails/pull/51154

The introduction of `ActiveRecord::Base.with_connection` somewhat broke some expectations, namely that calling `.connection` would cause the connection to be permenently leased, hence that future calls to it would return the same connection, with all it's possible environmental changes.

So any call to `.connection`, even inside `.with_connection` should cause the lease to be sticky, and persist beyond the `with_connection` block.

After discussing with @matthewd, one big worry is that people might hold onto the return value of `Base.connection` beyond the scope of the `.transaction` block, which could leak to segfaults or worse data leak.

So in the end I think we need to do this. That makes https://github.com/rails/rails/pull/50793 a bit harder to achieve, but not the end of the world.