### PR TITLE
Fix `remove_prefix_and_suffix` in `ActiveRecord::SchemaDumper`

### DIFF
--- a/activerecord/lib/active_record/schema_dumper.rb
+++ b/activerecord/lib/active_record/schema_dumper.rb
@@ -70,7 +70,7 @@ module ActiveRecord
     private
       attr_accessor :table_name
 
-      def initialize(connection, version, options = {})
+      def initialize(connection, options = {})
         @connection = connection
         @version = connection.pool.migration_context.current_version rescue nil
         @options = options

--- a/activerecord/test/cases/schema_dumper_test.rb
+++ b/activerecord/test/cases/schema_dumper_test.rb
@@ -473,21 +473,21 @@ class SchemaDumperTest < ActiveRecord::TestCase
     end
   end
 
-  class CreateDogMigration < ActiveRecord::Migration::Current
+  class CreateCatMigration < ActiveRecord::Migration::Current
     def up
-      create_table("dog_owners") do |t|
+      create_table("cat_owners") do |t|
       end
 
-      create_table("dogs") do |t|
+      create_table("cats") do |t|
         t.column :name, :string
         t.references :owner
         t.index [:name]
-        t.foreign_key :dog_owners, column: "owner_id"
+        t.foreign_key :cat_owners, column: "owner_id"
       end
     end
     def down
-      drop_table("dogs")
-      drop_table("dog_owners")
+      drop_table("cats")
+      drop_table("cat_owners")
     end
   end
 
@@ -497,16 +497,21 @@ class SchemaDumperTest < ActiveRecord::TestCase
     ActiveRecord::Base.table_name_prefix = "foo_"
     ActiveRecord::Base.table_name_suffix = "_bar"
 
-    migration = CreateDogMigration.new
+    migration = CreateCatMigration.new
     migration.migrate(:up)
 
-    output = dump_table_schema("dog_owners", "dogs")
+    output = dump_table_schema("foo_cat_owners_bar", "foo_cats_bar")
+
+    assert_match %r{create_table "cat_owners"}, output
+    assert_match %r{create_table "cats"}, output
+    assert_match %r{t\.index \["name"\], name: "index_foo_cats_bar_on_name"}, output
     assert_no_match %r{create_table "foo_.+_bar"}, output
     assert_no_match %r{add_index "foo_.+_bar"}, output
     assert_no_match %r{create_table "schema_migrations"}, output
     assert_no_match %r{create_table "ar_internal_metadata"}, output
 
     if ActiveRecord::Base.lease_connection.supports_foreign_keys?
+      assert_match %r{add_foreign_key "cats", "cat_owners", column: "owner_id"}, output
       assert_no_match %r{add_foreign_key "foo_.+_bar"}, output
       assert_no_match %r{add_foreign_key "[^"]+", "foo_.+_bar"}, output
     end
@@ -524,16 +529,21 @@ class SchemaDumperTest < ActiveRecord::TestCase
     ActiveRecord::Base.table_name_prefix = "foo$"
     ActiveRecord::Base.table_name_suffix = "$bar"
 
-    migration = CreateDogMigration.new
+    migration = CreateCatMigration.new
     migration.migrate(:up)
 
-    output = dump_table_schema("dog_owners", "dog")
+    output = dump_table_schema("foo$cat_owners$bar", "foo$cat$bar")
+
+    assert_match %r{create_table "cat_owners"}, output
+    assert_match %r{create_table "cats"}, output
+    assert_match %r{t\.index \["name"\], name: "index_foo\$cats\$bar_on_name"}, output
     assert_no_match %r{create_table "foo\$.+\$bar"}, output
     assert_no_match %r{add_index "foo\$.+\$bar"}, output
     assert_no_match %r{create_table "schema_migrations"}, output
     assert_no_match %r{create_table "ar_internal_metadata"}, output
 
     if ActiveRecord::Base.lease_connection.supports_foreign_keys?
+      assert_match %r{add_foreign_key "cats", "cat_owners", column: "owner_id"}, output
       assert_no_match %r{add_foreign_key "foo\$.+\$bar"}, output
       assert_no_match %r{add_foreign_key "[^"]+", "foo\$.+\$bar"}, output
     end


### PR DESCRIPTION
Accidentally `remove_prefix_and_suffix` in `ActiveRecord::SchemaDumper` has broken due to table name prefix and suffix options is assigned to unused `version` argument in `SchemaDumper#initialize` added in #51162.
