### PR TITLE
Emphasize mention of `Migration.verbose` [ci skip]

### DIFF
--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -485,7 +485,7 @@ module ActiveRecord
   # them to the console as they happen, along with benchmarks describing how
   # long each step took.
   #
-  # You can quiet them down by setting ActiveRecord::Migration.verbose = false.
+  # You can quiet them down by setting <tt>ActiveRecord::Migration.verbose = false</tt>.
   #
   # You can also insert your own messages and benchmarks by using the +say_with_time+
   # method:
@@ -791,6 +791,25 @@ module ActiveRecord
       self.class.disable_ddl_transaction
     end
 
+    ##
+    # :singleton-method: verbose
+    #
+    # By default, migrations will describe the actions they are taking, writing
+    # them to the console as they happen, along with benchmarks describing how
+    # long each step took.
+    #
+    # You read that setting through <tt>ActiveRecord::Migration.verbose</tt>.
+
+    ##
+    # :singleton-method: verbose=
+    #
+    # :call-seq: verbose=(value)
+    #
+    # By default, migrations will describe the actions they are taking, writing
+    # them to the console as they happen, along with benchmarks describing how
+    # long each step took.
+    #
+    # You can quiet them down by setting <tt>ActiveRecord::Migration.verbose = false</tt>.
     cattr_accessor :verbose
     attr_accessor :name, :version
 


### PR DESCRIPTION
The API documentation for `ActiveRecord::Migration` mentions controlling the level of log output through a `.verbose` class attribute. The line isn't wrapped in `<tt>`, `+`, or backticks, so isn't emphasized as if it were code.

This commit visually emphasizes that line so that it's more obviously code.

