### PR TITLE
Improve Rails console helper methods' descriptions

### DIFF
--- a/railties/lib/rails/commands/console/irb_console.rb
+++ b/railties/lib/rails/commands/console/irb_console.rb
@@ -10,7 +10,7 @@ module Rails
     end
 
     class ControllerHelper < RailsHelperBase
-      description "Gets the helper methods available to the controller."
+      description "Gets helper methods available to ApplicationController."
 
       # This method assumes an +ApplicationController+ exists, and that it extends ActionController::Base.
       def execute
@@ -19,7 +19,7 @@ module Rails
     end
 
     class ControllerInstance < RailsHelperBase
-      description "Gets a new instance of a controller object."
+      description "Gets a new instance of ApplicationController."
 
       # This method assumes an +ApplicationController+ exists, and that it extends ActionController::Base.
       def execute
@@ -28,7 +28,7 @@ module Rails
     end
 
     class NewSession < RailsHelperBase
-      description "Create a new session. If a block is given, the new session will be yielded to the block before being returned."
+      description "[Deprecated] Please use `app(true)` instead."
 
       def execute(*)
         app = Rails.application
@@ -43,7 +43,7 @@ module Rails
     end
 
     class AppInstance < NewSession
-      description "Reference the global 'app' instance, created on demand. To recreate the instance, pass a non-false value as the parameter."
+      description "Creates a new ActionDispatch::Integration::Session and memoizes it. Use `app(true)` to create a new instance."
 
       def execute(create = false)
         @app_integration_instance = nil if create
@@ -55,7 +55,7 @@ module Rails
       include ConsoleMethods
 
       category "Rails console"
-      description "Reloads the environment."
+      description "Reloads the Rails application."
 
       def execute(*)
         puts "Reloading..."


### PR DESCRIPTION
### Motivation / Background

When demonstrating the result of #51705, I received some feedback around the description of the new helpers.

### Detail

1. I made descriptions clearer around what components the methods are interacting with or return, which I think should make them easier to understand.
2. When updating the descriptions, I noticed that `new_session` has stopped taking block argument after #44748, which nobody seems to discover and it's perhaps never used. And after that update, `new_session` is the same as `app(true)`, which makes me think it has become obsolete and can be depracted.

**Result**

```
Helper methods
  conf           Returns the current IRB context.
  helper         Gets helper methods available to ApplicationController.
  controller     Gets a new instance of ApplicationController.
  new_session    [Deprecated] Please use `app(true)` instead.
  app            Creates a new ActionDispatch::Integration::Session and memoizes it. Use `app(true)` to create a new instance.
```

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
