### PR TITLE
Explain that the default Dockerfile is intended for production

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/Dockerfile.tt
+++ b/railties/lib/rails/generators/rails/app/templates/Dockerfile.tt
@@ -1,5 +1,8 @@
 # syntax = docker/dockerfile:1
 
+# Note: This Dockerfile is optimized for production deployment and isn't a good base
+# for development enviroments.
+
 # Make sure RUBY_VERSION matches the Ruby version in .ruby-version
 ARG RUBY_VERSION=<%= gem_ruby_version %>
 FROM registry.docker.com/library/ruby:$RUBY_VERSION-slim as base


### PR DESCRIPTION
If people want to use Docker in development, they'd need a radically different setup, and are likely much better served by dev containers.
