### PR TITLE
Empty embeds when RichText is set to an empty content

### DIFF
--- a/actiontext/CHANGELOG.md
+++ b/actiontext/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Clear embeds when emptying an `ActionText::RichText`.
+
+    *Joé Dupuis*
+
 *   The Trix dependency is now satisfied by a gem, `action_text-trix`, rather than vendored
     files. This allows applications to bump Trix versions independently of Rails
     releases. Effectively this also upgrades Trix to `>= 2.1.15`.

--- a/actiontext/app/models/action_text/rich_text.rb
+++ b/actiontext/app/models/action_text/rich_text.rb
@@ -55,7 +55,7 @@ module ActionText
     has_many_attached :embeds
 
     before_validation do
-      self.embeds = body.attachables.grep(ActiveStorage::Blob).uniq if body.present?
+      self.embeds = body.blank? ? [] : body.attachables.grep(ActiveStorage::Blob).uniq
     end
 
     # Returns a plain-text version of the markup contained by the `body` attribute,

--- a/actiontext/test/unit/model_test.rb
+++ b/actiontext/test/unit/model_test.rb
@@ -76,6 +76,24 @@ class ActionText::ModelTest < ActiveSupport::TestCase
     assert_equal blob, embeds.first.blob
   end
 
+  test "saving empty content empties the embeds" do
+    blob = create_file_blob(filename: "racecar.jpg", content_type: "image/jpeg")
+    message = Message.create!(subject: "Greetings", content: ActionText::Content.new("Hello world").append_attachables(blob))
+
+    assert_changes -> { message.content.embeds.count }, from: 1, to: 0 do
+      message.update!(content: "")
+    end
+  end
+
+  test "saving nil content empties the embeds" do
+    blob = create_file_blob(filename: "racecar.jpg", content_type: "image/jpeg")
+    message = Message.create!(subject: "Greetings", content: ActionText::Content.new("Hello world").append_attachables(blob))
+
+    assert_changes -> { message.content.embeds.count }, from: 1, to: 0 do
+      message.update!(content: nil)
+    end
+  end
+
   test "saving content" do
     message = Message.create!(subject: "Greetings", content: "<h1>Hello world</h1>")
     assert_equal "Hello world", message.content.to_plain_text


### PR DESCRIPTION
Fix #51269

Passing `" "` to a RichText will clear all embeds, but passing `""` or `nil` doesn't. It defies expectation. 
This change make sure we empty embeds when emptying a RichText.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
