### PR TITLE
Update oracle connection name to match adapter in tests

### DIFF
--- a/activerecord/Rakefile
+++ b/activerecord/Rakefile
@@ -56,7 +56,7 @@ namespace :db do
   task drop: ["db:mysql:drop", "db:postgresql:drop"]
 end
 
-%w( mysql2 trilogy postgresql sqlite3 sqlite3_mem oracle jdbcmysql jdbcpostgresql jdbcsqlite3 jdbcderby jdbch2 jdbchsqldb ).each do |adapter|
+%w( mysql2 trilogy postgresql sqlite3 sqlite3_mem oracle_enhanced jdbcmysql jdbcpostgresql jdbcsqlite3 jdbcderby jdbch2 jdbchsqldb ).each do |adapter|
   namespace :test do
     Rake::TestTask.new(adapter => "#{adapter}:env") do |t|
       adapter_short = adapter[/^[a-z0-9]+/]

--- a/activerecord/test/config.example.yml
+++ b/activerecord/test/config.example.yml
@@ -91,7 +91,7 @@ connections:
       socket: "<%= ENV['MYSQL_SOCK'] %>"
     <% end %>
 
-  oracle:
+  oracle_enhanced:
      arunit:
        adapter: oracle_enhanced
        database: <%= ENV['ARUNIT_DB_NAME'] || 'orcl' %>


### PR DESCRIPTION

<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created to enable running the activerecord test suite with the oracle-enhanced adapter post activerecord 7.1.0

### Detail

https://github.com/rails/rails/pull/48015 (specifically 7572a13af6444abf51720051c6a93d72a7aead0e) adds a check to ensure the connection name matches the adapter name for the test run. For oracle databases, the testing files call the connection `oracle`, but the adapter we use is `oracle_enhanced`, resulting in an error when the tests are run:

```
bundle exec rake test:oracle TEST=test/cases/base_test.rb
/usr/local/bin/ruby -w -I"lib:test" /usr/local/lib/ruby/gems/3.2.0/gems/rake-13.0.6/lib/rake/rake_test_loader.rb "test/cases/base_test.rb"
Using oracle
/app/activerecord/test/support/connection.rb:38:in `connect': The connection name did not match the adapter name. Connection name is 'oracle' and the adapter name is 'oracle_enhanced'. (ArgumentError)

      raise ArgumentError, "The connection name did not match the adapter name. Connection name is '#{connection_name}' and the adapter name is '#{arunit_adapter}'."
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
	from /app/activerecord/test/cases/test_case.rb:248:in `<class:TestCase>'
	from /app/activerecord/test/cases/test_case.rb:20:in `<module:ActiveRecord>'
	from /app/activerecord/test/cases/test_case.rb:16:in `<top (required)>'
	from /app/activerecord/test/cases/helper.rb:8:in `require'
	from /app/activerecord/test/cases/helper.rb:8:in `<top (required)>'
	from /app/activerecord/test/cases/base_test.rb:3:in `require'
	from /app/activerecord/test/cases/base_test.rb:3:in `<top (required)>'
	from /usr/local/lib/ruby/gems/3.2.0/gems/rake-13.0.6/lib/rake/rake_test_loader.rb:21:in `require'
	from /usr/local/lib/ruby/gems/3.2.0/gems/rake-13.0.6/lib/rake/rake_test_loader.rb:21:in `block in <main>'
	from /usr/local/lib/ruby/gems/3.2.0/gems/rake-13.0.6/lib/rake/rake_test_loader.rb:6:in `select'
	from /usr/local/lib/ruby/gems/3.2.0/gems/rake-13.0.6/lib/rake/rake_test_loader.rb:6:in `<main>'
rake aborted!
```

This change updates the connection name to be `oracle_enhanced` so it matches the adapter. With these changes I can run
```
bundle exec rake test:oracle_enhanced TEST=test/cases/base_test.rb
```
without getting the connection name error.

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

I did not rename `activerecord/test/schema/oracle_specific_schema.rb` because the config.example.yml has emulate_oracle_adapter set to true so `oracle_specific_schema` is still the name the LoadSchemaHelper looks for.


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
