### PR TITLE
Make it possible to opt-out of sending Link header in `preload_link_tag`

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add the `preload_links_header` option for `preload_link_tag` to opt-out of sending the Link header.
+
+    *Stan Hu*
+
 *   Raise `ArgumentError` if `:renderable` object does not respond to `#render_in`
 
     *Sean Doyle*

--- a/actionview/lib/action_view/helpers/asset_tag_helper.rb
+++ b/actionview/lib/action_view/helpers/asset_tag_helper.rb
@@ -357,25 +357,26 @@ module ActionView
         crossorigin = "anonymous" if crossorigin == true || (crossorigin.blank? && as_type == "font")
         integrity = options[:integrity]
         nopush = options.delete(:nopush) || false
+        send_link_header = options.key?(:preload_links_header) ? options.delete(:preload_links_header) : true
         rel = mime_type == "module" ? "modulepreload" : "preload"
 
-        link_tag = tag.link(
+        if send_link_header
+          preload_link = "<#{href}>; rel=#{rel}; as=#{as_type}"
+          preload_link += "; type=#{mime_type}" if mime_type
+          preload_link += "; crossorigin=#{crossorigin}" if crossorigin
+          preload_link += "; integrity=#{integrity}" if integrity
+          preload_link += "; nopush" if nopush
+
+          send_preload_links_header([preload_link])
+        end
+
+        tag.link(
           rel: rel,
           href: href,
           as: as_type,
           type: mime_type,
           crossorigin: crossorigin,
           **options.symbolize_keys)
-
-        preload_link = "<#{href}>; rel=#{rel}; as=#{as_type}"
-        preload_link += "; type=#{mime_type}" if mime_type
-        preload_link += "; crossorigin=#{crossorigin}" if crossorigin
-        preload_link += "; integrity=#{integrity}" if integrity
-        preload_link += "; nopush" if nopush
-
-        send_preload_links_header([preload_link])
-
-        link_tag
       end
 
       # Returns an HTML image tag for the +source+. The +source+ can be a full

--- a/actionview/test/template/asset_tag_helper_test.rb
+++ b/actionview/test/template/asset_tag_helper_test.rb
@@ -715,6 +715,13 @@ class AssetTagHelperTest < ActionView::TestCase
     end
   end
 
+  def test_should_not_set_preload_link_with_rel_modulepreload
+    with_preload_links_header do
+      preload_link_tag("http://example.com/all.js", type: "module", preload_links_header: false)
+      assert_nil @response.headers["Link"]
+    end
+  end
+
   def test_should_set_preload_links_with_integrity_hashes
     with_preload_links_header do
       stylesheet_link_tag("http://example.com/style.css", integrity: "sha256-AbpHGcgLb+kRsJGnwFEktk7uzpZOCcBY74+YBdrKVGs")


### PR DESCRIPTION
This commit adds a `preload_links_header` option to `preload_link_tag` to disable sending of the Link header in the HTTP response.

Currently `ActionView::Helpers::AssetTagHelper.preload_links_header` only controls whether `javascript_include_tag` and `stylesheet_link_tag` send the Link header, but there is no way to control the behavior of `preload_link_tag`. We could just check that variable, but existing applications might be relying on `preload_link_tag` to add the header. Users also might want control over this on a per call basis.

Closes #51436

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
