### PR TITLE
Revert "Merge pull request #51184 from ConfusedVorlon/document_after_commit_deduplication"

### DIFF
--- a/activerecord/lib/active_record/transactions.rb
+++ b/activerecord/lib/active_record/transactions.rb
@@ -188,16 +188,6 @@ module ActiveRecord
     # #after_commit is a good spot to put in a hook to clearing a cache since clearing it from
     # within a transaction could trigger the cache to be regenerated before the database is updated.
     #
-    # *Warning*: Callbacks are deduplicated according to the callback and method.
-    # This means you cannot have multiple <tt>after_xxx_commit</tt> shortcuts calling the same method.
-    #
-    #   after_create_commit :do_foo # This will NOT fire
-    #   after_save_commit :do_foo
-    #
-    # Instead, use after_commit directly
-    #
-    #   after_commit :do_foo, on: [:create, :save]
-    #
     # === Caveats
     #
     # If you're on MySQL, then do not use Data Definition Language (DDL) operations in nested
@@ -252,32 +242,24 @@ module ActiveRecord
       end
 
       # Shortcut for <tt>after_commit :hook, on: [ :create, :update ]</tt>.
-      #
-      # *Warning*: only one <tt>after_xxx_commit</tt> shortcut can call any given method.
       def after_save_commit(*args, &block)
         set_options_for_callbacks!(args, on: [ :create, :update ], **prepend_option)
         set_callback(:commit, :after, *args, &block)
       end
 
       # Shortcut for <tt>after_commit :hook, on: :create</tt>.
-      #
-      # *Warning*: only one <tt>after_xxx_commit</tt> shortcut can call any given method.
       def after_create_commit(*args, &block)
         set_options_for_callbacks!(args, on: :create, **prepend_option)
         set_callback(:commit, :after, *args, &block)
       end
 
       # Shortcut for <tt>after_commit :hook, on: :update</tt>.
-      #
-      # *Warning*: only one <tt>after_xxx_commit</tt> shortcut can call any given method.
       def after_update_commit(*args, &block)
         set_options_for_callbacks!(args, on: :update, **prepend_option)
         set_callback(:commit, :after, *args, &block)
       end
 
       # Shortcut for <tt>after_commit :hook, on: :destroy</tt>.
-      #
-      # *Warning*: only one <tt>after_xxx_commit</tt> shortcut can call any given method.
       def after_destroy_commit(*args, &block)
         set_options_for_callbacks!(args, on: :destroy, **prepend_option)
         set_callback(:commit, :after, *args, &block)


### PR DESCRIPTION
This reverts commit 2abee307fe622939f005e9dd9a6925df0dd7ec4c, reversing changes made to e34a0eec38767920e04f56a7aa7978b7c5fb685a.

A warning on each method is excessive and the warning should already be covered under the guide: https://edgeguides.rubyonrails.org/active_record_callbacks.html#transaction-callbacks

> Using both after_create_commit and after_update_commit with the same method name will only allow the last callback defined to take effect, as they both internally alias to after_commit which overrides previously defined callbacks with the same method name.