### PR TITLE
Define column methods on the ColumnMethods module

### DIFF
--- a/activerecord/lib/active_record/connection_adapters.rb
+++ b/activerecord/lib/active_record/connection_adapters.rb
@@ -84,6 +84,7 @@ module ActiveRecord
     autoload_at "active_record/connection_adapters/abstract/schema_definitions" do
       autoload :IndexDefinition
       autoload :ColumnDefinition
+      autoload :ColumnMethods
       autoload :ChangeColumnDefinition
       autoload :ChangeColumnDefaultDefinition
       autoload :ForeignKeyDefinition

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
@@ -299,6 +299,21 @@ module ActiveRecord
     module ColumnMethods
       extend ActiveSupport::Concern
 
+      class_methods do
+        private
+          def define_column_methods(*column_types) # :nodoc:
+            column_types.each do |column_type|
+              module_eval <<-RUBY, __FILE__, __LINE__ + 1
+              def #{column_type}(*names, **options)
+                raise ArgumentError, "Missing column name(s) for #{column_type}" if names.empty?
+                names.each { |name| column(name, :#{column_type}, **options) }
+              end
+              RUBY
+            end
+          end
+      end
+      extend ClassMethods
+
       # Appends a primary key definition to the table definition.
       # Can be called multiple times, but this is probably not a good idea.
       def primary_key(name, type = :primary_key, **options)
@@ -316,27 +331,11 @@ module ActiveRecord
       #
       # See TableDefinition#column
 
-      included do
-        define_column_methods :bigint, :binary, :boolean, :date, :datetime, :decimal,
-          :float, :integer, :json, :string, :text, :time, :timestamp, :virtual
+      define_column_methods :bigint, :binary, :boolean, :date, :datetime, :decimal,
+        :float, :integer, :json, :string, :text, :time, :timestamp, :virtual
 
-        alias :blob :binary
-        alias :numeric :decimal
-      end
-
-      class_methods do
-        def define_column_methods(*column_types) # :nodoc:
-          column_types.each do |column_type|
-            module_eval <<-RUBY, __FILE__, __LINE__ + 1
-              def #{column_type}(*names, **options)
-                raise ArgumentError, "Missing column name(s) for #{column_type}" if names.empty?
-                names.each { |name| column(name, :#{column_type}, **options) }
-              end
-            RUBY
-          end
-        end
-        private :define_column_methods
-      end
+      alias :blob :binary
+      alias :numeric :decimal
     end
 
     # = Active Record Connection Adapters \Table \Definition

--- a/activerecord/lib/active_record/connection_adapters/mysql/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/schema_definitions.rb
@@ -5,6 +5,7 @@ module ActiveRecord
     module MySQL
       module ColumnMethods
         extend ActiveSupport::Concern
+        extend ConnectionAdapters::ColumnMethods::ClassMethods
 
         ##
         # :method: blob
@@ -42,13 +43,11 @@ module ActiveRecord
         # :method: unsigned_bigint
         # :call-seq: unsigned_bigint(*names, **options)
 
-        included do
-          define_column_methods :blob, :tinyblob, :mediumblob, :longblob,
-            :tinytext, :mediumtext, :longtext, :unsigned_integer, :unsigned_bigint,
-            :unsigned_float, :unsigned_decimal
+        define_column_methods :blob, :tinyblob, :mediumblob, :longblob,
+          :tinytext, :mediumtext, :longtext, :unsigned_integer, :unsigned_bigint,
+          :unsigned_float, :unsigned_decimal
 
-          deprecate :unsigned_float, :unsigned_decimal, deprecator: ActiveRecord.deprecator
-        end
+        deprecate :unsigned_float, :unsigned_decimal, deprecator: ActiveRecord.deprecator
       end
 
       # = Active Record MySQL Adapter \Table Definition

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_definitions.rb
@@ -5,6 +5,7 @@ module ActiveRecord
     module PostgreSQL
       module ColumnMethods
         extend ActiveSupport::Concern
+        extend ConnectionAdapters::ColumnMethods::ClassMethods
 
         # Defines the primary key field.
         # Use of the native PostgreSQL UUID type is supported, and can be used
@@ -181,12 +182,10 @@ module ActiveRecord
         # :method: enum
         # :call-seq: enum(*names, **options)
 
-        included do
-          define_column_methods :bigserial, :bit, :bit_varying, :cidr, :citext, :daterange,
-            :hstore, :inet, :interval, :int4range, :int8range, :jsonb, :ltree, :macaddr,
-            :money, :numrange, :oid, :point, :line, :lseg, :box, :path, :polygon, :circle,
-            :serial, :tsrange, :tstzrange, :tsvector, :uuid, :xml, :timestamptz, :enum
-        end
+        define_column_methods :bigserial, :bit, :bit_varying, :cidr, :citext, :daterange,
+          :hstore, :inet, :interval, :int4range, :int8range, :jsonb, :ltree, :macaddr,
+          :money, :numrange, :oid, :point, :line, :lseg, :box, :path, :polygon, :circle,
+          :serial, :tsrange, :tstzrange, :tsvector, :uuid, :xml, :timestamptz, :enum
       end
 
       ExclusionConstraintDefinition = Struct.new(:table_name, :expression, :options) do


### PR DESCRIPTION
### Motivation / Background

I was writing some code that parses our migrations and extracts information about newly added columns. It was missing some columns because they were of a less column datatype that we weren't explicitly handling. I went to see if I could just list the methods on a module to find the valid column method aliases, and was happy to see such a module exists. Except that due to how it's structured, none of the column method aliases _actually_ exist on that module.

### Detail

The way they were being defined inside the `included` hook meant they ended up being defined directly on `TableDefinition`, contrary to the documentation:
https://api.rubyonrails.org/classes/ActiveRecord/ConnectionAdapters/PostgreSQL/ColumnMethods.html. By extending `ClassMethods` onto `ColumnMethods`, the module can call the macro directly, and end up with the methods defined on the `ColumnMethods` module, instead of deferring their creation until they're `included`, and defining them on the including class.

### Additional information

I left `define_column_methods` as a class method that gets extended onto TableDefinition, since there's at least one gem that relies on being able to call it there to define their own column types

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
