### PR TITLE
Don’t create storage folder if not needed

### DIFF
--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -366,6 +366,10 @@ module Rails
         options[:skip_active_storage]
       end
 
+      def skip_storage? # :doc:
+        skip_active_storage? && !sqlite3?
+      end
+
       def skip_action_cable? # :doc:
         options[:skip_action_cable]
       end
@@ -784,7 +788,7 @@ module Rails
       def dockerfile_chown_directories
         directories = %w(log tmp)
 
-        directories << "storage" unless skip_active_storage? && !sqlite3?
+        directories << "storage" unless skip_storage?
         directories << "db" unless skip_active_record?
 
         directories.sort

--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -455,7 +455,7 @@ module Rails
       end
 
       def create_storage_files
-        build(:storage)
+        build(:storage) unless skip_storage?
       end
 
       def create_devcontainer_files

--- a/railties/test/generators/shared_generator_tests.rb
+++ b/railties/test/generators/shared_generator_tests.rb
@@ -312,6 +312,13 @@ module SharedGeneratorTests
     assert_no_file "#{application_path}/config/storage.yml"
   end
 
+  def test_generator_does_not_create_storage_dir_if_skip_active_storage_is_given_and_not_using_sqlite
+    run_generator [destination_root, "--skip-active-storage", "--database=postgresql"]
+
+    assert_no_directory "#{application_path}/storage"
+    assert_no_directory "#{application_path}/tmp/storage"
+  end
+
   def test_generator_if_skip_action_mailer_is_given
     run_generator [destination_root, "--skip-action-mailer"]
     assert_file "#{application_path}/config/application.rb", /#\s+require\s+["']action_mailer\/railtie["']/


### PR DESCRIPTION
Fixes https://github.com/rails/rails/issues/51835.

### Motivation / Background

This Pull Request has been created because the `storage/` directory seems to be used only for sqlite or
Active Storage. If using a different database and the `--skip-active-storage` option, this directory does not seem like it is needed.

### Detail

This Pull Request changes the rails app generator to not create the storage directory if skipping Active Storage and using a database that is different from sqlite.

### Additional information

The condition I implemented is the same as the one used [further down](https://github.com/rails/rails/blob/72fccfb5d665b0e16a4238e5a7c73a37f2712fa2/railties/lib/rails/generators/app_base.rb#L787) in the generator.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
