### PR TITLE
Fix running migrations on other databases when `database_tasks: false` on primary

### DIFF
--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -89,7 +89,7 @@ db_namespace = namespace :db do
   task migrate: :load_config do
     db_configs = ActiveRecord::Base.configurations.configs_for(env_name: ActiveRecord::Tasks::DatabaseTasks.env)
 
-    if db_configs.size == 1
+    if db_configs.size == 1 && db_configs.first.primary?
       ActiveRecord::Tasks::DatabaseTasks.migrate
     else
       mapped_versions = ActiveRecord::Tasks::DatabaseTasks.db_configs_with_versions


### PR DESCRIPTION
Fixes #51757.

When we have `database_tasks: false` on primary and we have 2 databases, we fall into the `if db_configs.size == 1` branch, which tries to run migrations on the primary database, which is not correct.