### PR TITLE
Fix with_rake

### DIFF
--- a/railties/lib/rails/commands/rake/rake_command.rb
+++ b/railties/lib/rails/commands/rake/rake_command.rb
@@ -38,7 +38,7 @@ module Rails
             Rake::TaskManager.record_task_metadata = true
 
             result = nil
-            Rake.with_application do |rake|
+            Rake.with_application(Rake.application) do |rake|
               rake.init(bin, args) unless args.empty?
               rake.load_rakefile
               result = block.call(rake)


### PR DESCRIPTION
### Motivation / Background

When calling `Rake.with_application` without an application, Rake will just substitute a new `Rake::Application.new`.

https://github.com/ruby/rake/blob/675498cb71f7267e0a5d66947325dc0c7386296f/lib/rake/rake_module.rb#L54

This is a problem because already loaded Rails tasks by Rails may vanish in the `with_rake`.

### Detail

n/a

### Additional information

n/a

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
