### PR TITLE
Add `ostruct` to the gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,6 +38,9 @@ gem "cgi", ">= 0.3.6", require: false
 
 gem "prism"
 
+# Became a bundled gem in Ruby 3.5
+gem "ostruct"
+
 group :lint do
   gem "syntax_tree", "6.1.1", require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -368,6 +368,7 @@ GEM
     nokogiri (1.16.0-x86_64-linux)
       racc (~> 1.4)
     os (1.1.4)
+    ostruct (0.6.0)
     parallel (1.24.0)
     parser (3.2.2.4)
       ast (~> 2.4.1)
@@ -623,6 +624,7 @@ DEPENDENCIES
   msgpack (>= 1.7.0)
   mysql2 (~> 0.5)
   nokogiri (>= 1.8.1, != 1.11.0)
+  ostruct
   pg (~> 1.3)
   prism
   propshaft (>= 0.1.7)


### PR DESCRIPTION
Ruby 3.4 will warn, 3.5 will raise. Also see https://bugs.ruby-lang.org/issues/20309, ruby/ruby#10428. This is a test-only dependency, framework code itself doesn't use it (enforced by RuboCop).

#44473 tried to remove `OpenStruct` entirely but that didn't go through, so just adding it to the Gemfile seems like the way to go.