### PR TITLE
Update Filter Attributes to perform exact matches instead of Fuzzy matches

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Encrypted attributes will now be filtered by exact matches by FilterParameters.
+
+    *Keshav Biswa*
+
 *   Deserialize binary data before decrypting
 
     This ensures that we call `PG::Connection.unescape_bytea` on PostgreSQL before decryption.

--- a/activerecord/lib/active_record/encryption/auto_filtered_parameters.rb
+++ b/activerecord/lib/active_record/encryption/auto_filtered_parameters.rb
@@ -54,7 +54,7 @@ module ActiveRecord
           filter = [("#{klass.model_name.element}" if klass.name), attribute.to_s].compact.join(".")
           unless excluded_from_filter_parameters?(filter)
             app.config.filter_parameters << filter unless app.config.filter_parameters.include?(filter)
-            klass.filter_attributes += [ attribute ]
+            klass.filter_attributes += [ /^#{attribute}$/ ]
           end
         end
 

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -3693,7 +3693,7 @@ module ApplicationTests
       assert_equal [ :password, :credit_card_number ], ActiveRecord::Base.filter_attributes
     end
 
-    test "encrypted attributes are added to record's filter_attributes by default" do
+    test "encrypted attributes are added to record's filter_attributes as exact matches by default" do
       app_file "app/models/post.rb", <<-RUBY
         class Post < ActiveRecord::Base
           encrypts :content
@@ -3707,8 +3707,8 @@ module ApplicationTests
 
       app "production"
 
-      assert_includes Post.filter_attributes, :content
-      assert_not_includes ActiveRecord::Base.filter_attributes, :content
+      assert_includes Post.filter_attributes, /^content$/
+      assert_not_includes ActiveRecord::Base.filter_attributes, /^content$/
     end
 
     test "encrypted attributes are not added to record filter_attributes if disabled" do


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because of a bug mentioned in #51254 wherein encrypting one attribute in a model filters out other similar matching attributes in inspect.

### Detail

This PR makes the following changes:
- Updates `filter_attributes` to exact regex matches instead of fuzzy matching

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
