### PR TITLE
[ci skip] Remove outdated comment in `ActiveSupport::Duration::ISO8601Serializer`

### DIFF
--- a/activesupport/lib/active_support/duration/iso8601_serializer.rb
+++ b/activesupport/lib/active_support/duration/iso8601_serializer.rb
@@ -35,7 +35,6 @@ module ActiveSupport
         # Return pair of duration's parts and whole duration sign.
         # Parts are summarized (as they can become repetitive due to addition, etc).
         # Zero parts are removed as not significant.
-        # If all parts are negative it will negate all of them and return minus as a sign.
         def normalize
           parts = @duration.parts.each_with_object(Hash.new(0)) do |(k, v), p|
             p[k] += v  unless v.zero?


### PR DESCRIPTION
This comment was true when created https://github.com/rails/rails/commit/04c512da1247a54474cfd8bef17a9e9019c34004 but now it is outdated because of https://github.com/rails/rails/commit/fdfac8760f2a0db4de7bb83862df8b26f6c2916a. So I think's it better to remove this comment.