### PR TITLE
Change `BatchEnumerator#destroy_all` to return the total number of affected rows

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,2 +1,7 @@
+*   Change `BatchEnumerator#destroy_all` to return the total number of affected rows.
+
+    Previously, it always returned `nil`.
+
+    *fatkodima*
 
 Please check [7-2-stable](https://github.com/rails/rails/blob/7-2-stable/activerecord/CHANGELOG.md) for previous changes.

--- a/activerecord/lib/active_record/relation/batches/batch_enumerator.rb
+++ b/activerecord/lib/active_record/relation/batches/batch_enumerator.rb
@@ -88,13 +88,15 @@ module ActiveRecord
         end
       end
 
-      # Destroys records in batches.
+      # Destroys records in batches. Returns the total number of rows affected.
       #
       #   Person.where("age < 10").in_batches.destroy_all
       #
       # See Relation#destroy_all for details of how each batch is destroyed.
       def destroy_all
-        each(&:destroy_all)
+        sum do |relation|
+          relation.destroy_all.count(&:destroyed?)
+        end
       end
 
       # Yields an ActiveRecord::Relation object for each batch of records.

--- a/activerecord/test/models/post.rb
+++ b/activerecord/test/models/post.rb
@@ -1,5 +1,10 @@
 # frozen_string_literal: true
 
+require "models/tag"
+require "models/tagging"
+require "models/comment"
+require "models/category"
+
 class Post < ActiveRecord::Base
   class CategoryPost < ActiveRecord::Base
     self.table_name = "categories_posts"
@@ -327,6 +332,15 @@ class ConditionalStiPost < Post
 end
 
 class SubConditionalStiPost < ConditionalStiPost
+end
+
+class PostWithDestroyCallback < ActiveRecord::Base
+  self.inheritance_column = :disabled
+  self.table_name = "posts"
+
+  before_destroy do
+    throw :abort if id == 1
+  end
 end
 
 class FakeKlass


### PR DESCRIPTION
Currently, `ActiveRecord::Relation.destroy_all` returns all the affected records, so users can implement some custom logic based on that without querying the database prior to the `destroy_all` call.

But, `in_batches.destroy_all` always returns `nil`, which is not very much useful. And in this case, to implement some custom logic based on the affected rows, we actually need to query the database prior to the operation.

This PR changes that method to always return the number of destroyed records.