### PR TITLE
Update config.assets.debug documentation to reflect actual defaults [ci-skip]  #51747

### DIFF
--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -662,6 +662,15 @@ Enables the use of SHA256 fingerprints in asset names. Set to `true` by default.
 
 Disables the concatenation and compression of assets. Set to `true` by default in `development.rb`.
 
+In previous versions of Rails, `config.assets.debug` was set to `true` by default in the development environment, which disabled the concatenation and preprocessing of assets to facilitate easier debugging. This was particularly useful when working with a large number of complex assets, as it allowed developers to trace issues directly to specific files.
+
+However, as of Rails 7.0 (commit adec7e7 on Aug 10, 2021), this setting is no longer included by default in the `development.rb` configuration. The change was made because the move towards using ECMAScript Modules (ESM) in development generally eliminates the need for concatenating or preprocessing large JavaScript files, rendering debug mode less relevant.
+
+To explicitly enable or disable asset debugging in the current version of Rails, developers may add the following line to `config/environments/development.rb`
+: #Enable or disable asset concatenation and preprocessing for easier debugging
+  config.assets.debug = true  # Set to `false` to enable concatenation and compression
+
+
 #### `config.assets.version`
 
 Is an option string that is used in SHA256 hash generation. This can be changed to force all files to be recompiled.

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -666,10 +666,12 @@ In previous versions of Rails, `config.assets.debug` was set to `true` by defaul
 
 However, as of Rails 7.0 (commit adec7e7 on Aug 10, 2021), this setting is no longer included by default in the `development.rb` configuration. The change was made because the move towards using ECMAScript Modules (ESM) in development generally eliminates the need for concatenating or preprocessing large JavaScript files, rendering debug mode less relevant.
 
-To explicitly enable or disable asset debugging in the current version of Rails, developers may add the following line to `config/environments/development.rb`
-: #Enable or disable asset concatenation and preprocessing for easier debugging
-  config.assets.debug = true  # Set to `false` to enable concatenation and compression
+To explicitly enable or disable asset debugging in the current version of Rails, developers may add the following line to `config/environments/development.rb`:
 
+```ruby
+# Enable or disable asset concatenation and preprocessing for easier debugging
+config.assets.debug = true  # Set to `false` to enable concatenation and compression
+```
 
 #### `config.assets.version`
 


### PR DESCRIPTION

### Motivation / Background

This Pull Request has been created because the Rails documentation currently states that `config.assets.debug` is enabled by default in the development environment. However, as of Rails 7.0 (commit adec7e7 on Aug 10, 2021), this setting is not included by default in the `development.rb` file. This discrepancy can lead to confusion for developers relying on outdated documentation. Updating this will provide clearer guidance and reflect the actual current behavior of Rails applications in development. Fixes #51747.

### Checklist

Before submitting the PR make sure the following are checked:

- [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
- [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
- [ ] Tests are added or updated if you fix a bug or add a feature.
- [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
