### PR TITLE
Default Active Storage strict loading to strict_loading_by_default

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -59,4 +59,9 @@
 
     *Yogesh Khater*
 
+*   Default strict loading for `has_one_attached` and `has_many_attached` to
+    `strict_loading_by_default`
+
+    *Adam Rice*
+
 Please check [7-1-stable](https://github.com/rails/rails/blob/7-1-stable/activestorage/CHANGELOG.md) for previous changes.

--- a/activestorage/lib/active_storage/attached/model.rb
+++ b/activestorage/lib/active_storage/attached/model.rb
@@ -103,7 +103,7 @@ module ActiveStorage
       # When renaming classes that use <tt>has_one_attached</tt>, make sure to also update the class names in the
       # <tt>active_storage_attachments.record_type</tt> polymorphic type column of
       # the corresponding rows.
-      def has_one_attached(name, dependent: :purge_later, service: nil, strict_loading: false)
+      def has_one_attached(name, dependent: :purge_later, service: nil, strict_loading: strict_loading_by_default)
         ActiveStorage::Blob.validate_service_configuration(service, self, name) unless service.is_a?(Proc)
 
         generated_association_methods.class_eval <<-CODE, __FILE__, __LINE__ + 1
@@ -203,7 +203,7 @@ module ActiveStorage
       # When renaming classes that use <tt>has_many</tt>, make sure to also update the class names in the
       # <tt>active_storage_attachments.record_type</tt> polymorphic type column of
       # the corresponding rows.
-      def has_many_attached(name, dependent: :purge_later, service: nil, strict_loading: false)
+      def has_many_attached(name, dependent: :purge_later, service: nil, strict_loading: strict_loading_by_default)
         ActiveStorage::Blob.validate_service_configuration(service, self, name) unless service.is_a?(Proc)
 
         generated_association_methods.class_eval <<-CODE, __FILE__, __LINE__ + 1

--- a/activestorage/test/models/strict_loading_test.rb
+++ b/activestorage/test/models/strict_loading_test.rb
@@ -20,10 +20,32 @@ class ActiveStorage::StrictLoadingTest < ActiveSupport::TestCase
     end
   end
 
+  test "has_one_attached defaults to the value of strict_loading_by_default" do
+    assert_raises ActiveRecord::StrictLoadingViolationError do
+      with_strict_loading_by_default do
+        Admin.has_one_attached :document
+
+        admins = Admin.all
+        admins.as_json(include: :document)
+      end
+    end
+  end
+
   test "has_many_attached raises if strict loading and lazy loading" do
     assert_raises ActiveRecord::StrictLoadingViolationError do
       admins = Admin.all
       admins.as_json(include: :images)
+    end
+  end
+
+  test "has_many_attached defaults to the value of strict_loading_by_default" do
+    assert_raises ActiveRecord::StrictLoadingViolationError do
+      with_strict_loading_by_default do
+        Admin.has_one_attached :documents
+
+        admins = Admin.all
+        admins.as_json(include: :documents)
+      end
     end
   end
 end


### PR DESCRIPTION
### Motivation / Background

While Active Storage supports strict loading, it [defaults to false](https://github.com/rails/rails/blob/f7353283fd771e99b9675bcb9394e398964195f8/activestorage/lib/active_storage/attached/model.rb#L106). This can be problematic in applications that enforce strict loading by default. It can be assumed that `strict_loading_by_default` includes Active Storage attachments, leading to n+1 issues.

### Detail

This Pull Request changes the default of the `strict_loading` keyword parameter for `has_one_attached` and  `has_many_attached` to use the model's `strict_loading_by_default` to create a consistent developer experience.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
