### PR TITLE
Fix md label-lists rendering incorrectly [ci-skip]

### DIFF
--- a/actioncable/lib/action_cable/channel/test_case.rb
+++ b/actioncable/lib/action_cable/channel/test_case.rb
@@ -142,12 +142,14 @@ module ActionCable
     # ActionCable::Channel::TestCase will also automatically provide the following
     # instance methods for use in the tests:
     #
-    # **connection**
+    # connection
     # :   An ActionCable::Channel::ConnectionStub, representing the current HTTP
     #     connection.
-    # **subscription**
+    #
+    # subscription
     # :   An instance of the current channel, created when you call `subscribe`.
-    # **transmissions**
+    #
+    # transmissions
     # :   A list of all messages that have been transmitted into the channel.
     #
     #

--- a/actionpack/lib/action_controller/test_case.rb
+++ b/actionpack/lib/action_controller/test_case.rb
@@ -288,14 +288,16 @@ module ActionController
   # ActionController::TestCase will also automatically provide the following
   # instance variables for use in the tests:
   #
-  # **@controller**
+  # @controller
   # :   The controller instance that will be tested.
-  # **@request**
+  #
+  # @request
   # :   An ActionController::TestRequest, representing the current HTTP request.
   #     You can modify this object before sending the HTTP request. For example,
   #     you might want to set some session properties before sending a GET
   #     request.
-  # **@response**
+  #
+  # @response
   # :   An ActionDispatch::TestResponse object, representing the response of the
   #     last HTTP response. In the above example, `@response` becomes valid after
   #     calling `post`. If the various assert methods are not sufficient, then you


### PR DESCRIPTION
Ref #50759

When converting docs from RDoc to Markdown, some label-lists ended up not rendering properly. This appears to be due to RDoc's Markdown parser not recognizing label-list labels if the label has additional markup around it (in this case, bold markers `**`).

Additionally, the markdown label-list was missing newlines between list items which also caused the label-list to not render correctly (I submitted a fix for this upstream in ruby/rdoc#1094)

This commit fixes both of these issues for cases where the RDoc originally used `<b>` tags in a label-list label. Since label-list labels will already be bolded, there is no reason to also use `**` on the labels.

Before:

![image](https://github.com/rails/rails/assets/6014046/292ed049-d5c7-44b8-8946-d2ec0ef4474f)

![image](https://github.com/rails/rails/assets/6014046/cdc9a410-d2b9-4489-b9c5-434a2ba7f85c)

After:

![image](https://github.com/rails/rails/assets/6014046/ec0f5cca-0be1-4b22-b48c-e52cd5424dd8)

![image](https://github.com/rails/rails/assets/6014046/fe91461b-1e72-48c1-9878-c2f8442d60bc)
