### PR TITLE
Scan application for unused routes in `ci.yml`

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   Scan application for unused routes in `cy.yml`
+
+    Adds job to scan application for unused routes in `ci.yml` by running:
+
+    ```
+    bin/rails routes --unused
+    ```
+
+    *Steve Polito*
+
 *   Fix sanitizer vendor configuration in 7.1 defaults.
 
     In apps where rails-html-sanitizer was not eagerly loaded, the sanitizer default could end up

--- a/railties/lib/rails/generators/rails/app/templates/github/ci.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/github/ci.yml.tt
@@ -6,6 +6,22 @@ on:
     branches: [ main ]
 
 jobs:
+  lint_routes:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: .ruby-version
+          bundler-cache: true
+
+      - name: Scan for unused routes
+        run: bin/rails routes --unused
+
 <%- unless skip_brakeman? -%>
   scan_ruby:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Motivation / Background

5613b1240a3 introduced the ability to detect unused routes. I felt this was a good candidate for a CI job. 

### Detail

Adds job to scan application for unused routes in `ci.yml` by running:

```
bin/rails routes --unused
```

### Additional information

By default, this will pass on any new Rails application.
![CleanShot 2024-03-12 at 20 40 38@2x](https://github.com/rails/rails/assets/5122678/0b34e0d9-8c6f-44df-91ae-25915d4b3ffe)

If any unused routes are detected, a non-zero exit code is returned, resulting in a failure:

![CleanShot 2024-03-12 at 20 33 48@2x](https://github.com/rails/rails/assets/5122678/d9957608-f001-46d6-9b3b-e84acc080251)

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
