### PR TITLE
Deprecate `ConnectionPool#connection`

### DIFF
--- a/actioncable/test/subscription_adapter/postgresql_test.rb
+++ b/actioncable/test/subscription_adapter/postgresql_test.rb
@@ -23,7 +23,7 @@ class PostgresqlAdapterTest < ActionCable::TestCase
     ActiveRecord::Base.establish_connection database_config
 
     begin
-      ActiveRecord::Base.connection.connect!
+      ActiveRecord::Base.lease_connection.connect!
     rescue
       @rx_adapter = @tx_adapter = nil
       skip "Couldn't connect to PostgreSQL: #{database_config.inspect}"
@@ -68,7 +68,7 @@ class PostgresqlAdapterTest < ActionCable::TestCase
   def test_default_subscription_connection_identifier
     subscribe_as_queue("channel") { }
 
-    identifiers = ActiveRecord::Base.connection.exec_query("SELECT application_name FROM pg_stat_activity").rows
+    identifiers = ActiveRecord::Base.lease_connection.exec_query("SELECT application_name FROM pg_stat_activity").rows
     assert_includes identifiers, ["ActionCable-PID-#{$$}"]
   end
 
@@ -81,7 +81,7 @@ class PostgresqlAdapterTest < ActionCable::TestCase
 
     subscribe_as_queue("channel", adapter) { }
 
-    identifiers = ActiveRecord::Base.connection.exec_query("SELECT application_name FROM pg_stat_activity").rows
+    identifiers = ActiveRecord::Base.lease_connection.exec_query("SELECT application_name FROM pg_stat_activity").rows
     assert_includes identifiers, ["hello-world-42"]
   end
 end

--- a/actionmailbox/test/migrations_test.rb
+++ b/actionmailbox/test/migrations_test.rb
@@ -8,7 +8,7 @@ class ActionMailbox::MigrationsTest < ActiveSupport::TestCase
     @original_verbose = ActiveRecord::Migration.verbose
     ActiveRecord::Migration.verbose = false
 
-    @connection = ActiveRecord::Base.connection
+    @connection = ActiveRecord::Base.lease_connection
     @original_options = Rails.configuration.generators.options.deep_dup
   end
 

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,20 @@
+*   Deprecate `ActiveRecord::Base.connection` in favor of `.lease_connection`
+
+    The method has been renamed as `lease_connection` to better reflect that the returned
+    connection will be held for the duration of the request or job.
+
+    This deprecation is a soft deprecation, no warnings will be issued and there is no
+    current plan to remove the method.
+
+    *Jean Boussier*
+
+*   Deprecate `ActiveRecord::ConnectionAdapters::ConnectionPool#connection`
+
+    The method has been renamed as `lease_connection` to better reflect that the returned
+    connection will be held for the duration of the request or job.
+
+    *Jean Boussier*
+
 *   Expose a generic fixture accessor for fixture names that may conflict with Minitest
 
     ```ruby

--- a/activerecord/examples/performance.rb
+++ b/activerecord/examples/performance.rb
@@ -176,10 +176,10 @@ Benchmark.ips(TIME) do |x|
   end
 
   x.report "Model.log" do
-    Exhibit.connection.send(:log, "hello", "world") { }
+    Exhibit.lease_connection.send(:log, "hello", "world") { }
   end
 
   x.report "AR.execute(query)" do
-    ActiveRecord::Base.connection.execute("SELECT * FROM exhibits WHERE id = #{(rand * 1000 + 1).to_i}")
+    ActiveRecord::Base.lease_connection.execute("SELECT * FROM exhibits WHERE id = #{(rand * 1000 + 1).to_i}")
   end
 end

--- a/activerecord/lib/active_record/associations/association.rb
+++ b/activerecord/lib/active_record/associations/association.rb
@@ -63,7 +63,7 @@ module ActiveRecord
       # Reloads the \target and returns +self+ on success.
       # The QueryCache is cleared if +force+ is true.
       def reload(force = false)
-        klass.connection.clear_query_cache if force && klass
+        klass.connection_pool.clear_query_cache if force && klass
         reset
         reset_scope
         load_target
@@ -231,12 +231,14 @@ module ActiveRecord
           end
 
           binds = AssociationScope.get_bind_values(owner, reflection.chain)
-          sc.execute(binds, klass.connection) do |record|
-            set_inverse_instance(record)
-            if owner.strict_loading_n_plus_one_only? && reflection.macro == :has_many
-              record.strict_loading!
-            else
-              record.strict_loading!(false, mode: owner.strict_loading_mode)
+          klass.with_connection do |c|
+            sc.execute(binds, c) do |record|
+              set_inverse_instance(record)
+              if owner.strict_loading_n_plus_one_only? && reflection.macro == :has_many
+                record.strict_loading!
+              else
+                record.strict_loading!(false, mode: owner.strict_loading_mode)
+              end
             end
           end
         end

--- a/activerecord/lib/active_record/associations/join_dependency/join_association.rb
+++ b/activerecord/lib/active_record/associations/join_dependency/join_association.rb
@@ -91,7 +91,7 @@ module ActiveRecord
           def append_constraints(join, constraints)
             if join.is_a?(Arel::Nodes::StringJoin)
               join_string = Arel::Nodes::And.new(constraints.unshift join.left)
-              join.left = Arel.sql(base_klass.connection.visitor.compile(join_string))
+              join.left = Arel.sql(base_klass.lease_connection.visitor.compile(join_string))
             else
               right = join.right
               right.expr = Arel::Nodes::And.new(constraints.unshift right.expr)

--- a/activerecord/lib/active_record/base.rb
+++ b/activerecord/lib/active_record/base.rb
@@ -233,7 +233,7 @@ module ActiveRecord # :nodoc:
   #
   # Connections are usually created through
   # {ActiveRecord::Base.establish_connection}[rdoc-ref:ConnectionHandling#establish_connection] and retrieved
-  # by ActiveRecord::Base.connection. All classes inheriting from ActiveRecord::Base will use this
+  # by ActiveRecord::Base.lease_connection. All classes inheriting from ActiveRecord::Base will use this
   # connection. But you can also set a class-specific connection. For example, if Course is an
   # ActiveRecord::Base, but resides in a different database, you can just say <tt>Course.establish_connection</tt>
   # and Course and all of its subclasses will use this connection instead.

--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_handler.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_handler.rb
@@ -190,7 +190,7 @@ module ActiveRecord
       # for (not necessarily the current class).
       def retrieve_connection(connection_name, role: ActiveRecord::Base.current_role, shard: ActiveRecord::Base.current_shard) # :nodoc:
         pool = retrieve_connection_pool(connection_name, role: role, shard: shard, strict: true)
-        pool.connection
+        pool.lease_connection
       end
 
       # Returns true if a connection that's accessible to this class has

--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -296,9 +296,9 @@ module ActiveRecord
       # #transaction will raise exceptions when it tries to release the
       # already-automatically-released savepoints:
       #
-      #   Model.connection.transaction do  # BEGIN
-      #     Model.connection.transaction(requires_new: true) do  # CREATE SAVEPOINT active_record_1
-      #       Model.connection.create_table(...)
+      #   Model.lease_connection.transaction do  # BEGIN
+      #     Model.lease_connection.transaction(requires_new: true) do  # CREATE SAVEPOINT active_record_1
+      #       Model.lease_connection.create_table(...)
       #       # active_record_1 now automatically released
       #     end  # RELEASE SAVEPOINT active_record_1  <--- BOOM! database error!
       #   end

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -23,7 +23,7 @@ module ActiveRecord
     # and +:limit+ options, etc.
     #
     # All the concrete database adapters follow the interface laid down in this class.
-    # {ActiveRecord::Base.connection}[rdoc-ref:ConnectionHandling#connection] returns an AbstractAdapter object, which
+    # {ActiveRecord::Base.lease_connection}[rdoc-ref:ConnectionHandling#lease_connection] returns an AbstractAdapter object, which
     # you can use.
     #
     # Most of the methods in the adapter are useful during migrations. Most

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -377,8 +377,8 @@ module ActiveRecord
       end
 
       def cached_find_by_statement(key, &block) # :nodoc:
-        cache = @find_by_statement_cache[connection.prepared_statements]
-        cache.compute_if_absent(key) { StatementCache.create(connection, &block) }
+        cache = @find_by_statement_cache[lease_connection.prepared_statements]
+        cache.compute_if_absent(key) { StatementCache.create(lease_connection, &block) }
       end
 
       private
@@ -431,7 +431,7 @@ module ActiveRecord
           }
 
           begin
-            statement.execute(values.flatten, connection).first
+            statement.execute(values.flatten, lease_connection).first
           rescue TypeError
             raise ActiveRecord::StatementInvalid
           end

--- a/activerecord/lib/active_record/errors.rb
+++ b/activerecord/lib/active_record/errors.rb
@@ -58,7 +58,7 @@ module ActiveRecord
   end
 
   # Raised when connection to the database could not been established (for example when
-  # {ActiveRecord::Base.connection=}[rdoc-ref:ConnectionHandling#connection]
+  # {ActiveRecord::Base.lease_connection=}[rdoc-ref:ConnectionHandling#lease_connection]
   # is given a +nil+ object).
   class ConnectionNotEstablished < AdapterError
     def initialize(message = nil, connection_pool: nil)

--- a/activerecord/lib/active_record/explain.rb
+++ b/activerecord/lib/active_record/explain.rb
@@ -17,16 +17,17 @@ module ActiveRecord
     # Makes the adapter execute EXPLAIN for the tuples of queries and bindings.
     # Returns a formatted string ready to be logged.
     def exec_explain(queries, options = []) # :nodoc:
-      str = queries.map do |sql, binds|
-        msg = +"#{build_explain_clause(options)} #{sql}"
-        unless binds.empty?
-          msg << " "
-          msg << binds.map { |attr| render_bind(attr) }.inspect
-        end
-        msg << "\n"
-        msg << connection.explain(sql, binds, options)
-      end.join("\n")
-
+      str = with_connection do |c|
+        queries.map do |sql, binds|
+          msg = +"#{build_explain_clause(c, options)} #{sql}"
+          unless binds.empty?
+            msg << " "
+            msg << binds.map { |attr| render_bind(c, attr) }.inspect
+          end
+          msg << "\n"
+          msg << c.explain(sql, binds, options)
+        end.join("\n")
+      end
       # Overriding inspect to be more human readable, especially in the console.
       def str.inspect
         self
@@ -36,7 +37,7 @@ module ActiveRecord
     end
 
     private
-      def render_bind(attr)
+      def render_bind(connection, attr)
         if ActiveModel::Attribute === attr
           value = if attr.type.binary? && attr.value
             "<#{attr.value_for_database.to_s.bytesize} bytes of binary data>"
@@ -51,7 +52,7 @@ module ActiveRecord
         [attr&.name, value]
       end
 
-      def build_explain_clause(options = [])
+      def build_explain_clause(connection, options = [])
         if connection.respond_to?(:build_explain_clause, true)
           connection.build_explain_clause(options)
         else

--- a/activerecord/lib/active_record/future_result.rb
+++ b/activerecord/lib/active_record/future_result.rb
@@ -143,7 +143,9 @@ module ActiveRecord
           start = Process.clock_gettime(Process::CLOCK_MONOTONIC, :float_millisecond)
           @mutex.synchronize do
             if pending?
-              execute_query(@pool.connection)
+              @pool.with_connection do |connection|
+                execute_query(connection)
+              end
             else
               @lock_wait = (Process.clock_gettime(Process::CLOCK_MONOTONIC, :float_millisecond) - start)
             end

--- a/activerecord/lib/active_record/insert_all.rb
+++ b/activerecord/lib/active_record/insert_all.rb
@@ -8,7 +8,7 @@ module ActiveRecord
     attr_reader :on_duplicate, :update_only, :returning, :unique_by, :update_sql
 
     def initialize(model, inserts, on_duplicate:, update_only: nil, returning: nil, unique_by: nil, record_timestamps: nil)
-      @model, @connection, @inserts = model, model.connection, inserts.map(&:stringify_keys)
+      @model, @connection, @inserts = model, model.lease_connection, inserts.map(&:stringify_keys)
       @on_duplicate, @update_only, @returning, @unique_by = on_duplicate, update_only, returning, unique_by
       @record_timestamps = record_timestamps.nil? ? model.record_timestamps : record_timestamps
 

--- a/activerecord/lib/active_record/integration.rb
+++ b/activerecord/lib/active_record/integration.rb
@@ -178,7 +178,7 @@ module ActiveRecord
       def can_use_fast_cache_version?(timestamp)
         timestamp.is_a?(String) &&
           cache_timestamp_format == :usec &&
-          self.class.connection.default_timezone == :utc &&
+          self.class.lease_connection.default_timezone == :utc &&
           !updated_at_came_from_user?
       end
 

--- a/activerecord/lib/active_record/query_cache.rb
+++ b/activerecord/lib/active_record/query_cache.rb
@@ -42,7 +42,7 @@ module ActiveRecord
       end
 
       ActiveRecord::Base.connection_handler.each_connection_pool do |pool|
-        pool.release_connection if pool.active_connection? && !pool.connection.transaction_open?
+        pool.release_connection if pool.active_connection? && !pool.lease_connection.transaction_open?
       end
     end
 

--- a/activerecord/lib/active_record/querying.rb
+++ b/activerecord/lib/active_record/querying.rb
@@ -59,7 +59,7 @@ module ActiveRecord
     end
 
     def _query_by_sql(sql, binds = [], preparable: nil, async: false) # :nodoc:
-      connection.select_all(sanitize_sql(sql), "#{name} Load", binds, preparable: preparable, async: async)
+      lease_connection.select_all(sanitize_sql(sql), "#{name} Load", binds, preparable: preparable, async: async)
     end
 
     def _load_from_sql(result_set, &block) # :nodoc:
@@ -99,12 +99,12 @@ module ActiveRecord
     #
     # * +sql+ - An SQL statement which should return a count query from the database, see the example above.
     def count_by_sql(sql)
-      connection.select_value(sanitize_sql(sql), "#{name} Count").to_i
+      lease_connection.select_value(sanitize_sql(sql), "#{name} Count").to_i
     end
 
     # Same as <tt>#count_by_sql</tt> but perform the query asynchronously and returns an ActiveRecord::Promise.
     def async_count_by_sql(sql)
-      connection.select_value(sanitize_sql(sql), "#{name} Count", async: true).then(&:to_i)
+      lease_connection.select_value(sanitize_sql(sql), "#{name} Count", async: true).then(&:to_i)
     end
   end
 end

--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -374,7 +374,11 @@ module ActiveRecord
       relation = construct_relation_for_exists(conditions)
       return false if relation.where_clause.contradiction?
 
-      skip_query_cache_if_necessary { connection.select_rows(relation.arel, "#{name} Exists?").size == 1 }
+      skip_query_cache_if_necessary do
+        with_connection do |c|
+          c.select_rows(relation.arel, "#{name} Exists?").size == 1
+        end
+      end
     end
 
     # Returns true if the relation contains the given record or false otherwise.
@@ -467,7 +471,9 @@ module ActiveRecord
             )
           )
           relation = skip_query_cache_if_necessary do
-            klass.connection.distinct_relation_for_primary_key(relation)
+            klass.with_connection do |c|
+              c.distinct_relation_for_primary_key(relation)
+            end
           end
         end
 

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -1653,7 +1653,7 @@ module ActiveRecord
 
         arel.where(where_clause.ast) unless where_clause.empty?
         arel.having(having_clause.ast) unless having_clause.empty?
-        arel.take(build_cast_value("LIMIT", connection.sanitize_limit(limit_value))) if limit_value
+        arel.take(build_cast_value("LIMIT", lease_connection.sanitize_limit(limit_value))) if limit_value
         arel.skip(build_cast_value("OFFSET", offset_value.to_i)) if offset_value
         arel.group(*arel_columns(group_values.uniq)) unless group_values.empty?
 

--- a/activerecord/lib/active_record/result.rb
+++ b/activerecord/lib/active_record/result.rb
@@ -8,7 +8,7 @@ module ActiveRecord
   # {#exec_query}[rdoc-ref:ConnectionAdapters::DatabaseStatements#exec_query]
   # on any database connection adapter. For example:
   #
-  #   result = ActiveRecord::Base.connection.exec_query('SELECT id, title, body FROM posts')
+  #   result = ActiveRecord::Base.lease_connection.exec_query('SELECT id, title, body FROM posts')
   #   result # => #<ActiveRecord::Result:0xdeadbeef>
   #
   #   # Get the column names of the result:

--- a/activerecord/lib/active_record/sanitization.rb
+++ b/activerecord/lib/active_record/sanitization.rb
@@ -169,7 +169,7 @@ module ActiveRecord
         elsif statement.blank?
           statement
         else
-          statement % values.collect { |value| connection.quote_string(value.to_s) }
+          statement % values.collect { |value| lease_connection.quote_string(value.to_s) }
         end
       end
 
@@ -196,13 +196,13 @@ module ActiveRecord
         def replace_bind_variables(statement, values)
           raise_if_bind_arity_mismatch(statement, statement.count("?"), values.size)
           bound = values.dup
-          c = connection
+          c = lease_connection
           statement.gsub(/\?/) do
             replace_bind_variable(bound.shift, c)
           end
         end
 
-        def replace_bind_variable(value, c = connection)
+        def replace_bind_variable(value, c = lease_connection)
           if ActiveRecord::Relation === value
             value.to_sql
           else
@@ -224,7 +224,7 @@ module ActiveRecord
           end
         end
 
-        def quote_bound_value(value, c = connection)
+        def quote_bound_value(value, c = lease_connection)
           if value.respond_to?(:map) && !value.acts_like?(:string)
             values = value.map { |v| v.respond_to?(:id_for_database) ? v.id_for_database : v }
             if values.empty?

--- a/activerecord/lib/active_record/statement_cache.rb
+++ b/activerecord/lib/active_record/statement_cache.rb
@@ -4,14 +4,14 @@ module ActiveRecord
   # Statement cache is used to cache a single statement in order to avoid creating the AST again.
   # Initializing the cache is done by passing the statement in the create block:
   #
-  #   cache = StatementCache.create(Book.connection) do |params|
+  #   cache = StatementCache.create(ClothingItem.lease_connection) do |params|
   #     Book.where(name: "my book").where("author_id > 3")
   #   end
   #
   # The cached statement is executed by using the
   # {connection.execute}[rdoc-ref:ConnectionAdapters::DatabaseStatements#execute] method:
   #
-  #   cache.execute([], Book.connection)
+  #   cache.execute([], ClothingItem.lease_connection)
   #
   # The relation returned by the block is cached, and for each
   # {execute}[rdoc-ref:ConnectionAdapters::DatabaseStatements#execute]
@@ -20,13 +20,13 @@ module ActiveRecord
   # If you want to cache the statement without the values you can use the +bind+ method of the
   # block parameter.
   #
-  #   cache = StatementCache.create(Book.connection) do |params|
+  #   cache = StatementCache.create(ClothingItem.lease_connection) do |params|
   #     Book.where(name: params.bind)
   #   end
   #
   # And pass the bind values as the first argument of +execute+ call.
   #
-  #   cache.execute(["my book"], Book.connection)
+  #   cache.execute(["my book"], ClothingItem.lease_connection)
   class StatementCache # :nodoc:
     class Substitute; end # :nodoc:
 

--- a/activerecord/lib/active_record/tasks/database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/database_tasks.rb
@@ -489,7 +489,7 @@ module ActiveRecord
       # Dumps the schema cache in YAML format for the connection into the file
       #
       # ==== Examples
-      #   ActiveRecord::Tasks::DatabaseTasks.dump_schema_cache(ActiveRecord::Base.connection, "tmp/schema_dump.yaml")
+      #   ActiveRecord::Tasks::DatabaseTasks.dump_schema_cache(ActiveRecord::Base.lease_connection, "tmp/schema_dump.yaml")
       def dump_schema_cache(conn_or_pool, filename)
         conn_or_pool.schema_cache.dump_to(filename)
       end
@@ -509,9 +509,9 @@ module ActiveRecord
         end
       end
 
-      def with_temporary_connection(db_config, clobber: false) # :nodoc:
+      def with_temporary_connection(db_config, clobber: false, &block) # :nodoc:
         with_temporary_pool(db_config, clobber: clobber) do |pool|
-          yield pool.connection
+          pool.with_connection(&block)
         end
       end
 
@@ -520,7 +520,7 @@ module ActiveRecord
       end
 
       def migration_connection # :nodoc:
-        migration_class.connection
+        migration_class.lease_connection
       end
 
       def migration_connection_pool # :nodoc:

--- a/activerecord/lib/active_record/tasks/mysql_database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/mysql_database_tasks.rb
@@ -71,7 +71,7 @@ module ActiveRecord
         attr_reader :db_config, :configuration_hash
 
         def connection
-          ActiveRecord::Base.connection
+          ActiveRecord::Base.lease_connection
         end
 
         def establish_connection(config = db_config)

--- a/activerecord/lib/active_record/tasks/postgresql_database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/postgresql_database_tasks.rb
@@ -88,7 +88,7 @@ module ActiveRecord
         attr_reader :db_config, :configuration_hash
 
         def connection
-          ActiveRecord::Base.connection
+          ActiveRecord::Base.lease_connection
         end
 
         def establish_connection(config = db_config)

--- a/activerecord/lib/active_record/tasks/sqlite_database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/sqlite_database_tasks.rb
@@ -66,7 +66,7 @@ module ActiveRecord
         attr_reader :db_config, :root
 
         def connection
-          ActiveRecord::Base.connection
+          ActiveRecord::Base.lease_connection
         end
 
         def establish_connection(config = db_config)

--- a/activerecord/lib/active_record/test_fixtures.rb
+++ b/activerecord/lib/active_record/test_fixtures.rb
@@ -157,7 +157,7 @@ module ActiveRecord
         @fixture_connection_pools = ActiveRecord::Base.connection_handler.connection_pool_list(:writing)
         @fixture_connection_pools.each do |pool|
           pool.pin_connection!(lock_threads)
-          pool.connection
+          pool.lease_connection
         end
 
         # When connections are established in the future, begin a transaction too
@@ -172,7 +172,7 @@ module ActiveRecord
 
               unless @fixture_connection_pools.include?(pool)
                 pool.pin_connection!(lock_threads)
-                pool.connection
+                pool.lease_connection
                 @fixture_connection_pools << pool
               end
             end

--- a/activerecord/lib/active_record/testing/query_assertions.rb
+++ b/activerecord/lib/active_record/testing/query_assertions.rb
@@ -16,7 +16,7 @@ module ActiveRecord
       #   assert_queries_count(1, include_schema: true) { Post.columns }
       #
       def assert_queries_count(count = nil, include_schema: false, &block)
-        ActiveRecord::Base.connection.materialize_transactions
+        ActiveRecord::Base.lease_connection.materialize_transactions
 
         counter = SQLCounter.new
         ActiveSupport::Notifications.subscribed(counter, "sql.active_record") do
@@ -57,7 +57,7 @@ module ActiveRecord
       #   assert_queries_match(/FROM pg_attribute/i, include_schema: true) { Post.columns }
       #
       def assert_queries_match(match, count: nil, include_schema: false, &block)
-        ActiveRecord::Base.connection.materialize_transactions
+        ActiveRecord::Base.lease_connection.materialize_transactions
 
         counter = SQLCounter.new
         ActiveSupport::Notifications.subscribed(counter, "sql.active_record") do

--- a/activerecord/lib/active_record/timestamp.rb
+++ b/activerecord/lib/active_record/timestamp.rb
@@ -75,7 +75,7 @@ module ActiveRecord
       end
 
       def current_time_from_proper_timezone
-        connection.default_timezone == :utc ? Time.now.utc : Time.now
+        lease_connection.default_timezone == :utc ? Time.now.utc : Time.now
       end
 
       protected

--- a/activerecord/lib/active_record/transactions.rb
+++ b/activerecord/lib/active_record/transactions.rb
@@ -208,9 +208,9 @@ module ActiveRecord
     # database error will occur because the savepoint has already been
     # automatically released. The following example demonstrates the problem:
     #
-    #   Model.connection.transaction do                           # BEGIN
-    #     Model.connection.transaction(requires_new: true) do     # CREATE SAVEPOINT active_record_1
-    #       Model.connection.create_table(...)                    # active_record_1 now automatically released
+    #   Model.lease_connection.transaction do                           # BEGIN
+    #     Model.lease_connection.transaction(requires_new: true) do     # CREATE SAVEPOINT active_record_1
+    #       Model.lease_connection.create_table(...)                    # active_record_1 now automatically released
     #     end                                                     # RELEASE SAVEPOINT active_record_1
     #                                                             # ^^^^ BOOM! database error!
     #   end
@@ -394,7 +394,7 @@ module ActiveRecord
     # instance.
     def with_transaction_returning_status
       status = nil
-      connection = self.class.connection
+      connection = self.class.lease_connection
       ensure_finalize = !connection.transaction_open?
 
       connection.transaction do
@@ -496,7 +496,7 @@ module ActiveRecord
       # Add the record to the current transaction so that the #after_rollback and #after_commit
       # callbacks can be called.
       def add_to_transaction(ensure_finalize = true)
-        self.class.connection.add_transaction_record(self, ensure_finalize)
+        self.class.lease_connection.add_transaction_record(self, ensure_finalize)
       end
 
       def has_transactional_callbacks?

--- a/activerecord/lib/active_record/type_caster/connection.rb
+++ b/activerecord/lib/active_record/type_caster/connection.rb
@@ -19,7 +19,7 @@ module ActiveRecord
         if schema_cache.data_source_exists?(table_name)
           column = schema_cache.columns_hash(table_name)[attr_name.to_s]
           if column
-            type = @klass.connection.lookup_cast_type_from_column(column)
+            type = @klass.lease_connection.lookup_cast_type_from_column(column)
           end
         end
 

--- a/activerecord/lib/active_record/validations/uniqueness.rb
+++ b/activerecord/lib/active_record/validations/uniqueness.rb
@@ -114,12 +114,12 @@ module ActiveRecord
           return relation.none! if bind.unboundable?
 
           if !options.key?(:case_sensitive) || bind.nil?
-            klass.connection.default_uniqueness_comparison(attr, bind)
+            klass.lease_connection.default_uniqueness_comparison(attr, bind)
           elsif options[:case_sensitive]
-            klass.connection.case_sensitive_comparison(attr, bind)
+            klass.lease_connection.case_sensitive_comparison(attr, bind)
           else
             # will use SQL LOWER function before comparison, unless it detects a case insensitive collation
-            klass.connection.case_insensitive_comparison(attr, bind)
+            klass.lease_connection.case_insensitive_comparison(attr, bind)
           end
         end
 

--- a/activerecord/lib/arel/nodes/node.rb
+++ b/activerecord/lib/arel/nodes/node.rb
@@ -147,7 +147,7 @@ module Arel # :nodoc: all
       # Maybe we should just use `Table.engine`?  :'(
       def to_sql(engine = Table.engine)
         collector = Arel::Collectors::SQLString.new
-        collector = engine.connection.visitor.accept self, collector
+        collector = engine.lease_connection.visitor.accept self, collector
         collector.value
       end
 

--- a/activerecord/lib/arel/tree_manager.rb
+++ b/activerecord/lib/arel/tree_manager.rb
@@ -52,7 +52,7 @@ module Arel # :nodoc: all
 
     def to_sql(engine = Table.engine)
       collector = Arel::Collectors::SQLString.new
-      collector = engine.connection.visitor.accept @ast, collector
+      collector = engine.lease_connection.visitor.accept @ast, collector
       collector.value
     end
 

--- a/activerecord/test/activejob/destroy_association_async_test.rb
+++ b/activerecord/test/activejob/destroy_association_async_test.rb
@@ -72,7 +72,7 @@ class DestroyAssociationAsyncTest < ActiveRecord::TestCase
     assert_equal 2, delete_sqls.count
 
     delete_sqls.each do |sql|
-      assert_match(/#{Regexp.escape(Sharded::Tag.connection.quote_table_name("sharded_tags.blog_id"))} =/, sql)
+      assert_match(/#{Regexp.escape(Sharded::Tag.lease_connection.quote_table_name("sharded_tags.blog_id"))} =/, sql)
     end
   ensure
     Sharded::Tag.delete_all
@@ -185,7 +185,7 @@ class DestroyAssociationAsyncTest < ActiveRecord::TestCase
 
     delete_sqls = sql.select { |sql| sql.start_with?("DELETE") }
     assert_equal 1, delete_sqls.count
-    assert_match(/#{Regexp.escape(Sharded::BlogPost.connection.quote_table_name("sharded_blog_posts.blog_id"))} =/, delete_sqls.first)
+    assert_match(/#{Regexp.escape(Sharded::BlogPost.lease_connection.quote_table_name("sharded_blog_posts.blog_id"))} =/, delete_sqls.first)
   ensure
     Sharded::BlogPostDestroyAsync.delete_all
     Sharded::CommentDestroyAsync.delete_all
@@ -307,7 +307,7 @@ class DestroyAssociationAsyncTest < ActiveRecord::TestCase
     assert_equal 2, delete_sqls.count
 
     delete_sqls.each do |sql|
-      assert_match(/#{Regexp.escape(Sharded::Tag.connection.quote_table_name("sharded_comments.blog_id"))} =/, sql)
+      assert_match(/#{Regexp.escape(Sharded::Tag.lease_connection.quote_table_name("sharded_comments.blog_id"))} =/, sql)
     end
   ensure
     Sharded::CommentDestroyAsync.delete_all

--- a/activerecord/test/cases/active_record_schema_test.rb
+++ b/activerecord/test/cases/active_record_schema_test.rb
@@ -8,7 +8,7 @@ class ActiveRecordSchemaTest < ActiveRecord::TestCase
   setup do
     @original_verbose = ActiveRecord::Migration.verbose
     ActiveRecord::Migration.verbose = false
-    @connection = ActiveRecord::Base.connection
+    @connection = ActiveRecord::Base.lease_connection
     @pool = ActiveRecord::Base.connection_pool
     @schema_migration = @pool.schema_migration
     @schema_migration.delete_all_versions
@@ -162,7 +162,7 @@ class ActiveRecordSchemaTest < ActiveRecord::TestCase
     assert @connection.column_exists?(:has_timestamps, :updated_at, null: false)
   end
 
-  if ActiveRecord::Base.connection.supports_bulk_alter?
+  if ActiveRecord::Base.lease_connection.supports_bulk_alter?
     def test_timestamps_without_null_set_null_to_false_on_change_table_with_bulk
       ActiveRecord::Schema.define do
         create_table :has_timestamps
@@ -212,7 +212,7 @@ class ActiveRecordSchemaTest < ActiveRecord::TestCase
       assert @connection.column_exists?(:has_timestamps, :updated_at, precision: 6, null: false)
     end
 
-    if ActiveRecord::Base.connection.supports_bulk_alter?
+    if ActiveRecord::Base.lease_connection.supports_bulk_alter?
       def test_timestamps_sets_precision_on_change_table_with_bulk
         ActiveRecord::Schema.define do
           create_table :has_timestamps

--- a/activerecord/test/cases/active_record_test.rb
+++ b/activerecord/test/cases/active_record_test.rb
@@ -8,13 +8,13 @@ class ActiveRecordTest < ActiveRecord::TestCase
 
   unless in_memory_db?
     test ".disconnect_all! closes all connections" do
-      ActiveRecord::Base.connection.connect!
+      ActiveRecord::Base.lease_connection.connect!
       assert_predicate ActiveRecord::Base, :connected?
 
       ActiveRecord.disconnect_all!
       assert_not_predicate ActiveRecord::Base, :connected?
 
-      ActiveRecord::Base.connection.connect!
+      ActiveRecord::Base.lease_connection.connect!
       assert_predicate ActiveRecord::Base, :connected?
     end
   end

--- a/activerecord/test/cases/adapter_prevent_writes_test.rb
+++ b/activerecord/test/cases/adapter_prevent_writes_test.rb
@@ -10,7 +10,7 @@ require "models/event"
 module ActiveRecord
   class AdapterPreventWritesTest < ActiveRecord::TestCase
     def setup
-      @connection = ActiveRecord::Base.connection
+      @connection = ActiveRecord::Base.lease_connection
     end
 
     def test_preventing_writes_predicate
@@ -79,7 +79,7 @@ module ActiveRecord
       end
     end
 
-    if ActiveRecord::Base.connection.supports_common_table_expressions?
+    if ActiveRecord::Base.lease_connection.supports_common_table_expressions?
       def test_doesnt_error_when_a_read_query_with_a_cte_is_called_while_preventing_writes
         @connection.insert("INSERT INTO subscribers(nick) VALUES ('138853948594')")
 

--- a/activerecord/test/cases/adapters/abstract_mysql_adapter/active_schema_test.rb
+++ b/activerecord/test/cases/adapters/abstract_mysql_adapter/active_schema_test.rb
@@ -7,8 +7,8 @@ class ActiveSchemaTest < ActiveRecord::AbstractMysqlTestCase
   include ConnectionHelper
 
   def setup
-    ActiveRecord::Base.connection.send(:default_row_format)
-    ActiveRecord::Base.connection.singleton_class.class_eval do
+    ActiveRecord::Base.lease_connection.send(:default_row_format)
+    ActiveRecord::Base.lease_connection.singleton_class.class_eval do
       alias_method :execute_without_stub, :execute
       def execute(sql, name = nil)
         ActiveSupport::Notifications.instrumenter.instrument(
@@ -83,14 +83,14 @@ class ActiveSchemaTest < ActiveRecord::AbstractMysqlTestCase
   def test_index_in_create
     %w(SPATIAL FULLTEXT UNIQUE).each do |type|
       expected = /\ACREATE TABLE `people` \(#{type} INDEX `index_people_on_last_name` \(`last_name`\)\)/
-      actual = ActiveRecord::Base.connection.create_table(:people, id: false) do |t|
+      actual = ActiveRecord::Base.lease_connection.create_table(:people, id: false) do |t|
         t.index :last_name, type: type
       end
       assert_match expected, actual
     end
 
     expected = /\ACREATE TABLE `people` \(INDEX `index_people_on_last_name` USING btree \(`last_name`\(10\)\)\)/
-    actual = ActiveRecord::Base.connection.create_table(:people, id: false) do |t|
+    actual = ActiveRecord::Base.lease_connection.create_table(:people, id: false) do |t|
       t.index :last_name, length: 10, using: :btree
     end
     assert_match expected, actual
@@ -100,7 +100,7 @@ class ActiveSchemaTest < ActiveRecord::AbstractMysqlTestCase
     %w(SPATIAL FULLTEXT UNIQUE).each do |type|
       expected = "ALTER TABLE `people` ADD #{type} INDEX `index_people_on_last_name` (`last_name`)"
       assert_queries_match(expected) do
-        ActiveRecord::Base.connection.change_table(:people, bulk: true) do |t|
+        ActiveRecord::Base.lease_connection.change_table(:people, bulk: true) do |t|
           t.index :last_name, type: type
         end
       end
@@ -108,7 +108,7 @@ class ActiveSchemaTest < ActiveRecord::AbstractMysqlTestCase
 
     expected = "ALTER TABLE `people` ADD INDEX `index_people_on_last_name` USING btree (`last_name`(10)), ALGORITHM = COPY"
     assert_queries_match(expected) do
-      ActiveRecord::Base.connection.change_table(:people, bulk: true) do |t|
+      ActiveRecord::Base.lease_connection.change_table(:people, bulk: true) do |t|
         t.index :last_name, length: 10, using: :btree, algorithm: :copy
       end
     end
@@ -119,7 +119,7 @@ class ActiveSchemaTest < ActiveRecord::AbstractMysqlTestCase
   end
 
   def test_create_mysql_database_with_encoding
-    if ActiveRecord::Base.connection.send(:row_format_dynamic_by_default?)
+    if ActiveRecord::Base.lease_connection.send(:row_format_dynamic_by_default?)
       assert_equal "CREATE DATABASE `matt` DEFAULT CHARACTER SET `utf8mb4`", create_database(:matt)
     else
       error = assert_raises(RuntimeError) { create_database(:matt) }
@@ -149,31 +149,31 @@ class ActiveSchemaTest < ActiveRecord::AbstractMysqlTestCase
 
   def test_add_timestamps
     with_real_execute do
-      ActiveRecord::Base.connection.create_table :delete_me
-      ActiveRecord::Base.connection.add_timestamps :delete_me, null: true
+      ActiveRecord::Base.lease_connection.create_table :delete_me
+      ActiveRecord::Base.lease_connection.add_timestamps :delete_me, null: true
       assert column_exists?("delete_me", "updated_at", "datetime")
       assert column_exists?("delete_me", "created_at", "datetime")
     ensure
-      ActiveRecord::Base.connection.drop_table :delete_me rescue nil
+      ActiveRecord::Base.lease_connection.drop_table :delete_me rescue nil
     end
   end
 
   def test_remove_timestamps
     with_real_execute do
-      ActiveRecord::Base.connection.create_table :delete_me do |t|
+      ActiveRecord::Base.lease_connection.create_table :delete_me do |t|
         t.timestamps null: true
       end
-      ActiveRecord::Base.connection.remove_timestamps :delete_me, null: true
+      ActiveRecord::Base.lease_connection.remove_timestamps :delete_me, null: true
       assert_not column_exists?("delete_me", "updated_at", "datetime")
       assert_not column_exists?("delete_me", "created_at", "datetime")
     ensure
-      ActiveRecord::Base.connection.drop_table :delete_me rescue nil
+      ActiveRecord::Base.lease_connection.drop_table :delete_me rescue nil
     end
   end
 
   def test_indexes_in_create
     expected = /\ACREATE TEMPORARY TABLE `temp` \(INDEX `index_temp_on_zip` \(`zip`\)\)(?: ROW_FORMAT=DYNAMIC)? AS SELECT id, name, zip FROM a_really_complicated_query/
-    actual = ActiveRecord::Base.connection.create_table(:temp, temporary: true, as: "SELECT id, name, zip FROM a_really_complicated_query") do |t|
+    actual = ActiveRecord::Base.lease_connection.create_table(:temp, temporary: true, as: "SELECT id, name, zip FROM a_really_complicated_query") do |t|
       t.index :zip
     end
 
@@ -182,7 +182,7 @@ class ActiveSchemaTest < ActiveRecord::AbstractMysqlTestCase
 
   private
     def with_real_execute
-      ActiveRecord::Base.connection.singleton_class.class_eval do
+      ActiveRecord::Base.lease_connection.singleton_class.class_eval do
         alias_method :execute_with_stub, :execute
         remove_method :execute
         alias_method :execute, :execute_without_stub
@@ -190,13 +190,13 @@ class ActiveSchemaTest < ActiveRecord::AbstractMysqlTestCase
 
       yield
     ensure
-      ActiveRecord::Base.connection.singleton_class.class_eval do
+      ActiveRecord::Base.lease_connection.singleton_class.class_eval do
         remove_method :execute
         alias_method :execute, :execute_with_stub
       end
     end
 
     def method_missing(...)
-      ActiveRecord::Base.connection.public_send(...)
+      ActiveRecord::Base.lease_connection.public_send(...)
     end
 end

--- a/activerecord/test/cases/adapters/abstract_mysql_adapter/adapter_prevent_writes_test.rb
+++ b/activerecord/test/cases/adapters/abstract_mysql_adapter/adapter_prevent_writes_test.rb
@@ -7,7 +7,7 @@ class AdapterPreventWritesTest < ActiveRecord::AbstractMysqlTestCase
   include DdlHelper
 
   def setup
-    @conn = ActiveRecord::Base.connection
+    @conn = ActiveRecord::Base.lease_connection
   end
 
   def test_errors_when_an_insert_query_is_called_while_preventing_writes

--- a/activerecord/test/cases/adapters/abstract_mysql_adapter/auto_increment_test.rb
+++ b/activerecord/test/cases/adapters/abstract_mysql_adapter/auto_increment_test.rb
@@ -7,7 +7,7 @@ class AutoIncrementTest < ActiveRecord::AbstractMysqlTestCase
   include SchemaDumpingHelper
 
   def setup
-    @connection = ActiveRecord::Base.connection
+    @connection = ActiveRecord::Base.lease_connection
   end
 
   def teardown

--- a/activerecord/test/cases/adapters/abstract_mysql_adapter/charset_collation_test.rb
+++ b/activerecord/test/cases/adapters/abstract_mysql_adapter/charset_collation_test.rb
@@ -7,7 +7,7 @@ class CharsetCollationTest < ActiveRecord::AbstractMysqlTestCase
   include SchemaDumpingHelper
 
   setup do
-    @connection = ActiveRecord::Base.connection
+    @connection = ActiveRecord::Base.lease_connection
     @connection.create_table :charset_collations, id: { type: :string, collation: "utf8mb4_bin" }, force: true do |t|
       t.string :string_ascii_bin, charset: "ascii", collation: "ascii_bin"
       t.text :text_ucs2_unicode_ci, charset: "ucs2", collation: "ucs2_unicode_ci"

--- a/activerecord/test/cases/adapters/abstract_mysql_adapter/connection_test.rb
+++ b/activerecord/test/cases/adapters/abstract_mysql_adapter/connection_test.rb
@@ -10,7 +10,7 @@ class ConnectionTest < ActiveRecord::AbstractMysqlTestCase
     super
     @subscriber = SQLSubscriber.new
     @subscription = ActiveSupport::Notifications.subscribe("sql.active_record", @subscriber)
-    @connection = ActiveRecord::Base.connection
+    @connection = ActiveRecord::Base.lease_connection
   end
 
   def teardown
@@ -37,7 +37,7 @@ class ConnectionTest < ActiveRecord::AbstractMysqlTestCase
     assert_not_predicate @connection, :active?
   ensure
     # Repair all fixture connections so other tests won't break.
-    @fixture_connection_pools.each { |p| p.connection.verify! }
+    @fixture_connection_pools.each { |p| p.lease_connection.verify! }
   end
 
   def test_successful_reconnection_after_timeout_with_manual_reconnect
@@ -74,7 +74,7 @@ class ConnectionTest < ActiveRecord::AbstractMysqlTestCase
   def test_wait_timeout_as_string
     run_without_connection do |orig_connection|
       ActiveRecord::Base.establish_connection(orig_connection.merge(wait_timeout: "60"))
-      result = ActiveRecord::Base.connection.select_value("SELECT @@SESSION.wait_timeout")
+      result = ActiveRecord::Base.lease_connection.select_value("SELECT @@SESSION.wait_timeout")
       assert_equal 60, result
     end
   end
@@ -82,7 +82,7 @@ class ConnectionTest < ActiveRecord::AbstractMysqlTestCase
   def test_wait_timeout_as_url
     run_without_connection do |orig_connection|
       ActiveRecord::Base.establish_connection(orig_connection.merge("url" => "#{orig_connection[:adapter]}:///?wait_timeout=60"))
-      result = ActiveRecord::Base.connection.select_value("SELECT @@SESSION.wait_timeout")
+      result = ActiveRecord::Base.lease_connection.select_value("SELECT @@SESSION.wait_timeout")
       assert_equal 60, result
     end
   end
@@ -91,7 +91,7 @@ class ConnectionTest < ActiveRecord::AbstractMysqlTestCase
     run_without_connection do |orig_connection|
       configuration_hash = orig_connection.except(:encoding, :collation)
       ActiveRecord::Base.establish_connection(configuration_hash.merge!(encoding: "cp932"))
-      connection = ActiveRecord::Base.connection
+      connection = ActiveRecord::Base.lease_connection
 
       assert_equal "cp932", connection.show_variable("character_set_client")
       assert_equal "cp932", connection.show_variable("character_set_results")
@@ -107,8 +107,8 @@ class ConnectionTest < ActiveRecord::AbstractMysqlTestCase
     assert_equal "utf8mb4_unicode_ci", @connection.show_variable("collation_connection")
     assert_equal 1, @connection.query_value("SELECT 'こんにちは' = 'コンニチハ'")
 
-    assert_equal "utf8mb4_general_ci", ARUnit2Model.connection.show_variable("collation_connection")
-    assert_equal 0, ARUnit2Model.connection.query_value("SELECT 'こんにちは' = 'コンニチハ'")
+    assert_equal "utf8mb4_general_ci", ARUnit2Model.lease_connection.show_variable("collation_connection")
+    assert_equal 0, ARUnit2Model.lease_connection.query_value("SELECT 'こんにちは' = 'コンニチハ'")
   end
 
   def test_mysql_default_in_strict_mode
@@ -119,7 +119,7 @@ class ConnectionTest < ActiveRecord::AbstractMysqlTestCase
   def test_mysql_strict_mode_disabled
     run_without_connection do |orig_connection|
       ActiveRecord::Base.establish_connection(orig_connection.merge(strict: false))
-      result = ActiveRecord::Base.connection.select_value("SELECT @@SESSION.sql_mode")
+      result = ActiveRecord::Base.lease_connection.select_value("SELECT @@SESSION.sql_mode")
       assert_no_match %r(STRICT_ALL_TABLES), result
     end
   end
@@ -127,8 +127,8 @@ class ConnectionTest < ActiveRecord::AbstractMysqlTestCase
   def test_mysql_strict_mode_specified_default
     run_without_connection do |orig_connection|
       ActiveRecord::Base.establish_connection(orig_connection.merge(strict: :default))
-      global_sql_mode = ActiveRecord::Base.connection.select_value("SELECT @@GLOBAL.sql_mode")
-      session_sql_mode = ActiveRecord::Base.connection.select_value("SELECT @@SESSION.sql_mode")
+      global_sql_mode = ActiveRecord::Base.lease_connection.select_value("SELECT @@GLOBAL.sql_mode")
+      session_sql_mode = ActiveRecord::Base.lease_connection.select_value("SELECT @@SESSION.sql_mode")
       assert_equal global_sql_mode, session_sql_mode
     end
   end
@@ -136,7 +136,7 @@ class ConnectionTest < ActiveRecord::AbstractMysqlTestCase
   def test_mysql_sql_mode_variable_overrides_strict_mode
     run_without_connection do |orig_connection|
       ActiveRecord::Base.establish_connection(orig_connection.deep_merge(variables: { "sql_mode" => "ansi" }))
-      result = ActiveRecord::Base.connection.select_value("SELECT @@SESSION.sql_mode")
+      result = ActiveRecord::Base.lease_connection.select_value("SELECT @@SESSION.sql_mode")
       assert_no_match %r(STRICT_ALL_TABLES), result
     end
   end
@@ -145,14 +145,14 @@ class ConnectionTest < ActiveRecord::AbstractMysqlTestCase
     def test_passing_arbitrary_flags_to_adapter
       run_without_connection do |orig_connection|
         ActiveRecord::Base.establish_connection(orig_connection.merge(flags: Mysql2::Client::COMPRESS))
-        assert_equal (Mysql2::Client::COMPRESS | Mysql2::Client::FOUND_ROWS), ActiveRecord::Base.connection.raw_connection.query_options[:flags]
+        assert_equal (Mysql2::Client::COMPRESS | Mysql2::Client::FOUND_ROWS), ActiveRecord::Base.lease_connection.raw_connection.query_options[:flags]
       end
     end
 
     def test_passing_flags_by_array_to_adapter
       run_without_connection do |orig_connection|
         ActiveRecord::Base.establish_connection(orig_connection.merge(flags: ["COMPRESS"]))
-        assert_equal ["COMPRESS", "FOUND_ROWS"], ActiveRecord::Base.connection.raw_connection.query_options[:flags]
+        assert_equal ["COMPRESS", "FOUND_ROWS"], ActiveRecord::Base.lease_connection.raw_connection.query_options[:flags]
       end
     end
   end
@@ -160,7 +160,7 @@ class ConnectionTest < ActiveRecord::AbstractMysqlTestCase
   def test_mysql_set_session_variable
     run_without_connection do |orig_connection|
       ActiveRecord::Base.establish_connection(orig_connection.deep_merge(variables: { default_week_format: 3 }))
-      session_mode = ActiveRecord::Base.connection.exec_query "SELECT @@SESSION.DEFAULT_WEEK_FORMAT"
+      session_mode = ActiveRecord::Base.lease_connection.exec_query "SELECT @@SESSION.DEFAULT_WEEK_FORMAT"
       assert_equal 3, session_mode.rows.first.first.to_i
     end
   end
@@ -168,14 +168,14 @@ class ConnectionTest < ActiveRecord::AbstractMysqlTestCase
   def test_mysql_set_session_variable_to_default
     run_without_connection do |orig_connection|
       ActiveRecord::Base.establish_connection(orig_connection.deep_merge(variables: { default_week_format: :default }))
-      global_mode = ActiveRecord::Base.connection.exec_query "SELECT @@GLOBAL.DEFAULT_WEEK_FORMAT"
-      session_mode = ActiveRecord::Base.connection.exec_query "SELECT @@SESSION.DEFAULT_WEEK_FORMAT"
+      global_mode = ActiveRecord::Base.lease_connection.exec_query "SELECT @@GLOBAL.DEFAULT_WEEK_FORMAT"
+      session_mode = ActiveRecord::Base.lease_connection.exec_query "SELECT @@SESSION.DEFAULT_WEEK_FORMAT"
       assert_equal global_mode.rows, session_mode.rows
     end
   end
 
   def test_logs_name_show_variable
-    ActiveRecord::Base.connection.materialize_transactions
+    ActiveRecord::Base.lease_connection.materialize_transactions
     @subscriber.logged.clear
     @connection.show_variable "foo"
     assert_equal "SCHEMA", @subscriber.logged[0][1]

--- a/activerecord/test/cases/adapters/abstract_mysql_adapter/datetime_precision_quoting_test.rb
+++ b/activerecord/test/cases/adapters/abstract_mysql_adapter/datetime_precision_quoting_test.rb
@@ -4,7 +4,7 @@ require "cases/helper"
 
 class DatetimePrecisionQuotingTest < ActiveRecord::AbstractMysqlTestCase
   setup do
-    @connection = ActiveRecord::Base.connection
+    @connection = ActiveRecord::Base.lease_connection
   end
 
   test "microsecond precision for MySQL gte 5.6.4" do

--- a/activerecord/test/cases/adapters/abstract_mysql_adapter/json_test.rb
+++ b/activerecord/test/cases/adapters/abstract_mysql_adapter/json_test.rb
@@ -3,7 +3,7 @@
 require "cases/helper"
 require "cases/json_shared_test_cases"
 
-if ActiveRecord::Base.connection.supports_json?
+if ActiveRecord::Base.lease_connection.supports_json?
   class JSONTest < ActiveRecord::AbstractMysqlTestCase
     include JSONSharedTestCases
     self.use_transactional_tests = false

--- a/activerecord/test/cases/adapters/abstract_mysql_adapter/mysql_boolean_test.rb
+++ b/activerecord/test/cases/adapters/abstract_mysql_adapter/mysql_boolean_test.rb
@@ -10,7 +10,7 @@ class MySQLBooleanTest < ActiveRecord::AbstractMysqlTestCase
   end
 
   setup do
-    @connection = ActiveRecord::Base.connection
+    @connection = ActiveRecord::Base.lease_connection
     @connection.clear_cache!
     @connection.create_table("mysql_booleans") do |t|
       t.boolean "archived"

--- a/activerecord/test/cases/adapters/abstract_mysql_adapter/mysql_enum_test.rb
+++ b/activerecord/test/cases/adapters/abstract_mysql_adapter/mysql_enum_test.rb
@@ -19,7 +19,7 @@ class MySQLEnumTest < ActiveRecord::AbstractMysqlTestCase
   end
 
   def setup
-    EnumTest.connection.create_table :enum_tests, id: false, force: true do |t|
+    EnumTest.lease_connection.create_table :enum_tests, id: false, force: true do |t|
       t.column :enum_column, "enum('text','blob','tiny','medium','long','unsigned','bigint')"
       t.column :state, "TINYINT(1)"
     end

--- a/activerecord/test/cases/adapters/abstract_mysql_adapter/mysql_explain_test.rb
+++ b/activerecord/test/cases/adapters/abstract_mysql_adapter/mysql_explain_test.rb
@@ -66,6 +66,6 @@ class MySQLExplainTest < ActiveRecord::AbstractMysqlTestCase
     end
 
     def conn
-      ActiveRecord::Base.connection
+      ActiveRecord::Base.lease_connection
     end
 end

--- a/activerecord/test/cases/adapters/abstract_mysql_adapter/quoting_test.rb
+++ b/activerecord/test/cases/adapters/abstract_mysql_adapter/quoting_test.rb
@@ -5,7 +5,7 @@ require "cases/helper"
 class QuotingTest < ActiveRecord::AbstractMysqlTestCase
   def setup
     super
-    @conn = ActiveRecord::Base.connection
+    @conn = ActiveRecord::Base.lease_connection
   end
 
   def test_cast_bound_integer

--- a/activerecord/test/cases/adapters/abstract_mysql_adapter/schema_migrations_test.rb
+++ b/activerecord/test/cases/adapters/abstract_mysql_adapter/schema_migrations_test.rb
@@ -59,7 +59,7 @@ class SchemaMigrationsTest < ActiveRecord::AbstractMysqlTestCase
     end
 
     def connection
-      @connection ||= ActiveRecord::Base.connection
+      @connection ||= ActiveRecord::Base.lease_connection
     end
 
     def execute(sql)

--- a/activerecord/test/cases/adapters/abstract_mysql_adapter/schema_test.rb
+++ b/activerecord/test/cases/adapters/abstract_mysql_adapter/schema_test.rb
@@ -10,7 +10,7 @@ module ActiveRecord
       fixtures :posts
 
       def setup
-        @connection = ActiveRecord::Base.connection
+        @connection = ActiveRecord::Base.lease_connection
         db          = Post.connection_pool.db_config.database
         table       = Post.table_name
         @db_name    = db
@@ -108,7 +108,7 @@ end
 
 class MysqlAnsiQuotesTest < ActiveRecord::AbstractMysqlTestCase
   def setup
-    @connection = ActiveRecord::Base.connection
+    @connection = ActiveRecord::Base.lease_connection
     @connection.execute("SET SESSION sql_mode='ANSI_QUOTES'")
   end
 

--- a/activerecord/test/cases/adapters/abstract_mysql_adapter/set_test.rb
+++ b/activerecord/test/cases/adapters/abstract_mysql_adapter/set_test.rb
@@ -10,7 +10,7 @@ class SetTest < ActiveRecord::AbstractMysqlTestCase
   end
 
   def setup
-    SetTest.connection.create_table :set_tests, id: false, force: true do |t|
+    SetTest.lease_connection.create_table :set_tests, id: false, force: true do |t|
       t.column :set_column, "set('text','blob','tiny','medium','long','unsigned','bigint')"
     end
   end

--- a/activerecord/test/cases/adapters/abstract_mysql_adapter/sp_test.rb
+++ b/activerecord/test/cases/adapters/abstract_mysql_adapter/sp_test.rb
@@ -8,8 +8,8 @@ class StoredProcedureTest < ActiveRecord::AbstractMysqlTestCase
   fixtures :topics
 
   def setup
-    @connection = ActiveRecord::Base.connection
-    unless ActiveRecord::Base.connection.database_version >= "5.6.0"
+    @connection = ActiveRecord::Base.lease_connection
+    unless ActiveRecord::Base.lease_connection.database_version >= "5.6.0"
       skip("no stored procedure support")
     end
   end

--- a/activerecord/test/cases/adapters/abstract_mysql_adapter/sql_types_test.rb
+++ b/activerecord/test/cases/adapters/abstract_mysql_adapter/sql_types_test.rb
@@ -11,6 +11,6 @@ class SqlTypesTest < ActiveRecord::AbstractMysqlTestCase
   end
 
   def type_to_sql(type, limit = nil)
-    ActiveRecord::Base.connection.type_to_sql(type, limit: limit)
+    ActiveRecord::Base.lease_connection.type_to_sql(type, limit: limit)
   end
 end

--- a/activerecord/test/cases/adapters/abstract_mysql_adapter/table_options_test.rb
+++ b/activerecord/test/cases/adapters/abstract_mysql_adapter/table_options_test.rb
@@ -7,7 +7,7 @@ class TableOptionsTest < ActiveRecord::AbstractMysqlTestCase
   include SchemaDumpingHelper
 
   def setup
-    @connection = ActiveRecord::Base.connection
+    @connection = ActiveRecord::Base.lease_connection
   end
 
   def teardown
@@ -92,12 +92,12 @@ class DefaultEngineOptionTest < ActiveRecord::AbstractMysqlTestCase
   def teardown
     ActiveRecord::Base.logger       = @logger_was
     ActiveRecord::Migration.verbose = @verbose_was
-    ActiveRecord::Base.connection.drop_table "mysql_table_options", if_exists: true
+    ActiveRecord::Base.lease_connection.drop_table "mysql_table_options", if_exists: true
     ActiveRecord::Base.connection_pool.schema_migration.delete_all_versions rescue nil
   end
 
   test "new migrations do not contain default ENGINE=InnoDB option" do
-    ActiveRecord::Base.connection.create_table "mysql_table_options", force: true
+    ActiveRecord::Base.lease_connection.create_table "mysql_table_options", force: true
 
     assert_no_match %r{ENGINE=InnoDB}, @log.string
 

--- a/activerecord/test/cases/adapters/abstract_mysql_adapter/unsigned_type_test.rb
+++ b/activerecord/test/cases/adapters/abstract_mysql_adapter/unsigned_type_test.rb
@@ -11,7 +11,7 @@ class UnsignedTypeTest < ActiveRecord::AbstractMysqlTestCase
   end
 
   setup do
-    @connection = ActiveRecord::Base.connection
+    @connection = ActiveRecord::Base.lease_connection
     @connection.create_table("unsigned_types", force: true) do |t|
       t.integer :unsigned_integer, unsigned: true
       t.bigint  :unsigned_bigint,  unsigned: true

--- a/activerecord/test/cases/adapters/abstract_mysql_adapter/virtual_column_test.rb
+++ b/activerecord/test/cases/adapters/abstract_mysql_adapter/virtual_column_test.rb
@@ -3,7 +3,7 @@
 require "cases/helper"
 require "support/schema_dumping_helper"
 
-if ActiveRecord::Base.connection.supports_virtual_columns?
+if ActiveRecord::Base.lease_connection.supports_virtual_columns?
   class VirtualColumnTest < ActiveRecord::AbstractMysqlTestCase
     include SchemaDumpingHelper
 
@@ -13,7 +13,7 @@ if ActiveRecord::Base.connection.supports_virtual_columns?
     end
 
     def setup
-      @connection = ActiveRecord::Base.connection
+      @connection = ActiveRecord::Base.lease_connection
       @connection.create_table :virtual_columns, force: true do |t|
         t.string   :name
         t.virtual  :upper_name,  type: :string,  as: "UPPER(`name`)"

--- a/activerecord/test/cases/adapters/abstract_mysql_adapter/warnings_test.rb
+++ b/activerecord/test/cases/adapters/abstract_mysql_adapter/warnings_test.rb
@@ -5,7 +5,7 @@ require "active_support/error_reporter/test_helper"
 
 class WarningsTest < ActiveRecord::AbstractMysqlTestCase
   def setup
-    @connection = ActiveRecord::Base.connection
+    @connection = ActiveRecord::Base.lease_connection
     @original_db_warnings_action = :ignore
   end
 

--- a/activerecord/test/cases/adapters/mysql2/check_constraint_quoting_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/check_constraint_quoting_test.rb
@@ -3,12 +3,12 @@
 require "cases/helper"
 require "support/schema_dumping_helper"
 
-if ActiveRecord::Base.connection.supports_check_constraints?
+if ActiveRecord::Base.lease_connection.supports_check_constraints?
   class Mysql2CheckConstraintQuotingTest < ActiveRecord::Mysql2TestCase
     include SchemaDumpingHelper
 
     setup do
-      @connection = ActiveRecord::Base.connection
+      @connection = ActiveRecord::Base.lease_connection
       @connection.create_table "trades", force: true do |t|
         t.string :name
       end
@@ -25,7 +25,7 @@ if ActiveRecord::Base.connection.supports_check_constraints?
       assert_equal 1, check_constraints.size
 
       expression = check_constraints.first.expression
-      if ActiveRecord::Base.connection.mariadb?
+      if ActiveRecord::Base.lease_connection.mariadb?
         assert_equal "`name` <> 'forbidden_string'", expression
       else
         assert_equal "`name` <> _utf8mb4'forbidden_string'", expression

--- a/activerecord/test/cases/adapters/mysql2/mysql2_adapter_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/mysql2_adapter_test.rb
@@ -7,7 +7,7 @@ class Mysql2AdapterTest < ActiveRecord::Mysql2TestCase
   include DdlHelper
 
   def setup
-    @conn = ActiveRecord::Base.connection
+    @conn = ActiveRecord::Base.lease_connection
     @original_db_warnings_action = :ignore
   end
 
@@ -265,7 +265,7 @@ class Mysql2AdapterTest < ActiveRecord::Mysql2TestCase
     ActiveRecord::Base.establish_connection(
       db_config.configuration_hash.merge("read_timeout" => 1)
     )
-    connection = ActiveRecord::Base.connection
+    connection = ActiveRecord::Base.lease_connection
 
     error = assert_raises(ActiveRecord::AdapterTimeout) do
       connection.execute("SELECT SLEEP(2)")

--- a/activerecord/test/cases/adapters/mysql2/mysql2_rake_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/mysql2_rake_test.rb
@@ -29,7 +29,7 @@ module ActiveRecord
       mock.expect(:call, nil, [adapter: "mysql2", database: nil])
       mock.expect(:call, nil, [db_config])
 
-      ActiveRecord::Base.stub(:connection, @connection) do
+      ActiveRecord::Base.stub(:lease_connection, @connection) do
         ActiveRecord::Base.stub(:establish_connection, mock) do
           ActiveRecord::Tasks::DatabaseTasks.create(db_config)
         end
@@ -76,7 +76,7 @@ module ActiveRecord
 
     def test_create_when_database_exists_outputs_info_to_stderr
       with_stubbed_connection_establish_connection do
-        ActiveRecord::Base.connection.stub(
+        ActiveRecord::Base.lease_connection.stub(
           :create_database,
           proc { raise ActiveRecord::DatabaseAlreadyExists }
         ) do
@@ -90,7 +90,7 @@ module ActiveRecord
     private
       def with_stubbed_connection_establish_connection(&block)
         ActiveRecord::Base.stub(:establish_connection, nil) do
-          ActiveRecord::Base.stub(:connection, @connection, &block)
+          ActiveRecord::Base.stub(:lease_connection, @connection, &block)
         end
       end
   end
@@ -139,7 +139,7 @@ module ActiveRecord
     def test_establishes_connection_to_mysql_database
       db_config = ActiveRecord::DatabaseConfigurations::HashConfig.new("default_env", "primary", @configuration)
 
-      ActiveRecord::Base.stub(:connection, @connection) do
+      ActiveRecord::Base.stub(:lease_connection, @connection) do
         assert_called_with(
           ActiveRecord::Base,
           :establish_connection,
@@ -169,7 +169,7 @@ module ActiveRecord
     private
       def with_stubbed_connection_establish_connection(&block)
         ActiveRecord::Base.stub(:establish_connection, nil) do
-          ActiveRecord::Base.stub(:connection, @connection, &block)
+          ActiveRecord::Base.stub(:lease_connection, @connection, &block)
         end
       end
   end
@@ -186,7 +186,7 @@ module ActiveRecord
     def test_establishes_connection_without_database
       db_config = ActiveRecord::DatabaseConfigurations::HashConfig.new("default_env", "primary", @configuration)
 
-      ActiveRecord::Base.stub(:connection, @connection) do
+      ActiveRecord::Base.stub(:lease_connection, @connection) do
         assert_called(ActiveRecord::Base, :establish_connection, times: 2) do
           ActiveRecord::Tasks::DatabaseTasks.purge(db_config)
         end
@@ -217,7 +217,7 @@ module ActiveRecord
     private
       def with_stubbed_connection_establish_connection(&block)
         ActiveRecord::Base.stub(:establish_connection, nil) do
-          ActiveRecord::Base.stub(:connection, @connection, &block)
+          ActiveRecord::Base.stub(:lease_connection, @connection, &block)
         end
       end
   end
@@ -232,7 +232,7 @@ module ActiveRecord
     end
 
     def test_db_retrieves_charset
-      ActiveRecord::Base.stub(:connection, @connection) do
+      ActiveRecord::Base.stub(:lease_connection, @connection) do
         assert_called(@connection, :charset) do
           ActiveRecord::Tasks::DatabaseTasks.charset @configuration
         end
@@ -250,7 +250,7 @@ module ActiveRecord
     end
 
     def test_db_retrieves_collation
-      ActiveRecord::Base.stub(:connection, @connection) do
+      ActiveRecord::Base.stub(:lease_connection, @connection) do
         assert_called(@connection, :collation) do
           ActiveRecord::Tasks::DatabaseTasks.collation @configuration
         end
@@ -313,7 +313,7 @@ module ActiveRecord
 
     def test_structure_dump_with_ignore_tables
       filename = "awesome-file.sql"
-      ActiveRecord::Base.connection.stub(:data_sources, ["foo", "bar", "prefix_foo", "ignored_foo"]) do
+      ActiveRecord::Base.lease_connection.stub(:data_sources, ["foo", "bar", "prefix_foo", "ignored_foo"]) do
         ActiveRecord::SchemaDumper.stub(:ignore_tables, [/^prefix_/, "ignored_foo"]) do
           assert_called_with(
             Kernel,

--- a/activerecord/test/cases/adapters/postgresql/active_schema_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/active_schema_test.rb
@@ -4,7 +4,7 @@ require "cases/helper"
 
 class PostgresqlActiveSchemaTest < ActiveRecord::PostgreSQLTestCase
   def setup
-    ActiveRecord::Base.connection.materialize_transactions
+    ActiveRecord::Base.lease_connection.materialize_transactions
 
     ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.class_eval do
       def execute(sql, name = nil) sql end
@@ -112,6 +112,6 @@ class PostgresqlActiveSchemaTest < ActiveRecord::PostgreSQLTestCase
 
   private
     def method_missing(...)
-      ActiveRecord::Base.connection.public_send(...)
+      ActiveRecord::Base.lease_connection.public_send(...)
     end
 end

--- a/activerecord/test/cases/adapters/postgresql/array_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/array_test.rb
@@ -12,7 +12,7 @@ class PostgresqlArrayTest < ActiveRecord::PostgreSQLTestCase
   end
 
   def setup
-    @connection = ActiveRecord::Base.connection
+    @connection = ActiveRecord::Base.lease_connection
 
     enable_extension!("hstore", @connection)
 
@@ -269,7 +269,7 @@ class PostgresqlArrayTest < ActiveRecord::PostgreSQLTestCase
     oid = ActiveRecord::ConnectionAdapters::PostgreSQL::OID
     comma_delim = oid::Array.new(ActiveRecord::Type::String.new, ",")
     semicolon_delim = oid::Array.new(ActiveRecord::Type::String.new, ";")
-    conn = PgArray.connection
+    conn = PgArray.lease_connection
 
     assert_equal %({"hello,",world;}), conn.type_cast(comma_delim.serialize(strings))
     assert_equal %({hello,;"world;"}), conn.type_cast(semicolon_delim.serialize(strings))

--- a/activerecord/test/cases/adapters/postgresql/bit_string_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/bit_string_test.rb
@@ -11,7 +11,7 @@ class PostgresqlBitStringTest < ActiveRecord::PostgreSQLTestCase
   class PostgresqlBitString < ActiveRecord::Base; end
 
   def setup
-    @connection = ActiveRecord::Base.connection
+    @connection = ActiveRecord::Base.lease_connection
     @connection.create_table("postgresql_bit_strings", force: true) do |t|
       t.bit :a_bit, default: "00000011", limit: 8
       t.bit_varying :a_bit_varying, default: "0011", limit: 4
@@ -59,7 +59,7 @@ class PostgresqlBitStringTest < ActiveRecord::PostgreSQLTestCase
     assert_match %r{t\.bit_varying\s+"a_bit_varying",\s+limit: 4,\s+default: "0011"$}, output
   end
 
-  if ActiveRecord::Base.connection.prepared_statements
+  if ActiveRecord::Base.lease_connection.prepared_statements
     def test_assigning_invalid_hex_string_raises_exception
       assert_raises(ActiveRecord::StatementInvalid) { PostgresqlBitString.create! a_bit: "FF" }
       assert_raises(ActiveRecord::StatementInvalid) { PostgresqlBitString.create! a_bit_varying: "F" }

--- a/activerecord/test/cases/adapters/postgresql/bytea_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/bytea_test.rb
@@ -11,7 +11,7 @@ class PostgresqlByteaTest < ActiveRecord::PostgreSQLTestCase
   end
 
   def setup
-    @connection = ActiveRecord::Base.connection
+    @connection = ActiveRecord::Base.lease_connection
     @connection.transaction do
       @connection.create_table("bytea_data_type") do |t|
         t.binary "payload"
@@ -87,7 +87,7 @@ class PostgresqlByteaTest < ActiveRecord::PostgreSQLTestCase
 
   def test_via_to_sql_with_complicating_connection
     Thread.new do
-      other_conn = ActiveRecord::Base.connection
+      other_conn = ActiveRecord::Base.lease_connection
       other_conn.execute("SET standard_conforming_strings = off")
       other_conn.execute("SET escape_string_warning = off")
     end.join

--- a/activerecord/test/cases/adapters/postgresql/case_insensitive_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/case_insensitive_test.rb
@@ -6,7 +6,7 @@ class PostgresqlCaseInsensitiveTest < ActiveRecord::PostgreSQLTestCase
   class Default < ActiveRecord::Base; end
 
   def test_case_insensitiveness
-    connection = ActiveRecord::Base.connection
+    connection = ActiveRecord::Base.lease_connection
 
     attr = Default.arel_table[:char1]
     comparison = connection.case_insensitive_comparison(attr, nil)

--- a/activerecord/test/cases/adapters/postgresql/change_schema_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/change_schema_test.rb
@@ -9,7 +9,7 @@ module ActiveRecord
 
       def setup
         super
-        @connection = ActiveRecord::Base.connection
+        @connection = ActiveRecord::Base.lease_connection
         connection.create_table(:strings) do |t|
           t.string :somedate
         end

--- a/activerecord/test/cases/adapters/postgresql/citext_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/citext_test.rb
@@ -10,7 +10,7 @@ class PostgresqlCitextTest < ActiveRecord::PostgreSQLTestCase
   end
 
   def setup
-    @connection = ActiveRecord::Base.connection
+    @connection = ActiveRecord::Base.lease_connection
 
     enable_extension!("citext", @connection)
 

--- a/activerecord/test/cases/adapters/postgresql/collation_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/collation_test.rb
@@ -7,7 +7,7 @@ class PostgresqlCollationTest < ActiveRecord::PostgreSQLTestCase
   include SchemaDumpingHelper
 
   def setup
-    @connection = ActiveRecord::Base.connection
+    @connection = ActiveRecord::Base.lease_connection
     @connection.create_table :postgresql_collations, force: true do |t|
       t.string :string_c, collation: "C"
       t.text :text_posix, collation: "POSIX"

--- a/activerecord/test/cases/adapters/postgresql/composite_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/composite_test.rb
@@ -13,7 +13,7 @@ module PostgresqlCompositeBehavior
   def setup
     super
 
-    @connection = ActiveRecord::Base.connection
+    @connection = ActiveRecord::Base.lease_connection
     @connection.transaction do
       @connection.execute <<~SQL
         CREATE TYPE full_address AS

--- a/activerecord/test/cases/adapters/postgresql/create_unlogged_tables_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/create_unlogged_tables_test.rb
@@ -19,7 +19,7 @@ class UnloggedTablesTest < ActiveRecord::PostgreSQLTestCase
 
   def setup
     @previous_unlogged_tables = ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.create_unlogged_tables
-    @connection = ActiveRecord::Base.connection
+    @connection = ActiveRecord::Base.lease_connection
     ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.create_unlogged_tables = false
   end
 

--- a/activerecord/test/cases/adapters/postgresql/datatype_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/datatype_test.rb
@@ -17,7 +17,7 @@ end
 
 class PostgresqlDataTypeTest < ActiveRecord::PostgreSQLTestCase
   def setup
-    @connection = ActiveRecord::Base.connection
+    @connection = ActiveRecord::Base.lease_connection
 
     @connection.execute("INSERT INTO postgresql_times (id, time_interval, scaled_time_interval) VALUES (1, '1 year 2 days ago', '3 weeks ago')")
     @first_time = PostgresqlTime.find(1)
@@ -75,7 +75,7 @@ class PostgresqlInternalDataTypeTest < ActiveRecord::PostgreSQLTestCase
   include DdlHelper
 
   setup do
-    @connection = ActiveRecord::Base.connection
+    @connection = ActiveRecord::Base.lease_connection
   end
 
   def test_name_column_type

--- a/activerecord/test/cases/adapters/postgresql/deferred_constraints_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/deferred_constraints_test.rb
@@ -5,7 +5,7 @@ require "models/author"
 
 class PostgresqlDeferredConstraintsTest < ActiveRecord::PostgreSQLTestCase
   def setup
-    @connection = ActiveRecord::Base.connection
+    @connection = ActiveRecord::Base.lease_connection
     @fk = @connection.foreign_keys("authors").first.name
     @other_fk = @connection.foreign_keys("lessons_students").first.name
   end

--- a/activerecord/test/cases/adapters/postgresql/domain_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/domain_test.rb
@@ -11,7 +11,7 @@ class PostgresqlDomainTest < ActiveRecord::PostgreSQLTestCase
   end
 
   def setup
-    @connection = ActiveRecord::Base.connection
+    @connection = ActiveRecord::Base.lease_connection
     @connection.transaction do
       @connection.execute "CREATE DOMAIN custom_money as numeric(8,2)"
       @connection.create_table("postgresql_domains") do |t|

--- a/activerecord/test/cases/adapters/postgresql/enum_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/enum_test.rb
@@ -20,7 +20,7 @@ class PostgresqlEnumTest < ActiveRecord::PostgreSQLTestCase
   end
 
   def setup
-    @connection = ActiveRecord::Base.connection
+    @connection = ActiveRecord::Base.lease_connection
     @connection.transaction do
       @connection.create_enum("mood", ["sad", "ok", "happy"])
       @connection.create_table("postgresql_enums") do |t|

--- a/activerecord/test/cases/adapters/postgresql/extension_migration_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/extension_migration_test.rb
@@ -26,7 +26,7 @@ class PostgresqlExtensionMigrationTest < ActiveRecord::PostgreSQLTestCase
   def setup
     super
 
-    @connection = ActiveRecord::Base.connection
+    @connection = ActiveRecord::Base.lease_connection
     @pool = ActiveRecord::Base.connection_pool
 
     @old_table_name_prefix = ActiveRecord::Base.table_name_prefix

--- a/activerecord/test/cases/adapters/postgresql/foreign_table_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/foreign_table_test.rb
@@ -3,7 +3,7 @@
 require "cases/helper"
 require "models/professor"
 
-if ActiveRecord::Base.connection.supports_foreign_tables?
+if ActiveRecord::Base.lease_connection.supports_foreign_tables?
   class ForeignTableTest < ActiveRecord::TestCase
     self.use_transactional_tests = false
 
@@ -18,7 +18,7 @@ if ActiveRecord::Base.connection.supports_foreign_tables?
     def setup
       @professor = Professor.create(name: "Nicola")
 
-      @connection = ActiveRecord::Base.connection
+      @connection = ActiveRecord::Base.lease_connection
       enable_extension!("postgres_fdw", @connection)
 
       foreign_db_config = ARTest.test_configuration_hashes["arunit2"]
@@ -52,7 +52,7 @@ if ActiveRecord::Base.connection.supports_foreign_tables?
 
     def test_table_exists
       table_name = ForeignProfessor.table_name
-      assert_not ActiveRecord::Base.connection.table_exists?(table_name)
+      assert_not ActiveRecord::Base.lease_connection.table_exists?(table_name)
     end
 
     def test_foreign_tables_are_valid_data_sources

--- a/activerecord/test/cases/adapters/postgresql/full_text_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/full_text_test.rb
@@ -8,7 +8,7 @@ class PostgresqlFullTextTest < ActiveRecord::PostgreSQLTestCase
   class Tsvector < ActiveRecord::Base; end
 
   setup do
-    @connection = ActiveRecord::Base.connection
+    @connection = ActiveRecord::Base.lease_connection
     @connection.create_table("tsvectors") do |t|
       t.tsvector "text_vector"
     end

--- a/activerecord/test/cases/adapters/postgresql/geometric_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/geometric_test.rb
@@ -19,7 +19,7 @@ class PostgresqlPointTest < ActiveRecord::PostgreSQLTestCase
   end
 
   def setup
-    @connection = ActiveRecord::Base.connection
+    @connection = ActiveRecord::Base.lease_connection
     @connection.create_table("postgresql_points") do |t|
       t.point :x
       t.point :y, default: [12.2, 13.3]
@@ -167,7 +167,7 @@ class PostgresqlGeometricTest < ActiveRecord::PostgreSQLTestCase
   class PostgresqlGeometric < ActiveRecord::Base; end
 
   setup do
-    @connection = ActiveRecord::Base.connection
+    @connection = ActiveRecord::Base.lease_connection
     @connection.create_table("postgresql_geometrics") do |t|
       t.lseg    :a_line_segment
       t.box     :a_box
@@ -247,10 +247,10 @@ class PostgreSQLGeometricLineTest < ActiveRecord::PostgreSQLTestCase
   class PostgresqlLine < ActiveRecord::Base; end
 
   setup do
-    unless ActiveRecord::Base.connection.database_version >= 90400
+    unless ActiveRecord::Base.lease_connection.database_version >= 90400
       skip("line type is not fully implemented")
     end
-    @connection = ActiveRecord::Base.connection
+    @connection = ActiveRecord::Base.lease_connection
     @connection.create_table("postgresql_lines") do |t|
       t.line :a_line
     end
@@ -293,7 +293,7 @@ class PostgreSQLGeometricTypesTest < ActiveRecord::PostgreSQLTestCase
 
   def setup
     super
-    @connection = ActiveRecord::Base.connection
+    @connection = ActiveRecord::Base.lease_connection
     @table_name = :testings
   end
 

--- a/activerecord/test/cases/adapters/postgresql/hstore_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/hstore_test.rb
@@ -13,7 +13,7 @@ class PostgresqlHstoreTest < ActiveRecord::PostgreSQLTestCase
   end
 
   def setup
-    @connection = ActiveRecord::Base.connection
+    @connection = ActiveRecord::Base.lease_connection
 
     enable_extension!("hstore", @connection)
 

--- a/activerecord/test/cases/adapters/postgresql/infinity_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/infinity_test.rb
@@ -9,7 +9,7 @@ class PostgresqlInfinityTest < ActiveRecord::PostgreSQLTestCase
   end
 
   setup do
-    @connection = ActiveRecord::Base.connection
+    @connection = ActiveRecord::Base.lease_connection
     @connection.create_table(:postgresql_infinities) do |t|
       t.float :float
       t.datetime :datetime

--- a/activerecord/test/cases/adapters/postgresql/integer_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/integer_test.rb
@@ -8,7 +8,7 @@ class PostgresqlIntegerTest < ActiveRecord::PostgreSQLTestCase
   end
 
   def setup
-    @connection = ActiveRecord::Base.connection
+    @connection = ActiveRecord::Base.lease_connection
 
     @connection.transaction do
       @connection.create_table "pg_integers", force: true do |t|

--- a/activerecord/test/cases/adapters/postgresql/interval_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/interval_test.rb
@@ -11,7 +11,7 @@ class PostgresqlIntervalTest < ActiveRecord::PostgreSQLTestCase
   end
 
   def setup
-    @connection = ActiveRecord::Base.connection
+    @connection = ActiveRecord::Base.lease_connection
     @connection.transaction do
       @connection.create_table("interval_data_types") do |t|
         t.interval "maximum_term"

--- a/activerecord/test/cases/adapters/postgresql/invertible_migration_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/invertible_migration_test.rb
@@ -50,7 +50,7 @@ class PostgresqlInvertibleMigrationTest < ActiveRecord::PostgreSQLTestCase
   end
 
   setup do
-    @connection = ActiveRecord::Base.connection
+    @connection = ActiveRecord::Base.lease_connection
   end
 
   teardown do

--- a/activerecord/test/cases/adapters/postgresql/ltree_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/ltree_test.rb
@@ -10,7 +10,7 @@ class PostgresqlLtreeTest < ActiveRecord::PostgreSQLTestCase
   end
 
   def setup
-    @connection = ActiveRecord::Base.connection
+    @connection = ActiveRecord::Base.lease_connection
 
     enable_extension!("ltree", @connection)
 

--- a/activerecord/test/cases/adapters/postgresql/money_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/money_test.rb
@@ -11,7 +11,7 @@ class PostgresqlMoneyTest < ActiveRecord::PostgreSQLTestCase
   end
 
   setup do
-    @connection = ActiveRecord::Base.connection
+    @connection = ActiveRecord::Base.lease_connection
     @connection.execute("set lc_monetary = 'C'")
     @connection.create_table("postgresql_moneys", force: true) do |t|
       t.money "wealth"

--- a/activerecord/test/cases/adapters/postgresql/network_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/network_test.rb
@@ -8,7 +8,7 @@ class PostgresqlNetworkTest < ActiveRecord::PostgreSQLTestCase
   class PostgresqlNetworkAddress < ActiveRecord::Base; end
 
   setup do
-    @connection = ActiveRecord::Base.connection
+    @connection = ActiveRecord::Base.lease_connection
     @connection.create_table("postgresql_network_addresses", force: true) do |t|
       t.inet "inet_address", default: "192.168.1.1"
       t.cidr "cidr_address", default: "192.168.1.0/24"

--- a/activerecord/test/cases/adapters/postgresql/numbers_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/numbers_test.rb
@@ -6,7 +6,7 @@ class PostgresqlNumberTest < ActiveRecord::PostgreSQLTestCase
   class PostgresqlNumber < ActiveRecord::Base; end
 
   setup do
-    @connection = ActiveRecord::Base.connection
+    @connection = ActiveRecord::Base.lease_connection
     @connection.create_table("postgresql_numbers", force: true) do |t|
       t.column "single", "REAL"
       t.column "double", "DOUBLE PRECISION"

--- a/activerecord/test/cases/adapters/postgresql/optimizer_hints_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/optimizer_hints_test.rb
@@ -8,7 +8,7 @@ class PostgresqlOptimizerHintsTest < ActiveRecord::PostgreSQLTestCase
     fixtures :posts
 
     def setup
-      enable_extension!("pg_hint_plan", ActiveRecord::Base.connection)
+      enable_extension!("pg_hint_plan", ActiveRecord::Base.lease_connection)
     end
 
     def test_optimizer_hints

--- a/activerecord/test/cases/adapters/postgresql/partitions_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/partitions_test.rb
@@ -4,7 +4,7 @@ require "cases/helper"
 
 class PostgreSQLPartitionsTest < ActiveRecord::PostgreSQLTestCase
   def setup
-    @connection = ActiveRecord::Base.connection
+    @connection = ActiveRecord::Base.lease_connection
   end
 
   def teardown
@@ -12,7 +12,7 @@ class PostgreSQLPartitionsTest < ActiveRecord::PostgreSQLTestCase
   end
 
   def test_partitions_table_exists
-    skip unless ActiveRecord::Base.connection.database_version >= 100000
+    skip unless ActiveRecord::Base.lease_connection.database_version >= 100000
     @connection.create_table :partitioned_events, force: true, id: false,
       options: "partition by range (issued_at)" do |t|
       t.timestamp :issued_at

--- a/activerecord/test/cases/adapters/postgresql/postgresql_adapter_prevent_writes_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/postgresql_adapter_prevent_writes_test.rb
@@ -11,7 +11,7 @@ module ActiveRecord
       include ConnectionHelper
 
       def setup
-        @connection = ActiveRecord::Base.connection
+        @connection = ActiveRecord::Base.lease_connection
       end
 
       def test_errors_when_an_insert_query_is_called_while_preventing_writes

--- a/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
@@ -14,7 +14,7 @@ module ActiveRecord
       include ConnectionHelper
 
       def setup
-        @connection = ActiveRecord::Base.connection
+        @connection = ActiveRecord::Base.lease_connection
         @original_db_warnings_action = :ignore
       end
 
@@ -477,7 +477,7 @@ module ActiveRecord
 
       def test_only_reload_type_map_once_for_every_unrecognized_type
         reset_connection
-        connection = ActiveRecord::Base.connection
+        connection = ActiveRecord::Base.lease_connection
         connection.select_all "SELECT 1" # eagerly initialize the connection
 
         silence_warnings do
@@ -497,7 +497,7 @@ module ActiveRecord
 
       def test_only_warn_on_first_encounter_of_unrecognized_oid
         reset_connection
-        connection = ActiveRecord::Base.connection
+        connection = ActiveRecord::Base.lease_connection
 
         warning = capture(:stderr) {
           connection.select_all "select 'pg_catalog.pg_class'::regclass"

--- a/activerecord/test/cases/adapters/postgresql/postgresql_rake_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/postgresql_rake_test.rb
@@ -26,7 +26,7 @@ module ActiveRecord
       mock.expect(:call, nil, [{ adapter: "postgresql", database: "postgres", schema_search_path: "public" }])
       mock.expect(:call, nil, [db_config])
 
-      ActiveRecord::Base.stub(:connection, @connection) do
+      ActiveRecord::Base.stub(:lease_connection, @connection) do
         ActiveRecord::Base.stub(:establish_connection, mock) do
           ActiveRecord::Tasks::DatabaseTasks.create(db_config)
         end
@@ -87,7 +87,7 @@ module ActiveRecord
       mock.expect(:call, nil, [{ adapter: "postgresql", database: "postgres", schema_search_path: "public" }])
       mock.expect(:call, nil, [db_config])
 
-      ActiveRecord::Base.stub(:connection, @connection) do
+      ActiveRecord::Base.stub(:lease_connection, @connection) do
         ActiveRecord::Base.stub(:establish_connection, mock) do
           ActiveRecord::Tasks::DatabaseTasks.create(db_config)
         end
@@ -97,7 +97,7 @@ module ActiveRecord
     end
 
     def test_db_create_with_error_prints_message
-      ActiveRecord::Base.stub(:connection, @connection) do
+      ActiveRecord::Base.stub(:lease_connection, @connection) do
         ActiveRecord::Base.stub(:establish_connection, -> * { raise Exception }) do
           assert_raises(Exception) { ActiveRecord::Tasks::DatabaseTasks.create @configuration }
           assert_match "Couldn't create '#{@configuration['database']}' database. Please check your configuration.", $stderr.string
@@ -115,7 +115,7 @@ module ActiveRecord
 
     def test_create_when_database_exists_outputs_info_to_stderr
       with_stubbed_connection_establish_connection do
-        ActiveRecord::Base.connection.stub(
+        ActiveRecord::Base.lease_connection.stub(
           :create_database,
           proc { raise ActiveRecord::DatabaseAlreadyExists }
         ) do
@@ -128,7 +128,7 @@ module ActiveRecord
 
     private
       def with_stubbed_connection_establish_connection(&block)
-        ActiveRecord::Base.stub(:connection, @connection) do
+        ActiveRecord::Base.stub(:lease_connection, @connection) do
           ActiveRecord::Base.stub(:establish_connection, nil, &block)
         end
       end
@@ -150,7 +150,7 @@ module ActiveRecord
     end
 
     def test_establishes_connection_to_postgresql_database
-      ActiveRecord::Base.stub(:connection, @connection) do
+      ActiveRecord::Base.stub(:lease_connection, @connection) do
         assert_called_with(
           ActiveRecord::Base,
           :establish_connection,
@@ -187,7 +187,7 @@ module ActiveRecord
 
     private
       def with_stubbed_connection_establish_connection(&block)
-        ActiveRecord::Base.stub(:connection, @connection) do
+        ActiveRecord::Base.stub(:lease_connection, @connection) do
           ActiveRecord::Base.stub(:establish_connection, nil, &block)
         end
       end
@@ -273,7 +273,7 @@ module ActiveRecord
 
     private
       def with_stubbed_connection(&block)
-        ActiveRecord::Base.stub(:connection, @connection, &block)
+        ActiveRecord::Base.stub(:lease_connection, @connection, &block)
       end
   end
 
@@ -290,7 +290,7 @@ module ActiveRecord
     end
 
     def test_db_retrieves_charset
-      ActiveRecord::Base.stub(:connection, @connection) do
+      ActiveRecord::Base.stub(:lease_connection, @connection) do
         assert_called(@connection, :encoding) do
           ActiveRecord::Tasks::DatabaseTasks.charset @configuration
         end
@@ -308,7 +308,7 @@ module ActiveRecord
     end
 
     def test_db_retrieves_collation
-      ActiveRecord::Base.stub(:connection, @connection) do
+      ActiveRecord::Base.stub(:lease_connection, @connection) do
         assert_called(@connection, :collation) do
           ActiveRecord::Tasks::DatabaseTasks.collation @configuration
         end
@@ -407,7 +407,7 @@ module ActiveRecord
     end
 
     def test_structure_dump_with_ignore_tables
-      ActiveRecord::Base.connection.stub(:data_sources, ["foo", "bar", "prefix_foo", "ignored_foo"]) do
+      ActiveRecord::Base.lease_connection.stub(:data_sources, ["foo", "bar", "prefix_foo", "ignored_foo"]) do
         ActiveRecord::SchemaDumper.stub(:ignore_tables, [/^prefix_/, "ignored_foo"]) do
           assert_called_with(
             Kernel,

--- a/activerecord/test/cases/adapters/postgresql/prepared_statements_disabled_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/prepared_statements_disabled_test.rb
@@ -17,7 +17,7 @@ class PreparedStatementsDisabledTest < ActiveRecord::PostgreSQLTestCase
   end
 
   def test_select_query_works_even_when_prepared_statements_are_disabled
-    assert_not Developer.connection.prepared_statements
+    assert_not Developer.lease_connection.prepared_statements
 
     david = developers(:david)
 

--- a/activerecord/test/cases/adapters/postgresql/quoting_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/quoting_test.rb
@@ -7,7 +7,7 @@ module ActiveRecord
     class PostgreSQLAdapter
       class QuotingTest < ActiveRecord::PostgreSQLTestCase
         def setup
-          @conn = ActiveRecord::Base.connection
+          @conn = ActiveRecord::Base.lease_connection
           @raise_int_wider_than_64bit = ActiveRecord.raise_int_wider_than_64bit
         end
 

--- a/activerecord/test/cases/adapters/postgresql/range_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/range_test.rb
@@ -13,7 +13,7 @@ class PostgresqlRangeTest < ActiveRecord::PostgreSQLTestCase
   include InTimeZone
 
   def setup
-    @connection = PostgresqlRange.connection
+    @connection = PostgresqlRange.lease_connection
     @connection.transaction do
       @connection.execute <<~SQL
         CREATE TYPE floatrange AS RANGE (

--- a/activerecord/test/cases/adapters/postgresql/referential_integrity_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/referential_integrity_test.rb
@@ -32,12 +32,12 @@ class PostgreSQLReferentialIntegrityTest < ActiveRecord::PostgreSQLTestCase
   end
 
   def setup
-    @connection = ActiveRecord::Base.connection
+    @connection = ActiveRecord::Base.lease_connection
   end
 
   def teardown
     reset_connection
-    if ActiveRecord::Base.connection.is_a?(MissingSuperuserPrivileges)
+    if ActiveRecord::Base.lease_connection.is_a?(MissingSuperuserPrivileges)
       raise "MissingSuperuserPrivileges patch was not removed"
     end
   end

--- a/activerecord/test/cases/adapters/postgresql/rename_table_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/rename_table_test.rb
@@ -4,7 +4,7 @@ require "cases/helper"
 
 class PostgresqlRenameTableTest < ActiveRecord::PostgreSQLTestCase
   def setup
-    @connection = ActiveRecord::Base.connection
+    @connection = ActiveRecord::Base.lease_connection
   end
 
   def teardown

--- a/activerecord/test/cases/adapters/postgresql/schema_authorization_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/schema_authorization_test.rb
@@ -16,7 +16,7 @@ class SchemaAuthorizationTest < ActiveRecord::PostgreSQLTestCase
   USERS = ["rails_pg_schema_user1", "rails_pg_schema_user2"]
 
   def setup
-    @connection = ActiveRecord::Base.connection
+    @connection = ActiveRecord::Base.lease_connection
     @connection.execute "SET search_path TO '$user',public"
     set_session_auth
     USERS.each do |u|
@@ -63,7 +63,7 @@ class SchemaAuthorizationTest < ActiveRecord::PostgreSQLTestCase
     end
   end
 
-  if ActiveRecord::Base.connection.prepared_statements
+  if ActiveRecord::Base.lease_connection.prepared_statements
     def test_auth_with_bind
       assert_nothing_raised do
         set_session_auth

--- a/activerecord/test/cases/adapters/postgresql/serial_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/serial_test.rb
@@ -9,7 +9,7 @@ class PostgresqlSerialTest < ActiveRecord::PostgreSQLTestCase
   class PostgresqlSerial < ActiveRecord::Base; end
 
   setup do
-    @connection = ActiveRecord::Base.connection
+    @connection = ActiveRecord::Base.lease_connection
     @connection.create_table "postgresql_serials", force: true do |t|
       t.serial :seq
       t.integer :serials_id, default: -> { "nextval('postgresql_serials_id_seq')" }
@@ -51,7 +51,7 @@ class PostgresqlBigSerialTest < ActiveRecord::PostgreSQLTestCase
   class PostgresqlBigSerial < ActiveRecord::Base; end
 
   setup do
-    @connection = ActiveRecord::Base.connection
+    @connection = ActiveRecord::Base.lease_connection
     @connection.create_table "postgresql_big_serials", force: true do |t|
       t.bigserial :seq
       t.bigint :serials_id, default: -> { "nextval('postgresql_big_serials_id_seq')" }
@@ -92,7 +92,7 @@ module SequenceNameDetectionTestCases
     include SchemaDumpingHelper
 
     def setup
-      @connection = ActiveRecord::Base.connection
+      @connection = ActiveRecord::Base.lease_connection
       @connection.create_table :foo_bar, force: true do |t|
         t.serial :baz_id
       end
@@ -127,7 +127,7 @@ module SequenceNameDetectionTestCases
 
     def setup
       @table_name = "long_table_name_to_test_sequence_name_detection_for_serial_cols"
-      @connection = ActiveRecord::Base.connection
+      @connection = ActiveRecord::Base.lease_connection
       @connection.create_table @table_name, force: true, _uses_legacy_table_name: true do |t|
         t.serial :seq
         t.bigserial :bigseq

--- a/activerecord/test/cases/adapters/postgresql/statement_pool_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/statement_pool_test.rb
@@ -47,7 +47,7 @@ module ActiveRecord
         end
 
         def test_prepared_statements_do_not_get_stuck_on_query_interruption
-          pg_connection = ActiveRecord::Base.connection.connect!.instance_variable_get(:@raw_connection)
+          pg_connection = ActiveRecord::Base.lease_connection.connect!.instance_variable_get(:@raw_connection)
           pg_connection.stub(:get_last_result, -> { raise "random error" }) do
             assert_raises(RuntimeError) do
               Developer.where(name: "David").last

--- a/activerecord/test/cases/adapters/postgresql/type_lookup_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/type_lookup_test.rb
@@ -4,7 +4,7 @@ require "cases/helper"
 
 class PostgresqlTypeLookupTest < ActiveRecord::PostgreSQLTestCase
   setup do
-    @connection = ActiveRecord::Base.connection
+    @connection = ActiveRecord::Base.lease_connection
   end
 
   test "array delimiters are looked up correctly" do

--- a/activerecord/test/cases/adapters/postgresql/uuid_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/uuid_test.rb
@@ -5,7 +5,7 @@ require "support/schema_dumping_helper"
 
 module PostgresqlUUIDHelper
   def connection
-    @connection ||= ActiveRecord::Base.connection
+    @connection ||= ActiveRecord::Base.lease_connection
   end
 
   def drop_table(name)
@@ -43,8 +43,8 @@ class PostgresqlUUIDTest < ActiveRecord::PostgreSQLTestCase
     drop_table "uuid_data_type"
   end
 
-  if ActiveRecord::Base.connection.respond_to?(:supports_pgcrypto_uuid?) &&
-      ActiveRecord::Base.connection.supports_pgcrypto_uuid?
+  if ActiveRecord::Base.lease_connection.respond_to?(:supports_pgcrypto_uuid?) &&
+      ActiveRecord::Base.lease_connection.supports_pgcrypto_uuid?
     def test_uuid_column_default
       connection.add_column :uuid_data_type, :thingy, :uuid, null: false, default: "gen_random_uuid()"
       UUIDType.reset_column_information

--- a/activerecord/test/cases/adapters/postgresql/virtual_column_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/virtual_column_test.rb
@@ -3,7 +3,7 @@
 require "cases/helper"
 require "support/schema_dumping_helper"
 
-if ActiveRecord::Base.connection.supports_virtual_columns?
+if ActiveRecord::Base.lease_connection.supports_virtual_columns?
   class PostgresqlVirtualColumnTest < ActiveRecord::PostgreSQLTestCase
     include SchemaDumpingHelper
 
@@ -11,7 +11,7 @@ if ActiveRecord::Base.connection.supports_virtual_columns?
     end
 
     def setup
-      @connection = ActiveRecord::Base.connection
+      @connection = ActiveRecord::Base.lease_connection
       @connection.create_table :virtual_columns, force: true do |t|
         t.string  :name
         t.virtual :upper_name,  type: :string,  as: "UPPER(name)", stored: true

--- a/activerecord/test/cases/adapters/postgresql/xml_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/xml_test.rb
@@ -10,7 +10,7 @@ class PostgresqlXMLTest < ActiveRecord::PostgreSQLTestCase
   end
 
   def setup
-    @connection = ActiveRecord::Base.connection
+    @connection = ActiveRecord::Base.lease_connection
     @connection.create_table("xml_data_type") do |t|
       t.xml "payload"
     end

--- a/activerecord/test/cases/adapters/sqlite3/collation_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/collation_test.rb
@@ -7,7 +7,7 @@ class SQLite3CollationTest < ActiveRecord::SQLite3TestCase
   include SchemaDumpingHelper
 
   def setup
-    @connection = ActiveRecord::Base.connection
+    @connection = ActiveRecord::Base.lease_connection
     @connection.create_table :collation_table_sqlite3, force: true do |t|
       t.string :string_nocase, collation: "NOCASE"
       t.text :text_rtrim, collation: "RTRIM"

--- a/activerecord/test/cases/adapters/sqlite3/copy_table_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/copy_table_test.rb
@@ -6,7 +6,7 @@ class CopyTableTest < ActiveRecord::SQLite3TestCase
   fixtures :customers
 
   def setup
-    @connection = ActiveRecord::Base.connection
+    @connection = ActiveRecord::Base.lease_connection
   end
 
   def test_copy_table(from = "customers", to = "customers2", options = {})

--- a/activerecord/test/cases/adapters/sqlite3/quoting_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/quoting_test.rb
@@ -7,7 +7,7 @@ require "securerandom"
 class SQLite3QuotingTest < ActiveRecord::SQLite3TestCase
   def setup
     super
-    @conn = ActiveRecord::Base.connection
+    @conn = ActiveRecord::Base.lease_connection
   end
 
   def test_quote_string

--- a/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_prevent_writes_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_prevent_writes_test.rb
@@ -11,7 +11,7 @@ module ActiveRecord
       self.use_transactional_tests = false
 
       def setup
-        @conn = ActiveRecord::Base.connection
+        @conn = ActiveRecord::Base.lease_connection
       end
 
       def test_errors_when_an_insert_query_is_called_while_preventing_writes

--- a/activerecord/test/cases/adapters/sqlite3/sqlite_rake_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/sqlite_rake_test.rb
@@ -139,7 +139,7 @@ module ActiveRecord
     end
 
     def test_db_retrieves_charset
-      ActiveRecord::Base.stub(:connection, @connection) do
+      ActiveRecord::Base.stub(:lease_connection, @connection) do
         assert_called(@connection, :encoding) do
           ActiveRecord::Tasks::DatabaseTasks.charset @configuration, "/rails/root"
         end
@@ -192,7 +192,7 @@ module ActiveRecord
     def test_structure_dump_with_ignore_tables
       dbfile   = @database
       filename = "awesome-file.sql"
-      ActiveRecord::Base.connection.stub(:data_sources, ["foo", "bar", "prefix_foo", "ignored_foo"]) do
+      ActiveRecord::Base.lease_connection.stub(:data_sources, ["foo", "bar", "prefix_foo", "ignored_foo"]) do
         ActiveRecord::SchemaDumper.stub(:ignore_tables, [/^prefix_/, "ignored_foo"]) do
           ActiveRecord::Tasks::DatabaseTasks.structure_dump(@configuration, filename, "/rails/root")
         end

--- a/activerecord/test/cases/adapters/sqlite3/virtual_column_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/virtual_column_test.rb
@@ -3,7 +3,7 @@
 require "cases/helper"
 require "support/schema_dumping_helper"
 
-if ActiveRecord::Base.connection.supports_virtual_columns?
+if ActiveRecord::Base.lease_connection.supports_virtual_columns?
   class SQLite3VirtualColumnTest < ActiveRecord::SQLite3TestCase
     include SchemaDumpingHelper
 
@@ -11,7 +11,7 @@ if ActiveRecord::Base.connection.supports_virtual_columns?
     end
 
     def setup
-      @connection = ActiveRecord::Base.connection
+      @connection = ActiveRecord::Base.lease_connection
       @connection.create_table :virtual_columns, force: true do |t|
         t.string  :name
         t.virtual :upper_name, type: :string, as: "UPPER(name)", stored: true

--- a/activerecord/test/cases/adapters/trilogy/trilogy_adapter_test.rb
+++ b/activerecord/test/cases/adapters/trilogy/trilogy_adapter_test.rb
@@ -7,7 +7,7 @@ require "models/post"
 
 class TrilogyAdapterTest < ActiveRecord::TrilogyTestCase
   setup do
-    @conn = ActiveRecord::Base.connection
+    @conn = ActiveRecord::Base.lease_connection
   end
 
   test "connection_error" do
@@ -343,7 +343,7 @@ class TrilogyAdapterTest < ActiveRecord::TrilogyTestCase
     ActiveRecord::Base.establish_connection(
       db_config.configuration_hash.merge("read_timeout" => 1)
     )
-    connection = ActiveRecord::Base.connection
+    connection = ActiveRecord::Base.lease_connection
 
     error = assert_raises(ActiveRecord::AdapterTimeout) do
       connection.execute("SELECT SLEEP(2)")

--- a/activerecord/test/cases/adapters/trilogy/trilogy_rake_test.rb
+++ b/activerecord/test/cases/adapters/trilogy/trilogy_rake_test.rb
@@ -29,7 +29,7 @@ module ActiveRecord
       mock.expect(:call, nil, [adapter: "trilogy", database: nil])
       mock.expect(:call, nil, [db_config])
 
-      ActiveRecord::Base.stub(:connection, @connection) do
+      ActiveRecord::Base.stub(:lease_connection, @connection) do
         ActiveRecord::Base.stub(:establish_connection, mock) do
           ActiveRecord::Tasks::DatabaseTasks.create(db_config)
         end
@@ -76,7 +76,7 @@ module ActiveRecord
 
     def test_create_when_database_exists_outputs_info_to_stderr
       with_stubbed_connection_establish_connection do
-        ActiveRecord::Base.connection.stub(
+        ActiveRecord::Base.lease_connection.stub(
           :create_database,
           proc { raise ActiveRecord::DatabaseAlreadyExists }
         ) do
@@ -90,7 +90,7 @@ module ActiveRecord
     private
       def with_stubbed_connection_establish_connection(&block)
         ActiveRecord::Base.stub(:establish_connection, nil) do
-          ActiveRecord::Base.stub(:connection, @connection, &block)
+          ActiveRecord::Base.stub(:lease_connection, @connection, &block)
         end
       end
   end
@@ -139,7 +139,7 @@ module ActiveRecord
     def test_establishes_connection_to_mysql_database
       db_config = ActiveRecord::DatabaseConfigurations::HashConfig.new("default_env", "primary", @configuration)
 
-      ActiveRecord::Base.stub(:connection, @connection) do
+      ActiveRecord::Base.stub(:lease_connection, @connection) do
         assert_called_with(
           ActiveRecord::Base,
           :establish_connection,
@@ -169,7 +169,7 @@ module ActiveRecord
     private
       def with_stubbed_connection_establish_connection(&block)
         ActiveRecord::Base.stub(:establish_connection, nil) do
-          ActiveRecord::Base.stub(:connection, @connection, &block)
+          ActiveRecord::Base.stub(:lease_connection, @connection, &block)
         end
       end
   end
@@ -186,7 +186,7 @@ module ActiveRecord
     def test_establishes_connection_without_database
       db_config = ActiveRecord::DatabaseConfigurations::HashConfig.new("default_env", "primary", @configuration)
 
-      ActiveRecord::Base.stub(:connection, @connection) do
+      ActiveRecord::Base.stub(:lease_connection, @connection) do
         assert_called(ActiveRecord::Base, :establish_connection, times: 2) do
           ActiveRecord::Tasks::DatabaseTasks.purge(db_config)
         end
@@ -217,7 +217,7 @@ module ActiveRecord
     private
       def with_stubbed_connection_establish_connection(&block)
         ActiveRecord::Base.stub(:establish_connection, nil) do
-          ActiveRecord::Base.stub(:connection, @connection, &block)
+          ActiveRecord::Base.stub(:lease_connection, @connection, &block)
         end
       end
   end
@@ -232,7 +232,7 @@ module ActiveRecord
     end
 
     def test_db_retrieves_charset
-      ActiveRecord::Base.stub(:connection, @connection) do
+      ActiveRecord::Base.stub(:lease_connection, @connection) do
         assert_called(@connection, :charset) do
           ActiveRecord::Tasks::DatabaseTasks.charset @configuration
         end
@@ -250,7 +250,7 @@ module ActiveRecord
     end
 
     def test_db_retrieves_collation
-      ActiveRecord::Base.stub(:connection, @connection) do
+      ActiveRecord::Base.stub(:lease_connection, @connection) do
         assert_called(@connection, :collation) do
           ActiveRecord::Tasks::DatabaseTasks.collation @configuration
         end
@@ -313,7 +313,7 @@ module ActiveRecord
 
     def test_structure_dump_with_ignore_tables
       filename = "awesome-file.sql"
-      ActiveRecord::Base.connection.stub(:data_sources, ["foo", "bar", "prefix_foo", "ignored_foo"]) do
+      ActiveRecord::Base.lease_connection.stub(:data_sources, ["foo", "bar", "prefix_foo", "ignored_foo"]) do
         ActiveRecord::SchemaDumper.stub(:ignore_tables, [/^prefix_/, "ignored_foo"]) do
           assert_called_with(
             Kernel,

--- a/activerecord/test/cases/annotate_test.rb
+++ b/activerecord/test/cases/annotate_test.rb
@@ -46,6 +46,6 @@ class AnnotateTest < ActiveRecord::TestCase
 
   private
     def regexp_escape_table_name(name)
-      Regexp.escape(Post.connection.quote_table_name(name))
+      Regexp.escape(Post.lease_connection.quote_table_name(name))
     end
 end

--- a/activerecord/test/cases/arel/collectors/bind_test.rb
+++ b/activerecord/test/cases/arel/collectors/bind_test.rb
@@ -8,7 +8,7 @@ module Arel
     class TestBind < Arel::Test
       def setup
         @conn = FakeRecord::Base.new
-        @visitor = Visitors::ToSql.new @conn.connection
+        @visitor = Visitors::ToSql.new @conn.lease_connection
         super
       end
 

--- a/activerecord/test/cases/arel/collectors/composite_test.rb
+++ b/activerecord/test/cases/arel/collectors/composite_test.rb
@@ -10,7 +10,7 @@ module Arel
     class TestComposite < Arel::Test
       def setup
         @conn = FakeRecord::Base.new
-        @visitor = Visitors::ToSql.new @conn.connection
+        @visitor = Visitors::ToSql.new @conn.lease_connection
         super
       end
 

--- a/activerecord/test/cases/arel/collectors/sql_string_test.rb
+++ b/activerecord/test/cases/arel/collectors/sql_string_test.rb
@@ -7,7 +7,7 @@ module Arel
     class TestSqlString < Arel::Test
       def setup
         @conn = FakeRecord::Base.new
-        @visitor = Visitors::ToSql.new @conn.connection
+        @visitor = Visitors::ToSql.new @conn.lease_connection
         super
       end
 

--- a/activerecord/test/cases/arel/collectors/substitute_bind_collector_test.rb
+++ b/activerecord/test/cases/arel/collectors/substitute_bind_collector_test.rb
@@ -9,7 +9,7 @@ module Arel
     class TestSubstituteBindCollector < Arel::Test
       def setup
         @conn = FakeRecord::Base.new
-        @visitor = Visitors::ToSql.new @conn.connection
+        @visitor = Visitors::ToSql.new @conn.lease_connection
         super
       end
 

--- a/activerecord/test/cases/arel/insert_manager_test.rb
+++ b/activerecord/test/cases/arel/insert_manager_test.rb
@@ -104,7 +104,7 @@ module Arel
 
         manager.insert [[attribute, time]]
         _(manager.to_sql).must_be_like %{
-          INSERT INTO "users" ("created_at") VALUES (#{Table.engine.connection.quote time})
+          INSERT INTO "users" ("created_at") VALUES (#{Table.engine.lease_connection.quote time})
         }
       end
 

--- a/activerecord/test/cases/arel/nodes/equality_test.rb
+++ b/activerecord/test/cases/arel/nodes/equality_test.rb
@@ -10,18 +10,18 @@ module Arel
         describe "to_sql" do
           it "takes an engine" do
             engine = FakeRecord::Base.new
-            engine.connection.extend Module.new {
+            engine.lease_connection.extend Module.new {
               attr_accessor :quote_count
               def quote(*args) @quote_count += 1; super; end
               def quote_column_name(*args) @quote_count += 1; super; end
               def quote_table_name(*args) @quote_count += 1; super; end
             }
-            engine.connection.quote_count = 0
+            engine.lease_connection.quote_count = 0
 
             attr = Table.new(:users)[:id]
             test = attr.eq(10)
             test.to_sql engine
-            _(engine.connection.quote_count).must_equal 3
+            _(engine.lease_connection.quote_count).must_equal 3
           end
         end
       end

--- a/activerecord/test/cases/arel/nodes/sql_literal_test.rb
+++ b/activerecord/test/cases/arel/nodes/sql_literal_test.rb
@@ -7,7 +7,7 @@ module Arel
   module Nodes
     class SqlLiteralTest < Arel::Spec
       before do
-        @visitor = Visitors::ToSql.new Table.engine.connection
+        @visitor = Visitors::ToSql.new Table.engine.lease_connection
       end
 
       def compile(node)

--- a/activerecord/test/cases/arel/select_manager_test.rb
+++ b/activerecord/test/cases/arel/select_manager_test.rb
@@ -964,15 +964,15 @@ module Arel
       end
 
       it "handles database-specific statements" do
-        old_visitor = Table.engine.connection.visitor
-        Table.engine.connection.visitor = Visitors::PostgreSQL.new Table.engine.connection
+        old_visitor = Table.engine.lease_connection.visitor
+        Table.engine.lease_connection.visitor = Visitors::PostgreSQL.new Table.engine.lease_connection
         table   = Table.new :users
         manager = Arel::SelectManager.new
         manager.from table
         manager.where table[:id].eq 10
         manager.where table[:name].matches "foo%"
         _(manager.where_sql).must_be_like %{ WHERE "users"."id" = 10 AND "users"."name" ILIKE 'foo%' }
-        Table.engine.connection.visitor = old_visitor
+        Table.engine.lease_connection.visitor = old_visitor
       end
 
       it "returns nil when there are no wheres" do

--- a/activerecord/test/cases/arel/support/fake_record.rb
+++ b/activerecord/test/cases/arel/support/fake_record.rb
@@ -93,30 +93,32 @@ module FakeRecord
   end
 
   class ConnectionPool
-    attr_reader :connection
-
     def initialize
       @connection = Connection.new
     end
 
+    def lease_connection
+      @connection
+    end
+
     def with_connection
-      yield connection
+      yield @connection
     end
 
     def table_exists?(name)
-      connection.tables.include? name.to_s
+      @connection.tables.include? name.to_s
     end
 
     def columns_hash
-      connection.columns_hash
+      @connection.columns_hash
     end
 
     def schema_cache
-      connection
+      @connection
     end
 
     def quote(thing)
-      connection.quote thing
+      @connection.quote thing
     end
   end
 
@@ -127,8 +129,8 @@ module FakeRecord
       @connection_pool = ConnectionPool.new
     end
 
-    def connection
-      connection_pool.connection
+    def lease_connection
+      connection_pool.lease_connection
     end
   end
 end

--- a/activerecord/test/cases/arel/visitors/dispatch_contamination_test.rb
+++ b/activerecord/test/cases/arel/visitors/dispatch_contamination_test.rb
@@ -40,7 +40,7 @@ module Arel
 
     class DispatchContaminationTest < Arel::Spec
       before do
-        @connection = Table.engine.connection
+        @connection = Table.engine.lease_connection
         @table = Table.new(:users)
       end
 

--- a/activerecord/test/cases/arel/visitors/mysql_test.rb
+++ b/activerecord/test/cases/arel/visitors/mysql_test.rb
@@ -6,7 +6,7 @@ module Arel
   module Visitors
     class MysqlTest < Arel::Spec
       before do
-        @visitor = MySQL.new Table.engine.connection
+        @visitor = MySQL.new Table.engine.lease_connection
       end
 
       def compile(node)

--- a/activerecord/test/cases/arel/visitors/postgres_test.rb
+++ b/activerecord/test/cases/arel/visitors/postgres_test.rb
@@ -6,7 +6,7 @@ module Arel
   module Visitors
     class PostgresTest < Arel::Spec
       before do
-        @visitor = PostgreSQL.new Table.engine.connection
+        @visitor = PostgreSQL.new Table.engine.lease_connection
         @table = Table.new(:users)
         @attr = @table[:id]
       end

--- a/activerecord/test/cases/arel/visitors/sqlite_test.rb
+++ b/activerecord/test/cases/arel/visitors/sqlite_test.rb
@@ -6,7 +6,7 @@ module Arel
   module Visitors
     class SqliteTest < Arel::Spec
       before do
-        @visitor = SQLite.new Table.engine.connection
+        @visitor = SQLite.new Table.engine.lease_connection
       end
 
       def compile(node)

--- a/activerecord/test/cases/arel/visitors/to_sql_test.rb
+++ b/activerecord/test/cases/arel/visitors/to_sql_test.rb
@@ -8,7 +8,7 @@ module Arel
     describe "the to_sql visitor" do
       before do
         @conn = FakeRecord::Base.new
-        @visitor = ToSql.new @conn.connection
+        @visitor = ToSql.new @conn.lease_connection
         @table = Table.new(:users)
         @attr = @table[:id]
       end

--- a/activerecord/test/cases/associations/belongs_to_associations_test.rb
+++ b/activerecord/test/cases/associations/belongs_to_associations_test.rb
@@ -270,7 +270,7 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
   def test_raises_type_mismatch_with_namespaced_class
     assert_nil defined?(Region), "This test requires that there is no top-level Region class"
 
-    ActiveRecord::Base.connection.instance_eval do
+    ActiveRecord::Base.lease_connection.instance_eval do
       create_table(:admin_regions, force: true) { |t| t.string :name }
       add_column :admin_users, :region_id, :integer
     end
@@ -285,7 +285,7 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
     Admin.send :remove_const, "Region" if Admin.const_defined?("Region")
     Admin.send :remove_const, "RegionalUser" if Admin.const_defined?("RegionalUser")
 
-    ActiveRecord::Base.connection.instance_eval do
+    ActiveRecord::Base.lease_connection.instance_eval do
       remove_column :admin_users, :region_id if column_exists?(:admin_users, :region_id)
       drop_table :admin_regions, if_exists: true
     end
@@ -460,7 +460,7 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
   def test_reload_the_belonging_object_with_query_cache
     odegy_account_id = accounts(:odegy_account).id
 
-    connection = ActiveRecord::Base.connection
+    connection = ActiveRecord::Base.lease_connection
     connection.enable_query_cache!
     connection.clear_query_cache
 
@@ -478,7 +478,7 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
     # This query is not cached anymore, so it should make a real SQL query
     assert_queries_count(1) { Account.find(odegy_account_id) }
   ensure
-    ActiveRecord::Base.connection.disable_query_cache!
+    ActiveRecord::Base.lease_connection.disable_query_cache!
   end
 
   def test_resetting_the_association

--- a/activerecord/test/cases/associations/eager_singularization_test.rb
+++ b/activerecord/test/cases/associations/eager_singularization_test.rb
@@ -143,6 +143,6 @@ class EagerSingularizationTest < ActiveRecord::TestCase
 
   private
     def connection
-      ActiveRecord::Base.connection
+      ActiveRecord::Base.lease_connection
     end
 end

--- a/activerecord/test/cases/associations/eager_test.rb
+++ b/activerecord/test/cases/associations/eager_test.rb
@@ -497,7 +497,7 @@ class EagerAssociationTest < ActiveRecord::TestCase
   end
 
   def test_eager_association_loading_with_belongs_to_and_conditions_string_with_quoted_table_name
-    quoted_posts_id = Comment.connection.quote_table_name("posts") + "." + Comment.connection.quote_column_name("id")
+    quoted_posts_id = Comment.lease_connection.quote_table_name("posts") + "." + Comment.lease_connection.quote_column_name("id")
     assert_nothing_raised do
       Comment.includes(:post).references(:posts).where("#{quoted_posts_id} = ?", 4)
     end
@@ -510,7 +510,7 @@ class EagerAssociationTest < ActiveRecord::TestCase
   end
 
   def test_eager_association_loading_with_belongs_to_and_order_string_with_quoted_table_name
-    quoted_posts_id = Comment.connection.quote_table_name("posts") + "." + Comment.connection.quote_column_name("id")
+    quoted_posts_id = Comment.lease_connection.quote_table_name("posts") + "." + Comment.lease_connection.quote_column_name("id")
     assert_nothing_raised do
       Comment.includes(:post).references(:posts).order(quoted_posts_id)
     end
@@ -1697,7 +1697,7 @@ class EagerAssociationTest < ActiveRecord::TestCase
       assert_equal 3, comments_collection.size
     end.last
 
-    c = Sharded::BlogPost.connection
+    c = Sharded::BlogPost.lease_connection
     quoted_blog_id = Regexp.escape(c.quote_table_name("sharded_comments.blog_id"))
     quoted_blog_post_id = Regexp.escape(c.quote_table_name("sharded_comments.blog_post_id"))
     assert_match(/WHERE #{quoted_blog_id} IN \(.+\) AND #{quoted_blog_post_id} IN \(.+\)/, sql)

--- a/activerecord/test/cases/associations/has_and_belongs_to_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_and_belongs_to_many_associations_test.rb
@@ -129,7 +129,7 @@ class HasAndBelongsToManyAssociationsTest < ActiveRecord::TestCase
            :parrots, :pirates, :parrots_pirates, :treasures, :price_estimates, :tags, :taggings, :computers
 
   def setup_data_for_habtm_case
-    ActiveRecord::Base.connection.execute("delete from countries_treaties")
+    ActiveRecord::Base.lease_connection.execute("delete from countries_treaties")
 
     country = Country.new(name: "India")
     country.country_id = "c1"
@@ -149,7 +149,7 @@ class HasAndBelongsToManyAssociationsTest < ActiveRecord::TestCase
   def test_should_property_quote_string_primary_keys
     setup_data_for_habtm_case
 
-    con = ActiveRecord::Base.connection
+    con = ActiveRecord::Base.lease_connection
     sql = "select * from countries_treaties"
     record = con.select_rows(sql).last
     assert_equal "c1", record[0]
@@ -435,7 +435,7 @@ class HasAndBelongsToManyAssociationsTest < ActiveRecord::TestCase
     assert_not_empty david.projects
     david.destroy
     assert_empty david.projects
-    assert_empty DeveloperWithBeforeDestroyRaise.connection.select_all("SELECT * FROM developers_projects WHERE developer_id = 1")
+    assert_empty DeveloperWithBeforeDestroyRaise.lease_connection.select_all("SELECT * FROM developers_projects WHERE developer_id = 1")
   end
 
   def test_destroying
@@ -449,7 +449,7 @@ class HasAndBelongsToManyAssociationsTest < ActiveRecord::TestCase
       david.projects.destroy(project)
     end
 
-    join_records = Developer.connection.select_all("SELECT * FROM developers_projects WHERE developer_id = #{david.id} AND project_id = #{project.id}")
+    join_records = Developer.lease_connection.select_all("SELECT * FROM developers_projects WHERE developer_id = #{david.id} AND project_id = #{project.id}")
     assert_empty join_records
 
     assert_equal 1, david.reload.projects.size
@@ -465,7 +465,7 @@ class HasAndBelongsToManyAssociationsTest < ActiveRecord::TestCase
       david.projects.destroy(*projects)
     end
 
-    join_records = Developer.connection.select_all("SELECT * FROM developers_projects WHERE developer_id = #{david.id}")
+    join_records = Developer.lease_connection.select_all("SELECT * FROM developers_projects WHERE developer_id = #{david.id}")
     assert_empty join_records
 
     assert_equal 0, david.reload.projects.size
@@ -481,7 +481,7 @@ class HasAndBelongsToManyAssociationsTest < ActiveRecord::TestCase
       david.projects.destroy_all
     end
 
-    join_records = Developer.connection.select_all("SELECT * FROM developers_projects WHERE developer_id = #{david.id}")
+    join_records = Developer.lease_connection.select_all("SELECT * FROM developers_projects WHERE developer_id = #{david.id}")
     assert_empty join_records
 
     assert_empty david.projects
@@ -499,11 +499,11 @@ class HasAndBelongsToManyAssociationsTest < ActiveRecord::TestCase
       end
     end
 
-    join_records = Parrot.connection.select_all("SELECT * FROM parrots_pirates WHERE parrot_id = #{george.id}")
+    join_records = Parrot.lease_connection.select_all("SELECT * FROM parrots_pirates WHERE parrot_id = #{george.id}")
     assert_empty join_records
     assert_empty george.pirates.reload
 
-    join_records = Parrot.connection.select_all("SELECT * FROM parrots_treasures WHERE parrot_id = #{george.id}")
+    join_records = Parrot.lease_connection.select_all("SELECT * FROM parrots_treasures WHERE parrot_id = #{george.id}")
     assert_empty join_records
     assert_empty george.treasures.reload
   end
@@ -659,7 +659,7 @@ class HasAndBelongsToManyAssociationsTest < ActiveRecord::TestCase
     assert developer.save
     developer.projects << project
     developer.update_columns("name" => "Bruza")
-    assert_equal 1, Developer.connection.select_value(<<-end_sql).to_i
+    assert_equal 1, Developer.lease_connection.select_value(<<-end_sql).to_i
       SELECT count(*) FROM developers_projects
       WHERE project_id = #{project.id}
       AND developer_id = #{developer.id}

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -925,7 +925,7 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
   end
 
   def test_reload_with_query_cache
-    connection = ActiveRecord::Base.connection
+    connection = ActiveRecord::Base.lease_connection
     connection.enable_query_cache!
     connection.clear_query_cache
 
@@ -943,11 +943,11 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
 
     assert_equal 1, connection.query_cache.size
   ensure
-    ActiveRecord::Base.connection.disable_query_cache!
+    ActiveRecord::Base.lease_connection.disable_query_cache!
   end
 
   def test_reloading_unloaded_associations_with_query_cache
-    connection = ActiveRecord::Base.connection
+    connection = ActiveRecord::Base.lease_connection
     connection.enable_query_cache!
     connection.clear_query_cache
 
@@ -963,7 +963,7 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
 
     assert_equal [client.name], firm.clients.reload.map(&:name)
   ensure
-    ActiveRecord::Base.connection.disable_query_cache!
+    ActiveRecord::Base.lease_connection.disable_query_cache!
   end
 
   def test_find_all_with_include_and_conditions
@@ -1315,7 +1315,7 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
       blog_post.delete_comments.delete(comments_to_delete)
     end
 
-    c = Sharded::Comment.connection
+    c = Sharded::Comment.lease_connection
 
     blog_id = Regexp.escape(c.quote_table_name("sharded_comments.blog_id"))
     id = Regexp.escape(c.quote_table_name("sharded_comments.id"))

--- a/activerecord/test/cases/associations/has_many_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_through_associations_test.rb
@@ -1618,7 +1618,7 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
       tag_ids = blog_post.tags.to_a.map(&:id)
     end.first
 
-    c = Sharded::Blog.connection
+    c = Sharded::Blog.lease_connection
     quoted_tags_blog_id = Regexp.escape(c.quote_table_name("sharded_tags.blog_id"))
     quoted_posts_tags_blog_id = Regexp.escape(c.quote_table_name("sharded_blog_posts_tags.blog_id"))
     assert_match(/.* ON.* #{quoted_tags_blog_id} = #{quoted_posts_tags_blog_id} .* WHERE/, sql)
@@ -1636,7 +1636,7 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
       blog_post_ids = tag.blog_posts.to_a.map(&:id)
     end.first
 
-    c = Sharded::Blog.connection
+    c = Sharded::Blog.lease_connection
     quoted_blog_posts_blog_id = Regexp.escape(c.quote_table_name("sharded_blog_posts.blog_id"))
     quoted_posts_tags_blog_id = Regexp.escape(c.quote_table_name("sharded_blog_posts_tags.blog_id"))
     assert_match(/.* ON.* #{quoted_blog_posts_blog_id} = #{quoted_posts_tags_blog_id} .* WHERE/, sql)

--- a/activerecord/test/cases/associations/has_one_associations_test.rb
+++ b/activerecord/test/cases/associations/has_one_associations_test.rb
@@ -385,7 +385,7 @@ class HasOneAssociationsTest < ActiveRecord::TestCase
   def test_reload_association_with_query_cache
     odegy_id = companies(:odegy).id
 
-    connection = ActiveRecord::Base.connection
+    connection = ActiveRecord::Base.lease_connection
     connection.enable_query_cache!
     connection.clear_query_cache
 
@@ -402,7 +402,7 @@ class HasOneAssociationsTest < ActiveRecord::TestCase
     # This query is not cached anymore, so it should make a real SQL query
     assert_queries_count(1) { Company.find(odegy_id) }
   ensure
-    ActiveRecord::Base.connection.disable_query_cache!
+    ActiveRecord::Base.lease_connection.disable_query_cache!
   end
 
   def test_reset_association

--- a/activerecord/test/cases/associations/has_one_through_disable_joins_associations_test.rb
+++ b/activerecord/test/cases/associations/has_one_through_disable_joins_associations_test.rb
@@ -77,6 +77,6 @@ class HasOneThroughDisableJoinsAssociationsTest < ActiveRecord::TestCase
       assert_no_match(/INNER JOIN/, nj)
     end
 
-    assert_match(/#{Regexp.escape(Member.connection.quote_table_name('memberships.type'))}/, no_joins.first)
+    assert_match(/#{Regexp.escape(Member.lease_connection.quote_table_name('memberships.type'))}/, no_joins.first)
   end
 end

--- a/activerecord/test/cases/associations/nested_through_associations_test.rb
+++ b/activerecord/test/cases/associations/nested_through_associations_test.rb
@@ -171,7 +171,7 @@ class NestedThroughAssociationsTest < ActiveRecord::TestCase
   end
 
   def test_has_many_through_has_one_with_has_many_through_source_reflection_preload
-    ActiveRecord::Base.connection.table_alias_length  # preheat cache
+    ActiveRecord::Base.lease_connection.table_alias_length  # preheat cache
     member = assert_queries_count(4) { Member.includes(:organization_member_details).first }
     groucho_details, other_details = member_details(:groucho), member_details(:some_other_guy)
 

--- a/activerecord/test/cases/associations/required_test.rb
+++ b/activerecord/test/cases/associations/required_test.rb
@@ -12,7 +12,7 @@ class RequiredAssociationsTest < ActiveRecord::TestCase
   end
 
   setup do
-    @connection = ActiveRecord::Base.connection
+    @connection = ActiveRecord::Base.lease_connection
     @connection.create_table :parents, force: true
     @connection.create_table :children, force: true do |t|
       t.belongs_to :parent

--- a/activerecord/test/cases/associations_test.rb
+++ b/activerecord/test/cases/associations_test.rb
@@ -166,8 +166,8 @@ class AssociationsTest < ActiveRecord::TestCase
       comment.blog_post
     end.first
 
-    assert_match(/#{Regexp.escape(Sharded::BlogPost.connection.quote_table_name("sharded_blog_posts.blog_id"))} =/, sql)
-    assert_match(/#{Regexp.escape(Sharded::BlogPost.connection.quote_table_name("sharded_blog_posts.id"))} =/, sql)
+    assert_match(/#{Regexp.escape(Sharded::BlogPost.lease_connection.quote_table_name("sharded_blog_posts.blog_id"))} =/, sql)
+    assert_match(/#{Regexp.escape(Sharded::BlogPost.lease_connection.quote_table_name("sharded_blog_posts.id"))} =/, sql)
   end
 
   def test_querying_by_whole_associated_records_using_query_constraints
@@ -246,7 +246,7 @@ class AssociationsTest < ActiveRecord::TestCase
       comments = blog_post.comments.to_a
     end.first
 
-    assert_match(/WHERE .*#{Regexp.escape(Sharded::Comment.connection.quote_table_name("sharded_comments.blog_id"))} =/, sql)
+    assert_match(/WHERE .*#{Regexp.escape(Sharded::Comment.lease_connection.quote_table_name("sharded_comments.blog_id"))} =/, sql)
     assert_not_empty(comments)
     assert_equal(expected_comments.sort, comments.sort)
   end
@@ -270,8 +270,8 @@ class AssociationsTest < ActiveRecord::TestCase
       blog_post.comments.to_a
     end.first
 
-    assert_match(/#{Regexp.escape(Sharded::Comment.connection.quote_table_name("sharded_comments.blog_post_id"))} =/, sql)
-    assert_match(/#{Regexp.escape(Sharded::Comment.connection.quote_table_name("sharded_comments.blog_id"))} =/, sql)
+    assert_match(/#{Regexp.escape(Sharded::Comment.lease_connection.quote_table_name("sharded_comments.blog_post_id"))} =/, sql)
+    assert_match(/#{Regexp.escape(Sharded::Comment.lease_connection.quote_table_name("sharded_comments.blog_id"))} =/, sql)
   end
 
   def test_belongs_to_association_does_not_use_parent_query_constraints_if_not_configured_to
@@ -1493,7 +1493,7 @@ class PreloaderTest < ActiveRecord::TestCase
     assert_equal 2, sql.size
     preload_sql = sql.last
 
-    c = Cpk::OrderAgreement.connection
+    c = Cpk::OrderAgreement.lease_connection
     order_id_column = Regexp.escape(c.quote_table_name("cpk_order_agreements.order_id"))
     order_id_constraint = /#{order_id_column} = (\?|(\d+)|\$\d)$/
     expectation = /SELECT.*WHERE.* #{order_id_constraint}/
@@ -1515,7 +1515,7 @@ class PreloaderTest < ActiveRecord::TestCase
     assert_equal 2, sql.size
     preload_sql = sql.last
 
-    c = Cpk::Order.connection
+    c = Cpk::Order.lease_connection
     order_id = Regexp.escape(c.quote_table_name("cpk_orders.id"))
     order_constraint = /#{order_id} = (\?|(\d+)|\$\d)$/
     expectation = /SELECT.*WHERE.* #{order_constraint}/

--- a/activerecord/test/cases/asynchronous_queries_test.rb
+++ b/activerecord/test/cases/asynchronous_queries_test.rb
@@ -99,7 +99,7 @@ class AsynchronousQueriesTest < ActiveRecord::TestCase
   include AsynchronousQueriesSharedTests
 
   def setup
-    @connection = ActiveRecord::Base.connection
+    @connection = ActiveRecord::Base.lease_connection
   end
 
   def test_async_select_all
@@ -134,7 +134,7 @@ class AsynchronousQueriesWithTransactionalTest < ActiveRecord::TestCase
   include AsynchronousQueriesSharedTests
 
   def setup
-    @connection = ActiveRecord::Base.connection
+    @connection = ActiveRecord::Base.lease_connection
     @connection.materialize_transactions
   end
 end

--- a/activerecord/test/cases/attributes_test.rb
+++ b/activerecord/test/cases/attributes_test.rb
@@ -357,7 +357,7 @@ module ActiveRecord
     end
 
     test "attributes do not require a connection is established" do
-      assert_not_called(ActiveRecord::Base, :connection) do
+      assert_not_called(ActiveRecord::Base, :lease_connection) do
         Class.new(OverloadedType) do
           attribute :foo, :string
         end

--- a/activerecord/test/cases/autosave_association_test.rb
+++ b/activerecord/test/cases/autosave_association_test.rb
@@ -1318,7 +1318,7 @@ class TestDestroyAsPartOfAutosaveAssociation < ActiveRecord::TestCase
   end
 
   def test_should_save_new_record_that_has_same_value_as_existing_record_marked_for_destruction_on_field_that_has_unique_index
-    Bird.connection.add_index :birds, :name, unique: true
+    Bird.lease_connection.add_index :birds, :name, unique: true
 
     3.times { |i| @pirate.birds.create(name: "unique_birds_#{i}") }
 
@@ -1328,7 +1328,7 @@ class TestDestroyAsPartOfAutosaveAssociation < ActiveRecord::TestCase
 
     assert_equal 3, @pirate.birds.reload.length
   ensure
-    Bird.connection.remove_index :birds, column: :name
+    Bird.lease_connection.remove_index :birds, column: :name
   end
 
   # Add and remove callbacks tests for association collections.
@@ -1378,7 +1378,7 @@ class TestDestroyAsPartOfAutosaveAssociation < ActiveRecord::TestCase
 
     assert_empty @pirate.reload.parrots
 
-    join_records = Pirate.connection.select_all("SELECT * FROM parrots_pirates WHERE pirate_id = #{@pirate.id}")
+    join_records = Pirate.lease_connection.select_all("SELECT * FROM parrots_pirates WHERE pirate_id = #{@pirate.id}")
     assert_empty join_records
   end
 

--- a/activerecord/test/cases/base_prevent_writes_test.rb
+++ b/activerecord/test/cases/base_prevent_writes_test.rb
@@ -59,7 +59,7 @@ class BasePreventWritesTest < ActiveRecord::TestCase
       ActiveRecord::Base.while_preventing_writes do
         assert_queries_count(2, include_schema: true) do
           Bird.transaction do
-            ActiveRecord::Base.connection.materialize_transactions
+            ActiveRecord::Base.lease_connection.materialize_transactions
           end
         end
       end
@@ -68,8 +68,8 @@ class BasePreventWritesTest < ActiveRecord::TestCase
     test "preventing writes applies to all connections in block" do
       ActiveRecord::Base.while_preventing_writes do
         conn1_error = assert_raises ActiveRecord::ReadOnlyError do
-          assert_equal ActiveRecord::Base.connection, Bird.connection
-          assert_not_equal ARUnit2Model.connection, Bird.connection
+          assert_equal ActiveRecord::Base.lease_connection, Bird.lease_connection
+          assert_not_equal ARUnit2Model.lease_connection, Bird.lease_connection
           Bird.create!(name: "Bluejay")
         end
 
@@ -78,8 +78,8 @@ class BasePreventWritesTest < ActiveRecord::TestCase
 
       ActiveRecord::Base.while_preventing_writes do
         conn2_error = assert_raises ActiveRecord::ReadOnlyError do
-          assert_not_equal ActiveRecord::Base.connection, Professor.connection
-          assert_equal ARUnit2Model.connection, Professor.connection
+          assert_not_equal ActiveRecord::Base.lease_connection, Professor.lease_connection
+          assert_equal ARUnit2Model.lease_connection, Professor.lease_connection
           Professor.create!(name: "Professor Bluejay")
         end
 

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -138,7 +138,7 @@ class BasicsTest < ActiveRecord::TestCase
   end
 
   def test_column_names_are_escaped
-    conn      = ActiveRecord::Base.connection
+    conn      = ActiveRecord::Base.lease_connection
     classname = conn.class.name[/[^:]*$/]
     badchar   = {
       "SQLite3Adapter"    => '"',
@@ -691,7 +691,7 @@ class BasicsTest < ActiveRecord::TestCase
   end
 
   def test_create_without_prepared_statement
-    topic = Topic.connection.unprepared_statement do
+    topic = Topic.lease_connection.unprepared_statement do
       Topic.create(title: "foo")
     end
 
@@ -700,7 +700,7 @@ class BasicsTest < ActiveRecord::TestCase
 
   def test_destroy_without_prepared_statement
     topic = Topic.create(title: "foo")
-    Topic.connection.unprepared_statement do
+    Topic.lease_connection.unprepared_statement do
       Topic.find(topic.id).destroy
     end
 
@@ -1346,11 +1346,11 @@ class BasicsTest < ActiveRecord::TestCase
 
     klass.table_name = "foo"
     assert_equal "foo", klass.table_name
-    assert_equal klass.connection.quote_table_name("foo"), klass.quoted_table_name
+    assert_equal klass.lease_connection.quote_table_name("foo"), klass.quoted_table_name
 
     klass.table_name = "bar"
     assert_equal "bar", klass.table_name
-    assert_equal klass.connection.quote_table_name("bar"), klass.quoted_table_name
+    assert_equal klass.lease_connection.quote_table_name("bar"), klass.quoted_table_name
   end
 
   def test_set_table_name_with_inheritance
@@ -1451,7 +1451,7 @@ class BasicsTest < ActiveRecord::TestCase
   end
 
   def test_assert_queries_count
-    query = lambda { ActiveRecord::Base.connection.execute "select count(*) from developers" }
+    query = lambda { ActiveRecord::Base.lease_connection.execute "select count(*) from developers" }
     assert_queries_count(2) { 2.times { query.call } }
     assert_queries_count 1, &query
     assert_no_queries { assert true }
@@ -1662,7 +1662,7 @@ class BasicsTest < ActiveRecord::TestCase
 
   if current_adapter?(:PostgreSQLAdapter)
     def test_column_types_on_queries_on_postgresql
-      result = ActiveRecord::Base.connection.exec_query("SELECT 1 AS test")
+      result = ActiveRecord::Base.lease_connection.exec_query("SELECT 1 AS test")
       assert_equal ActiveModel::Type::Integer, result.column_types["test"].class
     end
   end

--- a/activerecord/test/cases/batches_test.rb
+++ b/activerecord/test/cases/batches_test.rb
@@ -151,7 +151,7 @@ class EachTest < ActiveRecord::TestCase
   end
 
   def test_find_in_batches_should_quote_batch_order
-    c = Post.connection
+    c = Post.lease_connection
     assert_queries_match(/ORDER BY #{Regexp.escape(c.quote_table_name("posts.id"))}/i) do
       Post.find_in_batches(batch_size: 1) do |batch|
         assert_kind_of Array, batch
@@ -161,7 +161,7 @@ class EachTest < ActiveRecord::TestCase
   end
 
   def test_find_in_batches_should_quote_batch_order_with_desc_order
-    c = Post.connection
+    c = Post.lease_connection
     assert_queries_match(/ORDER BY #{Regexp.escape(c.quote_table_name("posts.id"))} DESC/) do
       Post.find_in_batches(batch_size: 1, order: :desc) do |batch|
         assert_kind_of Array, batch
@@ -514,7 +514,7 @@ class EachTest < ActiveRecord::TestCase
   end
 
   def test_in_batches_executes_range_queries_when_unconstrained
-    c = Post.connection
+    c = Post.lease_connection
     quoted_posts_id = Regexp.escape(c.quote_table_name("posts.id"))
     assert_queries_match(/WHERE #{quoted_posts_id} > .+ AND #{quoted_posts_id} <= .+/i) do
       Post.in_batches(of: 2) { |relation| assert_kind_of Post, relation.first }
@@ -522,7 +522,7 @@ class EachTest < ActiveRecord::TestCase
   end
 
   def test_in_batches_executes_in_queries_when_unconstrained_and_opted_out_of_ranges
-    c = Post.connection
+    c = Post.lease_connection
     quoted_posts_id = Regexp.escape(c.quote_table_name("posts.id"))
     assert_queries_match(/#{quoted_posts_id} IN \(.+\)/i) do
       Post.in_batches(of: 2, use_ranges: false) { |relation| assert_kind_of Post, relation.first }
@@ -530,7 +530,7 @@ class EachTest < ActiveRecord::TestCase
   end
 
   def test_in_batches_executes_in_queries_when_constrained
-    c = Post.connection
+    c = Post.lease_connection
     quoted_posts_id = Regexp.escape(c.quote_table_name("posts.id"))
     assert_queries_match(/#{quoted_posts_id} IN \(.+\)/i) do
       Post.where("id < ?", 5).in_batches(of: 2) { |relation| assert_kind_of Post, relation.first }
@@ -538,7 +538,7 @@ class EachTest < ActiveRecord::TestCase
   end
 
   def test_in_batches_executes_range_queries_when_constrained_and_opted_in_into_ranges
-    c = Post.connection
+    c = Post.lease_connection
     quoted_posts_id = Regexp.escape(c.quote_table_name("posts.id"))
     assert_queries_match(/#{quoted_posts_id} > .+ AND #{quoted_posts_id} <= .+/i) do
       Post.where("id < ?", 5).in_batches(of: 2, use_ranges: true) { |relation| assert_kind_of Post, relation.first }
@@ -546,7 +546,7 @@ class EachTest < ActiveRecord::TestCase
   end
 
   def test_in_batches_no_subqueries_for_whole_tables_batching
-    c = Post.connection
+    c = Post.lease_connection
     quoted_posts_id = Regexp.escape(c.quote_table_name("posts.id"))
     assert_queries_match(/DELETE FROM #{Regexp.escape(c.quote_table_name("posts"))} WHERE #{quoted_posts_id} > .+ AND #{quoted_posts_id} <=/i) do
       Post.in_batches(of: 2).delete_all
@@ -564,7 +564,7 @@ class EachTest < ActiveRecord::TestCase
   end
 
   def test_in_batches_should_quote_batch_order
-    c = Post.connection
+    c = Post.lease_connection
     assert_queries_match(/ORDER BY #{Regexp.escape(c.quote_table_name('posts'))}\.#{Regexp.escape(c.quote_column_name('id'))}/) do
       Post.in_batches(of: 1) do |relation|
         assert_kind_of ActiveRecord::Relation, relation
@@ -574,7 +574,7 @@ class EachTest < ActiveRecord::TestCase
   end
 
   def test_in_batches_should_quote_batch_order_with_desc_order
-    c = Post.connection
+    c = Post.lease_connection
     assert_queries_match(/ORDER BY #{Regexp.escape(c.quote_table_name("posts.id"))} DESC/) do
       Post.in_batches(of: 1, order: :desc) do |relation|
         assert_kind_of ActiveRecord::Relation, relation
@@ -584,7 +584,7 @@ class EachTest < ActiveRecord::TestCase
   end
 
   def test_in_batches_enumerator_should_quote_batch_order_with_desc_order
-    c = Post.connection
+    c = Post.lease_connection
     assert_queries_match(/ORDER BY #{Regexp.escape(c.quote_table_name("posts.id"))} DESC/) do
       relation = Post.in_batches(of: 1, order: :desc).first
       assert_kind_of ActiveRecord::Relation, relation
@@ -593,7 +593,7 @@ class EachTest < ActiveRecord::TestCase
   end
 
   def test_in_batches_enumerator_each_record_should_quote_batch_order_with_desc_order
-    c = Post.connection
+    c = Post.lease_connection
     assert_queries_match(/ORDER BY #{Regexp.escape(c.quote_table_name("posts.id"))} DESC/) do
       Post.in_batches(of: 1, order: :desc).each_record do |record|
         assert_kind_of Post, record

--- a/activerecord/test/cases/bind_parameter_test.rb
+++ b/activerecord/test/cases/bind_parameter_test.rb
@@ -6,7 +6,7 @@ require "models/reply"
 require "models/author"
 require "models/post"
 
-if ActiveRecord::Base.connection.prepared_statements
+if ActiveRecord::Base.lease_connection.prepared_statements
   module ActiveRecord
     class BindParameterTest < ActiveRecord::TestCase
       fixtures :topics, :authors, :author_addresses, :posts
@@ -25,7 +25,7 @@ if ActiveRecord::Base.connection.prepared_statements
 
       def setup
         super
-        @connection = ActiveRecord::Base.connection
+        @connection = ActiveRecord::Base.lease_connection
         @subscriber = LogListener.new
         @subscription = ActiveSupport::Notifications.subscribe("sql.active_record", @subscriber)
       end

--- a/activerecord/test/cases/cache_key_test.rb
+++ b/activerecord/test/cases/cache_key_test.rb
@@ -15,7 +15,7 @@ module ActiveRecord
     end
 
     setup do
-      @connection = ActiveRecord::Base.connection
+      @connection = ActiveRecord::Base.lease_connection
       @connection.create_table(:cache_mes, force: true) { |t| t.timestamps }
       @connection.create_table(:cache_me_with_versions, force: true) { |t| t.timestamps }
     end

--- a/activerecord/test/cases/calculations_test.rb
+++ b/activerecord/test/cases/calculations_test.rb
@@ -227,7 +227,7 @@ class CalculationsTest < ActiveRecord::TestCase
   end
 
   def test_should_not_use_alias_for_grouped_field
-    assert_queries_match(/GROUP BY #{Regexp.escape(Account.connection.quote_table_name("accounts.firm_id"))}/i) do
+    assert_queries_match(/GROUP BY #{Regexp.escape(Account.lease_connection.quote_table_name("accounts.firm_id"))}/i) do
       c = Account.group(:firm_id).order("accounts_firm_id").sum(:credit_limit)
       assert_equal [1, 2, 6, 9], c.keys.compact
     end
@@ -468,7 +468,7 @@ class CalculationsTest < ActiveRecord::TestCase
   end
 
   def test_should_calculate_grouped_with_longer_field
-    field = "a" * Account.connection.max_identifier_length
+    field = "a" * Account.lease_connection.max_identifier_length
 
     Account.update_all("#{field} = credit_limit")
 
@@ -1130,7 +1130,7 @@ class CalculationsTest < ActiveRecord::TestCase
   end
 
   def test_group_by_with_quoted_count_and_order_by_alias
-    quoted_posts_id = Post.connection.quote_table_name("posts.id")
+    quoted_posts_id = Post.lease_connection.quote_table_name("posts.id")
     expected = { "SpecialPost" => 1, "StiPost" => 1, "Post" => 9 }
     actual = Post.group(:type).order("count_posts_id").count(quoted_posts_id)
     assert_equal expected, actual
@@ -1390,7 +1390,7 @@ class CalculationsTest < ActiveRecord::TestCase
 
   def test_count_takes_attribute_type_precedence_over_database_type
     assert_called(
-      Account.connection, :select_all,
+      Account.lease_connection, :select_all,
       returns: ActiveRecord::Result.new(["count"], [["10"]])
     ) do
       result = Account.count
@@ -1401,7 +1401,7 @@ class CalculationsTest < ActiveRecord::TestCase
 
   def test_sum_takes_attribute_type_precedence_over_database_type
     assert_called(
-      Account.connection, :select_all,
+      Account.lease_connection, :select_all,
       returns: ActiveRecord::Result.new(["sum"], [[10.to_d]])
     ) do
       result = Account.sum(:credit_limit)

--- a/activerecord/test/cases/column_alias_test.rb
+++ b/activerecord/test/cases/column_alias_test.rb
@@ -7,7 +7,7 @@ class TestColumnAlias < ActiveRecord::TestCase
   fixtures :topics
 
   def test_column_alias
-    records = Topic.connection.select_all("SELECT id AS pk FROM topics")
+    records = Topic.lease_connection.select_all("SELECT id AS pk FROM topics")
     assert_equal ["pk"], records.columns
   end
 end

--- a/activerecord/test/cases/comment_test.rb
+++ b/activerecord/test/cases/comment_test.rb
@@ -3,7 +3,7 @@
 require "cases/helper"
 require "support/schema_dumping_helper"
 
-if ActiveRecord::Base.connection.supports_comments?
+if ActiveRecord::Base.lease_connection.supports_comments?
   class CommentTest < ActiveRecord::TestCase
     include SchemaDumpingHelper
 
@@ -18,7 +18,7 @@ if ActiveRecord::Base.connection.supports_comments?
     end
 
     setup do
-      @connection = ActiveRecord::Base.connection
+      @connection = ActiveRecord::Base.lease_connection
 
       @connection.create_table("commenteds", comment: "A table with comment", force: true) do |t|
         t.string  "name",    comment: "Comment should help clarify the column purpose"

--- a/activerecord/test/cases/connection_adapters/adapter_leasing_test.rb
+++ b/activerecord/test/cases/connection_adapters/adapter_leasing_test.rb
@@ -46,14 +46,14 @@ module ActiveRecord
         @adapter.pool = pool
 
         # Make sure the pool marks the connection in use
-        assert_equal @adapter, pool.connection
+        assert_equal @adapter, pool.lease_connection
         assert_predicate @adapter, :in_use?
 
         # Close should put the adapter back in the pool
         @adapter.close
         assert_not_predicate @adapter, :in_use?
 
-        assert_equal @adapter, pool.connection
+        assert_equal @adapter, pool.lease_connection
       end
     end
   end

--- a/activerecord/test/cases/connection_adapters/connection_handlers_multi_db_test.rb
+++ b/activerecord/test/cases/connection_adapters/connection_handlers_multi_db_test.rb
@@ -37,30 +37,30 @@ module ActiveRecord
         # and won't be able to write to the second connection.
         SecondaryBase.connects_to database: { writing: { database: tf_writing.path, adapter: "sqlite3" }, secondary: { database: tf_reading.path, adapter: "sqlite3" } }
 
-        MultiConnectionTestModel.connection.execute("CREATE TABLE `multi_connection_test_models` (connection_role VARCHAR (255))")
-        MultiConnectionTestModel.connection.execute("INSERT INTO multi_connection_test_models VALUES ('writing')")
+        MultiConnectionTestModel.lease_connection.execute("CREATE TABLE `multi_connection_test_models` (connection_role VARCHAR (255))")
+        MultiConnectionTestModel.lease_connection.execute("INSERT INTO multi_connection_test_models VALUES ('writing')")
 
         ActiveRecord::Base.connected_to(role: :secondary) do
-          MultiConnectionTestModel.connection.execute("CREATE TABLE `multi_connection_test_models` (connection_role VARCHAR (255))")
-          MultiConnectionTestModel.connection.execute("INSERT INTO multi_connection_test_models VALUES ('reading')")
+          MultiConnectionTestModel.lease_connection.execute("CREATE TABLE `multi_connection_test_models` (connection_role VARCHAR (255))")
+          MultiConnectionTestModel.lease_connection.execute("INSERT INTO multi_connection_test_models VALUES ('reading')")
         end
 
         read_latch = Concurrent::CountDownLatch.new
         write_latch = Concurrent::CountDownLatch.new
 
-        MultiConnectionTestModel.connection
+        MultiConnectionTestModel.lease_connection
 
         thread = Thread.new do
-          MultiConnectionTestModel.connection
+          MultiConnectionTestModel.lease_connection
 
           write_latch.wait
-          assert_equal "writing", MultiConnectionTestModel.connection.select_value("SELECT connection_role from multi_connection_test_models")
+          assert_equal "writing", MultiConnectionTestModel.lease_connection.select_value("SELECT connection_role from multi_connection_test_models")
           read_latch.count_down
         end
 
         ActiveRecord::Base.connected_to(role: :secondary) do
           write_latch.count_down
-          assert_equal "reading", MultiConnectionTestModel.connection.select_value("SELECT connection_role from multi_connection_test_models")
+          assert_equal "reading", MultiConnectionTestModel.lease_connection.select_value("SELECT connection_role from multi_connection_test_models")
           read_latch.wait
         end
 
@@ -78,7 +78,7 @@ module ActiveRecord
         SecondaryBase.connects_to database: { writing: { database: ":memory:", adapter: "sqlite3" }, secondary: { database: ":memory:", adapter: "sqlite3" } }
 
         relation = ActiveRecord::Base.connected_to(role: :secondary) do
-          MultiConnectionTestModel.connection.execute("CREATE TABLE `multi_connection_test_models` (connection_role VARCHAR (255))")
+          MultiConnectionTestModel.lease_connection.execute("CREATE TABLE `multi_connection_test_models` (connection_role VARCHAR (255))")
           MultiConnectionTestModel.create!(connection_role: "reading")
           MultiConnectionTestModel.where(connection_role: "reading")
         end
@@ -130,14 +130,14 @@ module ActiveRecord
             assert_equal :reading, ActiveRecord::Base.current_role
             assert ActiveRecord::Base.connected_to?(role: :reading)
             assert_not ActiveRecord::Base.connected_to?(role: :writing)
-            assert_predicate ActiveRecord::Base.connection, :preventing_writes?
+            assert_predicate ActiveRecord::Base.lease_connection, :preventing_writes?
           end
 
           ActiveRecord::Base.connected_to(role: :writing) do
             assert_equal :writing, ActiveRecord::Base.current_role
             assert ActiveRecord::Base.connected_to?(role: :writing)
             assert_not ActiveRecord::Base.connected_to?(role: :reading)
-            assert_not_predicate ActiveRecord::Base.connection, :preventing_writes?
+            assert_not_predicate ActiveRecord::Base.lease_connection, :preventing_writes?
           end
         ensure
           ActiveRecord::Base.configurations = @prev_configs

--- a/activerecord/test/cases/connection_adapters/connection_swapping_nested_test.rb
+++ b/activerecord/test/cases/connection_adapters/connection_swapping_nested_test.rb
@@ -385,44 +385,44 @@ module ActiveRecord
 
           # Switch everything to writing
           ActiveRecord::Base.connected_to(role: :writing) do
-            assert_not_predicate ActiveRecord::Base.connection, :preventing_writes?
-            assert_not_predicate PrimaryBase.connection, :preventing_writes?
-            assert_not_predicate SecondaryBase.connection, :preventing_writes?
+            assert_not_predicate ActiveRecord::Base.lease_connection, :preventing_writes?
+            assert_not_predicate PrimaryBase.lease_connection, :preventing_writes?
+            assert_not_predicate SecondaryBase.lease_connection, :preventing_writes?
 
             # Switch only primary to reading
             PrimaryBase.connected_to(role: :reading) do
-              assert_predicate PrimaryBase.connection, :preventing_writes?
-              assert_not_predicate SecondaryBase.connection, :preventing_writes?
+              assert_predicate PrimaryBase.lease_connection, :preventing_writes?
+              assert_not_predicate SecondaryBase.lease_connection, :preventing_writes?
 
               # Switch global to reading
               ActiveRecord::Base.connected_to(role: :reading) do
-                assert_predicate PrimaryBase.connection, :preventing_writes?
-                assert_predicate SecondaryBase.connection, :preventing_writes?
+                assert_predicate PrimaryBase.lease_connection, :preventing_writes?
+                assert_predicate SecondaryBase.lease_connection, :preventing_writes?
 
                 # Switch only secondary to writing
                 SecondaryBase.connected_to(role: :writing) do
-                  assert_predicate PrimaryBase.connection, :preventing_writes?
-                  assert_not_predicate SecondaryBase.connection, :preventing_writes?
+                  assert_predicate PrimaryBase.lease_connection, :preventing_writes?
+                  assert_not_predicate SecondaryBase.lease_connection, :preventing_writes?
                 end
 
                 # Ensure restored to global reading
-                assert_predicate PrimaryBase.connection, :preventing_writes?
-                assert_predicate SecondaryBase.connection, :preventing_writes?
+                assert_predicate PrimaryBase.lease_connection, :preventing_writes?
+                assert_predicate SecondaryBase.lease_connection, :preventing_writes?
               end
 
               # Switch everything to writing
               ActiveRecord::Base.connected_to(role: :writing) do
-                assert_not_predicate PrimaryBase.connection, :preventing_writes?
-                assert_not_predicate SecondaryBase.connection, :preventing_writes?
+                assert_not_predicate PrimaryBase.lease_connection, :preventing_writes?
+                assert_not_predicate SecondaryBase.lease_connection, :preventing_writes?
               end
 
-              assert_predicate PrimaryBase.connection, :preventing_writes?
-              assert_not_predicate SecondaryBase.connection, :preventing_writes?
+              assert_predicate PrimaryBase.lease_connection, :preventing_writes?
+              assert_not_predicate SecondaryBase.lease_connection, :preventing_writes?
             end
 
             # Ensure restored to global writing
-            assert_not_predicate PrimaryBase.connection, :preventing_writes?
-            assert_not_predicate SecondaryBase.connection, :preventing_writes?
+            assert_not_predicate PrimaryBase.lease_connection, :preventing_writes?
+            assert_not_predicate SecondaryBase.lease_connection, :preventing_writes?
           end
         ensure
           ActiveRecord::Base.configurations = @prev_configs
@@ -441,17 +441,17 @@ module ActiveRecord
 
           # Switch everything to writing
           ActiveRecord::Base.connected_to(role: :writing) do
-            assert_not_predicate ActiveRecord::Base.connection, :preventing_writes?
-            assert_not_predicate ApplicationRecord.connection, :preventing_writes?
+            assert_not_predicate ActiveRecord::Base.lease_connection, :preventing_writes?
+            assert_not_predicate ApplicationRecord.lease_connection, :preventing_writes?
 
             ApplicationRecord.connected_to(role: :reading) do
-              assert_predicate ApplicationRecord.connection, :preventing_writes?
+              assert_predicate ApplicationRecord.lease_connection, :preventing_writes?
             end
 
             # reading is fine bc it's looking up by AppRec but writing is not fine
             # bc its looking up by ARB in the stack
             ApplicationRecord.connected_to(role: :writing, prevent_writes: true) do
-              assert_predicate ApplicationRecord.connection, :preventing_writes?
+              assert_predicate ApplicationRecord.lease_connection, :preventing_writes?
             end
           end
         ensure

--- a/activerecord/test/cases/connection_adapters/mysql_type_lookup_test.rb
+++ b/activerecord/test/cases/connection_adapters/mysql_type_lookup_test.rb
@@ -10,7 +10,7 @@ module ActiveRecord
         include ConnectionHelper
 
         setup do
-          @connection = ActiveRecord::Base.connection
+          @connection = ActiveRecord::Base.lease_connection
         end
 
         def teardown

--- a/activerecord/test/cases/connection_adapters/schema_cache_test.rb
+++ b/activerecord/test/cases/connection_adapters/schema_cache_test.rb
@@ -9,7 +9,7 @@ module ActiveRecord
 
       def setup
         @pool = ARUnit2Model.connection_pool
-        @connection = ARUnit2Model.connection
+        @connection = ARUnit2Model.lease_connection
         @cache = new_bound_reflection
         @check_schema_cache_dump_version_was = SchemaReflection.check_schema_cache_dump_version
       end
@@ -372,7 +372,7 @@ module ActiveRecord
           old_config = ActiveRecord.lazily_load_schema_cache
           ActiveRecord.lazily_load_schema_cache = true
           ActiveRecord::Base.establish_connection(new_config)
-          ActiveRecord::Base.connection_pool.connection.verify!
+          ActiveRecord::Base.connection_pool.lease_connection.verify!
 
           assert File.exist?(tempfile)
           assert_not_nil ActiveRecord::Base.connection_pool.schema_reflection.instance_variable_get(:@cache)

--- a/activerecord/test/cases/connection_adapters/type_lookup_test.rb
+++ b/activerecord/test/cases/connection_adapters/type_lookup_test.rb
@@ -7,7 +7,7 @@ module ActiveRecord
     class TypeLookupTest < ActiveRecord::TestCase
       unless current_adapter?(:PostgreSQLAdapter) # PostgreSQL does not use type strings for lookup
         setup do
-          @connection = ActiveRecord::Base.connection
+          @connection = ActiveRecord::Base.lease_connection
         end
 
         def test_boolean_types

--- a/activerecord/test/cases/connection_handling_test.rb
+++ b/activerecord/test/cases/connection_handling_test.rb
@@ -25,43 +25,43 @@ module ActiveRecord
           conn = connection
           assert_predicate ActiveRecord::Base.connection_pool, :active_connection?
           2.times do
-            assert_same connection, ActiveRecord::Base.connection
+            assert_same connection, ActiveRecord::Base.lease_connection
           end
         end
 
         assert_predicate ActiveRecord::Base.connection_pool, :active_connection?
-        assert_same conn, ActiveRecord::Base.connection
+        assert_same conn, ActiveRecord::Base.lease_connection
       end
 
       test "#with_connection use the already leased connection if available" do
-        leased_connection = ActiveRecord::Base.connection
+        leased_connection = ActiveRecord::Base.lease_connection
         assert_predicate ActiveRecord::Base.connection_pool, :active_connection?
 
         ActiveRecord::Base.with_connection do |connection|
           assert_same leased_connection, connection
-          assert_same ActiveRecord::Base.connection, connection
+          assert_same ActiveRecord::Base.lease_connection, connection
         end
 
         assert_predicate ActiveRecord::Base.connection_pool, :active_connection?
-        assert_same ActiveRecord::Base.connection, leased_connection
+        assert_same ActiveRecord::Base.lease_connection, leased_connection
       end
 
       test "#with_connection is reentrant" do
-        leased_connection = ActiveRecord::Base.connection
+        leased_connection = ActiveRecord::Base.lease_connection
         assert_predicate ActiveRecord::Base.connection_pool, :active_connection?
 
         ActiveRecord::Base.with_connection do |connection|
           assert_same leased_connection, connection
-          assert_same ActiveRecord::Base.connection, connection
+          assert_same ActiveRecord::Base.lease_connection, connection
 
           ActiveRecord::Base.with_connection do |connection2|
             assert_same leased_connection, connection2
-            assert_same ActiveRecord::Base.connection, connection2
+            assert_same ActiveRecord::Base.lease_connection, connection2
           end
         end
 
         assert_predicate ActiveRecord::Base.connection_pool, :active_connection?
-        assert_same ActiveRecord::Base.connection, leased_connection
+        assert_same ActiveRecord::Base.lease_connection, leased_connection
       end
     end
   end

--- a/activerecord/test/cases/connection_management_test.rb
+++ b/activerecord/test/cases/connection_management_test.rb
@@ -26,7 +26,7 @@ module ActiveRecord
         @management = middleware(@app)
 
         # make sure we have an active connection
-        assert ActiveRecord::Base.connection
+        assert ActiveRecord::Base.lease_connection
         assert ActiveRecord::Base.connection_handler.active_connections?(:all)
       end
 
@@ -75,7 +75,7 @@ module ActiveRecord
       end
 
       test "cancel asynchronous queries if an exception is raised" do
-        unless ActiveRecord::Base.connection.supports_concurrent_connections?
+        unless ActiveRecord::Base.lease_connection.supports_concurrent_connections?
           skip "This adapter doesn't support asynchronous queries"
         end
 
@@ -83,7 +83,7 @@ module ActiveRecord
           attr_reader :future_result
 
           def call(env)
-            @future_result = ActiveRecord::Base.connection.select_all("SELECT * FROM does_not_exists", async: true)
+            @future_result = ActiveRecord::Base.lease_connection.select_all("SELECT * FROM does_not_exists", async: true)
             raise NotImplementedError
           end
         end.new

--- a/activerecord/test/cases/core_test.rb
+++ b/activerecord/test/cases/core_test.rb
@@ -167,7 +167,7 @@ class CoreTest < ActiveRecord::TestCase
 
   def test_find_by_cache_does_not_duplicate_entries
     Topic.initialize_find_by_cache
-    using_prepared_statements = Topic.connection.prepared_statements
+    using_prepared_statements = Topic.lease_connection.prepared_statements
     topic_find_by_cache = Topic.instance_variable_get("@find_by_statement_cache")[using_prepared_statements]
 
     assert_difference -> { topic_find_by_cache.size }, +1 do

--- a/activerecord/test/cases/database_selector_test.rb
+++ b/activerecord/test/cases/database_selector_test.rb
@@ -62,15 +62,15 @@ module ActiveRecord
           called = true
 
           assert ActiveRecord::Base.connected_to?(role: :reading)
-          assert_predicate ActiveRecord::Base.connection, :preventing_writes?
+          assert_predicate ActiveRecord::Base.lease_connection, :preventing_writes?
 
           ActiveRecord::Base.connected_to(role: :writing, prevent_writes: false) do
             assert ActiveRecord::Base.connected_to?(role: :writing)
-            assert_not_predicate ActiveRecord::Base.connection, :preventing_writes?
+            assert_not_predicate ActiveRecord::Base.lease_connection, :preventing_writes?
           end
 
           assert ActiveRecord::Base.connected_to?(role: :reading)
-          assert_predicate ActiveRecord::Base.connection, :preventing_writes?
+          assert_predicate ActiveRecord::Base.lease_connection, :preventing_writes?
         end
         assert called
       end
@@ -202,12 +202,12 @@ module ActiveRecord
       write = false
       resolver.read do
         assert ActiveRecord::Base.connected_to?(role: :writing)
-        assert_predicate ActiveRecord::Base.connection, :preventing_writes?
+        assert_predicate ActiveRecord::Base.lease_connection, :preventing_writes?
         read = true
 
         resolver.write do
           assert ActiveRecord::Base.connected_to?(role: :writing)
-          assert_not_predicate ActiveRecord::Base.connection, :preventing_writes?
+          assert_not_predicate ActiveRecord::Base.lease_connection, :preventing_writes?
           write = true
         end
       end
@@ -227,7 +227,7 @@ module ActiveRecord
         resolver.read do
           inside_preventing.wait
           assert ActiveRecord::Base.connected_to?(role: :writing)
-          assert_predicate ActiveRecord::Base.connection, :preventing_writes?
+          assert_predicate ActiveRecord::Base.lease_connection, :preventing_writes?
           finished_checking.set
         end
       end
@@ -235,7 +235,7 @@ module ActiveRecord
       t2 = Thread.new do
         resolver.write do
           assert ActiveRecord::Base.connected_to?(role: :writing)
-          assert_not_predicate ActiveRecord::Base.connection, :preventing_writes?
+          assert_not_predicate ActiveRecord::Base.lease_connection, :preventing_writes?
           inside_preventing.set
           finished_checking.wait
         end
@@ -244,7 +244,7 @@ module ActiveRecord
       t3 = Thread.new do
         resolver.read do
           assert ActiveRecord::Base.connected_to?(role: :writing)
-          assert_predicate ActiveRecord::Base.connection, :preventing_writes?
+          assert_predicate ActiveRecord::Base.lease_connection, :preventing_writes?
         end
       end
 

--- a/activerecord/test/cases/database_statements_test.rb
+++ b/activerecord/test/cases/database_statements_test.rb
@@ -4,7 +4,7 @@ require "cases/helper"
 
 class DatabaseStatementsTest < ActiveRecord::TestCase
   def setup
-    @connection = ActiveRecord::Base.connection
+    @connection = ActiveRecord::Base.lease_connection
   end
 
   unless current_adapter?(:OracleAdapter)

--- a/activerecord/test/cases/date_time_precision_test.rb
+++ b/activerecord/test/cases/date_time_precision_test.rb
@@ -12,7 +12,7 @@ class DateTimePrecisionTest < ActiveRecord::TestCase
     class Foo < ActiveRecord::Base; end
 
     setup do
-      @connection = ActiveRecord::Base.connection
+      @connection = ActiveRecord::Base.lease_connection
       Foo.reset_column_information
     end
 

--- a/activerecord/test/cases/dirty_test.rb
+++ b/activerecord/test/cases/dirty_test.rb
@@ -608,14 +608,14 @@ class DirtyTest < ActiveRecord::TestCase
 
   class Testings < ActiveRecord::Base; end
   def test_field_named_field
-    ActiveRecord::Base.connection.create_table :testings do |t|
+    ActiveRecord::Base.lease_connection.create_table :testings do |t|
       t.string :field
     end
     assert_nothing_raised do
       Testings.new.attributes
     end
   ensure
-    ActiveRecord::Base.connection.drop_table :testings rescue nil
+    ActiveRecord::Base.lease_connection.drop_table :testings rescue nil
     ActiveRecord::Base.clear_cache!
   end
 

--- a/activerecord/test/cases/disconnected_test.rb
+++ b/activerecord/test/cases/disconnected_test.rb
@@ -7,7 +7,7 @@ end
 
 class TestDisconnectedAdapter < ActiveRecord::TestCase
   def setup
-    @connection = ActiveRecord::Base.connection
+    @connection = ActiveRecord::Base.lease_connection
   end
 
   teardown do

--- a/activerecord/test/cases/encryption/helper.rb
+++ b/activerecord/test/cases/encryption/helper.rb
@@ -78,7 +78,7 @@ module ActiveRecord::Encryption
         end
 
         # Skip type casting to simulate an upcase value. Not supported in AR without using private apis
-        EncryptedBookThatIgnoresCase.connection.execute <<~SQL
+        EncryptedBookThatIgnoresCase.lease_connection.execute <<~SQL
           UPDATE encrypted_books SET name = '#{name}' WHERE id = #{book.id};
         SQL
 

--- a/activerecord/test/cases/excluding_test.rb
+++ b/activerecord/test/cases/excluding_test.rb
@@ -25,7 +25,7 @@ class ExcludingTest < ActiveRecord::TestCase
   def test_result_set_does_not_include_collection_of_excluded_records_from_a_query
     query = Post.where(id: @post)
 
-    assert_queries_match(/SELECT #{Regexp.escape Post.connection.quote_table_name("posts.id")} FROM/) do
+    assert_queries_match(/SELECT #{Regexp.escape Post.lease_connection.quote_table_name("posts.id")} FROM/) do
       records = Post.excluding(query).to_a
 
       assert_not_includes records, @post
@@ -72,7 +72,7 @@ class ExcludingTest < ActiveRecord::TestCase
   def test_result_set_through_association_does_not_include_collection_of_excluded_records_from_a_relation
     relation = @post.comments
 
-    assert_queries_match(/SELECT #{Regexp.escape Comment.connection.quote_table_name("comments.id")} FROM/) do
+    assert_queries_match(/SELECT #{Regexp.escape Comment.lease_connection.quote_table_name("comments.id")} FROM/) do
       records = Comment.excluding(relation).to_a
 
       assert_not_empty records

--- a/activerecord/test/cases/explain_subscriber_test.rb
+++ b/activerecord/test/cases/explain_subscriber_test.rb
@@ -4,7 +4,7 @@ require "cases/helper"
 require "active_record/explain_subscriber"
 require "active_record/explain_registry"
 
-if ActiveRecord::Base.connection.supports_explain?
+if ActiveRecord::Base.lease_connection.supports_explain?
   class ExplainSubscriberTest < ActiveRecord::TestCase
     SUBSCRIBER = ActiveRecord::ExplainSubscriber.new
 

--- a/activerecord/test/cases/helper.rb
+++ b/activerecord/test/cases/helper.rb
@@ -22,11 +22,15 @@ Thread.abort_on_exception = true
 # Show backtraces for deprecated behavior for quicker cleanup.
 ActiveRecord.deprecator.debug = true
 
+# ActiveRecord::Base.connection is only soft deprecated but we remove it
+# in the test suite to ensure we're not using it internally.
+ActiveRecord::ConnectionHandling.remove_method(:connection)
+
 # Disable available locale checks to avoid warnings running the test suite.
 I18n.enforce_available_locales = false
 
 # Quote "type" if it's a reserved word for the current connection.
-QUOTED_TYPE = ActiveRecord::Base.connection.quote_column_name("type")
+QUOTED_TYPE = ActiveRecord::Base.lease_connection.quote_column_name("type")
 
 ActiveRecord.raise_on_assign_to_attr_readonly = true
 ActiveRecord.belongs_to_required_validates_foreign_key = false

--- a/activerecord/test/cases/insert_all_test.rb
+++ b/activerecord/test/cases/insert_all_test.rb
@@ -235,7 +235,7 @@ class InsertAllTest < ActiveRecord::TestCase
     skip unless supports_insert_conflict_target?
 
     columns = [:author_id, :name]
-    assert ActiveRecord::Base.connection.index_exists?(:books, columns)
+    assert ActiveRecord::Base.lease_connection.index_exists?(:books, columns)
 
     assert_difference "Book.count", +2 do
       Book.insert_all [{ name: "Remote", author_id: 1 }], unique_by: columns.reverse
@@ -769,7 +769,7 @@ class InsertAllTest < ActiveRecord::TestCase
     error = assert_raises ArgumentError do
       Book.upsert_all [{ name: "Rework", author_id: 1 }], unique_by: :isbn
     end
-    assert_match "#{ActiveRecord::Base.connection.class} does not support :unique_by", error.message
+    assert_match "#{ActiveRecord::Base.lease_connection.class} does not support :unique_by", error.message
   end
 
   private

--- a/activerecord/test/cases/instrumentation_test.rb
+++ b/activerecord/test/cases/instrumentation_test.rb
@@ -2,6 +2,7 @@
 
 require "cases/helper"
 require "models/book"
+require "models/clothing_item"
 
 module ActiveRecord
   class InstrumentationTest < ActiveRecord::TestCase
@@ -142,13 +143,13 @@ module ActiveRecord
           assert_equal 10, payload[:row_count]
         end
       end
-      ActiveRecord::Base.connection.execute("SELECT * FROM books WHERE name='row count book 3';")
+      ActiveRecord::Base.lease_connection.execute("SELECT * FROM books WHERE name='row count book 3';")
     ensure
       ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
     end
 
     def test_payload_connection_with_query_cache_disabled
-      connection = Book.connection
+      connection = ClothingItem.lease_connection
       subscriber = ActiveSupport::Notifications.subscribe("sql.active_record") do |_, _, _, _, payload|
         assert_equal connection, payload[:connection]
       end
@@ -158,7 +159,7 @@ module ActiveRecord
     end
 
     def test_payload_connection_with_query_cache_enabled
-      connection = Book.connection
+      connection = ClothingItem.lease_connection
       subscriber = ActiveSupport::Notifications.subscribe("sql.active_record") do |_, _, _, _, payload|
         assert_equal connection, payload[:connection]
       end

--- a/activerecord/test/cases/json_shared_test_cases.rb
+++ b/activerecord/test/cases/json_shared_test_cases.rb
@@ -13,7 +13,7 @@ module JSONSharedTestCases
   end
 
   def setup
-    @connection = ActiveRecord::Base.connection
+    @connection = ActiveRecord::Base.lease_connection
   end
 
   def teardown
@@ -276,7 +276,7 @@ module JSONSharedTestCases
     end
 
     def assert_type_match(type, sql_type)
-      native_type = ActiveRecord::Base.connection.native_database_types[type][:name]
+      native_type = ActiveRecord::Base.lease_connection.native_database_types[type][:name]
       assert_match %r(\A#{native_type}\b), sql_type
     end
 

--- a/activerecord/test/cases/locking_test.rb
+++ b/activerecord/test/cases/locking_test.rb
@@ -293,7 +293,7 @@ class OptimisticLockingTest < ActiveRecord::TestCase
   end
 
   def test_touch_existing_lock_without_default_should_work_with_null_in_the_database
-    ActiveRecord::Base.connection.execute("INSERT INTO lock_without_defaults(title) VALUES('title1')")
+    ActiveRecord::Base.lease_connection.execute("INSERT INTO lock_without_defaults(title) VALUES('title1')")
     t1 = LockWithoutDefault.last
 
     assert_equal 0, t1.lock_version
@@ -322,7 +322,7 @@ class OptimisticLockingTest < ActiveRecord::TestCase
   end
 
   def test_lock_without_default_should_work_with_null_in_the_database
-    ActiveRecord::Base.connection.execute("INSERT INTO lock_without_defaults(title) VALUES('title1')")
+    ActiveRecord::Base.lease_connection.execute("INSERT INTO lock_without_defaults(title) VALUES('title1')")
     t1 = LockWithoutDefault.last
     t2 = LockWithoutDefault.find(t1.id)
 
@@ -344,7 +344,7 @@ class OptimisticLockingTest < ActiveRecord::TestCase
   end
 
   def test_update_with_lock_version_without_default_should_work_on_dirty_value_before_type_cast
-    ActiveRecord::Base.connection.execute("INSERT INTO lock_without_defaults(title) VALUES('title1')")
+    ActiveRecord::Base.lease_connection.execute("INSERT INTO lock_without_defaults(title) VALUES('title1')")
     t1 = LockWithoutDefault.last
 
     assert_equal 0, t1.lock_version
@@ -361,7 +361,7 @@ class OptimisticLockingTest < ActiveRecord::TestCase
   end
 
   def test_destroy_with_lock_version_without_default_should_work_on_dirty_value_before_type_cast
-    ActiveRecord::Base.connection.execute("INSERT INTO lock_without_defaults(title) VALUES('title1')")
+    ActiveRecord::Base.lease_connection.execute("INSERT INTO lock_without_defaults(title) VALUES('title1')")
     t1 = LockWithoutDefault.last
 
     assert_equal 0, t1.lock_version
@@ -411,7 +411,7 @@ class OptimisticLockingTest < ActiveRecord::TestCase
   end
 
   def test_lock_with_custom_column_without_default_should_work_with_null_in_the_database
-    ActiveRecord::Base.connection.execute("INSERT INTO lock_without_defaults_cust(title) VALUES('title1')")
+    ActiveRecord::Base.lease_connection.execute("INSERT INTO lock_without_defaults_cust(title) VALUES('title1')")
 
     t1 = LockWithCustomColumnWithoutDefault.last
     t2 = LockWithCustomColumnWithoutDefault.find(t1.id)
@@ -550,7 +550,7 @@ class OptimisticLockingTest < ActiveRecord::TestCase
     assert_not_empty p.treasures
     p.destroy
     assert_empty p.treasures
-    assert_empty RichPerson.connection.select_all("SELECT * FROM peoples_treasures WHERE rich_person_id = 1")
+    assert_empty RichPerson.lease_connection.select_all("SELECT * FROM peoples_treasures WHERE rich_person_id = 1")
   end
 
   def test_yaml_dumping_with_lock_column
@@ -613,7 +613,7 @@ class OptimisticLockingWithSchemaChangeTest < ActiveRecord::TestCase
   end
 
   def test_destroy_existing_object_with_locking_column_value_null_in_the_database
-    ActiveRecord::Base.connection.execute("INSERT INTO lock_without_defaults(title) VALUES('title1')")
+    ActiveRecord::Base.lease_connection.execute("INSERT INTO lock_without_defaults(title) VALUES('title1')")
     t1 = LockWithoutDefault.last
 
     assert_equal 0, t1.lock_version
@@ -639,12 +639,12 @@ class OptimisticLockingWithSchemaChangeTest < ActiveRecord::TestCase
 
   private
     def add_counter_column_to(model, col = "test_count")
-      model.connection.add_column model.table_name, col, :integer, null: false, default: 0
+      model.lease_connection.add_column model.table_name, col, :integer, null: false, default: 0
       model.reset_column_information
     end
 
     def remove_counter_column_from(model, col = :test_count)
-      model.connection.remove_column model.table_name, col
+      model.lease_connection.remove_column model.table_name, col
       model.reset_column_information
     end
 
@@ -747,10 +747,10 @@ class PessimisticLockingTest < ActiveRecord::TestCase
     def test_with_lock_configures_transaction
       person = Person.find 1
       Person.transaction do
-        outer_transaction = Person.connection.transaction_manager.current_transaction
+        outer_transaction = Person.lease_connection.transaction_manager.current_transaction
         assert_equal true, outer_transaction.joinable?
         person.with_lock(requires_new: true, joinable: false) do
-          current_transaction = Person.connection.transaction_manager.current_transaction
+          current_transaction = Person.lease_connection.transaction_manager.current_transaction
           assert_not_equal outer_transaction, current_transaction
           assert_equal false, current_transaction.joinable?
         end
@@ -770,7 +770,7 @@ class PessimisticLockingTest < ActiveRecord::TestCase
       def test_with_lock_sets_isolation
         person = Person.find 1
         person.with_lock(isolation: :read_uncommitted) do
-          current_transaction = Person.connection.transaction_manager.current_transaction
+          current_transaction = Person.lease_connection.transaction_manager.current_transaction
           assert_equal :read_uncommitted, current_transaction.isolation_level
         end
       end

--- a/activerecord/test/cases/log_subscriber_test.rb
+++ b/activerecord/test/cases/log_subscriber_test.rb
@@ -44,7 +44,7 @@ class LogSubscriberTest < ActiveRecord::TestCase
   def setup
     @old_logger = ActiveRecord::Base.logger
     Developer.primary_key
-    ActiveRecord::Base.connection.materialize_transactions
+    ActiveRecord::Base.lease_connection.materialize_transactions
     super
     ActiveRecord::LogSubscriber.attach_to(:active_record)
   end
@@ -247,7 +247,7 @@ class LogSubscriberTest < ActiveRecord::TestCase
     assert_equal 0, @logger.logged(:debug).size
   end
 
-  if ActiveRecord::Base.connection.prepared_statements
+  if ActiveRecord::Base.lease_connection.prepared_statements
     def test_where_in_binds_logging_include_attribute_names
       Developer.where(id: [1, 2, 3, 4, 5]).load
       wait

--- a/activerecord/test/cases/marshal_serialization_test.rb
+++ b/activerecord/test/cases/marshal_serialization_test.rb
@@ -100,7 +100,7 @@ class MarshalSerializationTest < ActiveRecord::TestCase
 
     def marshal_fixture_path(file_name)
       File.expand_path(
-        "support/marshal_compatibility_fixtures/#{ActiveRecord::Base.connection.adapter_name}/#{file_name}.dump",
+        "support/marshal_compatibility_fixtures/#{ActiveRecord::Base.lease_connection.adapter_name}/#{file_name}.dump",
         TEST_ROOT
       )
     end

--- a/activerecord/test/cases/migration/change_schema_test.rb
+++ b/activerecord/test/cases/migration/change_schema_test.rb
@@ -9,7 +9,7 @@ module ActiveRecord
 
       def setup
         super
-        @connection = ActiveRecord::Base.connection
+        @connection = ActiveRecord::Base.lease_connection
         @table_name = :testings
       end
 
@@ -368,45 +368,45 @@ module ActiveRecord
         person_klass = Class.new(ActiveRecord::Base)
         person_klass.table_name = "testings"
 
-        person_klass.connection.add_column "testings", "wealth", :integer, null: false, default: 99
+        person_klass.lease_connection.add_column "testings", "wealth", :integer, null: false, default: 99
         person_klass.reset_column_information
         assert_equal 99, person_klass.column_defaults["wealth"]
         assert_equal false, person_klass.columns_hash["wealth"].null
         # Oracle needs primary key value from sequence
         if current_adapter?(:OracleAdapter)
-          assert_nothing_raised { person_klass.connection.execute("insert into testings (id, title) values (testings_seq.nextval, 'tester')") }
+          assert_nothing_raised { person_klass.lease_connection.execute("insert into testings (id, title) values (testings_seq.nextval, 'tester')") }
         else
-          assert_nothing_raised { person_klass.connection.execute("insert into testings (title) values ('tester')") }
+          assert_nothing_raised { person_klass.lease_connection.execute("insert into testings (title) values ('tester')") }
         end
 
         # change column default to see that column doesn't lose its not null definition
-        person_klass.connection.change_column_default "testings", "wealth", 100
+        person_klass.lease_connection.change_column_default "testings", "wealth", 100
         person_klass.reset_column_information
         assert_equal 100, person_klass.column_defaults["wealth"]
         assert_equal false, person_klass.columns_hash["wealth"].null
 
         # rename column to see that column doesn't lose its not null and/or default definition
-        person_klass.connection.rename_column "testings", "wealth", "money"
+        person_klass.lease_connection.rename_column "testings", "wealth", "money"
         person_klass.reset_column_information
         assert_nil person_klass.columns_hash["wealth"]
         assert_equal 100, person_klass.column_defaults["money"]
         assert_equal false, person_klass.columns_hash["money"].null
 
         # change column
-        person_klass.connection.change_column "testings", "money", :integer, null: false, default: 1000
+        person_klass.lease_connection.change_column "testings", "money", :integer, null: false, default: 1000
         person_klass.reset_column_information
         assert_equal 1000, person_klass.column_defaults["money"]
         assert_equal false, person_klass.columns_hash["money"].null
 
         # change column, make it nullable and clear default
-        person_klass.connection.change_column "testings", "money", :integer, null: true, default: nil
+        person_klass.lease_connection.change_column "testings", "money", :integer, null: true, default: nil
         person_klass.reset_column_information
         assert_nil person_klass.columns_hash["money"].default
         assert_equal true, person_klass.columns_hash["money"].null
 
         # change_column_null, make it not nullable and set null values to a default value
-        person_klass.connection.execute("UPDATE testings SET money = NULL")
-        person_klass.connection.change_column_null "testings", "money", false, 2000
+        person_klass.lease_connection.execute("UPDATE testings SET money = NULL")
+        person_klass.lease_connection.change_column_null "testings", "money", false, 2000
         person_klass.reset_column_information
         assert_nil person_klass.columns_hash["money"].default
         assert_equal false, person_klass.columns_hash["money"].null
@@ -500,12 +500,12 @@ module ActiveRecord
         end
     end
 
-    if ActiveRecord::Base.connection.supports_foreign_keys?
+    if ActiveRecord::Base.lease_connection.supports_foreign_keys?
       class ChangeSchemaWithDependentObjectsTest < ActiveRecord::TestCase
         self.use_transactional_tests = false
 
         setup do
-          @connection = ActiveRecord::Base.connection
+          @connection = ActiveRecord::Base.lease_connection
           @connection.create_table :trains
           @connection.create_table(:wagons) { |t| t.references :train }
           @connection.add_foreign_key :wagons, :trains

--- a/activerecord/test/cases/migration/change_table_test.rb
+++ b/activerecord/test/cases/migration/change_table_test.rb
@@ -14,7 +14,7 @@ module ActiveRecord
       end
 
       def with_change_table
-        yield ActiveRecord::Base.connection.update_table_definition(:delete_me, @connection)
+        yield ActiveRecord::Base.lease_connection.update_table_definition(:delete_me, @connection)
       end
 
       if Minitest::Mock.instance_method(:expect).parameters.map(&:first).include?(:keyrest)

--- a/activerecord/test/cases/migration/check_constraint_test.rb
+++ b/activerecord/test/cases/migration/check_constraint_test.rb
@@ -3,7 +3,7 @@
 require "cases/helper"
 require "support/schema_dumping_helper"
 
-if ActiveRecord::Base.connection.supports_check_constraints?
+if ActiveRecord::Base.lease_connection.supports_check_constraints?
   module ActiveRecord
     class Migration
       class CheckConstraintTest < ActiveRecord::TestCase
@@ -13,7 +13,7 @@ if ActiveRecord::Base.connection.supports_check_constraints?
         end
 
         setup do
-          @connection = ActiveRecord::Base.connection
+          @connection = ActiveRecord::Base.lease_connection
           @connection.create_table "trades", force: true do |t|
             t.integer :price
             t.integer :quantity
@@ -165,7 +165,7 @@ if ActiveRecord::Base.connection.supports_check_constraints?
           end
         end
 
-        if ActiveRecord::Base.connection.supports_validate_constraints?
+        if ActiveRecord::Base.lease_connection.supports_validate_constraints?
           def test_not_valid_check_constraint
             Trade.create(quantity: -1)
 
@@ -315,7 +315,7 @@ else
     class Migration
       class NoForeignKeySupportTest < ActiveRecord::TestCase
         setup do
-          @connection = ActiveRecord::Base.connection
+          @connection = ActiveRecord::Base.lease_connection
         end
 
         def test_add_check_constraint_should_be_noop

--- a/activerecord/test/cases/migration/column_positioning_test.rb
+++ b/activerecord/test/cases/migration/column_positioning_test.rb
@@ -11,7 +11,7 @@ module ActiveRecord
       def setup
         super
 
-        @connection = ActiveRecord::Base.connection
+        @connection = ActiveRecord::Base.lease_connection
 
         connection.create_table :testings, id: false do |t|
           t.column :first, :integer

--- a/activerecord/test/cases/migration/command_recorder_test.rb
+++ b/activerecord/test/cases/migration/command_recorder_test.rb
@@ -6,7 +6,7 @@ module ActiveRecord
   class Migration
     class CommandRecorderTest < ActiveRecord::TestCase
       def setup
-        connection = ActiveRecord::Base.connection
+        connection = ActiveRecord::Base.lease_connection
         @recorder  = CommandRecorder.new(connection)
       end
 
@@ -113,7 +113,7 @@ module ActiveRecord
         end
       end
 
-      if ActiveRecord::Base.connection.supports_bulk_alter?
+      if ActiveRecord::Base.lease_connection.supports_bulk_alter?
         def test_bulk_invert_change_table
           block = Proc.new do |t|
             t.string :name
@@ -225,7 +225,7 @@ module ActiveRecord
         assert_equal [:change_column_default, [:table, :column, from: false, to: true]], change
       end
 
-      if ActiveRecord::Base.connection.supports_comments?
+      if ActiveRecord::Base.lease_connection.supports_comments?
         def test_invert_change_column_comment
           assert_raises(ActiveRecord::IrreversibleMigration) do
             @recorder.inverse_of :change_column_comment, [:table, :column, "comment"]

--- a/activerecord/test/cases/migration/compatibility_test.rb
+++ b/activerecord/test/cases/migration/compatibility_test.rb
@@ -15,7 +15,7 @@ module ActiveRecord
 
       def setup
         super
-        @connection = ActiveRecord::Base.connection
+        @connection = ActiveRecord::Base.lease_connection
         @pool = ActiveRecord::Base.connection_pool
         @schema_migration = @pool.schema_migration
         @internal_metadata = @pool.internal_metadata
@@ -114,7 +114,7 @@ module ActiveRecord
         assert connection.column_exists?(:testings, :updated_at, null: true)
       end
 
-      if ActiveRecord::Base.connection.supports_bulk_alter?
+      if ActiveRecord::Base.lease_connection.supports_bulk_alter?
         def test_timestamps_have_null_constraints_if_not_present_in_migration_of_change_table_with_bulk
           migration = Class.new(ActiveRecord::Migration[4.2]) {
             def migrate(x)
@@ -176,7 +176,7 @@ module ActiveRecord
         assert connection.column_exists?(:testings, :updated_at, null: false, **precision_implicit_default)
       end
 
-      if ActiveRecord::Base.connection.supports_bulk_alter?
+      if ActiveRecord::Base.lease_connection.supports_bulk_alter?
         def test_timestamps_doesnt_set_precision_on_change_table_with_bulk
           migration = Class.new(ActiveRecord::Migration[5.2]) {
             def migrate(x)
@@ -227,7 +227,7 @@ module ActiveRecord
         end
       end
 
-      if ActiveRecord::Base.connection.supports_comments?
+      if ActiveRecord::Base.lease_connection.supports_comments?
         def test_change_column_comment_can_be_reverted
           migration = Class.new(ActiveRecord::Migration[5.2]) {
             def migrate(x)
@@ -620,7 +620,7 @@ module ActiveRecord
 
           ActiveRecord::Migrator.new(:up, [migration], @schema_migration, @internal_metadata).migrate
 
-          foreign_keys = Testing.connection.foreign_keys("sub_testings")
+          foreign_keys = Testing.lease_connection.foreign_keys("sub_testings")
           assert_equal 1, foreign_keys.size
           assert_equal :immediate, foreign_keys.first.deferrable
         ensure
@@ -828,7 +828,7 @@ class BaseCompatibilityTest < ActiveRecord::TestCase
   attr_reader :connection
 
   def setup
-    @connection = ActiveRecord::Base.connection
+    @connection = ActiveRecord::Base.lease_connection
     @pool = ActiveRecord::Base.connection_pool
     @schema_migration = @pool.schema_migration
     @internal_metadata = @pool.internal_metadata
@@ -917,7 +917,7 @@ module LegacyPolymorphicReferenceIndexTestCases
   attr_reader :connection
 
   def setup
-    @connection = ActiveRecord::Base.connection
+    @connection = ActiveRecord::Base.lease_connection
     @pool = ActiveRecord::Base.connection_pool
     @schema_migration = @pool.schema_migration
     @internal_metadata = @pool.internal_metadata

--- a/activerecord/test/cases/migration/create_join_table_test.rb
+++ b/activerecord/test/cases/migration/create_join_table_test.rb
@@ -9,7 +9,7 @@ module ActiveRecord
 
       def setup
         super
-        @connection = ActiveRecord::Base.connection
+        @connection = ActiveRecord::Base.lease_connection
       end
 
       teardown do

--- a/activerecord/test/cases/migration/exclusion_constraint_test.rb
+++ b/activerecord/test/cases/migration/exclusion_constraint_test.rb
@@ -3,7 +3,7 @@
 require "cases/helper"
 require "support/schema_dumping_helper"
 
-if ActiveRecord::Base.connection.supports_exclusion_constraints?
+if ActiveRecord::Base.lease_connection.supports_exclusion_constraints?
   module ActiveRecord
     class Migration
       class ExclusionConstraintTest < ActiveRecord::TestCase
@@ -13,7 +13,7 @@ if ActiveRecord::Base.connection.supports_exclusion_constraints?
         end
 
         setup do
-          @connection = ActiveRecord::Base.connection
+          @connection = ActiveRecord::Base.lease_connection
           @connection.create_table "invoices", force: true do |t|
             t.date :start_date
             t.date :end_date
@@ -162,7 +162,7 @@ if ActiveRecord::Base.connection.supports_exclusion_constraints?
 
           assert_nothing_raised do
             Invoice.transaction(requires_new: true) do
-              Invoice.connection.set_constraints(:deferred, "invoices_date_overlap")
+              Invoice.lease_connection.set_constraints(:deferred, "invoices_date_overlap")
               Invoice.create!(start_date: "2020-12-31", end_date: "2021-01-01")
               invoice.update!(end_date: "2020-12-31")
 

--- a/activerecord/test/cases/migration/helper.rb
+++ b/activerecord/test/cases/migration/helper.rb
@@ -18,7 +18,7 @@ module ActiveRecord
 
       def setup
         super
-        @connection = ActiveRecord::Base.connection
+        @connection = ActiveRecord::Base.lease_connection
         connection.create_table :test_models do |t|
           t.timestamps null: true
         end

--- a/activerecord/test/cases/migration/index_test.rb
+++ b/activerecord/test/cases/migration/index_test.rb
@@ -9,7 +9,7 @@ module ActiveRecord
 
       def setup
         super
-        @connection = ActiveRecord::Base.connection
+        @connection = ActiveRecord::Base.lease_connection
         @table_name = :testings
 
         connection.create_table table_name do |t|

--- a/activerecord/test/cases/migration/references_foreign_key_test.rb
+++ b/activerecord/test/cases/migration/references_foreign_key_test.rb
@@ -2,12 +2,12 @@
 
 require "cases/helper"
 
-if ActiveRecord::Base.connection.supports_foreign_keys?
+if ActiveRecord::Base.lease_connection.supports_foreign_keys?
   module ActiveRecord
     class Migration
       class ReferencesForeignKeyInCreateTest < ActiveRecord::TestCase
         setup do
-          @connection = ActiveRecord::Base.connection
+          @connection = ActiveRecord::Base.lease_connection
           @connection.create_table(:testing_parents, force: true)
         end
 
@@ -63,7 +63,7 @@ if ActiveRecord::Base.connection.supports_foreign_keys?
                        fks.map { |fk| [fk.from_table, fk.to_table, fk.column] })
         end
 
-        if ActiveRecord::Base.connection.supports_deferrable_constraints?
+        if ActiveRecord::Base.lease_connection.supports_deferrable_constraints?
           test "deferrable: false option can be passed" do
             @connection.create_table :testings do |t|
               t.references :testing_parent, foreign_key: { deferrable: false }
@@ -112,7 +112,7 @@ if ActiveRecord::Base.connection.supports_foreign_keys?
     class Migration
       class ReferencesForeignKeyTest < ActiveRecord::TestCase
         setup do
-          @connection = ActiveRecord::Base.connection
+          @connection = ActiveRecord::Base.lease_connection
           @connection.create_table(:testing_parents, force: true)
         end
 

--- a/activerecord/test/cases/migration/references_index_test.rb
+++ b/activerecord/test/cases/migration/references_index_test.rb
@@ -9,7 +9,7 @@ module ActiveRecord
 
       def setup
         super
-        @connection = ActiveRecord::Base.connection
+        @connection = ActiveRecord::Base.lease_connection
         @table_name = :testings
       end
 

--- a/activerecord/test/cases/migration/schema_definitions_test.rb
+++ b/activerecord/test/cases/migration/schema_definitions_test.rb
@@ -8,7 +8,7 @@ module ActiveRecord
       attr_reader :connection
 
       def setup
-        @connection = ActiveRecord::Base.connection
+        @connection = ActiveRecord::Base.lease_connection
       end
 
       def test_build_create_table_definition_with_block

--- a/activerecord/test/cases/migration/unique_constraint_test.rb
+++ b/activerecord/test/cases/migration/unique_constraint_test.rb
@@ -3,7 +3,7 @@
 require "cases/helper"
 require "support/schema_dumping_helper"
 
-if ActiveRecord::Base.connection.supports_unique_constraints?
+if ActiveRecord::Base.lease_connection.supports_unique_constraints?
   module ActiveRecord
     class Migration
       class UniqueConstraintTest < ActiveRecord::TestCase
@@ -13,7 +13,7 @@ if ActiveRecord::Base.connection.supports_unique_constraints?
         end
 
         setup do
-          @connection = ActiveRecord::Base.connection
+          @connection = ActiveRecord::Base.lease_connection
           @connection.create_table "sections", force: true do |t|
             t.integer "position", null: false
           end
@@ -137,7 +137,7 @@ if ActiveRecord::Base.connection.supports_unique_constraints?
 
           assert_nothing_raised do
             Section.transaction(requires_new: true) do
-              Section.connection.exec_query("SET CONSTRAINTS unique_section_position DEFERRED")
+              Section.lease_connection.exec_query("SET CONSTRAINTS unique_section_position DEFERRED")
               Section.create!(position: 1)
               section.update!(position: 2)
 

--- a/activerecord/test/cases/migration_test.rb
+++ b/activerecord/test/cases/migration_test.rb
@@ -40,7 +40,7 @@ class MigrationTest < ActiveRecord::TestCase
   def setup
     super
     %w(reminders people_reminders prefix_reminders_suffix p_things_s).each do |table|
-      Reminder.connection.drop_table(table) rescue nil
+      Reminder.lease_connection.drop_table(table) rescue nil
     end
     Reminder.reset_column_information
     @verbose_was, ActiveRecord::Migration.verbose = ActiveRecord::Migration.verbose, false
@@ -58,23 +58,23 @@ class MigrationTest < ActiveRecord::TestCase
     @schema_migration.delete_all_versions
 
     %w(things awesome_things prefix_things_suffix p_awesome_things_s).each do |table|
-      Thing.connection.drop_table(table) rescue nil
+      Thing.lease_connection.drop_table(table) rescue nil
     end
     Thing.reset_column_information
 
     %w(reminders people_reminders prefix_reminders_suffix).each do |table|
-      Reminder.connection.drop_table(table) rescue nil
+      Reminder.lease_connection.drop_table(table) rescue nil
     end
     Reminder.reset_table_name
     Reminder.reset_column_information
 
     %w(last_name key bio age height wealth birthday favorite_day
        moment_of_truth male administrator funny).each do |column|
-      Person.connection.remove_column("people", column) rescue nil
+      Person.lease_connection.remove_column("people", column) rescue nil
     end
-    Person.connection.remove_column("people", "first_name") rescue nil
-    Person.connection.remove_column("people", "middle_name") rescue nil
-    Person.connection.add_column("people", "first_name", :string)
+    Person.lease_connection.remove_column("people", "first_name") rescue nil
+    Person.lease_connection.remove_column("people", "middle_name") rescue nil
+    Person.lease_connection.add_column("people", "first_name", :string)
     Person.reset_column_information
 
     ActiveRecord::Migration.verbose = @verbose_was
@@ -153,7 +153,7 @@ class MigrationTest < ActiveRecord::TestCase
   end
 
   def test_create_table_raises_if_already_exists
-    connection = Person.connection
+    connection = Person.lease_connection
     connection.create_table :testings, force: true do |t|
       t.string :foo
     end
@@ -168,7 +168,7 @@ class MigrationTest < ActiveRecord::TestCase
   end
 
   def test_create_table_with_if_not_exists_true
-    connection = Person.connection
+    connection = Person.lease_connection
     connection.create_table :testings, force: true do |t|
       t.string :foo
     end
@@ -183,7 +183,7 @@ class MigrationTest < ActiveRecord::TestCase
   end
 
   def test_create_table_raises_for_long_table_names
-    connection = Person.connection
+    connection = Person.lease_connection
     name_limit = connection.table_name_length
     long_name = "a" * (name_limit + 1)
     short_name = "a" * name_limit
@@ -200,7 +200,7 @@ class MigrationTest < ActiveRecord::TestCase
   end
 
   def test_create_table_with_indexes_and_if_not_exists_true
-    connection = Person.connection
+    connection = Person.lease_connection
     connection.create_table :testings, force: true do |t|
       t.references :people
       t.string :foo
@@ -219,15 +219,15 @@ class MigrationTest < ActiveRecord::TestCase
   def test_create_table_with_force_true_does_not_drop_nonexisting_table
     # using a copy as we need the drop_table method to
     # continue to work for the ensure block of the test
-    temp_conn = Person.connection.dup
+    temp_conn = Person.lease_connection.dup
 
-    assert_not_equal temp_conn, Person.connection
+    assert_not_equal temp_conn, Person.lease_connection
 
     temp_conn.create_table :testings2, force: true do |t|
       t.column :foo, :string
     end
   ensure
-    Person.connection.drop_table :testings2, if_exists: true
+    Person.lease_connection.drop_table :testings2, if_exists: true
   end
 
   def test_remove_column_with_if_not_exists_not_set
@@ -270,7 +270,7 @@ class MigrationTest < ActiveRecord::TestCase
       end
 
       if current_adapter?(:Mysql2Adapter, :TrilogyAdapter)
-        if ActiveRecord::Base.connection.mariadb?
+        if ActiveRecord::Base.lease_connection.mariadb?
           assert_match(/Can't DROP COLUMN `last_name`; check that it exists/, error.message)
         else
           assert_match(/check that column\/key exists/, error.message)
@@ -344,7 +344,7 @@ class MigrationTest < ActiveRecord::TestCase
   ensure
     Person.reset_column_information
     if Person.column_names.include?("last_name")
-      Person.connection.remove_column("people", "last_name")
+      Person.lease_connection.remove_column("people", "last_name")
     end
   end
 
@@ -372,7 +372,7 @@ class MigrationTest < ActiveRecord::TestCase
   ensure
     Person.reset_column_information
     if Person.column_names.include?("last_name")
-      Person.connection.remove_column("people", "last_name")
+      Person.lease_connection.remove_column("people", "last_name")
     end
   end
 
@@ -402,7 +402,7 @@ class MigrationTest < ActiveRecord::TestCase
   ensure
     Person.reset_column_information
     if Person.column_names.include?("last_name")
-      Person.connection.remove_column("people", "last_name")
+      Person.lease_connection.remove_column("people", "last_name")
     end
   end
 
@@ -430,13 +430,13 @@ class MigrationTest < ActiveRecord::TestCase
   ensure
     Person.reset_column_information
     if Person.column_names.include?("last_name")
-      Person.connection.remove_column("people", "last_name")
+      Person.lease_connection.remove_column("people", "last_name")
     end
   end
 
   def test_migration_instance_has_connection
     migration = Class.new(ActiveRecord::Migration::Current).new
-    assert_equal ActiveRecord::Base.connection, migration.connection
+    assert_equal ActiveRecord::Base.lease_connection, migration.connection
   end
 
   def test_method_missing_delegates_to_connection
@@ -452,7 +452,7 @@ class MigrationTest < ActiveRecord::TestCase
   end
 
   def test_add_table_with_decimals
-    Person.connection.drop_table :big_numbers rescue nil
+    Person.lease_connection.drop_table :big_numbers rescue nil
 
     assert_not_predicate BigNumber, :table_exists?
     GiveMeBigNumbers.up
@@ -565,7 +565,7 @@ class MigrationTest < ActiveRecord::TestCase
     assert migration.went_down, "have not gone down"
   end
 
-  if ActiveRecord::Base.connection.supports_ddl_transactions?
+  if ActiveRecord::Base.lease_connection.supports_ddl_transactions?
     def test_migrator_one_up_with_exception_and_rollback
       assert_no_column Person, :last_name
 
@@ -630,7 +630,7 @@ class MigrationTest < ActiveRecord::TestCase
     ensure
       Person.reset_column_information
       if Person.column_names.include?("last_name")
-        Person.connection.remove_column("people", "last_name")
+        Person.lease_connection.remove_column("people", "last_name")
       end
     end
   end
@@ -742,18 +742,18 @@ class MigrationTest < ActiveRecord::TestCase
 
   def test_updating_an_existing_entry_into_internal_metadata
     @internal_metadata[:version] = "foo"
-    updated_at = @internal_metadata.send(:select_entry, @pool.connection, :version)["updated_at"]
+    updated_at = @internal_metadata.send(:select_entry, @pool.lease_connection, :version)["updated_at"]
     assert_equal "foo", @internal_metadata[:version]
 
     # same version doesn't update timestamps
     @internal_metadata[:version] = "foo"
     assert_equal "foo", @internal_metadata[:version]
-    assert_equal updated_at, @internal_metadata.send(:select_entry, @pool.connection, :version)["updated_at"]
+    assert_equal updated_at, @internal_metadata.send(:select_entry, @pool.lease_connection, :version)["updated_at"]
 
     # updated version updates timestamps
     @internal_metadata[:version] = "not_foo"
     assert_equal "not_foo", @internal_metadata[:version]
-    assert_not_equal updated_at, @internal_metadata.send(:select_entry, @pool.connection, :version)["updated_at"]
+    assert_not_equal updated_at, @internal_metadata.send(:select_entry, @pool.lease_connection, :version)["updated_at"]
   ensure
     @internal_metadata.delete_all_entries
   end
@@ -880,134 +880,134 @@ class MigrationTest < ActiveRecord::TestCase
 
   def test_create_table_with_binary_column
     assert_nothing_raised {
-      Person.connection.create_table :binary_testings do |t|
+      Person.lease_connection.create_table :binary_testings do |t|
         t.column "data", :binary, null: false
       end
     }
 
-    columns = Person.connection.columns(:binary_testings)
+    columns = Person.lease_connection.columns(:binary_testings)
     data_column = columns.detect { |c| c.name == "data" }
 
     assert_nil data_column.default
   ensure
-    Person.connection.drop_table :binary_testings, if_exists: true
+    Person.lease_connection.drop_table :binary_testings, if_exists: true
   end
 
   unless mysql_enforcing_gtid_consistency?
     def test_create_table_with_query
-      Person.connection.create_table :table_from_query_testings, as: "SELECT id FROM people WHERE id = 1"
+      Person.lease_connection.create_table :table_from_query_testings, as: "SELECT id FROM people WHERE id = 1"
 
-      columns = Person.connection.columns(:table_from_query_testings)
-      assert_equal [1], Person.connection.select_values("SELECT * FROM table_from_query_testings")
+      columns = Person.lease_connection.columns(:table_from_query_testings)
+      assert_equal [1], Person.lease_connection.select_values("SELECT * FROM table_from_query_testings")
       assert_equal 1, columns.length
       assert_equal "id", columns.first.name
     ensure
-      Person.connection.drop_table :table_from_query_testings rescue nil
+      Person.lease_connection.drop_table :table_from_query_testings rescue nil
     end
 
     def test_create_table_with_query_from_relation
-      Person.connection.create_table :table_from_query_testings, as: Person.select(:id).where(id: 1)
+      Person.lease_connection.create_table :table_from_query_testings, as: Person.select(:id).where(id: 1)
 
-      columns = Person.connection.columns(:table_from_query_testings)
-      assert_equal [1], Person.connection.select_values("SELECT * FROM table_from_query_testings")
+      columns = Person.lease_connection.columns(:table_from_query_testings)
+      assert_equal [1], Person.lease_connection.select_values("SELECT * FROM table_from_query_testings")
       assert_equal 1, columns.length
       assert_equal "id", columns.first.name
     ensure
-      Person.connection.drop_table :table_from_query_testings rescue nil
+      Person.lease_connection.drop_table :table_from_query_testings rescue nil
     end
   end
 
   if current_adapter?(:SQLite3Adapter)
     def test_allows_sqlite3_rollback_on_invalid_column_type
-      Person.connection.create_table :something, force: true do |t|
+      Person.lease_connection.create_table :something, force: true do |t|
         t.column :number, :integer
         t.column :name, :string
         t.column :foo, :bar
       end
-      assert Person.connection.column_exists?(:something, :foo)
-      assert_nothing_raised { Person.connection.remove_column :something, :foo, :bar }
-      assert_not Person.connection.column_exists?(:something, :foo)
-      assert Person.connection.column_exists?(:something, :name)
-      assert Person.connection.column_exists?(:something, :number)
+      assert Person.lease_connection.column_exists?(:something, :foo)
+      assert_nothing_raised { Person.lease_connection.remove_column :something, :foo, :bar }
+      assert_not Person.lease_connection.column_exists?(:something, :foo)
+      assert Person.lease_connection.column_exists?(:something, :name)
+      assert Person.lease_connection.column_exists?(:something, :number)
     ensure
-      Person.connection.drop_table :something, if_exists: true
+      Person.lease_connection.drop_table :something, if_exists: true
     end
   end
 
   def test_decimal_scale_without_precision_should_raise
     e = assert_raise(ArgumentError) do
-      Person.connection.create_table :test_decimal_scales, force: true do |t|
+      Person.lease_connection.create_table :test_decimal_scales, force: true do |t|
         t.decimal :scaleonly, scale: 10
       end
     end
 
     assert_equal "Error adding decimal column: precision cannot be empty if scale is specified", e.message
   ensure
-    Person.connection.drop_table :test_decimal_scales, if_exists: true
+    Person.lease_connection.drop_table :test_decimal_scales, if_exists: true
   end
 
   if current_adapter?(:Mysql2Adapter, :TrilogyAdapter, :PostgreSQLAdapter)
     def test_out_of_range_integer_limit_should_raise
       e = assert_raise(ArgumentError) do
-        Person.connection.create_table :test_integer_limits, force: true do |t|
+        Person.lease_connection.create_table :test_integer_limits, force: true do |t|
           t.column :bigone, :integer, limit: 10
         end
       end
 
       assert_includes e.message, "No integer type has byte size 10"
     ensure
-      Person.connection.drop_table :test_integer_limits, if_exists: true
+      Person.lease_connection.drop_table :test_integer_limits, if_exists: true
     end
 
     def test_out_of_range_text_limit_should_raise
       e = assert_raise(ArgumentError) do
-        Person.connection.create_table :test_text_limits, force: true do |t|
+        Person.lease_connection.create_table :test_text_limits, force: true do |t|
           t.text :bigtext, limit: 0xfffffffff
         end
       end
 
       assert_includes e.message, "No text type has byte size #{0xfffffffff}"
     ensure
-      Person.connection.drop_table :test_text_limits, if_exists: true
+      Person.lease_connection.drop_table :test_text_limits, if_exists: true
     end
 
     def test_out_of_range_binary_limit_should_raise
       e = assert_raise(ArgumentError) do
-        Person.connection.create_table :test_binary_limits, force: true do |t|
+        Person.lease_connection.create_table :test_binary_limits, force: true do |t|
           t.binary :bigbinary, limit: 0xfffffffff
         end
       end
 
       assert_includes e.message, "No binary type has byte size #{0xfffffffff}"
     ensure
-      Person.connection.drop_table :test_binary_limits, if_exists: true
+      Person.lease_connection.drop_table :test_binary_limits, if_exists: true
     end
   end
 
   if current_adapter?(:Mysql2Adapter, :TrilogyAdapter)
     def test_invalid_text_size_should_raise
       e = assert_raise(ArgumentError) do
-        Person.connection.create_table :test_text_sizes, force: true do |t|
+        Person.lease_connection.create_table :test_text_sizes, force: true do |t|
           t.text :bigtext, size: 0xfffffffff
         end
       end
 
       assert_equal "#{0xfffffffff} is invalid :size value. Only :tiny, :medium, and :long are allowed.", e.message
     ensure
-      Person.connection.drop_table :test_text_sizes, if_exists: true
+      Person.lease_connection.drop_table :test_text_sizes, if_exists: true
     end
   end
 
-  if ActiveRecord::Base.connection.supports_advisory_locks?
+  if ActiveRecord::Base.lease_connection.supports_advisory_locks?
     def test_migrator_generates_valid_lock_id
       migration = Class.new(ActiveRecord::Migration::Current).new
       migrator = ActiveRecord::Migrator.new(:up, [migration], @schema_migration, @internal_metadata, 100)
 
       lock_id = migrator.send(:generate_migrator_advisory_lock_id)
 
-      assert ActiveRecord::Base.connection.get_advisory_lock(lock_id),
+      assert ActiveRecord::Base.lease_connection.get_advisory_lock(lock_id),
         "the Migrator should have generated a valid lock id, but it didn't"
-      assert ActiveRecord::Base.connection.release_advisory_lock(lock_id),
+      assert ActiveRecord::Base.lease_connection.release_advisory_lock(lock_id),
         "the Migrator should have generated a valid lock id, but it didn't"
     end
 
@@ -1019,7 +1019,7 @@ class MigrationTest < ActiveRecord::TestCase
 
       lock_id = migrator.send(:generate_migrator_advisory_lock_id)
 
-      current_database = ActiveRecord::Base.connection.current_database
+      current_database = ActiveRecord::Base.lease_connection.current_database
       salt = ActiveRecord::Migrator::MIGRATOR_SALT
       expected_id = Zlib.crc32(current_database) * salt
 
@@ -1088,7 +1088,7 @@ class MigrationTest < ActiveRecord::TestCase
         AND query LIKE '%#{lock_id}%'
         SQL
 
-        assert_no_changes -> { ActiveRecord::Base.connection.exec_query(query).rows.flatten } do
+        assert_no_changes -> { ActiveRecord::Base.lease_connection.exec_query(query).rows.flatten } do
           migrator.migrate
         end
       end
@@ -1102,7 +1102,7 @@ class MigrationTest < ActiveRecord::TestCase
       e = assert_raises(ActiveRecord::ConcurrentMigrationError) do
         silence_stream($stderr) do
           migrator.send(:with_advisory_lock) do
-            ActiveRecord::Base.connection.release_advisory_lock(lock_id)
+            ActiveRecord::Base.lease_connection.release_advisory_lock(lock_id)
           end
         end
       end
@@ -1153,7 +1153,7 @@ end
 
 class ReservedWordsMigrationTest < ActiveRecord::TestCase
   def test_drop_index_from_table_named_values
-    connection = Person.connection
+    connection = Person.lease_connection
     connection.create_table :values, force: true do |t|
       t.integer :value
     end
@@ -1169,7 +1169,7 @@ end
 
 class ExplicitlyNamedIndexMigrationTest < ActiveRecord::TestCase
   def test_drop_index_by_name
-    connection = Person.connection
+    connection = Person.lease_connection
     connection.create_table :values, force: true do |t|
       t.integer :value
     end
@@ -1186,7 +1186,7 @@ end
 class IndexForTableWithSchemaMigrationTest < ActiveRecord::TestCase
   if current_adapter?(:PostgreSQLAdapter)
     def test_add_and_remove_index
-      connection = Person.connection
+      connection = Person.lease_connection
       connection.create_schema("my_schema")
       connection.create_table("my_schema.values", force: true) do |t|
         t.integer :value
@@ -1203,21 +1203,21 @@ class IndexForTableWithSchemaMigrationTest < ActiveRecord::TestCase
   end
 end
 
-if ActiveRecord::Base.connection.supports_bulk_alter?
+if ActiveRecord::Base.lease_connection.supports_bulk_alter?
   class BulkAlterTableMigrationsTest < ActiveRecord::TestCase
     def setup
-      @connection = Person.connection
+      @connection = Person.lease_connection
       @connection.create_table(:delete_me, force: true) { |t| }
       Person.reset_column_information
       Person.reset_sequence_name
     end
 
     teardown do
-      Person.connection.drop_table(:delete_me) rescue nil
+      Person.lease_connection.drop_table(:delete_me) rescue nil
     end
 
     def test_adding_multiple_columns
-      classname = ActiveRecord::Base.connection.class.name[/[^:]*$/]
+      classname = ActiveRecord::Base.lease_connection.class.name[/[^:]*$/]
       expected_query_count = {
         "Mysql2Adapter"     => 1,
         "TrilogyAdapter"    => 1,
@@ -1320,7 +1320,7 @@ if ActiveRecord::Base.connection.supports_bulk_alter?
         t.integer :age
       end
 
-      classname = ActiveRecord::Base.connection.class.name[/[^:]*$/]
+      classname = ActiveRecord::Base.lease_connection.class.name[/[^:]*$/]
       expected_query_count = {
         "Mysql2Adapter"     => 1, # mysql2 supports creating two indexes using one statement
         "TrilogyAdapter"    => 1, # trilogy supports creating two indexes using one statement
@@ -1354,7 +1354,7 @@ if ActiveRecord::Base.connection.supports_bulk_alter?
 
       assert index(:index_delete_me_on_name)
 
-      classname = ActiveRecord::Base.connection.class.name[/[^:]*$/]
+      classname = ActiveRecord::Base.lease_connection.class.name[/[^:]*$/]
       expected_query_count = {
         "Mysql2Adapter"     => 1, # mysql2 supports dropping and creating two indexes using one statement
         "TrilogyAdapter"    => 1, # trilogy supports dropping and creating two indexes using one statement
@@ -1385,7 +1385,7 @@ if ActiveRecord::Base.connection.supports_bulk_alter?
       assert_not column(:name).default
       assert_equal :date, column(:birthdate).type
 
-      classname = ActiveRecord::Base.connection.class.name[/[^:]*$/]
+      classname = ActiveRecord::Base.lease_connection.class.name[/[^:]*$/]
       expected_query_count = {
         "Mysql2Adapter"     => 3, # one query for columns, one query for primary key, one query to do the bulk change
         "TrilogyAdapter"    => 3, # one query for columns, one query for primary key, one query to do the bulk change
@@ -1416,7 +1416,7 @@ if ActiveRecord::Base.connection.supports_bulk_alter?
       assert_not column(:name).default
       assert_equal :date, column(:birthdate).type
 
-      classname = ActiveRecord::Base.connection.class.name[/[^:]*$/]
+      classname = ActiveRecord::Base.lease_connection.class.name[/[^:]*$/]
       expected_query_count = {
         "Mysql2Adapter"     => 7, # four queries to retrieve schema info, one for bulk change, one for UPDATE, one for NOT NULL
         "TrilogyAdapter"    => 7, # four queries to retrieve schema info, one for bulk change, one for UPDATE, one for NOT NULL
@@ -1452,13 +1452,13 @@ if ActiveRecord::Base.connection.supports_bulk_alter?
 
         if current_adapter?(:PostgreSQLAdapter)
           assert_equal "gen_random_uuid()", column(:name).default_function
-          Person.connection.execute("INSERT INTO delete_me DEFAULT VALUES")
+          Person.lease_connection.execute("INSERT INTO delete_me DEFAULT VALUES")
         else
           assert_equal "uuid()", column(:name).default_function
-          Person.connection.execute("INSERT INTO delete_me () VALUES ()")
+          Person.lease_connection.execute("INSERT INTO delete_me () VALUES ()")
         end
 
-        person_data = Person.connection.select_one("SELECT * FROM delete_me ORDER BY id DESC")
+        person_data = Person.lease_connection.select_one("SELECT * FROM delete_me ORDER BY id DESC")
         assert_match(/\A(.+)-(.+)-(.+)-(.+)\Z/, person_data.fetch("name"))
       end
     end
@@ -1487,7 +1487,7 @@ if ActiveRecord::Base.connection.supports_bulk_alter?
       assert index(:username_index)
       assert_not index(:username_index).unique
 
-      classname = ActiveRecord::Base.connection.class.name[/[^:]*$/]
+      classname = ActiveRecord::Base.lease_connection.class.name[/[^:]*$/]
       expected_query_count = {
         "Mysql2Adapter"     => 1, # mysql2 supports dropping and creating two indexes using one statement
         "TrilogyAdapter"    => 1, # trilogy supports dropping and creating two indexes using one statement
@@ -1512,7 +1512,7 @@ if ActiveRecord::Base.connection.supports_bulk_alter?
         # Reset columns/indexes cache as we're changing the table
         @columns = @indexes = nil
 
-        Person.connection.change_table(:delete_me, bulk: true, &block)
+        Person.lease_connection.change_table(:delete_me, bulk: true, &block)
       end
 
       def column(name)
@@ -1520,7 +1520,7 @@ if ActiveRecord::Base.connection.supports_bulk_alter?
       end
 
       def columns
-        @columns ||= Person.connection.columns("delete_me")
+        @columns ||= Person.lease_connection.columns("delete_me")
       end
 
       def index(name)
@@ -1528,7 +1528,7 @@ if ActiveRecord::Base.connection.supports_bulk_alter?
       end
 
       def indexes
-        @indexes ||= Person.connection.indexes("delete_me")
+        @indexes ||= Person.lease_connection.indexes("delete_me")
       end
   end # AlterTableMigrationsTest
 
@@ -1536,7 +1536,7 @@ if ActiveRecord::Base.connection.supports_bulk_alter?
     self.use_transactional_tests = false
 
     def setup
-      @connection = Person.connection
+      @connection = Person.lease_connection
       Person.reset_column_information
       Person.reset_sequence_name
     end

--- a/activerecord/test/cases/multi_db_migrator_test.rb
+++ b/activerecord/test/cases/multi_db_migrator_test.rb
@@ -157,18 +157,18 @@ class MultiDbMigratorTest < ActiveRecord::TestCase
     migrator = migrator.new(@path_a, @schema_migration_a, @internal_metadata_a)
 
     @schema_migration_a.drop_table
-    assert_not @pool_a.connection.table_exists?("schema_migrations")
+    assert_not @pool_a.lease_connection.table_exists?("schema_migrations")
     migrator.migrate(1)
-    assert @pool_a.connection.table_exists?("schema_migrations")
+    assert @pool_a.lease_connection.table_exists?("schema_migrations")
     migrator.rollback
 
     _, migrator = migrator_class(3)
     migrator = migrator.new(@path_b, @schema_migration_b, @internal_metadata_b)
 
     @schema_migration_b.drop_table
-    assert_not @pool_b.connection.table_exists?("schema_migrations")
+    assert_not @pool_b.lease_connection.table_exists?("schema_migrations")
     migrator.migrate(1)
-    assert @pool_b.connection.table_exists?("schema_migrations")
+    assert @pool_b.lease_connection.table_exists?("schema_migrations")
     migrator.rollback
   end
 
@@ -197,7 +197,7 @@ class MultiDbMigratorTest < ActiveRecord::TestCase
   end
 
   def test_internal_metadata_stores_environment
-    current_env     = ActiveRecord::Base.connection.pool.db_config.env_name
+    current_env     = ActiveRecord::Base.lease_connection.pool.db_config.env_name
     migrations_path = MIGRATIONS_ROOT + "/valid"
     migrator = ActiveRecord::MigrationContext.new(migrations_path, @schema_migration_b, @internal_metadata_b)
 

--- a/activerecord/test/cases/persistence_test.rb
+++ b/activerecord/test/cases/persistence_test.rb
@@ -744,7 +744,7 @@ class PersistenceTest < ActiveRecord::TestCase
 
   def test_becomes_default_sti_subclass
     original_type = Topic.columns_hash["type"].default
-    ActiveRecord::Base.connection.change_column_default :topics, :type, "Reply"
+    ActiveRecord::Base.lease_connection.change_column_default :topics, :type, "Reply"
     Topic.reset_column_information
 
     reply = topics(:second)
@@ -754,7 +754,7 @@ class PersistenceTest < ActiveRecord::TestCase
     assert_instance_of Topic, topic
 
   ensure
-    ActiveRecord::Base.connection.change_column_default :topics, :type, original_type
+    ActiveRecord::Base.lease_connection.change_column_default :topics, :type, original_type
     Topic.reset_column_information
   end
 
@@ -1463,9 +1463,9 @@ class PersistenceTest < ActiveRecord::TestCase
   end
 
   def test_reload_via_querycache
-    ActiveRecord::Base.connection.enable_query_cache!
-    ActiveRecord::Base.connection.clear_query_cache
-    assert ActiveRecord::Base.connection.query_cache_enabled, "cache should be on"
+    ActiveRecord::Base.lease_connection.enable_query_cache!
+    ActiveRecord::Base.lease_connection.clear_query_cache
+    assert ActiveRecord::Base.lease_connection.query_cache_enabled, "cache should be on"
     parrot = Parrot.create(name: "Shane")
 
     # populate the cache with the SELECT result
@@ -1473,7 +1473,7 @@ class PersistenceTest < ActiveRecord::TestCase
     assert_equal parrot.id, found_parrot.id
 
     # Manually update the 'name' attribute in the DB directly
-    assert_equal 1, ActiveRecord::Base.connection.query_cache.size
+    assert_equal 1, ActiveRecord::Base.lease_connection.query_cache.size
     ActiveRecord::Base.uncached do
       found_parrot.name = "Mary"
       found_parrot.save
@@ -1486,7 +1486,7 @@ class PersistenceTest < ActiveRecord::TestCase
     found_parrot = Parrot.find(parrot.id)
     assert_equal "Mary", found_parrot.name
   ensure
-    ActiveRecord::Base.connection.disable_query_cache!
+    ActiveRecord::Base.lease_connection.disable_query_cache!
   end
 
   def test_save_touch_false
@@ -1508,7 +1508,7 @@ class PersistenceTest < ActiveRecord::TestCase
     child_class = Class.new(Topic)
     child_class.new # force schema to load
 
-    ActiveRecord::Base.connection.add_column(:topics, :foo, :string)
+    ActiveRecord::Base.lease_connection.add_column(:topics, :foo, :string)
     Topic.reset_column_information
 
     # this should redefine attribute methods
@@ -1518,7 +1518,7 @@ class PersistenceTest < ActiveRecord::TestCase
     assert child_class.instance_methods.include?(:foo_changed?)
     assert_equal "bar", child_class.new(foo: :bar).foo
   ensure
-    ActiveRecord::Base.connection.remove_column(:topics, :foo)
+    ActiveRecord::Base.lease_connection.remove_column(:topics, :foo)
     Topic.reset_column_information
   end
 

--- a/activerecord/test/cases/pooled_connections_test.rb
+++ b/activerecord/test/cases/pooled_connections_test.rb
@@ -33,10 +33,10 @@ class PooledConnectionsTest < ActiveRecord::TestCase
 
     def test_pooled_connection_remove
       ActiveRecord::Base.establish_connection(@connection.merge(pool: 2, checkout_timeout: 0.5))
-      old_connection = ActiveRecord::Base.connection
+      old_connection = ActiveRecord::Base.lease_connection
       extra_connection = ActiveRecord::Base.connection_pool.checkout
       ActiveRecord::Base.connection_pool.remove(extra_connection)
-      assert_equal ActiveRecord::Base.connection.object_id, old_connection.object_id
+      assert_equal ActiveRecord::Base.lease_connection.object_id, old_connection.object_id
     end
 
     private
@@ -65,7 +65,7 @@ class PooledConnectionsTest < ActiveRecord::TestCase
           conn = ActiveRecord::Base.connection_pool.checkout
           ActiveRecord::Base.connection_pool.checkin conn
           @connection_count += 1
-          ActiveRecord::Base.connection.data_sources
+          ActiveRecord::Base.lease_connection.data_sources
         rescue ActiveRecord::ConnectionTimeoutError
           @timed_out += 1
         end

--- a/activerecord/test/cases/prepared_statement_status_test.rb
+++ b/activerecord/test/cases/prepared_statement_status_test.rb
@@ -7,8 +7,8 @@ require "models/entrant"
 module ActiveRecord
   class PreparedStatementStatusTest < ActiveRecord::TestCase
     def test_prepared_statement_status_is_thread_and_instance_specific
-      course_conn = Course.connection
-      entrant_conn = Entrant.connection
+      course_conn = Course.lease_connection
+      entrant_conn = Entrant.lease_connection
 
       inside = Concurrent::Event.new
       preventing = Concurrent::Event.new
@@ -16,7 +16,7 @@ module ActiveRecord
 
       assert_not_same course_conn, entrant_conn
 
-      if ActiveRecord::Base.connection.prepared_statements
+      if ActiveRecord::Base.lease_connection.prepared_statements
         t1 = Thread.new do
           course_conn.unprepared_statement do
             inside.set

--- a/activerecord/test/cases/primary_class_test.rb
+++ b/activerecord/test/cases/primary_class_test.rb
@@ -108,7 +108,7 @@ class PrimaryClassTest < ActiveRecord::TestCase
 
       assert_predicate ApplicationRecord, :primary_class?
       assert_predicate ApplicationRecord, :application_record_class?
-      assert_equal ActiveRecord::Base.connection, ApplicationRecord.connection
+      assert_equal ActiveRecord::Base.lease_connection, ApplicationRecord.lease_connection
     ensure
       ApplicationRecord.remove_connection
       ActiveRecord.application_record_class = nil
@@ -124,7 +124,7 @@ class PrimaryClassTest < ActiveRecord::TestCase
       assert_predicate PrimaryClassTest::PrimaryAppRecord, :primary_class?
       assert_predicate PrimaryClassTest::PrimaryAppRecord, :application_record_class?
       assert_predicate PrimaryClassTest::PrimaryAppRecord, :abstract_class?
-      assert_equal ActiveRecord::Base.connection, PrimaryClassTest::PrimaryAppRecord.connection
+      assert_equal ActiveRecord::Base.lease_connection, PrimaryClassTest::PrimaryAppRecord.lease_connection
     ensure
       PrimaryClassTest::PrimaryAppRecord.remove_connection
       ActiveRecord.application_record_class = nil

--- a/activerecord/test/cases/primary_keys_test.rb
+++ b/activerecord/test/cases/primary_keys_test.rb
@@ -221,9 +221,9 @@ class PrimaryKeysTest < ActiveRecord::TestCase
   def test_quoted_primary_key_after_set_primary_key
     k = Class.new(ActiveRecord::Base)
     k.table_name = "bar"
-    assert_equal k.connection.quote_column_name("id"), k.quoted_primary_key
+    assert_equal k.lease_connection.quote_column_name("id"), k.quoted_primary_key
     k.primary_key = "foo"
-    assert_equal k.connection.quote_column_name("foo"), k.quoted_primary_key
+    assert_equal k.lease_connection.quote_column_name("foo"), k.quoted_primary_key
   end
 
   def test_auto_detect_primary_key_from_schema
@@ -291,7 +291,7 @@ class PrimaryKeyWithAutoIncrementTest < ActiveRecord::TestCase
   end
 
   def setup
-    @connection = ActiveRecord::Base.connection
+    @connection = ActiveRecord::Base.lease_connection
   end
 
   def teardown
@@ -328,7 +328,7 @@ class PrimaryKeyAnyTypeTest < ActiveRecord::TestCase
   end
 
   setup do
-    @connection = ActiveRecord::Base.connection
+    @connection = ActiveRecord::Base.lease_connection
     @connection.create_table(:barcodes, primary_key: "code", id: :string, limit: 42, force: true)
   end
 
@@ -371,7 +371,7 @@ class CompositePrimaryKeyTest < ActiveRecord::TestCase
 
   def setup
     ActiveRecord::Base.schema_cache.clear!
-    @connection = ActiveRecord::Base.connection
+    @connection = ActiveRecord::Base.lease_connection
     @connection.create_table(:uber_barcodes, primary_key: ["region", "code"], force: true) do |t|
       t.string :region
       t.integer :code
@@ -502,7 +502,7 @@ class PrimaryKeyIntegerNilDefaultTest < ActiveRecord::TestCase
   include SchemaDumpingHelper
 
   def setup
-    @connection = ActiveRecord::Base.connection
+    @connection = ActiveRecord::Base.lease_connection
   end
 
   def teardown
@@ -533,7 +533,7 @@ class PrimaryKeyIntegerTest < ActiveRecord::TestCase
     end
 
     setup do
-      @connection = ActiveRecord::Base.connection
+      @connection = ActiveRecord::Base.lease_connection
       @pk_type = current_adapter?(:PostgreSQLAdapter) ? :serial : :integer
     end
 

--- a/activerecord/test/cases/quoting_test.rb
+++ b/activerecord/test/cases/quoting_test.rb
@@ -202,7 +202,7 @@ module ActiveRecord
 
     class TypeCastingTest < ActiveRecord::TestCase
       def setup
-        @conn = ActiveRecord::Base.connection
+        @conn = ActiveRecord::Base.lease_connection
       end
 
       def test_type_cast_symbol
@@ -250,7 +250,7 @@ module ActiveRecord
 
     class QuoteBooleanTest < ActiveRecord::TestCase
       def setup
-        @connection = ActiveRecord::Base.connection
+        @connection = ActiveRecord::Base.lease_connection
       end
 
       def test_quote_returns_frozen_string

--- a/activerecord/test/cases/relation/delete_all_test.rb
+++ b/activerecord/test/cases/relation/delete_all_test.rb
@@ -83,9 +83,9 @@ class DeleteAllTest < ActiveRecord::TestCase
     end
 
     if current_adapter?(:Mysql2Adapter, :TrilogyAdapter)
-      assert_no_match %r/SELECT DISTINCT #{Regexp.escape(Pet.connection.quote_table_name("pets.pet_id"))}/, sqls.last
+      assert_no_match %r/SELECT DISTINCT #{Regexp.escape(Pet.lease_connection.quote_table_name("pets.pet_id"))}/, sqls.last
     else
-      assert_match %r/SELECT #{Regexp.escape(Pet.connection.quote_table_name("pets.pet_id"))}/, sqls.last
+      assert_match %r/SELECT #{Regexp.escape(Pet.lease_connection.quote_table_name("pets.pet_id"))}/, sqls.last
     end
   end
 

--- a/activerecord/test/cases/relation/load_async_test.rb
+++ b/activerecord/test/cases/relation/load_async_test.rb
@@ -9,7 +9,7 @@ require "models/other_dog"
 module ActiveRecord
   module WaitForAsyncTestHelper
     private
-      def wait_for_async_query(connection = ActiveRecord::Base.connection, timeout: 5)
+      def wait_for_async_query(connection = ActiveRecord::Base.lease_connection, timeout: 5)
         return unless connection.async_enabled?
 
         executor = connection.pool.async_executor
@@ -124,9 +124,9 @@ module ActiveRecord
       wait_for_async_query
 
       assert_equal expected_records, deferred_posts.to_a
-      assert_equal Post.connection.supports_concurrent_connections?, status[:async]
+      assert_equal Post.lease_connection.supports_concurrent_connections?, status[:async]
       assert_equal Thread.current.object_id, status[:thread_id]
-      if Post.connection.supports_concurrent_connections?
+      if Post.lease_connection.supports_concurrent_connections?
         assert_instance_of Float, status[:lock_wait]
       else
         assert_nil status[:lock_wait]
@@ -151,7 +151,7 @@ module ActiveRecord
       wait_for_async_query
 
       assert_equal expected_records, deferred_posts.to_a
-      assert_equal Post.connection.supports_concurrent_connections?, status[:async]
+      assert_equal Post.lease_connection.supports_concurrent_connections?, status[:async]
     ensure
       ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
     end
@@ -199,7 +199,7 @@ module ActiveRecord
       assert_queries_count(0) do
         deferred_posts.each(&:comments)
       end
-      assert_equal Post.connection.supports_concurrent_connections?, status[:async]
+      assert_equal Post.lease_connection.supports_concurrent_connections?, status[:async]
     ensure
       ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
     end
@@ -286,7 +286,7 @@ module ActiveRecord
         deferred_posts = Post.where(author_id: 1).load_async
 
         assert_equal expected_records, deferred_posts.to_a
-        assert_not_equal Post.connection.supports_concurrent_connections?, status[:async]
+        assert_not_equal Post.lease_connection.supports_concurrent_connections?, status[:async]
       ensure
         ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
       end
@@ -326,7 +326,7 @@ module ActiveRecord
           deferred_posts.each(&:comments)
         end
 
-        assert_predicate Post.connection, :supports_concurrent_connections?
+        assert_predicate Post.lease_connection, :supports_concurrent_connections?
         assert_not status[:async], "Expected status[:async] to be false with NullExecutor"
       ensure
         ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
@@ -429,7 +429,7 @@ module ActiveRecord
         wait_for_async_query
 
         assert_equal expected_records, deferred_posts.to_a
-        assert_equal Post.connection.supports_concurrent_connections?, status[:async]
+        assert_equal Post.lease_connection.supports_concurrent_connections?, status[:async]
       ensure
         ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
       end
@@ -468,7 +468,7 @@ module ActiveRecord
         assert_queries_count(0) do
           deferred_posts.each(&:comments)
         end
-        assert_equal Post.connection.supports_concurrent_connections?, status[:async]
+        assert_equal Post.lease_connection.supports_concurrent_connections?, status[:async]
       ensure
         ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
       end
@@ -577,8 +577,8 @@ module ActiveRecord
         assert_equal expected_records, deferred_posts.to_a
         assert_equal expected_dogs, deferred_dogs.to_a
 
-        assert_equal Post.connection.async_enabled?, status[:async]
-        assert_equal OtherDog.connection.async_enabled?, dog_status[:async]
+        assert_equal Post.lease_connection.async_enabled?, status[:async]
+        assert_equal OtherDog.lease_connection.async_enabled?, dog_status[:async]
       ensure
         ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
       end

--- a/activerecord/test/cases/relation/predicate_builder_test.rb
+++ b/activerecord/test/cases/relation/predicate_builder_test.rb
@@ -39,7 +39,7 @@ module ActiveRecord
 
     private
       def topic_title
-        Topic.connection.quote_table_name("topics.title")
+        Topic.lease_connection.quote_table_name("topics.title")
       end
   end
 end

--- a/activerecord/test/cases/relation/update_all_test.rb
+++ b/activerecord/test/cases/relation/update_all_test.rb
@@ -69,9 +69,9 @@ class UpdateAllTest < ActiveRecord::TestCase
     end
 
     if current_adapter?(:Mysql2Adapter, :TrilogyAdapter)
-      assert_no_match %r/SELECT DISTINCT #{Regexp.escape(Pet.connection.quote_table_name("pets.pet_id"))}/, sqls.last
+      assert_no_match %r/SELECT DISTINCT #{Regexp.escape(Pet.lease_connection.quote_table_name("pets.pet_id"))}/, sqls.last
     else
-      assert_match %r/SELECT #{Regexp.escape(Pet.connection.quote_table_name("pets.pet_id"))}/, sqls.last
+      assert_match %r/SELECT #{Regexp.escape(Pet.lease_connection.quote_table_name("pets.pet_id"))}/, sqls.last
     end
   end
 

--- a/activerecord/test/cases/relation/with_test.rb
+++ b/activerecord/test/cases/relation/with_test.rb
@@ -15,7 +15,7 @@ module ActiveRecord
     POSTS_WITH_TAGS_AND_COMMENTS = (POSTS_WITH_COMMENTS & POSTS_WITH_TAGS).sort.freeze
     POSTS_WITH_TAGS_AND_MULTIPLE_COMMENTS = (POSTS_WITH_MULTIPLE_COMMENTS & POSTS_WITH_TAGS).sort.freeze
 
-    if ActiveRecord::Base.connection.supports_common_table_expressions?
+    if ActiveRecord::Base.lease_connection.supports_common_table_expressions?
       def test_with_when_hash_is_passed_as_an_argument
         relation = Post
           .with(posts_with_comments: Post.where("legacy_comments_count > 0"))

--- a/activerecord/test/cases/reserved_word_test.rb
+++ b/activerecord/test/cases/reserved_word_test.rb
@@ -28,7 +28,7 @@ class ReservedWordTest < ActiveRecord::TestCase
   end
 
   def setup
-    @connection = ActiveRecord::Base.connection
+    @connection = ActiveRecord::Base.lease_connection
     @connection.create_table :select, force: true
     @connection.create_table :distinct, force: true
     @connection.create_table :distinct_select, id: false, force: true do |t|

--- a/activerecord/test/cases/serialized_attribute_test.rb
+++ b/activerecord/test/cases/serialized_attribute_test.rb
@@ -133,7 +133,7 @@ class SerializedAttributeTest < ActiveRecord::TestCase
 
     # Force a row to have a JSON "null" instead of a database NULL (this is how
     # null values are saved on 4.1 and before)
-    id = Topic.connection.insert "INSERT INTO topics (content) VALUES('null')"
+    id = Topic.lease_connection.insert "INSERT INTO topics (content) VALUES('null')"
     t = Topic.find(id)
 
     assert_nil t.content
@@ -143,7 +143,7 @@ class SerializedAttributeTest < ActiveRecord::TestCase
     Topic.serialize :content, coder: JSON
 
     # Force a row to have a database NULL instead of a JSON "null"
-    id = Topic.connection.insert "INSERT INTO topics (content) VALUES(NULL)"
+    id = Topic.lease_connection.insert "INSERT INTO topics (content) VALUES(NULL)"
     t = Topic.find(id)
 
     assert_nil t.content

--- a/activerecord/test/cases/statement_cache_test.rb
+++ b/activerecord/test/cases/statement_cache_test.rb
@@ -6,24 +6,25 @@ require "models/liquid"
 require "models/molecule"
 require "models/numeric_data"
 require "models/electron"
+require "models/clothing_item"
 
 module ActiveRecord
   class StatementCacheTest < ActiveRecord::TestCase
     def setup
-      @connection = ActiveRecord::Base.connection
+      @connection = ActiveRecord::Base.lease_connection
     end
 
     def test_statement_cache
       Book.create(name: "my book")
       Book.create(name: "my other book")
 
-      cache = StatementCache.create(Book.connection) do |params|
+      cache = StatementCache.create(ClothingItem.lease_connection) do |params|
         Book.where(name: params.bind)
       end
 
-      b = cache.execute([ "my book" ], Book.connection)
+      b = cache.execute([ "my book" ], ClothingItem.lease_connection)
       assert_equal "my book", b[0].name
-      b = cache.execute([ "my other book" ], Book.connection)
+      b = cache.execute([ "my other book" ], ClothingItem.lease_connection)
       assert_equal "my other book", b[0].name
     end
 
@@ -31,13 +32,13 @@ module ActiveRecord
       b1 = Book.create(name: "my book")
       b2 = Book.create(name: "my other book")
 
-      cache = StatementCache.create(Book.connection) do |params|
+      cache = StatementCache.create(ClothingItem.lease_connection) do |params|
         Book.where(id: params.bind)
       end
 
-      b = cache.execute([ b1.id ], Book.connection)
+      b = cache.execute([ b1.id ], ClothingItem.lease_connection)
       assert_equal b1.name, b[0].name
-      b = cache.execute([ b2.id ], Book.connection)
+      b = cache.execute([ b2.id ], ClothingItem.lease_connection)
       assert_equal b2.name, b[0].name
     end
 
@@ -52,18 +53,18 @@ module ActiveRecord
     end
 
     def test_statement_cache_with_simple_statement
-      cache = ActiveRecord::StatementCache.create(Book.connection) do |params|
+      cache = ActiveRecord::StatementCache.create(ClothingItem.lease_connection) do |params|
         Book.where(name: "my book").where("author_id > 3")
       end
 
       Book.create(name: "my book", author_id: 4)
 
-      books = cache.execute([], Book.connection)
+      books = cache.execute([], ClothingItem.lease_connection)
       assert_equal "my book", books[0].name
     end
 
     def test_statement_cache_with_complex_statement
-      cache = ActiveRecord::StatementCache.create(Book.connection) do |params|
+      cache = ActiveRecord::StatementCache.create(ClothingItem.lease_connection) do |params|
         Liquid.joins(molecules: :electrons).where("molecules.name" => "dioxane", "electrons.name" => "lepton")
       end
 
@@ -71,7 +72,7 @@ module ActiveRecord
       molecule = salty.molecules.create(name: "dioxane")
       molecule.electrons.create(name: "lepton")
 
-      liquids = cache.execute([], Book.connection)
+      liquids = cache.execute([], ClothingItem.lease_connection)
       assert_equal "salty", liquids[0].name
     end
 
@@ -81,7 +82,7 @@ module ActiveRecord
     end
 
     def test_statement_cache_values_differ
-      cache = ActiveRecord::StatementCache.create(Book.connection) do |params|
+      cache = ActiveRecord::StatementCache.create(ClothingItem.lease_connection) do |params|
         Book.where(name: "my book")
       end
 
@@ -89,13 +90,13 @@ module ActiveRecord
         Book.create(name: "my book")
       end
 
-      first_books = cache.execute([], Book.connection)
+      first_books = cache.execute([], ClothingItem.lease_connection)
 
       3.times do
         Book.create(name: "my book")
       end
 
-      additional_books = cache.execute([], Book.connection)
+      additional_books = cache.execute([], ClothingItem.lease_connection)
       assert_not_equal first_books, additional_books
     end
 
@@ -104,7 +105,7 @@ module ActiveRecord
       Book.create(name: "my other book")
 
       book = Book.find_by(name: "my book")
-      other_book = Book.connection.unprepared_statement do
+      other_book = Book.lease_connection.unprepared_statement do
         Book.find_by(name: "my other book")
       end
 

--- a/activerecord/test/cases/statement_invalid_test.rb
+++ b/activerecord/test/cases/statement_invalid_test.rb
@@ -20,8 +20,8 @@ module ActiveRecord
     test "message contains no sql" do
       sql = Book.where(author_id: 96, cover: "hard").to_sql
       error = assert_raises(ActiveRecord::StatementInvalid) do
-        Book.connection.send(:log, sql, Book.name) do
-          Book.connection.send(:with_raw_connection) do
+        Book.lease_connection.send(:log, sql, Book.name) do
+          Book.lease_connection.send(:with_raw_connection) do
             raise MockDatabaseError
           end
         end
@@ -33,8 +33,8 @@ module ActiveRecord
       sql = Book.where(author_id: 96, cover: "hard").to_sql
       binds = [Minitest::Mock.new, Minitest::Mock.new]
       error = assert_raises(ActiveRecord::StatementInvalid) do
-        Book.connection.send(:log, sql, Book.name, binds) do
-          Book.connection.send(:with_raw_connection) do
+        Book.lease_connection.send(:log, sql, Book.name, binds) do
+          Book.lease_connection.send(:with_raw_connection) do
             raise MockDatabaseError
           end
         end

--- a/activerecord/test/cases/store_test.rb
+++ b/activerecord/test/cases/store_test.rb
@@ -164,7 +164,7 @@ class StoreTest < ActiveRecord::TestCase
   end
 
   test "saved changes tracking for accessors with json column" do
-    if current_adapter?(:Mysql2Adapter, :TrilogyAdapter) && ActiveRecord::Base.connection.mariadb?
+    if current_adapter?(:Mysql2Adapter, :TrilogyAdapter) && ActiveRecord::Base.lease_connection.mariadb?
       skip "MariaDB doesn't support JSON store_accessor"
     end
     @john.enable_friend_requests = true

--- a/activerecord/test/cases/tasks/database_tasks_test.rb
+++ b/activerecord/test/cases/tasks/database_tasks_test.rb
@@ -290,7 +290,7 @@ module ActiveRecord
         ActiveRecord::Tasks::DatabaseTasks.stub(:db_dir, dir) do
           path = File.join(dir, "schema_cache.yml")
           assert_not File.file?(path)
-          ActiveRecord::Tasks::DatabaseTasks.dump_schema_cache(ActiveRecord::Base.connection, path)
+          ActiveRecord::Tasks::DatabaseTasks.dump_schema_cache(ActiveRecord::Base.lease_connection, path)
           assert File.file?(path)
         end
       end
@@ -1131,11 +1131,11 @@ module ActiveRecord
       # Use a memory db here to avoid having to rollback at the end
       setup do
         migrations_path = [MIGRATIONS_ROOT, folder_name].join("/")
-        file = ActiveRecord::Base.connection.raw_connection.filename
+        file = ActiveRecord::Base.lease_connection.raw_connection.filename
         @conn = ActiveRecord::Base.establish_connection adapter: "sqlite3",
           database: ":memory:", migrations_paths: migrations_path
         source_db = SQLite3::Database.new file
-        dest_db = ActiveRecord::Base.connection.raw_connection
+        dest_db = ActiveRecord::Base.lease_connection.raw_connection
         backup = SQLite3::Backup.new(dest_db, "main", source_db, "main")
         backup.step(-1)
         backup.finish

--- a/activerecord/test/cases/test_case.rb
+++ b/activerecord/test/cases/test_case.rb
@@ -170,13 +170,13 @@ module ActiveRecord
       ActiveRecord.db_warnings_action = action
       ActiveRecord.db_warnings_ignore = warnings_to_ignore
 
-      ActiveRecord::Base.connection.disconnect! # Disconnect from the db so that we reconfigure the connection
+      ActiveRecord::Base.lease_connection.disconnect! # Disconnect from the db so that we reconfigure the connection
 
       yield
     ensure
       ActiveRecord.db_warnings_action = @original_db_warnings_action
       ActiveRecord.db_warnings_ignore = original_db_warnings_ignore
-      ActiveRecord::Base.connection.disconnect!
+      ActiveRecord::Base.lease_connection.disconnect!
     end
 
     def reset_callbacks(klass, kind)

--- a/activerecord/test/cases/time_precision_test.rb
+++ b/activerecord/test/cases/time_precision_test.rb
@@ -11,7 +11,7 @@ class TimePrecisionTest < ActiveRecord::TestCase
     class Foo < ActiveRecord::Base; end
 
     setup do
-      @connection = ActiveRecord::Base.connection
+      @connection = ActiveRecord::Base.lease_connection
       Foo.reset_column_information
     end
 

--- a/activerecord/test/cases/timestamp_test.rb
+++ b/activerecord/test/cases/timestamp_test.rb
@@ -588,7 +588,7 @@ class TimestampsWithoutTransactionTest < ActiveRecord::TestCase
   end
 
   def test_do_not_write_timestamps_on_save_if_they_are_not_attributes
-    with_example_table ActiveRecord::Base.connection, "timestamp_attribute_posts", "id integer primary key" do
+    with_example_table ActiveRecord::Base.lease_connection, "timestamp_attribute_posts", "id integer primary key" do
       post = TimestampAttributePost.new(id: 1)
       post.save! # should not try to assign and persist created_at, updated_at
       assert_nil post.created_at
@@ -597,13 +597,13 @@ class TimestampsWithoutTransactionTest < ActiveRecord::TestCase
   end
 
   def test_index_is_created_for_both_timestamps
-    ActiveRecord::Base.connection.create_table(:foos, force: true) do |t|
+    ActiveRecord::Base.lease_connection.create_table(:foos, force: true) do |t|
       t.timestamps null: true, index: true
     end
 
-    indexes = ActiveRecord::Base.connection.indexes("foos")
+    indexes = ActiveRecord::Base.lease_connection.indexes("foos")
     assert_equal ["created_at", "updated_at"], indexes.flat_map(&:columns).sort
   ensure
-    ActiveRecord::Base.connection.drop_table(:foos)
+    ActiveRecord::Base.lease_connection.drop_table(:foos)
   end
 end

--- a/activerecord/test/cases/transaction_callbacks_test.rb
+++ b/activerecord/test/cases/transaction_callbacks_test.rb
@@ -100,13 +100,13 @@ class TransactionCallbacksTest < ActiveRecord::TestCase
   def test_before_commit_exception_should_pop_transaction_stack
     @first.before_commit_block { raise "better pop this txn from the stack!" }
 
-    original_txn = @first.class.connection.current_transaction
+    original_txn = @first.class.lease_connection.current_transaction
 
     begin
       @first.save!
       fail
     rescue
-      assert_equal original_txn, @first.class.connection.current_transaction
+      assert_equal original_txn, @first.class.lease_connection.current_transaction
     end
   end
 
@@ -314,7 +314,7 @@ class TransactionCallbacksTest < ActiveRecord::TestCase
 
     assert_raises RuntimeError do
       @first.transaction do
-        tx = @first.class.connection.transaction_manager.current_transaction
+        tx = @first.class.lease_connection.transaction_manager.current_transaction
         def tx.commit
           raise
         end

--- a/activerecord/test/cases/unconnected_test.rb
+++ b/activerecord/test/cases/unconnected_test.rb
@@ -9,7 +9,7 @@ class TestUnconnectedAdapter < ActiveRecord::TestCase
   self.use_transactional_tests = false
 
   def setup
-    @underlying = ActiveRecord::Base.connection
+    @underlying = ActiveRecord::Base.lease_connection
     @connection_name = ActiveRecord::Base.remove_connection
 
     # Clear out connection info from other pids (like a fork parent) too

--- a/activerecord/test/cases/unsafe_raw_sql_test.rb
+++ b/activerecord/test/cases/unsafe_raw_sql_test.rb
@@ -74,7 +74,7 @@ class UnsafeRawSqlTest < ActiveRecord::TestCase
   test "order: allows quoted table and column names" do
     ids_expected = Post.order(Arel.sql("title")).pluck(:id)
 
-    quoted_title = Post.connection.quote_table_name("posts.title")
+    quoted_title = Post.lease_connection.quote_table_name("posts.title")
     ids = Post.order(quoted_title).pluck(:id)
 
     assert_equal ids_expected, ids
@@ -172,7 +172,7 @@ class UnsafeRawSqlTest < ActiveRecord::TestCase
       "Mysql2" => "utf8mb4_bin",
       "Trilogy" => "utf8mb4_bin",
       "SQLite" => "binary"
-    }[ActiveRecord::Base.connection.adapter_name]
+    }[ActiveRecord::Base.lease_connection.adapter_name]
 
     ids_expected = Post.order(Arel.sql(%Q'author_id, title COLLATE "#{collation_name}" DESC')).pluck(:id)
 
@@ -256,7 +256,7 @@ class UnsafeRawSqlTest < ActiveRecord::TestCase
   test "pluck: allows quoted table and column names" do
     titles_expected = Post.pluck(Arel.sql("title"))
 
-    quoted_title = Post.connection.quote_table_name("posts.title")
+    quoted_title = Post.lease_connection.quote_table_name("posts.title")
     titles = Post.pluck(quoted_title)
 
     assert_equal titles_expected, titles

--- a/activerecord/test/cases/validations/uniqueness_validation_test.rb
+++ b/activerecord/test/cases/validations/uniqueness_validation_test.rb
@@ -638,7 +638,7 @@ class UniquenessValidationWithIndexTest < ActiveRecord::TestCase
   self.use_transactional_tests = false
 
   def setup
-    @connection = Topic.connection
+    @connection = Topic.lease_connection
     @connection.schema_cache.clear!
     Topic.delete_all
     Event.delete_all

--- a/activerecord/test/cases/view_test.rb
+++ b/activerecord/test/cases/view_test.rb
@@ -19,7 +19,7 @@ module ViewBehavior
 
   def setup
     super
-    @connection = ActiveRecord::Base.connection
+    @connection = ActiveRecord::Base.lease_connection
     create_view "ebooks'", <<~SQL
       SELECT id, name, cover, status FROM books WHERE format = 'ebook'
     SQL
@@ -85,7 +85,7 @@ module ViewBehavior
     end
 end
 
-if ActiveRecord::Base.connection.supports_views?
+if ActiveRecord::Base.lease_connection.supports_views?
   class ViewWithPrimaryKeyTest < ActiveRecord::TestCase
     include ViewBehavior
 
@@ -108,7 +108,7 @@ if ActiveRecord::Base.connection.supports_views?
     class Paperback < ActiveRecord::Base; end
 
     setup do
-      @connection = ActiveRecord::Base.connection
+      @connection = ActiveRecord::Base.lease_connection
       @connection.execute <<~SQL
         CREATE VIEW paperbacks
           AS SELECT name, status FROM books WHERE format = 'paperback'
@@ -169,7 +169,7 @@ if ActiveRecord::Base.connection.supports_views?
       end
 
       setup do
-        @connection = ActiveRecord::Base.connection
+        @connection = ActiveRecord::Base.lease_connection
         @connection.execute <<~SQL
           CREATE VIEW printed_books
             AS SELECT id, name, status, format FROM books WHERE format = 'paperback'
@@ -212,9 +212,9 @@ if ActiveRecord::Base.connection.supports_views?
       end
     end # end of `if current_adapter?(:Mysql2Adapter, :TrilogyAdapter, :PostgreSQLAdapter, :SQLServerAdapter)`
   end
-end # end of `if ActiveRecord::Base.connection.supports_views?`
+end # end of `if ActiveRecord::Base.lease_connection.supports_views?`
 
-if ActiveRecord::Base.connection.supports_materialized_views?
+if ActiveRecord::Base.lease_connection.supports_materialized_views?
   class MaterializedViewTest < ActiveRecord::PostgreSQLTestCase
     include ViewBehavior
 

--- a/activerecord/test/models/bird.rb
+++ b/activerecord/test/models/bird.rb
@@ -8,7 +8,7 @@ class Bird < ActiveRecord::Base
 
   before_save do
     # force materialize_transactions
-    self.class.connection.materialize_transactions
+    self.class.lease_connection.materialize_transactions
   end
 
   attr_accessor :cancel_save_from_callback

--- a/activerecord/test/models/contact.rb
+++ b/activerecord/test/models/contact.rb
@@ -5,8 +5,8 @@ module ContactFakeColumns
     base.class_eval do
       establish_connection(adapter: "fake")
 
-      connection.data_sources = [table_name]
-      connection.primary_keys = {
+      lease_connection.data_sources = [table_name]
+      lease_connection.primary_keys = {
         table_name => "id"
       }
 
@@ -27,7 +27,7 @@ module ContactFakeColumns
 
   # mock out self.columns so no pesky db is needed for these tests
   def column(name, sql_type = nil, options = {})
-    connection.merge_column(table_name, name, sql_type, options)
+    lease_connection.merge_column(table_name, name, sql_type, options)
   end
 end
 

--- a/activerecord/test/models/parrot.rb
+++ b/activerecord/test/models/parrot.rb
@@ -22,8 +22,10 @@ class Parrot < ActiveRecord::Base
   end
 
   def self.delete_all(*)
-    connection.delete("DELETE FROM parrots_pirates")
-    connection.delete("DELETE FROM parrots_treasures")
+    with_connection do |c|
+      c.delete("DELETE FROM parrots_pirates")
+      c.delete("DELETE FROM parrots_treasures")
+    end
     super
   end
 end

--- a/activerecord/test/models/post.rb
+++ b/activerecord/test/models/post.rb
@@ -341,8 +341,8 @@ class FakeKlass
       Post.adapter_class
     end
 
-    def connection
-      Post.connection
+    def lease_connection
+      Post.lease_connection
     end
 
     def table_name

--- a/activerecord/test/schema/postgresql_specific_schema.rb
+++ b/activerecord/test/schema/postgresql_specific_schema.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 ActiveRecord::Schema.define do
-  ActiveRecord::TestCase.enable_extension!("uuid-ossp", ActiveRecord::Base.connection)
-  ActiveRecord::TestCase.enable_extension!("pgcrypto",  ActiveRecord::Base.connection) if ActiveRecord::Base.connection.supports_pgcrypto_uuid?
+  ActiveRecord::TestCase.enable_extension!("uuid-ossp", ActiveRecord::Base.lease_connection)
+  ActiveRecord::TestCase.enable_extension!("pgcrypto",  ActiveRecord::Base.lease_connection) if ActiveRecord::Base.lease_connection.supports_pgcrypto_uuid?
 
   uuid_default = connection.supports_pgcrypto_uuid? ? {} : { default: "uuid_generate_v4()" }
 

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -1486,13 +1486,13 @@ ActiveRecord::Schema.define do
   end
 end
 
-if ActiveRecord::Base.connection.supports_insert_returning? && !ActiveRecord::TestCase.current_adapter?(:SQLite3Adapter)
-  ActiveRecord::Base.connection.create_table :pk_autopopulated_by_a_trigger_records, force: true, id: false do |t|
+if ActiveRecord::Base.lease_connection.supports_insert_returning? && !ActiveRecord::TestCase.current_adapter?(:SQLite3Adapter)
+  ActiveRecord::Base.lease_connection.create_table :pk_autopopulated_by_a_trigger_records, force: true, id: false do |t|
     t.integer :id, null: false
   end
 
   if ActiveRecord::TestCase.current_adapter?(:PostgreSQLAdapter)
-    ActiveRecord::Base.connection.execute(
+    ActiveRecord::Base.lease_connection.execute(
       <<-SQL
         CREATE OR REPLACE FUNCTION populate_column()
         RETURNS TRIGGER AS $$
@@ -1512,7 +1512,7 @@ if ActiveRecord::Base.connection.supports_insert_returning? && !ActiveRecord::Te
       SQL
     )
   elsif ActiveRecord::TestCase.current_adapter?(:Mysql2Adapter, :TrilogyAdapter)
-    ActiveRecord::Base.connection.execute(
+    ActiveRecord::Base.lease_connection.execute(
       <<-SQL
         CREATE TRIGGER before_insert_trigger
         BEFORE INSERT ON pk_autopopulated_by_a_trigger_records
@@ -1523,22 +1523,22 @@ if ActiveRecord::Base.connection.supports_insert_returning? && !ActiveRecord::Te
   end
 end
 
-Course.connection.create_table :courses, force: true do |t|
+Course.lease_connection.create_table :courses, force: true do |t|
   t.column :name, :string, null: false
   t.column :college_id, :integer, index: true
 end
 
-College.connection.create_table :colleges, force: true do |t|
+College.lease_connection.create_table :colleges, force: true do |t|
   t.column :name, :string, null: false
 end
 
-Professor.connection.create_table :professors, force: true do |t|
+Professor.lease_connection.create_table :professors, force: true do |t|
   t.column :name, :string, null: false
 end
 
-Professor.connection.create_table :courses_professors, id: false, force: true do |t|
+Professor.lease_connection.create_table :courses_professors, id: false, force: true do |t|
   t.references :course
   t.references :professor
 end
 
-OtherDog.connection.create_table :dogs, force: true
+OtherDog.lease_connection.create_table :dogs, force: true

--- a/activerecord/test/support/adapter_helper.rb
+++ b/activerecord/test/support/adapter_helper.rb
@@ -4,7 +4,7 @@ module AdapterHelper
   def current_adapter?(*types)
     types.any? do |type|
       ActiveRecord::ConnectionAdapters.const_defined?(type) &&
-        ActiveRecord::Base.connection.is_a?(ActiveRecord::ConnectionAdapters.const_get(type))
+        ActiveRecord::Base.lease_connection.is_a?(ActiveRecord::ConnectionAdapters.const_get(type))
     end
   end
 
@@ -14,14 +14,14 @@ module AdapterHelper
   end
 
   def mysql_enforcing_gtid_consistency?
-    current_adapter?(:Mysql2Adapter, :TrilogyAdapter) && "ON" == ActiveRecord::Base.connection.show_variable("enforce_gtid_consistency")
+    current_adapter?(:Mysql2Adapter, :TrilogyAdapter) && "ON" == ActiveRecord::Base.lease_connection.show_variable("enforce_gtid_consistency")
   end
 
   def supports_default_expression?
     if current_adapter?(:PostgreSQLAdapter)
       true
     elsif current_adapter?(:Mysql2Adapter, :TrilogyAdapter)
-      conn = ActiveRecord::Base.connection
+      conn = ActiveRecord::Base.lease_connection
       (conn.mariadb? && conn.database_version >= "10.2.1") ||
         (!conn.mariadb? && conn.database_version >= "8.0.13")
     end
@@ -29,7 +29,7 @@ module AdapterHelper
 
   def supports_non_unique_constraint_name?
     if current_adapter?(:Mysql2Adapter, :TrilogyAdapter)
-      conn = ActiveRecord::Base.connection
+      conn = ActiveRecord::Base.lease_connection
       conn.mariadb?
     else
       false
@@ -38,7 +38,7 @@ module AdapterHelper
 
   def supports_text_column_with_default?
     if current_adapter?(:Mysql2Adapter, :TrilogyAdapter)
-      conn = ActiveRecord::Base.connection
+      conn = ActiveRecord::Base.lease_connection
       conn.mariadb? && conn.database_version >= "10.2.1"
     else
       true
@@ -62,7 +62,7 @@ module AdapterHelper
     supports_virtual_columns?
   ].each do |method_name|
     define_method method_name do
-      ActiveRecord::Base.connection.public_send(method_name)
+      ActiveRecord::Base.lease_connection.public_send(method_name)
     end
   end
 

--- a/activerecord/test/support/connection.rb
+++ b/activerecord/test/support/connection.rb
@@ -32,7 +32,7 @@ module ARTest
     ActiveRecord::Base.establish_connection :arunit
     ARUnit2Model.establish_connection :arunit2
 
-    arunit_adapter = ActiveRecord::Base.connection.pool.db_config.adapter
+    arunit_adapter = ActiveRecord::Base.lease_connection.pool.db_config.adapter
 
     unless connection_name.include?(arunit_adapter)
       raise ArgumentError, "The connection name did not match the adapter name. Connection name is '#{connection_name}' and the adapter name is '#{arunit_adapter}'."

--- a/activerecord/test/support/load_schema_helper.rb
+++ b/activerecord/test/support/load_schema_helper.rb
@@ -6,7 +6,7 @@ module LoadSchemaHelper
     original_stdout = $stdout
     $stdout = StringIO.new
 
-    adapter_name = ActiveRecord::Base.connection.adapter_name.downcase
+    adapter_name = ActiveRecord::Base.lease_connection.adapter_name.downcase
     adapter_specific_schema_file = SCHEMA_ROOT + "/#{adapter_name}_specific_schema.rb"
 
     load SCHEMA_ROOT + "/schema.rb"

--- a/activerecord/test/support/schema_dumping_helper.rb
+++ b/activerecord/test/support/schema_dumping_helper.rb
@@ -4,7 +4,9 @@ module SchemaDumpingHelper
   def dump_table_schema(*tables)
     pool = ActiveRecord::Base.connection_pool
     old_ignore_tables = ActiveRecord::SchemaDumper.ignore_tables
-    ActiveRecord::SchemaDumper.ignore_tables = pool.connection.data_sources - tables
+    pool.with_connection do |connection|
+      ActiveRecord::SchemaDumper.ignore_tables = connection.data_sources - tables
+    end
 
     output, = capture_io do
       ActiveRecord::SchemaDumper.dump(pool)

--- a/activestorage/test/migrations_test.rb
+++ b/activestorage/test/migrations_test.rb
@@ -8,7 +8,7 @@ class ActiveStorage::MigrationsTest < ActiveSupport::TestCase
     @original_verbose = ActiveRecord::Migration.verbose
     ActiveRecord::Migration.verbose = false
 
-    @connection = ActiveRecord::Base.connection
+    @connection = ActiveRecord::Base.lease_connection
     @original_options = Rails.configuration.generators.options.deep_dup
   end
 

--- a/activestorage/test/models/attachment_test.rb
+++ b/activestorage/test/models/attachment_test.rb
@@ -174,11 +174,11 @@ class ActiveStorage::AttachmentTest < ActiveSupport::TestCase
     end
 
     def assert_blob_identified_outside_transaction(blob, &block)
-      baseline_transaction_depth = ActiveRecord::Base.connection.open_transactions
+      baseline_transaction_depth = ActiveRecord::Base.lease_connection.open_transactions
       max_transaction_depth = -1
 
       track_transaction_depth = ->(*) do
-        max_transaction_depth = [ActiveRecord::Base.connection.open_transactions, max_transaction_depth].max
+        max_transaction_depth = [ActiveRecord::Base.lease_connection.open_transactions, max_transaction_depth].max
       end
 
       blob.stub(:identify_without_saving, track_transaction_depth, &block)

--- a/railties/lib/rails/commands/dbconsole/dbconsole_command.rb
+++ b/railties/lib/rails/commands/dbconsole/dbconsole_command.rb
@@ -67,7 +67,7 @@ module Rails
           Rails::DBConsole#find_cmd_and_exec is deprecated and will be removed in Rails 7.2.
           Please use find_cmd_and_exec on the connection adapter class instead.
         MSG
-        ActiveRecord::Base.connection.find_cmd_and_exec(commands, *args)
+        ActiveRecord::Base.lease_connection.find_cmd_and_exec(commands, *args)
       end
   end
 

--- a/railties/lib/rails/generators/generated_attribute.rb
+++ b/railties/lib/rails/generators/generated_attribute.rb
@@ -72,7 +72,7 @@ module Rails
         def valid_type?(type)
           DEFAULT_TYPES.include?(type.to_s) ||
             !defined?(ActiveRecord::Base) ||
-            ActiveRecord::Base.connection.valid_type?(type)
+            ActiveRecord::Base.lease_connection.valid_type?(type)
         end
 
         def valid_index_type?(index_type)

--- a/railties/test/application/bin_setup_test.rb
+++ b/railties/test/application/bin_setup_test.rb
@@ -13,7 +13,7 @@ module ApplicationTests
       Dir.chdir(app_path) do
         rails "generate", "model", "article"
 
-        list_tables = lambda { rails("runner", "p ActiveRecord::Base.connection.tables").strip }
+        list_tables = lambda { rails("runner", "p ActiveRecord::Base.lease_connection.tables").strip }
         File.write("log/test.log", "zomg!")
 
         assert_equal "[]", list_tables.call

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -2926,9 +2926,9 @@ module ApplicationTests
 
       assert_equal false, ActiveRecord::ConnectionAdapters::SQLite3Adapter.strict_strings_by_default
 
-      Post.connection.create_table :posts
+      Post.lease_connection.create_table :posts
       assert_nothing_raised do
-        Post.connection.add_index :posts, :non_existent
+        Post.lease_connection.add_index :posts, :non_existent
       end
     end
 
@@ -2963,9 +2963,9 @@ module ApplicationTests
 
       assert_equal true, ActiveRecord::ConnectionAdapters::SQLite3Adapter.strict_strings_by_default
 
-      Post.connection.create_table :posts
+      Post.lease_connection.create_table :posts
       error = assert_raises(StandardError) do
-        Post.connection.add_index :posts, :non_existent
+        Post.lease_connection.add_index :posts, :non_existent
       end
       assert_match(/no such column: non_existent/, error.message)
     end
@@ -4751,8 +4751,8 @@ module ApplicationTests
 
       app "development"
 
-      assert_equal "potato", ActiveRecord::Base.connection.pool.db_config.adapter
-      assert_equal "SQLite", ActiveRecord::Base.connection.adapter_name
+      assert_equal "potato", ActiveRecord::Base.lease_connection.pool.db_config.adapter
+      assert_equal "SQLite", ActiveRecord::Base.lease_connection.adapter_name
     end
 
     private

--- a/railties/test/application/console_test.rb
+++ b/railties/test/application/console_test.rb
@@ -109,7 +109,7 @@ class FullStackConsoleTest < ActiveSupport::TestCase
       class Post < ActiveRecord::Base
       end
     CODE
-    system "#{app_path}/bin/rails runner 'Post.connection.create_table :posts'"
+    system "#{app_path}/bin/rails runner 'Post.lease_connection.create_table :posts'"
 
     @primary, @replica = PTY.open
   end

--- a/railties/test/application/loading_test.rb
+++ b/railties/test/application/loading_test.rb
@@ -494,10 +494,10 @@ class LoadingTest < ActiveSupport::TestCase
         class OmgController < ActionController::Metal
           ActiveSupport.run_load_hooks(:action_controller, self)
           def show
-            if ActiveRecord::Base.connection.query_cache_enabled
+            if ActiveRecord::Base.lease_connection.query_cache_enabled
               self.response_body = ["Query cache is enabled."]
             else
-              self.response_body = ["Expected ActiveRecord::Base.connection.query_cache_enabled to be true"]
+              self.response_body = ["Expected ActiveRecord::Base.lease_connection.query_cache_enabled to be true"]
             end
           end
         end
@@ -527,10 +527,10 @@ class LoadingTest < ActiveSupport::TestCase
         class OmgController < ActionController::Metal
           ActiveSupport.run_load_hooks(:action_controller, self)
           def show
-            if ActiveRecord::Base.connection.query_cache_enabled
+            if ActiveRecord::Base.lease_connection.query_cache_enabled
               self.response_body = ["Query cache is enabled."]
             else
-              self.response_body = ["Expected ActiveRecord::Base.connection.query_cache_enabled to be true"]
+              self.response_body = ["Expected ActiveRecord::Base.lease_connection.query_cache_enabled to be true"]
             end
           end
         end

--- a/railties/test/application/query_logs_test.rb
+++ b/railties/test/application/query_logs_test.rb
@@ -31,7 +31,7 @@ module ApplicationTests
       app_file "app/controllers/name_spaced/users_controller.rb", <<-RUBY
         class NameSpaced::UsersController < ApplicationController
           def index
-            render inline: ActiveRecord::QueryLogs.call("", ActiveRecord::Base.connection)
+            render inline: ActiveRecord::QueryLogs.call("", ActiveRecord::Base.lease_connection)
           end
         end
       RUBY
@@ -39,7 +39,7 @@ module ApplicationTests
       app_file "app/jobs/user_job.rb", <<-RUBY
         class UserJob < ActiveJob::Base
           def perform
-            ActiveRecord::QueryLogs.call("", ActiveRecord::Base.connection)
+            ActiveRecord::QueryLogs.call("", ActiveRecord::Base.lease_connection)
           end
 
           def dynamic_content
@@ -89,8 +89,8 @@ module ApplicationTests
     test "controller and job tags are defined by default" do
       add_to_config "config.active_record.query_log_tags_enabled = true"
       app_file "config/initializers/active_record.rb", <<-RUBY
-        raise "Expected prepared_statements to be enabled" unless ActiveRecord::Base.connection.prepared_statements
-        ActiveRecord::Base.connection.execute("SELECT 1")
+        raise "Expected prepared_statements to be enabled" unless ActiveRecord::Base.lease_connection.prepared_statements
+        ActiveRecord::Base.lease_connection.execute("SELECT 1")
       RUBY
 
       boot_app

--- a/railties/test/application/test_test.rb
+++ b/railties/test/application/test_test.rb
@@ -277,12 +277,12 @@ Expected: ["id", "name"]
 
       app_file "lib/tasks/hooks.rake", <<-RUBY
         task :before_hook do
-          has_user_table = ActiveRecord::Base.connection.table_exists?('users')
+          has_user_table = ActiveRecord::Base.lease_connection.table_exists?('users')
           puts "before: " + has_user_table.to_s
         end
 
         task :after_hook do
-          has_user_table = ActiveRecord::Base.connection.table_exists?('users')
+          has_user_table = ActiveRecord::Base.lease_connection.table_exists?('users')
           puts "after: " + has_user_table.to_s
         end
 

--- a/railties/test/json_params_parsing_test.rb
+++ b/railties/test/json_params_parsing_test.rb
@@ -35,7 +35,7 @@ class JsonParamsParsingTest < ActionDispatch::IntegrationTest
       assert_nil app.call(make_env("t" => data))
     end
   ensure
-    klass.connection.drop_table("foos")
+    klass.lease_connection.drop_table("foos")
   end
 
   private


### PR DESCRIPTION
Replaced by `#lease_connection` to better reflect what it does.

`ActiveRecord::Base.connection` is deprecated in the same way but without a removal timeline nor a deprecation warning.

Inside the Active Record test suite, we do remove `Base.connection` to ensure it's not used internally.

Some callsites have been converted to use `with_connection`, some other have been more simply migrated to `lease_connection` and will serve as a list of callsites to convert for https://github.com/rails/rails/pull/50793

FYI: @matthewd 