### PR TITLE
✨ Add `DateAndTime::Calculations.on_or_after?` and `DateAndTime::Calculations.on_or_before?`

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,14 @@
+*   Add `DateTimeAndCalculations.on_or_before?` and `DateTimeAndCalculations.on_or_after?`
+
+    Currently there is no equivalent `<=` or `>=` for `DateAndTime`, this adds `on_or_before?`
+    and `on_or_after?`.
+
+    ```ruby
+    Date.new(2017, 3, 6).on_or_before?(Date.new(2017, 3, 6)) # true
+    Date.new(2017, 3, 6).on_or_after?(Date.new(2017, 3, 6)) # true
+    ```
+    *Daniel Vu Dao*
+
 *   Make ActiveSupport::BacktraceCleaner copy filters and silencers on dup and clone
 
     Previously the copy would still share the internal silencers and filters array,

--- a/activesupport/lib/active_support/core_ext/date_and_time/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/date_and_time/calculations.rb
@@ -68,9 +68,19 @@ module DateAndTime
       self < date_or_time
     end
 
+    # Returns true if the date/time falls on or before <tt>date_or_time</tt>.
+    def on_or_before?(date_or_time)
+      self <= date_or_time
+    end
+
     # Returns true if the date/time falls after <tt>date_or_time</tt>.
     def after?(date_or_time)
       self > date_or_time
+    end
+
+    # Returns true if the date/time falls on or after <tt>date_or_time</tt>.
+    def on_or_after?(date_or_time)
+      self >= date_or_time
     end
 
     # Returns a new date/time the specified number of days ago.

--- a/activesupport/lib/active_support/time_with_zone.rb
+++ b/activesupport/lib/active_support/time_with_zone.rb
@@ -233,7 +233,9 @@ module ActiveSupport
       utc <=> other
     end
     alias_method :before?, :<
+    alias_method :on_or_before?, :<
     alias_method :after?, :>
+    alias_method :on_or_after?, :>=
 
     # Returns true if the current object's time is within the specified
     # +min+ and +max+ time.

--- a/activesupport/test/core_ext/date_and_time_behavior.rb
+++ b/activesupport/test/core_ext/date_and_time_behavior.rb
@@ -346,10 +346,22 @@ module DateAndTimeBehavior
     assert_equal true, date_time_init(2017, 3, 6, 12, 0, 0).before?(date_time_init(2017, 3, 7, 12, 0, 0))
   end
 
+  def test_on_or_before
+    assert_equal false, date_time_init(2017, 3, 6, 12, 0, 0).on_or_before?(date_time_init(2017, 3, 5, 12, 0, 0))
+    assert_equal true, date_time_init(2017, 3, 6, 12, 0, 0).on_or_before?(date_time_init(2017, 3, 6, 12, 0, 0))
+    assert_equal true, date_time_init(2017, 3, 6, 12, 0, 0).on_or_before?(date_time_init(2017, 3, 7, 12, 0, 0))
+  end
+
   def test_after
     assert_equal true, date_time_init(2017, 3, 6, 12, 0, 0).after?(date_time_init(2017, 3, 5, 12, 0, 0))
     assert_equal false, date_time_init(2017, 3, 6, 12, 0, 0).after?(date_time_init(2017, 3, 6, 12, 0, 0))
     assert_equal false, date_time_init(2017, 3, 6, 12, 0, 0).after?(date_time_init(2017, 3, 7, 12, 0, 0))
+  end
+
+  def test_on_or_after
+    assert_equal true, date_time_init(2017, 3, 6, 12, 0, 0).on_or_after?(date_time_init(2017, 3, 5, 12, 0, 0))
+    assert_equal true, date_time_init(2017, 3, 6, 12, 0, 0).on_or_after?(date_time_init(2017, 3, 6, 12, 0, 0))
+    assert_equal false, date_time_init(2017, 3, 6, 12, 0, 0).on_or_after?(date_time_init(2017, 3, 7, 12, 0, 0))
   end
 
   def with_bw_default(bw = :monday)


### PR DESCRIPTION
### Motivation / Background

Currently there is no equivalent to `<=` or `>=` in the `DateAndTime::Calculations` module. Personally I love using `after?` and `before?` so I was hoping to find something similar and wasn't able to do so.

### Detail

This introduces a couple of new methods to the `DateAndTime::Calculations` module, `on_or_before?` and `on_or_after?` which should function as `<=` and `>=`, respectively.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
