### PR TITLE
Add support for `expires_in:` when using `render` with `collection:`

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,2 +1,6 @@
 
 Please check [8-1-stable](https://github.com/rails/rails/blob/8-1-stable/actionview/CHANGELOG.md) for previous changes.
+
+*   Add `key:` and `expires_in:` options under `cached:` to `render` when used with `collection:`
+
+    *Jarrett Lusso*

--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,6 +1,5 @@
-
-Please check [8-1-stable](https://github.com/rails/rails/blob/8-1-stable/actionview/CHANGELOG.md) for previous changes.
-
 *   Add `key:` and `expires_in:` options under `cached:` to `render` when used with `collection:`
 
     *Jarrett Lusso*
+    
+Please check [8-1-stable](https://github.com/rails/rails/blob/8-1-stable/actionview/CHANGELOG.md) for previous changes.

--- a/actionview/test/template/render_test.rb
+++ b/actionview/test/template/render_test.rb
@@ -912,6 +912,17 @@ class CachedCollectionViewRenderTest < ActiveSupport::TestCase
     assert_equal "Hello: david", ActionView::PartialRenderer.collection_cache.read(key)
   end
 
+  test "template body written to cache with expiration when expires_in set" do
+    customer = Customer.new("jarrett", 2)
+    key = cache_key(customer, "test/_customer")
+    @view.render(partial: "test/customer", collection: [customer], cached: { expires_in: 1.hour })
+    assert_equal "Hello: jarrett", ActionView::PartialRenderer.collection_cache.read(key)
+
+    travel 2.hours
+
+    assert_nil ActionView::PartialRenderer.collection_cache.read(key)
+  end
+
   test "collection caching does not cache by default" do
     customer = Customer.new("david", 1)
     key = cache_key(customer, "test/_customer")

--- a/guides/source/caching_with_rails.md
+++ b/guides/source/caching_with_rails.md
@@ -123,6 +123,14 @@ do not overwrite each other:
            cached: ->(product) { [I18n.locale, product] } %>
 ```
 
+Additionally, you can configure `cached` with an options hash that takes `expires_in` and `key` so you can explicitly set the expiration.
+
+```html+erb
+<%= render partial: 'products/product',
+           collection: @products,
+           cached: { expires_in: 1.hour, key: ->(product) { [I18n.locale, product] } } %>
+```
+
 ### Russian Doll Caching
 
 You may want to nest cached fragments inside other cached fragments. This is


### PR DESCRIPTION
### Motivation / Background

When using the following code you'd expect that you can pass `expires_in` as you can with rendering individual partials. This PR aims to achive this.

```html+erb
<%= render(collection: @posts, partial: 'post', cached: true) %>
```

### Solution

Simple usage with just `expires_in`
```html+erb
<%= render(collection: @posts, partial: 'post', cached: { expires_in: 1.day.from_now }) %>
```

More advanced usage with `expires_in` and `key`
```html+erb
<%= render(collection: @posts, partial: 'post', cached: { expires_in: 1.day.from_now, key: ->(post) { [I18n.locale, post] } }) %>
```


### Detail

- Pass `expires_in` to `write_multi` so the cache key is written with the expiration.
- Added tests.
- Added documentation.

### Checklist

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.