### PR TITLE
Allow string keys for SQLCommenter

### DIFF
--- a/activerecord/lib/active_record/query_logs_formatter.rb
+++ b/activerecord/lib/active_record/query_logs_formatter.rb
@@ -28,7 +28,7 @@ module ActiveRecord
       end
 
       def format(pairs)
-        pairs.sort_by!(&:first)
+        pairs.sort_by! { |pair| pair.first.to_s }
         super
       end
 

--- a/activerecord/test/cases/query_logs_test.rb
+++ b/activerecord/test/cases/query_logs_test.rb
@@ -229,6 +229,23 @@ class QueryLogsTest < ActiveRecord::TestCase
     end
   end
 
+  def test_sqlcommenter_format_allows_string_keys
+    ActiveRecord::QueryLogs.update_formatter(:sqlcommenter)
+
+    ActiveRecord::QueryLogs.tags = [
+      :application,
+      {
+        "string" => "value",
+        tracestate: "congo=t61rcWkgMzE,rojo=00f067aa0ba902b7",
+        custom_proc: -> { "Joe's Shack" }
+      },
+    ]
+
+    assert_queries_match(%r{custom_proc='Joe%27s%20Shack',tracestate='congo%3Dt61rcWkgMzE%2Crojo%3D00f067aa0ba902b7',string='value'\*/}) do
+      Dashboard.first
+    end
+  end
+
   def test_sqlcommenter_format_value_string_coercible
     ActiveRecord::QueryLogs.update_formatter(:sqlcommenter)
 


### PR DESCRIPTION
### Motivation / Background

After https://github.com/rails/rails/pull/46326, the SQLCommenter formatter no longer allows for string keys. Eg.

```
config.active_record.query_log_tags = [
  {
    "my_custom_key" => "foobar"
  },
  {
    my_custom_symbol_key: "static value"
  }
]
```

### Checklist

Before submitting the PR make sure the following are checked:

* [ ] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [ ] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
