### PR TITLE
Add `active_record.postgresql_adapter_decode_dates` config

### DIFF
--- a/activerecord/lib/active_record/railtie.rb
+++ b/activerecord/lib/active_record/railtie.rb
@@ -217,6 +217,16 @@ To keep using the current cache store, you can turn off cache versioning entirel
       end
     end
 
+    initializer "active_record.postgresql_adapter_decode_dates" do
+      config.after_initialize do
+        if config.active_record.postgresql_adapter_decode_dates
+          ActiveSupport.on_load(:active_record_postgresqladapter) do
+            self.decode_dates = true
+          end
+        end
+      end
+    end
+
     initializer "active_record.set_configs" do |app|
       configs = app.config.active_record
 
@@ -245,7 +255,8 @@ To keep using the current cache store, you can turn off cache versioning entirel
           :cache_query_log_tags,
           :sqlite3_adapter_strict_strings_by_default,
           :check_schema_cache_dump_version,
-          :use_schema_cache_dump
+          :use_schema_cache_dump,
+          :postgresql_adapter_decode_dates,
         )
 
         configs.each do |k, v|

--- a/activerecord/test/cases/adapters/postgresql/date_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/date_test.rb
@@ -39,10 +39,4 @@ class PostgresqlDateTest < ActiveRecord::PostgreSQLTestCase
     topic = Topic.create!(last_read: date)
     assert_equal date, Topic.find(topic.id).last_read
   end
-
-  def test_date_decoder
-    date = ActiveRecord::Base.connection.select_value("select '2024-01-01'::date")
-    assert_equal Date.new(2024, 01, 01), date
-    assert_equal Date, date.class
-  end
 end

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -62,6 +62,7 @@ Below are the default values associated with each target version. In cases of co
 
 - [`config.active_job.enqueue_after_transaction_commit`](#config-active-job-enqueue-after-transaction-commit): `:default`
 - [`config.active_record.automatically_invert_plural_associations`](#config-active-record-automatically-invert-plural-associations): `true`
+- [`config.active_record.postgresql_adapter_decode_dates`](#config-active-record-postgresql-adapter-decode-dates): `true`
 - [`config.active_record.validate_migration_timestamps`](#config-active-record-validate-migration-timestamps): `true`
 - [`config.active_storage.web_image_content_types`](#config-active-storage-web-image-content-types): `%w[image/png image/jpeg image/gif image/webp]`
 
@@ -1489,6 +1490,24 @@ The default value depends on the `config.load_defaults` target version:
 | --------------------- | -------------------- |
 | (original)            | `false`              |
 | 7.1                   | `true`               |
+
+#### `config.active_record.postgresql_adapter_decode_dates`
+
+Specifies whether the PostgresqlAdapter should decode date columns.
+
+```ruby
+ActiveRecord::Base.connection
+     .select_value("select '2024-01-01'::date").class #=> Date
+```
+
+
+The default value depends on the `config.load_defaults` target version:
+
+| Starting with version | The default value is |
+| --------------------- | -------------------- |
+| (original)            | `false`              |
+| 7.2                   | `true`               |
+
 
 #### `config.active_record.async_query_executor`
 

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -327,6 +327,7 @@ module Rails
           end
 
           if respond_to?(:active_record)
+            active_record.postgresql_adapter_decode_dates = true
             active_record.validate_migration_timestamps = true
             active_record.automatically_invert_plural_associations = true
           end

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -2793,6 +2793,40 @@ module ApplicationTests
       assert_equal false, ActiveRecord::Base.run_commit_callbacks_on_first_saved_instances_in_transaction
     end
 
+    test "PostgresqlAdapter.decode_dates is true by default for new apps" do
+      app_file "config/initializers/active_record.rb", <<~RUBY
+        ActiveRecord::Base.establish_connection(adapter: "postgresql")
+      RUBY
+
+      app "development"
+
+      assert_equal true, ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.decode_dates
+    end
+
+    test "PostgresqlAdapter.decode_dates is false by default for upgraded apps" do
+      remove_from_config '.*config\.load_defaults.*\n'
+      app_file "config/initializers/active_record.rb", <<~RUBY
+        ActiveRecord::Base.establish_connection(adapter: "postgresql")
+      RUBY
+
+      app "development"
+
+      assert_equal false, ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.decode_dates
+    end
+
+    test "PostgresqlAdapter.decode_dates can be configured via config.active_record.postgresql_adapter_decode_dates" do
+      remove_from_config '.*config\.load_defaults.*\n'
+      add_to_config "config.active_record.postgresql_adapter_decode_dates = true"
+
+      app_file "config/initializers/active_record.rb", <<~RUBY
+        ActiveRecord::Base.establish_connection(adapter: "postgresql")
+      RUBY
+
+      app "development"
+
+      assert_equal true, ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.decode_dates
+    end
+
     test "SQLite3Adapter.strict_strings_by_default is true by default for new apps" do
       app_file "config/initializers/active_record.rb", <<~RUBY
         ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")


### PR DESCRIPTION
Add `active_record.postgresql_adapter_decode_dates` config
to toggle automatic decoding of dates column with the PostgresqlAdapter.

PR #51483 is a breaking change and should have been gated behind a config.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
