### PR TITLE
Stop generating files with `git_source(:github)`

### DIFF
--- a/guides/bug_report_templates/action_controller.rb
+++ b/guides/bug_report_templates/action_controller.rb
@@ -5,8 +5,6 @@ require "bundler/inline"
 gemfile(true) do
   source "https://rubygems.org"
 
-  git_source(:github) { |repo| "https://github.com/#{repo}.git" }
-
   gem "rails"
   # If you want to test against edge Rails replace the previous line with this:
   # gem "rails", github: "rails/rails", branch: "main"

--- a/guides/bug_report_templates/action_mailbox.rb
+++ b/guides/bug_report_templates/action_mailbox.rb
@@ -5,8 +5,6 @@ require "bundler/inline"
 gemfile(true) do
   source "https://rubygems.org"
 
-  git_source(:github) { |repo| "https://github.com/#{repo}.git" }
-
   gem "rails"
   # If you want to test against edge Rails replace the previous line with this:
   # gem "rails", github: "rails/rails", branch: "main"

--- a/guides/bug_report_templates/action_mailer.rb
+++ b/guides/bug_report_templates/action_mailer.rb
@@ -5,8 +5,6 @@ require "bundler/inline"
 gemfile(true) do
   source "https://rubygems.org"
 
-  git_source(:github) { |repo| "https://github.com/#{repo}.git" }
-
   gem "rails"
   # If you want to test against edge Rails replace the previous line with this:
   # gem "rails", github: "rails/rails", branch: "main"

--- a/guides/bug_report_templates/action_view.rb
+++ b/guides/bug_report_templates/action_view.rb
@@ -5,8 +5,6 @@ require "bundler/inline"
 gemfile(true) do
   source "https://rubygems.org"
 
-  git_source(:github) { |repo| "https://github.com/#{repo}.git" }
-
   gem "rails"
   # If you want to test against edge Rails replace the previous line with this:
   # gem "rails", github: "rails/rails", branch: "main"

--- a/guides/bug_report_templates/active_job.rb
+++ b/guides/bug_report_templates/active_job.rb
@@ -5,8 +5,6 @@ require "bundler/inline"
 gemfile(true) do
   source "https://rubygems.org"
 
-  git_source(:github) { |repo| "https://github.com/#{repo}.git" }
-
   gem "rails"
   # If you want to test against edge Rails replace the previous line with this:
   # gem "rails", github: "rails/rails", branch: "main"

--- a/guides/bug_report_templates/active_record.rb
+++ b/guides/bug_report_templates/active_record.rb
@@ -5,8 +5,6 @@ require "bundler/inline"
 gemfile(true) do
   source "https://rubygems.org"
 
-  git_source(:github) { |repo| "https://github.com/#{repo}.git" }
-
   gem "rails"
   # If you want to test against edge Rails replace the previous line with this:
   # gem "rails", github: "rails/rails", branch: "main"

--- a/guides/bug_report_templates/active_record_migrations.rb
+++ b/guides/bug_report_templates/active_record_migrations.rb
@@ -5,8 +5,6 @@ require "bundler/inline"
 gemfile(true) do
   source "https://rubygems.org"
 
-  git_source(:github) { |repo| "https://github.com/#{repo}.git" }
-
   gem "rails"
   # If you want to test against edge Rails replace the previous line with this:
   # gem "rails", github: "rails/rails", branch: "main"

--- a/guides/bug_report_templates/active_storage.rb
+++ b/guides/bug_report_templates/active_storage.rb
@@ -5,8 +5,6 @@ require "bundler/inline"
 gemfile(true) do
   source "https://rubygems.org"
 
-  git_source(:github) { |repo| "https://github.com/#{repo}.git" }
-
   gem "rails"
   # If you want to test against edge Rails replace the previous line with this:
   # gem "rails", github: "rails/rails", branch: "main"

--- a/guides/bug_report_templates/benchmark.rb
+++ b/guides/bug_report_templates/benchmark.rb
@@ -5,8 +5,6 @@ require "bundler/inline"
 gemfile(true) do
   source "https://rubygems.org"
 
-  git_source(:github) { |repo| "https://github.com/#{repo}.git" }
-
   gem "rails"
   # If you want to test against edge Rails replace the previous line with this:
   # gem "rails", github: "rails/rails", branch: "main"

--- a/guides/bug_report_templates/generic.rb
+++ b/guides/bug_report_templates/generic.rb
@@ -5,8 +5,6 @@ require "bundler/inline"
 gemfile(true) do
   source "https://rubygems.org"
 
-  git_source(:github) { |repo| "https://github.com/#{repo}.git" }
-
   gem "rails"
   # If you want to test against edge Rails replace the previous line with this:
   # gem "rails", github: "rails/rails", branch: "main"

--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -672,7 +672,6 @@ module Rails
         if !File.exist?(File.expand_path("Gemfile", destination_root))
           create_file("Gemfile", <<~GEMFILE)
             source "https://rubygems.org"
-            git_source(:github) { |repo| "https://github.com/\#{repo}.git" }
             #{rails_gemfile_entry}
           GEMFILE
 

--- a/railties/lib/rails/generators/rails/plugin/templates/Gemfile.tt
+++ b/railties/lib/rails/generators/rails/plugin/templates/Gemfile.tt
@@ -1,5 +1,4 @@
 source "https://rubygems.org"
-git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 <% unless options[:skip_gemspec] -%>
 
 # Specify your gem's dependencies in <%= name %>.gemspec.

--- a/railties/test/generators/plugin_generator_test.rb
+++ b/railties/test/generators/plugin_generator_test.rb
@@ -183,11 +183,6 @@ class PluginGeneratorTest < Rails::Generators::TestCase
     assert_file "test/integration/navigation_test.rb", /ActionDispatch::IntegrationTest/
   end
 
-  def test_inclusion_of_git_source
-    run_generator [destination_root]
-    assert_file "Gemfile", /git_source/
-  end
-
   def test_inclusion_of_a_debugger
     run_generator [destination_root, "--full"]
     if defined?(JRUBY_VERSION)


### PR DESCRIPTION
This has been built-in in Bundler for years now, and the builtin version is much better as it allows to point to a PR directly.
