### PR TITLE
Ignore destroyed records in CollectionAssociation#empty?

### DIFF
--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -231,7 +231,7 @@ module ActiveRecord
         if loaded? || @association_ids || reflection.has_cached_counter?
           size.zero?
         else
-          target.empty? && !scope.exists?
+          (target.empty? || target.all?(&:destroyed?)) && !scope.exists?
         end
       end
 


### PR DESCRIPTION
Fix: https://github.com/rails/rails/issues/51388

This commit isn't in a mergeable state, it's just to better understand the issue at hand. There is likely similar issues in other methods and it would need some tests.

