### PR TITLE
Fix `ActiveRecord::Encryption::Errors::Encoding` incorrectly raises for not-encrypted binary encoded values

### DIFF
--- a/activerecord/lib/active_record/encryption/encrypted_attribute_type.rb
+++ b/activerecord/lib/active_record/encryption/encrypted_attribute_type.rb
@@ -134,12 +134,12 @@ module ActiveRecord
         end
 
         def encrypt_as_text(value)
+          if encryptor.binary? && !cast_type.binary?
+            raise Errors::Encoding, "Binary encoded data can only be stored in binary columns"
+          end
+
           with_context do
-            encryptor.encrypt(value, **encryption_options).tap do |encrypted|
-              if !cast_type.binary? && encrypted.encoding == Encoding::BINARY
-                raise Errors::Encoding, "Binary encoded data can only be stored in binary columns"
-              end
-            end
+            encryptor.encrypt(value, **encryption_options)
           end
         end
 

--- a/activerecord/lib/active_record/encryption/encryptor.rb
+++ b/activerecord/lib/active_record/encryption/encryptor.rb
@@ -74,6 +74,10 @@ module ActiveRecord
         false
       end
 
+      def binary?
+        serializer.binary?
+      end
+
       private
         DECRYPT_ERRORS = [OpenSSL::Cipher::CipherError, Errors::EncryptedContentIntegrity, Errors::Decryption]
         ENCODING_ERRORS = [EncodingError, Errors::Encoding]

--- a/activerecord/lib/active_record/encryption/message_pack_message_serializer.rb
+++ b/activerecord/lib/active_record/encryption/message_pack_message_serializer.rb
@@ -31,6 +31,10 @@ module ActiveRecord
         raise Errors::Decryption
       end
 
+      def binary?
+        true
+      end
+
       private
         def message_to_hash(message)
           {

--- a/activerecord/lib/active_record/encryption/message_serializer.rb
+++ b/activerecord/lib/active_record/encryption/message_serializer.rb
@@ -33,6 +33,10 @@ module ActiveRecord
         JSON.dump message_to_json(message)
       end
 
+      def binary?
+        false
+      end
+
       private
         def parse_message(data, level)
           validate_message_data_format(data, level)

--- a/activerecord/lib/active_record/encryption/null_encryptor.rb
+++ b/activerecord/lib/active_record/encryption/null_encryptor.rb
@@ -16,6 +16,10 @@ module ActiveRecord
       def encrypted?(text)
         false
       end
+
+      def binary?
+        false
+      end
     end
   end
 end

--- a/activerecord/lib/active_record/encryption/read_only_null_encryptor.rb
+++ b/activerecord/lib/active_record/encryption/read_only_null_encryptor.rb
@@ -19,6 +19,10 @@ module ActiveRecord
       def encrypted?(text)
         false
       end
+
+      def binary?
+        false
+      end
     end
   end
 end

--- a/activerecord/test/cases/encryption/contexts_test.rb
+++ b/activerecord/test/cases/encryption/contexts_test.rb
@@ -61,6 +61,14 @@ class ActiveRecord::Encryption::ContextsTest < ActiveRecord::EncryptionTestCase
     assert_not_encrypted_attribute @post, :title, "Some new title"
   end
 
+  test ".without_encryption doesn't raise on binary encoded data" do
+    assert_nothing_raised do
+      ActiveRecord::Encryption.without_encryption do
+        EncryptedBook.create!(name: "Dune".encode(Encoding::BINARY))
+      end
+    end
+  end
+
   test ".protecting_encrypted_data don't decrypt attributes automatically" do
     ActiveRecord::Encryption.protecting_encrypted_data do
       assert_equal @title_ciphertext, @post.reload.title

--- a/activerecord/test/cases/encryption/encryption_schemes_test.rb
+++ b/activerecord/test/cases/encryption/encryption_schemes_test.rb
@@ -199,6 +199,10 @@ class ActiveRecord::Encryption::EncryptionSchemesTest < ActiveRecord::Encryption
       rescue ActiveRecord::Encryption::Errors::Decryption
         false
       end
+
+      def binary?
+        false
+      end
     end
 
     class EncryptedAuthor1 < Author


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

~Pending open issue. Please bear with me, I needed to get this up semi-urgently as we ran into this issue when running against latest `main` and it wasn't caught by our test suite.~

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request fixes an issue where `ActiveRecord::Encryption::Errors::Encoding` raises when the value is not encrypted (e.g. when using `ActiveRecord::Encryption::NullEncryptor`) and is binary encoded.

The raise was introduced in https://github.com/rails/rails/pull/51102 seemingly for the case where the encrypted value is binary encoded and will be inserted into a text column after encryption (I think this is only possible if the encryption is not deterministic, else encoding is forced), but didn't take into account cases where encryption is bypassed to support unencrypted data.

### Detail

This Pull Request changes `ActiveRecord::Encryption::EncryptedAttributeType#encrypt_as_text` (which is used by `#encrypt`) to not raise on binary encoded values unless the value was actually encrypted.

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
