### PR TITLE
Support `touch_all` in batches

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Support `touch_all` in batches.
+
+    ```ruby
+    Post.in_batches.touch_all
+    ```
+
+    *fatkodima*
+
 *   Add support for `:if_not_exists` and `:force` options to `create_schema`
 
     *fatkodima*

--- a/activerecord/lib/active_record/relation/batches/batch_enumerator.rb
+++ b/activerecord/lib/active_record/relation/batches/batch_enumerator.rb
@@ -77,6 +77,17 @@ module ActiveRecord
         end
       end
 
+      # Touches records in batches. Returns the total number of rows affected.
+      #
+      #   Person.in_batches.touch_all
+      #
+      # See Relation#touch_all for details of how each batch is touched.
+      def touch_all(...)
+        sum do |relation|
+          relation.touch_all(...)
+        end
+      end
+
       # Destroys records in batches.
       #
       #   Person.where("age < 10").in_batches.destroy_all


### PR DESCRIPTION
Currently, ActiveRecord is missing the ability to run `touch_all` via batches (compared to `update_all`/`delete_all`/etc).
```ruby
Post.in_batches.touch_all
```