### PR TITLE
Stop showing select prompts for false attributes

### DIFF
--- a/actionview/lib/action_view/helpers/tags/select_renderer.rb
+++ b/actionview/lib/action_view/helpers/tags/select_renderer.rb
@@ -40,7 +40,7 @@ module ActionView
               option_tags = tag_builder.content_tag_string("option", content, value: "", label: label) + "\n" + option_tags
             end
 
-            if value.blank? && options[:prompt]
+            if value != false && value.blank? && options[:prompt]
               tag_options = { value: "" }.tap do |prompt_opts|
                 prompt_opts[:disabled] = true if options[:disabled] == ""
                 prompt_opts[:selected] = true if options[:selected] == ""

--- a/actionview/test/template/form_options_helper_test.rb
+++ b/actionview/test/template/form_options_helper_test.rb
@@ -790,7 +790,7 @@ class FormOptionsHelperTest < ActionView::TestCase
     )
   end
 
-  def test_select_no_prompt_when_select_has_value
+  def test_select_no_prompt_when_attribute_has_non_blank_string_value
     @post = Post.new
     @post.category = "<mus>"
     assert_dom_equal(
@@ -799,12 +799,30 @@ class FormOptionsHelperTest < ActionView::TestCase
     )
   end
 
-  def test_select_with_given_prompt
+  def test_select_no_prompt_when_attribute_has_false_value
+    @post = Post.new
+    @post.allow_comments = false
+    assert_dom_equal(
+      "<select id=\"post_allow_comments\" name=\"post[allow_comments]\"><option value=\"false\" selected=\"selected\">false</option>\n<option value=\"true\">true</option></select>",
+      select("post", "allow_comments", [false, true], prompt: true)
+    )
+  end
+
+  def test_select_with_given_prompt_for_blank_string_value
     @post = Post.new
     @post.category = ""
     assert_dom_equal(
       "<select id=\"post_category\" name=\"post[category]\"><option value=\"\">The prompt</option>\n<option value=\"abe\">abe</option>\n<option value=\"&lt;mus&gt;\">&lt;mus&gt;</option>\n<option value=\"hest\">hest</option></select>",
       select("post", "category", %w( abe <mus> hest), prompt: "The prompt")
+    )
+  end
+
+  def test_select_with_given_prompt_for_nil_value
+    @post = Post.new
+    @post.allow_comments = nil
+    assert_dom_equal(
+      "<select id=\"post_allow_comments\" name=\"post[allow_comments]\"><option value=\"\">The prompt</option>\n<option value=\"false\">false</option>\n<option value=\"true\">true</option></select>",
+      select("post", "allow_comments", [false, true], prompt: "The prompt")
     )
   end
 


### PR DESCRIPTION
Fixes #51602, whereby select prompts are shown for `false` boolean attributes, when that should be reserved for when they're `nil`.

I wasn't sure whether to put it in the CHANGELOG, so I haven't.