### PR TITLE
Look up route from requirements

### DIFF
--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -26,7 +26,6 @@ module ActionDispatch
       # Then the following will return the Route for the `show` action:
       #
       #   Rails.application.routes.from_requirements(controller: "posts", action: "show")
-      #
       def from_requirements(requirements)
         routes.find { |route| route.requirements == requirements }
       end

--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -25,7 +25,7 @@ module ActionDispatch
       #
       # Then the following will return the Route for the `show` action:
       #
-      #   Rails.application.routes.set.from_requirements(controller: :posts, action: :show)
+      #   Rails.application.routes.set.from_requirements(controller: "posts", action: "show")
       #
       def from_requirements(requirements)
         routes.find { |route| route.requirements == requirements }

--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -12,8 +12,12 @@ require "action_dispatch/routing/endpoint"
 
 module ActionDispatch
   module Routing
-    # :stopdoc:
     class RouteSet
+      def from_requirements(requirements)
+        routes.find { |route| route.requirements == requirements }
+      end
+      # :stopdoc:
+
       # Since the router holds references to many parts of the system like engines,
       # controllers and the application itself, inspecting the route set can actually
       # be really slow, therefore we default alias inspect to to_s.

--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -14,7 +14,6 @@ module ActionDispatch
   module Routing
     # The RouteSet contains a collection of Route instances, representing the routes
     # typically defined in `config/routes.rb`.
-    #
     class RouteSet
       # Returns a Route matching the given requirements, or `nil` if none are found.
       # This is intended for use by tools such as Language Servers.

--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -12,7 +12,21 @@ require "action_dispatch/routing/endpoint"
 
 module ActionDispatch
   module Routing
+    # The RouteSet contains a collection of Route instances, representing the routes
+    # typically defined in `config/routes.rb`.
+    #
     class RouteSet
+      # Returns a Route matching the given requirements, or `nil` if none are found.
+      # This is intended for use by tools such as Language Servers.
+      #
+      # Given the routes are defined as:
+      #
+      #   resources :posts
+      #
+      # Then the following will return the Route for the `show` action:
+      #
+      #   Rails.application.routes.set.from_requirements(controller: :posts, action: :show)
+      #
       def from_requirements(requirements)
         routes.find { |route| route.requirements == requirements }
       end

--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -25,7 +25,7 @@ module ActionDispatch
       #
       # Then the following will return the Route for the `show` action:
       #
-      #   Rails.application.routes.set.from_requirements(controller: "posts", action: "show")
+      #   Rails.application.routes.from_requirements(controller: "posts", action: "show")
       #
       def from_requirements(requirements)
         routes.find { |route| route.requirements == requirements }

--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -16,6 +16,7 @@ module ActionDispatch
     # typically defined in `config/routes.rb`.
     class RouteSet
       # Returns a Route matching the given requirements, or `nil` if none are found.
+      #
       # This is intended for use by tools such as Language Servers.
       #
       # Given the routes are defined as:

--- a/actionpack/test/dispatch/routing/route_set_test.rb
+++ b/actionpack/test/dispatch/routing/route_set_test.rb
@@ -165,6 +165,28 @@ module ActionDispatch
         assert_equal "/wildcard/a%0Anewline", url_helpers.wildcard_path(wildcard_segment: "a\nnewline")
       end
 
+      test "find a route for the given requirements" do
+        draw do
+          resources :foo
+          resources :bar
+        end
+
+        route = @set.from_requirements(controller: "bar", action: "index")
+
+        assert_equal "bar_index", route.name
+      end
+
+      test "find a route for the given requirements returns nil for no match" do
+        draw do
+          resources :foo
+          resources :bar
+        end
+
+        route = @set.from_requirements(controller: "baz", action: "index")
+
+        assert_nil route
+      end
+
       private
         def draw(&block)
           @set.draw(&block)


### PR DESCRIPTION
### Motivation / Background

For [Ruby LSP Rails](https://github.com/Shopify/ruby-lsp-rails/), we are looking to add a Code Lens for controller actions which displays the corresponding path:

https://github.com/Shopify/ruby-lsp-rails/pull/241

It is working, but calls into `RouteSet` which is marked as private/internal.

### Detail

This adds a small `from_requirements` method as part of the public API, that can be used by editor tooling to determine the route corresponding to a given requirements hash.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
