### PR TITLE
Improve ActionCable's TestCookieJar interface

### DIFF
--- a/actioncable/lib/action_cable/connection/test_case.rb
+++ b/actioncable/lib/action_cable/connection/test_case.rb
@@ -30,16 +30,23 @@ module ActionCable
       end
     end
 
+    class TestCookies < ActiveSupport::HashWithIndifferentAccess
+      def []=(name, options)
+        value = options.is_a?(Hash) ? options.symbolize_keys[:value] : options
+        super(name, value)
+      end
+    end
+
     # We don't want to use the whole "encryption stack" for connection unit-tests,
     # but we want to make sure that users test against the correct types of cookies
     # (i.e. signed or encrypted or plain)
-    class TestCookieJar < ActiveSupport::HashWithIndifferentAccess
+    class TestCookieJar < TestCookies
       def signed
-        self[:signed] ||= {}.with_indifferent_access
+        @signed ||= TestCookies.new
       end
 
       def encrypted
-        self[:encrypted] ||= {}.with_indifferent_access
+        @encrypted ||= TestCookies.new
       end
     end
 

--- a/actioncable/test/connection/test_case_test.rb
+++ b/actioncable/test/connection/test_case_test.rb
@@ -47,6 +47,14 @@ class ConnectionSimpleTest < ActionCable::Connection::TestCase
     assert_equal "456", connection.user_id
   end
 
+  def test_plain_cookie_with_explicit_value_and_string_key
+    cookies["user_id"] = { "value" => "456" }
+
+    connect
+
+    assert_equal "456", connection.user_id
+  end
+
   def test_disconnect
     cookies["user_id"] = "456"
 
@@ -127,6 +135,14 @@ class EncryptedCookiesConnectionTest < ActionCable::Connection::TestCase
 
   def test_connected_with_encrypted_cookies
     cookies.encrypted["user_id"] = "456"
+
+    connect
+
+    assert_equal "456", connection.user_id
+  end
+
+  def test_connected_with_encrypted_cookies_with_explicit_value_and_symbol_key
+    cookies.encrypted["user_id"] = { value: "456" }
 
     connect
 


### PR DESCRIPTION
Fixes #51914

### Motivation / Background

This change brings `ActionCable::Connection::TestCookieJar` in alignment with `ActionDispatch::Cookies::CookieJar` in regards to setting the cookie value.

Before:

```ruby
cookies[:foo] = { value: "bar" }
puts cookies[:foo] # => { value: "bar" }
```

After:

```ruby
cookies[:foo] = { value: "bar" }
puts cookies[:foo] # => "bar"
```

### Additional information

Technically this is a breaking change but I don't know why the user would depend on an incorrect interface.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
