### PR TITLE
ActionController::Parameters#extract_value example requires delimiter

### DIFF
--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -979,7 +979,7 @@ module ActionController
     # returned array will include empty strings.
     #
     #     params = ActionController::Parameters.new(tags: "ruby,rails,,web")
-    #     params.extract_value(:tags) # => ["ruby", "rails", "", "web"]
+    #     params.extract_value(:tags, delimiter: ",") # => ["ruby", "rails", "", "web"]
     def extract_value(key, delimiter: "_")
       @parameters[key]&.split(delimiter, -1)
     end


### PR DESCRIPTION

### Detail

This Pull Request changes a code example in `ActionController::Parameters#extract_value`.
