### PR TITLE
Remove reference to builders BlankSlate

### DIFF
--- a/activesupport/lib/active_support/proxy_object.rb
+++ b/activesupport/lib/active_support/proxy_object.rb
@@ -3,8 +3,8 @@
 module ActiveSupport
   # = Active Support Proxy \Object
   #
-  # A class with no predefined methods that behaves similarly to Builder's
-  # BlankSlate. Used for proxy classes.
+  # A class with no predefined methods that behaves similarly to Ruby's
+  # BasicObject. Used for proxy classes.
   class ProxyObject < ::BasicObject
     undef_method :==
     undef_method :equal?


### PR DESCRIPTION
This has actually been removed from the builder gem in https://github.com/rails/builder/pull/15 (currently unreleased). Additionally, `BasicObject` will be more familiar to users.

Should this class be deprecated instead? There are no usages in Rails itself, and no tests. I believe this is a vestige from when Ruby had no `BasicObject`.