### PR TITLE
Support hexBinary type in XML

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Support `hexBinary` type in `ActiveSupport::XmlMini`.
+
+    *heka1024*
+
 *   Deprecate `ActiveSupport::ProxyObject` in favor of Ruby's buildin `BasicObject`
 
     *Earlopain*

--- a/activesupport/lib/active_support/xml_mini.rb
+++ b/activesupport/lib/active_support/xml_mini.rb
@@ -79,6 +79,7 @@ module ActiveSupport
         "string"       => Proc.new { |string|  string.to_s },
         "yaml"         => Proc.new { |yaml|    YAML.load(yaml) rescue yaml },
         "base64Binary" => Proc.new { |bin|     ::Base64.decode64(bin) },
+        "hexBinary"    => Proc.new { |bin|     parse_hex_binary(bin) },
         "binary"       => Proc.new { |bin, entity| _parse_binary(bin, entity) },
         "file"         => Proc.new { |file, entity| _parse_file(file, entity) }
       }
@@ -162,11 +163,12 @@ module ActiveSupport
         "#{left}#{middle.tr('_ ', '--')}#{right}"
       end
 
-      # TODO: Add support for other encodings
       def _parse_binary(bin, entity)
         case entity["encoding"]
         when "base64"
           ::Base64.decode64(bin)
+        when "hex", "hexBinary"
+          parse_hex_binary(bin)
         else
           bin
         end
@@ -178,6 +180,10 @@ module ActiveSupport
         f.original_filename = entity["name"]
         f.content_type = entity["content_type"]
         f
+      end
+
+      def parse_hex_binary(bin)
+        [bin].pack("H*")
       end
 
       def current_thread_backend

--- a/activesupport/test/xml_mini_test.rb
+++ b/activesupport/test/xml_mini_test.rb
@@ -337,6 +337,19 @@ YAML
       assert_equal({ "1 => 'test'" => nil }, parser.call("{1 => 'test'}"))
     end
 
+    def test_hexBinary
+      parser = @parsing["hexBinary"]
+
+      expected = "Hello, World!"
+      hex_binary = "48656C6C6F2C20576F726C6421"
+
+      assert_equal expected, parser.call(hex_binary)
+
+      parser = @parsing["binary"]
+      assert_equal expected, parser.call(hex_binary, "encoding" => "hexBinary")
+      assert_equal expected, parser.call(hex_binary, "encoding" => "hex")
+    end
+
     def test_base64Binary_and_binary
       base64 = <<BASE64
 TWFuIGlzIGRpc3Rpbmd1aXNoZWQsIG5vdCBvbmx5IGJ5IGhpcyByZWFzb24sIGJ1dCBieSB0aGlz


### PR DESCRIPTION
### Motivation / Background

This Pull Request add `hexBinary` parser in XML. `hexBinary` is one of the primitive data type in XML https://www.w3.org/TR/xmlschema-2/#hexBinary. But rails does not support that type now.

### Detail

This Pull Request add hex binary parser on `ActiveSupport::XmlMini`. 

### Additional information
- https://www.w3.org/TR/xmlschema-2/#hexBinary

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [X] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
