### PR TITLE
[Bugfix] Memoize `queue_adapter_for_test`

### DIFF
--- a/activejob/lib/active_job/test_helper.rb
+++ b/activejob/lib/active_job/test_helper.rb
@@ -39,8 +39,9 @@ module ActiveJob
     end
 
     def before_setup # :nodoc:
+      queue_adapter_specific_to_this_test_class = queue_adapter_for_test
       queue_adapter_changed_jobs.each do |klass|
-        if (queue_adapter_specific_to_this_test_class = queue_adapter_for_test)
+        if queue_adapter_specific_to_this_test_class
           klass.enable_test_adapter(queue_adapter_specific_to_this_test_class)
         elsif klass._queue_adapter.nil?
           klass.enable_test_adapter(ActiveJob::QueueAdapters::TestAdapter.new)

--- a/activejob/test/cases/test_helper_test.rb
+++ b/activejob/test/cases/test_helper_test.rb
@@ -806,6 +806,24 @@ class EnqueuedJobsTest < ActiveJob::TestCase
   end
 end
 
+class QueueAdapterTest < ActiveJob::TestCase
+  class JobWithAnAdapter < ActiveJob::Base
+    self.queue_adapter = :async
+
+    def perform; end
+  end
+
+  def queue_adapter_for_test
+    ActiveJob::QueueAdapters::TestAdapter.new
+  end
+
+  test "assert_enqueued_with enqueues a job with a queue_adapter and queue_adapter_for_test" do
+    assert_enqueued_with(job: JobWithAnAdapter) do
+      JobWithAnAdapter.perform_later
+    end
+  end
+end
+
 class PerformedJobsTest < ActiveJob::TestCase
   if adapter_is?(:test)
     include DoNotPerformEnqueuedJobs


### PR DESCRIPTION
### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

Our team at Shopify upgrades the company's core monolith to the latest commit of `rails/rails` every week, we noticed that this week's upgrade had a lot of failures because of `https://github.com/rails/rails/pull/48585` and so we investigated. The majority of the PR did what it set out to do, but [one change](https://github.com/rails/rails/pull/48585/files#diff-80449b7606c5229d2740774082ef21627dee51282a6e2c9299b7e5dbd5da32d6R43-R47) seems to have caused some regression.

### Detail


<details><summary> 🐛 Bug Report Template: </summary>

```ruby
# frozen_string_literal: true

require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"

  gem "rails", path: "."
  gem "debug"
end

require "active_job"
require "minitest/autorun"

class JobWithAnAdapter < ActiveJob::Base
  queue_as :default
  self.queue_adapter = :async

  def perform
    puts "performed"
  end
end

class JobTestWithQueueAdapterForTest < ActiveJob::TestCase
  def queue_adapter_for_test
    ActiveJob::QueueAdapters::TestAdapter.new
  end

  test "assert_enqueued_with the CustomAdapterJob" do
    assert_enqueued_with(job: JobWithAnAdapter) do
      JobWithAnAdapter.perform_later
    end
  end
end
```

</details>

Running the above script with the previous implementation, ie. pointed to revision [343e781](https://github.com/rails/rails/commit/343e781884b2efa64f5070598e15fef45919d339) like we had, both queue adapters `[JobWithAnAdapter, ActiveJob::Base]`, would be set to the same TestAdapter (`ActiveJob::QueueAdapters::TestAdapter:0x0000000123220ed8` for example)

With the [change made here](https://github.com/rails/rails/pull/48585/files#diff-80449b7606c5229d2740774082ef21627dee51282a6e2c9299b7e5dbd5da32d6R43-R47) however, they are set to TestAdapters with different IDs `ActiveJob::QueueAdapters::TestAdapter:0x000000013039f9c8`, `ActiveJob::QueueAdapters::TestAdapter:0x0000000125a79e20`).
This can be tested by checking out a revision made after https://github.com/rails/rails/pull/48585 merged such as the one we ran on, [397db3b](https://github.com/rails/rails/commit/e97db3b3957781c781a61fb01265feb2b57688bb) and running the bug report.

This PR fixes this regression by re-adding memoization to `queue_adapter_for_test`.

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
