### PR TITLE
Fix duplicate view template loading

### DIFF
--- a/actionview/lib/action_view/template.rb
+++ b/actionview/lib/action_view/template.rb
@@ -198,6 +198,7 @@ module ActionView
 
     def initialize(source, identifier, handler, locals:, format: nil, variant: nil, virtual_path: nil)
       @source            = source.dup
+      @source_string     = nil
       @identifier        = identifier
       @handler           = handler
       @compiled          = false
@@ -292,7 +293,7 @@ module ActionView
     end
 
     def source
-      @source.to_s
+      @source_string ||= @source.to_s
     end
 
     LEADING_ENCODING_REGEXP = /\A#{ENCODING_FLAG}/

--- a/actionview/test/template/template_test.rb
+++ b/actionview/test/template/template_test.rb
@@ -102,6 +102,16 @@ class TestERBTemplate < ActiveSupport::TestCase
     assert_equal "Hello", @template.source
   end
 
+  def test_template_only_loads_template_source_once
+    source_loaded = 0
+    source = Class.new do |klass|
+      klass.define_method(:to_s) { source_loaded += 1; +"hello" }
+    end.new
+    @template = new_template(source)
+    render
+    assert_equal 1, source_loaded
+  end
+
   def test_locals
     @template = new_template("<%= my_local %>", locals: [:my_local])
     assert_equal "I am a local", render(my_local: "I am a local")


### PR DESCRIPTION
### Motivation / Background

Currently, when rendering an `ActionView::Template`, the template source is loaded from the disk twice.

During one rendering process, `Template#source` is called at least twice (once in `encode!` and once in `strict_locals!`), each of these calls runs `@source.to_s`. As `@source` is usually a `Template::Sources::File`, `#to_s` hits the disk to load the template.

It is unnecessary to load the file from disk more than once just to check whether the `# locals:` comment is present.

### Detail

This Pull Request changes the `Template#source` so that it memoizes the loaded source.

### Additional information
This pull request introduces a small behavior change: The `# locals: (...)` comment is now removed from the source before passing the source to the handler. It looks like this was the intended behavior all along. Previously the line
```
self.source.sub!(STRICT_LOCALS_REGEX, "")
```
had no effect, because the source was reloaded from disk afterwards and the magic comment was present again.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
