### PR TITLE
Fix load_async to work with query cache

### DIFF
--- a/activerecord/lib/active_record/future_result.rb
+++ b/activerecord/lib/active_record/future_result.rb
@@ -60,7 +60,6 @@ module ActiveRecord
     end
 
     delegate :empty?, :to_a, to: :result
-    delegate_missing_to :result
 
     attr_reader :lock_wait
 

--- a/activerecord/test/cases/relation/load_async_test.rb
+++ b/activerecord/test/cases/relation/load_async_test.rb
@@ -217,6 +217,11 @@ module ActiveRecord
       assert_equal titles, Post.where(author_id: 1).load_async.pluck(:title)
     end
 
+    def test_count
+      count = Post.where(author_id: 1).count
+      assert_equal count, Post.where(author_id: 1).load_async.count
+    end
+
     def test_size
       expected_size = Post.where(author_id: 1).size
 
@@ -233,10 +238,17 @@ module ActiveRecord
       assert_predicate deferred_posts, :loaded?
     end
 
-    def test_load_async_with_query_cache
+    def test_load_async_pluck_with_query_cache
       titles = Post.where(author_id: 1).pluck(:title)
       Post.cache do
         assert_equal titles, Post.where(author_id: 1).load_async.pluck(:title)
+      end
+    end
+
+    def test_load_async_count_with_query_cache
+      count = Post.where(author_id: 1).count
+      Post.cache do
+        assert_equal count, Post.where(author_id: 1).load_async.count
       end
     end
   end


### PR DESCRIPTION
After the merge of [PR 50410](https://github.com/rails/rails/pull/50410) into the Rails repository, an issue has arisen where load_async is not functioning as expected. Additionally, the subsequent merge of [PR 50492](https://github.com/rails/rails/pull/50492) failed to fully address this problem.

For example 
```ruby
User.cache do 
  User.all.load_async.count 
end
```

will got

```
undefined method `cancel' for #<ActiveRecord::FutureResult::Complete:0x00007f949cbf8398
```

cc @byroot @fatkodima 