### PR TITLE
Add `config.active_record.permanent_connection_checkout` setting

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,18 @@
+*   Add `config.active_record.permanent_connection_checkout` setting.
+
+    Controls whether `ActiveRecord::Base.connection` raises an error, emits a deprecation warning, or neither.
+
+    `ActiveRecord::Base.connection` checkouts a database connection from the pool and keep it leased until the end of
+    the request or job. This behavior can be undesirable in environments that use many more threads or fibers than there
+    is available connections.
+
+    This configuration can be used to track down and eliminate code that calls `ActiveRecord::Base.connection` and
+    migrate it to use `ActiveRecord::Base.with_connection` instead.
+
+    The default behavior remains unchanged, and there is currently no plans to change the default.
+
+    *Jean Boussier*
+
 *   Add dirties option to uncached
 
     This adds a `dirties` option to `ActiveRecord::Base.uncached` and

--- a/activerecord/lib/active_record.rb
+++ b/activerecord/lib/active_record.rb
@@ -300,6 +300,17 @@ module ActiveRecord
     @global_executor_concurrency ||= nil
   end
 
+  @permanent_connection_checkout = true
+  singleton_class.attr_reader :permanent_connection_checkout
+
+  # Defines whether +ActiveRecord::Base.connection+ is allowed, deprecated or entirely disallowed
+  def self.permanent_connection_checkout=(value)
+    unless [true, :deprecated, :disallowed].include?(value)
+      raise ArgumentError, "permanent_connection_checkout must be one of: `true`, `:deprecated` or `:disallowed`"
+    end
+    @permanent_connection_checkout = value
+  end
+
   singleton_class.attr_accessor :index_nested_attribute_errors
   self.index_nested_attribute_errors = false
 

--- a/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb
@@ -93,7 +93,7 @@ module ActiveRecord
             end
         end
 
-        def lease_connection
+        def lease_connection(**)
           connection = super
           connection.query_cache ||= query_cache
           connection

--- a/activerecord/lib/active_record/connection_handling.rb
+++ b/activerecord/lib/active_record/connection_handling.rb
@@ -259,7 +259,7 @@ module ActiveRecord
     # Soft deprecated. Use +#with_connection+ or +#lease_connection+ instead.
     def connection
       pool = connection_pool
-      unless pool.sticky_lease?
+      if pool.permanent_lease?
         case ActiveRecord.permanent_connection_checkout
         when :deprecated
           ActiveRecord.deprecator.warn <<~MESSAGE
@@ -274,8 +274,10 @@ module ActiveRecord
             Either use `with_connection` or `lease_connection`.
           MESSAGE
         end
+        pool.lease_connection
+      else
+        pool.active_connection
       end
-      pool.lease_connection
     end
 
     # Return the currently leased connection into the pool
@@ -286,8 +288,12 @@ module ActiveRecord
     # Checkouts a connection from the pool, yield it and then check it back in.
     # If a connection was already leased via #lease_connection or a parent call to
     # #with_connection, that same connection is yieled.
-    def with_connection(&block)
-      connection_pool.with_connection(&block)
+    # If #lease_connection is called inside the block, the connection won't be checked
+    # back in.
+    # If #connection is called inside the block, the connection won't be checked back in
+    # unless the +prevent_permanent_checkout+ argument is set to +true+.
+    def with_connection(prevent_permanent_checkout: false, &block)
+      connection_pool.with_connection(prevent_permanent_checkout: prevent_permanent_checkout, &block)
     end
 
     attr_writer :connection_specification_name

--- a/activerecord/lib/active_record/connection_handling.rb
+++ b/activerecord/lib/active_record/connection_handling.rb
@@ -256,15 +256,35 @@ module ActiveRecord
       connection_pool.lease_connection
     end
 
-    alias_method :connection, :lease_connection
+    # Soft deprecated. Use +#with_connection+ or +#lease_connection+ instead.
+    def connection
+      pool = connection_pool
+      unless pool.sticky_lease?
+        case ActiveRecord.permanent_connection_checkout
+        when :deprecated
+          ActiveRecord.deprecator.warn <<~MESSAGE
+            Called deprecated `ActionRecord::Base.connection`method.
+
+            Either use `with_connection` or `lease_connection`.
+          MESSAGE
+        when :disallowed
+          raise ActiveRecordError, <<~MESSAGE
+            Called deprecated `ActionRecord::Base.connection`method.
+
+            Either use `with_connection` or `lease_connection`.
+          MESSAGE
+        end
+      end
+      pool.lease_connection
+    end
 
     # Return the currently leased connection into the pool
     def release_connection
-      connection.release_connection
+      connection_pool.release_connection
     end
 
     # Checkouts a connection from the pool, yield it and then check it back in.
-    # If a connection was already leased via #connection or a parent call to
+    # If a connection was already leased via #lease_connection or a parent call to
     # #with_connection, that same connection is yieled.
     def with_connection(&block)
       connection_pool.with_connection(&block)

--- a/activerecord/test/cases/helper.rb
+++ b/activerecord/test/cases/helper.rb
@@ -22,9 +22,9 @@ Thread.abort_on_exception = true
 # Show backtraces for deprecated behavior for quicker cleanup.
 ActiveRecord.deprecator.debug = true
 
-# ActiveRecord::Base.connection is only soft deprecated but we remove it
-# in the test suite to ensure we're not using it internally.
-ActiveRecord::ConnectionHandling.remove_method(:connection)
+# ActiveRecord::Base.connection is only soft deprecated but we ban it from the test suite
+# to ensure it's not used internally.
+ActiveRecord.permanent_connection_checkout = :disallowed
 
 # Disable available locale checks to avoid warnings running the test suite.
 I18n.enforce_available_locales = false

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -1526,6 +1526,25 @@ record.token # => "fwZcXX6SkJBJRogzMdciS7wf"
 | (original)            | `:create`            |
 | 7.1                   | `:initialize`        |
 
+
+#### `config.active_record.permanent_connection_checkout`
+
+Controls whether `ActiveRecord::Base.connection` raises an error, emits a deprecation warning, or neither.
+
+`ActiveRecord::Base.connection` checkouts a database connection from the pool and keep it leased until the end of
+the request or job. This behavior can be undesirable in environments that use many more threads or fibers than there
+is available connections.
+
+This configuration can be used to track down and eliminate code that calls `ActiveRecord::Base.connection` and
+migrate it to use `ActiveRecord::Base.with_connection` instead.
+
+The value can be set to `:disallowed`, `:deprecated` or `true` to respectively raise an error, emit a deprecation
+warning, or neither.
+
+| Starting with version | The default value is |
+| --------------------- | -------------------- |
+| (original)            | `true`               |
+
 #### `ActiveRecord::ConnectionAdapters::Mysql2Adapter.emulate_booleans` and `ActiveRecord::ConnectionAdapters::TrilogyAdapter.emulate_booleans`
 
 Controls whether the Active Record MySQL adapter will consider all `tinyint(1)` columns as booleans. Defaults to `true`.


### PR DESCRIPTION
Ref: https://github.com/rails/rails/pull/50793

Controls whether `ActiveRecord::Base.connection` raises an error, emits a deprecation warning, or neither.

`ActiveRecord::Base.connection` checkouts a database connection from the pool and keep it leased until the end of the request or job. This behavior can be undesirable in environments that use many more threads or fibers than there is available connections.

This configuration can be used to track down and eliminate code that calls `ActiveRecord::Base.connection` and migrate it to use `ActiveRecord::Base.with_connection` instead.

The default behavior remains unchanged, and there is currently no plans to change the default.

One thing that I think may be missing is a way to wrap legacy code with something akin to `.with_connection`, but that wouldn't cause `.connection` to persist the checkout. Perhaps that should be a `.with_connection` keyword argument?

@matthewd any opinion on the above?