### PR TITLE
Only serialize associations that were loaded

### DIFF
--- a/activerecord/lib/active_record/marshalling.rb
+++ b/activerecord/lib/active_record/marshalling.rb
@@ -25,7 +25,7 @@ module ActiveRecord
         payload = [attributes_for_database, new_record?]
 
         cached_associations = self.class.reflect_on_all_associations.select do |reflection|
-          association_cached?(reflection.name)
+          association_cached?(reflection.name) && association(reflection.name).loaded?
         end
 
         unless cached_associations.empty?

--- a/activerecord/lib/active_record/message_pack.rb
+++ b/activerecord/lib/active_record/message_pack.rb
@@ -80,7 +80,7 @@ module ActiveRecord
 
       def add_cached_associations(record, entry)
         record.class.normalized_reflections.each_value do |reflection|
-          if record.association_cached?(reflection.name)
+          if record.association_cached?(reflection.name) && record.association(reflection.name).loaded?
             entry << reflection.name << encode(record.association(reflection.name).target)
           end
         end

--- a/activerecord/test/cases/marshal_serialization_test.rb
+++ b/activerecord/test/cases/marshal_serialization_test.rb
@@ -78,6 +78,10 @@ class MarshalSerializationTest < ActiveRecord::TestCase
       assert_same topic, reply.topic
     end
 
+    topic.association(:open_replies)
+    assert_equal true, topic.association_cached?(:open_replies)
+    assert_not_predicate topic.association(:open_replies), :loaded?
+
     topic = Marshal.load(Marshal.dump(topic))
 
     assert_not_predicate topic, :new_record?
@@ -85,6 +89,8 @@ class MarshalSerializationTest < ActiveRecord::TestCase
     assert_equal "The First Topic", topic.title
     assert_equal "Have a nice day", topic.content
     assert_predicate topic.association(:replies), :loaded?
+
+    assert_not_predicate topic.association(:open_replies), :loaded?
 
     assert_not_equal 0, topic.replies.size
     topic.replies.each do |reply|


### PR DESCRIPTION
Fix: https://github.com/rails/rails/issues/51807

`association_cached?` only means the Association object was created, not that the records were loaded.
