### PR TITLE
Handling relative paths with extra URI parts.

### DIFF
--- a/actionpack/lib/action_controller/metal/request_forgery_protection.rb
+++ b/actionpack/lib/action_controller/metal/request_forgery_protection.rb
@@ -637,10 +637,10 @@ module ActionController # :nodoc:
         uri = URI.parse(action_path)
 
         if uri.relative? && (action_path.blank? || !action_path.start_with?("/"))
-          return normalize_relative_action_path(uri.path)
+          normalize_relative_action_path(uri.path)
+        else
+          uri.path.chomp("/")
         end
-
-        uri.path.chomp("/")
       end
 
       def normalize_relative_action_path(rel_action_path) # :doc:

--- a/actionpack/lib/action_controller/metal/request_forgery_protection.rb
+++ b/actionpack/lib/action_controller/metal/request_forgery_protection.rb
@@ -637,12 +637,18 @@ module ActionController # :nodoc:
         uri = URI.parse(action_path)
 
         if uri.relative? && (action_path.blank? || !action_path.start_with?("/"))
-          uri = URI.parse(request.path)
-          # add the action path to the request.path
-          uri.path += "/#{action_path}"
-          # relative path with "./path"
-          uri.path.gsub!("/./", "/")
+          return normalize_relative_action_path(uri.path)
         end
+
+        uri.path.chomp("/")
+      end
+
+      def normalize_relative_action_path(rel_action_path) # :doc:
+        uri = URI.parse(request.path)
+        # add the action path to the request.path
+        uri.path += "/#{rel_action_path}"
+        # relative path with "./path"
+        uri.path.gsub!("/./", "/")
 
         uri.path.chomp("/")
       end

--- a/actionpack/test/controller/request_forgery_protection_test.rb
+++ b/actionpack/test/controller/request_forgery_protection_test.rb
@@ -1151,6 +1151,32 @@ class PerFormTokensControllerTest < ActionController::TestCase
     assert_response :success
   end
 
+  def test_handles_query_string
+    get :index, params: { form_path: "./post_one?a=b" }
+
+    form_token = assert_presence_and_fetch_form_csrf_token
+
+    # This is required because PATH_INFO isn't reset between requests.
+    @request.env["PATH_INFO"] = "/per_form_tokens/post_one"
+    assert_nothing_raised do
+      post :post_one, params: { custom_authenticity_token: form_token }
+    end
+    assert_response :success
+  end
+
+  def test_handles_fragment
+    get :index, params: { form_path: "./post_one#a" }
+
+    form_token = assert_presence_and_fetch_form_csrf_token
+
+    # This is required because PATH_INFO isn't reset between requests.
+    @request.env["PATH_INFO"] = "/per_form_tokens/post_one"
+    assert_nothing_raised do
+      post :post_one, params: { custom_authenticity_token: form_token }
+    end
+    assert_response :success
+  end
+
   def test_ignores_origin_during_generation
     get :index, params: { form_path: "https://example.com/per_form_tokens/post_one/" }
 


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

After https://github.com/rails/rails/pull/32770, we started seeing `bad component(expected relative path component) ...` error when passing paths with extra URI parts like query strings and fragments (#)

### Details

I added a couple of tests to reproduce the scenarios, with the previous code they fail

```
Error:
PerFormTokensControllerTest#test_handles_fragment:
ActionView::Template::Error: bad component(expected relative path component): /per_form_tokens/./post_one#a
    /usr/local/lib/ruby/3.2.0/uri/generic.rb:776:in `check_path'
    /usr/local/lib/ruby/3.2.0/uri/generic.rb:816:in `path='
    lib/action_controller/metal/request_forgery_protection.rb:642:in `normalize_action_path'
...

Error:
PerFormTokensControllerTest#test_handles_query_string:
ActionView::Template::Error: bad component(expected relative path component): /per_form_tokens/./post_one?a=b
    /usr/local/lib/ruby/3.2.0/uri/generic.rb:776:in `check_path'
    /usr/local/lib/ruby/3.2.0/uri/generic.rb:816:in `path='
    lib/action_controller/metal/request_forgery_protection.rb:642:in `normalize_action_path'
```

`URI.parse` already handles the extra action_path parts passed in the action_path. I reused the one instantiated at [the beginning of the method](https://github.com/rails/rails/blob/6e0b89c533a70473972012a262b91ef623b57b4e/actionpack/lib/action_controller/metal/request_forgery_protection.rb#L637) to get the clean path.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [ ] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
