### PR TITLE
Raise `ActiveRecord:: InverseOfAssociationNotFoundError` if invalid inverse_of is specified

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,22 @@
+*   Raise `ActiveRecord::InverseOfAssociationNotFoundError` if invalid inverse_of is specified.
+
+    This error occurs when the association specified in the `inverse_of` option does not exist on the associated class.
+    Previously this would be implicitly ignored, so the developer wouldn't know they tried to make an invalid association.
+
+    ```ruby
+    Post.belongs_to(:user, inverse_of: :comment) # Correct inverse_of is :post
+    user = User.create!
+
+    # Before:
+    Post.new(user: user) #=> No error
+
+    # After:
+    Post.new(user: user)
+    #=> ActiveRecord::InverseOfAssociationNotFoundError: Could not find the inverse association for user (:comment in User).
+    ```
+
+    *Hiroyuki Ishii*
+
 *   PoolConfig no longer keeps a reference to the connection class.
 
     Keeping a reference to the class caused subtle issues when combined with reloading in

--- a/activerecord/lib/active_record/associations/errors.rb
+++ b/activerecord/lib/active_record/associations/errors.rb
@@ -49,8 +49,11 @@ module ActiveRecord
       def corrections
         if reflection && associated_class
           @corrections ||= begin
-            maybe_these = associated_class.reflections.keys
-            DidYouMean::SpellChecker.new(dictionary: maybe_these).correct(reflection.options[:inverse_of].to_s)
+            maybe_these = associated_class.reflections.filter_map do |name, ref|
+              name if !ref.polymorphic? && ref.table_name == reflection.active_record.table_name
+            end
+
+            DidYouMean::SpellChecker.new(dictionary: maybe_these).correct(reflection.options[:inverse_of].to_s).presence || maybe_these
           end
         else
           []

--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -263,7 +263,7 @@ module ActiveRecord
 
       def check_validity_of_inverse!
         if !polymorphic? && has_inverse?
-          if inverse_of.nil?
+          if inverse_of.nil? || (!inverse_of.polymorphic? && active_record.table_name != inverse_of.klass.table_name)
             raise InverseOfAssociationNotFoundError.new(self)
           end
           if inverse_of == self

--- a/activerecord/test/cases/associations/inverse_associations_test.rb
+++ b/activerecord/test/cases/associations/inverse_associations_test.rb
@@ -912,6 +912,30 @@ class InverseBelongsToTests < ActiveRecord::TestCase
     assert_equal "confused_face", error.corrections.first
   end
 
+  def test_trying_to_use_non_inverse_relations_should_have_suggestions_for_fix
+    face_klass = Class.new(ActiveRecord::Base) do
+      self.table_name = Face.table_name
+
+      def self.name
+        "Face"
+      end
+    end
+
+    # Correct inverse_of should be `:face`, but the incorrect configuration `:interests` was used.
+    face_klass.belongs_to(:human, inverse_of: :interests)
+
+    error = assert_raises(ActiveRecord::InverseOfAssociationNotFoundError, match: /Could not find the inverse association for human \(:interests in Human\)/) do
+      face_klass.preload(:human).load
+    end
+
+    if error.respond_to?(:detailed_message)
+      assert_match "Did you mean?", error.detailed_message
+    else
+      assert_match "Did you mean?", error.message
+    end
+    assert_equal "face", error.corrections.first
+  end
+
   def test_building_has_many_parent_association_inverses_one_record
     with_has_many_inversing(Interest) do
       interest = Interest.new


### PR DESCRIPTION
### Motivation / Background

This error occurs when the association specified in the `inverse_of` option does not exist on the associated class.
Previously this would be implicitly ignored, so the developer wouldn't know they tried to make an invalid association.

### Detail

```ruby
Post.belongs_to(:user, inverse_of: :comment) # Correct inverse_of is :post
user = User.create!

 # Before:
Post.new(user: user) #=> No error

 # After:
Post.new(user: user)
#=> ActiveRecord::InverseOfAssociationNotFoundError: Could not find the inverse association for user (:comment in User).
```

### Additional information

When checking the bi-directionality of inverse_of reflection, it is intuitive to
compare classes. However, the implementation compares `table_name` instead, because
class name comparisons are challenging with anonymous classes (such as those used in Rails testing).

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
