### PR TITLE
Fix flaky `upsert` test

### DIFF
--- a/activerecord/test/cases/insert_all_test.rb
+++ b/activerecord/test/cases/insert_all_test.rb
@@ -337,19 +337,21 @@ class InsertAllTest < ActiveRecord::TestCase
     end
   end
 
-  def test_upsert_and_db_warnings
-    skip unless supports_insert_on_duplicate_update?
+  unless in_memory_db?
+    def test_upsert_and_db_warnings
+      skip unless supports_insert_on_duplicate_update?
 
-    begin
-      with_db_warnings_action(:raise) do
-        assert_nothing_raised do
-          Book.upsert({ id: 1001, name: "Remote", author_id: 1 })
+      begin
+        with_db_warnings_action(:raise) do
+          assert_nothing_raised do
+            Book.upsert({ id: 1001, name: "Remote", author_id: 1 })
+          end
         end
+      ensure
+        # We need to explicitly remove the record, because `with_db_warnings_action`
+        # prevents the wrapping transaction to be rolled back.
+        Book.delete(1001)
       end
-    ensure
-      # We need to explicitly remove the record, because `with_db_warnings_action`
-      # prevents the wrapping transaction to be rolled back.
-      Book.delete(1001)
     end
   end
 


### PR DESCRIPTION
I apologize, I introduced a flaky test in https://github.com/rails/rails/pull/51274 (see https://buildkite.com/rails/rails/builds/105531#018e1af3-9204-488d-bd5e-b56319ef7635).

The problem is that `with_db_warnings_action` closes an old connection and creates a new one, which is a problem for an in-memory sqlite, because it essentially creates a new empty database. 