### PR TITLE
Remove misleading comment related to lazily_load_schema_cache and use_schema_cache_dump

### DIFF
--- a/activerecord/lib/active_record.rb
+++ b/activerecord/lib/active_record.rb
@@ -184,8 +184,7 @@ module ActiveRecord
   ##
   # :singleton-method: lazily_load_schema_cache
   # Lazily load the schema cache. This option will load the schema cache
-  # when a connection is established rather than on boot. If set,
-  # +config.active_record.use_schema_cache_dump+ will be set to false.
+  # when a connection is established rather than on boot.
   singleton_class.attr_accessor :lazily_load_schema_cache
   self.lazily_load_schema_cache = false
 


### PR DESCRIPTION
This PR removed a now misleading comment that if `lazily_load_schema_cache` is set then `use_schema_cache_dump` will be set to false. In fact, with `lazily_load_schema_cache = true` and `use_schema_cache_dump` explcitly disabled , after https://github.com/rails/rails/pull/48716 lazy loading of cache from schema cache dump does not happen.
