### PR TITLE
Fix count queries on `includes+references` for models with composite primary keys

### DIFF
--- a/activerecord/test/cases/calculations_test.rb
+++ b/activerecord/test/cases/calculations_test.rb
@@ -403,6 +403,10 @@ class CalculationsTest < ActiveRecord::TestCase
     assert_equal(expected, Cpk::Book.where(author_id: book.author_id).group(:author_id).count)
   end
 
+  def test_count_for_a_composite_primary_key_model_with_includes_and_references
+    assert_equal Cpk::Book.count, Cpk::Book.includes(:chapters).references(:chapters).count
+  end
+
   def test_should_group_by_summed_field_having_condition
     c = Account.group(:firm_id).having("sum(credit_limit) > 50").sum(:credit_limit)
     assert_nil        c[1]


### PR DESCRIPTION
Fixes #51634.

SQLite and older MySQL do not support using `COUNT DISTINCT` with multiple columns, so we need to use a subquery for them.