### PR TITLE
Fix framework defaults template for v7.0

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_7_0.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_7_0.rb.tt
@@ -140,4 +140,4 @@
 # ** Please read carefully, this must be configured in config/application.rb (NOT this file) **
 # Disables the deprecated #to_s override in some Ruby core classes
 # See https://guides.rubyonrails.org/configuring.html#config-active-support-disable-to-s-conversion for more information.
-# config.active_support.disable_to_s_conversion = true
+# Rails.application.config.active_support.disable_to_s_conversion = true


### PR DESCRIPTION
Uncommenting the last option (`disable_to_s_conversion`) resulted in an error before this change.

```
FrozenError: can't modify frozen Array
```