### PR TITLE
Bump mysql2 to fix build error with mysql-client 8.3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -347,7 +347,7 @@ GEM
     msgpack (1.7.2)
     multi_json (1.15.0)
     multipart-post (2.3.0)
-    mysql2 (0.5.5)
+    mysql2 (0.5.6)
     net-http-persistent (4.0.2)
       connection_pool (~> 2.2)
     net-imap (0.4.9)


### PR DESCRIPTION
### Motivation / Background

This fixes bundle install when using the latest version of mysql-client, 8.3

### Detail

<details>
<summary>Sample installation log</summary>

```
bundle install
Fetching gem metadata from https://rubygems.org/.........
Installing mysql2 0.5.5 with native extensions
Gem::Ext::BuildError: ERROR: Failed to build gem native extension.

    current directory: /Users/josh/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/mysql2-0.5.5/ext/mysql2
/Users/josh/.rbenv/versions/3.3.0/bin/ruby extconf.rb
checking for rb_absint_size()... yes
checking for rb_absint_singlebit_p()... yes
checking for rb_gc_mark_movable()... yes
checking for rb_wait_for_single_fd()... yes
checking for rb_enc_interned_str() in ruby.h... yes
-----
Using --with-openssl-dir=/opt/homebrew/opt/openssl@3
-----
-----
Using mysql_config at /opt/homebrew/bin/mysql_config
-----
checking for mysql.h... yes
checking for errmsg.h... yes
checking for SSL_MODE_DISABLED in mysql.h... yes
checking for SSL_MODE_PREFERRED in mysql.h... yes
checking for SSL_MODE_REQUIRED in mysql.h... yes
checking for SSL_MODE_VERIFY_CA in mysql.h... yes
checking for SSL_MODE_VERIFY_IDENTITY in mysql.h... yes
checking for MYSQL.net.vio in mysql.h... yes
checking for MYSQL.net.pvio in mysql.h... no
checking for MYSQL_DEFAULT_AUTH in mysql.h... yes
checking for MYSQL_ENABLE_CLEARTEXT_PLUGIN in mysql.h... yes
checking for SERVER_QUERY_NO_GOOD_INDEX_USED in mysql.h... yes
checking for SERVER_QUERY_NO_INDEX_USED in mysql.h... yes
checking for SERVER_QUERY_WAS_SLOW in mysql.h... yes
checking for MYSQL_OPTION_MULTI_STATEMENTS_ON in mysql.h... yes
checking for MYSQL_OPTION_MULTI_STATEMENTS_OFF in mysql.h... yes
checking for my_bool in mysql.h... no
-----
Don't know how to set rpath on your system, if MySQL libraries are not in path mysql2 may not load
-----
-----
Setting libpath to /opt/homebrew/Cellar/mysql/8.3.0/lib
-----
creating Makefile

current directory: /Users/josh/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/mysql2-0.5.5/ext/mysql2
make DESTDIR\= sitearchdir\=./.gem.20240328-28015-xyw7df sitelibdir\=./.gem.20240328-28015-xyw7df clean

current directory: /Users/josh/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/mysql2-0.5.5/ext/mysql2
make DESTDIR\= sitearchdir\=./.gem.20240328-28015-xyw7df sitelibdir\=./.gem.20240328-28015-xyw7df
compiling client.c
In file included from client.c:15:
./mysql_enc_name_to_ruby.h:43:1: warning: a function definition without a prototype is deprecated in all versions of C and is
not supported in C2x [-Wdeprecated-non-prototype]
mysql2_mysql_enc_name_to_rb_hash (str, len)
^
./mysql_enc_name_to_ruby.h:86:1: warning: a function definition without a prototype is deprecated in all versions of C and is
not supported in C2x [-Wdeprecated-non-prototype]
mysql2_mysql_enc_name_to_rb (str, len)
^
client.c:1438:3: error: call to undeclared function 'mysql_ssl_set'; ISO C99 and later do not support implicit function
declarations [-Wimplicit-function-declaration]
  mysql_ssl_set(wrapper->client,
  ^
client.c:1438:3: note: did you mean 'mysql_close'?
/opt/homebrew/Cellar/mysql/8.3.0/include/mysql/mysql.h:797:14: note: 'mysql_close' declared here
void STDCALL mysql_close(MYSQL *sock);
             ^
2 warnings and 1 error generated.
make: *** [client.o] Error 1

make failed, exit code 2

Gem files will remain installed in /Users/josh/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/mysql2-0.5.5 for inspection.
Results logged to
/Users/josh/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/extensions/arm64-darwin-23/3.3.0/mysql2-0.5.5/gem_make.out

  /Users/josh/.rbenv/versions/3.3.0/lib/ruby/site_ruby/3.3.0/rubygems/ext/builder.rb:125:in `run'
  /Users/josh/.rbenv/versions/3.3.0/lib/ruby/site_ruby/3.3.0/rubygems/ext/builder.rb:51:in `block in make'
  /Users/josh/.rbenv/versions/3.3.0/lib/ruby/site_ruby/3.3.0/rubygems/ext/builder.rb:43:in `each'
  /Users/josh/.rbenv/versions/3.3.0/lib/ruby/site_ruby/3.3.0/rubygems/ext/builder.rb:43:in `make'
  /Users/josh/.rbenv/versions/3.3.0/lib/ruby/site_ruby/3.3.0/rubygems/ext/ext_conf_builder.rb:42:in `build'
  /Users/josh/.rbenv/versions/3.3.0/lib/ruby/site_ruby/3.3.0/rubygems/ext/builder.rb:193:in `build_extension'
  /Users/josh/.rbenv/versions/3.3.0/lib/ruby/site_ruby/3.3.0/rubygems/ext/builder.rb:227:in `block in build_extensions'
  /Users/josh/.rbenv/versions/3.3.0/lib/ruby/site_ruby/3.3.0/rubygems/ext/builder.rb:224:in `each'
  /Users/josh/.rbenv/versions/3.3.0/lib/ruby/site_ruby/3.3.0/rubygems/ext/builder.rb:224:in `build_extensions'
  /Users/josh/.rbenv/versions/3.3.0/lib/ruby/site_ruby/3.3.0/rubygems/installer.rb:852:in `build_extensions'
/Users/josh/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/bundler-2.5.4/lib/bundler/rubygems_gem_installer.rb:76:in
`build_extensions'
/Users/josh/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/bundler-2.5.4/lib/bundler/rubygems_gem_installer.rb:28:in
`install'
  /Users/josh/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/bundler-2.5.4/lib/bundler/source/rubygems.rb:205:in `install'
/Users/josh/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/bundler-2.5.4/lib/bundler/installer/gem_installer.rb:54:in
`install'
/Users/josh/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/bundler-2.5.4/lib/bundler/installer/gem_installer.rb:16:in
`install_from_spec'
/Users/josh/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/bundler-2.5.4/lib/bundler/installer/parallel_installer.rb:132:in
`do_install'
/Users/josh/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/bundler-2.5.4/lib/bundler/installer/parallel_installer.rb:123:in
`block in worker_pool'
  /Users/josh/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/bundler-2.5.4/lib/bundler/worker.rb:62:in `apply_func'
/Users/josh/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/bundler-2.5.4/lib/bundler/worker.rb:57:in `block in
process_queue'
  <internal:kernel>:187:in `loop'
  /Users/josh/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/bundler-2.5.4/lib/bundler/worker.rb:54:in `process_queue'
/Users/josh/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/bundler-2.5.4/lib/bundler/worker.rb:90:in `block (2 levels) in
create_threads'

An error occurred while installing mysql2 (0.5.5), and Bundler cannot continue.

In Gemfile:
  mysql2
```

</details>

### Additional information

- [GitHub Issue in mysql2](https://github.com/brianmario/mysql2/issues/1346)
- [0.5.6 release notes listing the fix](https://github.com/brianmario/mysql2/releases/tag/0.5.6)

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] n/a - Tests are added or updated if you fix a bug or add a feature.
* [x] n/a - CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
