### PR TITLE
Unify `Relation#klass` and `Relation#model`

### DIFF
--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -94,7 +94,7 @@ module ActiveRecord
       def find(*args)
         if options[:inverse_of] && loaded?
           args_flatten = args.flatten
-          model = scope.klass
+          model = scope.model
 
           if args_flatten.blank?
             error_message = "Couldn't find #{model.name} without an ID"

--- a/activerecord/lib/active_record/associations/disable_joins_association_scope.rb
+++ b/activerecord/lib/active_record/associations/disable_joins_association_scope.rb
@@ -47,7 +47,7 @@ module ActiveRecord
           end
 
           if scope.order_values.empty? && ordered
-            split_scope = DisableJoinsAssociationRelation.create(scope.klass, key, join_ids)
+            split_scope = DisableJoinsAssociationRelation.create(scope.model, key, join_ids)
             split_scope.where_clause += scope.where_clause
             split_scope
           else

--- a/activerecord/lib/active_record/associations/has_many_through_association.rb
+++ b/activerecord/lib/active_record/associations/has_many_through_association.rb
@@ -140,7 +140,7 @@ module ActiveRecord
 
           case method
           when :destroy
-            if scope.klass.primary_key
+            if scope.model.primary_key
               count = scope.destroy_all.count(&:destroyed?)
             else
               scope.each(&:_run_destroy_callbacks)

--- a/activerecord/lib/active_record/encryption/extended_deterministic_queries.rb
+++ b/activerecord/lib/active_record/encryption/extended_deterministic_queries.rb
@@ -104,12 +104,12 @@ module ActiveRecord
         end
 
         def scope_for_create
-          return super unless klass.deterministic_encrypted_attributes&.any?
+          return super unless model.deterministic_encrypted_attributes&.any?
 
           scope_attributes = super
           wheres = where_values_hash
 
-          klass.deterministic_encrypted_attributes.each do |attribute_name|
+          model.deterministic_encrypted_attributes.each do |attribute_name|
             attribute_name = attribute_name.to_s
             values = wheres[attribute_name]
             if values.is_a?(Array) && values[1..].all?(AdditionalValue)

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -68,19 +68,19 @@ module ActiveRecord
     include FinderMethods, Calculations, SpawnMethods, QueryMethods, Batches, Explain, Delegation
     include SignedId::RelationMethods, TokenFor::RelationMethods
 
-    attr_reader :table, :klass, :loaded, :predicate_builder
+    attr_reader :table, :model, :loaded, :predicate_builder
     attr_accessor :skip_preloading_value
-    alias :model :klass
+    alias :klass :model
     alias :loaded? :loaded
     alias :locked? :lock_value
 
-    def initialize(klass, table: klass.arel_table, predicate_builder: klass.predicate_builder, values: {})
-      @klass  = klass
+    def initialize(model, table: model.arel_table, predicate_builder: model.predicate_builder, values: {})
+      @model  = model
       @table  = table
       @values = values
       @loaded = false
       @predicate_builder = predicate_builder
-      @delegate_to_klass = false
+      @delegate_to_model = false
       @future_result = nil
       @records = nil
       @async = false
@@ -93,7 +93,7 @@ module ActiveRecord
     end
 
     def bind_attribute(name, value) # :nodoc:
-      if reflection = klass._reflect_on_association(name)
+      if reflection = model._reflect_on_association(name)
         name = reflection.foreign_key
         value = value.read_attribute(reflection.association_primary_key) unless value.nil?
       end
@@ -430,12 +430,12 @@ module ActiveRecord
     #   Product.where("name like ?", "%Game%").cache_key(:last_reviewed_at)
     def cache_key(timestamp_column = "updated_at")
       @cache_keys ||= {}
-      @cache_keys[timestamp_column] ||= klass.collection_cache_key(self, timestamp_column)
+      @cache_keys[timestamp_column] ||= model.collection_cache_key(self, timestamp_column)
     end
 
     def compute_cache_key(timestamp_column = :updated_at) # :nodoc:
       query_signature = ActiveSupport::Digest.hexdigest(to_sql)
-      key = "#{klass.model_name.cache_key}/query-#{query_signature}"
+      key = "#{model.model_name.cache_key}/query-#{query_signature}"
 
       if model.collection_cache_versioning
         key
@@ -475,7 +475,7 @@ module ActiveRecord
 
         with_connection do |c|
           column = c.visitor.compile(table[timestamp_column])
-          select_values = "COUNT(*) AS #{klass.adapter_class.quote_column_name("size")}, MAX(%s) AS timestamp"
+          select_values = "COUNT(*) AS #{model.adapter_class.quote_column_name("size")}, MAX(%s) AS timestamp"
 
           if collection.has_limit_or_offset?
             query = collection.select("#{column} AS collection_cache_key_timestamp")
@@ -492,7 +492,7 @@ module ActiveRecord
           size, timestamp = c.select_rows(arel, nil).first
 
           if size
-            column_type = klass.type_for_attribute(timestamp_column)
+            column_type = model.type_for_attribute(timestamp_column)
             timestamp = column_type.deserialize(timestamp)
           else
             size = 0
@@ -532,7 +532,7 @@ module ActiveRecord
     # Please check unscoped if you want to remove all previous scopes (including
     # the default_scope) during the execution of a block.
     def scoping(all_queries: nil, &block)
-      registry = klass.scope_registry
+      registry = model.scope_registry
       if global_scope?(registry) && all_queries == false
         raise ArgumentError, "Scoping is set to apply to all queries and cannot be unset in a nested block."
       elsif already_in_scope?(registry)
@@ -543,11 +543,11 @@ module ActiveRecord
     end
 
     def _exec_scope(...) # :nodoc:
-      @delegate_to_klass = true
-      registry = klass.scope_registry
+      @delegate_to_model = true
+      registry = model.scope_registry
       _scoping(nil, registry) { instance_exec(...) || self }
     ensure
-      @delegate_to_klass = false
+      @delegate_to_model = false
     end
 
     # Updates all records in the current relation with details given. This method constructs a single SQL UPDATE
@@ -584,30 +584,30 @@ module ActiveRecord
       return 0 if @none
 
       if updates.is_a?(Hash)
-        if klass.locking_enabled? &&
-            !updates.key?(klass.locking_column) &&
-            !updates.key?(klass.locking_column.to_sym)
-          attr = table[klass.locking_column]
+        if model.locking_enabled? &&
+            !updates.key?(model.locking_column) &&
+            !updates.key?(model.locking_column.to_sym)
+          attr = table[model.locking_column]
           updates[attr.name] = _increment_attribute(attr)
         end
         values = _substitute_values(updates)
       else
-        values = Arel.sql(klass.sanitize_sql_for_assignment(updates, table.name))
+        values = Arel.sql(model.sanitize_sql_for_assignment(updates, table.name))
       end
 
-      klass.with_connection do |c|
+      model.with_connection do |c|
         arel = eager_loading? ? apply_join_dependency.arel : build_arel(c)
         arel.source.left = table
 
         group_values_arel_columns = arel_columns(group_values.uniq)
         having_clause_ast = having_clause.ast unless having_clause.empty?
-        key = if klass.composite_primary_key?
+        key = if model.composite_primary_key?
           primary_key.map { |pk| table[pk] }
         else
           table[primary_key]
         end
         stmt = arel.compile_update(values, key, having_clause_ast, group_values_arel_columns)
-        c.update(stmt, "#{klass} Update All").tap { reset }
+        c.update(stmt, "#{model} Update All").tap { reset }
       end
     end
 
@@ -615,7 +615,7 @@ module ActiveRecord
       if id == :all
         each { |record| record.update(attributes) }
       else
-        klass.update(id, attributes)
+        model.update(id, attributes)
       end
     end
 
@@ -623,7 +623,7 @@ module ActiveRecord
       if id == :all
         each { |record| record.update!(attributes) }
       else
-        klass.update!(id, attributes)
+        model.update!(id, attributes)
       end
     end
 
@@ -929,7 +929,7 @@ module ActiveRecord
         names = touch if touch != true
         names = Array.wrap(names)
         options = names.extract_options!
-        touch_updates = klass.touch_attributes_with_time(*names, **options)
+        touch_updates = model.touch_attributes_with_time(*names, **options)
         updates.merge!(touch_updates) unless touch_updates.empty?
       end
 
@@ -960,7 +960,7 @@ module ActiveRecord
     #   Person.where(name: 'David').touch_all
     #   # => "UPDATE \"people\" SET \"updated_at\" = '2018-01-04 22:55:23.132670' WHERE \"people\".\"name\" = 'David'"
     def touch_all(*names, time: nil)
-      update_all klass.touch_attributes_with_time(*names, time: time)
+      update_all model.touch_attributes_with_time(*names, time: time)
     end
 
     # Destroys the records by instantiating each
@@ -1012,20 +1012,20 @@ module ActiveRecord
         raise ActiveRecordError.new("delete_all doesn't support #{invalid_methods.join(', ')}")
       end
 
-      klass.with_connection do |c|
+      model.with_connection do |c|
         arel = eager_loading? ? apply_join_dependency.arel : build_arel(c)
         arel.source.left = table
 
         group_values_arel_columns = arel_columns(group_values.uniq)
         having_clause_ast = having_clause.ast unless having_clause.empty?
-        key = if klass.composite_primary_key?
+        key = if model.composite_primary_key?
           primary_key.map { |pk| table[pk] }
         else
           table[primary_key]
         end
         stmt = arel.compile_delete(key, having_clause_ast, group_values_arel_columns)
 
-        c.delete(stmt, "#{klass} Delete All").tap { reset }
+        c.delete(stmt, "#{model} Delete All").tap { reset }
       end
     end
 
@@ -1180,7 +1180,7 @@ module ActiveRecord
     def reset
       @future_result&.cancel
       @future_result = nil
-      @delegate_to_klass = false
+      @delegate_to_model = false
       @to_sql = @arel = @loaded = @should_eager_load = nil
       @offsets = @take = nil
       @cache_keys = nil
@@ -1200,7 +1200,7 @@ module ActiveRecord
           relation.to_sql
         end
       else
-        klass.with_connection do |conn|
+        model.with_connection do |conn|
           conn.unprepared_statement { conn.to_sql(arel) }
         end
       end
@@ -1210,12 +1210,12 @@ module ActiveRecord
     #
     #   User.where(name: 'Oscar').where_values_hash
     #   # => {name: "Oscar"}
-    def where_values_hash(relation_table_name = klass.table_name) # :nodoc:
+    def where_values_hash(relation_table_name = model.table_name) # :nodoc:
       where_clause.to_h(relation_table_name)
     end
 
     def scope_for_create
-      hash = where_clause.to_h(klass.table_name, equality_only: true)
+      hash = where_clause.to_h(model.table_name, equality_only: true)
       create_with_value.each { |k, v| hash[k.to_s] = v } unless create_with_value.empty?
       hash
     end
@@ -1283,7 +1283,7 @@ module ActiveRecord
     end
 
     def empty_scope? # :nodoc:
-      @values == klass.unscoped.values
+      @values == model.unscoped.values
     end
 
     def has_limit_or_offset? # :nodoc:
@@ -1291,7 +1291,7 @@ module ActiveRecord
     end
 
     def alias_tracker(joins = [], aliases = nil) # :nodoc:
-      ActiveRecord::Associations::AliasTracker.create(klass.connection_pool, table.name, joins, aliases)
+      ActiveRecord::Associations::AliasTracker.create(model.connection_pool, table.name, joins, aliases)
     end
 
     class StrictLoadingScope # :nodoc:
@@ -1321,46 +1321,46 @@ module ActiveRecord
 
     private
       def already_in_scope?(registry)
-        @delegate_to_klass && registry.current_scope(klass, true)
+        @delegate_to_model && registry.current_scope(model, true)
       end
 
       def global_scope?(registry)
-        registry.global_current_scope(klass, true)
+        registry.global_current_scope(model, true)
       end
 
       def current_scope_restoring_block(&block)
-        current_scope = klass.current_scope(true)
+        current_scope = model.current_scope(true)
         -> record do
-          klass.current_scope = current_scope
+          model.current_scope = current_scope
           yield record if block_given?
         end
       end
 
       def _new(attributes, &block)
-        klass.new(attributes, &block)
+        model.new(attributes, &block)
       end
 
       def _create(attributes, &block)
-        klass.create(attributes, &block)
+        model.create(attributes, &block)
       end
 
       def _create!(attributes, &block)
-        klass.create!(attributes, &block)
+        model.create!(attributes, &block)
       end
 
       def _scoping(scope, registry, all_queries = false)
-        previous = registry.current_scope(klass, true)
-        registry.set_current_scope(klass, scope)
+        previous = registry.current_scope(model, true)
+        registry.set_current_scope(model, scope)
 
         if all_queries
-          previous_global = registry.global_current_scope(klass, true)
-          registry.set_global_current_scope(klass, scope)
+          previous_global = registry.global_current_scope(model, true)
+          registry.set_global_current_scope(model, scope)
         end
         yield
       ensure
-        registry.set_current_scope(klass, previous)
+        registry.set_current_scope(model, previous)
         if all_queries
-          registry.set_global_current_scope(klass, previous_global)
+          registry.set_global_current_scope(model, previous_global)
         end
       end
 
@@ -1372,7 +1372,7 @@ module ActiveRecord
               value = Arel::Nodes::Grouping.new(value)
             end
           else
-            type = klass.type_for_attribute(attr.name)
+            type = model.type_for_attribute(attr.name)
             value = predicate_builder.build_bind_attribute(attr.name, type.cast(value))
           end
           [attr, value]
@@ -1419,7 +1419,7 @@ module ActiveRecord
           if where_clause.contradiction?
             [].freeze
           elsif eager_loading?
-            klass.with_connection do |c|
+            model.with_connection do |c|
               apply_join_dependency do |relation, join_dependency|
                 if relation.null_relation?
                   [].freeze
@@ -1431,8 +1431,8 @@ module ActiveRecord
               end
             end
           else
-            klass.with_connection do |c|
-              klass._query_by_sql(c, arel, async: async)
+            model.with_connection do |c|
+              model._query_by_sql(c, arel, async: async)
             end
           end
         end
@@ -1445,7 +1445,7 @@ module ActiveRecord
           @_join_dependency = nil
           records
         else
-          klass._load_from_sql(rows, &block).freeze
+          model._load_from_sql(rows, &block).freeze
         end
       end
 

--- a/activerecord/lib/active_record/relation/batches.rb
+++ b/activerecord/lib/active_record/relation/batches.rb
@@ -367,7 +367,7 @@ module ActiveRecord
         relation = apply_limits(relation, start, finish, batch_orders)
         relation.skip_query_cache! # Retaining the results in the query cache would undermine the point of batching
         batch_relation = relation
-        empty_scope = to_sql == klass.unscoped.all.to_sql
+        empty_scope = to_sql == model.unscoped.all.to_sql
 
         loop do
           if load

--- a/activerecord/lib/active_record/relation/delegation.rb
+++ b/activerecord/lib/active_record/relation/delegation.rb
@@ -78,12 +78,12 @@ module ActiveRecord
           if /\A[a-zA-Z_]\w*[!?]?\z/.match?(method) && !::ActiveSupport::Delegation::RESERVED_METHOD_NAMES.include?(method.to_s)
             module_eval <<-RUBY, __FILE__, __LINE__ + 1
               def #{method}(...)
-                scoping { klass.#{method}(...) }
+                scoping { model.#{method}(...) }
               end
             RUBY
           else
             define_method(method) do |*args, **kwargs, &block|
-              scoping { klass.public_send(method, *args, **kwargs, &block) }
+              scoping { model.public_send(method, *args, **kwargs, &block) }
             end
           end
         end
@@ -95,15 +95,15 @@ module ActiveRecord
 
     # This module creates compiled delegation methods dynamically at runtime, which makes
     # subsequent calls to that method faster by avoiding method_missing. The delegations
-    # may vary depending on the klass of a relation, so we create a subclass of Relation
-    # for each different klass, and the delegations are compiled into that subclass only.
+    # may vary depending on the model of a relation, so we create a subclass of Relation
+    # for each different model, and the delegations are compiled into that subclass only.
 
     delegate :to_xml, :encode_with, :length, :each, :join, :intersect?,
              :[], :&, :|, :+, :-, :sample, :reverse, :rotate, :compact, :in_groups, :in_groups_of,
              :to_sentence, :to_fs, :to_formatted_s, :as_json,
              :shuffle, :split, :slice, :index, :rindex, to: :records
 
-    delegate :primary_key, :with_connection, :connection, :table_name, :transaction, :sanitize_sql_like, :unscoped, to: :klass
+    delegate :primary_key, :with_connection, :connection, :table_name, :transaction, :sanitize_sql_like, :unscoped, to: :model
 
     module ClassSpecificRelation # :nodoc:
       extend ActiveSupport::Concern
@@ -116,7 +116,7 @@ module ActiveRecord
 
       private
         def method_missing(method, ...)
-          if @klass.respond_to?(method)
+          if model.respond_to?(method)
             if !DelegateCache.delegate_base_methods && Base.respond_to?(method)
               # A common mistake in Active Record's own code is to call `ActiveRecord::Base`
               # class methods on Association. It works because it's automatically delegated, but
@@ -125,10 +125,10 @@ module ActiveRecord
               # can ban it from Active Record's own test suite to avoid regressions.
               raise NotImplementedError, "Active Record code shouldn't rely on association delegation into ActiveRecord::Base methods"
             elsif !Delegation.uncacheable_methods.include?(method)
-              @klass.generate_relation_method(method)
+              model.generate_relation_method(method)
             end
 
-            scoping { @klass.public_send(method, ...) }
+            scoping { model.public_send(method, ...) }
           else
             super
           end
@@ -136,19 +136,19 @@ module ActiveRecord
     end
 
     module ClassMethods # :nodoc:
-      def create(klass, *args, **kwargs)
-        relation_class_for(klass).new(klass, *args, **kwargs)
+      def create(model, ...)
+        relation_class_for(model).new(model, ...)
       end
 
       private
-        def relation_class_for(klass)
-          klass.relation_delegate_class(self)
+        def relation_class_for(model)
+          model.relation_delegate_class(self)
         end
     end
 
     private
       def respond_to_missing?(method, _)
-        super || @klass.respond_to?(method)
+        super || model.respond_to?(method)
       end
   end
 end

--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -376,7 +376,7 @@ module ActiveRecord
 
       skip_query_cache_if_necessary do
         with_connection do |c|
-          c.select_rows(relation.arel, "#{klass.name} Exists?").size == 1
+          c.select_rows(relation.arel, "#{model.name} Exists?").size == 1
         end
       end
     end
@@ -389,7 +389,7 @@ module ActiveRecord
     def include?(record)
       # The existing implementation relies on receiving an Active Record instance as the input parameter named record.
       # Any non-Active Record object passed to this implementation is guaranteed to return `false`.
-      return false unless record.is_a?(klass)
+      return false unless record.is_a?(model)
 
       if loaded? || offset_value || limit_value || having_clause.any?
         records.include?(record)
@@ -415,9 +415,9 @@ module ActiveRecord
     # the expected number of results should be provided in the +expected_size+
     # argument.
     def raise_record_not_found_exception!(ids = nil, result_size = nil, expected_size = nil, key = primary_key, not_found_ids = nil) # :nodoc:
-      conditions = " [#{arel.where_sql(klass)}]" unless where_clause.empty?
+      conditions = " [#{arel.where_sql(model)}]" unless where_clause.empty?
 
-      name = @klass.name
+      name = model.name
 
       if ids.nil?
         error = +"Couldn't find #{name}"
@@ -471,7 +471,7 @@ module ActiveRecord
             )
           )
           relation = skip_query_cache_if_necessary do
-            klass.with_connection do |c|
+            model.with_connection do |c|
               c.distinct_relation_for_primary_key(relation)
             end
           end
@@ -489,9 +489,9 @@ module ActiveRecord
       end
 
       def find_with_ids(*ids)
-        raise UnknownPrimaryKey.new(@klass) if primary_key.nil?
+        raise UnknownPrimaryKey.new(model) if primary_key.nil?
 
-        expects_array = if klass.composite_primary_key?
+        expects_array = if model.composite_primary_key?
           ids.first.first.is_a?(Array)
         else
           ids.first.is_a?(Array)
@@ -503,7 +503,7 @@ module ActiveRecord
 
         ids = ids.compact.uniq
 
-        model_name = @klass.name
+        model_name = model.name
 
         case ids.size
         when 0
@@ -525,7 +525,7 @@ module ActiveRecord
           MSG
         end
 
-        relation = if klass.composite_primary_key?
+        relation = if model.composite_primary_key?
           where(primary_key.zip(id).to_h)
         else
           where(primary_key => id)
@@ -573,7 +573,7 @@ module ActiveRecord
         result = relation.records
 
         if result.size == ids.size
-          result.in_order_of(:id, ids.map { |id| @klass.type_for_attribute(primary_key).cast(id) })
+          result.in_order_of(:id, ids.map { |id| model.type_for_attribute(primary_key).cast(id) })
         else
           raise_record_not_found_exception!(ids, result.size, ids.size)
         end

--- a/activerecord/lib/active_record/relation/merger.rb
+++ b/activerecord/lib/active_record/relation/merger.rb
@@ -24,7 +24,7 @@ module ActiveRecord
       # the values.
       def other
         other = Relation.create(
-          relation.klass,
+          relation.model,
           table: relation.table,
           predicate_builder: relation.predicate_builder
         )
@@ -84,7 +84,7 @@ module ActiveRecord
         def merge_select_values
           return if other.select_values.empty?
 
-          if other.klass == relation.klass
+          if other.model == relation.model
             relation.select_values |= other.select_values
           else
             relation.select_values |= other.instance_eval do
@@ -96,12 +96,12 @@ module ActiveRecord
         def merge_preloads
           return if other.preload_values.empty? && other.includes_values.empty?
 
-          if other.klass == relation.klass
+          if other.model == relation.model
             relation.preload_values |= other.preload_values unless other.preload_values.empty?
             relation.includes_values |= other.includes_values unless other.includes_values.empty?
           else
-            reflection = relation.klass.reflect_on_all_associations.find do |r|
-              r.class_name == other.klass.name
+            reflection = relation.model.reflect_on_all_associations.find do |r|
+              r.class_name == other.model.name
             end || return
 
             unless other.preload_values.empty?
@@ -117,7 +117,7 @@ module ActiveRecord
         def merge_joins
           return if other.joins_values.empty?
 
-          if other.klass == relation.klass
+          if other.model == relation.model
             relation.joins_values |= other.joins_values
           else
             associations, others = other.joins_values.partition do |join|
@@ -136,7 +136,7 @@ module ActiveRecord
         def merge_outer_joins
           return if other.left_outer_joins_values.empty?
 
-          if other.klass == relation.klass
+          if other.model == relation.model
             relation.left_outer_joins_values |= other.left_outer_joins_values
           else
             associations, others = other.left_outer_joins_values.partition do |join|
@@ -185,7 +185,7 @@ module ActiveRecord
 
         def replace_from_clause?
           relation.from_clause.empty? && !other.from_clause.empty? &&
-            relation.klass.base_class == other.klass.base_class
+            relation.model.base_class == other.model.base_class
         end
     end
   end

--- a/activerecord/lib/active_record/relation/predicate_builder/polymorphic_array_value.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder/polymorphic_array_value.rb
@@ -37,7 +37,7 @@ module ActiveRecord
           if value.is_a?(Base)
             value.class
           elsif value.is_a?(Relation)
-            value.klass
+            value.model
           end
         end
 

--- a/activerecord/lib/active_record/relation/predicate_builder/relation_handler.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder/relation_handler.rb
@@ -9,10 +9,11 @@ module ActiveRecord
         end
 
         if value.select_values.empty?
-          if value.klass.composite_primary_key?
-            raise ArgumentError, "Cannot map composite primary key #{value.klass.primary_key} to #{attribute.name}"
+          model = value.model
+          if model.composite_primary_key?
+            raise ArgumentError, "Cannot map composite primary key #{model.primary_key} to #{attribute.name}"
           else
-            value = value.select(value.table[value.klass.primary_key])
+            value = value.select(value.table[model.primary_key])
           end
         end
 

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -702,7 +702,7 @@ module ActiveRecord
     #   #   END ASC
     #
     def in_order_of(column, values)
-      klass.disallow_raw_sql!([column], permit: model.adapter_class.column_name_with_order_matcher)
+      model.disallow_raw_sql!([column], permit: model.adapter_class.column_name_with_order_matcher)
       return spawn.none! if values.empty?
 
       references = column_references([column])
@@ -1559,8 +1559,8 @@ module ActiveRecord
       records.flatten!(1)
       records.compact!
 
-      unless records.all?(klass) && relations.all? { |relation| relation.klass == klass }
-        raise ArgumentError, "You must only pass a single or collection of #{klass.name} objects to ##{__callee__}."
+      unless records.all?(model) && relations.all? { |relation| relation.model == model }
+        raise ArgumentError, "You must only pass a single or collection of #{model.name} objects to ##{__callee__}."
       end
 
       spawn.excluding!(records + relations.flat_map(&:ids))
@@ -1580,7 +1580,7 @@ module ActiveRecord
 
     def construct_join_dependency(associations, join_type) # :nodoc:
       ActiveRecord::Associations::JoinDependency.new(
-        klass, table, associations, join_type
+        model, table, associations, join_type
       )
     end
 
@@ -1609,15 +1609,15 @@ module ActiveRecord
           elsif opts.include?("?")
             parts = [build_bound_sql_literal(opts, rest)]
           else
-            parts = [klass.sanitize_sql(rest.empty? ? opts : [opts, *rest])]
+            parts = [model.sanitize_sql(rest.empty? ? opts : [opts, *rest])]
           end
         when Hash
           opts = opts.transform_keys do |key|
             if key.is_a?(Array)
-              key.map { |k| klass.attribute_aliases[k.to_s] || k.to_s }
+              key.map { |k| model.attribute_aliases[k.to_s] || k.to_s }
             else
               key = key.to_s
-              klass.attribute_aliases[key] || key
+              model.attribute_aliases[key] || key
             end
           end
           references = PredicateBuilder.references(opts)
@@ -1813,7 +1813,7 @@ module ActiveRecord
 
         joins = joins_values.dup
         if joins.last.is_a?(ActiveRecord::Associations::JoinDependency)
-          stashed_eager_load = joins.pop if joins.last.base_klass == klass
+          stashed_eager_load = joins.pop if joins.last.base_klass == model
         end
 
         joins.each_with_index do |join, i|
@@ -1870,8 +1870,8 @@ module ActiveRecord
       def build_select(arel)
         if select_values.any?
           arel.project(*arel_columns(select_values))
-        elsif klass.ignored_columns.any? || klass.enumerate_columns_in_select_statements
-          arel.project(*klass.column_names.map { |field| table[field] })
+        elsif model.ignored_columns.any? || model.enumerate_columns_in_select_statements
+          arel.project(*model.column_names.map { |field| table[field] })
         else
           arel.project(table[Arel.star])
         end
@@ -1910,7 +1910,7 @@ module ActiveRecord
         with_table = Arel::Table.new(name)
 
         table.join(with_table, kind).on(
-          with_table[klass.model_name.to_s.foreign_key].eq(table[klass.primary_key])
+          with_table[model.model_name.to_s.foreign_key].eq(table[model.primary_key])
         ).join_sources.first
       end
 
@@ -1919,7 +1919,7 @@ module ActiveRecord
           case field
           when Symbol
             arel_column(field.to_s) do |attr_name|
-              klass.adapter_class.quote_table_name(attr_name)
+              model.adapter_class.quote_table_name(attr_name)
             end
           when String
             arel_column(field, &:itself)
@@ -1934,10 +1934,10 @@ module ActiveRecord
       end
 
       def arel_column(field)
-        field = klass.attribute_aliases[field] || field
+        field = model.attribute_aliases[field] || field
         from = from_clause.name || from_clause.value
 
-        if klass.columns_hash.key?(field) && (!from || table_name_matches?(from))
+        if model.columns_hash.key?(field) && (!from || table_name_matches?(from))
           table[field]
         elsif field.match?(/\A\w+\.\w+\z/)
           table, column = field.split(".")
@@ -1951,7 +1951,7 @@ module ActiveRecord
 
       def table_name_matches?(from)
         table_name = Regexp.escape(table.name)
-        quoted_table_name = Regexp.escape(klass.adapter_class.quote_table_name(table.name))
+        quoted_table_name = Regexp.escape(model.adapter_class.quote_table_name(table.name))
         /(?:\A|(?<!FROM)\s)(?:\b#{table_name}\b|#{quoted_table_name})(?!\.)/i.match?(from.to_s)
       end
 
@@ -2022,7 +2022,7 @@ module ActiveRecord
       end
 
       def preprocess_order_args(order_args)
-        @klass.disallow_raw_sql!(
+        model.disallow_raw_sql!(
           flattened_args(order_args),
           permit: model.adapter_class.column_name_with_order_matcher
         )
@@ -2060,7 +2060,7 @@ module ActiveRecord
 
       def sanitize_order_arguments(order_args)
         order_args.map! do |arg|
-          klass.sanitize_sql_for_order(arg)
+          model.sanitize_sql_for_order(arg)
         end
       end
 
@@ -2086,7 +2086,7 @@ module ActiveRecord
           if attr_name == "count" && !group_values.empty?
             table[attr_name]
           else
-            Arel.sql(klass.adapter_class.quote_table_name(attr_name), retryable: true)
+            Arel.sql(model.adapter_class.quote_table_name(attr_name), retryable: true)
           end
         end
       end
@@ -2180,7 +2180,7 @@ module ActiveRecord
             end
           when String, Symbol
             arel_column(key.to_s) do
-              predicate_builder.resolve_arel_attribute(klass.table_name, key.to_s)
+              predicate_builder.resolve_arel_attribute(model.table_name, key.to_s)
             end.as(columns_aliases.to_s)
           end
         end

--- a/activerecord/lib/active_record/relation/spawn_methods.rb
+++ b/activerecord/lib/active_record/relation/spawn_methods.rb
@@ -7,7 +7,7 @@ require "active_record/relation/merger"
 module ActiveRecord
   module SpawnMethods
     def spawn # :nodoc:
-      already_in_scope?(klass.scope_registry) ? klass.all : clone
+      already_in_scope?(model.scope_registry) ? model.all : clone
     end
 
     # Merges in the conditions from <tt>other</tt>, if <tt>other</tt> is an ActiveRecord::Relation.

--- a/activerecord/lib/active_record/scoping/named.rb
+++ b/activerecord/lib/active_record/scoping/named.rb
@@ -23,7 +23,7 @@ module ActiveRecord
           scope = current_scope
 
           if scope
-            if self == scope.klass
+            if self == scope.model
               scope.clone
             else
               relation.merge!(scope)

--- a/activerecord/lib/active_record/statement_cache.rb
+++ b/activerecord/lib/active_record/statement_cache.rb
@@ -133,21 +133,21 @@ module ActiveRecord
       relation = (callable || block).call Params.new
       query_builder, binds = connection.cacheable_query(self, relation.arel)
       bind_map = BindMap.new(binds)
-      new(query_builder, bind_map, relation.klass)
+      new(query_builder, bind_map, relation.model)
     end
 
-    def initialize(query_builder, bind_map, klass)
+    def initialize(query_builder, bind_map, model)
       @query_builder = query_builder
       @bind_map = bind_map
-      @klass = klass
+      @model = model
     end
 
     def execute(params, connection, allow_retry: false, &block)
-      bind_values = bind_map.bind params
+      bind_values = @bind_map.bind params
 
-      sql = query_builder.sql_for bind_values, connection
+      sql = @query_builder.sql_for bind_values, connection
 
-      klass.find_by_sql(sql, bind_values, preparable: true, allow_retry: allow_retry, &block)
+      @model.find_by_sql(sql, bind_values, preparable: true, allow_retry: allow_retry, &block)
     rescue ::RangeError
       []
     end
@@ -157,8 +157,5 @@ module ActiveRecord
       when NilClass, Array, Range, Hash, Relation, Base then true
       end
     end
-
-    private
-      attr_reader :query_builder, :bind_map, :klass
   end
 end

--- a/activerecord/test/cases/bind_parameter_test.rb
+++ b/activerecord/test/cases/bind_parameter_test.rb
@@ -261,7 +261,7 @@ if ActiveRecord::Base.lease_connection.prepared_statements
           cache = klass.send(:cached_find_by_statement, @connection, key) do
             raise "#{klass} has no cached statement by #{key.inspect}"
           end
-          cache.send(:query_builder).instance_variable_get(:@sql)
+          cache.instance_variable_get(:@query_builder).instance_variable_get(:@sql)
         end
 
         def statement_cache

--- a/activerecord/test/cases/helper.rb
+++ b/activerecord/test/cases/helper.rb
@@ -28,6 +28,9 @@ ActiveRecord.permanent_connection_checkout = :disallowed
 
 ActiveRecord::Delegation::DelegateCache.delegate_base_methods = false
 
+# Ensure this alias isn't being used by Active Record itself.
+ActiveRecord::Relation.remove_method(:klass)
+
 # Disable available locale checks to avoid warnings running the test suite.
 I18n.enforce_available_locales = false
 

--- a/activerecord/test/cases/relation_test.rb
+++ b/activerecord/test/cases/relation_test.rb
@@ -13,7 +13,7 @@ module ActiveRecord
 
     def test_construction
       relation = Relation.new(FakeKlass, table: :b)
-      assert_equal FakeKlass, relation.klass
+      assert_equal FakeKlass, relation.model
       assert_equal :b, relation.table
       assert_not relation.loaded, "relation is not loaded"
     end

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -57,7 +57,7 @@ class RelationTest < ActiveRecord::TestCase
 
   def test_dynamic_finder
     x = Post.where("author_id = ?", 1)
-    assert_respond_to x.klass, :find_by_id
+    assert_respond_to x.model, :find_by_id
   end
 
   def test_multivalue_where


### PR DESCRIPTION
One is the alias of the other, and have been so for a very long time.

My issue with this is that `klass` is really a bad name, and it's very confusing when reading code to see a mix of both names being used.

There is no point officially deprecating either, but inside Active Record we should consistently only use one, I chose to use `model` as it's way more descriptive in my opinion.
