### PR TITLE
[7-1-stable] Fix a crash when an  Executor wrapped fork exit.

### DIFF
--- a/activerecord/lib/active_record/query_cache.rb
+++ b/activerecord/lib/active_record/query_cache.rb
@@ -30,7 +30,7 @@ module ActiveRecord
     end
 
     def self.complete(pools)
-      pools.each { |pool| pool.disable_query_cache! }
+      pools.each { |pool| pool.disable_query_cache! unless pool.discarded? }
 
       ActiveRecord::Base.connection_handler.each_connection_pool do |pool|
         pool.release_connection if pool.active_connection? && !pool.connection.transaction_open?


### PR DESCRIPTION
Fix #51298

forking inside an Execution Wrapper crashes when running the completion callbacks.

Rails 7.0 was wrapping the `runner` command with an ExecutionWrapper. 
Rails 7.2 changed the definition of `active_connection?`, the new definition doesn't contain the bug. 

Therefore forking inside a script intended to be run with the `runner` command on 7.1 crashes. (see #51298)

This PR is targeting `7-1-stable`

Edit: The regression test (with the fork) blew up the tests. I removed it, I'll revisit. 

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
