### PR TITLE
Fix RuboCop autocorrect for Windows compatibility

### DIFF
--- a/railties/lib/rails/configuration.rb
+++ b/railties/lib/rails/configuration.rb
@@ -135,7 +135,7 @@ module Rails
         after_generate do |files|
           parsable_files = files.filter { |file| File.exist?(file) && file.end_with?(".rb") }
           unless parsable_files.empty?
-            system("bin/rubocop -A --fail-level=E #{parsable_files.shelljoin}", exception: true)
+            system(RbConfig.ruby, "bin/rubocop", "-A", "--fail-level=E", *parsable_files, exception: true)
           end
         end
       end


### PR DESCRIPTION
### Motivation / Background

New behaviour was added in https://github.com/rails/rails/pull/50506 which runs RuboCop after a generator, but the approach fails on Windows.

### Detail

As documented in the Rails Guides, when calling a binstub on Windows, we need to prefix it with `ruby`:
https://guides.rubyonrails.org/getting_started.html#starting-up-the-web-server

Otherwise it will fail with:

```
D:/Ruby33-x64/lib/ruby/gems/3.3.0/bundler/gems/rails-fc4407eed00e/railties/lib/rails/configuration.rb:138:in `system': Exec format error - bin/rubocop -A --fail-level=E app/controllers/home_controller.rb app/helpers/home_helper.rb (Errno::ENOEXEC)
        from D:/Ruby33-x64/lib/ruby/gems/3.3.0/bundler/gems/rails-fc4407eed00e/railties/lib/rails/configuration.rb:138:in `block in apply_rubocop_autocorrect_after_generate!'
        from D:/Ruby33-x64/lib/ruby/gems/3.3.0/bundler/gems/rails-fc4407eed00e/railties/lib/rails/generators.rb:317:in `block in run_after_generate_callback'
        from D:/Ruby33-x64/lib/ruby/gems/3.3.0/bundler/gems/rails-fc4407eed00e/railties/lib/rails/generators.rb:316:in `each'
```

I am not a Windows user so I cannot fully test the fix myself, but it was reported [here](https://github.com/Shopify/ruby-lsp-rails/issues/351#issuecomment-2081482736).

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.

cc @koic 