### PR TITLE
Do not use the alpha version if the major version is released

### DIFF
--- a/actiontext/package.json
+++ b/actiontext/package.json
@@ -22,7 +22,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "@rails/activestorage": ">= 7.1.0-alpha"
+    "@rails/activestorage": ">= 7.1.3"
   },
   "peerDependencies": {
     "trix": "^2.0.0"


### PR DESCRIPTION
This PR changes the active storage dependency version for action text. 
