### PR TITLE
Mark `preview_image_needed_before_processing_variants?` as private API

### DIFF
--- a/activestorage/app/models/active_storage/blob/representable.rb
+++ b/activestorage/app/models/active_storage/blob/representable.rb
@@ -98,7 +98,7 @@ module ActiveStorage::Blob::Representable
     variable? || previewable?
   end
 
-  def preview_image_needed_before_processing_variants?
+  def preview_image_needed_before_processing_variants? # :nodoc:
     previewable? && !preview_image.attached?
   end
 


### PR DESCRIPTION
### Motivation
It looks like `preview_image_needed_before_processing_variants?` was added recently, but it's stated as being public API.

However, it looks like it's more of an implementation detail that's not meant for Active Storage users.
    
So this marks it as nodoc, so we're not on the hook for maintaining it.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
