### PR TITLE
Raise when both `:force` and `:if_not_exists` provided to `create_table`

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -293,6 +293,11 @@ module ActiveRecord
       def create_table(table_name, id: :primary_key, primary_key: nil, force: nil, **options, &block)
         validate_create_table_options!(options)
         validate_table_length!(table_name) unless options[:_uses_legacy_table_name]
+
+        if force && options.key?(:if_not_exists)
+          raise ArgumentError, "Options `:force` and `:if_not_exists` cannot be used simultaneously."
+        end
+
         td = build_create_table_definition(table_name, id: id, primary_key: primary_key, force: force, **options, &block)
 
         if force

--- a/activerecord/test/cases/migration_test.rb
+++ b/activerecord/test/cases/migration_test.rb
@@ -199,6 +199,13 @@ class MigrationTest < ActiveRecord::TestCase
     connection.drop_table short_name, if_exists: true
   end
 
+  def test_create_table_with_force_and_if_not_exists
+    connection = Person.lease_connection
+    assert_raises(ArgumentError, match: /Options `:force` and `:if_not_exists` cannot be used simultaneously/) do
+      connection.create_table(:testings, force: true, if_not_exists: true)
+    end
+  end
+
   def test_create_table_with_indexes_and_if_not_exists_true
     connection = Person.lease_connection
     connection.create_table :testings, force: true do |t|


### PR DESCRIPTION
Fixes #51067.
Closes #51067 (added original author as a coauthor).

Should we also think about backwards compatibility for existing migrations in this case?

cc @adrianna-chang-shopify (as original reviewer)