### PR TITLE
Add `require: "debug/prelude"` after `debug`'s Gemfile entry

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,14 @@
+*   Generated Gemfile will include `require: "debug/prelude"` for the `debug` gem
+
+    Requiring `debug` gem directly automatically activates it, which could introduce
+    additional overhead and memory usage even without entering a debugging session.
+
+    By making Bundler require `debug/prelude` instead, developers can keep their access
+    to breakpoint methods like `debugger` or `binding.break`, but the debugger won't be
+    activated until a breakpoint is hit.
+
+    *Stan Lo*
+
 *   Allow Actionable Errors encountered when running tests to be retried.
 
     ```txt

--- a/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
@@ -33,7 +33,7 @@ gem "bootsnap", require: false
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
-  gem "debug", platforms: %i[ mri <%= bundler_windows_platforms %> ]
+  gem "debug", platforms: %i[ mri <%= bundler_windows_platforms %> ], require: "debug/prelude"
 <%- unless options.skip_brakeman? -%>
 
   # Static analysis for security vulnerabilities [https://brakemanscanner.org/]


### PR DESCRIPTION
### Motivation / Background

In https://github.com/ruby/debug/issues/797, we found that requiring `debug` automatically activates it, which could introduce runtime overhead and cause memory bloat. And I think many users aren't aware of this and could be taxed by this unnecessarily (e.g. having longer builds on CI).

### Detail

Therefore, I propose to add `require: "debug/prelude"` after `debug`'s Gemfile entry in the default Gemfile template. This way, users can still use breakpoint methods like `debugger`, `binding.break`, and `binding.b`, but the debugger won't be activated until a breakpoint is hit.

### Additional information

For the most recent overhead/memory issue report, please see the issue's [comment 1](https://github.com/ruby/debug/issues/797#issuecomment-2085230516) and [comment 2](https://github.com/ruby/debug/issues/797#issuecomment-2085609036).

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
