### PR TITLE
Illustrator .ai files are previewable as PDFs

### DIFF
--- a/activestorage/lib/active_storage/previewer/mupdf_previewer.rb
+++ b/activestorage/lib/active_storage/previewer/mupdf_previewer.rb
@@ -4,7 +4,11 @@ module ActiveStorage
   class Previewer::MuPDFPreviewer < Previewer
     class << self
       def accept?(blob)
-        blob.content_type == "application/pdf" && mutool_exists?
+        pdf?(blob.content_type) && mutool_exists?
+      end
+
+      def pdf?(content_type)
+        Marcel::Magic.child? content_type, "application/pdf"
       end
 
       def mutool_path

--- a/activestorage/test/previewer/mupdf_previewer_test.rb
+++ b/activestorage/test/previewer/mupdf_previewer_test.rb
@@ -32,6 +32,19 @@ class ActiveStorage::Previewer::MuPDFPreviewerTest < ActiveSupport::TestCase
     end
   end
 
+  test "previewing an Illustrator document that's a PDF subtype" do
+    blob = create_file_blob(fixture: "report.pdf", filename: "file.ai", content_type: "application/illustrator")
+
+    ActiveStorage::Previewer::MuPDFPreviewer.new(blob).preview do |attachable|
+      assert_equal "image/png", attachable[:content_type]
+      assert_equal "file.png", attachable[:filename]
+
+      image = MiniMagick::Image.read(attachable[:io])
+      assert_equal 612, image.width
+      assert_equal 792, image.height
+    end
+  end
+
   test "previewing a PDF that can't be previewed" do
     blob = create_file_blob(filename: "video.mp4", content_type: "application/pdf")
 


### PR DESCRIPTION
This happened to work with Marcel 1.0.2 and earlier since magic byte sniffing sees that Illustrator files are PDFs internally, causing these files to be treated as `application/pdf` despite having a declared content type of `application/illustrator` and an `.ai` file extension.

Marcel 1.0.3 corrected this to the more specific `application/illustrator` subtype of `application/pdf`, but the MuPDF previewer only accepts the parent `application/pdf` type.

Changing it to accept PDF and any child types allows the previewer to explicitly work with Illustrator files again, which was only a happy accident previously.

Related to #51234

/cc @intrip 