### PR TITLE
[ci skip] [docs] Update "Running EXPLAIN" section in the "Active Record Query Interface" guide.

### DIFF
--- a/guides/source/active_record_querying.md
+++ b/guides/source/active_record_querying.md
@@ -2610,13 +2610,13 @@ Running EXPLAIN
 
 You can run [`explain`][] on a relation. EXPLAIN output varies for each database.
 
-For example, running
+For example, running:
 
 ```ruby
 Customer.where(id: 1).joins(:orders).explain
 ```
 
-may yield
+may yield this for MySQL and MariaDB:
 
 ```sql
 EXPLAIN SELECT `customers`.* FROM `customers` INNER JOIN `orders` ON `orders`.`customer_id` = `customers`.`id` WHERE `customers`.`id` = 1
@@ -2636,11 +2636,9 @@ EXPLAIN SELECT `customers`.* FROM `customers` INNER JOIN `orders` ON `orders`.`c
 2 rows in set (0.00 sec)
 ```
 
-under MySQL and MariaDB.
-
 Active Record performs a pretty printing that emulates that of the
 corresponding database shell. So, the same query running with the
-PostgreSQL adapter would yield instead
+PostgreSQL adapter would yield instead:
 
 ```sql
 EXPLAIN SELECT "customers".* FROM "customers" INNER JOIN "orders" ON "orders"."customer_id" = "customers"."id" WHERE "customers"."id" = $1 [["id", 1]]
@@ -2658,7 +2656,7 @@ EXPLAIN SELECT "customers".* FROM "customers" INNER JOIN "orders" ON "orders"."c
 
 Eager loading may trigger more than one query under the hood, and some queries
 may need the results of previous ones. Because of that, `explain` actually
-executes the query, and then asks for the query plans. For example,
+executes the query, and then asks for the query plans. For example, running:
 
 ```ruby
 Customer.where(id: 1).includes(:orders).explain


### PR DESCRIPTION
### Motivation / Background

I found the following issues when reading [the "Running EXPLAIN" section of the "Active Record Query Interface" guide](https://edgeguides.rubyonrails.org/active_record_querying.html#running-explain):

![Captura de pantalla 2024-04-06 a las 0 19 21](https://github.com/rails/rails/assets/390398/d23d9188-2630-47bb-9f24-da51b38ecc4a)

### Detail

I fixed the issues described above. This is how it reads with the changes in this PR:

![image](https://github.com/rails/rails/assets/390398/3d5a2308-0f6d-4500-8082-d088ddc81658)

I added one more colon and a verb that (I think) makes the section more consistent.

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

Not much to add here 🤐.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [ ] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
