### PR TITLE
Prevent autosave association with has_one defined on child class

### DIFF
--- a/activerecord/lib/active_record/autosave_association.rb
+++ b/activerecord/lib/active_record/autosave_association.rb
@@ -527,7 +527,7 @@ module ActiveRecord
         return false unless reflection.inverse_of&.polymorphic?
 
         class_name = record._read_attribute(reflection.inverse_of.foreign_type)
-        reflection.active_record != record.class.polymorphic_class_for(class_name)
+        reflection.active_record.polymorphic_name != class_name
       end
 
       # Saves the associated record if it's new or <tt>:autosave</tt> is enabled.

--- a/activerecord/test/cases/autosave_association_test.rb
+++ b/activerecord/test/cases/autosave_association_test.rb
@@ -41,6 +41,8 @@ require "models/chef"
 require "models/cake_designer"
 require "models/drink_designer"
 require "models/cpk"
+require "models/human"
+require "models/face"
 
 class TestAutosaveAssociationsInGeneral < ActiveRecord::TestCase
   def test_autosave_works_even_when_other_callbacks_update_the_parent_model
@@ -1800,6 +1802,41 @@ class TestAutosaveAssociationOnAHasOneAssociation < ActiveRecord::TestCase
     ship.parts.build.mark_for_destruction
 
     assert_not_predicate ship, :valid?
+  end
+
+  def test_should_not_saved_for_unchanged_sti_type_on_polymorphic_association
+    face = Class.new(Face) do
+      def self.name; "Face"; end
+
+      after_save :count_saves
+
+      def count_saves
+        @count ||= 0
+        @count += 1
+      end
+    end
+
+    super_human = Class.new(SuperHuman) do
+      self.table_name = "humans"
+      def self.name; "SuperHuman"; end
+
+      attribute :name, :string
+
+      # Polymorphic has_one needs to be defined on the child class
+      has_one :polymorphic_face, class_name: "Face", as: :polymorphic_human, inverse_of: :polymorphic_human
+    end
+
+    face_record = face.create!
+
+    super_human_record = super_human.create!(name: "S. Human", polymorphic_face: face_record)
+
+    super_human_record.update!(name: "Super Human")
+
+    assert_equal "Human", face_record.polymorphic_human_type
+    assert_equal super_human_record.id, face_record.polymorphic_human_id
+
+    # Saves on create of face and create of super human, but not update
+    assert_equal 2, face_record.instance_variable_get(:@count)
   end
 
   def test_recognizes_inverse_polymorphic_association_changes_with_same_foreign_key


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

Adjusts the logic in inverse_polymorphic_association_changed? to determine if a has_one association's polymorphic association should autosave the associated record for a type change.

Previously this would see the type as changed every time if the has_one is defined on a child class, since the polymorphic relationship saves the parent class as the *_type value. The new check resolves the correct class name to avoid these extra saves.

Fixes #51280

### Detail

Also confirmed that the new test fails without the code change:

```
Failure:
TestAutosaveAssociationOnAHasOneAssociation#test_should_not_saved_for_unchanged_sti_type_on_polymorphic_association [test/cases/autosave_association_test.rb:1652]:
Expected: 2
  Actual: 3


bin/rails test test/cases/autosave_association_test.rb:1620
```

### Additional information

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
