### PR TITLE
Refactor InsertAll not to permanently lease a connection

### DIFF
--- a/activerecord/lib/active_record/insert_all.rb
+++ b/activerecord/lib/active_record/insert_all.rb
@@ -7,8 +7,16 @@ module ActiveRecord
     attr_reader :model, :connection, :inserts, :keys
     attr_reader :on_duplicate, :update_only, :returning, :unique_by, :update_sql
 
-    def initialize(model, inserts, on_duplicate:, update_only: nil, returning: nil, unique_by: nil, record_timestamps: nil)
-      @model, @connection, @inserts = model, model.lease_connection, inserts.map(&:stringify_keys)
+    class << self
+      def execute(model, ...)
+        model.with_connection do |c|
+          new(model, c, ...).execute
+        end
+      end
+    end
+
+    def initialize(model, connection, inserts, on_duplicate:, update_only: nil, returning: nil, unique_by: nil, record_timestamps: nil)
+      @model, @connection, @inserts = model, connection, inserts.map(&:stringify_keys)
       @on_duplicate, @update_only, @returning, @unique_by = on_duplicate, update_only, returning, unique_by
       @record_timestamps = record_timestamps.nil? ? model.record_timestamps : record_timestamps
 

--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -173,7 +173,7 @@ module ActiveRecord
       #     { id: 2, title: "Eloquent Ruby" }
       #   ])
       def insert_all(attributes, returning: nil, unique_by: nil, record_timestamps: nil)
-        InsertAll.new(self, attributes, on_duplicate: :skip, returning: returning, unique_by: unique_by, record_timestamps: record_timestamps).execute
+        InsertAll.execute(self, attributes, on_duplicate: :skip, returning: returning, unique_by: unique_by, record_timestamps: record_timestamps)
       end
 
       # Inserts a single record into the database in a single SQL INSERT
@@ -240,7 +240,7 @@ module ActiveRecord
       #     { id: 1, title: "Eloquent Ruby", author: "Russ" }
       #   ])
       def insert_all!(attributes, returning: nil, record_timestamps: nil)
-        InsertAll.new(self, attributes, on_duplicate: :raise, returning: returning, record_timestamps: record_timestamps).execute
+        InsertAll.execute(self, attributes, on_duplicate: :raise, returning: returning, record_timestamps: record_timestamps)
       end
 
       # Updates or inserts (upserts) a single record into the database in a
@@ -360,7 +360,7 @@ module ActiveRecord
       #
       #   Book.find_by(isbn: "1").title # => "Eloquent Ruby"
       def upsert_all(attributes, on_duplicate: :update, update_only: nil, returning: nil, unique_by: nil, record_timestamps: nil)
-        InsertAll.new(self, attributes, on_duplicate: on_duplicate, update_only: update_only, returning: returning, unique_by: unique_by, record_timestamps: record_timestamps).execute
+        InsertAll.execute(self, attributes, on_duplicate: on_duplicate, update_only: update_only, returning: returning, unique_by: unique_by, record_timestamps: record_timestamps)
       end
 
       # Given an attributes hash, +instantiate+ returns a new instance of


### PR DESCRIPTION
Extracted from: https://github.com/rails/rails/pull/50793

Avoid not calling `lease_connection` we avoid creating a permanent lease if there wasn't one before.