### PR TITLE
Fix devcontainer smoke test for forked repos

### DIFF
--- a/.github/workflows/devcontainer-smoke-test.yml
+++ b/.github/workflows/devcontainer-smoke-test.yml
@@ -46,5 +46,6 @@ jobs:
           imageName: ghcr.io/rails/smoke-test-devcontainer
           cacheFrom: ghcr.io/rails/smoke-test-devcontainer
           imageTag: ${{ matrix.DATABASE }}
+          push: ${{ github.repository_owner == 'rails' && 'filter' || 'never' }}
           refFilterForPush: refs/heads/main
           runCmd: bin/rails g scaffold Post && bin/rails db:migrate && bin/rails test


### PR DESCRIPTION
### Motivation / Background

When we run the smoke test on main, we push the devcontainer images to ghcr to be used as a cache for future workflow runs. This causes an error on forks because they don't have permission to push (which is good). ([for example](https://github.com/Shopify/rails/actions/runs/8689604455/job/23827610434))

### Detail

Let's set the step to never push if the repo is a fork. The github context doesn't have a way of checking if the repo is a fork, so I check the repo owner instead, but that's ok since it's the repo owner (rails) who has permissions to push the package.

Here is an example of it working when I commit this change to main on my personal fork: https://github.com/andrewn617/rails/actions/runs/8691193827/job/23832849684

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
