### PR TITLE
Adds `assert_error` and `assert_no_error`

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,2 +1,9 @@
+*   Added new test assertions  `assert_error_on` and `assert_no_error_on` to simplify testing for specific validation errors on models.
+    Example usage:
+    ```ruby
+    assert_error_on user :name, :blank
+    assert_no_error user, :name, :blank
+    ```
 
+    *Daniela Velasquez*
 Please check [8-0-stable](https://github.com/rails/rails/blob/8-0-stable/activesupport/CHANGELOG.md) for previous changes.

--- a/activesupport/lib/active_support/testing/assertions.rb
+++ b/activesupport/lib/active_support/testing/assertions.rb
@@ -282,6 +282,86 @@ module ActiveSupport
         retval
       end
 
+      # Asserts that an ActiveModel object has a specific error on a given attribute.
+      #
+      # This assertion checks whether a validation error of a specific type
+      # exists on the provided attribute of the object. If the error does not
+      # exist, the test will fail, displaying an optional custom error message or
+      # a default one indicating the expected and actual outcomes.
+      #
+      # Example:
+      #
+      #   assert_error_on(user, :name, :blank)
+      #   # Asserts that the `user` object has a `:blank` validation error on the `:name` attribute.
+      #
+      # Arguments:
+      #   obj: The ActiveModel object being validated. It must respond to `#errors`.
+      #   attribute: The attribute for which the validation error is expected (e.g., `:name`).
+      #   type: The specific type of validation error (e.g., `:blank`, `:invalid`, etc.).
+      #   msg: An optional custom message to display if the assertion fails. If not provided,
+      #        a default message is generated based on the provided attribute and error type.
+      #
+      # Raises:
+      #   ArgumentError: If the `obj` does not respond to `#errors`.
+      #
+      # Example Custom Error Message:
+      #
+      #   assert_error_on(user, :name, :blank, "Expected 'name' to be present but it's blank.")
+      #
+      # Failing Example:
+      #
+      #   assert_error_on(user, :email, :invalid)
+      #   # Fails if `user.errors` does not contain an `:invalid` error for the `:email` attribute.
+      def assert_error_on(obj, attribute, type, msg = nil)
+        raise ArgumentError.new("#{obj.inspect} does not respond to #errors") unless obj.respond_to?(:errors)
+
+        msg = message(msg) {
+          data = [type, attribute]
+          "Expected error %s on %s" % data
+        }
+
+        assert(obj.errors.added?(attribute, type), msg)
+      end
+
+      # Asserts that an ActiveModel object does not have a specific error on a given attribute.
+      #
+      # This assertion checks that a validation error of a specific type is not present
+      # on the provided attribute of the object. If the error exists, the test will fail,
+      # displaying an optional custom error message or a default one indicating the
+      # unexpected error on the attribute.
+      #
+      # Example:
+      #
+      #   assert_no_error_on(user, :name, :blank)
+      #   # Asserts that the `user` object does not have a `:blank` validation error on the `:name` attribute.
+      #
+      # Arguments:
+      #   obj: The ActiveModel object being validated. It must respond to `#errors`.
+      #   attribute: The attribute for which the absence of a specific validation error is expected (e.g., `:name`).
+      #   type: The specific type of validation error that is expected *not* to be present (e.g., `:blank`, `:invalid`).
+      #   msg: An optional custom message to display if the assertion fails. If not provided,
+      #        a default message is generated based on the provided attribute and error type.
+      #
+      # Raises:
+      #   ArgumentError: If the `obj` does not respond to `#errors`.
+      #
+      # Example Custom Error Message:
+      #
+      #   assert_no_error_on(user, :name, :blank, "Expected 'name' to be valid and not blank.")
+      #
+      # Failing Example:
+      #
+      #   assert_no_error_on(user, :email, :invalid)
+      #   # Fails if `user.errors` contains an `:invalid` error for the `:email` attribute.
+      def assert_no_error_on(obj, attribute, type, msg = nil)
+        raise ArgumentError.new("#{obj.inspect} does not respond to #errors") unless obj.respond_to?(:errors)
+        msg = message(msg) {
+          data = [attribute, type]
+          "Expected %s to not be %s" % data
+        }
+        assert_not(obj.errors.added?(attribute, type), msg)
+      end
+
       private
         def _assert_nothing_raised_or_warn(assertion, &block)
           assert_nothing_raised(&block)

--- a/activesupport/test/validation_errors_test.rb
+++ b/activesupport/test/validation_errors_test.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require_relative "abstract_unit"
+require "active_model"
+
+class ValidationErrorsTest < ActiveSupport::TestCase
+  def setup
+    @active_model = Class.new do
+      include ActiveModel::Model
+      include ActiveModel::Attributes
+
+      attribute :name, :string
+      attribute :last_name, :string
+      validates :name, :last_name, presence: true
+      validate :name_doesnt_contain_numbers
+
+      private
+        def name_doesnt_contain_numbers
+          unless name.nil? || name.scan(/\d/).empty?
+            errors.add(:name, "shouldn't contain numbers")
+          end
+        end
+    end.new
+  end
+
+  test "#assert_no_error_on asserts active model does not have an error on a field" do
+    @active_model.name = "name"
+    @active_model.validate
+
+    assert_no_error_on @active_model, :name, :blank
+  end
+
+  test "#assert_no_error_on raises ArgumentError with an object that doesn't respond to errors" do
+    error = assert_raises(ArgumentError) do
+        assert_no_error_on Object.new, :name, :blank, Object.new
+      end
+
+    assert_includes error.message, "does not respond to #errors"
+  end
+
+  test "#assert_no_error_on raises a Minitest::Assertion when validation fails" do
+    @active_model.validate
+    error = assert_raises(Minitest::Assertion) do
+      assert_no_error_on @active_model, :name, :blank
+    end
+    assert_includes error.message, "Expected name to not be blank"
+  end
+
+  test "#assert_error_on asserts active model has an error on name field" do
+    @active_model.validate
+    assert_error_on @active_model, :name, :blank
+  end
+
+  test "#assert_error_on asserts active model has an error on a field with a string" do
+    error_message = "must start with H"
+    @active_model.errors.add(:name, error_message)
+
+    assert_error_on @active_model, :name, error_message
+  end
+
+  test "#assert_error_on raises ArgumentError on an object that doesn't respond to errors" do
+    error = assert_raises(ArgumentError) do
+      assert_error_on :name, :blank, Object.new
+    end
+
+    assert_includes error.message, "does not respond to #errors"
+  end
+
+  test "#assert_error_on raises a Minitest::Assertion when validation fails" do
+    @active_model.name = "h"
+    @active_model.validate
+    error = assert_raises(Minitest::Assertion) do
+      assert_error_on @active_model, :name, :blank
+    end
+    assert_includes error.message, "Expected error blank on name"
+  end
+end


### PR DESCRIPTION
### Motivation / Background
Ensuring the correctness of validations in Rails models is a fundamental aspect of robust testing. However, the current approach to such validations can often lead to cluttered and less readable test code. For instance, manually asserting validation errors requires multiple lines of code, detracting from the clarity of the test suite. This PR addresses this issue by introducing a streamlined solution that enhances readability and conciseness in model testing.

```ruby
test "name cannot be blank" do
    user = users(:one)
    
   user.validate
   refute_empty user.errors.where(:name, :blank)
end
```
or 

```ruby
test "name cannot be blank" do
    user = users(:one)
    
   user.validate
   assert user.errors.added? :name, :blank
end
```

### Detail
This PR introduces a new assertion method, `assert_error` and `assert_invalid`, designed to simplify the validation testing process. With them developers can now verify the presence of specific validation errors with a single, expressive line of code. This enhancement not only improves the readability of tests but also promotes better understanding and maintenance of the validation logic within Rails models.

```ruby
test "name cannot be blank" do
    user = users(:one)
    
   assert_not_valid :name, :blank, user
end
```

```ruby
test "name cannot be blank" do
    user = users(:one)
    user.validate
    
   assert_error :name, :blank, user
end
```

In the same way the validation `assert_valid` and `assert_no_error` ensures that the model has no errors for a specific field

```ruby
test "name is not blank" do
    user = users(:one)
    
   assert_no_error :name, :blank, user
end
```

```ruby
test "name is not blank" do
    user = users(:one)
    
   assert_valid :name, :blank, user
end
```


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
