### PR TITLE
Reset ActionCable reconnect_count when Redis attempt limit reached

### DIFF
--- a/actioncable/CHANGELOG.md
+++ b/actioncable/CHANGELOG.md
@@ -1,2 +1,3 @@
+*   Reset reconnect_count when Redis reconnect_attempt limit is reached to avoid wedging.
 
-Please check [7-2-stable](https://github.com/rails/rails/blob/7-2-stable/actioncable/CHANGELOG.md) for previous changes.
+    *Elijah Buck*

--- a/actioncable/lib/action_cable/subscription_adapter/redis.rb
+++ b/actioncable/lib/action_cable/subscription_adapter/redis.rb
@@ -78,6 +78,7 @@ module ActionCable
             # Use the same config as used by Redis conn
             @reconnect_attempts = config_options.fetch(:reconnect_attempts, 1)
             @reconnect_attempts = Array.new(@reconnect_attempts, 0) if @reconnect_attempts.is_a?(Integer)
+            @reconnect_reset_delay = config_options.fetch(:reconnect_reset_delay, 3)
 
             @subscribed_client = nil
 
@@ -168,6 +169,10 @@ module ActionCable
                   reset
                   if retry_connecting?
                     when_connected { resubscribe }
+                    retry
+                  else
+                    @reconnect_attempt = 0
+                    sleep @reconnect_reset_delay
                     retry
                   end
                 end


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because when the ActionCable reconnect_attempt limit is reached, the server wedges and continues to accept connections but cannot deliver messages since Redis is disconnected.

### Detail

This is based on https://github.com/rails/rails/pull/45478 and https://github.com/rails/rails/pull/44626 and building on https://github.com/rails/rails/pull/46562. https://github.com/rails/rails/pull/46562 added a Redis reconnect option, but when the number of reconnect attempts is exceeded the server cannot currently recover.

This Pull Request changes the ActionCable Redis subscription adapter to reset the reconnect_attempt counter when the configured retry count has been exceeded, allowing the retry process to start over.

~This Pull Request changes the ActionCable Redis subscription adapter to restart the ActionCable server when the number of reconnect_attempts is reached. The benefit of doing a restart is that it announces to the clients that the server is restarting. Combined with a health check that takes the server out of service (in the event of an extended Redis outage), this can allow clients to migrate to a healthy server.~

cc @palkan @MrChrisW @engwan

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
