### PR TITLE
Temporarily fix multi-paragraph definition lists [ci skip]

### DIFF
--- a/actionpack/lib/action_controller/metal/conditional_get.rb
+++ b/actionpack/lib/action_controller/metal/conditional_get.rb
@@ -48,7 +48,7 @@ module ActionController
     #     `If-None-Match` header may receive a `304 Not Modified` response if the
     #     ETag matches exactly.
     #
-    #     A weak ETag indicates semantic equivalence, not byte-for-byte equality, so
+    # :   A weak ETag indicates semantic equivalence, not byte-for-byte equality, so
     #     they're good for caching HTML pages in browser caches. They can't be used
     #     for responses that must be byte-identical, like serving `Range` requests
     #     within a PDF file.
@@ -58,7 +58,7 @@ module ActionController
     #     `If-None-Match` header may receive a `304 Not Modified` response if the
     #     ETag matches exactly.
     #
-    #     A strong ETag implies exact equality -- the response must match byte for
+    # :   A strong ETag implies exact equality -- the response must match byte for
     #     byte. This is necessary for serving `Range` requests within a large video
     #     or PDF file, for example, or for compatibility with some CDNs that don't
     #     support weak ETags.


### PR DESCRIPTION
### Motivation / Background

Ref #50759

The rdoc markdown parser does not currently parse multi-paragraph definition lists correctly. Instead of putting both paragraphs inside a single definition, only the first paragraph ends up in the definition and the second paragraph is rendered after the definition list as a code block.

### Detail

Since 7.2 appears to be coming soon, this commit fixes the second paragraph rendering as a code block by turning it into a second definition. This doesn't strictly seem like the "correct" fix (compared to fixing the rdoc markdown parser) but it gives us the visual result that we want until rdoc is fixed.

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
