### PR TITLE
Action Cable Guide - add Transmit method

### DIFF
--- a/guides/source/action_cable_overview.md
+++ b/guides/source/action_cable_overview.md
@@ -520,6 +520,28 @@ The rebroadcast will be received by all connected clients, _including_ the
 client that sent the message. Note that params are the same as they were when
 you subscribed to the channel.
 
+### Transmiting To A Subscriber
+
+In certain scenarios, there may be a need to send data exclusively to the subscriber who initiated a subscription request or sent a message.
+
+In these cases, [`transmit`][] can be utilized to send a hash of data to the subscriber. The hash will automatically be encapsulated in a JSON envelope with the appropriate channel identifier designated as the recipient.
+
+```ruby
+class ChatChannel < ApplicationCable::Channel
+  def subscribed
+    stream_from "chat_#{params[:room]}"
+    transmit({ body: "Important data for new subscriber" })
+  end
+
+  def receive(data)
+    ActionCable.server.broadcast("chat_#{params[:room]}", data)
+    transmit({ body: "Important data for sender of message" })
+  end
+end
+```
+
+[`transmit`]: https://api.rubyonrails.org/classes/ActionCable/Channel/Base.html#method-i-transmit
+
 ## Full-Stack Examples
 
 The following setup steps are common to both examples:


### PR DESCRIPTION
### Motivation / Background

I was exploring making use of Action Cables for a project I was working on, and didn't find any mention of the `transmit` method of channels, which allows you to transmit data to the specific subscriber that initiated the interaction.

As someone relatively new to Rails and entirely new to Action Cables I spun my wheels for a bit trying to figure out how interactions like this should be handled, and I was surprised to see the method wasn't even mentioned in the guide on Action Cables.

### Detail

Documentation PR

This Pull Request updates the Action Cable guide to add information on the existence of the `transmit` method, allowing channels to send data to a specific subscriber.

### Additional information

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
