### PR TITLE
Update the Rails app devcontainer to use the Rail's orgs ruby feature

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/.devcontainer/Dockerfile.tt
+++ b/railties/lib/rails/generators/rails/app/templates/.devcontainer/Dockerfile.tt
@@ -1,6 +1,6 @@
 # Make sure RUBY_VERSION matches the Ruby version in .ruby-version
 ARG RUBY_VERSION=<%= devcontainer_ruby_version %>
-FROM mcr.microsoft.com/devcontainers/ruby:1-$RUBY_VERSION-bookworm
+FROM mcr.microsoft.com/devcontainers/base:1-bookworm
 
 <%- unless options.skip_active_storage -%>
 # Install packages needed to build gems

--- a/railties/lib/rails/generators/rails/app/templates/.devcontainer/devcontainer.json.tt
+++ b/railties/lib/rails/generators/rails/app/templates/.devcontainer/devcontainer.json.tt
@@ -8,7 +8,10 @@
 
   // Features to add to the dev container. More info: https://containers.dev/features.
   "features": {
-    "ghcr.io/devcontainers/features/github-cli:1": {}
+    "ghcr.io/devcontainers/features/github-cli:1": {},
+    "ghcr.io/rails/devcontainer/features/ruby:latest": {
+      "version": "3.2.2"
+    }
   },
 
 <%- if !devcontainer_variables.empty? -%>


### PR DESCRIPTION
### Motivation / Background


This Pull Request has been created because in rails/devcontainer@37a2abf we published our own Ruby feature. Let's use it in the rails app devcontainer.

### Detail

This Pull Request uses in the rails app the `rails/devcontainer/ruby` feature to install ruby and its dependencies.

### Additional information

- I want to use this in the Rails devcontainer as well, to get more feedback on the feature. However doing so would require undoing the work in https://github.com/rails/rails/pull/43061, so I will hold off until we are hosting our own images
- Merging this will let us un-revert https://github.com/rails/rails/commit/707b5cb60616c86cd554ada2ef8754dd0ab5e72a

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
