### PR TITLE
Switch to Active Storage Azure service backend to azure-blob

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -120,7 +120,7 @@ end
 group :storage do
   gem "aws-sdk-s3", require: false
   gem "google-cloud-storage", "~> 1.11", require: false
-  gem "azure-storage-blob", "~> 2.0", require: false
+  gem "azure-blob-storage", require: false
 
   gem "image_processing", "~> 1.2"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -144,14 +144,8 @@ GEM
       aws-sigv4 (~> 1.1)
     aws-sigv4 (1.8.0)
       aws-eventstream (~> 1, >= 1.0.2)
-    azure-storage-blob (2.0.3)
-      azure-storage-common (~> 2.0)
-      nokogiri (~> 1, >= 1.10.8)
-    azure-storage-common (2.0.4)
-      faraday (~> 1.0)
-      faraday_middleware (~> 1.0, >= 1.0.0.rc1)
-      net-http-persistent (~> 4.0)
-      nokogiri (~> 1, >= 1.10.8)
+    azure-blob-storage (0.2.0)
+      rexml
     backburner (1.6.1)
       beaneater (~> 1.0)
       concurrent-ruby (~> 1.0, >= 1.0.1)
@@ -238,8 +232,6 @@ GEM
     faraday-patron (1.0.0)
     faraday-rack (1.0.0)
     faraday-retry (1.0.3)
-    faraday_middleware (1.2.0)
-      faraday (~> 1.0)
     ffi (1.16.3)
     fugit (1.9.0)
       et-orbi (~> 1, >= 1.2.7)
@@ -365,8 +357,6 @@ GEM
     multipart-post (2.3.0)
     mutex_m (0.2.0)
     mysql2 (0.5.6)
-    net-http-persistent (4.0.2)
-      connection_pool (~> 2.2)
     net-imap (0.4.9)
       date
       net-protocol
@@ -618,7 +608,7 @@ PLATFORMS
 DEPENDENCIES
   aws-sdk-s3
   aws-sdk-sns
-  azure-storage-blob (~> 2.0)
+  azure-blob-storage
   backburner
   bcrypt (~> 3.1.11)
   bootsnap (>= 1.4.4)

--- a/activestorage/test/service/azure_storage_service_test.rb
+++ b/activestorage/test/service/azure_storage_service_test.rb
@@ -26,7 +26,7 @@ if SERVICE_CONFIGURATIONS[:azure]
         http.request request
       end
 
-      assert_equal(content_type, @service.client.get_blob_properties(@service.container, key).properties[:content_type])
+      assert_equal(content_type, @service.client.get_blob_properties(key).content_type)
     ensure
       @service.delete key
     end
@@ -47,7 +47,7 @@ if SERVICE_CONFIGURATIONS[:azure]
         http.request request
       end
 
-      assert_equal("attachment; filename=\"test.txt\"; filename*=UTF-8''test.txt", @service.client.get_blob_properties(@service.container, key).properties[:content_disposition])
+      assert_equal("attachment; filename=\"test.txt\"; filename*=UTF-8''test.txt", @service.client.get_blob_properties(key).content_disposition)
     ensure
       @service.delete key
     end
@@ -72,7 +72,7 @@ if SERVICE_CONFIGURATIONS[:azure]
 
       @service.upload(key, StringIO.new(data), checksum: OpenSSL::Digest::MD5.base64digest(data), filename: ActiveStorage::Filename.new("test.txt"), disposition: :inline)
 
-      assert_equal("inline; filename=\"test.txt\"; filename*=UTF-8''test.txt", @service.client.get_blob_properties(@service.container, key).properties[:content_disposition])
+      assert_equal("inline; filename=\"test.txt\"; filename*=UTF-8''test.txt", @service.client.get_blob_properties(key).content_disposition)
 
       url = @service.url(key, expires_in: 2.minutes, disposition: :attachment, content_type: nil, filename: ActiveStorage::Filename.new("test.html"))
       response = Net::HTTP.get_response(URI(url))


### PR DESCRIPTION
Fix #49983 / Rails 8 Milestone

### Motivation / Background

`azure-storage-blob` is deprecated and will be retired permanently on September 13, 2024.

`azure-storage-blob` is quite large and depends on outdated gems.

This change replaces `azure-storage-blob` with [azure-blob](https://github.com/JoeDupuis/azure-blob), a smaller gem specifically designed and written for Active Storage.

It depends only on default and bundled gems and includes only the features needed by Active Storage, making it easier to maintain.

### Detail

#### To extract, or not to extract, that is the question
Azure has been part of Active Storage for a long time (7+ years?) and, inferring from RubyGems downloads, sees a lot of usage. It's a major provider. I feel like the adapter should live inside of Rails.

That being said, an alternative to this change would be to completely remove the adapter from Rails and move it to a gem. If that's the desired path, I can write a migration guide and the PR to remove the adapter.

#### Trust issues

Using a non-official third-party library is a potential concern. I am considering transferring the repo and ownership of the gem to Test Double if it helps alleviate the bus factor and trust issues.

I opened this PR early to start the discussion, but I'll ask internally (Test Double) for reviews on the gem code too. I very likely overlooked a couple of issues.

#### Left to do

The PR doesn't include any changelog, guide, or documentation changes. Depending on what Rails core decides to do with this change, I'll amend the PR. I didn't want to write documentation before verifying if we want to keep or drop Azure support.

There is also a bunch of work left to do on the gem side, but all Rails tests pass.

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
