### PR TITLE
Arel: only wrap SELECT statements in UNION if they involve ORDER BY, LIMIT or OFFSET

### DIFF
--- a/activerecord/lib/arel/visitors/to_sql.rb
+++ b/activerecord/lib/arel/visitors/to_sql.rb
@@ -965,21 +965,21 @@ module Arel # :nodoc: all
           collector = if o.left.class == o.class
             infix_value_with_paren(o.left, collector, value, true)
           else
-            grouping_parentheses o.left, collector
+            grouping_parentheses o.left, collector, false
           end
           collector << value
           collector = if o.right.class == o.class
             infix_value_with_paren(o.right, collector, value, true)
           else
-            grouping_parentheses o.right, collector
+            grouping_parentheses o.right, collector, false
           end
           collector << " )" unless suppress_parens
           collector
         end
 
         # Used by some visitors to enclose select queries in parentheses
-        def grouping_parentheses(o, collector)
-          if o.is_a?(Nodes::SelectStatement)
+        def grouping_parentheses(o, collector, always_wrap_selects = true)
+          if o.is_a?(Nodes::SelectStatement) && (always_wrap_selects || o.orders.present? || o.limit.present? || o.offset.present?)
             collector << "("
             visit o, collector
             collector << ")"

--- a/activerecord/test/cases/arel/attributes/attribute_test.rb
+++ b/activerecord/test/cases/arel/attributes/attribute_test.rb
@@ -963,7 +963,7 @@ module Arel
           union = mgr1.union(mgr2)
           node = relation[:id].in(union)
           _(node.to_sql).must_be_like %{
-            "users"."id" IN (( (SELECT "users"."id" FROM "users") UNION (SELECT "users"."id" FROM "users") ))
+            "users"."id" IN (( SELECT "users"."id" FROM "users" UNION SELECT "users"."id" FROM "users" ))
           }
         end
 

--- a/activerecord/test/cases/arel/select_manager_test.rb
+++ b/activerecord/test/cases/arel/select_manager_test.rb
@@ -253,7 +253,7 @@ module Arel
 
         # maybe FIXME: decide when wrapper parens are needed
         _(node.to_sql).must_be_like %{
-          ( (SELECT * FROM "users"  WHERE "users"."age" < 18) UNION (SELECT * FROM "users"  WHERE "users"."age" > 99) )
+          ( SELECT * FROM "users"  WHERE "users"."age" < 18 UNION SELECT * FROM "users"  WHERE "users"."age" > 99 )
         }
       end
 
@@ -261,7 +261,7 @@ module Arel
         node = @m1.union :all, @m2
 
         _(node.to_sql).must_be_like %{
-          ( (SELECT * FROM "users"  WHERE "users"."age" < 18) UNION ALL (SELECT * FROM "users"  WHERE "users"."age" > 99) )
+          ( SELECT * FROM "users"  WHERE "users"."age" < 18 UNION ALL SELECT * FROM "users"  WHERE "users"."age" > 99 )
         }
       end
     end
@@ -354,9 +354,9 @@ module Arel
         sql = manager.to_sql
         _(sql).must_be_like %{
           WITH RECURSIVE "replies" AS (
-              (SELECT "comments"."id", "comments"."parent_id" FROM "comments" WHERE "comments"."id" = 42)
+              SELECT "comments"."id", "comments"."parent_id" FROM "comments" WHERE "comments"."id" = 42
             UNION
-              (SELECT "comments"."id", "comments"."parent_id" FROM "comments" INNER JOIN "replies" ON "comments"."parent_id" = "replies"."id")
+              SELECT "comments"."id", "comments"."parent_id" FROM "comments" INNER JOIN "replies" ON "comments"."parent_id" = "replies"."id"
           )
           SELECT * FROM "replies"
         }


### PR DESCRIPTION
This change introduced by #51549 was not compatible with the SQLite3 adapter, so revert it, except for the specific cases where this actually fixed an issue.

### Motivation / Background

The change introduced in #51549 was not compatible with SQLite3, introducing a syntax error when using `UNION` or `UNION ALL`.

This PR reverts to the previous behavior except when `LIMIT`, `ORDER BY` or `OFFSET` are involved.

### Detail

Wrapping `SELECT` statements to either side of a `UNION` is not allowed in SQLite3:
```
sqlite> (SELECT 1) UNION ALL (SELECT 2);
Parse error: near "(": syntax error
  (SELECT 1) UNION ALL (SELECT 2);
  ^--- error here
```

Therefore, this PR changes the behavior to only wrap in parentheses if the `Nodes::SelectStatement` has non-empty `orders`, `limit` or `offset`, in which case the generated SQL would be invalid without parentheses.

### Additional information

In cases involving `LIMIT`, `ORDER BY` OR `OFFSET`, the generated SQL is still invalid in SQLite3, but it would have been invalid as well without parentheses:
```
sqlite> SELECT 1 LIMIT 1 UNION ALL SELECT 2;
Parse error: LIMIT clause should come after UNION ALL not before
```

An alternative could be to just revert #51549 and make massaging the query (by wrapping the query with a `Nodes::Grouping` or a second `SELECT`) the caller's responsibility, but I believe this solution to be preferable, especially considering that without the change, the following code will output SQL that is valid but likely not what is intended:
```ruby
Post.where("tags_count > ?", 0).arel.union(Post.where("comments_count > ?", 0).limit(1).arel)
```
```sql
SELECT "posts".* FROM "posts" WHERE (tags_count > 0)
UNION ALL
SELECT "posts".* FROM "posts" WHERE (comments_count > 0)
LIMIT 1
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
