### PR TITLE
Fix `ActiveSupport::TestCase` being loaded too early

### DIFF
--- a/activesupport/lib/active_support/railtie.rb
+++ b/activesupport/lib/active_support/railtie.rb
@@ -125,7 +125,9 @@ module ActiveSupport
         elsif k == :use_rfc4122_namespaced_uuids
           ActiveSupport.deprecator.warn("config.active_support.use_rfc4122_namespaced_uuids is deprecated and will be removed in Rails 7.2.")
         elsif k == :assertionless_tests_behavior
-          ActiveSupport::TestCase.assertionless_tests_behavior = v
+          ActiveSupport.on_load(:active_support_test_case) do
+            ActiveSupport::TestCase.assertionless_tests_behavior = v
+          end
         else
           k = "#{k}="
           ActiveSupport.public_send(k, v) if ActiveSupport.respond_to? k


### PR DESCRIPTION
### Motivation / Background

rails/rails@76966f9 implemented configuration to report assertionless tests. But the configuration causes `ActiveSupport::TestCase` to be loaded too early in the boot process. It causes issues when other engines define load hooks on `:active_support_test_case` because they are run immediately. 

### Detail

Instead, we should wrap the configuration in a load hook so it gets set once `ActiveSupport::TestCase` is loaded.

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
