### PR TITLE
Add support for pattern matching for parameters

### DIFF
--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -398,6 +398,10 @@ module ActionController
     end
     alias_method :to_unsafe_hash, :to_unsafe_h
 
+    def deconstruct_keys(keys)
+      to_unsafe_h
+    end
+
     # Convert all hashes in values into parameters, then yield each pair in the same
     # way as `Hash#each_pair`.
     def each_pair(&block)

--- a/actionpack/test/controller/parameters/parameters_permit_test.rb
+++ b/actionpack/test/controller/parameters/parameters_permit_test.rb
@@ -529,6 +529,22 @@ class ParametersPermitTest < ActiveSupport::TestCase
     assert_not_predicate params[:f], :permitted?
   end
 
+  test "deconstruct_keys matches string parameters" do
+    params = ActionController::Parameters.new("f" => { "language_facet" => ["Tibetan"] })
+    case params
+    in {"f": {"language_facet": }}
+      assert_equal ["Tibetan"], language_facet
+    end
+  end
+
+  test "deconstruct_keys matches symbol parameters" do
+    params = ActionController::Parameters.new("f" => { "language_facet" => ["Tibetan"] })
+    case params
+    in {f: {language_facet: }}
+      assert_equal ["Tibetan"], language_facet
+    end
+  end
+
   test "to_h only deep dups Ruby collections" do
     company = Class.new do
       attr_reader :dupped


### PR DESCRIPTION
### Motivation / Background

I have some RESTful endpoints where it makes sense to pattern match params to deal with different shape of incoming payloads, as illustrated in this endpoint:

```ruby
def create
  case params
  in interview_time_availability: { interview_time_id:, person_id: }
    @interview_time_availabilities.create! interview_time_id:, person_id:
  in interview_time: { id: }
    @students.each do |student|
      student.interview_time_availabilities.create interview_time_id: id
    end
  end

  redirect_to students_interview_time_availabilities_path
end
```

### Detail

This PR adds a `deconstruct_keys(keys)` method on `StrongParameters` that called `to_unsafe_h` for pattern matching:

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
