### PR TITLE
Declare Rails::Railtie::ABSTRACT_RAILTIES as frozen (for using in Ractor)

### DIFF
--- a/railties/lib/rails/railtie.rb
+++ b/railties/lib/rails/railtie.rb
@@ -139,7 +139,7 @@ module Rails
     extend ActiveSupport::DescendantsTracker
     include Initializable
 
-    ABSTRACT_RAILTIES = %w(Rails::Railtie Rails::Engine Rails::Application)
+    ABSTRACT_RAILTIES = %w(Rails::Railtie Rails::Engine Rails::Application).freeze
 
     class << self
       private :new


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because Railtie could not be load in Ractor (Ractor::IsolationError occured). See #51543 

### Additional information

I did not append new tests because Ractor cannot be used in Rails yet. But this change appear as very safe. Existing tests are passed.

### Checklist

Before submitting the PR make sure the following are checked:

[ * ] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
[ * ] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
[   ] Tests are added or updated if you fix a bug or add a feature.
[   ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
