### PR TITLE
Fix ActionView backtrace filtering on Ruby 3.4+

### DIFF
--- a/railties/lib/rails/backtrace_cleaner.rb
+++ b/railties/lib/rails/backtrace_cleaner.rb
@@ -6,7 +6,7 @@ require "active_support/core_ext/string/access"
 module Rails
   class BacktraceCleaner < ActiveSupport::BacktraceCleaner # :nodoc:
     APP_DIRS_PATTERN = /\A(?:\.\/)?(?:app|config|lib|test|\(\w*\))/
-    RENDER_TEMPLATE_PATTERN = /:in `.*_\w+_{2,3}\d+_\d+'/
+    RENDER_TEMPLATE_PATTERN = /:in [`'].*_\w+_{2,3}\d+_\d+'/
 
     def initialize
       super

--- a/railties/test/backtrace_cleaner_test.rb
+++ b/railties/test/backtrace_cleaner_test.rb
@@ -43,6 +43,13 @@ class BacktraceCleanerTest < ActiveSupport::TestCase
     assert_equal "app/views/application/index.html.erb:4", result[0]
   end
 
+  test "#clean should omit ActionView template methods names on Ruby 3.4+" do
+    method_name = ActionView::Template.new(nil, "app/views/application/index.html.erb", nil, locals: []).send :method_name
+    backtrace = [ "app/views/application/index.html.erb:4:in 'block in #{method_name}'"]
+    result = @cleaner.clean(backtrace, :all)
+    assert_equal "app/views/application/index.html.erb:4", result[0]
+  end
+
   test "#clean_frame should consider traces from irb lines as User code" do
     assert_equal "(irb):1", @cleaner.clean_frame("(irb):1")
     assert_nil @cleaner.clean_frame("/Path/to/rails/railties/lib/rails/commands/console.rb:77:in `start'")
@@ -65,6 +72,12 @@ class BacktraceCleanerTest < ActiveSupport::TestCase
   test "#clean_frame should omit ActionView template methods names" do
     method_name = ActionView::Template.new(nil, "app/views/application/index.html.erb", nil, locals: []).send :method_name
     frame = @cleaner.clean_frame("app/views/application/index.html.erb:4:in `block in #{method_name}'", :all)
+    assert_equal "app/views/application/index.html.erb:4", frame
+  end
+
+  test "#clean_frame should omit ActionView template methods names on Ruby 3.4+" do
+    method_name = ActionView::Template.new(nil, "app/views/application/index.html.erb", nil, locals: []).send :method_name
+    frame = @cleaner.clean_frame("app/views/application/index.html.erb:4:in 'block in #{method_name}'", :all)
     assert_equal "app/views/application/index.html.erb:4", frame
   end
 end


### PR DESCRIPTION
In Ruby 3.4+ backtraces are going to use a single quote rather than a backtick https://bugs.ruby-lang.org/issues/16495

This adjusts our backtrace cleaner regex to work with either format. I considered making it just work on whatever output we expect to see from the current Ruby version, but we are already using a regex here and this seemed much simpler.