### PR TITLE
railties: configure sanitizer vendor in 7.1 defaults more robustly

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Fix sanitizer vendor configuration in 7.1 defaults.
+
+    In apps where rails-html-sanitizer was not eagerly loaded, the sanitizer default could end up
+    being Rails::HTML4::Sanitizer when it should be set to Rails::HTML5::Sanitizer.
+
+    *Mike Dalessio*, *Rafael Mendonça França*
+
 *   Set `action_mailer.default_url_options` values in `development` and `test`.
 
     Prior to this commit, new Rails applications would raise `ActionView::Template::Error`

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -310,14 +310,14 @@ module Rails
             active_support.raise_on_invalid_cache_expiration_time = true
           end
 
-          if defined?(Rails::HTML::Sanitizer) # nested ifs to avoid linter errors
-            if respond_to?(:action_view)
-              action_view.sanitizer_vendor = Rails::HTML::Sanitizer.best_supported_vendor
-            end
+          if respond_to?(:action_view)
+            require "rails-html-sanitizer"
+            action_view.sanitizer_vendor = Rails::HTML::Sanitizer.best_supported_vendor
+          end
 
-            if respond_to?(:action_text)
-              action_text.sanitizer_vendor = Rails::HTML::Sanitizer.best_supported_vendor
-            end
+          if respond_to?(:action_text)
+            require "rails-html-sanitizer"
+            action_text.sanitizer_vendor = Rails::HTML::Sanitizer.best_supported_vendor
           end
         when "7.2"
           load_defaults "7.1"


### PR DESCRIPTION
### Motivation / Background

rails-html-santizer is a dependency of Action View and a transitive dependency of Action Text (via Action Pack), but may not be loaded until after railties sets configuration defaults, meaning that the sanitizer vendor may remain `Rails::HTML4` and not be set to `Rails::HTML5` as we intend in Rails 7.1.

This change `require`s rails-html-sanitizer immediately before it's needed, and avoids the possibly-incorrect assumption that Rails::HTML::Sanitizer is already defined.

Closes #51246

If merged, this should be backported to 7-1-stable.

### Additional information

Because the buggy behavior is dependent on the order in which libraries are loaded, it's difficult to add to the test suite.

I tested manually using the repro from #51246:

```ruby
#! /usr/bin/env ruby

require "bundler/inline"

gemfile do
  source "https://rubygems.org"
  gem "rails", path: ".."
end

require "action_controller/railtie"
require "action_view/railtie"
require "minitest/autorun"

class TestApp < Rails::Application
  config.load_defaults 7.1
  config.eager_load = true
end

TestApp.initialize!

class BugTest < Minitest::Test
  def test_sanitizer_vendor
    assert_equal ActionView::Helpers::SanitizeHelper.sanitizer_vendor, Rails::HTML5::Sanitizer
  end
end
```



### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
