### PR TITLE
UnrecognizedCommandError can be corrected and retried

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,17 @@
+*   When encountering an Unrecognized Command Error, while running `rails` commands, the developer will be
+    given the option to run the suggested corrections.
+
+    ```txt
+    bin/rails action_txt:install
+    Unrecognized command "action_txt:install"
+
+    Did you mean?  action_text:install [Yn] Y
+    Installing JavaScript dependencies
+    ...
+    ```
+
+    *Andrew Novoselac & Gannon McGibbon*
+
 *   Allow Actionable Errors encountered when running tests to be retried.
 
     ```txt


### PR DESCRIPTION
### Motivation / Background

This is a follow up to https://github.com/rails/rails/pull/50941. "Did you mean?" style errors were introduced in rails/rails@2530160 for unrecognized commands. With this change, we give the user the option to retry with the corrected command name - instead of needing to retype and rerun the command.

### Detail

We iterate through all the possible commands returned by `DidYouMean::SpellChecker` and give the user the option to rerun the suggested correction.

```
 ➜  myapp git:(main) bin/rails vershen
Unrecognized command "vershen"

Did you mean?  version [Yn] y
Rails 7.2.0.alpha
```

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
