### PR TITLE
Require master key by default in production

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
@@ -20,7 +20,7 @@ Rails.application.configure do
 
   # Ensures that a master key has been made available in ENV["RAILS_MASTER_KEY"], config/master.key, or an environment
   # key such as config/credentials/production.key. This key is used to decrypt credentials (and other encrypted files).
-  # config.require_master_key = true
+  config.require_master_key = true
 
   # Disable serving static files from `public/`, relying on NGINX/Apache to do so instead.
   # config.public_file_server.enabled = false

--- a/railties/test/generators/shared_generator_tests.rb
+++ b/railties/test/generators/shared_generator_tests.rb
@@ -234,7 +234,7 @@ module SharedGeneratorTests
     end
     assert_file "#{application_path}/config/environments/production.rb" do |content|
       assert_match(/# config\.action_mailer\.raise_delivery_errors = false/, content)
-      assert_match(/^  # config\.require_master_key = true/, content)
+      assert_match(/^  config\.require_master_key = true/, content)
     end
   end
 


### PR DESCRIPTION
The secret_key_base necessary for running the app is already encrypted behind the master key. So if this is not turned on, you just get a nonsensical error message. Better to fail fast with a good error message when the master key is missing.