### PR TITLE
Allow one to set `strict_loading_mode` globally

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Allow to configure `strict_loading_mode` globally or within a model.
+
+    Defaults to `:all`, can be changed to `:n_plus_one_only`.
+
+    *Garen Torikian*
+
 *   Add `ActiveRecord::Relation#readonly?`.
 
     Reflects if the relation has been marked as readonly.

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -89,6 +89,7 @@ module ActiveRecord
       class_attribute :belongs_to_required_by_default, instance_accessor: false
 
       class_attribute :strict_loading_by_default, instance_accessor: false, default: false
+      class_attribute :strict_loading_mode, instance_accessor: false, default: :all
 
       class_attribute :has_many_inversing, instance_accessor: false, default: false
 
@@ -784,7 +785,7 @@ module ActiveRecord
 
         @primary_key         = klass.primary_key
         @strict_loading      = klass.strict_loading_by_default
-        @strict_loading_mode = :all
+        @strict_loading_mode = klass.strict_loading_mode
 
         klass.define_attribute_methods
       end

--- a/activerecord/test/cases/strict_loading_test.rb
+++ b/activerecord/test/cases/strict_loading_test.rb
@@ -98,6 +98,20 @@ class StrictLoadingTest < ActiveRecord::TestCase
     end
   end
 
+  def test_default_mode_is_all
+    developer = Developer.first
+    assert_predicate developer, :strict_loading_all?
+  end
+
+  def test_default_mode_can_be_changed_globally
+    developer = Class.new(ActiveRecord::Base) do
+      self.strict_loading_mode = :n_plus_one_only
+      self.table_name = "developers"
+    end.new
+
+    assert_predicate developer, :strict_loading_n_plus_one_only?
+  end
+
   def test_strict_loading
     Developer.all.each { |d| assert_not d.strict_loading? }
     Developer.strict_loading.each { |d| assert_predicate d, :strict_loading? }

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -1284,6 +1284,12 @@ changed to `:log` to send violations to the logger instead of raising.
 Is a boolean value that either enables or disables strict_loading mode by
 default. Defaults to `false`.
 
+#### `config.active_record.strict_loading_mode`
+
+Sets the mode in which strict loading is reported. Defaults to `:all`. It can be
+changed to `:n_plus_one_only` to only report when loading associations that will
+lead to an N + 1 query.
+
 #### `config.active_record.warn_on_records_fetched_greater_than`
 
 Allows setting a warning threshold for query result size. If the number of


### PR DESCRIPTION
### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

I was reading through [this summary of Rails' strict loading](https://jordanhollinger.com/2023/11/11/rails-strict-loading/) and came across this paragraph:

> If you’re very brave, you can opt your entire application into strict loading. (Oddly, there doesn’t seem to be an equivalent of :n_plus_one_only here. I can’t imagine using this.)

In my app, we're setting `strict_loading!(mode: :n_plus_one_only)` on individual records; this paragraph made me realize it didn't have to be this way.

This Pull Request has been created because currently, `strict_loading_mode` is always set to `:all`. It may be preferable for users to have `:n_plus_one_only` on an individual model, or even on the entire app.

### Detail

This Pull Request adds a new class_attribute `:strict_loading_mode`, defaulted to `:all`.  If it's set to `:n_plus_one_only`, that mode is used by default when doing strict loading checks.

### Additional information

n/a

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
