### PR TITLE
Allow `ActiveRecord::QueryMethods#pluck` to accept hash args with symbol & string values

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Allow `ActiveRecord::Base#pluck` to accept hash arguments with symbol and string values.
+
+    ```ruby
+    Post.joins(:comments).pluck(:id, comments: :id)
+    Post.joins(:comments).pluck("id", "comments" => "id")
+    ```
+
+    *Joshua Young*
+
 *   Make Float distinguish between `float4` and `float8` in PostgreSQL.
 
     Fixes #52742

--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -275,9 +275,13 @@ module ActiveRecord
     #   # SELECT people.id FROM people WHERE people.age = 21 LIMIT 5
     #   # => [2, 3]
     #
-    #   Comment.joins(:person).pluck(:id, person: [:id])
+    #   Comment.joins(:person).pluck(:id, person: :id)
     #   # SELECT comments.id, people.id FROM comments INNER JOIN people on comments.person_id = people.id
     #   # => [[1, 2], [2, 2]]
+    #
+    #   Comment.joins(:person).pluck(:id, person: [:id, :name])
+    #   # SELECT comments.id, people.id, people.name FROM comments INNER JOIN people on comments.person_id = people.id
+    #   # => [[1, 2, 'David'], [2, 2, 'David']]
     #
     #   Person.pluck(Arel.sql('DATEDIFF(updated_at, created_at)'))
     #   # SELECT DATEDIFF(updated_at, created_at) FROM people

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -1956,6 +1956,25 @@ module ActiveRecord
         end
       end
 
+      def arel_columns_from_array(columns, table_name = model.table_name)
+        columns.map do |column|
+          arel_column("#{table_name}.#{column}")
+        end
+      end
+
+      def arel_columns_from_hash(fields)
+        fields.flat_map do |table_name, columns|
+          case columns
+          when Array
+            arel_columns_from_array(columns, table_name)
+          when Symbol, String
+            arel_column(columns)
+          else
+            raise TypeError, "Expected Symbol, String or Array, got: #{columns.class}"
+          end
+        end
+      end
+
       def arel_column(field)
         field = field.name if is_symbol = field.is_a?(Symbol)
 
@@ -2194,14 +2213,14 @@ module ActiveRecord
       def process_select_args(fields)
         fields.flat_map do |field|
           if field.is_a?(Hash)
-            arel_columns_from_hash(field)
+            arel_column_aliases_from_hash(field)
           else
             field
           end
         end
       end
 
-      def arel_columns_from_hash(fields)
+      def arel_column_aliases_from_hash(fields)
         fields.flat_map do |key, columns_aliases|
           case columns_aliases
           when Hash

--- a/activerecord/test/cases/calculations_test.rb
+++ b/activerecord/test/cases/calculations_test.rb
@@ -976,7 +976,10 @@ class CalculationsTest < ActiveRecord::TestCase
       [2, "The Second Topic of the day"],
       [3, "The Third Topic of the day"]
     ]
+    assert_equal expected, Topic.order(:id).limit(3).pluck(:id, topics: :title)
+    assert_equal expected, Topic.order(:id).limit(3).pluck("id", "topics" => "title")
     assert_equal expected, Topic.order(:id).limit(3).pluck(:id, topics: [:title])
+    assert_equal expected, Topic.order(:id).limit(3).pluck("id", "topics" => ["title"])
   end
 
   def test_pluck_with_hash_argument_with_multiple_tables
@@ -985,6 +988,8 @@ class CalculationsTest < ActiveRecord::TestCase
       [1, 2, "Thank you again for the welcome"],
       [2, 3, "Don't think too hard"]
     ]
+    assert_equal expected, Post.joins(:comments).order(posts: { id: :asc }, comments: { id: :asc }).limit(3).pluck(:id, comments: [:id, :body])
+    assert_equal expected, Post.joins(:comments).order(posts: { id: :asc }, comments: { id: :asc }).limit(3).pluck(posts: :id, comments: [:id, :body])
     assert_equal expected, Post.joins(:comments).order(posts: { id: :asc }, comments: { id: :asc }).limit(3).pluck(posts: [:id], comments: [:id, :body])
   end
 


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

Extends the feature added in #51565 to allow symbol and string hash values when plucking a single column for a specific table. When trying out this new feature I naturally thought this would be valid since other query methods offer a similar API (with differing functionality based on the method) e.g. `includes(foo: :bar)`, `order(foo: :desc)`.

```ruby
Post.joins(:comments).pluck(:id, comments: :id)
```

### Detail

Updates `ActiveRecord::QueryMethods#arel_columns_from_hash` which is used by `#pluck` to simply return the Arel attribute for the column by default if the hash value is a symbol or string, while maintaining `#select` specific aliasing functionality.

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

While working on this I realised that #51565 introduced a bit of a non-obvious side effect where a query like:

```ruby
Post.joins(:comments).pluck(:id, comments: { id: :foo })
```

would return the correct result, but also alias the column in the query (`"comments"."id" AS foo`).

Just thought it was worth mentioning in case this is classified as a 'bug'. If so, it might be worth separating out the `#select` specific logic from the rest (or `#pluck` from the rest), which would also simplify the conditional logic for the extension in this PR.

cc/ @fatkodima Keen for your thoughts on this feature and my last note.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
