### PR TITLE
Added option to validate which models are allowed to be associated to a polymorphic belongs_to

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   Add option to validate which models are allowed to be associated to a polymorphic `belongs_to`.
+
+    Ex:
+    ```ruby
+    belongs_to :commentable, polymorphic: ["Post", "Comment"]
+    ```
+    This automatically adds an inclusion validator to commentable_type, to ensure that it's either Post or Comment.
+
+    *Nate Matykiewicz*
+
 *   Allow `drop_table` to accept an array of table names.
 
     This will let you to drop multiple tables in a single call.

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,21 @@
+*   Validate the delegated type's foreign key by passing the `types` to the underlying polymorphic `belongs_to`
+    association.
+
+    Ex:
+    ```ruby
+    delegated_type :entryable, types: ["Message", "Comment"]
+    ```
+    previously called:
+    ```ruby
+    belongs_to :entryable, polymorphic: true
+    ```
+    and now calls:
+    ```ruby
+    belongs_to :entryable, polymorphic: ["Message", "Comment"]
+    ```
+
+    *Nate Matykiewicz*
+
 *   Add option to validate which models are allowed to be associated to a polymorphic `belongs_to`.
 
     Ex:

--- a/activerecord/lib/active_record/associations.rb
+++ b/activerecord/lib/active_record/associations.rb
@@ -1613,7 +1613,8 @@ module ActiveRecord
         #   Note: If you've enabled the counter cache, then you may want to add the counter cache attribute
         #   to the +attr_readonly+ list in the associated classes (e.g. <tt>class Post; attr_readonly :comments_count; end</tt>).
         # [+:polymorphic+]
-        #   Specify this association is a polymorphic association by passing +true+.
+        #   Specify this association is a polymorphic association by passing +true+. Or pass an array of allowed class names
+        #   to additionally add an inclusion validator to the +foreign_key+ column.
         #   Note: Since polymorphic associations rely on storing class names in the database, make sure to update the class names in the
         #   <tt>*_type</tt> polymorphic type column of the corresponding rows.
         # [+:validate+]

--- a/activerecord/lib/active_record/associations/belongs_to_polymorphic_association.rb
+++ b/activerecord/lib/active_record/associations/belongs_to_polymorphic_association.rb
@@ -6,7 +6,9 @@ module ActiveRecord
     class BelongsToPolymorphicAssociation < BelongsToAssociation # :nodoc:
       def klass
         type = owner[reflection.foreign_type]
-        type.presence && owner.class.polymorphic_class_for(type)
+        return unless type.present? && valid_polymorphic_type?(reflection, type)
+
+        owner.class.polymorphic_class_for(type)
       end
 
       def target_changed?
@@ -22,6 +24,13 @@ module ActiveRecord
       end
 
       private
+        def valid_polymorphic_type?(reflection, type)
+          polymorphic = reflection.options[:polymorphic]
+
+          return polymorphic.include?(type) if polymorphic.is_a?(Array)
+          !!polymorphic
+        end
+
         def replace_keys(record, force: false)
           super
 

--- a/activerecord/lib/active_record/associations/builder/belongs_to.rb
+++ b/activerecord/lib/active_record/associations/builder/belongs_to.rb
@@ -121,6 +121,12 @@ module ActiveRecord::Associations::Builder # :nodoc:
         required = !reflection.options[:optional]
       end
 
+      if reflection.options[:polymorphic].is_a?(Array)
+        model.validates reflection.foreign_type,
+          inclusion: { in: reflection.options[:polymorphic].map { |klass| klass.to_s } },
+          allow_blank: true
+      end
+
       super
 
       if required

--- a/activerecord/lib/active_record/associations/builder/belongs_to.rb
+++ b/activerecord/lib/active_record/associations/builder/belongs_to.rb
@@ -122,8 +122,10 @@ module ActiveRecord::Associations::Builder # :nodoc:
       end
 
       if reflection.options[:polymorphic].is_a?(Array)
+        reflection.options[:polymorphic] = reflection.options[:polymorphic].map(&:to_s)
+
         model.validates reflection.foreign_type,
-          inclusion: { in: reflection.options[:polymorphic].map { |klass| klass.to_s } },
+          inclusion: { in: reflection.options[:polymorphic] },
           allow_blank: true
       end
 

--- a/activerecord/lib/active_record/delegated_type.rb
+++ b/activerecord/lib/active_record/delegated_type.rb
@@ -206,6 +206,8 @@ module ActiveRecord
     #
     # The +options+ are passed directly to the +belongs_to+ call, so this is where you declare +dependent+ etc.
     # The following options can be included to specialize the behavior of the delegated type convenience methods.
+    # The +types+ are passed to the +belongs_to+'s +:polymorphic+ option, adding an inclusion validator to the
+    # +:foreign_key+ field.
     #
     # [:foreign_key]
     #   Specify the foreign key used for the convenience methods. By default this is guessed to be the passed
@@ -229,7 +231,7 @@ module ActiveRecord
     #   Entry#message_uuid      # => returns entryable_uuid, when entryable_type == "Message", otherwise nil
     #   Entry#comment_uuid      # => returns entryable_uuid, when entryable_type == "Comment", otherwise nil
     def delegated_type(role, types:, **options)
-      belongs_to role, options.delete(:scope), **options.merge(polymorphic: true)
+      belongs_to role, options.delete(:scope), **options.merge(polymorphic: types)
       define_delegated_type_methods role, types: types, options: options
     end
 

--- a/activerecord/test/cases/associations/belongs_to_associations_test.rb
+++ b/activerecord/test/cases/associations/belongs_to_associations_test.rb
@@ -1374,6 +1374,28 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
     end
   end
 
+  class TestPolymorphicArrayAllowed < ActiveRecord::Base
+    self.table_name = "wheels"
+    belongs_to :wheelable, polymorphic: ["Book", :Essay], optional: false
+  end
+
+  def test_polymorphic_with_allowed_class_string_array
+    wheel = TestPolymorphicArrayAllowed.new
+
+    assert_not_predicate wheel, :valid?
+    assert_equal ["Wheelable must exist"], wheel.errors.full_messages
+
+    wheel.wheelable = Book.create!
+    assert_predicate wheel, :valid?
+
+    wheel.wheelable = Essay.create!
+    assert_predicate wheel, :valid?
+
+    wheel.wheelable = Citation.create!
+    assert_not_predicate wheel, :valid?
+    assert_equal ["Wheelable type is not included in the list"], wheel.errors.full_messages
+  end
+
   def test_polymorphic_with_custom_foreign_type
     sponsor = sponsors(:moustache_club_sponsor_for_groucho)
     groucho = members(:groucho)

--- a/activerecord/test/cases/associations/belongs_to_associations_test.rb
+++ b/activerecord/test/cases/associations/belongs_to_associations_test.rb
@@ -1396,6 +1396,23 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
     assert_equal ["Wheelable type is not included in the list"], wheel.errors.full_messages
   end
 
+  def test_polymorphic_unpermitted_class
+    citation = Citation.create!
+
+    wheel = TestPolymorphicArrayAllowed.new(wheelable_type: "Citation", wheelable_id: citation.id)
+    assert_equal "Citation", wheel.wheelable_type
+    assert_equal citation.id, wheel.wheelable_id
+    assert_nil wheel.wheelable
+  end
+
+  def test_polymorphic_unknown_class
+    wheel = TestPolymorphicArrayAllowed.new(wheelable_type: "FakeModel", wheelable_id: 1)
+
+    assert_equal "FakeModel", wheel.wheelable_type
+    assert_equal 1, wheel.wheelable_id
+    assert_nil wheel.wheelable
+  end
+
   def test_polymorphic_with_custom_foreign_type
     sponsor = sponsors(:moustache_club_sponsor_for_groucho)
     groucho = members(:groucho)

--- a/activerecord/test/cases/delegated_type_test.rb
+++ b/activerecord/test/cases/delegated_type_test.rb
@@ -34,9 +34,14 @@ class DelegatedTypeTest < ActiveRecord::TestCase
   end
 
   test "delegated class with custom foreign_type" do
-    assert_equal Message, @entry_with_message.thing_class
-    assert_equal Comment, @entry_with_comment.thing_class
     assert_equal Post, @entry_with_post.thing_class
+  end
+
+  test "invalid delegated type class" do
+    @entry_with_message.entryable = posts(:welcome)
+
+    assert_not_predicate @entry_with_message, :valid?
+    assert_equal ["Entryable type is not included in the list"], @entry_with_message.errors.full_messages
   end
 
   test "delegated type name" do

--- a/activerecord/test/models/entry.rb
+++ b/activerecord/test/models/entry.rb
@@ -6,5 +6,5 @@ class Entry < ActiveRecord::Base
 
   # alternate delegation for custom foreign_key/foreign_type
   delegated_type :thing, types: %w[ Post ],
-    foreign_key: :entryable_id, foreign_type: :entryable_type
+    foreign_key: :fooable_id, foreign_type: :fooable_type
 end

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -592,8 +592,10 @@ ActiveRecord::Schema.define do
   end
 
   create_table :entries, force: true do |t|
-    t.string   :entryable_type, null: false
-    t.integer  :entryable_id, null: false
+    t.string   :entryable_type
+    t.integer  :entryable_id
+    t.string   :fooable_type
+    t.integer  :fooable_id
     t.integer  :account_id, null: false
     t.datetime :updated_at
   end

--- a/guides/source/association_basics.md
+++ b/guides/source/association_basics.md
@@ -1642,6 +1642,15 @@ class CreatePictures < ActiveRecord::Migration[8.0]
 end
 ```
 
+In this example, `imageable` can have any model assigned to it. If you wanted to ensure that the `imageable_type` is only `Employee` or `Product`, you can set the `polymorphic` option to an array of allowed class names. This will [add an inclusion validator][inclusion validator] to the `imageable_type` column, which adds a validation error if `imageable` is not one of the expected classes:
+
+[inclusion validator]: active_record_validations.html#inclusion
+
+```ruby
+class Picture < ApplicationRecord
+  belongs_to :imageable, polymorphic: ["Employee", "Product"]
+end
+
 WARNING: Since polymorphic associations rely on storing class names in the
 database, that data must remain synchronized with the class name used by the
 Ruby code. When renaming a class, make sure to update the data in the


### PR DESCRIPTION
### Motivation / Background

When using a polymorphic belongs_to, I usually have a list of allowed classes that I expect this association to use. Oftentimes there's even certain views that need to handle each expected option. Unexpected types in the table would cause problems and potentially pose a security risk.

I've manually added an inclusion validator before, but wished I could just tell the association what the allowed options are.

### Detail

This Pull Request changes `belongs_to`'s `polymorphic` option to allow an array of Strings/Symbols of allowed model names. When provided, an inclusion validator is added to the model to ensure the `_type` field is in the list of allowed class names.

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [X] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
