### PR TITLE
Use `Module#include` rather than `prepend` for faster method lookup

### DIFF
--- a/activesupport/lib/active_support/core_ext/numeric/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/numeric/conversions.rb
@@ -140,6 +140,6 @@ module ActiveSupport
   end
 end
 
-Integer.prepend ActiveSupport::NumericWithFormat
-Float.prepend ActiveSupport::NumericWithFormat
-BigDecimal.prepend ActiveSupport::NumericWithFormat
+Integer.include ActiveSupport::NumericWithFormat
+Float.include ActiveSupport::NumericWithFormat
+BigDecimal.include ActiveSupport::NumericWithFormat

--- a/activesupport/lib/active_support/core_ext/object/json.rb
+++ b/activesupport/lib/active_support/core_ext/object/json.rb
@@ -46,7 +46,7 @@ module ActiveSupport
 end
 
 [Enumerable, Object, Array, FalseClass, Float, Hash, Integer, NilClass, String, TrueClass].reverse_each do |klass|
-  klass.prepend(ActiveSupport::ToJsonWithActiveSupportEncoder)
+  klass.include(ActiveSupport::ToJsonWithActiveSupportEncoder)
 end
 
 class Module


### PR DESCRIPTION
### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

While looking at some performance work with @eregon, we noticed that Rails is using `Module#prepend` on core classes. Usually that's done when introducing a new implementation of an existing method and needing to ensure the correct one is used. Here, the methods being introduced are all brand new, so I think `Module#include` can be used instead. Modules prepended go through a more involved method lookup than included methods and can hamper VM optimization.

### Detail

This PR changes some mixed in modules that don't need to be prepended to be included instead.

### Additional information

The use of `prepend` on core classes like `Integer` undoes some interpreter optimizations performed in TruffleRuby. Arguably, the interpreter should detect that core methods aren't being redefined in this case and avoid a cache invalidation. We're planning on [fixing that](https://github.com/oracle/truffleruby/issues/3546) for the next TruffleRuby release. However, I still think using `include` when possible is preferable for simpler method lookup semantics in all Ruby implementations.

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
