### PR TITLE
Fix documentation and sample code for `ActiveSupport::Logger.logger_outputs_to?`

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,7 +1,8 @@
-*   Add filename support for `Logger.logger_outputs_to?`
+*   Add filename support for `ActiveSupport::Logger.logger_outputs_to?`
 
     ```ruby
-    Logger.logger_outputs_to?('/var/log/rails.log')
+    logger = Logger.new('/var/log/rails.log')    
+    ActiveSupport::Logger.logger_outputs_to?(logger, '/var/log/rails.log')
     ```
 
     *Christian Schmidt*

--- a/activesupport/lib/active_support/logger.rb
+++ b/activesupport/lib/active_support/logger.rb
@@ -15,7 +15,7 @@ module ActiveSupport
     #   # => true
     #
     #   logger = Logger.new('/var/log/rails.log')
-    #   ActiveSupport::Logger.logger_outputs_to?('var/log/rails.log', STDOUT)
+    #   ActiveSupport::Logger.logger_outputs_to?(logger, '/var/log/rails.log')
     #   # => true
     def self.logger_outputs_to?(logger, *sources)
       loggers = if logger.is_a?(BroadcastLogger)


### PR DESCRIPTION
Fixed incorrect documentation for `ActiveSupport::Logger.logger_outputs_to?`. The method expects the first argument to be a Logger object and subsequent variadic arguments to be either IO objects or strings representing file paths.

Also corrected the sample code in CHANGELOG.md, which previously only passed a single argument, not reflecting the correct usage.

related PR: https://github.com/rails/rails/pull/51125