### PR TITLE
Fix some more ignored block warnings

### DIFF
--- a/actionpack/test/controller/filters_test.rb
+++ b/actionpack/test/controller/filters_test.rb
@@ -514,7 +514,7 @@ class FilterTest < ActionController::TestCase
         @filters << "action_two"
       end
 
-      def non_yielding_action
+      def non_yielding_action(&_)
         @filters << "it didn't yield"
       end
 

--- a/actionpack/test/controller/resources_test.rb
+++ b/actionpack/test/controller/resources_test.rb
@@ -1218,7 +1218,11 @@ class ResourcesTest < ActionController::TestCase
       assert_recognizes(options[:shallow_options].merge(action: "update",  id: "1", format: "xml"), path: "#{member_path}.xml",       method: :put)
       assert_recognizes(options[:shallow_options].merge(action: "destroy", id: "1", format: "xml"), path: "#{member_path}.xml",       method: :delete)
 
-      yield route_options if block_given?
+      if block_given?
+        _assert_nothing_raised_or_warn("assert_restful_routes_for") do
+          yield route_options
+        end
+      end
     end
 
     # test named routes like foo_path and foos_path map to the correct options.
@@ -1267,7 +1271,11 @@ class ResourcesTest < ActionController::TestCase
       assert_named_route "#{shallow_path}/1/#{edit_action}", "edit_#{shallow_prefix}#{singular_name}_path", options[:shallow_options].merge(id: "1")
       assert_named_route "#{shallow_path}/1/#{edit_action}.xml", "edit_#{shallow_prefix}#{singular_name}_path", options[:shallow_options].merge(id: "1", format: "xml")
 
-      yield route_options if block_given?
+      if block_given?
+        _assert_nothing_raised_or_warn("assert_restful_named_routes_for") do
+          yield route_options
+        end
+      end
     end
 
     def assert_singleton_routes_for(singleton_name, options = {})
@@ -1302,7 +1310,11 @@ class ResourcesTest < ActionController::TestCase
       assert_recognizes(route_options.merge(action: "update",  format: "xml"), path: "#{full_path}.xml",  method: :put)
       assert_recognizes(route_options.merge(action: "destroy", format: "xml"), path: "#{full_path}.xml",  method: :delete)
 
-      yield route_options if block_given?
+      if block_given?
+        _assert_nothing_raised_or_warn("assert_singleton_routes_for") do
+          yield route_options
+        end
+      end
     end
 
     def assert_singleton_named_routes_for(singleton_name, options = {})
@@ -1323,6 +1335,12 @@ class ResourcesTest < ActionController::TestCase
       assert_named_route "#{full_path}/new.xml",  "new_#{name_prefix}#{singleton_name}_path",  route_options.merge(format: "xml")
       assert_named_route "#{full_path}/edit",     "edit_#{name_prefix}#{singleton_name}_path",           route_options
       assert_named_route "#{full_path}/edit.xml", "edit_#{name_prefix}#{singleton_name}_path", route_options.merge(format: "xml")
+
+      if block_given?
+        _assert_nothing_raised_or_warn("assert_singleton_named_routes_for") do
+          yield route_options
+        end
+      end
     end
 
     def assert_named_route(expected, route, options)

--- a/activejob/lib/active_job/enqueuing.rb
+++ b/activejob/lib/active_job/enqueuing.rb
@@ -75,7 +75,7 @@ module ActiveJob
       end
 
       private
-        def job_or_instantiate(*args) # :doc:
+        def job_or_instantiate(*args, &_) # :doc:
           args.first.is_a?(self) ? args.first : new(*args)
         end
         ruby2_keywords(:job_or_instantiate)

--- a/activerecord/test/cases/serialized_attribute_test.rb
+++ b/activerecord/test/cases/serialized_attribute_test.rb
@@ -502,12 +502,12 @@ class SerializedAttributeTest < ActiveRecord::TestCase
     klass = Class.new(ActiveRecord::Base) do
       self.table_name = Topic.table_name
       store :content, coder: ActiveRecord::Coders::JSON
-      attribute(:content) { |subtype| EncryptedType.new(subtype: subtype) }
+      attribute(:content, EncryptedType.new(subtype: Topic.attribute_types.fetch("content")))
     end
 
     topic = klass.create!(content: { trial: true })
 
-    assert_equal({ "trial" => true }, topic.content)
+    assert_equal({ trial: true }, topic.content)
   end
 
   def test_mutation_detection_does_not_double_serialize


### PR DESCRIPTION
Ref: https://bugs.ruby-lang.org/issues/15554

A couple are harmless, but another couple found actual problems in the test suite where we passed blocks to `assert_*` methods that didn't expect one.
