### PR TITLE
Deprecate `ActiveSupport::ProxyObject`

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Deprecate `ActiveSupport::ProxyObject` in favor of Ruby's buildin `BasicObject`
+
+    *Earlopain*
+
 *   `stub_const` now accepts a `exists: false` parameter to allow stubbing missing constants.
 
     *Jean Boussier*

--- a/activesupport/lib/active_support/proxy_object.rb
+++ b/activesupport/lib/active_support/proxy_object.rb
@@ -1,17 +1,20 @@
 # frozen_string_literal: true
 
 module ActiveSupport
-  # = Active Support Proxy \Object
-  #
-  # A class with no predefined methods that behaves similarly to Ruby's
-  # BasicObject. Used for proxy classes.
-  class ProxyObject < ::BasicObject
+  class ProxyObject < ::BasicObject # :nodoc:
     undef_method :==
     undef_method :equal?
 
     # Let ActiveSupport::ProxyObject at least raise exceptions.
     def raise(*args)
       ::Object.send(:raise, *args)
+    end
+
+    def self.inherited(_subclass)
+      ::ActiveSupport.deprecator.warn(<<~MSG)
+        ActiveSupport::ProxyObject is deprecated and will be removed in Rails 7.3.
+        Use Ruby's buildin BasicObject instead.
+      MSG
     end
   end
 end

--- a/activesupport/test/proxy_object_test.rb
+++ b/activesupport/test/proxy_object_test.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require_relative "abstract_unit"
+
+class ProxyObjectTest < ActiveSupport::TestCase
+  def test_accessing_proxy_object_is_deprecated
+    proxy = assert_deprecated(ActiveSupport.deprecator) do
+      Class.new(ActiveSupport::ProxyObject) do
+        def some_method
+          "foo"
+        end
+      end
+    end
+    assert_equal("foo", proxy.new.some_method)
+  end
+end


### PR DESCRIPTION
### Motivation / Background

Let's give this a try: https://github.com/rails/rails/pull/51632#issuecomment-2070137234. cc @carlosantoniodasilva

This class had its uses in Ruby 1.8 times when `BasicObject` didn't exist yet, nowadays it is jus a wrapper. 
The last internal usage was removed about 10 years ago in #16574.

Rails used to ship with a dependecy on the `builder` gem, which was (probably among other things) used to backport `BasicObject` to Ruby 1.8: https://github.com/rails/rails/commit/34b576700dff8b14ee959072cf303f577b9fc2cd

### Detail

Deprecate `ActiveSupport::ProxyObject`.

### Additional information

There are a few uses in rails related projects. I plan to make PRs against `jbuilder` and `activeresource` if this is accepted.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
