### PR TITLE
Eliminate remaining uses of `lease_connection` inside Active Record

### DIFF
--- a/activerecord/lib/active_record/associations/join_dependency/join_association.rb
+++ b/activerecord/lib/active_record/associations/join_dependency/join_association.rb
@@ -37,39 +37,41 @@ module ActiveRecord
             chain << [reflection, table]
           end
 
-          # The chain starts with the target table, but we want to end with it here (makes
-          # more sense in this context), so we reverse
-          chain.reverse_each do |reflection, table|
-            klass = reflection.klass
+          base_klass.with_connection do |connection|
+            # The chain starts with the target table, but we want to end with it here (makes
+            # more sense in this context), so we reverse
+            chain.reverse_each do |reflection, table|
+              klass = reflection.klass
 
-            scope = reflection.join_scope(table, foreign_table, foreign_klass)
+              scope = reflection.join_scope(table, foreign_table, foreign_klass)
 
-            unless scope.references_values.empty?
-              associations = scope.eager_load_values | scope.includes_values
+              unless scope.references_values.empty?
+                associations = scope.eager_load_values | scope.includes_values
 
-              unless associations.empty?
-                scope.joins! scope.construct_join_dependency(associations, Arel::Nodes::OuterJoin)
+                unless associations.empty?
+                  scope.joins! scope.construct_join_dependency(associations, Arel::Nodes::OuterJoin)
+                end
               end
-            end
 
-            arel = scope.arel(alias_tracker.aliases)
-            nodes = arel.constraints.first
+              arel = scope.arel(alias_tracker.aliases)
+              nodes = arel.constraints.first
 
-            if nodes.is_a?(Arel::Nodes::And)
-              others = nodes.children.extract! do |node|
-                !Arel.fetch_attribute(node) { |attr| attr.relation.name == table.name }
+              if nodes.is_a?(Arel::Nodes::And)
+                others = nodes.children.extract! do |node|
+                  !Arel.fetch_attribute(node) { |attr| attr.relation.name == table.name }
+                end
               end
+
+              joins << join_type.new(table, Arel::Nodes::On.new(nodes))
+
+              if others && !others.empty?
+                joins.concat arel.join_sources
+                append_constraints(connection, joins.last, others)
+              end
+
+              # The current table in this iteration becomes the foreign table in the next
+              foreign_table, foreign_klass = table, klass
             end
-
-            joins << join_type.new(table, Arel::Nodes::On.new(nodes))
-
-            if others && !others.empty?
-              joins.concat arel.join_sources
-              append_constraints(joins.last, others)
-            end
-
-            # The current table in this iteration becomes the foreign table in the next
-            foreign_table, foreign_klass = table, klass
           end
 
           joins
@@ -88,10 +90,10 @@ module ActiveRecord
         end
 
         private
-          def append_constraints(join, constraints)
+          def append_constraints(connection, join, constraints)
             if join.is_a?(Arel::Nodes::StringJoin)
               join_string = Arel::Nodes::And.new(constraints.unshift join.left)
-              join.left = Arel.sql(base_klass.lease_connection.visitor.compile(join_string))
+              join.left = Arel.sql(connection.visitor.compile(join_string))
             else
               right = join.right
               right.expr = Arel::Nodes::And.new(constraints.unshift right.expr)

--- a/activerecord/lib/active_record/integration.rb
+++ b/activerecord/lib/active_record/integration.rb
@@ -178,7 +178,10 @@ module ActiveRecord
       def can_use_fast_cache_version?(timestamp)
         timestamp.is_a?(String) &&
           cache_timestamp_format == :usec &&
-          self.class.lease_connection.default_timezone == :utc &&
+          # FIXME: checking out a connection for this is wasteful
+          # we should store/cache this information in the schema cache
+          # or similar.
+          self.class.with_connection(&:default_timezone) == :utc &&
           !updated_at_came_from_user?
       end
 

--- a/activerecord/lib/active_record/table_metadata.rb
+++ b/activerecord/lib/active_record/table_metadata.rb
@@ -44,7 +44,7 @@ module ActiveRecord
         arel_table = arel_table.alias(table_name) if arel_table.name != table_name
         TableMetadata.new(association_klass, arel_table, reflection)
       else
-        type_caster = TypeCaster::Connection.new(klass, table_name)
+        type_caster = TypeCaster::Connection.new(klass)
         arel_table = Arel::Table.new(table_name, type_caster: type_caster)
         TableMetadata.new(nil, arel_table, reflection)
       end

--- a/activerecord/lib/active_record/type_caster/connection.rb
+++ b/activerecord/lib/active_record/type_caster/connection.rb
@@ -3,9 +3,8 @@
 module ActiveRecord
   module TypeCaster
     class Connection # :nodoc:
-      def initialize(klass, table_name)
+      def initialize(klass)
         @klass = klass
-        @table_name = table_name
       end
 
       def type_cast_for_database(attr_name, value)
@@ -14,20 +13,8 @@ module ActiveRecord
       end
 
       def type_for_attribute(attr_name)
-        schema_cache = @klass.schema_cache
-
-        if schema_cache.data_source_exists?(table_name)
-          column = schema_cache.columns_hash(table_name)[attr_name.to_s]
-          if column
-            type = @klass.lease_connection.lookup_cast_type_from_column(column)
-          end
-        end
-
-        type || Type.default_value
+        @klass.type_for_attribute(attr_name) || Type.default_value
       end
-
-      private
-        attr_reader :table_name
     end
   end
 end

--- a/activerecord/lib/arel/nodes/node.rb
+++ b/activerecord/lib/arel/nodes/node.rb
@@ -147,8 +147,9 @@ module Arel # :nodoc: all
       # Maybe we should just use `Table.engine`?  :'(
       def to_sql(engine = Table.engine)
         collector = Arel::Collectors::SQLString.new
-        collector = engine.lease_connection.visitor.accept self, collector
-        collector.value
+        engine.with_connection do |connection|
+          connection.visitor.accept(self, collector).value
+        end
       end
 
       def fetch_attribute

--- a/activerecord/lib/arel/tree_manager.rb
+++ b/activerecord/lib/arel/tree_manager.rb
@@ -52,8 +52,9 @@ module Arel # :nodoc: all
 
     def to_sql(engine = Table.engine)
       collector = Arel::Collectors::SQLString.new
-      collector = engine.lease_connection.visitor.accept @ast, collector
-      collector.value
+      engine.with_connection do |connection|
+        engine.lease_connection.visitor.accept(@ast, collector).value
+      end
     end
 
     def initialize_copy(other)

--- a/activerecord/test/cases/arel/support/fake_record.rb
+++ b/activerecord/test/cases/arel/support/fake_record.rb
@@ -129,6 +129,10 @@ module FakeRecord
       @connection_pool = ConnectionPool.new
     end
 
+    def with_connection(...)
+      connection_pool.with_connection(...)
+    end
+
     def lease_connection
       connection_pool.lease_connection
     end


### PR DESCRIPTION
Ref: https://github.com/rails/rails/pull/51349

Prevent acquiring a permanent lease when using mundane Active Record API. A couple of these are eliminated in a non-ideal way so I added some TODO/FIXME. Hopefully I'll get around to improve them in the future but I wanted these fixed short term so `config.active_record.permanent_connection_checkout` can be experimented with in 7.2