### PR TITLE
Illustrator files are previewable with Poppler as well

### DIFF
--- a/activestorage/lib/active_storage/previewer/poppler_pdf_previewer.rb
+++ b/activestorage/lib/active_storage/previewer/poppler_pdf_previewer.rb
@@ -4,7 +4,11 @@ module ActiveStorage
   class Previewer::PopplerPDFPreviewer < Previewer
     class << self
       def accept?(blob)
-        blob.content_type == "application/pdf" && pdftoppm_exists?
+        pdf?(blob.content_type) && pdftoppm_exists?
+      end
+
+      def pdf?(content_type)
+        Marcel::Magic.child? content_type, "application/pdf"
       end
 
       def pdftoppm_path

--- a/activestorage/test/models/preview_test.rb
+++ b/activestorage/test/models/preview_test.rb
@@ -30,6 +30,19 @@ class ActiveStorage::PreviewTest < ActiveSupport::TestCase
     assert_equal 145, image.height
   end
 
+  test "previewing a PDF-based Illustrator file" do
+    blob = create_file_blob(fixture: "report.pdf", filename: "file.ai", content_type: "application/illustrator")
+    preview = blob.preview(resize_to_limit: [640, 280]).processed
+
+    assert_predicate preview.image, :attached?
+    assert_equal "file.png", preview.image.filename.to_s
+    assert_equal "image/png", preview.image.content_type
+
+    image = read_image(preview.image)
+    assert_equal 612, image.width
+    assert_equal 792, image.height
+  end
+
   test "previewing an MP4 video" do
     blob = create_file_blob(filename: "video.mp4", content_type: "video/mp4")
     preview = blob.preview(resize_to_limit: [640, 280]).processed

--- a/activestorage/test/models/representation_test.rb
+++ b/activestorage/test/models/representation_test.rb
@@ -22,6 +22,15 @@ class ActiveStorage::RepresentationTest < ActiveSupport::TestCase
     assert_equal 792, image.height
   end
 
+  test "representing a PDF-based Illustrator file" do
+    blob = create_file_blob(fixture: "report.pdf", filename: "file.ai", content_type: "application/illustrator")
+    representation = blob.representation(resize_to_limit: [640, 280]).processed
+
+    image = read_image(representation.image)
+    assert_equal 612, image.width
+    assert_equal 792, image.height
+  end
+
   test "representing an MP4 video" do
     blob = create_file_blob(filename: "video.mp4", content_type: "video/mp4")
     representation = blob.representation(resize_to_limit: [640, 280]).processed

--- a/activestorage/test/previewer/poppler_pdf_previewer_test.rb
+++ b/activestorage/test/previewer/poppler_pdf_previewer_test.rb
@@ -32,6 +32,19 @@ class ActiveStorage::Previewer::PopplerPDFPreviewerTest < ActiveSupport::TestCas
     end
   end
 
+  test "previewing an Illustrator document that's a PDF subtype" do
+    blob = create_file_blob(fixture: "report.pdf", filename: "file.ai", content_type: "application/illustrator")
+
+    ActiveStorage::Previewer::PopplerPDFPreviewer.new(blob).preview do |attachable|
+      assert_equal "image/png", attachable[:content_type]
+      assert_equal "file.png", attachable[:filename]
+
+      image = MiniMagick::Image.read(attachable[:io])
+      assert_equal 612, image.width
+      assert_equal 792, image.height
+    end
+  end
+
   test "previewing a PDF that can't be previewed" do
     blob = create_file_blob(filename: "video.mp4", content_type: "application/pdf")
 


### PR DESCRIPTION
Extends #51235's MuPDF support to Poppler.

Add test coverage for Blob previews and representation.