### PR TITLE
Expire caching when a download fail while proxying in ActiveStorage

### DIFF
--- a/activestorage/app/controllers/concerns/active_storage/streaming.rb
+++ b/activestorage/app/controllers/concerns/active_storage/streaming.rb
@@ -61,6 +61,15 @@ module ActiveStorage::Streaming
         blob.download do |chunk|
           stream.write chunk
         end
+      rescue ActiveStorage::FileNotFoundError
+        expires_now
+        head :not_found
+      rescue
+        # Status and caching headers are already set, but not commited.
+        # Change the status to 500 manually.
+        expires_now
+        head :internal_server_error
+        raise
       end
     end
 end

--- a/activestorage/test/controllers/blobs/proxy_controller_test.rb
+++ b/activestorage/test/controllers/blobs/proxy_controller_test.rb
@@ -16,6 +16,32 @@ class ActiveStorage::Blobs::ProxyControllerTest < ActionDispatch::IntegrationTes
     assert_equal "max-age=3155695200, public", response.headers["Cache-Control"]
   end
 
+  test "invalidates cache and returns a 404 if the file is not found on download" do
+    blob = create_file_blob(filename: "racecar.jpg")
+    mock_download = lambda do |_|
+      raise ActiveStorage::FileNotFoundError.new "File still uploading!"
+    end
+    blob.service.stub(:download, mock_download) do
+      get rails_storage_proxy_url(blob)
+    end
+    assert_response :not_found
+    assert_equal "no-cache", response.headers["Cache-Control"]
+  end
+
+
+  test "invalidates cache and returns a 500 if an error is raised on download" do
+    blob = create_file_blob(filename: "racecar.jpg")
+    mock_download = lambda do |_|
+      raise StandardError.new "Something is not cool!"
+    end
+    blob.service.stub(:download, mock_download) do
+      get rails_storage_proxy_url(blob)
+    end
+    assert_response :internal_server_error
+    assert_equal "no-cache", response.headers["Cache-Control"]
+  end
+
+
   test "forcing Content-Type to binary" do
     get rails_storage_proxy_url(create_blob(content_type: "text/html"))
     assert_equal "application/octet-stream", response.headers["Content-Type"]

--- a/activestorage/test/controllers/representations/proxy_controller_test.rb
+++ b/activestorage/test/controllers/representations/proxy_controller_test.rb
@@ -2,6 +2,7 @@
 
 require "test_helper"
 require "database/setup"
+require "minitest/mock"
 
 class ActiveStorage::Representations::ProxyControllerWithVariantsTest < ActionDispatch::IntegrationTest
   setup do
@@ -83,6 +84,39 @@ class ActiveStorage::Representations::ProxyControllerWithVariantsWithStrictLoadi
     assert_response :ok
     assert_match(/^inline/, response.headers["Content-Disposition"])
     assert_equal @blob.variant(@transformations).download, response.body
+  end
+
+
+  test "invalidates cache and returns a 404 if the file is not found on download" do
+    # This mock requires a pre-processed variant as processing the variant will call to download
+    mock_download = lambda do |_|
+      raise ActiveStorage::FileNotFoundError.new "File still uploading!"
+    end
+
+    @blob.service.stub(:download, mock_download) do
+      get rails_blob_representation_proxy_url(
+        filename: @blob.filename,
+        signed_blob_id: @blob.signed_id,
+        variation_key: ActiveStorage::Variation.encode(@transformations))
+    end
+    assert_response :not_found
+    assert_equal "no-cache", response.headers["Cache-Control"]
+  end
+
+  test "invalidates cache and returns a 500 if the an error is raised on download" do
+    # This mock requires a pre-processed variant as processing the variant will call to download
+    mock_download = lambda do |_|
+      raise StandardError.new "Something is not cool!"
+    end
+
+    @blob.service.stub(:download, mock_download) do
+      get rails_blob_representation_proxy_url(
+        filename: @blob.filename,
+        signed_blob_id: @blob.signed_id,
+        variation_key: ActiveStorage::Variation.encode(@transformations))
+    end
+    assert_response :internal_server_error
+    assert_equal "no-cache", response.headers["Cache-Control"]
   end
 end
 


### PR DESCRIPTION
Fix #51284

Both Proxy controllers in Active Storage set the caching headers early before streaming. 

In some instances (see #51284), it is possible for the file download (from the storage service to Active Storage) to fail before we send the first byte to the client (response not yet committed). 

In those instances, this change would invalidate the cache and return a better response status before closing the stream.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
