### PR TITLE
Devcontainer using ruby image

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,31 +1,16 @@
 # See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.191.1/containers/ruby/.devcontainer/base.Dockerfile
 
 # [Choice] Ruby version: 3, 3.3, 3.2, 3.1, 3.0, 2, 2.7, 2.6
-ARG VARIANT="3.3"
-FROM mcr.microsoft.com/devcontainers/ruby:${VARIANT}
-
-# [Choice] Node.js version: none, lts/*, 16, 14, 12, 10
-ARG NODE_VERSION="lts/*"
-RUN if [ "${NODE_VERSION}" != "none" ]; then su vscode -c "umask 0002 && . /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"; fi
+ARG VARIANT="3.3.0"
+FROM ghcr.io/rails/devcontainer/images/ruby:${VARIANT}
 
 # [Optional] Uncomment this section to install additional OS packages.
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && apt-get -y install --no-install-recommends \
         mariadb-client libmariadb-dev \
         postgresql-client postgresql-contrib libpq-dev \
-        ffmpeg mupdf mupdf-tools libvips poppler-utils
-
-
-ARG IMAGEMAGICK_VERSION="7.1.0-5"
-RUN wget -qO /tmp/im.tar.xz https://imagemagick.org/archive/releases/ImageMagick-$IMAGEMAGICK_VERSION.tar.xz \
-    && wget -qO /tmp/im.sig https://imagemagick.org/archive/releases/ImageMagick-$IMAGEMAGICK_VERSION.tar.xz.asc \
-    && gpg --batch --keyserver keyserver.ubuntu.com --recv 89AB63D48277377A \
-    && gpg --batch --verify /tmp/im.sig /tmp/im.tar.xz \
-    && tar xJf /tmp/im.tar.xz -C /tmp \
-    && cd /tmp/ImageMagick-$IMAGEMAGICK_VERSION \
-    && ./configure --with-rsvg && make -j 9 && make install \
-    && ldconfig /usr/local/lib \
-    && rm -rf /tmp/*
+        ffmpeg mupdf mupdf-tools libvips-dev poppler-utils \
+        libxml2-dev sqlite3 imagemagick
 
 # Add the Rails main Gemfile and install the gems. This means the gem install can be done
 # during build instead of on start. When a fork or branch has different gems, we still have an
@@ -44,8 +29,11 @@ COPY activerecord/activerecord.gemspec /tmp/rails/activerecord/
 COPY activestorage/activestorage.gemspec /tmp/rails/activestorage/
 COPY activesupport/activesupport.gemspec /tmp/rails/activesupport/
 COPY railties/railties.gemspec /tmp/rails/railties/
+# Docker does not support COPY as users other than root. So we need to chown this dir so we
+# can bundle as vscode user and then remove the tmp dir
+RUN chown -R vscode:vscode /tmp/rails
+USER vscode
 RUN cd /tmp/rails \
-    && bundle install \
-    && yarn install \
+    && /home/vscode/.rbenv/shims/bundle install \
     && rm -rf /tmp/rails
-RUN chown -R vscode:vscode /usr/local/rvm
+

--- a/.devcontainer/boot.sh
+++ b/.devcontainer/boot.sh
@@ -1,7 +1,7 @@
 bundle install
-yarn install
 
-sudo chown -R vscode:vscode /usr/local/bundle
+. ${NVM_DIR}/nvm.sh && nvm install --lts
+yarn install
 
 cd activerecord
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,6 +9,9 @@
 	"features": {
 		"ghcr.io/devcontainers/features/github-cli:1": {
 			"version": "latest"
+		},
+		"ghcr.io/devcontainers/features/node:1": {
+			"version": "latest"
 		}
 	},
 

--- a/railties/lib/rails/generators/devcontainer.rb
+++ b/railties/lib/rails/generators/devcontainer.rb
@@ -4,10 +4,6 @@ module Rails
   module Generators
     module Devcontainer
       private
-        def devcontainer_ruby_version
-          gem_ruby_version.to_s.match(/^\d+\.\d+/).to_s
-        end
-
         def devcontainer_dependencies
           return @devcontainer_dependencies if @devcontainer_dependencies
 
@@ -60,6 +56,13 @@ module Rails
           when "mysql"          then "mysql-data"
           when "trilogy"        then "mariadb-data"
           when "postgresql"     then "postgres-data"
+          end
+        end
+
+        def db_package_for_dockerfile(database = options[:database])
+          case database
+          when "mysql"          then "default-libmysqlclient-dev"
+          when "postgresql"     then "libpq-dev"
           end
         end
 

--- a/railties/lib/rails/generators/rails/app/templates/.devcontainer/Dockerfile.tt
+++ b/railties/lib/rails/generators/rails/app/templates/.devcontainer/Dockerfile.tt
@@ -1,12 +1,12 @@
 # Make sure RUBY_VERSION matches the Ruby version in .ruby-version
-ARG RUBY_VERSION=<%= devcontainer_ruby_version %>
-FROM mcr.microsoft.com/devcontainers/ruby:1-$RUBY_VERSION-bookworm
+ARG RUBY_VERSION=<%= gem_ruby_version %>
+FROM ghcr.io/rails/devcontainer/images/ruby:$RUBY_VERSION
 
 <%- unless options.skip_active_storage -%>
 # Install packages needed to build gems
 RUN apt-get update -qq && \
     apt-get install --no-install-recommends -y \
-      libvips \
+      <%= db_package_for_dockerfile %> libvips \
       #  For video thumbnails
       ffmpeg \
       # For pdf thumbnails. If you want to use mupdf instead of poppler,

--- a/railties/lib/rails/generators/rails/db/system/change/change_generator.rb
+++ b/railties/lib/rails/generators/rails/db/system/change/change_generator.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 require "rails/generators/base"
+require "yaml"
+require "json"
 
 module Rails
   module Generators

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -1011,8 +1011,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
     ruby_version = "#{Gem::Version.new(Gem::VERSION) >= Gem::Version.new("3.3.13") ? Gem.ruby_version : RUBY_VERSION}"
 
     assert_file ".devcontainer/Dockerfile" do |content|
-      minor_ruby_version = ruby_version.match(/^\d+\.\d+/).to_s
-      assert_match(/ARG RUBY_VERSION=#{minor_ruby_version}$/, content)
+      assert_match(/ARG RUBY_VERSION=#{ruby_version}$/, content)
     end
     assert_file "Dockerfile" do |content|
       assert_match(/ARG RUBY_VERSION=#{ruby_version}/, content)
@@ -1320,6 +1319,9 @@ class AppGeneratorTest < Rails::Generators::TestCase
     assert_file("config/database.yml") do |content|
       assert_match(/host: <%= ENV\["DB_HOST"\] %>/, content)
     end
+    assert_file(".devcontainer/Dockerfile") do |content|
+      assert_match(/libpq-dev/, content)
+    end
   end
 
   def test_devonctainer_mysql
@@ -1347,6 +1349,9 @@ class AppGeneratorTest < Rails::Generators::TestCase
     end
     assert_file("config/database.yml") do |content|
       assert_match(/host: <%= ENV.fetch\("DB_HOST"\) \{ "localhost" } %>/, content)
+    end
+    assert_file(".devcontainer/Dockerfile") do |content|
+      assert_match(/default-libmysqlclient-dev/, content)
     end
   end
 


### PR DESCRIPTION
This Pull Request has been created because the Rails org now has a [ruby docker image](https://github.com/rails/devcontainer/tree/main/images/ruby/.devcontainer) based on the [devcontainer feature](https://github.com/rails/devcontainer/blob/main/features/ruby/README.md) that we built a couple weeks ago. The goal of this PR is to use that ruby image in the Rails dev container.

### Detail

This Pull Request changes both the Rails devcontainer and the devcontainer generated for Rails apps. A few changes were needed:

First of all, our image allows minor version to be specified. So I have updated that in both devcontainers.

For rails app devcontainer, we need to install libpq or mysql headers (if we are using those dbs) because the image does not have them. This is just a temporary fix, as our plan is to create devcontainer features that will install everything needed for those dbs, which I plan to work on next week. I did not update the db system change generator to add these packages to the dockerfile as it's a bit tricky to get right since we don't want to mess up the user's dockerfile (which may be customized). I will wait for the feature to be ready and then db system change can simply add a new feature to `devcontainer.json` when appropriate.

For the rails devcontainer there were a few more changes. I had to add a couple libraries that don't exist on our image. Also I noticed we are doing extra ceremony to build imagemagick instead of apt get. This is because of issue with some activestorage tests going [back to the original PR creating the devcontainer](https://github.com/rails/rails/pull/43061#issuecomment-903658579). But we just [use apt get in CI](https://github.com/rails/buildkite-config/blob/main/Dockerfile#L46) and there is no issue. I realized the difference is that we use libvips in the devcontainer but libvips-dev on CI. Making that change to the devcontainer got the tests passing. I think its a win because building imagemagick was one of the slowest parts of building this container.

Additionally, we are no longer doing yarn install in the dockerfile. Our image does not include nvm or node. After discussion with @rafaelfranca we decided just to move yarn install out of the dockerfile and let it be done in the post setup script.

### Additional information

While testing I noticed I failed to add requires to the DB System Change generator when I modified it to work with devcontainers in rails/rails@c90a870. Not sure how I missed that but I figured I'd just add the fix to this branch.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
