### PR TITLE
Make `pretty_print` behave more similar to `inspect`.

### DIFF
--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -748,9 +748,8 @@ module ActiveRecord
               pp.text attr_name
               pp.text ":"
               pp.breakable
-              value = _read_attribute(attr_name)
-              value = inspection_filter.filter_param(attr_name, value) unless value.nil?
-              pp.pp value
+              value = attribute_for_inspect(attr_name)
+              pp.text value
             end
           end
         else

--- a/activerecord/test/cases/core_test.rb
+++ b/activerecord/test/cases/core_test.rb
@@ -78,6 +78,22 @@ class CoreTest < ActiveRecord::TestCase
     assert_match(/virtual_field: 1/, relation.first.full_inspect)
   end
 
+  def test_inspect_with_overridden_attribute_for_inspect
+    topic = topics(:first)
+
+    topic.instance_eval do
+      def attribute_for_inspect(attr_name)
+        if attr_name == 'title'
+          title.upcase.inspect
+        else
+          super
+        end
+      end
+    end
+
+    assert_match(/title: "THE FIRST TOPIC"/, topic.full_inspect)
+  end
+
   def test_full_inspect_lists_all_attributes
     topic = topics(:first)
 
@@ -118,9 +134,9 @@ class CoreTest < ActiveRecord::TestCase
          title: "The First Topic",
          author_name: "David",
          author_email_address: "david@loudthinking.com",
-         written_on: 2003-07-16 14:28:11(?:\.2233)? UTC,
-         bonus_time: 2000-01-01 14:28:00 UTC,
-         last_read: Thu, 15 Apr 2004,
+         written_on: "2003-07-16 14:28:11\\.223300000 \\+0000",
+         bonus_time: "2000-01-01 14:28:00\\.000000000 \\+0000",
+         last_read: "2004-04-15",
          content: "Have a nice day",
          important: nil,
          binary_content: nil,
@@ -163,6 +179,26 @@ class CoreTest < ActiveRecord::TestCase
     actual = +""
     PP.pp(topic, StringIO.new(actual))
     assert_match(/id: 1/, actual)
+  end
+
+  def test_pretty_print_with_overridden_attribute_for_inspect
+    topic = topics(:first)
+
+    topic.instance_eval do
+      def attribute_for_inspect(attr_name)
+        if attr_name == 'title'
+          title.upcase.inspect
+        else
+          super
+        end
+      end
+    end
+
+    Topic.stub(:attributes_for_inspect, :all) do
+      actual = +""
+      PP.pp(topic, StringIO.new(actual))
+      assert_match(/title: "THE FIRST TOPIC"/, actual)
+    end
   end
 
   def test_find_by_cache_does_not_duplicate_entries

--- a/activerecord/test/cases/core_test.rb
+++ b/activerecord/test/cases/core_test.rb
@@ -83,7 +83,7 @@ class CoreTest < ActiveRecord::TestCase
 
     topic.instance_eval do
       def attribute_for_inspect(attr_name)
-        if attr_name == 'title'
+        if attr_name == "title"
           title.upcase.inspect
         else
           super
@@ -186,7 +186,7 @@ class CoreTest < ActiveRecord::TestCase
 
     topic.instance_eval do
       def attribute_for_inspect(attr_name)
-        if attr_name == 'title'
+        if attr_name == "title"
           title.upcase.inspect
         else
           super

--- a/activerecord/test/cases/filter_attributes_test.rb
+++ b/activerecord/test/cases/filter_attributes_test.rb
@@ -121,7 +121,7 @@ class FilterAttributesTest < ActiveRecord::TestCase
     actual = "".dup
     PP.pp(user, StringIO.new(actual))
 
-    assert_includes actual, 'name: "[FILTERED]"'
+    assert_includes actual, 'name: [FILTERED]'
     assert_equal 1, actual.scan("[FILTERED]").length
   end
 
@@ -141,8 +141,8 @@ class FilterAttributesTest < ActiveRecord::TestCase
     actual = "".dup
     PP.pp(user, StringIO.new(actual))
 
-    assert_includes actual, 'auth_token: "[FILTERED]"'
-    assert_includes actual, 'token: "[FILTERED]"'
+    assert_includes actual, 'auth_token: [FILTERED]'
+    assert_includes actual, 'token: [FILTERED]'
   ensure
     User.instance_variable_set(:@filter_attributes, nil)
   end

--- a/activerecord/test/cases/filter_attributes_test.rb
+++ b/activerecord/test/cases/filter_attributes_test.rb
@@ -121,7 +121,7 @@ class FilterAttributesTest < ActiveRecord::TestCase
     actual = "".dup
     PP.pp(user, StringIO.new(actual))
 
-    assert_includes actual, 'name: [FILTERED]'
+    assert_includes actual, "name: [FILTERED]"
     assert_equal 1, actual.scan("[FILTERED]").length
   end
 
@@ -141,8 +141,8 @@ class FilterAttributesTest < ActiveRecord::TestCase
     actual = "".dup
     PP.pp(user, StringIO.new(actual))
 
-    assert_includes actual, 'auth_token: [FILTERED]'
-    assert_includes actual, 'token: [FILTERED]'
+    assert_includes actual, "auth_token: [FILTERED]"
+    assert_includes actual, "token: [FILTERED]"
   ensure
     User.instance_variable_set(:@filter_attributes, nil)
   end


### PR DESCRIPTION
I discovered that `pretty_print` does not call `attribute_for_inspect`.

With this Pull Request I make the behaviour of `pretty_print` match that of `inspect` in the sense that it calls `attribute_for_inspect` (which can be overridden by the developer in their model class), instead of using the "raw" attribute.

The relevant test that covers the behaviour is: `test_pretty_print_with_overridden_attribute_for_inspect`

For completeness I added a similar test for `inspect`, but that passed even before the code change: `test_inspect_with_overridden_attribute_for_inspect`

I also had to update some other tests to reflect the new behaviour. I find this is _good_ because now the behaviour of `pretty_print` is similar to `inspect` (for example `[FILTERED]` is now printed the same by both, without any quotes).

Date objects are now also printed using the same format by both `inspect` and `pretty_print`.