### PR TITLE
Regenerate some broken markdown in Action Pack [ci-skip]

### DIFF
--- a/actionpack/lib/action_controller/metal/conditional_get.rb
+++ b/actionpack/lib/action_controller/metal/conditional_get.rb
@@ -42,6 +42,7 @@ module ActionController
     #
     # `:etag`
     # :   Sets a "weak" ETag validator on the response. See the `:weak_etag` option.
+    #
     # `:weak_etag`
     # :   Sets a "weak" ETag validator on the response. Requests that specify an
     #     `If-None-Match` header may receive a `304 Not Modified` response if the
@@ -51,6 +52,7 @@ module ActionController
     #     they're good for caching HTML pages in browser caches. They can't be used
     #     for responses that must be byte-identical, like serving `Range` requests
     #     within a PDF file.
+    #
     # `:strong_etag`
     # :   Sets a "strong" ETag validator on the response. Requests that specify an
     #     `If-None-Match` header may receive a `304 Not Modified` response if the
@@ -60,19 +62,23 @@ module ActionController
     #     byte. This is necessary for serving `Range` requests within a large video
     #     or PDF file, for example, or for compatibility with some CDNs that don't
     #     support weak ETags.
+    #
     # `:last_modified`
     # :   Sets a "weak" last-update validator on the response. Subsequent requests
     #     that specify an `If-Modified-Since` header may receive a `304 Not
     #     Modified` response if `last_modified` <= `If-Modified-Since`.
+    #
     # `:public`
     # :   By default the `Cache-Control` header is private. Set this option to
     #     `true` if you want your application to be cacheable by other devices, such
     #     as proxy caches.
+    #
     # `:cache_control`
     # :   When given, will overwrite an existing `Cache-Control` header. For a list
     #     of `Cache-Control` directives, see the [article on
     #     MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Contr
     #     ol).
+    #
     # `:template`
     # :   By default, the template digest for the current controller/action is
     #     included in ETags. If the action renders a different template, you can
@@ -244,10 +250,13 @@ module ActionController
     # `:public`
     # :   If true, replaces the default `private` directive with the `public`
     #     directive.
+    #
     # `:must_revalidate`
     # :   If true, adds the `must-revalidate` directive.
+    #
     # `:stale_while_revalidate`
     # :   Sets the value of the `stale-while-revalidate` directive.
+    #
     # `:stale_if_error`
     # :   Sets the value of the `stale-if-error` directive.
     #
@@ -306,7 +315,6 @@ module ActionController
     # *   `public`: By default, HTTP responses are private, cached only on the
     #     user's web browser. To allow proxies to cache the response, set `true` to
     #     indicate that they can serve the cached response to all users.
-    #
     def http_cache_forever(public: false)
       expires_in 100.years, public: public
 


### PR DESCRIPTION
This can be reproduced using a version of rdoc that includes this fix:
- https://github.com/ruby/rdoc/commit/c65266437cb2b2960fe3d8af8c01156e2f88d905

The fix correctly adds a newline between definition list items, which was not added previously.

This commit was generated with the following commands:

```
$ git checkout 3079e8b0f894e9a7e85a3bbf42383dc0a616af41 -- actionpack/lib/action_controller/metal/conditional_get.rb
$ ./tools/rdoc-to-md --only=actionpack -a
```

Before:
![image](https://github.com/rails/rails/assets/6014046/e25c926b-e3b2-478c-8cfd-0b74e4eb6dc2)

After:
![image](https://github.com/rails/rails/assets/6014046/e2f54b0e-6455-4c3c-955b-ce5621d43a82)

After once rdoc includes https://github.com/ruby/rdoc/commit/8f943bbba40c626015c1bd6494fd77f21a08552b:
![image](https://github.com/rails/rails/assets/6014046/34ef006c-bf4c-40e8-9739-d0d1af7dbbce)
