### PR TITLE
Add support for recursive CTEs in ActiveRecord

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,27 @@
+*   Added support for recursive commont table expressions.
+
+    ```ruby
+    Post.with_recursive(
+      post_and_replies: [
+        Post.where(id: 42),
+        Post.joins('JOIN post_and_replies ON posts.in_reply_to_id = post_and_replies.id'),
+      ]
+    )
+    ```
+
+    Generates the following SQL:
+
+    ```sql
+    WITH RECURSIVE "post_and_replies" AS (
+      (SELECT "posts".* FROM "posts" WHERE "posts"."id" = 42)
+      UNION ALL
+      (SELECT "posts".* FROM "posts" JOIN post_and_replies ON posts.in_reply_to_id = post_and_replies.id)
+    )
+    SELECT "posts".* FROM "posts"
+    ```
+
+    *ClearlyClaire*
+
 *   `validate_constraint` can be called in a `change_table` block.
 
     ex:

--- a/activerecord/lib/active_record/querying.rb
+++ b/activerecord/lib/active_record/querying.rb
@@ -17,7 +17,7 @@ module ActiveRecord
       :and, :or, :annotate, :optimizer_hints, :extending,
       :having, :create_with, :distinct, :references, :none, :unscope, :merge, :except, :only,
       :count, :average, :minimum, :maximum, :sum, :calculate,
-      :pluck, :pick, :ids, :async_ids, :strict_loading, :excluding, :without, :with,
+      :pluck, :pick, :ids, :async_ids, :strict_loading, :excluding, :without, :with, :with_recursive,
       :async_count, :async_average, :async_minimum, :async_maximum, :async_sum, :async_pluck, :async_pick,
     ].freeze # :nodoc:
     delegate(*QUERYING_METHODS, to: :all)

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -60,7 +60,7 @@ module ActiveRecord
                             :reverse_order, :distinct, :create_with, :skip_query_cache]
 
     CLAUSE_METHODS = [:where, :having, :from]
-    INVALID_METHODS_FOR_DELETE_ALL = [:distinct, :with]
+    INVALID_METHODS_FOR_DELETE_ALL = [:distinct, :with, :with_recursive]
 
     VALUE_METHODS = MULTI_VALUE_METHODS + SINGLE_VALUE_METHODS + CLAUSE_METHODS
 

--- a/activerecord/test/cases/relation/with_test.rb
+++ b/activerecord/test/cases/relation/with_test.rb
@@ -3,11 +3,11 @@
 require "cases/helper"
 require "models/comment"
 require "models/post"
+require "models/company"
 
 module ActiveRecord
   class WithTest < ActiveRecord::TestCase
-    fixtures :comments
-    fixtures :posts
+    fixtures :comments, :posts, :companies
 
     POSTS_WITH_TAGS = [1, 2, 7, 8, 9, 10, 11].freeze
     POSTS_WITH_COMMENTS = [1, 2, 4, 5, 7].freeze
@@ -57,9 +57,35 @@ module ActiveRecord
       end
 
       def test_with_when_invalid_params_are_passed
-        assert_raise(ArgumentError) { Post.with }
         assert_raise(ArgumentError) { Post.with(posts_with_tags: nil).load }
-        assert_raise(ArgumentError) { Post.with(posts_with_tags: [Post.where("tags_count > 0")]).load }
+        assert_raise(ArgumentError) { Post.with(posts_with_tags: [Post.where("tags_count > 0"), 5]).load }
+      end
+
+      def test_with_when_passing_arrays
+        relation = Post
+          .with(posts_with_tags_or_comments: [
+            Post.where("tags_count > 0"),
+            Post.where("legacy_comments_count > 0")
+          ])
+          .from("posts_with_tags_or_comments AS posts")
+
+        assert_equal (POSTS_WITH_TAGS + POSTS_WITH_COMMENTS).sort, relation.order(:id).pluck(:id)
+      end
+
+      def test_with_recursive
+        top_companies = Company.where(firm_id: nil).to_a
+        child_companies = Company.where(firm_id: top_companies).to_a
+        top_companies_and_children = (top_companies.map(&:id) + child_companies.map(&:id)).sort
+
+        relation = Company.with_recursive(
+          top_companies_and_children: [
+            Company.where(firm_id: nil),
+            Company.joins("JOIN top_companies_and_children ON companies.firm_id = top_companies_and_children.id"),
+          ]
+        ).from("top_companies_and_children AS companies")
+
+        assert_equal top_companies_and_children, relation.order(:id).pluck(:id)
+        assert_match "WITH RECURSIVE", relation.to_sql
       end
 
       def test_with_joins


### PR DESCRIPTION
### Motivation / Background

While Rails 7.1 has added support for writing Common Table Expressions, this support does not extend to recursive CTEs.

This PR adds a `QueryMethods#with_recursive` construct to enable recursive CTEs.

In addition, it enables passing arrays of queries as `with` hash values, as recursive CTEs are generally only useful with `UNION` or `UNION ALL`, which, to my knowledge, are currently not exposed outside of Arel.

### Detail

This Pull Request adds a `WithChain` placeholder object to chain `with` and `recursive`, in the manner of `where.not`. Calling `QueryMethods#with_recursive` returns a scope with a `with_is_recursive` flag turned on, which is then used in `build_with` to pass `:recursive` to Arel.

The Pull Request also changes `build_with_value_from_hash` to allow arrays of values as queries, in which case the subqueries are joined with `UNION ALL`.

This enables writing queries such as:
```ruby
Post.with_recursive(
  post_and_replies: [
    Post.where(id: 42),
    Post.joins('JOIN post_and_replies ON posts.in_reply_to_id = post_and_replies.id'),
  ]
)
```

Generating the following SQL:
```sql
WITH RECURSIVE "post_and_replies" AS (
  (SELECT "posts".* FROM "posts" WHERE "posts"."id" = 42)
  UNION ALL
  (SELECT "posts".* FROM "posts" JOIN post_and_replies ON posts.in_reply_to_id = post_and_replies.id)
)
SELECT "posts".* FROM "posts"
```

### Additional information

Several syntaxes have previously been discussed to support recursive CTEs, as well as unions.
- https://github.com/rails/rails/pull/37944#issuecomment-565796643 proposes `.with(:recursive, …)`
- https://github.com/rails/rails/pull/37944#issuecomment-565803484 also suggests `.with.recursive(…)` (which this PR implements) and `.with_recursive(…)`
- https://github.com/vlado/activerecord-cte/issues/16#issuecomment-1433043310 suggests `.with_recursive(cte_name, base_case, recursive_case)`

I took a lot of inspiration from that last monkey-patch, but the API felt significantly at odds with the existing `QueryMethods#with`, so I decided to go with the `.with_recursive` approach and extend that interface to offer to `UNION ALL` sub-queries.

I have decided to put both the array support and the `.with_recursive` support in the same PR, as they are closely related, but I can split it into two PRs if preferred.

Tests are updated accordingly, but don't actually test inherently recursive queries, as I'm not sure there are existing fixtures lending themselves to that.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
