### PR TITLE
Fix `.with_connection` to not set current scope

### DIFF
--- a/activerecord/lib/active_record/relation/delegation.rb
+++ b/activerecord/lib/active_record/relation/delegation.rb
@@ -100,7 +100,7 @@ module ActiveRecord
              :to_sentence, :to_fs, :to_formatted_s, :as_json,
              :shuffle, :split, :slice, :index, :rindex, to: :records
 
-    delegate :primary_key, :connection, :transaction, to: :klass
+    delegate :primary_key, :lease_connection, :connection, :with_connection, :transaction, to: :klass
 
     module ClassSpecificRelation # :nodoc:
       extend ActiveSupport::Concern


### PR DESCRIPTION
Fix: https://github.com/rails/rails/issues/51775

This us us being bitten by https://github.com/rails/rails/pull/50396 once more. We should really make this delegation much stricter.

cc @ghiculescu 

@ghiculescu sorry for not adding a test but I got some travel coming up, feel free to add one in a PR and I'll merge it.

Also I really need to finish https://github.com/rails/rails/pull/50396