### PR TITLE
Deduplicate watched filenames in `FileUpdateChecker`

### DIFF
--- a/activesupport/lib/active_support/file_update_checker.rb
+++ b/activesupport/lib/active_support/file_update_checker.rb
@@ -104,7 +104,7 @@ module ActiveSupport
         @watched || begin
           all = @files.select { |f| File.exist?(f) }
           all.concat(Dir[@glob]) if @glob
-          all
+          all.tap(&:uniq!)
         end
       end
 


### PR DESCRIPTION
Currently `FileUpdateChecker` may end up watching the same file twice, and check the `mtime` twice:
https://github.com/rails/rails/blob/3b5ab678fcdc123e832056a9c2c305f1cc6643da/activesupport/lib/active_support/file_update_checker.rb#L130-L132

when its configured using both `files` and `dirs` arguments
https://github.com/rails/rails/blob/3b5ab678fcdc123e832056a9c2c305f1cc6643da/activesupport/lib/active_support/file_update_checker.rb#L44

For example:
https://github.com/rails/rails/blob/3b5ab678fcdc123e832056a9c2c305f1cc6643da/activesupport/lib/active_support/i18n_railtie.rb#L65

Which even in a `rails new` application results in some duplicated entries:

A hacky way to see it:
```ruby
Rails.application.reloaders.filter_map { |reloader| reloader.is_a?(ActiveSupport::FileUpdateChecker) && reloader.send(:watched).tally.select { |
_, count| count > 1 } }
```

```ruby
[
{"<app_path>/config/locales/en.yml"=>2},
 {"/home/spin/.gem/ruby/3.2.2/gems/activestorage-7.1.3.2/app/controllers/concerns/active_storage/disable_session.rb"=>2,
  "/home/spin/.gem/ruby/3.2.2/gems/activestorage-7.1.3.2/app/controllers/concerns/active_storage/file_server.rb"=>2,
  "/home/spin/.gem/ruby/3.2.2/gems/activestorage-7.1.3.2/app/controllers/concerns/active_storage/set_blob.rb"=>2,
  "/home/spin/.gem/ruby/3.2.2/gems/activestorage-7.1.3.2/app/controllers/concerns/active_storage/set_current.rb"=>2,
  "/home/spin/.gem/ruby/3.2.2/gems/activestorage-7.1.3.2/app/controllers/concerns/active_storage/streaming.rb"=>2}]
```


Deduplicating the array won't be visible for a small application but could help in a bigger one. Even though large application tend to use `EventedFileUpdateChecker` I can see how some may prefer to keep using default `FileUpdateChecker` due to it's lower cost to initialize, compared to `Evented`.

### Alternative

A general alternative would be to ensure that callers deduplicate files & paths before passing those to the file watcher but this doesn't solve the issue long-term.

### Tests

`watched` array is not publicly exposed so I can't think of a proper test to verify that. I assume it's okay to rely on existing behavior tests

### Changelog

I don't think we need one as from user perspective nothing changes.