### PR TITLE
Correct typo in activerecord changelog [ci skip]

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -560,7 +560,7 @@
 
     *Hartley McGuire*
 
-*   Add `<role>_types` class method to `ActiveRecord::DelegatedType` so that the delegated types can be instrospected
+*   Add `<role>_types` class method to `ActiveRecord::DelegatedType` so that the delegated types can be introspected
 
     *JP Rosevear*
 


### PR DESCRIPTION
Correct typo in activerecord changelog for -https://github.com/rails/rails/pull/50662
