### PR TITLE
Lazily generate UUIDs for AR transactions

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "active_support/core_ext/digest"
+
 module ActiveRecord
   module ConnectionAdapters
     # = Active Record Connection Adapters Transaction State
@@ -119,6 +121,7 @@ module ActiveRecord
       def before_commit; yield; end
       def after_commit; yield; end
       def after_rollback; end # noop
+      def uuid; Digest::UUID.nil_uuid; end
     end
 
     class Transaction < ActiveRecord::Transaction # :nodoc:

--- a/activerecord/lib/active_record/transaction.rb
+++ b/activerecord/lib/active_record/transaction.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "active_support/core_ext/digest"
+
 module ActiveRecord
   class Transaction
     class Callback # :nodoc:
@@ -23,6 +25,7 @@ module ActiveRecord
 
     def initialize # :nodoc:
       @callbacks = nil
+      @uuid = nil
     end
 
     # Registers a block to be called before the current transaction is fully committed.
@@ -58,6 +61,11 @@ module ActiveRecord
     # the block is never called.
     def after_rollback(&block)
       (@callbacks ||= []) << Callback.new(:after_rollback, block)
+    end
+
+    # Returns a UUID for this transaction.
+    def uuid
+      @uuid ||= Digest::UUID.uuid_v4
     end
 
     protected


### PR DESCRIPTION
This patch introduces UUIDs for transaction objects.

These are computed lazily because the only use cases I can think of are related to tracing database activity, which is rare.

As an edge case, null transactions have a nil UUID.