### PR TITLE
Remove outdated `mathn` related test

### DIFF
--- a/actionview/test/template/date_helper_test.rb
+++ b/actionview/test/template/date_helper_test.rb
@@ -143,16 +143,6 @@ class DateHelperTest < ActionView::TestCase
     assert_equal "10 minutes", distance_of_time_in_words(Time.at(600), 0)
   end
 
-  def test_distance_in_words_doesnt_use_the_quotient_operator
-    # Make sure that we avoid Integer#/ (redefined by mathn gem to return Rational)
-    Integer.send :private, :/
-
-    from = Time.utc(2004, 6, 6, 21, 45, 0)
-    assert_distance_of_time_in_words(from)
-  ensure
-    Integer.send :public, :/
-  end
-
   def test_time_ago_in_words_passes_include_seconds
     assert_equal "less than 20 seconds", time_ago_in_words(15.seconds.ago, include_seconds: true)
     assert_equal "less than a minute", time_ago_in_words(15.seconds.ago, include_seconds: false)


### PR DESCRIPTION
Ref: https://github.com/rails/rails/pull/8222

`mathn` used to be in the standard library, hence this was a relatively common issue. But it has been extracted and deprecated a long time ago, so It's no longer a big concern.

Making `Integer#/` private now emits a warning on Ruby 3.4:

```
/rails/actionview/test/template/date_helper_test.rb:148: warning: Redefining 'Integer#/' disables interpreter and JIT optimizations
```
