### PR TITLE
Ensure all needed options are added to association options list unconditionally

### DIFF
--- a/activerecord/lib/active_record/associations/builder/has_many.rb
+++ b/activerecord/lib/active_record/associations/builder/has_many.rb
@@ -7,11 +7,10 @@ module ActiveRecord::Associations::Builder # :nodoc:
     end
 
     def self.valid_options(options)
-      valid = super + [:counter_cache, :join_table, :index_errors]
-      valid += [:as, :foreign_type] if options[:as]
-      valid += [:through, :source, :source_type] if options[:through]
+      valid = super + [:counter_cache, :join_table, :index_errors, :as, :through]
+      valid += [:foreign_type] if options[:as]
+      valid += [:source, :source_type, :disable_joins] if options[:through]
       valid += [:ensuring_owner_was] if options[:dependent] == :destroy_async
-      valid += [:disable_joins] if options[:disable_joins] && options[:through]
       valid
     end
 

--- a/activerecord/lib/active_record/associations/builder/has_one.rb
+++ b/activerecord/lib/active_record/associations/builder/has_one.rb
@@ -7,11 +7,10 @@ module ActiveRecord::Associations::Builder # :nodoc:
     end
 
     def self.valid_options(options)
-      valid = super
-      valid += [:as, :foreign_type] if options[:as]
+      valid = super + [:as, :through]
+      valid += [:foreign_type] if options[:as]
       valid += [:ensuring_owner_was] if options[:dependent] == :destroy_async
-      valid += [:through, :source, :source_type] if options[:through]
-      valid += [:disable_joins] if options[:disable_joins] && options[:through]
+      valid += [:source, :source_type, :disable_joins] if options[:through]
       valid
     end
 

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -3184,6 +3184,22 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     assert_match(/Unknown key: :ensuring_owner_was/, error.message)
   end
 
+  def test_invalid_key_raises_with_message_including_all_default_options
+    error = assert_raises(ArgumentError) do
+      Class.new(ActiveRecord::Base) do
+        has_many :books, trough: :users
+      end
+    end
+
+    assert_equal(<<~MESSAGE.squish, error.message)
+      Unknown key: :trough. Valid keys are:
+      :class_name, :anonymous_class, :primary_key, :foreign_key, :dependent,
+      :validate, :inverse_of, :strict_loading, :query_constraints, :autosave, :before_add,
+      :after_add, :before_remove, :after_remove, :extend, :counter_cache, :join_table,
+      :index_errors, :as, :through
+    MESSAGE
+  end
+
   def test_key_ensuring_owner_was_is_valid_when_dependent_option_is_destroy_async
     Class.new(ActiveRecord::Base) do
       self.destroy_association_async_job = Class.new


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created because is case of typo on `through` association option it's not listed in raised error's message.

For example, if we make a simple typo like this (t(h)rough)

```ruby
class User < ApplicationRecord
  has_many :courses
  has_many :assignments, trough: :courses
end
```

the error message on rails boot is kind of misleading:

>  Unknown key: :trough. Valid keys are: :class_name, :anonymous_class, :primary_key, :foreign_key, :dependent, :validate, :inverse_of, :strict_loading, :query_constraints, :autosave, :before_add, :after_add, :before_remove, :after_remove, :extend, :counter_cache, :join_table, :index_errors (ArgumentError)

There is not `through` which I expect to be noted.

### Detail

This PR fixes all of these issues for `HasOne` and `HasMany` association builders.

The reason of this is that `ActiveRecord::Associations::Builder::HasMany.valid_options` adds `through` only if it is present in provided options:

```ruby
def self.valid_options(options)
  ...
  valid += [:through, :source, :source_type] if options[:through]
  ...
end
```

That logic seems to be appropriate only for `source` and `source_type`, but I do not see why `through` can't be added in the list unconditionally. The same stands for `ActiveRecord::Associations::Builder::HasOne.valid_options`.

Applying patch fixes the problem:

> Unknown key: :trough. Valid keys are: :class_name, :anonymous_class, :primary_key, :foreign_key, :dependent, :validate, :inverse_of, :strict_loading, :query_constraints, :autosave, :before_add, :after_add, :before_remove, :after_remove, :extend, :counter_cache, :join_table, :index_errors, :through (ArgumentError)

### Additional information

If I didn't miss anything and there's an actual problem, there might be some other occurrences of it.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
