### PR TITLE
Allow subdomain with underscore in config.hosts when using `.example.com` notation

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/host_authorization.rb
+++ b/actionpack/lib/action_dispatch/middleware/host_authorization.rb
@@ -22,7 +22,7 @@ module ActionDispatch
   class HostAuthorization
     ALLOWED_HOSTS_IN_DEVELOPMENT = [".localhost", ".test", IPAddr.new("0.0.0.0/0"), IPAddr.new("::/0")]
     PORT_REGEX = /(?::\d+)/ # :nodoc:
-    SUBDOMAIN_REGEX = /(?:[a-z0-9-]+\.)/i # :nodoc:
+    SUBDOMAIN_REGEX = /(?:[a-z0-9_-]+\.)/i # :nodoc:
     IPV4_HOSTNAME = /(?<host>\d+\.\d+\.\d+\.\d+)#{PORT_REGEX}?/ # :nodoc:
     IPV6_HOSTNAME = /(?<host>[a-f0-9]*:[a-f0-9.:]+)/i # :nodoc:
     IPV6_HOSTNAME_WITH_PORT = /\[#{IPV6_HOSTNAME}\]#{PORT_REGEX}/i # :nodoc:

--- a/actionpack/test/dispatch/host_authorization_test.rb
+++ b/actionpack/test/dispatch/host_authorization_test.rb
@@ -105,6 +105,18 @@ class HostAuthorizationTest < ActionDispatch::IntegrationTest
     assert_equal "Success", body
   end
 
+  test "allows underscore in subdomain when using domain name notation" do
+    @app = build_app(".localhost")
+
+    get "/", env: {
+      "HOST" => "my_app.localhost",
+      "action_dispatch.show_detailed_exceptions" => true
+    }
+
+    assert_response :ok
+    assert_equal "Success", body
+  end
+
   test "does not allow domain name notation in the HOST header itself" do
     @app = build_app(".example.com")
 


### PR DESCRIPTION
Following up on #51086 and #51088, routing development requests to `*.test` and `*.localhost` should Just Work.

However, creating a fresh app with `rails new --main AppName` (or any multiword app name) will still give us the error message:

![image](https://github.com/rails/rails/assets/986290/0c403d1a-beb8-4011-8557-79a1f0566f0d)

This is because the subdomain regex in `HostAuthorization` only allows letters, numbers and dashes.

This Pull Request also allows underscores in subdomains for hosts added to `config.hosts` using the `.domain.com` notation.