### PR TITLE
`ActiveRecord::Migration.verbose` documentation [ci skip]

### DIFF
--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -794,22 +794,9 @@ module ActiveRecord
     ##
     # :singleton-method: verbose
     #
-    # By default, migrations will describe the actions they are taking, writing
-    # them to the console as they happen, along with benchmarks describing how
-    # long each step took.
-    #
-    # You read that setting through <tt>ActiveRecord::Migration.verbose</tt>.
-
-    ##
-    # :singleton-method: verbose=
-    #
-    # :call-seq: verbose=(value)
-    #
-    # By default, migrations will describe the actions they are taking, writing
-    # them to the console as they happen, along with benchmarks describing how
-    # long each step took.
-    #
-    # You can quiet them down by setting <tt>ActiveRecord::Migration.verbose = false</tt>.
+    # Specifies if migrations will write the actions they are taking to the console as they
+    # happen, along with benchmarks describing how long each step took. Defaults to
+    # true.
     cattr_accessor :verbose
     attr_accessor :name, :version
 


### PR DESCRIPTION
Follow-up to [#51258][]

Re-write `ActiveRecord::Migration.verbose` documentation to incorporate [review feedback][] from [#51258][].

[#51258]: https://github.com/rails/rails/pull/51258
[review feedback]: https://github.com/rails/rails/pull/51258#discussion_r1519637097