### PR TITLE
Make local rails available to devcontainer generated with `--dev`

### DIFF
--- a/railties/lib/rails/generators/devcontainer.rb
+++ b/railties/lib/rails/generators/devcontainer.rb
@@ -39,6 +39,16 @@ module Rails
           @devcontainer_volumes
         end
 
+        def devcontainer_mounts
+          return @devcontainer_mounts if @devcontainer_mounts
+
+          @devcontainer_mounts = []
+
+          @devcontainer_mounts << local_rails_mount if options.dev?
+
+          @devcontainer_mounts
+        end
+
         def devcontainer_needs_redis?
           !(options.skip_action_cable? && options.skip_active_job?)
         end
@@ -126,6 +136,14 @@ module Rails
 
         def db_service_names
           ["mysql", "mariadb", "postgres"]
+        end
+
+        def local_rails_mount
+          {
+            type: "bind",
+            source: Rails::Generators::RAILS_DEV_PATH,
+            target: Rails::Generators::RAILS_DEV_PATH
+          }
         end
     end
   end

--- a/railties/lib/rails/generators/rails/app/templates/.devcontainer/devcontainer.json.tt
+++ b/railties/lib/rails/generators/rails/app/templates/.devcontainer/devcontainer.json.tt
@@ -29,6 +29,12 @@
   // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
   // "remoteUser": "root",
 
+<%- if !devcontainer_mounts.empty? -%>
+  "mounts": [
+    <%= devcontainer_mounts.map { |mount| "{\n      " + mount.map { |key, value| "\"#{key}\": \"#{value}\"" }.join(",\n      ") + "\n    }" }.join(",\n    ") %>
+  ],
+<%- end -%>
+
   // Use 'postCreateCommand' to run commands after the container is created.
   "postCreateCommand": "bin/setup"
 }

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -1415,6 +1415,18 @@ class AppGeneratorTest < Rails::Generators::TestCase
     end
   end
 
+  def test_devcontainer_dev_flag_mounts_local_rails_repo
+    run_generator_using_prerelease [ destination_root, "--dev" ]
+
+    assert_devcontainer_json_file do |devcontainer_config|
+      rails_mount = devcontainer_config["mounts"].sole
+
+      assert_equal "bind", rails_mount["type"]
+      assert_equal Rails::Generators::RAILS_DEV_PATH, rails_mount["source"]
+      assert_equal Rails::Generators::RAILS_DEV_PATH, rails_mount["target"]
+    end
+  end
+
   def test_skip_devcontainer
     run_generator [ destination_root, "--skip-devcontainer" ]
 

--- a/railties/test/generators/generators_test_helper.rb
+++ b/railties/test/generators/generators_test_helper.rb
@@ -122,6 +122,12 @@ module GeneratorsTestHelper
     end
   end
 
+  def assert_devcontainer_json_file
+    assert_file ".devcontainer/devcontainer.json" do |content|
+      yield JSON.load(content)
+    end
+  end
+
   private
     def gemfile_locals
       {


### PR DESCRIPTION
### Motivation / Background

When generating a rails app with the `--dev` flag, the generated devcontainer is unusable because it does not have access to the local rails install and so the app cannot be bundled. This is annoying when testing changes locally, and more importantly it is blocking us from creating a CI workflow to test the devcontainer generation.

### Detail

This Pull Request updates the devcontainer setup to mount the local rails install in the devcontainer when generating an app with the `--dev` flag.

I chose to target the mount to the same path as it is on the filesystem. I think it's unconventional to do that, but afaik it shouldn't cause any issues. If we targeted it to a different path, then we would need to update the gemfile to be aware of the path to find rails in the devcontainer, which I do not want to do.

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
