### PR TITLE
Add support for `:if_not_exists` and `:force` options to `create_schema`

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add support for `:if_not_exists` and `:force` options to `create_schema`
+
+    *fatkodima*
+
 *   Fix `index_errors` having incorrect index in association validation errors.
 
     *lulalala*

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -209,8 +209,16 @@ module ActiveRecord
         end
 
         # Creates a schema for the given schema name.
-        def create_schema(schema_name)
-          execute "CREATE SCHEMA #{quote_schema_name(schema_name)}"
+        def create_schema(schema_name, force: nil, if_not_exists: nil)
+          if force && if_not_exists
+            raise ArgumentError, "Options `:force` and `:if_not_exists` cannot be used simultaneously."
+          end
+
+          if force
+            drop_schema(schema_name, if_exists: true)
+          end
+
+          execute("CREATE SCHEMA#{' IF NOT EXISTS' if if_not_exists} #{quote_schema_name(schema_name)}")
         end
 
         # Drops the schema for the given schema name.

--- a/activerecord/test/cases/adapters/postgresql/schema_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/schema_test.rb
@@ -131,6 +131,32 @@ class SchemaTest < ActiveRecord::PostgreSQLTestCase
     @connection.drop_schema "test_schema3"
   end
 
+  def test_force_create_schema
+    @connection.create_schema "test_schema3"
+    assert_queries_match(/DROP SCHEMA IF EXISTS "test_schema3"/) do
+      @connection.create_schema "test_schema3", force: true
+    end
+    assert @connection.schema_names.include?("test_schema3")
+  ensure
+    @connection.drop_schema "test_schema3"
+  end
+
+  def test_create_schema_if_not_exists
+    @connection.create_schema "test_schema3"
+    assert_queries_match('CREATE SCHEMA IF NOT EXISTS "test_schema3"') do
+      @connection.create_schema "test_schema3", if_not_exists: true
+    end
+    assert @connection.schema_names.include?("test_schema3")
+  ensure
+    @connection.drop_schema "test_schema3"
+  end
+
+  def test_create_schema_raises_if_both_force_and_if_not_exists_provided
+    assert_raises(ArgumentError, match: "Options `:force` and `:if_not_exists` cannot be used simultaneously.") do
+      @connection.create_schema "test_schema3", force: true, if_not_exists: true
+    end
+  end
+
   def test_drop_schema
     begin
       @connection.create_schema "test_schema3"


### PR DESCRIPTION
Recently rediscovered, that `create_schema` for PostgreSQL does not support convenient `:force` and `:if_not_exists` options. While `drop_schema` supports `:if_exists`.