### PR TITLE
Update output of `bin/rails test -h` in testing guide [ci-skip]

### DIFF
--- a/guides/source/testing.md
+++ b/guides/source/testing.md
@@ -460,29 +460,36 @@ at the end of the test run and so on. Check the documentation of the test runner
 
 ```bash
 $ bin/rails test -h
-Usage: rails test [options] [files or directories]
+Usage:
+  bin/rails test [PATHS...]
 
-You can run a single test by appending a line number to a filename:
+Run tests except system tests
 
-    bin/rails test test/models/user_test.rb:27
+Examples:
+    You can run a single test by appending a line number to a filename:
 
-You can run multiple tests with in a line range by appending the line range to a filename:
+        bin/rails test test/models/user_test.rb:27
 
-    bin/rails test test/models/user_test.rb:10-20
+    You can run multiple tests with in a line range by appending the line range to a filename:
 
-You can run multiple files and directories at the same time:
+        bin/rails test test/models/user_test.rb:10-20
 
-    bin/rails test test/controllers test/integration/login_test.rb
+    You can run multiple files and directories at the same time:
 
-By default test failures and errors are reported inline during a run.
+        bin/rails test test/controllers test/integration/login_test.rb
+
+    By default test failures and errors are reported inline during a run.
 
 minitest options:
     -h, --help                       Display this help.
         --no-plugins                 Bypass minitest plugin auto-loading (or set $MT_NO_PLUGINS).
     -s, --seed SEED                  Sets random seed. Also via env. Eg: SEED=n rake
     -v, --verbose                    Verbose. Show progress processing files.
+    -q, --quiet                      Quiet. Show no progress processing files.
+        --show-skips                 Show skipped at the end of run.
     -n, --name PATTERN               Filter run on /regexp/ or string.
         --exclude PATTERN            Exclude /regexp/ or string from run.
+    -S, --skip CODES                 Skip reporting of certain types of results (eg E).
 
 Known extensions: rails, pride
     -w, --warnings                   Run with Ruby warnings enabled
@@ -491,6 +498,7 @@ Known extensions: rails, pride
     -d, --defer-output               Output test failures and errors after the test run
     -f, --fail-fast                  Abort test run on first failure or error
     -c, --[no-]color                 Enable color in the output
+        --profile [COUNT]            Enable profiling of tests and list the slowest test cases (default: 10)
     -p, --pride                      Pride. Show your testing pride!
 ```
 


### PR DESCRIPTION
### Motivation / Background

#49082 added `--profile` which is a pretty cool feature. But discoverability is pretty low currently, with not even being mentioned in the testing guide. This does the thing requiring the least effort by at least documenting it in the available options.

Things seem to have changed in general since this was last updated. Formatting changed and a few new minitest options were added. I generated this output while being on the current latest version of minitest (5.22.2).

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
