### PR TITLE
Improve compatibility for `ActiveSupport::BroadcastLogger`

### DIFF
--- a/activesupport/lib/active_support/broadcast_logger.rb
+++ b/activesupport/lib/active_support/broadcast_logger.rb
@@ -229,6 +229,7 @@ module ActiveSupport
     private
       def dispatch(&block)
         @broadcasts.each { |logger| block.call(logger) }
+        true
       end
 
       def method_missing(name, ...)

--- a/activesupport/test/broadcast_logger_test.rb
+++ b/activesupport/test/broadcast_logger_test.rb
@@ -302,7 +302,7 @@ module ActiveSupport
       assert_same logger, broadcast_logger.broadcasts.sole
     end
 
-    test "logging has no return value" do
+    test "logging always returns true" do
       assert_equal true, @logger.info("Hello")
       assert_equal true, @logger.error("Hello")
     end

--- a/activesupport/test/broadcast_logger_test.rb
+++ b/activesupport/test/broadcast_logger_test.rb
@@ -302,6 +302,11 @@ module ActiveSupport
       assert_same logger, broadcast_logger.broadcasts.sole
     end
 
+    test "logging has no return value" do
+      assert_equal true, @logger.info("Hello")
+      assert_equal true, @logger.error("Hello")
+    end
+
     class CustomLogger
       attr_reader :adds, :closed, :chevrons
       attr_accessor :level, :progname, :formatter, :local_level


### PR DESCRIPTION
### Motivation / Background

The usage of `dispatch` in all logging methods causes common usages such as `logger.info` to return an array of loggers.

However, the default behavior when using `Logger` and `ActiveSupport::Logger` is that these methods return `true`.

Returning `true` makes it compatible and more efficient.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
