### PR TITLE
Fix console_test to make pass after IRB's behavior change

### DIFF
--- a/railties/test/application/console_test.rb
+++ b/railties/test/application/console_test.rb
@@ -25,11 +25,11 @@ class FullStackConsoleTest < ActiveSupport::TestCase
     teardown_app
   end
 
-  def write_prompt(command, expected_output = nil)
+  def write_prompt(command, expected_output = nil, prompt: "> ")
     @primary.puts command
     assert_output command, @primary
     assert_output expected_output, @primary, 100 if expected_output
-    assert_output "> ", @primary
+    assert_output prompt, @primary
   end
 
   def spawn_console(options, wait_for_prompt: true, env: {})
@@ -123,21 +123,21 @@ class FullStackConsoleTest < ActiveSupport::TestCase
     options = "-e production"
     spawn_console(options)
 
-    write_prompt "123", "app-template(prod)> 123"
+    write_prompt "123", prompt: "app-template(prod)>"
   end
 
   def test_development_console_prompt
     options = "-e development"
     spawn_console(options)
 
-    write_prompt "123", "app-template(dev)> 123"
+    write_prompt "123", prompt: "app-template(dev)> "
   end
 
   def test_test_console_prompt
     options = "-e test"
     spawn_console(options)
 
-    write_prompt "123", "app-template(test)> 123"
+    write_prompt "123", prompt: "app-template(test)> "
   end
 
   def test_helper_helper_method
@@ -219,7 +219,7 @@ class FullStackConsoleTest < ActiveSupport::TestCase
     options = "-e test"
     spawn_console(options, env: { "IRBRC" => irbrc.path })
 
-    write_prompt "123", ">> 123"
+    write_prompt "123", prompt: ">> "
   ensure
     File.unlink(irbrc)
   end


### PR DESCRIPTION
### Motivation / Background

In IRB's pull request https://github.com/ruby/irb/pull/907, IRB's behavior with `ENV['TERM']=dumb` will change.
After the change, some test in `railties/test/application/console_test.rb` will fail like this.
```
Failure:
FullStackConsoleTest#test_console_respects_user_defined_prompt_mode [test/application/console_test.rb:124]:
">> 123" expected, but got:


=> 123
>> .
Expected "\r\n=> 123\r\n>> " to include ">> 123".
```

This pull request makes console_test pass.

### Detail

`write_prompt "123", "prompt> 123"` will execute
```ruby
@primary.puts("123")
assert_output("123", @primary)
assert_output("prompt> 123", @primary)
assert_output("> ", @primary)
```

Output from IRB will change like this
```
prompt> prompt> 1prompt> 12prompt> 123 (Reline <= 0.5.2) prompt> 112123 (Reline >= 0.5.3)
prompt> 123 (Reline Prints prompt and whole input again)
123 (IRB's --verbose option prints this)
=> 123
prompt> (Reline prints next prompt)
```
↓
```
prompt> 123 (IRB prints "promt> ", PTY echos "123")
123 (IRB's --verbose option prints this)
=> 123
prompt> (IRB prints next prompt)
```
This pull request changes it to
`write_prompt "123", prompt: "prompt> "` which will execute below, and correctly matches in both cases.
```ruby
@primary.puts("123")
assert_output("123", @primary)
assert_output("prompt> ", @primary)
```

### Additional information

Adding `-- --nomultiline --nosingleline` will emulate IRB's behavior change
```diff
--- a/railties/test/application/console_test.rb
+++ b/railties/test/application/console_test.rb
@@ -128,7 +128,7 @@ def write_prompt(command, expected_output = nil, prompt: "> ")
   def spawn_console(options, wait_for_prompt: true, env: {})
     pid = Process.spawn(
       { "TERM" => "dumb" }.merge(env),
-      "#{app_path}/bin/rails console #{options}",
+      "#{app_path}/bin/rails console #{options} #{'--' unless options.include?(' -- ')} --nomultiline --nosingleline",
       in: @replica, out: @replica, err: @replica
     )
```

TERM=dumb is used in emacs shell. IRB/Reline used to print many redundant test and make it unusable.
```
% TERM=dumb irb
irb(main):001> 123
irb(main):001> 1irb(main):001> 12irb(main):001> 123=> 123
irb(main):002> 
```
The old test was matching to this redundant output part.