### PR TITLE
Avoid setting fixed app name in console prompt

### DIFF
--- a/railties/lib/rails/commands/console/irb_console.rb
+++ b/railties/lib/rails/commands/console/irb_console.rb
@@ -81,7 +81,8 @@ module Rails
 
         env = colorized_env
         app_name = @app.class.module_parent_name.underscore.dasherize
-        prompt_prefix = "#{app_name}(#{env})"
+        prompt_prefix = "%N(#{env})"
+        IRB.conf[:IRB_NAME] = app_name
 
         IRB.conf[:PROMPT][:RAILS_PROMPT] = {
           PROMPT_I: "#{prompt_prefix}> ",

--- a/railties/test/application/console_test.rb
+++ b/railties/test/application/console_test.rb
@@ -110,6 +110,22 @@ class FullStackConsoleTest < ActiveSupport::TestCase
     @primary.puts "quit"
   end
 
+  def test_prompt_is_properly_set
+    options = "-e test"
+    spawn_console(options)
+
+    write_prompt "a = 1", "a = 1", prompt: "app-template(test)>"
+  end
+
+  def test_prompt_allows_changing_irb_name
+    options = "-e test"
+    spawn_console(options)
+
+    write_prompt "conf.irb_name = 'foo'"
+    write_prompt "a = 1", "a = 1", prompt: "foo(test)>"
+    @primary.puts "quit"
+  end
+
   def test_environment_option_and_irb_option
     options = "-e test -- --verbose"
     spawn_console(options)


### PR DESCRIPTION
### Motivation / Background

IRB allows changing its prompt's name during the session, like:

```
irb(main):001> conf.irb_name = "foo"
=> "foo"
foo(main):002> 
```

But because I previously set the app name as part of the prompt, instead of via the `irb_name` config, such change can't happen in a Rails console:

```
Loading development environment (Rails 7.2.0.alpha)
test-app(dev)> conf.irb_name = "foo"
=> "foo"
test-app(dev)> 
```

This can be problematic as tools/features can rely on the name change to indicate state change ([example](https://github.com/ruby/irb/blob/master/lib/irb/debug.rb#L87)).

### Detail

Instead of setting app name as a fixed value in prompt, I replaced it with `%N`, which IRB uses to display the `irb_name` attribute. And then we can set assign the app name to `IRB.conf[:IRB_NAME]` (default is `"irb"`).

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
