### PR TITLE
Use devcontainer features for optional dependencies

### DIFF
--- a/railties/lib/rails/generators/devcontainer.rb
+++ b/railties/lib/rails/generators/devcontainer.rb
@@ -39,6 +39,19 @@ module Rails
           @devcontainer_volumes
         end
 
+        def devcontainer_features
+          return @devcontainer_features if @devcontainer_features
+
+          @devcontainer_features = {
+            "ghcr.io/devcontainers/features/github-cli:1" => {}
+          }
+
+          @devcontainer_features["ghcr.io/rails/devcontainer/features/activestorage"] = {} unless options[:skip_active_storage]
+          @devcontainer_features.merge!(db_feature_for_devcontainer) if db_feature_for_devcontainer
+
+          @devcontainer_features
+        end
+
         def devcontainer_mounts
           return @devcontainer_mounts if @devcontainer_mounts
 
@@ -90,6 +103,13 @@ module Rails
           end
         end
 
+        def db_feature_for_devcontainer(database = options[:database])
+          case database
+          when "mysql"          then mysql_feature
+          when "postgresql"     then postgres_feature
+          end
+        end
+
         def postgres_service
           {
             "postgres" => {
@@ -136,6 +156,21 @@ module Rails
 
         def db_service_names
           ["mysql", "mariadb", "postgres"]
+        end
+
+        def mysql_feature
+          { "ghcr.io/rails/devcontainer/features/mysql-client" => {} }
+        end
+
+        def postgres_feature
+          { "ghcr.io/rails/devcontainer/features/postgres-client" => {} }
+        end
+
+        def db_features
+          [
+            "ghcr.io/rails/devcontainer/features/mysql-client",
+            "ghcr.io/rails/devcontainer/features/postgres-client"
+          ]
         end
 
         def local_rails_mount

--- a/railties/lib/rails/generators/rails/app/templates/.devcontainer/Dockerfile.tt
+++ b/railties/lib/rails/generators/rails/app/templates/.devcontainer/Dockerfile.tt
@@ -1,16 +1,3 @@
 # Make sure RUBY_VERSION matches the Ruby version in .ruby-version
 ARG RUBY_VERSION=<%= gem_ruby_version %>
 FROM ghcr.io/rails/devcontainer/images/ruby:$RUBY_VERSION
-
-<%- unless options.skip_active_storage -%>
-# Install packages needed to build gems
-RUN apt-get update -qq && \
-    apt-get install --no-install-recommends -y \
-      <%= db_package_for_dockerfile %> libvips \
-      #  For video thumbnails
-      ffmpeg \
-      # For pdf thumbnails. If you want to use mupdf instead of poppler,
-      # you can install the following packages instead:
-      # mupdf mupdf-tools
-      poppler-utils
-<%- end -%>

--- a/railties/lib/rails/generators/rails/app/templates/.devcontainer/devcontainer.json.tt
+++ b/railties/lib/rails/generators/rails/app/templates/.devcontainer/devcontainer.json.tt
@@ -8,7 +8,7 @@
 
   // Features to add to the dev container. More info: https://containers.dev/features.
   "features": {
-    "ghcr.io/devcontainers/features/github-cli:1": {}
+    <%= devcontainer_features.map { |key, value| "\"#{key}\": #{value}" }.join(",\n    ") %>
   },
 
 <%- if !devcontainer_variables.empty? -%>

--- a/railties/test/fixtures/.devcontainer/devcontainer.json
+++ b/railties/test/fixtures/.devcontainer/devcontainer.json
@@ -17,9 +17,6 @@
     "REDIS_URL": "redis://redis:6379/1"
   },
 
-  // Features to add to the dev container. More info: https://containers.dev/features.
-  // "features": {},
-
   // Use 'forwardPorts' to make a list of ports inside the container available locally.
   // "forwardPorts": [],
 

--- a/railties/test/generators/db_system_change_generator_test.rb
+++ b/railties/test/generators/db_system_change_generator_test.rb
@@ -54,6 +54,7 @@ module Rails
 
             assert_file(".devcontainer/devcontainer.json") do |content|
               assert_match(/"DB_HOST": "postgres"/, content)
+              assert_match(/"ghcr.io\/rails\/devcontainer\/features\/postgres-client":/, content)
             end
 
             assert_compose_file do |compose_config|
@@ -95,6 +96,7 @@ module Rails
 
             assert_file(".devcontainer/devcontainer.json") do |content|
               assert_match(/"DB_HOST": "mysql"/, content)
+              assert_match(/"ghcr.io\/rails\/devcontainer\/features\/mysql-client":/, content)
             end
 
             assert_compose_file do |compose_config|
@@ -203,6 +205,7 @@ module Rails
 
             assert_file(".devcontainer/devcontainer.json") do |content|
               assert_no_match(/"DB_HOST"/, content)
+              assert_no_match(/"ghcr.io\/rails\/devcontainer\/features\/mysql-client":/, content)
             end
 
             assert_compose_file do |compose_config|


### PR DESCRIPTION
### Motivation / Background

We have created our own features for optional Rails dependencies needed for active storage, postgres and mysql. Features provide a bit better ergonomics for adding or removing these from the devcontainer, and previously we were always installing these dependencies via the devcontainer's dockerfile, whether the app was using them or not.

### Detail

With this change, when we generate the app, we just add the features we need to the `devcontainer.json`. And also, we swap features in and out as need when doing `db:system:change`.

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
