### PR TITLE
Don't enqueue jobs to process a preview image if no variant requires it

### DIFF
--- a/activestorage/app/models/active_storage/attachment.rb
+++ b/activestorage/app/models/active_storage/attachment.rb
@@ -138,7 +138,7 @@ class ActiveStorage::Attachment < ActiveStorage::Record
         end
       }
 
-      if blob.preview_image_needed_before_processing_variants?
+      if blob.preview_image_needed_before_processing_variants? && preprocessed_variations.any?
         blob.create_preview_image_later(preprocessed_variations)
       else
         preprocessed_variations.each do |transformations|

--- a/activestorage/test/jobs/preview_image_job_test.rb
+++ b/activestorage/test/jobs/preview_image_job_test.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "database/setup"
+
+class ActiveStorage::PreviewImageJobTest < ActiveJob::TestCase
+  setup do
+    @blob = create_file_blob(filename: "report.pdf", content_type: "application/pdf")
+    @transformation = { resize_to_limit: [ 100, 100 ] }
+  end
+
+  test "creates preview" do
+    assert_changes -> { @blob.preview_image.attached? }, from: false, to: true do
+      ActiveStorage::PreviewImageJob.perform_now @blob, [ @transformation ]
+    end
+  end
+
+  test "enqueues transform variant jobs" do
+    assert_enqueued_with job: ActiveStorage::TransformJob, args: [ @blob, @transformation ] do
+      ActiveStorage::PreviewImageJob.perform_now @blob, [ @transformation ]
+    end
+  end
+end

--- a/activestorage/test/models/reflection_test.rb
+++ b/activestorage/test/models/reflection_test.rb
@@ -39,8 +39,8 @@ class ActiveStorage::ReflectionTest < ActiveSupport::TestCase
   test "reflecting on all attachments" do
     reflections = User.reflect_on_all_attachments.sort_by(&:name)
     assert_equal [ User ], reflections.collect(&:active_record).uniq
-    assert_equal %i[ avatar avatar_with_conditional_preprocessed avatar_with_preprocessed avatar_with_variants cover_photo highlights highlights_with_conditional_preprocessed highlights_with_preprocessed highlights_with_variants intro_video name_pronunciation_audio vlogs ], reflections.collect(&:name)
-    assert_equal %i[ has_one_attached has_one_attached has_one_attached has_one_attached has_one_attached has_many_attached has_many_attached has_many_attached has_many_attached has_one_attached has_one_attached has_many_attached ], reflections.collect(&:macro)
-    assert_equal [ :purge_later, :purge_later, :purge_later, :purge_later, false, :purge_later, :purge_later, :purge_later, :purge_later, :purge_later, :purge_later, false ], reflections.collect { |reflection| reflection.options[:dependent] }
+    assert_equal %i[ avatar avatar_with_conditional_preprocessed avatar_with_preprocessed avatar_with_variants cover_photo highlights highlights_with_conditional_preprocessed highlights_with_preprocessed highlights_with_variants intro_video name_pronunciation_audio resume resume_with_preprocessing vlogs ], reflections.collect(&:name)
+    assert_equal %i[ has_one_attached has_one_attached has_one_attached has_one_attached has_one_attached has_many_attached has_many_attached has_many_attached has_many_attached has_one_attached has_one_attached has_one_attached has_one_attached has_many_attached ], reflections.collect(&:macro)
+    assert_equal [ :purge_later, :purge_later, :purge_later, :purge_later, false, :purge_later, :purge_later, :purge_later, :purge_later, :purge_later, :purge_later, :purge_later, :purge_later, false ], reflections.collect { |reflection| reflection.options[:dependent] }
   end
 end

--- a/activestorage/test/test_helper.rb
+++ b/activestorage/test/test_helper.rb
@@ -160,6 +160,12 @@ class User < ActiveRecord::Base
     attachable.variant :method, resize_to_limit: [3, 3],
       preprocessed: :should_preprocessed?
   end
+  has_one_attached :resume do |attachable|
+    attachable.variant :preview, resize_to_fill: [400, 400]
+  end
+  has_one_attached :resume_with_preprocessing do |attachable|
+    attachable.variant :preview, resize_to_fill: [400, 400], preprocessed: true
+  end
 
   accepts_nested_attributes_for :highlights_attachments, allow_destroy: true
 


### PR DESCRIPTION
This follows up on https://github.com/rails/rails/pull/51030, which introduced a behaviour change for previewable attachments for previewable attachments that don't specify any variants at all or no variants that require pre-processing via `TransformJob`. Before, when no variant required pre-processing, `Attachment#transform_variants_later` didn't do anything (`named_variants` would be empty below):
```ruby
def transform_variants_later
  named_variants.each do |_name, named_variant|
    blob.preprocessed(named_variant.transformations) if named_variant.preprocessed?(record)
  end
end
```

After #51030 an `ActiveStorage::PreviewImageJob` is enqueued with the attachment's blob and an empty array. `preprocessed_variations` would be empty below on the call to `blob.create_preview_image_later(preprocessed_variations)`

```ruby
def transform_variants_later
  preprocessed_variations = named_variants.filter_map { |_name, named_variant|
    if named_variant.preprocessed?(record)
      named_variant.transformations
    end
  }

  if blob.preview_image_needed_before_processing_variants?
    blob.create_preview_image_later(preprocessed_variations)
  else
    preprocessed_variations.each do |transformations|
      blob.preprocessed(transformations)
    end
  end
end
```

For us, besides the unexpected influx of new jobs, this caused a bunch of job failures due to deadlocks for blobs and attachments that were created as part of inbound email processing, which was quite surprising. We purposely create previews inline when they're requested, not when these blobs are ingested, embedded in Action Text's rich text records. Ingesting the blob and creating a preview in parallel to the `InboundEmail::RoutingJob` being processed triggered `touch` up the hierarchy, happening in two jobs at once, which is very prone to deadlocks. 

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
