### PR TITLE
Fixes/union select parentheses

### DIFF
--- a/activerecord/lib/arel/visitors/postgresql.rb
+++ b/activerecord/lib/arel/visitors/postgresql.rb
@@ -63,7 +63,7 @@ module Arel # :nodoc: all
 
         def visit_Arel_Nodes_Lateral(o, collector)
           collector << "LATERAL "
-          grouping_parentheses o, collector
+          grouping_parentheses o.expr, collector
         end
 
         def visit_Arel_Nodes_IsNotDistinctFrom(o, collector)
@@ -82,17 +82,6 @@ module Arel # :nodoc: all
         private_constant :BIND_BLOCK
 
         def bind_block; BIND_BLOCK; end
-
-        # Used by Lateral visitor to enclose select queries in parentheses
-        def grouping_parentheses(o, collector)
-          if o.expr.is_a? Nodes::SelectStatement
-            collector << "("
-            visit o.expr, collector
-            collector << ")"
-          else
-            visit o.expr, collector
-          end
-        end
 
         # Utilized by GroupingSet, Cube & RollUp visitors to
         # handle grouping aggregation semantics

--- a/activerecord/lib/arel/visitors/to_sql.rb
+++ b/activerecord/lib/arel/visitors/to_sql.rb
@@ -965,16 +965,28 @@ module Arel # :nodoc: all
           collector = if o.left.class == o.class
             infix_value_with_paren(o.left, collector, value, true)
           else
-            visit o.left, collector
+            grouping_parentheses o.left, collector
           end
           collector << value
           collector = if o.right.class == o.class
             infix_value_with_paren(o.right, collector, value, true)
           else
-            visit o.right, collector
+            grouping_parentheses o.right, collector
           end
           collector << " )" unless suppress_parens
           collector
+        end
+
+        # Used by some visitors to enclose select queries in parentheses
+        def grouping_parentheses(o, collector)
+          if o.is_a?(Nodes::SelectStatement)
+            collector << "("
+            visit o, collector
+            collector << ")"
+            collector
+          else
+            visit o, collector
+          end
         end
 
         def aggregate(name, o, collector)

--- a/activerecord/test/cases/arel/attributes/attribute_test.rb
+++ b/activerecord/test/cases/arel/attributes/attribute_test.rb
@@ -963,7 +963,7 @@ module Arel
           union = mgr1.union(mgr2)
           node = relation[:id].in(union)
           _(node.to_sql).must_be_like %{
-            "users"."id" IN (( SELECT "users"."id" FROM "users" UNION SELECT "users"."id" FROM "users" ))
+            "users"."id" IN (( (SELECT "users"."id" FROM "users") UNION (SELECT "users"."id" FROM "users") ))
           }
         end
 

--- a/activerecord/test/cases/arel/select_manager_test.rb
+++ b/activerecord/test/cases/arel/select_manager_test.rb
@@ -253,7 +253,7 @@ module Arel
 
         # maybe FIXME: decide when wrapper parens are needed
         _(node.to_sql).must_be_like %{
-          ( SELECT * FROM "users"  WHERE "users"."age" < 18 UNION SELECT * FROM "users"  WHERE "users"."age" > 99 )
+          ( (SELECT * FROM "users"  WHERE "users"."age" < 18) UNION (SELECT * FROM "users"  WHERE "users"."age" > 99) )
         }
       end
 
@@ -261,7 +261,7 @@ module Arel
         node = @m1.union :all, @m2
 
         _(node.to_sql).must_be_like %{
-          ( SELECT * FROM "users"  WHERE "users"."age" < 18 UNION ALL SELECT * FROM "users"  WHERE "users"."age" > 99 )
+          ( (SELECT * FROM "users"  WHERE "users"."age" < 18) UNION ALL (SELECT * FROM "users"  WHERE "users"."age" > 99) )
         }
       end
     end
@@ -354,9 +354,9 @@ module Arel
         sql = manager.to_sql
         _(sql).must_be_like %{
           WITH RECURSIVE "replies" AS (
-              SELECT "comments"."id", "comments"."parent_id" FROM "comments" WHERE "comments"."id" = 42
+              (SELECT "comments"."id", "comments"."parent_id" FROM "comments" WHERE "comments"."id" = 42)
             UNION
-              SELECT "comments"."id", "comments"."parent_id" FROM "comments" INNER JOIN "replies" ON "comments"."parent_id" = "replies"."id"
+              (SELECT "comments"."id", "comments"."parent_id" FROM "comments" INNER JOIN "replies" ON "comments"."parent_id" = "replies"."id")
           )
           SELECT * FROM "replies"
         }

--- a/activerecord/test/cases/arel/visitors/to_sql_test.rb
+++ b/activerecord/test/cases/arel/visitors/to_sql_test.rb
@@ -635,6 +635,14 @@ module Arel
           node = Nodes::Union.new Arel.sql("topleft"), subnode
           assert_equal("( topleft UNION left UNION right )", compile(node))
         end
+
+        it "encloses SELECT statements with parentheses" do
+          table = Table.new(:users)
+          left = table.where(table[:name].eq(0)).take(1).ast
+          right = table.where(table[:name].eq(1)).take(1).ast
+          node = Nodes::Union.new left, right
+          assert_match(/LIMIT 1\) UNION \(/, compile(node))
+        end
       end
 
       describe "Nodes::UnionAll" do
@@ -645,6 +653,14 @@ module Arel
           subnode = Nodes::UnionAll.new Arel.sql("left"), Arel.sql("right")
           node = Nodes::UnionAll.new Arel.sql("topleft"), subnode
           assert_equal("( topleft UNION ALL left UNION ALL right )", compile(node))
+        end
+
+        it "encloses SELECT statements with parentheses" do
+          table = Table.new(:users)
+          left = table.where(table[:name].eq(0)).take(1).ast
+          right = table.where(table[:name].eq(1)).take(1).ast
+          node = Nodes::UnionAll.new left, right
+          assert_match(/LIMIT 1\) UNION ALL \(/, compile(node))
         end
       end
 


### PR DESCRIPTION
### Motivation / Background

When building `UNION` or `UNION ALL` queries involving `LIMIT` or `ORDER BY`, Arel generates invalid SQL, as described in https://github.com/rails/rails/issues/40181

I do not think it is currently possible to build such a query without using Arel directly, but we are interested in building recursive CTEs that involve `LIMIT` (see https://github.com/mastodon/mastodon/pull/29889 for more context), and one of the stumbling blocks has been Arel generating invalid SQL.

### Detail

This pull request changes `Arel::Visitors::ToSql` so so that `SELECT` statements in `Union` and `UnionAll` nodes get enclosed in parentheses to avoid syntax errors.

To do this, the existing `Arel::Visitors::PostgreSQL#grouping_parentheses` is generalized and moved to `Arel::Visitors::ToSql`, where it is now used by `infix_value_with_paren`.

### Additional information

I am not very knowledgeable about ActiveRecord's internals and all the backends it supports, but I am fairly confident in this solution.

I had to update some of the tests because of the precise assumptions they made on the resulting SQL.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
