### PR TITLE
Model.insert_all can accept an array of records with separate column names

### DIFF
--- a/activerecord/lib/active_record/insert_all.rb
+++ b/activerecord/lib/active_record/insert_all.rb
@@ -15,8 +15,15 @@ module ActiveRecord
       end
     end
 
-    def initialize(model, connection, inserts, on_duplicate:, update_only: nil, returning: nil, unique_by: nil, record_timestamps: nil)
-      @model, @connection, @inserts = model, connection, inserts.map(&:stringify_keys)
+    def initialize(model, connection, inserts, on_duplicate:, update_only: nil, returning: nil, unique_by: nil, record_timestamps: nil, column_names: nil)
+      @model, @connection, @inserts = model, connection
+
+      if column_names
+        @inserts = inserts.map { |values| column_names.map(&:to_s).zip(values).to_h }
+      else
+        @inserts = inserts.map(&:stringify_keys)
+      end
+
       @on_duplicate, @update_only, @returning, @unique_by = on_duplicate, update_only, returning, unique_by
       @record_timestamps = record_timestamps.nil? ? model.record_timestamps : record_timestamps
 

--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -172,8 +172,8 @@ module ActiveRecord
       #     { id: 1, title: "Rework" },
       #     { id: 2, title: "Eloquent Ruby" }
       #   ])
-      def insert_all(attributes, returning: nil, unique_by: nil, record_timestamps: nil)
-        InsertAll.execute(self, attributes, on_duplicate: :skip, returning: returning, unique_by: unique_by, record_timestamps: record_timestamps)
+      def insert_all(attributes, returning: nil, unique_by: nil, record_timestamps: nil, column_names: nil)
+        InsertAll.execute(self, attributes, on_duplicate: :skip, returning: returning, unique_by: unique_by, record_timestamps: record_timestamps, column_names: column_names)
       end
 
       # Inserts a single record into the database in a single SQL INSERT

--- a/activerecord/test/cases/insert_all_test.rb
+++ b/activerecord/test/cases/insert_all_test.rb
@@ -64,6 +64,26 @@ class InsertAllTest < ActiveRecord::TestCase
     end
   end
 
+  def test_insert_all_with_column_names
+    assert_difference "Book.count", +10 do
+      column_names = [:name, :author_id]
+      books_data = [
+        ["Rework", 1],
+        ["Patterns of Enterprise Application Architecture", 1],
+        ["Design of Everyday Things", 1],
+        ["Practical Object-Oriented Design in Ruby", 1],
+        ["Clean Code", 1],
+        ["Ruby Under a Microscope", 1],
+        ["The Principles of Product Development Flow", 1],
+        ["Peopleware", 1],
+        ["About Face", 1],
+        ["Eloquent Ruby", 1]
+      ]
+
+      Book.insert_all(books_data, column_names: column_names)
+    end
+  end
+
   def test_insert_all_should_handle_empty_arrays
     skip unless supports_insert_on_duplicate_update?
 


### PR DESCRIPTION
### Motivation / Background

Expanding the `Model.insert_all` functionality to receive an array containing records and column names separately. This improvement eliminates the need for records to be in the hash format, providing a more streamlined approach, especially useful for handling large datasets when both the order of attributes and their alignment with the table structure are known in advance.

```ruby
column_names = [:name, :author_id]
book_batches.each do |book_batch|
	Book.insert_all(book_batch, column_names: column_names)
end
```

This update enables users to provide an array of arrays for the records, while also specifying the column names separately. This enhancement enhances code flexibility and readability, simplifying data insertion without requiring pre-formatting into hashes.

### Detail

- Modified insert_all method to accept an array of arrays for records.
- Added support for specifying column names separately using the columns option.

```ruby
Book.insert_all([
  ["Rework", 1],
  ["Patterns of Enterprise Application Architecture", 1]
], column_names: [:name, :author_id])
```

To showcase the API proposal, I opted for the simplest approach, which involved converting the array of records and column names into a Hash, as it aligns with the existing code.