### PR TITLE
Remove `proxy_association` references from guides [ci-skip]

### DIFF
--- a/guides/source/association_basics.md
+++ b/guides/source/association_basics.md
@@ -2821,12 +2821,6 @@ class Supplier < ApplicationRecord
 end
 ```
 
-Extensions can refer to the internals of the association proxy using these three attributes of the `proxy_association` accessor:
-
-* `proxy_association.owner` returns the object that the association is a part of.
-* `proxy_association.reflection` returns the reflection object that describes the association.
-* `proxy_association.target` returns the associated object for `belongs_to` or `has_one`, or the collection of associated objects for `has_many` or `has_and_belongs_to_many`.
-
 ### Association Scoping using the Association Owner
 
 The owner of the association can be passed as a single argument to the scope


### PR DESCRIPTION
Commit 6795a24c61b038c64abff834df86d2d2459b2b23 made `proxy_assocation` non-public API by marking it `:nodoc`.
This change remove references to `proxy_association` from the guides.

Similar to `proxy_association`, do we also need to make `target` non-public?
https://edgeapi.rubyonrails.org/classes/ActiveRecord/Associations/CollectionProxy.html#method-i-target

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
