### PR TITLE
Fix regression in isolated engine's `table_name_prefix` behaviour

### DIFF
--- a/railties/lib/rails/engine.rb
+++ b/railties/lib/rails/engine.rb
@@ -395,13 +395,7 @@ module Rails
             define_method(:railtie_namespace) { railtie }
 
             unless mod.respond_to?(:table_name_prefix)
-              define_method(:table_name_prefix) { "#{name}_" }
-
-              ActiveSupport.on_load(:active_record) do
-                mod.singleton_class.redefine_method(:table_name_prefix) do
-                  "#{ActiveRecord::Base.table_name_prefix}#{name}_"
-                end
-              end
+              define_method(:table_name_prefix) { [ActiveRecord::Base.table_name_prefix, name].compact.join + "_" }
             end
 
             unless mod.respond_to?(:use_relative_model_naming?)

--- a/railties/test/railties/engine_test.rb
+++ b/railties/test/railties/engine_test.rb
@@ -1298,6 +1298,40 @@ en:
       assert_equal "foo", Bukkits.table_name_prefix
     end
 
+    test "respect the engine table_name_prefix method" do
+      @plugin = engine "blog" do |plugin|
+        plugin.write "lib/blog.rb", <<-RUBY
+          require "blog/engine"
+
+          module Blog
+            def self.table_name_prefix
+              ""
+            end
+          end
+        RUBY
+
+        plugin.write "lib/blog/engine.rb", <<-RUBY
+          module Blog
+            class Engine < ::Rails::Engine
+              railtie_name "blog"
+              isolate_namespace(Blog)
+            end
+          end
+        RUBY
+
+        plugin.write "app/models/blog/post.rb", <<-RUBY
+          module Blog
+            class Post < ActiveRecord::Base
+            end
+          end
+        RUBY
+      end
+
+      boot_rails
+
+      assert_equal "posts", Blog::Post.table_name
+    end
+
     test "take ActiveRecord table_name_prefix into consideration when defining table_name_prefix" do
       @plugin.write "lib/bukkits.rb", <<-RUBY
         module Bukkits


### PR DESCRIPTION
### Motivation / Background

https://github.com/rails/rails/pull/50247 introduced a regression for engines already defining a `table_name_prefix` method which would make the default behaviour (ActiveRecord's config + engine's name) take precedence over the user defined method.

### Detail

This Pull Request changes how `table_name_prefix` is programmatically defined when not already user-defined, removing usage of `ActiveSupport.on_load(:active_record)` which delay execution of the block until later.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [ ] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
