### PR TITLE
Raise a descriptive error when a Store column is misconfigured

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,19 @@
+*   Improve `ActiveRecord::Store` to raise a descriptive exception if the column is not either
+    structured (e.g., PostgreSQL +hstore+/+json+, or MySQL +json+) or declared serializable via
+    `ActiveRecord.store`.
+
+    Previously, a `NoMethodError` would be raised when the accessor was read or written:
+
+        NoMethodError: undefined method `accessor' for an instance of ActiveRecord::Type::Text
+
+    Now, a descriptive `ConfigurationError` is raised:
+
+        ActiveRecord::ConfigurationError: the column 'metadata' has not been configured as a store.
+          Please make sure the column is declared serializable via 'ActiveRecord.store' or, if your
+          database supports it, use a structured column type like hstore or json.
+
+    *Mike Dalessio*
+
 *   Fix inference of association model on nested models with the same demodularized name.
 
     E.g. with the following setup:

--- a/activerecord/lib/active_record/store.rb
+++ b/activerecord/lib/active_record/store.rb
@@ -217,7 +217,11 @@ module ActiveRecord
       end
 
       def store_accessor_for(store_attribute)
-        type_for_attribute(store_attribute).accessor
+        type_for_attribute(store_attribute).tap do |type|
+          unless type.respond_to?(:accessor)
+            raise ConfigurationError, "the column '#{store_attribute}' has not been configured as a store. Please make sure the column is declared serializable via 'ActiveRecord.store' or, if your database supports it, use a structured column type like hstore or json."
+          end
+        end.accessor
       end
 
       class HashAccessor # :nodoc:

--- a/activerecord/test/cases/store_test.rb
+++ b/activerecord/test/cases/store_test.rb
@@ -359,4 +359,18 @@ class StoreTest < ActiveRecord::TestCase
   test "prefix/suffix do not affect stored attributes" do
     assert_equal [:secret_question, :two_factor_auth, :login_retry], Admin::User.stored_attributes[:configs]
   end
+
+  test "store_accessor raises an exception if the column is not either serializable or a structured type" do
+    user = Class.new(Admin::User) do
+      store_accessor :name, :color
+    end.new
+
+    assert_raises ActiveRecord::ConfigurationError do
+      user.color
+    end
+
+    assert_raises ActiveRecord::ConfigurationError do
+      user.color = "blue"
+    end
+  end
 end


### PR DESCRIPTION
### Motivation / Background

If a developer has neglected to use a structured column type (hstore or json) or to declare a serializer with `ActiveRecord.store`:

```ruby
  class User < ActiveRecord::Base
    store_accessor :settings, :notifications
  end
```

then a `ConfigurationError` will now be raised with a descriptive error message when the accessor is read or written:

```ruby
  puts user.notifications
  # ActiveRecord::ConfigurationError: the column 'settings' has not
  # been configured as a store.  Please make sure the column is
  # declared serializable via 'ActiveRecord.store' or, if your
  # database supports it, use a structured column type like hstore or
  # json.
```

Previously, in this situation, a `NoMethodError` was raised when the accessor was read or written:

```ruby
  puts user.notifications
  # NoMethodError: undefined method `accessor' for an instance of ActiveRecord::Type::Text
```

Raising a descriptive exception should help developers understand more quickly what's wrong and how to fix it.

Closes #51699


### Detail

In `ActiveRecord::Store#store_accessor_for`, where the previous `NoMethodError` came from, we check if the attribute responds to `#accessor` and if so, raise the more descriptive exception.


### Additional information

See an alternative implementation at #51897 that does this check earlier, in `ActiveRecord.store_accessor`. I think this implementation is better, less invasive, and does not break the case where a developer calls `store_accessor` before `store`.


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
