### PR TITLE
Typo fixes on JS page [ci skip]

### DIFF
--- a/guides/source/working_with_javascript_in_rails.md
+++ b/guides/source/working_with_javascript_in_rails.md
@@ -10,7 +10,7 @@ Rails.
 After reading this guide, you will know:
 
 * How to use Rails without the need for a Node.js, Yarn, or a JavaScript bundler.
-* How to create a new Rails application using import maps, bun, esbuild, rollup, or webpack to bundle
+* How to create a new Rails application using import maps, Bun, esbuild, Rollup, or Webpack to bundle
   your JavaScript.
 * What Turbo is, and how to use it.
 * How to use the Turbo HTML helpers provided by Rails.
@@ -68,9 +68,9 @@ Adding npm Packages with JavaScript Bundlers
 Import maps are the default for new Rails applications, but if you prefer traditional JavaScript
 bundling, you can create new Rails applications with your choice of
 [Bun](https://bun.sh), [esbuild](https://esbuild.github.io/),
-[webpack](https://webpack.js.org/), or [rollup.js](https://rollupjs.org/guide/en/).
+[Webpack](https://webpack.js.org/), or [Rollup.js](https://rollupjs.org/guide/en/).
 
-To use a bundler instead of import maps in a new Rails application, pass the `—javascript` or `-j`
+To use a bundler instead of import maps in a new Rails application, pass the `--javascript` or `-j`
 option to `rails new`:
 
 ```bash
@@ -87,7 +87,7 @@ development.
 
 ### Installing a JavaScript Runtime
 
-If you are using a esbuild, rollup.js or Webpack, to bundle your JavaScript in
+If you are using esbuild, Rollup.js, or Webpack to bundle your JavaScript in
 your Rails application, Node.js and Yarn must be installed. If you are using
 Bun, then you just need to install Bun as it is both a JavaScript runtime and a bundler.
 
@@ -103,11 +103,11 @@ $ bun --version
 The version of your Bun runtime should be printed out. If it says something
 like `1.0.0`, Bun has been installed correctly.
 
-If not, you may need to reinstall bun in the current directory or restart your terminal.
+If not, you may need to reinstall Bun in the current directory or restart your terminal.
 
 #### Installing Node.js and Yarn
 
-If you are using esbuild, rollup.js or Webpack you will need Node.js and Yarn.
+If you are using esbuild, Rollup.js, or Webpack you will need Node.js and Yarn.
 
 Find the installation instructions at the [Node.js website](https://nodejs.org/en/download/) and
 verify it’s installed correctly with the following command:


### PR DESCRIPTION
- Makes capitalization of bundler tool names consistent with official docs (lowercase for esbuild, capitalized for others)
- Fixes an instance of a double-hyphen command flag showing as an em-dash (or en-dash, not sure)
- Fixes a sentence that does not read correctly since it was edited when adding Bun