### PR TITLE
Fix typo

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/puma.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/puma.rb.tt
@@ -7,7 +7,7 @@
 #
 # The ideal number of threads per worker depends both on how much time the
 # application spends waiting for IO operations and on how much you wish to
-# to prioritize throughput over latency.
+# prioritize throughput over latency.
 #
 # As a rule of thumb, increasing the number of threads will increase how much
 # traffic a given process can handle (throughput), but due to CRuby's


### PR DESCRIPTION
I have corrected the typo in the text added below.
https://github.com/rails/rails/commit/06d614ada9e4609ff83659e842f48af3232a03a5

`to to` -> `to`