### PR TITLE
Bump `NODE_LTS_VERSION` to 20.11.1

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Update the `.node-version` file conditionally generated for new applications to 20.11.1
+
+    *Steve Polito*
+
 *   Fix sanitizer vendor configuration in 7.1 defaults.
 
     In apps where rails-html-sanitizer was not eagerly loaded, the sanitizer default could end up

--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -16,7 +16,7 @@ module Rails
       include Devcontainer
       include AppName
 
-      NODE_LTS_VERSION = "18.15.0"
+      NODE_LTS_VERSION = "20.11.1"
       BUN_VERSION = "1.0.1"
 
       JAVASCRIPT_OPTIONS = %w( importmap bun webpack esbuild rollup )


### PR DESCRIPTION
### Motivation / Background

In e8638c9a942e94f097dc8f37a3b58ac067a5ca16 we introduced a constant to
store the version of Node to be used when generating `.node-version`.

Since then, the [current LTS][LTS] version of Node is now `20.11.1` as
of [2024-02-14][date].

[LTS]: https://nodejs.github.io/nodejs.dev/en/about/releases/
[date]: https://nodejs.org/en/blog/release/v20.11.1

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
