### PR TITLE
Restore `to:` option in routes with an implicit controller

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,15 @@
+*   Fix a regression in 7.1.3 passing a `to:` option without a controller when the controller is already defined by a scope.
+
+    ```ruby
+    Rails.application.routes.draw do
+      controller :home do
+        get "recent", to: "recent_posts"
+      end
+    end
+    ```
+
+    *Étienne Barrié*
+
 *   Request Forgery takes relative paths into account.
 
     *Stefan Wienert*

--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -231,12 +231,17 @@ module ActionDispatch
               if to.nil?
                 controller = default_controller
                 action = default_action
-              elsif to.is_a?(String) && to.include?("#")
-                to_endpoint = to.split("#").map!(&:-@)
-                controller  = to_endpoint[0]
-                action      = to_endpoint[1]
+              elsif to.is_a?(String)
+                if to.include?("#")
+                  to_endpoint = to.split("#").map!(&:-@)
+                  controller  = to_endpoint[0]
+                  action      = to_endpoint[1]
+                else
+                  controller = default_controller
+                  action = to
+                end
               else
-                raise ArgumentError, ":to must respond to `action` or `call`, or it must be a String that includes '#'"
+                raise ArgumentError, ":to must respond to `action` or `call`, or it must be a String that includes '#', or the controller should be implicit"
               end
 
               controller = add_controller_module(controller, modyoule)

--- a/actionpack/test/dispatch/routing_test.rb
+++ b/actionpack/test/dispatch/routing_test.rb
@@ -4037,6 +4037,7 @@ class TestNamespaceWithControllerOption < ActionDispatch::IntegrationTest
     routes = ActionDispatch::Routing::RouteSet.new
     routes.draw(&block)
     @app = self.class.build_app routes
+    @routes = routes
   end
 
   def test_missing_controller
@@ -4054,7 +4055,16 @@ class TestNamespaceWithControllerOption < ActionDispatch::IntegrationTest
         get "/foo/bar", to: "foo"
       end
     }
-    assert_match(/:to must respond to/, ex.message)
+    assert_match(/Missing :controller/, ex.message)
+  end
+
+  def test_implicit_controller_with_to
+    draw do
+      controller :foo do
+        get "/foo/bar", to: "bar"
+      end
+    end
+    assert_routing "/foo/bar", controller: "foo", action: "bar"
   end
 
   def test_to_is_a_symbol
@@ -4066,7 +4076,7 @@ class TestNamespaceWithControllerOption < ActionDispatch::IntegrationTest
     assert_match(/:to must respond to/, ex.message)
   end
 
-  def test_missing_action_on_hash
+  def test_missing_action_with_to
     ex = assert_raises(ArgumentError) {
       draw do
         get "/foo/bar", to: "foo#"


### PR DESCRIPTION
Ref https://github.com/rails/rails/issues/50465

In https://github.com/rails/rails/pull/50466, routes that use the `to:` option without providing a controller (e.g. `to: "action"`) started to raise an ArgumentError. Before that it was possible to use the `to:` option without a controller as long as it was nested within a `controller`, `resource` or `resources` scope.

This broke one of our apps between 7.1.2 and 7.1.3, here's a repro script:

```ruby
# frozen_string_literal: true

require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"

  gem "rails", ARGV.first || "7.1.3"
end

require "action_controller/railtie"
require "minitest/autorun"

class FoosController < ActionController::Base
end

class BugTest < ActionController::TestCase
  def test_routing
    with_routing do |routes|
      routes.draw do
        resources :foos, only: [] do
          get "bar", to: "bar"
        end
      end

      assert_routing "/foos/1/bar", controller: "foos", action: "bar", foo_id: "1"
    end
  end
end
```

This fails using 7.1.3 and passes using 7.1.2:

```console
$ ruby route-implicit-controller.rb |tail -1
1 runs, 0 assertions, 0 failures, 1 errors, 0 skips
$ ruby route-implicit-controller.rb 7.1.2 |tail -1                                                                                                                                                                                 
1 runs, 3 assertions, 0 failures, 0 errors, 0 skips
```

This PR fixes this and also allows passing a Symbol in those cases (e.g. `to: :action`).

The `:to` option for routes can once again be a Symbol or a String without a controller if the controller is implicitly provided by a nesting `controller` or `resources` call.

With these changes, the documentation changes from https://github.com/rails/rails/pull/50523 would not have been necessary, though it's fine to keep the documentation as it is now.

cc @skipkayhil @p8 
