### PR TITLE
Fix grammar in active_record_validations.md guide

### DIFF
--- a/guides/source/active_record_validations.md
+++ b/guides/source/active_record_validations.md
@@ -656,7 +656,7 @@ class Order < ApplicationRecord
 end
 ```
 
-NOTE: If you want to ensure that the association it is both present and valid,
+NOTE: If you want to ensure that the association is both present and valid,
 you also need to use `validates_associated`. More on that
 [below](#validates-associated)
 
@@ -713,7 +713,7 @@ class Order < ApplicationRecord
 end
 ```
 
-NOTE: If you want to ensure that the association it is both present and valid,
+NOTE: If you want to ensure that the association is both present and valid,
 you also need to use `validates_associated`. More on that
 [below](#validates-associated)
 


### PR DESCRIPTION
### Motivation / Background

Just a grammar mistake I've noticed while reading the guides.

### Detail

This Pull Request changes the ActiveRecord validations guide.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
