### PR TITLE
Update link to `i18n` gem repository [ci-skip]

### DIFF
--- a/guides/source/i18n.md
+++ b/guides/source/i18n.md
@@ -1206,9 +1206,8 @@ If you find your own locale (language) missing from our [example translations da
 Resources
 ---------
 
-* [Google group: rails-i18n](https://groups.google.com/g/rails-i18n) - The project's mailing list.
 * [GitHub: rails-i18n](https://github.com/svenfuchs/rails-i18n) - Code repository and issue tracker for the rails-i18n project. Most importantly you can find lots of [example translations](https://github.com/svenfuchs/rails-i18n/tree/master/rails/locale) for Rails that should work for your application in most cases.
-* [GitHub: i18n](https://github.com/svenfuchs/i18n) - Code repository and issue tracker for the i18n gem.
+* [GitHub: i18n](https://github.com/ruby-i18n/i18n) - Code repository and issue tracker for the i18n gem.
 
 
 Authors


### PR DESCRIPTION
The repository got moved to the `ruby-i18n` organization.