### PR TITLE
Support PG unbounded inclusive date/time range

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/quoting.rb
@@ -205,7 +205,17 @@ module ActiveRecord
           end
 
           def encode_range(range)
-            "[#{type_cast_range_value(range.begin)},#{type_cast_range_value(range.end)}#{range.exclude_end? ? ')' : ']'}"
+            lower_bound = type_cast_range_value(range.begin)
+            upper_bound = if date_or_time_range?(range)
+              # Postgres will convert `[today,]` to `[today,)`, making it exclusive.
+              # We can use the special timestamp value `infinity` to force inclusion.
+              # https://www.postgresql.org/docs/current/rangetypes.html#RANGETYPES-INFINITE
+              range.end.nil? ? "infinity" : type_cast(range.end)
+            else
+              type_cast_range_value(range.end)
+            end
+
+            "[#{lower_bound},#{upper_bound}#{range.exclude_end? ? ')' : ']'}"
           end
 
           def determine_encoding_of_strings_in_array(value)
@@ -228,6 +238,10 @@ module ActiveRecord
 
           def infinity?(value)
             value.respond_to?(:infinite?) && value.infinite?
+          end
+
+          def date_or_time_range?(range)
+            [range.begin.class, range.end.class].intersect?([Date, DateTime, Time])
           end
       end
     end

--- a/activerecord/test/cases/adapters/postgresql/range_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/range_test.rb
@@ -196,14 +196,14 @@ class PostgresqlRangeTest < ActiveRecord::PostgreSQLTestCase
       time_string = Time.current.to_s
       time = Time.zone.parse(time_string)
 
-      record = PostgresqlRange.new(tstz_range: time_string...)
-      assert_equal time..., record.tstz_range
+      record = PostgresqlRange.new(tstz_range: time_string..)
+      assert_equal time.., record.tstz_range
       assert_equal ActiveSupport::TimeZone[tz], record.tstz_range.begin.time_zone
 
       record.save!
       record.reload
 
-      assert_equal time..., record.tstz_range
+      assert_equal time.., record.tstz_range
       assert_equal ActiveSupport::TimeZone[tz], record.tstz_range.begin.time_zone
     end
   end
@@ -302,9 +302,12 @@ class PostgresqlRangeTest < ActiveRecord::PostgreSQLTestCase
   end
 
   def test_unbounded_tsrange
-    tz = ::ActiveRecord.default_timezone
-    assert_equal_round_trip @first_range, :ts_range, Time.public_send(tz, 2010, 1, 1, 14, 30, 0)...nil
-    assert_equal_round_trip @first_range, :ts_range, nil..Time.public_send(tz, 2010, 1, 1, 14, 30, 0)
+    time = Time.public_send(::ActiveRecord.default_timezone, 2010, 1, 1, 14, 30, 0)
+
+    assert_equal_round_trip @first_range, :ts_range, time..nil
+    assert_equal_round_trip @first_range, :ts_range, time...nil
+    assert_equal_round_trip @first_range, :ts_range, nil..time
+    assert_equal_round_trip @first_range, :ts_range, nil...time
   end
 
   def test_timezone_awareness_tsrange


### PR DESCRIPTION
Fixes #51745

### Motivation / Background

Suppose you have a PG `tsrange` column named `my_range`. If you create a record with `my_range: (Time.current..)` (inclusive), PG will insert the record with `[my_range,]`, but behind the scenes it'll [convert it](https://www.postgresql.org/docs/current/rangetypes.html#RANGETYPES-INFINITE) to `[my_range,)`, making it exclusive. 

The problem is when you `reload` or retrieve the record, it'll be `my_range: (Time.current...)` (exclusive).

You can "force" inclusivity by using the timestamp value of `infinity` on insertion: `[my_range, infinity]`

And that's what this change does.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
