### PR TITLE
Bump libxml-ruby to fix build failure

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -305,7 +305,7 @@ GEM
     kramdown-parser-gfm (1.1.0)
       kramdown (~> 2.0)
     language_server-protocol (3.17.0.3)
-    libxml-ruby (5.0.0)
+    libxml-ruby (5.0.3)
     listen (3.8.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)


### PR DESCRIPTION
### Motivation / Background

This fixes bundle install when using the latest version of `libxml2`

### Detail

<details>
<summary>Sample installation log</summary>

```
bundle install
Fetching gem metadata from https://rubygems.org/.........
Installing mysql2 0.5.5 with native extensions
Installing libxml-ruby 5.0.0 with native extensions
Gem::Ext::BuildError: ERROR: Failed to build gem native extension.

    current directory: /Users/josh/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/libxml-ruby-5.0.0/ext/libxml
/Users/josh/.rbenv/versions/3.3.0/bin/ruby extconf.rb
checking for libxml/xmlversion.h in
/opt/include/libxml2,/opt/local/include/libxml2,/opt/homebrew/opt/libxml2/include/libxml2,/usr/local/include/libxml2,/usr/include/libxml2,/usr/local/include,/usr/local/opt/libxml2/include/libxml2...
yes
checking for xmlParseDoc() in -lxml2... yes
creating extconf.h
creating Makefile

current directory: /Users/josh/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/libxml-ruby-5.0.0/ext/libxml
make DESTDIR\= sitearchdir\=./.gem.20240328-25424-bulg40 sitelibdir\=./.gem.20240328-25424-bulg40 clean

current directory: /Users/josh/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/libxml-ruby-5.0.0/ext/libxml
make DESTDIR\= sitearchdir\=./.gem.20240328-25424-bulg40 sitelibdir\=./.gem.20240328-25424-bulg40
compiling libxml.c
compiling ruby_xml.c
compiling ruby_xml_attr.c
compiling ruby_xml_attr_decl.c
compiling ruby_xml_attributes.c
compiling ruby_xml_cbg.c
compiling ruby_xml_document.c
compiling ruby_xml_dtd.c
compiling ruby_xml_encoding.c
compiling ruby_xml_error.c
ruby_xml_error.c:123:35: error: incompatible function pointer types passing 'void (void *, const xmlError *)' (aka
'void (void *, const struct _xmlError *)') to parameter of type 'xmlStructuredErrorFunc' (aka 'void (*)(void *,
struct _xmlError *)') [-Wincompatible-function-pointer-types]
  xmlSetStructuredErrorFunc(NULL, structuredErrorFunc);
                                  ^~~~~~~~~~~~~~~~~~~
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/libxml/xmlerror.h:870:29:
note: passing argument to parameter 'handler' here
                                 xmlStructuredErrorFunc handler);
                                                        ^
1 error generated.
make: *** [ruby_xml_error.o] Error 1

make failed, exit code 2

Gem files will remain installed in /Users/josh/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/libxml-ruby-5.0.0 for
inspection.
Results logged to
/Users/josh/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/extensions/arm64-darwin-23/3.3.0/libxml-ruby-5.0.0/gem_make.out

  /Users/josh/.rbenv/versions/3.3.0/lib/ruby/site_ruby/3.3.0/rubygems/ext/builder.rb:125:in `run'
  /Users/josh/.rbenv/versions/3.3.0/lib/ruby/site_ruby/3.3.0/rubygems/ext/builder.rb:51:in `block in make'
  /Users/josh/.rbenv/versions/3.3.0/lib/ruby/site_ruby/3.3.0/rubygems/ext/builder.rb:43:in `each'
  /Users/josh/.rbenv/versions/3.3.0/lib/ruby/site_ruby/3.3.0/rubygems/ext/builder.rb:43:in `make'
  /Users/josh/.rbenv/versions/3.3.0/lib/ruby/site_ruby/3.3.0/rubygems/ext/ext_conf_builder.rb:42:in `build'
  /Users/josh/.rbenv/versions/3.3.0/lib/ruby/site_ruby/3.3.0/rubygems/ext/builder.rb:193:in `build_extension'
/Users/josh/.rbenv/versions/3.3.0/lib/ruby/site_ruby/3.3.0/rubygems/ext/builder.rb:227:in `block in
build_extensions'
  /Users/josh/.rbenv/versions/3.3.0/lib/ruby/site_ruby/3.3.0/rubygems/ext/builder.rb:224:in `each'
  /Users/josh/.rbenv/versions/3.3.0/lib/ruby/site_ruby/3.3.0/rubygems/ext/builder.rb:224:in `build_extensions'
  /Users/josh/.rbenv/versions/3.3.0/lib/ruby/site_ruby/3.3.0/rubygems/installer.rb:852:in `build_extensions'
/Users/josh/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/bundler-2.5.4/lib/bundler/rubygems_gem_installer.rb:76:in
`build_extensions'
/Users/josh/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/bundler-2.5.4/lib/bundler/rubygems_gem_installer.rb:28:in
`install'
/Users/josh/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/bundler-2.5.4/lib/bundler/source/rubygems.rb:205:in
`install'
/Users/josh/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/bundler-2.5.4/lib/bundler/installer/gem_installer.rb:54:in
`install'
/Users/josh/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/bundler-2.5.4/lib/bundler/installer/gem_installer.rb:16:in
`install_from_spec'
/Users/josh/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/bundler-2.5.4/lib/bundler/installer/parallel_installer.rb:132:in
`do_install'
/Users/josh/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/bundler-2.5.4/lib/bundler/installer/parallel_installer.rb:123:in
`block in worker_pool'
  /Users/josh/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/bundler-2.5.4/lib/bundler/worker.rb:62:in `apply_func'
/Users/josh/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/bundler-2.5.4/lib/bundler/worker.rb:57:in `block in
process_queue'
  <internal:kernel>:187:in `loop'
/Users/josh/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/bundler-2.5.4/lib/bundler/worker.rb:54:in
`process_queue'
/Users/josh/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/bundler-2.5.4/lib/bundler/worker.rb:90:in `block (2
levels) in create_threads'

An error occurred while installing libxml-ruby (5.0.0), and Bundler cannot continue.

In Gemfile:
  libxml-ruby
```

</details>

### Additional information

- [GitHub Issue in libxml-ruby](https://github.com/xml4r/libxml-ruby/issues/213)
- [Fix for the issue in libxml-ruby](https://github.com/xml4r/libxml-ruby/commit/c7933a7f846953e06b564b7a546af4960d296742) - tagged as 5.0.3

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] - n/a - Tests are added or updated if you fix a bug or add a feature.
* [x] - n/a - CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
