### PR TITLE
Fix `Mime::Type.parse` for HTTP Accept with parameters

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Fix `Mime::Type.parse` handling type parameters for HTTP Accept headers.
+
+    *Taylor Chaparro*
+
 *   Fix the error page that is displayed when a view template is missing to account for nested controller paths in the
     suggested correct location for the missing template.
 

--- a/actionpack/lib/action_dispatch/http/mime_type.rb
+++ b/actionpack/lib/action_dispatch/http/mime_type.rb
@@ -165,8 +165,11 @@ module Mime
       end
 
       def lookup(string)
+        return LOOKUP[string] if LOOKUP.key?(string)
+
         # fallback to the media-type without parameters if it was not found
-        LOOKUP[string] || LOOKUP[string.split(";", 2)[0]&.rstrip] || Type.new(string)
+        string = string.split(";", 2)[0]&.rstrip
+        LOOKUP[string] || Type.new(string)
       end
 
       def lookup_by_extension(extension)

--- a/actionpack/test/dispatch/mime_type_test.rb
+++ b/actionpack/test/dispatch/mime_type_test.rb
@@ -68,6 +68,12 @@ class MimeTypeTest < ActiveSupport::TestCase
     assert_equal expect.map(&:to_s), Mime::Type.parse(accept).map(&:to_s)
   end
 
+  test "parse with q and media type parameters" do
+    accept = "text/xml,application/xhtml+xml,text/yaml; q=0.3,application/xml,text/html; q=0.8,image/png,text/plain; q=0.5,application/pdf,*/*; encoding=UTF-8; q=0.2"
+    expect = [Mime[:html], Mime[:xml], Mime[:png], Mime[:pdf], Mime[:text], Mime[:yaml], "*/*"]
+    assert_equal expect.map(&:to_s), Mime::Type.parse(accept).map(&:to_s)
+  end
+
   test "parse single media range with q" do
     accept = "text/html;q=0.9"
     expect = [Mime[:html]]
@@ -89,6 +95,12 @@ class MimeTypeTest < ActiveSupport::TestCase
   test "parse arbitrary media type parameters with comma and additional media type" do
     accept = 'multipart/form-data; boundary="simple, boundary", text/xml'
     expect = [Mime[:multipart_form], Mime[:xml]]
+    assert_equal expect, Mime::Type.parse(accept)
+  end
+
+  test "parse wildcard with arbitrary media type parameters" do
+    accept = '*/*; boundary="simple"'
+    expect = ["*/*"]
     assert_equal expect, Mime::Type.parse(accept)
   end
 


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

Fixes  #51594

This Pull Request has been created because to fix valid Mime::Type parsing of media range parameters.

### Detail

This Pull Request changes `Mime::Type.lookup` (indirectly `Mime::Type.parse`) to strip out custom media range parameters before falling back to default type creation. This _should_ fix at least some 406 responses that Rails 7.1 is returning for valid HTTP Accept headers.

An example of a failure currently:

`Accept: */*;encoding=UTF-8;q=0.9`

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->
It looks like the break was initially introduced in 7.1 from #48397 .

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
