### PR TITLE
Add initializer to set up remote debugging in local environments

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,17 @@
+*   Set up the `debug` for use with an IDE Debugger in local environments.
+
+    Set the `ENV['RUBY_DEBUG_PORT']` environment variable and then configure your editor to connect to the same port.
+
+    VS Code users can use the official rdbg extension, to connect:
+    https://marketplace.visualstudio.com/items?itemName=KoichiSasada.vscode-rdbg
+
+    Neovim users can use DAP to connect. This plugin expects RUBY_DEBUG_PORT to be set to 38698.
+    You can then connect to your debugger server with `:lua require("dap").continue()`
+    and then choosing the "debug current file" option.
+    https://github.com/suketa/nvim-dap-ruby
+
+    *Nate Matykiewicz*
+
 *   Set `action_mailer.default_url_options` values in `development` and `test`.
 
     Prior to this commit, new Rails applications would raise `ActionView::Template::Error`

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/debugger.rb
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/debugger.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+return unless Rails.env.local?
+
+begin
+  if Rails.env.test? ||
+    defined?(Rails::Console) ||
+    (defined?(Rake.application.top_level_tasks) && Rake.application.top_level_tasks.any?)
+
+    # Simply require `debug`, and use standard `binding.break`
+    require 'debug'
+  elsif ENV['RUBY_DEBUG_PORT'] && (defined?(Rails::Server) || ENV['PWD'].include?('.puma-dev'))
+    # When ENV['RUBY_DEBUG_PORT'] is set, debug/open_nonstop will start a TCP/IP debugger server
+    # on the provided port, which your editor can connect to.
+    #
+    # https://github.com/ruby/debug/blob/master/lib/debug/open_nonstop.rb
+    require 'debug'
+    require 'debug/open_nonstop'
+
+    # You can then create breakpoints using your editor's native debugger options
+    # (for example, F9 sets a breakpoint in VS Code).
+    #
+    # - Debug server whether you're running via `rails s` or puma-dev
+    # - Debug your tests
+    # - Do not debug rake tasks, console sessions, Sidekiq, Tailwind CLI, Vite CLI, etc
+    #
+    # VS Code users can use the official rdbg extension, to connect:
+    # https://marketplace.visualstudio.com/items?itemName=KoichiSasada.vscode-rdbg
+    #
+    # Neovim users can use DAP to connect. This plugin expects RUBY_DEBUG_PORT to be set to 38698.
+    # You can then connect to your debugger server with `:lua require("dap").continue()`
+    # and then choosing the "debug current file" option.
+    # https://github.com/suketa/nvim-dap-ruby
+  else
+    # No-op. This would be background job processors, Tailwind CLI, Vite CLI, etc.
+    # No debugger needed.
+  end
+rescue LoadError
+  # Debug gem is not installed
+end

--- a/railties/lib/rails/generators/rails/plugin/templates/Gemfile.tt
+++ b/railties/lib/rails/generators/rails/plugin/templates/Gemfile.tt
@@ -11,7 +11,7 @@ gemspec
 <% if RUBY_ENGINE == "ruby" -%>
 
 # Start debugger with binding.b [https://github.com/ruby/debug]
-# gem "debug", ">= 1.0.0"
+# gem "debug", ">= 1.8.0"
 <% end -%>
 <% if RUBY_PLATFORM.match?(/mingw|mswin|java/) -%>
 

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -55,6 +55,7 @@ DEFAULT_APP_FILES = %w(
   config/environments/test.rb
   config/initializers/assets.rb
   config/initializers/content_security_policy.rb
+  config/initializers/debugger.rb
   config/initializers/enable_yjit.rb
   config/initializers/filter_parameter_logging.rb
   config/initializers/inflections.rb

--- a/railties/test/generators/plugin_generator_test.rb
+++ b/railties/test/generators/plugin_generator_test.rb
@@ -50,6 +50,7 @@ DEFAULT_PLUGIN_FILES = %w(
   test/dummy/config/environments/production.rb
   test/dummy/config/environments/test.rb
   test/dummy/config/initializers/content_security_policy.rb
+  test/dummy/config/initializers/debugger.rb
   test/dummy/config/initializers/enable_yjit.rb
   test/dummy/config/initializers/filter_parameter_logging.rb
   test/dummy/config/initializers/inflections.rb


### PR DESCRIPTION
### Motivation / Background

I wanted to be able to use the native debugger tools in Neovim instead of having to use WebConsole or using the logger for debugging.

### Detail

The `debug` gem, which is included in the Gemfile template supports remote debugging as of [version 1.8.0](https://github.com/ruby/debug/releases/tag/v1.8.0). A `debug` gem maintainer also maintains a [VS Code extension](https://marketplace.visualstudio.com/items?itemName=KoichiSasada.vscode-rdbg) that can be used to connect to the running rdbg server in Rails.

### Additional information

I'm not sure how to go about testing this. The entire change is to require files at the right times.

I know the `gem 'debug'` line will auto-require the debug gem. I thought it was a nicer developer experience to manually require it in case someone included `, require: false`.

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [X] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.