### PR TITLE
Revert RuboCop workaround

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,7 +7,6 @@ require:
 
 AllCops:
   TargetRubyVersion: 3.1
-  TargetRailsVersion: 8.0
   # RuboCop has a bunch of cops enabled by default. This setting tells RuboCop
   # to ignore them, so only the ones explicitly set in this file are enabled.
   DisabledByDefault: true

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -470,7 +470,7 @@ GEM
     retriable (3.1.2)
     rexml (3.2.6)
     rouge (4.2.0)
-    rubocop (1.63.5)
+    rubocop (1.64.0)
       json (~> 2.3)
       language_server-protocol (>= 3.17.0)
       parallel (~> 1.10)


### PR DESCRIPTION
Was done in 3e08223ece75ab47a17459f9696ce1ebca68ffa5 to work around a RuboCop bug. The newest version has this fixed.

Also see https://github.com/rubocop/rubocop/issues/12898 and https://github.com/rubocop/rubocop/pull/12899