### PR TITLE
Use `ActiveRecord::Base.lease_connection` for uncached dirties tests

### DIFF
--- a/activerecord/test/cases/query_cache_test.rb
+++ b/activerecord/test/cases/query_cache_test.rb
@@ -709,11 +709,11 @@ class QueryCacheTest < ActiveRecord::TestCase
   def test_query_cache_uncached_dirties
     mw = middleware { |env|
       Post.first
-      assert_no_changes -> { ActiveRecord::Base.connection.query_cache.size } do
+      assert_no_changes -> { ActiveRecord::Base.lease_connection.query_cache.size } do
         Post.uncached(dirties: false) { Post.create!(title: "a new post", body: "and a body") }
       end
 
-      assert_changes -> { ActiveRecord::Base.connection.query_cache.size }, from: 1, to: 0 do
+      assert_changes -> { ActiveRecord::Base.lease_connection.query_cache.size }, from: 1, to: 0 do
         Post.uncached(dirties: true) { Post.create!(title: "a new post", body: "and a body") }
       end
     }
@@ -723,12 +723,12 @@ class QueryCacheTest < ActiveRecord::TestCase
   def test_query_cache_connection_uncached_dirties
     mw = middleware { |env|
       Post.first
-      assert_no_changes -> { ActiveRecord::Base.connection.query_cache.size } do
-        Post.connection.uncached(dirties: false) { Post.create!(title: "a new post", body: "and a body") }
+      assert_no_changes -> { ActiveRecord::Base.lease_connection.query_cache.size } do
+        Post.lease_connection.uncached(dirties: false) { Post.create!(title: "a new post", body: "and a body") }
       end
 
-      assert_changes -> { ActiveRecord::Base.connection.query_cache.size }, from: 1, to: 0 do
-        Post.connection.uncached(dirties: true) { Post.create!(title: "a new post", body: "and a body") }
+      assert_changes -> { ActiveRecord::Base.lease_connection.query_cache.size }, from: 1, to: 0 do
+        Post.lease_connection.uncached(dirties: true) { Post.create!(title: "a new post", body: "and a body") }
       end
     }
     mw.call({})
@@ -737,7 +737,7 @@ class QueryCacheTest < ActiveRecord::TestCase
   def test_query_cache_uncached_dirties_disabled_with_nested_cache
     mw = middleware { |env|
       Post.first
-      assert_changes -> { ActiveRecord::Base.connection.query_cache.size }, from: 1, to: 0 do
+      assert_changes -> { ActiveRecord::Base.lease_connection.query_cache.size }, from: 1, to: 0 do
         Post.uncached(dirties: false) do
           Post.cache do
             Post.create!(title: "a new post", body: "and a body")
@@ -746,9 +746,9 @@ class QueryCacheTest < ActiveRecord::TestCase
       end
 
       Post.first
-      assert_changes -> { ActiveRecord::Base.connection.query_cache.size }, from: 1, to: 0 do
-        Post.connection.uncached(dirties: false) do
-          Post.connection.cache do
+      assert_changes -> { ActiveRecord::Base.lease_connection.query_cache.size }, from: 1, to: 0 do
+        Post.lease_connection.uncached(dirties: false) do
+          Post.lease_connection.cache do
             Post.create!(title: "a new post", body: "and a body")
           end
         end


### PR DESCRIPTION
### Motivation / Background

This pull request addresses CI failure at https://buildkite.com/rails/rails/builds/105463 since #51192 renames `.connection` into `.lease_connection`

### Detail


```ruby
$ cd activerecord
$ bin/test test/cases/query_cache_test.rb -n /uncached_dirties/
Using sqlite3
Run options: -n /uncached_dirties/ --seed 57207

E

Error:
QueryCacheTest#test_query_cache_uncached_dirties:
NoMethodError: undefined method `connection' for class ActiveRecord::Base
    lib/active_record/dynamic_matchers.rb:22:in `method_missing'
    test/cases/query_cache_test.rb:712:in `block (2 levels) in test_query_cache_uncached_dirties'
    /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/testing/assertions.rb:241:in `assert_no_changes'
    test/cases/query_cache_test.rb:712:in `block in test_query_cache_uncached_dirties'
    test/cases/query_cache_test.rb:771:in `block (2 levels) in middleware'
    /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/execution_wrapper.rb:91:in `wrap'
    test/cases/query_cache_test.rb:771:in `block in middleware'
    test/cases/query_cache_test.rb:720:in `test_query_cache_uncached_dirties'

bin/test test/cases/query_cache_test.rb:709

E

Error:
QueryCacheTest#test_query_cache_connection_uncached_dirties:
NoMethodError: undefined method `connection' for class ActiveRecord::Base
    lib/active_record/dynamic_matchers.rb:22:in `method_missing'
    test/cases/query_cache_test.rb:726:in `block (2 levels) in test_query_cache_connection_uncached_dirties'
    /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/testing/assertions.rb:241:in `assert_no_changes'
    test/cases/query_cache_test.rb:726:in `block in test_query_cache_connection_uncached_dirties'
    test/cases/query_cache_test.rb:771:in `block (2 levels) in middleware'
    /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/execution_wrapper.rb:91:in `wrap'
    test/cases/query_cache_test.rb:771:in `block in middleware'
    test/cases/query_cache_test.rb:734:in `test_query_cache_connection_uncached_dirties'

bin/test test/cases/query_cache_test.rb:723

E

Error:
QueryCacheTest#test_query_cache_uncached_dirties_disabled_with_nested_cache:
NoMethodError: undefined method `connection' for class ActiveRecord::Base
    lib/active_record/dynamic_matchers.rb:22:in `method_missing'
    test/cases/query_cache_test.rb:740:in `block (2 levels) in test_query_cache_uncached_dirties_disabled_with_nested_cache'
    /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/testing/assertions.rb:194:in `assert_changes'
    test/cases/query_cache_test.rb:740:in `block in test_query_cache_uncached_dirties_disabled_with_nested_cache'
    test/cases/query_cache_test.rb:771:in `block (2 levels) in middleware'
    /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/execution_wrapper.rb:91:in `wrap'
    test/cases/query_cache_test.rb:771:in `block in middleware'
    test/cases/query_cache_test.rb:757:in `test_query_cache_uncached_dirties_disabled_with_nested_cache'

bin/test test/cases/query_cache_test.rb:737

Finished in 0.134429s, 22.3166 runs/s, 0.0000 assertions/s.
3 runs, 0 assertions, 0 failures, 3 errors, 0 skips
$
```

### Additional information
Follow up #51204
Related to #51192

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.




