### PR TITLE
Remove taps from Brewfile

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,9 +1,5 @@
 # frozen_string_literal: true
 
-tap "homebrew/core"
-tap "homebrew/bundle"
-tap "homebrew/services"
-tap "homebrew/cask"
 brew "ffmpeg"
 brew "memcached"
 brew "mysql"


### PR DESCRIPTION
### Motivation / Background

Running `brew bundle` successfully installs all specified dependencies but fails with an error:

```sh
Tapping homebrew/core
Error: Tapping homebrew/core is no longer typically necessary.
Add --force if you are sure you need it done.
Tapping homebrew/core has failed!
Using homebrew/bundle
Using homebrew/services
Tapping homebrew/cask
Error: Tapping homebrew/cask is no longer typically necessary.
Add --force if you are sure you need it done.
Tapping homebrew/cask has failed!
Using ffmpeg
Using memcached
Using mysql
Warning: Formula postgresql was renamed to postgresql@14.
Using postgresql
Using redis
Using yarn
Using xquartz
Using mupdf
Using poppler
Using imagemagick
Using vips
Homebrew Bundle failed! 2 Brewfile dependencies failed to install.
```
### Detail

This Pull Request updates `Brewfile`.

- Remove `homebrew/core` and `homebrew/cask` taps. They are built-in and, as of Homebrew 4.2.0 ([release](https://github.com/Homebrew/brew/releases/tag/4.2.0)|[PR](https://github.com/Homebrew/brew/pull/16306)), cause an error when tapped.
- Remove `homebrew/bundle` and `homebrew/services` taps. They are automatically installed when first run and don't need to be specified in the Brewfile.