### PR TITLE
Suppress RuboCop output when there are no offenses in code generation

### DIFF
--- a/railties/lib/rails/configuration.rb
+++ b/railties/lib/rails/configuration.rb
@@ -135,7 +135,7 @@ module Rails
         after_generate do |files|
           parsable_files = files.filter { |file| File.exist?(file) && file.end_with?(".rb") }
           unless parsable_files.empty?
-            system(RbConfig.ruby, "bin/rubocop", "-A", "--fail-level=E", *parsable_files, exception: true)
+            system(RbConfig.ruby, "bin/rubocop", "-A", "--fail-level=E", "--format=quiet", *parsable_files, exception: true)
           end
         end
       end

--- a/railties/test/application/generators_test.rb
+++ b/railties/test/application/generators_test.rb
@@ -263,7 +263,7 @@ module ApplicationTests
         end
 
         output = rails("generate", "model", "post", "title:string", "body:string")
-        assert_match(/3 files inspected, no offenses detected/, output)
+        assert_no_match(/3 files inspected, no offenses detected/, output)
       end
 
       test "generators with apply_rubocop_autocorrect_after_generate! and pretend" do


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

Follow up #51782.

> But it's overkill for the default case where people use the default style guide,
> and it introduces both delay and console output as a cost.

### Detail

When there are no offenses with the coding style generated by code generation, outputting RuboCop results to the console was redundant. Since RuboCop has `--format=quiet` option that suppresses console output when there are no offenses, this PR adds that option: https://docs.rubocop.org/rubocop/1.63/formatters.html#quiet-formatter

While this PR doesn't resolve any added execution speed by RuboCop, the frequency of using the generator is not high within the development flow. Therefore, depending on the execution speed, it might be possible to uncomment #51782, but this PR respects the defaults in #51782 and doesn't address that.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
