### PR TITLE
Fix: bi-direction accepts_nested_attributes_for validation.

### DIFF
--- a/activerecord/lib/active_record/autosave_association.rb
+++ b/activerecord/lib/active_record/autosave_association.rb
@@ -239,6 +239,10 @@ module ActiveRecord
       super
     end
 
+    def valid?(*args) # :nodoc:
+      _validating { super }
+    end
+
     # Marks this record to be destroyed as part of the parent's save transaction.
     # This does _not_ actually destroy the record instantly, rather child record will be destroyed
     # when <tt>parent.save</tt> is called.
@@ -274,10 +278,25 @@ module ActiveRecord
       new_record? || has_changes_to_save? || marked_for_destruction? || nested_records_changed_for_autosave?
     end
 
+    protected
+      def _can_validate? # :nodoc:
+        !destroyed? && !@_validating
+      end
+
     private
       def init_internals
         super
         @_already_called = nil
+        @_validating = false
+      end
+
+      # Tracks if this record is being validated.
+      # Used to avoid cyclic validations of bi-directional nested_attributes.
+      def _validating
+        previously_validating, @_validating = @_validating, true
+        yield
+      ensure
+        @_validating = previously_validating
       end
 
       # Returns the record for an association collection that should be validated
@@ -340,7 +359,7 @@ module ActiveRecord
       # the parent, <tt>self</tt>, if it wasn't. Skips any <tt>:autosave</tt>
       # enabled records if they're marked_for_destruction? or destroyed.
       def association_valid?(association, record)
-        return true if record.destroyed? || (association.options[:autosave] && record.marked_for_destruction?)
+        return true if !record._can_validate? || (association.options[:autosave] && record.marked_for_destruction?)
 
         context = validation_context if custom_validation_context?
 

--- a/activerecord/test/cases/autosave_association_test.rb
+++ b/activerecord/test/cases/autosave_association_test.rb
@@ -799,6 +799,17 @@ class TestDefaultAutosaveAssociationOnAHasManyAssociationWithAcceptsNestedAttrib
     assert_predicate molecule, :persisted?
     assert_equal 1, molecule.electrons.count
   end
+
+  def test_invalid_with_bi_directional_nested_attributes
+    pirate = FamousPirateNestedAttributes.new(famous_ship_nested_attributes_attributes: [
+      { name: "Nights Dirty Lightning" },
+      { name: nil },
+      { name: "The Black Rock" }
+    ])
+
+    assert_not_predicate pirate, :valid?
+    assert_equal ["can't be blank"], pirate.errors["famous_ship_nested_attributes.name"]
+  end
 end
 
 class TestDefaultAutosaveAssociationOnAHasManyAssociation < ActiveRecord::TestCase

--- a/activerecord/test/models/pirate.rb
+++ b/activerecord/test/models/pirate.rb
@@ -102,6 +102,13 @@ class FamousPirate < ActiveRecord::Base
   validates_presence_of :catchphrase, on: :conference
 end
 
+class FamousPirateNestedAttributes < ActiveRecord::Base
+  self.table_name = "pirates"
+  has_many :famous_ship_nested_attributes, inverse_of: :famous_pirate_nested_attributes, foreign_key: :pirate_id
+
+  accepts_nested_attributes_for :famous_ship_nested_attributes
+end
+
 class SpacePirate < ActiveRecord::Base
   self.table_name = "pirates"
 

--- a/activerecord/test/models/ship.rb
+++ b/activerecord/test/models/ship.rb
@@ -40,3 +40,12 @@ class FamousShip < ActiveRecord::Base
   belongs_to :famous_pirate, foreign_key: :pirate_id
   validates_presence_of :name, on: :conference
 end
+
+class FamousShipNestedAttribute < ActiveRecord::Base
+  self.table_name = "ships"
+  belongs_to :famous_pirate_nested_attributes, foreign_key: :pirate_id
+
+  validates_presence_of :name
+
+  accepts_nested_attributes_for :famous_pirate_nested_attributes
+end


### PR DESCRIPTION
### Motivation / Background

Fixes https://github.com/rails/rails/issues/41811

Addresses the issue with bi-directional accepts_nested_attributes where validation of a collection fails due to only the last record being considered. This occurs because each child item triggers a valid? call on the parent record, which overwrites previous validation errors.

```ruby
class Post < ActiveRecord::Base
  has_many :comments, inverse_of: :post
  accepts_nested_attributes_for :comments

  validates :title, presence: true
end

class Comment < ActiveRecord::Base
  belongs_to :post, inverse_of: :comments
  accepts_nested_attributes_for :post

  validates :body, presence: true
end

class BugTest < Minitest::Test
  # currently fails
  def test_invalid_attributes
    post = Post.new(title: "foo", comments_attributes: [{ body: "body 1" }, { body: nil }, { body: "body 3" }])

    refute post.valid?
    refute post.errors.empty?
  end

  # currently passes
  def test_invalid_attributes_end_of_list
    post = Post.new(title: "foo", comments_attributes: [{ body: "bar" }, { body: "baz" }, { body: nil }])

    refute post.valid?
    refute post.errors.empty?
  end

  # currently passes
  def test_invalid_attributes_one_attribute
    post = Post.new(title: "foo", comments_attributes: [{ body: nil }])

    refute post.valid?
    refute post.errors.empty?
  end
end
```

### Detail

This PR is followup of https://github.com/rails/rails/pull/41878 which done by @intrip in 2 years back, additionally I've a added minor change for initialising the variable. This fix involves tracking the current record under validation and avoiding cyclic valid? calls.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.

cc/ @byroot 
