### PR TITLE
Add composite key support to `Model.exists?`

### DIFF
--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -444,8 +444,7 @@ module ActiveRecord
           relation = except(:select, :distinct, :order)._select!(ONE_AS_ONE).limit!(1)
         end
 
-        case conditions
-        when Array, Hash
+        if conditions.is_a?(Array) && !conditions.first.is_a?(Array) || conditions.is_a?(Hash)
           relation.where!(conditions) unless conditions.empty?
         else
           relation.where!(primary_key => conditions) unless conditions == :none

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -195,11 +195,14 @@ class FinderTest < ActiveRecord::TestCase
     assert_equal true, Topic.exists?(author_name: "Mary", approved: true)
     assert_equal true, Topic.exists?(["parent_id = ?", 1])
     assert_equal true, Topic.exists?(id: [1, 9999])
+    assert_equal true, Cpk::Book.exists?([cpk_books(:cpk_great_author_first_book).id])
 
     assert_equal false, Topic.exists?(45)
     assert_equal false, Topic.exists?(9999999999999999999999999999999)
     assert_equal false, Topic.exists?(Topic.new.id)
+    assert_equal false, Cpk::Book.exists?([Cpk::Book.new.id])
 
+    assert_raises(ArgumentError) { Cpk::Book.exists?(cpk_books(:cpk_great_author_first_book).id) }
     assert_raise(ArgumentError) { Topic.exists?([1, 2]) }
   end
 


### PR DESCRIPTION
Fix #51295

`.exists?` does not support composite primary key because it would [clash with the current expectation when passing an array.](https://github.com/rails/rails/blob/main/activerecord/lib/active_record/relation/finder_methods.rb#L351)

This PR would make it possible to pass a composite primary key by wrapping it in an array:

```ruby
CpkModel.exists?([[1,1]]) # as in `CpkModel.exists?([composite_primary_key])`
```

Incidentally, it would also allow searching with multiple keys without having to use the hash form:

```ruby
CpkModel.exists?([[1,1], [1,2], [3,1]])  
RegularModel.exists?([[1,2,3]]) # Even works for non regular models! Generates: `SELECT 1 AS one FROM "regular_models" WHERE "users"."id" IN (1, 2, 3)`
``` 


## Considerations

This is a bit of hack and initially thought of answering #51295 by suggesting using the hash form instead, but after looking at what the hash form would look like for a primary key:

```ruby
CpkModel.exists?(CpkModel.primary_key => [[1,1]]) # You need to wrap the primary key in an array!
```
This is quite verbose. So perhaps there is value in this.
I did not edit the documentation and changelog yet. Only the code, plus a couple tests. If this diff is deemed valuable I'll add the required edits.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
