### PR TITLE
fix hex bit strings with leading zeroes in postgresql

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/oid/bit.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/oid/bit.rb
@@ -13,9 +13,11 @@ module ActiveRecord
             if ::String === value
               case value
               when /^0x/i
-                value[2..-1].hex.to_s(2) # Hexadecimal notation
+                # Hexadecimal notation (with possible leading zeroes)
+                format("%0*b", (value.rstrip.size - 2) * 4, value[2..].hex)
               else
-                value                    # Bit-string notation
+                # Bit-string notation
+                value
               end
             else
               value.to_s

--- a/activerecord/test/cases/adapters/postgresql/bit_string_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/bit_string_test.rb
@@ -75,10 +75,12 @@ class PostgresqlBitStringTest < ActiveRecord::PostgreSQLTestCase
 
     record.a_bit = "11111111"
     record.a_bit_varying = "0xF"
+    record.another_bit_varying = "0x0010"
     record.save!
 
     assert record.reload
     assert_equal "11111111", record.a_bit
     assert_equal "1111", record.a_bit_varying
+    assert_equal "0000000000010000", record.another_bit_varying
   end
 end


### PR DESCRIPTION
### Motivation / Background

Currently when casting a hex string argument for a PostgreSQL `bit` or `bit_varying` column, leading zeroes are discarded. This is unexpected, and differs from the behavior of binary strings.

### Detail

This Pull Request ensures leading zeroes are preserved, e.g. assigning a bit string column "0x5F" results in the bit string "01011111" instead of "1011111" being sent to Postgres.

### Additional information

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
