### PR TITLE
Fix fourth column issue in guides dropdown

### DIFF
--- a/guides/assets/stylesrc/_main.scss
+++ b/guides/assets/stylesrc/_main.scss
@@ -596,7 +596,7 @@ body.guide {
     display: block;
     border-radius: $base-border-radius;
     color: $gray-900;
-    height: 58em;
+    height: 61em;
     padding: 2em 2em 1.5em 2em;
     position: absolute;
       top: 25px;
@@ -616,7 +616,7 @@ body.guide {
       display: flex;
       flex-direction: column;
       flex-wrap: wrap;
-      max-height: 53em;
+      max-height: 60em;
       width: 100%;
 
       .guides-section {


### PR DESCRIPTION

<img width="831" alt="Screenshot 2024-04-09 at 2 42 17 PM" src="https://github.com/rails/rails/assets/2223/c8af682f-a675-40d5-a284-fcd411cdac5c">
<img width="1049" alt="Screenshot 2024-04-09 at 2 44 17 PM" src="https://github.com/rails/rails/assets/2223/0a8c3302-0046-4486-aeb4-f1059c283617">

### Motivation / Background

Due to additional pages being added to the guides, and the hard fix on height to create the columns with flex box, this began to break. Expanded that container height to 60em from 53em. If a large number of new pages are added to the guides, we will need to evaluate how to better show this area on smaller screens. 

Fixes the bug reported in Discussion #51530 

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
