### PR TITLE
Implement block_given? for ActiveSupport::ProxyObject

### DIFF
--- a/activesupport/lib/active_support/proxy_object.rb
+++ b/activesupport/lib/active_support/proxy_object.rb
@@ -9,9 +9,14 @@ module ActiveSupport
     undef_method :==
     undef_method :equal?
 
-    # Let ActiveSupport::ProxyObject at least raise exceptions.
+    # Let ActiveSupport::ProxyObject raise exceptions.
     def raise(*args)
       ::Object.send(:raise, *args)
+    end
+
+    # Let ActiveSupport::ProxyObject use "block_given?"".
+    def block_given?
+      ::Object.send(:block_given?)
     end
   end
 end


### PR DESCRIPTION
### Motivation / Background

I was using `ActiveSupport::ProxyObject` and I was hoping to do something like this:

```ruby
class Foo < ActiveSupport::ProxyObject
  def initialize
    @options = {}
    yield self if block_given?
  end

  # ...
end
```

It seems natural that you'd want to do something like:

```
Foo.new do |options|
  options.do_something
end

# in addition to the typical...

foo = Foo.new
foo.do_something
```

Then I realized you can't even use `block_given?`. AS::ProxyObject implements `raise` which makes sense...and it feels like `block_given?` seems right up there with what something that inherits from this object would typically need.

This is very opinionated so I figured I'd put up a PR instead of an issue for discussion. I can add tests (I don't think there are any tests currently) if y'all would like to move forward.

I also wanted to point out that an alternative is doing something like the following, but it's not very Ruby-esque 😅.

```ruby
class Foo < ActiveSupport::ProxyObject
  def initialize(&block)
    @options = {}
    yield self if block
  end
end
```

### Checklist

Before submitting the PR make sure the following are checked:

* [ ] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [ ] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
