### PR TITLE
Add `value_format` option to `numericality`, `length` and `comparison` validators

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -19,4 +19,23 @@
 
     *Jonathan Hefner*
 
+*   Add the `value_format` option for validations such as `numericality`,
+    `length`, and `comparison`.
+    This option enables formatting the value passed to `%{count}` in i18n
+    messages.
+
+    e.g. In the following code, it will be generated messages is
+    _"must be equal to 1,000"_.
+
+    ```ruby
+    class MyModel < ApplicationRecord
+      validates :my_attribute, numericality: {
+        equal_to: 1_000,
+        value_format: -> (value) { value.to_fs(:delimited) }
+      }
+    end
+    ```
+
+    *Ryoya Kato*
+
 Please check [7-1-stable](https://github.com/rails/rails/blob/7-1-stable/activemodel/CHANGELOG.md) for previous changes.

--- a/activemodel/lib/active_model/validations/comparison.rb
+++ b/activemodel/lib/active_model/validations/comparison.rb
@@ -2,12 +2,14 @@
 
 require "active_model/validations/comparability"
 require "active_model/validations/resolve_value"
+require "active_model/validations/format_value"
 
 module ActiveModel
   module Validations
     class ComparisonValidator < EachValidator # :nodoc:
       include Comparability
       include ResolveValue
+      include FormatValue
 
       def check_validity!
         unless options.keys.intersect?(COMPARE_CHECKS.keys)
@@ -25,7 +27,7 @@ module ActiveModel
           end
 
           unless value.public_send(COMPARE_CHECKS[option], option_value)
-            record.errors.add(attr_name, option, **error_options(value, option_value))
+            record.errors.add(attr_name, option, **error_options(value, format_value(record, option_value)))
           end
         rescue ArgumentError => e
           record.errors.add(attr_name, e.message)

--- a/activemodel/lib/active_model/validations/format_value.rb
+++ b/activemodel/lib/active_model/validations/format_value.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module ActiveModel
+  module Validations
+    module FormatValue # :nodoc:
+      def format_value(record, value)
+        value_format = options[:value_format]
+
+        case value_format
+        when Proc
+          value_format.call(value)
+        when Symbol
+          record.send(value_format, value)
+        else
+          if value_format.respond_to?(:call)
+            value_format.call(value)
+          else
+            value
+          end
+        end
+      end
+    end
+  end
+end

--- a/activemodel/lib/active_model/validations/length.rb
+++ b/activemodel/lib/active_model/validations/length.rb
@@ -1,11 +1,13 @@
 # frozen_string_literal: true
 
 require "active_model/validations/resolve_value"
+require "active_model/validations/format_value"
 
 module ActiveModel
   module Validations
     class LengthValidator < EachValidator # :nodoc:
       include ResolveValue
+      include FormatValue
 
       MESSAGES  = { is: :wrong_length, minimum: :too_short, maximum: :too_long }.freeze
       CHECKS    = { is: :==, minimum: :>=, maximum: :<= }.freeze
@@ -56,7 +58,7 @@ module ActiveModel
             next if value_length.public_send(validity_check, check_value)
           end
 
-          errors_options[:count] = check_value
+          errors_options[:count] = format_value(record, check_value)
 
           default_message = options[MESSAGES[key]]
           errors_options[:message] ||= default_message if default_message

--- a/activemodel/lib/active_model/validations/numericality.rb
+++ b/activemodel/lib/active_model/validations/numericality.rb
@@ -2,6 +2,7 @@
 
 require "active_model/validations/comparability"
 require "active_model/validations/resolve_value"
+require "active_model/validations/format_value"
 require "bigdecimal/util"
 
 module ActiveModel
@@ -9,6 +10,7 @@ module ActiveModel
     class NumericalityValidator < EachValidator # :nodoc:
       include Comparability
       include ResolveValue
+      include FormatValue
 
       RANGE_CHECKS = { in: :in? }
       NUMBER_CHECKS = { odd: :odd?, even: :even? }
@@ -53,12 +55,12 @@ module ActiveModel
             end
           elsif RANGE_CHECKS.include?(option)
             unless value.public_send(RANGE_CHECKS[option], option_value)
-              record.errors.add(attr_name, option, **filtered_options(value).merge!(count: option_value))
+              record.errors.add(attr_name, option, **filtered_options(value).merge!(count: format_value(record, option_value)))
             end
           elsif COMPARE_CHECKS.include?(option)
             option_value = option_as_number(record, option_value, precision, scale)
             unless value.public_send(COMPARE_CHECKS[option], option_value)
-              record.errors.add(attr_name, option, **filtered_options(value).merge!(count: option_value))
+              record.errors.add(attr_name, option, **filtered_options(value).merge!(count: format_value(record, option_value)))
             end
           end
         end

--- a/activemodel/test/cases/validations/comparison_validation_test.rb
+++ b/activemodel/test/cases/validations/comparison_validation_test.rb
@@ -311,6 +311,13 @@ class ComparisonValidationTest < ActiveModel::TestCase
                  " :less_than, :less_than_or_equal_to, or :other_than option to be supplied.", error.message
   end
 
+  def test_validates_comparison_with_value_format
+    date_value = Date.parse("2020-03-28")
+    Topic.validates_comparison_of :approved, equal_to: date_value, value_format: -> (value) { "3/28/2020" }
+
+    assert_invalid_values([Date.new(2020, 3, 27)], "must be equal to 3/28/2020")
+  end
+
   private
     def assert_invalid_values(values, error = nil)
       with_each_topic_approved_value(values) do |topic, value|

--- a/activemodel/test/cases/validations/format_value_test.rb
+++ b/activemodel/test/cases/validations/format_value_test.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+
+require "active_support/core_ext/numeric"
+
+class FormatValueTest < ActiveModel::TestCase
+  class Validator
+    include ActiveModel::Validations
+    include ActiveModel::Validations::FormatValue
+    attr_accessor :options
+  end
+
+  class Record; end
+
+  def setup
+    @validator = Validator.new
+  end
+
+  def test_format_value_with_proc
+    @validator.options = { value_format: Proc.new { |value| value.to_fs(:delimited) } }
+    assert_equal "1,000", @validator.format_value(Record.new, 1_000)
+  end
+
+  def test_format_value_with_method
+    Record.define_method(:value_format) { |value| value.to_fs(:delimited) }
+    @validator.options = { value_format: :value_format }
+    assert_equal "1,000", @validator.format_value(Record.new, 1_000)
+  ensure
+    Record.remove_method :value_format
+  end
+
+  def test_format_value_with_lambda
+    @validator.options = { value_format: -> (value) { value.to_fs(:delimited) } }
+    assert_equal "1,000", @validator.format_value(Record.new, 1_000)
+  end
+
+  def test_format_value_with_invalid_format
+    @validator.options = { value_format: "foo" }
+    assert_equal 1_000, @validator.format_value(Record.new, 1_000)
+  end
+end

--- a/activemodel/test/cases/validations/length_validation_test.rb
+++ b/activemodel/test/cases/validations/length_validation_test.rb
@@ -496,4 +496,12 @@ class LengthValidationTest < ActiveModel::TestCase
     t.title = ""
     assert_predicate t, :valid?
   end
+
+  def test_validates_length_with_value_format
+    Topic.validates_length_of :title, minimum: 1_000, value_format: -> (value) { "1,000" }
+
+    t = Topic.new("title" => "notvalid", "content" => "whatever")
+    assert_predicate t, :invalid?
+    assert_equal ["is too short (minimum is 1,000 characters)"], t.errors[:title]
+  end
 end

--- a/activemodel/test/cases/validations/numericality_validation_test.rb
+++ b/activemodel/test/cases/validations/numericality_validation_test.rb
@@ -348,6 +348,18 @@ class NumericalityValidationTest < ActiveModel::TestCase
     assert_valid_values([Float("65.6"), BigDecimal("65.6")])
   end
 
+  def test_validates_numericality_with_value_format_and_range_checks
+    Topic.validates_numericality_of :approved, in: 100..1_000, value_format: -> (value) { "100-1,000" }
+
+    assert_invalid_values([10], "must be in 100-1,000")
+  end
+
+  def test_validates_numericality_with_value_format_and_compare_checks
+    Topic.validates_numericality_of :approved, equal_to: 1_000, value_format: -> (value) { "1,000" }
+
+    assert_invalid_values([100], "must be equal to 1,000")
+  end
+
   private
     def assert_invalid_values(values, error = nil)
       with_each_topic_approved_value(values) do |topic, value|

--- a/guides/source/active_record_validations.md
+++ b/guides/source/active_record_validations.md
@@ -409,6 +409,7 @@ These options are all supported:
   less than or equal to %{count}"_.
 * `:other_than` - Specifies the value must be other than the supplied value.
   The default error message for this option is _"must be other than %{count}"_.
+* `:value_format` - Specifies the format for formatting the value passed to `%{count}` in i18n messages.
 
 NOTE: The validator requires a compare option be supplied. Each option accepts a
 value, proc, or symbol. Any class that includes Comparable can be compared.
@@ -509,6 +510,7 @@ The possible length constraint options are:
 * `:in` (or `:within`) - The attribute length must be included in a given
   interval. The value for this option must be a range.
 * `:is` - The attribute length must be equal to the given value.
+* `:value_format` - Specifies the format for formatting the value passed to `%{count}` in i18n messages.
 
 The default error messages depend on the type of length validation being
 performed. You can customize these messages using the `:wrong_length`,
@@ -593,6 +595,7 @@ values:
   for this option is _"must be odd"_.
 * `:even` - Specifies the value must be an even number. The default error
   message for this option is _"must be even"_.
+* `:value_format` - Specifies the format for formatting the value passed to `%{count}` in i18n messages.
 
 ### `presence`
 


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

In current implementations, formatting numerical or date values in messages generated by validations typically requires specifying the message option or implementing custom validators.
However, I only want to format the `%{count}` and do not need to handle the message, apart from the message option, so I believe it should be a native feature of the framework.

### Detail

This pull request introduces the value_format option for validations such as `numericality`, `length`, and `comparison`. With this option, it becomes possible to format the value passed to `%{count}` in i18n messages.

e.g. messages like _"must be equal to 1,000"_ can now be generated.
```ruby
class MyModel < ApplicationRecord
  validates :my_attribute, numericality: {
    equal_to: 1_000,
    value_format: -> (value) { value.to_fs(:delimited) }
  }
end
```

### Additional information

<!-- Provide additional information such as benchmarks, reference to other repositories or alternative solutions. -->

There have been several similar PRs submitted in the past:

- https://github.com/rails/rails/pull/44076
- https://github.com/rails/rails/pull/41482

Comparing them,

- There is no impact on existing implementation since it can be specified with options.
- It also supports `length` and `comparison` where `%{count}` is used, not limited to `numericality`.

<br />

If there are any errors or inconsistencies in the English language in the change log or documentation, please point them out.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
