### PR TITLE
Make public method for `schema_cache_ignored_tables?`

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,2 +1,13 @@
+*   Add public method for checking if a table is ignored by the schema cache.
+
+    Previously, an application would need to reimplement `ignored_table?` from the schema cache class to check if a table was set to be ignored. This adds a public method to support this and updates the schema cache to use that directly.
+
+    ```ruby
+    ActiveRecord.schema_cache_ignored_tables = ["developers"]
+    ActiveRecord.schema_cache_ignored_tables?("developers")
+    => true
+    ```
+
+    *Eileen M. Uchitelle*
 
 Please check [7-2-stable](https://github.com/rails/rails/blob/7-2-stable/activerecord/CHANGELOG.md) for previous changes.

--- a/activerecord/lib/active_record.rb
+++ b/activerecord/lib/active_record.rb
@@ -196,6 +196,17 @@ module ActiveRecord
   singleton_class.attr_accessor :schema_cache_ignored_tables
   self.schema_cache_ignored_tables = []
 
+  # Checks to see if the +table_name+ is ignored by checking
+  # against the +schema_cache_ignored_tables` option.
+  #
+  #   table_ignored?(:developers)
+  #
+  def self.schema_cache_ignored_table?(table_name)
+    ActiveRecord.schema_cache_ignored_tables.any? do |ignored|
+      ignored === table_name
+    end
+  end
+
   singleton_class.attr_reader :default_timezone
 
   # Determines whether to use Time.utc (using :utc) or Time.local (using :local) when pulling

--- a/activerecord/lib/active_record/connection_adapters/schema_cache.rb
+++ b/activerecord/lib/active_record/connection_adapters/schema_cache.rb
@@ -434,9 +434,7 @@ module ActiveRecord
         end
 
         def ignored_table?(table_name)
-          ActiveRecord.schema_cache_ignored_tables.any? do |ignored|
-            ignored === table_name
-          end
+          ActiveRecord.schema_cache_ignored_table?(table_name)
         end
 
         def derive_columns_hash_and_deduplicate_values


### PR DESCRIPTION
Previously we only provided a method to set the ignored schema cache tables, but there was no way to ask if a table was ignored by the schema cache. Applications may want to implement their own schema cache, or at least run this check. Rather than forcing them to implement an internal method, this adds a way to ask whether a table is ignored by the schema cache code.

Usage:

```ruby
ActiveRecord.schema_cache_ignored_tables = ["developers"]
ActiveRecord.schema_cache_ignored_tables?("developers")
```