### PR TITLE
Fix: guides styling issue on light mode [ci skip]

### DIFF
--- a/guides/assets/stylesrc/_main.scss
+++ b/guides/assets/stylesrc/_main.scss
@@ -278,7 +278,6 @@ body.guide {
     line-height: 1.5;
     margin: 1em 0;
     overflow: auto;
-    color: #222;
   } // pre, code
   
   p code, ul code {

--- a/guides/assets/stylesrc/highlight.scss
+++ b/guides/assets/stylesrc/highlight.scss
@@ -71,6 +71,7 @@
   .n   { color: #f8f8f2; } /* Name */
   .o   { color: #ff699b; } /* Operator */
   .p   { color: #f8f8f2; } /* Punctuation */
+  .pi  { color: #c74646; } /* Punctuation.Indicator */
   .cm  { color: #b4b4b3; } /* Comment.Multiline */
   .cp  { color: #b4b4b3; } /* Comment.Preproc */
   .c1  { color: #b4b4b3; } /* Comment.Single */


### PR DESCRIPTION
Fixes: https://github.com/rails/rails/issues/51723


### Detail

This Pull Request fixes the styling issue on code blocks when the system is in light mode.

<img width="882" alt="Screenshot 2024-05-03 at 3 34 29 PM" src="https://github.com/rails/rails/assets/22231095/d59b8fb3-3ae7-4441-ba07-ef0a31516db7">
<img width="852" alt="Screenshot 2024-05-03 at 3 34 17 PM" src="https://github.com/rails/rails/assets/22231095/6a0a91cf-97d3-4469-a53d-ea3ec4b2cc70">


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.


cc/ @jathayde 