### PR TITLE
Copy application code earlier in Dockerfile

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/Dockerfile.tt
+++ b/railties/lib/rails/generators/rails/app/templates/Dockerfile.tt
@@ -50,8 +50,10 @@ ARG BUN_VERSION=<%= dockerfile_bun_version %>
 RUN curl -fsSL https://bun.sh/install | bash -s -- "bun-v${BUN_VERSION}"
 
 <% end -%>
+# Copy application code
+COPY . .
+
 # Install application gems
-COPY Gemfile Gemfile.lock ./
 RUN bundle install && \
     rm -rf ~/.bundle/ "${BUNDLE_PATH}"/ruby/*/cache "${BUNDLE_PATH}"/ruby/*/bundler/gems/*/.git<% if depend_on_bootsnap? -%> && \
     bundle exec bootsnap precompile --gemfile<% end %>
@@ -68,8 +70,6 @@ COPY package.json bun.lockb ./
 RUN bun install --frozen-lockfile
 
 <% end -%>
-# Copy application code
-COPY . .
 
 <% if depend_on_bootsnap? -%>
 # Precompile bootsnap code for faster boot times


### PR DESCRIPTION
### Motivation / Background

Gemfiles now support a `file:` argument, allowing the Ruby version to be read from a file such as `.ruby-version`. With the current Dockerfile this results in an error as the file required hasn’t been copied prior to trying to read it. By moving the application code copy operation slightly earlier, this can be avoided.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
