### PR TITLE
Remove example filepaths from code blocks in guides

### DIFF
--- a/guides/rails_guides/markdown/renderer.rb
+++ b/guides/rails_guides/markdown/renderer.rb
@@ -8,6 +8,10 @@ Rouge::Lexers::Shell::BUILTINS << "|bin/rails|brew|bundle|gem|git|node|rails|rak
 module RailsGuides
   class Markdown
     class Renderer < Redcarpet::Render::HTML  # :nodoc:
+      APPLICATION_FILEPATH_REGEXP = /(app|config|db|lib|test)\//
+      ERB_FILEPATH_REGEXP = /^<%# #{APPLICATION_FILEPATH_REGEXP}.* %>/o
+      RUBY_FILEPATH_REGEXP = /^# #{APPLICATION_FILEPATH_REGEXP}/o
+
       cattr_accessor :edge, :version
 
       def block_code(code, language)
@@ -78,6 +82,7 @@ module RailsGuides
         end
 
         def clipboard_content(code, language)
+          # Remove prompt and results of commands.
           prompt_regexp =
             case language
             when "bash"
@@ -88,6 +93,19 @@ module RailsGuides
 
           if prompt_regexp
             code = code.lines.grep(prompt_regexp).join.gsub(prompt_regexp, "")
+          end
+
+          # Remove comments that reference an application file.
+          filepath_regexp =
+            case language
+            when "erb", "html+erb"
+              ERB_FILEPATH_REGEXP
+            when "ruby", "yaml", "yml"
+              RUBY_FILEPATH_REGEXP
+            end
+
+          if filepath_regexp
+            code = code.lines.grep_v(filepath_regexp).join
           end
 
           ERB::Util.html_escape(code)


### PR DESCRIPTION
Some code examples use commented out paths for the path where the code should be written to. These paths can be ignored in the clipboard when using the "copy" button.

cc @carlosantoniodasilva 

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
