### PR TITLE
Re-enable railtie non_existent sqlite3 test from #51901

### DIFF
--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -2890,12 +2890,11 @@ module ApplicationTests
       assert_equal true, ActiveRecord::ConnectionAdapters::SQLite3Adapter.strict_strings_by_default
 
       Post.lease_connection.create_table :posts
-      _error = assert_raises(StandardError) do
+      error = assert_raises(StandardError) do
         Post.lease_connection.add_index :posts, :non_existent
       end
 
-      # FIXME: Doesn't work in CI, bug when sprockets-rails is not required.
-      # assert_match(/no such column: non_existent/, error.message)
+      assert_match(/no such column: "?non_existent"?/, error.message)
     end
 
     test "ActiveSupport::MessageEncryptor.use_authenticated_message_encryption is true by default for new apps" do


### PR DESCRIPTION
This was disabled in #51799, assuming because my commit was not merged in their branch, so the test was still failing.

It only affects when sqlite 3.46.0 is installed