### PR TITLE
Respond with 406 when a browser is blocked by allow_browser

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 *   Add `allow_browser` to set minimum browser versions for the application.
 
-    A browser that's blocked will by default be served the file in `public/426.html` with a HTTP status code of "426 Upgrade Required".
+    A browser that's blocked will by default be served the file in `public/406-unsupported-browser.html` with a HTTP status code of "406 Not Acceptable".
 
     ```ruby
     class ApplicationController < ActionController::Base

--- a/actionpack/lib/action_controller/metal/allow_browser.rb
+++ b/actionpack/lib/action_controller/metal/allow_browser.rb
@@ -13,8 +13,9 @@ module ActionController # :nodoc:
       # versions specified. This means that all other browsers, as well as agents that
       # aren't reporting a user-agent header, will be allowed access.
       #
-      # A browser that's blocked will by default be served the file in public/426.html
-      # with a HTTP status code of "426 Upgrade Required".
+      # A browser that's blocked will by default be served the file in
+      # public/406-unsupported-browser.html with a HTTP status code of "406 Not
+      # Acceptable".
       #
       # In addition to specifically named browser versions, you can also pass
       # `:modern` as the set to restrict support to browsers natively supporting webp
@@ -43,7 +44,7 @@ module ActionController # :nodoc:
       #       # In addition to the browsers blocked by ApplicationController, also block Opera below 104 and Chrome below 119 for the show action.
       #       allow_browser versions: { opera: 104, chrome: 119 }, only: :show
       #     end
-      def allow_browser(versions:, block: -> { render file: Rails.root.join("public/426.html"), layout: false, status: :upgrade_required }, **options)
+      def allow_browser(versions:, block: -> { render file: Rails.root.join("public/406-unsupported-browser.html"), layout: false, status: :not_acceptable }, **options)
         before_action -> { allow_browser(versions: versions, block: block) }, **options
       end
     end

--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -495,8 +495,8 @@ module Rails
       def delete_public_files_if_api_option
         if options[:api]
           remove_file "public/404.html"
+          remove_file "public/406-unsupported-browser.html"
           remove_file "public/422.html"
-          remove_file "public/426.html"
           remove_file "public/500.html"
           remove_file "public/icon.png"
           remove_file "public/icon.svg"

--- a/railties/lib/rails/generators/rails/app/templates/public/406-unsupported-browser.html
+++ b/railties/lib/rails/generators/rails/app/templates/public/406-unsupported-browser.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <title>Your browser is not supported (426)</title>
+  <title>Your browser is not supported (406)</title>
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <style>
   .rails-default-error-page {
@@ -55,7 +55,7 @@
 </head>
 
 <body class="rails-default-error-page">
-  <!-- This file lives in public/426.html -->
+  <!-- This file lives in public/406-unsupported-browser.html -->
   <div class="dialog">
     <div>
       <h1>Your browser is not supported.</h1>

--- a/railties/test/generators/api_app_generator_test.rb
+++ b/railties/test/generators/api_app_generator_test.rb
@@ -191,7 +191,7 @@ class ApiAppGeneratorTest < Rails::Generators::TestCase
          test/helpers
          public/404.html
          public/422.html
-         public/426.html
+         public/406-unsupported-browser.html
          public/500.html
          public/icon.png
          public/icon.svg

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -69,8 +69,8 @@ DEFAULT_APP_FILES = %w(
   lib/tasks/.keep
   log/.keep
   public/404.html
+  public/406-unsupported-browser.html
   public/422.html
-  public/426.html
   public/500.html
   public/icon.png
   public/icon.svg

--- a/railties/test/generators/plugin_generator_test.rb
+++ b/railties/test/generators/plugin_generator_test.rb
@@ -61,8 +61,8 @@ DEFAULT_PLUGIN_FILES = %w(
   test/dummy/lib/assets/.keep
   test/dummy/log/.keep
   test/dummy/public/404.html
+  test/dummy/public/406-unsupported-browser.html
   test/dummy/public/422.html
-  test/dummy/public/426.html
   test/dummy/public/500.html
   test/dummy/public/icon.png
   test/dummy/public/icon.svg


### PR DESCRIPTION
Ref https://github.com/rails/rails/pull/50505

RFC 9110 specifies:

	The server MUST send an Upgrade header field in a 426 response
	to indicate the required protocol(s)

https://httpwg.org/specs/rfc9110.html#status.426

Status 406 Not Acceptable is more appropriate because it indicates the resource

	does not have a current representation that would be acceptable
	to the user agent, according to the proactive negotiation header
	fields received in the request

https://httpwg.org/specs/rfc9110.html#status.406

With the proactive negociation section mentionining:

	implicit characteristics, such as the client's network address
	or parts of the User-Agent field.

https://httpwg.org/specs/rfc9110.html#proactive.negotiation
