### PR TITLE
Eliminate missed `lease_connection` calls

### DIFF
--- a/activerecord/lib/active_record/attributes.rb
+++ b/activerecord/lib/active_record/attributes.rb
@@ -239,8 +239,10 @@ module ActiveRecord
 
       def _default_attributes # :nodoc:
         @default_attributes ||= begin
-          attributes_hash = columns_hash.transform_values do |column|
-            ActiveModel::Attribute.from_database(column.name, column.default, type_for_column(column))
+          attributes_hash = with_connection do |connection|
+            columns_hash.transform_values do |column|
+              ActiveModel::Attribute.from_database(column.name, column.default, type_for_column(connection, column))
+            end
           end
 
           attribute_set = ActiveModel::AttributeSet.new(attributes_hash)
@@ -295,7 +297,7 @@ module ActiveRecord
           Type.lookup(name, **options, adapter: Type.adapter_name_from(self))
         end
 
-        def type_for_column(column)
+        def type_for_column(connection, column)
           hook_attribute_type(column.name, super)
         end
     end

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -376,9 +376,9 @@ module ActiveRecord
         TypeCaster::Map.new(self)
       end
 
-      def cached_find_by_statement(key, &block) # :nodoc:
-        cache = @find_by_statement_cache[lease_connection.prepared_statements]
-        cache.compute_if_absent(key) { StatementCache.create(lease_connection, &block) }
+      def cached_find_by_statement(connection, key, &block) # :nodoc:
+        cache = @find_by_statement_cache[connection.prepared_statements]
+        cache.compute_if_absent(key) { StatementCache.create(connection, &block) }
       end
 
       private
@@ -419,21 +419,23 @@ module ActiveRecord
         end
 
         def cached_find_by(keys, values)
-          statement = cached_find_by_statement(keys) { |params|
-            wheres = keys.index_with do |key|
-              if key.is_a?(Array)
-                [key.map { params.bind }]
-              else
-                params.bind
+          with_connection do |connection|
+            statement = cached_find_by_statement(connection, keys) { |params|
+              wheres = keys.index_with do |key|
+                if key.is_a?(Array)
+                  [key.map { params.bind }]
+                else
+                  params.bind
+                end
               end
-            end
-            where(wheres).limit(1)
-          }
+              where(wheres).limit(1)
+            }
 
-          begin
-            statement.execute(values.flatten, lease_connection, allow_retry: true).first
-          rescue TypeError
-            raise ActiveRecord::StatementInvalid
+            begin
+              statement.execute(values.flatten, lease_connection, allow_retry: true).first
+            rescue TypeError
+              raise ActiveRecord::StatementInvalid
+            end
           end
         end
     end

--- a/activerecord/lib/active_record/model_schema.rb
+++ b/activerecord/lib/active_record/model_schema.rb
@@ -379,7 +379,7 @@ module ActiveRecord
 
       def reset_sequence_name # :nodoc:
         @explicit_sequence_name = false
-        @sequence_name          = lease_connection.default_sequence_name(table_name, primary_key)
+        @sequence_name          = with_connection { |c| c.default_sequence_name(table_name, primary_key) }
       end
 
       # Sets the name of the sequence to use when generating ids to the given
@@ -404,13 +404,13 @@ module ActiveRecord
       # Determines if the primary key values should be selected from their
       # corresponding sequence before the insert statement.
       def prefetch_primary_key?
-        lease_connection.prefetch_primary_key?(table_name)
+        with_connection { |c| c.prefetch_primary_key?(table_name) }
       end
 
       # Returns the next value that will be used as the primary key on
       # an insert statement.
       def next_sequence_value
-        lease_connection.next_sequence_value(sequence_name)
+        with_connection { |c| c.next_sequence_value(sequence_name) }
       end
 
       # Indicates whether the table associated with this class exists
@@ -435,10 +435,10 @@ module ActiveRecord
         @columns ||= columns_hash.values.freeze
       end
 
-      def _returning_columns_for_insert # :nodoc:
+      def _returning_columns_for_insert(connection) # :nodoc:
         @_returning_columns_for_insert ||= begin
           auto_populated_columns = columns.filter_map do |c|
-            c.name if lease_connection.return_value_after_insert?(c)
+            c.name if connection.return_value_after_insert?(c)
           end
 
           auto_populated_columns.empty? ? Array(primary_key) : auto_populated_columns
@@ -523,7 +523,7 @@ module ActiveRecord
       #    end
       #  end
       def reset_column_information
-        lease_connection.clear_cache!
+        connection_pool.active_connection&.clear_cache!
         ([self] + descendants).each(&:undefine_attribute_methods)
         schema_cache.clear_data_source_cache!(table_name)
 
@@ -617,8 +617,8 @@ module ActiveRecord
           end
         end
 
-        def type_for_column(column)
-          type = lease_connection.lookup_cast_type_from_column(column)
+        def type_for_column(connection, column)
+          type = connection.lookup_cast_type_from_column(column)
 
           if immutable_strings_by_default && type.respond_to?(:to_immutable_string)
             type = type.to_immutable_string

--- a/activerecord/lib/active_record/querying.rb
+++ b/activerecord/lib/active_record/querying.rb
@@ -48,18 +48,25 @@ module ActiveRecord
     # Note that building your own SQL query string from user input may expose your application to
     # injection attacks (https://guides.rubyonrails.org/security.html#sql-injection).
     def find_by_sql(sql, binds = [], preparable: nil, allow_retry: false, &block)
-      _load_from_sql(_query_by_sql(sql, binds, preparable: preparable, allow_retry: allow_retry), &block)
+      result = with_connection do |c|
+        _query_by_sql(c, sql, binds, preparable: preparable, allow_retry: allow_retry)
+      end
+      _load_from_sql(result, &block)
     end
 
     # Same as <tt>#find_by_sql</tt> but perform the query asynchronously and returns an ActiveRecord::Promise.
     def async_find_by_sql(sql, binds = [], preparable: nil, &block)
-      _query_by_sql(sql, binds, preparable: preparable, async: true).then do |result|
+      result = with_connection do |c|
+        _query_by_sql(c, sql, binds, preparable: preparable, async: true)
+      end
+
+      result.then do |result|
         _load_from_sql(result, &block)
       end
     end
 
-    def _query_by_sql(sql, binds = [], preparable: nil, async: false, allow_retry: false) # :nodoc:
-      lease_connection.select_all(sanitize_sql(sql), "#{name} Load", binds, preparable: preparable, async: async, allow_retry: allow_retry)
+    def _query_by_sql(connection, sql, binds = [], preparable: nil, async: false, allow_retry: false) # :nodoc:
+      connection.select_all(sanitize_sql(sql), "#{name} Load", binds, preparable: preparable, async: async, allow_retry: allow_retry)
     end
 
     def _load_from_sql(result_set, &block) # :nodoc:
@@ -99,12 +106,16 @@ module ActiveRecord
     #
     # * +sql+ - An SQL statement which should return a count query from the database, see the example above.
     def count_by_sql(sql)
-      lease_connection.select_value(sanitize_sql(sql), "#{name} Count").to_i
+      with_connection do |c|
+        c.select_value(sanitize_sql(sql), "#{name} Count").to_i
+      end
     end
 
     # Same as <tt>#count_by_sql</tt> but perform the query asynchronously and returns an ActiveRecord::Promise.
     def async_count_by_sql(sql)
-      lease_connection.select_value(sanitize_sql(sql), "#{name} Count", async: true).then(&:to_i)
+      with_connection do |c|
+        c.select_value(sanitize_sql(sql), "#{name} Count", async: true).then(&:to_i)
+      end
     end
   end
 end

--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -529,7 +529,9 @@ module ActiveRecord
         if polymorphic?
           key = [key, owner._read_attribute(@foreign_type)]
         end
-        klass.cached_find_by_statement(key, &block)
+        klass.with_connection do |connection|
+          klass.cached_find_by_statement(connection, key, &block)
+        end
       end
 
       def join_table

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -263,12 +263,14 @@ module ActiveRecord
     # and failed due to validation errors it won't be persisted, you get what #create returns in
     # such situation.
     def create_or_find_by(attributes, &block)
-      transaction(requires_new: true) { create(attributes, &block) }
-    rescue ActiveRecord::RecordNotUnique
-      if lease_connection.transaction_open?
-        where(attributes).lock.find_by!(attributes)
-      else
-        find_by!(attributes)
+      with_connection do |connection|
+        transaction(requires_new: true) { create(attributes, &block) }
+      rescue ActiveRecord::RecordNotUnique
+        if connection.transaction_open?
+          where(attributes).lock.find_by!(attributes)
+        else
+          find_by!(attributes)
+        end
       end
     end
 
@@ -276,12 +278,14 @@ module ActiveRecord
     # {create!}[rdoc-ref:Persistence::ClassMethods#create!] so an exception
     # is raised if the created record is invalid.
     def create_or_find_by!(attributes, &block)
-      transaction(requires_new: true) { create!(attributes, &block) }
-    rescue ActiveRecord::RecordNotUnique
-      if lease_connection.transaction_open?
-        where(attributes).lock.find_by!(attributes)
-      else
-        find_by!(attributes)
+      with_connection do |connection|
+        transaction(requires_new: true) { create!(attributes, &block) }
+      rescue ActiveRecord::RecordNotUnique
+        if connection.transaction_open?
+          where(attributes).lock.find_by!(attributes)
+        else
+          find_by!(attributes)
+        end
       end
     end
 
@@ -590,18 +594,18 @@ module ActiveRecord
         values = Arel.sql(klass.sanitize_sql_for_assignment(updates, table.name))
       end
 
-      arel = eager_loading? ? apply_join_dependency.arel : build_arel
-      arel.source.left = table
-
-      group_values_arel_columns = arel_columns(group_values.uniq)
-      having_clause_ast = having_clause.ast unless having_clause.empty?
-      key = if klass.composite_primary_key?
-        primary_key.map { |pk| table[pk] }
-      else
-        table[primary_key]
-      end
-      stmt = arel.compile_update(values, key, having_clause_ast, group_values_arel_columns)
       klass.with_connection do |c|
+        arel = eager_loading? ? apply_join_dependency.arel : build_arel(c)
+        arel.source.left = table
+
+        group_values_arel_columns = arel_columns(group_values.uniq)
+        having_clause_ast = having_clause.ast unless having_clause.empty?
+        key = if klass.composite_primary_key?
+          primary_key.map { |pk| table[pk] }
+        else
+          table[primary_key]
+        end
+        stmt = arel.compile_update(values, key, having_clause_ast, group_values_arel_columns)
         c.update(stmt, "#{klass} Update All").tap { reset }
       end
     end
@@ -730,19 +734,19 @@ module ActiveRecord
         raise ActiveRecordError.new("delete_all doesn't support #{invalid_methods.join(', ')}")
       end
 
-      arel = eager_loading? ? apply_join_dependency.arel : build_arel
-      arel.source.left = table
-
-      group_values_arel_columns = arel_columns(group_values.uniq)
-      having_clause_ast = having_clause.ast unless having_clause.empty?
-      key = if klass.composite_primary_key?
-        primary_key.map { |pk| table[pk] }
-      else
-        table[primary_key]
-      end
-      stmt = arel.compile_delete(key, having_clause_ast, group_values_arel_columns)
-
       klass.with_connection do |c|
+        arel = eager_loading? ? apply_join_dependency.arel : build_arel(c)
+        arel.source.left = table
+
+        group_values_arel_columns = arel_columns(group_values.uniq)
+        having_clause_ast = having_clause.ast unless having_clause.empty?
+        key = if klass.composite_primary_key?
+          primary_key.map { |pk| table[pk] }
+        else
+          table[primary_key]
+        end
+        stmt = arel.compile_delete(key, having_clause_ast, group_values_arel_columns)
+
         c.delete(stmt, "#{klass} Delete All").tap { reset }
       end
     end
@@ -947,7 +951,7 @@ module ActiveRecord
     end
 
     def alias_tracker(joins = [], aliases = nil) # :nodoc:
-      ActiveRecord::Associations::AliasTracker.create(lease_connection, table.name, joins, aliases)
+      ActiveRecord::Associations::AliasTracker.create(connection_pool, table.name, joins, aliases)
     end
 
     class StrictLoadingScope # :nodoc:
@@ -1075,7 +1079,7 @@ module ActiveRecord
           if where_clause.contradiction?
             [].freeze
           elsif eager_loading?
-            with_connection do |c|
+            klass.with_connection do |c|
               apply_join_dependency do |relation, join_dependency|
                 if relation.null_relation?
                   [].freeze
@@ -1087,7 +1091,9 @@ module ActiveRecord
               end
             end
           else
-            klass._query_by_sql(arel, async: async)
+            klass.with_connection do |c|
+              klass._query_by_sql(c, arel, async: async)
+            end
           end
         end
       end

--- a/activerecord/lib/active_record/sanitization.rb
+++ b/activerecord/lib/active_record/sanitization.rb
@@ -163,13 +163,19 @@ module ActiveRecord
       def sanitize_sql_array(ary)
         statement, *values = ary
         if values.first.is_a?(Hash) && /:\w+/.match?(statement)
-          replace_named_bind_variables(statement, values.first)
+          with_connection do |c|
+            replace_named_bind_variables(c, statement, values.first)
+          end
         elsif statement.include?("?")
-          replace_bind_variables(statement, values)
+          with_connection do |c|
+            replace_bind_variables(c, statement, values)
+          end
         elsif statement.blank?
           statement
         else
-          statement % values.collect { |value| lease_connection.quote_string(value.to_s) }
+          with_connection do |c|
+            statement % values.collect { |value| c.quote_string(value.to_s) }
+          end
         end
       end
 
@@ -193,48 +199,47 @@ module ActiveRecord
       end
 
       private
-        def replace_bind_variables(statement, values)
+        def replace_bind_variables(connection, statement, values)
           raise_if_bind_arity_mismatch(statement, statement.count("?"), values.size)
           bound = values.dup
-          c = lease_connection
           statement.gsub(/\?/) do
-            replace_bind_variable(bound.shift, c)
+            replace_bind_variable(connection, bound.shift)
           end
         end
 
-        def replace_bind_variable(value, c = lease_connection)
+        def replace_bind_variable(connection, value)
           if ActiveRecord::Relation === value
             value.to_sql
           else
-            quote_bound_value(value, c)
+            quote_bound_value(connection, value)
           end
         end
 
-        def replace_named_bind_variables(statement, bind_vars)
+        def replace_named_bind_variables(connection, statement, bind_vars)
           statement.gsub(/([:\\]?):([a-zA-Z]\w*)/) do |match|
             if $1 == ":" # skip PostgreSQL casts
               match # return the whole match
             elsif $1 == "\\" # escaped literal colon
               match[1..-1] # return match with escaping backlash char removed
             elsif bind_vars.include?(match = $2.to_sym)
-              replace_bind_variable(bind_vars[match])
+              replace_bind_variable(connection, bind_vars[match])
             else
               raise PreparedStatementInvalid, "missing value for :#{match} in #{statement}"
             end
           end
         end
 
-        def quote_bound_value(value, c = lease_connection)
+        def quote_bound_value(connection, value)
           if value.respond_to?(:map) && !value.acts_like?(:string)
             values = value.map { |v| v.respond_to?(:id_for_database) ? v.id_for_database : v }
             if values.empty?
-              c.quote(c.cast_bound_value(nil))
+              connection.quote(connection.cast_bound_value(nil))
             else
-              values.map! { |v| c.quote(c.cast_bound_value(v)) }.join(",")
+              values.map! { |v| connection.quote(connection.cast_bound_value(v)) }.join(",")
             end
           else
             value = value.id_for_database if value.respond_to?(:id_for_database)
-            c.quote(c.cast_bound_value(value))
+            connection.quote(connection.cast_bound_value(value))
           end
         end
 

--- a/activerecord/lib/active_record/timestamp.rb
+++ b/activerecord/lib/active_record/timestamp.rb
@@ -75,7 +75,7 @@ module ActiveRecord
       end
 
       def current_time_from_proper_timezone
-        lease_connection.default_timezone == :utc ? Time.now.utc : Time.now
+        with_connection { |c| c.default_timezone == :utc ? Time.now.utc : Time.now }
       end
 
       protected

--- a/activerecord/lib/active_record/transactions.rb
+++ b/activerecord/lib/active_record/transactions.rb
@@ -226,7 +226,7 @@ module ActiveRecord
 
       # Returns the current transaction. See ActiveRecord::Transactions API docs.
       def current_transaction
-        connection_pool.active_connection&.current_transaction || ConnectionAdapters::NULL_TRANSACTION
+        connection_pool.active_connection&.current_transaction || ConnectionAdapters::TransactionManager::NULL_TRANSACTION
       end
 
       def before_commit(*args, &block) # :nodoc:

--- a/activerecord/test/cases/bind_parameter_test.rb
+++ b/activerecord/test/cases/bind_parameter_test.rb
@@ -258,7 +258,7 @@ if ActiveRecord::Base.lease_connection.prepared_statements
         end
 
         def cached_statement(klass, key)
-          cache = klass.send(:cached_find_by_statement, key) do
+          cache = klass.send(:cached_find_by_statement, @connection, key) do
             raise "#{klass} has no cached statement by #{key.inspect}"
           end
           cache.send(:query_builder).instance_variable_get(:@sql)

--- a/activerecord/test/cases/sanitize_test.rb
+++ b/activerecord/test/cases/sanitize_test.rb
@@ -242,9 +242,13 @@ class SanitizeTest < ActiveRecord::TestCase
   private
     def bind(statement, *vars)
       if vars.first.is_a?(Hash)
-        ActiveRecord::Base.send(:replace_named_bind_variables, statement, vars.first)
+        ActiveRecord::Base.with_connection do |c|
+          ActiveRecord::Base.send(:replace_named_bind_variables, c, statement, vars.first)
+        end
       else
-        ActiveRecord::Base.send(:replace_bind_variables, statement, vars)
+        ActiveRecord::Base.with_connection do |c|
+          ActiveRecord::Base.send(:replace_bind_variables, c, statement, vars)
+        end
       end
     end
 end


### PR DESCRIPTION
Followup: https://github.com/rails/rails/pull/51353
Fix: https://github.com/rails/rails/issues/51722

Not too sure what happened, but I somehow missed quite a number of `lease_connection` calls inside Active Record.
