### PR TITLE
Suggest `inverse_of: nil` instead of `false`

### DIFF
--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -715,7 +715,7 @@ module ActiveRecord
                     " is disabled.\n\n" \
                     "If automatic inference is intended, you can consider enabling" \
                     " `config.active_record.automatically_invert_plural_associations`.\n\n" \
-                    "If automatic inference is not intended, you can silence this warning by defining the association with `inverse_of: false`."
+                    "If automatic inference is not intended, you can silence this warning by defining the association with `inverse_of: nil`."
                   )
                   reflection = nil
                 end

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -1090,7 +1090,7 @@ And on a per-association basis:
 class Comment < ApplicationRecord
   self.automatically_invert_plural_associations = true
 
-  belongs_to :post, inverse_of: false
+  belongs_to :post, inverse_of: nil
 end
 ```
 


### PR DESCRIPTION
Followup: https://github.com/rails/rails/pull/50883
Ref: https://github.com/rails/rails/pull/50284#issuecomment-2027722175

cc @rosa 

NB: this is meant as a quick fix. I intent to check if the `inverse_of: false` behavior in `set_inverse_instance` is deliberate or not. 