### PR TITLE
Backport CVE-2024-26143 to 6-1-stable branch

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Fix possible XSS vulnerability with the `translate` method in controllers
+
+    CVE-2024-26143
+
 *   Add `racc` as a dependency since it will become a bundled gem in Ruby 3.4.0
 
     *Hartley McGuire*

--- a/actionpack/lib/abstract_controller/translation.rb
+++ b/actionpack/lib/abstract_controller/translation.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "active_support/core_ext/symbol/starts_ends_with"
+require "active_support/html_safe_translation"
 
 module AbstractController
   module Translation
@@ -24,7 +25,8 @@ module AbstractController
       end
 
       i18n_raise = options.fetch(:raise, self.raise_on_missing_translations)
-      I18n.translate(key, **options, raise: i18n_raise)
+
+      ActiveSupport::HtmlSafeTranslation.translate(key, **options, raise: i18n_raise)
     end
     alias :t :translate
 

--- a/actionpack/lib/abstract_controller/translation.rb
+++ b/actionpack/lib/abstract_controller/translation.rb
@@ -31,18 +31,7 @@ module AbstractController
         end
       end
 
-      if options[:raise].nil?
-        options[:default] = [] unless options[:default]
-        options[:default] << MISSING_TRANSLATION
-      end
-
-      result = ActiveSupport::HtmlSafeTranslation.translate(key, **options)
-
-      if result == MISSING_TRANSLATION
-        +"translation missing: #{key}"
-      else
-        result
-      end
+      ActiveSupport::HtmlSafeTranslation.translate(key, **options)
     end
     alias :t :translate
 
@@ -51,9 +40,5 @@ module AbstractController
       I18n.localize(object, **options)
     end
     alias :l :localize
-
-    private
-      MISSING_TRANSLATION = -(2**60)
-      private_constant :MISSING_TRANSLATION
   end
 end

--- a/actionpack/lib/abstract_controller/translation.rb
+++ b/actionpack/lib/abstract_controller/translation.rb
@@ -24,9 +24,25 @@ module AbstractController
         key = "#{path}.#{action_name}#{key}"
       end
 
-      i18n_raise = options.fetch(:raise, self.raise_on_missing_translations)
+      if options[:default]
+        options[:default] = [options[:default]] unless options[:default].is_a?(Array)
+        options[:default] = options[:default].map do |value|
+          value.is_a?(String) ? ERB::Util.html_escape(value) : value
+        end
+      end
 
-      ActiveSupport::HtmlSafeTranslation.translate(key, **options, raise: i18n_raise)
+      if options[:raise].nil?
+        options[:default] = [] unless options[:default]
+        options[:default] << MISSING_TRANSLATION
+      end
+
+      result = ActiveSupport::HtmlSafeTranslation.translate(key, **options)
+
+      if result == MISSING_TRANSLATION
+        +"translation missing: #{key}"
+      else
+        result
+      end
     end
     alias :t :translate
 
@@ -35,5 +51,9 @@ module AbstractController
       I18n.localize(object, **options)
     end
     alias :l :localize
+
+    private
+      MISSING_TRANSLATION = -(2**60)
+      private_constant :MISSING_TRANSLATION
   end
 end

--- a/actionpack/test/abstract/translation_test.rb
+++ b/actionpack/test/abstract/translation_test.rb
@@ -152,15 +152,19 @@ module AbstractController
       def test_translate_marks_translation_with_missing_html_key_as_safe_html
         @controller.stub :action_name, :index do
           translation = @controller.t("<tag>.html")
-          assert_equal "translation missing: <tag>.html", translation
           assert_equal false, translation.html_safe?
+          assert_equal "Translation missing: en.<tag>.html", translation
         end
       end
       def test_translate_marks_translation_with_missing_nested_html_key_as_safe_html
         @controller.stub :action_name, :index do
           translation = @controller.t(".<tag>.html")
-          assert_equal "translation missing: abstract_controller.testing.translation.index.<tag>.html", translation
           assert_equal false, translation.html_safe?
+          assert_equal(<<~MSG.strip, translation)
+            Translation missing. Options considered were:
+            - en.abstract_controller.testing.translation.index.<tag>.html
+            - en.abstract_controller.testing.translation.<tag>.html
+          MSG
         end
       end
     end

--- a/activesupport/lib/active_support/html_safe_translation.rb
+++ b/activesupport/lib/active_support/html_safe_translation.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module ActiveSupport
+  module HtmlSafeTranslation # :nodoc:
+    extend self
+
+    def translate(key, **options)
+      if html_safe_translation_key?(key)
+        html_safe_options = html_escape_translation_options(options)
+        translation = I18n.translate(key, **html_safe_options)
+        html_safe_translation(translation)
+      else
+        I18n.translate(key, **options)
+      end
+    end
+
+    private
+      def html_safe_translation_key?(key)
+        /(?:_|\b)html\z/.match?(key)
+      end
+
+      def html_escape_translation_options(options)
+        options.each do |name, value|
+          unless i18n_option?(name) || (name == :count && value.is_a?(Numeric))
+            options[name] = ERB::Util.html_escape(value.to_s)
+          end
+        end
+      end
+
+      def i18n_option?(name)
+        (@i18n_option_names ||= I18n::RESERVED_KEYS.to_set).include?(name)
+      end
+
+
+      def html_safe_translation(translation)
+        if translation.respond_to?(:map)
+          translation.map { |element| element.respond_to?(:html_safe) ? element.html_safe : element }
+        else
+          translation.respond_to?(:html_safe) ? translation.html_safe : translation
+        end
+      end
+  end
+end

--- a/activesupport/lib/active_support/html_safe_translation.rb
+++ b/activesupport/lib/active_support/html_safe_translation.rb
@@ -7,8 +7,18 @@ module ActiveSupport
     def translate(key, **options)
       if html_safe_translation_key?(key)
         html_safe_options = html_escape_translation_options(options)
-        translation = I18n.translate(key, **html_safe_options)
-        html_safe_translation(translation)
+
+        exception = false
+        exception_handler = ->(*args) do
+          exception = true
+          I18n.exception_handler.call(*args)
+        end
+        translation = I18n.translate(key, **html_safe_options, exception_handler: exception_handler)
+        if exception
+          translation
+        else
+          html_safe_translation(translation)
+        end
       else
         I18n.translate(key, **options)
       end


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because there hasn't yet been a patch applied to the 6-1-stable branch resolving CVE-2024-26143. The [security announcement](https://discuss.rubyonrails.org/t/possible-xss-vulnerability-in-action-controller/84947) makes no mention of backporting those fixes to 6-1-stable. See also: @radar's #51190.

That's the background. I'd say my motivation is that I'd like to unblock myself and anyone else waiting for the backport.

### Detail

This Pull Request applies existing commits in the 7-0-stable branch related to resolving CVE-2024-26143. Applying the fixes did require(ish?) backporting the `ActiveSupport::HtmlSafeTranslation` module. I suppose the patches could be applied without adding that module, but that was the easiest path I could identify.

Most of the cherry picking introduced conflicts that I resolved by hand to the best of my ability. I'm certainly open to feedback on that approach or on any additional changes that should be made.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
