### PR TITLE
[ci skip] update delegated type doc to make it less confusing and in sync with rails guide

### DIFF
--- a/activerecord/lib/active_record/delegated_type.rb
+++ b/activerecord/lib/active_record/delegated_type.rb
@@ -36,7 +36,7 @@ module ActiveRecord
   #
   # Let's look at that entry/message/comment example using delegated types:
   #
-  #   # Schema: entries[ id, account_id, creator_id, created_at, updated_at, entryable_type, entryable_id ]
+  #   # Schema: entries[ id, account_id, creator_id, entryable_type, entryable_id, created_at, updated_at ]
   #   class Entry < ApplicationRecord
   #     belongs_to :account
   #     belongs_to :creator
@@ -51,12 +51,12 @@ module ActiveRecord
   #     end
   #   end
   #
-  #   # Schema: messages[ id, subject, body ]
+  #   # Schema: messages[ id, subject, body, created_at, updated_at ]
   #   class Message < ApplicationRecord
   #     include Entryable
   #   end
   #
-  #   # Schema: comments[ id, content ]
+  #   # Schema: comments[ id, content, created_at, updated_at ]
   #   class Comment < ApplicationRecord
   #     include Entryable
   #   end


### PR DESCRIPTION
### Motivation / Background

when looking at the [api doc](https://api.rubyonrails.org/classes/ActiveRecord/DelegatedType.html
) the example doesn't mention `created_at` and `updated_at` 

it confuse me, I think we not need to have that two columns in the delegated model 
but when I look at the [rails guides](https://guides.rubyonrails.org/association_basics.html#delegated-types) the example mentioning `created_at` and `updated_at` at the delegated models

This Pull Request has been created  to make it less confusing add consitencies between the rails guide and api doc

### Detail

This Pull Request changes doc in delegated_type.rb

