### PR TITLE
Stablize ConnectionPoolTests#test_idle_timeout_configuration

### DIFF
--- a/activerecord/test/cases/connection_pool_test.rb
+++ b/activerecord/test/cases/connection_pool_test.rb
@@ -280,7 +280,7 @@ module ActiveRecord
 
         idle_conn.instance_variable_set(
           :@idle_since,
-          Process.clock_gettime(Process::CLOCK_MONOTONIC) - 0.02
+          Process.clock_gettime(Process::CLOCK_MONOTONIC) - 0.03
         )
 
         @pool.flush


### PR DESCRIPTION
It flakes a lot on my machine because the timeouts are identical.
