### PR TITLE
form_helper documentation using article instead of post [ci skip]

### DIFF
--- a/actionview/lib/action_view/helpers/form_helper.rb
+++ b/actionview/lib/action_view/helpers/form_helper.rb
@@ -213,18 +213,18 @@ module ActionView
       # In the examples above, the object to be created or edited was
       # represented by a symbol passed to +form_for+, and we noted that
       # a string can also be used equivalently. It is also possible, however,
-      # to pass a model object itself to +form_for+. For example, if <tt>@post</tt>
+      # to pass a model object itself to +form_for+. For example, if <tt>@article</tt>
       # is an existing record you wish to edit, you can create the form using
       #
-      #   <%= form_for @post do |f| %>
+      #   <%= form_for @article do |f| %>
       #     ...
       #   <% end %>
       #
       # This behaves in almost the same way as outlined previously, with a
       # couple of small exceptions. First, the prefix used to name the input
       # elements within the form (hence the key that denotes them in the +params+
-      # hash) is actually derived from the object's _class_, e.g. <tt>params[:post]</tt>
-      # if the object's class is +Post+. However, this can be overwritten using
+      # hash) is actually derived from the object's _class_, e.g. <tt>params[:article]</tt>
+      # if the object's class is +Article+. However, this can be overwritten using
       # the <tt>:as</tt> option, e.g. -
       #
       #   <%= form_for(@person, as: :client) do |f| %>
@@ -236,15 +236,15 @@ module ActionView
       # Secondly, the field values shown when the form is initially displayed
       # are taken from the attributes of the object passed to +form_for+,
       # regardless of whether the object is an instance
-      # variable. So, for example, if we had a _local_ variable +post+
+      # variable. So, for example, if we had a _local_ variable +article+
       # representing an existing record,
       #
-      #   <%= form_for post do |f| %>
+      #   <%= form_for article do |f| %>
       #     ...
       #   <% end %>
       #
       # would produce a form with fields whose initial state reflect the current
-      # values of the attributes of +post+.
+      # values of the attributes of +article+.
       #
       # === Resource-oriented style
       #
@@ -256,49 +256,49 @@ module ActionView
       # in <tt>config/routes.rb</tt>. In this case \Rails will simply infer the
       # appropriate URL from the record itself. For example,
       #
-      #   <%= form_for @post do |f| %>
+      #   <%= form_for @article do |f| %>
       #     ...
       #   <% end %>
       #
       # is then equivalent to something like:
       #
-      #   <%= form_for @post, as: :post, url: post_path(@post), method: :patch, html: { class: "edit_post", id: "edit_post_45" } do |f| %>
+      #   <%= form_for @article, as: :article, url: article_path(@article), method: :patch, html: { class: "edit_article", id: "edit_article_45" } do |f| %>
       #     ...
       #   <% end %>
       #
       # And for a new record
       #
-      #   <%= form_for(Post.new) do |f| %>
+      #   <%= form_for(Article.new) do |f| %>
       #     ...
       #   <% end %>
       #
       # is equivalent to something like:
       #
-      #   <%= form_for @post, as: :post, url: posts_path, html: { class: "new_post", id: "new_post" } do |f| %>
+      #   <%= form_for @article, as: :article, url: articles_path, html: { class: "new_article", id: "new_article" } do |f| %>
       #     ...
       #   <% end %>
       #
       # However you can still overwrite individual conventions, such as:
       #
-      #   <%= form_for(@post, url: super_posts_path) do |f| %>
+      #   <%= form_for(@article, url: super_articles_path) do |f| %>
       #     ...
       #   <% end %>
       #
       # You can omit the <tt>action</tt> attribute by passing <tt>url: false</tt>:
       #
-      #   <%= form_for(@post, url: false) do |f| %>
+      #   <%= form_for(@article, url: false) do |f| %>
       #     ...
       #   <% end %>
       #
       # You can also set the answer format, like this:
       #
-      #   <%= form_for(@post, format: :json) do |f| %>
+      #   <%= form_for(@article, format: :json) do |f| %>
       #     ...
       #   <% end %>
       #
-      # For namespaced routes, like +admin_post_url+:
+      # For namespaced routes, like +admin_article_url+:
       #
-      #   <%= form_for([:admin, @post]) do |f| %>
+      #   <%= form_for([:admin, @article]) do |f| %>
       #    ...
       #   <% end %>
       #
@@ -334,7 +334,7 @@ module ActionView
       #
       # Example:
       #
-      #   <%= form_for(@post, remote: true) do |f| %>
+      #   <%= form_for(@article, remote: true) do |f| %>
       #     ...
       #   <% end %>
       #
@@ -350,7 +350,7 @@ module ActionView
       # You can set data attributes directly by passing in a data hash, but all other HTML options must be wrapped in
       # the HTML key. Example:
       #
-      #   <%= form_for(@post, data: { behavior: "autosave" }, html: { name: "go" }) do |f| %>
+      #   <%= form_for(@article, data: { behavior: "autosave" }, html: { name: "go" }) do |f| %>
       #     ...
       #   <% end %>
       #
@@ -368,12 +368,12 @@ module ActionView
       # Some ORM systems do not use IDs on nested models so in this case you want to be able
       # to disable the hidden id.
       #
-      # In the following example the Post model has many Comments stored within it in a NoSQL database,
+      # In the following example the Article model has many Comments stored within it in a NoSQL database,
       # thus there is no primary key for comments.
       #
       # Example:
       #
-      #   <%= form_for(@post) do |f| %>
+      #   <%= form_for(@article) do |f| %>
       #     <%= f.fields_for(:comments, include_id: false) do |cf| %>
       #       ...
       #     <% end %>
@@ -485,12 +485,12 @@ module ActionView
       # Creates a form tag based on mixing URLs, scopes, or models.
       #
       #   # Using just a URL:
-      #   <%= form_with url: posts_path do |form| %>
+      #   <%= form_with url: articles_path do |form| %>
       #     <%= form.text_field :title %>
       #   <% end %>
       #   # =>
-      #   <form action="/posts" method="post">
-      #     <input type="text" name="title">
+      #   <form action="/articles" method="post">
+      #     <input type="text" name="title" />
       #   </form>
       #
       #   # With an intentionally empty URL:
@@ -499,37 +499,36 @@ module ActionView
       #   <% end %>
       #   # =>
       #   <form method="post">
-      #     <input type="text" name="title">
+      #     <input type="text" name="title" />
       #   </form>
       #
       #   # Adding a scope prefixes the input field names:
-      #   <%= form_with scope: :post, url: posts_path do |form| %>
+      #   <%= form_with scope: :article, url: articles_path do |form| %>
       #     <%= form.text_field :title %>
       #   <% end %>
       #   # =>
-      #   <form action="/posts" method="post">
-      #     <input type="text" name="post[title]">
+      #   <form action="/articles" method="post">
+      #     <input type="text" name="article[title]" />
       #   </form>
       #
       #   # Using a model infers both the URL and scope:
-      #   <%= form_with model: Post.new do |form| %>
+      #   <%= form_with model: Article.new do |form| %>
       #     <%= form.text_field :title %>
       #   <% end %>
       #   # =>
-      #   <form action="/posts" method="post">
-      #     <input type="text" name="post[title]">
+      #   <form action="/articles" method="post">
+      #     <input type="text" name="article[title]" />
       #   </form>
       #
       #   # An existing model makes an update form and fills out field values:
-      #   <%= form_with model: Post.first do |form| %>
+      #   <%= form_with model: Article.first do |form| %>
       #     <%= form.text_field :title %>
       #   <% end %>
       #   # =>
-      #   <form action="/posts/1" method="post">
-      #     <input type="hidden" name="_method" value="patch">
-      #     <input type="text" name="post[title]" value="<the title of the post>">
+      #   <form action="/articles/1" method="post">
+      #     <input type="hidden" name="_method" value="patch" />
+      #     <input type="text" name="article[title]" value="<the title of the article>" />
       #   </form>
-      #
       #   # Though the fields don't have to correspond to model attributes:
       #   <%= form_with model: Cat.new do |form| %>
       #     <%= form.text_field :cats_dont_have_gills %>
@@ -537,13 +536,13 @@ module ActionView
       #   <% end %>
       #   # =>
       #   <form action="/cats" method="post">
-      #     <input type="text" name="cat[cats_dont_have_gills]">
-      #     <input type="text" name="cat[but_in_forms_they_can]">
+      #     <input type="text" name="cat[cats_dont_have_gills]" />
+      #     <input type="text" name="cat[but_in_forms_they_can]" />
       #   </form>
       #
       # The parameters in the forms are accessible in controllers according to
-      # their name nesting. So inputs named +title+ and <tt>post[title]</tt> are
-      # accessible as <tt>params[:title]</tt> and <tt>params[:post][:title]</tt>
+      # their name nesting. So inputs named +title+ and <tt>article[title]</tt> are
+      # accessible as <tt>params[:title]</tt> and <tt>params[:article][:title]</tt>
       # respectively.
       #
       # For ease of comparison the examples above left out the submit button,
@@ -559,25 +558,25 @@ module ActionView
       #
       # So when passing such a model record, \Rails infers the URL and method.
       #
-      #   <%= form_with model: @post do |form| %>
+      #   <%= form_with model: @article do |form| %>
       #     ...
       #   <% end %>
       #
       # is then equivalent to something like:
       #
-      #   <%= form_with scope: :post, url: post_path(@post), method: :patch do |form| %>
+      #   <%= form_with scope: :article, url: article_path(@article), method: :patch do |form| %>
       #     ...
       #   <% end %>
       #
       # And for a new record
       #
-      #   <%= form_with model: Post.new do |form| %>
+      #   <%= form_with model: Article.new do |form| %>
       #     ...
       #   <% end %>
       #
       # is equivalent to something like:
       #
-      #   <%= form_with scope: :post, url: posts_path do |form| %>
+      #   <%= form_with scope: :article, url: articles_path do |form| %>
       #     ...
       #   <% end %>
       #
@@ -606,7 +605,7 @@ module ActionView
       #   If the model is a new record a create form is generated, if an
       #   existing record, however, an update form is generated.
       #   Pass <tt>:scope</tt> or <tt>:url</tt> to override the defaults.
-      #   E.g. turn <tt>params[:post]</tt> into <tt>params[:article]</tt>.
+      #   E.g. turn <tt>params[:article]</tt> into <tt>params[:blog]</tt>.
       # * <tt>:authenticity_token</tt> - Authenticity token to use in the form.
       #   Override with a custom authenticity token or pass <tt>false</tt> to
       #   skip the authenticity token field altogether.
@@ -639,14 +638,14 @@ module ActionView
       #
       # When not passing a block, +form_with+ just generates an opening form tag.
       #
-      #   <%= form_with(model: @post, url: super_posts_path) %>
-      #   <%= form_with(model: @post, scope: :article) %>
-      #   <%= form_with(model: @post, format: :json) %>
-      #   <%= form_with(model: @post, authenticity_token: false) %> # Disables the token.
+      #   <%= form_with(model: @article, url: super_articles_path) %>
+      #   <%= form_with(model: @article, scope: :blog) %>
+      #   <%= form_with(model: @article, format: :json) %>
+      #   <%= form_with(model: @article, authenticity_token: false) %> # Disables the token.
       #
-      # For namespaced routes, like +admin_post_url+:
+      # For namespaced routes, like +admin_article_url+:
       #
-      #   <%= form_with(model: [ :admin, @post ]) do |form| %>
+      #   <%= form_with(model: [ :admin, @article ]) do |form| %>
       #     ...
       #   <% end %>
       #
@@ -694,13 +693,13 @@ module ActionView
       # You can set data attributes directly in a data hash, but HTML options
       # besides id and class must be wrapped in an HTML key:
       #
-      #   <%= form_with(model: @post, data: { behavior: "autosave" }, html: { name: "go" }) do |form| %>
+      #   <%= form_with(model: @article, data: { behavior: "autosave" }, html: { name: "go" }) do |form| %>
       #     ...
       #   <% end %>
       #
       # generates
       #
-      #   <form action="/posts/123" method="post" data-behavior="autosave" name="go">
+      #   <form action="/articles/123" method="post" data-behavior="autosave" name="go">
       #     <input name="_method" type="hidden" value="patch" />
       #     ...
       #   </form>
@@ -712,10 +711,10 @@ module ActionView
       # Some ORM systems do not use IDs on nested models so in this case you want to be able
       # to disable the hidden id.
       #
-      # In the following example the Post model has many Comments stored within it in a NoSQL database,
+      # In the following example the Article model has many Comments stored within it in a NoSQL database,
       # thus there is no primary key for comments.
       #
-      #   <%= form_with(model: @post) do |form| %>
+      #   <%= form_with(model: @article) do |form| %>
       #     <%= form.fields(:comments, skip_id: true) do |fields| %>
       #       ...
       #     <% end %>
@@ -1049,7 +1048,7 @@ module ActionView
       #   # => <input type="text" name="comment[body]" value="full bodied">
       #
       #   # Using +fields+ with +form_with+:
-      #   <%= form_with model: @post do |form| %>
+      #   <%= form_with model: @article do |form| %>
       #     <%= form.text_field :title %>
       #
       #     <%= form.fields :comment do |fields| %>
@@ -1097,58 +1096,58 @@ module ActionView
       # target labels for radio_button tags (where the value is used in the ID of the input tag).
       #
       # ==== Examples
-      #   label(:post, :title)
-      #   # => <label for="post_title">Title</label>
+      #   label(:article, :title)
+      #   # => <label for="article_title">Title</label>
       #
       # You can localize your labels based on model and attribute names.
       # For example you can define the following in your locale (e.g. en.yml)
       #
       #   helpers:
       #     label:
-      #       post:
+      #       article:
       #         body: "Write your entire text here"
       #
       # Which then will result in
       #
-      #   label(:post, :body)
-      #   # => <label for="post_body">Write your entire text here</label>
+      #   label(:article, :body)
+      #   # => <label for="article_body">Write your entire text here</label>
       #
       # Localization can also be based purely on the translation of the attribute-name
       # (if you are using ActiveRecord):
       #
       #   activerecord:
       #     attributes:
-      #       post:
+      #       article:
       #         cost: "Total cost"
       #
       # <code></code>
       #
-      #   label(:post, :cost)
-      #   # => <label for="post_cost">Total cost</label>
+      #   label(:article, :cost)
+      #   # => <label for="article_cost">Total cost</label>
       #
-      #   label(:post, :title, "A short title")
-      #   # => <label for="post_title">A short title</label>
+      #   label(:article, :title, "A short title")
+      #   # => <label for="article_title">A short title</label>
       #
-      #   label(:post, :title, "A short title", class: "title_label")
-      #   # => <label for="post_title" class="title_label">A short title</label>
+      #   label(:article, :title, "A short title", class: "title_label")
+      #   # => <label for="article_title" class="title_label">A short title</label>
       #
-      #   label(:post, :privacy, "Public Post", value: "public")
-      #   # => <label for="post_privacy_public">Public Post</label>
+      #   label(:article, :privacy, "Public Article", value: "public")
+      #   # => <label for="article_privacy_public">Public Article</label>
       #
-      #   label(:post, :cost) do |translation|
+      #   label(:article, :cost) do |translation|
       #     content_tag(:span, translation, class: "cost_label")
       #   end
-      #   # => <label for="post_cost"><span class="cost_label">Total cost</span></label>
+      #   # => <label for="article_cost"><span class="cost_label">Total cost</span></label>
       #
-      #   label(:post, :cost) do |builder|
+      #   label(:article, :cost) do |builder|
       #     content_tag(:span, builder.translation, class: "cost_label")
       #   end
-      #   # => <label for="post_cost"><span class="cost_label">Total cost</span></label>
+      #   # => <label for="article_cost"><span class="cost_label">Total cost</span></label>
       #
-      #   label(:post, :terms) do
+      #   label(:article, :terms) do
       #     raw('Accept <a href="/terms">Terms</a>.')
       #   end
-      #   # => <label for="post_terms">Accept <a href="/terms">Terms</a>.</label>
+      #   # => <label for="article_terms">Accept <a href="/terms">Terms</a>.</label>
       def label(object_name, method, content_or_options = nil, options = nil, &block)
         Tags::Label.new(object_name, method, self, content_or_options, options).render(&block)
       end
@@ -1159,14 +1158,14 @@ module ActionView
       # shown.
       #
       # ==== Examples
-      #   text_field(:post, :title, size: 20)
-      #   # => <input type="text" id="post_title" name="post[title]" size="20" value="#{@post.title}" />
+      #   text_field(:article, :title, size: 20)
+      #   # => <input type="text" id="article_title" name="article[title]" size="20" value="#{@article.title}" />
       #
-      #   text_field(:post, :title, class: "create_input")
-      #   # => <input type="text" id="post_title" name="post[title]" value="#{@post.title}" class="create_input" />
+      #   text_field(:article, :title, class: "create_input")
+      #   # => <input type="text" id="article_title" name="article[title]" value="#{@article.title}" class="create_input" />
       #
-      #   text_field(:post, :title,  maxlength: 30, class: "title_input")
-      #   # => <input type="text" id="post_title" name="post[title]" maxlength="30" size="30" value="#{@post.title}" class="title_input" />
+      #   text_field(:article, :title,  maxlength: 30, class: "title_input")
+      #   # => <input type="text" id="article_title" name="article[title]" maxlength="30" size="30" value="#{@article.title}" class="title_input" />
       #
       #   text_field(:session, :user, onchange: "if ($('#session_user').val() === 'admin') { alert('Your login cannot be admin!'); }")
       #   # => <input type="text" id="session_user" name="session[user]" value="#{@session.user}" onchange="if ($('#session_user').val() === 'admin') { alert('Your login cannot be admin!'); }"/>
@@ -1207,8 +1206,8 @@ module ActionView
       #   hidden_field(:signup, :pass_confirm)
       #   # => <input type="hidden" id="signup_pass_confirm" name="signup[pass_confirm]" value="#{@signup.pass_confirm}" />
       #
-      #   hidden_field(:post, :tag_list)
-      #   # => <input type="hidden" id="post_tag_list" name="post[tag_list]" value="#{@post.tag_list}" />
+      #   hidden_field(:article, :tag_list)
+      #   # => <input type="hidden" id="article_tag_list" name="article[tag_list]" value="#{@article.tag_list}" />
       #
       #   hidden_field(:user, :token)
       #   # => <input type="hidden" id="user_token" name="user[token]" value="#{@user.token}" />
@@ -1234,14 +1233,14 @@ module ActionView
       #   file_field(:user, :avatar)
       #   # => <input type="file" id="user_avatar" name="user[avatar]" />
       #
-      #   file_field(:post, :image, multiple: true)
-      #   # => <input type="file" id="post_image" name="post[image][]" multiple="multiple" />
+      #   file_field(:article, :image, multiple: true)
+      #   # => <input type="file" id="article_image" name="article[image][]" multiple="multiple" />
       #
-      #   file_field(:post, :attached, accept: 'text/html')
-      #   # => <input accept="text/html" type="file" id="post_attached" name="post[attached]" />
+      #   file_field(:article, :attached, accept: 'text/html')
+      #   # => <input accept="text/html" type="file" id="article_attached" name="article[attached]" />
       #
-      #   file_field(:post, :image, accept: 'image/png,image/gif,image/jpeg')
-      #   # => <input type="file" id="post_image" name="post[image]" accept="image/png,image/gif,image/jpeg" />
+      #   file_field(:article, :image, accept: 'image/png,image/gif,image/jpeg')
+      #   # => <input type="file" id="article_image" name="article[image]" accept="image/png,image/gif,image/jpeg" />
       #
       #   file_field(:attachment, :file, class: 'file_input')
       #   # => <input type="file" id="attachment_file" name="attachment[file]" class="file_input" />
@@ -1256,9 +1255,9 @@ module ActionView
       # hash with +options+.
       #
       # ==== Examples
-      #   text_area(:post, :body, cols: 20, rows: 40)
-      #   # => <textarea cols="20" rows="40" id="post_body" name="post[body]">
-      #   #      #{@post.body}
+      #   text_area(:article, :body, cols: 20, rows: 40)
+      #   # => <textarea cols="20" rows="40" id="article_body" name="article[body]">
+      #   #      #{@article.body}
       #   #    </textarea>
       #
       #   text_area(:comment, :text, size: "20x30")
@@ -1330,10 +1329,10 @@ module ActionView
       #
       # ==== Examples
       #
-      #   # Let's say that @post.validated? is 1:
-      #   check_box("post", "validated")
-      #   # => <input name="post[validated]" type="hidden" value="0" />
-      #   #    <input checked="checked" type="checkbox" id="post_validated" name="post[validated]" value="1" />
+      #   # Let's say that @article.validated? is 1:
+      #   check_box("article", "validated")
+      #   # => <input name="article[validated]" type="hidden" value="0" />
+      #   #    <input checked="checked" type="checkbox" id="article_validated" name="article[validated]" value="1" />
       #
       #   # Let's say that @puppy.gooddog is "no":
       #   check_box("puppy", "gooddog", {}, "yes", "no")
@@ -1354,11 +1353,11 @@ module ActionView
       # To force the radio button to be checked pass <tt>checked: true</tt> in the
       # +options+ hash. You may pass HTML options there as well.
       #
-      #   # Let's say that @post.category returns "rails":
-      #   radio_button("post", "category", "rails")
-      #   radio_button("post", "category", "java")
-      #   # => <input type="radio" id="post_category_rails" name="post[category]" value="rails" checked="checked" />
-      #   #    <input type="radio" id="post_category_java" name="post[category]" value="java" />
+      #   # Let's say that @article.category returns "rails":
+      #   radio_button("article", "category", "rails")
+      #   radio_button("article", "category", "java")
+      #   # => <input type="radio" id="article_category_rails" name="article[category]" value="rails" checked="checked" />
+      #   #    <input type="radio" id="article_category_java" name="article[category]" value="java" />
       #
       #   # Let's say that @user.receive_newsletter returns "no":
       #   radio_button("user", "receive_newsletter", "yes")
@@ -1739,7 +1738,7 @@ module ActionView
       #
       # return the <tt><form></tt> element's <tt>id</tt> attribute.
       #
-      #   <%= form_for @post do |f| %>
+      #   <%= form_for @article do |f| %>
       #     <%# ... %>
       #
       #     <% content_for :sticky_footer do %>
@@ -1761,7 +1760,7 @@ module ActionView
       # Return the value generated by the <tt>FormBuilder</tt> for the given
       # attribute name.
       #
-      #   <%= form_for @post do |f| %>
+      #   <%= form_for @article do |f| %>
       #     <%= f.label :title %>
       #     <%= f.text_field :title, aria: { describedby: f.field_id(:title, :error) } %>
       #     <%= tag.span("is blank", id: f.field_id(:title, :error) %>
@@ -1770,7 +1769,7 @@ module ActionView
       # In the example above, the <tt><input type="text"></tt> element built by
       # the call to <tt>FormBuilder#text_field</tt> declares an
       # <tt>aria-describedby</tt> attribute referencing the <tt><span></tt>
-      # element, sharing a common <tt>id</tt> root (<tt>post_title</tt>, in this
+      # element, sharing a common <tt>id</tt> root (<tt>article_title</tt>, in this
       # case).
       def field_id(method, *suffixes, namespace: @options[:namespace], index: @options[:index])
         @template.field_id(@object_name, method, *suffixes, namespace: namespace, index: index)
@@ -1782,14 +1781,14 @@ module ActionView
       # Return the value generated by the <tt>FormBuilder</tt> for the given
       # attribute name.
       #
-      #   <%= form_for @post do |f| %>
+      #   <%= form_for @article do |f| %>
       #     <%= f.text_field :title, name: f.field_name(:title, :subtitle) %>
-      #     <%# => <input type="text" name="post[title][subtitle]"> %>
+      #     <%# => <input type="text" name="article[title][subtitle]"> %>
       #   <% end %>
       #
-      #   <%= form_for @post do |f| %>
+      #   <%= form_for @article do |f| %>
       #     <%= f.text_field :tag, name: f.field_name(:tag, multiple: true) %>
-      #     <%# => <input type="text" name="post[tag][]"> %>
+      #     <%# => <input type="text" name="article[tag][]"> %>
       #   <% end %>
       #
       def field_name(method, *methods, multiple: false, index: @options[:index])
@@ -2344,52 +2343,52 @@ module ActionView
       #
       # ==== Examples
       #   label(:title)
-      #   # => <label for="post_title">Title</label>
+      #   # => <label for="article_title">Title</label>
       #
       # You can localize your labels based on model and attribute names.
       # For example you can define the following in your locale (e.g. en.yml)
       #
       #   helpers:
       #     label:
-      #       post:
+      #       article:
       #         body: "Write your entire text here"
       #
       # Which then will result in
       #
       #   label(:body)
-      #   # => <label for="post_body">Write your entire text here</label>
+      #   # => <label for="article_body">Write your entire text here</label>
       #
       # Localization can also be based purely on the translation of the attribute-name
       # (if you are using ActiveRecord):
       #
       #   activerecord:
       #     attributes:
-      #       post:
+      #       article:
       #         cost: "Total cost"
       #
       # <code></code>
       #
       #   label(:cost)
-      #   # => <label for="post_cost">Total cost</label>
+      #   # => <label for="article_cost">Total cost</label>
       #
       #   label(:title, "A short title")
-      #   # => <label for="post_title">A short title</label>
+      #   # => <label for="article_title">A short title</label>
       #
       #   label(:title, "A short title", class: "title_label")
-      #   # => <label for="post_title" class="title_label">A short title</label>
+      #   # => <label for="article_title" class="title_label">A short title</label>
       #
-      #   label(:privacy, "Public Post", value: "public")
-      #   # => <label for="post_privacy_public">Public Post</label>
+      #   label(:privacy, "Public Article", value: "public")
+      #   # => <label for="article_privacy_public">Public Article</label>
       #
       #   label(:cost) do |translation|
       #     content_tag(:span, translation, class: "cost_label")
       #   end
-      #   # => <label for="post_cost"><span class="cost_label">Total cost</span></label>
+      #   # => <label for="article_cost"><span class="cost_label">Total cost</span></label>
       #
       #   label(:cost) do |builder|
       #     content_tag(:span, builder.translation, class: "cost_label")
       #   end
-      #   # => <label for="post_cost"><span class="cost_label">Total cost</span></label>
+      #   # => <label for="article_cost"><span class="cost_label">Total cost</span></label>
       #
       #   label(:cost) do |builder|
       #     content_tag(:span, builder.translation, class: [
@@ -2397,12 +2396,12 @@ module ActionView
       #       ("error_label" if builder.object.errors.include?(:cost))
       #     ])
       #   end
-      #   # => <label for="post_cost"><span class="cost_label error_label">Total cost</span></label>
+      #   # => <label for="article_cost"><span class="cost_label error_label">Total cost</span></label>
       #
       #   label(:terms) do
       #     raw('Accept <a href="/terms">Terms</a>.')
       #   end
-      #   # => <label for="post_terms">Accept <a href="/terms">Terms</a>.</label>
+      #   # => <label for="article_terms">Accept <a href="/terms">Terms</a>.</label>
       def label(method, text = nil, options = {}, &block)
         @template.label(@object_name, method, text, objectify_options(options), &block)
       end
@@ -2458,10 +2457,10 @@ module ActionView
       #
       # ==== Examples
       #
-      #   # Let's say that @post.validated? is 1:
+      #   # Let's say that @article.validated? is 1:
       #   check_box("validated")
-      #   # => <input name="post[validated]" type="hidden" value="0" />
-      #   #    <input checked="checked" type="checkbox" id="post_validated" name="post[validated]" value="1" />
+      #   # => <input name="article[validated]" type="hidden" value="0" />
+      #   #    <input checked="checked" type="checkbox" id="article_validated" name="article[validated]" value="1" />
       #
       #   # Let's say that @puppy.gooddog is "no":
       #   check_box("gooddog", {}, "yes", "no")
@@ -2483,11 +2482,11 @@ module ActionView
       # To force the radio button to be checked pass <tt>checked: true</tt> in the
       # +options+ hash. You may pass HTML options there as well.
       #
-      #   # Let's say that @post.category returns "rails":
+      #   # Let's say that @article.category returns "rails":
       #   radio_button("category", "rails")
       #   radio_button("category", "java")
-      #   # => <input type="radio" id="post_category_rails" name="post[category]" value="rails" checked="checked" />
-      #   #    <input type="radio" id="post_category_java" name="post[category]" value="java" />
+      #   # => <input type="radio" id="article_category_rails" name="article[category]" value="rails" checked="checked" />
+      #   #    <input type="radio" id="article_category_java" name="article[category]" value="java" />
       #
       #   # Let's say that @user.receive_newsletter returns "no":
       #   radio_button("receive_newsletter", "yes")
@@ -2508,9 +2507,9 @@ module ActionView
       #   hidden_field(:pass_confirm)
       #   # => <input type="hidden" id="signup_pass_confirm" name="signup[pass_confirm]" value="true" />
       #
-      #   # Let's say that @post.tag_list returns "blog, ruby":
+      #   # Let's say that @article.tag_list returns "blog, ruby":
       #   hidden_field(:tag_list)
-      #   # => <input type="hidden" id="post_tag_list" name="post[tag_list]" value="blog, ruby" />
+      #   # => <input type="hidden" id="article_tag_list" name="article[tag_list]" value="blog, ruby" />
       #
       #   # Let's say that @user.token returns "abcde":
       #   hidden_field(:token)
@@ -2540,17 +2539,17 @@ module ActionView
       #   file_field(:avatar)
       #   # => <input type="file" id="user_avatar" name="user[avatar]" />
       #
-      #   # Let's say that @post has image:
+      #   # Let's say that @article has image:
       #   file_field(:image, :multiple => true)
-      #   # => <input type="file" id="post_image" name="post[image][]" multiple="multiple" />
+      #   # => <input type="file" id="article_image" name="article[image][]" multiple="multiple" />
       #
-      #   # Let's say that @post has attached:
+      #   # Let's say that @article has attached:
       #   file_field(:attached, accept: 'text/html')
-      #   # => <input accept="text/html" type="file" id="post_attached" name="post[attached]" />
+      #   # => <input accept="text/html" type="file" id="article_attached" name="article[attached]" />
       #
-      #   # Let's say that @post has image:
+      #   # Let's say that @article has image:
       #   file_field(:image, accept: 'image/png,image/gif,image/jpeg')
-      #   # => <input type="file" id="post_image" name="post[image]" accept="image/png,image/gif,image/jpeg" />
+      #   # => <input type="file" id="article_image" name="article[image]" accept="image/png,image/gif,image/jpeg" />
       #
       #   # Let's say that @attachment has file:
       #   file_field(:file, class: 'file_input')
@@ -2563,12 +2562,12 @@ module ActionView
       # Add the submit button for the given form. When no value is given, it checks
       # if the object is a new resource or not to create the proper label:
       #
-      #   <%= form_for @post do |f| %>
+      #   <%= form_for @article do |f| %>
       #     <%= f.submit %>
       #   <% end %>
       #
-      # In the example above, if <tt>@post</tt> is a new record, it will use "Create Post" as
-      # submit button label; otherwise, it uses "Update Post".
+      # In the example above, if <tt>@article</tt> is a new record, it will use "Create Article" as
+      # submit button label; otherwise, it uses "Update Article".
       #
       # Those labels can be customized using I18n under the +helpers.submit+ key and using
       # <tt>%{model}</tt> for translation interpolation:
@@ -2584,7 +2583,7 @@ module ActionView
       #   en:
       #     helpers:
       #       submit:
-      #         post:
+      #         article:
       #           create: "Add %{model}"
       #
       def submit(value = nil, options = {})
@@ -2596,12 +2595,11 @@ module ActionView
       # Add the submit button for the given form. When no value is given, it checks
       # if the object is a new resource or not to create the proper label:
       #
-      #   <%= form_for @post do |f| %>
+      #   <%= form_for @article do |f| %>
       #     <%= f.button %>
       #   <% end %>
-      #
-      # In the example above, if <tt>@post</tt> is a new record, it will use "Create Post" as
-      # button label; otherwise, it uses "Update Post".
+      # In the example above, if <tt>@article</tt> is a new record, it will use "Create Article" as
+      # button label; otherwise, it uses "Update Article".
       #
       # Those labels can be customized using I18n under the +helpers.submit+ key
       # (the same as submit helper) and using <tt>%{model}</tt> for translation interpolation:
@@ -2617,15 +2615,15 @@ module ActionView
       #   en:
       #     helpers:
       #       submit:
-      #         post:
+      #         article:
       #           create: "Add %{model}"
       #
       # ==== Examples
-      #   button("Create post")
-      #   # => <button name='button' type='submit'>Create post</button>
+      #   button("Create article")
+      #   # => <button name='button' type='submit'>Create article</button>
       #
       #   button(:draft, value: true)
-      #   # => <button id="post_draft" name="post[draft]" value="true" type="submit">Create post</button>
+      #   # => <button id="article_draft" name="article[draft]" value="true" type="submit">Create article</button>
       #
       #   button do
       #     content_tag(:strong, 'Ask me!')
@@ -2638,13 +2636,13 @@ module ActionView
       #     content_tag(:strong, text)
       #   end
       #   # => <button name='button' type='submit'>
-      #   #      <strong>Create post</strong>
+      #   #      <strong>Create article</strong>
       #   #    </button>
       #
       #   button(:draft, value: true) do
       #     content_tag(:strong, "Save as draft")
       #   end
-      #   # =>  <button id="post_draft" name="post[draft]" value="true" type="submit">
+      #   # =>  <button id="article_draft" name="article[draft]" value="true" type="submit">
       #   #       <strong>Save as draft</strong>
       #   #     </button>
       #


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because it will make the form_with documentation clearer.

### Detail

Documentation previously uses post which is confusing as the methods/verb is also post.

Before
`<form action="/posts" method="post">`

After
`<form action="/articles" method="post">`

### Method

Worked through a new Rails app with scaffold of article and checking the output of the HTML. Other HTML changes make it more authentic:
- /> => at the end of the input
- value attribute before name attribute

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [X] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
