### PR TITLE
Add name to DevContainer compose file

### DIFF
--- a/.github/workflows/devcontainer-smoke-test.yml
+++ b/.github/workflows/devcontainer-smoke-test.yml
@@ -33,6 +33,10 @@ jobs:
       - name: Generate rails app sqlite3
         run: bundle exec railties/exe/rails new myapp_sqlite --database="sqlite3" --dev
 
+      - name: Remove old deprecated docker-compose
+        run: |
+          sudo rm /usr/local/bin/docker-compose
+
       - name: Test devcontainer sqlite3
         uses: devcontainers/ci@v0.3
         with:

--- a/railties/lib/rails/generators/rails/app/templates/.devcontainer/compose.yaml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/.devcontainer/compose.yaml.tt
@@ -1,3 +1,5 @@
+name: "<%= app_name %>"
+
 services:
   rails-app:
     build:

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -1295,6 +1295,8 @@ class AppGeneratorTest < Rails::Generators::TestCase
       assert_match(/ARG RUBY_VERSION=#{RUBY_VERSION}/, content)
     end
     assert_compose_file do |compose_config|
+      assert_equal "my_app", compose_config["name"]
+
       expected_rails_app_config = {
         "build" => {
           "context" => "..",


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.

-->


Currently when you generate a project the compose.yaml generated file does not include the top-level name property. Not having this top-level name property makes all containers / volumes started by devcontainer to be prepended with the folder name, which is `devcontainer` in the case of the .devcontainer/compose.yml` file.

```
docker compose -f .devcontainer/compose.yaml up -d

[+] Running 4/4
 ✔ Container devcontainer-postgres-1   Started                                                                                                   0.0s
 ✔ Container devcontainer-selenium-1   Started                                                                                                   0.0s
 ✔ Container devcontainer-rails-app-1  Started
```

This is ok if you run only one project with devcontainer but starts to get problem if you run multiple projects. If you have one project that runs on postgresql 15 and a new one that runs on postgresql 16 it will fail to boot the postgresql container because both devcontainers is using the same volume: `devcontainer_postgres-data`.

`docker logs PGCONTAINERID`

```
PostgreSQL Database directory appears to contain a database; Skipping initialization

2024-05-11 04:15:34.246 UTC [1] FATAL:  database files are incompatible with server
2024-05-11 04:15:34.246 UTC [1] DETAIL:  The data directory was initialized by PostgreSQL version 15, which is not compatible with this version 16.1 (Debian 16.1-1.pgdg120+1).
```

### Detail

This commit fixes this by [setting the top-lavel name property](https://docs.docker.com/compose/project-name/#set-a-project-name) with the project name, which will make the containers and volumes to be prepended with the project name and not with `devcontainer`.

With the top name property:

```
➜  my_app git:(main) ✗ docker compose -f .devcontainer/compose.yaml up
```

```
[+] Running 4/4
 ✔ Container my_app-selenium-1   Created                                                                                                       0.0s
 ✔ Container my_app-postgres-1   Created                                                                                                       0.0s
 ✔ Container my_app-rails-app-1  Recreated
```

`docker inspect -f '{{ .Mounts }}' PGCONTAINERID`

```
[{volume my_app_postgres-data /var/lib/docker/volumes/my_app_postgres-data/_data /var/lib/postgresql/data local z true }]
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* n/a CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
