### PR TITLE
[FIX] Sqlite3 Should create db for missing parent directories as well

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -112,13 +112,9 @@ module ActiveRecord
           dirname = File.dirname(@config[:database])
           unless File.directory?(dirname)
             begin
-              Dir.mkdir(dirname)
-            rescue Errno::ENOENT => error
-              if error.message.include?("No such file or directory")
-                raise ActiveRecord::NoDatabaseError.new(connection_pool: @pool)
-              else
-                raise
-              end
+              FileUtils.mkdir_p(dirname)
+            rescue SystemCallError
+              raise ActiveRecord::NoDatabaseError.new(connection_pool: @pool)
             end
           end
         end

--- a/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
@@ -23,12 +23,14 @@ module ActiveRecord
         )
       end
 
-      def test_bad_connection
-        error = assert_raise ActiveRecord::NoDatabaseError do
-          connection = SQLite3Adapter.new(adapter: "sqlite3", database: "/tmp/should/_not/_exist/-cinco-dog.db")
+      def test_database_should_get_created_when_missing_parent_directories_for_database_path
+        dir = Dir.mktmpdir
+        db_path = File.join(dir, "_not_exist/-cinco-dog.sqlite3")
+        assert_nothing_raised do
+          connection = SQLite3Adapter.new(adapter: "sqlite3", database: db_path)
           connection.drop_table "ex", if_exists: true
         end
-        assert_kind_of ActiveRecord::ConnectionAdapters::NullPool, error.connection_pool
+        assert SQLite3Adapter.database_exists?(adapter: "sqlite3", database: db_path)
       end
 
       def test_database_exists_returns_false_when_the_database_does_not_exist


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created to fix #51623 

[ActiveRecord::ConnectionAdapters::SQLite3Adapter#initialize](https://github.com/rails/rails/blob/284baa18c2c62abec170b61e285aefbd9604f675/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb#L112-L122) will check if a sqlite3 database file path exists, and if not it will attempt to create the directory using Dir.mkdir. However, Dir.mkdir cannot create all parent directories like FileUtils.mkdir_p. Thus an No such file or directory @ dir_s_mkdir - does/not/exist/yet (Errno::ENOENT) will be raised if one of the parent-parent directories of the sqlite3 database file do not exist yet.

### Detail

This Pull Request changes:
ActiveRecord::ConnectionAdapters::SQLite3Adapter#initialize

Replaced the `Dir.mkdir(dirname)` with `FileUtils.mkdir_p(dirname)` to create the directory for the parent directories in the path if they don't exists.


### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #51623 ]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
