### PR TITLE
Add JSON output format option to `rails stats` command

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,33 @@
+*   Add JSON output format to `rails stats` via `format` option.
+
+    Enables JSON formatted output for better integration with automated systems. Maintains default table format unless specified.
+
+    ```shell
+    $ bin/rails stats[json] | jq .
+    {
+      "code_statistics": [
+        {
+          "name": "Controllers",
+          "statistic": {
+            "lines": 12345,
+            "code_lines": 12345,
+            "classes": 123,
+            "methods": 1234
+          }
+        },
+        ...
+      ],
+      "total": {
+        "lines": 12345,
+        "code_lines": 12345,
+        "classes": 123,
+        "methods": 1234
+      }
+    }
+    ```
+
+    *Teppei Shintani*
+
 *   Allow Actionable Errors encountered when running tests to be retried.
 
     ```txt

--- a/railties/lib/rails/code_statistics.rb
+++ b/railties/lib/rails/code_statistics.rb
@@ -35,6 +35,18 @@ class CodeStatistics # :nodoc:
     print_code_test_stats
   end
 
+  def to_h
+    {
+      code_statistics: @statistics.map do |k, v|
+        {
+          name: k,
+          statistic: v.to_h
+        }
+      end,
+      total: @total&.to_h
+    }
+  end
+
   private
     def calculate_statistics
       Hash[@pairs.map { |pair| [pair.first, calculate_directory_statistics(pair.last)] }]

--- a/railties/lib/rails/code_statistics_calculator.rb
+++ b/railties/lib/rails/code_statistics_calculator.rb
@@ -86,6 +86,15 @@ class CodeStatisticsCalculator # :nodoc:
     end
   end
 
+  def to_h
+    {
+      lines: lines,
+      code_lines: code_lines,
+      classes: classes,
+      methods: methods
+    }
+  end
+
   private
     def file_type(file_path)
       if file_path.end_with? "_test.rb"

--- a/railties/lib/rails/tasks/statistics.rake
+++ b/railties/lib/rails/tasks/statistics.rake
@@ -29,10 +29,16 @@ STATS_DIRECTORIES ||= [
 ]
 
 desc "Report code statistics (KLOCs, etc) from the application or engine"
-task :stats do
+task :stats, :format do |_, args|
   require "rails/code_statistics"
   stat_directories = STATS_DIRECTORIES.collect do |name, dir|
     [ name, "#{File.dirname(Rake.application.rakefile_location)}/#{dir}" ]
   end.select { |name, dir| File.directory?(dir) }
-  CodeStatistics.new(*stat_directories).to_s
+  statistics = CodeStatistics.new(*stat_directories)
+  case args[:format]
+  when "json"
+    puts statistics.to_h.to_json
+  else
+    statistics.to_s
+  end
 end

--- a/railties/test/code_statistics_calculator_test.rb
+++ b/railties/test/code_statistics_calculator_test.rb
@@ -84,6 +84,11 @@ class CodeStatisticsCalculatorTest < ActiveSupport::TestCase
     assert_equal 6, @code_statistics_calculator.methods
   end
 
+  test "return statistics as a hash" do
+    code_statistics_calculator = CodeStatisticsCalculator.new(1, 2, 3, 4)
+    assert_equal({ lines: 1, code_lines: 2, classes: 3, methods: 4 }, code_statistics_calculator.to_h)
+  end
+
   test "calculate number of Ruby methods" do
     code = <<-'CODE'
       def foo

--- a/railties/test/code_statistics_test.rb
+++ b/railties/test/code_statistics_test.rb
@@ -31,4 +31,59 @@ class CodeStatisticsTest < ActiveSupport::TestCase
       CodeStatistics.new(["hidden file", @tmp_path])
     end
   end
+
+  test "output results in table format" do
+    File.write File.join(@tmp_path, "example.rb"), <<-CODE
+      class Example
+        def foo
+          puts 'foo'
+        end
+      end
+    CODE
+
+    code_statistics = CodeStatistics.new(["tmp dir", @tmp_path])
+    expected = <<~TABLE
+      +----------------------+--------+--------+---------+---------+-----+-------+
+      | Name                 |  Lines |    LOC | Classes | Methods | M/C | LOC/M |
+      +----------------------+--------+--------+---------+---------+-----+-------+
+      | tmp dir              |      5 |      5 |       1 |       1 |   1 |     3 |
+      +----------------------+--------+--------+---------+---------+-----+-------+
+        Code LOC: 5     Test LOC: 0     Code to Test Ratio: 1:0.0
+
+    TABLE
+
+    output, _ = capture_io do
+      code_statistics.to_s
+    end
+
+    assert_equal expected, output
+  end
+
+  test "return results in hash format" do
+    File.write File.join(@tmp_path, "example.rb"), <<-CODE
+      class Example
+        def foo
+          puts 'foo'
+        end
+      end
+    CODE
+
+    code_statistics = CodeStatistics.new(["tmp dir", @tmp_path])
+    expected = {
+      code_statistics: [
+        {
+          name: "tmp dir",
+          statistic: {
+            lines: 5,
+            code_lines: 5,
+            classes: 1,
+            methods: 1
+          }
+        }
+      ],
+      total: nil
+    }
+
+    assert_equal expected, code_statistics.to_h
+  end
 end


### PR DESCRIPTION

<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

The `rails stats` command is extremely useful for assessing the health and maturity of Rails applications. Currently, the output of this command is primarily in table format, which is suitable for human interpretation but not well-suited for use with automated systems.

In this Pull Request, I propose a feature that allows the rails stats command to output in JSON format, facilitating continuous monitoring of application maturity and health. By supporting JSON output, it becomes easier to analyze statistical data and integrate it with monitoring tools and dashboards. This enhancement will enable developers to visualize changes in the codebase in real time and respond swiftly as needed.

### Detail

This change introduces a format option to the rails stats command. When utilized, this option allows for the output to be provided in JSON format, enabling programs and automated systems to directly parse the statistical data.

Example usage:
```shell
$ bin/rails stats[json] | jq .
{
  "code_statistics": [
    {
      "name": "Controllers",
      "statistic": {
        "lines": 12345,
        "code_lines": 12345,
        "classes": 123,
        "methods": 1234
      }
    },
    ...
  ],
  "total": {
    "lines": 12345,
    "code_lines": 12345,
    "classes": 123,
    "methods": 1234
  }
}
```

This change does not affect existing functionalities. The format option is optional, and the default behavior remains unchanged. If the option is not provided, the command will continue to output results in the traditional table format, as before.

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
