### PR TITLE
Skip ActiveStorage previewer tests if required tools are unavailable

### DIFF
--- a/activestorage/test/previewer/mupdf_previewer_test.rb
+++ b/activestorage/test/previewer/mupdf_previewer_test.rb
@@ -6,6 +6,10 @@ require "database/setup"
 require "active_storage/previewer/mupdf_previewer"
 
 class ActiveStorage::Previewer::MuPDFPreviewerTest < ActiveSupport::TestCase
+  setup do
+    skip "mutool unavailable" unless ActiveStorage::Previewer::MuPDFPreviewer.mutool_exists?
+  end
+
   test "previewing a PDF document" do
     blob = create_file_blob(filename: "report.pdf", content_type: "application/pdf")
 

--- a/activestorage/test/previewer/poppler_pdf_previewer_test.rb
+++ b/activestorage/test/previewer/poppler_pdf_previewer_test.rb
@@ -6,6 +6,10 @@ require "database/setup"
 require "active_storage/previewer/poppler_pdf_previewer"
 
 class ActiveStorage::Previewer::PopplerPDFPreviewerTest < ActiveSupport::TestCase
+  setup do
+    skip "pdftoppm unavailable" unless ActiveStorage::Previewer::PopplerPDFPreviewer.pdftoppm_exists?
+  end
+
   test "previewing a PDF document" do
     blob = create_file_blob(filename: "report.pdf", content_type: "application/pdf")
 

--- a/activestorage/test/previewer/video_previewer_test.rb
+++ b/activestorage/test/previewer/video_previewer_test.rb
@@ -6,6 +6,10 @@ require "database/setup"
 require "active_storage/previewer/video_previewer"
 
 class ActiveStorage::Previewer::VideoPreviewerTest < ActiveSupport::TestCase
+  setup do
+    skip "ffmpeg unavailable" unless ActiveStorage::Previewer::VideoPreviewer.ffmpeg_exists?
+  end
+
   test "previewing an MP4 video" do
     blob = create_file_blob(filename: "video.mp4", content_type: "video/mp4")
 


### PR DESCRIPTION
These tests require certain tools to be available, if they aren't these tests will fail. Skip instead.