### PR TITLE
dep: allow sqlite3 gem to float to version 2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -154,7 +154,7 @@ platforms :ruby, :windows do
   gem "racc", ">=1.4.6", require: false
 
   # Active Record.
-  gem "sqlite3", "~> 1.6", ">= 1.6.6"
+  gem "sqlite3", ">= 1.6.6"
 
   group :db do
     gem "pg", "~> 1.3"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -327,7 +327,7 @@ GEM
       mixlib-shellout
     mini_magick (4.12.0)
     mini_mime (1.1.5)
-    mini_portile2 (2.8.5)
+    mini_portile2 (2.8.6)
     minitest (5.21.1)
     minitest-bisect (1.7.0)
       minitest-server (~> 1.0)
@@ -525,10 +525,10 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
-    sqlite3 (1.7.0)
+    sqlite3 (2.0.0)
       mini_portile2 (~> 2.8.0)
-    sqlite3 (1.7.0-x86_64-darwin)
-    sqlite3 (1.7.0-x86_64-linux)
+    sqlite3 (2.0.0-x86_64-darwin)
+    sqlite3 (2.0.0-x86_64-linux-gnu)
     stackprof (0.2.25)
     stimulus-rails (1.3.0)
       railties (>= 6.0.0)
@@ -654,7 +654,7 @@ DEPENDENCIES
   sidekiq
   sneakers
   sprockets-rails (>= 2.0.0)
-  sqlite3 (~> 1.6, >= 1.6.6)
+  sqlite3 (>= 1.6.6)
   stackprof
   stimulus-rails
   sucker_punch

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Allow `Sqlite3Adapter` to use `sqlite3` gem version `2.x`
+
+    *Mike Dalessio*
+
 *   Allow `ActiveRecord::Base#pluck` to accept hash values
 
     ```ruby

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -11,7 +11,7 @@ require "active_record/connection_adapters/sqlite3/schema_definitions"
 require "active_record/connection_adapters/sqlite3/schema_dumper"
 require "active_record/connection_adapters/sqlite3/schema_statements"
 
-gem "sqlite3", "~> 1.4"
+gem "sqlite3", ">= 1.4"
 require "sqlite3"
 
 module ActiveRecord

--- a/railties/lib/rails/generators/database.rb
+++ b/railties/lib/rails/generators/database.rb
@@ -16,7 +16,7 @@ module Rails
         when "mysql"          then ["mysql2", ["~> 0.5"]]
         when "trilogy"        then ["trilogy", ["~> 2.7"]]
         when "postgresql"     then ["pg", ["~> 1.1"]]
-        when "sqlite3"        then ["sqlite3", ["~> 1.4"]]
+        when "sqlite3"        then ["sqlite3", [">= 1.4"]]
         when "oracle"         then ["activerecord-oracle_enhanced-adapter", nil]
         when "sqlserver"      then ["activerecord-sqlserver-adapter", nil]
         when "jdbcmysql"      then ["activerecord-jdbcmysql-adapter", nil]

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -441,7 +441,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
     if defined?(JRUBY_VERSION)
       assert_gem "activerecord-jdbcsqlite3-adapter"
     else
-      assert_gem "sqlite3", '"~> 1.4"'
+      assert_gem "sqlite3", '">= 1.4"'
     end
   end
 

--- a/railties/test/generators/db_system_change_generator_test.rb
+++ b/railties/test/generators/db_system_change_generator_test.rb
@@ -128,7 +128,7 @@ module Rails
 
             assert_file("Gemfile") do |content|
               assert_match "# Use sqlite3 as the database for Active Record", content
-              assert_match 'gem "sqlite3", "~> 1.4"', content
+              assert_match 'gem "sqlite3", ">= 1.4"', content
             end
 
             assert_file("Dockerfile") do |content|


### PR DESCRIPTION
### Motivation / Background

sqlite3 version v2.0.0 was just released, and has been tested against Rails. This PR will allow the sqlite3 version to float where previously it was pinned to `~> 1.4`.

### Detail

- Updates the Rails app dependency on sqlite3 to `>= 1.4` from `~> 1.4`.
- Updates the `Gemfile` to sqlite `>= 1.6.6` and `Gemfile.lock` to sqlite3 v2.0.0
 
### Additional information

The sqlite3 gem has automated integrations tests with Rails:

https://github.com/sparklemotion/sqlite3-ruby/actions/workflows/downstream.yml

Earlier today #51591 was also created in response to the 2.0.0 release.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] ~Tests are added or updated if you fix a bug or add a feature.~
* [ ] ~CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.~
