### PR TITLE
Add `x86_64-linux` platform to Gemfile.lock

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -16,7 +16,7 @@ jobs:
       with:
         ruby-version: 2.7
         bundler-cache: true
-        cache-version: 6-1-stable
+        cache-version: 6-1-stable-1
 
     - name: Run RuboCop
       run: bundle exec rubocop --parallel

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -583,6 +583,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-22
+  x86_64-linux
 
 DEPENDENCIES
   activerecord-jdbcmysql-adapter (>= 1.3.0)


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because I noticed that the `build` job in the RuboCop GitHub Actions workflow is failing owing to a missing platform setting.

### Detail

This Pull Request adds `x86_64-linux` to the `PLATFORMS` section of  `Gemfile.lock`.

### Additional information

The `PLATFORMS` section seems to vary wildly across time and `*-stable` branches in this repo. So, I'm not terribly sure what _should_ be listed here, but at the very least, this change unblocks the GitHub Actions workflow.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
