### PR TITLE
Handle case where script_name is a blank string

### DIFF
--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -714,7 +714,7 @@ module ActionDispatch
               def optimize_routes_generation?; false; end
 
               define_method :find_script_name do |options|
-                if options.key? :script_name
+                if options.key?(:script_name) && options[:script_name].present?
                   super(options)
                 else
                   script_namer.call(options)


### PR DESCRIPTION
Fixes: #51910

Added regression test:

```
Failure:
RailtiesTest::EngineTest#test_nested_isolated_engines_should_set_correct_route_module_prefix [test/railties/engine_test.rb:1135]:
--- expected
+++ actual
@@ -1 +1,3 @@
-"/bukkits/awesome/bar"\
+"/awesome/bar"
```