### PR TITLE
[ci skip] Fix Typo in Guides for Redis Adapter on Action Cable Overview Page

### DIFF
--- a/guides/source/action_cable_overview.md
+++ b/guides/source/action_cable_overview.md
@@ -760,7 +760,7 @@ The Redis adapter also supports SSL/TLS connections. The required SSL/TLS parame
 ```yaml
 production:
   adapter: redis
-  url: rediss://10.10.3.153:tls_port
+  url: redis://10.10.3.153:tls_port
   channel_prefix: appname_production
   ssl_params:
     ca_file: "/path/to/ca.crt"


### PR DESCRIPTION
### Motivation / Background

~Fixes a typo in the guides for the [Redis Adapter](https://guides.rubyonrails.org/action_cable_overview.html#redis-adapter) url on the Action Cable Overview page.~

Update: This is expected, because `rediss` is the scheme for Redis Standalone SSL.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why.
* [x] N/A – Tests are added or updated if you fix a bug or add a feature.
* [X] N/A – CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
