### PR TITLE
Refactor change generator database implementation

### DIFF
--- a/railties/lib/rails/generators/database.rb
+++ b/railties/lib/rails/generators/database.rb
@@ -46,14 +46,6 @@ module Rails
         raise NotImplementedError
       end
 
-      def docker_base
-        raise NotImplementedError
-      end
-
-      def docker_build
-        raise NotImplementedError
-      end
-
       def base_package
         raise NotImplementedError
       end
@@ -125,14 +117,6 @@ module Rails
           ["mysql2", ["~> 0.5"]]
         end
 
-        def docker_base
-          "curl default-mysql-client libvips"
-        end
-
-        def docker_build
-          "build-essential default-libmysqlclient-dev git"
-        end
-
         def base_package
           "default-mysql-client"
         end
@@ -170,14 +154,6 @@ module Rails
 
         def gem
           ["pg", ["~> 1.1"]]
-        end
-
-        def docker_base
-          "curl libvips postgresql-client"
-        end
-
-        def docker_build
-          "build-essential git libpq-dev"
         end
 
         def base_package
@@ -220,14 +196,6 @@ module Rails
           ["trilogy", ["~> 2.7"]]
         end
 
-        def docker_base
-          "curl libvips"
-        end
-
-        def docker_build
-          "build-essential git"
-        end
-
         def base_package
           nil
         end
@@ -258,14 +226,6 @@ module Rails
           ["sqlite3", [">= 1.4"]]
         end
 
-        def docker_base
-          "curl libsqlite3-0 libvips"
-        end
-
-        def docker_build
-          "build-essential git"
-        end
-
         def base_package
           "libsqlite3-0"
         end
@@ -284,8 +244,6 @@ module Rails
         def service; end
         def port; end
         def volume; end
-        def docker_base; end
-        def docker_build; end
         def base_package; end
         def build_package; end
         def feature_name; end

--- a/railties/lib/rails/generators/rails/db/system/change/change_generator.rb
+++ b/railties/lib/rails/generators/rails/db/system/change/change_generator.rb
@@ -11,6 +11,9 @@ module Rails
         class ChangeGenerator < Base # :nodoc:
           include AppName
 
+          BASE_PACKAGES = %w( curl libvips )
+          BUILD_PACKAGES = %w( build-essential git )
+
           class_option :to, required: true,
             desc: "The database system to switch to."
 
@@ -45,14 +48,8 @@ module Rails
             dockerfile_path = File.expand_path("Dockerfile", destination_root)
             return unless File.exist?(dockerfile_path)
 
-            base_name = database.docker_base
-            build_name = database.docker_build
-            if base_name
-              gsub_file("Dockerfile", all_docker_bases_regex, base_name)
-            end
-            if build_name
-              gsub_file("Dockerfile", all_docker_builds_regex, build_name)
-            end
+            gsub_file("Dockerfile", all_docker_bases_regex, docker_base_packages(database.base_package))
+            gsub_file("Dockerfile", all_docker_builds_regex, docker_build_packages(database.build_package))
           end
 
           def edit_devcontainer_files
@@ -69,11 +66,27 @@ module Rails
             end
 
             def all_docker_bases
-              Database.all.filter_map { |database| database.docker_base }
+              Database.all.map { |database| docker_base_packages(database.base_package) }.uniq
+            end
+
+            def docker_base_packages(database_package)
+              if database_package
+                [database_package].concat(BASE_PACKAGES).sort
+              else
+                BASE_PACKAGES
+              end.join("\s")
             end
 
             def all_docker_builds
-              Database.all.filter_map { |database| database.docker_build }
+              Database.all.map { |database| docker_build_packages(database.build_package) }.uniq
+            end
+
+            def docker_build_packages(database_package)
+              if database_package
+                [database_package].concat(BUILD_PACKAGES).sort
+              else
+                BUILD_PACKAGES
+              end.join("\s")
             end
 
             def all_database_gems_regex


### PR DESCRIPTION
### Motivation / Background

While working on https://github.com/rails/rails/pull/51765 I noticed that the `Database` mixin (now object) for generators has info about packages for Docker like `libvips`, `curl`, `git` etc. I thought that was strange because those are not dependencies of the database packages. So I came back to clean this up.

### Detail

The database object has `docker_build` and `docker_base` methods which return a list of packages, including things not related to the database like `git` etc. It turns out they are only used by the `ChangeGenerator`. That generator needs them to create a regex that finds the right `apt-get` line in the `Dockerfile` and replace the current database package with the new package. So, the database object does not need to know about these other packages. It can just tell the change generator what its package is and the generator can build the right regex.

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
