### PR TITLE
Expose a generic fixture accessor for fixture names that may conflict with Minitest

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Expose a generic fixture accessor for fixture names that may conflict with Minitest
+
+    ```ruby
+    assert_equal "Ruby on Rails", web_sites(:rubyonrails).name
+    assert_equal "Ruby on Rails", fixture(:web_sites, :rubyonrails).name
+    ```
+
+    *Jean Boussier*
+
 *   Using `Model.query_constraints` with a single non-primary-key column used to raise as expected, but with an
     incorrect error message. This has been fixed to raise with a more appropriate error message.
 

--- a/activerecord/lib/active_record/fixtures.rb
+++ b/activerecord/lib/active_record/fixtures.rb
@@ -110,6 +110,12 @@ module ActiveRecord
   #     assert_raise(StandardError) { web_sites(:reddit) }
   #   end
   #
+  # If the model names conflicts with a +TestCase+ methods, you can use the generic +fixture+ accessor
+  #
+  #   test "generic find" do
+  #     assert_equal "Ruby on Rails", fixture(:web_sites, :rubyonrails).name
+  #   end
+  #
   # Alternatively, you may enable auto-instantiation of the fixture data. For instance, take the
   # following tests:
   #

--- a/activerecord/lib/active_record/test_fixtures.rb
+++ b/activerecord/lib/active_record/test_fixtures.rb
@@ -254,8 +254,8 @@ module ActiveRecord
       end
 
       def method_missing(method, ...)
-        if fs_name = fixture_sets[method.name]
-          access_fixture(fs_name, ...)
+        if fixture_sets.key?(method.name)
+          fixture(method, ...)
         else
           super
         end
@@ -266,6 +266,14 @@ module ActiveRecord
           true
         else
           super
+        end
+      end
+
+      def fixture(fixture_set_name, *fixture_names)
+        if fs_name = fixture_sets[fixture_set_name.name]
+          access_fixture(fs_name, *fixture_names)
+        else
+          raise StandardError, "No fixture set named '#{fixture_set_name.inspect}'"
         end
       end
 


### PR DESCRIPTION
```ruby
assert_equal "Ruby on Rails", web_sites(:rubyonrails).name
assert_equal "Ruby on Rails", fixture(:web_sites, :rubyonrails).name
```

This was brought to me by someone with a `Metadata` model. The fixtures accessor being `metadata` which conflicts with the `metadata` method recently added in `Minitest`.

cc @zk-1