### PR TITLE
Support custom blob key in ActiveStorage::Blob#compose similar to other Blob APIs

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add support for custom `key` in `ActiveStorage::Blob#compose`.
+
+    *Elvin Efendiev*
+
 *   Add `image/webp` to `config.active_storage.web_image_content_types` when `load_defaults "7.2"`
     is set.
 

--- a/activestorage/app/models/active_storage/blob.rb
+++ b/activestorage/app/models/active_storage/blob.rb
@@ -142,12 +142,12 @@ class ActiveStorage::Blob < ActiveStorage::Record
     end
 
     # Concatenate multiple blobs into a single "composed" blob.
-    def compose(blobs, filename:, content_type: nil, metadata: nil)
+    def compose(blobs, key: nil, filename:, content_type: nil, metadata: nil)
       raise ActiveRecord::RecordNotSaved, "All blobs must be persisted." if blobs.any?(&:new_record?)
 
       content_type ||= blobs.pluck(:content_type).compact.first
 
-      new(filename: filename, content_type: content_type, metadata: metadata, byte_size: blobs.sum(&:byte_size)).tap do |combined_blob|
+      new(key: key, filename: filename, content_type: content_type, metadata: metadata, byte_size: blobs.sum(&:byte_size)).tap do |combined_blob|
         combined_blob.compose(blobs.pluck(:key))
         combined_blob.save!
       end

--- a/activestorage/test/models/blob_test.rb
+++ b/activestorage/test/models/blob_test.rb
@@ -135,6 +135,14 @@ class ActiveStorage::BlobTest < ActiveSupport::TestCase
     assert_equal "All blobs must be persisted.", error.message
   end
 
+  test "compose with custom key" do
+    blobs = 3.times.map { create_blob(data: "123", filename: "numbers.txt", content_type: "text/plain", identify: false) }
+    blob = ActiveStorage::Blob.compose(blobs, key: "custom_key", filename: "all_numbers.txt")
+
+    assert_equal "custom_key", blob.key
+    assert_equal "123123123", blob.download
+  end
+
   test "image?" do
     blob = create_file_blob filename: "racecar.jpg"
     assert_predicate blob, :image?


### PR DESCRIPTION
https://github.com/rails/rails/commit/4dba136c83cc808282625c0d5b195ce5e0bbaa68 added support for custom keys in the `ActiveStorage::Blob` APIs however we missed to replicate that when introducing the `compose` method in https://github.com/rails/rails/commit/79a5e0b7591759817b846d1dd632003f7b6dfa25#diff-3c9b81c772d32ff6805463595e04d8d7e9031e875ebf2f9fb964ca1a78b5e56dR151. This PR changes `compose` method so that it can accept custom `key` argument to customize the name of the underlying service object.