### PR TITLE
Add a `.missing?` method as opposite for a `.exists?`

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Add a new method `.missing?` that is opposite for a `.exists?` method, like `blank?` for `present?` as syntax sugar.
+
+    This method allows to avoid cases, when you need to use `unless` or converting to the negative value like `if !User.exists?(params[:id])`, so now it looks like `if User.missing?(params[:id])`.
+
+    *Ivan Marynych*
+
 *   Fix `has_one` association autosave setting the foreign key attribute when it is unchanged.
 
     This behaviour is also inconsistent with autosaving `belongs_to` and can have unintended side effects like raising

--- a/activerecord/lib/active_record/querying.rb
+++ b/activerecord/lib/active_record/querying.rb
@@ -6,7 +6,7 @@ module ActiveRecord
       :find, :find_by, :find_by!, :take, :take!, :sole, :find_sole_by, :first, :first!, :last, :last!,
       :second, :second!, :third, :third!, :fourth, :fourth!, :fifth, :fifth!,
       :forty_two, :forty_two!, :third_to_last, :third_to_last!, :second_to_last, :second_to_last!,
-      :exists?, :any?, :many?, :none?, :one?,
+      :exists?, :missing?, :any?, :many?, :none?, :one?,
       :first_or_create, :first_or_create!, :first_or_initialize,
       :find_or_create_by, :find_or_create_by!, :find_or_initialize_by,
       :create_or_find_by, :create_or_find_by!,

--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -377,6 +377,38 @@ module ActiveRecord
       skip_query_cache_if_necessary { connection.select_rows(relation.arel, "#{name} Exists?").size == 1 }
     end
 
+    # Returns true if a record missing in the table that matches the +id+ or
+    # conditions given, or false otherwise. The argument can take six forms:
+    #
+    # * Integer - Finds the record with this primary key.
+    # * String - Finds the record with a primary key corresponding to this
+    #   string (such as <tt>'5'</tt>).
+    # * Array - Finds the record that matches these +where+-style conditions
+    #   (such as <tt>['name LIKE ?', "%#{query}%"]</tt>).
+    # * Hash - Finds the record that matches these +where+-style conditions
+    #   (such as <tt>{name: 'David'}</tt>).
+    # * +false+ - Returns always +false+.
+    # * No args - Returns +false+ if the relation is empty, +true+ otherwise.
+    #
+    # For more information about specifying conditions as a hash or array,
+    # see the Conditions section in the introduction to ActiveRecord::Base.
+    #
+    # Note: You can't pass in a condition as a string (like <tt>name =
+    # 'Jamie'</tt>), since it would be sanitized and then queried against
+    # the primary key column, like <tt>id = 'name = \'Jamie\''</tt>.
+    #
+    #   Person.missing?(5)
+    #   Person.missing?('5')
+    #   Person.missing?(['name LIKE ?', "%#{query}%"])
+    #   Person.missing?(id: [1, 4, 8])
+    #   Person.missing?(name: 'David')
+    #   Person.missing?(false)
+    #   Person.missing?
+    #   Person.where(name: 'Spartacus', rating: 4).missing?
+    def missing?(conditions = :none)
+      !exists?(conditions)
+    end
+
     # Returns true if the relation contains the given record or false otherwise.
     #
     # No query is performed if the relation is loaded; the given record is

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -411,6 +411,22 @@ class FinderTest < ActiveRecord::TestCase
     end
   end
 
+  def test_missing
+    assert_equal false, Topic.missing?(1)
+    assert_equal false, Topic.missing?("1")
+    assert_equal false, Topic.missing?(title: "The First Topic")
+    assert_equal false, Topic.missing?(heading: "The First Topic")
+    assert_equal false, Topic.missing?(author_name: "Mary", approved: true)
+    assert_equal false, Topic.missing?(["parent_id = ?", 1])
+    assert_equal false, Topic.missing?(id: [1, 9999])
+
+    assert_equal true, Topic.missing?(45)
+    assert_equal true, Topic.missing?(9999999999999999999999999999999)
+    assert_equal true, Topic.missing?(Topic.new.id)
+
+    assert_raise(ArgumentError) { Topic.missing?([1, 2]) }
+  end
+
   def test_include_when_non_AR_object_passed_on_unloaded_relation
     assert_no_queries do
       assert_equal false, Customer.where(name: "David").include?("I'm not an AR object")


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because we have so many syntax sugar, like for `present?` method we have `blank?`, and so on, so, that's would be really nice to add opposite method for a `exists?` instead of writing always `!`, or using unless

### Detail

This Pull Request changes adds just an inverted `exists?` method called `missing?`. So, it's really simple, but powerful change

Rework of #51138 PR

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
