### PR TITLE
Clear all threads query cache when a connection is pinned

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb
@@ -129,7 +129,14 @@ module ActiveRecord
         end
 
         def clear_query_cache
-          query_cache.clear
+          if @pinned_connection
+            # With transactional fixtures, and especially systems test
+            # another thread may use the same connection, but with a different
+            # query cache. So we must clear them all.
+            @thread_query_caches.each_value(&:clear)
+          else
+            query_cache.clear
+          end
         end
 
         private


### PR DESCRIPTION
Ref: https://github.com/Shopify/maintenance_tasks/pull/983#issuecomment-1969407080
Ref: https://github.com/rails/rails/pull/51151

Now that query caches are owned by the pool, and assigned on connections during checkout, when running multithreaded code inside transactional tests (typically system tests), the two threads uses the same connection but not the same cache.

So it's important that we do clear the caches for all threads when a connection is pinned.

cc @adrianna-chang-shopify 