### PR TITLE
Fix "no anonymous block parameter" in ruby 3.1

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb
@@ -174,8 +174,8 @@ module ActiveRecord
       end
 
       # Enable the query cache within the block.
-      def cache(&)
-        pool.enable_query_cache(&)
+      def cache(&block)
+        pool.enable_query_cache(&block)
       end
 
       def enable_query_cache!
@@ -186,8 +186,8 @@ module ActiveRecord
       #
       # Set <tt>dirties: false</tt> to prevent query caches on all connections from being cleared by write operations.
       # (By default, write operations dirty all connections' query caches in case they are replicas whose cache would now be outdated.)
-      def uncached(dirties: true, &)
-        pool.disable_query_cache(dirties: dirties, &)
+      def uncached(dirties: true, &block)
+        pool.disable_query_cache(dirties: dirties, &block)
       end
 
       def disable_query_cache!


### PR DESCRIPTION
### Motivation / Background

On
ruby 3.1.2p20 (2022-04-12 revision 4491bb740a) [x86_64-linux-gnu] (e.g. Ubuntu 23.10), simple rails commands fail with
`no anonymous block parameter`:

```
vendor/bundle/ruby/3.1.0/bundler/gems/rails-0e0da316ca80/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:38:in `require': vendor/bundle/ruby/3.1.0/bundler/gems/rails-0e0da316ca80/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb:190: no anonymous block parameter (SyntaxError)
        from vendor/bundle/ruby/3.1.0/bundler/gems/rails-0e0da316ca80/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:38:in `<class:AbstractAdapter>'
        from vendor/bundle/ruby/3.1.0/bundler/gems/rails-0e0da316ca80/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:31:in `<module:ConnectionAdapters>'
        from vendor/bundle/ruby/3.1.0/bundler/gems/rails-0e0da316ca80/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:15:in `<module:ActiveRecord>'
        from vendor/bundle/ruby/3.1.0/bundler/gems/rails-0e0da316ca80/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:14:in `<top (required)>'
        from vendor/bundle/ruby/3.1.0/bundler/gems/rails-0e0da316ca80/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb:3:in `require'
        from vendor/bundle/ruby/3.1.0/bundler/gems/rails-0e0da316ca80/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb:3:in `<top (required)>'
        from vendor/bundle/ruby/3.1.0/bundler/gems/rails-0e0da316ca80/activerecord/lib/active_record/connection_adapters.rb:100:in `require'
        from vendor/bundle/ruby/3.1.0/bundler/gems/rails-0e0da316ca80/activerecord/lib/active_record/connection_adapters.rb:100:in `resolve'
        from vendor/bundle/ruby/3.1.0/bundler/gems/rails-0e0da316ca80/activerecord/lib/active_record/database_configurations/database_config.rb:18:in `adapter_class'
        from vendor/bundle/ruby/3.1.0/bundler/gems/rails-0e0da316ca80/activerecord/lib/active_record/database_configurations/database_config.rb:26:in `validate!'
        from vendor/bundle/ruby/3.1.0/bundler/gems/rails-0e0da316ca80/activerecord/lib/active_record/connection_adapters/abstract/connection_handler.rb:268:in `resolve_pool_config'
        from vendor/bundle/ruby/3.1.0/bundler/gems/rails-0e0da316ca80/activerecord/lib/active_record/connection_adapters/abstract/connection_handler.rb:116:in `establish_connection'
        from vendor/bundle/ruby/3.1.0/bundler/gems/rails-0e0da316ca80/activerecord/lib/active_record/connection_handling.rb:53:in `establish_connection'
        from repro.rb:20:in `<main>'

```

One file repro:
```ruby
# frozen_string_literal: true

require "bundler/inline"
require 'bundler'
Bundler.configure

gemfile(true) do
  source "https://rubygems.org"

  git_source(:github) { |repo| "https://github.com/#{repo}.git" }

  gem "rails", github: "rails/rails", branch: "main"

  gem "sqlite3"
end

require "active_record"

# This connection will do for database-independent bug reports.
ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")

```

This Pull Request has been created to fix this issue.

### Detail

I do not know why this triggers "no anonymous block parameter", as the parameter is clearly there.
It was introduced when a named parameter was added, without the named parameter the error does not occur.
However, converting to a named block parameter fixes this issue.
