### PR TITLE
Show warning for `secret_key_base` in development too

### DIFF
--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -930,6 +930,7 @@ module ApplicationTests
     end
 
     test "secrets.secret_key_base is used when config/secrets.yml is present" do
+      remove_file "config/credentials.yml.enc"
       app_file "config/secrets.yml", <<-YAML
         development:
           secret_key_base: 3b7cd727ee24e8444053437c36cc66c3
@@ -964,6 +965,20 @@ module ApplicationTests
       assert_not_deprecated(Rails.deprecator) do
         assert_equal "3b7cd727ee24e8444053437c36cc66c3", app.secret_key_base
       end
+    end
+
+    test "config.secret_key_base leads to a deprecation in development when config/secrets.yml is present" do
+      remove_file "config/credentials.yml.enc"
+      app_file "config/secrets.yml", <<-YAML
+        development:
+          secret_key_base: 3b7cd727ee24e8444053437c36cc66c3
+      YAML
+
+      app "development"
+      assert_deprecated(Rails.deprecator) do
+        assert_equal "3b7cd727ee24e8444053437c36cc66c3", app.secrets.secret_key_base
+      end
+      assert_equal "3b7cd727ee24e8444053437c36cc66c3", app.secret_key_base
     end
 
     test "custom secrets saved in config/secrets.yml are loaded in app secrets" do


### PR DESCRIPTION
Fixes https://github.com/rails/rails/issues/51322 (see there for more context).

The problem is that the `secret_key_base` warning is shown only in production environments. But it will be much more helpful if that is shown in development to detect it before pushing to production.