### PR TITLE
Raise named exception in `AbstractMysqlAdapter` when DB reports an invalid version

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Raise an `ActiveRecord::ActiveRecordError` error when the MySQL database returns an invalid version string.
+
+    *Kevin McPhillips*
+
 *   `ActiveRecord::Base.transaction` now yields an `ActiveRecord::Transation` object.
 
     This allows to register callbacks on it.

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -680,7 +680,7 @@ module ActiveRecord
 
       def check_version # :nodoc:
         if database_version < "5.5.8"
-          raise "Your version of MySQL (#{database_version}) is too old. Active Record supports MySQL >= 5.5.8."
+          raise DatabaseVersionError, "Your version of MySQL (#{database_version}) is too old. Active Record supports MySQL >= 5.5.8."
         end
       end
 
@@ -1023,7 +1023,11 @@ module ActiveRecord
         end
 
         def version_string(full_version_string)
-          full_version_string.match(/^(?:5\.5\.5-)?(\d+\.\d+\.\d+)/)[1]
+          if full_version_string && matches = full_version_string.match(/^(?:5\.5\.5-)?(\d+\.\d+\.\d+)/)
+            matches[1]
+          else
+            raise DatabaseVersionError, "Unable to parse MySQL version from #{full_version_string.inspect}"
+          end
         end
     end
   end

--- a/activerecord/lib/active_record/errors.rb
+++ b/activerecord/lib/active_record/errors.rb
@@ -575,4 +575,9 @@ module ActiveRecord
   # values, such as request parameters or model attributes to query methods.
   class UnknownAttributeReference < ActiveRecordError
   end
+
+  # DatabaseVersionError will be raised when the database version is not supported, or when
+  # the database version cannot be determined.
+  class DatabaseVersionError < ActiveRecordError
+  end
 end

--- a/activerecord/test/cases/adapters/abstract_mysql_adapter/connection_test.rb
+++ b/activerecord/test/cases/adapters/abstract_mysql_adapter/connection_test.rb
@@ -226,6 +226,12 @@ class ConnectionTest < ActiveRecord::AbstractMysqlTestCase
     end
   end
 
+  def test_version_string_with_mariadb
+    @connection.stub(:get_full_version, "5.5.5-10.6.5-MariaDB-1:10.6.5+maria~focal") do
+      assert_equal "10.6.5", @connection.get_database_version.to_s
+    end
+  end
+
   def test_version_string_invalid
     @connection.stub(:get_full_version, "some-database-proxy") do
       error = assert_raises(ActiveRecord::DatabaseVersionError) do


### PR DESCRIPTION
### Problem

In the `AbstractMysqlAdapter` the `get_full_version` is called on the concrete implementing class, and then the result is parsed here:
https://github.com/rails/rails/blob/a134d9166e4d34ab0d97fb82f3e4f0092b3b98ee/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb#L1026

This assumes a numeric version string of an exact format can be extracted and returned. If it cannot, the call to `match` returns `nil` and then `[1]` will raise.

We encountered a problem where we are using a proxy that sometimes returns an unexpected value. This is a problem with the proxy, to be clear, but it was challenging to debug because the `[] for nil` error deep in the framework is not descriptive and did not report the invalid value.


### Solution

Guard the regex match, and if it is not matched raise an `ActiveRecord::ActiveRecordError` with a descriptive message **that includes the unexpected version string**. That would have been invaluable for debugging.

cc @nvasilevski 


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
