### PR TITLE
Filter internal frames in deprecation warnings for Ruby 3.4

### DIFF
--- a/activesupport/lib/active_support/deprecation/reporting.rb
+++ b/activesupport/lib/active_support/deprecation/reporting.rb
@@ -172,7 +172,7 @@ module ActiveSupport
         LIB_DIR = RbConfig::CONFIG["libdir"]
 
         def ignored_callstack?(path)
-          path.start_with?(RAILS_GEM_ROOT, LIB_DIR)
+          path.start_with?(RAILS_GEM_ROOT, LIB_DIR) || path.include?("<internal:")
         end
     end
   end

--- a/activesupport/test/deprecation_test.rb
+++ b/activesupport/test/deprecation_test.rb
@@ -975,9 +975,20 @@ class DeprecationTest < ActiveSupport::TestCase
     end
   end
 
+  test "warn deprecation can blame code from internal methods" do
+    @deprecator.behavior = ->(message, *) { @message = message }
+    method_that_emits_deprecation_with_internal_method(@deprecator)
+
+    assert_not_includes(@message, "internal")
+  end
+
   private
     def method_that_emits_deprecation(deprecator)
       deprecator.warn
+    end
+
+    def method_that_emits_deprecation_with_internal_method(deprecator)
+      [1].each { deprecator.warn }
     end
 
     def with_rails_application_deprecators(&block)


### PR DESCRIPTION
### Motivation / Background

Followup to #50923. On Ruby 3.4 with rails main I get a bunch of deprecation warnings that look like this:
> ... If automatic inference is not intended, you can silence this warning by defining the association with `inverse_of: nil`. (called from Array#each at <internal:array>:54)

### Additional information

This test fails for me locally on 3.4 without this change:
> Expected "DEPRECATION WARNING: You are using deprecated behavior which will be removed from the next major or minor release. (called from Array#each at <internal:array>:54)" to not include "internal".

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
