### PR TITLE
Add missing `ostruct` require to `http_token_authentication_test.rb`

### DIFF
--- a/actionpack/test/controller/http_token_authentication_test.rb
+++ b/actionpack/test/controller/http_token_authentication_test.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "ostruct"
 require "abstract_unit"
 
 class HttpTokenAuthenticationTest < ActionController::TestCase


### PR DESCRIPTION
CI fails (https://buildkite.com/rails/rails/builds/106122#018ea915-24d5-42e7-ac76-2c344ed66683) on rack HEAD because we do not explicitly require `ostruct` in the test file. 
Previously, it was required by the rack itself (https://github.com/rack/rack/pull/2166/files) and so worked well.