### PR TITLE
Support duration in `ActiveSupport::XmlMini`

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Support `duration` type in `ActiveSupport::XmlMini`.
+
+    *heka1024*
+
 *   Remove deprecated `ActiveSupport::Notifications::Event#children` and  `ActiveSupport::Notifications::Event#parent_of?`.
 
     *Rafael Mendonça França*

--- a/activesupport/lib/active_support/xml_mini.rb
+++ b/activesupport/lib/active_support/xml_mini.rb
@@ -46,6 +46,7 @@ module ActiveSupport
         "Date"       => "date",
         "DateTime"   => "dateTime",
         "Time"       => "dateTime",
+        "ActiveSupport::Duration" => "duration",
         "Array"      => "array",
         "Hash"       => "hash"
       }
@@ -56,6 +57,7 @@ module ActiveSupport
       "symbol"   => Proc.new { |symbol| symbol.to_s },
       "date"     => Proc.new { |date| date.to_fs(:db) },
       "dateTime" => Proc.new { |time| time.xmlschema },
+      "duration" => Proc.new { |duration| duration.iso8601 },
       "binary"   => Proc.new { |binary| ::Base64.encode64(binary) },
       "yaml"     => Proc.new { |yaml| yaml.to_yaml }
     } unless defined?(FORMATTING)
@@ -66,6 +68,7 @@ module ActiveSupport
         "symbol"       => Proc.new { |symbol|  symbol.to_s.to_sym },
         "date"         => Proc.new { |date|    ::Date.parse(date) },
         "datetime"     => Proc.new { |time|    Time.xmlschema(time).utc rescue ::DateTime.parse(time).utc },
+        "duration"     => Proc.new { |duration| Duration.parse(duration) },
         "integer"      => Proc.new { |integer| integer.to_i },
         "float"        => Proc.new { |float|   float.to_f },
         "decimal"      => Proc.new do |number|

--- a/activesupport/test/xml_mini_test.rb
+++ b/activesupport/test/xml_mini_test.rb
@@ -6,6 +6,7 @@ require "active_support/builder"
 require "active_support/core_ext/hash"
 require "active_support/core_ext/big_decimal"
 require "active_support/core_ext/date/conversions"
+require "active_support/core_ext/integer/time"
 require "yaml"
 
 module XmlMiniTest
@@ -142,6 +143,12 @@ module XmlMiniTest
       end
     end
 
+    test "#to_tag accepts duration types" do
+      duration = 3.years + 6.months + 4.days + 12.hours + 30.minutes + 5.seconds
+      @xml.to_tag(:b, duration, @options)
+      assert_xml("<b type=\"duration\">P3Y6M4DT12H30M5S</b>")
+    end
+
     test "#to_tag accepts array types" do
       @xml.to_tag(:b, ["first_name", "last_name"], @options)
       assert_xml("<b type=\"array\"><b>first_name</b><b>last_name</b></b>")
@@ -265,6 +272,15 @@ module XmlMiniTest
       assert_equal DateTime.new(2013, 11, 12, 02, 11), parser.call("2013-11-12T02:11Z")
       assert_equal DateTime.new(2013, 11, 12, 02, 11), parser.call("2013-11-12T11:11+9")
       assert_raises(ArgumentError) { parser.call("1384190018") }
+    end
+
+    def test_duration
+      parser = @parsing["duration"]
+
+      assert_equal 1, parser.call("PT1S")
+      assert_equal 1.minutes, parser.call("PT1M")
+      assert_equal 3.years + 6.months + 4.days + 12.hours + 30.minutes + 5.seconds, parser.call("P3Y6M4DT12H30M5S")
+      assert_raises(ArgumentError) { parser.call("not really a duration") }
     end
 
     def test_integer


### PR DESCRIPTION
### Motivation / Background

Similar to #51631, `ActiveSupport::XmlMini` could not handle `duration` type in XML, which is one of primitive data type. ( https://www.w3.org/TR/xmlschema-2/#duration )

### Detail

This Pull Request add duration parser and formatter on `ActiveSupport::XmlMini`, using `ActiveSupport::Duration`.

### Additional information

https://www.w3.org/TR/xmlschema-2/#duration

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [X] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
