### PR TITLE
Allow `IN` with subselect to be preparable

### DIFF
--- a/activerecord/lib/arel/visitors/to_sql.rb
+++ b/activerecord/lib/arel/visitors/to_sql.rb
@@ -586,10 +586,11 @@ module Arel # :nodoc: all
         end
 
         def visit_Arel_Nodes_In(o, collector)
-          collector.preparable = false
           attr, values = o.left, o.right
 
           if Array === values
+            collector.preparable = false
+
             unless values.empty?
               values.delete_if { |value| unboundable?(value) }
             end
@@ -602,10 +603,11 @@ module Arel # :nodoc: all
         end
 
         def visit_Arel_Nodes_NotIn(o, collector)
-          collector.preparable = false
           attr, values = o.left, o.right
 
           if Array === values
+            collector.preparable = false
+
             unless values.empty?
               values.delete_if { |value| unboundable?(value) }
             end

--- a/activerecord/test/cases/arel/visitors/to_sql_test.rb
+++ b/activerecord/test/cases/arel/visitors/to_sql_test.rb
@@ -520,6 +520,24 @@ module Arel
             "users"."id" IN (SELECT id FROM "users" WHERE "users"."name" = 'Aaron')
           }
         end
+
+        it "is not preparable when an array" do
+          node = @attr.in [1, 2, 3]
+
+          collector = Collectors::SQLString.new.tap { |c| c.preparable = true }
+          @visitor.accept(node, collector)
+          _(collector.preparable).must_equal false
+        end
+
+        it "is preparable when a subselect" do
+          table = Table.new(:users)
+          subquery = table.project(table[:id]).where(table[:name].eq("Aaron"))
+          node = @attr.in subquery
+
+          collector = Collectors::SQLString.new.tap { |c| c.preparable = true }
+          @visitor.accept(node, collector)
+          _(collector.preparable).must_equal true
+        end
       end
 
       describe "Nodes::InfixOperation" do
@@ -681,6 +699,24 @@ module Arel
           _(compile(node)).must_be_like %{
             "users"."id" NOT IN (SELECT id FROM "users" WHERE "users"."name" = 'Aaron')
           }
+        end
+
+        it "is not preparable when an array" do
+          node = @attr.not_in [1, 2, 3]
+
+          collector = Collectors::SQLString.new.tap { |c| c.preparable = true }
+          @visitor.accept(node, collector)
+          _(collector.preparable).must_equal false
+        end
+
+        it "is preparable when a subselect" do
+          table = Table.new(:users)
+          subquery = table.project(table[:id]).where(table[:name].eq("Aaron"))
+          node = @attr.not_in subquery
+
+          collector = Collectors::SQLString.new.tap { |c| c.preparable = true }
+          @visitor.accept(node, collector)
+          _(collector.preparable).must_equal true
         end
       end
 


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created because I noticed that all SQL `IN` statements get automatically marked as non-preparable (Prepared Statements). But it seems like subselects _should_ be preparable, at least to the extent that their Arel nodes are also preparable. With this change, the list of non-preparable Arel Nodes becomes:

- `SqlLiteral`, because they can contain anything.
- `In` when passed Arrays, because Arrays can contain an arbitrary number of items, as well as literal values and thus can have high variability and are therefore bad candidates for a Prepared Statement.
- `NotIn` when passed Arrays, for the same reason as `In`
- `HomogenousIn` which can [_only_ be passed Arrays](https://github.com/bensheldon/rails/commit/72fd0bae5948c1169411941aeea6fef4c58f34a9)

### Detail

This Pull Request changes Arel `Nodes` `In` and `NotIn` to only be marked as `preparable = false` when they are passed Arrays. Otherwise they do not modify the preparable collector state.

Because Arel is not a public API, I have not created a changelog entry. Happy do so if requested.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.

