### PR TITLE
[ci skip] Replace — with : in instrumentation subheadings

### DIFF
--- a/guides/source/active_support_instrumentation.md
+++ b/guides/source/active_support_instrumentation.md
@@ -213,7 +213,7 @@ Additional keys may be added by the caller.
 }
 ```
 
-### Action Controller — Caching
+### Action Controller: Caching
 
 #### `write_fragment.action_controller`
 
@@ -452,7 +452,7 @@ This event is only emitted when [`config.active_record.action_on_strict_loading_
 }
 ```
 
-### Active Support — Caching
+### Active Support: Caching
 
 #### `cache_read.active_support`
 
@@ -662,7 +662,7 @@ This event is only emitted when using [`MemoryStore`][ActiveSupport::Cache::Memo
 [ActiveSupport::Cache::Store#fetch]: https://api.rubyonrails.org/classes/ActiveSupport/Cache/Store.html#method-i-fetch
 [ActiveSupport::Cache::Store#fetch_multi]: https://api.rubyonrails.org/classes/ActiveSupport/Cache/Store.html#method-i-fetch_multi
 
-### Active Support — Messages
+### Active Support: Messages
 
 #### `message_serializer_fallback.active_support`
 
@@ -799,7 +799,7 @@ This event is only emitted when using [`MemoryStore`][ActiveSupport::Cache::Memo
 | ------------ | ------------------------------ |
 | `:analyzer`  | Name of analyzer e.g., ffprobe |
 
-### Active Storage — Storage Service
+### Active Storage: Storage Service
 
 #### `service_upload.active_storage`
 


### PR DESCRIPTION
### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created because when `—` is used in a subheading, anchor links for the heading will not jump to the referenced section. 

### Detail

This Pull Request changes headings in the Active Support Instrumentation guide that used — characters with : characters.

When — is used in a subtitle, the anchor links use -%E2%80%94- instead of —. This prevents the browser jumping to the anchor link, making the anchor link unusable.

### Additional information

I looked through the guides and it seems like the Active Support Instrumentation documentation is the only guide using — characters in headings. 

Being able to link to specific sub-sections of the Active Support Instrumentation guide is very helpful. I discovered this wasn't possible for the [Active Support — Caching](https://edgeguides.rubyonrails.org/active_support_instrumentation.html#active-support-%E2%80%94-caching) section, as well as the other sections with — in the heading. A `:` conveys a similar sentiment and is compatible with Google Chrome jumping to the correct section.

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [X] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
