### PR TITLE
Transform attributes during `ActiveModel::Serialization::JSON#from_json`

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,3 +1,30 @@
+*   Yield attributes to block when calling `ActiveModel::Serialization::JSON#from_json`
+
+    ```ruby
+    class Person
+      include ActiveModel::Serializers::JSON
+
+      attr_accessor :name, :born_on
+
+      def attributes=(hash)
+        hash.each do |key, value|
+        send("#{key}=", value)
+        end
+      end
+    end
+
+    payload <<~JSON
+      { "name": "Alice", "bornOn": "2024-03-08" }
+    JSON
+
+    person = Person.new
+    person.from_json(payload) { |attributes| attributes.deep_transform_keys!(&:underscore) }
+    person.name # => "Alice"
+    person.born_on # => "2024-03-08"
+    ```
+
+    *Sean Doyle*
+
 *   Fix a bug where type casting of string to `Time` and `DateTime` doesn't
     calculate minus minute value in TZ offset correctly.
 

--- a/activemodel/lib/active_model/serializers/json.rb
+++ b/activemodel/lib/active_model/serializers/json.rb
@@ -114,7 +114,7 @@ module ActiveModel
       #   class Person
       #     include ActiveModel::Serializers::JSON
       #
-      #     attr_accessor :name, :age, :awesome
+      #     attr_accessor :name, :age, :awesome, :born_on
       #
       #     def attributes=(hash)
       #       hash.each do |key, value|
@@ -127,25 +127,36 @@ module ActiveModel
       #     end
       #   end
       #
-      #   json = { name: 'bob', age: 22, awesome:true }.to_json
+      #   json = { name: 'bob', age: 22, awesome: true, born_on: '2024-03-07' }.to_json
       #   person = Person.new
       #   person.from_json(json) # => #<Person:0x007fec5e7a0088 @age=22, @awesome=true, @name="bob">
       #   person.name            # => "bob"
       #   person.age             # => 22
       #   person.awesome         # => true
+      #   person.born_on         # => "2024-03-07"
       #
       # The default value for +include_root+ is +false+. You can change it to
       # +true+ if the given JSON string includes a single root node.
       #
-      #   json = { person: { name: 'bob', age: 22, awesome:true } }.to_json
+      #   json = { person: { name: 'bob', age: 22, awesome: true, born_on: '2024-03-07' } }.to_json
       #   person = Person.new
       #   person.from_json(json, true) # => #<Person:0x007fec5e7a0088 @age=22, @awesome=true, @name="bob">
       #   person.name                  # => "bob"
       #   person.age                   # => 22
       #   person.awesome               # => true
+      #   person.born_on               # => "2024-03-07"
+      #
+      # The +attributes+ are yielded to a block to transform them before assignment:
+      #
+      #   json = { name: 'bob', bornOn: '2024-03-07' }.to_json
+      #   person = Person.new
+      #   person.from_json(json) { |attributes| attributes.deep_transform_keys!(&:underscore) }
+      #   person.name            # => "bob"
+      #   person.born_on         # => "2024-03-07"
       def from_json(json, include_root = include_root_in_json)
         hash = ActiveSupport::JSON.decode(json)
         hash = hash.values.first if include_root
+        hash = yield hash if block_given?
         self.attributes = hash
         self
       end


### PR DESCRIPTION
### Motivation / Background

The problem
---

Loading JSON into an Active Model instance with
`ActiveModel::Serializers:JSON#from_json` assumes that the property casings will match the class attribute casings. This works well with snake_casing, since idiomatic Ruby methods are snake_cased.

When `#from_json` loads JSON properties that are camelCased, it silently ignores them:

```ruby
class Person
  include ActiveModel::AttributeAssignment
  include ActiveModel::Serializers::JSON

  attr_accessor :name, :born_on
end

payload <<~JSON
  { "name": "Alice", "bornOn": "2024-03-08" }
JSON

person = Person.new.from_json(payload)
person.name     # => "Alice"
person.born_on  # => nil
```

### Detail

The proposal
---

This commit proposes extending `#from_json` to accept a block. After the JSON string is decoded (and un-nested from its root, depending on the model's configuration), yield the `Hash` to a block if one is passed as an argument:

```ruby
payload <<~JSON
  { "name": "Alice", "bornOn": "2024-03-08" }
JSON

person = Person.new.from_json(payload) { _1.deep_transform_keys!(&:underscore) }
person.name     # => "Alice"
person.born_on  # => "2024-03-08"
```

Supporting a block can be useful for context-specific overrides. If a class needs to provide a default transformation, it can override `#from_json`:

```ruby
class PersonFromCamelCaseAPI < Person
  def from_json(*, &block)
    default_transform = proc { _1.deep_transform_keys!(&:underscore) }

    super(*, &(block || defaul_transform))
  end
end
```

### Additional information

Without built-in support for transforming camelCased properties into snake_cased attributes, callers are responsible decoding the JSON themselves. In addition to the key transformations, they're also responsible for re-creating both the JSON decoding *and* the configurable root un-nesting provided by `#from_json`:

```ruby
payload <<~JSON
  { "name": "Alice", "bornOn": "2024-03-08" }
JSON

attributes = ActiveSupport::JSON.decode(payload)
attributes.deep_transform_keys!(&:underscore)
person = Person.new(attributes)
person.name     # => "Alice"
person.born_on  # => "2024-03-08"

nested_payload <<~JSON
  { "person": { "name": "Alice", "bornOn": "2024-03-08" } }
JSON

attributes = ActiveSupport::JSON.decode(nested_payload)
attributes.deep_transform_keys!(&:underscore)
person = Person.new(attributes["person"])
person.name     # => "Alice"
person.born_on  # => "2024-03-08"
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
