### PR TITLE
[ci skip] Fix documented version for `multiple_file_field_include_hidden`

### DIFF
--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -3080,7 +3080,7 @@ The default value depends on the `config.load_defaults` target version:
 
 #### `config.active_storage.multiple_file_field_include_hidden`
 
-In Rails 7.0 and beyond, Active Storage `has_many_attached` relationships will
+Since Rails 6.0, Active Storage `has_many_attached` relationships
 default to _replacing_ the current collection instead of _appending_ to it. Thus
 to support submitting an _empty_ collection, when `multiple_file_field_include_hidden`
 is `true`, the [`file_field`](https://api.rubyonrails.org/classes/ActionView/Helpers/FormBuilder.html#method-i-file_field)

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -3080,7 +3080,7 @@ The default value depends on the `config.load_defaults` target version:
 
 #### `config.active_storage.multiple_file_field_include_hidden`
 
-In Rails 7.1 and beyond, Active Storage `has_many_attached` relationships will
+In Rails 7.0 and beyond, Active Storage `has_many_attached` relationships will
 default to _replacing_ the current collection instead of _appending_ to it. Thus
 to support submitting an _empty_ collection, when `multiple_file_field_include_hidden`
 is `true`, the [`file_field`](https://api.rubyonrails.org/classes/ActionView/Helpers/FormBuilder.html#method-i-file_field)


### PR DESCRIPTION
Rails 6.0 upgrade mentioned that behaviour will change in 7.1 (see https://guides.rubyonrails.org/upgrading_ruby_on_rails.html#active-storage-assignment-behavior-change). But it at least formally did not, see https://guides.rubyonrails.org/7_1_release_notes.html#active-storage-removals

