### PR TITLE
MySQL 8.0.19 introduces aliases in the VALUES and SET clauses of INSERT INTO ... ON DUPLICATE KEY UPDATE statement

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -641,8 +641,9 @@ module ActiveRecord
       def build_insert_sql(insert) # :nodoc:
         no_op_column = quote_column_name(insert.keys.first)
 
-        # Avoid MySQL 8.0 deprecation warning, see https://dev.mysql.com/worklog/task/?id=13325.
-        if !mariadb? && database_version >= "8.0.0"
+        # MySQL 8.0.19 replaces `VALUES(<expression>)` clauses with row and column alias names, see https://dev.mysql.com/worklog/task/?id=6312 .
+        # then MySQL 8.0.20 deprecates the `VALUES(<expression>)` see https://dev.mysql.com/worklog/task/?id=13325 .
+        if !mariadb? && database_version >= "8.0.19"
           values_alias = quote_table_name("#{insert.model.table_name}_values")
           sql = +"INSERT #{insert.into} #{insert.values_list} AS #{values_alias}"
 


### PR DESCRIPTION
### Motivation / Background
This pull request addresses the following errors against MySQL 8.0.18 or lower version of MySQL 8.0.

### Detail
- Steps to reproduce

```ruby
git clone https://github.com/rails/rails
cd rails
git clone https://github.com/rails/buildkite-config .buildkite/
RUBY_IMAGE=ruby:3.3 docker-compose -f .buildkite/docker-compose.yml build base &&
  CI=1 MYSQL_IMAGE=mysql:8.0.18 docker-compose -f .buildkite/docker-compose.yml run mysqldb runner activerecord 'rake db:mysql:rebuild test:mysql2'
```

- Actual behavior without this commit

```ruby
... snip ...
Error:
InsertAllTest#test_upsert_all_implicitly_sets_timestamps_on_create_when_model_record_timestamps_is_false_but_overridden:
ActiveRecord::StatementInvalid: Mysql2::Error: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'AS `ships_values` ON DUPLICATE KEY UPDATE updated_at=(CASE WHEN (`ships`.`name`<' at line 1
    /usr/local/bundle/gems/mysql2-0.5.6/lib/mysql2/client.rb:151:in `_query'
    /usr/local/bundle/gems/mysql2-0.5.6/lib/mysql2/client.rb:151:in `block in query'
    /usr/local/bundle/gems/mysql2-0.5.6/lib/mysql2/client.rb:150:in `handle_interrupt'
    /usr/local/bundle/gems/mysql2-0.5.6/lib/mysql2/client.rb:150:in `query'
    lib/active_record/connection_adapters/mysql2/database_statements.rb:104:in `block (2 levels) in raw_execute'
    lib/active_record/connection_adapters/abstract_adapter.rb:997:in `block in with_raw_connection'
    /rails/activesupport/lib/active_support/concurrency/load_interlock_aware_monitor.rb:23:in `handle_interrupt'
    /rails/activesupport/lib/active_support/concurrency/load_interlock_aware_monitor.rb:23:in `block in synchronize'
    /rails/activesupport/lib/active_support/concurrency/load_interlock_aware_monitor.rb:19:in `handle_interrupt'
    /rails/activesupport/lib/active_support/concurrency/load_interlock_aware_monitor.rb:19:in `synchronize'
    lib/active_record/connection_adapters/abstract_adapter.rb:969:in `with_raw_connection'
    lib/active_record/connection_adapters/mysql2/database_statements.rb:102:in `block in raw_execute'
    /rails/activesupport/lib/active_support/notifications/instrumenter.rb:58:in `instrument'
    lib/active_record/connection_adapters/abstract_adapter.rb:1112:in `log'
    lib/active_record/connection_adapters/mysql2/database_statements.rb:101:in `raw_execute'
    lib/active_record/connection_adapters/abstract_mysql_adapter.rb:237:in `execute_and_free'
    lib/active_record/connection_adapters/mysql2/database_statements.rb:23:in `internal_exec_query'
    lib/active_record/connection_adapters/abstract/database_statements.rb:171:in `exec_insert_all'
    lib/active_record/connection_adapters/abstract/query_cache.rb:26:in `exec_insert_all'
    lib/active_record/insert_all.rb:55:in `execute'
    lib/active_record/insert_all.rb:13:in `block in execute'
    lib/active_record/connection_adapters/abstract/connection_pool.rb:384:in `with_connection'
    lib/active_record/connection_handling.rb:270:in `with_connection'
    lib/active_record/insert_all.rb:12:in `execute'
    lib/active_record/persistence.rb:363:in `upsert_all'
    test/cases/insert_all_test.rb:561:in `block in test_upsert_all_implicitly_sets_timestamps_on_create_when_model_record_timestamps_is_false_but_overridden'
    test/cases/insert_all_test.rb:809:in `with_record_timestamps'
    test/cases/insert_all_test.rb:560:in `test_upsert_all_implicitly_sets_timestamps_on_create_when_model_record_timestamps_is_false_but_overridden'

bin/rails test /rails/activerecord/test/cases/insert_all_test.rb:557

E
... snip ...
8856 runs, 25842 assertions, 1 failures, 52 errors, 41 skips
```

### Additional information
Follow up #51274

Refer to these release notes, WL and commits for MySQL 8.0.19 and 8.0.20.
- MySQL 8.0.19 supports aliases in the VALUES and SET clauses of INSERT INTO ... ON DUPLICATE KEY UPDATE statement https://dev.mysql.com/doc/relnotes/mysql/8.0/en/news-8-0-19.html

> MySQL now supports aliases in the VALUES and SET clauses of INSERT INTO ... ON DUPLICATE KEY UPDATE statement
> for the row to be inserted and its columns. Consider a statement such as this one:

https://dev.mysql.com/worklog/task/?id=6312
https://github.com/mysql/mysql-server/commit/c39355e9e6985a8aac4df58d8a56ce91f166d27d

- MySQL 8.0.20 deprecates the old `VALUES()` syntax in INSERT ... ON DUPLICATE KEY UPDATE statements

https://dev.mysql.com/doc/relnotes/mysql/8.0/en/news-8-0-20.html
> The use of VALUES() to access new row values in INSERT ... ON DUPLICATE KEY UPDATE statements
> is now deprecated, and is subject to removal in a future MySQL release.
> Instead, you should use aliases for the new row and its columns as implemented in MySQL 8.0.19 and later.

https://dev.mysql.com/worklog/task/?id=13325
https://github.com/mysql/mysql-server/commit/6f3b9df50b6aee5f1f868dc099cc27c660cac130

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
