### PR TITLE
Wrap YJIT guard clause in parentheses

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/enable_yjit.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/enable_yjit.rb.tt
@@ -4,7 +4,7 @@
 # If you are deploying to a memory constrained environment
 # you may want to delete this file, but otherwise it's free
 # performance.
-if defined? RubyVM::YJIT.enable
+if defined?(RubyVM::YJIT.enable)
   Rails.application.config.after_initialize do
     RubyVM::YJIT.enable
   end


### PR DESCRIPTION
### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created because we encountered a non-obvious bug in the YJIT initializer as defined in the template. To be clear, the bug was caused by changing the code—not the default itself, but it wasn't immediately obvious what was causing it.

Basically, `&&` is an expression. So `defined? RubyVM::YJIT.enable && false #=> "expression"`. 

When expanding on the requirements of this condition, I simply added `&& my_condition?` and broke our application for environments where Ruby wasn't built with YJIT. 

I think others might get caught out by this.

### Detail

This Pull Request wraps `defined?(RubyVM::YJIT.enable)` in parentheses to ensure the expression is still parsed as expected when additional conditions are added.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] ~Tests are added or updated if you fix a bug or add a feature.~
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included. (Not sure this is required?)
