### PR TITLE
Expose @association as a reader in ActiveRecord_Associations_CollectionProxy

### DIFF
--- a/activerecord/lib/active_record/associations/collection_proxy.rb
+++ b/activerecord/lib/active_record/associations/collection_proxy.rb
@@ -27,6 +27,8 @@ module ActiveRecord
     # is computed directly through SQL and does not trigger by itself the
     # instantiation of the actual post records.
     class CollectionProxy < Relation
+      attr_reader :association
+
       def initialize(klass, association, **) # :nodoc:
         @association = association
         super klass


### PR DESCRIPTION
This makes it possible to reflect on associations. For example, Blog.first.posts.association.owner would show that the blog is the owner of the association.

## Why?

I have a link helper in my Rails app that reflects on associations, like this: `show(@blog.posts)`. Currently I can't reflect on that association unless I access a private instance variable:

```ruby
@blog.posts.instance_variable_get("@association").target
```

This commit exposes the `@association` object in a public API so I can reflect on associations.
