### PR TITLE
Add templates from hidden directories

### DIFF
--- a/railties/railties.gemspec
+++ b/railties/railties.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.email    = "david@loudthinking.com"
   s.homepage = "https://rubyonrails.org"
 
-  s.files        = Dir["CHANGELOG.md", "README.rdoc", "MIT-LICENSE", "RDOC_MAIN.md", "exe/**/*", "lib/**/{*,.[a-z]*}"]
+  s.files        = Dir["CHANGELOG.md", "README.rdoc", "MIT-LICENSE", "RDOC_MAIN.md", "exe/**/*", "lib/**/{*,.[a-z]*}", "lib/**/.[a-z]*/*"]
   s.require_path = "lib"
 
   s.bindir      = "exe"


### PR DESCRIPTION
### Motivation / Background

The `.devcontainer/*` template files (introduced in https://github.com/rails/rails/pull/50914 ) were not included in the `railties` gem, resulting in a failure to create a new project (`rails new foo`).

The error was `Could not find ".devcontainer/devcontainer.json" in any of your source paths.`

### Detail

The `.devcontainer/*` template files were not included in the `railties` gem, because the old file pattern didn't match files in hidden directories, only hidden files.

### Additional information

The issue was observed with `ruby 3.3.0 (2023-12-25 revision 5124f9ac75) [x86_64-linux]`

Gem contents for `devcontainer` **before** the change:
![image](https://github.com/rails/rails/assets/6901651/08f6ce8e-d2e1-4e5b-860a-3c72992be155)


Gem contents **after** the change:
![image](https://github.com/rails/rails/assets/6901651/edaa36d5-177c-45ac-a314-9a58112d7d0a)


File diff between the two:
![image](https://github.com/rails/rails/assets/6901651/f9f84724-e588-412c-824b-4c0739638922)

#### Alternative pattern
An alternative could be
```ruby
Dir[..., "exe/**/*", "lib/{**,**/.[a-z]*/**}/{*,.[a-z]*}"])
```
but I think it is harder to read.

### Checklist

Before submitting the PR make sure the following are checked:

* [*] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [*] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [*] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
