### PR TITLE
Counter cache columns are not marked as readonly [skip ci]

### DIFF
--- a/activerecord/lib/active_record/associations.rb
+++ b/activerecord/lib/active_record/associations.rb
@@ -1816,7 +1816,7 @@ module ActiveRecord
         #   named <tt>#{table_name}_count</tt> (such as +comments_count+ for a belonging Comment class)
         #   is used on the associate class (such as a Post class) - that is the migration for
         #   <tt>#{table_name}_count</tt> is created on the associate class (such that <tt>Post.comments_count</tt> will
-        #   return the count cached, see note below). You can also specify a custom counter
+        #   return the count cached). You can also specify a custom counter
         #   cache column by providing a column name instead of a +true+/+false+ value to this
         #   option (e.g., <tt>counter_cache: :my_custom_counter</tt>.)
         #
@@ -1829,12 +1829,10 @@ module ActiveRecord
         #   use <tt>counter_cache: { active: false }</tt>.
         #   If you also need to specify a custom column name, use <tt>counter_cache: { active: false, column: :my_custom_counter }</tt>.
         #
-        #   Note: Specifying a counter cache will add it to that model's list of readonly attributes
-        #   using +attr_readonly+.
-        # [+:polymorphic+]
-        #   Specify this association is a polymorphic association by passing +true+.
         #   Note: If you've enabled the counter cache, then you may want to add the counter cache attribute
         #   to the +attr_readonly+ list in the associated classes (e.g. <tt>class Post; attr_readonly :comments_count; end</tt>).
+        # [+:polymorphic+]
+        #   Specify this association is a polymorphic association by passing +true+.
         #   Note: Since polymorphic associations rely on storing class names in the database, make sure to update the class names in the
         #   <tt>*_type</tt> polymorphic type column of the corresponding rows.
         # [+:validate+]

--- a/guides/source/association_basics.md
+++ b/guides/source/association_basics.md
@@ -1227,9 +1227,6 @@ end
 NOTE: You only need to specify the `:counter_cache` option on the `belongs_to`
 side of the association.
 
-Counter cache columns are added to the owner model's list of read-only
-attributes through `attr_readonly`.
-
 Starting to use counter caches on existing large tables can be troublesome, because the column
 values must be backfilled separately of the column addition (to not lock the table for too long)
 and before the use of `:counter_cache` (otherwise methods like `size`/`any?`/etc, which use


### PR DESCRIPTION
Counter caches were marked as readonly a very long time ago (rails 2), https://github.com/rails/rails/blob/c1bc61cba0be6e5e830dae2f1497237f5ce3eb0d/activerecord/lib/active_record/associations.rb#L848-L850 but this is no longer true.

I was confused by this before, but I do not remember what I tested last time that it looked correct for me 🤦 😅  https://github.com/rails/rails/pull/44950

Reproducible test
```ruby
# frozen_string_literal: true

require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"

  git_source(:github) { |repo| "https://github.com/#{repo}.git" }

  # gem "rails"
  # If you want to test against edge Rails replace the previous line with this:
  gem "rails", github: "rails/rails", branch: "main"

  gem "sqlite3"
end

require "active_record"
require "minitest/autorun"
require "logger"

# This connection will do for database-independent bug reports.
ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")
ActiveRecord::Base.logger = Logger.new(STDOUT)

ActiveRecord.raise_on_assign_to_attr_readonly = true

ActiveRecord::Schema.define do
  create_table :posts, force: true do |t|
    t.integer :comments_count
  end

  create_table :comments, force: true do |t|
    t.integer :post_id
  end
end

class Post < ActiveRecord::Base
  has_many :comments
end

class Comment < ActiveRecord::Base
  belongs_to :post, counter_cache: true
end

class BugTest < Minitest::Test
  def test_counter_cache
    post = Post.create!
    post.comments.create!

    assert Post.readonly_attributes.any?  # <---- fails

    assert_raises do  # <---- will also fail
      post.update!(comments_count: 10)
    end
  end
end
```

cc @jonathanhefner 