### PR TITLE
Remove reference to ci skip in PR title

### DIFF
--- a/guides/source/contributing_to_ruby_on_rails.md
+++ b/guides/source/contributing_to_ruby_on_rails.md
@@ -139,8 +139,6 @@ You can help improve the Rails guides or the API reference by making them more c
 
 To do so, make changes to Rails guides source files (located [here](https://github.com/rails/rails/tree/main/guides/source) on GitHub) or RDoc comments in source code. Then open a pull request to apply your changes to the main branch.
 
-Use `[ci skip]` in your pull request title to avoid running the CI build for documentation changes.
-
 Once you open a PR, a preview of the documentation will be deployed for easy review and collaboration. At the bottom of the Pull Request page, you should see a list of status checks, look for the `buildkite/docs-preview` and click "details".
 
 ![GitHub rails/rails Pull Request status checks](images/docs_preview/status_checks.png)


### PR DESCRIPTION
This doesn't do anything anymore, see https://github.com/rails/rails/pull/51796#issuecomment-2108157340

cc @skipkayhil