### PR TITLE
Add `comment` and `table_comment` table schema definition

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -52,4 +52,15 @@
 
     *Eileen M. Uchitelle*
 
+*   Add `comment` and `table_comment` for `change_table` definition.
+
+    ```ruby
+    change_table :users do |t|
+      t.comment :login, "Username"
+      t.table_comment "Usual users"
+    end
+    ```
+
+    *Edem Topuzov*
+
 Please check [7-2-stable](https://github.com/rails/rails/blob/7-2-stable/activerecord/CHANGELOG.md) for previous changes.

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
@@ -701,6 +701,8 @@ module ActiveRecord
     #     t.remove_index
     #     t.remove_check_constraint
     #     t.remove_timestamps
+    #     t.comment
+    #     t.table_comment
     #   end
     #
     class Table
@@ -939,6 +941,24 @@ module ActiveRecord
       # See {connection.check_constraint_exists?}[rdoc-ref:SchemaStatements#check_constraint_exists?]
       def check_constraint_exists?(*args, **options)
         @base.check_constraint_exists?(name, *args, **options)
+      end
+
+      # Changes the comment for a column.
+      #
+      #   t.comment(:state, "State column comment")
+      #
+      # See {connection.change_column_comment}[rdoc-ref:SchemaStatements#change_column_comment]
+      def comment(column_name, comment_or_changes)
+        @base.change_column_comment(name, column_name, comment_or_changes)
+      end
+
+      # Changes the comment for a table.
+      #
+      #   t.table_comment("Table comment")
+      #
+      # See {connection.change_table_comment}[rdoc-ref:SchemaStatements#change_table_comment]
+      def table_comment(comment_or_changes)
+        @base.change_table_comment(name, comment_or_changes)
       end
 
       private

--- a/activerecord/test/cases/migration/change_table_test.rb
+++ b/activerecord/test/cases/migration/change_table_test.rb
@@ -359,6 +359,22 @@ module ActiveRecord
         end
       end
 
+      if ActiveRecord::Base.lease_connection.supports_comments?
+        def test_change_column_comment
+          with_change_table do |t|
+            expect :change_column_comment, nil, [:delete_me, :bar, "Edited column comment"]
+            t.comment :bar, "Edited column comment"
+          end
+        end
+
+        def test_change_table_comment
+          with_change_table do |t|
+            expect :change_table_comment, nil, [:delete_me, "Edited table comment"]
+            t.table_comment "Edited table comment"
+          end
+        end
+      end
+
       def test_remove_column_with_if_exists_raises_error
         assert_raises(ArgumentError) do
           with_change_table do |t|


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because these methods are missing, but could be helpful for bulk changes of the table. This will allow you to add comment(s) to the table and/or to the column(s) using single block, improving readability and performance because of single query

### Detail

This Pull Request adds `comment` and `table_comment` for `change_table` definition

```ruby
change_table :users, bulk: true do |t|
  t.comment :login, "Username"
  t.table_comment "Usual users"
end
```

### Additional information

This was intended as non-breaking change

### Checklist

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
