### PR TITLE
Pass validate(_check)_constraint through change_table

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,15 @@
+*   `validate_constraint` can be called in a `change_table` block.
+
+    ex:
+    ```ruby
+    change_table :products do |t|
+      t.check_constraint "price > discounted_price", name: "price_check", validate: false
+      t.validate_check_constraint "price_check"
+    end
+    ```
+
+    *Cody Cutrer*
+
 *   `PostgreSQLAdapter` now decodes columns of type date to `Date` instead of string.
 
     Ex:

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_definitions.rb
@@ -332,6 +332,26 @@ module ActiveRecord
         def remove_unique_constraint(*args)
           @base.remove_unique_constraint(name, *args)
         end
+
+        # Validates the given constraint on the table.
+        #
+        #  t.check_constraint("price > 0", name: "price_check", validate: false)
+        #  t.validate_constraint "price_check"
+        #
+        # See {connection.validate_constraint}[rdoc-ref:SchemaStatements#validate_constraint]
+        def validate_constraint(*args)
+          @base.validate_constraint(name, *args)
+        end
+
+        # Validates the given check constraint on the table
+        #
+        #  t.check_constraint("price > 0", name: "price_check", validate: false)
+        #  t.validate_check_constraint name: "price_check"
+        #
+        # See {connection.validate_check_constraint}[rdoc-ref:SchemaStatements#validate_check_constraint]
+        def validate_check_constraint(*args)
+          @base.validate_check_constraint(name, *args)
+        end
       end
 
       # = Active Record PostgreSQL Adapter Alter \Table

--- a/activerecord/test/cases/migration/change_table_test.rb
+++ b/activerecord/test/cases/migration/change_table_test.rb
@@ -339,6 +339,26 @@ module ActiveRecord
         end
       end
 
+      if current_adapter?(:PostgreSQLAdapter)
+        def test_validate_check_constraint
+          with_change_table do |t|
+            expect :add_check_constraint, nil, [:delete_me, "price > discounted_price"], name: "price_check", validate: false
+            t.check_constraint "price > discounted_price", name: "price_check", validate: false
+            expect :validate_check_constraint, :nil, [:delete_me, "price_check"]
+            t.validate_check_constraint "price_check"
+          end
+        end
+
+        def test_validate_constraint
+          with_change_table do |t|
+            expect :add_check_constraint, nil, [:delete_me, "price > discounted_price"], name: "price_check", validate: false
+            t.check_constraint "price > discounted_price", name: "price_check", validate: false
+            expect :validate_constraint, :nil, [:delete_me, "price_check"]
+            t.validate_constraint "price_check"
+          end
+        end
+      end
+
       def test_remove_column_with_if_exists_raises_error
         assert_raises(ArgumentError) do
           with_change_table do |t|


### PR DESCRIPTION
### Motivation / Background

I was creating a migration that added a few columns, and a check constraint across them. I assumed I could do it all in a `change_table :my_table, bulk: true` block, but realized `validate_constraint` didn't exist there. So I added it.

### Detail

Just add delegation for both `validate_constraint` and `validate_check_constraint` from the Postgres' `Table` definition object to `validate_constraint` and `validate_check_constraint` on the underlying connection (or, the bulk change object in the case of `bulk: true`).

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
