### PR TITLE
Address `Rails::Command::HelpIntegrationTest` failure against ruby 3.4.0dev

### DIFF
--- a/railties/test/command/help_integration_test.rb
+++ b/railties/test/command/help_integration_test.rb
@@ -34,7 +34,7 @@ class Rails::Command::HelpIntegrationTest < ActiveSupport::TestCase
     help = rails "dev:help"
     output = rails "dev", allow_failure: true
 
-    assert_equal help, output
+    assert_match help, output
   end
 
   test "prints Rake tasks on --tasks / -T option" do


### PR DESCRIPTION
### Motivation / Background

This commit addresses Rails Nightly CI failure at https://buildkite.com/rails/rails-nightly/builds/391#018ec54f-a2ef-40de-9749-6cc3ecae4ebd/1368-1376

### Detail

```ruby
$ ruby -v
ruby 3.4.0dev (2024-04-09T16:29:01Z master 0107954f25) [x86_64-linux]
$ bin/test test/command/help_integration_test.rb:33
Run options: --seed 3363

F

Failure:
Rails::Command::HelpIntegrationTest#test_prints_help_via_`X:help`_command_when_running_`X`_and_`X:X`_command_is_not_defined [test/command/help_integration_test.rb:37]:
--- expected
+++ actual
@@ -1,4 +1,5 @@
-"Commands:
+"/home/yahonda/.rbenv/versions/trunk/lib/ruby/gems/3.4.0+0/gems/zeitwerk-2.6.13/lib/zeitwerk/kernel.rb:34: warning: ostruct was loaded from the standard library, but will no longer be part of the default gems since Ruby 3.5.0. Add ostruct to your Gemfile or gemspec.
+Commands:
   bin/rails dev:cache           # Toggle development mode caching on/off
   bin/rails dev:help [COMMAND]  # Describe available commands or one specific...

bin/test test/command/help_integration_test.rb:33

Finished in 0.738986s, 1.3532 runs/s, 1.3532 assertions/s.
1 runs, 1 assertions, 1 failures, 0 errors, 0 skips
$
```

### Additional information
This commit can be reverted once both rack and jbuilder take care of it.

Related to
https://github.com/rack/rack/pull/2166
https://github.com/rails/jbuilder/issues/561

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.

