### PR TITLE
Add `touch` option to `#update_columns` and `#update_column` methods

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,15 @@
+*   Add `:touch` option to `update_column`/`update_columns` methods.
+
+    ```ruby
+    # Will update :updated_at/:updated_on alongside :nice column.
+    user.update_column(:nice, true, touch: true)
+
+    # Will update :updated_at/:updated_on alongside :last_ip column
+    user.update_columns(last_ip: request.remote_ip, touch: true)
+    ```
+
+    *Dmitrii Ivliev*
+
 *   Optimize Active Record batching further when using ranges.
 
     Tested on a PostgreSQL table with 10M records and batches of 10k records, the generation

--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -582,8 +582,8 @@ module ActiveRecord
     end
 
     # Equivalent to <code>update_columns(name => value)</code>.
-    def update_column(name, value)
-      update_columns(name => value)
+    def update_column(name, value, touch: nil)
+      update_columns(name => value, :touch => touch)
     end
 
     # Updates the attributes directly in the database issuing an UPDATE SQL
@@ -597,11 +597,25 @@ module ActiveRecord
     #
     # * \Validations are skipped.
     # * \Callbacks are skipped.
-    # * +updated_at+/+updated_on+ are not updated.
+    # * +updated_at+/+updated_on+ are updated if the +touch+ option is set to +true+.
     # * However, attributes are serialized with the same rules as ActiveRecord::Relation#update_all
     #
     # This method raises an ActiveRecord::ActiveRecordError when called on new
     # objects, or when at least one of the attributes is marked as readonly.
+    #
+    # ==== Parameters
+    #
+    # * <tt>:touch</tt> option - Touch the timestamp columns when updating.
+    # * If attribute names are passed, they are updated along with +updated_at+/+updated_on+ attributes.
+    #
+    # ==== Examples
+    #
+    #   # Update a single attribute.
+    #   user.update_columns(last_request_at: Time.current)
+    #
+    #   # Update with touch option.
+    #   user.update_columns(last_request_at: Time.current, touch: true)
+
     def update_columns(attributes)
       raise ActiveRecordError, "cannot update a new record" if new_record?
       raise ActiveRecordError, "cannot update a destroyed record" if destroyed?
@@ -611,6 +625,15 @@ module ActiveRecord
         name = key.to_s
         name = self.class.attribute_aliases[name] || name
         verify_readonly_attribute(name) || name
+      end
+
+      touch = attributes.delete("touch")
+      if touch
+        names = touch if touch != true
+        names = Array.wrap(names)
+        options = names.extract_options!
+        touch_updates = self.class.touch_attributes_with_time(*names, **options)
+        attributes.with_defaults!(touch_updates) unless touch_updates.empty?
       end
 
       update_constraints = _query_constraints_hash

--- a/activerecord/test/cases/persistence_test.rb
+++ b/activerecord/test/cases/persistence_test.rb
@@ -1139,6 +1139,16 @@ class PersistenceTest < ActiveRecord::TestCase
     assert_not_predicate topic, :approved?
   end
 
+  def test_update_column_touch_option
+    topic = Topic.find(1)
+
+    assert_changes -> { topic.updated_at } do
+      travel(1.second) do
+        topic.update_column(:title, "super_title", touch: true)
+      end
+    end
+  end
+
   def test_update_column_should_not_use_setter_method
     dev = Developer.find(1)
     dev.instance_eval { def salary=(value); write_attribute(:salary, value * 2); end }
@@ -1228,6 +1238,44 @@ class PersistenceTest < ActiveRecord::TestCase
     topic.reload
     assert_predicate topic, :approved?
     assert_equal "Sebastian Topic", topic.title
+  end
+
+  def test_update_columns_touch_option_updates_timestamps
+    topic = Topic.find(1)
+
+    assert_changes -> { topic.updated_at } do
+      travel(1.second) do
+        topic.update_columns(title: "super_title", touch: true)
+      end
+    end
+  end
+
+  def test_update_columns_touch_option_explicit_column_names
+    topic = Topic.find(1)
+
+    assert_changes -> { [topic.updated_at, topic.written_on] } do
+      travel(1.second) do
+        topic.update_columns(title: "super_title", touch: :written_on)
+      end
+    end
+  end
+
+  def test_update_columns_touch_option_not_overwrite_explicit_attribute
+    topic = Topic.find(1)
+    new_updated_at = Date.parse("2024-03-31 12:00:00")
+
+    assert_changes -> { topic.updated_at }, to: new_updated_at do
+      topic.update_columns(title: "super_title", updated_at: new_updated_at, touch: true)
+    end
+  end
+
+  def test_update_columns_touch_option_not_overwrite_explicit_attribute_with_string_key
+    topic = Topic.find(1)
+    new_updated_at = Date.parse("2024-03-31 12:00:00")
+
+    assert_changes -> { topic.updated_at }, to: new_updated_at do
+      topic.update_columns(title: "super_title", "updated_at" => new_updated_at, touch: true)
+    end
   end
 
   def test_update_columns_should_not_use_setter_method


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->
I've created this Pull Request because not all ActiveRecord persistence methods affect timestamps or have a touch option. This can be problematic, especially when there is some ETL processing that relies on the `updated_at` timestamps instead of copying the whole table. For instance, if someone uses `#update_columns` for performance reasons, it may result in lost updates. This is particularly an issue for `#update_column`. If a user wants to keep timestamps current, they have to explicitly call the `#touch` method after using `#update_column`.

Examples:
```ruby
# we don't want to perform any callbacks or validations here so use #update_columns
current_user.update_columns(
  last_ip: request.remote_ip,
  updated_at: Time.current # but we still want to keep track of the last changes, so have to provide a timestamp explicitly
)
```

```ruby
current_user.update_column(:last_ip, request.remote_ip)
current_user.touch
```

Rails discussion: https://discuss.rubyonrails.org/t/proposal-add-touch-option-for-update-columns-update-column/85388

### Detail

This PR adds a `touch` option to the `#update_columns` and `#update_column` methods.
The option allows to update `updated_at`/`updated_on` attributes with 

```ruby
    person.update_columns(name: 'John Doe', touch: true)
```

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
