### PR TITLE
Bump Prism to 0.24 (dev dependency)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -375,7 +375,7 @@ GEM
     path_expander (1.1.1)
     pg (1.5.4)
     prettier_print (1.2.1)
-    prism (0.19.0)
+    prism (0.24.0)
     propshaft (0.8.0)
       actionpack (>= 7.0.0)
       activesupport (>= 7.0.0)


### PR DESCRIPTION
### Motivation / Background

1. Prism 0.19 is 3 months old now, and 0.24 is the latest version that addressed several issues and improves performance.
2. To have the latest Ruby LSP working for this project, Prism needs to be greater than 0.22.

### Detail

This Pull Request changes [REPLACE ME]

### Additional information

<!-- Provide additional information such as benchmarks, reference to other repositories or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
