### PR TITLE
Add a Date decoder to the pg adapter 

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   `PostgreSQLAdapter` now decodes columns of type date to `Date` instead of string.
+
+    Ex:
+    ```ruby
+    ActiveRecord::Base.connection
+         .select_value("select '2024-01-01'::date").class #=> Date
+    ```
+
+    *Joé Dupuis*
+
 *   Strict loading using `:n_plus_one_only` does not eagerly load child associations.
 
     With this change, child associations are no longer eagerly loaded, to

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -1159,6 +1159,7 @@ module ActiveRecord
             "bool" => PG::TextDecoder::Boolean,
             "timestamp" => PG::TextDecoder::TimestampUtc,
             "timestamptz" => PG::TextDecoder::TimestampWithTimeZone,
+            "date" => PG::TextDecoder::Date,
           }
 
           known_coder_types = coders_by_name.keys.map { |n| quote(n) }

--- a/activerecord/test/cases/adapters/postgresql/date_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/date_test.rb
@@ -39,4 +39,10 @@ class PostgresqlDateTest < ActiveRecord::PostgreSQLTestCase
     topic = Topic.create!(last_read: date)
     assert_equal date, Topic.find(topic.id).last_read
   end
+
+  def test_date_decoder
+    date = ActiveRecord::Base.connection.select_value("select '2024-01-01'::date")
+    assert_equal Date.new(2024, 01, 01), date
+    assert_equal Date, date.class
+  end
 end


### PR DESCRIPTION
Fix #51448

Add a Date decoder to the pg adapter to type cast dates at the connection level

This would type cast columns of type `date` to ruby `Date` when running a raw query through `ActiveRecord::Base.connection.select_all`.

Before:

```ruby
ActiveRecord::Base.connection.select_value("select '2024-01-01'::date").class 
#=> String
```

After:
```ruby
ActiveRecord::Base.connection.select_value("select '2024-01-01'::date").class 
#=>  Date 
```


While I don't think we'd want to to set a type cast expectation at this level (not all adapters have dates), this would brings the PG adapter to parity (for dates) with the Mysql2 adapter. 

We already convert timestamp, it would makes sense to also convert dates. 

I wasn't sure if I should add a test. I am thinking that a test sets an expectation about type casting at the adapter level. 
This changes a public API, albeit a pretty low level one, but it seems like we don't test the other types either. I removed timestamps + float/numeric and all tests still pass. 

I added a message in the changelog entry to make sure it doesn't burn anyone. 

Unsure if we should merge this. Impact radius is large, but after digging into it and running the tests, it looks pretty benign.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
