### PR TITLE
[Fix #50118] `:prepend` option not working with `run_after_transaction_callbacks_in_order_defined` config

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Fix incorrect callback execution order when `config.active_record.run_after_transaction_callbacks_in_order_defined = true`
+    and using `after_commit` and `after_rollback` callbacks with `prepend: true`.
+
+    *Joshua Young*
+
 *   Accept encryption credentials as ENV
 
     Taking advantage of Rails.apps.creds (#56455), the `primary_key`, `deterministic_key` and

--- a/activerecord/lib/active_record/transactions.rb
+++ b/activerecord/lib/active_record/transactions.rb
@@ -265,7 +265,7 @@ module ActiveRecord
       end
 
       def before_commit(*args, &block) # :nodoc:
-        set_options_for_callbacks!(args)
+        set_options_for_callbacks!(:before, args)
         set_callback(:before_commit, :before, *args, &block)
       end
 
@@ -282,31 +282,31 @@ module ActiveRecord
       #   after_commit :do_bar_baz, on: [:update, :destroy]
       #
       def after_commit(*args, &block)
-        set_options_for_callbacks!(args, prepend_option)
+        set_options_for_callbacks!(:after, args)
         set_callback(:commit, :after, *args, &block)
       end
 
       # Shortcut for <tt>after_commit :hook, on: [ :create, :update ]</tt>.
       def after_save_commit(*args, &block)
-        set_options_for_callbacks!(args, on: [ :create, :update ], **prepend_option)
+        set_options_for_callbacks!(:after, args, on: [ :create, :update ])
         set_callback(:commit, :after, *args, &block)
       end
 
       # Shortcut for <tt>after_commit :hook, on: :create</tt>.
       def after_create_commit(*args, &block)
-        set_options_for_callbacks!(args, on: :create, **prepend_option)
+        set_options_for_callbacks!(:after, args, on: :create)
         set_callback(:commit, :after, *args, &block)
       end
 
       # Shortcut for <tt>after_commit :hook, on: :update</tt>.
       def after_update_commit(*args, &block)
-        set_options_for_callbacks!(args, on: :update, **prepend_option)
+        set_options_for_callbacks!(:after, args, on: :update)
         set_callback(:commit, :after, *args, &block)
       end
 
       # Shortcut for <tt>after_commit :hook, on: :destroy</tt>.
       def after_destroy_commit(*args, &block)
-        set_options_for_callbacks!(args, on: :destroy, **prepend_option)
+        set_options_for_callbacks!(:after, args, on: :destroy)
         set_callback(:commit, :after, *args, &block)
       end
 
@@ -314,7 +314,7 @@ module ActiveRecord
       #
       # Please check the documentation of #after_commit for options.
       def after_rollback(*args, &block)
-        set_options_for_callbacks!(args, prepend_option)
+        set_options_for_callbacks!(:after, args)
         set_callback(:rollback, :after, *args, &block)
       end
 
@@ -338,16 +338,11 @@ module ActiveRecord
       end
 
       private
-        def prepend_option
-          if ActiveRecord.run_after_transaction_callbacks_in_order_defined
-            { prepend: true }
-          else
-            {}
-          end
-        end
+        def set_options_for_callbacks!(position, args, enforced_options = {})
+          options = args.extract_options!
+          enforced_options.merge!(enforced_prepend_option(position, options))
+          options.merge!(enforced_options)
 
-        def set_options_for_callbacks!(args, enforced_options = {})
-          options = args.extract_options!.merge!(enforced_options)
           args << options
 
           if options[:on]
@@ -357,6 +352,14 @@ module ActiveRecord
               -> { transaction_include_any_action?(fire_on) },
               *options[:if]
             ]
+          end
+        end
+
+        def enforced_prepend_option(position, options)
+          if position == :after && ActiveRecord.run_after_transaction_callbacks_in_order_defined
+            { prepend: !options[:prepend] }
+          else
+            {}
           end
         end
 

--- a/activerecord/test/cases/transaction_callbacks_test.rb
+++ b/activerecord/test/cases/transaction_callbacks_test.rb
@@ -655,6 +655,8 @@ class CallbackOrderTest < ActiveRecord::TestCase
 
       after_commit { |record| record.history << 3 }
       after_commit { |record| record.history << 4 }
+      after_commit(prepend: true) { |record| record.history << "prepend 1" }
+      after_commit(prepend: true) { |record| record.history << "prepend 2" }
       after_save_commit { |record| record.history << "save" }
       after_create_commit { |record| record.history << "create" }
       after_update_commit { |record| record.history << "update" }
@@ -693,12 +695,12 @@ class CallbackOrderTest < ActiveRecord::TestCase
   def test_callbacks_run_in_order_defined_in_model_if_using_run_after_transaction_callbacks_in_order_defined
     topic = TopicWithCallbacksWithSpecificOrderWithSettingTrue.new
     topic.save
-    assert_equal [1, 2, 3, 4, "save", "create"], topic.history
+    assert_equal [1, 2, "prepend 2", "prepend 1", 3, 4, "save", "create"], topic.history
 
     topic.clear_history
     topic.approved = true
     topic.save
-    assert_equal [1, 2, 3, 4, "save", "update"], topic.history
+    assert_equal [1, 2, "prepend 2", "prepend 1", 3, 4, "save", "update"], topic.history
 
     topic.clear_history
     topic.transaction do
@@ -710,18 +712,18 @@ class CallbackOrderTest < ActiveRecord::TestCase
 
     topic.clear_history
     topic.destroy
-    assert_equal [1, 2, 3, 4, "destroy"], topic.history
+    assert_equal [1, 2, "prepend 2", "prepend 1", 3, 4, "destroy"], topic.history
   end
 
-  def test_callbacks_run_in_order_defined_in_model_if_not_using_run_after_transaction_callbacks_in_order_defined
+  def test_callbacks_run_in_reverse_order_defined_in_model_if_not_using_run_after_transaction_callbacks_in_order_defined
     topic = TopicWithCallbacksWithSpecificOrderWithSettingFalse.new
     topic.save
-    assert_equal [1, 2, "create", "save", 4, 3], topic.history
+    assert_equal [1, 2, "create", "save", 4, 3, "prepend 1", "prepend 2"], topic.history
 
     topic.clear_history
     topic.approved = true
     topic.save
-    assert_equal [1, 2, "update", "save", 4, 3], topic.history
+    assert_equal [1, 2, "update", "save", 4, 3, "prepend 1", "prepend 2"], topic.history
 
     topic.clear_history
     topic.transaction do
@@ -733,7 +735,7 @@ class CallbackOrderTest < ActiveRecord::TestCase
 
     topic.clear_history
     topic.destroy
-    assert_equal [1, 2, "destroy", 4, 3], topic.history
+    assert_equal [1, 2, "destroy", 4, 3, "prepend 1", "prepend 2"], topic.history
   end
 end
 


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

Fixes #50118
Ref: https://github.com/rails/rails/pull/46992

### Detail

Ensures that the `:prepend` option for after transaction callbacks is respected when `config.run_after_transaction_callbacks_in_order_defined = true`. This allows prepending certain `after_commit` and `after_rollback` callbacks while still running the rest in the order defined on the model.

### Additional information

<!-- Provide additional information such as benchmarks, reference to other repositories or alternative solutions. -->

In addition to the tests here there is also [this script](https://github.com/rails/rails/issues/50118#issuecomment-1975502684) which I tested against.

cc/ @ghiculescu

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
