### PR TITLE
Restore inferred association class with the same modularized name

### DIFF
--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -428,15 +428,19 @@ module ActiveRecord
       # a new association object. Use +build_association+ or +create_association+
       # instead. This allows plugins to hook into association object creation.
       def klass
-        @klass ||= compute_class(compute_name(class_name))
+        @klass ||= _klass(class_name)
+      end
+
+      def _klass(class_name) # :nodoc:
+        if active_record.name.demodulize == class_name
+          return compute_class("::#{class_name}") rescue NameError
+        end
+
+        compute_class(class_name)
       end
 
       def compute_class(name)
         name.constantize
-      end
-
-      def compute_name(name) # :nodoc:
-        active_record.name.demodulize == name ? "::#{name}" : name
       end
 
       # Returns +true+ if +self+ and +other_aggregation+ have the same +name+ attribute, +active_record+ attribute,
@@ -986,7 +990,7 @@ module ActiveRecord
       end
 
       def klass
-        @klass ||= delegate_reflection.compute_class(compute_name(class_name))
+        @klass ||= delegate_reflection._klass(class_name)
       end
 
       # Returns the source of the through reflection. It checks both a singularized

--- a/activerecord/test/cases/reflection_test.rb
+++ b/activerecord/test/cases/reflection_test.rb
@@ -208,6 +208,18 @@ class ReflectionTest < ActiveRecord::TestCase
     assert_equal Nested::User, reflection.klass
   end
 
+  def test_reflection_klass_with_same_modularized_name
+    reflection = ActiveRecord::Reflection.create(
+      :has_many,
+      :nested_users,
+      nil,
+      {},
+      Nested::NestedUser
+    )
+
+    assert_equal Nested::NestedUser, reflection.klass
+  end
+
   def test_aggregation_reflection
     reflection_for_address = AggregateReflection.new(
       :address, nil, { mapping: [ %w(address_street street), %w(address_city city), %w(address_country country) ] }, Customer

--- a/activerecord/test/models/user.rb
+++ b/activerecord/test/models/user.rb
@@ -28,4 +28,8 @@ module Nested
   class User < ActiveRecord::Base
     self.table_name = "users"
   end
+
+  class NestedUser < ActiveRecord::Base
+    has_many :nested_users
+  end
 end


### PR DESCRIPTION
Fixes #51938

### Motivation / Background

https://github.com/rails/rails/pull/51721 was a nice change, but it removed some existing behavior. 

### Detail

This change restores the ability for the inferred association class to be the same modularized name.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
