### PR TITLE
Update a guide about explanation related to es-module-shims [ci skip]

### DIFF
--- a/guides/source/asset_pipeline.md
+++ b/guides/source/asset_pipeline.md
@@ -141,17 +141,13 @@ All of the configured import maps should be attached in `<head>` element of your
 </script>
 ```
 
-- [`Es-module-shims`](https://github.com/guybedford/es-module-shims) acting as polyfill ensuring support for `import maps` on older browsers:
-
-```html
-<script src="/assets/es-module-shims.min" async="async" data-turbo-track="reload"></script>
-```
-
 - Entrypoint for loading JavaScript from `app/javascript/application.js`:
 
 ```html
 <script type="module">import "application"</script>
 ```
+
+NOTE: Before v2.0.0, `importmap-rails` put [`Es-module-shims`](https://github.com/guybedford/es-module-shims) in the output of `javascript_importmap_tags` as a polyfill to ensure support for import maps on older browsers. However, with the native support for import maps in all major browsers, v2.0.0 has dropped the bundled shim. If you want to support legacy browsers that lack support for import maps, manually insert `Es-module-shims` before `javascript_importmap_tags`. For more information, refer to [README for importmap-rails](https://github.com/rails/importmap-rails?tab=readme-ov-file#supporting-legacy-browsers-such-as-safari-on-ios-15).
 
 ### Using npm packages via JavaScript CDNs
 


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created to reflect dropping the bundled shim in [`importmap-rails`](https://github.com/rails/importmap-rails) to the guides.

### Detail

This Pull Request changes the descriptions related to `Es-module-shims`, since [`importmap-rails` v2.0.0 has dropped the bundled shim](https://github.com/rails/importmap-rails/pull/216).

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
