### PR TITLE
[ActiveRecord] Fixes wrong time field's default day with timezone

### DIFF
--- a/activerecord/lib/active_record/attribute_methods/time_zone_conversion.rb
+++ b/activerecord/lib/active_record/attribute_methods/time_zone_conversion.rb
@@ -37,6 +37,8 @@ module ActiveRecord
             return if value.nil?
 
             if value.acts_like?(:time)
+              return value.in_time_zone.change(year: 2000, day: 1, month: 1) if self.type == :time
+
               value.in_time_zone
             elsif value.respond_to?(:infinite?) && value.infinite?
               value

--- a/activerecord/test/cases/type/time_test.rb
+++ b/activerecord/test/cases/type/time_test.rb
@@ -24,6 +24,23 @@ module ActiveRecord
         assert_instance_of ::Time, topic.bonus_time
       end
 
+      def test_default_year_is_correct_with_time_zone
+        with_timezone_config default: :local, aware_attributes: true, zone: "America/New_York" do
+          Topic.reset_column_information
+
+          topic = Topic.new(bonus_time: "22:30")
+
+          before_save_time = topic.bonus_time
+
+          topic.save!
+          topic.reload
+
+          assert_equal before_save_time, topic.bonus_time
+        end
+      ensure
+        Topic.reset_column_information
+      end
+
       test "serialize_cast_value is equivalent to serialize after cast" do
         type = Type::Time.new(precision: 1)
         value = type.cast("1999-12-31T12:34:56.789-10:00")


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created to fix #51679, a bug that appears when working with time field and timezones.

Basically, the bug occurs when ActiveRecord deserialized time field's day in other day but not the default one (01-01-2000), and it impacts validations and comparisons.

More details from the bug in the issue https://github.com/rails/rails/issues/51679.

### Detail

This Pull Request changes the deserialized method `TimeZoneConverter` to always set the day for  (01-01-2000) when we are working with the default time field.

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->
For alternative solutions, we have some options thanks to [mkbehbehani](https://github.com/mkbehbehani) https://github.com/rails/rails/issues/51679#issuecomment-2083414034
- Using the ToD :time_only [ActiveRecord attribute](https://github.com/JackC/tod?tab=readme-ov-file#activerecord-attribute-support) for Time of Day representation in application logic
- In Postgres, using the time column type.
- Timezone config for both Rails and Postgres set to UTC and performing changes into desired local timezone before read/write/comparison using .in_time_zone(location_timezone).

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included. 