### PR TITLE
Raise a descriptive error from `store_accessor` if the column is not a Store

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,19 @@
+*   Improve `ActiveRecord.store_accessor` to raise an exception if the column is not either
+    structured (e.g., PostgreSQL +hstore+/+json+, or MySQL +json+) or declared serializable via
+    `ActiveRecord.store`.
+
+    Previously, an exception would be raised late when the accessor was read or written:
+
+        NoMethodError: undefined method `accessor' for an instance of ActiveRecord::Type::Text
+
+    Now, an exception is raised early when `store_accessor` is called:
+
+        ActiveRecord::ConfigurationError: the column 'metadata' has not been configured as a store.
+          Please make sure the column is declared serializable via 'ActiveRecord.store' or, if your
+          database supports it, use a structured column type like hstore or json.
+
+    *Mike Dalessio*
+
 *   Fix inference of association model on nested models with the same demodularized name.
 
     E.g. with the following setup:

--- a/activerecord/lib/active_record/store.rb
+++ b/activerecord/lib/active_record/store.rb
@@ -110,6 +110,10 @@ module ActiveRecord
       end
 
       def store_accessor(store_attribute, *keys, prefix: nil, suffix: nil)
+        unless type_for_attribute(store_attribute).respond_to?(:accessor)
+          raise ConfigurationError, "the column '#{store_attribute}' has not been configured as a store. Please make sure the column is declared serializable via 'ActiveRecord.store' or, if your database supports it, use a structured column type like hstore or json."
+        end
+
         keys = keys.flatten
 
         accessor_prefix =

--- a/activerecord/test/cases/json_shared_test_cases.rb
+++ b/activerecord/test/cases/json_shared_test_cases.rb
@@ -3,6 +3,12 @@
 require "support/schema_dumping_helper"
 require "pp"
 
+# ensure we have a "json_data_type" table when JsonDataType is defined,
+# because store_accessor checks the column for a store accessor.
+ActiveRecord::Base.lease_connection.create_table("json_data_type") do |t|
+  t.json "settings"
+end
+
 module JSONSharedTestCases
   include SchemaDumpingHelper
 

--- a/activerecord/test/cases/store_test.rb
+++ b/activerecord/test/cases/store_test.rb
@@ -285,9 +285,13 @@ class StoreTest < ActiveRecord::TestCase
 
   test "stored_attributes are tracked per class" do
     first_model = Class.new(ActiveRecord::Base) do
+      self.table_name = "admin_users"
+      store :data
       store_accessor :data, :color
     end
     second_model = Class.new(ActiveRecord::Base) do
+      self.table_name = "admin_users"
+      store :data
       store_accessor :data, :width, :height
     end
 
@@ -297,6 +301,8 @@ class StoreTest < ActiveRecord::TestCase
 
   test "stored_attributes are tracked per subclass" do
     first_model = Class.new(ActiveRecord::Base) do
+      self.table_name = "admin_users"
+      store :data
       store_accessor :data, :color
     end
     second_model = Class.new(first_model) do
@@ -358,5 +364,13 @@ class StoreTest < ActiveRecord::TestCase
 
   test "prefix/suffix do not affect stored attributes" do
     assert_equal [:secret_question, :two_factor_auth, :login_retry], Admin::User.stored_attributes[:configs]
+  end
+
+  test "store_accessor raises an exception if the column is not either serializable or a structured type" do
+    assert_raises ActiveRecord::ConfigurationError do
+      Class.new(Admin::User) do
+        store_accessor :name, :color
+      end
+    end
   end
 end


### PR DESCRIPTION
### Motivation / Background

If a developer has neglected to use a structured column type (hstore or json) or to declare a
serializer with `ActiveRecord.store`:

```ruby
  class User < ActiveRecord::Base
    store_accessor :settings, :notifications
  end
```

then a `ConfigurationError` will now be raised by `store_accessor` with a descriptive error message:

    ActiveRecord::ConfigurationError: the column 'settings' has not been configured as a store.
    Please make sure the column is declared serializable via 'ActiveRecord.store' or, if your
    database supports it, use a structured column type like hstore or json.

Previously, in this situation, a `NoMethodError` was raised when the accessor was read or written:

```ruby
  puts user.notifications
  # NoMethodError: undefined method `accessor' for an instance of ActiveRecord::Type::Text
```

Raising an exception earlier, with a helpful message, should help developers understand more quickly what's wrong and how to fix it.

Note that this change makes `store_accessor` call `type_for_attribute` which will potentially load the model's schema where it was not being loaded before. As a result, some small changes were needed to the test suite where the `json_data_type` table was not created early enough, and where an anonymous class needed to be bound to a real table. I don't think this should affect the majority of Store users.

Closes #51699


### Detail

`ActiveRecord.store_accessor` now checks whether the column type responds to `#accessor` and raises an exception if it does not.


### Questions for reviewers

Is it OK that `store_accessor` is doing this check? Currently it's possible to call `store_accessor` first and `store` later and everything works fine, and this change will require that they happen in this order: `store`, then `store_accessor`. See #51898 for an alternative implementation that does this check when the attribute is read or written.


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
