### PR TITLE
[ci skip] Use Ruby's official documentation urls

### DIFF
--- a/activerecord/README.rdoc
+++ b/activerecord/README.rdoc
@@ -131,7 +131,7 @@ A short rundown of some of the major features:
   SQLite3[https://api.rubyonrails.org/classes/ActiveRecord/ConnectionAdapters/SQLite3Adapter.html].
 
 
-* Logging support for Log4r[https://github.com/colbygk/log4r] and Logger[https://ruby-doc.org/stdlib/libdoc/logger/rdoc/].
+* Logging support for Log4r[https://github.com/colbygk/log4r] and Logger[https://docs.ruby-lang.org/en/master/Logger.html].
 
     ActiveRecord::Base.logger = ActiveSupport::Logger.new(STDOUT)
     ActiveRecord::Base.logger = Log4r::Logger.new('Application Log')

--- a/activesupport/lib/active_support/duration.rb
+++ b/activesupport/lib/active_support/duration.rb
@@ -371,8 +371,8 @@ module ActiveSupport
     #   1.year.to_i     # => 31556952
     #
     # In such cases, Ruby's core
-    # Date[https://ruby-doc.org/stdlib/libdoc/date/rdoc/Date.html] and
-    # Time[https://ruby-doc.org/stdlib/libdoc/time/rdoc/Time.html] should be used for precision
+    # Date[https://docs.ruby-lang.org/en/master/Date.html] and
+    # Time[https://docs.ruby-lang.org/en/master/Time.html] should be used for precision
     # date and time arithmetic.
     def to_i
       @value.to_i

--- a/guides/source/active_record_postgresql.md
+++ b/guides/source/active_record_postgresql.md
@@ -170,7 +170,7 @@ irb> Event.where("payload->>'kind' = ?", "user_renamed")
 * [type definition](https://www.postgresql.org/docs/current/static/rangetypes.html)
 * [functions and operators](https://www.postgresql.org/docs/current/static/functions-range.html)
 
-This type is mapped to Ruby [`Range`](https://ruby-doc.org/core-3.1.0/Range.html) objects.
+This type is mapped to Ruby [`Range`](https://docs.ruby-lang.org/en/master/Range.html) objects.
 
 ```ruby
 # db/migrate/20130923065404_create_events.rb
@@ -449,7 +449,7 @@ irb> user.save!
 * [type definition](https://www.postgresql.org/docs/current/static/datatype-net-types.html)
 
 The types `inet` and `cidr` are mapped to Ruby
-[`IPAddr`](https://ruby-doc.org/stdlib-3.1.0/libdoc/ipaddr/rdoc/IPAddr.html)
+[`IPAddr`](https://docs.ruby-lang.org/en/master/IPAddr.html)
 objects. The `macaddr` type is mapped to normal text.
 
 ```ruby


### PR DESCRIPTION
### Motivation / Background

Some links to unofficial Ruby documentation are broken. This PR replaces them with `https://docs.ruby-lang.org/en/master/*`.

### Checklist

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] (Not Applicable) Tests are added or updated if you fix a bug or add a feature.
* [ ] (Not Applicable) CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
