### PR TITLE
Record ping on every actioncable message

### DIFF
--- a/actioncable/CHANGELOG.md
+++ b/actioncable/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Record ping on every actioncable message
+
+    Previously only `ping` and `welcome` message types were keeping connection active.
+    Now every Action Cable message updates `pingedAt` value preventing connection from being marked as stale.
+
+    *yauhenininjia*
+
 *   Add two new assertion methods for ActionCable test cases: `assert_has_no_stream`
     and `assert_has_no_stream_for`. These methods can be used to assert that a
     stream has been stopped, e.g. via `stop_stream` or `stop_stream_for`. They complement

--- a/actioncable/app/assets/javascripts/action_cable.js
+++ b/actioncable/app/assets/javascripts/action_cable.js
@@ -43,12 +43,11 @@
     isRunning() {
       return this.startedAt && !this.stoppedAt;
     }
-    recordPing() {
+    recordMessage() {
       this.pingedAt = now();
     }
     recordConnect() {
       this.reconnectAttempts = 0;
-      this.recordPing();
       delete this.disconnectedAt;
       logger.log("ConnectionMonitor recorded connect");
     }
@@ -236,6 +235,7 @@
         return;
       }
       const {identifier: identifier, message: message, reason: reason, reconnect: reconnect, type: type} = JSON.parse(event.data);
+      this.monitor.recordMessage();
       switch (type) {
        case message_types.welcome:
         if (this.triedToReconnect()) {
@@ -251,7 +251,7 @@
         });
 
        case message_types.ping:
-        return this.monitor.recordPing();
+        return null;
 
        case message_types.confirmation:
         this.subscriptions.confirmSubscription(identifier);

--- a/actioncable/app/assets/javascripts/actioncable.esm.js
+++ b/actioncable/app/assets/javascripts/actioncable.esm.js
@@ -42,12 +42,11 @@ class ConnectionMonitor {
   isRunning() {
     return this.startedAt && !this.stoppedAt;
   }
-  recordPing() {
+  recordMessage() {
     this.pingedAt = now();
   }
   recordConnect() {
     this.reconnectAttempts = 0;
-    this.recordPing();
     delete this.disconnectedAt;
     logger.log("ConnectionMonitor recorded connect");
   }
@@ -244,6 +243,7 @@ Connection.prototype.events = {
       return;
     }
     const {identifier: identifier, message: message, reason: reason, reconnect: reconnect, type: type} = JSON.parse(event.data);
+    this.monitor.recordMessage();
     switch (type) {
      case message_types.welcome:
       if (this.triedToReconnect()) {
@@ -259,7 +259,7 @@ Connection.prototype.events = {
       });
 
      case message_types.ping:
-      return this.monitor.recordPing();
+      return null;
 
      case message_types.confirmation:
       this.subscriptions.confirmSubscription(identifier);

--- a/actioncable/app/assets/javascripts/actioncable.js
+++ b/actioncable/app/assets/javascripts/actioncable.js
@@ -43,12 +43,11 @@
     isRunning() {
       return this.startedAt && !this.stoppedAt;
     }
-    recordPing() {
+    recordMessage() {
       this.pingedAt = now();
     }
     recordConnect() {
       this.reconnectAttempts = 0;
-      this.recordPing();
       delete this.disconnectedAt;
       logger.log("ConnectionMonitor recorded connect");
     }
@@ -236,6 +235,7 @@
         return;
       }
       const {identifier: identifier, message: message, reason: reason, reconnect: reconnect, type: type} = JSON.parse(event.data);
+      this.monitor.recordMessage();
       switch (type) {
        case message_types.welcome:
         if (this.triedToReconnect()) {
@@ -251,7 +251,7 @@
         });
 
        case message_types.ping:
-        return this.monitor.recordPing();
+        return null;
 
        case message_types.confirmation:
         this.subscriptions.confirmSubscription(identifier);

--- a/actioncable/app/javascript/action_cable/connection.js
+++ b/actioncable/app/javascript/action_cable/connection.js
@@ -128,6 +128,7 @@ Connection.prototype.events = {
   message(event) {
     if (!this.isProtocolSupported()) { return }
     const {identifier, message, reason, reconnect, type} = JSON.parse(event.data)
+    this.monitor.recordMessage()
     switch (type) {
       case message_types.welcome:
         if (this.triedToReconnect()) {
@@ -139,7 +140,7 @@ Connection.prototype.events = {
         logger.log(`Disconnecting. Reason: ${reason}`)
         return this.close({allowReconnect: reconnect})
       case message_types.ping:
-        return this.monitor.recordPing()
+        return null
       case message_types.confirmation:
         this.subscriptions.confirmSubscription(identifier)
         if (this.reconnectAttempted) {

--- a/actioncable/app/javascript/action_cable/connection_monitor.js
+++ b/actioncable/app/javascript/action_cable/connection_monitor.js
@@ -37,13 +37,12 @@ class ConnectionMonitor {
     return this.startedAt && !this.stoppedAt
   }
 
-  recordPing() {
+  recordMessage() {
     this.pingedAt = now()
   }
 
   recordConnect() {
     this.reconnectAttempts = 0
-    this.recordPing()
     delete this.disconnectedAt
     logger.log("ConnectionMonitor recorded connect")
   }


### PR DESCRIPTION
Substitutes https://github.com/rails/rails/pull/49168
Fixes https://github.com/rails/rails/issues/42336

This is almost a copy of https://github.com/rails/rails/pull/49168 so all credits to @yauhenininjia, thanks for addressing this!

with a few tweaks:
- Rebased & re-generated `action_cable.js` and `actioncable.esm.js`
- CHANGELOG entry added
- As discussed in https://github.com/rails/rails/pull/49168#discussion_r1435079516 to avoid calling `recordPing` in multiple places we renamed `recordPing` to `recordMessage()` and only call it once before the `switch` statement. `recordConnect` and ` case message_types.ping` won't record ping anymore.


From original PR:

### Motivation / Background
This PR is a fix for this issue described and closed due to inactivity here https://github.com/rails/rails/issues/42336
It still happens in apps with rails 7.0.7.2, ruby 3.2.2 and @rails/actioncable 7.0.4: when large number of events is sent via actioncable (in our case they are turbo broadcast messages) it prevents ping messages from coming in time (currently ping threshold is 6 seconds), so actioncable assumes connection as stale and creates a new one. However, during a downtime between closing/opening connections events could (and are) miss(ed).

In this PR pings are also recorded on every normal message coming to the client.

### Expected behavior
Connection does not become stale and does not get reconnected when ping messages are delayed due to large number of normal messages.

### Actual behavior
The client is disconnected if it doesn't receive ping events within the `staleThreshold` even though it's receiving other events.


cc: @palkan 