### PR TITLE
Remove oracle sqlserver from tests

### DIFF
--- a/activerecord/Rakefile
+++ b/activerecord/Rakefile
@@ -56,7 +56,7 @@ namespace :db do
   task drop: ["db:mysql:drop", "db:postgresql:drop"]
 end
 
-%w( mysql2 trilogy postgresql sqlite3 sqlite3_mem oracle jdbcmysql jdbcpostgresql jdbcsqlite3 jdbcderby jdbch2 jdbchsqldb ).each do |adapter|
+%w( mysql2 trilogy postgresql sqlite3 sqlite3_mem ).each do |adapter|
   namespace :test do
     Rake::TestTask.new(adapter => "#{adapter}:env") do |t|
       adapter_short = adapter[/^[a-z0-9]+/]

--- a/activerecord/test/cases/associations/belongs_to_associations_test.rb
+++ b/activerecord/test/cases/associations/belongs_to_associations_test.rb
@@ -103,10 +103,6 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
     if current_adapter?(:Mysql2Adapter, :TrilogyAdapter)
       assert_no_match(/`firm_with_primary_keys_companies`\.`id`/, sql)
       assert_match(/`firm_with_primary_keys_companies`\.`name`/, sql)
-    elsif current_adapter?(:OracleAdapter)
-      # on Oracle aliases are truncated to 30 characters and are quoted in uppercase
-      assert_no_match(/"firm_with_primary_keys_compani"\."id"/i, sql)
-      assert_match(/"firm_with_primary_keys_compani"\."name"/i, sql)
     else
       assert_no_match(/"firm_with_primary_keys_companies"\."id"/, sql)
       assert_match(/"firm_with_primary_keys_companies"\."name"/, sql)

--- a/activerecord/test/cases/attribute_methods_test.rb
+++ b/activerecord/test/cases/attribute_methods_test.rb
@@ -692,23 +692,13 @@ class AttributeMethodsTest < ActiveRecord::TestCase
 
   test "typecast attribute from select to false" do
     Topic.create(title: "Budget")
-    # Oracle does not support boolean expressions in SELECT.
-    if current_adapter?(:OracleAdapter)
-      topic = Topic.all.merge!(select: "topics.*, 0 as is_test").first
-    else
-      topic = Topic.all.merge!(select: "topics.*, 1=2 as is_test").first
-    end
+    topic = Topic.all.merge!(select: "topics.*, 1=2 as is_test").first
     assert_not_predicate topic, :is_test?
   end
 
   test "typecast attribute from select to true" do
     Topic.create(title: "Budget")
-    # Oracle does not support boolean expressions in SELECT.
-    if current_adapter?(:OracleAdapter)
-      topic = Topic.all.merge!(select: "topics.*, 1 as is_test").first
-    else
-      topic = Topic.all.merge!(select: "topics.*, 2=2 as is_test").first
-    end
+    topic = Topic.all.merge!(select: "topics.*, 2=2 as is_test").first
     assert_predicate topic, :is_test?
   end
 

--- a/activerecord/test/cases/autosave_association_test.rb
+++ b/activerecord/test/cases/autosave_association_test.rb
@@ -1543,12 +1543,7 @@ class TestAutosaveAssociationOnAHasOneAssociation < ActiveRecord::TestCase
     @pirate.catchphrase = ""
     @pirate.ship.name = ""
     @pirate.save(validate: false)
-    # Oracle saves empty string as NULL
-    if current_adapter?(:OracleAdapter)
-      assert_equal [nil, nil], [@pirate.reload.catchphrase, @pirate.ship.name]
-    else
-      assert_equal ["", ""], [@pirate.reload.catchphrase, @pirate.ship.name]
-    end
+    assert_equal ["", ""], [@pirate.reload.catchphrase, @pirate.ship.name]
   end
 
   def test_should_allow_to_bypass_validations_on_associated_models_at_any_depth
@@ -1560,12 +1555,7 @@ class TestAutosaveAssociationOnAHasOneAssociation < ActiveRecord::TestCase
     @pirate.save(validate: false)
 
     values = [@pirate.reload.catchphrase, @pirate.ship.name, *@pirate.ship.parts.map(&:name)]
-    # Oracle saves empty string as NULL
-    if current_adapter?(:OracleAdapter)
-      assert_equal [nil, nil, nil, nil], values
-    else
-      assert_equal ["", "", "", ""], values
-    end
+    assert_equal ["", "", "", ""], values
   end
 
   def test_should_still_raise_an_ActiveRecordRecord_Invalid_exception_if_we_want_that
@@ -1732,12 +1722,7 @@ class TestAutosaveAssociationOnABelongsToAssociation < ActiveRecord::TestCase
     @ship.pirate.catchphrase = ""
     @ship.name = ""
     @ship.save(validate: false)
-    # Oracle saves empty string as NULL
-    if current_adapter?(:OracleAdapter)
-      assert_equal [nil, nil], [@ship.reload.name, @ship.pirate.catchphrase]
-    else
-      assert_equal ["", ""], [@ship.reload.name, @ship.pirate.catchphrase]
-    end
+    assert_equal ["", ""], [@ship.reload.name, @ship.pirate.catchphrase]
   end
 
   def test_should_still_raise_an_ActiveRecordRecord_Invalid_exception_if_we_want_that
@@ -1869,20 +1854,11 @@ module AutosaveAssociationOnACollectionAssociationTests
     @pirate.public_send(@association_name).each { |child| child.name = "" }
 
     assert @pirate.save(validate: false)
-    # Oracle saves empty string as NULL
-    if current_adapter?(:OracleAdapter)
-      assert_equal [nil, nil, nil], [
-        @pirate.reload.catchphrase,
-        @pirate.public_send(@association_name).first.name,
-        @pirate.public_send(@association_name).last.name
-      ]
-    else
-      assert_equal ["", "", ""], [
-        @pirate.reload.catchphrase,
-        @pirate.public_send(@association_name).first.name,
-        @pirate.public_send(@association_name).last.name
-      ]
-    end
+    assert_equal ["", "", ""], [
+      @pirate.reload.catchphrase,
+      @pirate.public_send(@association_name).first.name,
+      @pirate.public_send(@association_name).last.name
+    ]
   end
 
   def test_should_validation_the_associated_models_on_create

--- a/activerecord/test/cases/calculations_test.rb
+++ b/activerecord/test/cases/calculations_test.rb
@@ -277,24 +277,18 @@ class CalculationsTest < ActiveRecord::TestCase
   end
 
   def test_limit_is_kept
-    return if current_adapter?(:OracleAdapter)
-
     queries = capture_sql { Account.limit(1).count }
     assert_equal 1, queries.length
     assert_match(/LIMIT/, queries.first)
   end
 
   def test_offset_is_kept
-    return if current_adapter?(:OracleAdapter)
-
     queries = capture_sql { Account.offset(1).count }
     assert_equal 1, queries.length
     assert_match(/OFFSET/, queries.first)
   end
 
   def test_limit_with_offset_is_kept
-    return if current_adapter?(:OracleAdapter)
-
     queries = capture_sql { Account.limit(1).offset(1).count }
     assert_equal 1, queries.length
     assert_match(/LIMIT/, queries.first)
@@ -844,11 +838,7 @@ class CalculationsTest < ActiveRecord::TestCase
   end
 
   def test_pluck_without_column_names
-    if current_adapter?(:OracleAdapter)
-      assert_equal [[1, "Firm", 1, nil, "37signals", nil, 1, nil, nil, "active"]], Company.order(:id).limit(1).pluck
-    else
-      assert_equal [[1, "Firm", 1, nil, "37signals", nil, 1, nil, "", "active"]], Company.order(:id).limit(1).pluck
-    end
+    assert_equal [[1, "Firm", 1, nil, "37signals", nil, 1, nil, "", "active"]], Company.order(:id).limit(1).pluck
   end
 
   def test_pluck_type_cast

--- a/activerecord/test/cases/comment_test.rb
+++ b/activerecord/test/cases/comment_test.rb
@@ -87,11 +87,9 @@ if ActiveRecord::Base.lease_connection.supports_comments?
     end
 
     def test_add_index_with_comment_later
-      unless current_adapter?(:OracleAdapter)
-        @connection.add_index :commenteds, :obvious, name: "idx_obvious", comment: "We need to see obvious comments"
-        index = @connection.indexes("commenteds").find { |idef| idef.name == "idx_obvious" }
-        assert_equal "We need to see obvious comments", index.comment
-      end
+      @connection.add_index :commenteds, :obvious, name: "idx_obvious", comment: "We need to see obvious comments"
+      index = @connection.indexes("commenteds").find { |idef| idef.name == "idx_obvious" }
+      assert_equal "We need to see obvious comments", index.comment
     end
 
     def test_add_comment_to_column
@@ -139,13 +137,9 @@ if ActiveRecord::Base.lease_connection.supports_comments?
       assert_match %r[t\.string\s+"name",\s+comment: "Comment should help clarify the column purpose"], output
       assert_match %r[t\.string\s+"obvious"\n], output
       assert_match %r[t\.string\s+"content",\s+comment: "Whoa, content describes itself!"], output
-      if current_adapter?(:OracleAdapter)
-        assert_match %r[t\.integer\s+"rating",\s+precision: 38,\s+comment: "I am running out of imagination"], output
-      else
-        assert_match %r[t\.integer\s+"rating",\s+comment: "I am running out of imagination"], output
-        assert_match %r[t\.index\s+.+\s+comment: "\\"Very important\\" index that powers all the performance.\\nAnd it's fun!"], output
-        assert_match %r[t\.index\s+.+\s+name: "idx_obvious",\s+comment: "We need to see obvious comments"], output
-      end
+      assert_match %r[t\.integer\s+"rating",\s+comment: "I am running out of imagination"], output
+      assert_match %r[t\.index\s+.+\s+comment: "\\"Very important\\" index that powers all the performance.\\nAnd it's fun!"], output
+      assert_match %r[t\.index\s+.+\s+name: "idx_obvious",\s+comment: "We need to see obvious comments"], output
     end
 
     def test_schema_dump_omits_blank_comments

--- a/activerecord/test/cases/connection_adapters/type_lookup_test.rb
+++ b/activerecord/test/cases/connection_adapters/type_lookup_test.rb
@@ -83,29 +83,17 @@ module ActiveRecord
 
         def test_bigint_limit
           limit = @connection.send(:type_map).lookup("bigint").send(:_limit)
-          if current_adapter?(:OracleAdapter)
-            assert_equal 19, limit
-          else
-            assert_equal 8, limit
-          end
+
+          assert_equal 8, limit
         end
 
         def test_decimal_without_scale
-          if current_adapter?(:OracleAdapter)
-            {
-              decimal: %w{decimal(2) decimal(2,0) numeric(2) numeric(2,0)},
-              integer: %w{number(2) number(2,0)}
-            }
-          else
-            { decimal: %w{decimal(2) decimal(2,0) numeric(2) numeric(2,0) number(2) number(2,0)} }
-          end.each do |expected_type, types|
-            types.each do |type|
+           %w{decimal(2) decimal(2,0) numeric(2) numeric(2,0) number(2) number(2,0)}.each do |type|
               cast_type = @connection.send(:type_map).lookup(type)
 
-              assert_equal expected_type, cast_type.type
+              assert_equal :decimal, cast_type.type
               assert_equal 2, cast_type.cast(2.1)
-            end
-          end
+           end
         end
 
         private

--- a/activerecord/test/cases/database_statements_test.rb
+++ b/activerecord/test/cases/database_statements_test.rb
@@ -7,11 +7,9 @@ class DatabaseStatementsTest < ActiveRecord::TestCase
     @connection = ActiveRecord::Base.lease_connection
   end
 
-  unless current_adapter?(:OracleAdapter)
-    def test_exec_insert
-      result = @connection.exec_insert("INSERT INTO accounts (firm_id,credit_limit) VALUES (42,5000)", nil, [])
-      assert_not_nil @connection.send(:last_inserted_id, result)
-    end
+  def test_exec_insert
+    result = @connection.exec_insert("INSERT INTO accounts (firm_id,credit_limit) VALUES (42,5000)", nil, [])
+    assert_not_nil @connection.send(:last_inserted_id, result)
   end
 
   def test_insert_should_return_the_inserted_id
@@ -24,13 +22,6 @@ class DatabaseStatementsTest < ActiveRecord::TestCase
 
   private
     def return_the_inserted_id(method:)
-      # Oracle adapter uses prefetched primary key values from sequence and passes them to connection adapter insert method
-      if current_adapter?(:OracleAdapter)
-        sequence_name = "accounts_seq"
-        id_value = @connection.next_sequence_value(sequence_name)
-        @connection.send(method, "INSERT INTO accounts (id, firm_id,credit_limit) VALUES (accounts_seq.nextval,42,5000)", nil, :id, id_value, sequence_name)
-      else
-        @connection.send(method, "INSERT INTO accounts (firm_id,credit_limit) VALUES (42,5000)")
-      end
+      @connection.send(method, "INSERT INTO accounts (firm_id,credit_limit) VALUES (42,5000)")
     end
 end

--- a/activerecord/test/cases/date_time_precision_test.rb
+++ b/activerecord/test/cases/date_time_precision_test.rb
@@ -245,7 +245,7 @@ class DateTimePrecisionTest < ActiveRecord::TestCase
       assert_match %r{t\.datetime\s+"updated_at",\s+precision: nil,\s+null: false$}, output
     end
 
-    if current_adapter?(:PostgreSQLAdapter, :SQLServerAdapter)
+    if current_adapter?(:PostgreSQLAdapter)
       def test_datetime_precision_with_zero_should_be_dumped
         @connection.create_table(:foos, force: true) do |t|
           t.timestamps precision: 0

--- a/activerecord/test/cases/dup_test.rb
+++ b/activerecord/test/cases/dup_test.rb
@@ -175,8 +175,6 @@ module ActiveRecord
     end
 
     def test_dup_without_primary_key
-      skip if current_adapter?(:OracleAdapter)
-
       klass = Class.new(ActiveRecord::Base) do
         self.table_name = "parrots_pirates"
       end

--- a/activerecord/test/cases/invertible_migration_test.rb
+++ b/activerecord/test/cases/invertible_migration_test.rb
@@ -481,7 +481,7 @@ module ActiveRecord
     end
 
     # MySQL 5.7 and Oracle do not allow to create duplicate indexes on the same columns
-    unless current_adapter?(:Mysql2Adapter, :TrilogyAdapter, :OracleAdapter)
+    unless current_adapter?(:Mysql2Adapter, :TrilogyAdapter)
       def test_migrate_revert_add_index_with_name
         RevertNamedIndexMigration1.new.migrate(:up)
         RevertNamedIndexMigration2.new.migrate(:up)

--- a/activerecord/test/cases/json_shared_test_cases.rb
+++ b/activerecord/test/cases/json_shared_test_cases.rb
@@ -281,10 +281,6 @@ module JSONSharedTestCases
     end
 
     def insert_statement_per_database(values)
-      if current_adapter?(:OracleAdapter)
-        "insert into json_data_type (id, payload) VALUES (json_data_type_seq.nextval, '#{values}')"
-      else
-        "insert into json_data_type (payload) VALUES ('#{values}')"
-      end
+      "insert into json_data_type (payload) VALUES ('#{values}')"
     end
 end

--- a/activerecord/test/cases/migration/change_schema_test.rb
+++ b/activerecord/test/cases/migration/change_schema_test.rb
@@ -106,9 +106,7 @@ module ActiveRecord
         columns = connection.columns(:testings)
         eight   = columns.detect { |c| c.name == "eight_int"   }
 
-        if current_adapter?(:OracleAdapter)
-          assert_equal "NUMBER(19)", eight.sql_type
-        elsif current_adapter?(:SQLite3Adapter)
+        if current_adapter?(:SQLite3Adapter)
           assert_equal "bigint", eight.sql_type
         else
           assert_equal :integer, eight.type
@@ -148,11 +146,6 @@ module ActiveRecord
           assert_match %r/\Atinyint/, one.sql_type
           assert_match %r/\Aint/, four.sql_type
           assert_match %r/\Abigint/, eight.sql_type
-        elsif current_adapter?(:OracleAdapter)
-          assert_equal "NUMBER(38)", default.sql_type
-          assert_equal "NUMBER(1)", one.sql_type
-          assert_equal "NUMBER(4)", four.sql_type
-          assert_equal "NUMBER(8)", eight.sql_type
         end
       end
 
@@ -284,8 +277,6 @@ module ActiveRecord
           assert_equal "timestamp without time zone", column.sql_type
         elsif current_adapter?(:Mysql2Adapter, :TrilogyAdapter)
           assert_equal "timestamp", column.sql_type
-        elsif current_adapter?(:OracleAdapter)
-          assert_equal "TIMESTAMP(6)", column.sql_type
         else
           assert_equal connection.type_to_sql("datetime(6)"), column.sql_type
         end
@@ -340,8 +331,6 @@ module ActiveRecord
           assert_equal "timestamp without time zone", column.sql_type
         elsif current_adapter?(:Mysql2Adapter, :TrilogyAdapter)
           assert_equal "timestamp", column.sql_type
-        elsif current_adapter?(:OracleAdapter)
-          assert_equal "TIMESTAMP(6)", column.sql_type
         else
           assert_equal connection.type_to_sql("datetime(6)"), column.sql_type
         end
@@ -354,12 +343,7 @@ module ActiveRecord
 
         connection.change_column :testings, :select, :string, limit: 10
 
-        # Oracle needs primary key value from sequence
-        if current_adapter?(:OracleAdapter)
-          connection.execute "insert into testings (id, #{connection.quote_column_name('select')}) values (testings_seq.nextval, '7 chars')"
-        else
-          connection.execute "insert into testings (#{connection.quote_column_name('select')}) values ('7 chars')"
-        end
+        connection.execute "insert into testings (#{connection.quote_column_name('select')}) values ('7 chars')"
 
         assert_equal 1, connection.select_value("SELECT COUNT(*) FROM testings")
       end
@@ -375,12 +359,7 @@ module ActiveRecord
         person_klass.reset_column_information
         assert_equal 99, person_klass.column_defaults["wealth"]
         assert_equal false, person_klass.columns_hash["wealth"].null
-        # Oracle needs primary key value from sequence
-        if current_adapter?(:OracleAdapter)
-          assert_nothing_raised { person_klass.lease_connection.execute("insert into testings (id, title) values (testings_seq.nextval, 'tester')") }
-        else
-          assert_nothing_raised { person_klass.lease_connection.execute("insert into testings (title) values ('tester')") }
-        end
+        assert_nothing_raised { person_klass.lease_connection.execute("insert into testings (title) values ('tester')") }
 
         # change column default to see that column doesn't lose its not null definition
         person_klass.lease_connection.change_column_default "testings", "wealth", 100

--- a/activerecord/test/cases/migration/column_attributes_test.rb
+++ b/activerecord/test/cases/migration/column_attributes_test.rb
@@ -62,12 +62,7 @@ module ActiveRecord
 
           connection.add_column "test_models", "wealth", :decimal, precision: "30", scale: "10"
 
-          # Do a manual insertion
-          if current_adapter?(:OracleAdapter)
-            connection.execute "insert into test_models (id, wealth) values (people_seq.nextval, 12345678901234567890.0123456789)"
-          else
-            connection.execute "insert into test_models (wealth) values (12345678901234567890.0123456789)"
-          end
+          connection.execute "insert into test_models (wealth) values (12345678901234567890.0123456789)"
 
           # SELECT
           row = TestModel.first

--- a/activerecord/test/cases/migration/columns_test.rb
+++ b/activerecord/test/cases/migration/columns_test.rb
@@ -75,7 +75,7 @@ module ActiveRecord
       end
 
       def test_rename_nonexistent_column
-        exception = if current_adapter?(:PostgreSQLAdapter, :OracleAdapter)
+        exception = if current_adapter?(:PostgreSQLAdapter)
           ActiveRecord::StatementInvalid
         else
           ActiveRecord::ActiveRecordError
@@ -147,7 +147,7 @@ module ActiveRecord
 
         # Every database and/or database adapter has their own behavior
         # if it drops the multi-column index when any of the indexed columns dropped by remove_column.
-        if current_adapter?(:PostgreSQLAdapter, :OracleAdapter)
+        if current_adapter?(:PostgreSQLAdapter)
           assert_equal [], connection.indexes("test_models").map(&:name)
         else
           assert_equal ["index_test_models_on_hat_style_and_hat_size"], connection.indexes("test_models").map(&:name)

--- a/activerecord/test/cases/migration/references_index_test.rb
+++ b/activerecord/test/cases/migration/references_index_test.rb
@@ -51,22 +51,20 @@ module ActiveRecord
         assert connection.index_exists?(table_name, :bar_id, name: :index_testings_on_bar_id, unique: true)
       end
 
-      unless current_adapter? :OracleAdapter
-        def test_creates_polymorphic_index
-          connection.create_table table_name do |t|
-            t.references :foo, polymorphic: true, index: true
-          end
-
-          assert connection.index_exists?(table_name, [:foo_type, :foo_id], name: :index_testings_on_foo)
+      def test_creates_polymorphic_index
+        connection.create_table table_name do |t|
+          t.references :foo, polymorphic: true, index: true
         end
 
-        def test_creates_polymorphic_index_with_custom_name
-          connection.create_table table_name do |t|
-            t.references :foo, polymorphic: true, index: { name: :testings_foo_index }
-          end
+        assert connection.index_exists?(table_name, [:foo_type, :foo_id], name: :index_testings_on_foo)
+      end
 
-          assert connection.index_exists?(table_name, [:foo_type, :foo_id], name: :testings_foo_index)
+      def test_creates_polymorphic_index_with_custom_name
+        connection.create_table table_name do |t|
+          t.references :foo, polymorphic: true, index: { name: :testings_foo_index }
         end
+
+        assert connection.index_exists?(table_name, [:foo_type, :foo_id], name: :testings_foo_index)
       end
 
       def test_creates_index_for_existing_table
@@ -96,24 +94,22 @@ module ActiveRecord
         assert_not connection.index_exists?(table_name, :foo_id, name: :index_testings_on_foo_id)
       end
 
-      unless current_adapter? :OracleAdapter
-        def test_creates_polymorphic_index_for_existing_table
-          connection.create_table table_name
-          connection.change_table table_name do |t|
-            t.references :foo, polymorphic: true, index: true
-          end
-
-          assert connection.index_exists?(table_name, [:foo_type, :foo_id], name: :index_testings_on_foo)
+      def test_creates_polymorphic_index_for_existing_table
+        connection.create_table table_name
+        connection.change_table table_name do |t|
+          t.references :foo, polymorphic: true, index: true
         end
 
-        def test_creates_polymorphic_index_for_existing_table_with_custom_name
-          connection.create_table table_name
-          connection.change_table table_name do |t|
-            t.references :foo, polymorphic: true, index: { name: :testings_foo_index }
-          end
+        assert connection.index_exists?(table_name, [:foo_type, :foo_id], name: :index_testings_on_foo)
+      end
 
-          assert connection.index_exists?(table_name, [:foo_type, :foo_id], name: :testings_foo_index)
+      def test_creates_polymorphic_index_for_existing_table_with_custom_name
+        connection.create_table table_name
+        connection.change_table table_name do |t|
+          t.references :foo, polymorphic: true, index: { name: :testings_foo_index }
         end
+
+        assert connection.index_exists?(table_name, [:foo_type, :foo_id], name: :testings_foo_index)
       end
     end
   end

--- a/activerecord/test/cases/migration/rename_table_test.rb
+++ b/activerecord/test/cases/migration/rename_table_test.rb
@@ -21,24 +21,22 @@ module ActiveRecord
         super
       end
 
-      unless current_adapter?(:OracleAdapter)
-        def test_rename_table_should_work_with_reserved_words
-          renamed = false
+      def test_rename_table_should_work_with_reserved_words
+        renamed = false
 
-          connection.rename_table :references, :old_references
-          connection.rename_table :test_models, :references
+        connection.rename_table :references, :old_references
+        connection.rename_table :test_models, :references
 
-          renamed = true
+        renamed = true
 
-          # Using explicit id in insert for compatibility across all databases
-          table_name = connection.quote_table_name("references")
-          connection.execute "INSERT INTO #{table_name} (id, url) VALUES (123, 'http://rubyonrails.com')"
-          assert_equal "http://rubyonrails.com", connection.select_value("SELECT url FROM #{table_name} WHERE id=123")
-        ensure
-          if renamed
-            connection.rename_table :references, :test_models
-            connection.rename_table :old_references, :references
-          end
+        # Using explicit id in insert for compatibility across all databases
+        table_name = connection.quote_table_name("references")
+        connection.execute "INSERT INTO #{table_name} (id, url) VALUES (123, 'http://rubyonrails.com')"
+        assert_equal "http://rubyonrails.com", connection.select_value("SELECT url FROM #{table_name} WHERE id=123")
+      ensure
+        if renamed
+          connection.rename_table :references, :test_models
+          connection.rename_table :old_references, :references
         end
       end
 

--- a/activerecord/test/cases/multiparameter_attributes_test.rb
+++ b/activerecord/test/cases/multiparameter_attributes_test.rb
@@ -249,36 +249,33 @@ class MultiParameterAttributeTest < ActiveRecord::TestCase
     Topic.reset_column_information
   end
 
-  # Oracle does not have a TIME datatype.
-  unless current_adapter?(:OracleAdapter)
-    def test_multiparameter_attributes_on_time_only_column_with_time_zone_aware_attributes_does_not_do_time_zone_conversion
-      with_timezone_config default: :utc, aware_attributes: true, zone: -28800 do
-        Topic.reset_column_information
-        attributes = {
-          "bonus_time(1i)" => "2000", "bonus_time(2i)" => "1", "bonus_time(3i)" => "1",
-          "bonus_time(4i)" => "16", "bonus_time(5i)" => "24"
-        }
-        topic = Topic.find(1)
-        topic.attributes = attributes
-        assert_equal Time.zone.local(2000, 1, 1, 16, 24, 0), topic.bonus_time
-        assert_not_predicate topic.bonus_time, :utc?
-
-        attributes = {
-          "written_on(1i)" => "2000", "written_on(2i)" => "", "written_on(3i)" => "",
-          "written_on(4i)" => "", "written_on(5i)" => ""
-        }
-        topic.attributes = attributes
-        assert_nil topic.written_on
-      end
-    ensure
+  def test_multiparameter_attributes_on_time_only_column_with_time_zone_aware_attributes_does_not_do_time_zone_conversion
+    with_timezone_config default: :utc, aware_attributes: true, zone: -28800 do
       Topic.reset_column_information
-    end
+      attributes = {
+        "bonus_time(1i)" => "2000", "bonus_time(2i)" => "1", "bonus_time(3i)" => "1",
+        "bonus_time(4i)" => "16", "bonus_time(5i)" => "24"
+      }
+      topic = Topic.find(1)
+      topic.attributes = attributes
+      assert_equal Time.zone.local(2000, 1, 1, 16, 24, 0), topic.bonus_time
+      assert_not_predicate topic.bonus_time, :utc?
 
-    def test_multiparameter_attributes_setting_time_attribute
-      topic = Topic.new("bonus_time(4i)" => "01", "bonus_time(5i)" => "05")
-      assert_equal 1, topic.bonus_time.hour
-      assert_equal 5, topic.bonus_time.min
+      attributes = {
+        "written_on(1i)" => "2000", "written_on(2i)" => "", "written_on(3i)" => "",
+        "written_on(4i)" => "", "written_on(5i)" => ""
+      }
+      topic.attributes = attributes
+      assert_nil topic.written_on
     end
+  ensure
+    Topic.reset_column_information
+  end
+
+  def test_multiparameter_attributes_setting_time_attribute
+    topic = Topic.new("bonus_time(4i)" => "01", "bonus_time(5i)" => "05")
+    assert_equal 1, topic.bonus_time.hour
+    assert_equal 5, topic.bonus_time.min
   end
 
   def test_multiparameter_attributes_on_time_with_empty_seconds

--- a/activerecord/test/cases/primary_keys_test.rb
+++ b/activerecord/test/cases/primary_keys_test.rb
@@ -241,8 +241,6 @@ class PrimaryKeysTest < ActiveRecord::TestCase
   end
 
   def test_create_without_primary_key_no_extra_query
-    skip if current_adapter?(:OracleAdapter)
-
     klass = Class.new(ActiveRecord::Base) do
       self.table_name = "dashboards"
     end

--- a/activerecord/test/cases/readonly_test.rb
+++ b/activerecord/test/cases/readonly_test.rb
@@ -130,14 +130,10 @@ class ReadOnlyTest < ActiveRecord::TestCase
       assert_not_predicate Post.readonly(false).find(1), :readonly?
     end
 
-    # Oracle barfs on this because the join includes unqualified and
-    # conflicting column names
-    unless current_adapter?(:OracleAdapter)
-      Post.joins(", developers").scoping do
-        assert_not_predicate Post.find(1), :readonly?
-        assert_predicate Post.readonly.find(1), :readonly?
-        assert_not_predicate Post.readonly(false).find(1), :readonly?
-      end
+    Post.joins(", developers").scoping do
+      assert_not_predicate Post.find(1), :readonly?
+      assert_predicate Post.readonly.find(1), :readonly?
+      assert_not_predicate Post.readonly(false).find(1), :readonly?
     end
 
     Post.readonly(true).scoping do

--- a/activerecord/test/cases/relation/update_all_test.rb
+++ b/activerecord/test/cases/relation/update_all_test.rb
@@ -321,31 +321,28 @@ class UpdateAllTest < ActiveRecord::TestCase
     assert_equal 1, join_scope.update_all(status: "shipped")
   end
 
-  # Oracle UPDATE does not support ORDER BY
-  unless current_adapter?(:OracleAdapter)
-    def test_update_all_ignores_order_without_limit_from_association
-      author = authors(:david)
-      assert_nothing_raised do
-        assert_equal author.posts_with_comments_and_categories.length, author.posts_with_comments_and_categories.update_all([ "body = ?", "bulk update!" ])
-      end
+  def test_update_all_ignores_order_without_limit_from_association
+    author = authors(:david)
+    assert_nothing_raised do
+      assert_equal author.posts_with_comments_and_categories.length, author.posts_with_comments_and_categories.update_all([ "body = ?", "bulk update!" ])
+    end
+  end
+
+  def test_update_all_doesnt_ignore_order
+    assert_equal authors(:david).id + 1, authors(:mary).id # make sure there is going to be a duplicate PK error
+    test_update_with_order_succeeds = lambda do |order|
+      Author.order(order).update_all("id = id + 1")
+    rescue ActiveRecord::ActiveRecordError
+      false
     end
 
-    def test_update_all_doesnt_ignore_order
-      assert_equal authors(:david).id + 1, authors(:mary).id # make sure there is going to be a duplicate PK error
-      test_update_with_order_succeeds = lambda do |order|
-        Author.order(order).update_all("id = id + 1")
-      rescue ActiveRecord::ActiveRecordError
-        false
-      end
-
-      if test_update_with_order_succeeds.call("id DESC")
-        # test that this wasn't a fluke and using an incorrect order results in an exception
-        assert_not test_update_with_order_succeeds.call("id ASC")
-      else
-        # test that we're failing because the current Arel's engine doesn't support UPDATE ORDER BY queries is using subselects instead
-        assert_queries_match(/\AUPDATE .+ \(SELECT .* ORDER BY id DESC\)\z/i) do
-          test_update_with_order_succeeds.call("id DESC")
-        end
+    if test_update_with_order_succeeds.call("id DESC")
+      # test that this wasn't a fluke and using an incorrect order results in an exception
+      assert_not test_update_with_order_succeeds.call("id ASC")
+    else
+      # test that we're failing because the current Arel's engine doesn't support UPDATE ORDER BY queries is using subselects instead
+      assert_queries_match(/\AUPDATE .+ \(SELECT .* ORDER BY id DESC\)\z/i) do
+        test_update_with_order_succeeds.call("id DESC")
       end
     end
 

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -362,7 +362,7 @@ class RelationTest < ActiveRecord::TestCase
     assert_raises(ActiveRecord::IrreversibleOrderError) do
       Topic.order("author_name, title nulls last").reverse_order
     end
-  end if current_adapter?(:PostgreSQLAdapter, :OracleAdapter)
+  end if current_adapter?(:PostgreSQLAdapter)
 
   def test_default_reverse_order_on_table_without_primary_key
     assert_raises(ActiveRecord::IrreversibleOrderError) do
@@ -1894,11 +1894,8 @@ class RelationTest < ActiveRecord::TestCase
     assert_equal ["comments"], scope.references_values
 
     scope = Post.order("#{Comment.quoted_table_name}.#{Comment.quoted_primary_key}")
-    if current_adapter?(:OracleAdapter)
-      assert_equal ["COMMENTS"], scope.references_values
-    else
-      assert_equal ["comments"], scope.references_values
-    end
+
+    assert_equal ["comments"], scope.references_values
 
     scope = Post.order("comments.body", "yaks.body")
     assert_equal ["comments", "yaks"], scope.references_values
@@ -1919,11 +1916,8 @@ class RelationTest < ActiveRecord::TestCase
     assert_equal %w(comments), scope.references_values
 
     scope = Post.reorder("#{Comment.quoted_table_name}.#{Comment.quoted_primary_key}")
-    if current_adapter?(:OracleAdapter)
-      assert_equal ["COMMENTS"], scope.references_values
-    else
-      assert_equal ["comments"], scope.references_values
-    end
+
+    assert_equal ["comments"], scope.references_values
 
     scope = Post.reorder("comments.body", "yaks.body")
     assert_equal %w(comments yaks), scope.references_values

--- a/activerecord/test/cases/schema_dumper_test.rb
+++ b/activerecord/test/cases/schema_dumper_test.rb
@@ -138,7 +138,7 @@ class SchemaDumperTest < ActiveRecord::TestCase
       assert_match %r{c_int_4.*limit: 4}, output
     end
 
-    if current_adapter?(:SQLite3Adapter, :OracleAdapter)
+    if current_adapter?(:SQLite3Adapter)
       assert_match %r{c_int_5.*limit: 5}, output
       assert_match %r{c_int_6.*limit: 6}, output
       assert_match %r{c_int_7.*limit: 7}, output
@@ -423,12 +423,8 @@ class SchemaDumperTest < ActiveRecord::TestCase
 
   def test_schema_dump_keeps_large_precision_integer_columns_as_decimal
     output = standard_dump
-    # Oracle supports precision up to 38 and it identifies decimals with scale 0 as integers
-    if current_adapter?(:OracleAdapter)
-      assert_match %r{t\.integer\s+"atoms_in_universe",\s+precision: 38}, output
-    else
-      assert_match %r{t\.decimal\s+"atoms_in_universe",\s+precision: 55}, output
-    end
+
+    assert_match %r{t\.decimal\s+"atoms_in_universe",\s+precision: 55}, output
   end
 
   def test_schema_dump_keeps_id_column_when_id_is_false_and_id_column_added

--- a/activerecord/test/cases/time_precision_test.rb
+++ b/activerecord/test/cases/time_precision_test.rb
@@ -110,7 +110,7 @@ class TimePrecisionTest < ActiveRecord::TestCase
       assert_match %r{t\.time\s+"finish",\s+precision: 6$}, output
     end
 
-    if current_adapter?(:PostgreSQLAdapter, :SQLServerAdapter)
+    if current_adapter?(:PostgreSQLAdapter)
       def test_time_precision_with_zero_should_be_dumped
         @connection.create_table(:foos, force: true) do |t|
           t.time :start,  precision: 0

--- a/activerecord/test/cases/validations/uniqueness_validation_test.rb
+++ b/activerecord/test/cases/validations/uniqueness_validation_test.rb
@@ -442,7 +442,7 @@ class UniquenessValidationTest < ActiveRecord::TestCase
 
       e2 = Event.create(title: "abcdefgh")
       assert_not e2.valid?, "Created an event whose title is not unique"
-    elsif current_adapter?(:Mysql2Adapter, :TrilogyAdapter, :PostgreSQLAdapter, :OracleAdapter, :SQLServerAdapter)
+    elsif current_adapter?(:Mysql2Adapter, :TrilogyAdapter, :PostgreSQLAdapter)
       assert_raise(ActiveRecord::ValueTooLong) do
         Event.create(title: "abcdefgh")
       end
@@ -461,7 +461,7 @@ class UniquenessValidationTest < ActiveRecord::TestCase
 
       e2 = Event.create(title: "一二三四五六七八")
       assert_not e2.valid?, "Created an event whose title is not unique"
-    elsif current_adapter?(:Mysql2Adapter, :TrilogyAdapter, :PostgreSQLAdapter, :OracleAdapter, :SQLServerAdapter)
+    elsif current_adapter?(:Mysql2Adapter, :TrilogyAdapter, :PostgreSQLAdapter)
       assert_raise(ActiveRecord::ValueTooLong) do
         Event.create(title: "一二三四五六七八")
       end

--- a/activerecord/test/cases/view_test.rb
+++ b/activerecord/test/cases/view_test.rb
@@ -160,7 +160,7 @@ if ActiveRecord::Base.lease_connection.supports_views?
 
   class UpdateableViewTest < ActiveRecord::TestCase
     # SQLite does not support CREATE, INSERT, and DELETE for VIEW
-    if current_adapter?(:Mysql2Adapter, :TrilogyAdapter, :SQLServerAdapter, :PostgreSQLAdapter)
+    if current_adapter?(:Mysql2Adapter, :TrilogyAdapter, :PostgreSQLAdapter)
       self.use_transactional_tests = false
       fixtures :books
 
@@ -210,7 +210,7 @@ if ActiveRecord::Base.lease_connection.supports_views?
           book.reload
         end
       end
-    end # end of `if current_adapter?(:Mysql2Adapter, :TrilogyAdapter, :PostgreSQLAdapter, :SQLServerAdapter)`
+    end # end of `if current_adapter?(:Mysql2Adapter, :TrilogyAdapter, :PostgreSQLAdapter)`
   end
 end # end of `if ActiveRecord::Base.lease_connection.supports_views?`
 

--- a/activerecord/test/config.example.yml
+++ b/activerecord/test/config.example.yml
@@ -1,40 +1,4 @@
-default_connection: <%= defined?(JRUBY_VERSION) ? 'jdbcsqlite3' : 'sqlite3' %>
-
 connections:
-  jdbcderby:
-    arunit:  activerecord_unittest
-    arunit2: activerecord_unittest2
-
-  jdbch2:
-    arunit:  activerecord_unittest
-    arunit2: activerecord_unittest2
-
-  jdbchsqldb:
-    arunit:  activerecord_unittest
-    arunit2: activerecord_unittest2
-
-  jdbcmysql:
-    arunit:
-      username: rails
-      encoding: utf8
-    arunit2:
-      username: rails
-      encoding: utf8
-
-  jdbcpostgresql:
-    arunit:
-      username: <%= ENV['user'] || 'rails' %>
-    arunit2:
-      username: <%= ENV['user'] || 'rails' %>
-
-  jdbcsqlite3:
-    arunit:
-      database: <%= FIXTURES_ROOT %>/fixture_database.sqlite3
-      timeout:  5000
-    arunit2:
-      database: <%= FIXTURES_ROOT %>/fixture_database_2.sqlite3
-      timeout:  5000
-
   mysql2:
     arunit:
       username: rails
@@ -90,20 +54,6 @@ connections:
     <% if ENV['MYSQL_SOCK'] %>
       socket: "<%= ENV['MYSQL_SOCK'] %>"
     <% end %>
-
-  oracle:
-     arunit:
-       adapter: oracle_enhanced
-       database: <%= ENV['ARUNIT_DB_NAME'] || 'orcl' %>
-       username: <%= ENV['ARUNIT_USER_NAME'] || 'arunit' %>
-       password: <%= ENV['ARUNIT_PASSWORD'] || 'arunit' %>
-       emulate_oracle_adapter: true
-     arunit2:
-       adapter: oracle_enhanced
-       database: <%= ENV['ARUNIT_DB_NAME'] || 'orcl' %>
-       username: <%= ENV['ARUNIT2_USER_NAME'] || 'arunit2' %>
-       password: <%= ENV['ARUNIT2_PASSWORD'] || 'arunit2' %>
-       emulate_oracle_adapter: true
 
   postgresql:
     arunit:

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -382,13 +382,7 @@ ActiveRecord::Schema.define do
 
   create_table :comments, force: true do |t|
     t.integer :post_id, null: false
-    # use VARCHAR2(4000) instead of CLOB datatype as CLOB data type has many limitations in
-    # Oracle SELECT WHERE clause which causes many unit test failures
-    if ActiveRecord::TestCase.current_adapter?(:OracleAdapter)
-      t.string  :body, null: false, limit: 4000
-    else
-      t.text    :body, null: false
-    end
+    t.text    :body, null: false
     t.string  :type
     t.integer :label, default: 0
     t.integer :tags_count, default: 0
@@ -873,12 +867,7 @@ ActiveRecord::Schema.define do
     t.numeric :numeric_number
     t.float   :temperature
     t.decimal :decimal_number_big_precision, precision: 20
-    # Oracle/SQLServer supports precision up to 38
-    if ActiveRecord::TestCase.current_adapter?(:OracleAdapter, :SQLServerAdapter)
-      t.decimal :atoms_in_universe, precision: 38, scale: 0
-    else
-      t.decimal :atoms_in_universe, precision: 55, scale: 0
-    end
+    t.decimal :atoms_in_universe, precision: 55, scale: 0
   end
 
   create_table :orders, force: true do |t|
@@ -1012,13 +1001,7 @@ ActiveRecord::Schema.define do
   create_table :posts, force: true do |t|
     t.references :author
     t.string :title, null: false
-    # use VARCHAR2(4000) instead of CLOB datatype as CLOB data type has many limitations in
-    # Oracle SELECT WHERE clause which causes many unit test failures
-    if ActiveRecord::TestCase.current_adapter?(:OracleAdapter)
-      t.string  :body, null: false, limit: 4000
-    else
-      t.text    :body, null: false
-    end
+    t.text    :body, null: false
     t.string  :type
     t.integer :legacy_comments_count, default: 0
     t.integer :taggings_with_delete_all_count, default: 0
@@ -1258,15 +1241,8 @@ ActiveRecord::Schema.define do
     end
     t.time     :bonus_time
     t.date     :last_read
-    # use VARCHAR2(4000) instead of CLOB datatype as CLOB data type has many limitations in
-    # Oracle SELECT WHERE clause which causes many unit test failures
-    if ActiveRecord::TestCase.current_adapter?(:OracleAdapter)
-      t.string   :content, limit: 4000
-      t.string   :important, limit: 4000
-    else
-      t.text     :content
-      t.text     :important
-    end
+    t.text     :content
+    t.text     :important
     t.blob     :binary_content
     t.boolean  :approved, default: true
     t.integer  :replies_count, default: 0


### PR DESCRIPTION
### Motivation / Background

More clean up based on removing support for Oracle, SQLServer and Jbdc adapters.

Previous work:
https://github.com/rails/rails/commit/8eae75379cf3156228028006c54c82f5cf6c712d
https://github.com/rails/rails/pull/51765/commits/5b91084f20ed9a15c3137e5c84c09edc1b81ba3d

### Detail

Remove all the branching from tests where we have specific logic for those adapters. And I removed all the test db configs for those adapters.

~I also removed the `database.yml.tt` for those adapters, which I missed doing in my previous PR.~

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
