### PR TITLE
TestCase#create_fixtures no longer takes a block

### DIFF
--- a/activerecord/test/cases/fixtures_test.rb
+++ b/activerecord/test/cases/fixtures_test.rb
@@ -374,7 +374,7 @@ class FixturesTest < ActiveRecord::TestCase
   end
 
   def test_create_symbol_fixtures
-    fixtures = ActiveRecord::FixtureSet.create_fixtures(FIXTURES_ROOT, :collections, collections: Course) { Course.connection }
+    fixtures = ActiveRecord::FixtureSet.create_fixtures(FIXTURES_ROOT, :collections, collections: Course)
 
     assert Course.find_by_name("Collection"), "course is not in the database"
     assert fixtures.detect { |f| f.name == "collections" }, "no fixtures named 'collections' in #{fixtures.map(&:name).inspect}"

--- a/activerecord/test/cases/multiple_db_test.rb
+++ b/activerecord/test/cases/multiple_db_test.rb
@@ -9,8 +9,8 @@ class MultipleDbTest < ActiveRecord::TestCase
   self.use_transactional_tests = false
 
   def setup
-    @courses  = create_fixtures("courses") { Course.retrieve_connection }
-    @colleges = create_fixtures("colleges") { College.retrieve_connection }
+    @courses  = create_fixtures("courses")
+    @colleges = create_fixtures("colleges")
     @entrants = create_fixtures("entrants")
   end
 

--- a/activerecord/test/cases/test_case.rb
+++ b/activerecord/test/cases/test_case.rb
@@ -83,8 +83,8 @@ module ActiveRecord
       end
     end
 
-    def create_fixtures(*fixture_set_names, &block)
-      ActiveRecord::FixtureSet.create_fixtures(ActiveRecord::TestCase.fixture_paths, fixture_set_names, fixture_class_names, &block)
+    def create_fixtures(*fixture_set_names)
+      ActiveRecord::FixtureSet.create_fixtures(ActiveRecord::TestCase.fixture_paths, fixture_set_names, fixture_class_names)
     end
 
     def capture_sql(include_schema: false)


### PR DESCRIPTION
Found by new Ruby 3.4-dev warnings.