### PR TITLE
Add CSP mapping for 'wasm-unsafe-eval'

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,2 +1,13 @@
+*   Add `:wasm_unsafe_eval` mapping for `content_security_policy`
+
+    ```ruby
+    # Before
+    policy.script_src "'wasm-unsafe-eval'"
+
+    # After
+    policy.script_src :wasm_unsafe_eval
+    ```
+
+    *Joe Haig*
 
 Please check [7-2-stable](https://github.com/rails/rails/blob/7-2-stable/actionpack/CHANGELOG.md) for previous changes.

--- a/actionpack/lib/action_dispatch/http/content_security_policy.rb
+++ b/actionpack/lib/action_dispatch/http/content_security_policy.rb
@@ -126,6 +126,7 @@ module ActionDispatch # :nodoc:
     MAPPINGS = {
       self:             "'self'",
       unsafe_eval:      "'unsafe-eval'",
+      wasm_unsafe_eval: "'wasm-unsafe-eval'",
       unsafe_hashes:    "'unsafe-hashes'",
       unsafe_inline:    "'unsafe-inline'",
       none:             "'none'",

--- a/actionpack/test/dispatch/content_security_policy_test.rb
+++ b/actionpack/test/dispatch/content_security_policy_test.rb
@@ -45,6 +45,9 @@ class ContentSecurityPolicyTest < ActiveSupport::TestCase
     @policy.script_src :unsafe_eval
     assert_equal "script-src 'unsafe-eval'", @policy.build
 
+    @policy.script_src :wasm_unsafe_eval
+    assert_equal "script-src 'wasm-unsafe-eval'", @policy.build
+
     @policy.script_src :none
     assert_equal "script-src 'none'", @policy.build
 


### PR DESCRIPTION
### Motivation / Background

The `'wasm-unsafe-eval'` keyword for the Content Security Policy allows the loading and execution of WebAssembly modules without the need to allow unsafe JavaScript execution via `'unsafe-eval'`.

A mapping, defined at https://github.com/jrmhaig/rails/blob/e0c124094435cbdca51ad42755bd684a6ee96289/actionpack/lib/action_dispatch/http/content_security_policy.rb#L126-L145, allows the configuration in `config/initializers/content_security_policy.rb` to be defined using symbols to represent the policy keywords. The `wasm-unsafe-eval` keyword was introduced more recently than #31162, which added the CSP functionality to Rails, and so it is not currently included in the mapping list.

### Detail

This Pull Request changes the CSP keywork mapping to add the `wasm-unsafe-eval` option.

### Additional information

See https://github.com/WebAssembly/content-security-policy/blob/main/proposals/CSP.md#proposed-policy-behavior

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
