### PR TITLE
Add #unchanged? and #pristine? as opposite of #changed?

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Add a `ActiveModel::Dirty#unchanged?` method that returns wether none of the
+    attributes have changes. Also available as `ActiveModel::Dirty#pristine?`.
+
+    *Dennis Paagman*
+
 *   Fix a bug where type casting of string to `Time` and `DateTime` doesn't
     calculate minus minute value in TZ offset correctly.
 

--- a/activemodel/lib/active_model/dirty.rb
+++ b/activemodel/lib/active_model/dirty.rb
@@ -280,6 +280,16 @@ module ActiveModel
       mutations_from_database.any_changes?
     end
 
+    # Returns +true+ if none of the attributes have unsaved changes, +false+ otherwise.
+    #
+    #   person.unchanged? # => true
+    #   person.name = 'bob'
+    #   person.unchanged? # => false
+    def unchanged?
+      !changed?
+    end
+    alias_method :pristine?, :unchanged?
+
     # Returns an array with the name of the attributes with unsaved changes.
     #
     #   person.changed # => []

--- a/activemodel/test/cases/dirty_test.rb
+++ b/activemodel/test/cases/dirty_test.rb
@@ -47,9 +47,13 @@ class DirtyTest < ActiveModel::TestCase
   end
 
   test "setting attribute will result in change" do
+    assert_predicate @model, :unchanged?
+    assert_predicate @model, :pristine?
     assert_not_predicate @model, :changed?
     assert_not_predicate @model, :name_changed?
     @model.name = "Ringo"
+    assert_not_predicate @model, :unchanged?
+    assert_not_predicate @model, :pristine?
     assert_predicate @model, :changed?
     assert_predicate @model, :name_changed?
   end


### PR DESCRIPTION
### Motivation / Background

My use case is to return a different response in my controller when the user submits the same data as we already have in the database. Basically:

```ruby
# ...

@model.assign_attributes(params)

if !@model.changed? # or `unless @model.changed?`
  redirect_to ...
end

# ...
```

This Pull Request has been created because I feel like the code would read just be a little bit nicer if I can use a regular (non negated) if statement, ergo the introduction of `unchanged?` 🪄

### Additional information

I've also added `pristine?` as an aliased method, I think that method name is nice and has the exact meaning of what the method does:

> **pristine | ˈprɪstiːn |**
adjective
in its original condition; unspoilt: pristine copies of an early magazine.
• clean and fresh as if new; spotless: a pristine white shirt.

 but maybe less 'findable' or recognizable for most people. I'm of course happy to pick one or the other :)

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
