### PR TITLE
test: fix flaky schema dump test to prefer YAML to Marshal

### DIFF
--- a/activerecord/test/cases/connection_adapters/schema_cache_test.rb
+++ b/activerecord/test/cases/connection_adapters/schema_cache_test.rb
@@ -302,12 +302,12 @@ module ActiveRecord
         # Create an empty cache.
         cache = new_bound_reflection
 
-        tempfile_a = Tempfile.new(["schema_cache-", ".dump.gz"])
+        tempfile_a = Tempfile.new(["schema_cache-", ".yml.gz"])
         # Dump it. It should get populated before dumping.
         cache.dump_to(tempfile_a.path)
         digest_a = Digest::MD5.file(tempfile_a).hexdigest
         sleep(1) # ensure timestamp changes
-        tempfile_b = Tempfile.new(["schema_cache-", ".dump.gz"])
+        tempfile_b = Tempfile.new(["schema_cache-", ".yml.gz"])
         # Dump it. It should get populated before dumping.
         cache.dump_to(tempfile_b.path)
         digest_b = Digest::MD5.file(tempfile_b).hexdigest


### PR DESCRIPTION
### Motivation / Background

#### Context

In preparing for an upcoming major release of the [`sqlite3` gem](https://github.com/sparklemotion/sqlite3-ruby), I added an [integration testing pipeline](https://github.com/sparklemotion/sqlite3-ruby/blob/main/.github/workflows/downstream.yml) to ensure we stayed compatible with rails.

I've been seeing a flaky Active Record test when running against sqlite3 `main`:

https://github.com/rails/rails/blob/1428ef984e8be2e301c562c01b34f8d8c90bd4cf/activerecord/test/cases/connection_adapters/schema_cache_test.rb#L301-L320

This test was introduced in rails/rails#49166 to assert that the gzip header timestamp would not become part of a schema cache change.

Bisecting, I found that sparklemotion/sqlite3-ruby#480 started freezing some result strings, and that is when this test became flaky.


#### Reproduction

This test can reliably be made to fail by:

1. update `Gemfile` with `gem "sqlite3", git: "https://github.com/sparklemotion/sqlite3-ruby", branch: "main"`
2. `cd activerecord`
3. `bin/test test/cases/connection_adapters/schema_cache_test.rb -n/test_gzip_dumps_identical/`

You'll see something like:

```
Failure:
ActiveRecord::ConnectionAdapters::SchemaCacheTest#test_gzip_dumps_identical [test/cases/connection_adapters/schema_cache_test.rb:318]:
--- expected
+++ actual
@@ -1,3 +1,3 @@
 # encoding: US-ASCII
 #    valid: true
-"511db250054ca861dc324b0298e9dc81"
+"bf411f30188cfc16fe16ffcb26ea0ea7"
```


#### Diagnosis

Digging in further, I can see by visually parsing the Marshal dump of the schema that when this test fails it's because of string identity -- essentially, global state -- and that **Rails can't actually guarantee that a schema cache dump will be byte-for-byte reproducible when it is serialized with Marshal**.

The schema cache `@indexes` ivar looks like this at dump time:

```
{"ar_internal_metadata"=>[],
 "schema_migrations"=>[],
 "schema_migrations_s"=>[],
 "ar_internal_metadata_s"=>[],
 "p_schema_migrations"=>[],
 "p_ar_internal_metadata"=>[],
 "courses"=>
  [#<ActiveRecord::ConnectionAdapters::IndexDefinition:0x00007c931fccac98
    @columns=["college_id"],
    @comment=nil,
    @include=nil,
    @lengths={},
    @name="index_courses_on_college_id",
    @nulls_not_distinct=nil,
    @opclasses={},
    @orders={},
    @table="courses",
    @type=nil,
    @unique=false,
    @using=nil,
    @valid=true,
    @where=nil>],
 "colleges"=>[],
 "professors"=>[],
 "courses_professors"=>
  [#<ActiveRecord::ConnectionAdapters::IndexDefinition:0x00007c931fcc8038
    @columns=["professor_id"],
    @comment=nil,
    @include=nil,
    @lengths={},
    @name="index_courses_professors_on_professor_id",
    @nulls_not_distinct=nil,
    @opclasses={},
    @orders={},
    @table="courses_professors",
    @type=nil,
    @unique=false,
    @using=nil,
    @valid=true,
    @where=nil>,
   #<ActiveRecord::ConnectionAdapters::IndexDefinition:0x00007c931fcc7b38
    @columns=["course_id"],
    @comment=nil,
    @include=nil,
    @lengths={},
    @name="index_courses_professors_on_course_id",
    @nulls_not_distinct=nil,
    @opclasses={},
    @orders={},
    @table="courses_professors",
    @type=nil,
    @unique=false,
    @using=nil,
    @valid=true,
    @where=nil>],
 "dogs"=>[]}
```

What you can't see, but I found by parsing the Marshal dump, is that the following three references are all to the same string object:

- the toplevel hash key `"courses_professors"`
- under that key, the value of both `IndexDefinition` objects' ivar `@table`

When the test fails, it's because the first dump has one string referenced in all three places; and the second dump references three separate but identical strings.


#### Marshal is not a reproducible format

You can make this test pass by making this change to the test file:

``` patch
diff --git a/activerecord/test/cases/connection_adapters/schema_cache_test.rb b/activerecord/test/cases/connection_adapters/schema_cache_test.rb
index f816d9e9..11e01cd2 100644
--- a/activerecord/test/cases/connection_adapters/schema_cache_test.rb
+++ b/activerecord/test/cases/connection_adapters/schema_cache_test.rb
@@ -2,6 +2,8 @@

 require "cases/helper"

+puts "courses_professors"
+
 module ActiveRecord
   module ConnectionAdapters
     class SchemaCacheTest < ActiveRecord::TestCase
```

The existence of this string object changes the behavior of this test so that it emits three separate but identical strings in both dumps. Bonkers!

Although I'm not absolutely sure I understand the mechanics here, I've concluded that it's probably a bad idea to try to guarantee that the schema cache dump file will be reproducible when using Marshal format, and I hope you agree.


### Detail

This PR updates the test to prefer YAML to Marshal.

The default schema dump format these days is YAML, and we absolutely can guarantee that YAML format is reproducible.


### Additional information

- Test added in https://github.com/rails/rails/pull/49166
- Upstream sqlite3 change in https://github.com/sparklemotion/sqlite3-ruby/pull/480


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] ~CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.~
