### PR TITLE
Ensure association's `foreign_key:` and `query_constraints:` options …

### DIFF
--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -516,6 +516,10 @@ module ActiveRecord
         @foreign_key = nil
         @association_foreign_key = nil
         @association_primary_key = nil
+        # If the foreign key is an array, set query constraints options and don't use the foreign key
+        if options[:foreign_key].is_a?(Array)
+          options[:query_constraints] = options.delete(:foreign_key)
+        end
 
         ensure_option_not_given_as_class!(:class_name)
       end

--- a/activerecord/test/cases/associations/inverse_associations_test.rb
+++ b/activerecord/test/cases/associations/inverse_associations_test.rb
@@ -227,6 +227,20 @@ class AutomaticInverseFindingTests < ActiveRecord::TestCase
 
     assert_predicate human_reflection, :has_inverse?
   end
+
+  def test_has_many_inverse_of_derived_automatically_despite_of_composite_foreign_key
+    car_review_reflection = Cpk::Car.reflect_on_association(:car_reviews)
+
+    assert_predicate car_review_reflection, :has_inverse?
+    assert_equal Cpk::CarReview.reflect_on_association(:car), car_review_reflection.inverse_of
+  end
+
+  def test_belongs_to_inverse_of_derived_automatically_despite_of_composite_foreign_key
+    car_reflection = Cpk::CarReview.reflect_on_association(:car)
+
+    assert_predicate car_reflection, :has_inverse?
+    assert_equal Cpk::Car.reflect_on_association(:car_reviews), car_reflection.inverse_of
+  end
 end
 
 class InverseAssociationTests < ActiveRecord::TestCase

--- a/activerecord/test/models/cpk/car.rb
+++ b/activerecord/test/models/cpk/car.rb
@@ -3,5 +3,7 @@
 module Cpk
   class Car < ActiveRecord::Base
     self.table_name = :cpk_cars
+
+    has_many :car_reviews, foreign_key: [:car_make, :car_model]
   end
 end


### PR DESCRIPTION
Follow-up to https://github.com/rails/rails/pull/51334
Related to https://github.com/rails/rails/issues/49671#issuecomment-1997955187

Recently Rails allowed `foreign_key:` option to accept an Array which represent a composite foreign key. This was done for a few reasons:
- `foreign_key:` option makes more semantical sense when it comes to working with a real composite primary/foreign key concept (not sharding)
- We have an intention to rework `query_constraints:` behavior and `foreign_key:` option should be a way for applications to preserve current behavior.

Unfortunately currently setting `foreign_key:` is not exactly the same as setting `query_constraints` due to a few places where presence of `foreign_key:` option changes the behavior of a reflection. Specifically `inverse_of:` can't be automatically derived if `foreign_key` option is present. The `foreign_key` impact on `inverse_of` is a separate discussion but for know we can't allow this difference so to make `foreign_key: [:a, :b]` to behave exactly like `query_constraints: [:a, :b]` we will turn `foreign_key` option into `query_constraints` option on initialization, if it's an Array