### PR TITLE
Fix redundant resource_route Invocations in scaffold generator

### DIFF
--- a/railties/lib/rails/generators/rails/resource/resource_generator.rb
+++ b/railties/lib/rails/generators/rails/resource/resource_generator.rb
@@ -19,7 +19,7 @@ module Rails
 
       class << self
         def desc(description = nil)
-          ERB.new(File.read(usage_path)).result(binding)
+          @desc ||= ERB.new(File.read(usage_path)).result(binding)
         end
       end
     end

--- a/railties/lib/rails/generators/rails/scaffold/scaffold_generator.rb
+++ b/railties/lib/rails/generators/rails/scaffold/scaffold_generator.rb
@@ -6,11 +6,11 @@ module Rails
   module Generators
     class ScaffoldGenerator < ResourceGenerator # :nodoc:
       remove_hook_for :resource_controller
+      remove_hook_for :resource_route
       remove_class_option :actions
 
       class_option :api, type: :boolean,
         desc: "Generate API-only controller and tests, with no view templates"
-      class_option :resource_route, type: :boolean
 
       hook_for :scaffold_controller, required: true
     end

--- a/railties/test/generators/scaffold_generator_test.rb
+++ b/railties/test/generators/scaffold_generator_test.rb
@@ -383,8 +383,10 @@ class ScaffoldGeneratorTest < Rails::Generators::TestCase
     assert_file "config/routes.rb", /\.routes\.draw do\n  resources :products\n/
   end
 
-  def test_scaffold_generator_with_switch_resource_route_false
-    run_generator [ "posts", "--resource-route=false" ]
+  def test_scaffold_generator_with_switch_no_resource_route
+    output = run_generator [ "posts", "--no-resource-route" ]
+
+    assert_no_match(/error/, output)
     assert_file "config/routes.rb" do |route|
       assert_no_match(/resources :posts$/, route)
     end


### PR DESCRIPTION
### Motivation / Background

This PR comes form [this comment](https://github.com/rails/rails/pull/50335#pullrequestreview-1776597506). The rails generate scaffold command triggers the resource_route hook twice.

```
% bin/rails generate scaffold Post name:string
      invoke  active_record
      create    db/migrate/20240303140443_create_posts.rb
      create    app/models/post.rb
      invoke    test_unit
      create      test/models/post_test.rb
      create      test/fixtures/posts.yml
      invoke  resource_route
       route    resources :posts
      invoke  scaffold_controller
      create    app/controllers/posts_controller.rb
      invoke    erb
      create      app/views/posts
      create      app/views/posts/index.html.erb
      create      app/views/posts/edit.html.erb
      create      app/views/posts/show.html.erb
      create      app/views/posts/new.html.erb
      create      app/views/posts/_form.html.erb
      create      app/views/posts/_post.html.erb
      invoke    resource_route
      invoke    test_unit
      create      test/controllers/posts_controller_test.rb
      create      test/system/posts_test.rb
      invoke    helper
      create      app/helpers/posts_helper.rb
      invoke      test_unit
      invoke    jbuilder
      create      app/views/posts/index.json.jbuilder
      create      app/views/posts/show.json.jbuilder
      create      app/views/posts/_post.json.jbuilder
```

Despite setting the --skip-routes option, which is a feature of the ScaffoldControllerGenerator designed to prevent route generation, the command still produces routes.

```
% bin/rails g scaffold Post name:string --skip-routes
      invoke  active_record
      create    db/migrate/20240306035406_create_posts.rb
      create    app/models/post.rb
      invoke    test_unit
      create      test/models/post_test.rb
      create      test/fixtures/posts.yml
      invoke  resource_route
       route    resources :posts
      invoke  scaffold_controller
      create    app/controllers/posts_controller.rb
      invoke    erb
      create      app/views/posts
      create      app/views/posts/index.html.erb
      create      app/views/posts/edit.html.erb
      create      app/views/posts/show.html.erb
      create      app/views/posts/new.html.erb
      create      app/views/posts/_form.html.erb
      create      app/views/posts/_post.html.erb
      invoke    resource_route
      invoke    test_unit
      create      test/controllers/posts_controller_test.rb
      create      test/system/posts_test.rb
      invoke    helper
      create      app/helpers/posts_helper.rb
      invoke      test_unit
      invoke    jbuilder
      create      app/views/posts/index.json.jbuilder
      create      app/views/posts/show.json.jbuilder
      create      app/views/posts/_post.json.jbuilder
```

### Detail
Following three parts of the code are related to multiple invocation of resource_route.

- `hook_for :resource_route` within the ResourceGenerator, from which the ScaffoldGenerator inherits
- `class_option :resource_route` in ScaffoldGenerator
- `hook_for :resource_route` in ScaffoldControllerGenerator which is invoked by `hook_for :scaffold_controller` in ScaffoldGenerator

The resource_route hook within ScaffoldGenerator has been removed with remove_hook_for to ensure that the hook is called exclusively within the scaffold_controller hook.
The `class_option :resource_route, type: :boolean` has also been removed. Despite the removal of the resource_route hook in ScaffoldGenerator, invoking `class_option :resource_route` was still indirectly triggering resource_route.
This occurred due to a combination of the following reasons:

- generator classes, which inherit from Thor::Group, execute all defined public instance methods upon command execution.
- the hook_for method utilizes invoke_from_option, a method defined in Thor::Group to dynamically defines an invoke_from_option_* method at runtime, which persists even if remove_hook_for is called.
  - https://github.com/rails/thor/blob/a43d92fad7ebd77d359b7b96eb3db8a73ef9057c/lib/thor/group.rb#L124
- the invoke_from_option_* method returns early when the option isn't available but `class_option :resource_route` in ScaffoldGeneratore makes the option available and Rails sets the resource_route option as default.
  - https://github.com/rails/rails/blob/f7353283fd771e99b9675bcb9394e398964195f8/railties/lib/rails/generators.rb#L56

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
