### PR TITLE
Memoize `key_provider` from `key` or deterministic `key_provider` if any

### DIFF
--- a/activerecord/lib/active_record/encryption/scheme.rb
+++ b/activerecord/lib/active_record/encryption/scheme.rb
@@ -50,7 +50,7 @@ module ActiveRecord
       end
 
       def key_provider
-        @key_provider_param || build_key_provider || default_key_provider
+        @key_provider_param || key_provider_from_key || deterministic_key_provider || default_key_provider
       end
 
       def merge(other_scheme)
@@ -80,10 +80,14 @@ module ActiveRecord
           raise Errors::Configuration, "key_provider: and key: can't be used simultaneously" if @key_provider_param && @key
         end
 
-        def build_key_provider
-          return DerivedSecretKeyProvider.new(@key) if @key.present?
+        def key_provider_from_key
+          @key_provider_from_key ||= if @key.present?
+            DerivedSecretKeyProvider.new(@key)
+          end
+        end
 
-          if @deterministic
+        def deterministic_key_provider
+          @deterministic_key_provider ||= if @deterministic
             DeterministicKeyProvider.new(ActiveRecord::Encryption.config.deterministic_key)
           end
         end


### PR DESCRIPTION
### Motivation / Background

We're in the process of bringing one of our apps up to date with `main`, and in the process of doing so, we realised our tests were taking about 5 times longer to run. We traced the slowdown back to https://github.com/rails/rails/pull/51019.

The memoization of `Scheme#key_provider` was removed completely in that PR because it prevented overriding the `key_provider` via `with_encryption_context`. For encrypted attributes where we either provide a key or declare them as deterministic, we have to derive a key to instantiate the provider every time we load them. This might happen hundreds of times per test, and ultimately means we call
```
ActiveSupport::KeyGenerator#generate_key
```
and
```
OpenSSL::KDF.pbkdf2_hmac
```
hundreds of times. This adds significant overhead per test.

In reality, what's overridden by `with_encryption_context` is the value used as default provider, that is, `ActiveRecord::Encryption.key_provider`. This is only used in `Scheme#key_provider` if the scheme doesn't already have either a `key_provider` passed directly, or a `key`, or is `deterministic`, because it's called via `default_key_provider` here: https://github.com/rails/rails/blob/3efae445196da943c0532a00f6dfbafc74ae879d/activerecord/lib/active_record/encryption/scheme.rb#L52-L54
https://github.com/rails/rails/blob/3efae445196da943c0532a00f6dfbafc74ae879d/activerecord/lib/active_record/encryption/scheme.rb#L91-L93

However, `build_key_provider` takes precedence, and it's very expensive to do:

https://github.com/rails/rails/blob/3efae445196da943c0532a00f6dfbafc74ae879d/activerecord/lib/active_record/encryption/scheme.rb#L83-L89

Neither `@key` nor `@deterministic` can be overridden, so this PR memoizes them if we have to build them. 

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.

cc @jhawthorn @kstevens715