### PR TITLE
Document what higher/lower priority numbers mean in ActiveJob guide [ci skip]

### DIFF
--- a/guides/source/active_job_basics.md
+++ b/guides/source/active_job_basics.md
@@ -357,6 +357,10 @@ You can also pass a `:priority` option to `set`:
 MyJob.set(priority: 50).perform_later(record)
 ```
 
+NOTE: If a lower priority number performs before or after a higher priority number depends on the
+adapter implementation. Refer to documentation of your backend for more information.
+Adapter authors are encouraged to treat a lower number as more important.
+
 [`queue_with_priority`]: https://api.rubyonrails.org/classes/ActiveJob/QueuePriority/ClassMethods.html#method-i-queue_with_priority
 
 Callbacks


### PR DESCRIPTION
Or rather, what they could mean. What to do with priority numbers is up to the adapter implementation.

### Detail

All adapters that support priority and I know of treat lower priority as more urgent:
* Backburner: https://github.com/nesquena/backburner?tab=readme-ov-file#enqueuing-jobs
* Delayed Job: https://github.com/collectiveidea/delayed_job?tab=readme-ov-file#parameters
* Que: https://github.com/que-rb/que?tab=readme-ov-file#usage
* SolidQueue: https://github.com/rails/solid_queue?tab=readme-ov-file#queue-order-and-priorities
* GoodJob (in v4): https://github.com/bensheldon/good_job/?tab=readme-ov-file#job-priority

The example from this guide makes the same assumption: A video from a premium owner gets priority 0 while others "only" get 10.

![image](https://github.com/rails/rails/assets/14981592/f6941981-e546-47bf-a91b-52cf18ceb9ec)


There is also this snippet in source which makes a rather clear claim:

https://github.com/rails/rails/blob/ad41f711ced5fdef9fda2e89e8c7bb84570285c6/activejob/lib/active_job/core.rb#L24-L25

I don't think that's entirely correct given that adapters can just do whatever they want (it's the only reference I actually managed find about what you're supposed to do though). Case in point GoodJob which currently implements higher priority number = more urgent unless explicitly opted into the new beheaviour.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
