### PR TITLE
[Fix #51524] Fix `strict_loading` violations ignored when using `pluck`

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Fix `strict_loading` violations ignored when using `pluck`
+
+    *Johnson Chan*
+
 *   Move the defaulting of `prevent_writes` to `true` when using the `reading` role into the parameters
     of the role switching methods, and raise an `ArgumentError` if `prevent_writes: false` is provided
     with the `reading` role.

--- a/activerecord/lib/active_record/associations/association.rb
+++ b/activerecord/lib/active_record/associations/association.rb
@@ -232,6 +232,20 @@ module ActiveRecord
         _create_record(attributes, true, &block)
       end
 
+      def violates_strict_loading?
+        return if @skip_strict_loading
+
+        return unless owner.validation_context.nil?
+
+        return reflection.strict_loading? if reflection.options.key?(:strict_loading)
+
+        owner.strict_loading? && !owner.strict_loading_n_plus_one_only?
+      end
+
+      def find_target?
+        !loaded? && (!owner.new_record? || foreign_key_present?) && klass
+      end
+
       # Whether the association represents a single record
       # or a collection of records.
       def collection?
@@ -281,16 +295,6 @@ module ActiveRecord
           @skip_strict_loading = skip_strict_loading_was
         end
 
-        def violates_strict_loading?
-          return if @skip_strict_loading
-
-          return unless owner.validation_context.nil?
-
-          return reflection.strict_loading? if reflection.options.key?(:strict_loading)
-
-          owner.strict_loading? && !owner.strict_loading_n_plus_one_only?
-        end
-
         # The scope for this association.
         #
         # Note that the association_scope is merged into the target_scope only when the
@@ -315,10 +319,6 @@ module ActiveRecord
 
         def scope_for_create
           scope.scope_for_create
-        end
-
-        def find_target?
-          !loaded? && (!owner.new_record? || foreign_key_present?) && klass
         end
 
         # Returns true if there is a foreign key present on the owner which

--- a/activerecord/lib/active_record/associations/association.rb
+++ b/activerecord/lib/active_record/associations/association.rb
@@ -233,6 +233,8 @@ module ActiveRecord
       end
 
       def violates_strict_loading?
+        return unless find_target?
+
         return if @skip_strict_loading
 
         return unless owner.validation_context.nil?
@@ -240,10 +242,6 @@ module ActiveRecord
         return reflection.strict_loading? if reflection.options.key?(:strict_loading)
 
         owner.strict_loading? && !owner.strict_loading_n_plus_one_only?
-      end
-
-      def find_target?
-        !loaded? && (!owner.new_record? || foreign_key_present?) && klass
       end
 
       # Whether the association represents a single record
@@ -319,6 +317,10 @@ module ActiveRecord
 
         def scope_for_create
           scope.scope_for_create
+        end
+
+        def find_target?
+          !loaded? && (!owner.new_record? || foreign_key_present?) && klass
         end
 
         # Returns true if there is a foreign key present on the owner which

--- a/activerecord/lib/active_record/associations/collection_proxy.rb
+++ b/activerecord/lib/active_record/associations/collection_proxy.rb
@@ -726,6 +726,10 @@ module ActiveRecord
       end
 
       def pluck(*column_names)
+        if proxy_association.violates_strict_loading?
+          Base.strict_loading_violation!(owner: proxy_association.owner.class, reflection: proxy_association.reflection)
+        end
+
         null_scope? ? scope.pluck(*column_names) : super
       end
 

--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -293,7 +293,7 @@ module ActiveRecord
     #
     # See also #ids.
     def pluck(*column_names)
-      if respond_to?(:proxy_association) && proxy_association.violates_strict_loading? && proxy_association.find_target?
+      if respond_to?(:proxy_association) && proxy_association.violates_strict_loading?
         Base.strict_loading_violation!(owner: proxy_association.owner.class, reflection: proxy_association.reflection)
       end
 

--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -293,10 +293,6 @@ module ActiveRecord
     #
     # See also #ids.
     def pluck(*column_names)
-      if respond_to?(:proxy_association) && proxy_association.violates_strict_loading?
-        Base.strict_loading_violation!(owner: proxy_association.owner.class, reflection: proxy_association.reflection)
-      end
-
       if @none
         if @async
           return Promise::Complete.new([])

--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -293,6 +293,10 @@ module ActiveRecord
     #
     # See also #ids.
     def pluck(*column_names)
+      if respond_to?(:proxy_association) && proxy_association.violates_strict_loading? && proxy_association.find_target?
+        Base.strict_loading_violation!(owner: proxy_association.owner.class, reflection: proxy_association.reflection)
+      end
+
       if @none
         if @async
           return Promise::Complete.new([])

--- a/activerecord/test/cases/strict_loading_test.rb
+++ b/activerecord/test/cases/strict_loading_test.rb
@@ -355,6 +355,25 @@ class StrictLoadingTest < ActiveRecord::TestCase
     end
   end
 
+  def test_on_lazy_loading_and_strict_loading_with_pluck
+    with_strict_loading_by_default(Developer) do
+      dev = Developer.first
+
+      assert_raises ActiveRecord::StrictLoadingViolationError do
+        dev.audit_logs.pluck(:id)
+      end
+    end
+  end
+
+  def test_preload_audit_logs_are_strict_loading_with_pluck
+    with_strict_loading_by_default(Developer) do
+      dev = Developer.preload(:audit_logs).first
+
+      assert_nothing_raised do
+        dev.audit_logs.pluck(:id)
+      end
+    end
+  end
 
   def test_preload_audit_logs_are_strict_loading_because_parent_is_strict_loading
     developer = Developer.first


### PR DESCRIPTION
### Motivation / Background

Fixes https://github.com/rails/rails/issues/51524

### Detail


- Update `ActiveRecord::Calculations#pluck`  to raise an error or log on a strict loading violation.
- Update the `ActiveRecord::Associations::Association#violates_strict_loading?` make preloaded association won't violates strict loading

### Additional information

This PR will conflict with https://github.com/rails/rails/pull/50389 as we are fixing a similar issue in a different scenario.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
