### PR TITLE
Catch StandardError during Base64 decoding in message encryptor.

### DIFF
--- a/activesupport/lib/active_support/messages/codec.rb
+++ b/activesupport/lib/active_support/messages/codec.rb
@@ -28,7 +28,7 @@ module ActiveSupport
 
         def decode(encoded, url_safe: @url_safe)
           url_safe ? ::Base64.urlsafe_decode64(encoded) : ::Base64.strict_decode64(encoded)
-        rescue ArgumentError => error
+        rescue StandardError => error
           throw :invalid_message_format, error
         end
 

--- a/activesupport/test/message_encryptor_test.rb
+++ b/activesupport/test/message_encryptor_test.rb
@@ -157,6 +157,10 @@ class MessageEncryptorTest < ActiveSupport::TestCase
     assert_match(/\A#<ActiveSupport::MessageEncryptor:0x[0-9a-f]+>\z/, encryptor.inspect)
   end
 
+  def test_invalid_base64_argument
+    assert_not_decrypted("jrcc<!--esi-->rkls<!--esx-->tyx9")
+  end
+
   private
     def make_codec(**options)
       ActiveSupport::MessageEncryptor.new(@secret, **options)


### PR DESCRIPTION
### Motivation / Background

RubyGems.org got recently facing 500 HTTP responses since user mangled cookies (app uses cookie store) and provided custom value which (thanks to series of edge-cases) ended up triggering `NoMethodError: undefined method unpack1' for nil` raised down from `Base64` class. Per my understanding there is no way to catch this in application and this needs to be fixed in Rails itself.

### Detail

I have tracked this issue down to `ActiveSupport::Messages::Code` class expecting `Base64` failing with `ArgumentError` only. But `Base64` can fail also with other exceptions when wrong input type provided. In the shared case `nil` is actually passed to `Base64.strict_decode64` resulting into `NoMethodError`. I have changed rescue to handle `StandardError` since similar approach is used few lines bellow in `deserialize` method.

As an side effect, this tests this unhappy branch of `decode` method which wasn't covered by active support test suite before.

---

_I have originally considered updating Base64 to raise `ArgumentError` when `nil` passed, but there are other values which can still raise similar error and it would be needed to check if passed object responds to methods needed for Base64 calculation and that's not usually happening in stdlibs._