### PR TITLE
Fix textdecorator specificity on hovering in index [ci skip]

### DIFF
--- a/guides/assets/stylesrc/_main.scss
+++ b/guides/assets/stylesrc/_main.scss
@@ -654,8 +654,8 @@ body.guide {
       
           a:hover,
           a:active {
-            color: $rf-brand;
-            text-decoration: underline;
+            color: $rf-brand !important;
+            text-decoration: underline !important;
           }
         }
       }


### PR DESCRIPTION
In the guides index section, the text-decorator and color are not showing properly on hovering. And the issue is causing because of the higher specificity. 
![Screenshot 2024-04-04 at 10 26 58 AM](https://github.com/rails/rails/assets/22231095/2c36b760-594c-43c9-9991-f6318e279d4c)

![Screenshot 2024-04-04 at 10 17 39 AM](https://github.com/rails/rails/assets/22231095/03381990-fa57-4ce4-8d20-288477265470)

### Detail

This Pull Request fixes the hovering style issue.
![Screenshot 2024-04-04 at 9 06 11 AM](https://github.com/rails/rails/assets/22231095/7b34dec4-9f69-416a-b46b-172408e811df)


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.

cc/ @jathayde, @carlosantoniodasilva 
