### PR TITLE
Fix SQL query example in `ActiveRecord::Base#ids` docs [skip ci]

### DIFF
--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -363,7 +363,7 @@ module ActiveRecord
     # Returns the base model's ID's for the relation using the table's primary key
     #
     #   Person.ids # SELECT people.id FROM people
-    #   Person.joins(:companies).ids # SELECT people.id FROM people INNER JOIN companies ON companies.id = people.company_id
+    #   Person.joins(:company).ids # SELECT people.id FROM people INNER JOIN companies ON companies.id = people.company_id
     def ids
       primary_key_array = Array(primary_key)
 


### PR DESCRIPTION
For the fixed example, we have something like
```ruby
Person.has_many :companies
Company.belongs_to :person
```

so the query the `.joins` will produce is not currently correct.