### PR TITLE
[FIX] Enum methods should follow method naming convention

### DIFF
--- a/activerecord/lib/active_record/enum.rb
+++ b/activerecord/lib/active_record/enum.rb
@@ -280,17 +280,11 @@ module ActiveRecord
             enum_values[label] = value
             label = label.to_s
 
-            value_method_name = "#{prefix}#{label}#{suffix}"
+            method_friendly_label = label.gsub(/[\W&&[:ascii:]]+/, "_")
+
+            value_method_name = "#{prefix}#{method_friendly_label}#{suffix}"
             value_method_names << value_method_name
             define_enum_methods(name, value_method_name, value, scopes, instance_methods)
-
-            method_friendly_label = label.gsub(/[\W&&[:ascii:]]+/, "_")
-            value_method_alias = "#{prefix}#{method_friendly_label}#{suffix}"
-
-            if value_method_alias != value_method_name && !value_method_names.include?(value_method_alias)
-              value_method_names << value_method_alias
-              define_enum_methods(name, value_method_alias, value, scopes, instance_methods)
-            end
           end
         end
         detect_negative_enum_conditions!(value_method_names) if scopes

--- a/activerecord/test/cases/enum_test.rb
+++ b/activerecord/test/cases/enum_test.rb
@@ -956,13 +956,16 @@ class EnumTest < ActiveRecord::TestCase
     klass = assert_deprecated(ActiveRecord.deprecator) do
       Class.new(ActiveRecord::Base) do
         self.table_name = "computers"
-        enum timezone: [:"Etc/GMT+1", :"Etc/GMT-1"]
+        enum timezone: {
+          "Etc_GMT_plus_1" => 1,
+          "Etc_GMT_minus_1" => 2
+        }
       end
     end
 
-    computer = klass.public_send(:"Etc/GMT+1").build
-    assert_predicate computer, :"Etc/GMT+1?"
-    assert_not_predicate computer, :"Etc/GMT-1?"
+    computer = klass.public_send(:"Etc_GMT_plus_1").build
+    assert_predicate computer, :"Etc_GMT_plus_1?"
+    assert_not_predicate computer, :"Etc_GMT_minus_1?"
   end
 
   test "deserialize enum value to original hash key" do
@@ -1137,5 +1140,23 @@ class EnumTest < ActiveRecord::TestCase
     instance = klass.new
     assert_raises(NoMethodError) { instance.proposed? }
     assert_raises(NoMethodError) { instance.proposed! }
+  end
+
+  test "enum methods should be defined with friendly name" do
+    klass = assert_deprecated(ActiveRecord.deprecator) do
+      Class.new(ActiveRecord::Base) do
+        self.table_name = "computers"
+        enum extendedWarranty: {
+          "Basic (Silver)": "basic-silver",
+          "Premium (Gold)": "premium-gold"
+        }
+      end
+    end
+
+    computer = klass.build
+    assert_not_respond_to computer, :"Basic (Silver)?"
+    assert_not_respond_to computer, :"Basic (Silver)!"
+    assert_not_respond_to computer, :"Premium (Gold)?"
+    assert_not_respond_to computer, :"Premium (Gold)!"
   end
 end


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created because to fix #51621 

When we defined the enum in Rails, methods for the enums were generated on the fly. However, these enums do not adhere to the naming convention of the methods.

When listing the methods for a particular instance in the script below, Rails defines two methods for the same key: one with the naming convention and the other with the same name as the key.

For example:

```ruby
[1] pry(#<BugTest>)> john.methods.select { |method| method.to_s.include? "US"}
=> [:"US West (Oregon)!", :US_West_Oregon_?, :US_West_Oregon_!, :"US West (Oregon)?"]
```

The method :`"US West (Oregon)!"` contains spaces and round brackets in the name which doesn't follow the naming convention.

This PR addresses the above issue.

### Detail
In the previous version, within `activerecord/lib/active_record/enum.rb`, there was a practice of defining two variants of the same key:

1. One adhering to the method name convention.
2. Another method with the same name as the enum key.

This PR modifies the code to create the method only once, adhering to the naming convention.

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #51621 ]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
