### PR TITLE
Remove trailing slash from void HTML elements

### DIFF
--- a/actionpack/test/controller/renderer_test.rb
+++ b/actionpack/test/controller/renderer_test.rb
@@ -117,7 +117,7 @@ class RendererTest < ActiveSupport::TestCase
   end
 
   test "rendering with helpers" do
-    assert_equal "<p>1\n<br />2</p>", render(inline: '<%= simple_format "1\n2" %>')
+    assert_equal "<p>1\n<br>2</p>", render(inline: '<%= simple_format "1\n2" %>')
   end
 
   test "rendering with user specified defaults" do

--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,25 @@
+*   Removed the trailing slash from void HTML elements, except for elements included inside SVG tags.
+
+    The default value of the third argument (`open`) for `ActionView::TagHelper#tag` has been changed from `false` to `nil`.
+
+    For example, the following code now creates HTML without the trailing slash on the void element:
+
+    ```ruby
+    # Prints out `<br>`
+    tag("br")
+    ```
+
+    To force the trailing slash on the element, the third argument (`open`) can be provided with the value `false` as in:
+
+    ```ruby
+    # Prints out `<br />`
+    tag("br", nil, false)
+    ```
+
+    In order to preserve the legacy XHTML format, set `Rails.application.config.action_view.void_element_trailing_slash` to `true`.
+
+    *Antti Hukkanen*
+
 *   Add queries count to template rendering instrumentation
 
     ```
@@ -93,27 +115,5 @@
     ```
 
     *Akhil G Krishnan*
-
-*   Removed the trailing slash from void HTML elements, except for elements included inside SVG tags.
-
-    The default value of the third argument (`open`) for `ActionView::TagHelper#tag` has been changed from `false` to `nil`.
-
-    For example, the following code now creates HTML without the trailing slash on the void element:
-
-    ```ruby
-    # Prints out `<br>`
-    tag("br")
-    ```
-
-    To force the trailing slash on the element, the third argument (`open`) can be provided with the value `false` as in:
-
-    ```ruby
-    # Prints out `<br />`
-    tag("br", nil, false)
-    ```
-
-    In order to preserve the legacy XHTML format, set `Rails.application.config.action_view.void_element_trailing_slash` to `true`.
-
-    *Antti Hukkanen*
 
 Please check [7-1-stable](https://github.com/rails/rails/blob/7-1-stable/actionview/CHANGELOG.md) for previous changes.

--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -94,4 +94,26 @@
 
     *Akhil G Krishnan*
 
+*   Removed the trailing slash from void HTML elements, except for elements included inside SVG tags.
+
+    The default value of the third argument (`open`) for `ActionView::TagHelper#tag` has been changed from `false` to `nil`.
+
+    For example, the following code now creates HTML without the trailing slash on the void element:
+
+    ```ruby
+    # Prints out `<br>`
+    tag("br")
+    ```
+
+    To force the trailing slash on the element, the third argument (`open`) can be provided with the value `false` as in:
+
+    ```ruby
+    # Prints out `<br />`
+    tag("br", nil, false)
+    ```
+
+    In order to preserve the legacy XHTML format, set `Rails.application.config.action_view.void_element_trailing_slash` to `true`.
+
+    *Antti Hukkanen*
+
 Please check [7-1-stable](https://github.com/rails/rails/blob/7-1-stable/actionview/CHANGELOG.md) for previous changes.

--- a/actionview/app/assets/javascripts/rails-ujs.esm.js
+++ b/actionview/app/assets/javascripts/rails-ujs.esm.js
@@ -451,11 +451,11 @@ const handleMethodWithRails = rails => function(e) {
   const csrfToken$1 = csrfToken();
   const csrfParam$1 = csrfParam();
   const form = document.createElement("form");
-  let formContent = `<input name='_method' value='${method}' type='hidden'>`;
+  let formContent = `<input name='_method' value='${method}' type='hidden' />`;
   if (csrfParam$1 && csrfToken$1 && !isCrossDomain(href)) {
-    formContent += `<input name='${csrfParam$1}' value='${csrfToken$1}' type='hidden'>`;
+    formContent += `<input name='${csrfParam$1}' value='${csrfToken$1}' type='hidden' />`;
   }
-  formContent += '<input type="submit">';
+  formContent += '<input type="submit" />';
   form.method = "post";
   form.action = href;
   form.target = link.target;

--- a/actionview/app/assets/javascripts/rails-ujs.esm.js
+++ b/actionview/app/assets/javascripts/rails-ujs.esm.js
@@ -451,11 +451,11 @@ const handleMethodWithRails = rails => function(e) {
   const csrfToken$1 = csrfToken();
   const csrfParam$1 = csrfParam();
   const form = document.createElement("form");
-  let formContent = `<input name='_method' value='${method}' type='hidden' />`;
+  let formContent = `<input name='_method' value='${method}' type='hidden'>`;
   if (csrfParam$1 && csrfToken$1 && !isCrossDomain(href)) {
-    formContent += `<input name='${csrfParam$1}' value='${csrfToken$1}' type='hidden' />`;
+    formContent += `<input name='${csrfParam$1}' value='${csrfToken$1}' type='hidden'>`;
   }
-  formContent += '<input type="submit" />';
+  formContent += '<input type="submit">';
   form.method = "post";
   form.action = href;
   form.target = link.target;

--- a/actionview/app/assets/javascripts/rails-ujs.js
+++ b/actionview/app/assets/javascripts/rails-ujs.js
@@ -4,7 +4,7 @@ https://github.com/rails/rails/blob/main/actionview/app/javascript
 Released under the MIT license
  */
 (function(global, factory) {
-  typeof exports === "object" && typeof module !== "undefined" ? module.exports = factory() : typeof define === "function" && define.amd ? define(factory) : (global = typeof globalThis !== "undefined" ? globalThis : global || self,
+  typeof exports === "object" && typeof module !== "undefined" ? module.exports = factory() : typeof define === "function" && define.amd ? define(factory) : (global = typeof globalThis !== "undefined" ? globalThis : global || self, 
   global.Rails = factory());
 })(this, (function() {
   "use strict";
@@ -403,11 +403,11 @@ Released under the MIT license
     const csrfToken$1 = csrfToken();
     const csrfParam$1 = csrfParam();
     const form = document.createElement("form");
-    let formContent = `<input name='_method' value='${method}' type='hidden'>`;
+    let formContent = `<input name='_method' value='${method}' type='hidden' />`;
     if (csrfParam$1 && csrfToken$1 && !isCrossDomain(href)) {
-      formContent += `<input name='${csrfParam$1}' value='${csrfToken$1}' type='hidden'>`;
+      formContent += `<input name='${csrfParam$1}' value='${csrfToken$1}' type='hidden' />`;
     }
-    formContent += '<input type="submit">';
+    formContent += '<input type="submit" />';
     form.method = "post";
     form.action = href;
     form.target = link.target;

--- a/actionview/app/assets/javascripts/rails-ujs.js
+++ b/actionview/app/assets/javascripts/rails-ujs.js
@@ -4,7 +4,7 @@ https://github.com/rails/rails/blob/main/actionview/app/javascript
 Released under the MIT license
  */
 (function(global, factory) {
-  typeof exports === "object" && typeof module !== "undefined" ? module.exports = factory() : typeof define === "function" && define.amd ? define(factory) : (global = typeof globalThis !== "undefined" ? globalThis : global || self, 
+  typeof exports === "object" && typeof module !== "undefined" ? module.exports = factory() : typeof define === "function" && define.amd ? define(factory) : (global = typeof globalThis !== "undefined" ? globalThis : global || self,
   global.Rails = factory());
 })(this, (function() {
   "use strict";
@@ -403,11 +403,11 @@ Released under the MIT license
     const csrfToken$1 = csrfToken();
     const csrfParam$1 = csrfParam();
     const form = document.createElement("form");
-    let formContent = `<input name='_method' value='${method}' type='hidden' />`;
+    let formContent = `<input name='_method' value='${method}' type='hidden'>`;
     if (csrfParam$1 && csrfToken$1 && !isCrossDomain(href)) {
-      formContent += `<input name='${csrfParam$1}' value='${csrfToken$1}' type='hidden' />`;
+      formContent += `<input name='${csrfParam$1}' value='${csrfToken$1}' type='hidden'>`;
     }
-    formContent += '<input type="submit" />';
+    formContent += '<input type="submit">';
     form.method = "post";
     form.action = href;
     form.target = link.target;

--- a/actionview/lib/action_view/base.rb
+++ b/actionview/lib/action_view/base.rb
@@ -24,7 +24,7 @@ module ActionView # :nodoc:
   #
   #   <b>Names of all the people</b>
   #   <% @people.each do |person| %>
-  #     Name: <%= person.name %><br/>
+  #     Name: <%= person.name %><br>
   #   <% end %>
   #
   # The loop is set up in regular embedding tags <tt><% %></tt>, and the name is written using the output embedding tag <tt><%= %></tt>. Note that this

--- a/actionview/lib/action_view/helpers/asset_tag_helper.rb
+++ b/actionview/lib/action_view/helpers/asset_tag_helper.rb
@@ -15,9 +15,9 @@ module ActionView
     # the assets exist before linking to them:
     #
     #   image_tag("rails.png")
-    #   # => <img src="/assets/rails.png" />
+    #   # => <img src="/assets/rails.png">
     #   stylesheet_link_tag("application")
-    #   # => <link href="/assets/application.css?body=1" rel="stylesheet" />
+    #   # => <link href="/assets/application.css?body=1" rel="stylesheet">
     module AssetTagHelper
       include AssetUrlHelper
       include TagHelper
@@ -172,29 +172,29 @@ module ActionView
       # ==== Examples
       #
       #   stylesheet_link_tag "style"
-      #   # => <link href="/assets/style.css" rel="stylesheet" />
+      #   # => <link href="/assets/style.css" rel="stylesheet">
       #
       #   stylesheet_link_tag "style.css"
-      #   # => <link href="/assets/style.css" rel="stylesheet" />
+      #   # => <link href="/assets/style.css" rel="stylesheet">
       #
       #   stylesheet_link_tag "http://www.example.com/style.css"
-      #   # => <link href="http://www.example.com/style.css" rel="stylesheet" />
+      #   # => <link href="http://www.example.com/style.css" rel="stylesheet">
       #
       #   stylesheet_link_tag "style.less", extname: false, skip_pipeline: true, rel: "stylesheet/less"
       #   # => <link href="/stylesheets/style.less" rel="stylesheet/less">
       #
       #   stylesheet_link_tag "style", media: "all"
-      #   # => <link href="/assets/style.css" media="all" rel="stylesheet" />
+      #   # => <link href="/assets/style.css" media="all" rel="stylesheet">
       #
       #   stylesheet_link_tag "style", media: "print"
-      #   # => <link href="/assets/style.css" media="print" rel="stylesheet" />
+      #   # => <link href="/assets/style.css" media="print" rel="stylesheet">
       #
       #   stylesheet_link_tag "random.styles", "/css/stylish"
-      #   # => <link href="/assets/random.styles" rel="stylesheet" />
-      #   #    <link href="/css/stylish.css" rel="stylesheet" />
+      #   # => <link href="/assets/random.styles" rel="stylesheet">
+      #   #    <link href="/css/stylish.css" rel="stylesheet">
       #
       #   stylesheet_link_tag "style", nonce: true
-      #   # => <link href="/assets/style.css" rel="stylesheet" nonce="..." />
+      #   # => <link href="/assets/style.css" rel="stylesheet" nonce="...">
       def stylesheet_link_tag(*sources)
         options = sources.extract_options!.stringify_keys
         path_options = options.extract!("protocol", "extname", "host", "skip_pipeline").symbolize_keys
@@ -251,19 +251,19 @@ module ActionView
       # ==== Examples
       #
       #   auto_discovery_link_tag
-      #   # => <link rel="alternate" type="application/rss+xml" title="RSS" href="http://www.currenthost.com/controller/action" />
+      #   # => <link rel="alternate" type="application/rss+xml" title="RSS" href="http://www.currenthost.com/controller/action">
       #   auto_discovery_link_tag(:atom)
-      #   # => <link rel="alternate" type="application/atom+xml" title="ATOM" href="http://www.currenthost.com/controller/action" />
+      #   # => <link rel="alternate" type="application/atom+xml" title="ATOM" href="http://www.currenthost.com/controller/action">
       #   auto_discovery_link_tag(:json)
-      #   # => <link rel="alternate" type="application/json" title="JSON" href="http://www.currenthost.com/controller/action" />
+      #   # => <link rel="alternate" type="application/json" title="JSON" href="http://www.currenthost.com/controller/action">
       #   auto_discovery_link_tag(:rss, {action: "feed"})
-      #   # => <link rel="alternate" type="application/rss+xml" title="RSS" href="http://www.currenthost.com/controller/feed" />
+      #   # => <link rel="alternate" type="application/rss+xml" title="RSS" href="http://www.currenthost.com/controller/feed">
       #   auto_discovery_link_tag(:rss, {action: "feed"}, {title: "My RSS"})
-      #   # => <link rel="alternate" type="application/rss+xml" title="My RSS" href="http://www.currenthost.com/controller/feed" />
+      #   # => <link rel="alternate" type="application/rss+xml" title="My RSS" href="http://www.currenthost.com/controller/feed">
       #   auto_discovery_link_tag(:rss, {controller: "news", action: "feed"})
-      #   # => <link rel="alternate" type="application/rss+xml" title="RSS" href="http://www.currenthost.com/news/feed" />
+      #   # => <link rel="alternate" type="application/rss+xml" title="RSS" href="http://www.currenthost.com/news/feed">
       #   auto_discovery_link_tag(:rss, "http://www.example.com/feed.rss", {title: "Example RSS"})
-      #   # => <link rel="alternate" type="application/rss+xml" title="Example RSS" href="http://www.example.com/feed.rss" />
+      #   # => <link rel="alternate" type="application/rss+xml" title="Example RSS" href="http://www.example.com/feed.rss">
       def auto_discovery_link_tag(type = :rss, url_options = {}, tag_options = {})
         if !(type == :rss || type == :atom || type == :json) && tag_options[:type].blank?
           raise ArgumentError.new("You should pass :type tag_option key explicitly, because you have passed #{type} type other than :rss, :atom, or :json.")
@@ -294,17 +294,17 @@ module ActionView
       # respectively:
       #
       #   favicon_link_tag
-      #   # => <link href="/assets/favicon.ico" rel="icon" type="image/x-icon" />
+      #   # => <link href="/assets/favicon.ico" rel="icon" type="image/x-icon">
       #
       #   favicon_link_tag 'myicon.ico'
-      #   # => <link href="/assets/myicon.ico" rel="icon" type="image/x-icon" />
+      #   # => <link href="/assets/myicon.ico" rel="icon" type="image/x-icon">
       #
       # Mobile Safari looks for a different link tag, pointing to an image that
       # will be used if you add the page to the home screen of an iOS device.
       # The following call would generate such a tag:
       #
       #   favicon_link_tag 'mb-icon.png', rel: 'apple-touch-icon', type: 'image/png'
-      #   # => <link href="/assets/mb-icon.png" rel="apple-touch-icon" type="image/png" />
+      #   # => <link href="/assets/mb-icon.png" rel="apple-touch-icon" type="image/png">
       def favicon_link_tag(source = "favicon.ico", options = {})
         tag("link", {
           rel: "icon",
@@ -328,25 +328,25 @@ module ActionView
       # ==== Examples
       #
       #   preload_link_tag("custom_theme.css")
-      #   # => <link rel="preload" href="/assets/custom_theme.css" as="style" type="text/css" />
+      #   # => <link rel="preload" href="/assets/custom_theme.css" as="style" type="text/css">
       #
       #   preload_link_tag("/videos/video.webm")
-      #   # => <link rel="preload" href="/videos/video.mp4" as="video" type="video/webm" />
+      #   # => <link rel="preload" href="/videos/video.mp4" as="video" type="video/webm">
       #
       #   preload_link_tag(post_path(format: :json), as: "fetch")
-      #   # => <link rel="preload" href="/posts.json" as="fetch" type="application/json" />
+      #   # => <link rel="preload" href="/posts.json" as="fetch" type="application/json">
       #
       #   preload_link_tag("worker.js", as: "worker")
-      #   # => <link rel="preload" href="/assets/worker.js" as="worker" type="text/javascript" />
+      #   # => <link rel="preload" href="/assets/worker.js" as="worker" type="text/javascript">
       #
       #   preload_link_tag("//example.com/font.woff2")
-      #   # => <link rel="preload" href="//example.com/font.woff2" as="font" type="font/woff2" crossorigin="anonymous"/>
+      #   # => <link rel="preload" href="//example.com/font.woff2" as="font" type="font/woff2" crossorigin="anonymous">
       #
       #   preload_link_tag("//example.com/font.woff2", crossorigin: "use-credentials")
-      #   # => <link rel="preload" href="//example.com/font.woff2" as="font" type="font/woff2" crossorigin="use-credentials" />
+      #   # => <link rel="preload" href="//example.com/font.woff2" as="font" type="font/woff2" crossorigin="use-credentials">
       #
       #   preload_link_tag("/media/audio.ogg", nopush: true)
-      #   # => <link rel="preload" href="/media/audio.ogg" as="audio" type="audio/ogg" />
+      #   # => <link rel="preload" href="/media/audio.ogg" as="audio" type="audio/ogg">
       #
       def preload_link_tag(source, options = {})
         href = path_to_asset(source, skip_pipeline: options.delete(:skip_pipeline))
@@ -397,19 +397,19 @@ module ActionView
       # Assets (images that are part of your app):
       #
       #   image_tag("icon")
-      #   # => <img src="/assets/icon" />
+      #   # => <img src="/assets/icon">
       #   image_tag("icon.png")
-      #   # => <img src="/assets/icon.png" />
+      #   # => <img src="/assets/icon.png">
       #   image_tag("icon.png", size: "16x10", alt: "Edit Entry")
-      #   # => <img src="/assets/icon.png" width="16" height="10" alt="Edit Entry" />
+      #   # => <img src="/assets/icon.png" width="16" height="10" alt="Edit Entry">
       #   image_tag("/icons/icon.gif", size: "16")
-      #   # => <img src="/icons/icon.gif" width="16" height="16" />
+      #   # => <img src="/icons/icon.gif" width="16" height="16">
       #   image_tag("/icons/icon.gif", height: '32', width: '32')
-      #   # => <img height="32" src="/icons/icon.gif" width="32" />
+      #   # => <img height="32" src="/icons/icon.gif" width="32">
       #   image_tag("/icons/icon.gif", class: "menu_icon")
-      #   # => <img class="menu_icon" src="/icons/icon.gif" />
+      #   # => <img class="menu_icon" src="/icons/icon.gif">
       #   image_tag("/icons/icon.gif", data: { title: 'Rails Application' })
-      #   # => <img data-title="Rails Application" src="/icons/icon.gif" />
+      #   # => <img data-title="Rails Application" src="/icons/icon.gif">
       #   image_tag("icon.png", srcset: { "icon_2x.png" => "2x", "icon_4x.png" => "4x" })
       #   # => <img src="/assets/icon.png" srcset="/assets/icon_2x.png 2x, /assets/icon_4x.png 4x">
       #   image_tag("pic.jpg", srcset: [["pic_1024.jpg", "1024w"], ["pic_1980.jpg", "1980w"]], sizes: "100vw")
@@ -418,11 +418,11 @@ module ActionView
       # Active Storage blobs (images that are uploaded by the users of your app):
       #
       #   image_tag(user.avatar)
-      #   # => <img src="/rails/active_storage/blobs/.../tiger.jpg" />
+      #   # => <img src="/rails/active_storage/blobs/.../tiger.jpg">
       #   image_tag(user.avatar.variant(resize_to_limit: [100, 100]))
-      #   # => <img src="/rails/active_storage/representations/.../tiger.jpg" />
+      #   # => <img src="/rails/active_storage/representations/.../tiger.jpg">
       #   image_tag(user.avatar.variant(resize_to_limit: [100, 100]), size: '100')
-      #   # => <img width="100" height="100" src="/rails/active_storage/representations/.../tiger.jpg" />
+      #   # => <img width="100" height="100" src="/rails/active_storage/representations/.../tiger.jpg">
       def image_tag(source, options = {})
         options = options.symbolize_keys
         check_for_image_tag_errors(options)
@@ -464,26 +464,26 @@ module ActionView
       # ==== Examples
       #
       #   picture_tag("picture.webp")
-      #   # => <picture><img src="/images/picture.webp" /></picture>
+      #   # => <picture><img src="/images/picture.webp"></picture>
       #   picture_tag("gold.png", :image => { :size => "20" })
-      #   # => <picture><img height="20" src="/images/gold.png" width="20" /></picture>
+      #   # => <picture><img height="20" src="/images/gold.png" width="20"></picture>
       #   picture_tag("gold.png", :image => { :size => "45x70" })
-      #   # => <picture><img height="70" src="/images/gold.png" width="45" /></picture>
+      #   # => <picture><img height="70" src="/images/gold.png" width="45"></picture>
       #   picture_tag("picture.webp", "picture.png")
-      #   # => <picture><source srcset="/images/picture.webp" /><source srcset="/images/picture.png" /><img src="/images/picture.png" /></picture>
+      #   # => <picture><source srcset="/images/picture.webp"><source srcset="/images/picture.png"><img src="/images/picture.png"></picture>
       #   picture_tag("picture.webp", "picture.png", :image => { alt: "Image" })
-      #   # => <picture><source srcset="/images/picture.webp" /><source srcset="/images/picture.png" /><img alt="Image" src="/images/picture.png" /></picture>
+      #   # => <picture><source srcset="/images/picture.webp"><source srcset="/images/picture.png"><img alt="Image" src="/images/picture.png"></picture>
       #   picture_tag(["picture.webp", "picture.png"], :image => { alt: "Image" })
-      #   # => <picture><source srcset="/images/picture.webp" /><source srcset="/images/picture.png" /><img alt="Image" src="/images/picture.png" /></picture>
+      #   # => <picture><source srcset="/images/picture.webp"><source srcset="/images/picture.png"><img alt="Image" src="/images/picture.png"></picture>
       #   picture_tag(:class => "my-class") { tag(:source, :srcset => image_path("picture.webp")) + image_tag("picture.png", :alt => "Image") }
-      #   # => <picture class="my-class"><source srcset="/images/picture.webp" /><img alt="Image" src="/images/picture.png" /></picture>
+      #   # => <picture class="my-class"><source srcset="/images/picture.webp"><img alt="Image" src="/images/picture.png"></picture>
       #   picture_tag { tag(:source, :srcset => image_path("picture-small.webp"), :media => "(min-width: 600px)") + tag(:source, :srcset => image_path("picture-big.webp")) + image_tag("picture.png", :alt => "Image") }
-      #   # => <picture><source srcset="/images/picture-small.webp" media="(min-width: 600px)" /><source srcset="/images/picture-big.webp" /><img alt="Image" src="/images/picture.png" /></picture>
+      #   # => <picture><source srcset="/images/picture-small.webp" media="(min-width: 600px)"><source srcset="/images/picture-big.webp"><img alt="Image" src="/images/picture.png"></picture>
       #
       # Active Storage blobs (images that are uploaded by the users of your app):
       #
       #   picture_tag(user.profile_picture)
-      #   # => <picture><img src="/rails/active_storage/blobs/.../profile_picture.webp" /></picture>
+      #   # => <picture><img src="/rails/active_storage/blobs/.../profile_picture.webp"></picture>
       def picture_tag(*sources, &block)
         sources.flatten!
         options = sources.extract_options!.symbolize_keys
@@ -544,11 +544,11 @@ module ActionView
       #   video_tag("/trailers/hd.avi", height: '32', width: '32')
       #   # => <video height="32" src="/trailers/hd.avi" width="32"></video>
       #   video_tag("trailer.ogg", "trailer.flv")
-      #   # => <video><source src="/videos/trailer.ogg" /><source src="/videos/trailer.flv" /></video>
+      #   # => <video><source src="/videos/trailer.ogg"><source src="/videos/trailer.flv"></video>
       #   video_tag(["trailer.ogg", "trailer.flv"])
-      #   # => <video><source src="/videos/trailer.ogg" /><source src="/videos/trailer.flv" /></video>
+      #   # => <video><source src="/videos/trailer.ogg"><source src="/videos/trailer.flv"></video>
       #   video_tag(["trailer.ogg", "trailer.flv"], size: "160x120")
-      #   # => <video height="120" width="160"><source src="/videos/trailer.ogg" /><source src="/videos/trailer.flv" /></video>
+      #   # => <video height="120" width="160"><source src="/videos/trailer.ogg"><source src="/videos/trailer.flv"></video>
       #
       # Active Storage blobs (videos that are uploaded by the users of your app):
       #
@@ -580,7 +580,7 @@ module ActionView
       #   audio_tag("sound.wav", autoplay: true, controls: true)
       #   # => <audio autoplay="autoplay" controls="controls" src="/audios/sound.wav"></audio>
       #   audio_tag("sound.wav", "sound.mid")
-      #   # => <audio><source src="/audios/sound.wav" /><source src="/audios/sound.mid" /></audio>
+      #   # => <audio><source src="/audios/sound.wav"><source src="/audios/sound.mid"></audio>
       #
       # Active Storage blobs (audios that are uploaded by the users of your app):
       #

--- a/actionview/lib/action_view/helpers/asset_url_helper.rb
+++ b/actionview/lib/action_view/helpers/asset_url_helper.rb
@@ -30,9 +30,9 @@ module ActionView
     # Helpers take that into account:
     #
     #   image_tag("rails.png")
-    #   # => <img src="http://assets.example.com/assets/rails.png" />
+    #   # => <img src="http://assets.example.com/assets/rails.png">
     #   stylesheet_link_tag("application")
-    #   # => <link href="http://assets.example.com/assets/application.css" rel="stylesheet" />
+    #   # => <link href="http://assets.example.com/assets/application.css" rel="stylesheet">
     #
     # Browsers open a limited number of simultaneous connections to a single
     # host. The exact number varies by browser and version. This limit may cause
@@ -43,9 +43,9 @@ module ActionView
     # "assets0.example.com", ..., "assets3.example.com".
     #
     #   image_tag("rails.png")
-    #   # => <img src="http://assets0.example.com/assets/rails.png" />
+    #   # => <img src="http://assets0.example.com/assets/rails.png">
     #   stylesheet_link_tag("application")
-    #   # => <link href="http://assets2.example.com/assets/application.css" rel="stylesheet" />
+    #   # => <link href="http://assets2.example.com/assets/application.css" rel="stylesheet">
     #
     # This may improve the asset loading performance of your application.
     # It is also possible the combination of additional connection overhead
@@ -69,9 +69,9 @@ module ActionView
     #     "http://assets#{OpenSSL::Digest::SHA256.hexdigest(source).to_i(16) % 2 + 1}.example.com"
     #   }
     #   image_tag("rails.png")
-    #   # => <img src="http://assets1.example.com/assets/rails.png" />
+    #   # => <img src="http://assets1.example.com/assets/rails.png">
     #   stylesheet_link_tag("application")
-    #   # => <link href="http://assets2.example.com/assets/application.css" rel="stylesheet" />
+    #   # => <link href="http://assets2.example.com/assets/application.css" rel="stylesheet">
     #
     # The example above generates "http://assets1.example.com" and
     # "http://assets2.example.com". This option is useful for example if
@@ -88,9 +88,9 @@ module ActionView
     #      end
     #    }
     #   image_tag("rails.png")
-    #   # => <img src="http://assets.example.com/assets/rails.png" />
+    #   # => <img src="http://assets.example.com/assets/rails.png">
     #   stylesheet_link_tag("application")
-    #   # => <link href="http://stylesheets.example.com/assets/application.css" rel="stylesheet" />
+    #   # => <link href="http://stylesheets.example.com/assets/application.css" rel="stylesheet">
     #
     # Alternatively you may ask for a second parameter +request+. That one is
     # particularly useful for serving assets from an SSL-protected page. The

--- a/actionview/lib/action_view/helpers/date_helper.rb
+++ b/actionview/lib/action_view/helpers/date_helper.rb
@@ -1161,7 +1161,7 @@ module ActionView
         # Builds hidden input tag for date part and value.
         #
         #   build_hidden(:year, 2008)
-        #   => "<input type="hidden" id="date_year" name="date[year]" value="2008" autocomplete="off" />"
+        #   => "<input type="hidden" id="date_year" name="date[year]" value="2008" autocomplete="off">"
         def build_hidden(type, value)
           select_options = {
             type: "hidden",

--- a/actionview/lib/action_view/helpers/form_helper.rb
+++ b/actionview/lib/action_view/helpers/form_helper.rb
@@ -45,10 +45,10 @@ module ActionView
     #
     #   <%= form_for @person do |f| %>
     #     <%= f.label :first_name %>:
-    #     <%= f.text_field :first_name %><br />
+    #     <%= f.text_field :first_name %><br>
     #
     #     <%= f.label :last_name %>:
-    #     <%= f.text_field :last_name %><br />
+    #     <%= f.text_field :last_name %><br>
     #
     #     <%= f.submit %>
     #   <% end %>
@@ -56,14 +56,14 @@ module ActionView
     # The HTML generated for this would be (modulus formatting):
     #
     #   <form action="/people" class="new_person" id="new_person" method="post">
-    #     <input name="authenticity_token" type="hidden" value="NrOp5bsjoLRuK8IW5+dQEYjKGUJDe7TQoZVvq95Wteg=" />
+    #     <input name="authenticity_token" type="hidden" value="NrOp5bsjoLRuK8IW5+dQEYjKGUJDe7TQoZVvq95Wteg=">
     #     <label for="person_first_name">First name</label>:
-    #     <input id="person_first_name" name="person[first_name]" type="text" /><br />
+    #     <input id="person_first_name" name="person[first_name]" type="text"><br>
     #
     #     <label for="person_last_name">Last name</label>:
-    #     <input id="person_last_name" name="person[last_name]" type="text" /><br />
+    #     <input id="person_last_name" name="person[last_name]" type="text"><br>
     #
-    #     <input name="commit" type="submit" value="Create Person" />
+    #     <input name="commit" type="submit" value="Create Person">
     #   </form>
     #
     # As you see, the HTML reflects knowledge about the resource in several spots,
@@ -85,15 +85,15 @@ module ActionView
     # the code above as is would yield instead:
     #
     #   <form action="/people/256" class="edit_person" id="edit_person_256" method="post">
-    #     <input name="_method" type="hidden" value="patch" />
-    #     <input name="authenticity_token" type="hidden" value="NrOp5bsjoLRuK8IW5+dQEYjKGUJDe7TQoZVvq95Wteg=" />
+    #     <input name="_method" type="hidden" value="patch">
+    #     <input name="authenticity_token" type="hidden" value="NrOp5bsjoLRuK8IW5+dQEYjKGUJDe7TQoZVvq95Wteg=">
     #     <label for="person_first_name">First name</label>:
-    #     <input id="person_first_name" name="person[first_name]" type="text" value="John" /><br />
+    #     <input id="person_first_name" name="person[first_name]" type="text" value="John"><br>
     #
     #     <label for="person_last_name">Last name</label>:
-    #     <input id="person_last_name" name="person[last_name]" type="text" value="Smith" /><br />
+    #     <input id="person_last_name" name="person[last_name]" type="text" value="Smith"><br>
     #
-    #     <input name="commit" type="submit" value="Update Person" />
+    #     <input name="commit" type="submit" value="Update Person">
     #   </form>
     #
     # Note that the endpoint, default values, and submit button label are tailored for <tt>@person</tt>.
@@ -130,10 +130,10 @@ module ActionView
       # the object we are concerned with:
       #
       #   <%= form_for :person do |f| %>
-      #     First name: <%= f.text_field :first_name %><br />
-      #     Last name : <%= f.text_field :last_name %><br />
-      #     Biography : <%= f.text_area :biography %><br />
-      #     Admin?    : <%= f.check_box :admin %><br />
+      #     First name: <%= f.text_field :first_name %><br>
+      #     Last name : <%= f.text_field :last_name %><br>
+      #     Biography : <%= f.text_area :biography %><br>
+      #     Admin?    : <%= f.check_box :admin %><br>
       #     <%= f.submit %>
       #   <% end %>
       #
@@ -341,7 +341,7 @@ module ActionView
       # The HTML generated for this would be:
       #
       #   <form action='http://www.example.com' method='post' data-remote='true'>
-      #     <input name='_method' type='hidden' value='patch' />
+      #     <input name='_method' type='hidden' value='patch'>
       #     ...
       #   </form>
       #
@@ -357,7 +357,7 @@ module ActionView
       # The HTML generated for this would be:
       #
       #   <form action='http://www.example.com' method='post' data-behavior='autosave' name='go'>
-      #     <input name='_method' type='hidden' value='patch' />
+      #     <input name='_method' type='hidden' value='patch'>
       #     ...
       #   </form>
       #
@@ -490,7 +490,7 @@ module ActionView
       #   <% end %>
       #   # =>
       #   <form action="/articles" method="post">
-      #     <input type="text" name="title" />
+      #     <input type="text" name="title">
       #   </form>
       #
       #   # With an intentionally empty URL:
@@ -499,7 +499,7 @@ module ActionView
       #   <% end %>
       #   # =>
       #   <form method="post">
-      #     <input type="text" name="title" />
+      #     <input type="text" name="title">
       #   </form>
       #
       #   # Adding a scope prefixes the input field names:
@@ -508,7 +508,7 @@ module ActionView
       #   <% end %>
       #   # =>
       #   <form action="/articles" method="post">
-      #     <input type="text" name="article[title]" />
+      #     <input type="text" name="article[title]">
       #   </form>
       #
       #   # Using a model infers both the URL and scope:
@@ -517,7 +517,7 @@ module ActionView
       #   <% end %>
       #   # =>
       #   <form action="/articles" method="post">
-      #     <input type="text" name="article[title]" />
+      #     <input type="text" name="article[title]">
       #   </form>
       #
       #   # An existing model makes an update form and fills out field values:
@@ -526,8 +526,8 @@ module ActionView
       #   <% end %>
       #   # =>
       #   <form action="/articles/1" method="post">
-      #     <input type="hidden" name="_method" value="patch" />
-      #     <input type="text" name="article[title]" value="<the title of the article>" />
+      #     <input type="hidden" name="_method" value="patch">
+      #     <input type="text" name="article[title]" value="<the title of the article>">
       #   </form>
       #   # Though the fields don't have to correspond to model attributes:
       #   <%= form_with model: Cat.new do |form| %>
@@ -536,8 +536,8 @@ module ActionView
       #   <% end %>
       #   # =>
       #   <form action="/cats" method="post">
-      #     <input type="text" name="cat[cats_dont_have_gills]" />
-      #     <input type="text" name="cat[but_in_forms_they_can]" />
+      #     <input type="text" name="cat[cats_dont_have_gills]">
+      #     <input type="text" name="cat[but_in_forms_they_can]">
       #   </form>
       #
       # The parameters in the forms are accessible in controllers according to
@@ -700,7 +700,7 @@ module ActionView
       # generates
       #
       #   <form action="/articles/123" method="post" data-behavior="autosave" name="go">
-      #     <input name="_method" type="hidden" value="patch" />
+      #     <input name="_method" type="hidden" value="patch">
       #     ...
       #   </form>
       #
@@ -1159,19 +1159,19 @@ module ActionView
       #
       # ==== Examples
       #   text_field(:article, :title, size: 20)
-      #   # => <input type="text" id="article_title" name="article[title]" size="20" value="#{@article.title}" />
+      #   # => <input type="text" id="article_title" name="article[title]" size="20" value="#{@article.title}">
       #
       #   text_field(:article, :title, class: "create_input")
-      #   # => <input type="text" id="article_title" name="article[title]" value="#{@article.title}" class="create_input" />
+      #   # => <input type="text" id="article_title" name="article[title]" value="#{@article.title}" class="create_input">
       #
       #   text_field(:article, :title,  maxlength: 30, class: "title_input")
-      #   # => <input type="text" id="article_title" name="article[title]" maxlength="30" size="30" value="#{@article.title}" class="title_input" />
+      #   # => <input type="text" id="article_title" name="article[title]" maxlength="30" size="30" value="#{@article.title}" class="title_input">
       #
       #   text_field(:session, :user, onchange: "if ($('#session_user').val() === 'admin') { alert('Your login cannot be admin!'); }")
-      #   # => <input type="text" id="session_user" name="session[user]" value="#{@session.user}" onchange="if ($('#session_user').val() === 'admin') { alert('Your login cannot be admin!'); }"/>
+      #   # => <input type="text" id="session_user" name="session[user]" value="#{@session.user}" onchange="if ($('#session_user').val() === 'admin') { alert('Your login cannot be admin!'); }">
       #
       #   text_field(:snippet, :code, size: 20, class: 'code_input')
-      #   # => <input type="text" id="snippet_code" name="snippet[code]" size="20" value="#{@snippet.code}" class="code_input" />
+      #   # => <input type="text" id="snippet_code" name="snippet[code]" size="20" value="#{@snippet.code}" class="code_input">
       def text_field(object_name, method, options = {})
         Tags::TextField.new(object_name, method, self, options).render
       end
@@ -1183,16 +1183,16 @@ module ActionView
       #
       # ==== Examples
       #   password_field(:login, :pass, size: 20)
-      #   # => <input type="password" id="login_pass" name="login[pass]" size="20" />
+      #   # => <input type="password" id="login_pass" name="login[pass]" size="20">
       #
       #   password_field(:account, :secret, class: "form_input", value: @account.secret)
-      #   # => <input type="password" id="account_secret" name="account[secret]" value="#{@account.secret}" class="form_input" />
+      #   # => <input type="password" id="account_secret" name="account[secret]" value="#{@account.secret}" class="form_input">
       #
       #   password_field(:user, :password, onchange: "if ($('#user_password').val().length > 30) { alert('Your password needs to be shorter!'); }")
-      #   # => <input type="password" id="user_password" name="user[password]" onchange="if ($('#user_password').val().length > 30) { alert('Your password needs to be shorter!'); }"/>
+      #   # => <input type="password" id="user_password" name="user[password]" onchange="if ($('#user_password').val().length > 30) { alert('Your password needs to be shorter!'); }">
       #
       #   password_field(:account, :pin, size: 20, class: 'form_input')
-      #   # => <input type="password" id="account_pin" name="account[pin]" size="20" class="form_input" />
+      #   # => <input type="password" id="account_pin" name="account[pin]" size="20" class="form_input">
       def password_field(object_name, method, options = {})
         Tags::PasswordField.new(object_name, method, self, options).render
       end
@@ -1204,13 +1204,13 @@ module ActionView
       #
       # ==== Examples
       #   hidden_field(:signup, :pass_confirm)
-      #   # => <input type="hidden" id="signup_pass_confirm" name="signup[pass_confirm]" value="#{@signup.pass_confirm}" />
+      #   # => <input type="hidden" id="signup_pass_confirm" name="signup[pass_confirm]" value="#{@signup.pass_confirm}">
       #
       #   hidden_field(:article, :tag_list)
-      #   # => <input type="hidden" id="article_tag_list" name="article[tag_list]" value="#{@article.tag_list}" />
+      #   # => <input type="hidden" id="article_tag_list" name="article[tag_list]" value="#{@article.tag_list}">
       #
       #   hidden_field(:user, :token)
-      #   # => <input type="hidden" id="user_token" name="user[token]" value="#{@user.token}" />
+      #   # => <input type="hidden" id="user_token" name="user[token]" value="#{@user.token}">
       def hidden_field(object_name, method, options = {})
         Tags::HiddenField.new(object_name, method, self, options).render
       end
@@ -1231,19 +1231,19 @@ module ActionView
       #
       # ==== Examples
       #   file_field(:user, :avatar)
-      #   # => <input type="file" id="user_avatar" name="user[avatar]" />
+      #   # => <input type="file" id="user_avatar" name="user[avatar]">
       #
       #   file_field(:article, :image, multiple: true)
-      #   # => <input type="file" id="article_image" name="article[image][]" multiple="multiple" />
+      #   # => <input type="file" id="article_image" name="article[image][]" multiple="multiple">
       #
       #   file_field(:article, :attached, accept: 'text/html')
-      #   # => <input accept="text/html" type="file" id="article_attached" name="article[attached]" />
+      #   # => <input accept="text/html" type="file" id="article_attached" name="article[attached]">
       #
       #   file_field(:article, :image, accept: 'image/png,image/gif,image/jpeg')
-      #   # => <input type="file" id="article_image" name="article[image]" accept="image/png,image/gif,image/jpeg" />
+      #   # => <input type="file" id="article_image" name="article[image]" accept="image/png,image/gif,image/jpeg">
       #
       #   file_field(:attachment, :file, class: 'file_input')
-      #   # => <input type="file" id="attachment_file" name="attachment[file]" class="file_input" />
+      #   # => <input type="file" id="attachment_file" name="attachment[file]" class="file_input">
       def file_field(object_name, method, options = {})
         options = { include_hidden: multiple_file_field_include_hidden }.merge!(options)
 
@@ -1331,17 +1331,17 @@ module ActionView
       #
       #   # Let's say that @article.validated? is 1:
       #   check_box("article", "validated")
-      #   # => <input name="article[validated]" type="hidden" value="0" />
-      #   #    <input checked="checked" type="checkbox" id="article_validated" name="article[validated]" value="1" />
+      #   # => <input name="article[validated]" type="hidden" value="0">
+      #   #    <input checked="checked" type="checkbox" id="article_validated" name="article[validated]" value="1">
       #
       #   # Let's say that @puppy.gooddog is "no":
       #   check_box("puppy", "gooddog", {}, "yes", "no")
-      #   # => <input name="puppy[gooddog]" type="hidden" value="no" />
-      #   #    <input type="checkbox" id="puppy_gooddog" name="puppy[gooddog]" value="yes" />
+      #   # => <input name="puppy[gooddog]" type="hidden" value="no">
+      #   #    <input type="checkbox" id="puppy_gooddog" name="puppy[gooddog]" value="yes">
       #
       #   check_box("eula", "accepted", { class: 'eula_check' }, "yes", "no")
-      #   # => <input name="eula[accepted]" type="hidden" value="no" />
-      #   #    <input type="checkbox" class="eula_check" id="eula_accepted" name="eula[accepted]" value="yes" />
+      #   # => <input name="eula[accepted]" type="hidden" value="no">
+      #   #    <input type="checkbox" class="eula_check" id="eula_accepted" name="eula[accepted]" value="yes">
       def check_box(object_name, method, options = {}, checked_value = "1", unchecked_value = "0")
         Tags::CheckBox.new(object_name, method, self, checked_value, unchecked_value, options).render
       end
@@ -1356,14 +1356,14 @@ module ActionView
       #   # Let's say that @article.category returns "rails":
       #   radio_button("article", "category", "rails")
       #   radio_button("article", "category", "java")
-      #   # => <input type="radio" id="article_category_rails" name="article[category]" value="rails" checked="checked" />
-      #   #    <input type="radio" id="article_category_java" name="article[category]" value="java" />
+      #   # => <input type="radio" id="article_category_rails" name="article[category]" value="rails" checked="checked">
+      #   #    <input type="radio" id="article_category_java" name="article[category]" value="java">
       #
       #   # Let's say that @user.receive_newsletter returns "no":
       #   radio_button("user", "receive_newsletter", "yes")
       #   radio_button("user", "receive_newsletter", "no")
-      #   # => <input type="radio" id="user_receive_newsletter_yes" name="user[receive_newsletter]" value="yes" />
-      #   #    <input type="radio" id="user_receive_newsletter_no" name="user[receive_newsletter]" value="no" checked="checked" />
+      #   # => <input type="radio" id="user_receive_newsletter_yes" name="user[receive_newsletter]" value="yes">
+      #   #    <input type="radio" id="user_receive_newsletter_no" name="user[receive_newsletter]" value="no" checked="checked">
       def radio_button(object_name, method, tag_value, options = {})
         Tags::RadioButton.new(object_name, method, self, tag_value, options).render
       end
@@ -1371,7 +1371,7 @@ module ActionView
       # Returns a text_field of type "color".
       #
       #   color_field("car", "color")
-      #   # => <input id="car_color" name="car[color]" type="color" value="#000000" />
+      #   # => <input id="car_color" name="car[color]" type="color" value="#000000">
       def color_field(object_name, method, options = {})
         Tags::ColorField.new(object_name, method, self, options).render
       end
@@ -1381,20 +1381,20 @@ module ActionView
       # some browsers.
       #
       #   search_field(:user, :name)
-      #   # => <input id="user_name" name="user[name]" type="search" />
+      #   # => <input id="user_name" name="user[name]" type="search">
       #   search_field(:user, :name, autosave: false)
-      #   # => <input autosave="false" id="user_name" name="user[name]" type="search" />
+      #   # => <input autosave="false" id="user_name" name="user[name]" type="search">
       #   search_field(:user, :name, results: 3)
-      #   # => <input id="user_name" name="user[name]" results="3" type="search" />
+      #   # => <input id="user_name" name="user[name]" results="3" type="search">
       #   #  Assume request.host returns "www.example.com"
       #   search_field(:user, :name, autosave: true)
-      #   # => <input autosave="com.example.www" id="user_name" name="user[name]" results="10" type="search" />
+      #   # => <input autosave="com.example.www" id="user_name" name="user[name]" results="10" type="search">
       #   search_field(:user, :name, onsearch: true)
-      #   # => <input id="user_name" incremental="true" name="user[name]" onsearch="true" type="search" />
+      #   # => <input id="user_name" incremental="true" name="user[name]" onsearch="true" type="search">
       #   search_field(:user, :name, autosave: false, onsearch: true)
-      #   # => <input autosave="false" id="user_name" incremental="true" name="user[name]" onsearch="true" type="search" />
+      #   # => <input autosave="false" id="user_name" incremental="true" name="user[name]" onsearch="true" type="search">
       #   search_field(:user, :name, autosave: true, onsearch: true)
-      #   # => <input autosave="com.example.www" id="user_name" incremental="true" name="user[name]" onsearch="true" results="10" type="search" />
+      #   # => <input autosave="com.example.www" id="user_name" incremental="true" name="user[name]" onsearch="true" results="10" type="search">
       def search_field(object_name, method, options = {})
         Tags::SearchField.new(object_name, method, self, options).render
       end
@@ -1402,7 +1402,7 @@ module ActionView
       # Returns a text_field of type "tel".
       #
       #   telephone_field("user", "phone")
-      #   # => <input id="user_phone" name="user[phone]" type="tel" />
+      #   # => <input id="user_phone" name="user[phone]" type="tel">
       #
       def telephone_field(object_name, method, options = {})
         Tags::TelField.new(object_name, method, self, options).render
@@ -1413,7 +1413,7 @@ module ActionView
       # Returns a text_field of type "date".
       #
       #   date_field("user", "born_on")
-      #   # => <input id="user_born_on" name="user[born_on]" type="date" />
+      #   # => <input id="user_born_on" name="user[born_on]" type="date">
       #
       # The default value is generated by trying to call +strftime+ with "%Y-%m-%d"
       # on the object's value, which makes it behave as expected for instances
@@ -1422,19 +1422,19 @@ module ActionView
       #
       #   @user.born_on = Date.new(1984, 1, 27)
       #   date_field("user", "born_on", value: "1984-05-12")
-      #   # => <input id="user_born_on" name="user[born_on]" type="date" value="1984-05-12" />
+      #   # => <input id="user_born_on" name="user[born_on]" type="date" value="1984-05-12">
       #
       # You can create values for the "min" and "max" attributes by passing
       # instances of Date or Time to the options hash.
       #
       #   date_field("user", "born_on", min: Date.today)
-      #   # => <input id="user_born_on" name="user[born_on]" type="date" min="2014-05-20" />
+      #   # => <input id="user_born_on" name="user[born_on]" type="date" min="2014-05-20">
       #
       # Alternatively, you can pass a String formatted as an ISO8601 date as the
       # values for "min" and "max."
       #
       #   date_field("user", "born_on", min: "2014-05-20")
-      #   # => <input id="user_born_on" name="user[born_on]" type="date" min="2014-05-20" />
+      #   # => <input id="user_born_on" name="user[born_on]" type="date" min="2014-05-20">
       #
       def date_field(object_name, method, options = {})
         Tags::DateField.new(object_name, method, self, options).render
@@ -1454,26 +1454,26 @@ module ActionView
       # ==== Examples
       #
       #   time_field("task", "started_at")
-      #   # => <input id="task_started_at" name="task[started_at]" type="time" />
+      #   # => <input id="task_started_at" name="task[started_at]" type="time">
       #
       # You can create values for the "min" and "max" attributes by passing
       # instances of Date or Time to the options hash.
       #
       #   time_field("task", "started_at", min: Time.now)
-      #   # => <input id="task_started_at" name="task[started_at]" type="time" min="01:00:00.000" />
+      #   # => <input id="task_started_at" name="task[started_at]" type="time" min="01:00:00.000">
       #
       # Alternatively, you can pass a String formatted as an ISO8601 time as the
       # values for "min" and "max."
       #
       #   time_field("task", "started_at", min: "01:00:00")
-      #   # => <input id="task_started_at" name="task[started_at]" type="time" min="01:00:00.000" />
+      #   # => <input id="task_started_at" name="task[started_at]" type="time" min="01:00:00.000">
       #
       # By default, provided times will be formatted including seconds. You can render just the hour
       # and minute by passing <tt>include_seconds: false</tt>. Some browsers will render a simpler UI
       # if you exclude seconds in the timestamp format.
       #
       #   time_field("task", "started_at", value: Time.now, include_seconds: false)
-      #   # => <input id="task_started_at" name="task[started_at]" type="time" value="01:00" />
+      #   # => <input id="task_started_at" name="task[started_at]" type="time" value="01:00">
       def time_field(object_name, method, options = {})
         Tags::TimeField.new(object_name, method, self, options).render
       end
@@ -1481,7 +1481,7 @@ module ActionView
       # Returns a text_field of type "datetime-local".
       #
       #   datetime_field("user", "born_on")
-      #   # => <input id="user_born_on" name="user[born_on]" type="datetime-local" />
+      #   # => <input id="user_born_on" name="user[born_on]" type="datetime-local">
       #
       # The default value is generated by trying to call +strftime+ with "%Y-%m-%dT%T"
       # on the object's value, which makes it behave as expected for instances
@@ -1489,26 +1489,26 @@ module ActionView
       #
       #   @user.born_on = Date.new(1984, 1, 12)
       #   datetime_field("user", "born_on")
-      #   # => <input id="user_born_on" name="user[born_on]" type="datetime-local" value="1984-01-12T00:00:00" />
+      #   # => <input id="user_born_on" name="user[born_on]" type="datetime-local" value="1984-01-12T00:00:00">
       #
       # You can create values for the "min" and "max" attributes by passing
       # instances of Date or Time to the options hash.
       #
       #   datetime_field("user", "born_on", min: Date.today)
-      #   # => <input id="user_born_on" name="user[born_on]" type="datetime-local" min="2014-05-20T00:00:00.000" />
+      #   # => <input id="user_born_on" name="user[born_on]" type="datetime-local" min="2014-05-20T00:00:00.000">
       #
       # Alternatively, you can pass a String formatted as an ISO8601 datetime as
       # the values for "min" and "max."
       #
       #   datetime_field("user", "born_on", min: "2014-05-20T00:00:00")
-      #   # => <input id="user_born_on" name="user[born_on]" type="datetime-local" min="2014-05-20T00:00:00.000" />
+      #   # => <input id="user_born_on" name="user[born_on]" type="datetime-local" min="2014-05-20T00:00:00.000">
       #
       # By default, provided datetimes will be formatted including seconds. You can render just the date, hour,
       # and minute by passing <tt>include_seconds: false</tt>.
       #
       #   @user.born_on = Time.current
       #   datetime_field("user", "born_on", include_seconds: false)
-      #   # => <input id="user_born_on" name="user[born_on]" type="datetime-local" value="2014-05-20T14:35" />
+      #   # => <input id="user_born_on" name="user[born_on]" type="datetime-local" value="2014-05-20T14:35">
       def datetime_field(object_name, method, options = {})
         Tags::DatetimeLocalField.new(object_name, method, self, options).render
       end
@@ -1518,7 +1518,7 @@ module ActionView
       # Returns a text_field of type "month".
       #
       #   month_field("user", "born_on")
-      #   # => <input id="user_born_on" name="user[born_on]" type="month" />
+      #   # => <input id="user_born_on" name="user[born_on]" type="month">
       #
       # The default value is generated by trying to call +strftime+ with "%Y-%m"
       # on the object's value, which makes it behave as expected for instances
@@ -1526,7 +1526,7 @@ module ActionView
       #
       #   @user.born_on = Date.new(1984, 1, 27)
       #   month_field("user", "born_on")
-      #   # => <input id="user_born_on" name="user[born_on]" type="date" value="1984-01" />
+      #   # => <input id="user_born_on" name="user[born_on]" type="date" value="1984-01">
       #
       def month_field(object_name, method, options = {})
         Tags::MonthField.new(object_name, method, self, options).render
@@ -1535,7 +1535,7 @@ module ActionView
       # Returns a text_field of type "week".
       #
       #   week_field("user", "born_on")
-      #   # => <input id="user_born_on" name="user[born_on]" type="week" />
+      #   # => <input id="user_born_on" name="user[born_on]" type="week">
       #
       # The default value is generated by trying to call +strftime+ with "%Y-W%W"
       # on the object's value, which makes it behave as expected for instances
@@ -1543,7 +1543,7 @@ module ActionView
       #
       #   @user.born_on = Date.new(1984, 5, 12)
       #   week_field("user", "born_on")
-      #   # => <input id="user_born_on" name="user[born_on]" type="date" value="1984-W19" />
+      #   # => <input id="user_born_on" name="user[born_on]" type="date" value="1984-W19">
       #
       def week_field(object_name, method, options = {})
         Tags::WeekField.new(object_name, method, self, options).render
@@ -1552,7 +1552,7 @@ module ActionView
       # Returns a text_field of type "url".
       #
       #   url_field("user", "homepage")
-      #   # => <input id="user_homepage" name="user[homepage]" type="url" />
+      #   # => <input id="user_homepage" name="user[homepage]" type="url">
       #
       def url_field(object_name, method, options = {})
         Tags::UrlField.new(object_name, method, self, options).render
@@ -1561,7 +1561,7 @@ module ActionView
       # Returns a text_field of type "email".
       #
       #   email_field("user", "address")
-      #   # => <input id="user_address" name="user[address]" type="email" />
+      #   # => <input id="user_address" name="user[address]" type="email">
       #
       def email_field(object_name, method, options = {})
         Tags::EmailField.new(object_name, method, self, options).render
@@ -2459,18 +2459,18 @@ module ActionView
       #
       #   # Let's say that @article.validated? is 1:
       #   check_box("validated")
-      #   # => <input name="article[validated]" type="hidden" value="0" />
-      #   #    <input checked="checked" type="checkbox" id="article_validated" name="article[validated]" value="1" />
+      #   # => <input name="article[validated]" type="hidden" value="0">
+      #   #    <input checked="checked" type="checkbox" id="article_validated" name="article[validated]" value="1">
       #
       #   # Let's say that @puppy.gooddog is "no":
       #   check_box("gooddog", {}, "yes", "no")
-      #   # => <input name="puppy[gooddog]" type="hidden" value="no" />
-      #   #    <input type="checkbox" id="puppy_gooddog" name="puppy[gooddog]" value="yes" />
+      #   # => <input name="puppy[gooddog]" type="hidden" value="no">
+      #   #    <input type="checkbox" id="puppy_gooddog" name="puppy[gooddog]" value="yes">
       #
       #   # Let's say that @eula.accepted is "no":
       #   check_box("accepted", { class: 'eula_check' }, "yes", "no")
-      #   # => <input name="eula[accepted]" type="hidden" value="no" />
-      #   #    <input type="checkbox" class="eula_check" id="eula_accepted" name="eula[accepted]" value="yes" />
+      #   # => <input name="eula[accepted]" type="hidden" value="no">
+      #   #    <input type="checkbox" class="eula_check" id="eula_accepted" name="eula[accepted]" value="yes">
       def check_box(method, options = {}, checked_value = "1", unchecked_value = "0")
         @template.check_box(@object_name, method, objectify_options(options), checked_value, unchecked_value)
       end
@@ -2485,14 +2485,14 @@ module ActionView
       #   # Let's say that @article.category returns "rails":
       #   radio_button("category", "rails")
       #   radio_button("category", "java")
-      #   # => <input type="radio" id="article_category_rails" name="article[category]" value="rails" checked="checked" />
-      #   #    <input type="radio" id="article_category_java" name="article[category]" value="java" />
+      #   # => <input type="radio" id="article_category_rails" name="article[category]" value="rails" checked="checked">
+      #   #    <input type="radio" id="article_category_java" name="article[category]" value="java">
       #
       #   # Let's say that @user.receive_newsletter returns "no":
       #   radio_button("receive_newsletter", "yes")
       #   radio_button("receive_newsletter", "no")
-      #   # => <input type="radio" id="user_receive_newsletter_yes" name="user[receive_newsletter]" value="yes" />
-      #   #    <input type="radio" id="user_receive_newsletter_no" name="user[receive_newsletter]" value="no" checked="checked" />
+      #   # => <input type="radio" id="user_receive_newsletter_yes" name="user[receive_newsletter]" value="yes">
+      #   #    <input type="radio" id="user_receive_newsletter_no" name="user[receive_newsletter]" value="no" checked="checked">
       def radio_button(method, tag_value, options = {})
         @template.radio_button(@object_name, method, tag_value, objectify_options(options))
       end
@@ -2505,15 +2505,15 @@ module ActionView
       # ==== Examples
       #   # Let's say that @signup.pass_confirm returns true:
       #   hidden_field(:pass_confirm)
-      #   # => <input type="hidden" id="signup_pass_confirm" name="signup[pass_confirm]" value="true" />
+      #   # => <input type="hidden" id="signup_pass_confirm" name="signup[pass_confirm]" value="true">
       #
       #   # Let's say that @article.tag_list returns "blog, ruby":
       #   hidden_field(:tag_list)
-      #   # => <input type="hidden" id="article_tag_list" name="article[tag_list]" value="blog, ruby" />
+      #   # => <input type="hidden" id="article_tag_list" name="article[tag_list]" value="blog, ruby">
       #
       #   # Let's say that @user.token returns "abcde":
       #   hidden_field(:token)
-      #   # => <input type="hidden" id="user_token" name="user[token]" value="abcde" />
+      #   # => <input type="hidden" id="user_token" name="user[token]" value="abcde">
       #
       def hidden_field(method, options = {})
         @emitted_hidden_id = true if method == :id
@@ -2537,23 +2537,23 @@ module ActionView
       # ==== Examples
       #   # Let's say that @user has avatar:
       #   file_field(:avatar)
-      #   # => <input type="file" id="user_avatar" name="user[avatar]" />
+      #   # => <input type="file" id="user_avatar" name="user[avatar]">
       #
       #   # Let's say that @article has image:
       #   file_field(:image, :multiple => true)
-      #   # => <input type="file" id="article_image" name="article[image][]" multiple="multiple" />
+      #   # => <input type="file" id="article_image" name="article[image][]" multiple="multiple">
       #
       #   # Let's say that @article has attached:
       #   file_field(:attached, accept: 'text/html')
-      #   # => <input accept="text/html" type="file" id="article_attached" name="article[attached]" />
+      #   # => <input accept="text/html" type="file" id="article_attached" name="article[attached]">
       #
       #   # Let's say that @article has image:
       #   file_field(:image, accept: 'image/png,image/gif,image/jpeg')
-      #   # => <input type="file" id="article_image" name="article[image]" accept="image/png,image/gif,image/jpeg" />
+      #   # => <input type="file" id="article_image" name="article[image]" accept="image/png,image/gif,image/jpeg">
       #
       #   # Let's say that @attachment has file:
       #   file_field(:file, class: 'file_input')
-      #   # => <input type="file" id="attachment_file" name="attachment[file]" class="file_input" />
+      #   # => <input type="file" id="attachment_file" name="attachment[file]" class="file_input">
       def file_field(method, options = {})
         self.multipart = true
         @template.file_field(@object_name, method, objectify_options(options))

--- a/actionview/lib/action_view/helpers/form_options_helper.rb
+++ b/actionview/lib/action_view/helpers/form_options_helper.rb
@@ -646,11 +646,11 @@ module ActionView
       #   collection_radio_buttons(:post, :author_id, Author.all, :id, :name_with_initial)
       #
       # If <tt>@post.author_id</tt> is already <tt>1</tt>, this would return:
-      #   <input id="post_author_id_1" name="post[author_id]" type="radio" value="1" checked="checked" />
+      #   <input id="post_author_id_1" name="post[author_id]" type="radio" value="1" checked="checked">
       #   <label for="post_author_id_1">D. Heinemeier Hansson</label>
-      #   <input id="post_author_id_2" name="post[author_id]" type="radio" value="2" />
+      #   <input id="post_author_id_2" name="post[author_id]" type="radio" value="2">
       #   <label for="post_author_id_2">D. Thomas</label>
-      #   <input id="post_author_id_3" name="post[author_id]" type="radio" value="3" />
+      #   <input id="post_author_id_3" name="post[author_id]" type="radio" value="3">
       #   <label for="post_author_id_3">M. Clark</label>
       #
       # It is also possible to customize the way the elements will be shown by
@@ -726,13 +726,13 @@ module ActionView
       #   collection_check_boxes(:post, :author_ids, Author.all, :id, :name_with_initial)
       #
       # If <tt>@post.author_ids</tt> is already <tt>[1]</tt>, this would return:
-      #   <input id="post_author_ids_1" name="post[author_ids][]" type="checkbox" value="1" checked="checked" />
+      #   <input id="post_author_ids_1" name="post[author_ids][]" type="checkbox" value="1" checked="checked">
       #   <label for="post_author_ids_1">D. Heinemeier Hansson</label>
-      #   <input id="post_author_ids_2" name="post[author_ids][]" type="checkbox" value="2" />
+      #   <input id="post_author_ids_2" name="post[author_ids][]" type="checkbox" value="2">
       #   <label for="post_author_ids_2">D. Thomas</label>
-      #   <input id="post_author_ids_3" name="post[author_ids][]" type="checkbox" value="3" />
+      #   <input id="post_author_ids_3" name="post[author_ids][]" type="checkbox" value="3">
       #   <label for="post_author_ids_3">M. Clark</label>
-      #   <input name="post[author_ids][]" type="hidden" value="" />
+      #   <input name="post[author_ids][]" type="hidden" value="">
       #
       # It is also possible to customize the way the elements will be shown by
       # giving a block to the method:

--- a/actionview/lib/action_view/helpers/form_tag_helper.rb
+++ b/actionview/lib/action_view/helpers/form_tag_helper.rb
@@ -53,7 +53,7 @@ module ActionView
       #   # => <form action="/posts" method="post">
       #
       #   form_tag('/posts/1', method: :put)
-      #   # => <form action="/posts/1" method="post"> ... <input name="_method" type="hidden" value="put" /> ...
+      #   # => <form action="/posts/1" method="post"> ... <input name="_method" type="hidden" value="put"> ...
       #
       #   form_tag('/upload', multipart: true)
       #   # => <form action="/upload" method="post" enctype="multipart/form-data">
@@ -61,7 +61,7 @@ module ActionView
       #   <%= form_tag('/posts') do -%>
       #     <div><%= submit_tag 'Save' %></div>
       #   <% end -%>
-      #   # => <form action="/posts" method="post"><div><input type="submit" name="commit" value="Save" /></div></form>
+      #   # => <form action="/posts" method="post"><div><input type="submit" name="commit" value="Save"></div></form>
       #
       #   <%= form_tag('/posts', remote: true) %>
       #   # => <form action="/posts" method="post" data-remote="true">
@@ -238,28 +238,28 @@ module ActionView
       #
       # ==== Examples
       #   text_field_tag 'name'
-      #   # => <input id="name" name="name" type="text" />
+      #   # => <input id="name" name="name" type="text">
       #
       #   text_field_tag 'query', 'Enter your search query here'
-      #   # => <input id="query" name="query" type="text" value="Enter your search query here" />
+      #   # => <input id="query" name="query" type="text" value="Enter your search query here">
       #
       #   text_field_tag 'search', nil, placeholder: 'Enter search term...'
-      #   # => <input id="search" name="search" placeholder="Enter search term..." type="text" />
+      #   # => <input id="search" name="search" placeholder="Enter search term..." type="text">
       #
       #   text_field_tag 'request', nil, class: 'special_input'
-      #   # => <input class="special_input" id="request" name="request" type="text" />
+      #   # => <input class="special_input" id="request" name="request" type="text">
       #
       #   text_field_tag 'address', '', size: 75
-      #   # => <input id="address" name="address" size="75" type="text" value="" />
+      #   # => <input id="address" name="address" size="75" type="text" value="">
       #
       #   text_field_tag 'zip', nil, maxlength: 5
-      #   # => <input id="zip" maxlength="5" name="zip" type="text" />
+      #   # => <input id="zip" maxlength="5" name="zip" type="text">
       #
       #   text_field_tag 'payment_amount', '$0.00', disabled: true
-      #   # => <input disabled="disabled" id="payment_amount" name="payment_amount" type="text" value="$0.00" />
+      #   # => <input disabled="disabled" id="payment_amount" name="payment_amount" type="text" value="$0.00">
       #
       #   text_field_tag 'ip', '0.0.0.0', maxlength: 15, size: 20, class: "ip-input"
-      #   # => <input class="ip-input" id="ip" maxlength="15" name="ip" size="20" type="text" value="0.0.0.0" />
+      #   # => <input class="ip-input" id="ip" maxlength="15" name="ip" size="20" type="text" value="0.0.0.0">
       def text_field_tag(name, value = nil, options = {})
         tag :input, { "type" => "text", "name" => name, "id" => sanitize_to_id(name), "value" => value }.update(options.stringify_keys)
       end
@@ -297,14 +297,14 @@ module ActionView
       #
       # ==== Examples
       #   hidden_field_tag 'tags_list'
-      #   # => <input type="hidden" name="tags_list" id="tags_list" autocomplete="off" />
+      #   # => <input type="hidden" name="tags_list" id="tags_list" autocomplete="off">
       #
       #   hidden_field_tag 'token', 'VUBJKB23UIVI1UU1VOBVI@'
-      #   # => <input type="hidden" name="token" id="token" value="VUBJKB23UIVI1UU1VOBVI@" autocomplete="off" />
+      #   # => <input type="hidden" name="token" id="token" value="VUBJKB23UIVI1UU1VOBVI@" autocomplete="off">
       #
       #   hidden_field_tag 'collected_input', '', onchange: "alert('Input collected!')"
       #   # => <input type="hidden" name="collected_input" id="collected_input"
-      #        value="" onchange="alert(&#39;Input collected!&#39;)" autocomplete="off" />
+      #        value="" onchange="alert(&#39;Input collected!&#39;)" autocomplete="off">
       def hidden_field_tag(name, value = nil, options = {})
         text_field_tag(name, value, options.merge(type: :hidden, autocomplete: "off"))
       end
@@ -328,22 +328,22 @@ module ActionView
       #
       # ==== Examples
       #   file_field_tag 'attachment'
-      #   # => <input id="attachment" name="attachment" type="file" />
+      #   # => <input id="attachment" name="attachment" type="file">
       #
       #   file_field_tag 'avatar', class: 'profile_input'
-      #   # => <input class="profile_input" id="avatar" name="avatar" type="file" />
+      #   # => <input class="profile_input" id="avatar" name="avatar" type="file">
       #
       #   file_field_tag 'picture', disabled: true
-      #   # => <input disabled="disabled" id="picture" name="picture" type="file" />
+      #   # => <input disabled="disabled" id="picture" name="picture" type="file">
       #
       #   file_field_tag 'resume', value: '~/resume.doc'
-      #   # => <input id="resume" name="resume" type="file" value="~/resume.doc" />
+      #   # => <input id="resume" name="resume" type="file" value="~/resume.doc">
       #
       #   file_field_tag 'user_pic', accept: 'image/png,image/gif,image/jpeg'
-      #   # => <input accept="image/png,image/gif,image/jpeg" id="user_pic" name="user_pic" type="file" />
+      #   # => <input accept="image/png,image/gif,image/jpeg" id="user_pic" name="user_pic" type="file">
       #
       #   file_field_tag 'file', accept: 'text/html', class: 'upload', value: 'index.html'
-      #   # => <input accept="text/html" class="upload" id="file" name="file" type="file" value="index.html" />
+      #   # => <input accept="text/html" class="upload" id="file" name="file" type="file" value="index.html">
       def file_field_tag(name, options = {})
         text_field_tag(name, nil, convert_direct_upload_option_to_url(options.merge(type: :file)))
       end
@@ -358,25 +358,25 @@ module ActionView
       #
       # ==== Examples
       #   password_field_tag 'pass'
-      #   # => <input id="pass" name="pass" type="password" />
+      #   # => <input id="pass" name="pass" type="password">
       #
       #   password_field_tag 'secret', 'Your secret here'
-      #   # => <input id="secret" name="secret" type="password" value="Your secret here" />
+      #   # => <input id="secret" name="secret" type="password" value="Your secret here">
       #
       #   password_field_tag 'masked', nil, class: 'masked_input_field'
-      #   # => <input class="masked_input_field" id="masked" name="masked" type="password" />
+      #   # => <input class="masked_input_field" id="masked" name="masked" type="password">
       #
       #   password_field_tag 'token', '', size: 15
-      #   # => <input id="token" name="token" size="15" type="password" value="" />
+      #   # => <input id="token" name="token" size="15" type="password" value="">
       #
       #   password_field_tag 'key', nil, maxlength: 16
-      #   # => <input id="key" maxlength="16" name="key" type="password" />
+      #   # => <input id="key" maxlength="16" name="key" type="password">
       #
       #   password_field_tag 'confirm_pass', nil, disabled: true
-      #   # => <input disabled="disabled" id="confirm_pass" name="confirm_pass" type="password" />
+      #   # => <input disabled="disabled" id="confirm_pass" name="confirm_pass" type="password">
       #
       #   password_field_tag 'pin', '1234', maxlength: 4, size: 6, class: "pin_input"
-      #   # => <input class="pin_input" id="pin" maxlength="4" name="pin" size="6" type="password" value="1234" />
+      #   # => <input class="pin_input" id="pin" maxlength="4" name="pin" size="6" type="password" value="1234">
       def password_field_tag(name = "password", value = nil, options = {})
         text_field_tag(name, value, options.merge(type: :password))
       end
@@ -439,19 +439,19 @@ module ActionView
       #
       # ==== Examples
       #   check_box_tag 'accept'
-      #   # => <input id="accept" name="accept" type="checkbox" value="1" />
+      #   # => <input id="accept" name="accept" type="checkbox" value="1">
       #
       #   check_box_tag 'rock', 'rock music'
-      #   # => <input id="rock" name="rock" type="checkbox" value="rock music" />
+      #   # => <input id="rock" name="rock" type="checkbox" value="rock music">
       #
       #   check_box_tag 'receive_email', 'yes', true
-      #   # => <input checked="checked" id="receive_email" name="receive_email" type="checkbox" value="yes" />
+      #   # => <input checked="checked" id="receive_email" name="receive_email" type="checkbox" value="yes">
       #
       #   check_box_tag 'tos', 'yes', false, class: 'accept_tos'
-      #   # => <input class="accept_tos" id="tos" name="tos" type="checkbox" value="yes" />
+      #   # => <input class="accept_tos" id="tos" name="tos" type="checkbox" value="yes">
       #
       #   check_box_tag 'eula', 'accepted', false, disabled: true
-      #   # => <input disabled="disabled" id="eula" name="eula" type="checkbox" value="accepted" />
+      #   # => <input disabled="disabled" id="eula" name="eula" type="checkbox" value="accepted">
       def check_box_tag(name, *args)
         if args.length >= 4
           raise ArgumentError, "wrong number of arguments (given #{args.length + 1}, expected 1..4)"
@@ -478,16 +478,16 @@ module ActionView
       #
       # ==== Examples
       #   radio_button_tag 'favorite_color', 'maroon'
-      #   # => <input id="favorite_color_maroon" name="favorite_color" type="radio" value="maroon" />
+      #   # => <input id="favorite_color_maroon" name="favorite_color" type="radio" value="maroon">
       #
       #   radio_button_tag 'receive_updates', 'no', true
-      #   # => <input checked="checked" id="receive_updates_no" name="receive_updates" type="radio" value="no" />
+      #   # => <input checked="checked" id="receive_updates_no" name="receive_updates" type="radio" value="no">
       #
       #   radio_button_tag 'time_slot', "3:00 p.m.", false, disabled: true
-      #   # => <input disabled="disabled" id="time_slot_3:00_p.m." name="time_slot" type="radio" value="3:00 p.m." />
+      #   # => <input disabled="disabled" id="time_slot_3:00_p.m." name="time_slot" type="radio" value="3:00 p.m.">
       #
       #   radio_button_tag 'color', "green", true, class: "color_input"
-      #   # => <input checked="checked" class="color_input" id="color_green" name="color" type="radio" value="green" />
+      #   # => <input checked="checked" class="color_input" id="color_green" name="color" type="radio" value="green">
       def radio_button_tag(name, value, *args)
         if args.length >= 3
           raise ArgumentError, "wrong number of arguments (given #{args.length + 2}, expected 2..4)"
@@ -508,19 +508,19 @@ module ActionView
       #
       # ==== Examples
       #   submit_tag
-      #   # => <input name="commit" data-disable-with="Save changes" type="submit" value="Save changes" />
+      #   # => <input name="commit" data-disable-with="Save changes" type="submit" value="Save changes">
       #
       #   submit_tag "Edit this article"
-      #   # => <input name="commit" data-disable-with="Edit this article" type="submit" value="Edit this article" />
+      #   # => <input name="commit" data-disable-with="Edit this article" type="submit" value="Edit this article">
       #
       #   submit_tag "Save edits", disabled: true
-      #   # => <input disabled="disabled" name="commit" data-disable-with="Save edits" type="submit" value="Save edits" />
+      #   # => <input disabled="disabled" name="commit" data-disable-with="Save edits" type="submit" value="Save edits">
       #
       #   submit_tag nil, class: "form_submit"
-      #   # => <input class="form_submit" name="commit" type="submit" />
+      #   # => <input class="form_submit" name="commit" type="submit">
       #
       #   submit_tag "Edit", class: "edit_button"
-      #   # => <input class="edit_button" data-disable-with="Edit" name="commit" type="submit" value="Edit" />
+      #   # => <input class="edit_button" data-disable-with="Edit" name="commit" type="submit" value="Edit">
       #
       def submit_tag(value = "Save changes", options = {})
         options = options.deep_stringify_keys
@@ -596,19 +596,19 @@ module ActionView
       #
       # ==== Examples
       #   image_submit_tag("login.png")
-      #   # => <input src="/assets/login.png" type="image" />
+      #   # => <input src="/assets/login.png" type="image">
       #
       #   image_submit_tag("purchase.png", disabled: true)
-      #   # => <input disabled="disabled" src="/assets/purchase.png" type="image" />
+      #   # => <input disabled="disabled" src="/assets/purchase.png" type="image">
       #
       #   image_submit_tag("search.png", class: 'search_button', alt: 'Find')
-      #   # => <input class="search_button" src="/assets/search.png" type="image" />
+      #   # => <input class="search_button" src="/assets/search.png" type="image">
       #
       #   image_submit_tag("agree.png", disabled: true, class: "agree_disagree_button")
-      #   # => <input class="agree_disagree_button" disabled="disabled" src="/assets/agree.png" type="image" />
+      #   # => <input class="agree_disagree_button" disabled="disabled" src="/assets/agree.png" type="image">
       #
       #   image_submit_tag("save.png", data: { confirm: "Are you sure?" })
-      #   # => <input src="/assets/save.png" data-confirm="Are you sure?" type="image" />
+      #   # => <input src="/assets/save.png" data-confirm="Are you sure?" type="image">
       def image_submit_tag(source, options = {})
         options = options.stringify_keys
         src = path_to_image(source, skip_pipeline: options.delete("skip_pipeline"))
@@ -624,17 +624,17 @@ module ActionView
       #   <%= field_set_tag do %>
       #     <p><%= text_field_tag 'name' %></p>
       #   <% end %>
-      #   # => <fieldset><p><input id="name" name="name" type="text" /></p></fieldset>
+      #   # => <fieldset><p><input id="name" name="name" type="text"></p></fieldset>
       #
       #   <%= field_set_tag 'Your details' do %>
       #     <p><%= text_field_tag 'name' %></p>
       #   <% end %>
-      #   # => <fieldset><legend>Your details</legend><p><input id="name" name="name" type="text" /></p></fieldset>
+      #   # => <fieldset><legend>Your details</legend><p><input id="name" name="name" type="text"></p></fieldset>
       #
       #   <%= field_set_tag nil, class: 'format' do %>
       #     <p><%= text_field_tag 'name' %></p>
       #   <% end %>
-      #   # => <fieldset class="format"><p><input id="name" name="name" type="text" /></p></fieldset>
+      #   # => <fieldset class="format"><p><input id="name" name="name" type="text"></p></fieldset>
       def field_set_tag(legend = nil, options = nil, &block)
         content = []
         content << content_tag("legend", legend) unless legend.blank?
@@ -653,16 +653,16 @@ module ActionView
       # ==== Examples
       #
       #   color_field_tag 'name'
-      #   # => <input id="name" name="name" type="color" />
+      #   # => <input id="name" name="name" type="color">
       #
       #   color_field_tag 'color', '#DEF726'
-      #   # => <input id="color" name="color" type="color" value="#DEF726" />
+      #   # => <input id="color" name="color" type="color" value="#DEF726">
       #
       #   color_field_tag 'color', nil, class: 'special_input'
-      #   # => <input class="special_input" id="color" name="color" type="color" />
+      #   # => <input class="special_input" id="color" name="color" type="color">
       #
       #   color_field_tag 'color', '#DEF726', class: 'special_input', disabled: true
-      #   # => <input disabled="disabled" class="special_input" id="color" name="color" type="color" value="#DEF726" />
+      #   # => <input disabled="disabled" class="special_input" id="color" name="color" type="color" value="#DEF726">
       def color_field_tag(name, value = nil, options = {})
         text_field_tag(name, value, options.merge(type: :color))
       end
@@ -676,16 +676,16 @@ module ActionView
       # ==== Examples
       #
       #   search_field_tag 'name'
-      #   # => <input id="name" name="name" type="search" />
+      #   # => <input id="name" name="name" type="search">
       #
       #   search_field_tag 'search', 'Enter your search query here'
-      #   # => <input id="search" name="search" type="search" value="Enter your search query here" />
+      #   # => <input id="search" name="search" type="search" value="Enter your search query here">
       #
       #   search_field_tag 'search', nil, class: 'special_input'
-      #   # => <input class="special_input" id="search" name="search" type="search" />
+      #   # => <input class="special_input" id="search" name="search" type="search">
       #
       #   search_field_tag 'search', 'Enter your search query here', class: 'special_input', disabled: true
-      #   # => <input disabled="disabled" class="special_input" id="search" name="search" type="search" value="Enter your search query here" />
+      #   # => <input disabled="disabled" class="special_input" id="search" name="search" type="search" value="Enter your search query here">
       def search_field_tag(name, value = nil, options = {})
         text_field_tag(name, value, options.merge(type: :search))
       end
@@ -699,16 +699,16 @@ module ActionView
       # ==== Examples
       #
       #   telephone_field_tag 'name'
-      #   # => <input id="name" name="name" type="tel" />
+      #   # => <input id="name" name="name" type="tel">
       #
       #   telephone_field_tag 'tel', '0123456789'
-      #   # => <input id="tel" name="tel" type="tel" value="0123456789" />
+      #   # => <input id="tel" name="tel" type="tel" value="0123456789">
       #
       #   telephone_field_tag 'tel', nil, class: 'special_input'
-      #   # => <input class="special_input" id="tel" name="tel" type="tel" />
+      #   # => <input class="special_input" id="tel" name="tel" type="tel">
       #
       #   telephone_field_tag 'tel', '0123456789', class: 'special_input', disabled: true
-      #   # => <input disabled="disabled" class="special_input" id="tel" name="tel" type="tel" value="0123456789" />
+      #   # => <input disabled="disabled" class="special_input" id="tel" name="tel" type="tel" value="0123456789">
       def telephone_field_tag(name, value = nil, options = {})
         text_field_tag(name, value, options.merge(type: :tel))
       end
@@ -723,16 +723,16 @@ module ActionView
       # ==== Examples
       #
       #   date_field_tag 'name'
-      #   # => <input id="name" name="name" type="date" />
+      #   # => <input id="name" name="name" type="date">
       #
       #   date_field_tag 'date', '01/01/2014'
-      #   # => <input id="date" name="date" type="date" value="01/01/2014" />
+      #   # => <input id="date" name="date" type="date" value="01/01/2014">
       #
       #   date_field_tag 'date', nil, class: 'special_input'
-      #   # => <input class="special_input" id="date" name="date" type="date" />
+      #   # => <input class="special_input" id="date" name="date" type="date">
       #
       #   date_field_tag 'date', '01/01/2014', class: 'special_input', disabled: true
-      #   # => <input disabled="disabled" class="special_input" id="date" name="date" type="date" value="01/01/2014" />
+      #   # => <input disabled="disabled" class="special_input" id="date" name="date" type="date" value="01/01/2014">
       def date_field_tag(name, value = nil, options = {})
         text_field_tag(name, value, options.merge(type: :date))
       end
@@ -802,16 +802,16 @@ module ActionView
       # ==== Examples
       #
       #   url_field_tag 'name'
-      #   # => <input id="name" name="name" type="url" />
+      #   # => <input id="name" name="name" type="url">
       #
       #   url_field_tag 'url', 'http://rubyonrails.org'
-      #   # => <input id="url" name="url" type="url" value="http://rubyonrails.org" />
+      #   # => <input id="url" name="url" type="url" value="http://rubyonrails.org">
       #
       #   url_field_tag 'url', nil, class: 'special_input'
-      #   # => <input class="special_input" id="url" name="url" type="url" />
+      #   # => <input class="special_input" id="url" name="url" type="url">
       #
       #   url_field_tag 'url', 'http://rubyonrails.org', class: 'special_input', disabled: true
-      #   # => <input disabled="disabled" class="special_input" id="url" name="url" type="url" value="http://rubyonrails.org" />
+      #   # => <input disabled="disabled" class="special_input" id="url" name="url" type="url" value="http://rubyonrails.org">
       def url_field_tag(name, value = nil, options = {})
         text_field_tag(name, value, options.merge(type: :url))
       end
@@ -825,16 +825,16 @@ module ActionView
       # ==== Examples
       #
       #   email_field_tag 'name'
-      #   # => <input id="name" name="name" type="email" />
+      #   # => <input id="name" name="name" type="email">
       #
       #   email_field_tag 'email', 'email@example.com'
-      #   # => <input id="email" name="email" type="email" value="email@example.com" />
+      #   # => <input id="email" name="email" type="email" value="email@example.com">
       #
       #   email_field_tag 'email', nil, class: 'special_input'
-      #   # => <input class="special_input" id="email" name="email" type="email" />
+      #   # => <input class="special_input" id="email" name="email" type="email">
       #
       #   email_field_tag 'email', 'email@example.com', class: 'special_input', disabled: true
-      #   # => <input disabled="disabled" class="special_input" id="email" name="email" type="email" value="email@example.com" />
+      #   # => <input disabled="disabled" class="special_input" id="email" name="email" type="email" value="email@example.com">
       def email_field_tag(name, value = nil, options = {})
         text_field_tag(name, value, options.merge(type: :email))
       end
@@ -855,34 +855,34 @@ module ActionView
       # ==== Examples
       #
       #   number_field_tag 'quantity'
-      #   # => <input id="quantity" name="quantity" type="number" />
+      #   # => <input id="quantity" name="quantity" type="number">
       #
       #   number_field_tag 'quantity', '1'
-      #   # => <input id="quantity" name="quantity" type="number" value="1" />
+      #   # => <input id="quantity" name="quantity" type="number" value="1">
       #
       #   number_field_tag 'quantity', nil, class: 'special_input'
-      #   # => <input class="special_input" id="quantity" name="quantity" type="number" />
+      #   # => <input class="special_input" id="quantity" name="quantity" type="number">
       #
       #   number_field_tag 'quantity', nil, min: 1
-      #   # => <input id="quantity" name="quantity" min="1" type="number" />
+      #   # => <input id="quantity" name="quantity" min="1" type="number">
       #
       #   number_field_tag 'quantity', nil, max: 9
-      #   # => <input id="quantity" name="quantity" max="9" type="number" />
+      #   # => <input id="quantity" name="quantity" max="9" type="number">
       #
       #   number_field_tag 'quantity', nil, in: 1...10
-      #   # => <input id="quantity" name="quantity" min="1" max="9" type="number" />
+      #   # => <input id="quantity" name="quantity" min="1" max="9" type="number">
       #
       #   number_field_tag 'quantity', nil, within: 1...10
-      #   # => <input id="quantity" name="quantity" min="1" max="9" type="number" />
+      #   # => <input id="quantity" name="quantity" min="1" max="9" type="number">
       #
       #   number_field_tag 'quantity', nil, min: 1, max: 10
-      #   # => <input id="quantity" name="quantity" min="1" max="10" type="number" />
+      #   # => <input id="quantity" name="quantity" min="1" max="10" type="number">
       #
       #   number_field_tag 'quantity', nil, min: 1, max: 10, step: 2
-      #   # => <input id="quantity" name="quantity" min="1" max="10" step="2" type="number" />
+      #   # => <input id="quantity" name="quantity" min="1" max="10" step="2" type="number">
       #
       #   number_field_tag 'quantity', '1', class: 'special_input', disabled: true
-      #   # => <input disabled="disabled" class="special_input" id="quantity" name="quantity" type="number" value="1" />
+      #   # => <input disabled="disabled" class="special_input" id="quantity" name="quantity" type="number" value="1">
       def number_field_tag(name, value = nil, options = {})
         options = options.stringify_keys
         options["type"] ||= "number"
@@ -907,7 +907,7 @@ module ActionView
         # Use raw HTML to ensure the value is written as an HTML entity; it
         # needs to be the right character regardless of which encoding the
         # browser infers.
-        '<input name="utf8" type="hidden" value="&#x2713;" autocomplete="off" />'.html_safe
+        '<input name="utf8" type="hidden" value="&#x2713;" autocomplete="off">'.html_safe
       end
 
       private

--- a/actionview/lib/action_view/helpers/form_tag_helper.rb
+++ b/actionview/lib/action_view/helpers/form_tag_helper.rb
@@ -904,10 +904,7 @@ module ActionView
       # Creates the hidden UTF-8 enforcer tag. Override this method in a helper
       # to customize the tag.
       def utf8_enforcer_tag
-        # Use raw HTML to ensure the value is written as an HTML entity; it
-        # needs to be the right character regardless of which encoding the
-        # browser infers.
-        '<input name="utf8" type="hidden" value="&#x2713;" autocomplete="off">'.html_safe
+        hidden_field_tag("utf8", "&#x2713;".html_safe, id: nil)
       end
 
       private

--- a/actionview/lib/action_view/helpers/tag_helper.rb
+++ b/actionview/lib/action_view/helpers/tag_helper.rb
@@ -448,7 +448,7 @@ module ActionView
       #
       # The following format is for legacy (XHTML) syntax support. It will be deprecated in future versions of \Rails.
       #
-      #   tag(name, options = nil, open = true, escape = true)
+      #   tag(name, options = nil, open = nil, escape = true)
       #
       # It returns an empty HTML tag of type +name+ which by default is HTML
       # compliant. Set +open+ to false to create an open tag compatible
@@ -493,12 +493,12 @@ module ActionView
       #
       #   tag("div", class: { highlight: current_user.admin? })
       #   # => <div class="highlight">
-      def tag(name = nil, options = nil, open = true, escape = true)
+      def tag(name = nil, options = nil, open = nil, escape = true)
         if name.nil?
           tag_builder
         else
           ensure_valid_html5_tag_name(name)
-          "<#{name}#{tag_builder.tag_options(options, escape) if options}#{open || void_element_trailing_slash == false ? ">" : " />"}".html_safe
+          "<#{name}#{tag_builder.tag_options(options, escape) if options}#{" /" if open == false || (open.nil? && void_element_trailing_slash == true)}>".html_safe
         end
       end
 

--- a/actionview/lib/action_view/helpers/tag_helper.rb
+++ b/actionview/lib/action_view/helpers/tag_helper.rb
@@ -74,7 +74,8 @@ module ActionView
                   TEXT
                   tag_string("#{name}", content, options, escape: escape, &block)
                 else
-                  self_closing_tag_string("#{name}", options, escape, ">")
+                  tag_suffix = ActionView::Helpers::TagHelper.void_element_trailing_slash ? " />" : ">"
+                  self_closing_tag_string("#{name}", options, escape, tag_suffix)
                 end
               end
             RUBY
@@ -247,7 +248,7 @@ module ActionView
           content_tag_string(name, content, options, escape)
         end
 
-        def self_closing_tag_string(name, options, escape = true, tag_suffix = (void_element_trailing_slash == false ? ">" : " />"))
+        def self_closing_tag_string(name, options, escape = true, tag_suffix = ">")
           "<#{name}#{tag_options(options, escape)}#{tag_suffix}".html_safe
         end
 

--- a/actionview/lib/action_view/helpers/tag_helper.rb
+++ b/actionview/lib/action_view/helpers/tag_helper.rb
@@ -18,6 +18,8 @@ module ActionView
       include CaptureHelper
       include OutputSafetyHelper
 
+      mattr_accessor :void_element_trailing_slash, default: false
+
       BOOLEAN_ATTRIBUTES = %w(allowfullscreen allowpaymentrequest async autofocus
                               autoplay checked compact controls declare default
                               defaultchecked defaultmuted defaultselected defer
@@ -86,7 +88,7 @@ module ActionView
                 if content || block
                   tag_string("#{name}", content, options, escape: escape, &block)
                 else
-                  self_closing_tag_string("#{name}", options, escape)
+                  self_closing_tag_string("#{name}", options, escape, " />")
                 end
               end
             RUBY
@@ -245,7 +247,7 @@ module ActionView
           content_tag_string(name, content, options, escape)
         end
 
-        def self_closing_tag_string(name, options, escape = true, tag_suffix = " />")
+        def self_closing_tag_string(name, options, escape = true, tag_suffix = (void_element_trailing_slash == false ? ">" : " />"))
           "<#{name}#{tag_options(options, escape)}#{tag_suffix}".html_safe
         end
 
@@ -444,15 +446,17 @@ module ActionView
       #
       # === Legacy syntax
       #
-      # The following format is for legacy syntax support. It will be deprecated in future versions of \Rails.
+      # The following format is for legacy (XHTML) syntax support. It will be deprecated in future versions of \Rails.
       #
-      #   tag(name, options = nil, open = false, escape = true)
+      #   tag(name, options = nil, open = true, escape = true)
       #
-      # It returns an empty HTML tag of type +name+ which by default is XHTML
-      # compliant. Set +open+ to true to create an open tag compatible
-      # with HTML 4.0 and below. Add HTML attributes by passing an attributes
-      # hash to +options+. Set +escape+ to false to disable attribute value
-      # escaping.
+      # It returns an empty HTML tag of type +name+ which by default is HTML
+      # compliant. Set +open+ to false to create an open tag compatible
+      # with XHTML. Add HTML attributes by passing an attributes hash to
+      # +options+. Set +escape+ to false to disable attribute value escaping.
+      # Tags can be to be XHTML compliant by default by setting
+      # <tt>config.action_view.void_element_trailing_slash = true</tt>.
+      #
       #
       # ==== Options
       #
@@ -467,34 +471,34 @@ module ActionView
       # ==== Examples
       #
       #   tag("br")
-      #   # => <br />
-      #
-      #   tag("br", nil, true)
       #   # => <br>
       #
+      #   tag("br", nil, false)
+      #   # => <br />
+      #
       #   tag("input", type: 'text', disabled: true)
-      #   # => <input type="text" disabled="disabled" />
+      #   # => <input type="text" disabled="disabled">
       #
       #   tag("input", type: 'text', class: ["strong", "highlight"])
-      #   # => <input class="strong highlight" type="text" />
+      #   # => <input class="strong highlight" type="text">
       #
       #   tag("img", src: "open & shut.png")
-      #   # => <img src="open &amp; shut.png" />
+      #   # => <img src="open &amp; shut.png">
       #
       #   tag("img", { src: "open &amp; shut.png" }, false, false)
       #   # => <img src="open &amp; shut.png" />
       #
       #   tag("div", data: { name: 'Stephen', city_state: %w(Chicago IL) })
-      #   # => <div data-name="Stephen" data-city-state="[&quot;Chicago&quot;,&quot;IL&quot;]" />
+      #   # => <div data-name="Stephen" data-city-state="[&quot;Chicago&quot;,&quot;IL&quot;]">
       #
       #   tag("div", class: { highlight: current_user.admin? })
-      #   # => <div class="highlight" />
-      def tag(name = nil, options = nil, open = false, escape = true)
+      #   # => <div class="highlight">
+      def tag(name = nil, options = nil, open = true, escape = true)
         if name.nil?
           tag_builder
         else
           ensure_valid_html5_tag_name(name)
-          "<#{name}#{tag_builder.tag_options(options, escape) if options}#{open ? ">" : " />"}".html_safe
+          "<#{name}#{tag_builder.tag_options(options, escape) if options}#{open || void_element_trailing_slash == false ? ">" : " />"}".html_safe
         end
       end
 

--- a/actionview/lib/action_view/helpers/text_helper.rb
+++ b/actionview/lib/action_view/helpers/text_helper.rb
@@ -337,7 +337,7 @@ module ActionView
       # Two or more consecutive newlines (<tt>\n\n</tt> or <tt>\r\n\r\n</tt>) are
       # considered a paragraph and wrapped in <tt><p></tt> tags. One newline
       # (<tt>\n</tt> or <tt>\r\n</tt>) is considered a linebreak and a
-      # <tt><br /></tt> tag is appended. This method does not remove the
+      # <tt><br></tt> tag is appended. This method does not remove the
       # newlines from the +text+.
       #
       # You can pass any HTML attributes into <tt>html_options</tt>. These
@@ -352,10 +352,10 @@ module ActionView
       #   my_text = "Here is some basic text...\n...with a line break."
       #
       #   simple_format(my_text)
-      #   # => "<p>Here is some basic text...\n<br />...with a line break.</p>"
+      #   # => "<p>Here is some basic text...\n<br>...with a line break.</p>"
       #
       #   simple_format(my_text, {}, wrapper_tag: "div")
-      #   # => "<div>Here is some basic text...\n<br />...with a line break.</div>"
+      #   # => "<div>Here is some basic text...\n<br>...with a line break.</div>"
       #
       #   more_text = "We want to put a paragraph...\n\n...right there."
       #
@@ -533,7 +533,7 @@ module ActionView
           return [] if text.blank?
 
           text.to_str.gsub(/\r\n?/, "\n").split(/\n\n+/).map! do |t|
-            t.gsub!(/([^\n]\n)(?=[^\n])/, '\1<br />') || t
+            t.gsub!(/([^\n]\n)(?=[^\n])/, '\1<br>') || t
           end
         end
 

--- a/actionview/lib/action_view/helpers/text_helper.rb
+++ b/actionview/lib/action_view/helpers/text_helper.rb
@@ -533,7 +533,7 @@ module ActionView
           return [] if text.blank?
 
           text.to_str.gsub(/\r\n?/, "\n").split(/\n\n+/).map! do |t|
-            t.gsub!(/([^\n]\n)(?=[^\n])/, '\1<br>') || t
+            t.gsub!(/([^\n]\n)(?=[^\n])/, "\\1#{tag("br")}") || t
           end
         end
 

--- a/actionview/lib/action_view/helpers/url_helper.rb
+++ b/actionview/lib/action_view/helpers/url_helper.rb
@@ -236,7 +236,7 @@ module ActionView
       #   <%= button_to "New", false %>
       #   # => "<form method="post" class="button_to">
       #   #      <button type="submit">New</button>
-      #   #      <input name="authenticity_token" type="hidden" value="10f2163b45388899ad4d5ae948988266befcb6c3d1b2451cf657a0c293d605a6"/>
+      #   #      <input name="authenticity_token" type="hidden" value="10f2163b45388899ad4d5ae948988266befcb6c3d1b2451cf657a0c293d605a6">
       #   #    </form>"
       #
       # Most values in +html_options+ are passed through to the button element,
@@ -255,19 +255,19 @@ module ActionView
       #   <%= button_to "New", action: "new" %>
       #   # => "<form method="post" action="/controller/new" class="button_to">
       #   #      <button type="submit">New</button>
-      #   #      <input name="authenticity_token" type="hidden" value="10f2163b45388899ad4d5ae948988266befcb6c3d1b2451cf657a0c293d605a6" autocomplete="off"/>
+      #   #      <input name="authenticity_token" type="hidden" value="10f2163b45388899ad4d5ae948988266befcb6c3d1b2451cf657a0c293d605a6" autocomplete="off">
       #   #    </form>"
       #
       #   <%= button_to "New", new_article_path %>
       #   # => "<form method="post" action="/articles/new" class="button_to">
       #   #      <button type="submit">New</button>
-      #   #      <input name="authenticity_token" type="hidden" value="10f2163b45388899ad4d5ae948988266befcb6c3d1b2451cf657a0c293d605a6" autocomplete="off"/>
+      #   #      <input name="authenticity_token" type="hidden" value="10f2163b45388899ad4d5ae948988266befcb6c3d1b2451cf657a0c293d605a6" autocomplete="off">
       #   #    </form>"
       #
       #   <%= button_to "New", new_article_path, params: { time: Time.now  } %>
       #   # => "<form method="post" action="/articles/new" class="button_to">
       #   #      <button type="submit">New</button>
-      #   #      <input name="authenticity_token" type="hidden" value="10f2163b45388899ad4d5ae948988266befcb6c3d1b2451cf657a0c293d605a6"/>
+      #   #      <input name="authenticity_token" type="hidden" value="10f2163b45388899ad4d5ae948988266befcb6c3d1b2451cf657a0c293d605a6">
       #   #      <input type="hidden" name="time" value="2021-04-08 14:06:09 -0500" autocomplete="off">
       #   #    </form>"
       #
@@ -278,19 +278,19 @@ module ActionView
       #   #      <button type="submit">
       #   #        Make happy <strong><%= @user.name %></strong>
       #   #      </button>
-      #   #      <input name="authenticity_token" type="hidden" value="10f2163b45388899ad4d5ae948988266befcb6c3d1b2451cf657a0c293d605a6"  autocomplete="off"/>
+      #   #      <input name="authenticity_token" type="hidden" value="10f2163b45388899ad4d5ae948988266befcb6c3d1b2451cf657a0c293d605a6"  autocomplete="off">
       #   #    </form>"
       #
       #   <%= button_to "New", { action: "new" }, form_class: "new-thing" %>
       #   # => "<form method="post" action="/controller/new" class="new-thing">
       #   #      <button type="submit">New</button>
-      #   #      <input name="authenticity_token" type="hidden" value="10f2163b45388899ad4d5ae948988266befcb6c3d1b2451cf657a0c293d605a6"  autocomplete="off"/>
+      #   #      <input name="authenticity_token" type="hidden" value="10f2163b45388899ad4d5ae948988266befcb6c3d1b2451cf657a0c293d605a6"  autocomplete="off">
       #   #    </form>"
       #
       #   <%= button_to "Create", { action: "create" }, form: { "data-type" => "json" } %>
       #   # => "<form method="post" action="/images/create" class="button_to" data-type="json">
       #   #      <button type="submit">Create</button>
-      #   #      <input name="authenticity_token" type="hidden" value="10f2163b45388899ad4d5ae948988266befcb6c3d1b2451cf657a0c293d605a6"  autocomplete="off"/>
+      #   #      <input name="authenticity_token" type="hidden" value="10f2163b45388899ad4d5ae948988266befcb6c3d1b2451cf657a0c293d605a6"  autocomplete="off">
       #   #    </form>"
       #
       def button_to(name = nil, options = nil, html_options = nil, &block)

--- a/actionview/lib/action_view/railtie.rb
+++ b/actionview/lib/action_view/railtie.rb
@@ -14,12 +14,18 @@ module ActionView
     config.action_view.image_decoding = nil
     config.action_view.apply_stylesheet_media_default = true
     config.action_view.prepend_content_exfiltration_prevention = false
+    config.action_view.void_element_trailing_slash = false
 
     config.eager_load_namespaces << ActionView
 
     config.after_initialize do |app|
       ActionView::Helpers::FormTagHelper.embed_authenticity_token_in_remote_forms =
         app.config.action_view.delete(:embed_authenticity_token_in_remote_forms)
+    end
+
+    config.after_initialize do |app|
+      ActionView::Helpers::TagHelper.void_element_trailing_slash =
+        app.config.action_view.delete(:void_element_trailing_slash)
     end
 
     config.after_initialize do |app|

--- a/actionview/lib/action_view/railtie.rb
+++ b/actionview/lib/action_view/railtie.rb
@@ -14,7 +14,7 @@ module ActionView
     config.action_view.image_decoding = nil
     config.action_view.apply_stylesheet_media_default = true
     config.action_view.prepend_content_exfiltration_prevention = false
-    config.action_view.void_element_trailing_slash = false
+    config.action_view.void_element_trailing_slash = true
 
     config.eager_load_namespaces << ActionView
 

--- a/actionview/lib/action_view/record_identifier.rb
+++ b/actionview/lib/action_view/record_identifier.rb
@@ -19,14 +19,14 @@ module ActionView
   # is:
   #
   #    <form class="new_post" id="new_post" action="/posts" accept-charset="UTF-8" method="post">
-  #      <input type="text" name="post[body]" id="post_body" />
+  #      <input type="text" name="post[body]" id="post_body">
   #    </form>
   #
   # When +post+ is a persisted ActiveRecord::Base instance, the resulting HTML
   # is:
   #
   #   <form class="edit_post" id="edit_post_42" action="/posts/42" accept-charset="UTF-8" method="post">
-  #     <input type="text" value="What a wonderful world!" name="post[body]" id="post_body" />
+  #     <input type="text" value="What a wonderful world!" name="post[body]" id="post_body">
   #   </form>
   #
   # In both cases, the +id+ and +class+ of the wrapping DOM element are

--- a/actionview/test/activerecord/form_helper_activerecord_test.rb
+++ b/actionview/test/activerecord/form_helper_activerecord_test.rb
@@ -59,7 +59,7 @@ class FormHelperActiveRecordTest < ActionView::TestCase
 
   private
     def hidden_fields(method = nil)
-      txt = +%{<input name="utf8" type="hidden" value="&#x2713;" autocomplete="off">}
+      txt = +%{<input type="hidden" name="utf8" value="&#x2713;" autocomplete="off">}
 
       if method && !%w(get post).include?(method.to_s)
         txt << %{<input name="_method" type="hidden" value="#{method}" autocomplete="off">}

--- a/actionview/test/activerecord/form_helper_activerecord_test.rb
+++ b/actionview/test/activerecord/form_helper_activerecord_test.rb
@@ -50,8 +50,8 @@ class FormHelperActiveRecordTest < ActionView::TestCase
     end
 
     expected = whole_form("/developers/123", "edit_developer_123", "edit_developer", method: "patch") do
-      '<input id="developer_projects_attributes_abc_name" name="developer[projects_attributes][abc][name]" type="text" value="project #321" />' \
-          '<input id="developer_projects_attributes_abc_id" name="developer[projects_attributes][abc][id]" type="hidden" value="321" autocomplete="off" />'
+      '<input id="developer_projects_attributes_abc_name" name="developer[projects_attributes][abc][name]" type="text" value="project #321">' \
+          '<input id="developer_projects_attributes_abc_id" name="developer[projects_attributes][abc][id]" type="hidden" value="321" autocomplete="off">'
     end
 
     assert_dom_equal expected, @rendered
@@ -59,10 +59,10 @@ class FormHelperActiveRecordTest < ActionView::TestCase
 
   private
     def hidden_fields(method = nil)
-      txt = +%{<input name="utf8" type="hidden" value="&#x2713;" autocomplete="off" />}
+      txt = +%{<input name="utf8" type="hidden" value="&#x2713;" autocomplete="off">}
 
       if method && !%w(get post).include?(method.to_s)
-        txt << %{<input name="_method" type="hidden" value="#{method}" autocomplete="off" />}
+        txt << %{<input name="_method" type="hidden" value="#{method}" autocomplete="off">}
       end
 
       txt

--- a/actionview/test/template/active_model_helper_test.rb
+++ b/actionview/test/template/active_model_helper_test.rb
@@ -42,7 +42,7 @@ class ActiveModelHelperTest < ActionView::TestCase
 
   def test_text_field_with_errors
     assert_dom_equal(
-      %(<div class="field_with_errors"><input id="post_author_name" name="post[author_name]" type="text" value="" /></div>),
+      %(<div class="field_with_errors"><input id="post_author_name" name="post[author_name]" type="text" value=""></div>),
       text_field("post", "author_name")
     )
   end
@@ -81,21 +81,21 @@ class ActiveModelHelperTest < ActionView::TestCase
 
   def test_date_select_with_errors
     assert_dom_equal(
-      %(<div class="field_with_errors"><select id="post_updated_at_1i" name="post[updated_at(1i)]">\n<option selected="selected" value="2004">2004</option>\n<option value="2005">2005</option>\n</select>\n<input id="post_updated_at_2i" name="post[updated_at(2i)]" type="hidden" value="6" autocomplete="off" />\n<input id="post_updated_at_3i" name="post[updated_at(3i)]" type="hidden" value="1" autocomplete="off" />\n</div>),
+      %(<div class="field_with_errors"><select id="post_updated_at_1i" name="post[updated_at(1i)]">\n<option selected="selected" value="2004">2004</option>\n<option value="2005">2005</option>\n</select>\n<input id="post_updated_at_2i" name="post[updated_at(2i)]" type="hidden" value="6" autocomplete="off">\n<input id="post_updated_at_3i" name="post[updated_at(3i)]" type="hidden" value="1" autocomplete="off">\n</div>),
       date_select("post", "updated_at", discard_month: true, discard_day: true, start_year: 2004, end_year: 2005)
     )
   end
 
   def test_datetime_select_with_errors
     assert_dom_equal(
-      %(<div class="field_with_errors"><input id="post_updated_at_1i" name="post[updated_at(1i)]" type="hidden" value="2004" autocomplete="off" />\n<input id="post_updated_at_2i" name="post[updated_at(2i)]" type="hidden" value="6" autocomplete="off" />\n<input id="post_updated_at_3i" name="post[updated_at(3i)]" type="hidden" value="1" autocomplete="off" />\n<select id="post_updated_at_4i" name="post[updated_at(4i)]">\n<option selected="selected" value="00">00</option>\n<option value="01">01</option>\n<option value="02">02</option>\n<option value="03">03</option>\n<option value="04">04</option>\n<option value="05">05</option>\n<option value="06">06</option>\n<option value="07">07</option>\n<option value="08">08</option>\n<option value="09">09</option>\n<option value="10">10</option>\n<option value="11">11</option>\n<option value="12">12</option>\n<option value="13">13</option>\n<option value="14">14</option>\n<option value="15">15</option>\n<option value="16">16</option>\n<option value="17">17</option>\n<option value="18">18</option>\n<option value="19">19</option>\n<option value="20">20</option>\n<option value="21">21</option>\n<option value="22">22</option>\n<option value="23">23</option>\n</select>\n : <select id="post_updated_at_5i" name="post[updated_at(5i)]">\n<option selected="selected" value="00">00</option>\n</select>\n</div>),
+      %(<div class="field_with_errors"><input id="post_updated_at_1i" name="post[updated_at(1i)]" type="hidden" value="2004" autocomplete="off">\n<input id="post_updated_at_2i" name="post[updated_at(2i)]" type="hidden" value="6" autocomplete="off">\n<input id="post_updated_at_3i" name="post[updated_at(3i)]" type="hidden" value="1" autocomplete="off">\n<select id="post_updated_at_4i" name="post[updated_at(4i)]">\n<option selected="selected" value="00">00</option>\n<option value="01">01</option>\n<option value="02">02</option>\n<option value="03">03</option>\n<option value="04">04</option>\n<option value="05">05</option>\n<option value="06">06</option>\n<option value="07">07</option>\n<option value="08">08</option>\n<option value="09">09</option>\n<option value="10">10</option>\n<option value="11">11</option>\n<option value="12">12</option>\n<option value="13">13</option>\n<option value="14">14</option>\n<option value="15">15</option>\n<option value="16">16</option>\n<option value="17">17</option>\n<option value="18">18</option>\n<option value="19">19</option>\n<option value="20">20</option>\n<option value="21">21</option>\n<option value="22">22</option>\n<option value="23">23</option>\n</select>\n : <select id="post_updated_at_5i" name="post[updated_at(5i)]">\n<option selected="selected" value="00">00</option>\n</select>\n</div>),
       datetime_select("post", "updated_at", discard_year: true, discard_month: true, discard_day: true, minute_step: 60)
     )
   end
 
   def test_time_select_with_errors
     assert_dom_equal(
-      %(<div class="field_with_errors"><input id="post_updated_at_1i" name="post[updated_at(1i)]" type="hidden" value="2004" autocomplete="off" />\n<input id="post_updated_at_2i" name="post[updated_at(2i)]" type="hidden" value="6" autocomplete="off" />\n<input id="post_updated_at_3i" name="post[updated_at(3i)]" type="hidden" value="15" autocomplete="off" />\n<select id="post_updated_at_4i" name="post[updated_at(4i)]">\n<option selected="selected" value="00">00</option>\n<option value="01">01</option>\n<option value="02">02</option>\n<option value="03">03</option>\n<option value="04">04</option>\n<option value="05">05</option>\n<option value="06">06</option>\n<option value="07">07</option>\n<option value="08">08</option>\n<option value="09">09</option>\n<option value="10">10</option>\n<option value="11">11</option>\n<option value="12">12</option>\n<option value="13">13</option>\n<option value="14">14</option>\n<option value="15">15</option>\n<option value="16">16</option>\n<option value="17">17</option>\n<option value="18">18</option>\n<option value="19">19</option>\n<option value="20">20</option>\n<option value="21">21</option>\n<option value="22">22</option>\n<option value="23">23</option>\n</select>\n : <select id="post_updated_at_5i" name="post[updated_at(5i)]">\n<option selected="selected" value="00">00</option>\n</select>\n</div>),
+      %(<div class="field_with_errors"><input id="post_updated_at_1i" name="post[updated_at(1i)]" type="hidden" value="2004" autocomplete="off">\n<input id="post_updated_at_2i" name="post[updated_at(2i)]" type="hidden" value="6" autocomplete="off">\n<input id="post_updated_at_3i" name="post[updated_at(3i)]" type="hidden" value="15" autocomplete="off">\n<select id="post_updated_at_4i" name="post[updated_at(4i)]">\n<option selected="selected" value="00">00</option>\n<option value="01">01</option>\n<option value="02">02</option>\n<option value="03">03</option>\n<option value="04">04</option>\n<option value="05">05</option>\n<option value="06">06</option>\n<option value="07">07</option>\n<option value="08">08</option>\n<option value="09">09</option>\n<option value="10">10</option>\n<option value="11">11</option>\n<option value="12">12</option>\n<option value="13">13</option>\n<option value="14">14</option>\n<option value="15">15</option>\n<option value="16">16</option>\n<option value="17">17</option>\n<option value="18">18</option>\n<option value="19">19</option>\n<option value="20">20</option>\n<option value="21">21</option>\n<option value="22">22</option>\n<option value="23">23</option>\n</select>\n : <select id="post_updated_at_5i" name="post[updated_at(5i)]">\n<option selected="selected" value="00">00</option>\n</select>\n</div>),
       time_select("post", "updated_at", minute_step: 60)
     )
   end
@@ -109,49 +109,49 @@ class ActiveModelHelperTest < ActionView::TestCase
 
   def test_check_box_with_errors
     assert_dom_equal(
-      %(<input name="post[published]" type="hidden" value="0" autocomplete="off" /><div class="field_with_errors"><input type="checkbox" value="1" name="post[published]" id="post_published" /></div>),
+      %(<input name="post[published]" type="hidden" value="0" autocomplete="off"><div class="field_with_errors"><input type="checkbox" value="1" name="post[published]" id="post_published"></div>),
       check_box("post", "published")
     )
   end
 
   def test_check_boxes_with_errors
     assert_dom_equal(
-      %(<input name="post[published]" type="hidden" value="0" autocomplete="off" /><div class="field_with_errors"><input type="checkbox" value="1" name="post[published]" id="post_published" /></div><input name="post[published]" type="hidden" value="0" autocomplete="off" /><div class="field_with_errors"><input type="checkbox" value="1" name="post[published]" id="post_published" /></div>),
+      %(<input name="post[published]" type="hidden" value="0" autocomplete="off"><div class="field_with_errors"><input type="checkbox" value="1" name="post[published]" id="post_published"></div><input name="post[published]" type="hidden" value="0" autocomplete="off"><div class="field_with_errors"><input type="checkbox" value="1" name="post[published]" id="post_published"></div>),
       check_box("post", "published") + check_box("post", "published")
     )
   end
 
   def test_radio_button_with_errors
     assert_dom_equal(
-      %(<div class="field_with_errors"><input type="radio" value="rails" checked="checked" name="post[category]" id="post_category_rails" /></div>),
+      %(<div class="field_with_errors"><input type="radio" value="rails" checked="checked" name="post[category]" id="post_category_rails"></div>),
       radio_button("post", "category", "rails")
     )
   end
 
   def test_radio_buttons_with_errors
     assert_dom_equal(
-      %(<div class="field_with_errors"><input type="radio" value="rails" checked="checked" name="post[category]" id="post_category_rails" /></div><div class="field_with_errors"><input type="radio" value="java" name="post[category]" id="post_category_java" /></div>),
+      %(<div class="field_with_errors"><input type="radio" value="rails" checked="checked" name="post[category]" id="post_category_rails"></div><div class="field_with_errors"><input type="radio" value="java" name="post[category]" id="post_category_java"></div>),
       radio_button("post", "category", "rails") + radio_button("post", "category", "java")
     )
   end
 
   def test_collection_check_boxes_with_errors
     assert_dom_equal(
-      %(<input type="hidden" name="post[category][]" value="" autocomplete="off" /><div class="field_with_errors"><input type="checkbox" value="ruby" name="post[category][]" id="post_category_ruby" /></div><label for="post_category_ruby">ruby</label><div class="field_with_errors"><input type="checkbox" value="java" name="post[category][]" id="post_category_java" /></div><label for="post_category_java">java</label>),
+      %(<input type="hidden" name="post[category][]" value="" autocomplete="off"><div class="field_with_errors"><input type="checkbox" value="ruby" name="post[category][]" id="post_category_ruby"></div><label for="post_category_ruby">ruby</label><div class="field_with_errors"><input type="checkbox" value="java" name="post[category][]" id="post_category_java"></div><label for="post_category_java">java</label>),
       collection_check_boxes("post", "category", [:ruby, :java], :to_s, :to_s)
     )
   end
 
   def test_collection_radio_buttons_with_errors
     assert_dom_equal(
-      %(<input type="hidden" name="post[category]" value="" autocomplete="off" /><div class="field_with_errors"><input type="radio" value="ruby" name="post[category]" id="post_category_ruby" /></div><label for="post_category_ruby">ruby</label><div class="field_with_errors"><input type="radio" value="java" name="post[category]" id="post_category_java" /></div><label for="post_category_java">java</label>),
+      %(<input type="hidden" name="post[category]" value="" autocomplete="off"><div class="field_with_errors"><input type="radio" value="ruby" name="post[category]" id="post_category_ruby"></div><label for="post_category_ruby">ruby</label><div class="field_with_errors"><input type="radio" value="java" name="post[category]" id="post_category_java"></div><label for="post_category_java">java</label>),
       collection_radio_buttons("post", "category", [:ruby, :java], :to_s, :to_s)
     )
   end
 
   def test_hidden_field_does_not_render_errors
     assert_dom_equal(
-      %(<input id="post_author_name" name="post[author_name]" type="hidden" value="" autocomplete="off" />),
+      %(<input id="post_author_name" name="post[author_name]" type="hidden" value="" autocomplete="off">),
       hidden_field("post", "author_name")
     )
   end
@@ -163,7 +163,7 @@ class ActiveModelHelperTest < ActionView::TestCase
     end
 
     assert_dom_equal(
-      %(<div class="field_with_errors"><input id="post_author_name" name="post[author_name]" type="text" value="" /> <span class="error">can't be empty</span></div>),
+      %(<div class="field_with_errors"><input id="post_author_name" name="post[author_name]" type="text" value=""> <span class="error">can't be empty</span></div>),
       text_field("post", "author_name")
     )
   ensure

--- a/actionview/test/template/asset_tag_helper_test.rb
+++ b/actionview/test/template/asset_tag_helper_test.rb
@@ -84,19 +84,19 @@ class AssetTagHelperTest < ActionView::TestCase
   }
 
   AutoDiscoveryToTag = {
-    %(auto_discovery_link_tag) => %(<link href="http://www.example.com" rel="alternate" title="RSS" type="application/rss+xml" />),
-    %(auto_discovery_link_tag(:rss)) => %(<link href="http://www.example.com" rel="alternate" title="RSS" type="application/rss+xml" />),
-    %(auto_discovery_link_tag(:atom)) => %(<link href="http://www.example.com" rel="alternate" title="ATOM" type="application/atom+xml" />),
-    %(auto_discovery_link_tag(:json)) => %(<link href="http://www.example.com" rel="alternate" title="JSON" type="application/json" />),
-    %(auto_discovery_link_tag(:rss, :action => "feed")) => %(<link href="http://www.example.com" rel="alternate" title="RSS" type="application/rss+xml" />),
-    %(auto_discovery_link_tag(:rss, "http://localhost/feed")) => %(<link href="http://localhost/feed" rel="alternate" title="RSS" type="application/rss+xml" />),
-    %(auto_discovery_link_tag(:rss, "//localhost/feed")) => %(<link href="//localhost/feed" rel="alternate" title="RSS" type="application/rss+xml" />),
-    %(auto_discovery_link_tag(:rss, {:action => "feed"}, {:title => "My RSS"})) => %(<link href="http://www.example.com" rel="alternate" title="My RSS" type="application/rss+xml" />),
-    %(auto_discovery_link_tag(:rss, {}, {:title => "My RSS"})) => %(<link href="http://www.example.com" rel="alternate" title="My RSS" type="application/rss+xml" />),
-    %(auto_discovery_link_tag(nil, {}, {:type => "text/html"})) => %(<link href="http://www.example.com" rel="alternate" title="" type="text/html" />),
-    %(auto_discovery_link_tag(nil, {}, {:title => "No stream.. really", :type => "text/html"})) => %(<link href="http://www.example.com" rel="alternate" title="No stream.. really" type="text/html" />),
-    %(auto_discovery_link_tag(:rss, {}, {:title => "My RSS", :type => "text/html"})) => %(<link href="http://www.example.com" rel="alternate" title="My RSS" type="text/html" />),
-    %(auto_discovery_link_tag(:atom, {}, {:rel => "Not so alternate"})) => %(<link href="http://www.example.com" rel="Not so alternate" title="ATOM" type="application/atom+xml" />),
+    %(auto_discovery_link_tag) => %(<link href="http://www.example.com" rel="alternate" title="RSS" type="application/rss+xml">),
+    %(auto_discovery_link_tag(:rss)) => %(<link href="http://www.example.com" rel="alternate" title="RSS" type="application/rss+xml">),
+    %(auto_discovery_link_tag(:atom)) => %(<link href="http://www.example.com" rel="alternate" title="ATOM" type="application/atom+xml">),
+    %(auto_discovery_link_tag(:json)) => %(<link href="http://www.example.com" rel="alternate" title="JSON" type="application/json">),
+    %(auto_discovery_link_tag(:rss, :action => "feed")) => %(<link href="http://www.example.com" rel="alternate" title="RSS" type="application/rss+xml">),
+    %(auto_discovery_link_tag(:rss, "http://localhost/feed")) => %(<link href="http://localhost/feed" rel="alternate" title="RSS" type="application/rss+xml">),
+    %(auto_discovery_link_tag(:rss, "//localhost/feed")) => %(<link href="//localhost/feed" rel="alternate" title="RSS" type="application/rss+xml">),
+    %(auto_discovery_link_tag(:rss, {:action => "feed"}, {:title => "My RSS"})) => %(<link href="http://www.example.com" rel="alternate" title="My RSS" type="application/rss+xml">),
+    %(auto_discovery_link_tag(:rss, {}, {:title => "My RSS"})) => %(<link href="http://www.example.com" rel="alternate" title="My RSS" type="application/rss+xml">),
+    %(auto_discovery_link_tag(nil, {}, {:type => "text/html"})) => %(<link href="http://www.example.com" rel="alternate" title="" type="text/html">),
+    %(auto_discovery_link_tag(nil, {}, {:title => "No stream.. really", :type => "text/html"})) => %(<link href="http://www.example.com" rel="alternate" title="No stream.. really" type="text/html">),
+    %(auto_discovery_link_tag(:rss, {}, {:title => "My RSS", :type => "text/html"})) => %(<link href="http://www.example.com" rel="alternate" title="My RSS" type="text/html">),
+    %(auto_discovery_link_tag(:atom, {}, {:rel => "Not so alternate"})) => %(<link href="http://www.example.com" rel="Not so alternate" title="ATOM" type="application/atom+xml">),
   }
 
   JavascriptPathToTag = {
@@ -174,16 +174,16 @@ class AssetTagHelperTest < ActionView::TestCase
   }
 
   StyleLinkToTag = {
-    %(stylesheet_link_tag("bank")) => %(<link href="/stylesheets/bank.css" rel="stylesheet" />),
-    %(stylesheet_link_tag("bank.css")) => %(<link href="/stylesheets/bank.css" rel="stylesheet" />),
-    %(stylesheet_link_tag("/elsewhere/file")) => %(<link href="/elsewhere/file.css" rel="stylesheet" />),
-    %(stylesheet_link_tag("subdir/subdir")) => %(<link href="/stylesheets/subdir/subdir.css" rel="stylesheet" />),
-    %(stylesheet_link_tag("bank", :media => "all")) => %(<link href="/stylesheets/bank.css" media="all" rel="stylesheet" />),
-    %(stylesheet_link_tag("bank", :host => "assets.example.com")) => %(<link href="http://assets.example.com/stylesheets/bank.css" rel="stylesheet" />),
+    %(stylesheet_link_tag("bank")) => %(<link href="/stylesheets/bank.css" rel="stylesheet">),
+    %(stylesheet_link_tag("bank.css")) => %(<link href="/stylesheets/bank.css" rel="stylesheet">),
+    %(stylesheet_link_tag("/elsewhere/file")) => %(<link href="/elsewhere/file.css" rel="stylesheet">),
+    %(stylesheet_link_tag("subdir/subdir")) => %(<link href="/stylesheets/subdir/subdir.css" rel="stylesheet">),
+    %(stylesheet_link_tag("bank", :media => "all")) => %(<link href="/stylesheets/bank.css" media="all" rel="stylesheet">),
+    %(stylesheet_link_tag("bank", :host => "assets.example.com")) => %(<link href="http://assets.example.com/stylesheets/bank.css" rel="stylesheet">),
 
-    %(stylesheet_link_tag("http://www.example.com/styles/style")) => %(<link href="http://www.example.com/styles/style" rel="stylesheet" />),
-    %(stylesheet_link_tag("http://www.example.com/styles/style.css")) => %(<link href="http://www.example.com/styles/style.css" rel="stylesheet" />),
-    %(stylesheet_link_tag("//www.example.com/styles/style.css")) => %(<link href="//www.example.com/styles/style.css" rel="stylesheet" />),
+    %(stylesheet_link_tag("http://www.example.com/styles/style")) => %(<link href="http://www.example.com/styles/style" rel="stylesheet">),
+    %(stylesheet_link_tag("http://www.example.com/styles/style.css")) => %(<link href="http://www.example.com/styles/style.css" rel="stylesheet">),
+    %(stylesheet_link_tag("//www.example.com/styles/style.css")) => %(<link href="//www.example.com/styles/style.css" rel="stylesheet">),
   }
 
   ImagePathToTag = {
@@ -215,36 +215,36 @@ class AssetTagHelperTest < ActionView::TestCase
   }
 
   ImageLinkToTag = {
-    %(image_tag("xml.png")) => %(<img src="/images/xml.png" />),
-    %(image_tag("rss.gif", :alt => "RSS syndication")) => %(<img alt="RSS syndication" src="/images/rss.gif" />),
-    %(image_tag("gold.png", :size => "20")) => %(<img height="20" src="/images/gold.png" width="20" />),
-    %(image_tag("gold.png", :size => 20)) => %(<img height="20" src="/images/gold.png" width="20" />),
-    %(image_tag("silver.png", :size => "90.9")) => %(<img height="90.9" src="/images/silver.png" width="90.9" />),
-    %(image_tag("silver.png", :size => 90.9)) => %(<img height="90.9" src="/images/silver.png" width="90.9" />),
-    %(image_tag("gold.png", :size => "45x70")) => %(<img height="70" src="/images/gold.png" width="45" />),
-    %(image_tag("gold.png", "size" => "45x70")) => %(<img height="70" src="/images/gold.png" width="45" />),
-    %(image_tag("silver.png", :size => "67.12x74.09")) => %(<img height="74.09" src="/images/silver.png" width="67.12" />),
-    %(image_tag("silver.png", "size" => "67.12x74.09")) => %(<img height="74.09" src="/images/silver.png" width="67.12" />),
-    %(image_tag("bronze.png", :size => "10x15.7")) => %(<img height="15.7" src="/images/bronze.png" width="10" />),
-    %(image_tag("bronze.png", "size" => "10x15.7")) => %(<img height="15.7" src="/images/bronze.png" width="10" />),
-    %(image_tag("platinum.png", :size => "4.9x20")) => %(<img height="20" src="/images/platinum.png" width="4.9" />),
-    %(image_tag("platinum.png", "size" => "4.9x20")) => %(<img height="20" src="/images/platinum.png" width="4.9" />),
-    %(image_tag("error.png", "size" => "45 x 70")) => %(<img src="/images/error.png" />),
-    %(image_tag("error.png", "size" => "1,024x768")) => %(<img src="/images/error.png" />),
-    %(image_tag("error.png", "size" => "768x1,024")) => %(<img src="/images/error.png" />),
-    %(image_tag("error.png", "size" => "x")) => %(<img src="/images/error.png" />),
-    %(image_tag("google.com.png")) => %(<img src="/images/google.com.png" />),
-    %(image_tag("slash..png")) => %(<img src="/images/slash..png" />),
-    %(image_tag(".pdf.png")) => %(<img src="/images/.pdf.png" />),
-    %(image_tag("http://www.rubyonrails.com/images/rails.png")) => %(<img src="http://www.rubyonrails.com/images/rails.png" />),
-    %(image_tag("//www.rubyonrails.com/images/rails.png")) => %(<img src="//www.rubyonrails.com/images/rails.png" />),
-    %(image_tag("mouse.png", :alt => nil)) => %(<img src="/images/mouse.png" />),
-    %(image_tag("data:image/gif;base64,R0lGODlhAQABAID/AMDAwAAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==", :alt => nil)) => %(<img src="data:image/gif;base64,R0lGODlhAQABAID/AMDAwAAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==" />),
-    %(image_tag("")) => %(<img src="" />),
-    %(image_tag("gold.png", data: { title: 'Rails Application' })) => %(<img data-title="Rails Application" src="/images/gold.png" />),
-    %(image_tag("rss.gif", srcset: "/assets/pic_640.jpg 640w, /assets/pic_1024.jpg 1024w")) => %(<img srcset="/assets/pic_640.jpg 640w, /assets/pic_1024.jpg 1024w" src="/images/rss.gif" />),
-    %(image_tag("rss.gif", srcset: { "pic_640.jpg" => "640w", "pic_1024.jpg" => "1024w" })) => %(<img srcset="/images/pic_640.jpg 640w, /images/pic_1024.jpg 1024w" src="/images/rss.gif" />),
-    %(image_tag("rss.gif", srcset: [["pic_640.jpg", "640w"], ["pic_1024.jpg", "1024w"]])) => %(<img srcset="/images/pic_640.jpg 640w, /images/pic_1024.jpg 1024w" src="/images/rss.gif" />)
+    %(image_tag("xml.png")) => %(<img src="/images/xml.png">),
+    %(image_tag("rss.gif", :alt => "RSS syndication")) => %(<img alt="RSS syndication" src="/images/rss.gif">),
+    %(image_tag("gold.png", :size => "20")) => %(<img height="20" src="/images/gold.png" width="20">),
+    %(image_tag("gold.png", :size => 20)) => %(<img height="20" src="/images/gold.png" width="20">),
+    %(image_tag("silver.png", :size => "90.9")) => %(<img height="90.9" src="/images/silver.png" width="90.9">),
+    %(image_tag("silver.png", :size => 90.9)) => %(<img height="90.9" src="/images/silver.png" width="90.9">),
+    %(image_tag("gold.png", :size => "45x70")) => %(<img height="70" src="/images/gold.png" width="45">),
+    %(image_tag("gold.png", "size" => "45x70")) => %(<img height="70" src="/images/gold.png" width="45">),
+    %(image_tag("silver.png", :size => "67.12x74.09")) => %(<img height="74.09" src="/images/silver.png" width="67.12">),
+    %(image_tag("silver.png", "size" => "67.12x74.09")) => %(<img height="74.09" src="/images/silver.png" width="67.12">),
+    %(image_tag("bronze.png", :size => "10x15.7")) => %(<img height="15.7" src="/images/bronze.png" width="10">),
+    %(image_tag("bronze.png", "size" => "10x15.7")) => %(<img height="15.7" src="/images/bronze.png" width="10">),
+    %(image_tag("platinum.png", :size => "4.9x20")) => %(<img height="20" src="/images/platinum.png" width="4.9">),
+    %(image_tag("platinum.png", "size" => "4.9x20")) => %(<img height="20" src="/images/platinum.png" width="4.9">),
+    %(image_tag("error.png", "size" => "45 x 70")) => %(<img src="/images/error.png">),
+    %(image_tag("error.png", "size" => "1,024x768")) => %(<img src="/images/error.png">),
+    %(image_tag("error.png", "size" => "768x1,024")) => %(<img src="/images/error.png">),
+    %(image_tag("error.png", "size" => "x")) => %(<img src="/images/error.png">),
+    %(image_tag("google.com.png")) => %(<img src="/images/google.com.png">),
+    %(image_tag("slash..png")) => %(<img src="/images/slash..png">),
+    %(image_tag(".pdf.png")) => %(<img src="/images/.pdf.png">),
+    %(image_tag("http://www.rubyonrails.com/images/rails.png")) => %(<img src="http://www.rubyonrails.com/images/rails.png">),
+    %(image_tag("//www.rubyonrails.com/images/rails.png")) => %(<img src="//www.rubyonrails.com/images/rails.png">),
+    %(image_tag("mouse.png", :alt => nil)) => %(<img src="/images/mouse.png">),
+    %(image_tag("data:image/gif;base64,R0lGODlhAQABAID/AMDAwAAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==", :alt => nil)) => %(<img src="data:image/gif;base64,R0lGODlhAQABAID/AMDAwAAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==">),
+    %(image_tag("")) => %(<img src="">),
+    %(image_tag("gold.png", data: { title: 'Rails Application' })) => %(<img data-title="Rails Application" src="/images/gold.png">),
+    %(image_tag("rss.gif", srcset: "/assets/pic_640.jpg 640w, /assets/pic_1024.jpg 1024w")) => %(<img srcset="/assets/pic_640.jpg 640w, /assets/pic_1024.jpg 1024w" src="/images/rss.gif">),
+    %(image_tag("rss.gif", srcset: { "pic_640.jpg" => "640w", "pic_1024.jpg" => "1024w" })) => %(<img srcset="/images/pic_640.jpg 640w, /images/pic_1024.jpg 1024w" src="/images/rss.gif">),
+    %(image_tag("rss.gif", srcset: [["pic_640.jpg", "640w"], ["pic_1024.jpg", "1024w"]])) => %(<img srcset="/images/pic_640.jpg 640w, /images/pic_1024.jpg 1024w" src="/images/rss.gif">)
   }
 
   PicturePathToTag = {
@@ -276,57 +276,57 @@ class AssetTagHelperTest < ActionView::TestCase
   }
 
   PictureLinkToTag = {
-    %(picture_tag("picture.webp")) => %(<picture><img src="/images/picture.webp" /></picture>),
-    %(picture_tag("gold.png", :image => { :size => "20" })) => %(<picture><img height="20" src="/images/gold.png" width="20" /></picture>),
-    %(picture_tag("gold.png", :image => { :size => 20 })) => %(<picture><img height="20" src="/images/gold.png" width="20" /></picture>),
-    %(picture_tag("silver.png", :image => { :size => "90.9" })) => %(<picture><img height="90.9" src="/images/silver.png" width="90.9" /></picture>),
-    %(picture_tag("silver.png", :image => { :size => 90.9 })) => %(<picture><img height="90.9" src="/images/silver.png" width="90.9" /></picture>),
-    %(picture_tag("gold.png", :image => { :size => "45x70" })) => %(<picture><img height="70" src="/images/gold.png" width="45" /></picture>),
-    %(picture_tag("gold.png", :image => { "size" => "45x70" })) => %(<picture><img height="70" src="/images/gold.png" width="45" /></picture>),
-    %(picture_tag("silver.png", :image => { :size => "67.12x74.09" })) => %(<picture><img height="74.09" src="/images/silver.png" width="67.12" /></picture>),
-    %(picture_tag("silver.png", :image => { "size" => "67.12x74.09" })) => %(<picture><img height="74.09" src="/images/silver.png" width="67.12" /></picture>),
-    %(picture_tag("bronze.png", :image => { :size => "10x15.7" })) => %(<picture><img height="15.7" src="/images/bronze.png" width="10" /></picture>),
-    %(picture_tag("bronze.png", :image => { "size" => "10x15.7" })) => %(<picture><img height="15.7" src="/images/bronze.png" width="10" /></picture>),
-    %(picture_tag("platinum.png", :image => { :size => "4.9x20" })) => %(<picture><img height="20" src="/images/platinum.png" width="4.9" /></picture>),
-    %(picture_tag("platinum.png", :image => { "size" => "4.9x20" })) => %(<picture><img height="20" src="/images/platinum.png" width="4.9" /></picture>),
-    %(picture_tag("error.png", :image => { "size" => "45 x 70" })) => %(<picture><img src="/images/error.png" /></picture>),
-    %(picture_tag("error.png", :image => { "size" => "1,024x768" })) => %(<picture><img src="/images/error.png" /></picture>),
-    %(picture_tag("error.png", :image => { "size" => "768x1,024" })) => %(<picture><img src="/images/error.png" /></picture>),
-    %(picture_tag("error.png", :image => { "size" => "x" })) => %(<picture><img src="/images/error.png" /></picture>),
-    %(picture_tag("google.com.png")) => %(<picture><img src="/images/google.com.png" /></picture>),
-    %(picture_tag("slash..png")) => %(<picture><img src="/images/slash..png" /></picture>),
-    %(picture_tag(".pdf.png")) => %(<picture><img src="/images/.pdf.png" /></picture>),
-    %(picture_tag("http://www.rubyonrails.com/images/rails.png")) => %(<picture><img src="http://www.rubyonrails.com/images/rails.png" /></picture>),
-    %(picture_tag("//www.rubyonrails.com/images/rails.png")) => %(<picture><img src="//www.rubyonrails.com/images/rails.png" /></picture>),
-    %(picture_tag("mouse.png", :image => { :alt => nil })) => %(<picture><img src="/images/mouse.png" /></picture>),
-    %(picture_tag("data:image/gif;base64,R0lGODlhAQABAID/AMDAwAAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==", :image => { :alt => nil })) => %(<picture><img src="data:image/gif;base64,R0lGODlhAQABAID/AMDAwAAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==" /></picture>),
-    %(picture_tag("")) => %(<picture><img src="" /></picture>),
-    %(picture_tag("picture.webp", "picture.png")) => %(<picture><source srcset="/images/picture.webp" type="image/webp" /><source srcset="/images/picture.png" type="image/png" /><img src="/images/picture.png" /></picture>),
-    %(picture_tag("picture.webp", "picture.png", :class => "my-class")) => %(<picture class="my-class"><source srcset="/images/picture.webp" type="image/webp" /><source srcset="/images/picture.png" type="image/png" /><img src="/images/picture.png" /></picture>),
-    %(picture_tag("picture.webp", "picture.png", :image => { alt: "Image" })) => %(<picture><source srcset="/images/picture.webp" type="image/webp" /><source srcset="/images/picture.png" type="image/png" /><img alt="Image" src="/images/picture.png" /></picture>),
-    %(picture_tag(["picture.webp", "picture.png"], :image => { alt: "Image" })) => %(<picture><source srcset="/images/picture.webp" type="image/webp" /><source srcset="/images/picture.png" type="image/png" /><img alt="Image" src="/images/picture.png" /></picture>),
-    %(picture_tag(:class => "my-class") { tag(:source, :srcset => image_path("picture.webp")) + image_tag("picture.png", :alt => "Image") }) => %(<picture class="my-class"><source srcset="/images/picture.webp" /><img alt="Image" src="/images/picture.png" /></picture>),
-    %(picture_tag { tag(:source, :srcset => image_path("picture-small.webp"), :media => "(min-width: 600px)") + tag(:source, :srcset => image_path("picture-big.webp")) + image_tag("picture.png", :alt => "Image") }) => %(<picture><source srcset="/images/picture-small.webp" media="(min-width: 600px)" /><source srcset="/images/picture-big.webp" /><img alt="Image" src="/images/picture.png" /></picture>),
+    %(picture_tag("picture.webp")) => %(<picture><img src="/images/picture.webp"></picture>),
+    %(picture_tag("gold.png", :image => { :size => "20" })) => %(<picture><img height="20" src="/images/gold.png" width="20"></picture>),
+    %(picture_tag("gold.png", :image => { :size => 20 })) => %(<picture><img height="20" src="/images/gold.png" width="20"></picture>),
+    %(picture_tag("silver.png", :image => { :size => "90.9" })) => %(<picture><img height="90.9" src="/images/silver.png" width="90.9"></picture>),
+    %(picture_tag("silver.png", :image => { :size => 90.9 })) => %(<picture><img height="90.9" src="/images/silver.png" width="90.9"></picture>),
+    %(picture_tag("gold.png", :image => { :size => "45x70" })) => %(<picture><img height="70" src="/images/gold.png" width="45"></picture>),
+    %(picture_tag("gold.png", :image => { "size" => "45x70" })) => %(<picture><img height="70" src="/images/gold.png" width="45"></picture>),
+    %(picture_tag("silver.png", :image => { :size => "67.12x74.09" })) => %(<picture><img height="74.09" src="/images/silver.png" width="67.12"></picture>),
+    %(picture_tag("silver.png", :image => { "size" => "67.12x74.09" })) => %(<picture><img height="74.09" src="/images/silver.png" width="67.12"></picture>),
+    %(picture_tag("bronze.png", :image => { :size => "10x15.7" })) => %(<picture><img height="15.7" src="/images/bronze.png" width="10"></picture>),
+    %(picture_tag("bronze.png", :image => { "size" => "10x15.7" })) => %(<picture><img height="15.7" src="/images/bronze.png" width="10"></picture>),
+    %(picture_tag("platinum.png", :image => { :size => "4.9x20" })) => %(<picture><img height="20" src="/images/platinum.png" width="4.9"></picture>),
+    %(picture_tag("platinum.png", :image => { "size" => "4.9x20" })) => %(<picture><img height="20" src="/images/platinum.png" width="4.9"></picture>),
+    %(picture_tag("error.png", :image => { "size" => "45 x 70" })) => %(<picture><img src="/images/error.png"></picture>),
+    %(picture_tag("error.png", :image => { "size" => "1,024x768" })) => %(<picture><img src="/images/error.png"></picture>),
+    %(picture_tag("error.png", :image => { "size" => "768x1,024" })) => %(<picture><img src="/images/error.png"></picture>),
+    %(picture_tag("error.png", :image => { "size" => "x" })) => %(<picture><img src="/images/error.png"></picture>),
+    %(picture_tag("google.com.png")) => %(<picture><img src="/images/google.com.png"></picture>),
+    %(picture_tag("slash..png")) => %(<picture><img src="/images/slash..png"></picture>),
+    %(picture_tag(".pdf.png")) => %(<picture><img src="/images/.pdf.png"></picture>),
+    %(picture_tag("http://www.rubyonrails.com/images/rails.png")) => %(<picture><img src="http://www.rubyonrails.com/images/rails.png"></picture>),
+    %(picture_tag("//www.rubyonrails.com/images/rails.png")) => %(<picture><img src="//www.rubyonrails.com/images/rails.png"></picture>),
+    %(picture_tag("mouse.png", :image => { :alt => nil })) => %(<picture><img src="/images/mouse.png"></picture>),
+    %(picture_tag("data:image/gif;base64,R0lGODlhAQABAID/AMDAwAAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==", :image => { :alt => nil })) => %(<picture><img src="data:image/gif;base64,R0lGODlhAQABAID/AMDAwAAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw=="></picture>),
+    %(picture_tag("")) => %(<picture><img src=""></picture>),
+    %(picture_tag("picture.webp", "picture.png")) => %(<picture><source srcset="/images/picture.webp" type="image/webp"><source srcset="/images/picture.png" type="image/png"><img src="/images/picture.png"></picture>),
+    %(picture_tag("picture.webp", "picture.png", :class => "my-class")) => %(<picture class="my-class"><source srcset="/images/picture.webp" type="image/webp"><source srcset="/images/picture.png" type="image/png"><img src="/images/picture.png"></picture>),
+    %(picture_tag("picture.webp", "picture.png", :image => { alt: "Image" })) => %(<picture><source srcset="/images/picture.webp" type="image/webp"><source srcset="/images/picture.png" type="image/png"><img alt="Image" src="/images/picture.png"></picture>),
+    %(picture_tag(["picture.webp", "picture.png"], :image => { alt: "Image" })) => %(<picture><source srcset="/images/picture.webp" type="image/webp"><source srcset="/images/picture.png" type="image/png"><img alt="Image" src="/images/picture.png"></picture>),
+    %(picture_tag(:class => "my-class") { tag(:source, :srcset => image_path("picture.webp")) + image_tag("picture.png", :alt => "Image") }) => %(<picture class="my-class"><source srcset="/images/picture.webp"><img alt="Image" src="/images/picture.png"></picture>),
+    %(picture_tag { tag(:source, :srcset => image_path("picture-small.webp"), :media => "(min-width: 600px)") + tag(:source, :srcset => image_path("picture-big.webp")) + image_tag("picture.png", :alt => "Image") }) => %(<picture><source srcset="/images/picture-small.webp" media="(min-width: 600px)"><source srcset="/images/picture-big.webp"><img alt="Image" src="/images/picture.png"></picture>),
   }
 
   FaviconLinkToTag = {
-    %(favicon_link_tag) => %(<link href="/images/favicon.ico" rel="icon" type="image/x-icon" />),
-    %(favicon_link_tag 'favicon.ico') => %(<link href="/images/favicon.ico" rel="icon" type="image/x-icon" />),
-    %(favicon_link_tag 'favicon.ico', :rel => 'foo') => %(<link href="/images/favicon.ico" rel="foo" type="image/x-icon" />),
-    %(favicon_link_tag 'favicon.ico', :rel => 'foo', :type => 'bar') => %(<link href="/images/favicon.ico" rel="foo" type="bar" />),
-    %(favicon_link_tag 'mb-icon.png', :rel => 'apple-touch-icon', :type => 'image/png') => %(<link href="/images/mb-icon.png" rel="apple-touch-icon" type="image/png" />)
+    %(favicon_link_tag) => %(<link href="/images/favicon.ico" rel="icon" type="image/x-icon">),
+    %(favicon_link_tag 'favicon.ico') => %(<link href="/images/favicon.ico" rel="icon" type="image/x-icon">),
+    %(favicon_link_tag 'favicon.ico', :rel => 'foo') => %(<link href="/images/favicon.ico" rel="foo" type="image/x-icon">),
+    %(favicon_link_tag 'favicon.ico', :rel => 'foo', :type => 'bar') => %(<link href="/images/favicon.ico" rel="foo" type="bar">),
+    %(favicon_link_tag 'mb-icon.png', :rel => 'apple-touch-icon', :type => 'image/png') => %(<link href="/images/mb-icon.png" rel="apple-touch-icon" type="image/png">)
   }
 
   PreloadLinkToTag = {
     %(preload_link_tag '/application.js', type: 'module') => %(<link rel="modulepreload" href="/application.js" as="script" type="module" >),
-    %(preload_link_tag '/styles/custom_theme.css') => %(<link rel="preload" href="/styles/custom_theme.css" as="style" type="text/css" />),
-    %(preload_link_tag '/videos/video.webm') => %(<link rel="preload" href="/videos/video.webm" as="video" type="video/webm" />),
-    %(preload_link_tag '/posts.json', as: 'fetch') => %(<link rel="preload" href="/posts.json" as="fetch" type="application/json" />),
-    %(preload_link_tag '/users', as: 'fetch', type: 'application/json') => %(<link rel="preload" href="/users" as="fetch" type="application/json" />),
-    %(preload_link_tag '//example.com/map?callback=initMap', as: 'fetch', type: 'application/javascript') => %(<link rel="preload" href="//example.com/map?callback=initMap" as="fetch" type="application/javascript" />),
-    %(preload_link_tag '//example.com/font.woff2') => %(<link rel="preload" href="//example.com/font.woff2" as="font" type="font/woff2" crossorigin="anonymous"/>),
-    %(preload_link_tag '//example.com/font.woff2', crossorigin: 'use-credentials') => %(<link rel="preload" href="//example.com/font.woff2" as="font" type="font/woff2" crossorigin="use-credentials" />),
-    %(preload_link_tag '/media/audio.ogg', nopush: true) => %(<link rel="preload" href="/media/audio.ogg" as="audio" type="audio/ogg" />),
+    %(preload_link_tag '/styles/custom_theme.css') => %(<link rel="preload" href="/styles/custom_theme.css" as="style" type="text/css">),
+    %(preload_link_tag '/videos/video.webm') => %(<link rel="preload" href="/videos/video.webm" as="video" type="video/webm">),
+    %(preload_link_tag '/posts.json', as: 'fetch') => %(<link rel="preload" href="/posts.json" as="fetch" type="application/json">),
+    %(preload_link_tag '/users', as: 'fetch', type: 'application/json') => %(<link rel="preload" href="/users" as="fetch" type="application/json">),
+    %(preload_link_tag '//example.com/map?callback=initMap', as: 'fetch', type: 'application/javascript') => %(<link rel="preload" href="//example.com/map?callback=initMap" as="fetch" type="application/javascript">),
+    %(preload_link_tag '//example.com/font.woff2') => %(<link rel="preload" href="//example.com/font.woff2" as="font" type="font/woff2" crossorigin="anonymous">),
+    %(preload_link_tag '//example.com/font.woff2', crossorigin: 'use-credentials') => %(<link rel="preload" href="//example.com/font.woff2" as="font" type="font/woff2" crossorigin="use-credentials">),
+    %(preload_link_tag '/media/audio.ogg', nopush: true) => %(<link rel="preload" href="/media/audio.ogg" as="audio" type="audio/ogg">),
     %(preload_link_tag '/style.css', integrity: 'sha256-AbpHGcgLb+kRsJGnwFEktk7uzpZOCcBY74+YBdrKVGs') => %(<link rel="preload" href="/style.css" as="style" type="text/css" integrity="sha256-AbpHGcgLb+kRsJGnwFEktk7uzpZOCcBY74+YBdrKVGs">),
     %(preload_link_tag '/sprite.svg') => %(<link rel="preload" href="/sprite.svg" as="image" type="image/svg+xml">),
     %(preload_link_tag '/mb-icon.png') => %(<link rel="preload" href="/mb-icon.png" as="image" type="image/png">)
@@ -381,9 +381,9 @@ class AssetTagHelperTest < ActionView::TestCase
     %(video_tag("error.avi", "size" => "x")) => %(<video src="/videos/error.avi"></video>),
     %(video_tag("http://media.rubyonrails.org/video/rails_blog_2.mov")) => %(<video src="http://media.rubyonrails.org/video/rails_blog_2.mov"></video>),
     %(video_tag("//media.rubyonrails.org/video/rails_blog_2.mov")) => %(<video src="//media.rubyonrails.org/video/rails_blog_2.mov"></video>),
-    %(video_tag("multiple.ogg", "multiple.avi")) => %(<video><source src="/videos/multiple.ogg" /><source src="/videos/multiple.avi" /></video>),
-    %(video_tag(["multiple.ogg", "multiple.avi"])) => %(<video><source src="/videos/multiple.ogg" /><source src="/videos/multiple.avi" /></video>),
-    %(video_tag(["multiple.ogg", "multiple.avi"], :size => "160x120", :controls => true)) => %(<video controls="controls" height="120" width="160"><source src="/videos/multiple.ogg" /><source src="/videos/multiple.avi" /></video>)
+    %(video_tag("multiple.ogg", "multiple.avi")) => %(<video><source src="/videos/multiple.ogg"><source src="/videos/multiple.avi"></video>),
+    %(video_tag(["multiple.ogg", "multiple.avi"])) => %(<video><source src="/videos/multiple.ogg"><source src="/videos/multiple.avi"></video>),
+    %(video_tag(["multiple.ogg", "multiple.avi"], :size => "160x120", :controls => true)) => %(<video controls="controls" height="120" width="160"><source src="/videos/multiple.ogg"><source src="/videos/multiple.avi"></video>)
   }
 
   AudioPathToTag = {
@@ -419,9 +419,9 @@ class AssetTagHelperTest < ActionView::TestCase
     %(audio_tag("rss.wav", :autoplay => true, :controls => true)) => %(<audio autoplay="autoplay" controls="controls" src="/audios/rss.wav"></audio>),
     %(audio_tag("http://media.rubyonrails.org/audio/rails_blog_2.mov")) => %(<audio src="http://media.rubyonrails.org/audio/rails_blog_2.mov"></audio>),
     %(audio_tag("//media.rubyonrails.org/audio/rails_blog_2.mov")) => %(<audio src="//media.rubyonrails.org/audio/rails_blog_2.mov"></audio>),
-    %(audio_tag("audio.mp3", "audio.ogg")) => %(<audio><source src="/audios/audio.mp3" /><source src="/audios/audio.ogg" /></audio>),
-    %(audio_tag(["audio.mp3", "audio.ogg"])) => %(<audio><source src="/audios/audio.mp3" /><source src="/audios/audio.ogg" /></audio>),
-    %(audio_tag(["audio.mp3", "audio.ogg"], :preload => 'none', :controls => true)) => %(<audio preload="none" controls="controls"><source src="/audios/audio.mp3" /><source src="/audios/audio.ogg" /></audio>)
+    %(audio_tag("audio.mp3", "audio.ogg")) => %(<audio><source src="/audios/audio.mp3"><source src="/audios/audio.ogg"></audio>),
+    %(audio_tag(["audio.mp3", "audio.ogg"])) => %(<audio><source src="/audios/audio.mp3"><source src="/audios/audio.ogg"></audio>),
+    %(audio_tag(["audio.mp3", "audio.ogg"], :preload => 'none', :controls => true)) => %(<audio preload="none" controls="controls"><source src="/audios/audio.mp3"><source src="/audios/audio.ogg"></audio>)
   }
 
   FontPathToTag = {
@@ -458,7 +458,7 @@ class AssetTagHelperTest < ActionView::TestCase
 
   def test_autodiscovery_link_tag_with_unknown_type
     result = auto_discovery_link_tag(:xml, "/feed.xml", type: "application/xml")
-    expected = %(<link href="/feed.xml" rel="alternate" title="XML" type="application/xml" />)
+    expected = %(<link href="/feed.xml" rel="alternate" title="XML" type="application/xml">)
     assert_dom_equal expected, result
   end
 
@@ -577,7 +577,7 @@ class AssetTagHelperTest < ActionView::TestCase
   def test_stylesheet_link_tag_without_request
     @request = nil
     assert_dom_equal(
-      %(<link rel="stylesheet" href="/stylesheets/foo.css" />),
+      %(<link rel="stylesheet" href="/stylesheets/foo.css">),
       stylesheet_link_tag("foo.css")
     )
   end
@@ -588,36 +588,36 @@ class AssetTagHelperTest < ActionView::TestCase
   end
 
   def test_stylesheet_link_tag_escapes_options
-    assert_dom_equal %(<link href="/file.css" media="&lt;script&gt;" rel="stylesheet" />), stylesheet_link_tag("/file", media: "<script>")
+    assert_dom_equal %(<link href="/file.css" media="&lt;script&gt;" rel="stylesheet">), stylesheet_link_tag("/file", media: "<script>")
   end
 
   def test_stylesheet_link_tag_should_not_output_the_same_asset_twice
-    assert_dom_equal %(<link href="/stylesheets/wellington.css" rel="stylesheet" />\n<link href="/stylesheets/amsterdam.css" rel="stylesheet" />), stylesheet_link_tag("wellington", "wellington", "amsterdam")
+    assert_dom_equal %(<link href="/stylesheets/wellington.css" rel="stylesheet">\n<link href="/stylesheets/amsterdam.css" rel="stylesheet">), stylesheet_link_tag("wellington", "wellington", "amsterdam")
   end
 
   def test_stylesheet_link_tag_with_relative_protocol
     @controller.config.asset_host = "assets.example.com"
-    assert_dom_equal %(<link href="//assets.example.com/stylesheets/wellington.css" rel="stylesheet" />), stylesheet_link_tag("wellington", protocol: :relative)
+    assert_dom_equal %(<link href="//assets.example.com/stylesheets/wellington.css" rel="stylesheet">), stylesheet_link_tag("wellington", protocol: :relative)
   end
 
   def test_stylesheet_link_tag_with_default_protocol
     @controller.config.asset_host = "assets.example.com"
     @controller.config.default_asset_host_protocol = :relative
-    assert_dom_equal %(<link href="//assets.example.com/stylesheets/wellington.css" rel="stylesheet" />), stylesheet_link_tag("wellington")
+    assert_dom_equal %(<link href="//assets.example.com/stylesheets/wellington.css" rel="stylesheet">), stylesheet_link_tag("wellington")
   end
 
   def test_stylesheet_link_tag_with_configured_stylesheet_media_default
     original_default_media = ActionView::Helpers::AssetTagHelper.apply_stylesheet_media_default
     ActionView::Helpers::AssetTagHelper.apply_stylesheet_media_default = true
 
-    assert_dom_equal %(<link href="/file.css" media="screen" rel="stylesheet" />), stylesheet_link_tag("/file")
-    assert_dom_equal %(<link href="/file.css" media="all" rel="stylesheet" />), stylesheet_link_tag("/file", media: "all")
+    assert_dom_equal %(<link href="/file.css" media="screen" rel="stylesheet">), stylesheet_link_tag("/file")
+    assert_dom_equal %(<link href="/file.css" media="all" rel="stylesheet">), stylesheet_link_tag("/file", media: "all")
   ensure
     ActionView::Helpers::AssetTagHelper.apply_stylesheet_media_default = original_default_media
   end
 
   def test_stylesheet_link_tag_without_default_extension_applied
-    assert_dom_equal %(<link href="/stylesheets/wellington.less" rel="stylesheet" />), stylesheet_link_tag("wellington.less", extname: false)
+    assert_dom_equal %(<link href="/stylesheets/wellington.less" rel="stylesheet">), stylesheet_link_tag("wellington.less", extname: false)
   end
 
   def test_javascript_include_tag_without_default_extension_applied
@@ -770,8 +770,8 @@ class AssetTagHelperTest < ActionView::TestCase
     original_image_loading = ActionView::Helpers::AssetTagHelper.image_loading
     ActionView::Helpers::AssetTagHelper.image_loading = "lazy"
 
-    assert_dom_equal %(<img src="" loading="lazy" />), image_tag("")
-    assert_dom_equal %(<img src="" loading="eager" />), image_tag("", loading: "eager")
+    assert_dom_equal %(<img src="" loading="lazy">), image_tag("")
+    assert_dom_equal %(<img src="" loading="eager">), image_tag("", loading: "eager")
   ensure
     ActionView::Helpers::AssetTagHelper.image_loading = original_image_loading
   end
@@ -780,8 +780,8 @@ class AssetTagHelperTest < ActionView::TestCase
     original_image_decoding = ActionView::Helpers::AssetTagHelper.image_decoding
     ActionView::Helpers::AssetTagHelper.image_decoding = "async"
 
-    assert_dom_equal %(<img src="" decoding="async" />), image_tag("")
-    assert_dom_equal %(<img src="" decoding="sync" />), image_tag("", decoding: "sync")
+    assert_dom_equal %(<img src="" decoding="async">), image_tag("")
+    assert_dom_equal %(<img src="" decoding="sync">), image_tag("", decoding: "sync")
   ensure
     ActionView::Helpers::AssetTagHelper.image_decoding = original_image_decoding
   end
@@ -876,11 +876,11 @@ class AssetTagHelperTest < ActionView::TestCase
 
   def test_image_tag_interpreting_email_cid_correctly
     # An inline image has no need for an alt tag to be automatically generated from the cid:
-    assert_equal '<img src="cid:thi%25%25sis@acontentid" />', image_tag("cid:thi%25%25sis@acontentid")
+    assert_equal '<img src="cid:thi%25%25sis@acontentid">', image_tag("cid:thi%25%25sis@acontentid")
   end
 
   def test_image_tag_interpreting_email_adding_optional_alt_tag
-    assert_equal '<img alt="Image" src="cid:thi%25%25sis@acontentid" />', image_tag("cid:thi%25%25sis@acontentid", alt: "Image")
+    assert_equal '<img alt="Image" src="cid:thi%25%25sis@acontentid">', image_tag("cid:thi%25%25sis@acontentid", alt: "Image")
   end
 
   def test_should_not_modify_source_string
@@ -957,7 +957,7 @@ class AssetTagHelperNonVhostTest < ActionView::TestCase
   end
 
   def test_should_compute_proper_path
-    assert_dom_equal(%(<link href="http://www.example.com/collaboration/hieraki" rel="alternate" title="RSS" type="application/rss+xml" />), auto_discovery_link_tag)
+    assert_dom_equal(%(<link href="http://www.example.com/collaboration/hieraki" rel="alternate" title="RSS" type="application/rss+xml">), auto_discovery_link_tag)
     assert_dom_equal(%(/collaboration/hieraki/javascripts/xmlhr.js), javascript_path("xmlhr"))
     assert_dom_equal(%(/collaboration/hieraki/stylesheets/style.css), stylesheet_path("style"))
     assert_dom_equal(%(/collaboration/hieraki/images/xml.png), image_path("xml.png"))
@@ -996,7 +996,7 @@ class AssetTagHelperNonVhostTest < ActionView::TestCase
 
   def test_should_compute_proper_path_with_asset_host
     @controller.config.asset_host = "assets.example.com"
-    assert_dom_equal(%(<link href="http://www.example.com/collaboration/hieraki" rel="alternate" title="RSS" type="application/rss+xml" />), auto_discovery_link_tag)
+    assert_dom_equal(%(<link href="http://www.example.com/collaboration/hieraki" rel="alternate" title="RSS" type="application/rss+xml">), auto_discovery_link_tag)
     assert_dom_equal(%(gopher://assets.example.com/collaboration/hieraki/javascripts/xmlhr.js), javascript_path("xmlhr"))
     assert_dom_equal(%(gopher://assets.example.com/collaboration/hieraki/stylesheets/style.css), stylesheet_path("style"))
     assert_dom_equal(%(gopher://assets.example.com/collaboration/hieraki/images/xml.png), image_path("xml.png"))
@@ -1012,7 +1012,7 @@ class AssetTagHelperNonVhostTest < ActionView::TestCase
 
   def test_should_compute_proper_url_with_asset_host
     @controller.config.asset_host = "assets.example.com"
-    assert_dom_equal(%(<link href="http://www.example.com/collaboration/hieraki" rel="alternate" title="RSS" type="application/rss+xml" />), auto_discovery_link_tag)
+    assert_dom_equal(%(<link href="http://www.example.com/collaboration/hieraki" rel="alternate" title="RSS" type="application/rss+xml">), auto_discovery_link_tag)
     assert_dom_equal(%(gopher://assets.example.com/collaboration/hieraki/javascripts/xmlhr.js), javascript_url("xmlhr"))
     assert_dom_equal(%(gopher://assets.example.com/collaboration/hieraki/stylesheets/style.css), stylesheet_url("style"))
     assert_dom_equal(%(gopher://assets.example.com/collaboration/hieraki/images/xml.png), image_url("xml.png"))
@@ -1033,12 +1033,12 @@ class AssetTagHelperNonVhostTest < ActionView::TestCase
 
   def test_should_ignore_asset_host_on_complete_url
     @controller.config.asset_host = "http://assets.example.com"
-    assert_dom_equal(%(<link href="http://bar.example.com/stylesheets/style.css" rel="stylesheet" />), stylesheet_link_tag("http://bar.example.com/stylesheets/style.css"))
+    assert_dom_equal(%(<link href="http://bar.example.com/stylesheets/style.css" rel="stylesheet">), stylesheet_link_tag("http://bar.example.com/stylesheets/style.css"))
   end
 
   def test_should_ignore_asset_host_on_scheme_relative_url
     @controller.config.asset_host = "http://assets.example.com"
-    assert_dom_equal(%(<link href="//bar.example.com/stylesheets/style.css" rel="stylesheet" />), stylesheet_link_tag("//bar.example.com/stylesheets/style.css"))
+    assert_dom_equal(%(<link href="//bar.example.com/stylesheets/style.css" rel="stylesheet">), stylesheet_link_tag("//bar.example.com/stylesheets/style.css"))
   end
 
   def test_should_wildcard_asset_host
@@ -1077,7 +1077,7 @@ class AssetTagHelperWithoutRequestTest < ActionView::TestCase
 
   def test_stylesheet_link_tag_without_request
     assert_dom_equal(
-      %(<link rel="stylesheet" href="/stylesheets/foo.css" />),
+      %(<link rel="stylesheet" href="/stylesheets/foo.css">),
       stylesheet_link_tag("foo.css")
     )
   end
@@ -1100,7 +1100,7 @@ class AssetTagHelperWithStreamingRequest < ActionView::TestCase
   def test_stylesheet_link_tag_with_streaming
     with_preload_links_header do
       assert_dom_equal(
-        %(<link rel="stylesheet" href="/stylesheets/foo.css" />),
+        %(<link rel="stylesheet" href="/stylesheets/foo.css">),
         stylesheet_link_tag("foo.css")
       )
     end

--- a/actionview/test/template/csp_helper_test.rb
+++ b/actionview/test/template/csp_helper_test.rb
@@ -14,11 +14,11 @@ class CspHelperWithCspEnabledTest < ActionView::TestCase
   end
 
   def test_csp_meta_tag
-    assert_equal "<meta name=\"csp-nonce\" content=\"iyhD0Yc0W+c=\" />", csp_meta_tag
+    assert_equal "<meta name=\"csp-nonce\" content=\"iyhD0Yc0W+c=\">", csp_meta_tag
   end
 
   def test_csp_meta_tag_with_options
-    assert_equal "<meta property=\"csp-nonce\" name=\"csp-nonce\" content=\"iyhD0Yc0W+c=\" />", csp_meta_tag(property: "csp-nonce")
+    assert_equal "<meta property=\"csp-nonce\" name=\"csp-nonce\" content=\"iyhD0Yc0W+c=\">", csp_meta_tag(property: "csp-nonce")
   end
 end
 

--- a/actionview/test/template/csrf_helper_test.rb
+++ b/actionview/test/template/csrf_helper_test.rb
@@ -17,8 +17,8 @@ class CsrfHelperTest < ActiveSupport::TestCase
     self.request_forgery = true
 
     assert_dom_equal <<~DOM.chomp, csrf_meta_tags
-      <meta name="csrf-param" content="form_token" />
-      <meta name="csrf-token" content="secret" />
+      <meta name="csrf-param" content="form_token">
+      <meta name="csrf-token" content="secret">
     DOM
   ensure
     self.request_forgery = false

--- a/actionview/test/template/date_helper_test.rb
+++ b/actionview/test/template/date_helper_test.rb
@@ -411,11 +411,11 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_select_month_with_hidden
-    assert_dom_equal "<input type=\"hidden\" id=\"date_month\" name=\"date[month]\" value=\"8\" autocomplete=\"off\" />\n", select_month(8, use_hidden: true)
+    assert_dom_equal "<input type=\"hidden\" id=\"date_month\" name=\"date[month]\" value=\"8\" autocomplete=\"off\">\n", select_month(8, use_hidden: true)
   end
 
   def test_select_month_with_hidden_and_field_name
-    assert_dom_equal "<input type=\"hidden\" id=\"date_mois\" name=\"date[mois]\" value=\"8\" autocomplete=\"off\" />\n", select_month(8, use_hidden: true, field_name: "mois")
+    assert_dom_equal "<input type=\"hidden\" id=\"date_mois\" name=\"date[mois]\" value=\"8\" autocomplete=\"off\">\n", select_month(8, use_hidden: true, field_name: "mois")
   end
 
   def test_select_month_with_html_options
@@ -526,11 +526,11 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_select_year_with_hidden
-    assert_dom_equal "<input type=\"hidden\" id=\"date_year\" name=\"date[year]\" value=\"2007\" autocomplete=\"off\" />\n", select_year(2007, use_hidden: true)
+    assert_dom_equal "<input type=\"hidden\" id=\"date_year\" name=\"date[year]\" value=\"2007\" autocomplete=\"off\">\n", select_year(2007, use_hidden: true)
   end
 
   def test_select_year_with_hidden_and_field_name
-    assert_dom_equal "<input type=\"hidden\" id=\"date_anno\" name=\"date[anno]\" value=\"2007\" autocomplete=\"off\" />\n", select_year(2007, use_hidden: true, field_name: "anno")
+    assert_dom_equal "<input type=\"hidden\" id=\"date_anno\" name=\"date[anno]\" value=\"2007\" autocomplete=\"off\">\n", select_year(2007, use_hidden: true, field_name: "anno")
   end
 
   def test_select_year_with_html_options
@@ -734,11 +734,11 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_select_minute_with_hidden
-    assert_dom_equal "<input type=\"hidden\" id=\"date_minute\" name=\"date[minute]\" value=\"8\" autocomplete=\"off\" />\n", select_minute(8, use_hidden: true)
+    assert_dom_equal "<input type=\"hidden\" id=\"date_minute\" name=\"date[minute]\" value=\"8\" autocomplete=\"off\">\n", select_minute(8, use_hidden: true)
   end
 
   def test_select_minute_with_hidden_and_field_name
-    assert_dom_equal "<input type=\"hidden\" id=\"date_minuto\" name=\"date[minuto]\" value=\"8\" autocomplete=\"off\" />\n", select_minute(8, use_hidden: true, field_name: "minuto")
+    assert_dom_equal "<input type=\"hidden\" id=\"date_minuto\" name=\"date[minuto]\" value=\"8\" autocomplete=\"off\">\n", select_minute(8, use_hidden: true, field_name: "minuto")
   end
 
   def test_select_minute_with_html_options
@@ -904,9 +904,9 @@ class DateHelperTest < ActionView::TestCase
 
   def test_select_date_with_incomplete_order
     # Since the order is incomplete nothing will be shown
-    expected = +%(<input id="date_first_year" name="date[first][year]" type="hidden" value="2003" autocomplete="off" />\n)
-    expected << %(<input id="date_first_month" name="date[first][month]" type="hidden" value="8" autocomplete="off" />\n)
-    expected << %(<input id="date_first_day" name="date[first][day]" type="hidden" value="1" autocomplete="off" />\n)
+    expected = +%(<input id="date_first_year" name="date[first][year]" type="hidden" value="2003" autocomplete="off">\n)
+    expected << %(<input id="date_first_month" name="date[first][month]" type="hidden" value="8" autocomplete="off">\n)
+    expected << %(<input id="date_first_day" name="date[first][day]" type="hidden" value="1" autocomplete="off">\n)
 
     assert_dom_equal expected, select_date(Time.mktime(2003, 8, 16), start_year: 2003, end_year: 2005, prefix: "date[first]", order: [:day])
   end
@@ -1127,7 +1127,7 @@ class DateHelperTest < ActionView::TestCase
     expected << %(<option value="1">January</option>\n<option value="2">February</option>\n<option value="3">March</option>\n<option value="4">April</option>\n<option value="5">May</option>\n<option value="6">June</option>\n<option value="7">July</option>\n<option value="8" selected="selected">August</option>\n<option value="9">September</option>\n<option value="10">October</option>\n<option value="11">November</option>\n<option value="12">December</option>\n)
     expected << "</select>\n"
 
-    expected << %(<input type="hidden" id="date_first_day" name="date[first][day]" value="1" autocomplete="off" />\n)
+    expected << %(<input type="hidden" id="date_first_day" name="date[first][day]" value="1" autocomplete="off">\n)
 
     assert_dom_equal expected, select_date(Time.mktime(2003, 8, 16), date_separator: " / ", discard_day: true, start_year: 2003, end_year: 2005, prefix: "date[first]")
   end
@@ -1137,16 +1137,16 @@ class DateHelperTest < ActionView::TestCase
     expected << %(<option value="2003" selected="selected">2003</option>\n<option value="2004">2004</option>\n<option value="2005">2005</option>\n)
     expected << "</select>\n"
 
-    expected << %(<input type="hidden" id="date_first_month" name="date[first][month]" value="8" autocomplete="off" />\n)
-    expected << %(<input type="hidden" id="date_first_day" name="date[first][day]" value="1" autocomplete="off" />\n)
+    expected << %(<input type="hidden" id="date_first_month" name="date[first][month]" value="8" autocomplete="off">\n)
+    expected << %(<input type="hidden" id="date_first_day" name="date[first][day]" value="1" autocomplete="off">\n)
 
     assert_dom_equal expected, select_date(Time.mktime(2003, 8, 16), date_separator: " / ", discard_month: true, discard_day: true, start_year: 2003, end_year: 2005, prefix: "date[first]")
   end
 
   def test_select_date_with_hidden
-    expected =  +%(<input id="date_first_year" name="date[first][year]" type="hidden" value="2003" autocomplete="off"/>\n)
-    expected << %(<input id="date_first_month" name="date[first][month]" type="hidden" value="8" autocomplete="off" />\n)
-    expected << %(<input id="date_first_day" name="date[first][day]" type="hidden" value="16" autocomplete="off" />\n)
+    expected =  +%(<input id="date_first_year" name="date[first][year]" type="hidden" value="2003" autocomplete="off">\n)
+    expected << %(<input id="date_first_month" name="date[first][month]" type="hidden" value="8" autocomplete="off">\n)
+    expected << %(<input id="date_first_day" name="date[first][day]" type="hidden" value="16" autocomplete="off">\n)
 
     assert_dom_equal expected, select_date(Time.mktime(2003, 8, 16), prefix: "date[first]", use_hidden: true)
     assert_dom_equal expected, select_date(Time.mktime(2003, 8, 16), date_separator: " / ", prefix: "date[first]", use_hidden: true)
@@ -1568,11 +1568,11 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_select_datetime_with_hidden
-    expected =  +%(<input id="date_first_year" name="date[first][year]" type="hidden" value="2003" autocomplete="off" />\n)
-    expected << %(<input id="date_first_month" name="date[first][month]" type="hidden" value="8" autocomplete="off" />\n)
-    expected << %(<input id="date_first_day" name="date[first][day]" type="hidden" value="16" autocomplete="off" />\n)
-    expected << %(<input id="date_first_hour" name="date[first][hour]" type="hidden" value="8" autocomplete="off" />\n)
-    expected << %(<input id="date_first_minute" name="date[first][minute]" type="hidden" value="4" autocomplete="off" />\n)
+    expected =  +%(<input id="date_first_year" name="date[first][year]" type="hidden" value="2003" autocomplete="off">\n)
+    expected << %(<input id="date_first_month" name="date[first][month]" type="hidden" value="8" autocomplete="off">\n)
+    expected << %(<input id="date_first_day" name="date[first][day]" type="hidden" value="16" autocomplete="off">\n)
+    expected << %(<input id="date_first_hour" name="date[first][hour]" type="hidden" value="8" autocomplete="off">\n)
+    expected << %(<input id="date_first_minute" name="date[first][minute]" type="hidden" value="4" autocomplete="off">\n)
 
     assert_dom_equal expected, select_datetime(Time.mktime(2003, 8, 16, 8, 4, 18), prefix: "date[first]", use_hidden: true)
     assert_dom_equal expected, select_datetime(Time.mktime(2003, 8, 16, 8, 4, 18), datetime_separator: "&mdash;", date_separator: "/",
@@ -1580,9 +1580,9 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_select_time
-    expected = +%(<input name="date[year]" id="date_year" value="2003" type="hidden" autocomplete="off" />\n)
-    expected << %(<input name="date[month]" id="date_month" value="8" type="hidden" autocomplete="off" />\n)
-    expected << %(<input name="date[day]" id="date_day" value="16" type="hidden" autocomplete="off" />\n)
+    expected = +%(<input name="date[year]" id="date_year" value="2003" type="hidden" autocomplete="off">\n)
+    expected << %(<input name="date[month]" id="date_month" value="8" type="hidden" autocomplete="off">\n)
+    expected << %(<input name="date[day]" id="date_day" value="16" type="hidden" autocomplete="off">\n)
 
     expected << %(<select id="date_hour" name="date[hour]">\n)
     expected << %(<option value="00">00</option>\n<option value="01">01</option>\n<option value="02">02</option>\n<option value="03">03</option>\n<option value="04">04</option>\n<option value="05">05</option>\n<option value="06">06</option>\n<option value="07">07</option>\n<option value="08" selected="selected">08</option>\n<option value="09">09</option>\n<option value="10">10</option>\n<option value="11">11</option>\n<option value="12">12</option>\n<option value="13">13</option>\n<option value="14">14</option>\n<option value="15">15</option>\n<option value="16">16</option>\n<option value="17">17</option>\n<option value="18">18</option>\n<option value="19">19</option>\n<option value="20">20</option>\n<option value="21">21</option>\n<option value="22">22</option>\n<option value="23">23</option>\n)
@@ -1599,9 +1599,9 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_select_time_with_ampm
-    expected = +%(<input name="date[year]" id="date_year" value="2003" type="hidden" autocomplete="off" />\n)
-    expected << %(<input name="date[month]" id="date_month" value="8" type="hidden" autocomplete="off" />\n)
-    expected << %(<input name="date[day]" id="date_day" value="16" type="hidden" autocomplete="off" />\n)
+    expected = +%(<input name="date[year]" id="date_year" value="2003" type="hidden" autocomplete="off">\n)
+    expected << %(<input name="date[month]" id="date_month" value="8" type="hidden" autocomplete="off">\n)
+    expected << %(<input name="date[day]" id="date_day" value="16" type="hidden" autocomplete="off">\n)
 
     expected << %(<select id="date_hour" name="date[hour]">\n)
     expected << %(<option value="00">12 AM</option>\n<option value="01">01 AM</option>\n<option value="02">02 AM</option>\n<option value="03">03 AM</option>\n<option value="04">04 AM</option>\n<option value="05">05 AM</option>\n<option value="06">06 AM</option>\n<option value="07">07 AM</option>\n<option value="08" selected="selected">08 AM</option>\n<option value="09">09 AM</option>\n<option value="10">10 AM</option>\n<option value="11">11 AM</option>\n<option value="12">12 PM</option>\n<option value="13">01 PM</option>\n<option value="14">02 PM</option>\n<option value="15">03 PM</option>\n<option value="16">04 PM</option>\n<option value="17">05 PM</option>\n<option value="18">06 PM</option>\n<option value="19">07 PM</option>\n<option value="20">08 PM</option>\n<option value="21">09 PM</option>\n<option value="22">10 PM</option>\n<option value="23">11 PM</option>\n)
@@ -1617,9 +1617,9 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_select_time_with_separator
-    expected = +%(<input name="date[year]" id="date_year" value="2003" type="hidden" autocomplete="off" />\n)
-    expected << %(<input name="date[month]" id="date_month" value="8" type="hidden" autocomplete="off" />\n)
-    expected << %(<input name="date[day]" id="date_day" value="16" type="hidden" autocomplete="off" />\n)
+    expected = +%(<input name="date[year]" id="date_year" value="2003" type="hidden" autocomplete="off">\n)
+    expected << %(<input name="date[month]" id="date_month" value="8" type="hidden" autocomplete="off">\n)
+    expected << %(<input name="date[day]" id="date_day" value="16" type="hidden" autocomplete="off">\n)
     expected << %(<select id="date_hour" name="date[hour]">\n)
     expected << %(<option value="00">00</option>\n<option value="01">01</option>\n<option value="02">02</option>\n<option value="03">03</option>\n<option value="04">04</option>\n<option value="05">05</option>\n<option value="06">06</option>\n<option value="07">07</option>\n<option value="08" selected="selected">08</option>\n<option value="09">09</option>\n<option value="10">10</option>\n<option value="11">11</option>\n<option value="12">12</option>\n<option value="13">13</option>\n<option value="14">14</option>\n<option value="15">15</option>\n<option value="16">16</option>\n<option value="17">17</option>\n<option value="18">18</option>\n<option value="19">19</option>\n<option value="20">20</option>\n<option value="21">21</option>\n<option value="22">22</option>\n<option value="23">23</option>\n)
     expected << "</select>\n"
@@ -1635,9 +1635,9 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_select_time_with_seconds
-    expected = +%(<input name="date[year]" id="date_year" value="2003" type="hidden" autocomplete="off" />\n)
-    expected << %(<input name="date[month]" id="date_month" value="8" type="hidden" autocomplete="off" />\n)
-    expected << %(<input name="date[day]" id="date_day" value="16" type="hidden" autocomplete="off" />\n)
+    expected = +%(<input name="date[year]" id="date_year" value="2003" type="hidden" autocomplete="off">\n)
+    expected << %(<input name="date[month]" id="date_month" value="8" type="hidden" autocomplete="off">\n)
+    expected << %(<input name="date[day]" id="date_day" value="16" type="hidden" autocomplete="off">\n)
 
     expected << %(<select id="date_hour" name="date[hour]">\n)
     expected << %(<option value="00">00</option>\n<option value="01">01</option>\n<option value="02">02</option>\n<option value="03">03</option>\n<option value="04">04</option>\n<option value="05">05</option>\n<option value="06">06</option>\n<option value="07">07</option>\n<option value="08" selected="selected">08</option>\n<option value="09">09</option>\n<option value="10">10</option>\n<option value="11">11</option>\n<option value="12">12</option>\n<option value="13">13</option>\n<option value="14">14</option>\n<option value="15">15</option>\n<option value="16">16</option>\n<option value="17">17</option>\n<option value="18">18</option>\n<option value="19">19</option>\n<option value="20">20</option>\n<option value="21">21</option>\n<option value="22">22</option>\n<option value="23">23</option>\n)
@@ -1659,9 +1659,9 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_select_time_with_seconds_and_separator
-    expected = +%(<input name="date[year]" id="date_year" value="2003" type="hidden" autocomplete="off" />\n)
-    expected << %(<input name="date[month]" id="date_month" value="8" type="hidden" autocomplete="off" />\n)
-    expected << %(<input name="date[day]" id="date_day" value="16" type="hidden" autocomplete="off" />\n)
+    expected = +%(<input name="date[year]" id="date_year" value="2003" type="hidden" autocomplete="off">\n)
+    expected << %(<input name="date[month]" id="date_month" value="8" type="hidden" autocomplete="off">\n)
+    expected << %(<input name="date[day]" id="date_day" value="16" type="hidden" autocomplete="off">\n)
 
     expected << %(<select id="date_hour" name="date[hour]">\n)
     expected << %(<option value="00">00</option>\n<option value="01">01</option>\n<option value="02">02</option>\n<option value="03">03</option>\n<option value="04">04</option>\n<option value="05">05</option>\n<option value="06">06</option>\n<option value="07">07</option>\n<option value="08" selected="selected">08</option>\n<option value="09">09</option>\n<option value="10">10</option>\n<option value="11">11</option>\n<option value="12">12</option>\n<option value="13">13</option>\n<option value="14">14</option>\n<option value="15">15</option>\n<option value="16">16</option>\n<option value="17">17</option>\n<option value="18">18</option>\n<option value="19">19</option>\n<option value="20">20</option>\n<option value="21">21</option>\n<option value="22">22</option>\n<option value="23">23</option>\n)
@@ -1683,9 +1683,9 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_select_time_with_html_options
-    expected = +%(<input name="date[year]" id="date_year" value="2003" type="hidden" autocomplete="off" />\n)
-    expected << %(<input name="date[month]" id="date_month" value="8" type="hidden" autocomplete="off" />\n)
-    expected << %(<input name="date[day]" id="date_day" value="16" type="hidden" autocomplete="off" />\n)
+    expected = +%(<input name="date[year]" id="date_year" value="2003" type="hidden" autocomplete="off">\n)
+    expected << %(<input name="date[month]" id="date_month" value="8" type="hidden" autocomplete="off">\n)
+    expected << %(<input name="date[day]" id="date_day" value="16" type="hidden" autocomplete="off">\n)
 
     expected << %(<select id="date_hour" name="date[hour]" class="selector">\n)
     expected << %(<option value="00">00</option>\n<option value="01">01</option>\n<option value="02">02</option>\n<option value="03">03</option>\n<option value="04">04</option>\n<option value="05">05</option>\n<option value="06">06</option>\n<option value="07">07</option>\n<option value="08" selected="selected">08</option>\n<option value="09">09</option>\n<option value="10">10</option>\n<option value="11">11</option>\n<option value="12">12</option>\n<option value="13">13</option>\n<option value="14">14</option>\n<option value="15">15</option>\n<option value="16">16</option>\n<option value="17">17</option>\n<option value="18">18</option>\n<option value="19">19</option>\n<option value="20">20</option>\n<option value="21">21</option>\n<option value="22">22</option>\n<option value="23">23</option>\n)
@@ -1706,9 +1706,9 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_select_time_with_default_prompt
-    expected = +%(<input name="date[year]" id="date_year" value="2003" type="hidden" autocomplete="off" />\n)
-    expected << %(<input name="date[month]" id="date_month" value="8" type="hidden" autocomplete="off" />\n)
-    expected << %(<input name="date[day]" id="date_day" value="16" type="hidden" autocomplete="off" />\n)
+    expected = +%(<input name="date[year]" id="date_year" value="2003" type="hidden" autocomplete="off">\n)
+    expected << %(<input name="date[month]" id="date_month" value="8" type="hidden" autocomplete="off">\n)
+    expected << %(<input name="date[day]" id="date_day" value="16" type="hidden" autocomplete="off">\n)
 
     expected << %(<select id="date_hour" name="date[hour]">\n)
     expected << %(<option value="">Hour</option>\n<option value="00">00</option>\n<option value="01">01</option>\n<option value="02">02</option>\n<option value="03">03</option>\n<option value="04">04</option>\n<option value="05">05</option>\n<option value="06">06</option>\n<option value="07">07</option>\n<option value="08" selected="selected">08</option>\n<option value="09">09</option>\n<option value="10">10</option>\n<option value="11">11</option>\n<option value="12">12</option>\n<option value="13">13</option>\n<option value="14">14</option>\n<option value="15">15</option>\n<option value="16">16</option>\n<option value="17">17</option>\n<option value="18">18</option>\n<option value="19">19</option>\n<option value="20">20</option>\n<option value="21">21</option>\n<option value="22">22</option>\n<option value="23">23</option>\n)
@@ -1730,9 +1730,9 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_select_time_with_custom_prompt
-    expected = +%(<input name="date[year]" id="date_year" value="2003" type="hidden" autocomplete="off" />\n)
-    expected << %(<input name="date[month]" id="date_month" value="8" type="hidden" autocomplete="off" />\n)
-    expected << %(<input name="date[day]" id="date_day" value="16" type="hidden" autocomplete="off" />\n)
+    expected = +%(<input name="date[year]" id="date_year" value="2003" type="hidden" autocomplete="off">\n)
+    expected << %(<input name="date[month]" id="date_month" value="8" type="hidden" autocomplete="off">\n)
+    expected << %(<input name="date[day]" id="date_day" value="16" type="hidden" autocomplete="off">\n)
 
     expected << %(<select id="date_hour" name="date[hour]">\n)
     expected << %(<option value="">Choose hour</option>\n<option value="00">00</option>\n<option value="01">01</option>\n<option value="02">02</option>\n<option value="03">03</option>\n<option value="04">04</option>\n<option value="05">05</option>\n<option value="06">06</option>\n<option value="07">07</option>\n<option value="08" selected="selected">08</option>\n<option value="09">09</option>\n<option value="10">10</option>\n<option value="11">11</option>\n<option value="12">12</option>\n<option value="13">13</option>\n<option value="14">14</option>\n<option value="15">15</option>\n<option value="16">16</option>\n<option value="17">17</option>\n<option value="18">18</option>\n<option value="19">19</option>\n<option value="20">20</option>\n<option value="21">21</option>\n<option value="22">22</option>\n<option value="23">23</option>\n)
@@ -1755,9 +1755,9 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_select_time_with_generic_with_css_classes
-    expected = +%(<input name="date[year]" id="date_year" value="2003" type="hidden" autocomplete="off" />\n)
-    expected << %(<input name="date[month]" id="date_month" value="8" type="hidden" autocomplete="off" />\n)
-    expected << %(<input name="date[day]" id="date_day" value="16" type="hidden" autocomplete="off" />\n)
+    expected = +%(<input name="date[year]" id="date_year" value="2003" type="hidden" autocomplete="off">\n)
+    expected << %(<input name="date[month]" id="date_month" value="8" type="hidden" autocomplete="off">\n)
+    expected << %(<input name="date[day]" id="date_day" value="16" type="hidden" autocomplete="off">\n)
 
     expected << %(<select id="date_hour" name="date[hour]" class="hour">\n)
     expected << %(<option value="00">00</option>\n<option value="01">01</option>\n<option value="02">02</option>\n<option value="03">03</option>\n<option value="04">04</option>\n<option value="05">05</option>\n<option value="06">06</option>\n<option value="07">07</option>\n<option value="08" selected="selected">08</option>\n<option value="09">09</option>\n<option value="10">10</option>\n<option value="11">11</option>\n<option value="12">12</option>\n<option value="13">13</option>\n<option value="14">14</option>\n<option value="15">15</option>\n<option value="16">16</option>\n<option value="17">17</option>\n<option value="18">18</option>\n<option value="19">19</option>\n<option value="20">20</option>\n<option value="21">21</option>\n<option value="22">22</option>\n<option value="23">23</option>\n)
@@ -1779,9 +1779,9 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_select_time_with_a_single_default_prompt
-    expected = +%(<input name="date[year]" id="date_year" value="2003" type="hidden" autocomplete="off" />\n)
-    expected << %(<input name="date[month]" id="date_month" value="8" type="hidden" autocomplete="off" />\n)
-    expected << %(<input name="date[day]" id="date_day" value="16" type="hidden" autocomplete="off" />\n)
+    expected = +%(<input name="date[year]" id="date_year" value="2003" type="hidden" autocomplete="off">\n)
+    expected << %(<input name="date[month]" id="date_month" value="8" type="hidden" autocomplete="off">\n)
+    expected << %(<input name="date[day]" id="date_day" value="16" type="hidden" autocomplete="off">\n)
 
     expected << %(<select id="date_hour" name="date[hour]">\n)
     expected << %(<option value="">Hour</option>\n<option value="00">00</option>\n<option value="01">01</option>\n<option value="02">02</option>\n<option value="03">03</option>\n<option value="04">04</option>\n<option value="05">05</option>\n<option value="06">06</option>\n<option value="07">07</option>\n<option value="08" selected="selected">08</option>\n<option value="09">09</option>\n<option value="10">10</option>\n<option value="11">11</option>\n<option value="12">12</option>\n<option value="13">13</option>\n<option value="14">14</option>\n<option value="15">15</option>\n<option value="16">16</option>\n<option value="17">17</option>\n<option value="18">18</option>\n<option value="19">19</option>\n<option value="20">20</option>\n<option value="21">21</option>\n<option value="22">22</option>\n<option value="23">23</option>\n)
@@ -1804,9 +1804,9 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_select_time_with_custom_with_css_classes
-    expected = +%(<input name="date[year]" id="date_year" value="2003" type="hidden" autocomplete="off" />\n)
-    expected << %(<input name="date[month]" id="date_month" value="8" type="hidden" autocomplete="off" />\n)
-    expected << %(<input name="date[day]" id="date_day" value="16" type="hidden" autocomplete="off" />\n)
+    expected = +%(<input name="date[year]" id="date_year" value="2003" type="hidden" autocomplete="off">\n)
+    expected << %(<input name="date[month]" id="date_month" value="8" type="hidden" autocomplete="off">\n)
+    expected << %(<input name="date[day]" id="date_day" value="16" type="hidden" autocomplete="off">\n)
 
     expected << %(<select id="date_hour" name="date[hour]" class="my-hour">\n)
     expected << %(<option value="00">00</option>\n<option value="01">01</option>\n<option value="02">02</option>\n<option value="03">03</option>\n<option value="04">04</option>\n<option value="05">05</option>\n<option value="06">06</option>\n<option value="07">07</option>\n<option value="08" selected="selected">08</option>\n<option value="09">09</option>\n<option value="10">10</option>\n<option value="11">11</option>\n<option value="12">12</option>\n<option value="13">13</option>\n<option value="14">14</option>\n<option value="15">15</option>\n<option value="16">16</option>\n<option value="17">17</option>\n<option value="18">18</option>\n<option value="19">19</option>\n<option value="20">20</option>\n<option value="21">21</option>\n<option value="22">22</option>\n<option value="23">23</option>\n)
@@ -1828,11 +1828,11 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_select_time_with_hidden
-    expected =  +%(<input id="date_first_year" name="date[first][year]" type="hidden" value="2003" autocomplete="off" />\n)
-    expected << %(<input id="date_first_month" name="date[first][month]" type="hidden" value="8" autocomplete="off" />\n)
-    expected << %(<input id="date_first_day" name="date[first][day]" type="hidden" value="16" autocomplete="off" />\n)
-    expected << %(<input id="date_first_hour" name="date[first][hour]" type="hidden" value="8" autocomplete="off" />\n)
-    expected << %(<input id="date_first_minute" name="date[first][minute]" type="hidden" value="4" autocomplete="off" />\n)
+    expected =  +%(<input id="date_first_year" name="date[first][year]" type="hidden" value="2003" autocomplete="off">\n)
+    expected << %(<input id="date_first_month" name="date[first][month]" type="hidden" value="8" autocomplete="off">\n)
+    expected << %(<input id="date_first_day" name="date[first][day]" type="hidden" value="16" autocomplete="off">\n)
+    expected << %(<input id="date_first_hour" name="date[first][hour]" type="hidden" value="8" autocomplete="off">\n)
+    expected << %(<input id="date_first_minute" name="date[first][minute]" type="hidden" value="4" autocomplete="off">\n)
 
     assert_dom_equal expected, select_time(Time.mktime(2003, 8, 16, 8, 4, 18), prefix: "date[first]", use_hidden: true)
     assert_dom_equal expected, select_time(Time.mktime(2003, 8, 16, 8, 4, 18), time_separator: ":", prefix: "date[first]", use_hidden: true)
@@ -1902,7 +1902,7 @@ class DateHelperTest < ActionView::TestCase
     @post = Post.new
     @post.written_on = Date.new(2004, 6, 15)
 
-    expected = '<input id="post_written_on_1i" name="post[written_on(1i)]" type="hidden" value="1" autocomplete="off"/>' + "\n"
+    expected = '<input id="post_written_on_1i" name="post[written_on(1i)]" type="hidden" value="1" autocomplete="off">' + "\n"
 
     expected << %{<select id="post_written_on_2i" name="post[written_on(2i)]">\n}
     expected << %{<option value="" label=" "></option>\n<option value="1">January</option>\n<option value="2">February</option>\n<option value="3">March</option>\n<option value="4">April</option>\n<option value="5">May</option>\n<option value="6">June</option>\n<option value="7">July</option>\n<option value="8">August</option>\n<option value="9">September</option>\n<option value="10">October</option>\n<option value="11">November</option>\n<option value="12">December</option>\n}
@@ -1920,7 +1920,7 @@ class DateHelperTest < ActionView::TestCase
     @post = Post.new
     @post.written_on = Date.new(2004, 6, 15)
 
-    expected = +"<input type=\"hidden\" id=\"post_written_on_3i\" name=\"post[written_on(3i)]\" value=\"1\" autocomplete=\"off\" />\n"
+    expected = +"<input type=\"hidden\" id=\"post_written_on_3i\" name=\"post[written_on(3i)]\" value=\"1\" autocomplete=\"off\">\n"
 
     expected << %{<select id="post_written_on_2i" name="post[written_on(2i)]">\n}
     expected << %{<option value="1">January</option>\n<option value="2">February</option>\n<option value="3">March</option>\n<option value="4">April</option>\n<option value="5">May</option>\n<option value="6" selected="selected">June</option>\n<option value="7">July</option>\n<option value="8">August</option>\n<option value="9">September</option>\n<option value="10">October</option>\n<option value="11">November</option>\n<option value="12">December</option>\n}
@@ -1937,8 +1937,8 @@ class DateHelperTest < ActionView::TestCase
     @post = Post.new
     @post.written_on = Date.new(2004, 2, 29)
 
-    expected = +"<input type=\"hidden\" id=\"post_written_on_2i\" name=\"post[written_on(2i)]\" value=\"2\" autocomplete=\"off\" />\n"
-    expected << "<input type=\"hidden\" id=\"post_written_on_3i\" name=\"post[written_on(3i)]\" value=\"1\" autocomplete=\"off\" />\n"
+    expected = +"<input type=\"hidden\" id=\"post_written_on_2i\" name=\"post[written_on(2i)]\" value=\"2\" autocomplete=\"off\">\n"
+    expected << "<input type=\"hidden\" id=\"post_written_on_3i\" name=\"post[written_on(3i)]\" value=\"1\" autocomplete=\"off\">\n"
 
     expected << %{<select id="post_written_on_1i" name="post[written_on(1i)]">\n}
     expected << %{<option value="1999">1999</option>\n<option value="2000">2000</option>\n<option value="2001">2001</option>\n<option value="2002">2002</option>\n<option value="2003">2003</option>\n<option value="2004" selected="selected">2004</option>\n<option value="2005">2005</option>\n<option value="2006">2006</option>\n<option value="2007">2007</option>\n<option value="2008">2008</option>\n<option value="2009">2009</option>\n}
@@ -1951,7 +1951,7 @@ class DateHelperTest < ActionView::TestCase
     @post = Post.new
     @post.written_on = Date.new(2004, 6, 15)
 
-    expected = +"<input type=\"hidden\" id=\"post_written_on_3i\" name=\"post[written_on(3i)]\" value=\"1\" autocomplete=\"off\" />\n"
+    expected = +"<input type=\"hidden\" id=\"post_written_on_3i\" name=\"post[written_on(3i)]\" value=\"1\" autocomplete=\"off\">\n"
 
     expected << %{<select id="post_written_on_2i" name="post[written_on(2i)]">\n}
     expected << %{<option value="1">January</option>\n<option value="2">February</option>\n<option value="3">March</option>\n<option value="4">April</option>\n<option value="5">May</option>\n<option value="6" selected="selected">June</option>\n<option value="7">July</option>\n<option value="8">August</option>\n<option value="9">September</option>\n<option value="10">October</option>\n<option value="11">November</option>\n<option value="12">December</option>\n}
@@ -1970,7 +1970,7 @@ class DateHelperTest < ActionView::TestCase
     @post = Post.new
     @post.written_on = Date.new(2004, 6, 15)
 
-    expected = +"<input type=\"hidden\" id=\"post_written_on_3i\" disabled=\"disabled\" name=\"post[written_on(3i)]\" value=\"1\" autocomplete=\"off\" />\n"
+    expected = +"<input type=\"hidden\" id=\"post_written_on_3i\" disabled=\"disabled\" name=\"post[written_on(3i)]\" value=\"1\" autocomplete=\"off\">\n"
 
     expected << %{<select id="post_written_on_2i" disabled="disabled" name="post[written_on(2i)]">\n}
     expected << %{<option value="1">January</option>\n<option value="2">February</option>\n<option value="3">March</option>\n<option value="4">April</option>\n<option value="5">May</option>\n<option value="6" selected="selected">June</option>\n<option value="7">July</option>\n<option value="8">August</option>\n<option value="9">September</option>\n<option value="10">October</option>\n<option value="11">November</option>\n<option value="12">December</option>\n}
@@ -2138,7 +2138,7 @@ class DateHelperTest < ActionView::TestCase
     start_year = Time.now.year - 5
     end_year   = Time.now.year + 5
 
-    expected = '<input name="post[written_on(3i)]" type="hidden" id="post_written_on_3i" value="1" autocomplete="off"/>' + "\n"
+    expected = '<input name="post[written_on(3i)]" type="hidden" id="post_written_on_3i" value="1" autocomplete="off">' + "\n"
     expected << %{<select id="post_written_on_1i" name="post[written_on(1i)]">\n}
     expected << "<option value=\"\" label=\" \"></option>\n"
     start_year.upto(end_year) { |i| expected << %(<option value="#{i}">#{i}</option>\n) }
@@ -2162,8 +2162,8 @@ class DateHelperTest < ActionView::TestCase
     expected << "<option value=\"\" label=\" \"></option>\n"
     start_year.upto(end_year) { |i| expected << %(<option value="#{i}">#{i}</option>\n) }
     expected << "</select>\n"
-    expected << '<input name="post[written_on(2i)]" type="hidden" id="post_written_on_2i" value="1" autocomplete="off"/>' + "\n"
-    expected << '<input name="post[written_on(3i)]" type="hidden" id="post_written_on_3i" value="1" autocomplete="off"/>' + "\n"
+    expected << '<input name="post[written_on(2i)]" type="hidden" id="post_written_on_2i" value="1" autocomplete="off">' + "\n"
+    expected << '<input name="post[written_on(3i)]" type="hidden" id="post_written_on_3i" value="1" autocomplete="off">' + "\n"
 
     assert_dom_equal expected, date_select("post", "written_on", discard_month: true, include_blank: true)
   end
@@ -2171,7 +2171,7 @@ class DateHelperTest < ActionView::TestCase
   def test_date_select_with_nil_and_blank_and_discard_year
     @post = Post.new
 
-    expected = '<input id="post_written_on_1i" name="post[written_on(1i)]" type="hidden" value="1" autocomplete="off" />' + "\n"
+    expected = '<input id="post_written_on_1i" name="post[written_on(1i)]" type="hidden" value="1" autocomplete="off">' + "\n"
 
     expected << %{<select id="post_written_on_2i" name="post[written_on(2i)]">\n}
     expected << "<option value=\"\" label=\" \"></option>\n"
@@ -2309,7 +2309,7 @@ class DateHelperTest < ActionView::TestCase
     expected << %{<select id="post_written_on_2i" name="post[written_on(2i)]">\n}
     expected << %{<option value="1">January</option>\n<option value="2">February</option>\n<option value="3">March</option>\n<option value="4">April</option>\n<option value="5">May</option>\n<option value="6" selected="selected">June</option>\n<option value="7">July</option>\n<option value="8">August</option>\n<option value="9">September</option>\n<option value="10">October</option>\n<option value="11">November</option>\n<option value="12">December</option>\n}
     expected << "</select>\n"
-    expected << %{<input type="hidden" id="post_written_on_1i" name="post[written_on(1i)]" value="2004" autocomplete="off" />\n}
+    expected << %{<input type="hidden" id="post_written_on_1i" name="post[written_on(1i)]" value="2004" autocomplete="off">\n}
 
     assert_dom_equal expected, date_select("post", "written_on", order: [:day, :month, :year], discard_year: true, date_separator: " / ")
   end
@@ -2398,9 +2398,9 @@ class DateHelperTest < ActionView::TestCase
     @post = Post.new
     @post.written_on = Time.local(2004, 6, 15, 15, 16, 35)
 
-    expected = +%{<input type="hidden" id="post_written_on_1i" name="post[written_on(1i)]" value="2004" autocomplete="off" />\n}
-    expected << %{<input type="hidden" id="post_written_on_2i" name="post[written_on(2i)]" value="6" autocomplete="off" />\n}
-    expected << %{<input type="hidden" id="post_written_on_3i" name="post[written_on(3i)]" value="15" autocomplete="off" />\n}
+    expected = +%{<input type="hidden" id="post_written_on_1i" name="post[written_on(1i)]" value="2004" autocomplete="off">\n}
+    expected << %{<input type="hidden" id="post_written_on_2i" name="post[written_on(2i)]" value="6" autocomplete="off">\n}
+    expected << %{<input type="hidden" id="post_written_on_3i" name="post[written_on(3i)]" value="15" autocomplete="off">\n}
 
     expected << %(<select id="post_written_on_4i" name="post[written_on(4i)]">\n)
     0.upto(23) { |i| expected << %(<option value="#{sprintf("%02d", i)}"#{' selected="selected"' if i == 15}>#{sprintf("%02d", i)}</option>\n) }
@@ -2417,9 +2417,9 @@ class DateHelperTest < ActionView::TestCase
     @post = Post.new
     @post.written_on = Time.local(2004, 6, 15, 15, 16, 35)
 
-    expected = +%{<input type="hidden" id="post_written_on_1i" name="post[written_on(1i)]" value="2004" autocomplete="off" />\n}
-    expected << %{<input type="hidden" id="post_written_on_2i" name="post[written_on(2i)]" value="6" autocomplete="off" />\n}
-    expected << %{<input type="hidden" id="post_written_on_3i" name="post[written_on(3i)]" value="15" autocomplete="off" />\n}
+    expected = +%{<input type="hidden" id="post_written_on_1i" name="post[written_on(1i)]" value="2004" autocomplete="off">\n}
+    expected << %{<input type="hidden" id="post_written_on_2i" name="post[written_on(2i)]" value="6" autocomplete="off">\n}
+    expected << %{<input type="hidden" id="post_written_on_3i" name="post[written_on(3i)]" value="15" autocomplete="off">\n}
 
     expected << %(<select id="post_written_on_4i" name="post[written_on(4i)]">\n)
     0.upto(23) { |i| expected << %(<option value="#{sprintf("%02d", i)}"#{' selected="selected"' if i == 12}>#{sprintf("%02d", i)}</option>\n) }
@@ -2436,9 +2436,9 @@ class DateHelperTest < ActionView::TestCase
     @post = Post.new
     @post.written_on = Time.local(2004, 6, 15, 15, 16, 35)
 
-    expected = +%{<input type="hidden" id="post_written_on_1i" name="post[written_on(1i)]" value="1" autocomplete="off" />\n}
-    expected << %{<input type="hidden" id="post_written_on_2i" name="post[written_on(2i)]" value="1" autocomplete="off" />\n}
-    expected << %{<input type="hidden" id="post_written_on_3i" name="post[written_on(3i)]" value="1" autocomplete="off" />\n}
+    expected = +%{<input type="hidden" id="post_written_on_1i" name="post[written_on(1i)]" value="1" autocomplete="off">\n}
+    expected << %{<input type="hidden" id="post_written_on_2i" name="post[written_on(2i)]" value="1" autocomplete="off">\n}
+    expected << %{<input type="hidden" id="post_written_on_3i" name="post[written_on(3i)]" value="1" autocomplete="off">\n}
 
     expected << %(<select id="post_written_on_4i" name="post[written_on(4i)]">\n)
     0.upto(23) { |i| expected << %(<option value="#{sprintf("%02d", i)}">#{sprintf("%02d", i)}</option>\n) }
@@ -2470,9 +2470,9 @@ class DateHelperTest < ActionView::TestCase
     @post = Post.new
     @post.written_on = Time.local(2004, 6, 15, 15, 16, 35)
 
-    expected = +%{<input type="hidden" id="post_written_on_1i" name="post[written_on(1i)]" value="2004" autocomplete="off" />\n}
-    expected << %{<input type="hidden" id="post_written_on_2i" name="post[written_on(2i)]" value="6" autocomplete="off" />\n}
-    expected << %{<input type="hidden" id="post_written_on_3i" name="post[written_on(3i)]" value="15" autocomplete="off" />\n}
+    expected = +%{<input type="hidden" id="post_written_on_1i" name="post[written_on(1i)]" value="2004" autocomplete="off">\n}
+    expected << %{<input type="hidden" id="post_written_on_2i" name="post[written_on(2i)]" value="6" autocomplete="off">\n}
+    expected << %{<input type="hidden" id="post_written_on_3i" name="post[written_on(3i)]" value="15" autocomplete="off">\n}
 
     expected << %(<select id="post_written_on_4i" name="post[written_on(4i)]">\n)
     0.upto(23) { |i| expected << %(<option value="#{sprintf("%02d", i)}"#{' selected="selected"' if i == 15}>#{sprintf("%02d", i)}</option>\n) }
@@ -2493,9 +2493,9 @@ class DateHelperTest < ActionView::TestCase
     @post = Post.new
     @post.written_on = Time.local(2004, 6, 15, 15, 16, 35)
 
-    expected = +%{<input type="hidden" id="post_written_on_1i" name="post[written_on(1i)]" value="2004" autocomplete="off" />\n}
-    expected << %{<input type="hidden" id="post_written_on_2i" name="post[written_on(2i)]" value="6" autocomplete="off" />\n}
-    expected << %{<input type="hidden" id="post_written_on_3i" name="post[written_on(3i)]" value="15" autocomplete="off" />\n}
+    expected = +%{<input type="hidden" id="post_written_on_1i" name="post[written_on(1i)]" value="2004" autocomplete="off">\n}
+    expected << %{<input type="hidden" id="post_written_on_2i" name="post[written_on(2i)]" value="6" autocomplete="off">\n}
+    expected << %{<input type="hidden" id="post_written_on_3i" name="post[written_on(3i)]" value="15" autocomplete="off">\n}
 
     expected << %(<select id="post_written_on_4i" name="post[written_on(4i)]" class="selector">\n)
     0.upto(23) { |i| expected << %(<option value="#{sprintf("%02d", i)}"#{' selected="selected"' if i == 15}>#{sprintf("%02d", i)}</option>\n) }
@@ -2516,9 +2516,9 @@ class DateHelperTest < ActionView::TestCase
       concat f.time_select(:written_on, {}, { class: "selector" })
     end
 
-    expected = +%{<input type="hidden" id="post_written_on_1i" name="post[written_on(1i)]" value="2004" autocomplete="off" />\n}
-    expected << %{<input type="hidden" id="post_written_on_2i" name="post[written_on(2i)]" value="6" autocomplete="off" />\n}
-    expected << %{<input type="hidden" id="post_written_on_3i" name="post[written_on(3i)]" value="15" autocomplete="off" />\n}
+    expected = +%{<input type="hidden" id="post_written_on_1i" name="post[written_on(1i)]" value="2004" autocomplete="off">\n}
+    expected << %{<input type="hidden" id="post_written_on_2i" name="post[written_on(2i)]" value="6" autocomplete="off">\n}
+    expected << %{<input type="hidden" id="post_written_on_3i" name="post[written_on(3i)]" value="15" autocomplete="off">\n}
 
     expected << %(<select id="post_written_on_4i" name="post[written_on(4i)]" class="selector">\n)
     0.upto(23) { |i| expected << %(<option value="#{sprintf("%02d", i)}"#{' selected="selected"' if i == 15}>#{sprintf("%02d", i)}</option>\n) }
@@ -2535,9 +2535,9 @@ class DateHelperTest < ActionView::TestCase
     @post = Post.new
     @post.written_on = Time.local(2004, 6, 15, 15, 16, 35)
 
-    expected = +%{<input type="hidden" id="post_written_on_1i" name="post[written_on(1i)]" value="2004" autocomplete="off" />\n}
-    expected << %{<input type="hidden" id="post_written_on_2i" name="post[written_on(2i)]" value="6" autocomplete="off" />\n}
-    expected << %{<input type="hidden" id="post_written_on_3i" name="post[written_on(3i)]" value="15" autocomplete="off" />\n}
+    expected = +%{<input type="hidden" id="post_written_on_1i" name="post[written_on(1i)]" value="2004" autocomplete="off">\n}
+    expected << %{<input type="hidden" id="post_written_on_2i" name="post[written_on(2i)]" value="6" autocomplete="off">\n}
+    expected << %{<input type="hidden" id="post_written_on_3i" name="post[written_on(3i)]" value="15" autocomplete="off">\n}
 
     expected << %(<select id="post_written_on_4i" name="post[written_on(4i)]">\n)
     0.upto(23) { |i| expected << %(<option value="#{sprintf("%02d", i)}"#{' selected="selected"' if i == 15}>#{sprintf("%02d", i)}</option>\n) }
@@ -2562,9 +2562,9 @@ class DateHelperTest < ActionView::TestCase
     @post = Post.new
     @post.written_on = Time.local(2004, 6, 15, 15, 16, 35)
 
-    expected = +%{<input type="hidden" id="post_written_on_1i" name="post[written_on(1i)]" value="2004" autocomplete="off" />\n}
-    expected << %{<input type="hidden" id="post_written_on_2i" name="post[written_on(2i)]" value="6" autocomplete="off" />\n}
-    expected << %{<input type="hidden" id="post_written_on_3i" name="post[written_on(3i)]" value="15" autocomplete="off" />\n}
+    expected = +%{<input type="hidden" id="post_written_on_1i" name="post[written_on(1i)]" value="2004" autocomplete="off">\n}
+    expected << %{<input type="hidden" id="post_written_on_2i" name="post[written_on(2i)]" value="6" autocomplete="off">\n}
+    expected << %{<input type="hidden" id="post_written_on_3i" name="post[written_on(3i)]" value="15" autocomplete="off">\n}
 
     expected << %(<select id="post_written_on_4i" name="post[written_on(4i)]">\n)
     expected << %(<option value="">Hour</option>\n)
@@ -2583,9 +2583,9 @@ class DateHelperTest < ActionView::TestCase
     @post = Post.new
     @post.written_on = Time.local(2004, 6, 15, 15, 16, 35)
 
-    expected = +%{<input type="hidden" id="post_written_on_1i" name="post[written_on(1i)]" value="2004" autocomplete="off" />\n}
-    expected << %{<input type="hidden" id="post_written_on_2i" name="post[written_on(2i)]" value="6" autocomplete="off" />\n}
-    expected << %{<input type="hidden" id="post_written_on_3i" name="post[written_on(3i)]" value="15" autocomplete="off" />\n}
+    expected = +%{<input type="hidden" id="post_written_on_1i" name="post[written_on(1i)]" value="2004" autocomplete="off">\n}
+    expected << %{<input type="hidden" id="post_written_on_2i" name="post[written_on(2i)]" value="6" autocomplete="off">\n}
+    expected << %{<input type="hidden" id="post_written_on_3i" name="post[written_on(3i)]" value="15" autocomplete="off">\n}
 
     expected << %(<select id="post_written_on_4i" name="post[written_on(4i)]">\n)
     expected << %(<option value="">Choose hour</option>\n)
@@ -2604,9 +2604,9 @@ class DateHelperTest < ActionView::TestCase
     @post = Post.new
     @post.written_on = Time.local(2004, 6, 15, 15, 16, 35)
 
-    expected = +%{<input type="hidden" id="post_written_on_1i" name="post[written_on(1i)]" value="2004" autocomplete="off" />\n}
-    expected << %{<input type="hidden" id="post_written_on_2i" name="post[written_on(2i)]" value="6" autocomplete="off" />\n}
-    expected << %{<input type="hidden" id="post_written_on_3i" name="post[written_on(3i)]" value="15" autocomplete="off" />\n}
+    expected = +%{<input type="hidden" id="post_written_on_1i" name="post[written_on(1i)]" value="2004" autocomplete="off">\n}
+    expected << %{<input type="hidden" id="post_written_on_2i" name="post[written_on(2i)]" value="6" autocomplete="off">\n}
+    expected << %{<input type="hidden" id="post_written_on_3i" name="post[written_on(3i)]" value="15" autocomplete="off">\n}
 
     expected << %(<select id="post_written_on_4i" name="post[written_on(4i)]" class="hour">\n)
     0.upto(23) { |i| expected << %(<option value="#{sprintf("%02d", i)}"#{' selected="selected"' if i == 15}>#{sprintf("%02d", i)}</option>\n) }
@@ -2625,9 +2625,9 @@ class DateHelperTest < ActionView::TestCase
     @post = Post.new
     @post.written_on = Time.local(2004, 6, 15, 15, 16, 35)
 
-    expected = +%{<input type="hidden" id="post_written_on_1i" name="post[written_on(1i)]" value="2004" autocomplete="off" />\n}
-    expected << %{<input type="hidden" id="post_written_on_2i" name="post[written_on(2i)]" value="6" autocomplete="off" />\n}
-    expected << %{<input type="hidden" id="post_written_on_3i" name="post[written_on(3i)]" value="15" autocomplete="off" />\n}
+    expected = +%{<input type="hidden" id="post_written_on_1i" name="post[written_on(1i)]" value="2004" autocomplete="off">\n}
+    expected << %{<input type="hidden" id="post_written_on_2i" name="post[written_on(2i)]" value="6" autocomplete="off">\n}
+    expected << %{<input type="hidden" id="post_written_on_3i" name="post[written_on(3i)]" value="15" autocomplete="off">\n}
 
     expected << %(<select id="post_written_on_4i" name="post[written_on(4i)]" class="my-hour">\n)
     0.upto(23) { |i| expected << %(<option value="#{sprintf("%02d", i)}"#{' selected="selected"' if i == 15}>#{sprintf("%02d", i)}</option>\n) }
@@ -2646,9 +2646,9 @@ class DateHelperTest < ActionView::TestCase
     @post = Post.new
     @post.written_on = Time.local(2004, 6, 15, 15, 16, 35)
 
-    expected = +%{<input type="hidden" id="post_written_on_1i" disabled="disabled" name="post[written_on(1i)]" value="2004" autocomplete="off" />\n}
-    expected << %{<input type="hidden" id="post_written_on_2i" disabled="disabled" name="post[written_on(2i)]" value="6" autocomplete="off" />\n}
-    expected << %{<input type="hidden" id="post_written_on_3i" disabled="disabled" name="post[written_on(3i)]" value="15" autocomplete="off" />\n}
+    expected = +%{<input type="hidden" id="post_written_on_1i" disabled="disabled" name="post[written_on(1i)]" value="2004" autocomplete="off">\n}
+    expected << %{<input type="hidden" id="post_written_on_2i" disabled="disabled" name="post[written_on(2i)]" value="6" autocomplete="off">\n}
+    expected << %{<input type="hidden" id="post_written_on_3i" disabled="disabled" name="post[written_on(3i)]" value="15" autocomplete="off">\n}
 
     expected << %(<select id="post_written_on_4i" disabled="disabled" name="post[written_on(4i)]">\n)
     0.upto(23) { |i| expected << %(<option value="#{sprintf("%02d", i)}"#{' selected="selected"' if i == 15}>#{sprintf("%02d", i)}</option>\n) }
@@ -2723,7 +2723,7 @@ class DateHelperTest < ActionView::TestCase
     @post = Post.new
     @post.updated_at = Time.local(2004, 6, 15, 16, 35)
 
-    expected = '<input id="post_updated_at_1i" name="post[updated_at(1i)]" type="hidden" value="1" autocomplete="off" />' + "\n"
+    expected = '<input id="post_updated_at_1i" name="post[updated_at(1i)]" type="hidden" value="1" autocomplete="off">' + "\n"
 
     expected << %{<select id="post_updated_at_2i" name="post[updated_at(2i)]">\n}
     expected << %{<option value="1">January</option>\n<option value="2">February</option>\n<option value="3">March</option>\n<option value="4">April</option>\n<option value="5">May</option>\n<option value="6">June</option>\n<option value="7">July</option>\n<option value="8">August</option>\n<option value="9">September</option>\n<option value="10">October</option>\n<option value="11">November</option>\n<option value="12">December</option>\n}
@@ -3195,7 +3195,7 @@ class DateHelperTest < ActionView::TestCase
     @post = Post.new
     @post.updated_at = Time.local(2004, 6, 15, 15, 16, 35)
 
-    expected = +%{<input type="hidden" id="post_updated_at_1i" name="post[updated_at(1i)]" value="2004" autocomplete="off" />\n}
+    expected = +%{<input type="hidden" id="post_updated_at_1i" name="post[updated_at(1i)]" value="2004" autocomplete="off">\n}
     expected << %{<select id="post_updated_at_2i" name="post[updated_at(2i)]">\n}
     1.upto(12) { |i| expected << %(<option value="#{i}"#{' selected="selected"' if i == 6}>#{Date::MONTHNAMES[i]}</option>\n) }
     expected << "</select>\n"
@@ -3223,8 +3223,8 @@ class DateHelperTest < ActionView::TestCase
     expected = +%{<select id="post_updated_at_1i" name="post[updated_at(1i)]">\n}
     1999.upto(2009) { |i| expected << %(<option value="#{i}"#{' selected="selected"' if i == 2004}>#{i}</option>\n) }
     expected << "</select>\n"
-    expected << %{<input type="hidden" id="post_updated_at_2i" name="post[updated_at(2i)]" value="6" autocomplete="off" />\n}
-    expected << %{<input type="hidden" id="post_updated_at_3i" name="post[updated_at(3i)]" value="1" autocomplete="off" />\n}
+    expected << %{<input type="hidden" id="post_updated_at_2i" name="post[updated_at(2i)]" value="6" autocomplete="off">\n}
+    expected << %{<input type="hidden" id="post_updated_at_3i" name="post[updated_at(3i)]" value="1" autocomplete="off">\n}
 
     expected << " &mdash; "
 
@@ -3243,9 +3243,9 @@ class DateHelperTest < ActionView::TestCase
     @post = Post.new
     @post.updated_at = Time.local(2004, 6, 15, 15, 16, 35)
 
-    expected = +%{<input type="hidden" id="post_updated_at_1i" name="post[updated_at(1i)]" value="2004" autocomplete="off" />\n}
-    expected << %{<input type="hidden" id="post_updated_at_2i" name="post[updated_at(2i)]" value="6" autocomplete="off" />\n}
-    expected << %{<input type="hidden" id="post_updated_at_3i" name="post[updated_at(3i)]" value="1" autocomplete="off" />\n}
+    expected = +%{<input type="hidden" id="post_updated_at_1i" name="post[updated_at(1i)]" value="2004" autocomplete="off">\n}
+    expected << %{<input type="hidden" id="post_updated_at_2i" name="post[updated_at(2i)]" value="6" autocomplete="off">\n}
+    expected << %{<input type="hidden" id="post_updated_at_3i" name="post[updated_at(3i)]" value="1" autocomplete="off">\n}
 
     expected << %{<select id="post_updated_at_4i" name="post[updated_at(4i)]">\n}
     0.upto(23) { |i| expected << %(<option value="#{sprintf("%02d", i)}"#{' selected="selected"' if i == 15}>#{sprintf("%02d", i)}</option>\n) }
@@ -3262,9 +3262,9 @@ class DateHelperTest < ActionView::TestCase
     @post = Post.new
     @post.updated_at = Time.local(2004, 6, 15, 15, 16, 35)
 
-    expected = +%{<input type="hidden" id="post_updated_at_1i" disabled="disabled" name="post[updated_at(1i)]" value="2004" autocomplete="off" />\n}
-    expected << %{<input type="hidden" id="post_updated_at_2i" disabled="disabled" name="post[updated_at(2i)]" value="6" autocomplete="off" />\n}
-    expected << %{<input type="hidden" id="post_updated_at_3i" disabled="disabled" name="post[updated_at(3i)]" value="1" autocomplete="off" />\n}
+    expected = +%{<input type="hidden" id="post_updated_at_1i" disabled="disabled" name="post[updated_at(1i)]" value="2004" autocomplete="off">\n}
+    expected << %{<input type="hidden" id="post_updated_at_2i" disabled="disabled" name="post[updated_at(2i)]" value="6" autocomplete="off">\n}
+    expected << %{<input type="hidden" id="post_updated_at_3i" disabled="disabled" name="post[updated_at(3i)]" value="1" autocomplete="off">\n}
 
     expected << %{<select id="post_updated_at_4i" disabled="disabled" name="post[updated_at(4i)]">\n}
     0.upto(23) { |i| expected << %(<option value="#{sprintf("%02d", i)}"#{' selected="selected"' if i == 15}>#{sprintf("%02d", i)}</option>\n) }
@@ -3313,7 +3313,7 @@ class DateHelperTest < ActionView::TestCase
     expected << %{<select id="post_updated_at_4i" name="post[updated_at(4i)]">\n}
     0.upto(23) { |i| expected << %(<option value="#{sprintf("%02d", i)}"#{' selected="selected"' if i == 15}>#{sprintf("%02d", i)}</option>\n) }
     expected << "</select>\n"
-    expected << %{<input type="hidden" id="post_updated_at_5i" name="post[updated_at(5i)]" value="16" autocomplete="off" />\n}
+    expected << %{<input type="hidden" id="post_updated_at_5i" name="post[updated_at(5i)]" value="16" autocomplete="off">\n}
 
     assert_dom_equal expected, datetime_select("post", "updated_at", discard_minute: true)
   end
@@ -3337,7 +3337,7 @@ class DateHelperTest < ActionView::TestCase
     expected << %{<select id="post_updated_at_4i" disabled="disabled" name="post[updated_at(4i)]">\n}
     0.upto(23) { |i| expected << %(<option value="#{sprintf("%02d", i)}"#{' selected="selected"' if i == 15}>#{sprintf("%02d", i)}</option>\n) }
     expected << "</select>\n"
-    expected << %{<input type="hidden" id="post_updated_at_5i" disabled="disabled" name="post[updated_at(5i)]" value="16" autocomplete="off" />\n}
+    expected << %{<input type="hidden" id="post_updated_at_5i" disabled="disabled" name="post[updated_at(5i)]" value="16" autocomplete="off">\n}
 
     assert_dom_equal expected, datetime_select("post", "updated_at", discard_minute: true, disabled: true)
   end
@@ -3373,7 +3373,7 @@ class DateHelperTest < ActionView::TestCase
     @post = Post.new
     @post.updated_at = Time.local(2004, 6, 15, 15, 16, 35)
 
-    expected = +%{<input type="hidden" id="post_updated_at_1i" name="post[updated_at(1i)]" value="2004" autocomplete="off" />\n}
+    expected = +%{<input type="hidden" id="post_updated_at_1i" name="post[updated_at(1i)]" value="2004" autocomplete="off">\n}
     expected << %{<select id="post_updated_at_3i" name="post[updated_at(3i)]">\n}
     1.upto(31) { |i| expected << %(<option value="#{i}"#{' selected="selected"' if i == 15}>#{i}</option>\n) }
     expected << "</select>\n"

--- a/actionview/test/template/form_helper/form_with_test.rb
+++ b/actionview/test/template/form_helper/form_with_test.rb
@@ -39,11 +39,11 @@ class FormWithActsLikeFormTagTest < FormWithTest
 
     (+"").tap do |txt|
       unless skip_enforcing_utf8
-        txt << %{<input name="utf8" type="hidden" value="&#x2713;" autocomplete="off" />}
+        txt << %{<input name="utf8" type="hidden" value="&#x2713;" autocomplete="off">}
       end
 
       if method && !%w(get post).include?(method.to_s)
-        txt << %{<input name="_method" type="hidden" value="#{method}" autocomplete="off" />}
+        txt << %{<input name="_method" type="hidden" value="#{method}" autocomplete="off">}
       end
     end
   end
@@ -362,12 +362,12 @@ class FormWithActsLikeFormForTest < FormWithTest
 
     expected = whole_form("/posts/123", "create-post", method: "patch") do
       "<label for='post_title'>The Title</label>" \
-      "<input name='post[title]' type='text' value='Hello World' id='post_title' />" \
+      "<input name='post[title]' type='text' value='Hello World' id='post_title'>" \
       "<textarea name='post[body]' id='post_body'>\nBack to the hill and over it again!</textarea>" \
-      "<input name='post[secret]' type='hidden' value='0' autocomplete='off' />" \
-      "<input name='post[secret]' checked='checked' type='checkbox' value='1' id='post_secret' />" \
+      "<input name='post[secret]' type='hidden' value='0' autocomplete='off'>" \
+      "<input name='post[secret]' checked='checked' type='checkbox' value='1' id='post_secret'>" \
       "<select name='post[category]' id='post_category'><option value='animal'>animal</option>\n<option value='economy'>economy</option>\n<option value='sports'>sports</option></select>" \
-      "<input name='commit' data-disable-with='Create post' type='submit' value='Create post' />" \
+      "<input name='commit' data-disable-with='Create post' type='submit' value='Create post'>" \
       "<button name='button' type='submit'>Create post</button>" \
       "<button name='button' type='submit'><span>Create post</span></button>"
     end
@@ -422,12 +422,12 @@ class FormWithActsLikeFormForTest < FormWithTest
 
     expected = whole_form("/posts/123", "create-post", method: "patch") do
       "<label>The Title</label>" \
-      "<input name='post[title]' type='text' value='Hello World' />" \
+      "<input name='post[title]' type='text' value='Hello World'>" \
       "<textarea name='post[body]'>\nBack to the hill and over it again!</textarea>" \
-      "<input name='post[secret]' type='hidden' value='0' autocomplete='off' />" \
-      "<input name='post[secret]' checked='checked' type='checkbox' value='1' />" \
+      "<input name='post[secret]' type='hidden' value='0' autocomplete='off'>" \
+      "<input name='post[secret]' checked='checked' type='checkbox' value='1'>" \
       "<select name='post[category]'><option value='animal'>animal</option>\n<option value='economy'>economy</option>\n<option value='sports'>sports</option></select>" \
-      "<input name='commit' data-disable-with='Create post' type='submit' value='Create post' />"
+      "<input name='commit' data-disable-with='Create post' type='submit' value='Create post'>"
     end
 
     assert_dom_equal expected, @rendered
@@ -547,10 +547,10 @@ class FormWithActsLikeFormForTest < FormWithTest
     end
 
     expected = whole_form("/posts") do
-      "<input type='hidden' name='post[active]' value='' autocomplete='off' />" \
-      "<input name='post[active]' type='radio' value='true' id='post_active_true' />" \
+      "<input type='hidden' name='post[active]' value='' autocomplete='off'>" \
+      "<input name='post[active]' type='radio' value='true' id='post_active_true'>" \
       "<label for='post_active_true'>true</label>" \
-      "<input checked='checked' name='post[active]' type='radio' value='false' id='post_active_false' />" \
+      "<input checked='checked' name='post[active]' type='radio' value='false' id='post_active_false'>" \
       "<label for='post_active_false'>false</label>"
     end
 
@@ -569,12 +569,12 @@ class FormWithActsLikeFormForTest < FormWithTest
     end
 
     expected = whole_form("/posts") do
-      "<input type='hidden' name='post[active]' value='' autocomplete='off' />" \
+      "<input type='hidden' name='post[active]' value='' autocomplete='off'>" \
       "<label for='post_active_true'>" \
-      "<input name='post[active]' type='radio' value='true' id='post_active_true' />" \
+      "<input name='post[active]' type='radio' value='true' id='post_active_true'>" \
       "true</label>" \
       "<label for='post_active_false'>" \
-      "<input checked='checked' name='post[active]' type='radio' value='false' id='post_active_false' />" \
+      "<input checked='checked' name='post[active]' type='radio' value='false' id='post_active_false'>" \
       "false</label>"
     end
 
@@ -595,14 +595,14 @@ class FormWithActsLikeFormForTest < FormWithTest
     end
 
     expected = whole_form("/posts") do
-      "<input type='hidden' name='post[active]' value='' autocomplete='off' />" \
+      "<input type='hidden' name='post[active]' value='' autocomplete='off'>" \
       "<label for='post_active_true'>" \
-      "<input name='post[active]' type='radio' value='true' id='post_active_true' />" \
+      "<input name='post[active]' type='radio' value='true' id='post_active_true'>" \
       "true</label>" \
       "<label for='post_active_false'>" \
-      "<input checked='checked' name='post[active]' type='radio' value='false' id='post_active_false' />" \
+      "<input checked='checked' name='post[active]' type='radio' value='false' id='post_active_false'>" \
       "false</label>" \
-      "<input name='post[id]' type='hidden' value='1' id='post_id' autocomplete='off' />"
+      "<input name='post[id]' type='hidden' value='1' id='post_id' autocomplete='off'>"
     end
 
     assert_dom_equal expected, @rendered
@@ -617,10 +617,10 @@ class FormWithActsLikeFormForTest < FormWithTest
     end
 
     expected = whole_form("/posts") do
-      "<input type='hidden' name='post[1][active]' value='' autocomplete='off' />" \
-      "<input name='post[1][active]' type='radio' value='true' id='post_1_active_true' />" \
+      "<input type='hidden' name='post[1][active]' value='' autocomplete='off'>" \
+      "<input name='post[1][active]' type='radio' value='true' id='post_1_active_true'>" \
       "<label for='post_1_active_true'>true</label>" \
-      "<input checked='checked' name='post[1][active]' type='radio' value='false' id='post_1_active_false' />" \
+      "<input checked='checked' name='post[1][active]' type='radio' value='false' id='post_1_active_false'>" \
       "<label for='post_1_active_false'>false</label>"
     end
 
@@ -636,12 +636,12 @@ class FormWithActsLikeFormForTest < FormWithTest
     end
 
     expected = whole_form("/posts") do
-      "<input name='post[tag_ids][]' type='hidden' value='' autocomplete='off' />" \
-      "<input checked='checked' name='post[tag_ids][]' type='checkbox' value='1' id='post_tag_ids_1' />" \
+      "<input name='post[tag_ids][]' type='hidden' value='' autocomplete='off'>" \
+      "<input checked='checked' name='post[tag_ids][]' type='checkbox' value='1' id='post_tag_ids_1'>" \
       "<label for='post_tag_ids_1'>Tag 1</label>" \
-      "<input name='post[tag_ids][]' type='checkbox' value='2' id='post_tag_ids_2' />" \
+      "<input name='post[tag_ids][]' type='checkbox' value='2' id='post_tag_ids_2'>" \
       "<label for='post_tag_ids_2'>Tag 2</label>" \
-      "<input checked='checked' name='post[tag_ids][]' type='checkbox' value='3' id='post_tag_ids_3' />" \
+      "<input checked='checked' name='post[tag_ids][]' type='checkbox' value='3' id='post_tag_ids_3'>" \
       "<label for='post_tag_ids_3'>Tag 3</label>"
     end
 
@@ -660,15 +660,15 @@ class FormWithActsLikeFormForTest < FormWithTest
     end
 
     expected = whole_form("/posts") do
-      "<input name='post[tag_ids][]' type='hidden' value='' autocomplete='off' />" \
+      "<input name='post[tag_ids][]' type='hidden' value='' autocomplete='off'>" \
       "<label for='post_tag_ids_1'>" \
-      "<input checked='checked' name='post[tag_ids][]' type='checkbox' value='1' id='post_tag_ids_1' />" \
+      "<input checked='checked' name='post[tag_ids][]' type='checkbox' value='1' id='post_tag_ids_1'>" \
       "Tag 1</label>" \
       "<label for='post_tag_ids_2'>" \
-      "<input name='post[tag_ids][]' type='checkbox' value='2' id='post_tag_ids_2' />" \
+      "<input name='post[tag_ids][]' type='checkbox' value='2' id='post_tag_ids_2'>" \
       "Tag 2</label>" \
       "<label for='post_tag_ids_3'>" \
-      "<input checked='checked' name='post[tag_ids][]' type='checkbox' value='3' id='post_tag_ids_3' />" \
+      "<input checked='checked' name='post[tag_ids][]' type='checkbox' value='3' id='post_tag_ids_3'>" \
       "Tag 3</label>"
     end
 
@@ -690,17 +690,17 @@ class FormWithActsLikeFormForTest < FormWithTest
     end
 
     expected = whole_form("/posts") do
-      "<input name='post[tag_ids][]' type='hidden' value='' autocomplete='off' />" \
+      "<input name='post[tag_ids][]' type='hidden' value='' autocomplete='off'>" \
       "<label for='post_tag_ids_1'>" \
-      "<input checked='checked' name='post[tag_ids][]' type='checkbox' value='1' id='post_tag_ids_1' />" \
+      "<input checked='checked' name='post[tag_ids][]' type='checkbox' value='1' id='post_tag_ids_1'>" \
       "Tag 1</label>" \
       "<label for='post_tag_ids_2'>" \
-      "<input name='post[tag_ids][]' type='checkbox' value='2' id='post_tag_ids_2' />" \
+      "<input name='post[tag_ids][]' type='checkbox' value='2' id='post_tag_ids_2'>" \
       "Tag 2</label>" \
       "<label for='post_tag_ids_3'>" \
-      "<input checked='checked' name='post[tag_ids][]' type='checkbox' value='3' id='post_tag_ids_3' />" \
+      "<input checked='checked' name='post[tag_ids][]' type='checkbox' value='3' id='post_tag_ids_3'>" \
       "Tag 3</label>" \
-      "<input name='post[id]' type='hidden' value='1' id='post_id' autocomplete='off' />"
+      "<input name='post[id]' type='hidden' value='1' id='post_id' autocomplete='off'>"
     end
 
     assert_dom_equal expected, @rendered
@@ -716,8 +716,8 @@ class FormWithActsLikeFormForTest < FormWithTest
     end
 
     expected = whole_form("/posts") do
-      "<input name='post[1][tag_ids][]' type='hidden' value='' autocomplete='off' />" \
-      "<input checked='checked' name='post[1][tag_ids][]' type='checkbox' value='1' id='post_1_tag_ids_1' />" \
+      "<input name='post[1][tag_ids][]' type='hidden' value='' autocomplete='off'>" \
+      "<input checked='checked' name='post[1][tag_ids][]' type='checkbox' value='1' id='post_1_tag_ids_1'>" \
       "<label for='post_1_tag_ids_1'>Tag 1</label>"
     end
 
@@ -730,7 +730,7 @@ class FormWithActsLikeFormForTest < FormWithTest
     end
 
     expected = whole_form("/posts/123", "create-post", method: "patch", multipart: true) do
-      "<input name='post[file]' type='file' id='post_file' />"
+      "<input name='post[file]' type='file' id='post_file'>"
     end
 
     assert_dom_equal expected, @rendered
@@ -744,7 +744,7 @@ class FormWithActsLikeFormForTest < FormWithTest
     end
 
     expected = whole_form("/posts/123", method: "patch", multipart: true) do
-      "<input name='post[comment][file]' type='file' id='post_comment_file'/>"
+      "<input name='post[comment][file]' type='file' id='post_comment_file'>"
     end
 
     assert_dom_equal expected, @rendered
@@ -783,8 +783,8 @@ class FormWithActsLikeFormForTest < FormWithTest
     end
 
     expected = whole_form("/posts/44", method: "patch") do
-      "<input name='post[title]' type='text' value='And his name will be forty and four.' id='post_title' />" \
-      "<input name='commit' data-disable-with='Edit post' type='submit' value='Edit post' />"
+      "<input name='post[title]' type='text' value='And his name will be forty and four.' id='post_title'>" \
+      "<input name='commit' data-disable-with='Edit post' type='submit' value='Edit post'>"
     end
 
     assert_dom_equal expected, @rendered
@@ -801,11 +801,11 @@ class FormWithActsLikeFormForTest < FormWithTest
 
     expected = whole_form("/posts/123", "create-post", method: "patch") do
       "<label for='other_name_title' class='post_title'>Title</label>" \
-      "<input name='other_name[title]' value='Hello World' type='text' id='other_name_title' />" \
+      "<input name='other_name[title]' value='Hello World' type='text' id='other_name_title'>" \
       "<textarea name='other_name[body]' id='other_name_body'>\nBack to the hill and over it again!</textarea>" \
-      "<input name='other_name[secret]' value='0' type='hidden' autocomplete='off' />" \
-      "<input name='other_name[secret]' checked='checked' value='1' type='checkbox' id='other_name_secret' />" \
-      "<input name='commit' value='Create post' data-disable-with='Create post' type='submit' />"
+      "<input name='other_name[secret]' value='0' type='hidden' autocomplete='off'>" \
+      "<input name='other_name[secret]' checked='checked' value='1' type='checkbox' id='other_name_secret'>" \
+      "<input name='commit' value='Create post' data-disable-with='Create post' type='submit'>"
     end
 
     assert_dom_equal expected, @rendered
@@ -819,10 +819,10 @@ class FormWithActsLikeFormForTest < FormWithTest
     end
 
     expected = whole_form("/", "create-post", method: "delete") do
-      "<input name='post[title]' type='text' value='Hello World' id='post_title' />" \
+      "<input name='post[title]' type='text' value='Hello World' id='post_title'>" \
       "<textarea name='post[body]' id='post_body'>\nBack to the hill and over it again!</textarea>" \
-      "<input name='post[secret]' type='hidden' value='0' autocomplete='off' />" \
-      "<input name='post[secret]' checked='checked' type='checkbox' value='1' id='post_secret'/>"
+      "<input name='post[secret]' type='hidden' value='0' autocomplete='off'>" \
+      "<input name='post[secret]' checked='checked' type='checkbox' value='1' id='post_secret'>"
     end
 
     assert_dom_equal expected, @rendered
@@ -836,10 +836,10 @@ class FormWithActsLikeFormForTest < FormWithTest
     end
 
     expected = whole_form("/", "create-post", method: "delete") do
-      "<input name='post[title]' type='text' value='Hello World' id='post_title' />" \
+      "<input name='post[title]' type='text' value='Hello World' id='post_title'>" \
       "<textarea name='post[body]' id='post_body' >\nBack to the hill and over it again!</textarea>" \
-      "<input name='post[secret]' type='hidden' value='0' autocomplete='off' />" \
-      "<input name='post[secret]' checked='checked' type='checkbox' value='1' id='post_secret' />"
+      "<input name='post[secret]' type='hidden' value='0' autocomplete='off'>" \
+      "<input name='post[secret]' checked='checked' type='checkbox' value='1' id='post_secret'>"
     end
 
     assert_dom_equal expected, @rendered
@@ -853,7 +853,7 @@ class FormWithActsLikeFormForTest < FormWithTest
     end
 
     expected = whole_form("/search", "search-post", method: "get") do
-      "<input name='post[title]' type='search' id='post_title' />"
+      "<input name='post[title]' type='search' id='post_title'>"
     end
 
     assert_dom_equal expected, @rendered
@@ -867,10 +867,10 @@ class FormWithActsLikeFormForTest < FormWithTest
     end
 
     expected = whole_form("/", "create-post", method: "patch") do
-      "<input name='post[title]' type='text' value='Hello World' id='post_title' />" \
+      "<input name='post[title]' type='text' value='Hello World' id='post_title'>" \
       "<textarea name='post[body]' id='post_body' >\nBack to the hill and over it again!</textarea>" \
-      "<input name='post[secret]' type='hidden' value='0' autocomplete='off' />" \
-      "<input name='post[secret]' checked='checked' type='checkbox' value='1' id='post_secret' />"
+      "<input name='post[secret]' type='hidden' value='0' autocomplete='off'>" \
+      "<input name='post[secret]' checked='checked' type='checkbox' value='1' id='post_secret'>"
     end
 
     assert_dom_equal expected, @rendered
@@ -887,10 +887,10 @@ class FormWithActsLikeFormForTest < FormWithTest
     end
 
     expected = whole_form("/", "create-post", method: "patch", local: true) do
-      "<input name='post[title]' type='text' value='Hello World' id='post_title' />" \
+      "<input name='post[title]' type='text' value='Hello World' id='post_title'>" \
       "<textarea name='post[body]' id='post_body'>\nBack to the hill and over it again!</textarea>" \
-      "<input name='post[secret]' type='hidden' value='0' autocomplete='off' />" \
-      "<input name='post[secret]' checked='checked' type='checkbox' value='1' id='post_secret' />"
+      "<input name='post[secret]' type='hidden' value='0' autocomplete='off'>" \
+      "<input name='post[secret]' checked='checked' type='checkbox' value='1' id='post_secret'>"
     end
 
     assert_dom_equal expected, @rendered
@@ -904,7 +904,7 @@ class FormWithActsLikeFormForTest < FormWithTest
     end
 
     expected = whole_form("/", skip_enforcing_utf8: true) do
-      "<input name='post[title]' type='text' value='Hello World' id='post_title' />"
+      "<input name='post[title]' type='text' value='Hello World' id='post_title'>"
     end
 
     assert_dom_equal expected, @rendered
@@ -916,7 +916,7 @@ class FormWithActsLikeFormForTest < FormWithTest
     end
 
     expected = whole_form("/", skip_enforcing_utf8: false) do
-      "<input name='post[title]' type='text' value='Hello World' id='post_title' />"
+      "<input name='post[title]' type='text' value='Hello World' id='post_title'>"
     end
 
     assert_dom_equal expected, @rendered
@@ -929,7 +929,7 @@ class FormWithActsLikeFormForTest < FormWithTest
       end
 
       expected = whole_form("/", skip_enforcing_utf8: false) do
-        "<input name='post[title]' type='text' value='Hello World' id='post_title' />"
+        "<input name='post[title]' type='text' value='Hello World' id='post_title'>"
       end
 
       assert_dom_equal expected, @rendered
@@ -943,7 +943,7 @@ class FormWithActsLikeFormForTest < FormWithTest
       end
 
       expected = whole_form("/", skip_enforcing_utf8: true) do
-        "<input name='post[title]' type='text' value='Hello World' id='post_title' />"
+        "<input name='post[title]' type='text' value='Hello World' id='post_title'>"
       end
 
       assert_dom_equal expected, @rendered
@@ -958,10 +958,10 @@ class FormWithActsLikeFormForTest < FormWithTest
     end
 
     expected = whole_form("/", "create-post") do
-      "<input name='post[title]' type='text' value='Hello World' id='post_title' />" \
+      "<input name='post[title]' type='text' value='Hello World' id='post_title'>" \
       "<textarea name='post[body]' id='post_body' >\nBack to the hill and over it again!</textarea>" \
-      "<input name='post[secret]' type='hidden' value='0' autocomplete='off' />" \
-      "<input name='post[secret]' checked='checked' type='checkbox' value='1' id='post_secret' />"
+      "<input name='post[secret]' type='hidden' value='0' autocomplete='off'>" \
+      "<input name='post[secret]' checked='checked' type='checkbox' value='1' id='post_secret'>"
     end
 
     assert_dom_equal expected, @rendered
@@ -977,10 +977,10 @@ class FormWithActsLikeFormForTest < FormWithTest
 
     expected = whole_form("/posts/123", method: "patch") do
       "<label for='post_123_title'>Title</label>" \
-      "<input name='post[123][title]' type='text' value='Hello World' id='post_123_title' />" \
+      "<input name='post[123][title]' type='text' value='Hello World' id='post_123_title'>" \
       "<textarea name='post[123][body]' id='post_123_body'>\nBack to the hill and over it again!</textarea>" \
-      "<input name='post[123][secret]' type='hidden' value='0' autocomplete='off' />" \
-      "<input name='post[123][secret]' checked='checked' type='checkbox' value='1' id='post_123_secret' />"
+      "<input name='post[123][secret]' type='hidden' value='0' autocomplete='off'>" \
+      "<input name='post[123][secret]' checked='checked' type='checkbox' value='1' id='post_123_secret'>"
     end
 
     assert_dom_equal expected, @rendered
@@ -994,10 +994,10 @@ class FormWithActsLikeFormForTest < FormWithTest
     end
 
     expected = whole_form("/posts/123", method: "patch") do
-      "<input name='post[][title]' type='text' value='Hello World' id='post__title' />" \
+      "<input name='post[][title]' type='text' value='Hello World' id='post__title'>" \
       "<textarea name='post[][body]' id='post__body' >\nBack to the hill and over it again!</textarea>" \
-      "<input name='post[][secret]' type='hidden' value='0' autocomplete='off' />" \
-      "<input name='post[][secret]' checked='checked' type='checkbox' value='1' id='post__secret' />"
+      "<input name='post[][secret]' type='hidden' value='0' autocomplete='off'>" \
+      "<input name='post[][secret]' checked='checked' type='checkbox' value='1' id='post__secret'>"
     end
 
     assert_dom_equal expected, @rendered
@@ -1060,8 +1060,8 @@ class FormWithActsLikeFormForTest < FormWithTest
 
     expected = whole_form("/posts/123", method: "patch") do
       "<div class='field_with_errors'><label for='post_author_name' class='label'>Author name</label></div>" \
-      "<div class='field_with_errors'><input name='post[author_name]' type='text' value='' id='post_author_name' /></div>" \
-      "<input name='commit' data-disable-with='Create post' type='submit' value='Create post' />"
+      "<div class='field_with_errors'><input name='post[author_name]' type='text' value='' id='post_author_name'></div>" \
+      "<input name='commit' data-disable-with='Create post' type='submit' value='Create post'>"
     end
 
     assert_dom_equal expected, @rendered
@@ -1078,8 +1078,8 @@ class FormWithActsLikeFormForTest < FormWithTest
 
     expected = whole_form("/posts/123", method: "patch") do
       "<div class='field_with_errors'><label for='post_author_name' class='label'>Author name</label></div>" \
-      "<div class='field_with_errors'><input name='post[author_name]' type='text' value='' id='post_author_name' /></div>" \
-      "<input name='commit' data-disable-with='Create post' type='submit' value='Create post' />"
+      "<div class='field_with_errors'><input name='post[author_name]' type='text' value='' id='post_author_name'></div>" \
+      "<input name='commit' data-disable-with='Create post' type='submit' value='Create post'>"
     end
 
     assert_dom_equal expected, @rendered
@@ -1108,7 +1108,7 @@ class FormWithActsLikeFormForTest < FormWithTest
         end
 
         expected = whole_form("/posts") do
-          "<input name='commit' data-disable-with='Create Post' type='submit' value='Create Post' />"
+          "<input name='commit' data-disable-with='Create Post' type='submit' value='Create Post'>"
         end
 
         assert_dom_equal expected, @rendered
@@ -1123,7 +1123,7 @@ class FormWithActsLikeFormForTest < FormWithTest
       end
 
       expected = whole_form("/posts/123", method: "patch") do
-        "<input name='commit' data-disable-with='Confirm Post changes' type='submit' value='Confirm Post changes' />"
+        "<input name='commit' data-disable-with='Confirm Post changes' type='submit' value='Confirm Post changes'>"
       end
 
       assert_dom_equal expected, @rendered
@@ -1137,7 +1137,7 @@ class FormWithActsLikeFormForTest < FormWithTest
       end
 
       expected = whole_form do
-        "<input name='commit' class='extra' data-disable-with='Save changes' type='submit' value='Save changes' />"
+        "<input name='commit' class='extra' data-disable-with='Save changes' type='submit' value='Save changes'>"
       end
 
       assert_dom_equal expected, @rendered
@@ -1151,7 +1151,7 @@ class FormWithActsLikeFormForTest < FormWithTest
       end
 
       expected = whole_form("/posts/123", method: "patch") do
-        "<input name='commit' data-disable-with='Update your Post' type='submit' value='Update your Post' />"
+        "<input name='commit' data-disable-with='Update your Post' type='submit' value='Update your Post'>"
       end
 
       assert_dom_equal expected, @rendered
@@ -1166,7 +1166,7 @@ class FormWithActsLikeFormForTest < FormWithTest
       end
 
       expected = whole_form("/posts/44", method: "patch") do
-        "<input name='commit' data-disable-with='Update your Post' type='submit' value='Update your Post' />"
+        "<input name='commit' data-disable-with='Update your Post' type='submit' value='Update your Post'>"
       end
 
       assert_dom_equal expected, @rendered
@@ -1216,7 +1216,7 @@ class FormWithActsLikeFormForTest < FormWithTest
     end
 
     expected = whole_form("/posts/123", method: "patch") do
-      "<input name='post[comment][body]' type='text' value='Hello World' id='post_comment_body' />"
+      "<input name='post[comment][body]' type='text' value='Hello World' id='post_comment_body'>"
     end
 
     assert_dom_equal expected, @rendered
@@ -1236,7 +1236,7 @@ class FormWithActsLikeFormForTest < FormWithTest
     end
 
     expected = whole_form do
-      "<input name='posts[post][0][comment][1][name]' type='text' value='comment #1' id='posts_post_0_comment_1_name' />"
+      "<input name='posts[post][0][comment][1][name]' type='text' value='comment #1' id='posts_post_0_comment_1_name'>"
     end
 
     assert_dom_equal expected, @rendered
@@ -1251,8 +1251,8 @@ class FormWithActsLikeFormForTest < FormWithTest
     end
 
     expected = whole_form("/posts/123", method: "patch") do
-      "<input name='post[123][title]' type='text' value='Hello World' id='post_123_title' />" \
-      "<input name='post[123][comment][][name]' type='text' value='new comment' id='post_123_comment__name' />"
+      "<input name='post[123][title]' type='text' value='Hello World' id='post_123_title'>" \
+      "<input name='post[123][comment][][name]' type='text' value='new comment' id='post_123_comment__name'>"
     end
 
     assert_dom_equal expected, @rendered
@@ -1267,8 +1267,8 @@ class FormWithActsLikeFormForTest < FormWithTest
     end
 
     expected = whole_form("/posts/123", method: "patch") do
-      "<input name='post[1][title]' type='text' value='Hello World' id='post_1_title' />" \
-      "<input name='post[1][comment][1][name]' type='text' value='new comment' id='post_1_comment_1_name' />"
+      "<input name='post[1][title]' type='text' value='Hello World' id='post_1_title'>" \
+      "<input name='post[1][comment][1][name]' type='text' value='new comment' id='post_1_comment_1_name'>"
     end
 
     assert_dom_equal expected, @rendered
@@ -1282,7 +1282,7 @@ class FormWithActsLikeFormForTest < FormWithTest
     end
 
     expected = whole_form("/posts/123", method: "patch") do
-      "<input name='post[1][comment][title]' type='text' value='Hello World' id='post_1_comment_title' />"
+      "<input name='post[1][comment][title]' type='text' value='Hello World' id='post_1_comment_title'>"
     end
 
     assert_dom_equal expected, @rendered
@@ -1296,7 +1296,7 @@ class FormWithActsLikeFormForTest < FormWithTest
     end
 
     expected = whole_form("/posts/123", method: "patch") do
-      "<input name='post[1][comment][5][title]' type='text' value='Hello World' id='post_1_comment_5_title' />"
+      "<input name='post[1][comment][5][title]' type='text' value='Hello World' id='post_1_comment_5_title'>"
     end
 
     assert_dom_equal expected, @rendered
@@ -1310,7 +1310,7 @@ class FormWithActsLikeFormForTest < FormWithTest
     end
 
     expected = whole_form("/posts/123", method: "patch") do
-      "<input name='post[123][comment][title]' type='text' value='Hello World' id='post_123_comment_title' />"
+      "<input name='post[123][comment][title]' type='text' value='Hello World' id='post_123_comment_title'>"
     end
 
     assert_dom_equal expected, @rendered
@@ -1324,7 +1324,7 @@ class FormWithActsLikeFormForTest < FormWithTest
     end
 
     expected = whole_form("/posts/123", method: "patch") do
-      "<input name='post[comment][5][title]' type='radio' value='hello' id='post_comment_5_title_hello' />"
+      "<input name='post[comment][5][title]' type='radio' value='hello' id='post_comment_5_title_hello'>"
     end
 
     assert_dom_equal expected, @rendered
@@ -1338,7 +1338,7 @@ class FormWithActsLikeFormForTest < FormWithTest
     end
 
     expected = whole_form("/posts/123", method: "patch") do
-      "<input name='post[123][comment][123][title]' type='text' value='Hello World' id='post_123_comment_123_title' />"
+      "<input name='post[123][comment][123][title]' type='text' value='Hello World' id='post_123_comment_123_title'>"
     end
 
     assert_dom_equal expected, @rendered
@@ -1352,7 +1352,7 @@ class FormWithActsLikeFormForTest < FormWithTest
     end
 
     expected = whole_form("/posts/123", method: "patch") do
-      "<input name='post[123][comment][5][title]' type='text' value='Hello World' id='post_123_comment_5_title' />"
+      "<input name='post[123][comment][5][title]' type='text' value='Hello World' id='post_123_comment_5_title'>"
     end
 
     assert_dom_equal expected, @rendered
@@ -1364,7 +1364,7 @@ class FormWithActsLikeFormForTest < FormWithTest
     end
 
     expected = whole_form("/posts/123", method: "patch") do
-      "<input name='post[1][comment][123][title]' type='text' value='Hello World' id='post_1_comment_123_title' />"
+      "<input name='post[1][comment][123][title]' type='text' value='Hello World' id='post_1_comment_123_title'>"
     end
 
     assert_dom_equal expected, @rendered
@@ -1381,8 +1381,8 @@ class FormWithActsLikeFormForTest < FormWithTest
     end
 
     expected = whole_form("/posts/123", method: "patch") do
-      '<input name="post[title]" type="text" value="Hello World" id="post_title" />' \
-        '<input name="post[author_attributes][name]" type="text" value="new author" id="post_author_attributes_name" />'
+      '<input name="post[title]" type="text" value="Hello World" id="post_title">' \
+        '<input name="post[author_attributes][name]" type="text" value="new author" id="post_author_attributes_name">'
     end
 
     assert_dom_equal expected, @rendered
@@ -1408,9 +1408,9 @@ class FormWithActsLikeFormForTest < FormWithTest
     end
 
     expected = whole_form("/posts/123", method: "patch") do
-      '<input name="post[title]" type="text" value="Hello World" id="post_title" />' \
-      '<input name="post[author_attributes][name]" type="text" value="author #321" id="post_author_attributes_name" />' \
-      '<input name="post[author_attributes][id]" type="hidden" value="321" id="post_author_attributes_id" autocomplete="off" />'
+      '<input name="post[title]" type="text" value="Hello World" id="post_title">' \
+      '<input name="post[author_attributes][name]" type="text" value="author #321" id="post_author_attributes_name">' \
+      '<input name="post[author_attributes][id]" type="hidden" value="321" id="post_author_attributes_id" autocomplete="off">'
     end
 
     assert_dom_equal expected, @rendered
@@ -1427,9 +1427,9 @@ class FormWithActsLikeFormForTest < FormWithTest
     end
 
     expected = whole_form("/posts/123", method: "patch") do
-      '<input name="post[title]" type="text" value="Hello World" id="post_title" />' \
-      '<input name="post[author_attributes][name]" type="text" value="author #321" id="post_author_attributes_name" />' \
-      '<input name="post[author_attributes][id]" type="hidden" value="321" id="post_author_attributes_id" autocomplete="off" />'
+      '<input name="post[title]" type="text" value="Hello World" id="post_title">' \
+      '<input name="post[author_attributes][name]" type="text" value="author #321" id="post_author_attributes_name">' \
+      '<input name="post[author_attributes][id]" type="hidden" value="321" id="post_author_attributes_id" autocomplete="off">'
     end
 
     assert_dom_equal expected, @rendered
@@ -1446,8 +1446,8 @@ class FormWithActsLikeFormForTest < FormWithTest
     end
 
     expected = whole_form("/posts/123", method: "patch") do
-      '<input name="post[title]" type="text" value="Hello World" id="post_title" />' \
-      '<input name="post[author_attributes][name]" type="text" value="author #321" id="post_author_attributes_name" />'
+      '<input name="post[title]" type="text" value="Hello World" id="post_title">' \
+      '<input name="post[author_attributes][name]" type="text" value="author #321" id="post_author_attributes_name">'
     end
 
     assert_dom_equal expected, @rendered
@@ -1464,8 +1464,8 @@ class FormWithActsLikeFormForTest < FormWithTest
     end
 
     expected = whole_form("/posts/123", method: "patch") do
-      '<input name="post[title]" type="text" value="Hello World" id="post_title" />' \
-      '<input name="post[author_attributes][name]" type="text" value="author #321" id="post_author_attributes_name" />'
+      '<input name="post[title]" type="text" value="Hello World" id="post_title">' \
+      '<input name="post[author_attributes][name]" type="text" value="author #321" id="post_author_attributes_name">'
     end
 
     assert_dom_equal expected, @rendered
@@ -1482,9 +1482,9 @@ class FormWithActsLikeFormForTest < FormWithTest
     end
 
     expected = whole_form("/posts/123", method: "patch") do
-      '<input name="post[title]" type="text" value="Hello World" id="post_title" />' \
-      '<input name="post[author_attributes][name]" type="text" value="author #321" id="post_author_attributes_name" />' \
-      '<input name="post[author_attributes][id]" type="hidden" value="321" id="post_author_attributes_id" autocomplete="off" />'
+      '<input name="post[title]" type="text" value="Hello World" id="post_title">' \
+      '<input name="post[author_attributes][name]" type="text" value="author #321" id="post_author_attributes_name">' \
+      '<input name="post[author_attributes][id]" type="hidden" value="321" id="post_author_attributes_id" autocomplete="off">'
     end
 
     assert_dom_equal expected, @rendered
@@ -1502,9 +1502,9 @@ class FormWithActsLikeFormForTest < FormWithTest
     end
 
     expected = whole_form("/posts/123", method: "patch") do
-      '<input name="post[title]" type="text" value="Hello World" id="post_title" />' \
-      '<input name="post[author_attributes][id]" type="hidden" value="321" id="post_author_attributes_id" autocomplete="off" />' \
-      '<input name="post[author_attributes][name]" type="text" value="author #321" id="post_author_attributes_name" />'
+      '<input name="post[title]" type="text" value="Hello World" id="post_title">' \
+      '<input name="post[author_attributes][id]" type="hidden" value="321" id="post_author_attributes_id" autocomplete="off">' \
+      '<input name="post[author_attributes][name]" type="text" value="author #321" id="post_author_attributes_name">'
     end
 
     assert_dom_equal expected, @rendered
@@ -1523,11 +1523,11 @@ class FormWithActsLikeFormForTest < FormWithTest
     end
 
     expected = whole_form("/posts/123", method: "patch") do
-      '<input name="post[title]" type="text" value="Hello World" id="post_title" />' \
-      '<input name="post[comments_attributes][0][name]" type="text" value="comment #1" id="post_comments_attributes_0_name" />' \
-      '<input name="post[comments_attributes][0][id]" type="hidden" value="1" id="post_comments_attributes_0_id" autocomplete="off" />' \
-      '<input name="post[comments_attributes][1][name]" type="text" value="comment #2" id="post_comments_attributes_1_name" />' \
-      '<input name="post[comments_attributes][1][id]" type="hidden" value="2" id="post_comments_attributes_1_id" autocomplete="off" />'
+      '<input name="post[title]" type="text" value="Hello World" id="post_title">' \
+      '<input name="post[comments_attributes][0][name]" type="text" value="comment #1" id="post_comments_attributes_0_name">' \
+      '<input name="post[comments_attributes][0][id]" type="hidden" value="1" id="post_comments_attributes_0_id" autocomplete="off">' \
+      '<input name="post[comments_attributes][1][name]" type="text" value="comment #2" id="post_comments_attributes_1_name">' \
+      '<input name="post[comments_attributes][1][id]" type="hidden" value="2" id="post_comments_attributes_1_id" autocomplete="off">'
     end
 
     assert_dom_equal expected, @rendered
@@ -1550,11 +1550,11 @@ class FormWithActsLikeFormForTest < FormWithTest
     end
 
     expected = whole_form("/posts/123", method: "patch") do
-      '<input name="post[title]" type="text" value="Hello World" id="post_title" />' \
-      '<input name="post[author_attributes][name]" type="text" value="author #321" id="post_author_attributes_name" />' \
-      '<input name="post[author_attributes][id]" type="hidden" value="321" id="post_author_attributes_id" autocomplete="off" />' \
-      '<input name="post[comments_attributes][0][name]" type="text" value="comment #1" id="post_comments_attributes_0_name" />' \
-      '<input name="post[comments_attributes][1][name]" type="text" value="comment #2" id="post_comments_attributes_1_name" />'
+      '<input name="post[title]" type="text" value="Hello World" id="post_title">' \
+      '<input name="post[author_attributes][name]" type="text" value="author #321" id="post_author_attributes_name">' \
+      '<input name="post[author_attributes][id]" type="hidden" value="321" id="post_author_attributes_id" autocomplete="off">' \
+      '<input name="post[comments_attributes][0][name]" type="text" value="comment #1" id="post_comments_attributes_0_name">' \
+      '<input name="post[comments_attributes][1][name]" type="text" value="comment #2" id="post_comments_attributes_1_name">'
     end
 
     assert_dom_equal expected, @rendered
@@ -1577,10 +1577,10 @@ class FormWithActsLikeFormForTest < FormWithTest
     end
 
     expected = whole_form("/posts/123", method: "patch") do
-      '<input name="post[title]" type="text" value="Hello World" id="post_title" />' \
-      '<input name="post[author_attributes][name]" type="text" value="author #321" id="post_author_attributes_name" />' \
-      '<input name="post[comments_attributes][0][name]" type="text" value="comment #1" id="post_comments_attributes_0_name" />' \
-      '<input name="post[comments_attributes][1][name]" type="text" value="comment #2" id="post_comments_attributes_1_name" />'
+      '<input name="post[title]" type="text" value="Hello World" id="post_title">' \
+      '<input name="post[author_attributes][name]" type="text" value="author #321" id="post_author_attributes_name">' \
+      '<input name="post[comments_attributes][0][name]" type="text" value="comment #1" id="post_comments_attributes_0_name">' \
+      '<input name="post[comments_attributes][1][name]" type="text" value="comment #2" id="post_comments_attributes_1_name">'
     end
 
     assert_dom_equal expected, @rendered
@@ -1603,11 +1603,11 @@ class FormWithActsLikeFormForTest < FormWithTest
     end
 
     expected = whole_form("/posts/123", method: "patch") do
-      '<input name="post[title]" type="text" value="Hello World" id="post_title" />' \
-      '<input name="post[author_attributes][name]" type="text" value="author #321" id="post_author_attributes_name" />' \
-      '<input name="post[author_attributes][id]" type="hidden" value="321" id="post_author_attributes_id" autocomplete="off" />' \
-      '<input name="post[comments_attributes][0][name]" type="text" value="comment #1" id="post_comments_attributes_0_name" />' \
-      '<input name="post[comments_attributes][1][name]" type="text" value="comment #2" id="post_comments_attributes_1_name" />'
+      '<input name="post[title]" type="text" value="Hello World" id="post_title">' \
+      '<input name="post[author_attributes][name]" type="text" value="author #321" id="post_author_attributes_name">' \
+      '<input name="post[author_attributes][id]" type="hidden" value="321" id="post_author_attributes_id" autocomplete="off">' \
+      '<input name="post[comments_attributes][0][name]" type="text" value="comment #1" id="post_comments_attributes_0_name">' \
+      '<input name="post[comments_attributes][1][name]" type="text" value="comment #2" id="post_comments_attributes_1_name">'
     end
 
     assert_dom_equal expected, @rendered
@@ -1626,11 +1626,11 @@ class FormWithActsLikeFormForTest < FormWithTest
     end
 
     expected = whole_form("/posts/123", method: "patch") do
-      '<input name="post[title]" type="text" value="Hello World" id="post_title" />' \
-      '<input name="post[comments_attributes][0][name]" type="text" value="comment #1" id="post_comments_attributes_0_name" />' \
-      '<input name="post[comments_attributes][0][id]" type="hidden" value="1" id="post_comments_attributes_0_id" autocomplete="off" />' \
-      '<input name="post[comments_attributes][1][name]" type="text" value="comment #2" id="post_comments_attributes_1_name" />' \
-      '<input name="post[comments_attributes][1][id]" type="hidden" value="2" id="post_comments_attributes_1_id" autocomplete="off" />'
+      '<input name="post[title]" type="text" value="Hello World" id="post_title">' \
+      '<input name="post[comments_attributes][0][name]" type="text" value="comment #1" id="post_comments_attributes_0_name">' \
+      '<input name="post[comments_attributes][0][id]" type="hidden" value="1" id="post_comments_attributes_0_id" autocomplete="off">' \
+      '<input name="post[comments_attributes][1][name]" type="text" value="comment #2" id="post_comments_attributes_1_name">' \
+      '<input name="post[comments_attributes][1][id]" type="hidden" value="2" id="post_comments_attributes_1_id" autocomplete="off">'
     end
 
     assert_dom_equal expected, @rendered
@@ -1650,11 +1650,11 @@ class FormWithActsLikeFormForTest < FormWithTest
     end
 
     expected = whole_form("/posts/123", method: "patch") do
-      '<input name="post[title]" type="text" value="Hello World" id="post_title" />' \
-      '<input name="post[comments_attributes][0][id]" type="hidden" value="1" id="post_comments_attributes_0_id" autocomplete="off" />' \
-      '<input name="post[comments_attributes][0][name]" type="text" value="comment #1" id="post_comments_attributes_0_name" />' \
-      '<input name="post[comments_attributes][1][id]" type="hidden" value="2" id="post_comments_attributes_1_id" autocomplete="off" />' \
-      '<input name="post[comments_attributes][1][name]" type="text" value="comment #2" id="post_comments_attributes_1_name" />'
+      '<input name="post[title]" type="text" value="Hello World" id="post_title">' \
+      '<input name="post[comments_attributes][0][id]" type="hidden" value="1" id="post_comments_attributes_0_id" autocomplete="off">' \
+      '<input name="post[comments_attributes][0][name]" type="text" value="comment #1" id="post_comments_attributes_0_name">' \
+      '<input name="post[comments_attributes][1][id]" type="hidden" value="2" id="post_comments_attributes_1_id" autocomplete="off">' \
+      '<input name="post[comments_attributes][1][name]" type="text" value="comment #2" id="post_comments_attributes_1_name">'
     end
 
     assert_dom_equal expected, @rendered
@@ -1673,9 +1673,9 @@ class FormWithActsLikeFormForTest < FormWithTest
     end
 
     expected = whole_form("/posts/123", method: "patch") do
-      '<input name="post[title]" type="text" value="Hello World" id="post_title" />' \
-      '<input name="post[comments_attributes][0][name]" type="text" value="new comment" id="post_comments_attributes_0_name" />' \
-      '<input name="post[comments_attributes][1][name]" type="text" value="new comment" id="post_comments_attributes_1_name" />'
+      '<input name="post[title]" type="text" value="Hello World" id="post_title">' \
+      '<input name="post[comments_attributes][0][name]" type="text" value="new comment" id="post_comments_attributes_0_name">' \
+      '<input name="post[comments_attributes][1][name]" type="text" value="new comment" id="post_comments_attributes_1_name">'
     end
 
     assert_dom_equal expected, @rendered
@@ -1694,10 +1694,10 @@ class FormWithActsLikeFormForTest < FormWithTest
     end
 
     expected = whole_form("/posts/123", method: "patch") do
-      '<input name="post[title]" type="text" value="Hello World" id="post_title" />' \
-      '<input name="post[comments_attributes][0][name]" type="text" value="comment #321" id="post_comments_attributes_0_name" />' \
-      '<input name="post[comments_attributes][0][id]" type="hidden" value="321" id="post_comments_attributes_0_id" autocomplete="off"/>' \
-      '<input name="post[comments_attributes][1][name]" type="text" value="new comment" id="post_comments_attributes_1_name" />'
+      '<input name="post[title]" type="text" value="Hello World" id="post_title">' \
+      '<input name="post[comments_attributes][0][name]" type="text" value="comment #321" id="post_comments_attributes_0_name">' \
+      '<input name="post[comments_attributes][0][id]" type="hidden" value="321" id="post_comments_attributes_0_id" autocomplete="off">' \
+      '<input name="post[comments_attributes][1][name]" type="text" value="new comment" id="post_comments_attributes_1_name">'
     end
 
     assert_dom_equal expected, @rendered
@@ -1712,7 +1712,7 @@ class FormWithActsLikeFormForTest < FormWithTest
     end
 
     expected = whole_form("/posts/123", method: "patch") do
-      '<input name="post[title]" type="text" value="Hello World" id="post_title" />'
+      '<input name="post[title]" type="text" value="Hello World" id="post_title">'
     end
 
     assert_dom_equal expected, @rendered
@@ -1729,11 +1729,11 @@ class FormWithActsLikeFormForTest < FormWithTest
     end
 
     expected = whole_form("/posts/123", method: "patch") do
-      '<input name="post[title]" type="text" value="Hello World" id="post_title" />' \
-      '<input name="post[comments_attributes][0][name]" type="text" value="comment #1" id="post_comments_attributes_0_name" />' \
-      '<input name="post[comments_attributes][0][id]" type="hidden" value="1" id="post_comments_attributes_0_id" autocomplete="off" />' \
-      '<input name="post[comments_attributes][1][name]" type="text" value="comment #2" id="post_comments_attributes_1_name" />' \
-      '<input name="post[comments_attributes][1][id]" type="hidden" value="2" id="post_comments_attributes_1_id" autocomplete="off" />'
+      '<input name="post[title]" type="text" value="Hello World" id="post_title">' \
+      '<input name="post[comments_attributes][0][name]" type="text" value="comment #1" id="post_comments_attributes_0_name">' \
+      '<input name="post[comments_attributes][0][id]" type="hidden" value="1" id="post_comments_attributes_0_id" autocomplete="off">' \
+      '<input name="post[comments_attributes][1][name]" type="text" value="comment #2" id="post_comments_attributes_1_name">' \
+      '<input name="post[comments_attributes][1][id]" type="hidden" value="2" id="post_comments_attributes_1_id" autocomplete="off">'
     end
 
     assert_dom_equal expected, @rendered
@@ -1750,11 +1750,11 @@ class FormWithActsLikeFormForTest < FormWithTest
     end
 
     expected = whole_form("/posts/123", method: "patch") do
-      '<input name="post[title]" type="text" value="Hello World" id="post_title" />' \
-      '<input name="post[comments_attributes][0][name]" type="text" value="comment #1" id="post_comments_attributes_0_name" />' \
-      '<input name="post[comments_attributes][0][id]" type="hidden" value="1" id="post_comments_attributes_0_id" autocomplete="off" />' \
-      '<input name="post[comments_attributes][1][name]" type="text" value="comment #2" id="post_comments_attributes_1_name" />' \
-      '<input name="post[comments_attributes][1][id]" type="hidden" value="2" id="post_comments_attributes_1_id" autocomplete="off" />'
+      '<input name="post[title]" type="text" value="Hello World" id="post_title">' \
+      '<input name="post[comments_attributes][0][name]" type="text" value="comment #1" id="post_comments_attributes_0_name">' \
+      '<input name="post[comments_attributes][0][id]" type="hidden" value="1" id="post_comments_attributes_0_id" autocomplete="off">' \
+      '<input name="post[comments_attributes][1][name]" type="text" value="comment #2" id="post_comments_attributes_1_name">' \
+      '<input name="post[comments_attributes][1][id]" type="hidden" value="2" id="post_comments_attributes_1_id" autocomplete="off">'
     end
 
     assert_dom_equal expected, @rendered
@@ -1791,11 +1791,11 @@ class FormWithActsLikeFormForTest < FormWithTest
     end
 
     expected = whole_form("/posts/123", method: "patch") do
-      '<input name="post[title]" type="text" value="Hello World" id="post_title" />' \
-      '<input name="post[comments_attributes][0][name]" type="text" value="comment #1" id="post_comments_attributes_0_name" />' \
-      '<input name="post[comments_attributes][0][id]" type="hidden" value="1" id="post_comments_attributes_0_id" autocomplete="off" />' \
-      '<input name="post[comments_attributes][1][name]" type="text" value="comment #2" id="post_comments_attributes_1_name" />' \
-      '<input name="post[comments_attributes][1][id]" type="hidden" value="2" id="post_comments_attributes_1_id" autocomplete="off" />'
+      '<input name="post[title]" type="text" value="Hello World" id="post_title">' \
+      '<input name="post[comments_attributes][0][name]" type="text" value="comment #1" id="post_comments_attributes_0_name">' \
+      '<input name="post[comments_attributes][0][id]" type="hidden" value="1" id="post_comments_attributes_0_id" autocomplete="off">' \
+      '<input name="post[comments_attributes][1][name]" type="text" value="comment #2" id="post_comments_attributes_1_name">' \
+      '<input name="post[comments_attributes][1][id]" type="hidden" value="2" id="post_comments_attributes_1_id" autocomplete="off">'
     end
 
     assert_dom_equal expected, @rendered
@@ -1814,10 +1814,10 @@ class FormWithActsLikeFormForTest < FormWithTest
     end
 
     expected = whole_form("/posts/123", method: "patch") do
-      '<input name="post[title]" type="text" value="Hello World" id="post_title" />' \
-      '<input name="post[comments_attributes][0][name]" type="text" value="comment #321" id="post_comments_attributes_0_name" />' \
-      '<input name="post[comments_attributes][0][id]" type="hidden" value="321" id="post_comments_attributes_0_id" autocomplete="off" />' \
-      '<input name="post[comments_attributes][1][name]" type="text" value="new comment" id="post_comments_attributes_1_name" />'
+      '<input name="post[title]" type="text" value="Hello World" id="post_title">' \
+      '<input name="post[comments_attributes][0][name]" type="text" value="comment #321" id="post_comments_attributes_0_name">' \
+      '<input name="post[comments_attributes][0][id]" type="hidden" value="321" id="post_comments_attributes_0_id" autocomplete="off">' \
+      '<input name="post[comments_attributes][1][name]" type="text" value="new comment" id="post_comments_attributes_1_name">'
     end
 
     assert_dom_equal expected, @rendered
@@ -1834,8 +1834,8 @@ class FormWithActsLikeFormForTest < FormWithTest
     end
 
     expected = whole_form("/posts/123", method: "patch") do
-      '<input name="post[comments_attributes][abc][name]" type="text" value="comment #321" id="post_comments_attributes_abc_name" />' \
-      '<input name="post[comments_attributes][abc][id]" type="hidden" value="321" id="post_comments_attributes_abc_id" autocomplete="off" />'
+      '<input name="post[comments_attributes][abc][name]" type="text" value="comment #321" id="post_comments_attributes_abc_name">' \
+      '<input name="post[comments_attributes][abc][id]" type="hidden" value="321" id="post_comments_attributes_abc_id" autocomplete="off">'
     end
 
     assert_dom_equal expected, @rendered
@@ -1851,8 +1851,8 @@ class FormWithActsLikeFormForTest < FormWithTest
     end
 
     expected = whole_form("/posts/123", method: "patch") do
-      '<input name="post[comments_attributes][abc][name]" type="text" value="comment #321" id="post_comments_attributes_abc_name" />' \
-      '<input name="post[comments_attributes][abc][id]" type="hidden" value="321" id="post_comments_attributes_abc_id" autocomplete="off" />'
+      '<input name="post[comments_attributes][abc][name]" type="text" value="comment #321" id="post_comments_attributes_abc_name">' \
+      '<input name="post[comments_attributes][abc][id]" type="hidden" value="321" id="post_comments_attributes_abc_id" autocomplete="off">'
     end
 
     assert_dom_equal expected, @rendered
@@ -1874,8 +1874,8 @@ class FormWithActsLikeFormForTest < FormWithTest
     end
 
     expected = whole_form("/posts/123", method: "patch") do
-      '<input name="post[comments_attributes][abc][name]" type="text" value="comment #321" id="post_comments_attributes_abc_name" />' \
-      '<input name="post[comments_attributes][abc][id]" type="hidden" value="321" id="post_comments_attributes_abc_id" autocomplete="off" />'
+      '<input name="post[comments_attributes][abc][name]" type="text" value="comment #321" id="post_comments_attributes_abc_name">' \
+      '<input name="post[comments_attributes][abc][id]" type="hidden" value="321" id="post_comments_attributes_abc_id" autocomplete="off">'
     end
 
     assert_dom_equal expected, @rendered
@@ -1960,18 +1960,18 @@ class FormWithActsLikeFormForTest < FormWithTest
     end
 
     expected = whole_form("/posts/123", method: "patch") do
-      '<input name="post[comments_attributes][0][name]" type="text" value="comment #321" id="post_comments_attributes_0_name" />' \
-      '<input name="post[comments_attributes][0][relevances_attributes][0][value]" type="text" value="commentrelevance #314" id="post_comments_attributes_0_relevances_attributes_0_value" />' \
-      '<input name="post[comments_attributes][0][relevances_attributes][0][id]" type="hidden" value="314" id="post_comments_attributes_0_relevances_attributes_0_id" autocomplete="off"/>' \
-      '<input name="post[comments_attributes][0][id]" type="hidden" value="321" id="post_comments_attributes_0_id" autocomplete="off"/>' \
-      '<input name="post[tags_attributes][0][value]" type="text" value="tag #123" id="post_tags_attributes_0_value"/>' \
-      '<input name="post[tags_attributes][0][relevances_attributes][0][value]" type="text" value="tagrelevance #3141" id="post_tags_attributes_0_relevances_attributes_0_value"/>' \
-      '<input name="post[tags_attributes][0][relevances_attributes][0][id]" type="hidden" value="3141" id="post_tags_attributes_0_relevances_attributes_0_id" autocomplete="off"/>' \
-      '<input name="post[tags_attributes][0][id]" type="hidden" value="123" id="post_tags_attributes_0_id" autocomplete="off"/>' \
-      '<input name="post[tags_attributes][1][value]" type="text" value="tag #456" id="post_tags_attributes_1_value"/>' \
-      '<input name="post[tags_attributes][1][relevances_attributes][0][value]" type="text" value="tagrelevance #31415" id="post_tags_attributes_1_relevances_attributes_0_value"/>' \
-      '<input name="post[tags_attributes][1][relevances_attributes][0][id]" type="hidden" value="31415" id="post_tags_attributes_1_relevances_attributes_0_id" autocomplete="off"/>' \
-      '<input name="post[tags_attributes][1][id]" type="hidden" value="456" id="post_tags_attributes_1_id" autocomplete="off"/>'
+      '<input name="post[comments_attributes][0][name]" type="text" value="comment #321" id="post_comments_attributes_0_name">' \
+      '<input name="post[comments_attributes][0][relevances_attributes][0][value]" type="text" value="commentrelevance #314" id="post_comments_attributes_0_relevances_attributes_0_value">' \
+      '<input name="post[comments_attributes][0][relevances_attributes][0][id]" type="hidden" value="314" id="post_comments_attributes_0_relevances_attributes_0_id" autocomplete="off">' \
+      '<input name="post[comments_attributes][0][id]" type="hidden" value="321" id="post_comments_attributes_0_id" autocomplete="off">' \
+      '<input name="post[tags_attributes][0][value]" type="text" value="tag #123" id="post_tags_attributes_0_value">' \
+      '<input name="post[tags_attributes][0][relevances_attributes][0][value]" type="text" value="tagrelevance #3141" id="post_tags_attributes_0_relevances_attributes_0_value">' \
+      '<input name="post[tags_attributes][0][relevances_attributes][0][id]" type="hidden" value="3141" id="post_tags_attributes_0_relevances_attributes_0_id" autocomplete="off">' \
+      '<input name="post[tags_attributes][0][id]" type="hidden" value="123" id="post_tags_attributes_0_id" autocomplete="off">' \
+      '<input name="post[tags_attributes][1][value]" type="text" value="tag #456" id="post_tags_attributes_1_value">' \
+      '<input name="post[tags_attributes][1][relevances_attributes][0][value]" type="text" value="tagrelevance #31415" id="post_tags_attributes_1_relevances_attributes_0_value">' \
+      '<input name="post[tags_attributes][1][relevances_attributes][0][id]" type="hidden" value="31415" id="post_tags_attributes_1_relevances_attributes_0_id" autocomplete="off">' \
+      '<input name="post[tags_attributes][1][id]" type="hidden" value="456" id="post_tags_attributes_1_id" autocomplete="off">'
     end
 
     assert_dom_equal expected, @rendered
@@ -1987,7 +1987,7 @@ class FormWithActsLikeFormForTest < FormWithTest
     end
 
     expected = whole_form("/posts/123", method: "patch") do
-      '<input name="post[author_attributes][name]" type="text" value="hash backed author" id="post_author_attributes_name" />'
+      '<input name="post[author_attributes][name]" type="text" value="hash backed author" id="post_author_attributes_name">'
     end
 
     assert_dom_equal expected, @rendered
@@ -2003,7 +2003,7 @@ class FormWithActsLikeFormForTest < FormWithTest
     end
 
     expected = whole_form("/posts/123", method: "patch") do
-      '<input name="post[author_attributes][name]" type="text" value="hash backed author" id="post_author_attributes_name" />'
+      '<input name="post[author_attributes][name]" type="text" value="hash backed author" id="post_author_attributes_name">'
     end
 
     assert_dom_equal expected, @rendered
@@ -2017,10 +2017,10 @@ class FormWithActsLikeFormForTest < FormWithTest
     end
 
     expected =
-      "<input name='post[title]' type='text' value='Hello World' id='post_title' />" \
+      "<input name='post[title]' type='text' value='Hello World' id='post_title'>" \
       "<textarea name='post[body]' id='post_body'>\nBack to the hill and over it again!</textarea>" \
-      "<input name='post[secret]' type='hidden' value='0' autocomplete='off' />" \
-      "<input name='post[secret]' checked='checked' type='checkbox' value='1' id='post_secret' />"
+      "<input name='post[secret]' type='hidden' value='0' autocomplete='off'>" \
+      "<input name='post[secret]' checked='checked' type='checkbox' value='1' id='post_secret'>"
 
     assert_dom_equal expected, @rendered
   end
@@ -2033,10 +2033,10 @@ class FormWithActsLikeFormForTest < FormWithTest
     end
 
     expected =
-      "<input name='post[123][title]' type='text' value='Hello World' id='post_123_title' />" \
+      "<input name='post[123][title]' type='text' value='Hello World' id='post_123_title'>" \
       "<textarea name='post[123][body]' id='post_123_body'>\nBack to the hill and over it again!</textarea>" \
-      "<input name='post[123][secret]' type='hidden' value='0' autocomplete='off' />" \
-      "<input name='post[123][secret]' checked='checked' type='checkbox' value='1' id='post_123_secret' />"
+      "<input name='post[123][secret]' type='hidden' value='0' autocomplete='off'>" \
+      "<input name='post[123][secret]' checked='checked' type='checkbox' value='1' id='post_123_secret'>"
 
     assert_dom_equal expected, @rendered
   end
@@ -2049,10 +2049,10 @@ class FormWithActsLikeFormForTest < FormWithTest
     end
 
     expected =
-      "<input name='post[][title]' type='text' value='Hello World' id='post__title' />" \
+      "<input name='post[][title]' type='text' value='Hello World' id='post__title'>" \
       "<textarea name='post[][body]' id='post__body'>\nBack to the hill and over it again!</textarea>" \
-      "<input name='post[][secret]' type='hidden' value='0' autocomplete='off' />" \
-      "<input name='post[][secret]' checked='checked' type='checkbox' value='1' id='post__secret' />"
+      "<input name='post[][secret]' type='hidden' value='0' autocomplete='off'>" \
+      "<input name='post[][secret]' checked='checked' type='checkbox' value='1' id='post__secret'>"
 
     assert_dom_equal expected, @rendered
   end
@@ -2065,10 +2065,10 @@ class FormWithActsLikeFormForTest < FormWithTest
     end
 
     expected =
-      "<input name='post[abc][title]' type='text' value='Hello World' id='post_abc_title' />" \
+      "<input name='post[abc][title]' type='text' value='Hello World' id='post_abc_title'>" \
       "<textarea name='post[abc][body]' id='post_abc_body'>\nBack to the hill and over it again!</textarea>" \
-      "<input name='post[abc][secret]' type='hidden' value='0' autocomplete='off' />" \
-      "<input name='post[abc][secret]' checked='checked' type='checkbox' value='1' id='post_abc_secret' />"
+      "<input name='post[abc][secret]' type='hidden' value='0' autocomplete='off'>" \
+      "<input name='post[abc][secret]' checked='checked' type='checkbox' value='1' id='post_abc_secret'>"
 
     assert_dom_equal expected, @rendered
   end
@@ -2081,10 +2081,10 @@ class FormWithActsLikeFormForTest < FormWithTest
     end
 
     expected =
-      "<input name='post[title]' type='text' value='Hello World' id='post_title' />" \
+      "<input name='post[title]' type='text' value='Hello World' id='post_title'>" \
       "<textarea name='post[body]' id='post_body' >\nBack to the hill and over it again!</textarea>" \
-      "<input name='post[secret]' type='hidden' value='0' autocomplete='off' />" \
-      "<input name='post[secret]' checked='checked' type='checkbox' value='1' id='post_secret' />"
+      "<input name='post[secret]' type='hidden' value='0' autocomplete='off'>" \
+      "<input name='post[secret]' checked='checked' type='checkbox' value='1' id='post_secret'>"
 
     assert_dom_equal expected, @rendered
   end
@@ -2097,10 +2097,10 @@ class FormWithActsLikeFormForTest < FormWithTest
     end
 
     expected =
-      "<input name='post[title]' type='text' value='Hello World' id='post_title' />" \
+      "<input name='post[title]' type='text' value='Hello World' id='post_title'>" \
       "<textarea name='post[body]' id='post_body' >\nBack to the hill and over it again!</textarea>" \
-      "<input name='post[secret]' type='hidden' value='0' autocomplete='off' />" \
-      "<input name='post[secret]' checked='checked' type='checkbox' value='1' id='post_secret' />"
+      "<input name='post[secret]' type='hidden' value='0' autocomplete='off'>" \
+      "<input name='post[secret]' checked='checked' type='checkbox' value='1' id='post_secret'>"
 
     assert_dom_equal expected, @rendered
   end
@@ -2110,7 +2110,7 @@ class FormWithActsLikeFormForTest < FormWithTest
       concat f.text_field(:name)
     end
 
-    expected = %(<input type="text" value="new comment" name="comment[name]" id="comment_name" />)
+    expected = %(<input type="text" value="new comment" name="comment[name]" id="comment_name">)
 
     assert_dom_equal expected, @rendered
   end
@@ -2122,7 +2122,7 @@ class FormWithActsLikeFormForTest < FormWithTest
     end
 
     assert_dom_equal "<label for=\"author_post_title\">Title</label>" \
-    "<input name='author[post][title]' type='text' value='Hello World' id='author_post_title' id='author_post_1_title' />",
+    "<input name='author[post][title]' type='text' value='Hello World' id='author_post_title' id='author_post_1_title'>",
       @rendered
   end
 
@@ -2133,7 +2133,7 @@ class FormWithActsLikeFormForTest < FormWithTest
     end
 
     assert_dom_equal "<label for=\"author_post_1_title\">Title</label>" \
-      "<input name='author[post][1][title]' type='text' value='Hello World' id='author_post_1_title' />",
+      "<input name='author[post][1][title]' type='text' value='Hello World' id='author_post_1_title'>",
       @rendered
   end
 
@@ -2152,10 +2152,10 @@ class FormWithActsLikeFormForTest < FormWithTest
     end
 
     expected = whole_form("/posts/123", "create-post", method: "patch") do
-      "<input name='post[title]' type='text' value='Hello World' id='post_title' />" \
+      "<input name='post[title]' type='text' value='Hello World' id='post_title'>" \
       "<textarea name='post[body]' id='post_body' >\nBack to the hill and over it again!</textarea>" \
-      "<input name='parent_post[secret]' type='hidden' value='0' autocomplete='off' />" \
-      "<input name='parent_post[secret]' checked='checked' type='checkbox' value='1' id='parent_post_secret' />"
+      "<input name='parent_post[secret]' type='hidden' value='0' autocomplete='off'>" \
+      "<input name='parent_post[secret]' checked='checked' type='checkbox' value='1' id='parent_post_secret'>"
     end
 
     assert_dom_equal expected, @rendered
@@ -2172,9 +2172,9 @@ class FormWithActsLikeFormForTest < FormWithTest
     end
 
     expected = whole_form("/posts/123", "create-post", method: "patch") do
-      "<input name='post[title]' type='text' value='Hello World' id='post_title' />" \
+      "<input name='post[title]' type='text' value='Hello World' id='post_title'>" \
       "<textarea name='post[body]' id='post_body'>\nBack to the hill and over it again!</textarea>" \
-      "<input name='post[comment][name]' type='text' value='new comment' id='post_comment_name' />"
+      "<input name='post[comment][name]' type='text' value='new comment' id='post_comment_name'>"
     end
 
     assert_dom_equal expected, @rendered
@@ -2188,7 +2188,7 @@ class FormWithActsLikeFormForTest < FormWithTest
     end
 
     expected = whole_form("/posts/123", method: "patch") do
-      "<input name='post[category][name]' type='text' id='post_category_name' />"
+      "<input name='post[category][name]' type='text' id='post_category_name'>"
     end
 
     assert_dom_equal expected, @rendered
@@ -2198,7 +2198,7 @@ class FormWithActsLikeFormForTest < FormWithTest
     (field_helpers - %w(hidden_field)).each do |selector|
       class_eval <<-RUBY_EVAL, __FILE__, __LINE__ + 1
         def #{selector}(field, *args, &proc)
-          ("<label for='\#{field}'>\#{field.to_s.humanize}:</label> " + super + "<br/>").html_safe
+          ("<label for='\#{field}'>\#{field.to_s.humanize}:</label> " + super + "<br>").html_safe
         end
       RUBY_EVAL
     end
@@ -2213,9 +2213,9 @@ class FormWithActsLikeFormForTest < FormWithTest
     end
 
     expected = whole_form("/posts/123", method: "patch") do
-      "<label for='title'>Title:</label> <input name='post[title]' type='text' value='Hello World' id='post_title'/><br/>" \
-      "<label for='body'>Body:</label> <textarea name='post[body]' id='post_body'>\nBack to the hill and over it again!</textarea><br/>" \
-      "<label for='secret'>Secret:</label> <input name='post[secret]' type='hidden' value='0' autocomplete='off' /><input name='post[secret]' checked='checked' type='checkbox' value='1' id='post_secret' /><br/>"
+      "<label for='title'>Title:</label> <input name='post[title]' type='text' value='Hello World' id='post_title'><br>" \
+      "<label for='body'>Body:</label> <textarea name='post[body]' id='post_body'>\nBack to the hill and over it again!</textarea><br>" \
+      "<label for='secret'>Secret:</label> <input name='post[secret]' type='hidden' value='0' autocomplete='off'><input name='post[secret]' checked='checked' type='checkbox' value='1' id='post_secret'><br>"
     end
 
     assert_dom_equal expected, @rendered
@@ -2232,9 +2232,9 @@ class FormWithActsLikeFormForTest < FormWithTest
     end
 
     expected = whole_form("/posts/123", method: "patch") do
-      "<label for='title'>Title:</label> <input name='post[title]' type='text' value='Hello World' id='post_title' /><br/>" \
-      "<label for='body'>Body:</label> <textarea name='post[body]' id='post_body'>\nBack to the hill and over it again!</textarea><br/>" \
-      "<label for='secret'>Secret:</label> <input name='post[secret]' type='hidden' value='0' autocomplete='off' /><input name='post[secret]' checked='checked' type='checkbox' value='1' id='post_secret' /><br/>"
+      "<label for='title'>Title:</label> <input name='post[title]' type='text' value='Hello World' id='post_title'><br>" \
+      "<label for='body'>Body:</label> <textarea name='post[body]' id='post_body'>\nBack to the hill and over it again!</textarea><br>" \
+      "<label for='secret'>Secret:</label> <input name='post[secret]' type='hidden' value='0' autocomplete='off'><input name='post[secret]' checked='checked' type='checkbox' value='1' id='post_secret'><br>"
     end
 
     assert_dom_equal expected, @rendered
@@ -2251,7 +2251,7 @@ class FormWithActsLikeFormForTest < FormWithTest
     end
 
     expected = whole_form("/posts/123", method: "patch") do
-      "<label for='title'>Title:</label> <input name='post[title]' type='text' value='Hello World' id='post_title' /><br/>"
+      "<label for='title'>Title:</label> <input name='post[title]' type='text' value='Hello World' id='post_title'><br>"
     end
 
     assert_dom_equal expected, @rendered
@@ -2266,7 +2266,7 @@ class FormWithActsLikeFormForTest < FormWithTest
       concat f.text_field(:title)
     end
 
-    expected = "<label for='title'>Title:</label> <input name='post[title]' type='text' value='Hello World' id='post_title' /><br/>"
+    expected = "<label for='title'>Title:</label> <input name='post[title]' type='text' value='Hello World' id='post_title'><br>"
 
     assert_dom_equal expected, @rendered
   end
@@ -2278,7 +2278,7 @@ class FormWithActsLikeFormForTest < FormWithTest
       concat f.text_field(:title)
     end
 
-    expected = "<label for='title'>Title:</label> <input name='post[title]' type='text' value='Hello World' id='post_title' /><br/>"
+    expected = "<label for='title'>Title:</label> <input name='post[title]' type='text' value='Hello World' id='post_title'><br>"
 
     assert_dom_equal expected, @rendered
   end
@@ -2291,9 +2291,9 @@ class FormWithActsLikeFormForTest < FormWithTest
     end
 
     expected =
-      "<label for='title'>Title:</label> <input name='post[title]' type='text' value='Hello World' id='post_title'/><br/>" \
-      "<label for='body'>Body:</label> <textarea name='post[body]' id='post_body'>\nBack to the hill and over it again!</textarea><br/>" \
-      "<label for='secret'>Secret:</label> <input name='post[secret]' type='hidden' value='0' autocomplete='off' /><input name='post[secret]' checked='checked' type='checkbox' value='1' id='post_secret' /><br/>"
+      "<label for='title'>Title:</label> <input name='post[title]' type='text' value='Hello World' id='post_title'><br>" \
+      "<label for='body'>Body:</label> <textarea name='post[body]' id='post_body'>\nBack to the hill and over it again!</textarea><br>" \
+      "<label for='secret'>Secret:</label> <input name='post[secret]' type='hidden' value='0' autocomplete='off'><input name='post[secret]' checked='checked' type='checkbox' value='1' id='post_secret'><br>"
 
     assert_dom_equal expected, @rendered
   end
@@ -2505,11 +2505,11 @@ class FormWithActsLikeFormForTest < FormWithTest
       if options.fetch(:skip_enforcing_utf8, false)
         txt = +""
       else
-        txt = +%{<input name="utf8" type="hidden" value="&#x2713;" autocomplete="off" />}
+        txt = +%{<input name="utf8" type="hidden" value="&#x2713;" autocomplete="off">}
       end
 
       if method && !%w(get post).include?(method.to_s)
-        txt << %{<input name="_method" type="hidden" value="#{method}" autocomplete="off" />}
+        txt << %{<input name="_method" type="hidden" value="#{method}" autocomplete="off">}
       end
 
       txt

--- a/actionview/test/template/form_helper/form_with_test.rb
+++ b/actionview/test/template/form_helper/form_with_test.rb
@@ -39,7 +39,7 @@ class FormWithActsLikeFormTagTest < FormWithTest
 
     (+"").tap do |txt|
       unless skip_enforcing_utf8
-        txt << %{<input name="utf8" type="hidden" value="&#x2713;" autocomplete="off">}
+        txt << %{<input type="hidden" name="utf8" value="&#x2713;" autocomplete="off">}
       end
 
       if method && !%w(get post).include?(method.to_s)
@@ -2505,7 +2505,7 @@ class FormWithActsLikeFormForTest < FormWithTest
       if options.fetch(:skip_enforcing_utf8, false)
         txt = +""
       else
-        txt = +%{<input name="utf8" type="hidden" value="&#x2713;" autocomplete="off">}
+        txt = +%{<input type="hidden" name="utf8" value="&#x2713;" autocomplete="off">}
       end
 
       if method && !%w(get post).include?(method.to_s)

--- a/actionview/test/template/form_helper_test.rb
+++ b/actionview/test/template/form_helper_test.rb
@@ -4136,7 +4136,7 @@ class FormHelperTest < ActionView::TestCase
       method = options[:method]
 
       if options.fetch(:enforce_utf8, true)
-        txt = +%{<input name="utf8" type="hidden" value="&#x2713;" autocomplete="off">}
+        txt = +%{<input type="hidden" name="utf8" value="&#x2713;" autocomplete="off">}
       else
         txt = +""
       end

--- a/actionview/test/template/form_helper_test.rb
+++ b/actionview/test/template/form_helper_test.rb
@@ -373,7 +373,7 @@ class FormHelperTest < ActionView::TestCase
 
   def test_label_with_block_in_erb
     assert_dom_equal(
-      %{<label for="post_message">\n  Message\n  <input id="post_message" name="post[message]" type="text" />\n</label>},
+      %{<label for="post_message">\n  Message\n  <input id="post_message" name="post[message]" type="text">\n</label>},
       view.render("test/label_with_block")
     )
   end
@@ -396,20 +396,20 @@ class FormHelperTest < ActionView::TestCase
 
   def test_text_field_placeholder_without_locales
     I18n.with_locale :placeholder do
-      assert_dom_equal('<input id="post_body" name="post[body]" placeholder="Body" type="text" value="Back to the hill and over it again!" />', text_field(:post, :body, placeholder: true))
+      assert_dom_equal('<input id="post_body" name="post[body]" placeholder="Body" type="text" value="Back to the hill and over it again!">', text_field(:post, :body, placeholder: true))
     end
   end
 
   def test_text_field_placeholder_with_locales
     I18n.with_locale :placeholder do
-      assert_dom_equal('<input id="post_title" name="post[title]" placeholder="What is this about?" type="text" value="Hello World" />', text_field(:post, :title, placeholder: true))
+      assert_dom_equal('<input id="post_title" name="post[title]" placeholder="What is this about?" type="text" value="Hello World">', text_field(:post, :title, placeholder: true))
     end
   end
 
   def test_text_field_placeholder_with_locales_and_to_model
     I18n.with_locale :placeholder do
       assert_dom_equal(
-        '<input id="post_delegator_title" name="post_delegator[title]" placeholder="Delegate model_name title" type="text" value="Hello World" />',
+        '<input id="post_delegator_title" name="post_delegator[title]" placeholder="Delegate model_name title" type="text" value="Hello World">',
         text_field(:post_delegator, :title, placeholder: true)
       )
     end
@@ -417,32 +417,32 @@ class FormHelperTest < ActionView::TestCase
 
   def test_text_field_placeholder_with_human_attribute_name
     I18n.with_locale :placeholder do
-      assert_dom_equal('<input id="post_cost" name="post[cost]" placeholder="Total cost" type="text" />', text_field(:post, :cost, placeholder: true))
+      assert_dom_equal('<input id="post_cost" name="post[cost]" placeholder="Total cost" type="text">', text_field(:post, :cost, placeholder: true))
     end
   end
 
   def test_text_field_placeholder_with_human_attribute_name_and_to_model
     assert_dom_equal(
-      '<input id="post_delegator_title" name="post_delegator[title]" placeholder="Delegate Title" type="text" value="Hello World" />',
+      '<input id="post_delegator_title" name="post_delegator[title]" placeholder="Delegate Title" type="text" value="Hello World">',
       text_field(:post_delegator, :title, placeholder: true)
     )
   end
 
   def test_text_field_placeholder_with_string_value
     I18n.with_locale :placeholder do
-      assert_dom_equal('<input id="post_cost" name="post[cost]" placeholder="HOW MUCH?" type="text" />', text_field(:post, :cost, placeholder: "HOW MUCH?"))
+      assert_dom_equal('<input id="post_cost" name="post[cost]" placeholder="HOW MUCH?" type="text">', text_field(:post, :cost, placeholder: "HOW MUCH?"))
     end
   end
 
   def test_text_field_placeholder_with_human_attribute_name_and_value
     I18n.with_locale :placeholder do
-      assert_dom_equal('<input id="post_cost" name="post[cost]" placeholder="Pounds" type="text" />', text_field(:post, :cost, placeholder: :uk))
+      assert_dom_equal('<input id="post_cost" name="post[cost]" placeholder="Pounds" type="text">', text_field(:post, :cost, placeholder: :uk))
     end
   end
 
   def test_text_field_placeholder_with_locales_and_value
     I18n.with_locale :placeholder do
-      assert_dom_equal('<input id="post_written_on" name="post[written_on]" placeholder="Escrito en" type="text" value="2004-06-15" />', text_field(:post, :written_on, placeholder: :spanish))
+      assert_dom_equal('<input id="post_written_on" name="post[written_on]" placeholder="Escrito en" type="text" value="2004-06-15">', text_field(:post, :written_on, placeholder: :spanish))
     end
   end
 
@@ -455,7 +455,7 @@ class FormHelperTest < ActionView::TestCase
       end
 
       expected = whole_form("/posts/123", "create-post", "edit_post", method: "patch") do
-        '<input id="post_comments_attributes_0_body" name="post[comments_attributes][0][body]" placeholder="Write body here" type="text" />'
+        '<input id="post_comments_attributes_0_body" name="post[comments_attributes][0][body]" placeholder="Write body here" type="text">'
       end
 
       assert_dom_equal expected, @rendered
@@ -471,7 +471,7 @@ class FormHelperTest < ActionView::TestCase
       end
 
       expected = whole_form("/posts/123", "create-post", "edit_post", method: "patch") do
-        '<input id="post_tags_attributes_0_value" name="post[tags_attributes][0][value]" placeholder="Tag" type="text" value="new tag" />'
+        '<input id="post_tags_attributes_0_value" name="post[tags_attributes][0][value]" placeholder="Tag" type="text" value="new tag">'
       end
 
       assert_dom_equal expected, @rendered
@@ -480,19 +480,19 @@ class FormHelperTest < ActionView::TestCase
 
   def test_text_field
     assert_dom_equal(
-      '<input id="post_title" name="post[title]" type="text" value="Hello World" />',
+      '<input id="post_title" name="post[title]" type="text" value="Hello World">',
       text_field("post", "title")
     )
     assert_dom_equal(
-      '<input id="post_title" name="post[title]" type="password" />',
+      '<input id="post_title" name="post[title]" type="password">',
       password_field("post", "title")
     )
     assert_dom_equal(
-      '<input id="post_title" name="post[title]" type="password" value="Hello World" />',
+      '<input id="post_title" name="post[title]" type="password" value="Hello World">',
       password_field("post", "title", value: @post.title)
     )
     assert_dom_equal(
-      '<input id="person_name" name="person[name]" type="password" />',
+      '<input id="person_name" name="person[name]" type="password">',
       password_field("person", "name")
     )
   end
@@ -500,7 +500,7 @@ class FormHelperTest < ActionView::TestCase
   def test_text_field_with_escapes
     @post.title = "<b>Hello World</b>"
     assert_dom_equal(
-      '<input id="post_title" name="post[title]" type="text" value="&lt;b&gt;Hello World&lt;/b&gt;" />',
+      '<input id="post_title" name="post[title]" type="text" value="&lt;b&gt;Hello World&lt;/b&gt;">',
       text_field("post", "title")
     )
   end
@@ -508,52 +508,52 @@ class FormHelperTest < ActionView::TestCase
   def test_text_field_with_html_entities
     @post.title = "The HTML Entity for & is &amp;"
     assert_dom_equal(
-      '<input id="post_title" name="post[title]" type="text" value="The HTML Entity for &amp; is &amp;amp;" />',
+      '<input id="post_title" name="post[title]" type="text" value="The HTML Entity for &amp; is &amp;amp;">',
       text_field("post", "title")
     )
   end
 
   def test_text_field_with_options
-    expected = '<input id="post_title" name="post[title]" size="35" type="text" value="Hello World" />'
+    expected = '<input id="post_title" name="post[title]" size="35" type="text" value="Hello World">'
     assert_dom_equal expected, text_field("post", "title", "size" => 35)
     assert_dom_equal expected, text_field("post", "title", size: 35)
   end
 
   def test_text_field_assuming_size
-    expected = '<input id="post_title" maxlength="35" name="post[title]" size="35" type="text" value="Hello World" />'
+    expected = '<input id="post_title" maxlength="35" name="post[title]" size="35" type="text" value="Hello World">'
     assert_dom_equal expected, text_field("post", "title", "maxlength" => 35)
     assert_dom_equal expected, text_field("post", "title", maxlength: 35)
   end
 
   def test_text_field_removing_size
-    expected = '<input id="post_title" maxlength="35" name="post[title]" type="text" value="Hello World" />'
+    expected = '<input id="post_title" maxlength="35" name="post[title]" type="text" value="Hello World">'
     assert_dom_equal expected, text_field("post", "title", "maxlength" => 35, "size" => nil)
     assert_dom_equal expected, text_field("post", "title", maxlength: 35, size: nil)
   end
 
   def test_text_field_with_nil_value
-    expected = '<input id="post_title" name="post[title]" type="text" />'
+    expected = '<input id="post_title" name="post[title]" type="text">'
     assert_dom_equal expected, text_field("post", "title", value: nil)
   end
 
   def test_text_field_with_nil_name
-    expected = '<input id="post_title" type="text" value="Hello World" />'
+    expected = '<input id="post_title" type="text" value="Hello World">'
     assert_dom_equal expected, text_field("post", "title", name: nil)
   end
 
   def test_text_field_doesnt_change_param_values
     object_name = "post[]"
-    expected = '<input id="post_123_title" name="post[123][title]" type="text" value="Hello World" />'
+    expected = '<input id="post_123_title" name="post[123][title]" type="text" value="Hello World">'
     assert_dom_equal expected, text_field(object_name, "title")
   end
 
   def test_file_field_has_no_size
-    expected = '<input id="user_avatar" name="user[avatar]" type="file" />'
+    expected = '<input id="user_avatar" name="user[avatar]" type="file">'
     assert_dom_equal expected, file_field("user", "avatar")
   end
 
   def test_file_field_with_multiple_behavior
-    expected = '<input id="import_file" multiple="multiple" name="import[file][]" type="file" />'
+    expected = '<input id="import_file" multiple="multiple" name="import[file][]" type="file">'
     assert_dom_equal expected, file_field("import", "file", multiple: true)
   end
 
@@ -562,19 +562,19 @@ class FormHelperTest < ActionView::TestCase
     ActionView::Helpers::FormHelper.multiple_file_field_include_hidden = true
 
     expected = '<input type="hidden" name="import[file][]" autocomplete="off" value="">' \
-               '<input id="import_file" multiple="multiple" name="import[file][]" type="file" />'
+               '<input id="import_file" multiple="multiple" name="import[file][]" type="file">'
     assert_dom_equal expected, file_field("import", "file", multiple: true)
   ensure
     ActionView::Helpers::FormHelper.multiple_file_field_include_hidden = old_value
   end
 
   def test_file_field_with_multiple_behavior_include_hidden_false
-    expected = '<input id="import_file" multiple="multiple" name="import[file][]" type="file" />'
+    expected = '<input id="import_file" multiple="multiple" name="import[file][]" type="file">'
     assert_dom_equal expected, file_field("import", "file", multiple: true, include_hidden: false)
   end
 
   def test_file_field_with_multiple_behavior_and_explicit_name
-    expected = '<input id="import_file" multiple="multiple" name="custom" type="file" />'
+    expected = '<input id="import_file" multiple="multiple" name="custom" type="file">'
     assert_dom_equal expected, file_field("import", "file", multiple: true, name: "custom")
   end
 
@@ -583,28 +583,28 @@ class FormHelperTest < ActionView::TestCase
     ActionView::Helpers::FormHelper.multiple_file_field_include_hidden = true
 
     expected = '<input type="hidden" name="custom" autocomplete="off" value="">' \
-               '<input id="import_file" multiple="multiple" name="custom" type="file" />'
+               '<input id="import_file" multiple="multiple" name="custom" type="file">'
     assert_dom_equal expected, file_field("import", "file", multiple: true, name: "custom")
   ensure
     ActionView::Helpers::FormHelper.multiple_file_field_include_hidden = old_value
   end
 
   def test_file_field_with_direct_upload_when_rails_direct_uploads_url_is_not_defined
-    expected = '<input type="file" name="import[file]" id="import_file" />'
+    expected = '<input type="file" name="import[file]" id="import_file">'
     assert_dom_equal expected, file_field("import", "file", direct_upload: true)
   end
 
   def test_file_field_with_direct_upload_when_rails_direct_uploads_url_is_defined
     @controller = WithActiveStorageRoutesControllers.new
 
-    expected = '<input data-direct-upload-url="http://testtwo.host/rails/active_storage/direct_uploads" type="file" name="import[file]" id="import_file" />'
+    expected = '<input data-direct-upload-url="http://testtwo.host/rails/active_storage/direct_uploads" type="file" name="import[file]" id="import_file">'
     assert_dom_equal expected, file_field("import", "file", direct_upload: true)
   end
 
   def test_file_field_with_direct_upload_dont_mutate_arguments
     original_options = { class: "pix", direct_upload: true }
 
-    expected = '<input class="pix" type="file" name="import[file]" id="import_file" />'
+    expected = '<input class="pix" type="file" name="import[file]" id="import_file">'
     assert_dom_equal expected, file_field("import", "file", original_options)
 
     assert_equal({ class: "pix", direct_upload: true }, original_options)
@@ -612,11 +612,11 @@ class FormHelperTest < ActionView::TestCase
 
   def test_hidden_field
     assert_dom_equal(
-      '<input id="post_title" name="post[title]" type="hidden" value="Hello World" autocomplete="off" />',
+      '<input id="post_title" name="post[title]" type="hidden" value="Hello World" autocomplete="off">',
       hidden_field("post", "title")
     )
     assert_dom_equal(
-      '<input id="post_secret" name="post[secret]" type="hidden" value="1" autocomplete="off" />',
+      '<input id="post_secret" name="post[secret]" type="hidden" value="1" autocomplete="off">',
       hidden_field("post", "secret?")
     )
   end
@@ -624,26 +624,26 @@ class FormHelperTest < ActionView::TestCase
   def test_hidden_field_with_escapes
     @post.title = "<b>Hello World</b>"
     assert_dom_equal(
-      '<input id="post_title" name="post[title]" type="hidden" value="&lt;b&gt;Hello World&lt;/b&gt;" autocomplete="off" />',
+      '<input id="post_title" name="post[title]" type="hidden" value="&lt;b&gt;Hello World&lt;/b&gt;" autocomplete="off">',
       hidden_field("post", "title")
     )
   end
 
   def test_hidden_field_with_nil_value
-    expected = '<input id="post_title" name="post[title]" type="hidden" autocomplete="off" />'
+    expected = '<input id="post_title" name="post[title]" type="hidden" autocomplete="off">'
     assert_dom_equal expected, hidden_field("post", "title", value: nil)
   end
 
   def test_hidden_field_with_options
     assert_dom_equal(
-      '<input id="post_title" name="post[title]" type="hidden" value="Something Else" autocomplete="off" />',
+      '<input id="post_title" name="post[title]" type="hidden" value="Something Else" autocomplete="off">',
       hidden_field("post", "title", value: "Something Else")
     )
   end
 
   def test_text_field_with_custom_type
     assert_dom_equal(
-      '<input id="user_email" name="user[email]" type="email" />',
+      '<input id="user_email" name="user[email]" type="email">',
       text_field("user", "email", type: "email")
     )
   end
@@ -654,7 +654,7 @@ class FormHelperTest < ActionView::TestCase
 
   def test_check_box_checked_if_object_value_is_same_that_check_value
     assert_dom_equal(
-      '<input name="post[secret]" type="hidden" value="0" autocomplete="off" /><input checked="checked" id="post_secret" name="post[secret]" type="checkbox" value="1" />',
+      '<input name="post[secret]" type="hidden" value="0" autocomplete="off"><input checked="checked" id="post_secret" name="post[secret]" type="checkbox" value="1">',
       check_box("post", "secret")
     )
   end
@@ -662,14 +662,14 @@ class FormHelperTest < ActionView::TestCase
   def test_check_box_not_checked_if_object_value_is_same_that_unchecked_value
     @post.secret = 0
     assert_dom_equal(
-      '<input name="post[secret]" type="hidden" value="0" autocomplete="off" /><input id="post_secret" name="post[secret]" type="checkbox" value="1" />',
+      '<input name="post[secret]" type="hidden" value="0" autocomplete="off"><input id="post_secret" name="post[secret]" type="checkbox" value="1">',
       check_box("post", "secret")
     )
   end
 
   def test_check_box_checked_if_option_checked_is_present
     assert_dom_equal(
-      '<input name="post[secret]" type="hidden" value="0" autocomplete="off" /><input checked="checked" id="post_secret" name="post[secret]" type="checkbox" value="1" />',
+      '<input name="post[secret]" type="hidden" value="0" autocomplete="off"><input checked="checked" id="post_secret" name="post[secret]" type="checkbox" value="1">',
       check_box("post", "secret", "checked" => "checked")
     )
   end
@@ -677,12 +677,12 @@ class FormHelperTest < ActionView::TestCase
   def test_check_box_checked_if_object_value_is_true
     @post.secret = true
     assert_dom_equal(
-      '<input name="post[secret]" type="hidden" value="0" autocomplete="off" /><input checked="checked" id="post_secret" name="post[secret]" type="checkbox" value="1" />',
+      '<input name="post[secret]" type="hidden" value="0" autocomplete="off"><input checked="checked" id="post_secret" name="post[secret]" type="checkbox" value="1">',
       check_box("post", "secret")
     )
 
     assert_dom_equal(
-      '<input name="post[secret]" type="hidden" value="0" autocomplete="off" /><input checked="checked" id="post_secret" name="post[secret]" type="checkbox" value="1" />',
+      '<input name="post[secret]" type="hidden" value="0" autocomplete="off"><input checked="checked" id="post_secret" name="post[secret]" type="checkbox" value="1">',
       check_box("post", "secret?")
     )
   end
@@ -690,19 +690,19 @@ class FormHelperTest < ActionView::TestCase
   def test_check_box_checked_if_object_value_includes_checked_value
     @post.secret = ["0"]
     assert_dom_equal(
-      '<input name="post[secret]" type="hidden" value="0" autocomplete="off" /><input id="post_secret" name="post[secret]" type="checkbox" value="1" />',
+      '<input name="post[secret]" type="hidden" value="0" autocomplete="off"><input id="post_secret" name="post[secret]" type="checkbox" value="1">',
       check_box("post", "secret")
     )
 
     @post.secret = ["1"]
     assert_dom_equal(
-      '<input name="post[secret]" type="hidden" value="0" autocomplete="off" /><input checked="checked" id="post_secret" name="post[secret]" type="checkbox" value="1" />',
+      '<input name="post[secret]" type="hidden" value="0" autocomplete="off"><input checked="checked" id="post_secret" name="post[secret]" type="checkbox" value="1">',
       check_box("post", "secret")
     )
 
     @post.secret = Set.new(["1"])
     assert_dom_equal(
-      '<input name="post[secret]" type="hidden" value="0" autocomplete="off" /><input checked="checked" id="post_secret" name="post[secret]" type="checkbox" value="1" />',
+      '<input name="post[secret]" type="hidden" value="0" autocomplete="off"><input checked="checked" id="post_secret" name="post[secret]" type="checkbox" value="1">',
       check_box("post", "secret")
     )
   end
@@ -710,7 +710,7 @@ class FormHelperTest < ActionView::TestCase
   def test_check_box_with_include_hidden_false
     @post.secret = false
     assert_dom_equal(
-      '<input id="post_secret" name="post[secret]" type="checkbox" value="1" />',
+      '<input id="post_secret" name="post[secret]" type="checkbox" value="1">',
       check_box("post", "secret", include_hidden: false)
     )
   end
@@ -718,13 +718,13 @@ class FormHelperTest < ActionView::TestCase
   def test_check_box_with_explicit_checked_and_unchecked_values_when_object_value_is_string
     @post.secret = "on"
     assert_dom_equal(
-      '<input name="post[secret]" type="hidden" value="off" autocomplete="off" /><input checked="checked" id="post_secret" name="post[secret]" type="checkbox" value="on" />',
+      '<input name="post[secret]" type="hidden" value="off" autocomplete="off"><input checked="checked" id="post_secret" name="post[secret]" type="checkbox" value="on">',
       check_box("post", "secret", {}, "on", "off")
     )
 
     @post.secret = "off"
     assert_dom_equal(
-      '<input name="post[secret]" type="hidden" value="off" autocomplete="off" /><input id="post_secret" name="post[secret]" type="checkbox" value="on" />',
+      '<input name="post[secret]" type="hidden" value="off" autocomplete="off"><input id="post_secret" name="post[secret]" type="checkbox" value="on">',
       check_box("post", "secret", {}, "on", "off")
     )
   end
@@ -732,13 +732,13 @@ class FormHelperTest < ActionView::TestCase
   def test_check_box_with_explicit_checked_and_unchecked_values_when_object_value_is_boolean
     @post.secret = false
     assert_dom_equal(
-      '<input name="post[secret]" type="hidden" value="true" autocomplete="off" /><input checked="checked" id="post_secret" name="post[secret]" type="checkbox" value="false" />',
+      '<input name="post[secret]" type="hidden" value="true" autocomplete="off"><input checked="checked" id="post_secret" name="post[secret]" type="checkbox" value="false">',
       check_box("post", "secret", {}, false, true)
     )
 
     @post.secret = true
     assert_dom_equal(
-      '<input name="post[secret]" type="hidden" value="true" autocomplete="off" /><input id="post_secret" name="post[secret]" type="checkbox" value="false" />',
+      '<input name="post[secret]" type="hidden" value="true" autocomplete="off"><input id="post_secret" name="post[secret]" type="checkbox" value="false">',
       check_box("post", "secret", {}, false, true)
     )
   end
@@ -746,19 +746,19 @@ class FormHelperTest < ActionView::TestCase
   def test_check_box_with_explicit_checked_and_unchecked_values_when_object_value_is_integer
     @post.secret = 0
     assert_dom_equal(
-      '<input name="post[secret]" type="hidden" value="1" autocomplete="off" /><input checked="checked" id="post_secret" name="post[secret]" type="checkbox" value="0" />',
+      '<input name="post[secret]" type="hidden" value="1" autocomplete="off"><input checked="checked" id="post_secret" name="post[secret]" type="checkbox" value="0">',
       check_box("post", "secret", {}, 0, 1)
     )
 
     @post.secret = 1
     assert_dom_equal(
-      '<input name="post[secret]" type="hidden" value="1" autocomplete="off" /><input id="post_secret" name="post[secret]" type="checkbox" value="0" />',
+      '<input name="post[secret]" type="hidden" value="1" autocomplete="off"><input id="post_secret" name="post[secret]" type="checkbox" value="0">',
       check_box("post", "secret", {}, 0, 1)
     )
 
     @post.secret = 2
     assert_dom_equal(
-      '<input name="post[secret]" type="hidden" value="1" autocomplete="off" /><input id="post_secret" name="post[secret]" type="checkbox" value="0" />',
+      '<input name="post[secret]" type="hidden" value="1" autocomplete="off"><input id="post_secret" name="post[secret]" type="checkbox" value="0">',
       check_box("post", "secret", {}, 0, 1)
     )
   end
@@ -766,19 +766,19 @@ class FormHelperTest < ActionView::TestCase
   def test_check_box_with_explicit_checked_and_unchecked_values_when_object_value_is_float
     @post.secret = 0.0
     assert_dom_equal(
-      '<input name="post[secret]" type="hidden" value="1" autocomplete="off" /><input checked="checked" id="post_secret" name="post[secret]" type="checkbox" value="0" />',
+      '<input name="post[secret]" type="hidden" value="1" autocomplete="off"><input checked="checked" id="post_secret" name="post[secret]" type="checkbox" value="0">',
       check_box("post", "secret", {}, 0, 1)
     )
 
     @post.secret = 1.1
     assert_dom_equal(
-      '<input name="post[secret]" type="hidden" value="1" autocomplete="off" /><input id="post_secret" name="post[secret]" type="checkbox" value="0" />',
+      '<input name="post[secret]" type="hidden" value="1" autocomplete="off"><input id="post_secret" name="post[secret]" type="checkbox" value="0">',
       check_box("post", "secret", {}, 0, 1)
     )
 
     @post.secret = 2.2
     assert_dom_equal(
-      '<input name="post[secret]" type="hidden" value="1" autocomplete="off" /><input id="post_secret" name="post[secret]" type="checkbox" value="0" />',
+      '<input name="post[secret]" type="hidden" value="1" autocomplete="off"><input id="post_secret" name="post[secret]" type="checkbox" value="0">',
       check_box("post", "secret", {}, 0, 1)
     )
   end
@@ -786,19 +786,19 @@ class FormHelperTest < ActionView::TestCase
   def test_check_box_with_explicit_checked_and_unchecked_values_when_object_value_is_big_decimal
     @post.secret = BigDecimal(0)
     assert_dom_equal(
-      '<input name="post[secret]" type="hidden" value="1" autocomplete="off" /><input checked="checked" id="post_secret" name="post[secret]" type="checkbox" value="0" />',
+      '<input name="post[secret]" type="hidden" value="1" autocomplete="off"><input checked="checked" id="post_secret" name="post[secret]" type="checkbox" value="0">',
       check_box("post", "secret", {}, 0, 1)
     )
 
     @post.secret = BigDecimal(1)
     assert_dom_equal(
-      '<input name="post[secret]" type="hidden" value="1" autocomplete="off" /><input id="post_secret" name="post[secret]" type="checkbox" value="0" />',
+      '<input name="post[secret]" type="hidden" value="1" autocomplete="off"><input id="post_secret" name="post[secret]" type="checkbox" value="0">',
       check_box("post", "secret", {}, 0, 1)
     )
 
     @post.secret = BigDecimal(2.2, 1)
     assert_dom_equal(
-      '<input name="post[secret]" type="hidden" value="1" autocomplete="off" /><input id="post_secret" name="post[secret]" type="checkbox" value="0" />',
+      '<input name="post[secret]" type="hidden" value="1" autocomplete="off"><input id="post_secret" name="post[secret]" type="checkbox" value="0">',
       check_box("post", "secret", {}, 0, 1)
     )
   end
@@ -806,7 +806,7 @@ class FormHelperTest < ActionView::TestCase
   def test_check_box_with_nil_unchecked_value
     @post.secret = "on"
     assert_dom_equal(
-      '<input checked="checked" id="post_secret" name="post[secret]" type="checkbox" value="on" />',
+      '<input checked="checked" id="post_secret" name="post[secret]" type="checkbox" value="on">',
       check_box("post", "secret", {}, "on", nil)
     )
   end
@@ -818,11 +818,11 @@ class FormHelperTest < ActionView::TestCase
   def test_check_box_with_multiple_behavior
     @post.comment_ids = [2, 3]
     assert_dom_equal(
-      '<input name="post[comment_ids][]" type="hidden" value="0" autocomplete="off" /><input id="post_comment_ids_1" name="post[comment_ids][]" type="checkbox" value="1" />',
+      '<input name="post[comment_ids][]" type="hidden" value="0" autocomplete="off"><input id="post_comment_ids_1" name="post[comment_ids][]" type="checkbox" value="1">',
       check_box("post", "comment_ids", { multiple: true }, 1)
     )
     assert_dom_equal(
-      '<input name="post[comment_ids][]" type="hidden" value="0" autocomplete="off" /><input checked="checked" id="post_comment_ids_3" name="post[comment_ids][]" type="checkbox" value="3" />',
+      '<input name="post[comment_ids][]" type="hidden" value="0" autocomplete="off"><input checked="checked" id="post_comment_ids_3" name="post[comment_ids][]" type="checkbox" value="3">',
       check_box("post", "comment_ids", { multiple: true }, 3)
     )
   end
@@ -830,64 +830,64 @@ class FormHelperTest < ActionView::TestCase
   def test_check_box_with_multiple_behavior_and_index
     @post.comment_ids = [2, 3]
     assert_dom_equal(
-      '<input name="post[foo][comment_ids][]" type="hidden" value="0" autocomplete="off" /><input id="post_foo_comment_ids_1" name="post[foo][comment_ids][]" type="checkbox" value="1" />',
+      '<input name="post[foo][comment_ids][]" type="hidden" value="0" autocomplete="off"><input id="post_foo_comment_ids_1" name="post[foo][comment_ids][]" type="checkbox" value="1">',
       check_box("post", "comment_ids", { multiple: true, index: "foo" }, 1)
     )
     assert_dom_equal(
-      '<input name="post[bar][comment_ids][]" type="hidden" value="0" autocomplete="off" /><input checked="checked" id="post_bar_comment_ids_3" name="post[bar][comment_ids][]" type="checkbox" value="3" />',
+      '<input name="post[bar][comment_ids][]" type="hidden" value="0" autocomplete="off"><input checked="checked" id="post_bar_comment_ids_3" name="post[bar][comment_ids][]" type="checkbox" value="3">',
       check_box("post", "comment_ids", { multiple: true, index: "bar" }, 3)
     )
   end
 
   def test_checkbox_disabled_disables_hidden_field
     assert_dom_equal(
-      '<input name="post[secret]" type="hidden" value="0" disabled="disabled" autocomplete="off"/><input checked="checked" disabled="disabled" id="post_secret" name="post[secret]" type="checkbox" value="1" />',
+      '<input name="post[secret]" type="hidden" value="0" disabled="disabled" autocomplete="off"><input checked="checked" disabled="disabled" id="post_secret" name="post[secret]" type="checkbox" value="1">',
       check_box("post", "secret", disabled: true)
     )
   end
 
   def test_checkbox_form_html5_attribute
     assert_dom_equal(
-      '<input form="new_form" name="post[secret]" type="hidden" value="0" autocomplete="off" /><input checked="checked" form="new_form" id="post_secret" name="post[secret]" type="checkbox" value="1" />',
+      '<input form="new_form" name="post[secret]" type="hidden" value="0" autocomplete="off"><input checked="checked" form="new_form" id="post_secret" name="post[secret]" type="checkbox" value="1">',
       check_box("post", "secret", form: "new_form")
     )
   end
 
   def test_radio_button
-    assert_dom_equal('<input checked="checked" id="post_title_hello_world" name="post[title]" type="radio" value="Hello World" />',
+    assert_dom_equal('<input checked="checked" id="post_title_hello_world" name="post[title]" type="radio" value="Hello World">',
       radio_button("post", "title", "Hello World")
     )
-    assert_dom_equal('<input id="post_title_goodbye_world" name="post[title]" type="radio" value="Goodbye World" />',
+    assert_dom_equal('<input id="post_title_goodbye_world" name="post[title]" type="radio" value="Goodbye World">',
       radio_button("post", "title", "Goodbye World")
     )
-    assert_dom_equal('<input id="item_subobject_title_inside_world" name="item[subobject][title]" type="radio" value="inside world"/>',
+    assert_dom_equal('<input id="item_subobject_title_inside_world" name="item[subobject][title]" type="radio" value="inside world">',
       radio_button("item[subobject]", "title", "inside world")
     )
   end
 
   def test_radio_button_is_checked_with_integers
-    assert_dom_equal('<input checked="checked" id="post_secret_1" name="post[secret]" type="radio" value="1" />',
+    assert_dom_equal('<input checked="checked" id="post_secret_1" name="post[secret]" type="radio" value="1">',
       radio_button("post", "secret", "1")
     )
   end
 
   def test_radio_button_with_negative_integer_value
-    assert_dom_equal('<input id="post_secret_-1" name="post[secret]" type="radio" value="-1" />',
+    assert_dom_equal('<input id="post_secret_-1" name="post[secret]" type="radio" value="-1">',
       radio_button("post", "secret", "-1"))
   end
 
   def test_radio_button_respects_passed_in_id
-    assert_dom_equal('<input checked="checked" id="foo" name="post[secret]" type="radio" value="1" />',
+    assert_dom_equal('<input checked="checked" id="foo" name="post[secret]" type="radio" value="1">',
       radio_button("post", "secret", "1", id: "foo")
     )
   end
 
   def test_radio_button_with_booleans
-    assert_dom_equal('<input id="post_secret_true" name="post[secret]" type="radio" value="true" />',
+    assert_dom_equal('<input id="post_secret_true" name="post[secret]" type="radio" value="true">',
       radio_button("post", "secret", true)
     )
 
-    assert_dom_equal('<input id="post_secret_false" name="post[secret]" type="radio" value="false" />',
+    assert_dom_equal('<input id="post_secret_false" name="post[secret]" type="radio" value="false">',
       radio_button("post", "secret", false)
     )
   end
@@ -1050,49 +1050,49 @@ class FormHelperTest < ActionView::TestCase
   end
 
   def test_color_field_with_valid_hex_color_string
-    expected = %{<input id="car_color" name="car[color]" type="color" value="#000fff" />}
+    expected = %{<input id="car_color" name="car[color]" type="color" value="#000fff">}
     assert_dom_equal(expected, color_field("car", "color"))
   end
 
   def test_color_field_with_invalid_hex_color_string
-    expected = %{<input id="car_color" name="car[color]" type="color" value="#000000" />}
+    expected = %{<input id="car_color" name="car[color]" type="color" value="#000000">}
     @car.color = "#1234TR"
     assert_dom_equal(expected, color_field("car", "color"))
   end
 
   def test_color_field_with_value_attr
-    expected = %{<input id="car_color" name="car[color]" type="color" value="#00FF00" />}
+    expected = %{<input id="car_color" name="car[color]" type="color" value="#00FF00">}
     assert_dom_equal(expected, color_field("car", "color", value: "#00FF00"))
   end
 
   def test_search_field
-    expected = %{<input id="contact_notes_query" name="contact[notes_query]" type="search" />}
+    expected = %{<input id="contact_notes_query" name="contact[notes_query]" type="search">}
     assert_dom_equal(expected, search_field("contact", "notes_query"))
   end
 
   def test_search_field_with_onsearch_value
-    expected = %{<input onsearch="true" type="search" name="contact[notes_query]" id="contact_notes_query" incremental="true" />}
+    expected = %{<input onsearch="true" type="search" name="contact[notes_query]" id="contact_notes_query" incremental="true">}
     assert_dom_equal(expected, search_field("contact", "notes_query", onsearch: true))
   end
 
   def test_telephone_field
-    expected = %{<input id="user_cell" name="user[cell]" type="tel" />}
+    expected = %{<input id="user_cell" name="user[cell]" type="tel">}
     assert_dom_equal(expected, telephone_field("user", "cell"))
   end
 
   def test_date_field
-    expected = %{<input id="post_written_on" name="post[written_on]" type="date" value="2004-06-15" />}
+    expected = %{<input id="post_written_on" name="post[written_on]" type="date" value="2004-06-15">}
     assert_dom_equal(expected, date_field("post", "written_on"))
   end
 
   def test_date_field_with_datetime_value
-    expected = %{<input id="post_written_on" name="post[written_on]" type="date" value="2004-06-15" />}
+    expected = %{<input id="post_written_on" name="post[written_on]" type="date" value="2004-06-15">}
     @post.written_on = DateTime.new(2004, 6, 15, 1, 2, 3)
     assert_dom_equal(expected, date_field("post", "written_on"))
   end
 
   def test_date_field_with_extra_attrs
-    expected = %{<input id="post_written_on" step="2" max="2010-08-15" min="2000-06-15" name="post[written_on]" type="date" value="2004-06-15" />}
+    expected = %{<input id="post_written_on" step="2" max="2010-08-15" min="2000-06-15" name="post[written_on]" type="date" value="2004-06-15">}
     @post.written_on = DateTime.new(2004, 6, 15)
     min_value = DateTime.new(2000, 6, 15)
     max_value = DateTime.new(2010, 8, 15)
@@ -1101,20 +1101,20 @@ class FormHelperTest < ActionView::TestCase
   end
 
   def test_date_field_with_value_attr
-    expected = %{<input id="post_written_on" name="post[written_on]" type="date" value="2013-06-29" />}
+    expected = %{<input id="post_written_on" name="post[written_on]" type="date" value="2013-06-29">}
     value = Date.new(2013, 6, 29)
     assert_dom_equal(expected, date_field("post", "written_on", value: value))
   end
 
   def test_date_field_with_datetime_value_attr
-    expected = %{<input id="post_written_on" name="post[written_on]" type="date" value="2013-06-29" />}
+    expected = %{<input id="post_written_on" name="post[written_on]" type="date" value="2013-06-29">}
     value = DateTime.new(2013, 6, 29)
     assert_dom_equal(expected, date_field("post", "written_on", value: value))
   end
 
   def test_date_field_with_timewithzone_value
     previous_time_zone, Time.zone = Time.zone, "UTC"
-    expected = %{<input id="post_written_on" name="post[written_on]" type="date" value="2004-06-15" />}
+    expected = %{<input id="post_written_on" name="post[written_on]" type="date" value="2004-06-15">}
     @post.written_on = Time.zone.parse("2004-06-15 15:30:45")
     assert_dom_equal(expected, date_field("post", "written_on"))
   ensure
@@ -1122,13 +1122,13 @@ class FormHelperTest < ActionView::TestCase
   end
 
   def test_date_field_with_nil_value
-    expected = %{<input id="post_written_on" name="post[written_on]" type="date" />}
+    expected = %{<input id="post_written_on" name="post[written_on]" type="date">}
     @post.written_on = nil
     assert_dom_equal(expected, date_field("post", "written_on"))
   end
 
   def test_date_field_with_string_values_for_min_and_max
-    expected = %{<input id="post_written_on" max="2010-08-15" min="2000-06-15" name="post[written_on]" type="date" value="2004-06-15" />}
+    expected = %{<input id="post_written_on" max="2010-08-15" min="2000-06-15" name="post[written_on]" type="date" value="2004-06-15">}
     @post.written_on = DateTime.new(2004, 6, 15)
     min_value = "2000-06-15"
     max_value = "2010-08-15"
@@ -1136,7 +1136,7 @@ class FormHelperTest < ActionView::TestCase
   end
 
   def test_date_field_with_invalid_string_values_for_min_and_max
-    expected = %{<input id="post_written_on" name="post[written_on]" type="date" value="2004-06-15" />}
+    expected = %{<input id="post_written_on" name="post[written_on]" type="date" value="2004-06-15">}
     @post.written_on = DateTime.new(2004, 6, 15, 1, 2, 3)
     min_value = "foo"
     max_value = "bar"
@@ -1144,18 +1144,18 @@ class FormHelperTest < ActionView::TestCase
   end
 
   def test_time_field
-    expected = %{<input id="post_written_on" name="post[written_on]" type="time" value="00:00:00.000" />}
+    expected = %{<input id="post_written_on" name="post[written_on]" type="time" value="00:00:00.000">}
     assert_dom_equal(expected, time_field("post", "written_on"))
   end
 
   def test_time_field_with_datetime_value
-    expected = %{<input id="post_written_on" name="post[written_on]" type="time" value="01:02:03.000" />}
+    expected = %{<input id="post_written_on" name="post[written_on]" type="time" value="01:02:03.000">}
     @post.written_on = DateTime.new(2004, 6, 15, 1, 2, 3)
     assert_dom_equal(expected, time_field("post", "written_on"))
   end
 
   def test_time_field_with_extra_attrs
-    expected = %{<input id="post_written_on" step="60" max="10:25:00.000" min="20:45:30.000" name="post[written_on]" type="time" value="01:02:03.000" />}
+    expected = %{<input id="post_written_on" step="60" max="10:25:00.000" min="20:45:30.000" name="post[written_on]" type="time" value="01:02:03.000">}
     @post.written_on = DateTime.new(2004, 6, 15, 1, 2, 3)
     min_value = DateTime.new(2000, 6, 15, 20, 45, 30)
     max_value = DateTime.new(2010, 8, 15, 10, 25, 00)
@@ -1164,19 +1164,19 @@ class FormHelperTest < ActionView::TestCase
   end
 
   def test_time_field_with_value_attr
-    expected = %{<input id="post_written_on" name="post[written_on]" type="time" value="01:02:03.000" />}
+    expected = %{<input id="post_written_on" name="post[written_on]" type="time" value="01:02:03.000">}
     value = DateTime.new(2004, 6, 15, 1, 2, 3)
     assert_dom_equal(expected, time_field("post", "written_on", value: value))
   end
 
   def test_time_field_with_value_attr_that_excludes_seconds
-    expected = %{<input id="post_written_on" name="post[written_on]" type="time" value="01:45" />}
+    expected = %{<input id="post_written_on" name="post[written_on]" type="time" value="01:45">}
     assert_dom_equal(expected, time_field("post", "written_on", value: "01:45"))
   end
 
   def test_time_field_with_timewithzone_value
     previous_time_zone, Time.zone = Time.zone, "UTC"
-    expected = %{<input id="post_written_on" name="post[written_on]" type="time" value="01:02:03.000" />}
+    expected = %{<input id="post_written_on" name="post[written_on]" type="time" value="01:02:03.000">}
     @post.written_on = Time.zone.parse("2004-06-15 01:02:03")
     assert_dom_equal(expected, time_field("post", "written_on"))
   ensure
@@ -1184,13 +1184,13 @@ class FormHelperTest < ActionView::TestCase
   end
 
   def test_time_field_with_nil_value
-    expected = %{<input id="post_written_on" name="post[written_on]" type="time" />}
+    expected = %{<input id="post_written_on" name="post[written_on]" type="time">}
     @post.written_on = nil
     assert_dom_equal(expected, time_field("post", "written_on"))
   end
 
   def test_time_field_with_string_values_for_min_and_max
-    expected = %{<input id="post_written_on" max="10:25:00.000" min="20:45:30.000" name="post[written_on]" type="time" value="01:02:03.000" />}
+    expected = %{<input id="post_written_on" max="10:25:00.000" min="20:45:30.000" name="post[written_on]" type="time" value="01:02:03.000">}
     @post.written_on = DateTime.new(2004, 6, 15, 1, 2, 3)
     min_value = "20:45:30.000"
     max_value = "10:25:00.000"
@@ -1198,7 +1198,7 @@ class FormHelperTest < ActionView::TestCase
   end
 
   def test_time_field_with_invalid_string_values_for_min_and_max
-    expected = %{<input id="post_written_on" name="post[written_on]" type="time" value="01:02:03.000" />}
+    expected = %{<input id="post_written_on" name="post[written_on]" type="time" value="01:02:03.000">}
     @post.written_on = DateTime.new(2004, 6, 15, 1, 2, 3)
     min_value = "foo"
     max_value = "bar"
@@ -1206,7 +1206,7 @@ class FormHelperTest < ActionView::TestCase
   end
 
   def test_time_field_without_seconds
-    expected = %{<input id="post_written_on" name="post[written_on]" type="time" value="01:02" max="10:25" min="20:45" />}
+    expected = %{<input id="post_written_on" name="post[written_on]" type="time" value="01:02" max="10:25" min="20:45">}
     @post.written_on = DateTime.new(2004, 6, 15, 1, 2, 3)
     min_value = DateTime.new(2000, 6, 15, 20, 45, 30)
     max_value = DateTime.new(2010, 8, 15, 10, 25, 00)
@@ -1214,18 +1214,18 @@ class FormHelperTest < ActionView::TestCase
   end
 
   def test_datetime_field
-    expected = %{<input id="post_written_on" name="post[written_on]" type="datetime-local" value="2004-06-15T00:00:00" />}
+    expected = %{<input id="post_written_on" name="post[written_on]" type="datetime-local" value="2004-06-15T00:00:00">}
     assert_dom_equal(expected, datetime_field("post", "written_on"))
   end
 
   def test_datetime_field_with_datetime_value
-    expected = %{<input id="post_written_on" name="post[written_on]" type="datetime-local" value="2004-06-15T01:02:03" />}
+    expected = %{<input id="post_written_on" name="post[written_on]" type="datetime-local" value="2004-06-15T01:02:03">}
     @post.written_on = DateTime.new(2004, 6, 15, 1, 2, 3)
     assert_dom_equal(expected, datetime_field("post", "written_on"))
   end
 
   def test_datetime_field_with_extra_attrs
-    expected = %{<input id="post_written_on" step="60" max="2010-08-15T10:25:00" min="2000-06-15T20:45:30" name="post[written_on]" type="datetime-local" value="2004-06-15T01:02:03" />}
+    expected = %{<input id="post_written_on" step="60" max="2010-08-15T10:25:00" min="2000-06-15T20:45:30" name="post[written_on]" type="datetime-local" value="2004-06-15T01:02:03">}
     @post.written_on = DateTime.new(2004, 6, 15, 1, 2, 3)
     min_value = DateTime.new(2000, 6, 15, 20, 45, 30)
     max_value = DateTime.new(2010, 8, 15, 10, 25, 00)
@@ -1234,14 +1234,14 @@ class FormHelperTest < ActionView::TestCase
   end
 
   def test_datetime_field_with_value_attr
-    expected = %{<input id="post_written_on" name="post[written_on]" type="datetime-local" value="2013-06-29T13:37:00" />}
+    expected = %{<input id="post_written_on" name="post[written_on]" type="datetime-local" value="2013-06-29T13:37:00">}
     value = DateTime.new(2013, 6, 29, 13, 37)
     assert_dom_equal(expected, datetime_field("post", "written_on", value: value))
   end
 
   def test_datetime_field_with_timewithzone_value
     previous_time_zone, Time.zone = Time.zone, "UTC"
-    expected = %{<input id="post_written_on" name="post[written_on]" type="datetime-local" value="2004-06-15T15:30:45" />}
+    expected = %{<input id="post_written_on" name="post[written_on]" type="datetime-local" value="2004-06-15T15:30:45">}
     @post.written_on = Time.zone.parse("2004-06-15 15:30:45")
     assert_dom_equal(expected, datetime_field("post", "written_on"))
   ensure
@@ -1249,13 +1249,13 @@ class FormHelperTest < ActionView::TestCase
   end
 
   def test_datetime_field_with_nil_value
-    expected = %{<input id="post_written_on" name="post[written_on]" type="datetime-local" />}
+    expected = %{<input id="post_written_on" name="post[written_on]" type="datetime-local">}
     @post.written_on = nil
     assert_dom_equal(expected, datetime_field("post", "written_on"))
   end
 
   def test_datetime_field_with_string_values_for_min_and_max
-    expected = %{<input id="post_written_on" max="2010-08-15T10:25:00" min="2000-06-15T20:45:30" name="post[written_on]" type="datetime-local" value="2004-06-15T01:02:03" />}
+    expected = %{<input id="post_written_on" max="2010-08-15T10:25:00" min="2000-06-15T20:45:30" name="post[written_on]" type="datetime-local" value="2004-06-15T01:02:03">}
     @post.written_on = DateTime.new(2004, 6, 15, 1, 2, 3)
     min_value = "2000-06-15T20:45:30"
     max_value = "2010-08-15T10:25:00"
@@ -1263,7 +1263,7 @@ class FormHelperTest < ActionView::TestCase
   end
 
   def test_datetime_field_with_invalid_string_values_for_min_and_max
-    expected = %{<input id="post_written_on" name="post[written_on]" type="datetime-local" value="2004-06-15T01:02:03" />}
+    expected = %{<input id="post_written_on" name="post[written_on]" type="datetime-local" value="2004-06-15T01:02:03">}
     @post.written_on = DateTime.new(2004, 6, 15, 1, 2, 3)
     min_value = "foo"
     max_value = "bar"
@@ -1271,39 +1271,39 @@ class FormHelperTest < ActionView::TestCase
   end
 
   def test_datetime_local_field
-    expected = %{<input id="post_written_on" name="post[written_on]" type="datetime-local" value="2004-06-15T00:00:00" />}
+    expected = %{<input id="post_written_on" name="post[written_on]" type="datetime-local" value="2004-06-15T00:00:00">}
     assert_dom_equal(expected, datetime_local_field("post", "written_on"))
   end
 
   def test_datetime_local_field_without_seconds
-    expected = %{<input id="post_written_on" name="post[written_on]" type="datetime-local" value="2004-06-15T00:00" />}
+    expected = %{<input id="post_written_on" name="post[written_on]" type="datetime-local" value="2004-06-15T00:00">}
     assert_dom_equal(expected, datetime_local_field("post", "written_on", include_seconds: false))
   end
 
   def test_datetime_local_field_with_value_attr_that_excludes_seconds
-    expected = %{<input id="post_written_on" name="post[written_on]" type="datetime-local" value="2004-06-15T00:00" />}
+    expected = %{<input id="post_written_on" name="post[written_on]" type="datetime-local" value="2004-06-15T00:00">}
     assert_dom_equal(expected, datetime_local_field("post", "written_on", value: "2004-06-15T00:00"))
   end
 
   def test_month_field
-    expected = %{<input id="post_written_on" name="post[written_on]" type="month" value="2004-06" />}
+    expected = %{<input id="post_written_on" name="post[written_on]" type="month" value="2004-06">}
     assert_dom_equal(expected, month_field("post", "written_on"))
   end
 
   def test_month_field_with_nil_value
-    expected = %{<input id="post_written_on" name="post[written_on]" type="month" />}
+    expected = %{<input id="post_written_on" name="post[written_on]" type="month">}
     @post.written_on = nil
     assert_dom_equal(expected, month_field("post", "written_on"))
   end
 
   def test_month_field_with_datetime_value
-    expected = %{<input id="post_written_on" name="post[written_on]" type="month" value="2004-06" />}
+    expected = %{<input id="post_written_on" name="post[written_on]" type="month" value="2004-06">}
     @post.written_on = DateTime.new(2004, 6, 15, 1, 2, 3)
     assert_dom_equal(expected, month_field("post", "written_on"))
   end
 
   def test_month_field_with_extra_attrs
-    expected = %{<input id="post_written_on" step="2" max="2010-12" min="2000-02" name="post[written_on]" type="month" value="2004-06" />}
+    expected = %{<input id="post_written_on" step="2" max="2010-12" min="2000-02" name="post[written_on]" type="month" value="2004-06">}
     @post.written_on = DateTime.new(2004, 6, 15, 1, 2, 3)
     min_value = DateTime.new(2000, 2, 13)
     max_value = DateTime.new(2010, 12, 23)
@@ -1312,14 +1312,14 @@ class FormHelperTest < ActionView::TestCase
   end
 
   def test_month_field_with_datetime_value_attr
-    expected = %{<input id="post_written_on" name="post[written_on]" type="month" value="2004-06" />}
+    expected = %{<input id="post_written_on" name="post[written_on]" type="month" value="2004-06">}
     value = DateTime.new(2004, 6, 15, 1, 2, 3)
     assert_dom_equal(expected, month_field("post", "written_on", value: value))
   end
 
   def test_month_field_with_timewithzone_value
     previous_time_zone, Time.zone = Time.zone, "UTC"
-    expected = %{<input id="post_written_on" name="post[written_on]" type="month" value="2004-06" />}
+    expected = %{<input id="post_written_on" name="post[written_on]" type="month" value="2004-06">}
     @post.written_on = Time.zone.parse("2004-06-15 15:30:45")
     assert_dom_equal(expected, month_field("post", "written_on"))
   ensure
@@ -1327,24 +1327,24 @@ class FormHelperTest < ActionView::TestCase
   end
 
   def test_week_field
-    expected = %{<input id="post_written_on" name="post[written_on]" type="week" value="2004-W25" />}
+    expected = %{<input id="post_written_on" name="post[written_on]" type="week" value="2004-W25">}
     assert_dom_equal(expected, week_field("post", "written_on"))
   end
 
   def test_week_field_with_nil_value
-    expected = %{<input id="post_written_on" name="post[written_on]" type="week" />}
+    expected = %{<input id="post_written_on" name="post[written_on]" type="week">}
     @post.written_on = nil
     assert_dom_equal(expected, week_field("post", "written_on"))
   end
 
   def test_week_field_with_datetime_value
-    expected = %{<input id="post_written_on" name="post[written_on]" type="week" value="2004-W25" />}
+    expected = %{<input id="post_written_on" name="post[written_on]" type="week" value="2004-W25">}
     @post.written_on = DateTime.new(2004, 6, 15, 1, 2, 3)
     assert_dom_equal(expected, week_field("post", "written_on"))
   end
 
   def test_week_field_with_extra_attrs
-    expected = %{<input id="post_written_on" step="2" max="2010-W51" min="2000-W06" name="post[written_on]" type="week" value="2004-W25" />}
+    expected = %{<input id="post_written_on" step="2" max="2010-W51" min="2000-W06" name="post[written_on]" type="week" value="2004-W25">}
     @post.written_on = DateTime.new(2004, 6, 15, 1, 2, 3)
     min_value = DateTime.new(2000, 2, 13)
     max_value = DateTime.new(2010, 12, 23)
@@ -1353,14 +1353,14 @@ class FormHelperTest < ActionView::TestCase
   end
 
   def test_week_field_with_datetime_value_attr
-    expected = %{<input id="post_written_on" name="post[written_on]" type="week" value="2004-W25" />}
+    expected = %{<input id="post_written_on" name="post[written_on]" type="week" value="2004-W25">}
     value = DateTime.new(2004, 6, 15, 1, 2, 3)
     assert_dom_equal(expected, week_field("post", "written_on", value: value))
   end
 
   def test_week_field_with_timewithzone_value
     previous_time_zone, Time.zone = Time.zone, "UTC"
-    expected = %{<input id="post_written_on" name="post[written_on]" type="week" value="2004-W25" />}
+    expected = %{<input id="post_written_on" name="post[written_on]" type="week" value="2004-W25">}
     @post.written_on = Time.zone.parse("2004-06-15 15:30:45")
     assert_dom_equal(expected, week_field("post", "written_on"))
   ensure
@@ -1368,38 +1368,38 @@ class FormHelperTest < ActionView::TestCase
   end
 
   def test_week_field_week_number_base
-    expected = %{<input id="post_written_on" name="post[written_on]" type="week" value="2015-W01" />}
+    expected = %{<input id="post_written_on" name="post[written_on]" type="week" value="2015-W01">}
     @post.written_on = DateTime.new(2015, 1, 1, 1, 2, 3)
     assert_dom_equal(expected, week_field("post", "written_on"))
   end
 
   def test_url_field
-    expected = %{<input id="user_homepage" name="user[homepage]" type="url" />}
+    expected = %{<input id="user_homepage" name="user[homepage]" type="url">}
     assert_dom_equal(expected, url_field("user", "homepage"))
   end
 
   def test_email_field
-    expected = %{<input id="user_address" name="user[address]" type="email" />}
+    expected = %{<input id="user_address" name="user[address]" type="email">}
     assert_dom_equal(expected, email_field("user", "address"))
   end
 
   def test_number_field
-    expected = %{<input name="order[quantity]" max="9" id="order_quantity" type="number" min="1" />}
+    expected = %{<input name="order[quantity]" max="9" id="order_quantity" type="number" min="1">}
     assert_dom_equal(expected, number_field("order", "quantity", in: 1...10))
-    expected = %{<input name="order[quantity]" size="30" max="9" id="order_quantity" type="number" min="1" />}
+    expected = %{<input name="order[quantity]" size="30" max="9" id="order_quantity" type="number" min="1">}
     assert_dom_equal(expected, number_field("order", "quantity", size: 30, in: 1...10))
   end
 
   def test_range_input
-    expected = %{<input name="hifi[volume]" step="0.1" max="11" id="hifi_volume" type="range" min="0" />}
+    expected = %{<input name="hifi[volume]" step="0.1" max="11" id="hifi_volume" type="range" min="0">}
     assert_dom_equal(expected, range_field("hifi", "volume", in: 0..11, step: 0.1))
-    expected = %{<input name="hifi[volume]" step="0.1" size="30" max="11" id="hifi_volume" type="range" min="0" />}
+    expected = %{<input name="hifi[volume]" step="0.1" size="30" max="11" id="hifi_volume" type="range" min="0">}
     assert_dom_equal(expected, range_field("hifi", "volume", size: 30, in: 0..11, step: 0.1))
   end
 
   def test_explicit_name
     assert_dom_equal(
-      '<input id="post_title" name="dont guess" type="text" value="Hello World" />',
+      '<input id="post_title" name="dont guess" type="text" value="Hello World">',
       text_field("post", "title", "name" => "dont guess")
     )
     assert_dom_equal(
@@ -1407,7 +1407,7 @@ class FormHelperTest < ActionView::TestCase
       text_area("post", "body", "name" => "really!")
     )
     assert_dom_equal(
-      '<input name="i mean it" type="hidden" value="0" autocomplete="off" /><input checked="checked" id="post_secret" name="i mean it" type="checkbox" value="1" />',
+      '<input name="i mean it" type="hidden" value="0" autocomplete="off"><input checked="checked" id="post_secret" name="i mean it" type="checkbox" value="1">',
       check_box("post", "secret", "name" => "i mean it")
     )
     assert_dom_equal(
@@ -1426,7 +1426,7 @@ class FormHelperTest < ActionView::TestCase
 
   def test_explicit_id
     assert_dom_equal(
-      '<input id="dont guess" name="post[title]" type="text" value="Hello World" />',
+      '<input id="dont guess" name="post[title]" type="text" value="Hello World">',
       text_field("post", "title", "id" => "dont guess")
     )
     assert_dom_equal(
@@ -1434,7 +1434,7 @@ class FormHelperTest < ActionView::TestCase
       text_area("post", "body", "id" => "really!")
     )
     assert_dom_equal(
-      '<input name="post[secret]" type="hidden" value="0" autocomplete="off" /><input checked="checked" id="i mean it" name="post[secret]" type="checkbox" value="1" />',
+      '<input name="post[secret]" type="hidden" value="0" autocomplete="off"><input checked="checked" id="i mean it" name="post[secret]" type="checkbox" value="1">',
       check_box("post", "secret", "id" => "i mean it")
     )
     assert_dom_equal(
@@ -1453,7 +1453,7 @@ class FormHelperTest < ActionView::TestCase
 
   def test_nil_id
     assert_dom_equal(
-      '<input name="post[title]" type="text" value="Hello World" />',
+      '<input name="post[title]" type="text" value="Hello World">',
       text_field("post", "title", "id" => nil)
     )
     assert_dom_equal(
@@ -1461,11 +1461,11 @@ class FormHelperTest < ActionView::TestCase
       text_area("post", "body", "id" => nil)
     )
     assert_dom_equal(
-      '<input name="post[secret]" type="hidden" value="0" autocomplete="off" /><input checked="checked" name="post[secret]" type="checkbox" value="1" />',
+      '<input name="post[secret]" type="hidden" value="0" autocomplete="off"><input checked="checked" name="post[secret]" type="checkbox" value="1">',
       check_box("post", "secret", "id" => nil)
     )
     assert_dom_equal(
-      '<input type="radio" name="post[secret]" value="0" />',
+      '<input type="radio" name="post[secret]" value="0">',
       radio_button("post", "secret", "0", "id" => nil)
     )
     assert_dom_equal(
@@ -1492,7 +1492,7 @@ class FormHelperTest < ActionView::TestCase
 
   def test_index
     assert_dom_equal(
-      '<input name="post[5][title]" id="post_5_title" type="text" value="Hello World" />',
+      '<input name="post[5][title]" id="post_5_title" type="text" value="Hello World">',
       text_field("post", "title", "index" => 5)
     )
     assert_dom_equal(
@@ -1500,7 +1500,7 @@ class FormHelperTest < ActionView::TestCase
       text_area("post", "body", "index" => 5)
     )
     assert_dom_equal(
-      '<input name="post[5][secret]" type="hidden" value="0" autocomplete="off" /><input checked="checked" name="post[5][secret]" type="checkbox" value="1" id="post_5_secret" />',
+      '<input name="post[5][secret]" type="hidden" value="0" autocomplete="off"><input checked="checked" name="post[5][secret]" type="checkbox" value="1" id="post_5_secret">',
       check_box("post", "secret", "index" => 5)
     )
     assert_dom_equal(
@@ -1519,7 +1519,7 @@ class FormHelperTest < ActionView::TestCase
 
   def test_index_with_nil_id
     assert_dom_equal(
-      '<input name="post[5][title]" type="text" value="Hello World" />',
+      '<input name="post[5][title]" type="text" value="Hello World">',
       text_field("post", "title", "index" => 5, "id" => nil)
     )
     assert_dom_equal(
@@ -1527,7 +1527,7 @@ class FormHelperTest < ActionView::TestCase
       text_area("post", "body", "index" => 5, "id" => nil)
     )
     assert_dom_equal(
-      '<input name="post[5][secret]" type="hidden" value="0" autocomplete="off" /><input checked="checked" name="post[5][secret]" type="checkbox" value="1" />',
+      '<input name="post[5][secret]" type="hidden" value="0" autocomplete="off"><input checked="checked" name="post[5][secret]" type="checkbox" value="1">',
       check_box("post", "secret", "index" => 5, "id" => nil)
     )
     assert_dom_equal(
@@ -1551,7 +1551,7 @@ class FormHelperTest < ActionView::TestCase
       label("post[]", "title")
     )
     assert_dom_equal(
-      %{<input id="post_#{pid}_title" name="post[#{pid}][title]" type="text" value="Hello World" />},
+      %{<input id="post_#{pid}_title" name="post[#{pid}][title]" type="text" value="Hello World">},
       text_field("post[]", "title")
     )
     assert_dom_equal(
@@ -1559,15 +1559,15 @@ class FormHelperTest < ActionView::TestCase
       text_area("post[]", "body")
     )
     assert_dom_equal(
-      %{<input name="post[#{pid}][secret]" type="hidden" value="0" autocomplete="off" /><input checked="checked" id="post_#{pid}_secret" name="post[#{pid}][secret]" type="checkbox" value="1" />},
+      %{<input name="post[#{pid}][secret]" type="hidden" value="0" autocomplete="off"><input checked="checked" id="post_#{pid}_secret" name="post[#{pid}][secret]" type="checkbox" value="1">},
       check_box("post[]", "secret")
     )
     assert_dom_equal(
-      %{<input checked="checked" id="post_#{pid}_title_hello_world" name="post[#{pid}][title]" type="radio" value="Hello World" />},
+      %{<input checked="checked" id="post_#{pid}_title_hello_world" name="post[#{pid}][title]" type="radio" value="Hello World">},
       radio_button("post[]", "title", "Hello World")
     )
     assert_dom_equal(
-      %{<input id="post_#{pid}_title_goodbye_world" name="post[#{pid}][title]" type="radio" value="Goodbye World" />},
+      %{<input id="post_#{pid}_title_goodbye_world" name="post[#{pid}][title]" type="radio" value="Goodbye World">},
       radio_button("post[]", "title", "Goodbye World")
     )
   end
@@ -1575,7 +1575,7 @@ class FormHelperTest < ActionView::TestCase
   def test_auto_index_with_nil_id
     pid = 123
     assert_dom_equal(
-      %{<input name="post[#{pid}][title]" type="text" value="Hello World" />},
+      %{<input name="post[#{pid}][title]" type="text" value="Hello World">},
       text_field("post[]", "title", id: nil)
     )
     assert_dom_equal(
@@ -1583,15 +1583,15 @@ class FormHelperTest < ActionView::TestCase
       text_area("post[]", "body", id: nil)
     )
     assert_dom_equal(
-      %{<input name="post[#{pid}][secret]" type="hidden" value="0" autocomplete="off" /><input checked="checked" name="post[#{pid}][secret]" type="checkbox" value="1" />},
+      %{<input name="post[#{pid}][secret]" type="hidden" value="0" autocomplete="off"><input checked="checked" name="post[#{pid}][secret]" type="checkbox" value="1">},
       check_box("post[]", "secret", id: nil)
     )
     assert_dom_equal(
-      %{<input checked="checked" name="post[#{pid}][title]" type="radio" value="Hello World" />},
+      %{<input checked="checked" name="post[#{pid}][title]" type="radio" value="Hello World">},
        radio_button("post[]", "title", "Hello World", id: nil)
     )
     assert_dom_equal(
-      %{<input name="post[#{pid}][title]" type="radio" value="Goodbye World" />},
+      %{<input name="post[#{pid}][title]" type="radio" value="Goodbye World">},
       radio_button("post[]", "title", "Goodbye World", id: nil)
     )
   end
@@ -1632,11 +1632,11 @@ class FormHelperTest < ActionView::TestCase
 
     expected = whole_form("/posts/123", "create-post", "edit_post", method: "patch") do
       "<label for='post_title'>The Title</label>" \
-      "<input name='post[title]' type='text' id='post_title' value='Hello World' />" \
+      "<input name='post[title]' type='text' id='post_title' value='Hello World'>" \
       "<textarea name='post[body]' id='post_body'>\nBack to the hill and over it again!</textarea>" \
-      "<input name='post[secret]' type='hidden' value='0' autocomplete='off' />" \
-      "<input name='post[secret]' checked='checked' type='checkbox' id='post_secret' value='1' />" \
-      "<input name='commit' data-disable-with='Create post' type='submit' value='Create post' />" \
+      "<input name='post[secret]' type='hidden' value='0' autocomplete='off'>" \
+      "<input name='post[secret]' checked='checked' type='checkbox' id='post_secret' value='1'>" \
+      "<input name='commit' data-disable-with='Create post' type='submit' value='Create post'>" \
       "<button name='button' type='submit'>Create post</button>" \
       "<button name='button' type='submit'><span>Create post</span></button>"
     end
@@ -1662,11 +1662,11 @@ class FormHelperTest < ActionView::TestCase
 
     expected = whole_form("/posts/123", "create-post", "edit_post", method: "patch") do
       "<label for='post_title'>The Title</label>" \
-      "<input name='post[title]' type='text' id='post_title' value='Hello World' />" \
+      "<input name='post[title]' type='text' id='post_title' value='Hello World'>" \
       "<textarea name='post[body]' id='post_body'>\nBack to the hill and over it again!</textarea>" \
-      "<input name='post[secret]' type='hidden' value='0' autocomplete='off' />" \
-      "<input name='post[secret]' checked='checked' type='checkbox' id='post_secret' value='1' />" \
-      "<input name='commit' data-disable-with='Create post' type='submit' value='Create post' />" \
+      "<input name='post[secret]' type='hidden' value='0' autocomplete='off'>" \
+      "<input name='post[secret]' checked='checked' type='checkbox' id='post_secret' value='1'>" \
+      "<input name='commit' data-disable-with='Create post' type='submit' value='Create post'>" \
       "<button name='button' type='submit'>Create post</button>" \
       "<button name='button' type='submit'><span>Create post</span></button>"
     end
@@ -1957,10 +1957,10 @@ class FormHelperTest < ActionView::TestCase
     end
 
     expected = whole_form("/posts", "new_post", "new_post") do
-      "<input type='hidden' name='post[active]' value='' autocomplete='off' />" \
-      "<input id='post_active_true' name='post[active]' type='radio' value='true' />" \
+      "<input type='hidden' name='post[active]' value='' autocomplete='off'>" \
+      "<input id='post_active_true' name='post[active]' type='radio' value='true'>" \
       "<label for='post_active_true'>true</label>" \
-      "<input checked='checked' id='post_active_false' name='post[active]' type='radio' value='false' />" \
+      "<input checked='checked' id='post_active_false' name='post[active]' type='radio' value='false'>" \
       "<label for='post_active_false'>false</label>"
     end
 
@@ -1979,12 +1979,12 @@ class FormHelperTest < ActionView::TestCase
     end
 
     expected = whole_form("/posts", "new_post", "new_post") do
-      "<input type='hidden' name='post[active]' value='' autocomplete='off' />" \
+      "<input type='hidden' name='post[active]' value='' autocomplete='off'>" \
       "<label for='post_active_true'>" \
-      "<input id='post_active_true' name='post[active]' type='radio' value='true' />" \
+      "<input id='post_active_true' name='post[active]' type='radio' value='true'>" \
       "true</label>" \
       "<label for='post_active_false'>" \
-      "<input checked='checked' id='post_active_false' name='post[active]' type='radio' value='false' />" \
+      "<input checked='checked' id='post_active_false' name='post[active]' type='radio' value='false'>" \
       "false</label>"
     end
 
@@ -2005,14 +2005,14 @@ class FormHelperTest < ActionView::TestCase
     end
 
     expected = whole_form("/posts", "new_post_1", "new_post") do
-      "<input type='hidden' name='post[active]' value='' autocomplete='off' />" \
+      "<input type='hidden' name='post[active]' value='' autocomplete='off'>" \
       "<label for='post_active_true'>" \
-      "<input id='post_active_true' name='post[active]' type='radio' value='true' />" \
+      "<input id='post_active_true' name='post[active]' type='radio' value='true'>" \
       "true</label>" \
       "<label for='post_active_false'>" \
-      "<input checked='checked' id='post_active_false' name='post[active]' type='radio' value='false' />" \
+      "<input checked='checked' id='post_active_false' name='post[active]' type='radio' value='false'>" \
       "false</label>" \
-      "<input id='post_id' name='post[id]' type='hidden' value='1' autocomplete='off' />"
+      "<input id='post_id' name='post[id]' type='hidden' value='1' autocomplete='off'>"
     end
 
     assert_dom_equal expected, @rendered
@@ -2027,10 +2027,10 @@ class FormHelperTest < ActionView::TestCase
     end
 
     expected = whole_form("/posts", "foo_new_post", "new_post") do
-      "<input type='hidden' name='post[active]' value='' autocomplete='off' />" \
-      "<input id='foo_post_active_true' name='post[active]' type='radio' value='true' />" \
+      "<input type='hidden' name='post[active]' value='' autocomplete='off'>" \
+      "<input id='foo_post_active_true' name='post[active]' type='radio' value='true'>" \
       "<label for='foo_post_active_true'>true</label>" \
-      "<input checked='checked' id='foo_post_active_false' name='post[active]' type='radio' value='false' />" \
+      "<input checked='checked' id='foo_post_active_false' name='post[active]' type='radio' value='false'>" \
       "<label for='foo_post_active_false'>false</label>"
     end
 
@@ -2046,10 +2046,10 @@ class FormHelperTest < ActionView::TestCase
     end
 
     expected = whole_form("/posts", "new_post", "new_post") do
-      "<input type='hidden' name='post[1][active]' value='' autocomplete='off' />" \
-      "<input id='post_1_active_true' name='post[1][active]' type='radio' value='true' />" \
+      "<input type='hidden' name='post[1][active]' value='' autocomplete='off'>" \
+      "<input id='post_1_active_true' name='post[1][active]' type='radio' value='true'>" \
       "<label for='post_1_active_true'>true</label>" \
-      "<input checked='checked' id='post_1_active_false' name='post[1][active]' type='radio' value='false' />" \
+      "<input checked='checked' id='post_1_active_false' name='post[1][active]' type='radio' value='false'>" \
       "<label for='post_1_active_false'>false</label>"
     end
 
@@ -2065,12 +2065,12 @@ class FormHelperTest < ActionView::TestCase
     end
 
     expected = whole_form("/posts", "new_post", "new_post") do
-      "<input name='post[tag_ids][]' type='hidden' value='' autocomplete='off' />" \
-      "<input checked='checked' id='post_tag_ids_1' name='post[tag_ids][]' type='checkbox' value='1' />" \
+      "<input name='post[tag_ids][]' type='hidden' value='' autocomplete='off'>" \
+      "<input checked='checked' id='post_tag_ids_1' name='post[tag_ids][]' type='checkbox' value='1'>" \
       "<label for='post_tag_ids_1'>Tag 1</label>" \
-      "<input id='post_tag_ids_2' name='post[tag_ids][]' type='checkbox' value='2' />" \
+      "<input id='post_tag_ids_2' name='post[tag_ids][]' type='checkbox' value='2'>" \
       "<label for='post_tag_ids_2'>Tag 2</label>" \
-      "<input checked='checked' id='post_tag_ids_3' name='post[tag_ids][]' type='checkbox' value='3' />" \
+      "<input checked='checked' id='post_tag_ids_3' name='post[tag_ids][]' type='checkbox' value='3'>" \
       "<label for='post_tag_ids_3'>Tag 3</label>"
     end
 
@@ -2089,15 +2089,15 @@ class FormHelperTest < ActionView::TestCase
     end
 
     expected = whole_form("/posts", "new_post", "new_post") do
-      "<input name='post[tag_ids][]' type='hidden' value='' autocomplete='off' />" \
+      "<input name='post[tag_ids][]' type='hidden' value='' autocomplete='off'>" \
       "<label for='post_tag_ids_1'>" \
-      "<input checked='checked' id='post_tag_ids_1' name='post[tag_ids][]' type='checkbox' value='1' />" \
+      "<input checked='checked' id='post_tag_ids_1' name='post[tag_ids][]' type='checkbox' value='1'>" \
       "Tag 1</label>" \
       "<label for='post_tag_ids_2'>" \
-      "<input id='post_tag_ids_2' name='post[tag_ids][]' type='checkbox' value='2' />" \
+      "<input id='post_tag_ids_2' name='post[tag_ids][]' type='checkbox' value='2'>" \
       "Tag 2</label>" \
       "<label for='post_tag_ids_3'>" \
-      "<input checked='checked' id='post_tag_ids_3' name='post[tag_ids][]' type='checkbox' value='3' />" \
+      "<input checked='checked' id='post_tag_ids_3' name='post[tag_ids][]' type='checkbox' value='3'>" \
       "Tag 3</label>"
     end
 
@@ -2119,17 +2119,17 @@ class FormHelperTest < ActionView::TestCase
     end
 
     expected = whole_form("/posts", "new_post_1", "new_post") do
-      "<input name='post[tag_ids][]' type='hidden' value='' autocomplete='off' />" \
+      "<input name='post[tag_ids][]' type='hidden' value='' autocomplete='off'>" \
       "<label for='post_tag_ids_1'>" \
-      "<input checked='checked' id='post_tag_ids_1' name='post[tag_ids][]' type='checkbox' value='1' />" \
+      "<input checked='checked' id='post_tag_ids_1' name='post[tag_ids][]' type='checkbox' value='1'>" \
       "Tag 1</label>" \
       "<label for='post_tag_ids_2'>" \
-      "<input id='post_tag_ids_2' name='post[tag_ids][]' type='checkbox' value='2' />" \
+      "<input id='post_tag_ids_2' name='post[tag_ids][]' type='checkbox' value='2'>" \
       "Tag 2</label>" \
       "<label for='post_tag_ids_3'>" \
-      "<input checked='checked' id='post_tag_ids_3' name='post[tag_ids][]' type='checkbox' value='3' />" \
+      "<input checked='checked' id='post_tag_ids_3' name='post[tag_ids][]' type='checkbox' value='3'>" \
       "Tag 3</label>" \
-      "<input id='post_id' name='post[id]' type='hidden' value='1' autocomplete='off' />"
+      "<input id='post_id' name='post[id]' type='hidden' value='1' autocomplete='off'>"
     end
 
     assert_dom_equal expected, @rendered
@@ -2145,8 +2145,8 @@ class FormHelperTest < ActionView::TestCase
     end
 
     expected = whole_form("/posts", "foo_new_post", "new_post") do
-      "<input name='post[tag_ids][]' type='hidden' value='' autocomplete='off' />" \
-      "<input checked='checked' id='foo_post_tag_ids_1' name='post[tag_ids][]' type='checkbox' value='1' />" \
+      "<input name='post[tag_ids][]' type='hidden' value='' autocomplete='off'>" \
+      "<input checked='checked' id='foo_post_tag_ids_1' name='post[tag_ids][]' type='checkbox' value='1'>" \
       "<label for='foo_post_tag_ids_1'>Tag 1</label>"
     end
 
@@ -2163,8 +2163,8 @@ class FormHelperTest < ActionView::TestCase
     end
 
     expected = whole_form("/posts", "new_post", "new_post") do
-      "<input name='post[1][tag_ids][]' type='hidden' value='' autocomplete='off' />" \
-      "<input checked='checked' id='post_1_tag_ids_1' name='post[1][tag_ids][]' type='checkbox' value='1' />" \
+      "<input name='post[1][tag_ids][]' type='hidden' value='' autocomplete='off'>" \
+      "<input checked='checked' id='post_1_tag_ids_1' name='post[1][tag_ids][]' type='checkbox' value='1'>" \
       "<label for='post_1_tag_ids_1'>Tag 1</label>"
     end
 
@@ -2197,7 +2197,7 @@ class FormHelperTest < ActionView::TestCase
     end
 
     expected = whole_form("/posts/123", "create-post", "edit_post", method: "patch", multipart: true) do
-      "<input name='post[file]' type='file' id='post_file' />"
+      "<input name='post[file]' type='file' id='post_file'>"
     end
 
     assert_dom_equal expected, @rendered
@@ -2211,7 +2211,7 @@ class FormHelperTest < ActionView::TestCase
     end
 
     expected = whole_form("/posts/123", "edit_post_123", "edit_post", method: "patch", multipart: true) do
-      "<input name='post[comment][file]' type='file' id='post_comment_file' />"
+      "<input name='post[comment][file]' type='file' id='post_comment_file'>"
     end
 
     assert_dom_equal expected, @rendered
@@ -2250,8 +2250,8 @@ class FormHelperTest < ActionView::TestCase
     end
 
     expected = whole_form("/posts/44", "edit_post_44", "edit_post", method: "patch") do
-      "<input name='post[title]' type='text' id='post_title' value='And his name will be forty and four.' />" \
-      "<input name='commit' data-disable-with='Edit post' type='submit' value='Edit post' />"
+      "<input name='post[title]' type='text' id='post_title' value='And his name will be forty and four.'>" \
+      "<input name='commit' data-disable-with='Edit post' type='submit' value='Edit post'>"
     end
 
     assert_dom_equal expected, @rendered
@@ -2268,11 +2268,11 @@ class FormHelperTest < ActionView::TestCase
 
     expected = whole_form("/posts/123", "create-post", "edit_other_name", method: "patch") do
       "<label for='other_name_title' class='post_title'>Title</label>" \
-      "<input name='other_name[title]' id='other_name_title' value='Hello World' type='text' />" \
+      "<input name='other_name[title]' id='other_name_title' value='Hello World' type='text'>" \
       "<textarea name='other_name[body]' id='other_name_body'>\nBack to the hill and over it again!</textarea>" \
-      "<input name='other_name[secret]' value='0' type='hidden' autocomplete='off' />" \
-      "<input name='other_name[secret]' checked='checked' id='other_name_secret' value='1' type='checkbox' />" \
-      "<input name='commit' value='Create post' data-disable-with='Create post' type='submit' />"
+      "<input name='other_name[secret]' value='0' type='hidden' autocomplete='off'>" \
+      "<input name='other_name[secret]' checked='checked' id='other_name_secret' value='1' type='checkbox'>" \
+      "<input name='commit' value='Create post' data-disable-with='Create post' type='submit'>"
     end
 
     assert_dom_equal expected, @rendered
@@ -2299,10 +2299,10 @@ class FormHelperTest < ActionView::TestCase
     end
 
     expected = whole_form("/", "create-post", "edit_post", method: "delete") do
-      "<input name='post[title]' type='text' id='post_title' value='Hello World' />" \
+      "<input name='post[title]' type='text' id='post_title' value='Hello World'>" \
       "<textarea name='post[body]' id='post_body'>\nBack to the hill and over it again!</textarea>" \
-      "<input name='post[secret]' type='hidden' value='0' autocomplete='off' />" \
-      "<input name='post[secret]' checked='checked' type='checkbox' id='post_secret' value='1' />"
+      "<input name='post[secret]' type='hidden' value='0' autocomplete='off'>" \
+      "<input name='post[secret]' checked='checked' type='checkbox' id='post_secret' value='1'>"
     end
 
     assert_dom_equal expected, @rendered
@@ -2316,10 +2316,10 @@ class FormHelperTest < ActionView::TestCase
     end
 
     expected = whole_form("/", "create-post", "edit_post", method: "delete") do
-      "<input name='post[title]' type='text' id='post_title' value='Hello World' />" \
+      "<input name='post[title]' type='text' id='post_title' value='Hello World'>" \
       "<textarea name='post[body]' id='post_body'>\nBack to the hill and over it again!</textarea>" \
-      "<input name='post[secret]' type='hidden' value='0' autocomplete='off' />" \
-      "<input name='post[secret]' checked='checked' type='checkbox' id='post_secret' value='1' />"
+      "<input name='post[secret]' type='hidden' value='0' autocomplete='off'>" \
+      "<input name='post[secret]' checked='checked' type='checkbox' id='post_secret' value='1'>"
     end
 
     assert_dom_equal expected, @rendered
@@ -2333,7 +2333,7 @@ class FormHelperTest < ActionView::TestCase
     end
 
     expected = whole_form("/search", "search-post", "new_post", method: "get") do
-      "<input name='post[title]' type='search' id='post_title' />"
+      "<input name='post[title]' type='search' id='post_title'>"
     end
 
     assert_dom_equal expected, @rendered
@@ -2347,10 +2347,10 @@ class FormHelperTest < ActionView::TestCase
     end
 
     expected = whole_form("/", "create-post", "edit_post", method: "patch", remote: true) do
-      "<input name='post[title]' type='text' id='post_title' value='Hello World' />" \
+      "<input name='post[title]' type='text' id='post_title' value='Hello World'>" \
       "<textarea name='post[body]' id='post_body'>\nBack to the hill and over it again!</textarea>" \
-      "<input name='post[secret]' type='hidden' value='0' autocomplete='off' />" \
-      "<input name='post[secret]' checked='checked' type='checkbox' id='post_secret' value='1' />"
+      "<input name='post[secret]' type='hidden' value='0' autocomplete='off'>" \
+      "<input name='post[secret]' checked='checked' type='checkbox' id='post_secret' value='1'>"
     end
 
     assert_dom_equal expected, @rendered
@@ -2362,7 +2362,7 @@ class FormHelperTest < ActionView::TestCase
     end
 
     expected = whole_form("/", nil, nil, enforce_utf8: true) do
-      "<input name='post[title]' type='text' id='post_title' value='Hello World' />"
+      "<input name='post[title]' type='text' id='post_title' value='Hello World'>"
     end
 
     assert_dom_equal expected, @rendered
@@ -2374,7 +2374,7 @@ class FormHelperTest < ActionView::TestCase
     end
 
     expected = whole_form("/", nil, nil, enforce_utf8: false) do
-      "<input name='post[title]' type='text' id='post_title' value='Hello World' />"
+      "<input name='post[title]' type='text' id='post_title' value='Hello World'>"
     end
 
     assert_dom_equal expected, @rendered
@@ -2387,7 +2387,7 @@ class FormHelperTest < ActionView::TestCase
       end
 
       expected = whole_form("/", nil, nil, enforce_utf8: false) do
-        "<input name='post[title]' type='text' id='post_title' value='Hello World' />"
+        "<input name='post[title]' type='text' id='post_title' value='Hello World'>"
       end
 
       assert_dom_equal expected, @rendered
@@ -2401,7 +2401,7 @@ class FormHelperTest < ActionView::TestCase
       end
 
       expected = whole_form("/", nil, nil, enforce_utf8: true) do
-        "<input name='post[title]' type='text' id='post_title' value='Hello World' />"
+        "<input name='post[title]' type='text' id='post_title' value='Hello World'>"
       end
 
       assert_dom_equal expected, @rendered
@@ -2416,10 +2416,10 @@ class FormHelperTest < ActionView::TestCase
     end
 
     expected = whole_form("/", "create-post", "edit_post", method: "patch", remote: true) do
-      "<input name='post[title]' type='text' id='post_title' value='Hello World' />" \
+      "<input name='post[title]' type='text' id='post_title' value='Hello World'>" \
       "<textarea name='post[body]' id='post_body'>\nBack to the hill and over it again!</textarea>" \
-      "<input name='post[secret]' type='hidden' value='0' autocomplete='off' />" \
-      "<input name='post[secret]' checked='checked' type='checkbox' id='post_secret' value='1' />"
+      "<input name='post[secret]' type='hidden' value='0' autocomplete='off'>" \
+      "<input name='post[secret]' checked='checked' type='checkbox' id='post_secret' value='1'>"
     end
 
     assert_dom_equal expected, @rendered
@@ -2435,10 +2435,10 @@ class FormHelperTest < ActionView::TestCase
       end
 
       expected = whole_form("/posts", "new_post", "new_post", remote: true) do
-        "<input name='post[title]' type='text' id='post_title' value='Hello World' />" \
+        "<input name='post[title]' type='text' id='post_title' value='Hello World'>" \
         "<textarea name='post[body]' id='post_body'>\nBack to the hill and over it again!</textarea>" \
-        "<input name='post[secret]' type='hidden' value='0' autocomplete='off' />" \
-        "<input name='post[secret]' checked='checked' type='checkbox' id='post_secret' value='1' />"
+        "<input name='post[secret]' type='hidden' value='0' autocomplete='off'>" \
+        "<input name='post[secret]' checked='checked' type='checkbox' id='post_secret' value='1'>"
       end
 
       assert_dom_equal expected, @rendered
@@ -2453,10 +2453,10 @@ class FormHelperTest < ActionView::TestCase
     end
 
     expected = whole_form("/", "create-post") do
-      "<input name='post[title]' type='text' id='post_title' value='Hello World' />" \
+      "<input name='post[title]' type='text' id='post_title' value='Hello World'>" \
       "<textarea name='post[body]' id='post_body'>\nBack to the hill and over it again!</textarea>" \
-      "<input name='post[secret]' type='hidden' value='0' autocomplete='off' />" \
-      "<input name='post[secret]' checked='checked' type='checkbox' id='post_secret' value='1' />"
+      "<input name='post[secret]' type='hidden' value='0' autocomplete='off'>" \
+      "<input name='post[secret]' checked='checked' type='checkbox' id='post_secret' value='1'>"
     end
 
     assert_dom_equal expected, @rendered
@@ -2472,10 +2472,10 @@ class FormHelperTest < ActionView::TestCase
 
     expected = whole_form("/posts/123", "edit_post[]", "edit_post[]", method: "patch") do
       "<label for='post_123_title'>Title</label>" \
-      "<input name='post[123][title]' type='text' id='post_123_title' value='Hello World' />" \
+      "<input name='post[123][title]' type='text' id='post_123_title' value='Hello World'>" \
       "<textarea name='post[123][body]' id='post_123_body'>\nBack to the hill and over it again!</textarea>" \
-      "<input name='post[123][secret]' type='hidden' value='0' autocomplete='off' />" \
-      "<input name='post[123][secret]' checked='checked' type='checkbox' id='post_123_secret' value='1' />"
+      "<input name='post[123][secret]' type='hidden' value='0' autocomplete='off'>" \
+      "<input name='post[123][secret]' checked='checked' type='checkbox' id='post_123_secret' value='1'>"
     end
 
     assert_dom_equal expected, @rendered
@@ -2489,10 +2489,10 @@ class FormHelperTest < ActionView::TestCase
     end
 
     expected = whole_form("/posts/123", "edit_post[]", "edit_post[]", method: "patch") do
-      "<input name='post[][title]' type='text' id='post__title' value='Hello World' />" \
+      "<input name='post[][title]' type='text' id='post__title' value='Hello World'>" \
       "<textarea name='post[][body]' id='post__body'>\nBack to the hill and over it again!</textarea>" \
-      "<input name='post[][secret]' type='hidden' value='0' autocomplete='off' />" \
-      "<input name='post[][secret]' checked='checked' type='checkbox' id='post__secret' value='1' />"
+      "<input name='post[][secret]' type='hidden' value='0' autocomplete='off'>" \
+      "<input name='post[][secret]' checked='checked' type='checkbox' id='post__secret' value='1'>"
     end
 
     assert_dom_equal expected, @rendered
@@ -2507,8 +2507,8 @@ class FormHelperTest < ActionView::TestCase
 
     expected = whole_form("/posts/123", "edit_post_123", "edit_post", method: "patch") do
       "<div class='field_with_errors'><label for='post_author_name' class='label'>Author name</label></div>" \
-      "<div class='field_with_errors'><input name='post[author_name]' type='text' id='post_author_name' value='' /></div>" \
-      "<input name='commit' data-disable-with='Create post' type='submit' value='Create post' />"
+      "<div class='field_with_errors'><input name='post[author_name]' type='text' id='post_author_name' value=''></div>" \
+      "<input name='commit' data-disable-with='Create post' type='submit' value='Create post'>"
     end
 
     assert_dom_equal expected, @rendered
@@ -2525,8 +2525,8 @@ class FormHelperTest < ActionView::TestCase
 
     expected = whole_form("/posts/123", "edit_post_123", "edit_post", method: "patch") do
       "<div class='field_with_errors'><label for='post_author_name' class='label'>Author name</label></div>" \
-      "<div class='field_with_errors'><input name='post[author_name]' type='text' id='post_author_name' value='' /></div>" \
-      "<input name='commit' data-disable-with='Create post' type='submit' value='Create post' />"
+      "<div class='field_with_errors'><input name='post[author_name]' type='text' id='post_author_name' value=''></div>" \
+      "<input name='commit' data-disable-with='Create post' type='submit' value='Create post'>"
     end
 
     assert_dom_equal expected, @rendered
@@ -2554,10 +2554,10 @@ class FormHelperTest < ActionView::TestCase
     end
 
     expected = whole_form("/posts/123", "namespace_edit_post_123", "edit_post", method: "patch") do
-      "<input name='post[title]' type='text' id='namespace_post_title' value='Hello World' />" \
+      "<input name='post[title]' type='text' id='namespace_post_title' value='Hello World'>" \
       "<textarea name='post[body]' id='namespace_post_body'>\nBack to the hill and over it again!</textarea>" \
-      "<input name='post[secret]' type='hidden' value='0' autocomplete='off' />" \
-      "<input name='post[secret]' checked='checked' type='checkbox' id='namespace_post_secret' value='1' />"
+      "<input name='post[secret]' type='hidden' value='0' autocomplete='off'>" \
+      "<input name='post[secret]' checked='checked' type='checkbox' id='namespace_post_secret' value='1'>"
     end
 
     assert_dom_equal expected, @rendered
@@ -2579,7 +2579,7 @@ class FormHelperTest < ActionView::TestCase
 
     expected = whole_form("/posts/123", "namespace_edit_post_123", "edit_post", method: "patch") do
       "<label for='namespace_post_title'>Title</label>" \
-      "<input name='post[title]' type='text' id='namespace_post_title' value='Hello World' />"
+      "<input name='post[title]' type='text' id='namespace_post_title' value='Hello World'>"
     end
 
     assert_dom_equal expected, @rendered
@@ -2591,7 +2591,7 @@ class FormHelperTest < ActionView::TestCase
     end
 
     expected = whole_form("/posts/123", "namespace_edit_custom_name", "edit_custom_name", method: "patch") do
-      "<input id='namespace_custom_name_title' name='custom_name[title]' type='text' value='Hello World' />"
+      "<input id='namespace_custom_name_title' name='custom_name[title]' type='text' value='Hello World'>"
     end
 
     assert_dom_equal expected, @rendered
@@ -2605,7 +2605,7 @@ class FormHelperTest < ActionView::TestCase
 
     expected_1 = whole_form("/posts/123", "namespace_1_edit_post_123", "edit_post", method: "patch") do
       "<label for='namespace_1_post_title'>Title</label>" \
-      "<input name='post[title]' type='text' id='namespace_1_post_title' value='Hello World' />"
+      "<input name='post[title]' type='text' id='namespace_1_post_title' value='Hello World'>"
     end
 
     assert_dom_equal expected_1, @rendered
@@ -2617,7 +2617,7 @@ class FormHelperTest < ActionView::TestCase
 
     expected_2 = whole_form("/posts/123", "namespace_2_edit_post_123", "edit_post", method: "patch") do
       "<label for='namespace_2_post_title'>Title</label>" \
-      "<input name='post[title]' type='text' id='namespace_2_post_title' value='Hello World' />"
+      "<input name='post[title]' type='text' id='namespace_2_post_title' value='Hello World'>"
     end
 
     assert_dom_equal expected_2, @rendered
@@ -2634,9 +2634,9 @@ class FormHelperTest < ActionView::TestCase
     end
 
     expected = whole_form("/posts/123", "namespace_edit_post_123", "edit_post", method: "patch") do
-      "<input name='post[title]' type='text' id='namespace_post_title' value='Hello World' />" \
+      "<input name='post[title]' type='text' id='namespace_post_title' value='Hello World'>" \
       "<textarea name='post[body]' id='namespace_post_body'>\nBack to the hill and over it again!</textarea>" \
-      "<input name='post[comment][body]' type='text' id='namespace_post_comment_body' value='Hello World' />"
+      "<input name='post[comment][body]' type='text' id='namespace_post_comment_body' value='Hello World'>"
     end
 
     assert_dom_equal expected, @rendered
@@ -2651,7 +2651,7 @@ class FormHelperTest < ActionView::TestCase
         end
 
         expected = whole_form("/posts", "new_post", "new_post") do
-          "<input name='commit' data-disable-with='Create Post' type='submit' value='Create Post' />"
+          "<input name='commit' data-disable-with='Create Post' type='submit' value='Create Post'>"
         end
 
         assert_dom_equal expected, @rendered
@@ -2666,7 +2666,7 @@ class FormHelperTest < ActionView::TestCase
       end
 
       expected = whole_form("/posts/123", "edit_post_123", "edit_post", method: "patch") do
-        "<input name='commit' data-disable-with='Confirm Post changes' type='submit' value='Confirm Post changes' />"
+        "<input name='commit' data-disable-with='Confirm Post changes' type='submit' value='Confirm Post changes'>"
       end
 
       assert_dom_equal expected, @rendered
@@ -2680,7 +2680,7 @@ class FormHelperTest < ActionView::TestCase
       end
 
       expected = whole_form do
-        "<input name='commit' class='extra' data-disable-with='Save changes' type='submit' value='Save changes' />"
+        "<input name='commit' class='extra' data-disable-with='Save changes' type='submit' value='Save changes'>"
       end
 
       assert_dom_equal expected, @rendered
@@ -2694,7 +2694,7 @@ class FormHelperTest < ActionView::TestCase
       end
 
       expected = whole_form("/posts/123", "edit_another_post", "edit_another_post", method: "patch") do
-        "<input name='commit' data-disable-with='Update your Post' type='submit' value='Update your Post' />"
+        "<input name='commit' data-disable-with='Update your Post' type='submit' value='Update your Post'>"
       end
 
       assert_dom_equal expected, @rendered
@@ -2709,7 +2709,7 @@ class FormHelperTest < ActionView::TestCase
       end
 
       expected = whole_form("/posts/44", "edit_post_44", "edit_post", method: "patch") do
-        "<input name='commit' data-disable-with='Update your Post' type='submit' value='Update your Post' />"
+        "<input name='commit' data-disable-with='Update your Post' type='submit' value='Update your Post'>"
       end
 
       assert_dom_equal expected, @rendered
@@ -2821,7 +2821,7 @@ class FormHelperTest < ActionView::TestCase
     end
 
     expected = whole_form("/posts/123", "edit_post_123", "edit_post", method: "patch") do
-      "<input name='post[comment][body]' type='text' id='post_comment_body' value='Hello World' />"
+      "<input name='post[comment][body]' type='text' id='post_comment_body' value='Hello World'>"
     end
 
     assert_dom_equal expected, @rendered
@@ -2869,7 +2869,7 @@ class FormHelperTest < ActionView::TestCase
     end
 
     expected = whole_form do
-      "<input name='posts[post][0][comment][1][name]' type='text' id='posts_post_0_comment_1_name' value='comment #1' />"
+      "<input name='posts[post][0][comment][1][name]' type='text' id='posts_post_0_comment_1_name' value='comment #1'>"
     end
 
     assert_dom_equal expected, @rendered
@@ -2885,9 +2885,9 @@ class FormHelperTest < ActionView::TestCase
     end
 
     expected = whole_form("/posts/123", "edit_post[]", "edit_post[]", method: "patch") do
-      "<input name='post[123][title]' type='text' id='post_123_title' value='Hello World' />" \
-      "<input name='post[123][comment][][name]' type='text' id='post_123_comment__name' value='new comment' />" \
-      "<input name='post[123][body]' type='text' id='post_123_body' value='Back to the hill and over it again!' />"
+      "<input name='post[123][title]' type='text' id='post_123_title' value='Hello World'>" \
+      "<input name='post[123][comment][][name]' type='text' id='post_123_comment__name' value='new comment'>" \
+      "<input name='post[123][body]' type='text' id='post_123_body' value='Back to the hill and over it again!'>"
     end
 
     assert_dom_equal expected, @rendered
@@ -2902,8 +2902,8 @@ class FormHelperTest < ActionView::TestCase
     end
 
     expected = whole_form("/posts/123", "edit_post_123", "edit_post", method: "patch") do
-      "<input name='post[1][title]' type='text' id='post_1_title' value='Hello World' />" \
-      "<input name='post[1][comment][1][name]' type='text' id='post_1_comment_1_name' value='new comment' />"
+      "<input name='post[1][title]' type='text' id='post_1_title' value='Hello World'>" \
+      "<input name='post[1][comment][1][name]' type='text' id='post_1_comment_1_name' value='new comment'>"
     end
 
     assert_dom_equal expected, @rendered
@@ -2917,7 +2917,7 @@ class FormHelperTest < ActionView::TestCase
     end
 
     expected = whole_form("/posts/123", "edit_post_123", "edit_post", method: "patch") do
-      "<input name='post[1][comment][title]' type='text' id='post_1_comment_title' value='Hello World' />"
+      "<input name='post[1][comment][title]' type='text' id='post_1_comment_title' value='Hello World'>"
     end
 
     assert_dom_equal expected, @rendered
@@ -2931,7 +2931,7 @@ class FormHelperTest < ActionView::TestCase
     end
 
     expected = whole_form("/posts/123", "edit_post_123", "edit_post", method: "patch") do
-      "<input name='post[1][comment][5][title]' type='text' id='post_1_comment_5_title' value='Hello World' />"
+      "<input name='post[1][comment][5][title]' type='text' id='post_1_comment_5_title' value='Hello World'>"
     end
 
     assert_dom_equal expected, @rendered
@@ -2945,7 +2945,7 @@ class FormHelperTest < ActionView::TestCase
     end
 
     expected = whole_form("/posts/123", "edit_post[]", "edit_post[]", method: "patch") do
-      "<input name='post[123][comment][title]' type='text' id='post_123_comment_title' value='Hello World' />"
+      "<input name='post[123][comment][title]' type='text' id='post_123_comment_title' value='Hello World'>"
     end
 
     assert_dom_equal expected, @rendered
@@ -2959,7 +2959,7 @@ class FormHelperTest < ActionView::TestCase
     end
 
     expected = whole_form("/posts/123", "edit_post_123", "edit_post", method: "patch") do
-      "<input name='post[comment][5][title]' type='radio' id='post_comment_5_title_hello' value='hello' />"
+      "<input name='post[comment][5][title]' type='radio' id='post_comment_5_title_hello' value='hello'>"
     end
 
     assert_dom_equal expected, @rendered
@@ -2973,7 +2973,7 @@ class FormHelperTest < ActionView::TestCase
     end
 
     expected = whole_form("/posts/123", "edit_post[]", "edit_post[]", method: "patch") do
-      "<input name='post[123][comment][123][title]' type='text' id='post_123_comment_123_title' value='Hello World' />"
+      "<input name='post[123][comment][123][title]' type='text' id='post_123_comment_123_title' value='Hello World'>"
     end
 
     assert_dom_equal expected, @rendered
@@ -2987,7 +2987,7 @@ class FormHelperTest < ActionView::TestCase
     end
 
     expected = whole_form("/posts/123", "edit_post[]", "edit_post[]", method: "patch") do
-      "<input name='post[123][comment][5][title]' type='text' id='post_123_comment_5_title' value='Hello World' />"
+      "<input name='post[123][comment][5][title]' type='text' id='post_123_comment_5_title' value='Hello World'>"
     end
     assert_dom_equal expected, @rendered
 
@@ -2998,7 +2998,7 @@ class FormHelperTest < ActionView::TestCase
     end
 
     expected = whole_form("/posts/123", "edit_post", "edit_post", method: "patch") do
-      "<input name='post[1][comment][123][title]' type='text' id='post_1_comment_123_title' value='Hello World' />"
+      "<input name='post[1][comment][123][title]' type='text' id='post_1_comment_123_title' value='Hello World'>"
     end
 
     assert_dom_equal expected, @rendered
@@ -3015,8 +3015,8 @@ class FormHelperTest < ActionView::TestCase
     end
 
     expected = whole_form("/posts/123", "edit_post_123", "edit_post", method: "patch") do
-      '<input name="post[title]" type="text" id="post_title" value="Hello World" />' \
-        '<input id="post_author_attributes_name" name="post[author_attributes][name]" type="text" value="new author" />'
+      '<input name="post[title]" type="text" id="post_title" value="Hello World">' \
+        '<input id="post_author_attributes_name" name="post[author_attributes][name]" type="text" value="new author">'
     end
 
     assert_dom_equal expected, @rendered
@@ -3042,9 +3042,9 @@ class FormHelperTest < ActionView::TestCase
     end
 
     expected = whole_form("/posts/123", "edit_post_123", "edit_post", method: "patch") do
-      '<input name="post[title]" type="text" id="post_title" value="Hello World" />' \
-      '<input id="post_author_attributes_name" name="post[author_attributes][name]" type="text" value="author #321" />' \
-      '<input id="post_author_attributes_id" name="post[author_attributes][id]" type="hidden" value="321" autocomplete="off" />'
+      '<input name="post[title]" type="text" id="post_title" value="Hello World">' \
+      '<input id="post_author_attributes_name" name="post[author_attributes][name]" type="text" value="author #321">' \
+      '<input id="post_author_attributes_id" name="post[author_attributes][id]" type="hidden" value="321" autocomplete="off">'
     end
 
     assert_dom_equal expected, @rendered
@@ -3061,9 +3061,9 @@ class FormHelperTest < ActionView::TestCase
     end
 
     expected = whole_form("/posts/123", "edit_post_123", "edit_post", method: "patch") do
-      '<input name="post[title]" type="text" id="post_title" value="Hello World" />' \
-      '<input id="post_author_attributes_name" name="post[author_attributes][name]" type="text" value="author #321" />' \
-      '<input id="post_author_attributes_id" name="post[author_attributes][id]" type="hidden" value="321" autocomplete="off" />'
+      '<input name="post[title]" type="text" id="post_title" value="Hello World">' \
+      '<input id="post_author_attributes_name" name="post[author_attributes][name]" type="text" value="author #321">' \
+      '<input id="post_author_attributes_id" name="post[author_attributes][id]" type="hidden" value="321" autocomplete="off">'
     end
 
     assert_dom_equal expected, @rendered
@@ -3080,8 +3080,8 @@ class FormHelperTest < ActionView::TestCase
     end
 
     expected = whole_form("/posts/123", "edit_post_123", "edit_post", method: "patch") do
-      '<input name="post[title]" type="text" id="post_title" value="Hello World" />' \
-      '<input id="post_author_attributes_name" name="post[author_attributes][name]" type="text" value="author #321" />'
+      '<input name="post[title]" type="text" id="post_title" value="Hello World">' \
+      '<input id="post_author_attributes_name" name="post[author_attributes][name]" type="text" value="author #321">'
     end
 
     assert_dom_equal expected, @rendered
@@ -3098,8 +3098,8 @@ class FormHelperTest < ActionView::TestCase
     end
 
     expected = whole_form("/posts/123", "edit_post_123", "edit_post", method: "patch") do
-      '<input name="post[title]" type="text" id="post_title" value="Hello World" />' \
-      '<input id="post_author_attributes_name" name="post[author_attributes][name]" type="text" value="author #321" />'
+      '<input name="post[title]" type="text" id="post_title" value="Hello World">' \
+      '<input id="post_author_attributes_name" name="post[author_attributes][name]" type="text" value="author #321">'
     end
 
     assert_dom_equal expected, @rendered
@@ -3116,9 +3116,9 @@ class FormHelperTest < ActionView::TestCase
     end
 
     expected = whole_form("/posts/123", "edit_post_123", "edit_post", method: "patch") do
-      '<input name="post[title]" type="text" id="post_title" value="Hello World" />' \
-      '<input id="post_author_attributes_name" name="post[author_attributes][name]" type="text" value="author #321" />' \
-      '<input id="post_author_attributes_id" name="post[author_attributes][id]" type="hidden" value="321" autocomplete="off" />'
+      '<input name="post[title]" type="text" id="post_title" value="Hello World">' \
+      '<input id="post_author_attributes_name" name="post[author_attributes][name]" type="text" value="author #321">' \
+      '<input id="post_author_attributes_id" name="post[author_attributes][id]" type="hidden" value="321" autocomplete="off">'
     end
 
     assert_dom_equal expected, @rendered
@@ -3136,9 +3136,9 @@ class FormHelperTest < ActionView::TestCase
     end
 
     expected = whole_form("/posts/123", "edit_post_123", "edit_post", method: "patch") do
-      '<input name="post[title]" type="text" id="post_title" value="Hello World" />' \
-      '<input id="post_author_attributes_id" name="post[author_attributes][id]" type="hidden" value="321" autocomplete="off" />' \
-      '<input id="post_author_attributes_name" name="post[author_attributes][name]" type="text" value="author #321" />'
+      '<input name="post[title]" type="text" id="post_title" value="Hello World">' \
+      '<input id="post_author_attributes_id" name="post[author_attributes][id]" type="hidden" value="321" autocomplete="off">' \
+      '<input id="post_author_attributes_name" name="post[author_attributes][name]" type="text" value="author #321">'
     end
 
     assert_dom_equal expected, @rendered
@@ -3157,11 +3157,11 @@ class FormHelperTest < ActionView::TestCase
     end
 
     expected = whole_form("/posts/123", "edit_post_123", "edit_post", method: "patch") do
-      '<input name="post[title]" type="text" id="post_title" value="Hello World" />' \
-      '<input id="post_comments_attributes_0_name" name="post[comments_attributes][0][name]" type="text" value="comment #1" />' \
-      '<input id="post_comments_attributes_0_id" name="post[comments_attributes][0][id]" type="hidden" value="1" autocomplete="off" />' \
-      '<input id="post_comments_attributes_1_name" name="post[comments_attributes][1][name]" type="text" value="comment #2" />' \
-      '<input id="post_comments_attributes_1_id" name="post[comments_attributes][1][id]" type="hidden" value="2" autocomplete="off" />'
+      '<input name="post[title]" type="text" id="post_title" value="Hello World">' \
+      '<input id="post_comments_attributes_0_name" name="post[comments_attributes][0][name]" type="text" value="comment #1">' \
+      '<input id="post_comments_attributes_0_id" name="post[comments_attributes][0][id]" type="hidden" value="1" autocomplete="off">' \
+      '<input id="post_comments_attributes_1_name" name="post[comments_attributes][1][name]" type="text" value="comment #2">' \
+      '<input id="post_comments_attributes_1_id" name="post[comments_attributes][1][id]" type="hidden" value="2" autocomplete="off">'
     end
 
     assert_dom_equal expected, @rendered
@@ -3184,11 +3184,11 @@ class FormHelperTest < ActionView::TestCase
     end
 
     expected = whole_form("/posts/123", "edit_post_123", "edit_post", method: "patch") do
-      '<input name="post[title]" type="text" id="post_title" value="Hello World" />' \
-      '<input id="post_author_attributes_name" name="post[author_attributes][name]" type="text" value="author #321" />' \
-      '<input id="post_author_attributes_id" name="post[author_attributes][id]" type="hidden" value="321" autocomplete="off" />' \
-      '<input id="post_comments_attributes_0_name" name="post[comments_attributes][0][name]" type="text" value="comment #1" />' \
-      '<input id="post_comments_attributes_1_name" name="post[comments_attributes][1][name]" type="text" value="comment #2" />'
+      '<input name="post[title]" type="text" id="post_title" value="Hello World">' \
+      '<input id="post_author_attributes_name" name="post[author_attributes][name]" type="text" value="author #321">' \
+      '<input id="post_author_attributes_id" name="post[author_attributes][id]" type="hidden" value="321" autocomplete="off">' \
+      '<input id="post_comments_attributes_0_name" name="post[comments_attributes][0][name]" type="text" value="comment #1">' \
+      '<input id="post_comments_attributes_1_name" name="post[comments_attributes][1][name]" type="text" value="comment #2">'
     end
 
     assert_dom_equal expected, @rendered
@@ -3211,10 +3211,10 @@ class FormHelperTest < ActionView::TestCase
     end
 
     expected = whole_form("/posts/123", "edit_post_123", "edit_post", method: "patch") do
-      '<input name="post[title]" type="text" id="post_title" value="Hello World" />' \
-      '<input id="post_author_attributes_name" name="post[author_attributes][name]" type="text" value="author #321" />' \
-      '<input id="post_comments_attributes_0_name" name="post[comments_attributes][0][name]" type="text" value="comment #1" />' \
-      '<input id="post_comments_attributes_1_name" name="post[comments_attributes][1][name]" type="text" value="comment #2" />'
+      '<input name="post[title]" type="text" id="post_title" value="Hello World">' \
+      '<input id="post_author_attributes_name" name="post[author_attributes][name]" type="text" value="author #321">' \
+      '<input id="post_comments_attributes_0_name" name="post[comments_attributes][0][name]" type="text" value="comment #1">' \
+      '<input id="post_comments_attributes_1_name" name="post[comments_attributes][1][name]" type="text" value="comment #2">'
     end
 
     assert_dom_equal expected, @rendered
@@ -3237,11 +3237,11 @@ class FormHelperTest < ActionView::TestCase
     end
 
     expected = whole_form("/posts/123", "edit_post_123", "edit_post", method: "patch") do
-      '<input name="post[title]" type="text" id="post_title" value="Hello World" />' \
-      '<input id="post_author_attributes_name" name="post[author_attributes][name]" type="text" value="author #321" />' \
-      '<input id="post_author_attributes_id" name="post[author_attributes][id]" type="hidden" value="321" autocomplete="off" />' \
-      '<input id="post_comments_attributes_0_name" name="post[comments_attributes][0][name]" type="text" value="comment #1" />' \
-      '<input id="post_comments_attributes_1_name" name="post[comments_attributes][1][name]" type="text" value="comment #2" />'
+      '<input name="post[title]" type="text" id="post_title" value="Hello World">' \
+      '<input id="post_author_attributes_name" name="post[author_attributes][name]" type="text" value="author #321">' \
+      '<input id="post_author_attributes_id" name="post[author_attributes][id]" type="hidden" value="321" autocomplete="off">' \
+      '<input id="post_comments_attributes_0_name" name="post[comments_attributes][0][name]" type="text" value="comment #1">' \
+      '<input id="post_comments_attributes_1_name" name="post[comments_attributes][1][name]" type="text" value="comment #2">'
     end
 
     assert_dom_equal expected, @rendered
@@ -3260,11 +3260,11 @@ class FormHelperTest < ActionView::TestCase
     end
 
     expected = whole_form("/posts/123", "edit_post_123", "edit_post", method: "patch") do
-      '<input name="post[title]" type="text" id="post_title" value="Hello World" />' \
-      '<input id="post_comments_attributes_0_name" name="post[comments_attributes][0][name]" type="text" value="comment #1" />' \
-      '<input id="post_comments_attributes_0_id" name="post[comments_attributes][0][id]" type="hidden" value="1" autocomplete="off" />' \
-      '<input id="post_comments_attributes_1_name" name="post[comments_attributes][1][name]" type="text" value="comment #2" />' \
-      '<input id="post_comments_attributes_1_id" name="post[comments_attributes][1][id]" type="hidden" value="2" autocomplete="off" />'
+      '<input name="post[title]" type="text" id="post_title" value="Hello World">' \
+      '<input id="post_comments_attributes_0_name" name="post[comments_attributes][0][name]" type="text" value="comment #1">' \
+      '<input id="post_comments_attributes_0_id" name="post[comments_attributes][0][id]" type="hidden" value="1" autocomplete="off">' \
+      '<input id="post_comments_attributes_1_name" name="post[comments_attributes][1][name]" type="text" value="comment #2">' \
+      '<input id="post_comments_attributes_1_id" name="post[comments_attributes][1][id]" type="hidden" value="2" autocomplete="off">'
     end
 
     assert_dom_equal expected, @rendered
@@ -3284,11 +3284,11 @@ class FormHelperTest < ActionView::TestCase
     end
 
     expected = whole_form("/posts/123", "edit_post_123", "edit_post", method: "patch") do
-      '<input name="post[title]" type="text" id="post_title" value="Hello World" />' \
-      '<input id="post_comments_attributes_0_id" name="post[comments_attributes][0][id]" type="hidden" value="1" autocomplete="off" />' \
-      '<input id="post_comments_attributes_0_name" name="post[comments_attributes][0][name]" type="text" value="comment #1" />' \
-      '<input id="post_comments_attributes_1_id" name="post[comments_attributes][1][id]" type="hidden" value="2" autocomplete="off" />' \
-      '<input id="post_comments_attributes_1_name" name="post[comments_attributes][1][name]" type="text" value="comment #2" />'
+      '<input name="post[title]" type="text" id="post_title" value="Hello World">' \
+      '<input id="post_comments_attributes_0_id" name="post[comments_attributes][0][id]" type="hidden" value="1" autocomplete="off">' \
+      '<input id="post_comments_attributes_0_name" name="post[comments_attributes][0][name]" type="text" value="comment #1">' \
+      '<input id="post_comments_attributes_1_id" name="post[comments_attributes][1][id]" type="hidden" value="2" autocomplete="off">' \
+      '<input id="post_comments_attributes_1_name" name="post[comments_attributes][1][name]" type="text" value="comment #2">'
     end
 
     assert_dom_equal expected, @rendered
@@ -3307,9 +3307,9 @@ class FormHelperTest < ActionView::TestCase
     end
 
     expected = whole_form("/posts/123", "edit_post_123", "edit_post", method: "patch") do
-      '<input name="post[title]" type="text" id="post_title" value="Hello World" />' \
-      '<input id="post_comments_attributes_0_name" name="post[comments_attributes][0][name]" type="text" value="new comment" />' \
-      '<input id="post_comments_attributes_1_name" name="post[comments_attributes][1][name]" type="text" value="new comment" />'
+      '<input name="post[title]" type="text" id="post_title" value="Hello World">' \
+      '<input id="post_comments_attributes_0_name" name="post[comments_attributes][0][name]" type="text" value="new comment">' \
+      '<input id="post_comments_attributes_1_name" name="post[comments_attributes][1][name]" type="text" value="new comment">'
     end
 
     assert_dom_equal expected, @rendered
@@ -3328,10 +3328,10 @@ class FormHelperTest < ActionView::TestCase
     end
 
     expected = whole_form("/posts/123", "edit_post_123", "edit_post", method: "patch") do
-      '<input name="post[title]" type="text" id="post_title" value="Hello World" />' \
-      '<input id="post_comments_attributes_0_name" name="post[comments_attributes][0][name]" type="text" value="comment #321" />' \
-      '<input id="post_comments_attributes_0_id" name="post[comments_attributes][0][id]" type="hidden" value="321" autocomplete="off" />' \
-      '<input id="post_comments_attributes_1_name" name="post[comments_attributes][1][name]" type="text" value="new comment" />'
+      '<input name="post[title]" type="text" id="post_title" value="Hello World">' \
+      '<input id="post_comments_attributes_0_name" name="post[comments_attributes][0][name]" type="text" value="comment #321">' \
+      '<input id="post_comments_attributes_0_id" name="post[comments_attributes][0][id]" type="hidden" value="321" autocomplete="off">' \
+      '<input id="post_comments_attributes_1_name" name="post[comments_attributes][1][name]" type="text" value="new comment">'
     end
 
     assert_dom_equal expected, @rendered
@@ -3346,7 +3346,7 @@ class FormHelperTest < ActionView::TestCase
     end
 
     expected = whole_form("/posts/123", "edit_post_123", "edit_post", method: "patch") do
-      '<input name="post[title]" type="text" id="post_title" value="Hello World" />'
+      '<input name="post[title]" type="text" id="post_title" value="Hello World">'
     end
 
     assert_dom_equal expected, @rendered
@@ -3363,11 +3363,11 @@ class FormHelperTest < ActionView::TestCase
     end
 
     expected = whole_form("/posts/123", "edit_post_123", "edit_post", method: "patch") do
-      '<input name="post[title]" type="text" id="post_title" value="Hello World" />' \
-      '<input id="post_comments_attributes_0_name" name="post[comments_attributes][0][name]" type="text" value="comment #1" />' \
-      '<input id="post_comments_attributes_0_id" name="post[comments_attributes][0][id]" type="hidden" value="1" autocomplete="off" />' \
-      '<input id="post_comments_attributes_1_name" name="post[comments_attributes][1][name]" type="text" value="comment #2" />' \
-      '<input id="post_comments_attributes_1_id" name="post[comments_attributes][1][id]" type="hidden" value="2" autocomplete="off" />'
+      '<input name="post[title]" type="text" id="post_title" value="Hello World">' \
+      '<input id="post_comments_attributes_0_name" name="post[comments_attributes][0][name]" type="text" value="comment #1">' \
+      '<input id="post_comments_attributes_0_id" name="post[comments_attributes][0][id]" type="hidden" value="1" autocomplete="off">' \
+      '<input id="post_comments_attributes_1_name" name="post[comments_attributes][1][name]" type="text" value="comment #2">' \
+      '<input id="post_comments_attributes_1_id" name="post[comments_attributes][1][id]" type="hidden" value="2" autocomplete="off">'
     end
 
     assert_dom_equal expected, @rendered
@@ -3384,11 +3384,11 @@ class FormHelperTest < ActionView::TestCase
     end
 
     expected = whole_form("/posts/123", "edit_post_123", "edit_post", method: "patch") do
-      '<input name="post[title]" type="text" id="post_title" value="Hello World" />' \
-      '<input id="post_comments_attributes_0_name" name="post[comments_attributes][0][name]" type="text" value="comment #1" />' \
-      '<input id="post_comments_attributes_0_id" name="post[comments_attributes][0][id]" type="hidden" value="1" autocomplete="off" />' \
-      '<input id="post_comments_attributes_1_name" name="post[comments_attributes][1][name]" type="text" value="comment #2" />' \
-      '<input id="post_comments_attributes_1_id" name="post[comments_attributes][1][id]" type="hidden" value="2" autocomplete="off" />'
+      '<input name="post[title]" type="text" id="post_title" value="Hello World">' \
+      '<input id="post_comments_attributes_0_name" name="post[comments_attributes][0][name]" type="text" value="comment #1">' \
+      '<input id="post_comments_attributes_0_id" name="post[comments_attributes][0][id]" type="hidden" value="1" autocomplete="off">' \
+      '<input id="post_comments_attributes_1_name" name="post[comments_attributes][1][name]" type="text" value="comment #2">' \
+      '<input id="post_comments_attributes_1_id" name="post[comments_attributes][1][id]" type="hidden" value="2" autocomplete="off">'
     end
 
     assert_dom_equal expected, @rendered
@@ -3425,11 +3425,11 @@ class FormHelperTest < ActionView::TestCase
     end
 
     expected = whole_form("/posts/123", "edit_post_123", "edit_post", method: "patch") do
-      '<input name="post[title]" type="text" id="post_title" value="Hello World" />' \
-      '<input id="post_comments_attributes_0_name" name="post[comments_attributes][0][name]" type="text" value="comment #1" />' \
-      '<input id="post_comments_attributes_0_id" name="post[comments_attributes][0][id]" type="hidden" value="1" autocomplete="off" />' \
-      '<input id="post_comments_attributes_1_name" name="post[comments_attributes][1][name]" type="text" value="comment #2" />' \
-      '<input id="post_comments_attributes_1_id" name="post[comments_attributes][1][id]" type="hidden" value="2" autocomplete="off" />'
+      '<input name="post[title]" type="text" id="post_title" value="Hello World">' \
+      '<input id="post_comments_attributes_0_name" name="post[comments_attributes][0][name]" type="text" value="comment #1">' \
+      '<input id="post_comments_attributes_0_id" name="post[comments_attributes][0][id]" type="hidden" value="1" autocomplete="off">' \
+      '<input id="post_comments_attributes_1_name" name="post[comments_attributes][1][name]" type="text" value="comment #2">' \
+      '<input id="post_comments_attributes_1_id" name="post[comments_attributes][1][id]" type="hidden" value="2" autocomplete="off">'
     end
 
     assert_dom_equal expected, @rendered
@@ -3448,10 +3448,10 @@ class FormHelperTest < ActionView::TestCase
     end
 
     expected = whole_form("/posts/123", "edit_post_123", "edit_post", method: "patch") do
-      '<input name="post[title]" type="text" id="post_title" value="Hello World" />' \
-      '<input id="post_comments_attributes_0_name" name="post[comments_attributes][0][name]" type="text" value="comment #321" />' \
-      '<input id="post_comments_attributes_0_id" name="post[comments_attributes][0][id]" type="hidden" value="321" autocomplete="off" />' \
-      '<input id="post_comments_attributes_1_name" name="post[comments_attributes][1][name]" type="text" value="new comment" />'
+      '<input name="post[title]" type="text" id="post_title" value="Hello World">' \
+      '<input id="post_comments_attributes_0_name" name="post[comments_attributes][0][name]" type="text" value="comment #321">' \
+      '<input id="post_comments_attributes_0_id" name="post[comments_attributes][0][id]" type="hidden" value="321" autocomplete="off">' \
+      '<input id="post_comments_attributes_1_name" name="post[comments_attributes][1][name]" type="text" value="new comment">'
     end
 
     assert_dom_equal expected, @rendered
@@ -3468,8 +3468,8 @@ class FormHelperTest < ActionView::TestCase
     end
 
     expected = whole_form("/posts/123", "edit_post_123", "edit_post", method: "patch") do
-      '<input id="post_comments_attributes_abc_name" name="post[comments_attributes][abc][name]" type="text" value="comment #321" />' \
-      '<input id="post_comments_attributes_abc_id" name="post[comments_attributes][abc][id]" type="hidden" value="321" autocomplete="off" />'
+      '<input id="post_comments_attributes_abc_name" name="post[comments_attributes][abc][name]" type="text" value="comment #321">' \
+      '<input id="post_comments_attributes_abc_id" name="post[comments_attributes][abc][id]" type="hidden" value="321" autocomplete="off">'
     end
 
     assert_dom_equal expected, @rendered
@@ -3485,8 +3485,8 @@ class FormHelperTest < ActionView::TestCase
     end
 
     expected = whole_form("/posts/123", "edit_post_123", "edit_post", method: "patch") do
-      '<input id="post_comments_attributes_abc_name" name="post[comments_attributes][abc][name]" type="text" value="comment #321" />' \
-      '<input id="post_comments_attributes_abc_id" name="post[comments_attributes][abc][id]" type="hidden" value="321" autocomplete="off" />'
+      '<input id="post_comments_attributes_abc_name" name="post[comments_attributes][abc][name]" type="text" value="comment #321">' \
+      '<input id="post_comments_attributes_abc_id" name="post[comments_attributes][abc][id]" type="hidden" value="321" autocomplete="off">'
     end
 
     assert_dom_equal expected, @rendered
@@ -3508,8 +3508,8 @@ class FormHelperTest < ActionView::TestCase
     end
 
     expected = whole_form("/posts/123", "edit_post_123", "edit_post", method: "patch") do
-      '<input id="post_comments_attributes_abc_name" name="post[comments_attributes][abc][name]" type="text" value="comment #321" />' \
-      '<input id="post_comments_attributes_abc_id" name="post[comments_attributes][abc][id]" type="hidden" value="321" autocomplete="off" />'
+      '<input id="post_comments_attributes_abc_name" name="post[comments_attributes][abc][name]" type="text" value="comment #321">' \
+      '<input id="post_comments_attributes_abc_id" name="post[comments_attributes][abc][id]" type="hidden" value="321" autocomplete="off">'
     end
 
     assert_dom_equal expected, @rendered
@@ -3594,18 +3594,18 @@ class FormHelperTest < ActionView::TestCase
     end
 
     expected = whole_form("/posts/123", "edit_post_123", "edit_post", method: "patch") do
-      '<input id="post_comments_attributes_0_name" name="post[comments_attributes][0][name]" type="text" value="comment #321" />' \
-      '<input id="post_comments_attributes_0_relevances_attributes_0_value" name="post[comments_attributes][0][relevances_attributes][0][value]" type="text" value="commentrelevance #314" />' \
-      '<input id="post_comments_attributes_0_relevances_attributes_0_id" name="post[comments_attributes][0][relevances_attributes][0][id]" type="hidden" value="314" autocomplete="off" />' \
-      '<input id="post_comments_attributes_0_id" name="post[comments_attributes][0][id]" type="hidden" value="321" autocomplete="off" />' \
-      '<input id="post_tags_attributes_0_value" name="post[tags_attributes][0][value]" type="text" value="tag #123" />' \
-      '<input id="post_tags_attributes_0_relevances_attributes_0_value" name="post[tags_attributes][0][relevances_attributes][0][value]" type="text" value="tagrelevance #3141" />' \
-      '<input id="post_tags_attributes_0_relevances_attributes_0_id" name="post[tags_attributes][0][relevances_attributes][0][id]" type="hidden" value="3141" autocomplete="off" />' \
-      '<input id="post_tags_attributes_0_id" name="post[tags_attributes][0][id]" type="hidden" value="123" autocomplete="off" />' \
-      '<input id="post_tags_attributes_1_value" name="post[tags_attributes][1][value]" type="text" value="tag #456" />' \
-      '<input id="post_tags_attributes_1_relevances_attributes_0_value" name="post[tags_attributes][1][relevances_attributes][0][value]" type="text" value="tagrelevance #31415" />' \
-      '<input id="post_tags_attributes_1_relevances_attributes_0_id" name="post[tags_attributes][1][relevances_attributes][0][id]" type="hidden" value="31415" autocomplete="off" />' \
-      '<input id="post_tags_attributes_1_id" name="post[tags_attributes][1][id]" type="hidden" value="456" autocomplete="off" />'
+      '<input id="post_comments_attributes_0_name" name="post[comments_attributes][0][name]" type="text" value="comment #321">' \
+      '<input id="post_comments_attributes_0_relevances_attributes_0_value" name="post[comments_attributes][0][relevances_attributes][0][value]" type="text" value="commentrelevance #314">' \
+      '<input id="post_comments_attributes_0_relevances_attributes_0_id" name="post[comments_attributes][0][relevances_attributes][0][id]" type="hidden" value="314" autocomplete="off">' \
+      '<input id="post_comments_attributes_0_id" name="post[comments_attributes][0][id]" type="hidden" value="321" autocomplete="off">' \
+      '<input id="post_tags_attributes_0_value" name="post[tags_attributes][0][value]" type="text" value="tag #123">' \
+      '<input id="post_tags_attributes_0_relevances_attributes_0_value" name="post[tags_attributes][0][relevances_attributes][0][value]" type="text" value="tagrelevance #3141">' \
+      '<input id="post_tags_attributes_0_relevances_attributes_0_id" name="post[tags_attributes][0][relevances_attributes][0][id]" type="hidden" value="3141" autocomplete="off">' \
+      '<input id="post_tags_attributes_0_id" name="post[tags_attributes][0][id]" type="hidden" value="123" autocomplete="off">' \
+      '<input id="post_tags_attributes_1_value" name="post[tags_attributes][1][value]" type="text" value="tag #456">' \
+      '<input id="post_tags_attributes_1_relevances_attributes_0_value" name="post[tags_attributes][1][relevances_attributes][0][value]" type="text" value="tagrelevance #31415">' \
+      '<input id="post_tags_attributes_1_relevances_attributes_0_id" name="post[tags_attributes][1][relevances_attributes][0][id]" type="hidden" value="31415" autocomplete="off">' \
+      '<input id="post_tags_attributes_1_id" name="post[tags_attributes][1][id]" type="hidden" value="456" autocomplete="off">'
     end
 
     assert_dom_equal expected, @rendered
@@ -3621,7 +3621,7 @@ class FormHelperTest < ActionView::TestCase
     end
 
     expected = whole_form("/posts/123", "edit_post_123", "edit_post", method: "patch") do
-      '<input id="post_author_attributes_name" name="post[author_attributes][name]" type="text" value="hash backed author" />'
+      '<input id="post_author_attributes_name" name="post[author_attributes][name]" type="text" value="hash backed author">'
     end
 
     assert_dom_equal expected, @rendered
@@ -3637,7 +3637,7 @@ class FormHelperTest < ActionView::TestCase
     end
 
     expected = whole_form("/posts/123", "edit_post_123", "edit_post", method: "patch") do
-      '<input id="post_author_attributes_name" name="post[author_attributes][name]" type="text" value="hash backed author" />'
+      '<input id="post_author_attributes_name" name="post[author_attributes][name]" type="text" value="hash backed author">'
     end
 
     assert_dom_equal expected, @rendered
@@ -3665,10 +3665,10 @@ class FormHelperTest < ActionView::TestCase
     end
 
     expected =
-      "<input name='post[title]' type='text' id='post_title' value='Hello World' />" \
+      "<input name='post[title]' type='text' id='post_title' value='Hello World'>" \
       "<textarea name='post[body]' id='post_body'>\nBack to the hill and over it again!</textarea>" \
-      "<input name='post[secret]' type='hidden' value='0' autocomplete='off' />" \
-      "<input name='post[secret]' checked='checked' type='checkbox' id='post_secret' value='1' />"
+      "<input name='post[secret]' type='hidden' value='0' autocomplete='off'>" \
+      "<input name='post[secret]' checked='checked' type='checkbox' id='post_secret' value='1'>"
 
     assert_dom_equal expected, @rendered
   end
@@ -3687,10 +3687,10 @@ class FormHelperTest < ActionView::TestCase
     end
 
     expected =
-      "<input name='post[123][title]' type='text' id='post_123_title' value='Hello World' />" \
+      "<input name='post[123][title]' type='text' id='post_123_title' value='Hello World'>" \
       "<textarea name='post[123][body]' id='post_123_body'>\nBack to the hill and over it again!</textarea>" \
-      "<input name='post[123][secret]' type='hidden' value='0' autocomplete='off' />" \
-      "<input name='post[123][secret]' checked='checked' type='checkbox' id='post_123_secret' value='1' />"
+      "<input name='post[123][secret]' type='hidden' value='0' autocomplete='off'>" \
+      "<input name='post[123][secret]' checked='checked' type='checkbox' id='post_123_secret' value='1'>"
 
     assert_dom_equal expected, @rendered
   end
@@ -3709,10 +3709,10 @@ class FormHelperTest < ActionView::TestCase
     end
 
     expected =
-      "<input name='post[][title]' type='text' id='post__title' value='Hello World' />" \
+      "<input name='post[][title]' type='text' id='post__title' value='Hello World'>" \
       "<textarea name='post[][body]' id='post__body'>\nBack to the hill and over it again!</textarea>" \
-      "<input name='post[][secret]' type='hidden' value='0' autocomplete='off' />" \
-      "<input name='post[][secret]' checked='checked' type='checkbox' id='post__secret' value='1' />"
+      "<input name='post[][secret]' type='hidden' value='0' autocomplete='off'>" \
+      "<input name='post[][secret]' checked='checked' type='checkbox' id='post__secret' value='1'>"
 
     assert_dom_equal expected, @rendered
   end
@@ -3731,10 +3731,10 @@ class FormHelperTest < ActionView::TestCase
     end
 
     expected =
-      "<input name='post[abc][title]' type='text' id='post_abc_title' value='Hello World' />" \
+      "<input name='post[abc][title]' type='text' id='post_abc_title' value='Hello World'>" \
       "<textarea name='post[abc][body]' id='post_abc_body'>\nBack to the hill and over it again!</textarea>" \
-      "<input name='post[abc][secret]' type='hidden' value='0' autocomplete='off' />" \
-      "<input name='post[abc][secret]' checked='checked' type='checkbox' id='post_abc_secret' value='1' />"
+      "<input name='post[abc][secret]' type='hidden' value='0' autocomplete='off'>" \
+      "<input name='post[abc][secret]' checked='checked' type='checkbox' id='post_abc_secret' value='1'>"
 
     assert_dom_equal expected, @rendered
   end
@@ -3747,10 +3747,10 @@ class FormHelperTest < ActionView::TestCase
     end
 
     expected =
-      "<input name='post[title]' type='text' id='post_title' value='Hello World' />" \
+      "<input name='post[title]' type='text' id='post_title' value='Hello World'>" \
       "<textarea name='post[body]' id='post_body'>\nBack to the hill and over it again!</textarea>" \
-      "<input name='post[secret]' type='hidden' value='0' autocomplete='off' />" \
-      "<input name='post[secret]' checked='checked' type='checkbox' id='post_secret' value='1' />"
+      "<input name='post[secret]' type='hidden' value='0' autocomplete='off'>" \
+      "<input name='post[secret]' checked='checked' type='checkbox' id='post_secret' value='1'>"
 
     assert_dom_equal expected, @rendered
   end
@@ -3763,10 +3763,10 @@ class FormHelperTest < ActionView::TestCase
     end
 
     expected =
-      "<input name='post[title]' type='text' id='post_title' value='Hello World' />" \
+      "<input name='post[title]' type='text' id='post_title' value='Hello World'>" \
       "<textarea name='post[body]' id='post_body'>\nBack to the hill and over it again!</textarea>" \
-      "<input name='post[secret]' type='hidden' value='0' autocomplete='off' />" \
-      "<input name='post[secret]' checked='checked' type='checkbox' id='post_secret' value='1' />"
+      "<input name='post[secret]' type='hidden' value='0' autocomplete='off'>" \
+      "<input name='post[secret]' checked='checked' type='checkbox' id='post_secret' value='1'>"
 
     assert_dom_equal expected, @rendered
   end
@@ -3778,7 +3778,7 @@ class FormHelperTest < ActionView::TestCase
     end
 
     assert_dom_equal "<label for=\"author_post_title\">Title</label>" \
-    "<input name='author[post][title]' type='text' id='author_post_title' value='Hello World' />",
+    "<input name='author[post][title]' type='text' id='author_post_title' value='Hello World'>",
       @rendered
   end
 
@@ -3789,7 +3789,7 @@ class FormHelperTest < ActionView::TestCase
     end
 
     assert_dom_equal "<label for=\"author_post_1_title\">Title</label>" \
-      "<input name='author[post][1][title]' type='text' id='author_post_1_title' value='Hello World' />",
+      "<input name='author[post][1][title]' type='text' id='author_post_1_title' value='Hello World'>",
       @rendered
   end
 
@@ -3808,10 +3808,10 @@ class FormHelperTest < ActionView::TestCase
     end
 
     expected = whole_form("/posts/123", "create-post", "edit_post", method: "patch") do
-      "<input name='post[title]' type='text' id='post_title' value='Hello World' />" \
+      "<input name='post[title]' type='text' id='post_title' value='Hello World'>" \
       "<textarea name='post[body]' id='post_body'>\nBack to the hill and over it again!</textarea>" \
-      "<input name='parent_post[secret]' type='hidden' value='0' autocomplete='off' />" \
-      "<input name='parent_post[secret]' checked='checked' type='checkbox' id='parent_post_secret' value='1' />"
+      "<input name='parent_post[secret]' type='hidden' value='0' autocomplete='off'>" \
+      "<input name='parent_post[secret]' checked='checked' type='checkbox' id='parent_post_secret' value='1'>"
     end
 
     assert_dom_equal expected, @rendered
@@ -3828,9 +3828,9 @@ class FormHelperTest < ActionView::TestCase
     end
 
     expected = whole_form("/posts/123", "create-post", "edit_post", method: "patch") do
-      "<input name='post[title]' type='text' id='post_title' value='Hello World' />" \
+      "<input name='post[title]' type='text' id='post_title' value='Hello World'>" \
       "<textarea name='post[body]' id='post_body'>\nBack to the hill and over it again!</textarea>" \
-      "<input name='post[comment][name]' type='text' id='post_comment_name' value='new comment' />"
+      "<input name='post[comment][name]' type='text' id='post_comment_name' value='new comment'>"
     end
 
     assert_dom_equal expected, @rendered
@@ -3844,7 +3844,7 @@ class FormHelperTest < ActionView::TestCase
     end
 
     expected = whole_form("/posts/123", "edit_post_123", "edit_post", method: "patch") do
-      "<input name='post[category][name]' type='text' id='post_category_name' />"
+      "<input name='post[category][name]' type='text' id='post_category_name'>"
     end
 
     assert_dom_equal expected, @rendered
@@ -3854,7 +3854,7 @@ class FormHelperTest < ActionView::TestCase
     (field_helpers - %w(hidden_field)).each do |selector|
       class_eval <<-RUBY_EVAL, __FILE__, __LINE__ + 1
         def #{selector}(field, *args, &proc)
-          ("<label for='\#{field}'>\#{field.to_s.humanize}:</label> " + super + "<br/>").html_safe
+          ("<label for='\#{field}'>\#{field.to_s.humanize}:</label> " + super + "<br>").html_safe
         end
       RUBY_EVAL
     end
@@ -3868,9 +3868,9 @@ class FormHelperTest < ActionView::TestCase
     end
 
     expected = whole_form("/posts/123", "edit_post_123", "edit_post", method: "patch") do
-      "<label for='title'>Title:</label> <input name='post[title]' type='text' id='post_title' value='Hello World' /><br/>" \
-      "<label for='body'>Body:</label> <textarea name='post[body]' id='post_body'>\nBack to the hill and over it again!</textarea><br/>" \
-      "<label for='secret'>Secret:</label> <input name='post[secret]' type='hidden' value='0' autocomplete='off' /><input name='post[secret]' checked='checked' type='checkbox' id='post_secret' value='1' /><br/>"
+      "<label for='title'>Title:</label> <input name='post[title]' type='text' id='post_title' value='Hello World'><br>" \
+      "<label for='body'>Body:</label> <textarea name='post[body]' id='post_body'>\nBack to the hill and over it again!</textarea><br>" \
+      "<label for='secret'>Secret:</label> <input name='post[secret]' type='hidden' value='0' autocomplete='off'><input name='post[secret]' checked='checked' type='checkbox' id='post_secret' value='1'><br>"
     end
 
     assert_dom_equal expected, @rendered
@@ -3887,9 +3887,9 @@ class FormHelperTest < ActionView::TestCase
     end
 
     expected = whole_form("/posts/123", "edit_post_123", "edit_post", method: "patch") do
-      "<label for='title'>Title:</label> <input name='post[title]' type='text' id='post_title' value='Hello World' /><br/>" \
-      "<label for='body'>Body:</label> <textarea name='post[body]' id='post_body'>\nBack to the hill and over it again!</textarea><br/>" \
-      "<label for='secret'>Secret:</label> <input name='post[secret]' type='hidden' value='0' autocomplete='off' /><input name='post[secret]' checked='checked' type='checkbox' id='post_secret' value='1' /><br/>"
+      "<label for='title'>Title:</label> <input name='post[title]' type='text' id='post_title' value='Hello World'><br>" \
+      "<label for='body'>Body:</label> <textarea name='post[body]' id='post_body'>\nBack to the hill and over it again!</textarea><br>" \
+      "<label for='secret'>Secret:</label> <input name='post[secret]' type='hidden' value='0' autocomplete='off'><input name='post[secret]' checked='checked' type='checkbox' id='post_secret' value='1'><br>"
     end
 
     assert_dom_equal expected, @rendered
@@ -3906,7 +3906,7 @@ class FormHelperTest < ActionView::TestCase
     end
 
     expected = whole_form("/posts/123", "edit_post_123", "edit_post", method: "patch") do
-      "<label for='title'>Title:</label> <input name='post[title]' type='text' id='post_title' value='Hello World' /><br/>"
+      "<label for='title'>Title:</label> <input name='post[title]' type='text' id='post_title' value='Hello World'><br>"
     end
 
     assert_dom_equal expected, @rendered
@@ -3921,7 +3921,7 @@ class FormHelperTest < ActionView::TestCase
       concat f.text_field(:title)
     end
 
-    expected = "<label for='title'>Title:</label> <input name='post[title]' type='text' id='post_title' value='Hello World' /><br/>"
+    expected = "<label for='title'>Title:</label> <input name='post[title]' type='text' id='post_title' value='Hello World'><br>"
 
     assert_dom_equal expected, @rendered
   end
@@ -3933,7 +3933,7 @@ class FormHelperTest < ActionView::TestCase
       concat f.text_field(:title)
     end
 
-    expected = "<label for='title'>Title:</label> <input name='post[title]' type='text' id='post_title' value='Hello World' /><br/>"
+    expected = "<label for='title'>Title:</label> <input name='post[title]' type='text' id='post_title' value='Hello World'><br>"
 
     assert_dom_equal expected, @rendered
   end
@@ -3946,9 +3946,9 @@ class FormHelperTest < ActionView::TestCase
     end
 
     expected =
-      "<label for='title'>Title:</label> <input name='post[title]' type='text' id='post_title' value='Hello World' /><br/>" \
-      "<label for='body'>Body:</label> <textarea name='post[body]' id='post_body'>\nBack to the hill and over it again!</textarea><br/>" \
-      "<label for='secret'>Secret:</label> <input name='post[secret]' type='hidden' value='0' autocomplete='off' /><input name='post[secret]' checked='checked' type='checkbox' id='post_secret' value='1' /><br/>"
+      "<label for='title'>Title:</label> <input name='post[title]' type='text' id='post_title' value='Hello World'><br>" \
+      "<label for='body'>Body:</label> <textarea name='post[body]' id='post_body'>\nBack to the hill and over it again!</textarea><br>" \
+      "<label for='secret'>Secret:</label> <input name='post[secret]' type='hidden' value='0' autocomplete='off'><input name='post[secret]' checked='checked' type='checkbox' id='post_secret' value='1'><br>"
 
     assert_dom_equal expected, @rendered
   end
@@ -4136,13 +4136,13 @@ class FormHelperTest < ActionView::TestCase
       method = options[:method]
 
       if options.fetch(:enforce_utf8, true)
-        txt = +%{<input name="utf8" type="hidden" value="&#x2713;" autocomplete="off" />}
+        txt = +%{<input name="utf8" type="hidden" value="&#x2713;" autocomplete="off">}
       else
         txt = +""
       end
 
       if method && !%w(get post).include?(method.to_s)
-        txt << %{<input name="_method" type="hidden" value="#{method}" autocomplete="off" />}
+        txt << %{<input name="_method" type="hidden" value="#{method}" autocomplete="off">}
       end
 
       txt

--- a/actionview/test/template/form_options_helper_test.rb
+++ b/actionview/test/template/form_options_helper_test.rb
@@ -718,7 +718,7 @@ class FormOptionsHelperTest < ActionView::TestCase
   def test_select_with_multiple_to_add_hidden_input
     output_buffer = select(:post, :category, "", {}, { multiple: true })
     assert_dom_equal(
-      "<input type=\"hidden\" name=\"post[category][]\" value=\"\" autocomplete=\"off\"/><select multiple=\"multiple\" id=\"post_category\" name=\"post[category][]\"></select>",
+      "<input type=\"hidden\" name=\"post[category][]\" value=\"\" autocomplete=\"off\"><select multiple=\"multiple\" id=\"post_category\" name=\"post[category][]\"></select>",
       output_buffer
     )
   end
@@ -742,7 +742,7 @@ class FormOptionsHelperTest < ActionView::TestCase
   def test_select_with_multiple_and_disabled_to_add_disabled_hidden_input
     output_buffer = select(:post, :category, "", {}, { multiple: true, disabled: true })
     assert_dom_equal(
-      "<input disabled=\"disabled\"type=\"hidden\" name=\"post[category][]\" value=\"\" autocomplete=\"off\"/><select multiple=\"multiple\" disabled=\"disabled\" id=\"post_category\" name=\"post[category][]\"></select>",
+      "<input disabled=\"disabled\"type=\"hidden\" name=\"post[category][]\" value=\"\" autocomplete=\"off\"><select multiple=\"multiple\" disabled=\"disabled\" id=\"post_category\" name=\"post[category][]\"></select>",
       output_buffer
     )
   end
@@ -874,7 +874,7 @@ class FormOptionsHelperTest < ActionView::TestCase
     @continent = Continent.new
     @continent.countries = ["Africa", "Europe"]
 
-    expected_with_hidden_field_and_multiple = %(<input name="continent[countries][]" type="hidden" value="" autocomplete="off"/><select name="continent[countries][]" id="continent_countries" multiple="multiple"><option selected="selected" value="Africa">Africa</option>\n<option selected="selected" value="Europe">Europe</option>\n<option value="America">America</option></select>)
+    expected_with_hidden_field_and_multiple = %(<input name="continent[countries][]" type="hidden" value="" autocomplete="off"><select name="continent[countries][]" id="continent_countries" multiple="multiple"><option selected="selected" value="Africa">Africa</option>\n<option selected="selected" value="Europe">Europe</option>\n<option value="America">America</option></select>)
     expected_without_hidden_field = %(<select name="continent[countries]" id="continent_countries"><option selected="selected" value="Africa">Africa</option>\n<option selected="selected" value="Europe">Europe</option>\n<option value="America">America</option></select>)
 
     assert_dom_equal(expected_with_hidden_field_and_multiple, select("continent", "countries", %W(Africa Europe America), { multiple: true }))
@@ -919,7 +919,7 @@ class FormOptionsHelperTest < ActionView::TestCase
   end
 
   def test_required_select_with_multiple_option
-    expected = %(<input name="post[category][]" type="hidden" value="" autocomplete="off"/><select id="post_category" multiple="multiple" name="post[category][]" required="required"><option value="abe">abe</option>\n<option value="mus">mus</option>\n<option value="hest">hest</option></select>)
+    expected = %(<input name="post[category][]" type="hidden" value="" autocomplete="off"><select id="post_category" multiple="multiple" name="post[category][]" required="required"><option value="abe">abe</option>\n<option value="mus">mus</option>\n<option value="hest">hest</option></select>)
 
     assert_dom_equal(expected, select("post", "category", %w(abe mus hest), {}, { required: true, multiple: true }))
     assert_dom_equal(expected, select("post", "category", %w(abe mus hest), required: true, multiple: true))
@@ -1108,7 +1108,7 @@ class FormOptionsHelperTest < ActionView::TestCase
     @post = Post.new
     @post.author_name = "Babe"
 
-    expected = "<input type=\"hidden\" name=\"post[author_name][]\" value=\"\" autocomplete=\"off\"/><select id=\"post_author_name\" name=\"post[author_name][]\" multiple=\"multiple\"><option value=\"\" label=\" \"></option>\n<option value=\"&lt;Abe&gt;\">&lt;Abe&gt;</option>\n<option value=\"Babe\" selected=\"selected\">Babe</option>\n<option value=\"Cabe\">Cabe</option></select>"
+    expected = "<input type=\"hidden\" name=\"post[author_name][]\" value=\"\" autocomplete=\"off\"><select id=\"post_author_name\" name=\"post[author_name][]\" multiple=\"multiple\"><option value=\"\" label=\" \"></option>\n<option value=\"&lt;Abe&gt;\">&lt;Abe&gt;</option>\n<option value=\"Babe\" selected=\"selected\">Babe</option>\n<option value=\"Cabe\">Cabe</option></select>"
 
     # Should suffix default name with [].
     assert_dom_equal expected, collection_select("post", "author_name", dummy_posts, "author_name", "author_name", { include_blank: true }, { multiple: true })

--- a/actionview/test/template/form_tag_helper_test.rb
+++ b/actionview/test/template/form_tag_helper_test.rb
@@ -28,7 +28,7 @@ class FormTagHelperTest < ActionView::TestCase
 
     (+"").tap do |txt|
       if enforce_utf8
-        txt << %{<input name="utf8" type="hidden" value="&#x2713;" autocomplete="off">}
+        txt << %{<input type="hidden" name="utf8" value="&#x2713;" autocomplete="off">}
       end
 
       if method && !%w(get post).include?(method.to_s)
@@ -187,6 +187,16 @@ class FormTagHelperTest < ActionView::TestCase
     expected = whole_form("http://www.example.com", enforce_utf8: true)
     assert_dom_equal expected, actual
     assert_predicate actual, :html_safe?
+  end
+
+  def test_form_tag_enforce_utf8_true_with_void_element_trailing_slash
+    original_trailing_slash_config = ActionView::Helpers::TagHelper.void_element_trailing_slash
+    ActionView::Helpers::TagHelper.void_element_trailing_slash = true
+
+    actual = form_tag({}, { enforce_utf8: true })
+    assert_match %r{<input type="hidden" name="utf8" value="&#x2713;" autocomplete="off" />}, actual
+  ensure
+    ActionView::Helpers::TagHelper.void_element_trailing_slash = original_trailing_slash_config
   end
 
   def test_form_tag_enforce_utf8_false

--- a/actionview/test/template/form_tag_helper_test.rb
+++ b/actionview/test/template/form_tag_helper_test.rb
@@ -28,11 +28,11 @@ class FormTagHelperTest < ActionView::TestCase
 
     (+"").tap do |txt|
       if enforce_utf8
-        txt << %{<input name="utf8" type="hidden" value="&#x2713;" autocomplete="off" />}
+        txt << %{<input name="utf8" type="hidden" value="&#x2713;" autocomplete="off">}
       end
 
       if method && !%w(get post).include?(method.to_s)
-        txt << %{<input name="_method" type="hidden" value="#{method}" autocomplete="off" />}
+        txt << %{<input name="_method" type="hidden" value="#{method}" autocomplete="off">}
       end
     end
   end
@@ -72,49 +72,49 @@ class FormTagHelperTest < ActionView::TestCase
 
   def test_check_box_tag
     actual = check_box_tag "admin"
-    expected = %(<input id="admin" name="admin" type="checkbox" value="1" />)
+    expected = %(<input id="admin" name="admin" type="checkbox" value="1">)
     assert_dom_equal expected, actual
   end
 
   def test_check_box_tag_disabled
     actual = check_box_tag "admin", "1", false, disabled: true
-    expected = %(<input id="admin" disabled="disabled" name="admin" type="checkbox" value="1" />)
+    expected = %(<input id="admin" disabled="disabled" name="admin" type="checkbox" value="1">)
     assert_dom_equal expected, actual
   end
 
   def test_check_box_tag_default_checked
     actual = check_box_tag "admin", "1", true
-    expected = %(<input id="admin" checked="checked" name="admin" type="checkbox" value="1" />)
+    expected = %(<input id="admin" checked="checked" name="admin" type="checkbox" value="1">)
     assert_dom_equal expected, actual
   end
 
   def test_check_box_tag_checked_kwarg_true
     actual = check_box_tag "admin", "yes", checked: true
-    expected = %(<input id="admin" checked="checked" name="admin" type="checkbox" value="yes" />)
+    expected = %(<input id="admin" checked="checked" name="admin" type="checkbox" value="yes">)
     assert_dom_equal expected, actual
   end
 
   def test_check_box_tag_checked_kwarg_false
     actual = check_box_tag "admin", "1", checked: false
-    expected = %(<input id="admin" name="admin" type="checkbox" value="1" />)
+    expected = %(<input id="admin" name="admin" type="checkbox" value="1">)
     assert_dom_equal expected, actual
   end
 
   def test_check_box_tag_checked_kwarg_false_and_disabled
     actual = check_box_tag "admin", "1", checked: false, disabled: true
-    expected = %(<input id="admin" name="admin" type="checkbox" value="1" disabled="disabled" />)
+    expected = %(<input id="admin" name="admin" type="checkbox" value="1" disabled="disabled">)
     assert_dom_equal expected, actual
   end
 
   def test_check_box_tag_checked_kwarg_true_value_argument_skipped
     actual = check_box_tag "admin", checked: true
-    expected = %(<input id="admin" checked="checked" name="admin" type="checkbox" value="1" />)
+    expected = %(<input id="admin" checked="checked" name="admin" type="checkbox" value="1">)
     assert_dom_equal expected, actual
   end
 
   def test_check_box_tag_value_kwarg
     actual = check_box_tag "admin", value: "0", checked: true
-    expected = %(<input id="admin" name="admin" type="checkbox" value="0" checked="checked" />)
+    expected = %(<input id="admin" name="admin" type="checkbox" value="0" checked="checked">)
     assert_dom_equal expected, actual
   end
 
@@ -323,7 +323,7 @@ class FormTagHelperTest < ActionView::TestCase
 
   def test_hidden_field_tag
     actual = hidden_field_tag "id", 3
-    expected = %(<input id="id" name="id" type="hidden" value="3" autocomplete="off" />)
+    expected = %(<input id="id" name="id" type="hidden" value="3" autocomplete="off">)
     assert_dom_equal expected, actual
   end
 
@@ -333,16 +333,16 @@ class FormTagHelperTest < ActionView::TestCase
   end
 
   def test_file_field_tag
-    assert_dom_equal "<input name=\"picsplz\" type=\"file\" id=\"picsplz\" />", file_field_tag("picsplz")
+    assert_dom_equal "<input name=\"picsplz\" type=\"file\" id=\"picsplz\">", file_field_tag("picsplz")
   end
 
   def test_file_field_tag_with_options
-    assert_dom_equal "<input name=\"picsplz\" type=\"file\" id=\"picsplz\" class=\"pix\"/>", file_field_tag("picsplz", class: "pix")
+    assert_dom_equal "<input name=\"picsplz\" type=\"file\" id=\"picsplz\" class=\"pix\">", file_field_tag("picsplz", class: "pix")
   end
 
   def test_file_field_tag_with_direct_upload_when_rails_direct_uploads_url_is_not_defined
     assert_dom_equal(
-      "<input name=\"picsplz\" type=\"file\" id=\"picsplz\" class=\"pix\"/>",
+      "<input name=\"picsplz\" type=\"file\" id=\"picsplz\" class=\"pix\">",
       file_field_tag("picsplz", class: "pix", direct_upload: true)
     )
   end
@@ -351,7 +351,7 @@ class FormTagHelperTest < ActionView::TestCase
     @controller = WithActiveStorageRoutesControllers.new
 
     assert_dom_equal(
-      "<input name=\"picsplz\" type=\"file\" id=\"picsplz\" class=\"pix\" data-direct-upload-url=\"http://testtwo.host/rails/active_storage/direct_uploads\"/>",
+      "<input name=\"picsplz\" type=\"file\" id=\"picsplz\" class=\"pix\" data-direct-upload-url=\"http://testtwo.host/rails/active_storage/direct_uploads\">",
       file_field_tag("picsplz", class: "pix", direct_upload: true)
     )
   end
@@ -360,7 +360,7 @@ class FormTagHelperTest < ActionView::TestCase
     original_options = { class: "pix", direct_upload: true }
 
     assert_dom_equal(
-      "<input name=\"picsplz\" type=\"file\" id=\"picsplz\" class=\"pix\"/>",
+      "<input name=\"picsplz\" type=\"file\" id=\"picsplz\" class=\"pix\">",
       file_field_tag("picsplz", original_options)
     )
 
@@ -369,64 +369,64 @@ class FormTagHelperTest < ActionView::TestCase
 
   def test_password_field_tag
     actual = password_field_tag
-    expected = %(<input id="password" name="password" type="password" />)
+    expected = %(<input id="password" name="password" type="password">)
     assert_dom_equal expected, actual
   end
 
   def test_multiple_field_tags_with_same_options
     options = { class: "important" }
-    assert_dom_equal %(<input name="title" type="file" id="title" class="important"/>), file_field_tag("title", options)
-    assert_dom_equal %(<input type="password" name="title" id="title" value="Hello!" class="important" />), password_field_tag("title", "Hello!", options)
-    assert_dom_equal %(<input type="text" name="title" id="title" value="Hello!" class="important" />), text_field_tag("title", "Hello!", options)
+    assert_dom_equal %(<input name="title" type="file" id="title" class="important">), file_field_tag("title", options)
+    assert_dom_equal %(<input type="password" name="title" id="title" value="Hello!" class="important">), password_field_tag("title", "Hello!", options)
+    assert_dom_equal %(<input type="text" name="title" id="title" value="Hello!" class="important">), text_field_tag("title", "Hello!", options)
   end
 
   def test_radio_button_tag
     actual = radio_button_tag "people", "david"
-    expected = %(<input id="people_david" name="people" type="radio" value="david" />)
+    expected = %(<input id="people_david" name="people" type="radio" value="david">)
     assert_dom_equal expected, actual
 
     actual = radio_button_tag("num_people", 5)
-    expected = %(<input id="num_people_5" name="num_people" type="radio" value="5" />)
+    expected = %(<input id="num_people_5" name="num_people" type="radio" value="5">)
     assert_dom_equal expected, actual
 
     actual = radio_button_tag("gender", "m") + radio_button_tag("gender", "f")
-    expected = %(<input id="gender_m" name="gender" type="radio" value="m" /><input id="gender_f" name="gender" type="radio" value="f" />)
+    expected = %(<input id="gender_m" name="gender" type="radio" value="m"><input id="gender_f" name="gender" type="radio" value="f">)
     assert_dom_equal expected, actual
 
     actual = radio_button_tag("opinion", "-1") + radio_button_tag("opinion", "1")
-    expected = %(<input id="opinion_-1" name="opinion" type="radio" value="-1" /><input id="opinion_1" name="opinion" type="radio" value="1" />)
+    expected = %(<input id="opinion_-1" name="opinion" type="radio" value="-1"><input id="opinion_1" name="opinion" type="radio" value="1">)
     assert_dom_equal expected, actual
 
     actual = radio_button_tag("person[gender]", "m")
-    expected = %(<input id="person_gender_m" name="person[gender]" type="radio" value="m" />)
+    expected = %(<input id="person_gender_m" name="person[gender]" type="radio" value="m">)
     assert_dom_equal expected, actual
 
     actual = radio_button_tag("ctrlname", "apache2.2")
-    expected = %(<input id="ctrlname_apache2.2" name="ctrlname" type="radio" value="apache2.2" />)
+    expected = %(<input id="ctrlname_apache2.2" name="ctrlname" type="radio" value="apache2.2">)
     assert_dom_equal expected, actual
 
     actual = radio_button_tag "people", "david", true
-    expected = %(<input id="people_david" name="people" type="radio" value="david" checked="checked" />)
+    expected = %(<input id="people_david" name="people" type="radio" value="david" checked="checked">)
     assert_dom_equal expected, actual
 
     actual = radio_button_tag "people", "david", false
-    expected = %(<input id="people_david" name="people" type="radio" value="david" />)
+    expected = %(<input id="people_david" name="people" type="radio" value="david">)
     assert_dom_equal expected, actual
 
     actual = radio_button_tag "people", "david", false, disabled: true
-    expected = %(<input id="people_david" name="people" type="radio" value="david" disabled="disabled" />)
+    expected = %(<input id="people_david" name="people" type="radio" value="david" disabled="disabled">)
     assert_dom_equal expected, actual
 
     actual = radio_button_tag "people", "david", checked: true
-    expected = %(<input id="people_david" name="people" type="radio" value="david" checked="checked" />)
+    expected = %(<input id="people_david" name="people" type="radio" value="david" checked="checked">)
     assert_dom_equal expected, actual
 
     actual = radio_button_tag "people", "david", checked: false
-    expected = %(<input id="people_david" name="people" type="radio" value="david" />)
+    expected = %(<input id="people_david" name="people" type="radio" value="david">)
     assert_dom_equal expected, actual
 
     actual = radio_button_tag "people", "david", checked: false, disabled: true
-    expected = %(<input id="people_david" name="people" type="radio" value="david" disabled="disabled" />)
+    expected = %(<input id="people_david" name="people" type="radio" value="david" disabled="disabled">)
     assert_dom_equal expected, actual
   end
 
@@ -551,61 +551,61 @@ class FormTagHelperTest < ActionView::TestCase
 
   def test_text_field_tag
     actual = text_field_tag "title", "Hello!"
-    expected = %(<input id="title" name="title" type="text" value="Hello!" />)
+    expected = %(<input id="title" name="title" type="text" value="Hello!">)
     assert_dom_equal expected, actual
   end
 
   def test_text_field_tag_class_string
     actual = text_field_tag "title", "Hello!", "class" => "admin"
-    expected = %(<input class="admin" id="title" name="title" type="text" value="Hello!" />)
+    expected = %(<input class="admin" id="title" name="title" type="text" value="Hello!">)
     assert_dom_equal expected, actual
   end
 
   def test_text_field_tag_size_symbol
     actual = text_field_tag "title", "Hello!", size: 75
-    expected = %(<input id="title" name="title" size="75" type="text" value="Hello!" />)
+    expected = %(<input id="title" name="title" size="75" type="text" value="Hello!">)
     assert_dom_equal expected, actual
   end
 
   def test_text_field_tag_with_ac_parameters
     actual = text_field_tag "title", ActionController::Parameters.new(key: "value")
-    expected = %(<input id="title" name="title" type="text" value="{&quot;key&quot;=&gt;&quot;value&quot;}" />)
+    expected = %(<input id="title" name="title" type="text" value="{&quot;key&quot;=&gt;&quot;value&quot;}">)
     assert_dom_equal expected, actual
   end
 
   def test_text_field_tag_size_string
     actual = text_field_tag "title", "Hello!", "size" => "75"
-    expected = %(<input id="title" name="title" size="75" type="text" value="Hello!" />)
+    expected = %(<input id="title" name="title" size="75" type="text" value="Hello!">)
     assert_dom_equal expected, actual
   end
 
   def test_text_field_tag_maxlength_symbol
     actual = text_field_tag "title", "Hello!", maxlength: 75
-    expected = %(<input id="title" name="title" maxlength="75" type="text" value="Hello!" />)
+    expected = %(<input id="title" name="title" maxlength="75" type="text" value="Hello!">)
     assert_dom_equal expected, actual
   end
 
   def test_text_field_tag_maxlength_string
     actual = text_field_tag "title", "Hello!", "maxlength" => "75"
-    expected = %(<input id="title" name="title" maxlength="75" type="text" value="Hello!" />)
+    expected = %(<input id="title" name="title" maxlength="75" type="text" value="Hello!">)
     assert_dom_equal expected, actual
   end
 
   def test_text_field_tag_disabled
     actual = text_field_tag "title", "Hello!", disabled: true
-    expected = %(<input id="title" name="title" disabled="disabled" type="text" value="Hello!" />)
+    expected = %(<input id="title" name="title" disabled="disabled" type="text" value="Hello!">)
     assert_dom_equal expected, actual
   end
 
   def test_text_field_tag_with_placeholder_option
     actual = text_field_tag "title", "Hello!", placeholder: "Enter search term..."
-    expected = %(<input id="title" name="title" placeholder="Enter search term..." type="text" value="Hello!" />)
+    expected = %(<input id="title" name="title" placeholder="Enter search term..." type="text" value="Hello!">)
     assert_dom_equal expected, actual
   end
 
   def test_text_field_tag_with_multiple_options
     actual = text_field_tag "title", "Hello!", size: 70, maxlength: 80
-    expected = %(<input id="title" name="title" size="70" maxlength="80" type="text" value="Hello!" />)
+    expected = %(<input id="title" name="title" size="70" maxlength="80" type="text" value="Hello!">)
     assert_dom_equal expected, actual
   end
 
@@ -658,9 +658,9 @@ class FormTagHelperTest < ActionView::TestCase
   end
 
   def test_boolean_options
-    assert_dom_equal %(<input checked="checked" disabled="disabled" id="admin" name="admin" readonly="readonly" type="checkbox" value="1" />), check_box_tag("admin", 1, true, "disabled" => true, :readonly => "yes")
-    assert_dom_equal %(<input checked="checked" id="admin" name="admin" type="checkbox" value="1" />), check_box_tag("admin", 1, true, disabled: false, readonly: nil)
-    assert_dom_equal %(<input type="checkbox" />), tag(:input, type: "checkbox", checked: false)
+    assert_dom_equal %(<input checked="checked" disabled="disabled" id="admin" name="admin" readonly="readonly" type="checkbox" value="1">), check_box_tag("admin", 1, true, "disabled" => true, :readonly => "yes")
+    assert_dom_equal %(<input checked="checked" id="admin" name="admin" type="checkbox" value="1">), check_box_tag("admin", 1, true, disabled: false, readonly: nil)
+    assert_dom_equal %(<input type="checkbox">), tag(:input, type: "checkbox", checked: false)
     assert_dom_equal %(<select id="people" multiple="multiple" name="people[]"><option>david</option></select>), select_tag("people", raw("<option>david</option>"), multiple: true)
     assert_dom_equal %(<select id="people_" multiple="multiple" name="people[]"><option>david</option></select>), select_tag("people[]", raw("<option>david</option>"), multiple: true)
     assert_dom_equal %(<select id="people" name="people"><option>david</option></select>), select_tag("people", raw("<option>david</option>"), multiple: nil)
@@ -668,20 +668,20 @@ class FormTagHelperTest < ActionView::TestCase
 
   def test_stringify_symbol_keys
     actual = text_field_tag "title", "Hello!", id: "admin"
-    expected = %(<input id="admin" name="title" type="text" value="Hello!" />)
+    expected = %(<input id="admin" name="title" type="text" value="Hello!">)
     assert_dom_equal expected, actual
   end
 
   def test_submit_tag
     assert_dom_equal(
-      %(<input name='commit' data-disable-with="Saving..." onclick="alert(&#39;hello!&#39;)" type="submit" value="Save" />),
+      %(<input name='commit' data-disable-with="Saving..." onclick="alert(&#39;hello!&#39;)" type="submit" value="Save">),
       submit_tag("Save", onclick: "alert('hello!')", data: { disable_with: "Saving..." })
     )
   end
 
   def test_empty_submit_tag
     assert_dom_equal(
-      %(<input data-disable-with="Save" name='commit' type="submit" value="Save" />),
+      %(<input data-disable-with="Save" name='commit' type="submit" value="Save">),
       submit_tag("Save")
     )
   end
@@ -689,7 +689,7 @@ class FormTagHelperTest < ActionView::TestCase
   def test_empty_submit_tag_with_opt_out
     ActionView::Base.automatically_disable_submit_tag = false
     assert_dom_equal(
-      %(<input name='commit' type="submit" value="Save" />),
+      %(<input name='commit' type="submit" value="Save">),
       submit_tag("Save")
     )
   ensure
@@ -699,7 +699,7 @@ class FormTagHelperTest < ActionView::TestCase
   def test_empty_submit_tag_with_opt_out_and_explicit_disabling
     ActionView::Base.automatically_disable_submit_tag = false
     assert_dom_equal(
-      %(<input name='commit' type="submit" value="Save" />),
+      %(<input name='commit' type="submit" value="Save">),
       submit_tag("Save", data: { disable_with: false })
     )
   ensure
@@ -708,56 +708,56 @@ class FormTagHelperTest < ActionView::TestCase
 
   def test_submit_tag_having_data_disable_with_string
     assert_dom_equal(
-      %(<input data-disable-with="Processing..." data-confirm="Are you sure?" name='commit' type="submit" value="Save" />),
+      %(<input data-disable-with="Processing..." data-confirm="Are you sure?" name='commit' type="submit" value="Save">),
       submit_tag("Save", "data-disable-with" => "Processing...", "data-confirm" => "Are you sure?")
     )
   end
 
   def test_submit_tag_having_data_disable_with_boolean
     assert_dom_equal(
-      %(<input data-confirm="Are you sure?" name='commit' type="submit" value="Save" />),
+      %(<input data-confirm="Are you sure?" name='commit' type="submit" value="Save">),
       submit_tag("Save", "data-disable-with" => false, "data-confirm" => "Are you sure?")
     )
   end
 
   def test_submit_tag_having_data_hash_disable_with_boolean
     assert_dom_equal(
-      %(<input data-confirm="Are you sure?" name='commit' type="submit" value="Save" />),
+      %(<input data-confirm="Are you sure?" name='commit' type="submit" value="Save">),
       submit_tag("Save", data: { confirm: "Are you sure?", disable_with: false })
     )
   end
 
   def test_submit_tag_with_no_onclick_options
     assert_dom_equal(
-      %(<input name='commit' data-disable-with="Saving..." type="submit" value="Save" />),
+      %(<input name='commit' data-disable-with="Saving..." type="submit" value="Save">),
       submit_tag("Save", data: { disable_with: "Saving..." })
     )
   end
 
   def test_submit_tag_with_confirmation
     assert_dom_equal(
-      %(<input name='commit' type='submit' value='Save' data-confirm="Are you sure?" data-disable-with="Save" />),
+      %(<input name='commit' type='submit' value='Save' data-confirm="Are you sure?" data-disable-with="Save">),
       submit_tag("Save", data: { confirm: "Are you sure?" })
     )
   end
 
   def test_submit_tag_doesnt_have_data_disable_with_twice
     assert_equal(
-      %(<input type="submit" name="commit" value="Save" data-confirm="Are you sure?" data-disable-with="Processing..." />),
+      %(<input type="submit" name="commit" value="Save" data-confirm="Are you sure?" data-disable-with="Processing...">),
       submit_tag("Save", "data-disable-with" => "Processing...", "data-confirm" => "Are you sure?")
     )
   end
 
   def test_submit_tag_doesnt_have_data_disable_with_twice_with_hash
     assert_equal(
-      %(<input type="submit" name="commit" value="Save" data-disable-with="Processing..." />),
+      %(<input type="submit" name="commit" value="Save" data-disable-with="Processing...">),
       submit_tag("Save", data: { disable_with: "Processing..." })
     )
   end
 
   def test_submit_tag_with_symbol_value
     assert_dom_equal(
-      %(<input data-disable-with="Save" name='commit' type="submit" value="Save" />),
+      %(<input data-disable-with="Save" name='commit' type="submit" value="Save">),
       submit_tag(:Save)
     )
   end
@@ -834,73 +834,73 @@ class FormTagHelperTest < ActionView::TestCase
 
   def test_image_submit_tag_with_confirmation
     assert_dom_equal(
-      %(<input type="image" src="/images/save.gif" data-confirm="Are you sure?" />),
+      %(<input type="image" src="/images/save.gif" data-confirm="Are you sure?">),
       image_submit_tag("save.gif", data: { confirm: "Are you sure?" })
     )
   end
 
   def test_color_field_tag
-    expected = %{<input id="car" name="car" type="color" />}
+    expected = %{<input id="car" name="car" type="color">}
     assert_dom_equal(expected, color_field_tag("car"))
   end
 
   def test_search_field_tag
-    expected = %{<input id="query" name="query" type="search" />}
+    expected = %{<input id="query" name="query" type="search">}
     assert_dom_equal(expected, search_field_tag("query"))
   end
 
   def test_telephone_field_tag
-    expected = %{<input id="cell" name="cell" type="tel" />}
+    expected = %{<input id="cell" name="cell" type="tel">}
     assert_dom_equal(expected, telephone_field_tag("cell"))
   end
 
   def test_date_field_tag
-    expected = %{<input id="cell" name="cell" type="date" />}
+    expected = %{<input id="cell" name="cell" type="date">}
     assert_dom_equal(expected, date_field_tag("cell"))
   end
 
   def test_time_field_tag
-    expected = %{<input id="cell" name="cell" type="time" />}
+    expected = %{<input id="cell" name="cell" type="time">}
     assert_dom_equal(expected, time_field_tag("cell"))
   end
 
   def test_datetime_field_tag
-    expected = %{<input id="appointment" name="appointment" type="datetime-local" />}
+    expected = %{<input id="appointment" name="appointment" type="datetime-local">}
     assert_dom_equal(expected, datetime_field_tag("appointment"))
   end
 
   def test_datetime_local_field_tag
-    expected = %{<input id="appointment" name="appointment" type="datetime-local" />}
+    expected = %{<input id="appointment" name="appointment" type="datetime-local">}
     assert_dom_equal(expected, datetime_local_field_tag("appointment"))
   end
 
   def test_month_field_tag
-    expected = %{<input id="birthday" name="birthday" type="month" />}
+    expected = %{<input id="birthday" name="birthday" type="month">}
     assert_dom_equal(expected, month_field_tag("birthday"))
   end
 
   def test_week_field_tag
-    expected = %{<input id="birthday" name="birthday" type="week" />}
+    expected = %{<input id="birthday" name="birthday" type="week">}
     assert_dom_equal(expected, week_field_tag("birthday"))
   end
 
   def test_url_field_tag
-    expected = %{<input id="homepage" name="homepage" type="url" />}
+    expected = %{<input id="homepage" name="homepage" type="url">}
     assert_dom_equal(expected, url_field_tag("homepage"))
   end
 
   def test_email_field_tag
-    expected = %{<input id="address" name="address" type="email" />}
+    expected = %{<input id="address" name="address" type="email">}
     assert_dom_equal(expected, email_field_tag("address"))
   end
 
   def test_number_field_tag
-    expected = %{<input name="quantity" max="9" id="quantity" type="number" min="1" />}
+    expected = %{<input name="quantity" max="9" id="quantity" type="number" min="1">}
     assert_dom_equal(expected, number_field_tag("quantity", nil, in: 1...10))
   end
 
   def test_range_input_tag
-    expected = %{<input name="volume" step="0.1" max="11" id="volume" type="range" min="0" />}
+    expected = %{<input name="volume" step="0.1" max="11" id="volume" type="range" min="0">}
     assert_dom_equal(expected, range_field_tag("volume", nil, in: 0..11, step: 0.1))
   end
 

--- a/actionview/test/template/output_safety_helper_test.rb
+++ b/actionview/test/template/output_safety_helper_test.rb
@@ -23,8 +23,8 @@ class OutputSafetyHelperTest < ActionView::TestCase
     joined = safe_join([raw("<p>foo</p>"), "<p>bar</p>"], "<br />")
     assert_equal "<p>foo</p>&lt;br /&gt;&lt;p&gt;bar&lt;/p&gt;", joined
 
-    joined = safe_join([raw("<p>foo</p>"), raw("<p>bar</p>")], raw("<br />"))
-    assert_equal "<p>foo</p><br /><p>bar</p>", joined
+    joined = safe_join([raw("<p>foo</p>"), raw("<p>bar</p>")], raw("<br>"))
+    assert_equal "<p>foo</p><br><p>bar</p>", joined
   end
 
   test "safe_join should work recursively similarly to Array.join" do
@@ -80,7 +80,7 @@ class OutputSafetyHelperTest < ActionView::TestCase
       safe_join(["<marquee>shady stuff</marquee>", tag("br")])
     end
     url = "https://example.com"
-    expected = %(<a href="#{url}">#{url}</a> and <p>&lt;marquee&gt;shady stuff&lt;/marquee&gt;<br /></p>)
+    expected = %(<a href="#{url}">#{url}</a> and <p>&lt;marquee&gt;shady stuff&lt;/marquee&gt;<br></p>)
     actual = to_sentence([link_to(url, url), ptag])
     assert_predicate actual, :html_safe?
     assert_equal(expected, actual)

--- a/actionview/test/template/tag_helper_test.rb
+++ b/actionview/test/template/tag_helper_test.rb
@@ -112,11 +112,11 @@ class TagHelperTest < ActionView::TestCase
   end
 
   def test_tag_options_accepts_symbol_option_when_not_escaping
-    assert_equal "<p value=\"symbol\">", tag("p", { value: :symbol }, false, false)
+    assert_equal "<p value=\"symbol\">", tag("p", { value: :symbol }, true, false)
   end
 
   def test_tag_options_accepts_integer_option_when_not_escaping
-    assert_equal "<p value=\"42\">", tag("p", { value: 42 }, false, false)
+    assert_equal "<p value=\"42\">", tag("p", { value: 42 }, true, false)
   end
 
   def test_tag_options_converts_boolean_option
@@ -166,7 +166,7 @@ class TagHelperTest < ActionView::TestCase
                  tag("the-name", aria: { COMMON_DANGEROUS_CHARS => "the value" })
 
     assert_equal "<the-name aria-#{COMMON_DANGEROUS_CHARS}=\"the value\">",
-                 tag("the-name", { aria: { COMMON_DANGEROUS_CHARS => "the value" } }, false, false)
+                 tag("the-name", { aria: { COMMON_DANGEROUS_CHARS => "the value" } }, true, false)
   end
 
   def test_tag_builder_with_dangerous_aria_attribute_name
@@ -184,7 +184,7 @@ class TagHelperTest < ActionView::TestCase
                  tag("the-name", data: { COMMON_DANGEROUS_CHARS => "the value" })
 
     assert_equal "<the-name data-#{COMMON_DANGEROUS_CHARS}=\"the value\">",
-                 tag("the-name", { data: { COMMON_DANGEROUS_CHARS => "the value" } }, false, false)
+                 tag("the-name", { data: { COMMON_DANGEROUS_CHARS => "the value" } }, true, false)
   end
 
   def test_tag_builder_with_dangerous_data_attribute_name
@@ -202,7 +202,7 @@ class TagHelperTest < ActionView::TestCase
                  tag("the-name", COMMON_DANGEROUS_CHARS => "the value")
 
     assert_equal "<the-name #{COMMON_DANGEROUS_CHARS}=\"the value\">",
-                 tag("the-name", { COMMON_DANGEROUS_CHARS => "the value" }, false, false)
+                 tag("the-name", { COMMON_DANGEROUS_CHARS => "the value" }, true, false)
   end
 
   def test_tag_builder_with_dangerous_unknown_attribute_name
@@ -607,7 +607,7 @@ class TagHelperTest < ActionView::TestCase
   end
 
   def test_disable_escaping
-    assert_equal '<a href="&amp;">', tag("a", { href: "&amp;" }, false, false)
+    assert_equal '<a href="&amp;">', tag("a", { href: "&amp;" }, true, false)
   end
 
   def test_tag_builder_disable_escaping

--- a/actionview/test/template/tag_helper_test.rb
+++ b/actionview/test/template/tag_helper_test.rb
@@ -11,8 +11,8 @@ class TagHelperTest < ActionView::TestCase
   INVALID_TAG_CHARS = "> /"
 
   def test_tag
-    assert_equal "<br />", tag("br")
-    assert_equal "<br clear=\"left\" />", tag(:br, clear: "left")
+    assert_equal "<br>", tag("br")
+    assert_equal "<br clear=\"left\">", tag(:br, clear: "left")
     assert_equal "<br>", tag("br", nil, true)
   end
 
@@ -72,7 +72,7 @@ class TagHelperTest < ActionView::TestCase
   def test_tag_options_with_array_of_numeric
     str = tag(:input, value: [123, 456])
 
-    assert_equal("<input value=\"123 456\" />", str)
+    assert_equal("<input value=\"123 456\">", str)
   end
 
   def test_tag_options_with_array_of_random_objects
@@ -84,11 +84,11 @@ class TagHelperTest < ActionView::TestCase
 
     str = tag(:input, value: [klass.new])
 
-    assert_equal("<input value=\"hello\" />", str)
+    assert_equal("<input value=\"hello\">", str)
   end
 
   def test_tag_options_rejects_nil_option
-    assert_equal "<p />", tag("p", ignored: nil)
+    assert_equal "<p>", tag("p", ignored: nil)
   end
 
   def test_tag_builder_options_rejects_nil_option
@@ -96,7 +96,7 @@ class TagHelperTest < ActionView::TestCase
   end
 
   def test_tag_options_accepts_false_option
-    assert_equal "<p value=\"false\" />", tag("p", value: false)
+    assert_equal "<p value=\"false\">", tag("p", value: false)
   end
 
   def test_tag_builder_options_accepts_false_option
@@ -104,7 +104,7 @@ class TagHelperTest < ActionView::TestCase
   end
 
   def test_tag_options_accepts_blank_option
-    assert_equal "<p included=\"\" />", tag("p", included: "")
+    assert_equal "<p included=\"\">", tag("p", included: "")
   end
 
   def test_tag_builder_options_accepts_blank_option
@@ -112,20 +112,20 @@ class TagHelperTest < ActionView::TestCase
   end
 
   def test_tag_options_accepts_symbol_option_when_not_escaping
-    assert_equal "<p value=\"symbol\" />", tag("p", { value: :symbol }, false, false)
+    assert_equal "<p value=\"symbol\">", tag("p", { value: :symbol }, false, false)
   end
 
   def test_tag_options_accepts_integer_option_when_not_escaping
-    assert_equal "<p value=\"42\" />", tag("p", { value: 42 }, false, false)
+    assert_equal "<p value=\"42\">", tag("p", { value: 42 }, false, false)
   end
 
   def test_tag_options_converts_boolean_option
-    assert_dom_equal '<p disabled="disabled" itemscope="itemscope" multiple="multiple" readonly="readonly" allowfullscreen="allowfullscreen" seamless="seamless" typemustmatch="typemustmatch" sortable="sortable" default="default" inert="inert" truespeed="truespeed" allowpaymentrequest="allowpaymentrequest" nomodule="nomodule" playsinline="playsinline" />',
+    assert_dom_equal '<p disabled="disabled" itemscope="itemscope" multiple="multiple" readonly="readonly" allowfullscreen="allowfullscreen" seamless="seamless" typemustmatch="typemustmatch" sortable="sortable" default="default" inert="inert" truespeed="truespeed" allowpaymentrequest="allowpaymentrequest" nomodule="nomodule" playsinline="playsinline">',
       tag("p", disabled: true, itemscope: true, multiple: true, readonly: true, allowfullscreen: true, seamless: true, typemustmatch: true, sortable: true, default: true, inert: true, truespeed: true, allowpaymentrequest: true, nomodule: true, playsinline: true)
   end
 
   def test_tag_builder_options_converts_boolean_option
-    assert_dom_equal '<p disabled="disabled" itemscope="itemscope" multiple="multiple" readonly="readonly" allowfullscreen="allowfullscreen" seamless="seamless" typemustmatch="typemustmatch" sortable="sortable" default="default" inert="inert" truespeed="truespeed" allowpaymentrequest="allowpaymentrequest" nomodule="nomodule" playsinline="playsinline" />',
+    assert_dom_equal '<p disabled="disabled" itemscope="itemscope" multiple="multiple" readonly="readonly" allowfullscreen="allowfullscreen" seamless="seamless" typemustmatch="typemustmatch" sortable="sortable" default="default" inert="inert" truespeed="truespeed" allowpaymentrequest="allowpaymentrequest" nomodule="nomodule" playsinline="playsinline">',
       tag.p(disabled: true, itemscope: true, multiple: true, readonly: true, allowfullscreen: true, seamless: true, typemustmatch: true, sortable: true, default: true, inert: true, truespeed: true, allowpaymentrequest: true, nomodule: true, playsinline: true)
   end
 
@@ -137,7 +137,7 @@ class TagHelperTest < ActionView::TestCase
 
   def test_tag_builder_do_not_modify_html_safe_options
     html_safe_str = '"'.html_safe
-    assert_equal "<p value=\"&quot;\" />", tag("p", value: html_safe_str)
+    assert_equal "<p value=\"&quot;\">", tag("p", value: html_safe_str)
     assert_equal '"', html_safe_str
     assert_predicate html_safe_str, :html_safe?
   end
@@ -162,10 +162,10 @@ class TagHelperTest < ActionView::TestCase
 
   def test_tag_with_dangerous_aria_attribute_name
     escaped_dangerous_chars = "_" * COMMON_DANGEROUS_CHARS.size
-    assert_equal "<the-name aria-#{escaped_dangerous_chars}=\"the value\" />",
+    assert_equal "<the-name aria-#{escaped_dangerous_chars}=\"the value\">",
                  tag("the-name", aria: { COMMON_DANGEROUS_CHARS => "the value" })
 
-    assert_equal "<the-name aria-#{COMMON_DANGEROUS_CHARS}=\"the value\" />",
+    assert_equal "<the-name aria-#{COMMON_DANGEROUS_CHARS}=\"the value\">",
                  tag("the-name", { aria: { COMMON_DANGEROUS_CHARS => "the value" } }, false, false)
   end
 
@@ -180,10 +180,10 @@ class TagHelperTest < ActionView::TestCase
 
   def test_tag_with_dangerous_data_attribute_name
     escaped_dangerous_chars = "_" * COMMON_DANGEROUS_CHARS.size
-    assert_equal "<the-name data-#{escaped_dangerous_chars}=\"the value\" />",
+    assert_equal "<the-name data-#{escaped_dangerous_chars}=\"the value\">",
                  tag("the-name", data: { COMMON_DANGEROUS_CHARS => "the value" })
 
-    assert_equal "<the-name data-#{COMMON_DANGEROUS_CHARS}=\"the value\" />",
+    assert_equal "<the-name data-#{COMMON_DANGEROUS_CHARS}=\"the value\">",
                  tag("the-name", { data: { COMMON_DANGEROUS_CHARS => "the value" } }, false, false)
   end
 
@@ -198,10 +198,10 @@ class TagHelperTest < ActionView::TestCase
 
   def test_tag_with_dangerous_unknown_attribute_name
     escaped_dangerous_chars = "_" * COMMON_DANGEROUS_CHARS.size
-    assert_equal "<the-name #{escaped_dangerous_chars}=\"the value\" />",
+    assert_equal "<the-name #{escaped_dangerous_chars}=\"the value\">",
                  tag("the-name", COMMON_DANGEROUS_CHARS => "the value")
 
-    assert_equal "<the-name #{COMMON_DANGEROUS_CHARS}=\"the value\" />",
+    assert_equal "<the-name #{COMMON_DANGEROUS_CHARS}=\"the value\">",
                  tag("the-name", { COMMON_DANGEROUS_CHARS => "the value" }, false, false)
   end
 
@@ -574,14 +574,14 @@ class TagHelperTest < ActionView::TestCase
 
   def test_tag_honors_html_safe_for_param_values
     ["1&amp;2", "1 &lt; 2", "&#8220;test&#8220;"].each do |escaped|
-      assert_equal %(<a href="#{escaped}" />), tag("a", href: escaped.html_safe)
+      assert_equal %(<a href="#{escaped}">), tag("a", href: escaped.html_safe)
       assert_equal %(<a href="#{escaped}"></a>), tag.a(href: escaped.html_safe)
     end
   end
 
   def test_tag_honors_html_safe_with_escaped_array_class
-    assert_equal '<p class="song&gt; play>" />', tag("p", class: ["song>", raw("play>")])
-    assert_equal '<p class="song> play&gt;" />', tag("p", class: [raw("song>"), "play>"])
+    assert_equal '<p class="song&gt; play>">', tag("p", class: ["song>", raw("play>")])
+    assert_equal '<p class="song> play&gt;">', tag("p", class: [raw("song>"), "play>"])
   end
 
   def test_tag_builder_honors_html_safe_with_escaped_array_class
@@ -601,13 +601,13 @@ class TagHelperTest < ActionView::TestCase
 
   def test_skip_invalid_escaped_attributes
     ["&1;", "&#1dfa3;", "& #123;"].each do |escaped|
-      assert_equal %(<a href="#{escaped.gsub(/&/, '&amp;')}" />), tag("a", href: escaped)
+      assert_equal %(<a href="#{escaped.gsub(/&/, '&amp;')}">), tag("a", href: escaped)
       assert_equal %(<a href="#{escaped.gsub(/&/, '&amp;')}"></a>), tag.a(href: escaped)
     end
   end
 
   def test_disable_escaping
-    assert_equal '<a href="&amp;" />', tag("a", { href: "&amp;" }, false, false)
+    assert_equal '<a href="&amp;">', tag("a", { href: "&amp;" }, false, false)
   end
 
   def test_tag_builder_disable_escaping
@@ -620,20 +620,20 @@ class TagHelperTest < ActionView::TestCase
 
   def test_data_attributes
     ["data", :data].each { |data|
-      assert_dom_equal '<a data-a-float="3.14" data-a-big-decimal="-123.456" data-a-number="1" data-array="[1,2,3]" data-hash="{&quot;key&quot;:&quot;value&quot;}" data-string-with-quotes="double&quot;quote&quot;party&quot;" data-string="hello" data-symbol="foo" />',
+      assert_dom_equal '<a data-a-float="3.14" data-a-big-decimal="-123.456" data-a-number="1" data-array="[1,2,3]" data-hash="{&quot;key&quot;:&quot;value&quot;}" data-string-with-quotes="double&quot;quote&quot;party&quot;" data-string="hello" data-symbol="foo">',
         tag("a", data => { a_float: 3.14, a_big_decimal: BigDecimal("-123.456"), a_number: 1, string: "hello", symbol: :foo, array: [1, 2, 3], hash: { key: "value" }, string_with_quotes: 'double"quote"party"' })
-      assert_dom_equal '<a data-a-float="3.14" data-a-big-decimal="-123.456" data-a-number="1" data-array="[1,2,3]" data-hash="{&quot;key&quot;:&quot;value&quot;}" data-string-with-quotes="double&quot;quote&quot;party&quot;" data-string="hello" data-symbol="foo" />',
+      assert_dom_equal '<a data-a-float="3.14" data-a-big-decimal="-123.456" data-a-number="1" data-array="[1,2,3]" data-hash="{&quot;key&quot;:&quot;value&quot;}" data-string-with-quotes="double&quot;quote&quot;party&quot;" data-string="hello" data-symbol="foo">',
         tag.a(data: { a_float: 3.14, a_big_decimal: BigDecimal("-123.456"), a_number: 1, string: "hello", symbol: :foo, array: [1, 2, 3], hash: { key: "value" }, string_with_quotes: 'double"quote"party"' })
     }
   end
 
   def test_aria_attributes
     ["aria", :aria].each { |aria|
-      assert_dom_equal '<a aria-a-float="3.14" aria-a-big-decimal="-123.456" aria-a-number="1" aria-truthy="true" aria-falsey="false" aria-array="1 2 3" aria-hash="a b" aria-tokens="a b" aria-string-with-quotes="double&quot;quote&quot;party&quot;" aria-string="hello" aria-symbol="foo" />',
+      assert_dom_equal '<a aria-a-float="3.14" aria-a-big-decimal="-123.456" aria-a-number="1" aria-truthy="true" aria-falsey="false" aria-array="1 2 3" aria-hash="a b" aria-tokens="a b" aria-string-with-quotes="double&quot;quote&quot;party&quot;" aria-string="hello" aria-symbol="foo">',
         tag("a", aria => { nil: nil, a_float: 3.14, a_big_decimal: BigDecimal("-123.456"), a_number: 1, truthy: true, falsey: false, string: "hello", symbol: :foo, array: [1, 2, 3], empty_array: [], hash: { a: true, b: "truthy", falsey: false, nil: nil }, empty_hash: {}, tokens: ["a", { b: true, c: false }], empty_tokens: [{ a: false }], string_with_quotes: 'double"quote"party"' })
     }
 
-    assert_dom_equal '<a aria-a-float="3.14" aria-a-big-decimal="-123.456" aria-a-number="1" aria-truthy="true" aria-falsey="false" aria-array="1 2 3" aria-hash="a b" aria-tokens="a b" aria-string-with-quotes="double&quot;quote&quot;party&quot;" aria-string="hello" aria-symbol="foo" />',
+    assert_dom_equal '<a aria-a-float="3.14" aria-a-big-decimal="-123.456" aria-a-number="1" aria-truthy="true" aria-falsey="false" aria-array="1 2 3" aria-hash="a b" aria-tokens="a b" aria-string-with-quotes="double&quot;quote&quot;party&quot;" aria-string="hello" aria-symbol="foo">',
     tag.a(aria: { nil: nil, a_float: 3.14, a_big_decimal: BigDecimal("-123.456"), a_number: 1, truthy: true, falsey: false, string: "hello", symbol: :foo, array: [1, 2, 3], empty_array: [], hash: { a: true, b: "truthy", falsey: false, nil: nil }, empty_hash: {}, tokens: ["a", { b: true, c: false }], empty_tokens: [{ a: false }], string_with_quotes: 'double"quote"party"' })
   end
 

--- a/actionview/test/template/tag_helper_test.rb
+++ b/actionview/test/template/tag_helper_test.rb
@@ -12,8 +12,23 @@ class TagHelperTest < ActionView::TestCase
 
   def test_tag
     assert_equal "<br>", tag("br")
+    assert_equal "<br />", tag("br", nil, false)
     assert_equal "<br clear=\"left\">", tag(:br, clear: "left")
+    assert_equal "<br clear=\"left\" />", tag(:br, { clear: "left" }, false)
     assert_equal "<br>", tag("br", nil, true)
+    assert_equal "<br />", tag("br", nil, false)
+  end
+
+  def test_tag_with_void_element_trailing_slash
+    original_trailing_slash_config = ActionView::Helpers::TagHelper.void_element_trailing_slash
+    ActionView::Helpers::TagHelper.void_element_trailing_slash = true
+
+    assert_equal "<br />", tag("br")
+    assert_equal "<br clear=\"left\" />", tag(:br, clear: "left")
+    assert_equal "<br>", tag("br", nil, true)
+    assert_equal "<br />", tag("br", nil, false)
+  ensure
+    ActionView::Helpers::TagHelper.void_element_trailing_slash = original_trailing_slash_config
   end
 
   def test_tag_builder

--- a/actionview/test/template/text_helper_test.rb
+++ b/actionview/test/template/text_helper_test.rb
@@ -44,6 +44,23 @@ class TextHelperTest < ActionView::TestCase
     assert_equal %Q(<p class="test">para 1</p>\n\n<p class="test">para 2</p>), simple_format("para 1\n\npara 2", class: "test")
   end
 
+  def test_simple_format_with_void_element_trailing_slash
+    original_trailing_slash_config = ActionView::Helpers::TagHelper.void_element_trailing_slash
+    ActionView::Helpers::TagHelper.void_element_trailing_slash = true
+
+    assert_equal "<p>ridiculous\n<br /> cross\n<br /> platform linebreaks</p>", simple_format("ridiculous\r\n cross\r platform linebreaks")
+    assert_equal "<p>A paragraph</p>\n\n<p>and another one!</p>", simple_format("A paragraph\n\nand another one!")
+    assert_equal "<p>A paragraph\n<br /> With a newline</p>", simple_format("A paragraph\n With a newline")
+
+    text = "A\nB\nC\nD"
+    assert_equal "<p>A\n<br />B\n<br />C\n<br />D</p>", simple_format(text)
+
+    text = "A\r\n  \nB\n\n\r\n\t\nC\nD"
+    assert_equal "<p>A\n<br />  \n<br />B</p>\n\n<p>\t\n<br />C\n<br />D</p>", simple_format(text)
+  ensure
+    ActionView::Helpers::TagHelper.void_element_trailing_slash = original_trailing_slash_config
+  end
+
   def test_simple_format_should_sanitize_input_when_sanitize_option_is_not_false
     assert_equal "<p><b> test with unsafe string </b>code!</p>", simple_format("<b> test with unsafe string </b><script>code!</script>")
   end

--- a/actionview/test/template/text_helper_test.rb
+++ b/actionview/test/template/text_helper_test.rb
@@ -30,15 +30,15 @@ class TextHelperTest < ActionView::TestCase
   def test_simple_format
     assert_equal "<p></p>", simple_format(nil)
 
-    assert_equal "<p>ridiculous\n<br /> cross\n<br /> platform linebreaks</p>", simple_format("ridiculous\r\n cross\r platform linebreaks")
+    assert_equal "<p>ridiculous\n<br> cross\n<br> platform linebreaks</p>", simple_format("ridiculous\r\n cross\r platform linebreaks")
     assert_equal "<p>A paragraph</p>\n\n<p>and another one!</p>", simple_format("A paragraph\n\nand another one!")
-    assert_equal "<p>A paragraph\n<br /> With a newline</p>", simple_format("A paragraph\n With a newline")
+    assert_equal "<p>A paragraph\n<br> With a newline</p>", simple_format("A paragraph\n With a newline")
 
     text = "A\nB\nC\nD"
-    assert_equal "<p>A\n<br />B\n<br />C\n<br />D</p>", simple_format(text)
+    assert_equal "<p>A\n<br>B\n<br>C\n<br>D</p>", simple_format(text)
 
     text = "A\r\n  \nB\n\n\r\n\t\nC\nD"
-    assert_equal "<p>A\n<br />  \n<br />B</p>\n\n<p>\t\n<br />C\n<br />D</p>", simple_format(text)
+    assert_equal "<p>A\n<br>  \n<br>B</p>\n\n<p>\t\n<br>C\n<br>D</p>", simple_format(text)
 
     assert_equal '<p class="test">This is a classy test</p>', simple_format("This is a classy test", class: "test")
     assert_equal %Q(<p class="test">para 1</p>\n\n<p class="test">para 2</p>), simple_format("para 1\n\npara 2", class: "test")

--- a/actionview/test/template/url_helper_test.rb
+++ b/actionview/test/template/url_helper_test.rb
@@ -157,7 +157,7 @@ class UrlHelperTest < ActiveSupport::TestCase
     self.request_forgery = true
 
     assert_dom_equal(
-      %{<form method="post" action="http://www.example.com" class="button_to"><button type="submit">Hello</button><input name="form_token" type="hidden" value="token" autocomplete="off" /></form>},
+      %{<form method="post" action="http://www.example.com" class="button_to"><button type="submit">Hello</button><input name="form_token" type="hidden" value="token" autocomplete="off"></form>},
       button_to("Hello", "http://www.example.com", authenticity_token: "token")
     )
   ensure
@@ -168,7 +168,7 @@ class UrlHelperTest < ActiveSupport::TestCase
     self.request_forgery = true
 
     assert_dom_equal(
-      %{<form method="post" action="http://www.example.com" class="button_to"><button type="submit">Hello</button><input name="form_token" type="hidden" value="secret" autocomplete="off" /></form>},
+      %{<form method="post" action="http://www.example.com" class="button_to"><button type="submit">Hello</button><input name="form_token" type="hidden" value="secret" autocomplete="off"></form>},
       button_to("Hello", "http://www.example.com", authenticity_token: true)
     )
   ensure
@@ -243,7 +243,7 @@ class UrlHelperTest < ActiveSupport::TestCase
     workshop = Workshop.new("1")
 
     assert_dom_equal(
-      %{<form method="post" action="/workshops/1" class="button_to"><input type="hidden" name="_method" value="patch" autocomplete="off" /><button type="submit">Update</button></form>},
+      %{<form method="post" action="/workshops/1" class="button_to"><input type="hidden" name="_method" value="patch" autocomplete="off"><button type="submit">Update</button></form>},
       button_to(workshop) { "Update" }
     )
   end
@@ -252,7 +252,7 @@ class UrlHelperTest < ActiveSupport::TestCase
     workshop = Workshop.new("1")
 
     assert_dom_equal(
-      %{<form method="post" action="/workshops/1" class="button_to"><input type="hidden" name="_method" value="patch" autocomplete="off" /><button type="submit">Update</button></form>},
+      %{<form method="post" action="/workshops/1" class="button_to"><input type="hidden" name="_method" value="patch" autocomplete="off"><button type="submit">Update</button></form>},
       button_to(workshop) { "Update" }
     )
   end
@@ -262,7 +262,7 @@ class UrlHelperTest < ActiveSupport::TestCase
     session = Session.new("1")
 
     assert_dom_equal(
-      %{<form method="post" action="/workshops/1/sessions/1" class="button_to"><input type="hidden" name="_method" value="patch" autocomplete="off" /><button type="submit">Update</button></form>},
+      %{<form method="post" action="/workshops/1/sessions/1" class="button_to"><input type="hidden" name="_method" value="patch" autocomplete="off"><button type="submit">Update</button></form>},
       button_to([workshop, session]) { "Update" }
     )
   end
@@ -271,7 +271,7 @@ class UrlHelperTest < ActiveSupport::TestCase
     self.request_forgery = true
 
     assert_dom_equal(
-      %{<form method="post" action="http://www.example.com" class="button_to"><button type="submit">Hello</button><input name="form_token" type="hidden" value="secret" autocomplete="off" /></form>},
+      %{<form method="post" action="http://www.example.com" class="button_to"><button type="submit">Hello</button><input name="form_token" type="hidden" value="secret" autocomplete="off"></form>},
       button_to("Hello", "http://www.example.com")
     )
   ensure
@@ -357,7 +357,7 @@ class UrlHelperTest < ActiveSupport::TestCase
 
   def test_button_to_with_method_delete
     assert_dom_equal(
-      %{<form method="post" action="http://www.example.com" class="button_to"><input type="hidden" name="_method" value="delete" autocomplete="off" /><button type="submit">Hello</button></form>},
+      %{<form method="post" action="http://www.example.com" class="button_to"><input type="hidden" name="_method" value="delete" autocomplete="off"><button type="submit">Hello</button></form>},
       button_to("Hello", "http://www.example.com", method: :delete)
     )
   end
@@ -378,7 +378,7 @@ class UrlHelperTest < ActiveSupport::TestCase
 
   def test_button_to_with_params
     assert_dom_equal(
-      %{<form action="http://www.example.com" class="button_to" method="post"><button type="submit">Hello</button><input type="hidden" name="baz" value="quux" autocomplete="off" /><input type="hidden" name="foo" value="bar" autocomplete="off" /></form>},
+      %{<form action="http://www.example.com" class="button_to" method="post"><button type="submit">Hello</button><input type="hidden" name="baz" value="quux" autocomplete="off"><input type="hidden" name="foo" value="bar" autocomplete="off"></form>},
       button_to("Hello", "http://www.example.com", params: { foo: :bar, baz: "quux" })
     )
   end
@@ -395,7 +395,7 @@ class UrlHelperTest < ActiveSupport::TestCase
     ActionView::Helpers::UrlHelper.button_to_generates_button_tag = false
 
     assert_dom_equal(
-      %{<form method="post" action="http://www.example.com" class="button_to"><input type="submit" value="Save"/></form>},
+      %{<form method="post" action="http://www.example.com" class="button_to"><input type="submit" value="Save"></form>},
       button_to("Save", "http://www.example.com")
     )
   ensure
@@ -431,7 +431,7 @@ class UrlHelperTest < ActiveSupport::TestCase
 
   def test_button_to_with_permitted_strong_params
     assert_dom_equal(
-      %{<form action="http://www.example.com" class="button_to" method="post"><button type="submit">Hello</button><input type="hidden" name="baz" value="quux" autocomplete="off" /><input type="hidden" name="foo" value="bar" autocomplete="off" /></form>},
+      %{<form action="http://www.example.com" class="button_to" method="post"><button type="submit">Hello</button><input type="hidden" name="baz" value="quux" autocomplete="off"><input type="hidden" name="foo" value="bar" autocomplete="off"></form>},
       button_to("Hello", "http://www.example.com", params: FakeParams.new)
     )
   end
@@ -444,14 +444,14 @@ class UrlHelperTest < ActiveSupport::TestCase
 
   def test_button_to_with_nested_hash_params
     assert_dom_equal(
-      %{<form action="http://www.example.com" class="button_to" method="post"><button type="submit">Hello</button><input type="hidden" name="foo[bar]" value="baz" autocomplete="off" /></form>},
+      %{<form action="http://www.example.com" class="button_to" method="post"><button type="submit">Hello</button><input type="hidden" name="foo[bar]" value="baz" autocomplete="off"></form>},
       button_to("Hello", "http://www.example.com", params: { foo: { bar: "baz" } })
     )
   end
 
   def test_button_to_with_nested_array_params
     assert_dom_equal(
-      %{<form action="http://www.example.com" class="button_to" method="post"><button type="submit">Hello</button><input type="hidden" name="foo[]" value="bar" autocomplete="off" /></form>},
+      %{<form action="http://www.example.com" class="button_to" method="post"><button type="submit">Hello</button><input type="hidden" name="foo[]" value="bar" autocomplete="off"></form>},
       button_to("Hello", "http://www.example.com", params: { foo: ["bar"] })
     )
   end
@@ -494,8 +494,8 @@ class UrlHelperTest < ActiveSupport::TestCase
   end
 
   def test_link_tag_with_img
-    link = link_to(raw("<img src='/favicon.jpg' />"), "/")
-    expected = %{<a href="/"><img src='/favicon.jpg' /></a>}
+    link = link_to(raw("<img src='/favicon.jpg'>"), "/")
+    expected = %{<a href="/"><img src='/favicon.jpg'></a>}
     assert_dom_equal expected, link
   end
 
@@ -860,8 +860,8 @@ class UrlHelperTest < ActiveSupport::TestCase
   end
 
   def test_mail_to_with_img
-    assert_dom_equal %{<a href="mailto:feedback@example.com"><img src="/feedback.png" /></a>},
-      mail_to("feedback@example.com", raw('<img src="/feedback.png" />'))
+    assert_dom_equal %{<a href="mailto:feedback@example.com"><img src="/feedback.png"></a>},
+      mail_to("feedback@example.com", raw('<img src="/feedback.png">'))
   end
 
   def test_mail_to_with_html_safe_string
@@ -927,8 +927,8 @@ class UrlHelperTest < ActiveSupport::TestCase
   end
 
   def test_sms_to_with_img
-    assert_dom_equal %{<a href="sms:15155555785;"><img src="/feedback.png" /></a>},
-      sms_to("15155555785", raw('<img src="/feedback.png" />'))
+    assert_dom_equal %{<a href="sms:15155555785;"><img src="/feedback.png"></a>},
+      sms_to("15155555785", raw('<img src="/feedback.png">'))
   end
 
   def test_sms_to_with_html_safe_string
@@ -996,8 +996,8 @@ class UrlHelperTest < ActiveSupport::TestCase
   end
 
   def test_phone_to_with_img
-    assert_dom_equal %{<a href="tel:1234567890"><img src="/feedback.png" /></a>},
-      phone_to("1234567890", raw('<img src="/feedback.png" />'))
+    assert_dom_equal %{<a href="tel:1234567890"><img src="/feedback.png"></a>},
+      phone_to("1234567890", raw('<img src="/feedback.png">'))
   end
 
   def test_phone_to_with_html_safe_string

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -64,6 +64,7 @@ Below are the default values associated with each target version. In cases of co
 - [`config.active_record.automatically_invert_plural_associations`](#config-active-record-automatically-invert-plural-associations): `true`
 - [`config.active_record.validate_migration_timestamps`](#config-active-record-validate-migration-timestamps): `true`
 - [`config.active_storage.web_image_content_types`](#config-active-storage-web-image-content-types): `%w[image/png image/jpeg image/gif image/webp]`
+- [`config.action_view.void_element_trailing_slash`](#config-action-view-void-element-trailing-slash): `false`
 
 #### Default Values for Target Version 7.1
 
@@ -91,6 +92,7 @@ Below are the default values associated with each target version. In cases of co
 - [`config.dom_testing_default_html_version`](#config-dom-testing-default-html-version): `defined?(Nokogiri::HTML5) ? :html5 : :html4`
 - [`config.log_file_size`](#config-log-file-size): `100 * 1024 * 1024`
 - [`config.precompile_filter_parameters`](#config-precompile-filter-parameters): `true`
+- [`config.action_view.void_element_trailing_slash`](#config-action-view-void-element-trailing-slash): `true`
 
 #### Default Values for Target Version 7.0
 
@@ -2247,6 +2249,37 @@ Configures the set of HTML sanitizers used by Action View by setting `ActionView
 | 7.1                   | `Rails::HTML5::Sanitizer` (see NOTE) | HTML5                  |
 
 NOTE: `Rails::HTML5::Sanitizer` is not supported on JRuby, so on JRuby platforms Rails will fall back to `Rails::HTML4::Sanitizer`.
+
+#### `config.action_view.void_element_trailing_slash`
+
+Determines whether void HTML elements have a trailing slash or not.
+
+When `true`, the void HTML elements generated through Rails helpers have a trailing slash. For example:
+
+```erb
+<%= tag "br" %>
+# => <br />
+
+<%= text_field_tag "name" %>
+# => <input type="text" name="name" id="name" />
+```
+
+When `false`, the void HTML elements generated through Rails helpers do not have a trailing slash. For example:
+
+```erb
+<%= tag "br" %>
+# => <br>
+
+<%= text_field_tag "name" %>
+# => <input type="text" name="name" id="name">
+```
+
+The default value depends on the `config.load_defaults` target version:
+
+| Starting with version | The default value is |
+| --------------------- | -------------------- |
+| (original)            | `true`               |
+| 7.2                   | `false`              |
 
 ### Configuring Action Mailbox
 

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -60,11 +60,11 @@ Below are the default values associated with each target version. In cases of co
 
 #### Default Values for Target Version 7.2
 
+- [`config.action_view.void_element_trailing_slash`](#config-action-view-void-element-trailing-slash): `false`
 - [`config.active_job.enqueue_after_transaction_commit`](#config-active-job-enqueue-after-transaction-commit): `:default`
 - [`config.active_record.automatically_invert_plural_associations`](#config-active-record-automatically-invert-plural-associations): `true`
 - [`config.active_record.validate_migration_timestamps`](#config-active-record-validate-migration-timestamps): `true`
 - [`config.active_storage.web_image_content_types`](#config-active-storage-web-image-content-types): `%w[image/png image/jpeg image/gif image/webp]`
-- [`config.action_view.void_element_trailing_slash`](#config-action-view-void-element-trailing-slash): `false`
 
 #### Default Values for Target Version 7.1
 
@@ -92,7 +92,6 @@ Below are the default values associated with each target version. In cases of co
 - [`config.dom_testing_default_html_version`](#config-dom-testing-default-html-version): `defined?(Nokogiri::HTML5) ? :html5 : :html4`
 - [`config.log_file_size`](#config-log-file-size): `100 * 1024 * 1024`
 - [`config.precompile_filter_parameters`](#config-precompile-filter-parameters): `true`
-- [`config.action_view.void_element_trailing_slash`](#config-action-view-void-element-trailing-slash): `true`
 
 #### Default Values for Target Version 7.0
 
@@ -158,6 +157,7 @@ Below are the default values associated with each target version. In cases of co
 - [`ActiveSupport.to_time_preserves_timezone`](#activesupport-to-time-preserves-timezone): `true`
 - [`config.action_controller.forgery_protection_origin_check`](#config-action-controller-forgery-protection-origin-check): `true`
 - [`config.action_controller.per_form_csrf_tokens`](#config-action-controller-per-form-csrf-tokens): `true`
+- [`config.action_view.void_element_trailing_slash`](#config-action-view-void-element-trailing-slash): `true`
 - [`config.active_record.belongs_to_required_by_default`](#config-active-record-belongs-to-required-by-default): `true`
 - [`config.ssl_options`](#config-ssl-options): `{ hsts: { subdomains: true } }`
 

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -157,7 +157,6 @@ Below are the default values associated with each target version. In cases of co
 - [`ActiveSupport.to_time_preserves_timezone`](#activesupport-to-time-preserves-timezone): `true`
 - [`config.action_controller.forgery_protection_origin_check`](#config-action-controller-forgery-protection-origin-check): `true`
 - [`config.action_controller.per_form_csrf_tokens`](#config-action-controller-per-form-csrf-tokens): `true`
-- [`config.action_view.void_element_trailing_slash`](#config-action-view-void-element-trailing-slash): `true`
 - [`config.active_record.belongs_to_required_by_default`](#config-active-record-belongs-to-required-by-default): `true`
 - [`config.ssl_options`](#config-ssl-options): `{ hsts: { subdomains: true } }`
 

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -121,10 +121,6 @@ module Rails
             active_record.belongs_to_required_by_default = true
           end
 
-          if respond_to?(:action_view)
-            action_view.void_element_trailing_slash = true
-          end
-
           self.ssl_options = { hsts: { subdomains: true } }
         when "5.1"
           load_defaults "5.0"

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -121,6 +121,10 @@ module Rails
             active_record.belongs_to_required_by_default = true
           end
 
+          if respond_to?(:action_view)
+            action_view.void_element_trailing_slash = true
+          end
+
           self.ssl_options = { hsts: { subdomains: true } }
         when "5.1"
           load_defaults "5.0"
@@ -333,6 +337,10 @@ module Rails
           if respond_to?(:active_record)
             active_record.validate_migration_timestamps = true
             active_record.automatically_invert_plural_associations = true
+          end
+
+          if respond_to?(:action_view)
+            action_view.void_element_trailing_slash = false
           end
         else
           raise "Unknown version #{target_version.to_s.inspect}"

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_7_2.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_7_2.rb.tt
@@ -66,3 +66,12 @@
 # on `Post`. With this option enabled, it will also look for a `:comments` association.
 #++
 # Rails.application.config.active_record.automatically_invert_plural_associations = true
+
+###
+# Controls whether Action View's tag helpers add ending slashes to the void HTML elements or not.
+#
+# Affects any tag helpers that generate void HTML elements, such as `tag "br"` or `text_field_tag "name"`. When the
+# configuration is set to `false`, the trailing slash is not added, e.g. `<br>`. When the configuration is set to
+# `true`, the trailing slash is added, e.g. `<br />`.
+#++
+# Rails.application.config.action_view.void_element_trailing_slash = false

--- a/railties/test/application/asset_debugging_test.rb
+++ b/railties/test/application/asset_debugging_test.rb
@@ -77,12 +77,12 @@ module ApplicationTests
         javascript_path:        %r{/javascripts/#{contents}},
         stylesheet_path:        %r{/stylesheets/#{contents}},
         image_tag:              %r{<img src="/images/#{contents}"},
-        favicon_link_tag:       %r{<link rel="icon" type="image/x-icon" href="/images/#{contents}" />},
-        stylesheet_link_tag:    %r{<link rel="stylesheet" href="/stylesheets/#{contents}.css" />},
+        favicon_link_tag:       %r{<link rel="icon" type="image/x-icon" href="/images/#{contents}">},
+        stylesheet_link_tag:    %r{<link rel="stylesheet" href="/stylesheets/#{contents}.css">},
         javascript_include_tag: %r{<script src="/javascripts/#{contents}.js">},
         audio_tag:              %r{<audio src="/audios/#{contents}"></audio>},
         video_tag:              %r{<video src="/videos/#{contents}"></video>},
-        image_submit_tag:       %r{<input type="image" src="/images/#{contents}" />}
+        image_submit_tag:       %r{<input type="image" src="/images/#{contents}">}
       }
 
       class ::PostsController < ActionController::Base

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -3294,7 +3294,7 @@ module ApplicationTests
       app "development"
 
       get "/"
-      assert_match %r[<link rel="stylesheet" href="/application.css" />], last_response.body
+      assert_match %r[<link rel="stylesheet" href="/application.css">], last_response.body
       assert_equal "</application.css>; rel=preload; as=style; nopush", last_response.headers["Link"]
     end
 
@@ -3320,7 +3320,7 @@ module ApplicationTests
       app "development"
 
       get "/"
-      assert_match %r[<link rel="stylesheet" href="/application.css" />], last_response.body
+      assert_match %r[<link rel="stylesheet" href="/application.css">], last_response.body
       assert_nil last_response.headers["Link"]
     end
 

--- a/railties/test/railties/mounted_engine_test.rb
+++ b/railties/test/railties/mounted_engine_test.rb
@@ -284,7 +284,7 @@ module ApplicationTests
 
       # test that the Active Storage direct upload URL is added to a file field that explicitly requires it within en engine's view code
       get "/someone/blog/file_field_with_direct_upload_path"
-      assert_equal "<input type=\"file\" name=\"image\" id=\"image\" data-direct-upload-url=\"http://example.org/rails/active_storage/direct_uploads\" />", last_response.body
+      assert_equal "<input type=\"file\" name=\"image\" id=\"image\" data-direct-upload-url=\"http://example.org/rails/active_storage/direct_uploads\">", last_response.body
     end
 
     test "route path for controller action when engine is mounted at root" do


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because W3C HTML validator gives a lot of the following type of notices about the trailing slashes on void HTML elements:

> Trailing slash on void elements [has no effect](https://github.com/validator/validator/wiki/Markup-%C2%BB-Void-elements#trailing-slashes-in-void-element-start-tags-do-not-mark-the-start-tags-as-self-closing) and [interacts badly with unquoted attribute values](https://github.com/validator/validator/wiki/Markup-%C2%BB-Void-elements#trailing-slashes-directly-preceded-by-unquoted-attribute-values).

### Detail

This Pull Request changes the trailing slash ` />` on void HTML elements to `>` as suggested by the W3C validator.

This changes also the default value of the `tag` helper's `open` argument from `false` to `nil` and reflects this change in the documentation of the method.

The trailing slashes are removed from all void elements but preserved for the self-closing elements within SVGs, i.e. `animate`, `animateMotion`, `animateTransform`, `circle`, `ellipse`, `line`, `path`, `polygon`, `polyline`, `rect`, `set`, `stop`, `use` and `view` as defined here:

https://github.com/rails/rails/blob/185157fe18f33349536ebeddfc792974d81ce762/actionview/lib/action_view/helpers/tag_helper.rb#L112-L125

This is to prevent any SVGs breaking due to this change.

In addition, a new configuration value `config.action_view.void_element_trailing_slash` is added that can be used to revert to the legacy behavior, i.e. keeping the trailing slashes on the void elements. This is to help migrating to newer versions and to provide this as an option in case some implementations rely on the current behavior.

### Additional information

Fix #51643

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
