### PR TITLE
Fix `config.read_encrypted_secrets` deprecation warning quoting

### DIFF
--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -350,13 +350,12 @@ module Rails
       end
 
       def read_encrypted_secrets
-        Rails.deprecator.warn(`config.read_encrypted_secrets is deprecated and will be removed in Rails 7.3.`)
+        Rails.deprecator.warn("'config.read_encrypted_secrets' is deprecated and will be removed in Rails 7.3.")
       end
 
       def read_encrypted_secrets=(value)
-        Rails.deprecator.warn(`config.read_encrypted_secrets is deprecated and will be removed in Rails 7.3.`)
+        Rails.deprecator.warn("'config.read_encrypted_secrets=' is deprecated and will be removed in Rails 7.3.")
       end
-
 
       def encoding=(value)
         @encoding = value


### PR DESCRIPTION
[This commit ](https://github.com/rails/rails/commit/0c76f17f2dbf0d7ad90c890e6f334743cacce41f) deprecated `config.read_encrypted_secrets` but, surprisingly, deprecation used back-ticks instead of normal quoting (which leads to excuting string payload via shell).

### Motivation / Background

```
pry(main)> Rails::VERSION::STRING
"7.2.0.alpha"
pry(main)> Rails.application.config.read_encrypted_secrets
Errno::ENOENT: No such file or directory - config.read_encrypted_secrets
```

### Detail

If I'm not missing anything, normal quotes should be used.

### Additional information

After fix it works as expected:

```
[1] pry(main)> Rails.application.config.read_encrypted_secrets
ActiveSupport::DeprecationException: DEPRECATION WARNING: config.read_encrypted_secrets is deprecated and will be removed in Rails 7.3. (called from __pry__ at (pry):1)
```

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
