### PR TITLE
Support css background-image attributes with cid: on mail preview

### DIFF
--- a/actionmailer/CHANGELOG.md
+++ b/actionmailer/CHANGELOG.md
@@ -1,2 +1,5 @@
+*   Support css background-image attributes with cid: on mail preview
+
+    *Alexey Vasiliev*
 
 Please check [8-0-stable](https://github.com/rails/rails/blob/8-0-stable/actionmailer/CHANGELOG.md) for previous changes.

--- a/actionmailer/lib/action_mailer/inline_preview_interceptor.rb
+++ b/actionmailer/lib/action_mailer/inline_preview_interceptor.rb
@@ -15,7 +15,7 @@ module ActionMailer
   #   ActionMailer::Base.preview_interceptors.delete(ActionMailer::InlinePreviewInterceptor)
   #
   class InlinePreviewInterceptor
-    PATTERN = /src=(?:"cid:[^"]+"|'cid:[^']+')/i
+    PATTERN = /src=(?:"cid:[^"]+"|'cid:[^']+')|url\((?:"cid:[^"]+"|'cid:[^']+'|cid:[^)]+)\)/i
 
     include Base64
 
@@ -31,8 +31,8 @@ module ActionMailer
       return message if html_part.blank?
 
       html_part.body = html_part.decoded.gsub(PATTERN) do |match|
-        if part = find_part(match[9..-2])
-          %[src="#{data_url(part)}"]
+        if part = find_part(match.match(/cid:([^"')]+)/i)[1])
+          match.start_with?("src=") ? %[src="#{data_url(part)}"] : %[url(#{data_url(part)})]
         else
           match
         end


### PR DESCRIPTION
### Motivation / Background

Mail preview support show inline attachments for `<img>` tag, but have not support for `background-image` css attribute. But this is also valid way to use inline images in emails. More info: https://email2go.io/blog/how-to-use-background-images-in-email-templates

Example of usage in erb template:

```
<td style="width: 100%; background-image: url(<%= attachments['welcome-email-bg.png'].url %>)">
```

without this fix:

![Screenshot 2024-04-24 at 15 44 26](https://github.com/rails/rails/assets/98444/a200ac8e-900e-4c4a-ac56-ecf28c4693d5)


with this fix:

![Screenshot 2024-04-24 at 15 43 21](https://github.com/rails/rails/assets/98444/6df9f081-4d2a-41b8-b9d4-4a33c1408a71)

Did not found tests for `InlinePreviewInterceptor`, so if I am missed add test cases, please point me where to add its



