### PR TITLE
Add app.rb and helpers.rb back for backward compatibility

### DIFF
--- a/railties/lib/rails/console/app.rb
+++ b/railties/lib/rails/console/app.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+ActiveSupport::Deprecation.new.warn(<<~MSG, caller_locations(0..1))
+`rails/console/app.rb` has been deprecated and will be removed in Rails 8.0.
+Please require `rails/console/methods.rb` instead.
+MSG
+
+require "rails/console/methods"

--- a/railties/lib/rails/console/helpers.rb
+++ b/railties/lib/rails/console/helpers.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+ActiveSupport::Deprecation.new.warn(<<~MSG, caller_locations(0..1))
+`rails/console/helpers.rb` has been deprecated and will be removed in Rails 8.0.
+Please require `rails/console/methods.rb` instead.
+MSG
+
+require "rails/console/methods"


### PR DESCRIPTION
### Motivation / Background

Those files were removed in #51760, but gems like `console1984` depend on these files for legacy Rails console command extensions. So keeping files around is required for backward-compatibility.

### Detail

The files were added back and just require `rails/console/methods.rb` instead with messages like:

```
DEPRECATION WARNING: `rails/console/app.rb` has been deprecated and will be removed in Rails 8.0.
Please require `rails/console/methods.rb` instead.
 (called from <main> at /path_to_rails/railties/lib/rails/console/app.rb:3)

DEPRECATION WARNING: `rails/console/helpers.rb` has been deprecated and will be removed in Rails 8.0.
Please require `rails/console/methods.rb` instead.
 (called from <main> at /path_to_rails/railties/lib/rails/console/helpers.rb:3)
```
### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
