### PR TITLE
Quiet debug noise

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/boot.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/boot.rb.tt
@@ -4,3 +4,6 @@ require "bundler/setup" # Set up gems listed in the Gemfile.
 <% if depend_on_bootsnap? -%>
 require "bootsnap/setup" # Speed up boot time by caching expensive operations.
 <%- end -%>
+
+# Quiet noisy debug gem
+ENV["RUBY_DEBUG_LOG_LEVEL"] = "FATAL"


### PR DESCRIPTION
Every Rails console command, be it the runner or console, currently outputs this noisy line:

```
dhh@r13:~/work/basecamp/haystack$ r c
DEBUGGER: Debugger can attach via UNIX domain socket (/run/user/1000/ruby-debug-dhh-2026143)
Loading development environment (Rails 7.2.0.alpha)
haystack(dev)> exit
```

Or worse on a runner call:

```
dhh@r13:~/work/basecamp/haystack$ r runner 'puts "hello"'
DEBUGGER: Debugger can attach via UNIX domain socket (/run/user/1000/ruby-debug-dhh-2027271)
hello
```

That's just not reasonable.

So let's set the log level higher by default. I don't totally love setting it in boot.rb, so I'm open to other suggestions. But we gotta make it be quiet in normal operations.

Another option is to convince @ko1 not to warn log this line by default 😄