### PR TITLE
[ci skip] Undocumented - validations enabled by autosave

### DIFF
--- a/activerecord/lib/active_record/associations.rb
+++ b/activerecord/lib/active_record/associations.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module ActiveRecord
-  class AssociationNotFoundError < ConfigurationError # :nodoc:
+  class AssociavtionNotFoundError < ConfigurationError # :nodoc:
     attr_reader :record, :association_name
 
     def initialize(record = nil, association_name = nil)
@@ -1658,8 +1658,15 @@ module ActiveRecord
         #   Specifies type of the source association used by #has_one <tt>:through</tt> queries where the source
         #   association is a polymorphic #belongs_to.
         # [+:validate+]
-        #   When set to +true+, validates new objects added to association when saving the parent object. +false+ by default.
-        #   If you want to ensure associated objects are revalidated on every update, use +validates_associated+.
+        #   If +true+, validates new objects added to association when saving the parent object.
+        #   To ensure associated objects are revalidated on every update, use +validates_associated+.
+        #
+        #   Unless validation is explicitly disabled with
+        #   <tt>validate: false</tt>, validation takes place when:
+        #
+        #   * validation is explicitly enabled using; <tt>validate: true</tt>
+        #   * autosave is enabled; <tt>autosave: true</tt>
+        #   * the association is a +has_many+ association
         # [+:autosave+]
         #   If true, always save the associated object or destroy it if marked for destruction,
         #   when saving the parent object. If false, never save or destroy the associated object.
@@ -1828,8 +1835,15 @@ module ActiveRecord
         #   Note: Since polymorphic associations rely on storing class names in the database, make sure to update the class names in the
         #   <tt>*_type</tt> polymorphic type column of the corresponding rows.
         # [+:validate+]
-        #   When set to +true+, validates new objects added to association when saving the parent object. +false+ by default.
-        #   If you want to ensure associated objects are revalidated on every update, use +validates_associated+.
+        #   If +true+, validates new objects added to association when saving the parent object.
+        #   To ensure associated objects are revalidated on every update, use +validates_associated+.
+        #
+        #   Unless validation is explicitly disabled with
+        #   <tt>validate: false</tt>, validation takes place when:
+        #
+        #   * validation is explicitly enabled using; <tt>validate: true</tt>
+        #   * autosave is enabled; <tt>autosave: true</tt>
+        #   * the association is a +has_many+ association
         # [+:autosave+]
         #   If true, always save the associated object or destroy it if marked for destruction, when
         #   saving the parent object.


### PR DESCRIPTION
### Motivation / Background

Fixes #50807

As described in Issue #50807,  validations are enabled by default when the autosave option is set to true. Currently, that behavior is not documented for the `has_one` or `belongs_to` associations.   

### Detail

To resolve this issue, the  API documentation has been updated to document the validation behavior when the `autosave: true` option is set in `Activerecord::Associations` for the `has_one` or `belongs_to` associations.

### Checklist

Before submitting the PR make sure the following are checked:

* [ ] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [ ] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
