### PR TITLE
Define Digest::UUID.nil_uuid

### DIFF
--- a/activesupport/lib/active_support/core_ext/digest/uuid.rb
+++ b/activesupport/lib/active_support/core_ext/digest/uuid.rb
@@ -53,6 +53,12 @@ module Digest
       SecureRandom.uuid
     end
 
+    # Returns the nil UUID. This is a special form of UUID that is specified to
+    # have all 128 bits set to zero.
+    def self.nil_uuid
+      "00000000-0000-0000-0000-000000000000"
+    end
+
     def self.pack_uuid_namespace(namespace)
       if [DNS_NAMESPACE, OID_NAMESPACE, URL_NAMESPACE, X500_NAMESPACE].include?(namespace)
         namespace

--- a/activesupport/test/core_ext/digest/uuid_test.rb
+++ b/activesupport/test/core_ext/digest/uuid_test.rb
@@ -55,6 +55,10 @@ class DigestUUIDExt < ActiveSupport::TestCase
     end
   end
 
+  def test_nil_uuid
+    assert_equal "00000000-0000-0000-0000-000000000000", Digest::UUID.nil_uuid
+  end
+
   def test_invalid_hash_class
     assert_raise ArgumentError do
       Digest::UUID.uuid_from_hash(OpenSSL::Digest::SHA256, Digest::UUID::OID_NAMESPACE, "1.2.3")


### PR DESCRIPTION
[RFC 4122](https://www.ietf.org/rfc/rfc4122.txt) defines the so-called nil UUID. Let's add this to `Digest::UUID` to facilitate the use of this special UUID.