### PR TITLE
Improve contrast on dark mode [ci skip]

### DIFF
--- a/guides/README.md
+++ b/guides/README.md
@@ -2,7 +2,7 @@
 
 ## About the Project
 
-The Rails Guides Visual Refresh occured in Q1 2024, and was intended to bring the visual style of the guides inline with the rubyonrails.org site. 
+The Rails Guides Visual Refresh occured in Q1 2024, and was intended to bring the visual style of the guides inline with the rubyonrails.org site.
 
 ## Editing Depedencies
 
@@ -10,7 +10,7 @@ The editing files for the Guides rebuild reside in `stylesrc` and use SCSS to im
 
 ## Building the Guides in Development
 
-To generate new guides into static files, type `rake guides:generate` from inside the `guides` folder. If you make changes to the HTML or ERB, you'll need to remove the "output" directory before running this command. The master SCSS files (style.scss, highlight.scss) will compile as part of this process. 
+To generate new guides into static files, type `rake guides:generate` from inside the `guides` folder. If you make changes to the HTML or ERB, you'll need to remove the "output" directory before running this command. The master SCSS files (style.scss, highlight.scss) will compile as part of this process.
 
 ## FAQ
 
@@ -22,6 +22,6 @@ Per the MDN documentation on CSS custom properties (https://developer.mozilla.or
 
 LTR/RTL (Left to right/right to left) is a layout change based on the nature of the language the site is being displayed in. Arabic and Farsi are two well known "RTL" languages. If the site is automatically translated, then the layout will adjust (mirror horizontally) to be more in line with the text.
 
-### Why is Dark Mode in a seperate file
+### Why is Dark Mode in a separate file?
 
 IncludeMedia does not handle `prefers-color-scheme` at this time, so it was extracted.

--- a/guides/assets/stylesrc/style.scss
+++ b/guides/assets/stylesrc/style.scss
@@ -48,7 +48,7 @@ $gray-500: #A9A9A8;
 $gray-600: #666666;
 $gray-700: #3A3939;
 $gray-800: #343434;
-$gray-900: #2E2E2E;
+$gray-900: #181818;
 
 $note: #FFD600;
 $note-bkgnd: rgba($note, 15%); // Works for light and dark mode


### PR DESCRIPTION
### Motivation / Background

The red shades used on links, heading and other elements didn't have enough contrast with the dark background.

Fixes #51363


### Detail

To maintain the brand identity, I kept the red shades but made the background color darker. I tried not to change the color too much, so I used the lightest shade of gray that would get at least 3:1 on a contrast ratio checker.

#### Alternative solution

Alternatively, we could keep the background color and use white as the heading color. For links, we can use the same yellow as in the notes:

<img width="500" alt="image" src="https://github.com/rails/rails/assets/20938712/26c2c91b-dc04-4964-84fe-90faec7420b2">

If we don't want links to be fully yellow, we can just color the text-decoration on hover:

<img width="282" alt="image" src="https://github.com/rails/rails/assets/20938712/93487d86-97b0-4445-ae39-41fb5a51726d">



### Additional information

Before x after

<div>
<img width="400" alt="image" src="https://github.com/rails/rails/assets/20938712/9574fbaf-4554-4245-bfa6-6c327bf0a767">


<img width="400" alt="image" src="https://github.com/rails/rails/assets/20938712/7495e2b9-ee9b-4591-a980-8f3658b4970e">
</div>

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
