### PR TITLE
backport #51592 to 7-1-stable allowing sqlite3 v2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -154,7 +154,7 @@ platforms :ruby, :windows do
   gem "racc", ">=1.4.6", require: false
 
   # Active Record.
-  gem "sqlite3", "~> 1.6", ">= 1.6.6"
+  gem "sqlite3", ">= 1.6.6"
 
   group :db do
     gem "pg", "~> 1.3"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -617,7 +617,7 @@ DEPENDENCIES
   sidekiq
   sneakers
   sprockets-rails (>= 2.0.0)
-  sqlite3 (~> 1.6, >= 1.6.6)
+  sqlite3 (>= 1.6.6)
   stackprof
   stimulus-rails
   sucker_punch

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Allow `Sqlite3Adapter` to use `sqlite3` gem version `2.x`
+
+    *Mike Dalessio*
+
 *   Strict loading using `:n_plus_one_only` does not eagerly load child associations.
 
     With this change, child associations are no longer eagerly loaded, to

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -11,7 +11,7 @@ require "active_record/connection_adapters/sqlite3/schema_definitions"
 require "active_record/connection_adapters/sqlite3/schema_dumper"
 require "active_record/connection_adapters/sqlite3/schema_statements"
 
-gem "sqlite3", "~> 1.4"
+gem "sqlite3", ">= 1.4"
 require "sqlite3"
 
 module ActiveRecord

--- a/railties/lib/rails/generators/database.rb
+++ b/railties/lib/rails/generators/database.rb
@@ -16,7 +16,7 @@ module Rails
         when "mysql"          then ["mysql2", ["~> 0.5"]]
         when "trilogy"        then ["trilogy", ["~> 2.4"]]
         when "postgresql"     then ["pg", ["~> 1.1"]]
-        when "sqlite3"        then ["sqlite3", ["~> 1.4"]]
+        when "sqlite3"        then ["sqlite3", [">= 1.4"]]
         when "oracle"         then ["activerecord-oracle_enhanced-adapter", nil]
         when "sqlserver"      then ["activerecord-sqlserver-adapter", nil]
         when "jdbcmysql"      then ["activerecord-jdbcmysql-adapter", nil]

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -441,7 +441,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
     if defined?(JRUBY_VERSION)
       assert_gem "activerecord-jdbcsqlite3-adapter"
     else
-      assert_gem "sqlite3", '"~> 1.4"'
+      assert_gem "sqlite3", '">= 1.4"'
     end
   end
 

--- a/railties/test/generators/db_system_change_generator_test.rb
+++ b/railties/test/generators/db_system_change_generator_test.rb
@@ -81,7 +81,7 @@ module Rails
 
             assert_file("Gemfile") do |content|
               assert_match "# Use sqlite3 as the database for Active Record", content
-              assert_match 'gem "sqlite3", "~> 1.4"', content
+              assert_match 'gem "sqlite3", ">= 1.4"', content
             end
 
             assert_file("Dockerfile") do |content|


### PR DESCRIPTION
### Motivation / Background

The sqlite3 gem released v2.0 and `main` has been updated to allow usage of it in #51592.

However, speaking as a co-maintainer of sqlite3, we are getting issues from Rails users who can't upgrade to it (e.g. https://github.com/sparklemotion/sqlite3-ruby/issues/529).

So I'm opening this issue to suggest that it be backported to 7-1-stable for inclusion in a future patch release.


### Detail

Cherry-pick of fd1c635d


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] ~Tests are added or updated if you fix a bug or add a feature.~
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
