### PR TITLE
Point 7-2-stable branch CHANGELOGS in rails 7-2 release note [ci skip]

### DIFF
--- a/guides/source/7_2_release_notes.md
+++ b/guides/source/7_2_release_notes.md
@@ -316,16 +316,16 @@ See the
 for the many people who spent many hours making Rails, the stable and robust
 framework it is. Kudos to all of them.
 
-[railties]:       https://github.com/rails/rails/blob/main/railties/CHANGELOG.md
-[action-pack]:    https://github.com/rails/rails/blob/main/actionpack/CHANGELOG.md
-[action-view]:    https://github.com/rails/rails/blob/main/actionview/CHANGELOG.md
-[action-mailer]:  https://github.com/rails/rails/blob/main/actionmailer/CHANGELOG.md
-[action-cable]:   https://github.com/rails/rails/blob/main/actioncable/CHANGELOG.md
-[active-record]:  https://github.com/rails/rails/blob/main/activerecord/CHANGELOG.md
-[active-storage]: https://github.com/rails/rails/blob/main/activestorage/CHANGELOG.md
-[active-model]:   https://github.com/rails/rails/blob/main/activemodel/CHANGELOG.md
-[active-support]: https://github.com/rails/rails/blob/main/activesupport/CHANGELOG.md
-[active-job]:     https://github.com/rails/rails/blob/main/activejob/CHANGELOG.md
-[action-text]:    https://github.com/rails/rails/blob/main/actiontext/CHANGELOG.md
-[action-mailbox]: https://github.com/rails/rails/blob/main/actionmailbox/CHANGELOG.md
-[guides]:         https://github.com/rails/rails/blob/main/guides/CHANGELOG.md
+[railties]:       https://github.com/rails/rails/blob/7-2-stable/railties/CHANGELOG.md
+[action-pack]:    https://github.com/rails/rails/blob/7-2-stable/actionpack/CHANGELOG.md
+[action-view]:    https://github.com/rails/rails/blob/7-2-stable/actionview/CHANGELOG.md
+[action-mailer]:  https://github.com/rails/rails/blob/7-2-stable/actionmailer/CHANGELOG.md
+[action-cable]:   https://github.com/rails/rails/blob/7-2-stable/actioncable/CHANGELOG.md
+[active-record]:  https://github.com/rails/rails/blob/7-2-stable/activerecord/CHANGELOG.md
+[active-storage]: https://github.com/rails/rails/blob/7-2-stable/activestorage/CHANGELOG.md
+[active-model]:   https://github.com/rails/rails/blob/7-2-stable/activemodel/CHANGELOG.md
+[active-support]: https://github.com/rails/rails/blob/7-2-stable/activesupport/CHANGELOG.md
+[active-job]:     https://github.com/rails/rails/blob/7-2-stable/activejob/CHANGELOG.md
+[action-text]:    https://github.com/rails/rails/blob/7-2-stable/actiontext/CHANGELOG.md
+[action-mailbox]: https://github.com/rails/rails/blob/7-2-stable/actionmailbox/CHANGELOG.md
+[guides]:         https://github.com/rails/rails/blob/7-2-stable/guides/CHANGELOG.md


### PR DESCRIPTION
### Detail

This Pull Request updates the 7.2 release notes, to point `7-2-stable` instead of `main`.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
