### PR TITLE
Add bulk versions of all constraint management for Postgres

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_definitions.rb
@@ -311,8 +311,8 @@ module ActiveRecord
         #  t.remove_exclusion_constraint(name: "price_check")
         #
         # See {connection.remove_exclusion_constraint}[rdoc-ref:SchemaStatements#remove_exclusion_constraint]
-        def remove_exclusion_constraint(*args)
-          @base.remove_exclusion_constraint(name, *args)
+        def remove_exclusion_constraint(*args, **options)
+          @base.remove_exclusion_constraint(name, *args, **options)
         end
 
         # Adds a unique constraint.
@@ -329,8 +329,8 @@ module ActiveRecord
         #  t.remove_unique_constraint(name: "unique_position")
         #
         # See {connection.remove_unique_constraint}[rdoc-ref:SchemaStatements#remove_unique_constraint]
-        def remove_unique_constraint(*args)
-          @base.remove_unique_constraint(name, *args)
+        def remove_unique_constraint(*args, **options)
+          @base.remove_unique_constraint(name, *args, **options)
         end
       end
 

--- a/activerecord/test/cases/migration/change_table_test.rb
+++ b/activerecord/test/cases/migration/change_table_test.rb
@@ -172,7 +172,7 @@ module ActiveRecord
 
         def test_remove_exclusion_constraint_removes_exclusion_constraint
           with_change_table do |t|
-            expect :remove_exclusion_constraint, nil, [:delete_me, name: "date_overlap"]
+            expect :remove_exclusion_constraint, nil, [:delete_me], name: "date_overlap"
             t.remove_exclusion_constraint name: "date_overlap"
           end
         end
@@ -186,7 +186,7 @@ module ActiveRecord
 
         def test_remove_unique_constraint_removes_unique_constraint
           with_change_table do |t|
-            expect :remove_unique_constraint, nil, [:delete_me, name: "unique_constraint"]
+            expect :remove_unique_constraint, nil, [:delete_me], name: "unique_constraint"
             t.remove_unique_constraint name: "unique_constraint"
           end
         end


### PR DESCRIPTION
### Motivation / Background

I've been doing a lot with migrations and Postgres, and noticed that when do a bulk table change, all the constraint-related management was running as separate statements, when it could all be run as part of a single ALTER TABLE.

### Detail

This PR implements bulk versions of add and remove for foreign keys, check constraints, exclusion constraints, and unique constraints.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.

I'm not sure if this qualifies as a large enough behavior change to warrant a CHANGELOG entry.