### PR TITLE
Fix Ruby 3.4 internal frame cleaner test

### DIFF
--- a/activesupport/test/deprecation_test.rb
+++ b/activesupport/test/deprecation_test.rb
@@ -979,16 +979,18 @@ class DeprecationTest < ActiveSupport::TestCase
     @deprecator.behavior = ->(message, *) { @message = message }
     method_that_emits_deprecation_with_internal_method(@deprecator)
 
-    assert_not_includes(@message, "internal")
+    assert_includes(@message, "/path/to/user/code.rb")
   end
+
+  class_eval(<<~RUBY, "/path/to/user/code.rb", 1)
+    def method_that_emits_deprecation_with_internal_method(deprecator)
+      [1].each { deprecator.warn }
+    end
+  RUBY
 
   private
     def method_that_emits_deprecation(deprecator)
       deprecator.warn
-    end
-
-    def method_that_emits_deprecation_with_internal_method(deprecator)
-      [1].each { deprecator.warn }
     end
 
     def with_rails_application_deprecators(&block)


### PR DESCRIPTION
Fixup for c85eca47f0d5845bb23a252748610b6cc618c673. I probably switched ruby versions around a bit too much and accidentally ended up validating the fix on 3.3. The full stacktrace was being filtered (since test code is part of internal rails code) which made it fall back to the first entry.

I adapted the test layout from this to make it work: https://github.com/rails/rails/blob/107fd51a2242e28f1a9219dbd46673418837c600/activesupport/test/deprecation_test.rb#L955-L967

cc @yahonda

```
ruby 3.4.0dev (2024-04-24T03:22:22Z master 0b3bc7232a) [x86_64-linux]
[user@PC06 activesupport]$ bin/test test/deprecation_test.rb:978
Running 98 tests in parallel using 8 processes
Run options: --seed 4552

# Running:

.

Finished in 0.956182s, 1.0458 runs/s, 2.0917 assertions/s.
1 runs, 2 assertions, 0 failures, 0 errors, 0 skips
```