### PR TITLE
Add `ActiveRecord::Relation#readonly?`

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Add `ActiveRecord::Relation.readonly?`
+
+    Reflects if the relation has been marked as readonly.
+
+    *Theodor Tonum*
+
 *   Improve `ActiveRecord::Store` to raise a descriptive exception if the column is not either
     structured (e.g., PostgreSQL +hstore+/+json+, or MySQL +json+) or declared serializable via
     `ActiveRecord.store`.

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -1261,6 +1261,10 @@ module ActiveRecord
       records.blank?
     end
 
+    def readonly?
+      readonly_value
+    end
+
     def values
       @values.dup
     end

--- a/activerecord/test/cases/readonly_test.rb
+++ b/activerecord/test/cases/readonly_test.rb
@@ -79,9 +79,11 @@ class ReadOnlyTest < ActiveRecord::TestCase
 
   def test_find_with_readonly_option
     Developer.all.each { |d| assert_not d.readonly? }
+    Developer.all.tap { |rel| assert_not rel.readonly? }
     Developer.readonly(false).each { |d| assert_not d.readonly? }
     Developer.readonly(true).each { |d| assert_predicate d, :readonly? }
     Developer.readonly.each { |d| assert_predicate d, :readonly? }
+    Developer.readonly.tap { |rel| assert_predicate rel, :readonly? }
   end
 
   def test_find_with_joins_option_does_not_imply_readonly


### PR DESCRIPTION
Indicates whether a relation was marked readonly.

### Motivation / Background

There's currently no documented API to check if a relation is readonly. Workarounds include loading the records and checking those for `readonly?` or using accessing the undocumented `readonly_value`.

A Relation could be marked readonly and used as an indication to what should be rendered. This change makes that use case simpler.

### Detail

Adds `ActiveRecord::Relation#readonly?` which behaves the same as `ActiveRecord::Base#readonly?` for the contained records.


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.