### PR TITLE
Don’t configure Kamal storage volume if not needed

### DIFF
--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -366,6 +366,10 @@ module Rails
         options[:skip_active_storage]
       end
 
+      def skip_storage? # :doc:
+        skip_active_storage? && !sqlite3?
+      end
+
       def skip_action_cable? # :doc:
         options[:skip_action_cable]
       end
@@ -784,7 +788,7 @@ module Rails
       def dockerfile_chown_directories
         directories = %w(log tmp)
 
-        directories << "storage" unless skip_active_storage? && !sqlite3?
+        directories << "storage" unless skip_storage?
         directories << "db" unless skip_active_record?
 
         directories.sort

--- a/railties/lib/rails/generators/rails/app/templates/config/deploy.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/deploy.yml.tt
@@ -31,11 +31,13 @@ env:
   # clear:
   #   DB_HOST: 192.168.0.2
 
+<% unless skip_storage? %>
 # Use a persistent storage volume for sqlite database files and local Active Storage files.
 # Recommended to change this to a mounted volume path that is backed up off server.
 volumes:
   - "<%= app_name %>_storage:/rails/storage"
 
+<% end %>
 # Bridge fingerprinted assets, like JS and CSS, between versions to avoid
 # hitting 404 on in-flight requests. Combines all files from new and old
 # version inside the asset_path.

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -668,6 +668,34 @@ class AppGeneratorTest < Rails::Generators::TestCase
     assert_no_file ".env.erb"
   end
 
+  def test_inclusion_of_kamal_storage_volume
+    run_generator_and_bundler [destination_root]
+
+    assert_file "config/deploy.yml" do |content|
+      assert_match(%r{storage:/rails/storage}, content)
+    end
+  end
+
+  def test_inclusion_of_kamal_storage_volume_if_only_skip_active_storage_is_given
+    run_generator_and_bundler [destination_root, "--skip-active-storage"]
+
+    assert_file "config/deploy.yml" do |content|
+      assert_match(%r{storage:/rails/storage}, content)
+    end
+  end
+
+  def test_kamal_storage_volume_is_skipped_if_required
+    run_generator_and_bundler [
+      destination_root,
+      "--skip-active-storage",
+      "--database=postgresql"
+    ]
+
+    assert_file "config/deploy.yml" do |content|
+      assert_no_match(%r{storage:/rails/storage}, content)
+    end
+  end
+
   def test_usage_read_from_file
     assert_called(File, :read, returns: "USAGE FROM FILE") do
       assert_equal "USAGE FROM FILE", Rails::Generators::AppGenerator.desc


### PR DESCRIPTION
Fixes https://github.com/rails/rails/issues/51836.

### Motivation / Background

This Pull Request has been created because configuring a Docker persistent storage volume in Kamal seems to be only needed for sqlite or Active Storage. If using a different database and the `--skip-active-storage` option, configuration can be skipped.

### Detail

This Pull Request changes the `config/deploy.yml.tt` template to skip persistent storage volume configuration if skipping Active Storage and using a database that is different from sqlite.

### Additional information

The condition I implemented is the same as the one used [here](https://github.com/rails/rails/blob/72fccfb5d665b0e16a4238e5a7c73a37f2712fa2/railties/lib/rails/generators/app_base.rb#L787) in the rails app generator.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
