### PR TITLE
Add tests for regressions identified in rails/rails@640e3981

### DIFF
--- a/activerecord/test/cases/table_metadata_test.rb
+++ b/activerecord/test/cases/table_metadata_test.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+require "models/developer"
+
+module ActiveRecord
+  class TableMetadataTest < ActiveSupport::TestCase
+    test "#associated_table creates the right type caster for joined table with different association name" do
+      base_table_metadata = TableMetadata.new(AuditRequiredDeveloper, Arel::Table.new("developers"))
+
+      associated_table_metadata = base_table_metadata.associated_table("audit_logs")
+
+      assert_equal ActiveRecord::Type::String, associated_table_metadata.arel_table.type_for_attribute(:message).class
+    end
+  end
+end

--- a/activerecord/test/cases/type_caster/connection_test.rb
+++ b/activerecord/test/cases/type_caster/connection_test.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+require "models/developer"
+
+module ActiveRecord
+  module TypeCaster
+    class ConnectionTest < ActiveSupport::TestCase
+      test "#type_for_attribute is not aware of custom types" do
+        type_caster = Connection.new(AttributedDeveloper, "developers")
+
+        type = type_caster.type_for_attribute(:name)
+
+        assert_not_equal DeveloperName, type.class
+        assert_equal ActiveRecord::Type::String, type.class
+      end
+    end
+  end
+end

--- a/activerecord/test/models/developer.rb
+++ b/activerecord/test/models/developer.rb
@@ -372,3 +372,8 @@ class ColumnNamesCachedDeveloper < ActiveRecord::Base
   self.table_name = "developers"
   self.ignored_columns += ["name"] if column_names.include?("name")
 end
+
+class AuditRequiredDeveloper < ActiveRecord::Base
+  self.table_name = "developers"
+  has_many :required_audit_logs, class_name: "AuditLogRequired"
+end


### PR DESCRIPTION
### Motivation / Background

rails/rails@6dd1929 caused some regressions and was reverted. Adding tests to prevent regressions in the future.

### Detail

We reverted rails/rails@6dd1929 in https://github.com/rails/rails/pull/51425/commits/640e3981ca4f142c22ebc1f82f70f2275e5afd71. This PR adds tests for the two regressions identified by that change. See the original PR for more detail.

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
