### PR TITLE
Don't preload Selenium browser when remote

### DIFF
--- a/actionpack/lib/action_dispatch/system_testing/driver.rb
+++ b/actionpack/lib/action_dispatch/system_testing/driver.rb
@@ -18,7 +18,7 @@ module ActionDispatch
           gem "selenium-webdriver", ">= 4.0.0"
           require "selenium/webdriver"
           @browser = Browser.new(options[:using])
-          @browser.preload
+          @browser.preload unless @options[:browser] == :remote
         else
           @browser = nil
         end


### PR DESCRIPTION
### Motivation / Background
Fixes #50827 

### Detail

This Pull Request stops the preloading of the Selenium browser when the browser is remote.

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] NA - Tests are added or updated if you fix a bug or add a feature.
* [ ] NA - CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
