### PR TITLE
Fix typo in Feature Policy for idle-detection

### DIFF
--- a/actionpack/lib/action_dispatch/http/permissions_policy.rb
+++ b/actionpack/lib/action_dispatch/http/permissions_policy.rb
@@ -98,7 +98,7 @@ module ActionDispatch # :nodoc:
       geolocation:          "geolocation",
       gyroscope:            "gyroscope",
       hid:                  "hid",
-      idle_detection:       "idle_detection",
+      idle_detection:       "idle-detection",
       magnetometer:         "magnetometer",
       microphone:           "microphone",
       midi:                 "midi",


### PR DESCRIPTION
As listed in [MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Permissions-Policy/idle-detection), the policy is spelled as `idle-detection`, and not as `idle_detection`. Hence, browsers were unable to process the policy correctly, effectively ignoring it.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
