### PR TITLE
Fix railtie config test for sqlite 3.46.0

### DIFF
--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -2893,7 +2893,7 @@ module ApplicationTests
       error = assert_raises(StandardError) do
         Post.lease_connection.add_index :posts, :non_existent
       end
-      assert_match(/no such column: non_existent/, error.message)
+      assert_match(/no such column: "?non_existent"?/, error.message)
     end
 
     test "ActiveSupport::MessageEncryptor.use_authenticated_message_encryption is true by default for new apps" do


### PR DESCRIPTION
Follow up to #51891

This resolves the following test failure:
https://buildkite.com/rails/rails/builds/107520#018fa76e-0408-4630-a75d-eac5caa16463/1199-1209

```
Failure:
ApplicationTests::ConfigurationTest#test_SQLite3Adapter.strict_strings_by_default_can_be_configured_via_config.active_record.sqlite3_adapter_strict_strings_by_default_in_an_initializer [test/application/configuration_test.rb:2896]:
Expected /no such column: non_existent/ to match "SQLite3::SQLException: no such column: \"non_existent\" - should this be a string literal in single-quotes?".
```
