### PR TITLE
Fix label with `for` option not getting prefixed by form `namespace` value

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Fix label with `for` option not getting prefixed by form `namespace` value
+
+    *Abeid Ahmed*, *Hartley McGuire*, *Jerome Dalbert*
+
 *   Rename `text_area` methods into `textarea`
 
     Old names are still available as aliases.

--- a/actionview/lib/action_view/helpers/tags/label.rb
+++ b/actionview/lib/action_view/helpers/tags/label.rb
@@ -58,8 +58,8 @@ module ActionView
 
           add_default_name_and_id_for_value(tag_value, name_and_id)
           options.delete("index")
-          options.delete("namespace")
-          options["for"] = name_and_id["id"] unless options.key?("for")
+          namespace = options.delete("namespace")
+          options["for"] = name_and_id["id"] if namespace || !options.key?("for")
 
           builder = LabelBuilder.new(@template_object, @object_name, @method_name, @object, tag_value)
 

--- a/actionview/test/template/form_helper/form_with_test.rb
+++ b/actionview/test/template/form_helper/form_with_test.rb
@@ -1051,6 +1051,20 @@ class FormWithActsLikeFormForTest < FormWithTest
     assert_dom_equal expected, @rendered
   end
 
+  def test_form_with_label_namespace
+    form_with(model: Post.new, namespace: "namespace") do |f|
+      concat f.label(:title, for: "my_title")
+      concat f.text_field(:title, id: "my_title")
+    end
+
+    expected = whole_form("/posts") do
+      "<label for='namespace_my_title'>Title</label>" \
+      "<input id='namespace_my_title' name='post[title]' type='text' />"
+    end
+
+    assert_dom_equal expected, @rendered
+  end
+
   def test_form_with_label_error_wrapping
     form_with(model: @post) do |f|
       concat f.label(:author_name, class: "label")

--- a/actionview/test/template/form_helper_test.rb
+++ b/actionview/test/template/form_helper_test.rb
@@ -2598,6 +2598,20 @@ class FormHelperTest < ActionView::TestCase
     assert_dom_equal expected, @rendered
   end
 
+  def test_form_for_with_namespace_with_custom_label_for
+    form_for(@post, namespace: "namespace") do |f|
+      concat f.label(:title, for: "my_title")
+      concat f.text_field(:title, id: "my_title")
+    end
+
+    expected = whole_form("/posts/123", "namespace_edit_post_123", "edit_post", method: "patch") do
+      "<label for='namespace_my_title'>Title</label>" \
+      "<input name='post[title]' type='text' id='namespace_my_title' value='Hello World' />"
+    end
+
+    assert_dom_equal expected, @rendered
+  end
+
   def test_form_for_with_namespace_and_as_option
     form_for(@post, namespace: "namespace", as: "custom_name") do |f|
       concat f.text_field(:title)


### PR DESCRIPTION
### Motivation / Background

This PR is created because when a `form_for` has the `namespace` option, all other fields are prefixed with it except for the `label` tag which has the `for` option.

### Detail

Example:
```rb
form_for(@post, namespace: SecureRandom.urlsafe_base64) do |f|
  concat f.label(:title, for: "my_custom_post_title")
  concat f.text_field(:title, id: "my_custom_post_title")
end
```
In the above example, the label will not be linked to the text field, which shouldn't be the case just because the `namespace` option is present.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
