### PR TITLE
Enable Hash#compact_blank inside ActiveSupport::LogSubscriber

### DIFF
--- a/activesupport/lib/active_support/log_subscriber.rb
+++ b/activesupport/lib/active_support/log_subscriber.rb
@@ -2,6 +2,7 @@
 
 require "active_support/core_ext/module/attribute_accessors"
 require "active_support/core_ext/class/attribute"
+require "active_support/core_ext/enumerable"
 require "active_support/subscriber"
 require "active_support/deprecation/proxy_wrappers"
 


### PR DESCRIPTION
### Motivation / Background
Using ActiveSupport::LogSubscriber#color inside a custom log subscriber causes NoMethodError.

### Detail
```ruby
# frozen_string_literal: true

require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"

  gem "activesupport"
end

require "active_support"

class TestLogSubscriber < ActiveSupport::LogSubscriber
  attach_to :test

  def hi(event)
    info(color(event.payload[:message], GREEN))
  end

  private
    def log_exception(name, e)
      super
      raise e
    end
end

ActiveSupport::LogSubscriber.logger = ActiveSupport::Logger.new(STDOUT)
ActiveSupport::Notifications.instrument("hi.test", message: "Hello!")
```

```
/rails/activesupport/lib/active_support/log_subscriber.rb:193:in `mode_from': undefined method `compact_blank' for an instance of Hash (NoMethodError)
    
      modes = MODES.values_at(*options.compact_blank.keys)
                                      ^^^^^^^^^^^^^^
```

### Additional information
I have encountered this while using kredis locally, like;

```
$ cd kredis
$ bin/console
irb(main):001> Kredis.string "mystring"
Could not log "meta.kredis" event. NoMethodError: undefined method `compact_blank' for an instance of Hash
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
