### PR TITLE
Create a workflow for testing generated devcontainer setup

### DIFF
--- a/.github/workflows/devcontainer-smoke-test.yml
+++ b/.github/workflows/devcontainer-smoke-test.yml
@@ -1,0 +1,50 @@
+name: Devcontainer smoke test
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    name: Devcontainer smoke test
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        DATABASE:
+          - sqlite3
+          - postgresql
+          - mysql
+          - trilogy
+
+    steps:
+      - name: Checkout (GitHub)
+        uses: actions/checkout@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Ruby 3.3
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.3
+          bundler-cache: true
+
+      - name: Generate rails app
+        run: bundle exec railties/exe/rails new myapp --database="${{ matrix.DATABASE }}" --dev
+
+      - name: Test devcontainer
+        uses: devcontainers/ci@v0.3
+        with:
+          subFolder: myapp
+          imageName: ghcr.io/rails/smoke-test-devcontainer
+          cacheFrom: ghcr.io/rails/smoke-test-devcontainer
+          imageTag: ${{ matrix.DATABASE }}
+          refFilterForPush: refs/heads/main
+          runCmd: bin/rails g scaffold Post && bin/rails db:migrate && bin/rails test


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because we need a workflow to test the generated devcontainer setup for new rails apps to prevent regressions.

### Detail

This PR creates a workflow that:
- Generates a new rails app with the `--dev` flag
- Initializes the new app in a devcontainer
- Creates a scaffold
- Runs the tests

We run it for each db configuration supported by the devcontainer.

### Additional information

Uncached, the workflow seems to take about 3-4 mins to run. It is setup to prebuild and cache the devcontainer image when the workflow is run on main, so other runs can build their devcontainer using the cached layers, which will provide some speed ups especially for branches not touching the devcontainer.
### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
