### PR TITLE
Enable raising for assertionless tests for internal framework tests

### DIFF
--- a/actionpack/test/controller/action_pack_assertions_test.rb
+++ b/actionpack/test/controller/action_pack_assertions_test.rb
@@ -177,9 +177,11 @@ class ActionPackAssertionsControllerTest < ActionController::TestCase
   end
 
   def test_string_constraint
-    with_routing do |set|
-      set.draw do
-        get "photos", to: "action_pack_assertions#nothing", constraints: { subdomain: "admin" }
+    assert_nothing_raised do
+      with_routing do |set|
+        set.draw do
+          get "photos", to: "action_pack_assertions#nothing", constraints: { subdomain: "admin" }
+        end
       end
     end
   end

--- a/actionpack/test/controller/flash_test.rb
+++ b/actionpack/test/controller/flash_test.rb
@@ -310,7 +310,9 @@ class FlashIntegrationTest < ActionDispatch::IntegrationTest
     with_test_route_set do
       env = { "action_dispatch.request.flash_hash" => ActionDispatch::Flash::FlashHash.new }
       get "/set_flash", env: env
-      get "/set_flash", env: env
+      assert_nothing_raised do
+        get "/set_flash", env: env
+      end
     end
   end
 
@@ -318,7 +320,9 @@ class FlashIntegrationTest < ActionDispatch::IntegrationTest
     with_test_route_set do
       env = { "action_dispatch.request.flash_hash" => ActionDispatch::Flash::FlashHash.new }
       get "/set_flash_now", env: env
-      get "/set_flash_now", env: env
+      assert_nothing_raised do
+        get "/set_flash_now", env: env
+      end
     end
   end
 

--- a/actionpack/test/controller/live_stream_test.rb
+++ b/actionpack/test/controller/live_stream_test.rb
@@ -430,6 +430,7 @@ module ActionController
       res = get :write_sleep_autoload
       res.each { }
       ActiveSupport::Dependencies.interlock.done_running
+      pass
     end
 
     def test_async_stream

--- a/actionpack/test/controller/render_test.rb
+++ b/actionpack/test/controller/render_test.rb
@@ -1000,6 +1000,7 @@ class LiveHeadRenderTest < ActionController::TestCase
 
     @response.stream.on_error { flunk "action should not raise any errors" }
     sleep 0.2
+    pass
   end
 end
 

--- a/actionpack/test/controller/routing_test.rb
+++ b/actionpack/test/controller/routing_test.rb
@@ -508,9 +508,11 @@ class LegacyRouteSetTests < ActiveSupport::TestCase
   end
 
   def test_named_route_without_hash
-    rs.draw do
-      ActionDispatch.deprecator.silence do
-        get ":controller/:action/:id", as: "normal"
+    assert_nothing_raised do
+      rs.draw do
+        ActionDispatch.deprecator.silence do
+          get ":controller/:action/:id", as: "normal"
+        end
       end
     end
   end

--- a/actionpack/test/dispatch/mapper_test.rb
+++ b/actionpack/test/dispatch/mapper_test.rb
@@ -36,7 +36,9 @@ module ActionDispatch
       end
 
       def test_initialize
-        Mapper.new FakeSet.new
+        assert_nothing_raised do
+          Mapper.new FakeSet.new
+        end
       end
 
       def test_scope_raises_on_anchor

--- a/actionpack/test/dispatch/request/multipart_params_parsing_test.rb
+++ b/actionpack/test/dispatch/request/multipart_params_parsing_test.rb
@@ -159,6 +159,7 @@ class MultipartParamsParsingTest < ActionDispatch::IntegrationTest
       fixture = FIXTURE_PATH + "/ruby_on_rails.jpg"
       params = { uploaded_data: fixture_file_upload(fixture, "image/jpeg") }
       post "/read", params: params
+      assert_equal Encoding::ASCII_8BIT, response.body.encoding
     end
   end
 

--- a/actionpack/test/dispatch/request_test.rb
+++ b/actionpack/test/dispatch/request_test.rb
@@ -1152,7 +1152,9 @@ class RequestParameters < BaseRequestTest
     request = stub_request("QUERY_STRING" => "foo=%81E")
 
     ActionDispatch::Request::Utils.stub(:set_binary_encoding, { "foo" => "\x81E".b }) do
-      request.parameters
+      assert_nothing_raised do
+        request.parameters
+      end
     end
   end
 
@@ -1166,7 +1168,9 @@ class RequestParameters < BaseRequestTest
     )
 
     ActionDispatch::Request::Utils.stub(:set_binary_encoding, { "foo" => "\x81E".b }) do
-      request.parameters
+      assert_nothing_raised do
+        request.parameters
+      end
     end
   end
 

--- a/actionpack/test/dispatch/system_testing/driver_test.rb
+++ b/actionpack/test/dispatch/system_testing/driver_test.rb
@@ -30,8 +30,10 @@ class DriverTest < ActiveSupport::TestCase
 
   test "initializing the driver with a headless chrome and custom path" do
     original_driver_path = ::Selenium::WebDriver::Chrome::Service.driver_path
-    ::Selenium::WebDriver::Chrome::Service.driver_path = "bin/test"
-    ActionDispatch::SystemTesting::Driver.new(:selenium, using: :headless_chrome, screen_size: [1400, 1400])
+    assert_nothing_raised do
+      ::Selenium::WebDriver::Chrome::Service.driver_path = "bin/test"
+      ActionDispatch::SystemTesting::Driver.new(:selenium, using: :headless_chrome, screen_size: [1400, 1400])
+    end
   ensure
     ::Selenium::WebDriver::Chrome::Service.driver_path = original_driver_path
   end
@@ -47,8 +49,10 @@ class DriverTest < ActiveSupport::TestCase
 
   test "initializing the driver with a headless firefox and custom path" do
     original_driver_path = ::Selenium::WebDriver::Firefox::Service.driver_path
-    ::Selenium::WebDriver::Firefox::Service.driver_path = "bin/test"
-    ActionDispatch::SystemTesting::Driver.new(:selenium, using: :headless_firefox, screen_size: [1400, 1400])
+    assert_nothing_raised do
+      ::Selenium::WebDriver::Firefox::Service.driver_path = "bin/test"
+      ActionDispatch::SystemTesting::Driver.new(:selenium, using: :headless_firefox, screen_size: [1400, 1400])
+    end
   ensure
     ::Selenium::WebDriver::Firefox::Service.driver_path = original_driver_path
   end

--- a/actiontext/test/unit/strict_loading_test.rb
+++ b/actiontext/test/unit/strict_loading_test.rb
@@ -28,7 +28,9 @@ class ActionText::StrictLoadingTest < ActiveSupport::TestCase
 
     records = MessageWithStrictLoading.with_rich_text_strict_loading_content.all
 
-    records.map(&:strict_loading_content)
+    assert_nothing_raised do
+      records.map(&:strict_loading_content)
+    end
   end
 
   test "has_rich_text accepts strict_loading: overrides" do
@@ -36,6 +38,8 @@ class ActionText::StrictLoadingTest < ActiveSupport::TestCase
 
     records = MessageWithFooter.all
 
-    records.map(&:footer)
+    assert_nothing_raised do
+      records.map(&:footer)
+    end
   end
 end

--- a/actionview/test/template/date_helper_test.rb
+++ b/actionview/test/template/date_helper_test.rb
@@ -2848,13 +2848,17 @@ class DateHelperTest < ActionView::TestCase
   def test_datetime_select_with_integer
     @post = Post.new
     @post.updated_at = 3
-    datetime_select("post", "updated_at")
+    assert_nothing_raised do
+      datetime_select("post", "updated_at")
+    end
   end
 
   def test_datetime_select_with_infinity # Float
     @post = Post.new
     @post.updated_at = (-1.0 / 0)
-    datetime_select("post", "updated_at")
+    assert_nothing_raised do
+      datetime_select("post", "updated_at")
+    end
   end
 
   def test_datetime_select_with_default_prompt

--- a/actionview/test/template/template_test.rb
+++ b/actionview/test/template/template_test.rb
@@ -229,7 +229,9 @@ class TestERBTemplate < ActiveSupport::TestCase
 
   def test_rails_injected_locals_does_not_raise_error_if_not_passed
     @template = new_template("<%# locals: (message:) -%>")
-    render(message: "Hi", message_counter: 1, message_iteration: 1, implicit_locals: %i[message_counter message_iteration])
+    assert_nothing_raised do
+      render(message: "Hi", message_counter: 1, message_iteration: 1, implicit_locals: %i[message_counter message_iteration])
+    end
   end
 
   def test_rails_injected_locals_can_be_specified

--- a/actionview/test/template/text_helper_test.rb
+++ b/actionview/test/template/text_helper_test.rb
@@ -538,7 +538,9 @@ class TextHelperTest < ActionView::TestCase
   end
 
   def test_reset_unknown_cycle
-    reset_cycle("colors")
+    assert_nothing_raised do
+      reset_cycle("colors")
+    end
   end
 
   def test_reset_named_cycle

--- a/activejob/test/cases/logging_test.rb
+++ b/activejob/test/cases/logging_test.rb
@@ -270,7 +270,9 @@ class LoggingTest < ActiveSupport::TestCase
 
   def test_for_tagged_logger_support_is_consistent
     set_logger ::Logger.new(nil)
-    OverriddenLoggingJob.perform_later "Dummy"
+    assert_nothing_raised do
+      OverriddenLoggingJob.perform_later "Dummy"
+    end
   end
 
   def test_job_error_logging

--- a/activejob/test/cases/queuing_test.rb
+++ b/activejob/test/cases/queuing_test.rb
@@ -26,6 +26,7 @@ class QueuingTest < ActiveSupport::TestCase
     result = HelloJob.set(wait_until: 1.second.ago).perform_later "Jamie"
     assert result
   rescue NotImplementedError
+    pass
   end
 
   test "job returned by enqueue has the arguments available" do
@@ -37,6 +38,7 @@ class QueuingTest < ActiveSupport::TestCase
     job = HelloJob.set(wait_until: Time.utc(2014, 1, 1)).perform_later
     assert_equal Time.utc(2014, 1, 1), job.scheduled_at
   rescue NotImplementedError
+    pass
   end
 
   test "job is yielded to block after enqueue with successfully_enqueued property set" do
@@ -80,6 +82,7 @@ class QueuingTest < ActiveSupport::TestCase
     ActiveJob.perform_all_later(scheduled_job_1, scheduled_job_2)
     assert_equal ["Scheduled 2014 says hello", "Scheduled 2015 says hello"], JobBuffer.values.sort
   rescue NotImplementedError
+    pass
   end
 
   test "perform_all_later instrumentation" do

--- a/activejob/test/integration/queuing_test.rb
+++ b/activejob/test/integration/queuing_test.rb
@@ -67,6 +67,7 @@ class QueuingTest < ActiveSupport::TestCase
     wait_for_jobs_to_finish_for(5.seconds)
     assert_job_not_executed
   rescue NotImplementedError
+    pass
   end
 
   test "should run job enqueued in the future at the specified time" do
@@ -76,6 +77,7 @@ class QueuingTest < ActiveSupport::TestCase
     wait_for_jobs_to_finish_for(10.seconds)
     assert_job_executed
   rescue NotImplementedError
+    pass
   end
 
   test "should run job bulk enqueued in the future at the specified time" do
@@ -85,6 +87,7 @@ class QueuingTest < ActiveSupport::TestCase
     wait_for_jobs_to_finish_for(10.seconds)
     assert_job_executed
   rescue NotImplementedError
+    pass
   end
 
   if adapter_is?(:async, :delayed_job, :sidekiq, :queue_classic)

--- a/activemodel/test/cases/helper.rb
+++ b/activemodel/test/cases/helper.rb
@@ -15,14 +15,6 @@ require "active_support/core_ext/integer/time"
 
 class ActiveModel::TestCase < ActiveSupport::TestCase
   include ActiveSupport::Testing::MethodCallAssertions
-
-  class AssertionlessTest < StandardError; end
-
-  def after_teardown
-    super
-
-    raise AssertionlessTest, "No assertions made." if passed? && assertions.zero?
-  end
 end
 
 require_relative "../../../tools/test_common"

--- a/activerecord/test/cases/adapter_prevent_writes_test.rb
+++ b/activerecord/test/cases/adapter_prevent_writes_test.rb
@@ -65,7 +65,9 @@ module ActiveRecord
     else
       def test_doesnt_error_when_a_select_query_has_encoding_errors
         ActiveRecord::Base.while_preventing_writes do
-          @connection.select_all("SELECT '\xC8'")
+          assert_nothing_raised do
+            @connection.select_all("SELECT '\xC8'")
+          end
         end
       end
     end

--- a/activerecord/test/cases/adapter_test.rb
+++ b/activerecord/test/cases/adapter_test.rb
@@ -121,6 +121,8 @@ module ActiveRecord
     def test_current_database
       if @connection.respond_to?(:current_database)
         assert_equal ARTest.test_configuration_hashes["arunit"]["database"], @connection.current_database
+      else
+        skip
       end
     end
 
@@ -887,6 +889,7 @@ module ActiveRecord
         threads(2, 25) { @connection.disconnect! }
 
         join
+        pass
       end
 
       test "#verify! is synchronized" do
@@ -894,6 +897,7 @@ module ActiveRecord
         threads(2, 25) { @connection.disconnect! }
 
         join
+        pass
       end
     end
 

--- a/activerecord/test/cases/adapters/abstract_mysql_adapter/schema_test.rb
+++ b/activerecord/test/cases/adapters/abstract_mysql_adapter/schema_test.rb
@@ -96,9 +96,11 @@ module ActiveRecord
         def test_drop_temporary_table
           @connection.transaction do
             @connection.create_table(:temp_table, temporary: true)
-            # if it doesn't properly say DROP TEMPORARY TABLE, the transaction commit
-            # will complain that no transaction is active
-            @connection.drop_table(:temp_table, temporary: true)
+            assert_nothing_raised do
+              # if it doesn't properly say DROP TEMPORARY TABLE, the transaction commit
+              # will complain that no transaction is active
+              @connection.drop_table(:temp_table, temporary: true)
+            end
           end
         end
       end

--- a/activerecord/test/cases/adapters/postgresql/connection_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/connection_test.rb
@@ -167,14 +167,18 @@ module ActiveRecord
     def test_set_session_variable_nil
       run_without_connection do |orig_connection|
         # This should be a no-op that does not raise an error
-        ActiveRecord::Base.establish_connection(orig_connection.deep_merge(variables: { debug_print_plan: nil }))
+        assert_nothing_raised do
+          ActiveRecord::Base.establish_connection(orig_connection.deep_merge(variables: { debug_print_plan: nil }))
+        end
       end
     end
 
     def test_set_session_variable_default
       run_without_connection do |orig_connection|
         # This should execute a query that does not raise an error
-        ActiveRecord::Base.establish_connection(orig_connection.deep_merge(variables: { debug_print_plan: :default }))
+        assert_nothing_raised do
+          ActiveRecord::Base.establish_connection(orig_connection.deep_merge(variables: { debug_print_plan: :default }))
+        end
       end
     end
 

--- a/activerecord/test/cases/adapters/postgresql/schema_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/schema_test.rb
@@ -184,10 +184,13 @@ class SchemaTest < ActiveRecord::PostgreSQLTestCase
   if ActiveRecord::Base.lease_connection.prepared_statements
     def test_schema_change_with_prepared_stmt
       altered = false
-      @connection.exec_query "select * from developers where id = $1", "sql", [bind_param(1)]
-      @connection.exec_query "alter table developers add column zomg int", "sql", []
-      altered = true
-      @connection.exec_query "select * from developers where id = $1", "sql", [bind_param(1)]
+      assert_nothing_raised do
+        @connection.exec_query "select * from developers where id = $1", "sql", [bind_param(1)]
+        @connection.exec_query "alter table developers add column zomg int", "sql", []
+        altered = true
+        @connection.exec_query "select * from developers where id = $1", "sql", [bind_param(1)]
+      end
+      pass
     ensure
       # We are not using DROP COLUMN IF EXISTS because that syntax is only
       # supported by pg 9.X

--- a/activerecord/test/cases/adapters/postgresql/virtual_column_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/virtual_column_test.rb
@@ -82,7 +82,8 @@ if ActiveRecord::Base.lease_connection.supports_virtual_columns?
     end
 
     def test_build_fixture_sql
-      ActiveRecord::FixtureSet.create_fixtures(FIXTURES_ROOT, :virtual_columns)
+      fixtures = ActiveRecord::FixtureSet.create_fixtures(FIXTURES_ROOT, :virtual_columns).first
+      assert_equal 2, fixtures.size
     end
   end
 end

--- a/activerecord/test/cases/adapters/sqlite3/virtual_column_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/virtual_column_test.rb
@@ -97,7 +97,8 @@ if ActiveRecord::Base.lease_connection.supports_virtual_columns?
     end
 
     def test_build_fixture_sql
-      ActiveRecord::FixtureSet.create_fixtures(FIXTURES_ROOT, :virtual_columns)
+      fixtures = ActiveRecord::FixtureSet.create_fixtures(FIXTURES_ROOT, :virtual_columns).first
+      assert_equal 2, fixtures.size
     end
   end
 end

--- a/activerecord/test/cases/arel/visitors/dot_test.rb
+++ b/activerecord/test/cases/arel/visitors/dot_test.rb
@@ -25,12 +25,14 @@ module Arel
         define_method("test_#{klass.name.gsub('::', '_')}") do
           op = klass.new(:a, "z")
           @visitor.accept op, Collectors::PlainString.new
+          pass
         end
       end
 
       def test_named_function
         func = Nodes::NamedFunction.new "omg", "omg"
         @visitor.accept func, Collectors::PlainString.new
+        pass
       end
 
       # unary ops
@@ -48,6 +50,7 @@ module Arel
         define_method("test_#{klass.name.gsub('::', '_')}") do
           op = klass.new(:a)
           @visitor.accept op, Collectors::PlainString.new
+          pass
         end
       end
 
@@ -73,6 +76,7 @@ module Arel
         define_method("test_#{klass.name.gsub('::', '_')}") do
           binary = klass.new(:a, :b)
           @visitor.accept binary, Collectors::PlainString.new
+          pass
         end
       end
 
@@ -84,6 +88,7 @@ module Arel
         define_method("test_#{klass.name.gsub('::', '_')}") do
           binary = klass.new([:a, :b])
           @visitor.accept binary, Collectors::PlainString.new
+          pass
         end
       end
 

--- a/activerecord/test/cases/associations/belongs_to_associations_test.rb
+++ b/activerecord/test/cases/associations/belongs_to_associations_test.rb
@@ -1159,8 +1159,10 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
   end
 
   def test_belongs_to_proxy_should_respond_to_private_methods_via_send
-    companies(:first_firm).send(:private_method)
-    companies(:second_client).firm.send(:private_method)
+    assert_nothing_raised do
+      companies(:first_firm).send(:private_method)
+      companies(:second_client).firm.send(:private_method)
+    end
   end
 
   def test_save_of_record_with_loaded_belongs_to

--- a/activerecord/test/cases/associations/eager_test.rb
+++ b/activerecord/test/cases/associations/eager_test.rb
@@ -572,7 +572,7 @@ class EagerAssociationTest < ActiveRecord::TestCase
 
     Subscription.create!(subscriber_id: "PL", book_id: b.id)
     s.reload
-    s.book_ids = s.book_ids
+    assert_equal [b.id], s.book_ids
   end
 
   def test_eager_load_has_many_through_with_string_keys
@@ -816,7 +816,8 @@ class EagerAssociationTest < ActiveRecord::TestCase
   end
 
   def test_eager_with_inheritance
-    SpecialPost.all.merge!(includes: [ :comments ]).to_a
+    posts = SpecialPost.all.merge!(includes: [ :comments ]).to_a
+    assert_equal 1, posts.size
   end
 
   def test_eager_has_one_with_association_inheritance

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -3201,10 +3201,12 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
   end
 
   def test_key_ensuring_owner_was_is_valid_when_dependent_option_is_destroy_async
-    Class.new(ActiveRecord::Base) do
-      self.destroy_association_async_job = Class.new
+    assert_nothing_raised do
+      Class.new(ActiveRecord::Base) do
+        self.destroy_association_async_job = Class.new
 
-      has_many :books, dependent: :destroy_async, ensuring_owner_was: :destroyed?
+        has_many :books, dependent: :destroy_async, ensuring_owner_was: :destroyed?
+      end
     end
   end
 

--- a/activerecord/test/cases/associations/has_many_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_through_associations_test.rb
@@ -1253,7 +1253,9 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
   def test_create_should_not_raise_exception_when_join_record_has_errors
     repair_validations(Categorization) do
       Categorization.validate { |r| r.errors.add(:base, "Invalid Categorization") }
-      Category.create(name: "Fishing", authors: [Author.first])
+      assert_nothing_raised do
+        Category.create(name: "Fishing", authors: [Author.first])
+      end
     end
   end
 

--- a/activerecord/test/cases/associations/has_one_associations_test.rb
+++ b/activerecord/test/cases/associations/has_one_associations_test.rb
@@ -493,8 +493,10 @@ class HasOneAssociationsTest < ActiveRecord::TestCase
   end
 
   def test_has_one_proxy_should_respond_to_private_methods_via_send
-    accounts(:signals37).send(:private_method)
-    companies(:first_firm).account.send(:private_method)
+    assert_nothing_raised do
+      accounts(:signals37).send(:private_method)
+      companies(:first_firm).account.send(:private_method)
+    end
   end
 
   def test_save_of_record_with_loaded_has_one

--- a/activerecord/test/cases/associations/has_one_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_one_through_associations_test.rb
@@ -245,7 +245,9 @@ class HasOneThroughAssociationsTest < ActiveRecord::TestCase
 
   def test_has_one_through_proxy_should_respond_to_private_methods_via_send
     clubs(:moustache_club).send(:private_method)
-    @member.club.send(:private_method)
+    assert_nothing_raised do
+      @member.club.send(:private_method)
+    end
   end
 
   def test_assigning_to_has_one_through_preserves_decorated_join_record

--- a/activerecord/test/cases/connection_adapters/connection_handlers_sharding_db_test.rb
+++ b/activerecord/test/cases/connection_adapters/connection_handlers_sharding_db_test.rb
@@ -285,8 +285,10 @@ module ActiveRecord
 
           ActiveRecord::Base.connects_to(shards: { default: { writing: :primary, reading: :primary_replica } })
 
-          ActiveRecord::Base.prohibit_shard_swapping do # no exception
-            ActiveRecord::Base.connected_to(role: :reading) do
+          assert_nothing_raised do
+            ActiveRecord::Base.prohibit_shard_swapping do # no exception
+              ActiveRecord::Base.connected_to(role: :reading) do
+              end
             end
           end
         ensure

--- a/activerecord/test/cases/connection_adapters/schema_cache_test.rb
+++ b/activerecord/test/cases/connection_adapters/schema_cache_test.rb
@@ -325,7 +325,13 @@ module ActiveRecord
       end
 
       def test_clear_data_source_cache
+        # Cache data sources list.
+        assert @cache.data_source_exists?("courses")
+
         @cache.clear_data_source_cache!("courses")
+        assert_queries_count(1, include_schema: true) do
+          @cache.data_source_exists?("courses")
+        end
       end
 
       test "#columns_hash? is populated by #columns_hash" do

--- a/activerecord/test/cases/connection_adapters/standalone_connection_test.rb
+++ b/activerecord/test/cases/connection_adapters/standalone_connection_test.rb
@@ -31,6 +31,7 @@ module ActiveRecord
 
       def test_can_close
         @connection.close
+        assert_not @connection.active?
       end
     end
   end

--- a/activerecord/test/cases/custom_locking_test.rb
+++ b/activerecord/test/cases/custom_locking_test.rb
@@ -7,8 +7,8 @@ module ActiveRecord
   class CustomLockingTest < ActiveRecord::TestCase
     fixtures :people
 
-    def test_custom_lock
-      if current_adapter?(:Mysql2Adapter, :TrilogyAdapter)
+    if current_adapter?(:Mysql2Adapter, :TrilogyAdapter)
+      def test_custom_lock
         assert_match "SHARE MODE", Person.lock("LOCK IN SHARE MODE").to_sql
         assert_queries_match(/LOCK IN SHARE MODE/) do
           Person.all.merge!(lock: "LOCK IN SHARE MODE").find(1)

--- a/activerecord/test/cases/encryption/encryptable_record_api_test.rb
+++ b/activerecord/test/cases/encryption/encryptable_record_api_test.rb
@@ -27,7 +27,9 @@ class ActiveRecord::Encryption::EncryptableRecordApiTest < ActiveRecord::Encrypt
   end
 
   test "encrypt won't fail for classes without attributes to encrypt" do
-    posts(:welcome).encrypt
+    assert_nothing_raised do
+      posts(:welcome).encrypt
+    end
   end
 
   test "decrypt decrypts encrypted attributes" do

--- a/activerecord/test/cases/encryption/encryptor_test.rb
+++ b/activerecord/test/cases/encryption/encryptor_test.rb
@@ -70,7 +70,8 @@ class ActiveRecord::Encryption::EncryptorTest < ActiveRecord::EncryptionTestCase
     encryptor = ActiveRecord::Encryption::Encryptor.new
 
     key_provider.stub :decryption_keys, ->(message) { [key] } do
-      encryptor.decrypt encryptor.encrypt("some text", key_provider: key_provider), key_provider: key_provider
+      decrypted_text = encryptor.decrypt encryptor.encrypt("some text", key_provider: key_provider), key_provider: key_provider
+      assert decrypted_text
     end
   end
 

--- a/activerecord/test/cases/errors_test.rb
+++ b/activerecord/test/cases/errors_test.rb
@@ -7,10 +7,12 @@ class ErrorsTest < ActiveRecord::TestCase
     base = ActiveRecord::ActiveRecordError
     error_klasses = ObjectSpace.each_object(Class).select { |klass| klass < base }
 
-    (error_klasses - [ActiveRecord::AmbiguousSourceReflectionForThroughAssociation]).each do |error_klass|
-      error_klass.new.inspect
-    rescue ArgumentError
-      raise "Instance of #{error_klass} can't be initialized with no arguments"
+    assert_nothing_raised do
+      (error_klasses - [ActiveRecord::AmbiguousSourceReflectionForThroughAssociation]).each do |error_klass|
+        error_klass.new.inspect
+      rescue ArgumentError
+        raise "Instance of #{error_klass} can't be initialized with no arguments"
+      end
     end
   end
 end

--- a/activerecord/test/cases/fixtures_test.rb
+++ b/activerecord/test/cases/fixtures_test.rb
@@ -34,6 +34,7 @@ require "models/task"
 require "models/topic"
 require "models/traffic_light"
 require "models/treasure"
+require "models/tree"
 require "models/cpk"
 
 class FixturesTest < ActiveRecord::TestCase
@@ -43,7 +44,7 @@ class FixturesTest < ActiveRecord::TestCase
   self.use_transactional_tests = false
 
   # other_topics fixture should not be included here
-  fixtures :topics, :developers, :accounts, :tasks, :categories, :funny_jokes, :binaries, :traffic_lights
+  fixtures :topics, :developers, :accounts, :tasks, :categories, :funny_jokes, :binaries, :traffic_lights, :trees
 
   FIXTURES = %w( accounts binaries companies customers
                  developers developers_projects entrants
@@ -550,6 +551,8 @@ class FixturesTest < ActiveRecord::TestCase
 
   def test_yaml_file_with_symbol_columns
     ActiveRecord::FixtureSet.create_fixtures(FIXTURES_ROOT + "/naked/yml", "trees")
+    root = Tree.find(1)
+    assert root
   end
 
   def test_omap_fixtures
@@ -820,6 +823,7 @@ class SetupTest < ActiveRecord::TestCase
   end
 
   def test_nothing
+    pass
   end
 end
 
@@ -1428,9 +1432,11 @@ class FoxyFixturesTest < ActiveRecord::TestCase
   end
 
   def test_only_generates_a_pk_if_necessary
-    m = Matey.first
-    m.pirate = pirates(:blackbeard)
-    m.target = pirates(:redbeard)
+    assert_nothing_raised do
+      m = Matey.first
+      m.pirate = pirates(:blackbeard)
+      m.target = pirates(:redbeard)
+    end
   end
 
   def test_supports_sti

--- a/activerecord/test/cases/invertible_migration_test.rb
+++ b/activerecord/test/cases/invertible_migration_test.rb
@@ -475,7 +475,9 @@ module ActiveRecord
       migration = RevertCustomForeignKeyTable.new
       InvertibleMigration.migrate(:up)
       migration.migrate(:up)
+      assert ActiveRecord::Base.lease_connection.column_exists?(:horses, :owner_id)
       migration.migrate(:down)
+      assert_not ActiveRecord::Base.lease_connection.column_exists?(:horses, :owner_id)
     end
 
     # MySQL 5.7 and Oracle do not allow to create duplicate indexes on the same columns

--- a/activerecord/test/cases/migration/change_schema_test.rb
+++ b/activerecord/test/cases/migration/change_schema_test.rb
@@ -235,6 +235,7 @@ module ActiveRecord
 
       def test_create_table_without_a_block
         connection.create_table table_name
+        assert connection.table_exists?(table_name)
       end
 
       # SQLite3 will not allow you to add a NOT NULL
@@ -359,6 +360,8 @@ module ActiveRecord
         else
           connection.execute "insert into testings (#{connection.quote_column_name('select')}) values ('7 chars')"
         end
+
+        assert_equal 1, connection.select_value("SELECT COUNT(*) FROM testings")
       end
 
       def test_keeping_default_and_notnull_constraints_on_change

--- a/activerecord/test/cases/migration/check_constraint_test.rb
+++ b/activerecord/test/cases/migration/check_constraint_test.rb
@@ -319,11 +319,15 @@ else
         end
 
         def test_add_check_constraint_should_be_noop
-          @connection.add_check_constraint :products, "discounted_price > 0", name: "discounted_price_check"
+          assert_nothing_raised do
+            @connection.add_check_constraint :products, "discounted_price > 0", name: "discounted_price_check"
+          end
         end
 
         def test_remove_check_constraint_should_be_noop
-          @connection.remove_check_constraint :products, name: "price_check"
+          assert_nothing_raised do
+            @connection.remove_check_constraint :products, name: "price_check"
+          end
         end
 
         def test_check_constraints_should_raise_not_implemented

--- a/activerecord/test/cases/migration/index_test.rb
+++ b/activerecord/test/cases/migration/index_test.rb
@@ -220,7 +220,9 @@ module ActiveRecord
 
       def test_add_index
         connection.add_index("testings", "last_name")
+        assert connection.index_exists?("testings", "last_name")
         connection.remove_index("testings", "last_name")
+        assert_not connection.index_exists?("testings", "last_name")
 
         connection.add_index("testings", ["last_name", "first_name"])
         connection.remove_index("testings", column: ["last_name", "first_name"])

--- a/activerecord/test/cases/migration/logger_test.rb
+++ b/activerecord/test/cases/migration/logger_test.rb
@@ -31,7 +31,9 @@ module ActiveRecord
         previous_logger = ActiveRecord::Base.logger
         ActiveRecord::Base.logger = nil
         migrations = [Migration.new("a", 1), Migration.new("b", 2), Migration.new("c", 3)]
-        ActiveRecord::Migrator.new(:up, migrations, @schema_migration, @internal_metadata).migrate
+        assert_nothing_raised do
+          ActiveRecord::Migrator.new(:up, migrations, @schema_migration, @internal_metadata).migrate
+        end
       ensure
         ActiveRecord::Base.logger = previous_logger
       end

--- a/activerecord/test/cases/nested_attributes_test.rb
+++ b/activerecord/test/cases/nested_attributes_test.rb
@@ -380,6 +380,7 @@ class TestNestedAttributesOnAHasOneAssociation < ActiveRecord::TestCase
 
   def test_should_accept_update_only_option
     @pirate.update(update_only_ship_attributes: { id: @pirate.ship.id, name: "Mayflower" })
+    assert_equal "Mayflower", @pirate.reload.ship.name
   end
 
   def test_should_create_new_model_when_nothing_is_there_and_update_only_is_true

--- a/activerecord/test/cases/primary_keys_test.rb
+++ b/activerecord/test/cases/primary_keys_test.rb
@@ -457,15 +457,13 @@ class CompositePrimaryKeyTest < ActiveRecord::TestCase
   end
 
   def test_derives_composite_primary_key
-    def test_primary_key_issues_warning
-      model = Class.new(ActiveRecord::Base) do
-        def self.table_name
-          "uber_barcodes"
-        end
+    model = Class.new(ActiveRecord::Base) do
+      def self.table_name
+        "uber_barcodes"
       end
-
-      assert_equal ["region", "code"], model.primary_key
     end
+
+    assert_equal ["region", "code"], model.primary_key
   end
 
   def test_collectly_dump_composite_primary_key

--- a/activerecord/test/cases/reaper_test.rb
+++ b/activerecord/test/cases/reaper_test.rb
@@ -118,8 +118,10 @@ module ActiveRecord
         pool = ConnectionPool.new(pool_config)
 
         pool.discard!
-        pool.reap
-        pool.flush
+        assert_nothing_raised do
+          pool.reap
+          pool.flush
+        end
       end
 
       if Process.respond_to?(:fork)

--- a/activerecord/test/cases/serialized_attribute_test.rb
+++ b/activerecord/test/cases/serialized_attribute_test.rb
@@ -434,10 +434,13 @@ class SerializedAttributeTest < ActiveRecord::TestCase
     end
 
     subclass = Class.new(klass) do
-      self.table_name = "posts"
+      self.table_name = "topics"
     end
 
     subclass.define_attribute_methods
+
+    topic = subclass.create!(content: { foo: 1 })
+    assert_equal [topic], subclass.where(content: { foo: 1 }).to_a
   end
 
   def test_nil_is_always_persisted_as_null

--- a/activerecord/test/cases/transaction_isolation_test.rb
+++ b/activerecord/test/cases/transaction_isolation_test.rb
@@ -85,7 +85,9 @@ class TransactionIsolationTest < ActiveRecord::TestCase
     # constraint.
     test "serializable" do
       Tag.transaction(isolation: :serializable) do
-        Tag.create
+        assert_nothing_raised do
+          Tag.create
+        end
       end
     end
 

--- a/activerecord/test/cases/yaml_serialization_test.rb
+++ b/activerecord/test/cases/yaml_serialization_test.rb
@@ -45,7 +45,9 @@ class YamlSerializationTest < ActiveRecord::TestCase
   end
 
   def test_active_record_relation_serialization
-    [Topic.all].to_yaml
+    assert_nothing_raised do
+      [Topic.all].to_yaml
+    end
   end
 
   def test_raw_types_are_not_changed_on_round_trip

--- a/activestorage/test/controllers/disk_controller_test.rb
+++ b/activestorage/test/controllers/disk_controller_test.rb
@@ -43,6 +43,7 @@ class ActiveStorage::DiskControllerTest < ActionDispatch::IntegrationTest
     blob.delete
 
     get blob.url
+    assert_response :not_found
   end
 
   test "showing blob with invalid key" do

--- a/activesupport/lib/active_support/testing/strict_warnings.rb
+++ b/activesupport/lib/active_support/testing/strict_warnings.rb
@@ -5,6 +5,8 @@ Warning[:deprecated] = true
 
 module ActiveSupport
   module RaiseWarnings # :nodoc:
+    class WarningError < StandardError; end
+
     PROJECT_ROOT = File.expand_path("../../../../", __dir__)
     ALLOWED_WARNINGS = Regexp.union(
       /circular require considered harmful.*delayed_job/, # Bug in delayed job.
@@ -34,7 +36,7 @@ module ActiveSupport
       return if ALLOWED_WARNINGS.match?(message)
       return unless ENV["RAILS_STRICT_WARNINGS"] || ENV["BUILDKITE"]
 
-      raise message
+      raise WarningError.new(message)
     end
   end
 end

--- a/activesupport/lib/active_support/testing/tests_without_assertions.rb
+++ b/activesupport/lib/active_support/testing/tests_without_assertions.rb
@@ -9,12 +9,9 @@ module ActiveSupport
       def after_teardown
         super
 
-        return if skipped? || error?
-
-        if assertions == 0
+        if assertions.zero? && !skipped? && !error?
           file, line = method(name).source_location
-          message = "Test is missing assertions: `#{name}` #{file}:#{line}"
-          warn message
+          warn "Test is missing assertions: `#{name}` #{file}:#{line}"
         end
       end
     end

--- a/activesupport/test/cache/behaviors/local_cache_behavior.rb
+++ b/activesupport/test/cache/behaviors/local_cache_behavior.rb
@@ -55,6 +55,7 @@ module LocalCacheBehavior
     begin
       @cache.cleanup
     rescue NotImplementedError
+      pass
       return # Not implementing cleanup is valid
     end
 

--- a/activesupport/test/cache/stores/redis_cache_store_test.rb
+++ b/activesupport/test/cache/stores/redis_cache_store_test.rb
@@ -123,7 +123,9 @@ module ActiveSupport::Cache::RedisCacheStoreTests
     end
 
     test "instantiating the store doesn't connect to Redis" do
-      build(url: "redis://localhost:1")
+      assert_nothing_raised do
+        build(url: "redis://localhost:1")
+      end
     end
 
     private

--- a/activesupport/test/testing/test_without_assertions_test.rb
+++ b/activesupport/test/testing/test_without_assertions_test.rb
@@ -14,6 +14,7 @@ module TestsWithoutAssertionsTest
       def after_teardown
         _out, err = capture_io do
           super
+        rescue ActiveSupport::RaiseWarnings::WarningError
         end
 
         assert_match(/Test is missing assertions: `test_without_assertions` .+test_without_assertions_test\.rb:\d+/, err)

--- a/railties/test/generators/api_app_generator_test.rb
+++ b/railties/test/generators/api_app_generator_test.rb
@@ -124,6 +124,7 @@ class ApiAppGeneratorTest < Rails::Generators::TestCase
     generator = Rails::Generators::AppGenerator.new ["rails"],
       { api: true, update: true }, { destination_root: destination_root, shell: @shell }
     quietly { generator.update_bin_files }
+    pass
   end
 
   private


### PR DESCRIPTION
Follow up to #51625.

This PR now enables this feature for all the internal tests in the framework.