### PR TITLE
Change `ActionDispatch::RemoteIp` to not use `HTTP_X_FORWARDED_FOR` when `REMOTE_ADDR` is not a trusted proxy

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/remote_ip.rb
+++ b/actionpack/lib/action_dispatch/middleware/remote_ip.rb
@@ -164,7 +164,7 @@ module ActionDispatch
 
         # If every single IP option is in the trusted list, return the IP that's
         # furthest away
-        filter_proxies(ips + [remote_addr]).first || ips.last || remote_addr
+        filter_proxies([remote_addr] + ips).first || ips.last || remote_addr
       end
 
       # Memoizes the value returned by #calculate_ip and returns it for
@@ -191,7 +191,7 @@ module ActionDispatch
 
       def filter_proxies(ips) # :doc:
         ips.reject do |ip|
-          @proxies.any? { |proxy| proxy === ip }
+          ip.blank? || @proxies.any? { |proxy| proxy === ip }
         end
       end
     end

--- a/actionpack/test/dispatch/request_test.rb
+++ b/actionpack/test/dispatch/request_test.rb
@@ -74,7 +74,7 @@ class RequestIP < BaseRequestTest
 
     request = stub_request "REMOTE_ADDR" => "1.2.3.4",
                            "HTTP_X_FORWARDED_FOR" => "3.4.5.6"
-    assert_equal "3.4.5.6", request.remote_ip
+    assert_equal "1.2.3.4", request.remote_ip
 
     request = stub_request "REMOTE_ADDR" => "127.0.0.1",
                            "HTTP_X_FORWARDED_FOR" => "3.4.5.6"
@@ -155,7 +155,7 @@ class RequestIP < BaseRequestTest
 
     request = stub_request "REMOTE_ADDR" => "2001:0db8:85a3:0000:0000:8a2e:0370:7334",
                            "HTTP_X_FORWARDED_FOR" => "fe80:0000:0000:0000:0202:b3ff:fe1e:8329"
-    assert_equal "fe80:0000:0000:0000:0202:b3ff:fe1e:8329", request.remote_ip
+    assert_equal "2001:0db8:85a3:0000:0000:8a2e:0370:7334", request.remote_ip
 
     request = stub_request "REMOTE_ADDR" => "::1",
                            "HTTP_X_FORWARDED_FOR" => "fe80:0000:0000:0000:0202:b3ff:fe1e:8329"

--- a/railties/test/application/middleware/remote_ip_test.rb
+++ b/railties/test/application/middleware/remote_ip_test.rb
@@ -60,7 +60,12 @@ module ApplicationTests
 
     test "remote_ip works with HTTP_X_FORWARDED_FOR" do
       make_basic_app
-      assert_equal "4.2.42.42", remote_ip("REMOTE_ADDR" => "1.1.1.1", "HTTP_X_FORWARDED_FOR" => "4.2.42.42")
+      assert_equal "4.2.42.42", remote_ip("REMOTE_ADDR" => "10.0.1.1", "HTTP_X_FORWARDED_FOR" => "4.2.42.42")
+    end
+
+    test "remote_ip does not trust HTTP_X_FORWARDED_FOR for untrusted REMOTE_ADDR" do
+      make_basic_app
+      assert_equal "4.2.42.1", remote_ip("REMOTE_ADDR" => "4.2.42.1", "HTTP_X_FORWARDED_FOR" => "4.2.42.42")
     end
 
     test "the user can set trusted proxies with an enumerable of case equality comparable values" do
@@ -80,7 +85,7 @@ module ApplicationTests
       end
 
       assert_equal "10.0.0.0",
-                   remote_ip("REMOTE_ADDR" => "1.1.1.1", "HTTP_X_FORWARDED_FOR" => "10.0.0.0,4.2.42.42")
+                   remote_ip("REMOTE_ADDR" => "4.2.42.1", "HTTP_X_FORWARDED_FOR" => "10.0.0.0,4.2.42.42")
     end
 
     test "setting trusted proxies to a single value (deprecated) adds value to default trusted proxies" do


### PR DESCRIPTION
### Motivation / Background

As [pointed out](https://github.com/rails/rails/blob/1428ef984e8be2e301c562c01b34f8d8c90bd4cf/actionpack/lib/action_dispatch/middleware/remote_ip.rb#L25-L32) in the documentation, using `RemoteIp` while accessible without a reverse proxy opens you to IP spoofing. Returning `REMOTE_ADDR` when that is not considered a trusted proxy should make that less likely.

### Detail

The current implementation of `RemoteIp` assumes the Rails server is only directly accessible through a trusted reverse-proxy and requires users to filter the header or remove the middleware when that is not the case.

While such misconfigurations are unlikely, it is also somewhat of an unsafe fallback mode, and returning `REMOTE_ADDR` instead of trusting `X-Forwarded-For` from an untrusted client should be better.

### Additional information

In the test suite, there are cases where `REMOTE_ADDR` is unset. I don't know in which real-life situations this could happen, but if it does, the code essentially falls back to the old behavior of trusting the last `X-Forwarded-For`.

An alternative might be to raise an error when `REMOTE_ADDR` does not match one of the trusted proxies, as is done when `Client-Ip` and `X-Forwarded-For` are mismatched.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
