### PR TITLE
Do not try to alias on key update when raw SQL is supplied

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -650,10 +650,10 @@ module ActiveRecord
           if insert.skip_duplicates?
             sql << " ON DUPLICATE KEY UPDATE #{no_op_column}=#{values_alias}.#{no_op_column}"
           elsif insert.update_duplicates?
-            sql << " ON DUPLICATE KEY UPDATE "
             if insert.raw_update_sql?
-              sql << insert.raw_update_sql
+              sql = +"INSERT #{insert.into} #{insert.values_list} ON DUPLICATE KEY UPDATE #{insert.raw_update_sql}"
             else
+              sql << " ON DUPLICATE KEY UPDATE "
               sql << insert.touch_model_timestamps_unless { |column| "#{insert.model.quoted_table_name}.#{column}<=>#{values_alias}.#{column}" }
               sql << insert.updatable_columns.map { |column| "#{column}=#{values_alias}.#{column}" }.join(",")
             end


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

Following https://github.com/rails/rails/pull/51274/files#r1520277424, we started getting mixed queries when using raw SQL. For example:

```
Model.upsert_all(..., on_duplicate: Arel.sql("x=VALUES(x)"))
INSERT table (...) VALUES (...) as values_alias ON DUPLICATE KEY UPDATE x=VALUES(x)
```
and
```
Model.upsert_all(..., on_duplicate: Arel.sql("x=x"))
INSERT table (...) VALUES (...) as values_alias ON DUPLICATE KEY UPDATE x=x
```

Both cases cause:

```
ActiveRecord::StatementInvalid: Trilogy::ProtocolError: 1052: Column 'x' in field list is ambiguous
```

### Detail

In the case of raw SQL, I think using the old syntax without values aliases (previous behavior) is better since we can't determine whether it is aliased or not. For example: 

```
Model.upsert_all(..., on_duplicate: Arel.sql("x=VALUES(x)"))
INSERT table (...) VALUES (...) ON DUPLICATE KEY UPDATE x=VALUES(x)
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [ ] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
