### PR TITLE
Skip `selenium-webdriver` version 4.20.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ gem "rake", ">= 13"
 gem "sprockets-rails", ">= 2.0.0"
 gem "propshaft", ">= 0.1.7"
 gem "capybara", ">= 3.39"
-gem "selenium-webdriver", ">= 4.11.0"
+gem "selenium-webdriver", ">= 4.11.0", "!= 4.20.0"
 
 gem "rack-cache", "~> 1.2"
 gem "stimulus-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -491,7 +491,8 @@ GEM
       google-protobuf (~> 3.25)
     sass-embedded (1.69.6-x86_64-linux-gnu)
       google-protobuf (~> 3.25)
-    selenium-webdriver (4.16.0)
+    selenium-webdriver (4.19.0)
+      base64 (~> 0.2)
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
@@ -653,7 +654,7 @@ DEPENDENCIES
   rubocop-rails-omakase
   rubyzip (~> 2.0)
   sdoc!
-  selenium-webdriver (>= 4.11.0)
+  selenium-webdriver (>= 4.11.0, != 4.20.0)
   sidekiq
   sneakers
   sprockets-rails (>= 2.0.0)


### PR DESCRIPTION
### Motivation / Background

This commit will not allow to install the selenium-webdriver` version 4.20.0 because `Selenium::WebDriver::DriverFinder.path` was dropped in `selenium-webdriver` 4.20.0 that was not intentional.

It will be restored once the newer version of `selenium-webdriver` that includes https://github.com/SeleniumHQ/selenium/pull/13877 .
    
Fix #51658

### Detail
None

### Additional information
Feel free to open a pull request to support the newer versions of selenium-webdriver that deprecates `Selenium::WebDriver::DriverFinder.path`.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.


