### PR TITLE
[Fix #49259] Fix backtrace cleaning in the rails console

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Fix overly aggressive backtrace cleaning in the rails console.
+    Console backtraces now show all backtrace lines from within the
+    application code. Non-app lines are still silenced.
+
+    *Josh Broughton*
+
 *   Fix sanitizer vendor configuration in 7.1 defaults.
 
     In apps where rails-html-sanitizer was not eagerly loaded, the sanitizer default could end up

--- a/railties/lib/rails.rb
+++ b/railties/lib/rails.rb
@@ -57,6 +57,10 @@ module Rails
       @backtrace_cleaner ||= Rails::BacktraceCleaner.new
     end
 
+    def full_message_cleaner
+      @full_message_cleaner ||= Rails::FullMessageCleaner.new
+    end
+
     # Returns a Pathname object of the current \Rails project,
     # otherwise it returns +nil+ if there is no project:
     #

--- a/railties/lib/rails/commands/console/console_command.rb
+++ b/railties/lib/rails/commands/console/console_command.rb
@@ -1,13 +1,14 @@
 # frozen_string_literal: true
 
 require "rails/command/environment_argument"
+require "rails/full_message_cleaner"
 
 module Rails
   class Console
     module BacktraceCleaner
       def filter_backtrace(bt)
         if result = super
-          Rails.backtrace_cleaner.filter([result]).first
+          Rails.full_message_cleaner.filter([result]).first
         end
       end
     end

--- a/railties/lib/rails/full_message_cleaner.rb
+++ b/railties/lib/rails/full_message_cleaner.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "active_support/backtrace_cleaner"
+
+module Rails
+  class FullMessageCleaner < ActiveSupport::BacktraceCleaner # :nodoc:
+    def initialize
+      super
+      @root ||= Rails.root && "#{Rails.root}/"
+      add_filter do |line|
+        line = line.sub(@root, "")
+        line
+      end
+
+      add_silencer { |line| !line.include?(@root) && !line.include?("irb") }
+    end
+
+    # Overides to run silencers first, as that simplifies the filter and silencers here
+    def clean(backtrace)
+      silenced = silence(backtrace)
+      filter_backtrace(silenced)
+    end
+    alias :filter :clean
+  end
+end

--- a/railties/test/full_message_cleaner_test.rb
+++ b/railties/test/full_message_cleaner_test.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require "abstract_unit"
+require "rails/full_message_cleaner"
+
+class FullMessageCleanerTest < ActiveSupport::TestCase
+  def setup
+    @root = self.method(self.name).source_location.first
+    # anonymous class to override @root in order to pass the containerized tests
+    cleaner ||= Class.new(Rails::FullMessageCleaner) do
+      def initialize
+        @root = @root
+        super
+      end
+    end
+    @cleaner = cleaner.new
+  end
+
+  test "#filter removes all backtrace lines that don't originate from the app code from a real error" do
+    generate_error()
+    rescue Exception => error
+      backtrace = error.full_message.split("\n")
+      result = @cleaner.filter(backtrace)
+      assert_equal 3, result.length
+  end
+
+  test "#filter considers backtraces from irb lines as User code using full_message formatting from a real error" do
+    generate_error()
+    rescue Exception => error
+      backtrace = error.full_message.split("\n")
+      backtrace.insert(3, "\tfrom (irb):1:in `<main>'")
+      result = @cleaner.filter(backtrace)
+      assert_equal 4, result.length
+  end
+
+  test "#filter filters the root path out of the backtrace lines that are not silenced" do
+    generate_error()
+    rescue Exception => error
+      backtrace = error.full_message.split("\n")
+      assert backtrace[1].include?(@root)
+      result = @cleaner.filter(backtrace)
+      assert_not result[1].include?(@root)
+  end
+
+  test "#filter removes all backtrace lines that don't originate from the app code from a ruby 2 error" do
+    backtrace = [
+      "\t19: from arbtitrary_gem_path/gems/gems-1.3.1/lib/gem/invocation.rb:127:in `invoke_command'",
+      "\t18: from arbitrary_non_root_path/command.rb:28:in `run'",
+      "\t17: from /workspaces/rails/railties/test/arbitrary_file.rb:43:in `perform'",
+      "\t16: from /workspaces/rails/railties/test/arbitrary_file:47:in `start'",
+      "\t15: from /workspaces/rails/railties/test/arbitrary_file:53:in `start'",
+      "(irb):1:in `<main>': undefined local variable or method `wow' for main:Object (NameError)"
+    ]
+    result = @cleaner.filter(backtrace)
+    assert_equal 4, result.length
+  end
+
+  private
+    def generate_error
+      deep_error_context()
+    end
+
+    def deep_error_context
+      raise Exception.new("A test error")
+    end
+end


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because the current `backtrace_cleaner.rb` does not work as intended in the Rails console. The silencer is too aggressive and removes the entire backtrace. Users expect to be able to see what lines of their application code an exception was raised from. See the video below for a demo of the bug.

The reason this is an issue in the Rails console and not elsewhere is because of irb's `handle_exception` [method](https://github.com/ruby/irb/blob/89bca01bbac51325a605e31d55e451f251bc5255/lib/irb.rb#L1218), which generates the backtrace from `Exception#full_message` rather than `Exception#backtrace` - `Rails::BacktraceCleaner` expects the latter. The difference in formatting between the two results in the silencer removing all lines.

Closes #49259 

### Detail

This Pull Request creates a new `Rails::FullMessageCleaner` class which inherits from `ActiveSupport::BacktraceCleaner`. I'm proposing this as a solution rather than altering `Rails::BacktraceCleaner` because

1. The existing class works as expected in other contexts - changing it to work in both the console and the other contexts would be difficult, because
2. They are serving a similar but different enough purpose: one cleans `Exception#backtrace`, and one cleans an array of backtrace lines that irb gets from `Exception#full_message`. These inputs are different enough I think a new class is warranted.

### Additional information

I added tests that use a real exception from whatever ruby version the test environment is running, as well as a hard coded ruby 2 test. I wasn't able to tophat this on a rails app using a ruby 2 version - it was difficult to get a test rails app using my development version of rails running on ruby 2. 

https://github.com/rails/rails/assets/4535650/81d2b486-5c26-4a08-8705-e25630bd3602


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
