### PR TITLE
Restore unused block warnings condition for Ruby 3.4

### DIFF
--- a/activesupport/lib/active_support/testing/strict_warnings.rb
+++ b/activesupport/lib/active_support/testing/strict_warnings.rb
@@ -14,10 +14,6 @@ module ActiveSupport
       # Expected non-verbose warning emitted by Rails.
       /Ignoring .*\.yml because it has expired/,
       /Failed to validate the schema cache because/,
-
-      # Ref: https://bugs.ruby-lang.org/issues/15554
-      # This new Ruby 3.4 warning is still being fined tuned to reduce false positives
-      /the block passed to/,
     )
 
     SUPPRESSED_WARNINGS = Regexp.union(


### PR DESCRIPTION
### Motivation / Background
This pull request restores the warning conditions not to ignore "the block passed to" warnings

### Detail

https://github.com/ruby/ruby/pull/10403 raised many "the block passed to" warnings. then idnored these warnings because some of them might have contain false positives.

Now we can restore the warning condition because these false positives should have been addressed by these changes:

https://github.com/ruby/ruby/pull/10559
https://github.com/rails/rails/pull/51597
https://github.com/rails/rails/pull/51583

### Additional information
None

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
