### PR TITLE
Do not build View watcher until the first `updated?` check

### DIFF
--- a/actionview/lib/action_view/railtie.rb
+++ b/actionview/lib/action_view/railtie.rb
@@ -116,7 +116,6 @@ module ActionView
         view_reloader = ActionView::CacheExpiry::ViewReloader.new(watcher: app.config.file_watcher)
 
         app.reloaders << view_reloader
-        view_reloader.execute
         app.reloader.to_run do
           require_unload_lock!
           view_reloader.execute


### PR DESCRIPTION
Partially reworks https://github.com/rails/rails/pull/47347

Currently initialization of every Rails::Engine leads to the creation of a new View watcher when the engine prepends its paths.
https://github.com/rails/rails/blob/1555d9a5579b19acf7b9e14563b460b91ab83ddc/railties/lib/rails/engine.rb#L614
This contributes to the time it takes to perform the first cold request on a lazy loaded application.

`prepend_view_path` -> `_build_view_paths` -> `cast_file_system_resolvers` -> `file_system_resolver_hooks.each(&:call)` -> `rebuild_watcher` 

This change delays the initialization of the View watcher until the first `updated?` check is performed which leads to only one initialization of the watcher.

### Benchmark

It's not perfect but I believe it reliably shows the behavior and impact of unnecessary watcher rebuilds:

<details>
  <summary>Benchmark</summary>

  ```ruby
  require "bundler/inline"

  gemfile(true) do
    source "https://rubygems.org"

    gem "rails", path: "."
    gem "listen"
  end

  require "action_controller/railtie"

  class TestApp < Rails::Application
    config.root = __dir__
    config.hosts << "example.org"
    config.secret_key_base = "secret_key_base"
    config.file_watcher = ActiveSupport::EventedFileUpdateChecker

    config.logger = Logger.new($stdout)
    Rails.logger  = config.logger

    routes.draw do
      get "/" => "test#index"
    end
  end

  TestApp.initialize!

  class TestController < ActionController::Base
    include Rails.application.routes.url_helpers

    def index
      render plain: "Home"
    end
  end

  require "minitest/autorun"
  require "rack/test"

  class BugTest < Minitest::Test
    include Rack::Test::Methods

    def test_returns_success
      view_reloader = TestApp.reloaders.find { |reloader| reloader.is_a?(ActionView::CacheExpiry::ViewReloader) }
      result = Benchmark.ms do |x|
        20.times do |i|
          TestController.prepend_view_path "test#{i}"
        end
        view_reloader.updated?
      end
      puts "Time: #{result.round(2)} ms"
    end

    private
      def app
        Rails.application
      end
  end
  ```
  
</details>

Results:

`main`:  `Time: 17.98 ms`
this branch: `Time: 2.93 ms`

In our modular monolith we have about ~100 engines that prepend view paths causing the watcher to be rebuilt with a growing directories list and this change results in us cutting ~8s from the ~16s cold request   


### Tests

Since we only change implementation detail I believe relying on existing
https://github.com/rails/rails/blob/1555d9a5579b19acf7b9e14563b460b91ab83ddc/railties/test/application/view_reloading_test.rb#L7
test is sufficient