### PR TITLE
Don't query adapter in ensure blocks when connection is closed

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
@@ -350,7 +350,7 @@ module ActiveRecord
 
       def rollback
         unless @state.invalidated?
-          connection.rollback_to_savepoint(savepoint_name) if materialized?
+          connection.rollback_to_savepoint(savepoint_name) if materialized? && connection.active?
         end
         @state.rollback!
         @instrumenter.finish(:rollback) if materialized?

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -218,7 +218,7 @@ module ActiveRecord
           update("SET FOREIGN_KEY_CHECKS = 0")
           yield
         ensure
-          update("SET FOREIGN_KEY_CHECKS = #{old}")
+          update("SET FOREIGN_KEY_CHECKS = #{old}") if active?
         end
       end
 

--- a/activerecord/lib/active_record/connection_adapters/trilogy/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/trilogy/database_statements.rb
@@ -96,7 +96,7 @@ module ActiveRecord
 
               yield
             ensure
-              conn.set_server_option(::Trilogy::SET_SERVER_MULTI_STATEMENTS_OFF)
+              conn.set_server_option(::Trilogy::SET_SERVER_MULTI_STATEMENTS_OFF) if active?
             end
           end
       end

--- a/activerecord/test/cases/adapters/trilogy/trilogy_adapter_test.rb
+++ b/activerecord/test/cases/adapters/trilogy/trilogy_adapter_test.rb
@@ -4,6 +4,7 @@ require "cases/helper"
 require "support/ddl_helper"
 require "models/book"
 require "models/post"
+require "timeout"
 
 class TrilogyAdapterTest < ActiveRecord::TrilogyTestCase
   setup do
@@ -15,6 +16,40 @@ class TrilogyAdapterTest < ActiveRecord::TrilogyTestCase
       ActiveRecord::ConnectionAdapters::TrilogyAdapter.new(host: "invalid", port: 12345).connect!
     end
     assert_kind_of ActiveRecord::ConnectionAdapters::NullPool, error.connection_pool
+  end
+
+  test "timeout in transaction doesnt query closed connection" do
+    assert_raises(Timeout::Error) do
+      Timeout.timeout(0.1) do
+        @conn.transaction do
+          @conn.execute("SELECT SLEEP(1)")
+        end
+      end
+    end
+  end
+
+  test "timeout in fixture set insertion doesnt query closed connection" do
+    fixtures = [
+      ["traffic_lights", [
+        { "location" => "US", "state" => ["NY"], "long_state" => ["a"] },
+      ]]
+    ] * 1000
+
+    assert_raises(Timeout::Error) do
+      Timeout.timeout(0.1) do
+        @conn.insert_fixtures_set(fixtures)
+      end
+    end
+  end
+
+  test "timeout without referential integrity doesnt query closed connection" do
+    assert_raises(Timeout::Error) do
+      Timeout.timeout(0.1) do
+        @conn.disable_referential_integrity do
+          @conn.execute("SELECT SLEEP(1)")
+        end
+      end
+    end
   end
 
   test "#explain for one query" do


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because I was receiving errors when inserting a large amount of fixtures into my app while using the timeout gem to wrap the test. Trilogy [closes the connection on timeout](https://github.com/trilogy-libraries/trilogy/blob/99dab929919e1baba7bdb1a8602d1433c8dab9f5/contrib/ruby/test/client_test.rb#L616), and I don't think Active Record correctly accounts for this in some places.

### Detail

This Pull Request changes some adapter methods to check for an active connection before querying in ensure blocks.

### Additional information

I encountered this with fixtures, but it could happen in any query that is wrapped with the changed adapter methods.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
