### PR TITLE
Action View Caching code sample syntax [ci skip]

### DIFF
--- a/actionview/lib/action_view/helpers/cache_helper.rb
+++ b/actionview/lib/action_view/helpers/cache_helper.rb
@@ -76,11 +76,11 @@ module ActionView
       #   render 'comments/comments'
       #   render('comments/comments')
       #
-      #   render "header" translates to render("comments/header")
+      #   render "header"        # translates to render("comments/header")
       #
-      #   render(@topic)         translates to render("topics/topic")
-      #   render(topics)         translates to render("topics/topic")
-      #   render(message.topics) translates to render("topics/topic")
+      #   render(@topic)         # translates to render("topics/topic")
+      #   render(topics)         # translates to render("topics/topic")
+      #   render(message.topics) # translates to render("topics/topic")
       #
       # It's not possible to derive all render calls like that, though.
       # Here are a few examples of things that can't be derived:


### PR DESCRIPTION
The code sample for the Action View `cache` helper method mixed Ruby syntax with prose. This commit introduces `#` comment characters to separate the English from the Ruby.
