### PR TITLE
Allow assertionless tests to be reported

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,14 @@
+*   Allow assertionless tests to be reported.
+
+    `ActiveSupport::TestCase` can be configured to report tests that do not run any assertions.
+    This is helpful in detecting broken tests that do not perform intended assertions.
+
+    ```ruby
+    config.active_support.assertionless_tests_behavior = :raise
+    ```
+
+    *fatkodima*
+
 *   Support `hexBinary` type in `ActiveSupport::XmlMini`.
 
     *heka1024*

--- a/activesupport/lib/active_support/railtie.rb
+++ b/activesupport/lib/active_support/railtie.rb
@@ -124,6 +124,8 @@ module ActiveSupport
           ActiveSupport.deprecator.warn("config.active_support.remove_deprecated_time_with_zone_name is deprecated and will be removed in Rails 7.2.")
         elsif k == :use_rfc4122_namespaced_uuids
           ActiveSupport.deprecator.warn("config.active_support.use_rfc4122_namespaced_uuids is deprecated and will be removed in Rails 7.2.")
+        elsif k == :assertionless_tests_behavior
+          ActiveSupport::TestCase.assertionless_tests_behavior = v
         else
           k = "#{k}="
           ActiveSupport.public_send(k, v) if ActiveSupport.respond_to? k

--- a/activesupport/lib/active_support/test_case.rb
+++ b/activesupport/lib/active_support/test_case.rb
@@ -3,6 +3,7 @@
 require "minitest"
 require "active_support/testing/tagged_logging"
 require "active_support/testing/setup_and_teardown"
+require "active_support/testing/assertionless_tests"
 require "active_support/testing/assertions"
 require "active_support/testing/error_reporter_assertions"
 require "active_support/testing/deprecation"
@@ -142,6 +143,7 @@ module ActiveSupport
 
     include ActiveSupport::Testing::TaggedLogging
     prepend ActiveSupport::Testing::SetupAndTeardown
+    prepend ActiveSupport::Testing::AssertionlessTests
     include ActiveSupport::Testing::Assertions
     include ActiveSupport::Testing::ErrorReporterAssertions
     include ActiveSupport::Testing::Deprecation

--- a/activesupport/lib/active_support/testing/assertionless_tests.rb
+++ b/activesupport/lib/active_support/testing/assertionless_tests.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+module ActiveSupport
+  module Testing
+    # Allows to configure the behavior when the test case has no assertions in it.
+    # This is helpful in detecting broken tests that do not perform intended assertions.
+    module AssertionlessTests # :nodoc:
+      def self.prepended(klass)
+        klass.class_attribute :_assertionless_tests_behavior, instance_accessor: false, instance_predicate: false
+        klass.extend ClassMethods
+        klass.assertionless_tests_behavior = :ignore
+      end
+
+      module ClassMethods
+        def assertionless_tests_behavior
+          _assertionless_tests_behavior
+        end
+
+        def assertionless_tests_behavior=(behavior)
+          self._assertionless_tests_behavior =
+            case behavior
+            when :ignore, nil
+              nil
+            when :log
+              logger =
+                if defined?(Rails.logger) && Rails.logger
+                  Rails.logger
+                else
+                  require "active_support/logger"
+                  ActiveSupport::Logger.new($stderr)
+                end
+
+              ->(message) { logger.warn(message) }
+            when :raise
+              ->(message) { raise Minitest::Assertion, message }
+            when Proc
+              behavior
+            else
+              raise ArgumentError, "assertionless_tests_behavior must be one of :ignore, :log, :raise, or a custom proc."
+            end
+        end
+      end
+
+      def after_teardown
+        super
+
+        return if skipped? || error?
+
+        if assertions == 0 && (behavior = self.class.assertionless_tests_behavior)
+          file, line = method(name).source_location
+          message = "Test is missing assertions: `#{name}` #{file}:#{line}"
+          behavior.call(message)
+        end
+      end
+    end
+  end
+end

--- a/activesupport/test/testing/assertionless_tests_test.rb
+++ b/activesupport/test/testing/assertionless_tests_test.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require_relative "../abstract_unit"
+require "active_support/core_ext/object/with"
+
+module AssertionlessTestsTest
+  module Tests
+    def test_without_assertions
+    end
+  end
+
+  class AssertionlessTestsIgnore < ActiveSupport::TestCase
+    module AfterTeardown
+      def after_teardown
+        ActiveSupport::TestCase.with(assertionless_tests_behavior: :ignore) do
+          assert_nothing_raised do
+            super
+          end
+        end
+      end
+    end
+
+    include Tests
+    prepend AfterTeardown
+  end
+
+  class AssertionlessTestsLog < ActiveSupport::TestCase
+    module AfterTeardown
+      def after_teardown
+        _out, err = capture_io do
+          ActiveSupport::TestCase.with(assertionless_tests_behavior: :log) do
+            super
+          end
+        end
+        assert_match(/Test is missing assertions: `test_without_assertions` .+assertionless_tests_test\.rb:\d+/, err)
+      end
+    end
+
+    include Tests
+    prepend AfterTeardown
+  end
+
+  class AssertionlessTestsRaise < ActiveSupport::TestCase
+    module AfterTeardown
+      def after_teardown
+        ActiveSupport::TestCase.with(assertionless_tests_behavior: :raise) do
+          assert_raise(Minitest::Assertion,
+                       match: /Test is missing assertions: `test_without_assertions` .+assertionless_tests_test\.rb:\d+/) do
+            super
+          end
+        end
+      end
+    end
+
+    include Tests
+    prepend AfterTeardown
+  end
+
+  class AssertionlessTestsUnknown < ActiveSupport::TestCase
+    def test_raises_when_unknown_behavior
+      assert_raises(ArgumentError, match: /assertionless_tests_behavior must be one of/) do
+        ActiveSupport::TestCase.assertionless_tests_behavior = :unknown
+      end
+    end
+  end
+end

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -64,6 +64,7 @@ Below are the default values associated with each target version. In cases of co
 - [`config.active_record.automatically_invert_plural_associations`](#config-active-record-automatically-invert-plural-associations): `true`
 - [`config.active_record.validate_migration_timestamps`](#config-active-record-validate-migration-timestamps): `true`
 - [`config.active_storage.web_image_content_types`](#config-active-storage-web-image-content-types): `%w[image/png image/jpeg image/gif image/webp]`
+- [`config.active_support.assertionless_tests_behavior`](#config-active-support-assertionless-tests-behavior): `:log`
 
 #### Default Values for Target Version 7.1
 
@@ -2655,6 +2656,18 @@ The default value depends on the `config.load_defaults` target version:
 | --------------------- | -------------------- |
 | (original)            | `false`              |
 | 7.0                   | `true`               |
+
+#### `config.active_support.assertionless_tests_behavior`
+
+Controls the behavior when a test do not run any assertions. The following options are available:
+
+  * `:ignore` - Assertionless tests will be ignored. This is the default.
+
+  * `:log` - Assertionless tests will be logged via `Rails.logger` at the `:warn` level.
+
+  * `:raise` - Assertionless tests will be considered as failed and raise an error.
+
+  * Custom proc - A custom proc can be provided. It should accept an error message.
 
 #### `ActiveSupport::Logger.silencer`
 

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -334,6 +334,12 @@ module Rails
             active_record.validate_migration_timestamps = true
             active_record.automatically_invert_plural_associations = true
           end
+
+          if respond_to?(:active_support)
+            if Rails.env.local?
+              active_support.assertionless_tests_behavior = :log
+            end
+          end
         else
           raise "Unknown version #{target_version.to_s.inspect}"
         end

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_7_2.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_7_2.rb.tt
@@ -66,3 +66,11 @@
 # on `Post`. With this option enabled, it will also look for a `:comments` association.
 #++
 # Rails.application.config.active_record.automatically_invert_plural_associations = true
+
+###
+# Controls whether Active Support should log tests without assertions.
+# This is helpful in detecting broken tests that do not perform intended assertions.
+# To disable this behavior, set the value to `:ignore` inside the `config/application.rb` (NOT this file).
+#
+#++
+# Rails.application.config.active_support.assertionless_tests_behavior = :log


### PR DESCRIPTION
Inspired by https://railsatscale.com/2024-01-25-catching-assertionless-tests/.

It is very easy to write a "false positive" broken test (as can be seen from the linked article) that actually tests nothing (or can become such in the future). A simple example:

```ruby
def test_active
  active_users = User.active.to_a
  active_users.each do |user|
    assert user.active?
  end
end
```

We have some assertions used in the test case, so, looks good? But if we change the scope and it will now return 0 records, this test will still pass and none of the assertions will be run. For this test to be more robust, we need at least to test that `active_users` contains any records.

This PR now allows to easily detect such tests. 
```ruby
# config/environments/test.rb
config.active_support.assertionless_tests_behavior = :raise # also available :ignore and :log
```

With this configuration, assertionless tests we will now be marked as failed and not silently pass.

Currently, this feature is configured to `:ignore` such tests by default, but we can rollout it to eventually `:log` and then `:raise` in the future. 

Some of such problematic tests were already fixed before, like in https://github.com/rails/rails/pull/48065.

As a follow up to this PR, I would like to enable `:raise` behavior for all the frameworks. Currently there are a few offences fixing which will make this PR bigger than is needed.

cc @nvasilevski @byroot (interested in your thoughts about this)