### PR TITLE
ExceptionWrapper take out backtrace setter from initialize stage

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/exception_wrapper.rb
+++ b/actionpack/lib/action_dispatch/middleware/exception_wrapper.rb
@@ -55,7 +55,6 @@ module ActionDispatch
       if exception.is_a?(SyntaxError)
         @exception = ActiveSupport::SyntaxErrorProxy.new(exception)
       end
-      @backtrace = build_backtrace
     end
 
     def routing_error?
@@ -255,7 +254,9 @@ module ActionDispatch
         end
       end
 
-      attr_reader :backtrace
+      def backtrace
+        @backtrace = build_backtrace
+      end
 
       def build_backtrace
         built_methods = {}

--- a/actionpack/lib/action_dispatch/middleware/exception_wrapper.rb
+++ b/actionpack/lib/action_dispatch/middleware/exception_wrapper.rb
@@ -255,7 +255,7 @@ module ActionDispatch
       end
 
       def backtrace
-        @backtrace = build_backtrace
+        @backtrace ||= build_backtrace
       end
 
       def build_backtrace


### PR DESCRIPTION
### Motivation / Background

This is my first PR to rails, I couldn't locate any similar or identical issues documented or discussed.

The backtrace of errors starts exhibiting the following output post the Rails 7.08 => Rails 7.1 update:
The last attempt I made was to create a new database migration, which hasn't been migrated yet. An error occurred, indicating 'You have 1 pending migration.' The error traceback is as follows when I tried to fetch kaminari paginated page from api:
```
Puma caught this error: undefined method `built_templates' for #<ActionView::FileSystemResolver:0x000000011b4f9540 @unbound_templates=#<Concurrent::Map:0x000000011b4f94a0 entries=0 default_proc=nil>, @path_parser=#<ActionView::Resolver::PathParser:0x00000001283b1748>, @path="/Users/user/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/kaminari-core-1.2.2/app/views"> (NoMethodError)
/Users/user/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/actionpack-7.1.3.2/lib/action_dispatch/middleware/exception_wrapper.rb:269:in `block in build_backtrace'
/Users/user/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/actionpack-7.1.3.2/lib/action_dispatch/middleware/exception_wrapper.rb:268:in `each'
/Users/user/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/actionpack-7.1.3.2/lib/action_dispatch/middleware/exception_wrapper.rb:268:in `build_backtrace'
/Users/user/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/actionpack-7.1.3.2/lib/action_dispatch/middleware/exception_wrapper.rb:56:in `initialize'
/Users/user/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/actionpack-7.1.3.2/lib/action_dispatch/middleware/exception_wrapper.rb:295:in `new'
/Users/user/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/actionpack-7.1.3.2/lib/action_dispatch/middleware/exception_wrapper.rb:295:in `block in wrapped_causes_for'
/Users/user/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/actionpack-7.1.3.2/lib/action_dispatch/middleware/exception_wrapper.rb:291:in `causes_for'
/Users/user/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/actionpack-7.1.3.2/lib/action_dispatch/middleware/exception_wrapper.rb:295:in `each'
/Users/user/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/actionpack-7.1.3.2/lib/action_dispatch/middleware/exception_wrapper.rb:295:in `map'
/Users/user/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/actionpack-7.1.3.2/lib/action_dispatch/middleware/exception_wrapper.rb:295:in `wrapped_causes_for'
/Users/user/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/actionpack-7.1.3.2/lib/action_dispatch/middleware/exception_wrapper.rb:51:in `initialize'
/Users/user/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/actionpack-7.1.3.2/lib/action_dispatch/middleware/exception_wrapper.rb:295:in `new'
/Users/user/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/actionpack-7.1.3.2/lib/action_dispatch/middleware/exception_wrapper.rb:295:in `block in wrapped_causes_for'
/Users/user/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/actionpack-7.1.3.2/lib/action_dispatch/middleware/exception_wrapper.rb:291:in `causes_for'
/Users/user/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/actionpack-7.1.3.2/lib/action_dispatch/middleware/exception_wrapper.rb:295:in `each'
/Users/user/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/actionpack-7.1.3.2/lib/action_dispatch/middleware/exception_wrapper.rb:295:in `map'
/Users/user/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/actionpack-7.1.3.2/lib/action_dispatch/middleware/exception_wrapper.rb:295:in `wrapped_causes_for'
/Users/user/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/actionpack-7.1.3.2/lib/action_dispatch/middleware/exception_wrapper.rb:51:in `initialize'
/Users/user/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/actionpack-7.1.3.2/lib/action_dispatch/middleware/exception_wrapper.rb:295:in `new'
/Users/user/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/actionpack-7.1.3.2/lib/action_dispatch/middleware/exception_wrapper.rb:295:in `block in wrapped_causes_for'
/Users/user/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/actionpack-7.1.3.2/lib/action_dispatch/middleware/exception_wrapper.rb:291:in `causes_for'
/Users/user/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/actionpack-7.1.3.2/lib/action_dispatch/middleware/exception_wrapper.rb:295:in `each'
/Users/user/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/actionpack-7.1.3.2/lib/action_dispatch/middleware/exception_wrapper.rb:295:in `map'
/Users/user/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/actionpack-7.1.3.2/lib/action_dispatch/middleware/exception_wrapper.rb:295:in `wrapped_causes_for'
/Users/user/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/actionpack-7.1.3.2/lib/action_dispatch/middleware/exception_wrapper.rb:51:in `initialize'
/Users/user/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/actionpack-7.1.3.2/lib/action_dispatch/middleware/show_exceptions.rb:35:in `new'
/Users/user/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/actionpack-7.1.3.2/lib/action_dispatch/middleware/show_exceptions.rb:35:in `rescue in call'
/Users/user/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/actionpack-7.1.3.2/lib/action_dispatch/middleware/show_exceptions.rb:30:in `call'
/Users/user/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/railties-7.1.3.2/lib/rails/rack/logger.rb:37:in `call_app'
/Users/user/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/railties-7.1.3.2/lib/rails/rack/logger.rb:24:in `block in call'
/Users/user/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/activesupport-7.1.3.2/lib/active_support/tagged_logging.rb:135:in `block in tagged'
/Users/user/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/activesupport-7.1.3.2/lib/active_support/tagged_logging.rb:39:in `tagged'
/Users/user/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/activesupport-7.1.3.2/lib/active_support/tagged_logging.rb:135:in `tagged'
/Users/user/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/activesupport-7.1.3.2/lib/active_support/broadcast_logger.rb:240:in `method_missing'
/Users/user/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/railties-7.1.3.2/lib/rails/rack/logger.rb:24:in `call'
/Users/user/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/sprockets-rails-3.4.2/lib/sprockets/rails/quiet_assets.rb:13:in `call'
/Users/user/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/actionpack-7.1.3.2/lib/action_dispatch/middleware/remote_ip.rb:92:in `call'
/Users/user/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/request_store-1.5.1/lib/request_store/middleware.rb:19:in `call'
/Users/user/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/actionpack-7.1.3.2/lib/action_dispatch/middleware/request_id.rb:28:in `call'
/Users/user/.gem/ruby/3.2.0/gems/rack-3.0.10/lib/rack/method_override.rb:28:in `call'
/Users/user/.gem/ruby/3.2.0/gems/rack-3.0.10/lib/rack/runtime.rb:24:in `call'
/Users/user/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/actionpack-7.1.3.2/lib/action_dispatch/middleware/executor.rb:14:in `call'
/Users/user/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/actionpack-7.1.3.2/lib/action_dispatch/middleware/static.rb:25:in `call'
/Users/user/.gem/ruby/3.2.0/gems/rack-3.0.10/lib/rack/sendfile.rb:114:in `call'
/Users/user/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/actionpack-7.1.3.2/lib/action_dispatch/middleware/host_authorization.rb:141:in `call'
/Users/user/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/rack-cors-2.0.2/lib/rack/cors.rb:102:in `call'
/Users/user/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/railties-7.1.3.2/lib/rails/engine.rb:536:in `call'
/Users/user/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/puma-6.4.2/lib/puma/configuration.rb:272:in `call'
/Users/user/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/puma-6.4.2/lib/puma/request.rb:100:in `block in handle_request'
/Users/user/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/puma-6.4.2/lib/puma/thread_pool.rb:378:in `with_force_shutdown'
/Users/user/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/puma-6.4.2/lib/puma/request.rb:99:in `handle_request'
/Users/user/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/puma-6.4.2/lib/puma/server.rb:464:in `process_client'
/Users/user/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/puma-6.4.2/lib/puma/server.rb:245:in `block in run'
/Users/user/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/puma-6.4.2/lib/puma/thread_pool.rb:155:in `block in spawn_thread'
```

This error isn't exclusive to Kaminari. I've attempted to isolate the issue by removing gems individually, but each time, I encounter the same backtrace, albeit with a different gem's view route (such as Active Admin or Devise).

There could be other gems interfering with the middleware, but I'm uncertain what's necessary to establish a backtrace at the initialization stage.

This Pull Request has been created because, I believe it resolves the initialization backtrace error, thereby resolving the main issue at hand.

### Detail

This Pull Request changes ActionDispatch ExeptionWrapper class, and removes backtrace attribute to be set on initializing stage.

### Additional information

N/A

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
