### PR TITLE
Preserve encoding on `truncate_bytes`

### DIFF
--- a/activesupport/lib/active_support/core_ext/string/filters.rb
+++ b/activesupport/lib/active_support/core_ext/string/filters.rb
@@ -109,7 +109,7 @@ class String
     when omission.bytesize == truncate_to
       omission.dup
     else
-      self.class.new.tap do |cut|
+      self.class.new.force_encoding(encoding).tap do |cut|
         cut_at = truncate_to - omission.bytesize
 
         each_grapheme_cluster do |grapheme|

--- a/activesupport/test/core_ext/string_ext_test.rb
+++ b/activesupport/test/core_ext/string_ext_test.rb
@@ -376,6 +376,15 @@ class StringInflectionsTest < ActiveSupport::TestCase
     assert_equal "", "👩‍❤️‍👩".truncate_bytes(13, omission: nil)
   end
 
+  def test_truncates_bytes_preserves_encoding
+    original = String.new("a" * 30, encoding: Encoding::UTF_8)
+
+    assert_equal Encoding::UTF_8, original.truncate_bytes(15).encoding
+    assert_equal Encoding::UTF_8, original.truncate_bytes(15, omission: nil).encoding
+    assert_equal Encoding::UTF_8, original.truncate_bytes(15, omission: " ").encoding
+    assert_equal Encoding::UTF_8, original.truncate_bytes(15, omission: "🖖").encoding
+  end
+
   def test_truncate_words
     assert_equal "Hello Big World!", "Hello Big World!".truncate_words(3)
     assert_equal "Hello Big...", "Hello Big World!".truncate_words(2)


### PR DESCRIPTION
### Motivation / Background

Under some circumstances, `String#truncate_bytes` can return a string with a different encoding than the one being truncated. This is because [`String.new` with no arguments returns the empty string with `ASCII-8BIT` encoding](https://ruby-doc.org/3.2.2/String.html#method-c-new). Then, depending on each grapheme cluster of the string and on the omission string, the resulting string might keep the `ASCII-8BIT` encoding. With this change, we preserve the encoding of the original string instead.

Note that `String.new` accepts an `encoding` keyword argument, so we could do something like:
```
String.new(encoding: Encoding::UTF_8)
```
However, instead of using that, we rely on `force_encoding` to set the original encoding. This is so that String subclasses don't need to preserve this keyword argument. For example, [`SafeBuffer` doesn't](https://github.com/rails/rails/blob/4c2c8f8193d2ba26917132d2626a12305814003b/activesupport/lib/active_support/core_ext/string/output_safety.rb#L70-L73). Thanks to @jeremy for catching this!

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
