### PR TITLE
Enable `Style/CommandLiteral` cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -322,6 +322,10 @@ Style/OpenStructUse:
 Style/ArrayIntersect:
   Enabled: true
 
+Style/CommandLiteral:
+  Enabled: true
+  EnforcedStyle: percent_x
+
 Performance/BindCall:
   Enabled: true
 

--- a/activerecord/lib/active_record/tasks/sqlite_database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/sqlite_database_tasks.rb
@@ -59,7 +59,7 @@ module ActiveRecord
 
       def structure_load(filename, extra_flags)
         flags = extra_flags.join(" ") if extra_flags
-        `sqlite3 #{flags} #{db_config.database} < "#{filename}"`
+        %x(sqlite3 #{flags} #{db_config.database} < "#{filename}")
       end
 
       private

--- a/activerecord/test/cases/adapters/sqlite3/sqlite_rake_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/sqlite_rake_test.rb
@@ -171,8 +171,8 @@ module ActiveRecord
         "database" => @database
       }
 
-      `sqlite3 #{@database} 'CREATE TABLE bar(id INTEGER)'`
-      `sqlite3 #{@database} 'CREATE TABLE foo(id INTEGER)'`
+      %x(sqlite3 #{@database} 'CREATE TABLE bar(id INTEGER)')
+      %x(sqlite3 #{@database} 'CREATE TABLE foo(id INTEGER)')
     end
 
     def test_structure_dump

--- a/guides/README.md
+++ b/guides/README.md
@@ -10,7 +10,7 @@ The editing files for the Guides rebuild reside in `stylesrc` and use SCSS to im
 
 ## Building the Guides in Development
 
-To generate new guides into static files, type `rake guides:generate` from inside the `guides` folder. If you make changes to the HTML or ERB, you'll need to remove the "output" directory before running this command. The master SCSS files (style.scss, highlight.scss) will compile as part of this process. 
+To generate new guides into static files, type `rake guides:generate` from inside the `guides` folder. If you make changes to the HTML or ERB, you'll need to remove the "output" directory before running this command. The master SCSS files (style.scss, highlight.scss) will compile as part of this process.
 
 ## FAQ
 

--- a/guides/rails_guides.rb
+++ b/guides/rails_guides.rb
@@ -17,7 +17,7 @@ env_value = ->(name) { ENV[name].presence }
 env_flag  = ->(name) { "1" == env_value[name] }
 
 version = env_value["RAILS_VERSION"]
-edge    = `git rev-parse HEAD`.strip unless version
+edge    = %x(git rev-parse HEAD).strip unless version
 
 RailsGuides::Generator.new(
   edge:      edge,

--- a/railties/lib/rails/api/task.rb
+++ b/railties/lib/rails/api/task.rb
@@ -205,7 +205,7 @@ module Rails
 
     class EdgeTask < RepoTask
       def rails_version
-        "main@#{`git rev-parse HEAD`[0, 7]}"
+        "main@#{%x(git rev-parse HEAD)[0, 7]}"
       end
 
       def badge_version

--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -521,7 +521,7 @@ module Rails
       def node_version
         if using_node?
           ENV.fetch("NODE_VERSION") do
-            `node --version`[/\d+\.\d+\.\d+/]
+            %x(node --version)[/\d+\.\d+\.\d+/]
           rescue
             NODE_LTS_VERSION
           end
@@ -529,13 +529,13 @@ module Rails
       end
 
       def dockerfile_yarn_version
-        using_node? and `yarn --version`[/\d+\.\d+\.\d+/]
+        using_node? and %x(yarn --version)[/\d+\.\d+\.\d+/]
       rescue
         "latest"
       end
 
       def dockerfile_bun_version
-        using_bun? and `bun --version`[/\d+\.\d+\.\d+/]
+        using_bun? and %x(bun --version)[/\d+\.\d+\.\d+/]
       rescue
         BUN_VERSION
       end
@@ -745,13 +745,13 @@ module Rails
       end
 
       def user_default_branch
-        @user_default_branch ||= `git config init.defaultbranch`
+        @user_default_branch ||= %x(git config init.defaultbranch)
       end
 
       def git_init_command
         return "git init" if user_default_branch.strip.present?
 
-        git_version = `git --version`[/\d+\.\d+\.\d+/]
+        git_version = %x(git --version)[/\d+\.\d+\.\d+/]
 
         if Gem::Version.new(git_version) >= Gem::Version.new("2.28.0")
           "git init -b main"

--- a/railties/lib/rails/generators/rails/plugin/plugin_generator.rb
+++ b/railties/lib/rails/generators/rails/plugin/plugin_generator.rb
@@ -410,7 +410,7 @@ module Rails
         if skip_git?
           @author = default
         else
-          @author = `git config user.name`.chomp rescue default
+          @author = %x(git config user.name).chomp rescue default
         end
       end
 
@@ -419,7 +419,7 @@ module Rails
         if skip_git?
           @email = default
         else
-          @email = `git config user.email`.chomp rescue default
+          @email = %x(git config user.email).chomp rescue default
         end
       end
 

--- a/railties/lib/rails/tasks/yarn.rake
+++ b/railties/lib/rails/tasks/yarn.rake
@@ -10,7 +10,7 @@ namespace :yarn do
     end
 
     yarn_flags =
-      if `yarn --version`.start_with?("1")
+      if %x(yarn --version).start_with?("1")
         "--no-progress --frozen-lockfile"
       else
         "--immutable"

--- a/railties/test/application/bin_setup_test.rb
+++ b/railties/test/application/bin_setup_test.rb
@@ -20,7 +20,7 @@ module ApplicationTests
         assert_equal 5, File.size("log/test.log")
         assert_not File.exist?("tmp/restart.txt")
 
-        `bin/setup 2>&1`
+        %x(bin/setup 2>&1)
         assert_equal 0, File.size("log/test.log")
         assert_equal '["schema_migrations", "ar_internal_metadata", "articles"]', list_tables.call
         assert File.exist?("tmp/restart.txt")
@@ -35,7 +35,7 @@ module ApplicationTests
 
         app_file "db/schema.rb", ""
 
-        output = `bin/setup 2>&1`
+        output = %x(bin/setup 2>&1)
 
         # Ignore line that's only output by Bundler < 1.14
         output.sub!(/^Resolving dependencies\.\.\.\n/, "")

--- a/railties/test/application/console_test.rb
+++ b/railties/test/application/console_test.rb
@@ -68,7 +68,7 @@ class FullStackConsoleTest < ActiveSupport::TestCase
       config.disable_sandbox = true
     RUBY
 
-    output = `#{app_path}/bin/rails console --sandbox`
+    output = %x(#{app_path}/bin/rails console --sandbox)
 
     assert_includes output, "sandbox mode is disabled"
     assert_equal 1, $?.exitstatus

--- a/railties/test/application/rake/migrations_test.rb
+++ b/railties/test/application/rake/migrations_test.rb
@@ -295,7 +295,7 @@ module ApplicationTests
           rails "generate", "model", "user", "username:string", "password:string"
           rails "generate", "migration", "add_email_to_users", "email:string"
           rails "db:migrate"
-          `rm db/migrate/*email*.rb`
+          %x(rm db/migrate/*email*.rb)
 
           output = rails("db:migrate:status")
           assert_match(/up\s+\d{14}\s+Create users/, output)
@@ -509,7 +509,7 @@ module ApplicationTests
           rails "generate", "model", "user", "username:string", "password:string"
           rails "generate", "migration", "add_email_to_users", "email:string"
           rails "db:migrate"
-          `rm db/migrate/*email*.rb`
+          %x(rm db/migrate/*email*.rb)
 
           output = rails("db:migrate:status")
 

--- a/railties/test/application/rake_test.rb
+++ b/railties/test/application/rake_test.rb
@@ -177,7 +177,7 @@ module ApplicationTests
         end
       RUBY
 
-      output = Dir.chdir(app_path) { `bin/rails do_something RAILS_ENV=production` }
+      output = Dir.chdir(app_path) { %x(bin/rails do_something RAILS_ENV=production) }
       assert_equal "Answer: 42\n", output.lines.last
     end
 

--- a/railties/test/application/runner_test.rb
+++ b/railties/test/application/runner_test.rb
@@ -55,7 +55,7 @@ module ApplicationTests
       p $LOADED_FEATURES.grep(/minitest/)
       SCRIPT
       assert_match "[]", Dir.chdir(app_path) {
-        `RAILS_ENV=production bin/rails runner "bin/print_features.rb"`
+        %x(RAILS_ENV=production bin/rails runner "bin/print_features.rb")
       }
     end
 
@@ -88,7 +88,7 @@ module ApplicationTests
       puts User.count
       SCRIPT
 
-      assert_match "42", Dir.chdir(app_path) { `cat bin/count_users.rb | bin/rails runner -` }
+      assert_match "42", Dir.chdir(app_path) { %x(cat bin/count_users.rb | bin/rails runner -) }
     end
 
     def test_with_hook

--- a/railties/test/application/test_runner_test.rb
+++ b/railties/test/application/test_runner_test.rb
@@ -345,7 +345,7 @@ module ApplicationTests
       RUBY
 
       Dir.chdir(app_path) do
-        `ruby -Itest test/models/post_test.rb`.tap do |output|
+        %x(ruby -Itest test/models/post_test.rb).tap do |output|
           assert_match "PostTest", output
           assert_no_match "is already defined in", output
         end
@@ -977,7 +977,7 @@ module ApplicationTests
       create_test_file :models, "post", pass: false
       # This specifically verifies TEST for backwards compatibility with rake test
       # as `bin/rails test` already supports running tests from a single file more cleanly.
-      output = Dir.chdir(app_path) { `bin/rake test TEST=test/models/post_test.rb` }
+      output = Dir.chdir(app_path) { %x(bin/rake test TEST=test/models/post_test.rb) }
 
       assert_match "PostTest", output, "passing TEST= should run selected test"
       assert_no_match "AccountTest", output, "passing TEST= should only run selected test"
@@ -986,7 +986,7 @@ module ApplicationTests
 
     def test_pass_rake_options
       create_test_file :models, "account"
-      output = Dir.chdir(app_path) { `bin/rake --rakefile Rakefile --trace=stdout test` }
+      output = Dir.chdir(app_path) { %x(bin/rake --rakefile Rakefile --trace=stdout test) }
 
       assert_match "1 runs, 1 assertions", output
       assert_match "Execute test", output
@@ -995,7 +995,7 @@ module ApplicationTests
     def test_rails_db_create_all_restores_db_connection
       create_test_file :models, "account"
       rails "db:create:all", "db:migrate"
-      output = Dir.chdir(app_path) { `echo ".tables" | rails dbconsole` }
+      output = Dir.chdir(app_path) { %x(echo ".tables" | rails dbconsole) }
       assert_match "ar_internal_metadata", output, "tables should be dumped"
     end
 
@@ -1003,13 +1003,13 @@ module ApplicationTests
       create_test_file :models, "account"
       rails "db:create:all" # create all to avoid warnings
       rails "db:drop:all", "db:create:all", "db:migrate"
-      output = Dir.chdir(app_path) { `echo ".tables" | rails dbconsole` }
+      output = Dir.chdir(app_path) { %x(echo ".tables" | rails dbconsole) }
       assert_match "ar_internal_metadata", output, "tables should be dumped"
     end
 
     def test_rake_passes_TESTOPTS_to_minitest
       create_test_file :models, "account"
-      output = Dir.chdir(app_path) { `bin/rake test TESTOPTS=-v` }
+      output = Dir.chdir(app_path) { %x(bin/rake test TESTOPTS=-v) }
       assert_match "AccountTest#test_truth", output, "passing TESTOPTS= should be sent to the test runner"
     end
 
@@ -1020,7 +1020,7 @@ module ApplicationTests
 
       file = create_test_for_env("test")
       results = Dir.chdir(app_path) {
-        `ruby -Ilib:test #{file}`.each_line.filter_map { |line| JSON.parse(line) if line.start_with?("{") }
+        %x(ruby -Ilib:test #{file}).each_line.filter_map { |line| JSON.parse(line) if line.start_with?("{") }
       }
       assert_equal 1, results.length
       failures = results.first["failures"]
@@ -1037,7 +1037,7 @@ module ApplicationTests
 
       file = create_test_for_env("development")
       results = Dir.chdir(app_path) {
-        `RAILS_ENV=development ruby -Ilib:test #{file}`.each_line.
+        %x(RAILS_ENV=development ruby -Ilib:test #{file}).each_line.
           filter_map { |line| JSON.parse(line) if line.start_with?("{") }
       }
       assert_equal 1, results.length
@@ -1050,7 +1050,7 @@ module ApplicationTests
 
     def test_rake_passes_multiple_TESTOPTS_to_minitest
       create_test_file :models, "account"
-      output = Dir.chdir(app_path) { `bin/rake test TESTOPTS='-v --seed=1234'` }
+      output = Dir.chdir(app_path) { %x(bin/rake test TESTOPTS='-v --seed=1234') }
       assert_match "AccountTest#test_truth", output, "passing TEST= should run selected test"
       assert_match "seed=1234", output, "passing TEST= should run selected test"
     end
@@ -1058,14 +1058,14 @@ module ApplicationTests
     def test_rake_runs_multiple_test_tasks
       create_test_file :models, "account"
       create_test_file :controllers, "accounts_controller"
-      output = Dir.chdir(app_path) { `bin/rake test:models test:controllers TESTOPTS='-v'` }
+      output = Dir.chdir(app_path) { %x(bin/rake test:models test:controllers TESTOPTS='-v') }
       assert_match "AccountTest#test_truth", output
       assert_match "AccountsControllerTest#test_truth", output
     end
 
     def test_rake_db_and_test_tasks_parses_args_correctly
       create_test_file :models, "account"
-      output = Dir.chdir(app_path) { `bin/rake db:migrate test:models TESTOPTS='-v' && echo ".tables" | rails dbconsole` }
+      output = Dir.chdir(app_path) { %x(bin/rake db:migrate test:models TESTOPTS='-v' && echo ".tables" | rails dbconsole) }
       assert_match "AccountTest#test_truth", output
       assert_match "ar_internal_metadata", output
     end
@@ -1076,7 +1076,7 @@ module ApplicationTests
           puts "echo"
         end
       RUBY
-      output = Dir.chdir(app_path) { `bin/rake test echo` }
+      output = Dir.chdir(app_path) { %x(bin/rake test echo) }
       assert_equal "echo", output.split("\n").last
     end
 
@@ -1087,7 +1087,7 @@ module ApplicationTests
           puts "echo"
         end
       RUBY
-      output = Dir.chdir(app_path) { `bin/rake test echo` }
+      output = Dir.chdir(app_path) { %x(bin/rake test echo) }
       assert_no_match "echo", output
       assert_not_predicate $?, :success?
     end
@@ -1211,7 +1211,7 @@ module ApplicationTests
         end
       RUBY
 
-      output = Dir.chdir(app_path) { `bin/rake test` }
+      output = Dir.chdir(app_path) { %x(bin/rake test) }
       assert_match "0 runs, 0 assertions, 0 failures, 0 errors, 0 skips", output
     end
 
@@ -1227,7 +1227,7 @@ module ApplicationTests
         end
       RUBY
 
-      output = Dir.chdir(app_path) { `bin/rake test TEST=test/system/dummy_test.rb` }
+      output = Dir.chdir(app_path) { %x(bin/rake test TEST=test/system/dummy_test.rb) }
       assert_match "1 runs, 1 assertions, 0 failures, 0 errors, 0 skips", output
     end
 
@@ -1248,7 +1248,7 @@ module ApplicationTests
     def test_can_exclude_files_from_being_tested_via_rake_task_by_setting_DEFAULT_TEST_EXCLUDE_env_var
       create_test_file "smoke", "smoke_foo"
 
-      output = Dir.chdir(app_path) { `DEFAULT_TEST_EXCLUDE="test/smoke/**/*_test.rb" bin/rake test` }
+      output = Dir.chdir(app_path) { %x(DEFAULT_TEST_EXCLUDE="test/smoke/**/*_test.rb" bin/rake test) }
       assert_match "0 runs, 0 assertions, 0 failures, 0 errors, 0 skips", output
     end
 

--- a/railties/test/commands/credentials_test.rb
+++ b/railties/test/commands/credentials_test.rb
@@ -252,7 +252,7 @@ class Rails::Command::CredentialsTest < ActiveSupport::TestCase
     assert_match %r/git diff driver/i, run_edit_command
 
     Dir.chdir(app_path) do
-      assert_equal "bin/rails credentials:diff", `git config --get 'diff.rails_credentials.textconv'`.strip
+      assert_equal "bin/rails credentials:diff", %x(git config --get 'diff.rails_credentials.textconv').strip
     end
 
     assert_no_match %r/git diff driver/i, run_edit_command

--- a/railties/test/commands/db_system_change_test.rb
+++ b/railties/test/commands/db_system_change_test.rb
@@ -54,7 +54,7 @@ class Rails::Command::DbSystemChangeTest < ActiveSupport::TestCase
   end
 
   test "change can be forced" do
-    output = `cd #{app_path}; bin/rails db:system:change --to=postgresql --force`
+    output = %x(cd #{app_path}; bin/rails db:system:change --to=postgresql --force)
 
     assert_match "force  config/database.yml", output
     assert_match "gsub  Gemfile", output

--- a/railties/test/commands/runner_test.rb
+++ b/railties/test/commands/runner_test.rb
@@ -10,7 +10,7 @@ class Rails::RunnerTest < ActiveSupport::TestCase
   teardown :teardown_app
 
   def test_rails_runner_with_stdin
-    command_output = `echo "puts 'Hello world'" | #{app_path}/bin/rails runner -`
+    command_output = %x(echo "puts 'Hello world'" | #{app_path}/bin/rails runner -)
 
     assert_equal <<~OUTPUT, command_output
       Hello world

--- a/railties/test/engine/commands_test.rb
+++ b/railties/test/engine/commands_test.rb
@@ -20,7 +20,7 @@ class Rails::Engine::CommandsTest < ActiveSupport::TestCase
 
   def test_help_command_work_inside_engine
     output = capture(:stderr) do
-      in_plugin_context(plugin_path) { `bin/rails --help` }
+      in_plugin_context(plugin_path) { %x(bin/rails --help) }
     end
     assert_no_match "NameError", output
   end

--- a/railties/test/engine/test_test.rb
+++ b/railties/test/engine/test_test.rb
@@ -18,11 +18,11 @@ class Rails::Engine::TestTest < ActiveSupport::TestCase
   test "automatically synchronize test schema" do
     in_plugin_context(plugin_path) do
       # In order to confirm that migration files are loaded, generate multiple migration files.
-      `bin/rails generate model user name:string;
+      %x(bin/rails generate model user name:string;
        bin/rails generate model todo name:string;
-       RAILS_ENV=development bin/rails db:migrate`
+       RAILS_ENV=development bin/rails db:migrate)
 
-      output = `bin/rails test test/models/bukkits/user_test.rb`
+      output = %x(bin/rails test test/models/bukkits/user_test.rb)
       assert_includes(output, "0 runs, 0 assertions, 0 failures, 0 errors, 0 skips")
     end
   end

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -147,7 +147,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
     run_generator
     output = nil
     Dir.chdir(destination_root) do
-      output = `#{File.expand_path("../../exe/rails", __dir__)} new mysecondapp`
+      output = %x(#{File.expand_path("../../exe/rails", __dir__)} new mysecondapp)
     end
     assert_equal "Can't initialize a new Rails application within the directory of another, please change to a non-Rails directory first.\nType 'rails' for help.\n", output
     assert_equal false, $?.success?
@@ -156,7 +156,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
   def test_application_new_show_help_message_inside_existing_rails_directory
     run_generator
     output = Dir.chdir(destination_root) do
-      `#{File.expand_path("../../exe/rails", __dir__)} new --help`
+      %x(#{File.expand_path("../../exe/rails", __dir__)} new --help)
     end
     assert_match(/rails new APP_PATH \[options\]/, output)
     assert_equal true, $?.success?
@@ -611,7 +611,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
     run_generator [destination_root, "--skip-system-test"]
 
     Dir.chdir(destination_root) do
-      quietly { `./bin/rails g scaffold User` }
+      quietly { %x(./bin/rails g scaffold User) }
 
       assert_no_file("test/application_system_test_case.rb")
       assert_no_file("test/system/users_test.rb")
@@ -1078,31 +1078,31 @@ class AppGeneratorTest < Rails::Generators::TestCase
   end
 
   def test_default_branch_main_without_user_default
-    current_default_branch = `git config --global init.defaultBranch`
-    `git config --global --unset init.defaultBranch`
+    current_default_branch = %x(git config --global init.defaultBranch)
+    %x(git config --global --unset init.defaultBranch)
 
     run_generator [destination_root]
     assert_file ".git/HEAD", /main/
   ensure
     if !current_default_branch.strip.empty?
-      `git config --global init.defaultBranch #{current_default_branch}`
+      %x(git config --global init.defaultBranch #{current_default_branch})
     end
   end
 
   def test_version_control_initializes_git_repo_with_user_default_branch
-    git_version = `git --version`[/\d+.\d+.\d+/]
+    git_version = %x(git --version)[/\d+.\d+.\d+/]
     return if Gem::Version.new(git_version) < Gem::Version.new("2.28.0")
 
-    current_default_branch = `git config --global init.defaultBranch`
-    `git config --global init.defaultBranch master`
+    current_default_branch = %x(git config --global init.defaultBranch)
+    %x(git config --global init.defaultBranch master)
 
     run_generator [destination_root]
     assert_file ".git/HEAD", /master/
   ensure
     if current_default_branch && current_default_branch.strip.empty?
-      `git config --global --unset init.defaultBranch`
+      %x(git config --global --unset init.defaultBranch)
     elsif current_default_branch
-      `git config --global init.defaultBranch #{current_default_branch}`
+      %x(git config --global init.defaultBranch #{current_default_branch})
     end
   end
 

--- a/railties/test/generators/plugin_generator_test.rb
+++ b/railties/test/generators/plugin_generator_test.rb
@@ -135,31 +135,31 @@ class PluginGeneratorTest < Rails::Generators::TestCase
   end
 
   def test_initializes_git_repo_with_main_branch_without_user_default
-    current_default_branch = `git config --global init.defaultBranch`
-    `git config --global --unset init.defaultBranch`
+    current_default_branch = %x(git config --global init.defaultBranch)
+    %x(git config --global --unset init.defaultBranch)
 
     run_generator
     assert_file ".git/HEAD", /main/
   ensure
     if !current_default_branch.strip.empty?
-      `git config --global init.defaultBranch #{current_default_branch}`
+      %x(git config --global init.defaultBranch #{current_default_branch})
     end
   end
 
   def test_version_control_initializes_git_repo_with_user_default_branch
-    git_version = `git --version`[/\d+.\d+.\d+/]
+    git_version = %x(git --version)[/\d+.\d+.\d+/]
     return if Gem::Version.new(git_version) < Gem::Version.new("2.28.0")
 
-    current_default_branch = `git config --global init.defaultBranch`
-    `git config --global init.defaultBranch master`
+    current_default_branch = %x(git config --global init.defaultBranch)
+    %x(git config --global init.defaultBranch master)
 
     run_generator
     assert_file ".git/HEAD", /master/
   ensure
     if current_default_branch && current_default_branch.strip.empty?
-      `git config --global --unset init.defaultBranch`
+      %x(git config --global --unset init.defaultBranch)
     elsif current_default_branch
-      `git config --global init.defaultBranch #{current_default_branch}`
+      %x(git config --global init.defaultBranch #{current_default_branch})
     end
   end
 
@@ -314,7 +314,7 @@ class PluginGeneratorTest < Rails::Generators::TestCase
 
     in_plugin_context(destination_root) do
       quietly { system "bundle install" }
-      output = `bin/rails db:migrate 2>&1`
+      output = %x(bin/rails db:migrate 2>&1)
       assert_predicate $?, :success?, "Command failed: #{output}"
     end
   end
@@ -590,7 +590,7 @@ class PluginGeneratorTest < Rails::Generators::TestCase
     prepare_plugin(destination_root)
 
     in_plugin_context(destination_root) do
-      output = `bin/test 2>&1`
+      output = %x(bin/test 2>&1)
       assert_predicate $?, :success?, "Command failed: #{output}"
     end
   end
@@ -762,7 +762,7 @@ class PluginGeneratorTest < Rails::Generators::TestCase
     run_generator [destination_root, "--mountable"]
 
     capture(:stdout) do
-      `#{destination_root}/bin/rails g controller admin/dashboard foo`
+      %x(#{destination_root}/bin/rails g controller admin/dashboard foo)
     end
 
     assert_file "config/routes.rb" do |contents|
@@ -772,8 +772,8 @@ class PluginGeneratorTest < Rails::Generators::TestCase
   end
 
   def test_git_name_and_email_in_gemspec_file
-    name = `git config user.name`.chomp rescue "TODO: Write your name"
-    email = `git config user.email`.chomp rescue "TODO: Write your email address"
+    name = %x(git config user.name).chomp rescue "TODO: Write your name"
+    email = %x(git config user.email).chomp rescue "TODO: Write your email address"
 
     run_generator
     assert_file "bukkits.gemspec" do |contents|
@@ -783,7 +783,7 @@ class PluginGeneratorTest < Rails::Generators::TestCase
   end
 
   def test_git_name_in_license_file
-    name = `git config user.name`.chomp rescue "TODO: Write your name"
+    name = %x(git config user.name).chomp rescue "TODO: Write your name"
 
     run_generator
     assert_file "MIT-LICENSE" do |contents|
@@ -855,7 +855,7 @@ class PluginGeneratorTest < Rails::Generators::TestCase
     run_generator [destination_root, "--mountable", "--api"]
 
     capture(:stdout) do
-      `#{destination_root}/bin/rails g scaffold article`
+      %x(#{destination_root}/bin/rails g scaffold article)
     end
 
     assert_file "app/models/bukkits/article.rb"
@@ -871,7 +871,7 @@ class PluginGeneratorTest < Rails::Generators::TestCase
   def test_model_with_existent_application_record_in_mountable_engine
     run_generator [destination_root, "--mountable"]
     capture(:stdout) do
-      `#{destination_root}/bin/rails g model article`
+      %x(#{destination_root}/bin/rails g model article)
     end
 
     assert_file "app/models/bukkits/article.rb", /class Article < ApplicationRecord/
@@ -881,7 +881,7 @@ class PluginGeneratorTest < Rails::Generators::TestCase
     run_generator [destination_root, "--mountable"]
     FileUtils.rm "#{destination_root}/app/mailers/bukkits/application_mailer.rb"
     capture(:stdout) do
-      `#{destination_root}/bin/rails g mailer User`
+      %x(#{destination_root}/bin/rails g mailer User)
     end
 
     assert_file "#{destination_root}/app/mailers/bukkits/application_mailer.rb" do |mailer|
@@ -893,7 +893,7 @@ class PluginGeneratorTest < Rails::Generators::TestCase
   def test_generate_mailer_layouts_when_does_not_exist_in_mountable_engine
     run_generator [destination_root, "--mountable"]
     capture(:stdout) do
-      `#{destination_root}/bin/rails g mailer User`
+      %x(#{destination_root}/bin/rails g mailer User)
     end
 
     assert_file "#{destination_root}/app/views/layouts/bukkits/mailer.text.erb" do |view|
@@ -909,7 +909,7 @@ class PluginGeneratorTest < Rails::Generators::TestCase
     run_generator [destination_root, "--mountable"]
     FileUtils.rm "#{destination_root}/app/jobs/bukkits/application_job.rb"
     capture(:stdout) do
-      `#{destination_root}/bin/rails g job refresh_counters`
+      %x(#{destination_root}/bin/rails g job refresh_counters)
     end
 
     assert_file "#{destination_root}/app/jobs/bukkits/application_job.rb" do |record|

--- a/railties/test/generators/plugin_test_runner_test.rb
+++ b/railties/test/generators/plugin_test_runner_test.rb
@@ -120,7 +120,7 @@ class PluginTestRunnerTest < ActiveSupport::TestCase
 
     def run_test_command(arguments = "")
       Dir.chdir(plugin_path) do
-        switch_env("BUNDLE_GEMFILE", "") { `bin/test #{arguments}` }
+        switch_env("BUNDLE_GEMFILE", "") { %x(bin/test #{arguments}) }
       end
     end
 end

--- a/railties/test/generators/scaffold_controller_generator_test.rb
+++ b/railties/test/generators/scaffold_controller_generator_test.rb
@@ -276,9 +276,9 @@ class ScaffoldControllerGeneratorTest < Rails::Generators::TestCase
     engine_path = File.join(destination_root, "bukkits")
 
     with_new_plugin(engine_path, "--mountable") do
-      quietly { `bin/rails g controller dashboard foo` }
-      quietly { `bin/rails db:migrate RAILS_ENV=test` }
-      assert_match(/2 runs, 2 assertions, 0 failures, 0 errors/, `bin/rails test 2>&1`)
+      quietly { %x(bin/rails g controller dashboard foo) }
+      quietly { %x(bin/rails db:migrate RAILS_ENV=test) }
+      assert_match(/2 runs, 2 assertions, 0 failures, 0 errors/, %x(bin/rails test 2>&1))
     end
   end
 
@@ -286,9 +286,9 @@ class ScaffoldControllerGeneratorTest < Rails::Generators::TestCase
     engine_path = File.join(destination_root, "bukkits")
 
     with_new_plugin(engine_path, "--full") do
-      quietly { `bin/rails g controller dashboard foo` }
-      quietly { `bin/rails db:migrate RAILS_ENV=test` }
-      assert_match(/2 runs, 2 assertions, 0 failures, 0 errors/, `bin/rails test 2>&1`)
+      quietly { %x(bin/rails g controller dashboard foo) }
+      quietly { %x(bin/rails db:migrate RAILS_ENV=test) }
+      assert_match(/2 runs, 2 assertions, 0 failures, 0 errors/, %x(bin/rails test 2>&1))
     end
   end
 

--- a/railties/test/generators/scaffold_generator_test.rb
+++ b/railties/test/generators/scaffold_generator_test.rb
@@ -573,10 +573,10 @@ class ScaffoldGeneratorTest < Rails::Generators::TestCase
 
     with_new_plugin(engine_path, "--mountable") do
       quietly do
-        `bin/rails g scaffold User name:string age:integer;
-        bin/rails db:migrate`
+        %x(bin/rails g scaffold User name:string age:integer;
+        bin/rails db:migrate)
       end
-      assert_match(/8 runs, 12 assertions, 0 failures, 0 errors/, `bin/rails test 2>&1`)
+      assert_match(/8 runs, 12 assertions, 0 failures, 0 errors/, %x(bin/rails test 2>&1))
     end
   end
 
@@ -585,8 +585,8 @@ class ScaffoldGeneratorTest < Rails::Generators::TestCase
 
     with_new_plugin(engine_path, "--mountable") do
       quietly do
-        `bin/rails g scaffold User name:string age:integer;
-        bin/rails db:migrate`
+        %x(bin/rails g scaffold User name:string age:integer;
+        bin/rails db:migrate)
       end
 
       assert_file "bukkits-admin/app/controllers/bukkits/admin/users_controller.rb" do |content|
@@ -594,7 +594,7 @@ class ScaffoldGeneratorTest < Rails::Generators::TestCase
         assert_match(/class UsersController < ApplicationController/, content)
       end
 
-      assert_match(/8 runs, 12 assertions, 0 failures, 0 errors/, `bin/rails test 2>&1`)
+      assert_match(/8 runs, 12 assertions, 0 failures, 0 errors/, %x(bin/rails test 2>&1))
     end
   end
 
@@ -603,10 +603,10 @@ class ScaffoldGeneratorTest < Rails::Generators::TestCase
 
     with_new_plugin(engine_path, "--full") do
       quietly do
-        `bin/rails g scaffold User name:string age:integer;
-        bin/rails db:migrate`
+        %x(bin/rails g scaffold User name:string age:integer;
+        bin/rails db:migrate)
       end
-      assert_match(/8 runs, 12 assertions, 0 failures, 0 errors/, `bin/rails test 2>&1`)
+      assert_match(/8 runs, 12 assertions, 0 failures, 0 errors/, %x(bin/rails test 2>&1))
     end
   end
 
@@ -615,10 +615,10 @@ class ScaffoldGeneratorTest < Rails::Generators::TestCase
 
     with_new_plugin(engine_path, "--mountable", "--api") do
       quietly do
-        `bin/rails g scaffold User name:string age:integer;
-        bin/rails db:migrate`
+        %x(bin/rails g scaffold User name:string age:integer;
+        bin/rails db:migrate)
       end
-      assert_match(/6 runs, 10 assertions, 0 failures, 0 errors/, `bin/rails test 2>&1`)
+      assert_match(/6 runs, 10 assertions, 0 failures, 0 errors/, %x(bin/rails test 2>&1))
     end
   end
 
@@ -627,19 +627,19 @@ class ScaffoldGeneratorTest < Rails::Generators::TestCase
 
     with_new_plugin(engine_path, "--full", "--api") do
       quietly do
-        `bin/rails g scaffold User name:string age:integer;
-        bin/rails db:migrate`
+        %x(bin/rails g scaffold User name:string age:integer;
+        bin/rails db:migrate)
       end
-      assert_match(/6 runs, 10 assertions, 0 failures, 0 errors/, `bin/rails test 2>&1`)
+      assert_match(/6 runs, 10 assertions, 0 failures, 0 errors/, %x(bin/rails test 2>&1))
     end
   end
 
   def test_scaffold_on_invoke_inside_mountable_engine
-    Dir.chdir(destination_root) { `bundle exec rails plugin new bukkits --mountable` }
+    Dir.chdir(destination_root) { %x(bundle exec rails plugin new bukkits --mountable) }
     engine_path = File.join(destination_root, "bukkits")
 
     Dir.chdir(engine_path) do
-      quietly { `bin/rails generate scaffold User name:string age:integer` }
+      quietly { %x(bin/rails generate scaffold User name:string age:integer) }
 
       assert File.exist?("app/models/bukkits/user.rb")
       assert File.exist?("test/models/bukkits/user_test.rb")
@@ -661,12 +661,12 @@ class ScaffoldGeneratorTest < Rails::Generators::TestCase
   end
 
   def test_scaffold_on_revoke_inside_mountable_engine
-    Dir.chdir(destination_root) { `bundle exec rails plugin new bukkits --mountable` }
+    Dir.chdir(destination_root) { %x(bundle exec rails plugin new bukkits --mountable) }
     engine_path = File.join(destination_root, "bukkits")
 
     Dir.chdir(engine_path) do
-      quietly { `bin/rails generate scaffold User name:string age:integer` }
-      quietly { `bin/rails destroy scaffold User` }
+      quietly { %x(bin/rails generate scaffold User name:string age:integer) }
+      quietly { %x(bin/rails destroy scaffold User) }
 
       assert_not File.exist?("app/models/bukkits/user.rb")
       assert_not File.exist?("test/models/bukkits/user_test.rb")

--- a/railties/test/generators/test_runner_in_engine_test.rb
+++ b/railties/test/generators/test_runner_in_engine_test.rb
@@ -38,7 +38,7 @@ class TestRunnerInEngineTest < ActiveSupport::TestCase
 
     def run_test_command(arguments = "")
       Dir.chdir(plugin_path) do
-        switch_env("BUNDLE_GEMFILE", "") { `bin/rails test #{arguments}` }
+        switch_env("BUNDLE_GEMFILE", "") { %x(bin/rails test #{arguments}) }
       end
     end
 end

--- a/railties/test/isolation/abstract_unit.rb
+++ b/railties/test/isolation/abstract_unit.rb
@@ -403,7 +403,7 @@ module TestHelpers
       else
         ENV["BOOTSNAP_CACHE_DIR"] = bootsnap_cache_path
         begin
-          output = `cd #{app_path}; #{command}`
+          output = %x(cd #{app_path}; #{command})
         ensure
           ENV.delete("BOOTSNAP_CACHE_DIR")
         end
@@ -594,7 +594,7 @@ Module.new do
   extend TestHelpers::Paths
 
   def self.sh(cmd)
-    output = `#{cmd}`
+    output = %x(#{cmd})
     raise "Command #{cmd.inspect} failed. Output:\n#{output}" unless $?.success?
   end
 

--- a/railties/test/railties/engine_test.rb
+++ b/railties/test/railties/engine_test.rb
@@ -68,7 +68,7 @@ module RailtiesTest
       RUBY
 
       Dir.chdir(@plugin.path) do
-        output = `bundle exec rake foo`
+        output = %x(bundle exec rake foo)
         assert_match "Task ran", output
       end
     end
@@ -102,7 +102,7 @@ module RailtiesTest
       boot_rails
 
       Dir.chdir(app_path) do
-        output = `bundle exec rake bukkits:install:migrations`
+        output = %x(bundle exec rake bukkits:install:migrations)
 
         ["CreateUsers", "AddLastNameToUsers", "CreateSessions"].each do |migration_name|
           assert migrations.detect { |migration| migration.name == migration_name }
@@ -115,7 +115,7 @@ module RailtiesTest
 
         assert_equal migrations.length, migrations_count
 
-        output = `bundle exec rake railties:install:migrations`.split("\n")
+        output = %x(bundle exec rake railties:install:migrations).split("\n")
 
         assert_equal migrations_count, Dir["#{app_path}/db/migrate/*.rb"].length
 
@@ -155,7 +155,7 @@ module RailtiesTest
       boot_rails
 
       Dir.chdir(app_path) do
-        output = `bundle exec rake bukkits:install:migrations DATABASE=animals`
+        output = %x(bundle exec rake bukkits:install:migrations DATABASE=animals)
 
         ["CreateUsers", "AddLastNameToUsers", "CreateSessions"].each do |migration_name|
           assert migrations("animals").detect { |migration| migration.name == migration_name }
@@ -168,7 +168,7 @@ module RailtiesTest
 
         assert_equal migrations("animals").length, migrations_count
 
-        output = `bundle exec rake railties:install:migrations DATABASE=animals`.split("\n")
+        output = %x(bundle exec rake railties:install:migrations DATABASE=animals).split("\n")
 
         assert_equal migrations_count, Dir["#{app_path}/db/animals_migrate/*.rb"].length
 
@@ -206,7 +206,7 @@ module RailtiesTest
       boot_rails
 
       Dir.chdir(app_path) do
-        output = `bundle exec rake railties:install:migrations`.split("\n")
+        output = %x(bundle exec rake railties:install:migrations).split("\n")
 
         assert_match(/Copied migration \d+_create_users\.bukkits\.rb from bukkits/, output.first)
         assert_match(/Copied migration \d+_create_blogs\.blog_engine\.rb from blog_engine/, output.second)
@@ -245,7 +245,7 @@ module RailtiesTest
       boot_rails
 
       Dir.chdir(app_path) do
-        output = `bundle exec rake railties:install:migrations`.split("\n")
+        output = %x(bundle exec rake railties:install:migrations).split("\n")
 
         assert_match(/Copied migration \d+_create_users\.core_engine\.rb from core_engine/, output.first)
         assert_match(/Copied migration \d+_create_keys\.api_engine\.rb from api_engine/, output.second)
@@ -276,7 +276,7 @@ module RailtiesTest
       boot_rails
 
       Dir.chdir(@plugin.path) do
-        output = `bundle exec rake app:bukkits:install:migrations`
+        output = %x(bundle exec rake app:bukkits:install:migrations)
 
         migration_with_engine_path = migrations.detect { |migration| migration.name == "AddFirstNameToUsers" }
         assert migration_with_engine_path
@@ -1870,7 +1870,7 @@ en:
     end
 
     def assert_command_succeeds(command)
-      output = `#{command}`
+      output = %x(#{command})
       assert_predicate $?, :success?, "Command did not succeed: #{command}\n#{output}"
     end
   end

--- a/railties/test/railties/generators_test.rb
+++ b/railties/test/railties/generators_test.rb
@@ -24,11 +24,11 @@ module RailtiesTests
     end
 
     def bundled_rails(cmd)
-      `bundle exec rails #{cmd}`
+      %x(bundle exec rails #{cmd})
     end
 
     def rails(cmd)
-      `#{Gem.ruby} #{RAILS_FRAMEWORK_ROOT}/railties/exe/rails #{cmd}`
+      %x(#{Gem.ruby} #{RAILS_FRAMEWORK_ROOT}/railties/exe/rails #{cmd})
     end
 
     def build_engine(is_mountable = false)

--- a/tasks/release.rb
+++ b/tasks/release.rb
@@ -101,7 +101,7 @@ npm_version = version.gsub(/\./).with_index { |s, i| i >= 2 ? "-" : s }
     task push: :build do
       otp = ""
       begin
-        otp = " --otp " + `ykman oath accounts code -s rubygems.org`.chomp
+        otp = " --otp " + %x(ykman oath accounts code -s rubygems.org).chomp
       rescue
         # User doesn't have ykman
       end
@@ -112,7 +112,7 @@ npm_version = version.gsub(/\./).with_index { |s, i| i >= 2 ? "-" : s }
         Dir.chdir("#{framework}") do
           npm_otp = ""
           begin
-            npm_otp = " --otp " + `ykman oath accounts code -s npmjs.com`.chomp
+            npm_otp = " --otp " + %x(ykman oath accounts code -s npmjs.com).chomp
           rescue
             # User doesn't have ykman
           end
@@ -187,11 +187,11 @@ namespace :all do
   task push: FRAMEWORKS.map { |f| "#{f}:push"            } + ["rails:push"]
 
   task :ensure_clean_state do
-    unless `git status -s | grep -v 'RAILS_VERSION\\|CHANGELOG\\|Gemfile.lock\\|package.json\\|version.rb\\|tasks/release.rb'`.strip.empty?
+    unless %x(git status -s | grep -v 'RAILS_VERSION\\|CHANGELOG\\|Gemfile.lock\\|package.json\\|version.rb\\|tasks/release.rb').strip.empty?
       abort "[ABORTING] `git status` reports a dirty tree. Make sure all changes are committed"
     end
 
-    unless ENV["SKIP_TAG"] || `git tag | grep '^#{tag}$'`.strip.empty?
+    unless ENV["SKIP_TAG"] || %x(git tag | grep '^#{tag}$').strip.empty?
       abort "[ABORTING] `git tag` shows that #{tag} already exists. Has this version already\n"\
             "           been released? Git tagging can be skipped by setting SKIP_TAG=1"
     end
@@ -249,7 +249,7 @@ namespace :all do
 
     editor = ENV["VISUAL"] || ENV["EDITOR"]
     if editor
-      `#{editor} #{File.expand_path(app_name)}`
+      %x(#{editor} #{File.expand_path(app_name)})
     end
 
     puts "Booting a Rails server. Verify the release by:"
@@ -272,7 +272,7 @@ namespace :all do
   end
 
   task :commit do
-    unless `git status -s`.strip.empty?
+    unless %x(git status -s).strip.empty?
       File.open("pkg/commit_message.txt", "w") do |f|
         f.puts "# Preparing for #{version} release\n"
         f.puts
@@ -330,7 +330,7 @@ task :announce do
       future_date = Date.today + 5
       future_date += 1 while future_date.saturday? || future_date.sunday?
 
-      github_user = `git config github.user`.chomp
+      github_user = %x(git config github.user).chomp
     end
 
     require "erb"

--- a/tools/rail_inspector/lib/rail_inspector/configuring/check/framework_defaults.rb
+++ b/tools/rail_inspector/lib/rail_inspector/configuring/check/framework_defaults.rb
@@ -98,7 +98,7 @@ module RailInspector
                   code << configs.join("\n")
                   code.flush
 
-                  `git diff --color --no-index #{doc.path} #{code.path}`
+                  %x(git diff --color --no-index #{doc.path} #{code.path})
                 end
               end
 

--- a/tools/rail_inspector/rail_inspector.gemspec
+++ b/tools/rail_inspector/rail_inspector.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
   spec.files = Dir.chdir(__dir__) do
-    `git ls-files -z`.split("\x0").reject do |f|
+    %x(git ls-files -z).split("\x0").reject do |f|
       (File.expand_path(f) == __FILE__) || f.start_with?(*%w[bin/ test/ spec/ features/ .git .circleci appveyor])
     end
   end


### PR DESCRIPTION
### Motivation / Background

PR #49624 contained commit 0c76f17f which mistakenly used backticks instead of normal string quotes. This is easy to miss, but is a bug-without-test-failures at best and an opportunity for an attack vector at worst.

Forcing the use of `%x()` should make it more obvious visually where the command literals are.

See related #51739

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] ~Tests are added or updated if you fix a bug or add a feature.~
* [ ] ~CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.~
