### PR TITLE
Extract check for VALUES syntax

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -643,7 +643,7 @@ module ActiveRecord
 
         # MySQL 8.0.19 replaces `VALUES(<expression>)` clauses with row and column alias names, see https://dev.mysql.com/worklog/task/?id=6312 .
         # then MySQL 8.0.20 deprecates the `VALUES(<expression>)` see https://dev.mysql.com/worklog/task/?id=13325 .
-        if !mariadb? && database_version >= "8.0.19"
+        if supports_insert_raw_alias_syntax?
           values_alias = quote_table_name("#{insert.model.table_name}_values")
           sql = +"INSERT #{insert.into} #{insert.values_list} AS #{values_alias}"
 
@@ -892,6 +892,10 @@ module ActiveRecord
         def remove_index_for_alter(table_name, column_name = nil, **options)
           index_name = index_name_for_remove(table_name, column_name, options)
           "DROP INDEX #{quote_column_name(index_name)}"
+        end
+
+        def supports_insert_raw_alias_syntax?
+          !mariadb? && database_version >= "8.0.19"
         end
 
         def supports_rename_index?


### PR DESCRIPTION
### Motivation / Background

The change to upserts (https://github.com/rails/rails/pull/51274) is causing an issue with Vitess, since it doesn't support the `row_alias` syntax added in MySQL 8.0.19.

There is an ongoing work (https://github.com/vitessio/vitess/pull/15510) to add that support and it is likely to be included into Vitess v20, but in the meantime it would be nice to have an ability to control that behavior in the existing apps (e.g. via patching).

### Detail

Extracting the check for the `VALUES(<expression>)` syntax into it's own method.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
