### PR TITLE
Add dirties option to Model.uncached

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,15 @@
+*   Add dirties option to uncached
+
+    This adds a `dirties` option to `ActiveRecord::Base.uncached` and
+    `ActiveRecord::ConnectionAdapters::ConnectionPool#uncached`.
+
+    When set to `true` (the default), writes will clear all query caches belonging to the current thread.
+    When set to `false`, writes to the affected connection pool will not clear any query cache.
+
+    This is needed by Solid Cache so that cache writes do not clear query caches.
+
+    *Donal McBreen*
+
 *   Expose a generic fixture accessor for fixture names that may conflict with Minitest
 
     ```ruby

--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -41,8 +41,13 @@ module ActiveRecord
       def checkin(_); end
       def remove(_); end
       def async_executor; end
+
       def db_config
         NULL_CONFIG
+      end
+
+      def dirties_query_cache
+        true
       end
     end
 

--- a/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb
@@ -20,7 +20,9 @@ module ActiveRecord
           method_names.each do |method_name|
             base.class_eval <<-end_code, __FILE__, __LINE__ + 1
               def #{method_name}(...)
-                ActiveRecord::Base.clear_query_caches_for_current_thread
+                if pool.dirties_query_cache
+                  ActiveRecord::Base.clear_query_caches_for_current_thread
+                end
                 super
               end
             end_code
@@ -29,13 +31,15 @@ module ActiveRecord
       end
 
       class Store # :nodoc:
-        attr_accessor :enabled
+        attr_accessor :enabled, :dirties
         alias_method :enabled?, :enabled
+        alias_method :dirties?, :dirties
 
         def initialize(max_size)
           @map = {}
           @max_size = max_size
           @enabled = false
+          @dirties = true
         end
 
         def size
@@ -96,36 +100,40 @@ module ActiveRecord
         end
 
         # Disable the query cache within the block.
-        def disable_query_cache
+        def disable_query_cache(dirties: true)
           cache = query_cache
-          old, cache.enabled = cache.enabled, false
+          old_enabled, cache.enabled, old_dirties, cache.dirties = cache.enabled, false, cache.dirties, dirties
           begin
             yield
           ensure
-            cache.enabled = old
+            cache.enabled, cache.dirties = old_enabled, old_dirties
           end
         end
 
         def enable_query_cache
           cache = query_cache
-          old, cache.enabled = cache.enabled, true
+          old_enabled, cache.enabled, old_dirties, cache.dirties = cache.enabled, true, cache.dirties, true
           begin
             yield
           ensure
-            cache.enabled = old
+            cache.enabled, cache.dirties = old_enabled, old_dirties
           end
         end
 
         def enable_query_cache!
-          query_cache.enabled = true
+          query_cache.enabled, query_cache.dirties = true, true
         end
 
         def disable_query_cache!
-          query_cache.enabled = false
+          query_cache.enabled, query_cache.dirties = false, true
         end
 
         def query_cache_enabled
           query_cache.enabled
+        end
+
+        def dirties_query_cache
+          query_cache.dirties
         end
 
         def clear_query_cache
@@ -176,8 +184,11 @@ module ActiveRecord
       end
 
       # Disable the query cache within the block.
-      def uncached(&)
-        pool.disable_query_cache(&)
+      #
+      # Set <tt>dirties: false</tt> to prevent query caches on all connections from being cleared by write operations.
+      # (By default, write operations dirty all connections' query caches in case they are replicas whose cache would now be outdated.)
+      def uncached(dirties: true, &)
+        pool.disable_query_cache(dirties: dirties, &)
       end
 
       def disable_query_cache!

--- a/activerecord/lib/active_record/query_cache.rb
+++ b/activerecord/lib/active_record/query_cache.rb
@@ -22,9 +22,12 @@ module ActiveRecord
 
       # Disable the query cache within the block if Active Record is configured.
       # If it's not, it will execute the given block.
-      def uncached(&block)
+      #
+      # Set <tt>dirties: false</tt> to prevent query caches on all connections from being cleared by write operations.
+      # (By default, write operations dirty all connections' query caches in case they are replicas whose cache would now be outdated.)
+      def uncached(dirties: true, &block)
         if connected? || !configurations.empty?
-          connection_pool.disable_query_cache(&block)
+          connection_pool.disable_query_cache(dirties: dirties, &block)
         else
           yield
         end

--- a/activerecord/test/cases/query_cache_test.rb
+++ b/activerecord/test/cases/query_cache_test.rb
@@ -706,6 +706,57 @@ class QueryCacheTest < ActiveRecord::TestCase
     end
   end
 
+  def test_query_cache_uncached_dirties
+    mw = middleware { |env|
+      Post.first
+      assert_no_changes -> { ActiveRecord::Base.connection.query_cache.size } do
+        Post.uncached(dirties: false) { Post.create!(title: "a new post", body: "and a body") }
+      end
+
+      assert_changes -> { ActiveRecord::Base.connection.query_cache.size }, from: 1, to: 0 do
+        Post.uncached(dirties: true) { Post.create!(title: "a new post", body: "and a body") }
+      end
+    }
+    mw.call({})
+  end
+
+  def test_query_cache_connection_uncached_dirties
+    mw = middleware { |env|
+      Post.first
+      assert_no_changes -> { ActiveRecord::Base.connection.query_cache.size } do
+        Post.connection.uncached(dirties: false) { Post.create!(title: "a new post", body: "and a body") }
+      end
+
+      assert_changes -> { ActiveRecord::Base.connection.query_cache.size }, from: 1, to: 0 do
+        Post.connection.uncached(dirties: true) { Post.create!(title: "a new post", body: "and a body") }
+      end
+    }
+    mw.call({})
+  end
+
+  def test_query_cache_uncached_dirties_disabled_with_nested_cache
+    mw = middleware { |env|
+      Post.first
+      assert_changes -> { ActiveRecord::Base.connection.query_cache.size }, from: 1, to: 0 do
+        Post.uncached(dirties: false) do
+          Post.cache do
+            Post.create!(title: "a new post", body: "and a body")
+          end
+        end
+      end
+
+      Post.first
+      assert_changes -> { ActiveRecord::Base.connection.query_cache.size }, from: 1, to: 0 do
+        Post.connection.uncached(dirties: false) do
+          Post.connection.cache do
+            Post.create!(title: "a new post", body: "and a body")
+          end
+        end
+      end
+    }
+    mw.call({})
+  end
+
   private
     def with_temporary_connection_pool(&block)
       pool_config = ActiveRecord::Base.connection.pool.pool_config


### PR DESCRIPTION


### Motivation / Background

This is an alternative to https://github.com/rails/rails/pull/50721.

For [Solid Cache](https://github.com/rails/solid_cache), we want to be able to read and write from the cache database without using the query cache.

We also don't want to expire the query cache on other connection pools when we write. Writing to the Rails cache shouldn't invalidate the main query cache.

cc @byroot, @jeremy 

### Detail

This adds a `dirties` option to `ActiveRecord::Base.uncached` and `ActiveRecord::ConnectionAdapters::ConnectionPool#uncached`.

Setting `dirties` to `false`, means database writes to the connection pool will not mark any query caches as dirty.

The option defaults to `true` which retains the existing behaviour and clears query caches on all connection pools used by the current thread.

### Additional information

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
