### PR TITLE
Backport fix double bold label lists [ci-skip]

### DIFF
--- a/actioncable/lib/action_cable/channel/test_case.rb
+++ b/actioncable/lib/action_cable/channel/test_case.rb
@@ -140,11 +140,11 @@ module ActionCable
     # ActionCable::Channel::TestCase will also automatically provide the following instance
     # methods for use in the tests:
     #
-    # <b>connection</b>::
+    # connection::
     #      An ActionCable::Channel::ConnectionStub, representing the current HTTP connection.
-    # <b>subscription</b>::
+    # subscription::
     #      An instance of the current channel, created when you call +subscribe+.
-    # <b>transmissions</b>::
+    # transmissions::
     #      A list of all messages that have been transmitted into the channel.
     #
     #

--- a/actionpack/lib/action_controller/test_case.rb
+++ b/actionpack/lib/action_controller/test_case.rb
@@ -284,13 +284,13 @@ module ActionController
   # ActionController::TestCase will also automatically provide the following instance
   # variables for use in the tests:
   #
-  # <b>@controller</b>::
+  # @controller::
   #      The controller instance that will be tested.
-  # <b>@request</b>::
+  # @request::
   #      An ActionController::TestRequest, representing the current HTTP
   #      request. You can modify this object before sending the HTTP request. For example,
   #      you might want to set some session properties before sending a GET request.
-  # <b>@response</b>::
+  # @response::
   #      An ActionDispatch::TestResponse object, representing the response
   #      of the last HTTP response. In the above example, <tt>@response</tt> becomes valid
   #      after calling +post+. If the various assert methods are not sufficient, then you


### PR DESCRIPTION
Ref #51270 

Manual backport of 8922180af535e67ea694c9dce9f2f82fab6813e3

Unlike the commit on main, this list already renders correctly in the API docs. The only thing in this change is the removal of the extra bolding (label list labels are already bold, the extra `<b>` makes them even bolder)

![image](https://github.com/rails/rails/assets/6014046/a18c414e-1f34-4271-ada2-a6aea9c155a0)

This image shows the difference side by side, the extra bold was removed from `connection` (`font-weight: bold`) whereas the other two still have it (`font-weight: bolder`)
