### PR TITLE
Fix an error for `apply_rubocop_autocorrect_after_generate!` with `--pretend`

### DIFF
--- a/railties/lib/rails/configuration.rb
+++ b/railties/lib/rails/configuration.rb
@@ -133,7 +133,7 @@ module Rails
 
       def apply_rubocop_autocorrect_after_generate!
         after_generate do |files|
-          parsable_files = files.filter { |file| file.end_with?(".rb") }
+          parsable_files = files.filter { |file| File.exist?(file) && file.end_with?(".rb") }
           unless parsable_files.empty?
             system("bin/rubocop -A --fail-level=E #{parsable_files.shelljoin}", exception: true)
           end

--- a/railties/test/application/generators_test.rb
+++ b/railties/test/application/generators_test.rb
@@ -265,6 +265,16 @@ module ApplicationTests
         output = rails("generate", "model", "post", "title:string", "body:string")
         assert_match(/3 files inspected, no offenses detected/, output)
       end
+
+      test "generators with apply_rubocop_autocorrect_after_generate! and pretend" do
+        with_config do |c|
+          c.generators.apply_rubocop_autocorrect_after_generate!
+        end
+
+        assert_nothing_raised do
+          rails("generate", "model", "post", "title:string", "body:string", "--pretend")
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
## Motivation / Background

An issue was identified where an error occurs when executing `apply_rubocop_autocorrect_after_generate!` with `--pretend` option, according to feedback from https://github.com/rubocop/rubocop-rails/pull/1263.

## Details

This PR fixes the following error when executing `apply_rubocop_autocorrect_after_generate!` with `--pretend` option:

```console
$ bin/rails g migration create_users -p
```

### Before

An `Errno::ENOENT` error occurs:

```console
invoke  active_record
create    db/migrate/20240329060627_create_users.rb
/Users/koic/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/bundler/gems/rails-8e46af8c9396/railties/lib/rails/configuration.rb:138:in
`system': No such file or directory - bin/rubocop (Errno::ENOENT)
```

### After

No errors.

## Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
