### PR TITLE
Resolve deprecation warning in latest `selenium-webdriver`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ gem "rake", ">= 13"
 gem "sprockets-rails", ">= 2.0.0"
 gem "propshaft", ">= 0.1.7"
 gem "capybara", ">= 3.39"
-gem "selenium-webdriver", ">= 4.11.0", "!= 4.20.0"
+gem "selenium-webdriver", ">= 4.20.0"
 
 gem "rack-cache", "~> 1.2"
 gem "stimulus-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -491,7 +491,7 @@ GEM
       google-protobuf (~> 3.25)
     sass-embedded (1.69.6-x86_64-linux-gnu)
       google-protobuf (~> 3.25)
-    selenium-webdriver (4.19.0)
+    selenium-webdriver (4.20.1)
       base64 (~> 0.2)
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
@@ -654,7 +654,7 @@ DEPENDENCIES
   rubocop-rails-omakase
   rubyzip (~> 2.0)
   sdoc!
-  selenium-webdriver (>= 4.11.0, != 4.20.0)
+  selenium-webdriver (>= 4.20.0)
   sidekiq
   sneakers
   sprockets-rails (>= 2.0.0)

--- a/actionpack/lib/action_dispatch/system_testing/browser.rb
+++ b/actionpack/lib/action_dispatch/system_testing/browser.rb
@@ -72,7 +72,12 @@ module ActionDispatch
         end
 
         def resolve_driver_path(namespace)
-          namespace::Service.driver_path = ::Selenium::WebDriver::DriverFinder.path(options, namespace::Service)
+          # The path method has been deprecated in 4.20.0
+          if Gem::Version.new(::Selenium::WebDriver::VERSION) >= Gem::Version.new("4.20.0")
+            namespace::Service.driver_path = ::Selenium::WebDriver::DriverFinder.new(options, namespace::Service.new).driver_path
+          else
+            namespace::Service.driver_path = ::Selenium::WebDriver::DriverFinder.path(options, namespace::Service)
+          end
         end
     end
   end

--- a/actionpack/test/dispatch/system_testing/driver_test.rb
+++ b/actionpack/test/dispatch/system_testing/driver_test.rb
@@ -152,9 +152,10 @@ class DriverTest < ActiveSupport::TestCase
     original_driver_path = ::Selenium::WebDriver::Chrome::Service.driver_path
     ::Selenium::WebDriver::Chrome::Service.driver_path = nil
 
-    # Our stub must return a path to a real executable, otherwise an internal Selenium assertion will fail.
+    # Our stub must return paths to a real executables, otherwise an internal Selenium assertion will fail.
+    # Note: SeleniumManager is private api
     found_executable = RbConfig.ruby
-    ::Selenium::WebDriver::SeleniumManager.stub(:driver_path, found_executable) do
+    ::Selenium::WebDriver::SeleniumManager.stub(:binary_paths, { "driver_path" => found_executable, "browser_path" => found_executable }) do
       ActionDispatch::SystemTesting::Driver.new(:selenium, screen_size: [1400, 1400], using: :chrome)
     end
 


### PR DESCRIPTION
### Motivation / Background

Followup to #51658, to resolve the following deprecation warning on `selenium-webdriver` 4.20.1:

```
2024-04-26 09:36:45 INFO Selenium [:logger_info] Details on how to use and modify Selenium logger:
  https://selenium.dev/documentation/webdriver/troubleshooting/logging

2024-04-26 09:36:45 WARN Selenium [DEPRECATION] DriverFinder.path(options, service_class) is deprecated. Use DriverFinder.new(options, service).driver_path instead.
```

### Detail

Bumped the selenium version in the gemfile to test the new behaviour.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
