### PR TITLE
Kebabcase puma-dev configuration suggestion in bin/setup

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/bin/setup.tt
+++ b/railties/lib/rails/generators/rails/app/templates/bin/setup.tt
@@ -1,7 +1,7 @@
 require "fileutils"
 
 APP_ROOT = File.expand_path("..", __dir__)
-APP_NAME = "<%= app_name %>"
+APP_NAME = "<%= app_name.dasherize %>"
 
 def system!(*args)
   system(*args, exception: true)


### PR DESCRIPTION
Following up on #51266. Trying to make sure the suggested `puma-dev` setup introduced in #51088 works out of the box.

Creating a fresh app with `rails new --main AppName` (or any multi-word app name) will still give us the error message:

![image](https://github.com/rails/rails/assets/986290/7dd53909-8566-45ac-960c-84b58f3526a9)

This PR simply kebabcases the `puma-dev` symlink suggested in `bin/setup`, making it work without additional configuration.