### PR TITLE
Remove usage of `OpenStruct`

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -316,6 +316,9 @@ Style/RedundantCondition:
 Style/RedundantDoubleSplatHashBraces:
   Enabled: true
 
+Style/OpenStructUse:
+  Enabled: true
+
 Style/ArrayIntersect:
   Enabled: true
 
@@ -353,9 +356,6 @@ Performance/DeletePrefix:
   Enabled: true
 
 Performance/DeleteSuffix:
-  Enabled: true
-
-Performance/OpenStruct:
   Enabled: true
 
 Performance/InefficientHashSearch:

--- a/Gemfile
+++ b/Gemfile
@@ -38,9 +38,6 @@ gem "cgi", ">= 0.3.6", require: false
 
 gem "prism"
 
-# Became a bundled gem in Ruby 3.5
-gem "ostruct"
-
 group :lint do
   gem "syntax_tree", "6.1.1", require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -368,7 +368,6 @@ GEM
     nokogiri (1.16.0-x86_64-linux)
       racc (~> 1.4)
     os (1.1.4)
-    ostruct (0.6.0)
     parallel (1.24.0)
     parser (3.2.2.4)
       ast (~> 2.4.1)
@@ -624,7 +623,6 @@ DEPENDENCIES
   msgpack (>= 1.7.0)
   mysql2 (~> 0.5)
   nokogiri (>= 1.8.1, != 1.11.0)
-  ostruct
   pg (~> 1.3)
   prism
   propshaft (>= 0.1.7)

--- a/actionmailer/test/url_test.rb
+++ b/actionmailer/test/url_test.rb
@@ -2,7 +2,6 @@
 
 require "abstract_unit"
 require "action_controller"
-require "ostruct"
 
 class WelcomeController < ActionController::Base
 end
@@ -42,7 +41,7 @@ end
 class ActionMailerUrlTest < ActionMailer::TestCase
   class DummyModel
     def self.model_name
-      OpenStruct.new(route_key: "dummy_model")
+      Struct.new(:route_key, :name).new("dummy_model", nil)
     end
 
     def persisted?

--- a/actionpack/test/controller/http_token_authentication_test.rb
+++ b/actionpack/test/controller/http_token_authentication_test.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "ostruct"
 require "abstract_unit"
 
 class HttpTokenAuthenticationTest < ActionController::TestCase
@@ -240,7 +239,7 @@ class HttpTokenAuthenticationTest < ActionController::TestCase
     end
 
     def mock_authorization_request(authorization)
-      OpenStruct.new(authorization: authorization)
+      Struct.new(:authorization).new(authorization)
     end
 
     def encode_credentials(token, options = {})

--- a/actionview/test/lib/controller/fake_models.rb
+++ b/actionview/test/lib/controller/fake_models.rb
@@ -207,7 +207,7 @@ class Plane
 
   class << self
     def model_name
-      OpenStruct.new param_key: "airplane"
+      Struct.new(:param_key).new("airplane")
     end
   end
 

--- a/actionview/test/template/controller_helper_test.rb
+++ b/actionview/test/template/controller_helper_test.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "abstract_unit"
-require "ostruct"
 
 class ControllerHelperTest < ActionView::TestCase
   tests ActionView::Helpers::ControllerHelper
@@ -9,26 +8,28 @@ class ControllerHelperTest < ActionView::TestCase
   class SpecializedFormBuilder < ActionView::Helpers::FormBuilder ; end
 
   def test_assign_controller_sets_default_form_builder
-    @controller = OpenStruct.new(default_form_builder: SpecializedFormBuilder)
+    @controller = Struct.new(:default_form_builder).new(SpecializedFormBuilder)
     assign_controller(@controller)
 
     assert_equal SpecializedFormBuilder, default_form_builder
   end
 
   def test_assign_controller_skips_default_form_builder
-    @controller = OpenStruct.new
+    @controller = Object.new
     assign_controller(@controller)
 
     assert_nil default_form_builder
   end
 
   def test_respond_to
-    @controller = OpenStruct.new
+    @controller = Object.new
     assign_controller(@controller)
     assert_not respond_to?(:params)
     assert respond_to?(:assign_controller)
 
-    @controller.params = {}
+    def @controller.params
+      {}
+    end
     assert respond_to?(:params)
     assert respond_to?(:assign_controller)
   end

--- a/actionview/test/template/form_helper_test.rb
+++ b/actionview/test/template/form_helper_test.rb
@@ -2,7 +2,6 @@
 
 require "abstract_unit"
 require "controller/fake_models"
-require "ostruct"
 
 class FormHelperTest < ActionView::TestCase
   include RenderERBUtils
@@ -280,7 +279,7 @@ class FormHelperTest < ActionView::TestCase
   end
 
   def test_label_with_non_active_record_object
-    form_for(OpenStruct.new(name: "ok"), as: "person", url: "/an", html: { id: "create-person" }) do |f|
+    form_for(Struct.new(:name).new("ok"), as: "person", url: "/an", html: { id: "create-person" }) do |f|
       f.label(:name)
     end
 

--- a/actionview/test/template/record_identifier_test.rb
+++ b/actionview/test/template/record_identifier_test.rb
@@ -2,7 +2,6 @@
 
 require "abstract_unit"
 require "controller/fake_models"
-require "ostruct"
 
 class RecordIdentifierTest < ActiveSupport::TestCase
   include ActionView::RecordIdentifier

--- a/activejob/test/support/delayed_job/delayed/backend/test.rb
+++ b/activejob/test/support/delayed_job/delayed/backend/test.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 # copied from https://github.com/collectiveidea/delayed_job/blob/master/spec/delayed/backend/test.rb
-require "ostruct"
 
 # An in-memory backend suitable only for testing. Tries to behave as if it were an ORM.
 module Delayed

--- a/activerecord/test/cases/arel/attributes/attribute_test.rb
+++ b/activerecord/test/cases/arel/attributes/attribute_test.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require_relative "../helper"
-require "ostruct"
 
 module Arel
   module Attributes
@@ -1161,10 +1160,10 @@ module Arel
 
       private
         def quoted_range(begin_val, end_val, exclude)
-          OpenStruct.new(
-            begin: Nodes::Quoted.new(begin_val),
-            end: Nodes::Quoted.new(end_val),
-            exclude_end?: exclude,
+          Struct.new(:begin, :end, :exclude_end?).new(
+            Nodes::Quoted.new(begin_val),
+            Nodes::Quoted.new(end_val),
+            exclude,
           )
         end
 

--- a/activerecord/test/cases/encryption/configurable_test.rb
+++ b/activerecord/test/cases/encryption/configurable_test.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "ostruct"
 require "cases/encryption/helper"
 require "models/pirate"
 require "models/book"
@@ -43,7 +42,7 @@ class ActiveRecord::Encryption::ConfigurableTest < ActiveRecord::EncryptionTestC
   end
 
   test "installing autofiltered parameters will add the encrypted attribute as a filter parameter using the dot notation" do
-    application = OpenStruct.new(config: OpenStruct.new(filter_parameters: []))
+    application = Struct.new(:config).new(Struct.new(:filter_parameters).new([]))
 
     with_auto_filtered_parameters(application) do
       NamedPirate = Class.new(Pirate) do
@@ -56,7 +55,7 @@ class ActiveRecord::Encryption::ConfigurableTest < ActiveRecord::EncryptionTestC
   end
 
   test "installing autofiltered parameters will work with unnamed classes" do
-    application = OpenStruct.new(config: OpenStruct.new(filter_parameters: []))
+    application = Struct.new(:config).new(Struct.new(:filter_parameters).new([]))
 
     with_auto_filtered_parameters(application) do
       Class.new(Pirate) do
@@ -71,7 +70,7 @@ class ActiveRecord::Encryption::ConfigurableTest < ActiveRecord::EncryptionTestC
   test "exclude the installation of autofiltered params" do
     ActiveRecord::Encryption.config.excluded_from_filter_parameters = [:catchphrase]
 
-    application = OpenStruct.new(config: OpenStruct.new(filter_parameters: []))
+    application = Struct.new(:config).new(Struct.new(:filter_parameters).new([]))
 
     with_auto_filtered_parameters(application) do
       Class.new(Pirate) do

--- a/activerecord/test/models/developer.rb
+++ b/activerecord/test/models/developer.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "ostruct"
 require "models/computer"
 
 class Developer < ActiveRecord::Base
@@ -226,7 +225,7 @@ end
 
 class CallableDeveloperCalledDavid < ActiveRecord::Base
   self.table_name = "developers"
-  default_scope OpenStruct.new(call: where(name: "David"))
+  default_scope Struct.new(:call).new(where(name: "David"))
 end
 
 class ClassMethodDeveloperCalledDavid < ActiveRecord::Base
@@ -329,7 +328,7 @@ class EagerDeveloperWithCallableDefaultScope < ActiveRecord::Base
   self.table_name = "developers"
   has_and_belongs_to_many :projects, -> { order("projects.id") }, foreign_key: "developer_id", join_table: "developers_projects"
 
-  default_scope OpenStruct.new(call: includes(:projects))
+  default_scope Struct.new(:call).new(includes(:projects))
 end
 
 class ThreadsafeDeveloper < ActiveRecord::Base

--- a/railties/test/application/rake/dbs_test.rb
+++ b/railties/test/application/rake/dbs_test.rb
@@ -2,7 +2,6 @@
 
 require "isolation/abstract_unit"
 require "env_helpers"
-require "ostruct"
 
 module ApplicationTests
   module RakeTests
@@ -139,7 +138,7 @@ module ApplicationTests
 
         app_file "config/environments/development.rb", <<-RUBY
           Rails.application.configure do
-            config.other = OpenStruct.new(value: 123)
+            config.other = Struct.new(:value).new(123)
           end
         RUBY
 


### PR DESCRIPTION
Follow up to https://github.com/rails/rails/pull/51491#issuecomment-2037429653.

There was one more error regarding the missing `require "ostruct"` after that PR merge (https://buildkite.com/rails/rails/builds/106158#018eaee1-7e2b-4e8a-9876-8d3c358d5576), so maybe we can just remove its usage instead?

cc @byroot 