### PR TITLE
[ci skip] docs: add around_update callback example

### DIFF
--- a/activerecord/lib/active_record/callbacks.rb
+++ b/activerecord/lib/active_record/callbacks.rb
@@ -91,10 +91,18 @@ module ActiveRecord
   #
   #   class Topic < ActiveRecord::Base
   #     before_destroy :delete_parents
+  #     around_update :audit_title
   #
   #     private
   #       def delete_parents
   #         self.class.delete_by(parent_id: id)
+  #       end
+  #
+  #       def audit_title
+  #         was_title = title_was
+  #         yield
+  #         title_changed = (was_title != title)
+  #         Rails.logger.info("Audit Log: Title changed from '#{was_title}' to '#{title}'") if title_changed
   #       end
   #   end
   #

--- a/guides/source/active_record_callbacks.md
+++ b/guides/source/active_record_callbacks.md
@@ -161,6 +161,20 @@ Here is a list with all the available Active Record callbacks, listed in the sam
 [`around_update`]: https://api.rubyonrails.org/classes/ActiveRecord/Callbacks/ClassMethods.html#method-i-around_update
 [`before_update`]: https://api.rubyonrails.org/classes/ActiveRecord/Callbacks/ClassMethods.html#method-i-before_update
 
+```ruby
+class User < ApplicationRecord
+  around_update :audit_changes
+
+  private
+    def audit_changes
+      was_email = email_was
+      yield
+      email_changed = (was_email != email)
+      Rails.logger.info("Audit Log: Email changed from '#{was_email}' to '#{email}'") if email_changed
+    end
+end
+```
+
 WARNING. `after_save` runs both on create and update, but always _after_ the more specific callbacks `after_create` and `after_update`, no matter the order in which the macro calls were executed.
 
 ### Destroying an Object


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because there's no example for `around_ ` callbacks, so I think it's useful for newcomers like me

### Detail

This Pull Request changes 2 files, adding an example for an `around_update` callback:
- `activerecord/lib/active_record/callbacks.rb`
- `guides/source/active_record_callbacks.md`

### Additional information

<!-- Provide additional information such as benchmarks, reference to other repositories or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
