### PR TITLE
Allow unscoping ActiveRecord Query CTEs

### DIFF
--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -751,7 +751,7 @@ module ActiveRecord
     VALID_UNSCOPING_VALUES = Set.new([:where, :select, :group, :order, :lock,
                                      :limit, :offset, :joins, :left_outer_joins, :annotate,
                                      :includes, :eager_load, :preload, :from, :readonly,
-                                     :having, :optimizer_hints])
+                                     :having, :optimizer_hints, :with])
 
     # Removes an unwanted relation that is already defined on a chain of relations.
     # This is useful when passing around chains of relations and would like to

--- a/activerecord/test/cases/relation/with_test.rb
+++ b/activerecord/test/cases/relation/with_test.rb
@@ -114,6 +114,15 @@ module ActiveRecord
           Post.with(attributes_for_inspect: :id) { }
         end
       end
+
+      def test_unscoping
+        relation = Post.with(posts_with_comments: Post.where("legacy_comments_count > 0"))
+
+        assert_equal true, relation.values[:with].flat_map(&:keys).include?(:posts_with_comments)
+        relation = relation.unscope(:with)
+        assert_nil relation.values[:with]
+        assert_equal Post.count, relation.count
+      end
     else
       def test_common_table_expressions_are_unsupported
         assert_raises ActiveRecord::StatementInvalid do


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because ActiveRecord queries do not currently allow unscoping CTEs. There are instances where my team has complex queries that require its CTEs to be unscoped or else we run into issues related to nested CTEs (not allowed) and other issues. We have worked around this issue by extending the `QueryMethods` in our application to allow unscoping CTEs using the following snippet, but I believe that this change should be upstreamed.

```ruby
module ActiveRecord
  module QueryMethods
    VALID_UNSCOPING_VALUES += [:with]
  end
end
```

### Detail

This Pull Request appends `:with` to the set of `VALID_UNSCOPING_VALUES` in the `ActiveRecord::QueryMethods` module to allow unscoping CTEs included in a query (`relation.with(...)`). I expect to be able to unscope CTEs in the same way we can currently unscope selects, wheres, etc...
