### PR TITLE
Move "Advanced Active Record" guides to separate section [ci-skip]

### DIFF
--- a/guides/source/documents.yaml
+++ b/guides/source/documents.yaml
@@ -235,6 +235,10 @@
       name: Using Rails for API-only Applications
       url: api_app.html
       description: This guide explains how to effectively use Rails to develop a JSON API application.
+
+-
+  name: Advanced Active Record
+  documents:
     -
       name: Active Record and PostgreSQL
       work_in_progress: true


### PR DESCRIPTION
The "Digging Deeper" section is currently very large. We can move the advanced Active Record guides to their own section.
This also includes the WIP "AR encryption" and "AR Postgres" guides.

<img width="1110" alt="image" src="https://github.com/rails/rails/assets/28561/9bd7fe45-66f8-42c4-8eeb-bb1ade9e8e0c">

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
