### PR TITLE
Fix `ActiveRecord::Relation#touch_all` with custom attribute aliased as attribute for update

### DIFF
--- a/activerecord/lib/active_record/timestamp.rb
+++ b/activerecord/lib/active_record/timestamp.rb
@@ -54,8 +54,10 @@ module ActiveRecord
 
     module ClassMethods # :nodoc:
       def touch_attributes_with_time(*names, time: nil)
+        names = names.map(&:to_s)
+        names = names.map { |name| attribute_aliases[name] || name }
         attribute_names = timestamp_attributes_for_update_in_model
-        attribute_names |= names.map(&:to_s)
+        attribute_names |= names
         attribute_names.index_with(time || current_time_from_proper_timezone)
       end
 

--- a/activerecord/test/cases/relation/update_all_test.rb
+++ b/activerecord/test/cases/relation/update_all_test.rb
@@ -135,6 +135,19 @@ class UpdateAllTest < ActiveRecord::TestCase
     assert_not_equal previously_updated_at, developer.updated_at
   end
 
+  def test_touch_all_with_aliased_for_update_timestamp
+    assert Developer.attribute_aliases.key?("updated_at")
+
+    developer = developers(:david)
+    previously_created_at = developer.created_at
+    previously_updated_at = developer.updated_at
+    Developer.where(name: "David").touch_all(:updated_at)
+    developer.reload
+
+    assert_equal previously_created_at, developer.created_at
+    assert_not_equal previously_updated_at, developer.updated_at
+  end
+
   def test_touch_all_with_given_time
     developer = developers(:david)
     previously_created_at = developer.created_at


### PR DESCRIPTION
If we have something like 
```ruby
create_table :users do |t|
  t.timestamp :legacy_updated_at
end

class User < ActiveRecord::Base
  alias_attribute :updated_at, :legacy_updated_at
end

User.touch_all(:updated_at)
```

then ActiveRecord will not resolve `updated_at` to its alias correctly and result to a query that updates the same column twice.

For PostgreSQL, this produces an error similar to this:
```
ActiveRecord::StatementInvalid: PG::SyntaxError: ERROR:  multiple assignments to same column "legacy_updated_at"
```