### PR TITLE
Marcel 1.0.4

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -317,7 +317,7 @@ GEM
       net-imap
       net-pop
       net-smtp
-    marcel (1.0.2)
+    marcel (1.0.4)
     matrix (0.4.2)
     mdl (0.12.0)
       kramdown (~> 2.3)

--- a/activestorage/test/models/blob_test.rb
+++ b/activestorage/test/models/blob_test.rb
@@ -42,23 +42,33 @@ class ActiveStorage::BlobTest < ActiveSupport::TestCase
   end
 
   test "create_and_upload extracts content type from data" do
-    blob = create_file_blob content_type: "application/octet-stream"
+    blob = create_file_blob fixture: "racecar.jpg", content_type: "application/octet-stream", filename: "spoofed.txt"
     assert_equal "image/jpeg", blob.content_type
   end
 
+  test "create_and_upload prefers given content type over filename" do
+    blob = create_blob content_type: "specific/type", filename: "file.txt"
+    assert_equal "specific/type", blob.content_type
+  end
+
+  test "create_and_upload prefers filename over binary content type" do
+    blob = create_blob content_type: "application/octet-stream", filename: "file.txt"
+    assert_equal "text/plain", blob.content_type
+  end
+
   test "create_and_upload extracts content type from filename" do
-    blob = create_blob content_type: "application/octet-stream"
+    blob = create_blob content_type: nil, filename: "hello.txt"
     assert_equal "text/plain", blob.content_type
   end
 
-  test "create_and_upload extracts content_type from io when no content_type given and identify: false" do
-    blob = create_blob content_type: nil, identify: false
-    assert_equal "text/plain", blob.content_type
+  test "create_and_upload extracts content_type from io when missing and identify: false" do
+    blob = create_file_blob fixture: "racecar.jpg", content_type: nil, filename: "unknown", identify: false
+    assert_equal "image/jpeg", blob.content_type
   end
 
-  test "create_and_upload uses content_type when identify: false" do
-    blob = create_blob data: "Article,dates,analysis\n1, 2, 3", filename: "table.csv", content_type: "text/csv", identify: false
-    assert_equal "text/csv", blob.content_type
+  test "create_and_upload uses given content_type when identify: false" do
+    blob = create_file_blob fixture: "racecar.jpg", content_type: "given/type", filename: "unknown", identify: false
+    assert_equal "given/type", blob.content_type
   end
 
   test "create_and_upload generates a 28-character base36 key" do

--- a/activestorage/test/test_helper.rb
+++ b/activestorage/test/test_helper.rb
@@ -43,8 +43,8 @@ class ActiveSupport::TestCase
       ActiveStorage::Blob.create_and_upload! key: key, io: StringIO.new(data), filename: filename, content_type: content_type, identify: identify, service_name: service_name, record: record
     end
 
-    def create_file_blob(key: nil, filename: "racecar.jpg", content_type: "image/jpeg", metadata: nil, service_name: nil, record: nil)
-      ActiveStorage::Blob.create_and_upload! io: file_fixture(filename).open, filename: filename, content_type: content_type, metadata: metadata, service_name: service_name, record: record
+    def create_file_blob(key: nil, filename: "racecar.jpg", fixture: filename, content_type: "image/jpeg", identify: true, metadata: nil, service_name: nil, record: nil)
+      ActiveStorage::Blob.create_and_upload! io: file_fixture(fixture).open, filename: filename, content_type: content_type, identify: identify, metadata: metadata, service_name: service_name, record: record
     end
 
     def create_blob_before_direct_upload(key: nil, filename: "hello.txt", byte_size:, checksum:, content_type: "text/plain", record: nil)


### PR DESCRIPTION
Update tests to clarify content type detection heuristic after exposing a [regression in Marcel 1.0.3](https://github.com/rails/marcel/pull/99) that wasn't caught by its test suite:

1. magic bytes
2. declared content type, unless it's binary
3. filename extension
4. binary: application/octet-stream

Addresses regression found in #51221. /cc @yahonda 