### PR TITLE
Avoid allocating a column_type Hash when unnecessary

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -1182,7 +1182,7 @@ module ActiveRecord
         #
         # This is an internal hook to make possible connection adapters to build
         # custom result objects with connection-specific data.
-        def build_result(columns:, rows:, column_types: {})
+        def build_result(columns:, rows:, column_types: nil)
           ActiveRecord::Result.new(columns, rows, column_types)
         end
 

--- a/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
@@ -71,7 +71,7 @@ module ActiveRecord
               fmod  = result.fmod i
               types[fname] = types[i] = get_oid_type(ftype, fmod, fname)
             end
-            build_result(columns: fields, rows: result.values, column_types: types)
+            build_result(columns: fields, rows: result.values, column_types: types.freeze)
           end
         end
 

--- a/activerecord/lib/active_record/result.rb
+++ b/activerecord/lib/active_record/result.rb
@@ -46,11 +46,11 @@ module ActiveRecord
       end
     end
 
-    def initialize(columns, rows, column_types = {})
+    def initialize(columns, rows, column_types = nil)
       @columns      = columns
       @rows         = rows
       @hash_rows    = nil
-      @column_types = column_types
+      @column_types = column_types || EMPTY_HASH
     end
 
     # Returns true if this result set includes the column named +name+
@@ -192,7 +192,11 @@ module ActiveRecord
           end
       end
 
-      EMPTY = new([].freeze, [].freeze, {}.freeze).freeze
+      empty_array = [].freeze
+      EMPTY_HASH = {}.freeze
+      private_constant :EMPTY_HASH
+
+      EMPTY = new(empty_array, empty_array, EMPTY_HASH).freeze
       private_constant :EMPTY
 
       EMPTY_ASYNC = FutureResult.wrap(EMPTY).freeze


### PR DESCRIPTION
Only the Postgres provide these types, so no point allocating a hash every time for other adapters.
