### PR TITLE
Clarify documentation of authenticate_or_request_with_http_token [fix #51908] [ci skip]

### DIFF
--- a/actionpack/lib/action_controller/metal/http_authentication.rb
+++ b/actionpack/lib/action_controller/metal/http_authentication.rb
@@ -431,7 +431,7 @@ module ActionController
       module ControllerMethods
         # Authenticate using an HTTP Bearer token, or otherwise render an HTTP header
         # requesting the client to send a Bearer token. For the authentication to be
-        # considered successful, `login_procedure` should return a non-nil value.
+        # considered successful, `login_procedure` must not return a false value.
         # Typically, the authenticated user is returned.
         #
         # See ActionController::HttpAuthentication::Token for example usage.


### PR DESCRIPTION
### Motivation / Background

Documentation of authenticate_or_request_with_http_token is incorrect and this may also have security implications.

**Based on the current documentation, if you return false (which is non-nil), login procedure will be considered successful.**

**But that is not what happens!**

If you return false, the login procedure is considered UNSUCCESSFUL.

This pull request fixes the documentation.

### Detail

This pull request clarifies what happens if you return `false` in the login procedure.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
