### PR TITLE
Make source_reflection return nil when no name

### DIFF
--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -1007,6 +1007,8 @@ module ActiveRecord
       #   # => <ActiveRecord::Reflection::BelongsToReflection: @name=:tag, @active_record=Tagging, @plural_name="tags">
       #
       def source_reflection
+        return unless source_reflection_name
+
         through_reflection.klass._reflect_on_association(source_reflection_name)
       end
 

--- a/activerecord/test/cases/reflection_test.rb
+++ b/activerecord/test/cases/reflection_test.rb
@@ -607,6 +607,18 @@ class ReflectionTest < ActiveRecord::TestCase
     end
   end
 
+  def test_reflect_on_missing_source_assocation
+    assert_nothing_raised do
+      assert_nil Hotel.reflect_on_association(:lost_items).source_reflection
+    end
+  end
+
+  def test_reflect_on_missing_source_assocation_raise_exception
+    assert_raises(ActiveRecord::HasManyThroughSourceAssociationNotFoundError) do
+      Hotel.reflect_on_association(:lost_items).check_validity!
+    end
+  end
+
   def test_name_error_from_incidental_code_is_not_converted_to_name_error_for_association
     UserWithInvalidRelation.stub(:const_missing, proc { oops }) do
       reflection = UserWithInvalidRelation.reflect_on_association(:not_a_class)

--- a/activerecord/test/models/hotel.rb
+++ b/activerecord/test/models/hotel.rb
@@ -10,4 +10,6 @@ class Hotel < ActiveRecord::Base
   has_many :mocktail_designers, through: :chef_lists, source: :employable, source_type: "MocktailDesigner"
 
   has_many :recipes, through: :chefs
+
+  has_many :lost_items, through: :departments
 end


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because I've come across a build error in shoulda-matchers when running the tests against edge Rails.

After some investigation, there seems to be a regression from https://github.com/rails/rails/pull/51726. The tests added in this PR passes before #51726 and fails after. A `NoMethodError` is raised due to `to_sym` being called on a nil value.

### Detail

This Pull Request changes `ActiveRecord::Reflection::ThroughReflection#source_reflection` to return nil in case where the name of the source reflection cannot be established.

This should also resolve the intended behavior in `#check_validity!` to throw an exception:

https://github.com/Skalar/rails/blob/51ea6032ad42c5e5dadca1630f42e351fcf788e8/activerecord/lib/active_record/reflection.rb#L1152-L1154

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
