### PR TITLE
Add ability to modify read timeout in runtime

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/trilogy/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/trilogy/database_statements.rb
@@ -46,28 +46,65 @@ module ActiveRecord
             log(sql, name, async: async) do |notification_payload|
               with_raw_connection(allow_retry: allow_retry, materialize_transactions: materialize_transactions) do |conn|
                 sync_timezone_changes(conn)
-                with_custom_read_timeout(conn) do
-                  result = conn.query(sql)
-                  verified!
-                  handle_warnings(sql)
-                  notification_payload[:row_count] = result.count
-                  result
+                result = with_transient_conn_properties(conn) do
+                  conn.query(sql)
                 end
+                verified!
+                handle_warnings(sql)
+                notification_payload[:row_count] = result.count
+                result
               end
             end
           end
 
-          def with_custom_read_timeout(conn)
-            temp_timeout = ActiveRecord::ConnectionAdapters::TrilogyAdapter.custom_read_timeout
-            temp_timeout = temp_timeout.call if temp_timeout.respond_to?(:call)
+          def with_transient_conn_properties(conn)
+            return yield(conn) unless custom_conn_properties?
 
-            return yield(conn) if temp_timeout.nil?
+            original_read_timeout = conn.read_timeout
+            original_write_timeout = conn.write_timeout
+            original_query_flags = conn.query_flags
 
-            original_timeout = conn.read_timeout
-            conn.read_timeout = temp_timeout
+            read_timeout, write_timeout, query_flags = custom_conn_properties
+
+            conn.read_timeout = read_timeout || original_read_timeout
+            conn.write_timeout = write_timeout || original_write_timeout
+            conn.query_flags = query_flags || original_query_flags
+
             result = yield(conn)
-            conn.read_timeout = original_timeout
+
+            conn.read_timeout = original_read_timeout
+            conn.write_timeout = original_write_timeout
+            conn.query_flags = original_query_flags
+
             result
+          end
+
+          def custom_conn_properties?
+            !!ActiveSupport::IsolatedExecutionState[:active_record_custom_conn_properties]
+          end
+
+          def custom_conn_properties
+            read_timeout, write_timeout, query_flags = ActiveSupport::IsolatedExecutionState[:active_record_custom_conn_properties]
+
+            read_timeout = if read_timeout.respond_to?(:call)
+              read_timeout.call
+            else
+              read_timeout
+            end
+
+            write_timeout = if write_timeout.respond_to?(:call)
+              write_timeout.call
+            else
+              write_timeout
+            end
+
+            query_flags = if query_flags.respond_to?(:call)
+              query_flags.call
+            else
+              query_flags
+            end
+
+            [read_timeout, write_timeout, query_flags]
           end
 
           def last_inserted_id(result)

--- a/activerecord/lib/active_record/connection_adapters/trilogy_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/trilogy_adapter.rb
@@ -58,6 +58,18 @@ module ActiveRecord
           end
         end
 
+        def with_custom_read_timeout(timeout)
+          @custom_read_timeout = timeout
+          return unless block_given?
+
+          begin
+            yield
+          ensure
+            @custom_read_timeout = nil
+          end
+        end
+        attr_reader :custom_read_timeout
+
         private
           def initialize_type_map(m)
             super

--- a/activerecord/lib/active_record/connection_adapters/trilogy_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/trilogy_adapter.rb
@@ -58,18 +58,6 @@ module ActiveRecord
           end
         end
 
-        def with_custom_read_timeout(timeout)
-          @custom_read_timeout = timeout
-          return unless block_given?
-
-          begin
-            yield
-          ensure
-            @custom_read_timeout = nil
-          end
-        end
-        attr_reader :custom_read_timeout
-
         private
           def initialize_type_map(m)
             super

--- a/activerecord/lib/active_record/connection_handling.rb
+++ b/activerecord/lib/active_record/connection_handling.rb
@@ -333,6 +333,13 @@ module ActiveRecord
       connection_pool.schema_cache.clear!
     end
 
+    def with_custom_conn_properties(read_timeout: nil, write_timeout: nil, query_flags: nil, &block)
+      ActiveSupport::IsolatedExecutionState[:active_record_custom_conn_properties] = [read_timeout, write_timeout, query_flags]
+      yield
+    ensure
+      ActiveSupport::IsolatedExecutionState[:active_record_custom_conn_properties] = nil
+    end
+
     private
       def resolve_config_for_connection(config_or_env)
         raise "Anonymous class is not allowed." unless name


### PR DESCRIPTION
 ### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

Many different factors can impact the database query execution time from an application's point of view, such as network latency, query execution plan, table data shape, and others. 

Currently, the application can provide a "hardcoded" `read_timeout` value in the database.yml, which helps to cap the maximum time it will take to execute one query.

However, it is not uncommon for a web request to have multiple query executions, and multiple slow queries can impact its response time. To mitigate the long response times, our application has a maximum allowed request time budget, which can be exhausted by multiple types of these issues. We would like to control the application wait time dynamically and gradually reduce that as the web request progresses. It will allow us to prevent a query from exhausting the request time budget.

### Detail

I added the ability to customize the database `read_timeout` property dynamically. It will receive the `read_timeout` as a value or a callable object, and a block. Any connection execution within that block will have the read_timeout replaced by the provided value. For example:

```ruby
ActiveRecord::Base.with_custom_conn_properties(read_timeout: 1) do
  ...
  Model.where(...).to_a # The read_timeout will be set to 1s
  ...
end
```

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [ ] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [ ] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
