### PR TITLE
Emit deprecation warning about inverse_of inference only for valid reflections

### DIFF
--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -708,7 +708,7 @@ module ActiveRecord
                 plural_inverse_name = ActiveSupport::Inflector.pluralize(inverse_name)
                 reflection = klass._reflect_on_association(plural_inverse_name)
 
-                if reflection && !active_record.automatically_invert_plural_associations
+                if valid_inverse_reflection?(reflection) && !active_record.automatically_invert_plural_associations
                   ActiveRecord.deprecator.warn(
                     "The `#{active_record.name}##{name}` inverse association could have been automatically" \
                     " inferred as `#{klass.name}##{plural_inverse_name}` but wasn't because `automatically_invert_plural_associations`" \


### PR DESCRIPTION
### Motivation / Background

This is a small follow-up to https://github.com/rails/rails/pull/50883. 

As we went through all deprecation warnings while we run Rails edge with
```ruby
config.active_record.automatically_invert_plural_associations = false
```
we realised that we had warnings for an inferred reflection that would be wrong to infer. Digging deeper into whether this meant that enabling `automatically_invert_plural_associations` would actually mean we'd have completely wrong values in the collection of the inferred association, we realised that no, the reflection was correctly not inferred. However, the warning was emitted regardless. 

This happens because the deprecation warning is emitted without checking whether the found `reflection` is valid. The warning says that the inverse association could have been automatically inferred but wasn't because `automatically_invert_plural_associations` is disabled. However, this is not true, because later on, when we check whether the reflection is valid, we see it's not, and end up returning `nil`.

### Detail

This pull request just adds the `valid_inverse_reflection?(reflection)` condition to determine whether the deprecation warning needs to happen. That already checks that `reflection` is truthy. 

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
