### PR TITLE
chore: update mysql2 to @0.5.6

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -158,7 +158,7 @@ platforms :ruby, :windows do
 
   group :db do
     gem "pg", "~> 1.3"
-    gem "mysql2", "~> 0.5"
+    gem "mysql2", ">= 0.5.6"
     gem "trilogy", ">= 2.7.0"
   end
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -347,7 +347,7 @@ GEM
     msgpack (1.7.2)
     multi_json (1.15.0)
     multipart-post (2.3.0)
-    mysql2 (0.5.5)
+    mysql2 (0.5.6)
     net-http-persistent (4.0.2)
       connection_pool (~> 2.2)
     net-imap (0.4.9)
@@ -621,7 +621,7 @@ DEPENDENCIES
   minitest-ci
   minitest-retry
   msgpack (>= 1.7.0)
-  mysql2 (~> 0.5)
+  mysql2 (>= 0.5.6)
   nokogiri (>= 1.8.1, != 1.11.0)
   pg (~> 1.3)
   prism


### PR DESCRIPTION
### Motivation / Background

fixes https://github.com/rails/rails/issues/51199

This Pull Request has been created because [MySQL@8.3 removes a few APIs](https://dev.mysql.com/doc/relnotes/mysql/8.3/en/news-8-3-0.html) that the `mysql2` gem relied upon. This is fixed in the next patch release of `brianmario/mysql2` ([v0.5.6](https://github.com/brianmario/mysql2/releases/tag/0.5.6)).

### Detail

This Pull Request changes the specified version of the `mysql2` gem to be `>=0.5.6` to avoid installing a version that is incompatible with recent MySQL versions - namely `8.3.0`.

### Additional information

FWIW I am not familiar enough with Rails and its reliance on this gem to properly diagnose any potential negative side-effects with this change. It solves the immediate problem for me locally, but there is probably more due diligence to be done here, and I'd :heart: some guidance on the best way to ensure this change is solid. 

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* **N/A** Tests are added or updated if you fix a bug or add a feature.
* **N/A** CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
