### PR TITLE
Address `RendererTest#test_rendering_with_a_class_renderer` failure against Ruby 3.4.0dev

### DIFF
--- a/actionpack/test/fixtures/ruby_template.ruby
+++ b/actionpack/test/fixtures/ruby_template.ruby
@@ -1,2 +1,2 @@
-body = ""
+body = +""
 body << ["Hello", "from", "Ruby", "code"].join(" ")


### PR DESCRIPTION
### Motivation / Background
This pull request addresses the following Rails Nightly CI error since https://github.com/ruby/ruby/pull/10262 has been merged to Ruby master branch. https://buildkite.com/rails/rails-nightly/builds/310#018e5929-ff70-4397-b978-9a0a03cd4706/1255-1265

### Detail
- Without this commit:
```ruby
$ ruby -v
ruby 3.4.0dev (2024-03-19T08:26:49Z master 12be40ae6b) [x86_64-linux]
$ cd actionpack
$ RAILS_STRICT_WARNINGS=true bin/test test/controller/renderer_test.rb:37
Running 25 tests in a single process (parallelization threshold is 50)
Run options: --seed 14013

/home/yahonda/src/github.com/rails/rails/actionpack/test/fixtures/ruby_template.ruby:2: warning: literal string will be frozen in the future
E

Error:
RendererTest#test_rendering_with_a_class_renderer:
RuntimeError: Neutered Exception ActionView::Template::Error: /home/yahonda/src/github.com/rails/rails/actionpack/test/fixtures/ruby_template.ruby:2: warning: literal string will be frozen in the future

    /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/testing/strict_warnings.rb:33:in 'ActiveSupport::RaiseWarnings#warn'
    test/fixtures/ruby_template.ruby:2:in '_home_yahonda_src_github_com_rails_rails_actionpack_test_fixtures_ruby_template_ruby__3648742137162546161_6360'
    /home/yahonda/src/github.com/rails/rails/actionview/lib/action_view/base.rb:282:in 'Kernel#public_send'
    /home/yahonda/src/github.com/rails/rails/actionview/lib/action_view/base.rb:282:in 'ActionView::Base#_run'
    /home/yahonda/src/github.com/rails/rails/actionview/lib/action_view/template.rb:275:in 'block in ActionView::Template#render'
    /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/notifications.rb:212:in 'ActiveSupport::Notifications.instrument'
    /home/yahonda/src/github.com/rails/rails/actionview/lib/action_view/template.rb:567:in 'ActionView::Template#instrument_render_template'
    /home/yahonda/src/github.com/rails/rails/actionview/lib/action_view/template.rb:263:in 'ActionView::Template#render'
    /home/yahonda/src/github.com/rails/rails/actionview/lib/action_view/renderer/template_renderer.rb:66:in 'block (2 levels) in ActionView::TemplateRenderer#render_template'
    /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/notifications.rb:212:in 'ActiveSupport::Notifications.instrument'
    /home/yahonda/src/github.com/rails/rails/actionview/lib/action_view/renderer/template_renderer.rb:60:in 'block in ActionView::TemplateRenderer#render_template'
    /home/yahonda/src/github.com/rails/rails/actionview/lib/action_view/renderer/template_renderer.rb:80:in 'ActionView::TemplateRenderer#render_with_layout'
    /home/yahonda/src/github.com/rails/rails/actionview/lib/action_view/renderer/template_renderer.rb:59:in 'ActionView::TemplateRenderer#render_template'
    /home/yahonda/src/github.com/rails/rails/actionview/lib/action_view/renderer/template_renderer.rb:11:in 'ActionView::TemplateRenderer#render'
    /home/yahonda/src/github.com/rails/rails/actionview/lib/action_view/renderer/renderer.rb:58:in 'ActionView::Renderer#render_template_to_object'
    /home/yahonda/src/github.com/rails/rails/actionview/lib/action_view/renderer/renderer.rb:31:in 'ActionView::Renderer#render_to_object'
    /home/yahonda/src/github.com/rails/rails/actionview/lib/action_view/rendering.rb:135:in 'block in ActionView::Rendering#_render_template'
    /home/yahonda/src/github.com/rails/rails/actionview/lib/action_view/base.rb:309:in 'ActionView::Base#in_rendering_context'
    /home/yahonda/src/github.com/rails/rails/actionview/lib/action_view/rendering.rb:134:in 'ActionView::Rendering#_render_template'
    lib/action_controller/metal/streaming.rb:258:in 'ActionController::Streaming#_render_template'
    /home/yahonda/src/github.com/rails/rails/actionview/lib/action_view/rendering.rb:121:in 'ActionView::Rendering#render_to_body'
    lib/action_controller/metal/rendering.rb:186:in 'ActionController::Rendering#render_to_body'
    lib/action_controller/metal/renderers.rb:142:in 'ActionController::Renderers#render_to_body'
    lib/abstract_controller/rendering.rb:47:in 'AbstractController::Rendering#render_to_string'
    lib/action_controller/metal/rendering.rb:175:in 'ActionController::Rendering#render_to_string'
    lib/action_controller/renderer.rb:136:in 'ActionController::Renderer#render'
    test/controller/renderer_test.rb:37:in 'block in <class:RendererTest>'

bin/test test/controller/renderer_test.rb:35

Finished in 0.294798s, 3.3921 runs/s, 0.0000 assertions/s.
1 runs, 0 assertions, 0 failures, 1 errors, 0 skips
$
```

### Additional information

Refer to these Ruby issue and pull request for this change: https://bugs.ruby-lang.org/issues/20205
https://github.com/ruby/ruby/pull/10262

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
