### PR TITLE
add `file_exist?` method for ActiveStorage::Blob, ActiveStorage::Variant, ActiveStorage::VariantWithRecord

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add `file_exist?` method in `ActiveStorage::Blob`, `ActiveStorage::Variant`, `ActiveStorage::VariantWithRecord`.
+
+    *Clément Prod'homme*
+
 *   Add support for custom `key` in `ActiveStorage::Blob#compose`.
 
     *Elvin Efendiev*

--- a/activestorage/app/models/active_storage/blob.rb
+++ b/activestorage/app/models/active_storage/blob.rb
@@ -317,6 +317,11 @@ class ActiveStorage::Blob < ActiveStorage::Record
     service.mirror_later key, checksum: checksum if service.respond_to?(:mirror_later)
   end
 
+  # Returns +true+ if the file exist in the storage service.
+  def file_exist?
+    service.exist?(key)
+  end
+
   # Deletes the files on the service associated with the blob. This should only be done if the blob is going to be
   # deleted as well or you will essentially have a dead reference. It's recommended to use #purge and #purge_later
   # methods in most circumstances.

--- a/activestorage/app/models/active_storage/variant.rb
+++ b/activestorage/app/models/active_storage/variant.rb
@@ -103,9 +103,14 @@ class ActiveStorage::Variant
     service.delete(key)
   end
 
+  # Returns +true+ if the file exist in the storage service.
+  def file_exist?
+    service.exist?(key)
+  end
+
   private
     def processed?
-      service.exist?(key)
+      file_exist?
     end
 
     def process

--- a/activestorage/app/models/active_storage/variant_with_record.rb
+++ b/activestorage/app/models/active_storage/variant_with_record.rb
@@ -28,6 +28,11 @@ class ActiveStorage::VariantWithRecord
     ActiveStorage::Filename.new "#{blob.filename.base}.#{variation.format.downcase}"
   end
 
+  # Returns +true+ if the file exist in the storage service.
+  def file_exist?
+    service.exist?(key)
+  end
+
   # Destroys record and deletes file from service.
   def destroy
     record&.destroy

--- a/activestorage/test/models/blob_test.rb
+++ b/activestorage/test/models/blob_test.rb
@@ -265,6 +265,12 @@ class ActiveStorage::BlobTest < ActiveSupport::TestCase
     end
   end
 
+  test "file_exist? check if file exist on external service" do
+    blob = create_blob
+
+    assert_equal blob.file_exist?, ActiveStorage::Blob.service.exist?(blob.key)
+  end
+
   test "purge deletes file from external service" do
     blob = create_blob
 

--- a/activestorage/test/models/variant_test.rb
+++ b/activestorage/test/models/variant_test.rb
@@ -284,6 +284,12 @@ class ActiveStorage::VariantTest < ActiveSupport::TestCase
     end
   end
 
+  test "file_exist? check if file exist on external service" do
+    blob = create_file_blob
+
+    assert_equal blob.file_exist?, ActiveStorage::Blob.service.exist?(blob.key)
+  end
+
   test "destroy deletes file from service" do
     blob = create_file_blob(filename: "racecar.jpg")
     variant = blob.variant(resize_to_limit: [100, 100]).processed

--- a/activestorage/test/models/variant_with_record_test.rb
+++ b/activestorage/test/models/variant_with_record_test.rb
@@ -328,6 +328,13 @@ class ActiveStorage::VariantWithRecordTest < ActiveSupport::TestCase
     end
   end
 
+  test "file_exist? check if file exist on external service" do
+    blob = create_file_blob
+    variant = blob.variant(resize_to_limit: [100, 100]).processed
+
+    assert_equal variant.file_exist?, ActiveStorage::Blob.service.exist?(variant.key)
+  end
+
   test "destroy deletes file from service" do
     blob = create_file_blob(filename: "racecar.jpg")
     variant = blob.variant(resize_to_limit: [100, 100]).processed


### PR DESCRIPTION


It's help to check if all it's ok on the service storage

### Motivation / Background

This Pull Request has been created because we (@captive-studio) handle a large number of files using ActiveStorage in our application where these files are central to the business.

For some time now, we have noticed that certain variants are not being properly saved in the storage (specifically Google Cloud Storage). We want to rectify this situation by retrieving the variants for which the file does not exist in the storage.

### Detail

This Pull Request changes add new `file_exist?` method for ActiveStorage::Blob, ActiveStorage::Variant, ActiveStorage::VariantWithRecord

This method will help to check if a file exist on the storage service

### Additional information

/

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
