### PR TITLE
[Bugfix] Pass options along to write_entry in handle_expired_entry method

### DIFF
--- a/activesupport/lib/active_support/cache.rb
+++ b/activesupport/lib/active_support/cache.rb
@@ -1030,7 +1030,8 @@ module ActiveSupport
               # When an entry has a positive :race_condition_ttl defined, put the stale entry back into the cache
               # for a brief period while the entry is being recalculated.
               entry.expires_at = Time.now.to_f + race_ttl
-              write_entry(key, entry, expires_in: race_ttl * 2)
+              options[:expires_in] = race_ttl * 2
+              write_entry(key, entry, **options)
             else
               delete_entry(key, **options)
             end

--- a/activesupport/test/cache/behaviors/cache_store_coder_behavior.rb
+++ b/activesupport/test/cache/behaviors/cache_store_coder_behavior.rb
@@ -2,11 +2,12 @@
 
 module CacheStoreCoderBehavior
   class SpyCoder
-    attr_reader :dumped_entries, :loaded_entries
+    attr_reader :dumped_entries, :loaded_entries, :dump_compressed_entries
 
     def initialize
       @dumped_entries = []
       @loaded_entries = []
+      @dump_compressed_entries = []
     end
 
     def dump(entry)
@@ -18,6 +19,15 @@ module CacheStoreCoderBehavior
       entry = Marshal.load(payload)
       @loaded_entries << entry
       entry
+    end
+
+    def dump_compressed(entry, threshold)
+      if threshold == 0
+        @dump_compressed_entries << entry
+        Marshal.dump(entry)
+      else
+        dump(entry)
+      end
     end
   end
 
@@ -82,5 +92,29 @@ module CacheStoreCoderBehavior
     @store = lookup_store(coder: nil)
     entry = ActiveSupport::Cache::Entry.new("value")
     assert_same entry, @store.send(:serialize_entry, entry)
+  end
+
+  def test_coder_is_used_during_handle_expired_entry_when_expired
+    coder = SpyCoder.new
+    @store = lookup_store(coder: coder)
+    @store.write("foo", "bar", expires_in: 1.second)
+    assert_equal 0, coder.loaded_entries.size
+    assert_equal 1, coder.dumped_entries.size
+
+    travel_to(2.seconds.from_now) do
+      val = @store.fetch(
+          "foo",
+          race_condition_ttl: 5,
+          compress: true,
+          compress_threshold: 0
+        ) { "baz" }
+      assert_equal "baz", val
+      assert_equal 1, coder.loaded_entries.size # 1 read in fetch
+      assert_equal "bar", coder.loaded_entries.first.value
+      assert_equal 1, coder.dumped_entries.size # did not change from original write
+      assert_equal 2, coder.dump_compressed_entries.size # 1 write the expired entry handler, 1 in fetch
+      assert_equal "bar", coder.dump_compressed_entries.first.value
+      assert_equal "baz", coder.dump_compressed_entries.last.value
+    end
   end
 end


### PR DESCRIPTION
### Motivation / Background

We noticed when making our own cache store that options were not being passed correctly to writes in some cases. Upon further investigation the `handle_expired_entry` method calls `write_entry` during the `race_condition_ttl` period. However, this call to `write_entry` does not pass along the correct options meaning that in some cases (like the test case I provided with compression) does not correctly write the data.

### Detail

This Pull Request changes `handle_expired_entry` method to use options when writing the key back with a `race_condition_ttl`.

### Additional information

I am unsure of the implications of this for uses of this. It could be implicitly breaking as now options are used when they weren't being used before in this niche case.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
