### PR TITLE
ruby-head: handle unused block warnings

### DIFF
--- a/activesupport/lib/active_support/testing/strict_warnings.rb
+++ b/activesupport/lib/active_support/testing/strict_warnings.rb
@@ -12,6 +12,10 @@ module ActiveSupport
       # Expected non-verbose warning emitted by Rails.
       /Ignoring .*\.yml because it has expired/,
       /Failed to validate the schema cache because/,
+
+      # Ref: https://bugs.ruby-lang.org/issues/15554
+      # This new Ruby 3.4 warning is still being fined tuned to reduce false positives
+      /the block passed to/,
     )
 
     SUPPRESSED_WARNINGS = Regexp.union(

--- a/activesupport/test/time_travel_test.rb
+++ b/activesupport/test/time_travel_test.rb
@@ -332,11 +332,12 @@ class TimeTravelTest < ActiveSupport::TestCase
 
   def test_time_helper_freeze_time_with_usec_true
     # repeatedly test in case Time.now happened to actually be 0 usec
-    assert_predicate 9.times, :any? do
+    checks = 9.times.map do
       freeze_time(with_usec: true) do
         Time.now.usec != 0
       end
     end
+    assert_predicate checks, :any?
   end
 
   def test_time_helper_travel_with_subsequent_block


### PR DESCRIPTION
Ref: https://bugs.ruby-lang.org/issues/15554

This new Ruby 3.4 warning is still being fined tuned to reduce false positives, so we shouldn't fail builds on it just yet.

It however caught one mistake in the test suite which is valuable.
