### PR TITLE
Ensure devcontainer env variables are strings

### DIFF
--- a/railties/lib/rails/generators/devcontainer.rb
+++ b/railties/lib/rails/generators/devcontainer.rb
@@ -111,7 +111,7 @@ module Rails
               "image" => "mysql/mysql-server:8.0",
               "restart" => "unless-stopped",
               "environment" => {
-                "MYSQL_ALLOW_EMPTY_PASSWORD" => true,
+                "MYSQL_ALLOW_EMPTY_PASSWORD" => "true",
                 "MYSQL_ROOT_HOST" => "%"
               },
               "volumes" => ["mysql-data:/var/lib/mysql"],
@@ -128,7 +128,7 @@ module Rails
               "networks" => ["default"],
               "volumes" => ["mariadb-data:/var/lib/mysql"],
               "environment" => {
-                "MARIADB_ALLOW_EMPTY_ROOT_PASSWORD" => true,
+                "MARIADB_ALLOW_EMPTY_ROOT_PASSWORD" => "true",
               },
             }
           }

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -1338,7 +1338,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
         "image" => "mysql/mysql-server:8.0",
         "restart" => "unless-stopped",
         "environment" => {
-          "MYSQL_ALLOW_EMPTY_PASSWORD" => true,
+          "MYSQL_ALLOW_EMPTY_PASSWORD" => "true",
           "MYSQL_ROOT_HOST" => "%"
         },
         "volumes" => ["mysql-data:/var/lib/mysql"],
@@ -1370,7 +1370,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
         "networks" => ["default"],
         "volumes" => ["mariadb-data:/var/lib/mysql"],
         "environment" => {
-          "MARIADB_ALLOW_EMPTY_ROOT_PASSWORD" => true,
+          "MARIADB_ALLOW_EMPTY_ROOT_PASSWORD" => "true",
         },
       }
 

--- a/railties/test/generators/db_system_change_generator_test.rb
+++ b/railties/test/generators/db_system_change_generator_test.rb
@@ -104,7 +104,7 @@ module Rails
                 "image" => "mysql/mysql-server:8.0",
                 "restart" => "unless-stopped",
                 "environment" => {
-                  "MYSQL_ALLOW_EMPTY_PASSWORD" => true,
+                  "MYSQL_ALLOW_EMPTY_PASSWORD" => "true",
                   "MYSQL_ROOT_HOST" => "%"
                 },
                 "volumes" => ["mysql-data:/var/lib/mysql"],
@@ -171,7 +171,7 @@ module Rails
                 "networks" => ["default"],
                 "volumes" => ["mariadb-data:/var/lib/mysql"],
                 "environment" => {
-                  "MARIADB_ALLOW_EMPTY_ROOT_PASSWORD" => true,
+                  "MARIADB_ALLOW_EMPTY_ROOT_PASSWORD" => "true",
                 },
               }
 


### PR DESCRIPTION
### Motivation / Background

For the mysql and mariadb devcontainer setup, the `ALLOW_EMPTY_PASSWORD` flag needs to be set with a string not a boolean. 

I noticed this issue when [testing the GH workflow](https://github.com/Shopify/rails/actions/runs/8664018371/job/23759454963). It seems that using VSCode to initialize the devcontainer is coercing or somehow handling the boolean value, but it is causing an issue for the devcontainer cli (which is used on that ci step).

### Detail

We can simply use the string `"true"` instead of `true`.

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
