### PR TITLE
Remove package litter after each install to shrink layer sizes

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/Dockerfile.tt
+++ b/railties/lib/rails/generators/rails/app/templates/Dockerfile.tt
@@ -25,7 +25,8 @@ ENV RAILS_ENV="production" \
 FROM base as build
 
 # Install packages needed to build gems<%= using_node? ? " and node modules" : "" %>
-RUN apt-get install --no-install-recommends -y <%= dockerfile_build_packages.join(" ") %> && \
+RUN apt-get update -qq && \
+    apt-get install --no-install-recommends -y <%= dockerfile_build_packages.join(" ") %> && \
     rm -rf /var/lib/apt/lists /var/cache/apt/archives
 
 <% if using_node? -%>

--- a/railties/lib/rails/generators/rails/app/templates/Dockerfile.tt
+++ b/railties/lib/rails/generators/rails/app/templates/Dockerfile.tt
@@ -12,7 +12,8 @@ WORKDIR /rails
 
 # Install base packages
 RUN apt-get update -qq && \
-    apt-get install --no-install-recommends -y <%= dockerfile_base_packages.join(" ") %>
+    apt-get install --no-install-recommends -y <%= dockerfile_base_packages.join(" ") %> && \
+    rm -rf /var/lib/apt/lists /var/cache/apt/archives
 
 # Set production environment
 ENV RAILS_ENV="production" \
@@ -24,7 +25,8 @@ ENV RAILS_ENV="production" \
 FROM base as build
 
 # Install packages needed to build gems<%= using_node? ? " and node modules" : "" %>
-RUN apt-get install --no-install-recommends -y <%= dockerfile_build_packages.join(" ") %>
+RUN apt-get install --no-install-recommends -y <%= dockerfile_build_packages.join(" ") %> && \
+    rm -rf /var/lib/apt/lists /var/cache/apt/archives
 
 <% if using_node? -%>
 # Install JavaScript dependencies
@@ -87,9 +89,6 @@ RUN rm -rf node_modules
 
 # Final stage for app image
 FROM base
-
-# Clean up installation packages to reduce image size
-RUN rm -rf /var/lib/apt/lists /var/cache/apt/archives
 
 # Copy built artifacts: gems, application
 COPY --from=build "${BUNDLE_PATH}" "${BUNDLE_PATH}"


### PR DESCRIPTION
Each layer is stored independently, so ensuring that the two apt-get runs we have don't balloon with package litter is more efficient than just removing all of it for the final image build.