### PR TITLE
[ci skip] Align documentation with conventional practice

### DIFF
--- a/railties/lib/rails/railtie.rb
+++ b/railties/lib/rails/railtie.rb
@@ -50,8 +50,8 @@ module Rails
   # To add an initialization step to the \Rails boot process from your railtie, just
   # define the initialization code with the +initializer+ macro:
   #
-  #   class MyRailtie < Rails::Railtie
-  #     initializer "my_railtie.configure_rails_initialization" do
+  #   class MyGem::Railtie < Rails::Railtie
+  #     initializer "my_gem.configure_rails_initialization" do
   #       # some initialization behavior
   #     end
   #   end
@@ -59,9 +59,9 @@ module Rails
   # If specified, the block can also receive the application object, in case you
   # need to access some application-specific configuration, like middleware:
   #
-  #   class MyRailtie < Rails::Railtie
-  #     initializer "my_railtie.configure_rails_initialization" do |app|
-  #       app.middleware.use MyRailtie::Middleware
+  #   class MyGem::Railtie < Rails::Railtie
+  #     initializer "my_gem.configure_rails_initialization" do |app|
+  #       app.middleware.use MyGem::Middleware
   #     end
   #   end
   #
@@ -74,14 +74,14 @@ module Rails
   # Railties can access a config object which contains configuration shared by all
   # railties and the application:
   #
-  #   class MyRailtie < Rails::Railtie
+  #   class MyGem::Railtie < Rails::Railtie
   #     # Customize the ORM
-  #     config.app_generators.orm :my_railtie_orm
+  #     config.app_generators.orm :my_gem_orm
   #
   #     # Add a to_prepare block which is executed once in production
   #     # and before each request in development.
   #     config.to_prepare do
-  #       MyRailtie.setup!
+  #       MyGem.setup!
   #     end
   #   end
   #
@@ -90,9 +90,9 @@ module Rails
   # If your railtie has Rake tasks, you can tell \Rails to load them through the method
   # +rake_tasks+:
   #
-  #   class MyRailtie < Rails::Railtie
+  #   class MyGem::Railtie < Rails::Railtie
   #     rake_tasks do
-  #       load "path/to/my_railtie.tasks"
+  #       load "path/to/my_gem.tasks"
   #     end
   #   end
   #
@@ -100,9 +100,9 @@ module Rails
   # your generators at a different location, you can specify in your railtie a block which
   # will load them during normal generators lookup:
   #
-  #   class MyRailtie < Rails::Railtie
+  #   class MyGem::Railtie < Rails::Railtie
   #     generators do
-  #       require "path/to/my_railtie_generator"
+  #       require "path/to/my_gem_generator"
   #     end
   #   end
   #
@@ -120,7 +120,7 @@ module Rails
   # this less confusing for everyone.
   # It can be used like this:
   #
-  #   class MyRailtie < Rails::Railtie
+  #   class MyGem::Railtie < Rails::Railtie
   #     server do
   #       WebpackServer.start
   #     end


### PR DESCRIPTION
### Motivation / Background

This pull request has been created to (1) align documentation with conventional practice, (2) prefer continuity by maintaining names from previous code blocks, and (3) clear up other potential sources of confusion.

### Detail

A search on GitHub reveals that, typically, custom Railtie classes are named `Railtie`, with Rails itself embracing this convention (perhaps even fostering it). If we named the class in the docs to align with this practice, learners can supplement the material with what they find on GitHub and within Rails itself.

Secondly, the first time we introduce a custom Railtie class, it's called `Railtie`. Unfortunately, in subsequent code examples, `MyRailtie` is introduced. In the first code block, we indicate the file path where the class is/could be defined [(`lib/my_gem/railtie.rb`)](https://github.com/rails/rails/blob/692f25a9254c58c64b138770e6b604e73de38620/railties/lib/rails/railtie.rb#L39). In the subsequent blocks we don't. I think this could also be a little confusing. If we were to keep the old class name, it might be easy for a learner to infer that we're developing the same class we created in the first code block.

The other changes replace `MyRailtie` and substitute it with `MyGem`. Reason is, the custom Railtie doesn't seem to be the appropriate place for those functions given that they are very specific to the gem. I think what we want to encourage there is this: the Railtie lets you specify what code to run for every hook. Your gem, not the custom Railtie, hosts the code. For example, I was confused by [`MyRailtie.setup!`](https://github.com/rails/rails/blob/692f25a9254c58c64b138770e6b604e73de38620/railties/lib/rails/railtie.rb#L84). I wondered where the `setup!` method came from and whether it could have been inherited from the `Rails::Railtie` parent. So I replaced `MyRailtie` with `MyGem` to make the arbitrariness of that code more obvious.

### Checklist

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why.
