### PR TITLE
Fix `indexes` method for non-existing MySQL tables

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/mysql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/schema_statements.rb
@@ -68,6 +68,12 @@ module ActiveRecord
 
             IndexDefinition.new(*index, **options)
           end
+        rescue StatementInvalid => e
+          if e.message.match?(/Table '.+' doesn't exist/)
+            []
+          else
+            raise
+          end
         end
 
         def remove_column(table_name, column_name, type = nil, **options)

--- a/activerecord/test/cases/adapter_test.rb
+++ b/activerecord/test/cases/adapter_test.rb
@@ -92,6 +92,10 @@ module ActiveRecord
       @connection.remove_index(:accounts, name: idx_name) rescue nil
     end
 
+    def test_returns_empty_indexes_for_non_existing_table
+      assert_equal [], @connection.indexes("nonexistingtable")
+    end
+
     def test_remove_index_when_name_and_wrong_column_name_specified
       index_name = "accounts_idx"
 


### PR DESCRIPTION
Fixes #51205.