### PR TITLE
Pin sqlite3 version in bug_report_templates

### DIFF
--- a/guides/bug_report_templates/action_mailbox.rb
+++ b/guides/bug_report_templates/action_mailbox.rb
@@ -9,7 +9,7 @@ gemfile(true) do
   # If you want to test against edge Rails replace the previous line with this:
   # gem "rails", github: "rails/rails", branch: "main"
 
-  gem "sqlite3"
+  gem "sqlite3", "~> 1.4"
 end
 
 require "active_record/railtie"

--- a/guides/bug_report_templates/active_record.rb
+++ b/guides/bug_report_templates/active_record.rb
@@ -9,7 +9,7 @@ gemfile(true) do
   # If you want to test against edge Rails replace the previous line with this:
   # gem "rails", github: "rails/rails", branch: "main"
 
-  gem "sqlite3"
+  gem "sqlite3", "~> 1.4"
 end
 
 require "active_record"

--- a/guides/bug_report_templates/active_record_migrations.rb
+++ b/guides/bug_report_templates/active_record_migrations.rb
@@ -9,7 +9,7 @@ gemfile(true) do
   # If you want to test against edge Rails replace the previous line with this:
   # gem "rails", github: "rails/rails", branch: "main"
 
-  gem "sqlite3"
+  gem "sqlite3", "~> 1.4"
 end
 
 require "active_record"

--- a/guides/bug_report_templates/active_storage.rb
+++ b/guides/bug_report_templates/active_storage.rb
@@ -9,7 +9,7 @@ gemfile(true) do
   # If you want to test against edge Rails replace the previous line with this:
   # gem "rails", github: "rails/rails", branch: "main"
 
-  gem "sqlite3"
+  gem "sqlite3", "~> 1.4"
 end
 
 require "active_record/railtie"


### PR DESCRIPTION
### Motivation / Background

This commit addresses the CI failure at https://buildkite.com/rails/rails-nightly/builds/424#018eee82-61fb-41ae-bc2b-21bc60dde483/1240

### Detail

- Steps to reproduce
```ruby
git clone https://github.com/rails/rails
cd guides/bug_report_templates
ruby action_mailbox.rb
ruby active_record.rb
ruby active_record_migrations.rb
ruby active_storage.rb
```

- Error without this commit
```ruby
$ ruby action_mailbox.rb
Fetching gem metadata from https://rubygems.org/...........
Resolving dependencies...
-- create_table(:active_storage_blobs, {:id=>:primary_key})
/home/yahonda/.rbenv/versions/3.3.0/lib/ruby/site_ruby/3.3.0/bundler/rubygems_integration.rb:237:in `block (2 levels) in replace_gem': Error loading the 'sqlite3' Active Record adapter. Missing a gem it depends on? can't activate sqlite3 (~> 1.4), already activated sqlite3-2.0.0-x86_64-linux-gnu. Make sure all dependencies are added to Gemfile. (LoadError)
	from /home/yahonda/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/activerecord-7.1.3.2/lib/active_record/connection_adapters/sqlite3_adapter.rb:14:in `<top (required)>'
	from /home/yahonda/.rbenv/versions/3.3.0/lib/ruby/3.3.0/bundled_gems.rb:74:in `require'
	from /home/yahonda/.rbenv/versions/3.3.0/lib/ruby/3.3.0/bundled_gems.rb:74:in `block (2 levels) in replace_require'
	from /home/yahonda/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/zeitwerk-2.6.13/lib/zeitwerk/kernel.rb:34:in `require'
	from /home/yahonda/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/activerecord-7.1.3.2/lib/active_record/connection_adapters/abstract/connection_handler.rb:333:in `resolve_pool_config'
	from /home/yahonda/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/activerecord-7.1.3.2/lib/active_record/connection_adapters/abstract/connection_handler.rb:134:in `establish_connection'
	from /home/yahonda/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/activerecord-7.1.3.2/lib/active_record/connection_handling.rb:53:in `establish_connection'
	from /home/yahonda/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/activerecord-7.1.3.2/lib/active_record/railtie.rb:304:in `block (2 levels) in <class:Railtie>'
	from /home/yahonda/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/activesupport-7.1.3.2/lib/active_support/lazy_load_hooks.rb:97:in `class_eval'
	from /home/yahonda/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/activesupport-7.1.3.2/lib/active_support/lazy_load_hooks.rb:97:in `block in execute_hook'
	from /home/yahonda/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/activesupport-7.1.3.2/lib/active_support/lazy_load_hooks.rb:87:in `with_execution_control'
	from /home/yahonda/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/activesupport-7.1.3.2/lib/active_support/lazy_load_hooks.rb:92:in `execute_hook'
	from /home/yahonda/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/activesupport-7.1.3.2/lib/active_support/lazy_load_hooks.rb:78:in `block in run_load_hooks'
	from /home/yahonda/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/activesupport-7.1.3.2/lib/active_support/lazy_load_hooks.rb:77:in `each'
	from /home/yahonda/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/activesupport-7.1.3.2/lib/active_support/lazy_load_hooks.rb:77:in `run_load_hooks'
	from /home/yahonda/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/activerecord-7.1.3.2/lib/active_record/base.rb:338:in `<module:ActiveRecord>'
	from /home/yahonda/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/activerecord-7.1.3.2/lib/active_record/base.rb:15:in `<top (required)>'
	from /home/yahonda/.rbenv/versions/3.3.0/lib/ruby/3.3.0/bundled_gems.rb:74:in `require'
	from /home/yahonda/.rbenv/versions/3.3.0/lib/ruby/3.3.0/bundled_gems.rb:74:in `block (2 levels) in replace_require'
	from /home/yahonda/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/zeitwerk-2.6.13/lib/zeitwerk/kernel.rb:34:in `require'
	from /home/yahonda/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/activerecord-7.1.3.2/lib/active_record/tasks/database_tasks.rb:506:in `migration_class'
	from /home/yahonda/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/activerecord-7.1.3.2/lib/active_record/tasks/database_tasks.rb:510:in `migration_connection'
	from /home/yahonda/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/activerecord-7.1.3.2/lib/active_record/migration.rb:1032:in `connection'
	from /home/yahonda/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/activerecord-7.1.3.2/lib/active_record/migration.rb:1037:in `block in method_missing'
	from /home/yahonda/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/activerecord-7.1.3.2/lib/active_record/migration.rb:1017:in `block in say_with_time'
	from /home/yahonda/.rbenv/versions/3.3.0/lib/ruby/3.3.0/benchmark.rb:298:in `measure'
	from /home/yahonda/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/activerecord-7.1.3.2/lib/active_record/migration.rb:1017:in `say_with_time'
	from /home/yahonda/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/activerecord-7.1.3.2/lib/active_record/migration.rb:1036:in `method_missing'
	from /home/yahonda/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/activerecord-7.1.3.2/lib/active_record/migration.rb:566:in `create_table'
	from /home/yahonda/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/activerecord-7.1.3.2/lib/active_record/migration/compatibility.rb:110:in `create_table'
	from /home/yahonda/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/activestorage-7.1.3.2/db/migrate/20170806125915_create_active_storage_tables.rb:6:in `change'
	from action_mailbox.rb:51:in `block in <main>'
	from /home/yahonda/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/activerecord-7.1.3.2/lib/active_record/schema.rb:55:in `instance_eval'
	from /home/yahonda/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/activerecord-7.1.3.2/lib/active_record/schema.rb:55:in `define'
	from /home/yahonda/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/activerecord-7.1.3.2/lib/active_record/schema.rb:50:in `define'
	from action_mailbox.rb:50:in `<main>'
/home/yahonda/.rbenv/versions/3.3.0/lib/ruby/site_ruby/3.3.0/bundler/rubygems_integration.rb:237:in `block (2 levels) in replace_gem': can't activate sqlite3 (~> 1.4), already activated sqlite3-2.0.0-x86_64-linux-gnu. Make sure all dependencies are added to Gemfile. (Gem::LoadError)
	from /home/yahonda/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/activerecord-7.1.3.2/lib/active_record/connection_adapters/sqlite3_adapter.rb:14:in `<top (required)>'
	from /home/yahonda/.rbenv/versions/3.3.0/lib/ruby/3.3.0/bundled_gems.rb:74:in `require'
	from /home/yahonda/.rbenv/versions/3.3.0/lib/ruby/3.3.0/bundled_gems.rb:74:in `block (2 levels) in replace_require'
	from /home/yahonda/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/zeitwerk-2.6.13/lib/zeitwerk/kernel.rb:34:in `require'
	from /home/yahonda/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/activerecord-7.1.3.2/lib/active_record/connection_adapters/abstract/connection_handler.rb:333:in `resolve_pool_config'
	from /home/yahonda/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/activerecord-7.1.3.2/lib/active_record/connection_adapters/abstract/connection_handler.rb:134:in `establish_connection'
	from /home/yahonda/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/activerecord-7.1.3.2/lib/active_record/connection_handling.rb:53:in `establish_connection'
	from /home/yahonda/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/activerecord-7.1.3.2/lib/active_record/railtie.rb:304:in `block (2 levels) in <class:Railtie>'
	from /home/yahonda/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/activesupport-7.1.3.2/lib/active_support/lazy_load_hooks.rb:97:in `class_eval'
	from /home/yahonda/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/activesupport-7.1.3.2/lib/active_support/lazy_load_hooks.rb:97:in `block in execute_hook'
	from /home/yahonda/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/activesupport-7.1.3.2/lib/active_support/lazy_load_hooks.rb:87:in `with_execution_control'
	from /home/yahonda/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/activesupport-7.1.3.2/lib/active_support/lazy_load_hooks.rb:92:in `execute_hook'
	from /home/yahonda/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/activesupport-7.1.3.2/lib/active_support/lazy_load_hooks.rb:78:in `block in run_load_hooks'
	from /home/yahonda/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/activesupport-7.1.3.2/lib/active_support/lazy_load_hooks.rb:77:in `each'
	from /home/yahonda/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/activesupport-7.1.3.2/lib/active_support/lazy_load_hooks.rb:77:in `run_load_hooks'
	from /home/yahonda/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/activerecord-7.1.3.2/lib/active_record/base.rb:338:in `<module:ActiveRecord>'
	from /home/yahonda/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/activerecord-7.1.3.2/lib/active_record/base.rb:15:in `<top (required)>'
	from /home/yahonda/.rbenv/versions/3.3.0/lib/ruby/3.3.0/bundled_gems.rb:74:in `require'
	from /home/yahonda/.rbenv/versions/3.3.0/lib/ruby/3.3.0/bundled_gems.rb:74:in `block (2 levels) in replace_require'
	from /home/yahonda/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/zeitwerk-2.6.13/lib/zeitwerk/kernel.rb:34:in `require'
	from /home/yahonda/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/activerecord-7.1.3.2/lib/active_record/tasks/database_tasks.rb:506:in `migration_class'
	from /home/yahonda/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/activerecord-7.1.3.2/lib/active_record/tasks/database_tasks.rb:510:in `migration_connection'
	from /home/yahonda/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/activerecord-7.1.3.2/lib/active_record/migration.rb:1032:in `connection'
	from /home/yahonda/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/activerecord-7.1.3.2/lib/active_record/migration.rb:1037:in `block in method_missing'
	from /home/yahonda/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/activerecord-7.1.3.2/lib/active_record/migration.rb:1017:in `block in say_with_time'
	from /home/yahonda/.rbenv/versions/3.3.0/lib/ruby/3.3.0/benchmark.rb:298:in `measure'
	from /home/yahonda/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/activerecord-7.1.3.2/lib/active_record/migration.rb:1017:in `say_with_time'
	from /home/yahonda/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/activerecord-7.1.3.2/lib/active_record/migration.rb:1036:in `method_missing'
	from /home/yahonda/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/activerecord-7.1.3.2/lib/active_record/migration.rb:566:in `create_table'
	from /home/yahonda/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/activerecord-7.1.3.2/lib/active_record/migration/compatibility.rb:110:in `create_table'
	from /home/yahonda/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/activestorage-7.1.3.2/db/migrate/20170806125915_create_active_storage_tables.rb:6:in `change'
	from action_mailbox.rb:51:in `block in <main>'
	from /home/yahonda/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/activerecord-7.1.3.2/lib/active_record/schema.rb:55:in `instance_eval'
	from /home/yahonda/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/activerecord-7.1.3.2/lib/active_record/schema.rb:55:in `define'
	from /home/yahonda/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/activerecord-7.1.3.2/lib/active_record/schema.rb:50:in `define'
	from action_mailbox.rb:50:in `<main>'
$
```

### Additional information
This version requiremnt is taken from that for Rails application. https://github.com/rails/rails/blob/0601929486398954a17b1985fcf7f9f0611d2d55/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb#L14 https://github.com/rails/rails/blob/0601929486398954a17b1985fcf7f9f0611d2d55/railties/lib/rails/generators/database.rb#L19

Gemfile for Rails framework has different version requirement, this commit uses the version requirement for Rails application. Both of them eventually install the sqlite3 1.*. https://github.com/rails/rails/blob/0601929486398954a17b1985fcf7f9f0611d2d55/Gemfile#L157

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.