### PR TITLE
Add rename_csp_helper_nonce_attribute ActionView configuration to avoid value exfiltration

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -7,7 +7,7 @@
     # renders
     <meta name="csp-nonce" nonce="..." />
 
-    app.config.action_view.csp_meta_tag_nonce_attribute = :content (current default)
+    app.config.action_view.csp_meta_tag_nonce_attribute = :content # (current default)
     # renders
     <meta name="csp-nonce" content="..." />
     ```

--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,19 @@
+*   Add a configuration `csp_meta_tag_nonce_attribute` to allow renaming the csp_meta_tag helper nonce attribute name.
+    This allows to rename the `content` attribute to `nonce` to avoid certain kinds of value exfiltration attacks.
+
+    ```
+    app.config.action_view.csp_meta_tag_nonce_attribute = :nonce
+    <%= csp_meta_tag %>
+    # renders
+    <meta name="csp-nonce" nonce="..." />
+
+    app.config.action_view.csp_meta_tag_nonce_attribute = :content (current default)
+    # renders
+    <meta name="csp-nonce" content="..." />
+    ```
+
+    *Niklas Häusele*
+
 ## Rails 8.0.0.beta1 (September 26, 2024) ##
 
 *   Enable DependencyTracker to evaluate renders with trailing interpolation.

--- a/actionview/lib/action_view/helpers/csp_helper.rb
+++ b/actionview/lib/action_view/helpers/csp_helper.rb
@@ -4,6 +4,8 @@ module ActionView
   module Helpers # :nodoc:
     # = Action View CSP \Helpers
     module CspHelper
+      mattr_accessor :csp_meta_tag_nonce_attribute, default: :content
+
       # Returns a meta tag "csp-nonce" with the per-session nonce value
       # for allowing inline <script> tags.
       #
@@ -17,7 +19,7 @@ module ActionView
       def csp_meta_tag(**options)
         if content_security_policy?
           options[:name] = "csp-nonce"
-          options[:content] = content_security_policy_nonce
+          options[csp_meta_tag_nonce_attribute] = content_security_policy_nonce
           tag("meta", options)
         end
       end

--- a/actionview/lib/action_view/railtie.rb
+++ b/actionview/lib/action_view/railtie.rb
@@ -14,8 +14,14 @@ module ActionView
     config.action_view.image_decoding = nil
     config.action_view.apply_stylesheet_media_default = true
     config.action_view.prepend_content_exfiltration_prevention = false
+    config.action_view.csp_meta_tag_nonce_attribute = :content
 
     config.eager_load_namespaces << ActionView
+
+    config.after_initialize do |app|
+      ActionView::Helpers::CspHelper.csp_meta_tag_nonce_attribute =
+        app.config.action_view.delete(:csp_meta_tag_nonce_attribute)
+    end
 
     config.after_initialize do |app|
       ActionView::Helpers::FormTagHelper.embed_authenticity_token_in_remote_forms =

--- a/actionview/test/template/csp_helper_test.rb
+++ b/actionview/test/template/csp_helper_test.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "abstract_unit"
+require "active_support/core_ext/object/with"
 
 class CspHelperWithCspEnabledTest < ActionView::TestCase
   tests ActionView::Helpers::CspHelper
@@ -13,7 +14,19 @@ class CspHelperWithCspEnabledTest < ActionView::TestCase
     true
   end
 
-  def test_csp_meta_tag
+  def test_csp_meta_tag_uses_nonce_attribute_with_helper_nonce_attribute_name_nonce
+    ActionView::Helpers::CspHelper.with(csp_meta_tag_nonce_attribute: :nonce) do
+      assert_equal "<meta name=\"csp-nonce\" nonce=\"iyhD0Yc0W+c=\" />", csp_meta_tag
+    end
+  end
+
+  def test_csp_meta_tag_uses_nonce_attribute_with_helper_nonce_attribute_name_content
+    ActionView::Helpers::CspHelper.with(csp_meta_tag_nonce_attribute: :content) do
+      assert_equal "<meta name=\"csp-nonce\" content=\"iyhD0Yc0W+c=\" />", csp_meta_tag
+    end
+  end
+
+  def test_csp_meta_tag_with_helper_nonce_attribute_default_setting
     assert_equal "<meta name=\"csp-nonce\" content=\"iyhD0Yc0W+c=\" />", csp_meta_tag
   end
 


### PR DESCRIPTION
Adds a configuration to rename the CSP helper attribute name to avoid value exfiltration as described in https://github.com/rails/rails/issues/51580#issue-2246912613

It's disabled by default currently until the JS libraries are updated to the new attribute name and Rails can ship with a new default attribute name.

Fixes the Rails part #51580. See this PR for a potential fix in Turbo: https://github.com/hotwired/turbo/pull/1254/files

If this approach makes sense in general, I'd try to fix ujs as well 👍