### PR TITLE
Raise when a block is passed to `ActiveRecord::Relation#with`

### DIFF
--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -473,6 +473,7 @@ module ActiveRecord
     #     .with(posts_with_comments: Post.where("comments_count > ?", 0))
     #     .with(posts_with_tags: Post.where("tags_count > ?", 0))
     def with(*args)
+      raise ArgumentError, "ActiveRecord::Relation#with does not accept a block" if block_given?
       check_if_method_has_arguments!(__callee__, args)
       spawn.with!(*args)
     end

--- a/activerecord/test/cases/core_test.rb
+++ b/activerecord/test/cases/core_test.rb
@@ -23,7 +23,7 @@ class CoreTest < ActiveRecord::TestCase
   end
 
   def test_inspect_includes_attributes_from_attributes_for_inspect
-    Topic.with(attributes_for_inspect: [:id, :title, :author_name]) do
+    Topic.stub(:attributes_for_inspect, [:id, :title, :author_name]) do
       topic = topics(:first)
 
       assert_equal %(#<Topic id: 1, title: "The First Topic", author_name: "David">), topic.inspect
@@ -33,7 +33,7 @@ class CoreTest < ActiveRecord::TestCase
   def test_inspect_instance_with_lambda_date_formatter
     before = Time::DATE_FORMATS[:inspect]
 
-    Topic.with(attributes_for_inspect: [:id, :last_read]) do
+    Topic.stub(:attributes_for_inspect, [:id, :last_read]) do
       Time::DATE_FORMATS[:inspect] = ->(date) { "my_format" }
       topic = topics(:first)
 
@@ -48,7 +48,7 @@ class CoreTest < ActiveRecord::TestCase
   end
 
   def test_inspect_limited_select_instance
-    Topic.with(attributes_for_inspect: [:id, :title]) do
+    Topic.stub(:attributes_for_inspect, [:id, :title]) do
       assert_equal %(#<Topic id: 1>), Topic.all.merge!(select: "id", where: "id = 1").first.inspect
       assert_equal %(#<Topic id: 1, title: "The First Topic">), Topic.all.merge!(select: "id, title", where: "id = 1").first.inspect
     end
@@ -64,7 +64,7 @@ class CoreTest < ActiveRecord::TestCase
   end
 
   def test_inspect_with_attributes_for_inspect_all_lists_all_attributes
-    Topic.with(attributes_for_inspect: :all) do
+    Topic.stub(:attributes_for_inspect, :all) do
       topic = topics(:first)
 
       assert_equal <<~STRING.squish, topic.inspect
@@ -108,7 +108,7 @@ class CoreTest < ActiveRecord::TestCase
   end
 
   def test_pretty_print_full
-    Topic.with(attributes_for_inspect: :all) do
+    Topic.stub(:attributes_for_inspect, :all) do
       topic = topics(:first)
       actual = +""
       PP.pp(topic, StringIO.new(actual))

--- a/activerecord/test/cases/integration_test.rb
+++ b/activerecord/test/cases/integration_test.rb
@@ -103,14 +103,14 @@ class IntegrationTest < ActiveRecord::TestCase
   end
 
   def test_param_delimiter_changes_delimiter_used_in_to_param
-    Cpk::Order.with(param_delimiter: ",") do
+    Cpk::Order.stub(:param_delimiter, ",") do
       assert_equal("1,123", Cpk::Order.new(id: [1, 123]).to_param)
     end
   end
 
   def test_param_delimiter_is_defined_per_class
-    Cpk::Order.with(param_delimiter: ",") do
-      Cpk::Book.with(param_delimiter: ";") do
+    Cpk::Order.stub(:param_delimiter, ",") do
+      Cpk::Book.stub(:param_delimiter, ";") do
         assert_equal("1,123", Cpk::Order.new(id: [1, 123]).to_param)
         assert_equal("1;123", Cpk::Book.new(id: [1, 123]).to_param)
       end

--- a/activerecord/test/cases/relation/with_test.rb
+++ b/activerecord/test/cases/relation/with_test.rb
@@ -82,6 +82,12 @@ module ActiveRecord
         assert_equal Post.count, records.size
         assert_equal POSTS_WITH_COMMENTS, records.filter_map { _1.id if _1.has_comments }
       end
+
+      def test_raises_when_using_block
+        assert_raises(ArgumentError, match: "does not accept a block") do
+          Post.with(attributes_for_inspect: :id) { }
+        end
+      end
     else
       def test_common_table_expressions_are_unsupported
         assert_raises ActiveRecord::StatementInvalid do


### PR DESCRIPTION
While working on a follow up to #51625 (I want to enable raising errors for assertionless tests in all the frameworks tests), using that feature I identified a few broken (but fortunately passing when fixed) tests inside active record.

The problem is that we have `Object#with` (#46681) and `ActiveRecord::Relation#with` (#37944). In the fixed tests in this PR, people were intended to use `Object#with`, but actually `ActiveRecord::Relation#with` was used and the tests were no-ops, because it does not support a block and silently ignores it.

I also found a relevant ticket https://bugs.ruby-lang.org/issues/15554.

cc @byroot 