### PR TITLE
Fix select helper with block returning non-string

### DIFF
--- a/actionview/lib/action_view/helpers/tags/select.rb
+++ b/actionview/lib/action_view/helpers/tags/select.rb
@@ -8,7 +8,7 @@ module ActionView
         include FormOptionsHelper
 
         def initialize(object_name, method_name, template_object, choices, options, html_options)
-          @choices = block_given? ? template_object.capture { yield || "" } : choices
+          @choices = block_given? ? template_object.capture { yield } || "" : choices
           @choices = @choices.to_a if @choices.is_a?(Range)
 
           @html_options = html_options

--- a/actionview/lib/action_view/helpers/tags/select.rb
+++ b/actionview/lib/action_view/helpers/tags/select.rb
@@ -7,8 +7,8 @@ module ActionView
         include SelectRenderer
         include FormOptionsHelper
 
-        def initialize(object_name, method_name, template_object, choices, options, html_options)
-          @choices = block_given? ? template_object.capture { yield } || "" : choices
+        def initialize(object_name, method_name, template_object, choices, options, html_options, &block)
+          @choices = block_given? ? template_object.capture(&block) || "" : choices
           @choices = @choices.to_a if @choices.is_a?(Range)
 
           @html_options = html_options

--- a/actionview/test/template/form_options_helper_test.rb
+++ b/actionview/test/template/form_options_helper_test.rb
@@ -715,6 +715,19 @@ class FormOptionsHelperTest < ActionView::TestCase
     )
   end
 
+  def test_select_under_fields_for_with_block_returning_a_non_string_value
+    @post = Post.new
+
+    output_buffer = fields_for :post, @post do |f|
+      concat(f.select(:category) { [] })
+    end
+
+    assert_dom_equal(
+      "<select id=\"post_category\" name=\"post[category]\"></select>",
+      output_buffer
+    )
+  end
+
   def test_select_with_multiple_to_add_hidden_input
     output_buffer = select(:post, :category, "", {}, { multiple: true })
     assert_dom_equal(


### PR DESCRIPTION
As suggested by the docs for [FormOptionsHelper#select][1], the helper can be called with a block to customize option tag attributes:

    select(report, :campaign_ids) do
      available_campaigns.each do |c|
        tag.option(c.name, value: c.id, data: { tags: c.tags.to_json })
      end
    end

Prior to this commit, a NoMethodError error would be raised when available_campaigns in the above example was the empty array. This happened because the block passed to select would return a non-string value (the empty array) causing the call to capture in Helpers::Tags::Select#initialize to return nil:

    def initialize(object_name, method_name, template_object, choices, options, html_options)
      @choices = block_given? ? template_object.capture { yield || "" } : choices

This commit fixes this by moving the `|| ""` outside the block passed to capture.

[1]: https://api.rubyonrails.org/classes/ActionView/Helpers/FormOptionsHelper.html#method-i-select