### PR TITLE
[7-2-stable] Fix changelogs lint for trailing whitespaces

### DIFF
--- a/actioncable/CHANGELOG.md
+++ b/actioncable/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 *   Add two new assertion methods for Action Cable test cases: `assert_has_no_stream`
     and `assert_has_no_stream_for`.
-    
+
     These methods can be used to assert that a stream has been stopped, e.g. via
     `stop_stream` or `stop_stream_for`. They complement the already existing
     `assert_has_stream` and `assert_has_stream_for` methods.

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -38,7 +38,7 @@
 
     *Nikita Vasilevsky*
 
-*   Add `ENV["SKIP_TEST_DATABASE_TRUNCATE"]` flag to speed up multi-process test runs on large DBs when all tests run within default transaction. 
+*   Add `ENV["SKIP_TEST_DATABASE_TRUNCATE"]` flag to speed up multi-process test runs on large DBs when all tests run within default transaction.
 
     This cuts ~10s from the test run of HEY when run by 24 processes against the 178 tables, since ~4,000 table truncates can then be skipped.
 
@@ -290,7 +290,7 @@
 
 *   Using `Model.query_constraints` with a single non-primary-key column used to raise as expected, but with an
     incorrect error message.
-    
+
     This has been fixed to raise with a more appropriate error message.
 
     *Joshua Young*

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -104,7 +104,7 @@
 
 *   Include `IPAddr#prefix` when serializing an `IPAddr` using the
     `ActiveSupport::MessagePack` serializer.
-    
+
     This change is backward and forward compatible — old payloads can
     still be read, and new payloads will be readable by older versions of Rails.
 

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,6 +1,6 @@
 *   Remove support for `oracle`, `sqlserver` and JRuby specific database adapters from the
     `rails new` and `rails db:system:change` commands.
-    
+
     The supported options are `sqlite3`, `mysql`, `postgresql` and `trilogy`.
 
     *Andrew Novoselac*
@@ -250,7 +250,7 @@
 
 *   In Action Mailer previews, list inline attachments separately from normal
     attachments.
-    
+
     For example, attachments that were previously listed like
 
       > Attachments: logo.png file1.pdf file2.pdf


### PR DESCRIPTION
Due to PR #51841 being created before rails/buildkite-config#105 was merged, lint job was still skipped and therefor we missed it.

Btw, if you need to test this locally you can run this from the root of your rails checkout:

```
$ bundle exec tools/railspect changelogs .
```

For example:

```
~/code/rails => bundle exec tools/railspect changelogs .
E.......E.E.E

Offenses:

actioncable/CHANGELOG.md:11 Trailing whitespace detected.

^^^^
activerecord/CHANGELOG.md:41 Trailing whitespace detected.
*   Add `ENV["SKIP_TEST_DATABASE_TRUNCATE"]` flag to speed up multi-process test runs on large DBs when all tests run within default transaction.
                                                                                                                                                 ^
activerecord/CHANGELOG.md:293 Trailing whitespace detected.

^^^^
activesupport/CHANGELOG.md:107 Trailing whitespace detected.

^^^^
railties/CHANGELOG.md:3 Trailing whitespace detected.

^^^^
railties/CHANGELOG.md:253 Trailing whitespace detected.

^^^^
13 changelogs inspected, 6 offenses detected
```