### PR TITLE
Don't mess with Minitest unless RAILS_ENV is set

### DIFF
--- a/railties/lib/minitest/rails_plugin.rb
+++ b/railties/lib/minitest/rails_plugin.rb
@@ -109,6 +109,9 @@ module Minitest
   # Owes great inspiration to test runner trailblazers like RSpec,
   # minitest-reporters, maxitest, and others.
   def self.plugin_rails_init(options)
+    # Don't mess with Minitest unless RAILS_ENV is set
+    return unless ENV["RAILS_ENV"]
+
     unless options[:full_backtrace]
       # Plugin can run without Rails loaded, check before filtering.
       if ::Rails.respond_to?(:backtrace_cleaner)


### PR DESCRIPTION
Minitest will automatically scan all installed gems and load plugins from those gems.  We should detect whether or not we're being run within the context of a Rails app and only change MT behavior in that case.

To determine if we're being run via `bin/rails` we'll just check if RAILS_ENV is set.

Ref: https://github.com/minitest/minitest/issues/996
Ref: https://github.com/minitest/minitest/issues/725
