### PR TITLE
[ci skip] Add more gem docs in Rails Application Templates guide

### DIFF
--- a/guides/source/rails_application_templates.md
+++ b/guides/source/rails_application_templates.md
@@ -62,6 +62,18 @@ gem "nokogiri"
 
 Note that this method only adds the gem to the `Gemfile`; it does not install the gem.
 
+You can also specify an exact version:
+
+```ruby
+gem "nokogiri", "~> 1.16.4"
+```
+
+And you can also add comments that will be added to the `Gemfile`:
+
+```ruby
+gem "nokogiri", "~> 1.16.4", comment: "Add the nokogiri gem for XML parsing"
+```
+
 ### gem_group(*names, &block)
 
 Wraps gem entries inside a group.


### PR DESCRIPTION
Added doc on how to add a gem with a specific version. Added doc on how to add a comment.

### Motivation / Background

We were making our rails template and it was difficult to know and assume what args the `gem` command had. The current guide mentions `gem(*args)` and we had to go inside the rails code itself to determine the arguments for this command. We also didn't realize that it supported the `comment:` argument until we saw it in the code, it is nice to know that it exists and is very helpful. I believe it would be helpful for other people making templates to know that these options exist without them going into the rails codebase.

This Pull Request has been created because we want other people to know that you can affix exact gem versions and also add comments through the `gem` command in the template API.

### Detail

This Pull Request changes the Rails Application Templates guide page.

### Additional information

N/A

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [X] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
