### PR TITLE
Don't enable automatically_invert_plural_associations by default

### DIFF
--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -760,21 +760,9 @@ module ActiveRecord
 
             begin
               reflection = klass._reflect_on_association(inverse_name)
-              if !reflection
+              if !reflection && active_record.automatically_invert_plural_associations
                 plural_inverse_name = ActiveSupport::Inflector.pluralize(inverse_name)
                 reflection = klass._reflect_on_association(plural_inverse_name)
-
-                if valid_inverse_reflection?(reflection) && !active_record.automatically_invert_plural_associations
-                  ActiveRecord.deprecator.warn(
-                    "The `#{active_record.name}##{name}` inverse association could have been automatically" \
-                    " inferred as `#{klass.name}##{plural_inverse_name}` but wasn't because `automatically_invert_plural_associations`" \
-                    " is disabled.\n\n" \
-                    "If automatic inference is intended, you can consider enabling" \
-                    " `config.active_record.automatically_invert_plural_associations`.\n\n" \
-                    "If automatic inference is not intended, you can silence this warning by defining the association with `inverse_of: nil`."
-                  )
-                  reflection = nil
-                end
               end
             rescue NameError => error
               raise unless error.name.to_s == class_name

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -61,7 +61,6 @@ Below are the default values associated with each target version. In cases of co
 #### Default Values for Target Version 7.2
 
 - [`config.active_job.enqueue_after_transaction_commit`](#config-active-job-enqueue-after-transaction-commit): `:default`
-- [`config.active_record.automatically_invert_plural_associations`](#config-active-record-automatically-invert-plural-associations): `true`
 - [`config.active_record.postgresql_adapter_decode_dates`](#config-active-record-postgresql-adapter-decode-dates): `true`
 - [`config.active_record.validate_migration_timestamps`](#config-active-record-validate-migration-timestamps): `true`
 - [`config.active_storage.web_image_content_types`](#config-active-storage-web-image-content-types): `%w[image/png image/jpeg image/gif image/webp]`
@@ -1094,6 +1093,10 @@ class Comment < ApplicationRecord
   belongs_to :post, inverse_of: nil
 end
 ```
+
+| Starting with version | The default value is |
+| --------------------- | -------------------- |
+| (original)            | `false`              |
 
 #### `config.active_record.validate_migration_timestamps`
 

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -329,7 +329,6 @@ module Rails
           if respond_to?(:active_record)
             active_record.postgresql_adapter_decode_dates = true
             active_record.validate_migration_timestamps = true
-            active_record.automatically_invert_plural_associations = true
           end
         when "8.0"
           load_defaults "7.2"


### PR DESCRIPTION
This can cause a lot of issues that are hard to detect.

It is better to make this opt-in for people that want to use it.

In Rails 8 we can revisit if we want to enable this config by default.

Behavior introduced in #50284.

Related to:

#51853
#51388
#51392
