### PR TITLE
Remove obsolete `ConnectionPool#connection` deprecation warning

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -303,10 +303,6 @@ module ActiveRecord
       end
 
       def connection
-        ActiveRecord.deprecator.warn(<<~MSG)
-          ActiveRecord::ConnectionAdapters::ConnectionPool#connection is deprecated
-          and will be removed in Rails 7.3. Use #lease_connection instead.
-        MSG
         lease_connection
       end
 


### PR DESCRIPTION
The new deprecation warning has been introduced in https://github.com/rails/rails/pull/51349 so this one is obsolete and it also ignores `config.active_record.permanent_connection_checkout` setting.