### PR TITLE
Changing background color of scrollbar to not be red

### DIFF
--- a/guides/assets/stylesrc/_main.scss
+++ b/guides/assets/stylesrc/_main.scss
@@ -1,7 +1,7 @@
 body.guide {
   &::-webkit-scrollbar {
     width: 12px;
-    background-color: transparent;
+    background-color: $gray-100;
   }
   
   &::-webkit-scrollbar-track {


### PR DESCRIPTION

![redbar](https://github.com/rails/rails/assets/2223/b91f9ce6-ceae-40c2-94e1-a28dc0a6fdce)
<img width="190" alt="Screenshot 2024-04-09 at 8 03 24 PM" src="https://github.com/rails/rails/assets/2223/fcf224a0-d73a-4ec4-be0d-0668ecce1836">

### Motivation / Background

Page scrollbar in light mode in safari had a red background. Explicitly defined it as the $gray-100. This only affected Safari/Webkit browsers. 

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
