### PR TITLE
docs: Fix `ActiveSupport::TimeWithZone#change` example [skip ci]

### DIFF
--- a/activesupport/lib/active_support/time_with_zone.rb
+++ b/activesupport/lib/active_support/time_with_zone.rb
@@ -375,8 +375,8 @@ module ActiveSupport
     #
     #   t = Time.zone.now          # => Fri, 14 Apr 2017 11:45:15.116992711 EST -05:00
     #   t.change(year: 2020)       # => Tue, 14 Apr 2020 11:45:15.116992711 EST -05:00
-    #   t.change(hour: 12)         # => Fri, 14 Apr 2017 12:00:00.116992711 EST -05:00
-    #   t.change(min: 30)          # => Fri, 14 Apr 2017 11:30:00.116992711 EST -05:00
+    #   t.change(hour: 12)         # => Fri, 14 Apr 2017 12:00:00.000000000 EST -05:00
+    #   t.change(min: 30)          # => Fri, 14 Apr 2017 11:30:00.000000000 EST -05:00
     #   t.change(offset: "-10:00") # => Fri, 14 Apr 2017 11:45:15.116992711 HST -10:00
     #   t.change(zone: "Hawaii")   # => Fri, 14 Apr 2017 11:45:15.116992711 HST -10:00
     def change(options)


### PR DESCRIPTION
## Motivation / Background
This Pull Request has been created because the documentation for  `ActiveSupport::TimeWithZone#change` wasn't correct.

## Detail
The behavior of `:hour` and `:min` is different from the example in the [documentation](https://api.rubyonrails.org/classes/ActiveSupport/TimeWithZone.html#method-i-change).
I checked with Rails 7.1.3.2 and all digits after nano seconds are 0.

```ruby
t = Time.zone.now   #=> Sat, 20 Apr 2024 14:55:55.688536000 JST +09:00
t.change(hour: 12)  #=> Sat, 20 Apr 2024 12:00:00.000000000 JST +09:00
t.change(min: 30)   #=> Sat, 20 Apr 2024 14:30:00.000000000 JST +09:00
```


## Checklist

Before submitting the PR make sure the following are checked:

- [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
- [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: [Fix #issue-number]
- [x] Tests are added or updated if you fix a bug or add a feature.
- [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.