### PR TITLE
Fix building guides outside ./guides directory

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -59,10 +59,12 @@ task :preview_docs do
   require "guides/rails_guides"
   Rake::Task[:rdoc].invoke
 
-  FileUtils.cp_r("doc/rdoc", "preview/api")
-  FileUtils.cp_r("guides/output", "preview/guides")
+  FileUtils.mv("doc/rdoc", "preview/api")
+  FileUtils.mv("guides/output", "preview/guides")
 
-  system("tar -czf preview.tar.gz preview")
+  Dir.chdir("preview") do
+    system("tar -czf preview.tar.gz .")
+  end
 end
 
 desc "Bump all versions to match RAILS_VERSION"

--- a/guides/rails_guides/generator.rb
+++ b/guides/rails_guides/generator.rb
@@ -107,7 +107,10 @@ module RailsGuides
       end
 
       def process_scss
-        system "bundle exec dartsass ./assets/stylesrc/style.scss:#{@output_dir}/stylesheets/style.css ./assets/stylesrc/highlight.scss:#{@output_dir}/stylesheets/highlight.css ./assets/stylesrc/print.scss:#{@output_dir}/stylesheets/print.css"
+        system "bundle exec dartsass \
+          #{@guides_dir}/assets/stylesrc/style.scss:#{@output_dir}/stylesheets/style.css \
+          #{@guides_dir}/assets/stylesrc/highlight.scss:#{@output_dir}/stylesheets/highlight.css \
+          #{@guides_dir}/assets/stylesrc/print.scss:#{@output_dir}/stylesheets/print.css"
       end
 
       def copy_assets


### PR DESCRIPTION
* [As is the case with the `rake preview_docs` task.](https://github.com/rails/rails/commit/7c7e4c5476e9c3e9f086b77fddab409905c04011)

```
Error reading assets/stylesrc/style.scss: Cannot open file.

Error reading assets/stylesrc/highlight.scss: Cannot open file.

Error reading assets/stylesrc/print.scss: Cannot open file.
```

* [Create preview tarball from directory](https://github.com/rails/rails/commit/6be0b7f7f3357549bf85edc297a0fa8fa037109e) 
  * Move the artifacts instead of copying to reduce waste
  
This is related to zzak/buildkite-config#12 where the goal is to make sure handling the tarball happens outside the working directory.