### PR TITLE
`7-1-stable` changelog typos [ci-skip]

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -21,8 +21,8 @@
 
 *   Fix `ActionDispatch::Executor` middleware to report errors handled by `ActionDispatch::ShowExceptions`
 
-    In the default production environment, `ShowExceptions` rescue uncaught errors
-    and returns a response. Because if this the executor wouldn't report production
+    In the default production environment, `ShowExceptions` rescues uncaught errors
+    and returns a response. Because of this the executor wouldn't report production
     errors with the default Rails configuration.
 
     *Jean Boussier*

--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,4 +1,4 @@
-*   Restore the ability for template to return any kind of object and not just strings
+*   Restore the ability for templates to return any kind of object and not just strings
 
     *Jean Boussier*
 

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,4 +1,4 @@
-*   Workaround a Ruby bug that can cause a VM crash.
+*   Work around a Ruby bug that can cause a VM crash.
 
     This would happen if using `TaggerLogger` with a Proc
     formatter on which you called `object_id`.

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,7 +1,7 @@
 *   Fix sanitizer vendor configuration in 7.1 defaults.
 
-    In apps where rails-html-sanitizer was not eagerly loaded, the sanitizer default could end up
-    being Rails::HTML4::Sanitizer when it should be set to Rails::HTML5::Sanitizer.
+    In apps where `rails-html-sanitizer` was not eagerly loaded, the sanitizer default could end up
+    being Rails::HTML4::Sanitizer when it should be set to `Rails::HTML5::Sanitizer`.
 
     *Mike Dalessio*, *Rafael Mendonça França*
 
@@ -11,7 +11,7 @@
     a shared hosting solution, this cause the default configuration to spawn
     way more workers than reasonable.
 
-    There is unfortunately no reliable way to detect how many core an application
+    There is unfortunately no reliable way to detect how many cores an application
     can realistically use, and even then, assuming the application should use
     all the machine resources is often wrong.
 


### PR DESCRIPTION
Read through the current changelog entries, these stood out to me.