### PR TITLE
Simplify `ActiveRecord::Result#hash_rows`

### DIFF
--- a/activerecord/test/cases/result_test.rb
+++ b/activerecord/test/cases/result_test.rb
@@ -115,5 +115,19 @@ module ActiveRecord
 
       assert_equal [[1.1, 2.2], [3.3, 4.4]], result.cast_values("col1" => Type::Float.new)
     end
+
+    test "each when two columns have the same name" do
+      result = Result.new(["foo", "foo"], [
+        ["col 1", "col 2"],
+        ["col 1", "col 2"],
+        ["col 1", "col 2"],
+      ])
+
+      assert_equal 2, result.columns.size
+      result.each do |row|
+        assert_equal 1, row.size
+        assert_equal "col 2", row["foo"]
+      end
+    end
   end
 end


### PR DESCRIPTION
Last big refactor was in https://github.com/rails/rails/pull/37614. Somewhat extracted from https://github.com/rails/rails/pull/51744.

The concern about columns with the same name didn't make much sense to me because in both code paths, the last one wins, so we can simplify the whole methods.

Additionally by implementing `columns_index`, we have a decent template always available.
