### PR TITLE
Switch example editor to code instead of mate

### DIFF
--- a/railties/lib/rails/command/helpers/editor.rb
+++ b/railties/lib/rails/command/helpers/editor.rb
@@ -16,7 +16,7 @@ module Rails
             if editor.to_s.empty?
               say "No $VISUAL or $EDITOR to open file in. Assign one like this:"
               say ""
-              say %(VISUAL="mate --wait" #{executable(current_subcommand)})
+              say %(VISUAL="code --wait" #{executable(current_subcommand)})
               say ""
               say "For editors that fork and exit immediately, it's important to pass a wait flag;"
               say "otherwise, the file will be saved immediately with no chance to edit."


### PR DESCRIPTION
### Motivation / Background

It's been almost 10 years since the last TextMate update. 😢

I've seen developers be confused here - "huh, what's mate?" - and while using a more common editor as an example isn't foolproof, it's less likely to be confusing since folks will be familiar with it, and it's more likely to work as written for them since more people will have it installed.

### Detail

I don't want to be seen as advocating for a particular editor, but [this 2022 survey of Rails developers](https://railsdeveloper.com/survey/2022/#os-editors-servers) puts VS Code usage at 43%, the front runner by a lot.