### PR TITLE
Add rubocop and GitHub Actions to plugin generator

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Add Rubocop and GitHub Actions to plugin generator.
+    This can be skipped using --skip-rubocop and --skip-ci.
+
+    *Chris Oliver*
+
 *   Use Kamal for deployment by default, which includes generating a Rails-specific config/deploy.yml.
     This can be skipped using --skip-kamal. See more: https://kamal-deploy.org/
 

--- a/railties/lib/rails/generators/rails/plugin/plugin_generator.rb
+++ b/railties/lib/rails/generators/rails/plugin/plugin_generator.rb
@@ -66,6 +66,16 @@ module Rails
       template "gitignore", ".gitignore"
     end
 
+    def cifiles
+      empty_directory ".github/workflows"
+      template "github/ci.yml", ".github/workflows/ci.yml"
+      template "github/dependabot.yml", ".github/dependabot.yml"
+    end
+
+    def rubocop
+      template "rubocop.yml", ".rubocop.yml"
+    end
+
     def version_control
       if !options[:skip_git] && !options[:pretend]
         run git_init_command, capture: options[:quiet], abort_on_failure: false
@@ -171,12 +181,12 @@ module Rails
       end
     end
 
-    def bin(force = false)
-      bin_file = engine? ? "bin/rails.tt" : "bin/test.tt"
-      template bin_file, force: force do |content|
+    def bin
+      exclude_pattern = Regexp.union([(engine? ? /test\.tt/ : /rails\.tt/), (/rubocop/ if skip_rubocop?)].compact)
+      directory "bin", { exclude_pattern: exclude_pattern } do |content|
         "#{shebang}\n" + content
       end
-      chmod "bin", 0755, verbose: false
+      chmod "bin", 0755 & ~File.umask, verbose: false
     end
 
     def gemfile_entry
@@ -245,6 +255,16 @@ module Rails
 
       def create_app_files
         build(:app)
+      end
+
+      def create_rubocop_file
+        return if skip_rubocop?
+        build(:rubocop)
+      end
+
+      def create_cifiles
+        return if skip_ci?
+        build(:cifiles)
       end
 
       def create_config_files
@@ -345,7 +365,7 @@ module Rails
           build(:test_dummy_sprocket_assets) unless skip_sprockets?
           build(:test_dummy_clean)
           # ensure that bin/rails has proper dummy_path
-          build(:bin, true)
+          build(:bin)
         end
       end
 
@@ -468,6 +488,14 @@ module Rails
       def relative_path
         return unless inside_application?
         app_path.delete_prefix("#{rails_app_path}/")
+      end
+
+      def test_command
+        if engine? && !options[:skip_active_record] && with_dummy_app?
+          "db:test:prepare test"
+        else
+          "test"
+        end
       end
     end
   end

--- a/railties/lib/rails/generators/rails/plugin/templates/%name%.gemspec.tt
+++ b/railties/lib/rails/generators/rails/plugin/templates/%name%.gemspec.tt
@@ -3,8 +3,8 @@ require_relative "lib/<%= namespaced_name %>/version"
 Gem::Specification.new do |spec|
   spec.name        = <%= name.inspect %>
   spec.version     = <%= camelized_modules %>::VERSION
-  spec.authors     = [<%= author.inspect %>]
-  spec.email       = [<%= email.inspect %>]
+  spec.authors     = [ <%= author.inspect %> ]
+  spec.email       = [ <%= email.inspect %> ]
   spec.homepage    = "TODO"
   spec.summary     = "TODO: Summary of <%= camelized_modules %>."
   spec.description = "TODO: Description of <%= camelized_modules %>."

--- a/railties/lib/rails/generators/rails/plugin/templates/Gemfile.tt
+++ b/railties/lib/rails/generators/rails/plugin/templates/Gemfile.tt
@@ -7,6 +7,11 @@ gemspec
 <% gemfile_entries.each do |gemfile_entry| %>
 <%= gemfile_entry %>
 <% end -%>
+<%- unless options.skip_rubocop? -%>
+
+# Omakase Ruby styling [https://github.com/rails/rubocop-rails-omakase/]
+gem "rubocop-rails-omakase", require: false
+<%- end -%>
 <% if RUBY_ENGINE == "ruby" -%>
 
 # Start debugger with binding.b [https://github.com/ruby/debug]

--- a/railties/lib/rails/generators/rails/plugin/templates/bin/rubocop.tt
+++ b/railties/lib/rails/generators/rails/plugin/templates/bin/rubocop.tt
@@ -1,0 +1,7 @@
+require "rubygems"
+require "bundler/setup"
+
+# explicit rubocop config increases performance slightly while avoiding config confusion.
+ARGV.unshift("--config", File.expand_path("../.rubocop.yml", __dir__))
+
+load Gem.bin_path("rubocop", "rubocop")

--- a/railties/lib/rails/generators/rails/plugin/templates/github/ci.yml.tt
+++ b/railties/lib/rails/generators/rails/plugin/templates/github/ci.yml.tt
@@ -1,0 +1,103 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [ main ]
+
+jobs:
+<%- unless skip_rubocop? -%>
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: <%= ENV["RBENV_VERSION"] || ENV["rvm_ruby_string"] || "#{RUBY_ENGINE}-#{RUBY_ENGINE_VERSION}" %>
+          bundler-cache: true
+
+      - name: Lint code for consistent style
+        run: bin/rubocop -f github
+
+<% end -%>
+<% unless options[:skip_test] -%>
+  test:
+    runs-on: ubuntu-latest
+
+    <%- if options[:database] == "sqlite3" -%>
+    # services:
+    #  redis:
+    #    image: redis
+    #    ports:
+    #      - 6379:6379
+    #    options: --health-cmd "redis-cli ping" --health-interval 10s --health-timeout 5s --health-retries 5
+    <%- else -%>
+    services:
+      <%- if options[:database] == "mysql" || options[:database] == "trilogy" -%>
+      mysql:
+        image: mysql
+        env:
+          MYSQL_ALLOW_EMPTY_PASSWORD: true
+        ports:
+          - 3306:3306
+        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+      <%- elsif options[:database] == "postgresql" -%>
+      postgres:
+        image: postgres
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: --health-cmd="pg_isready" --health-interval=10s --health-timeout=5s --health-retries=3
+      <%- end -%>
+
+      # redis:
+      #   image: redis
+      #   ports:
+      #     - 6379:6379
+      #   options: --health-cmd "redis-cli ping" --health-interval 10s --health-timeout 5s --health-retries 5
+
+    <%- end -%>
+    steps:
+      - name: Install packages
+        run: sudo apt-get update && sudo apt-get install --no-install-recommends -y google-chrome-stable <%= (dockerfile_base_packages + [database.base_package]).join(" ") %>
+
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: <%= ENV["RBENV_VERSION"] || ENV["rvm_ruby_string"] || "#{RUBY_ENGINE}-#{RUBY_ENGINE_VERSION}" %>
+          bundler-cache: true
+      <%- if using_bun? -%>
+
+      - uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: <%= dockerfile_bun_version %>
+      <%- end -%>
+
+      - name: Run tests
+        env:
+          RAILS_ENV: test
+          <%- if options[:database] == "mysql" || options[:database] == "trilogy" -%>
+          DATABASE_URL: mysql2://127.0.0.1:3306
+          <%- elsif options[:database] == "postgresql" -%>
+          DATABASE_URL: postgres://postgres:postgres@localhost:5432
+          <%- end -%>
+          # REDIS_URL: redis://localhost:6379/0
+        run: bin/rails <%= test_command %>
+
+      - name: Keep screenshots from failed system tests
+        uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: screenshots
+          path: ${{ github.workspace }}/tmp/screenshots
+          if-no-files-found: ignore
+<% end -%>
+

--- a/railties/lib/rails/generators/rails/plugin/templates/github/dependabot.yml
+++ b/railties/lib/rails/generators/rails/plugin/templates/github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+- package-ecosystem: bundler
+  directory: "/"
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 10
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 10

--- a/railties/lib/rails/generators/rails/plugin/templates/rubocop.yml.tt
+++ b/railties/lib/rails/generators/rails/plugin/templates/rubocop.yml.tt
@@ -1,0 +1,8 @@
+# Omakase Ruby styling for Rails
+inherit_gem: { rubocop-rails-omakase: rubocop.yml }
+
+# Overwrite or add rules to create your own house style
+#
+# # Use `[a, [b, c]]` not `[ a, [ b, c ] ]`
+# Layout/SpaceInsideArrayLiteralBrackets:
+#   Enabled: false

--- a/railties/test/generators/plugin_generator_test.rb
+++ b/railties/test/generators/plugin_generator_test.rb
@@ -8,11 +8,15 @@ require "rails/engine/updater"
 
 DEFAULT_PLUGIN_FILES = %w(
   .git
+  .github/dependabot.yml
+  .github/workflows/ci.yml
   .gitignore
+  .rubocop.yml
   Gemfile
   MIT-LICENSE
   README.md
   Rakefile
+  bin/rubocop
   bin/test
   bukkits.gemspec
   lib/bukkits.rb


### PR DESCRIPTION
### Motivation / Background

As I was working on my RailsConf 2024 talk, I realized the Rails plugin generator had not been updated to include the new rubocop and GitHub Actions files that ship with the app generator. These are particularly useful for plugin developers to make it easier to get started.

I spoke briefly with @rafaelfranca about making these additions which he agreed was a good idea. I also asked about brakeman, but he said that didn't make sense.

### Detail

This Pull Request updates the plugin generator to include templates for GitHub Actions and rubocop. It also updated a couple of files to ensure they pass the rubocop linting. 

I have kept these templates separate from the app templates as they are likely to diverge slightly over time.

### Additional information

I decided not to include any functionality for testing CI against multiple Rails versions, but this could be added in the future.
Same for testing multiple Ruby versions. This could be added later.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
