### PR TITLE
Raise when using key which can't respond to `#to_sym` in EncryptedConfiguration

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Raise when using key which can't respond to `#to_sym` in `EncryptedConfiguration`.
+
+    As is the case when trying to use an Integer or Float as a key, which is unsupported.
+
+    *zzak*
+
 *   Deprecate addition and since between two `Time` and `ActiveSupport::TimeWithZone`.
 
     Previously adding time instances together such as `10.days.ago + 10.days.ago` or `10.days.ago.since(10.days.ago)` produced a nonsensical future date. This behavior is deprecated and will be removed in Rails 8.1.

--- a/activesupport/lib/active_support/encrypted_configuration.rb
+++ b/activesupport/lib/active_support/encrypted_configuration.rb
@@ -43,6 +43,12 @@ module ActiveSupport
       end
     end
 
+    class InvalidKeyError < RuntimeError
+      def initialize(content_path, key)
+        super "Key '#{key}' is invalid, it must respond to '#to_sym' from configuration in '#{content_path}'."
+      end
+    end
+
     delegate_missing_to :options
 
     def initialize(config_path:, key_path:, env_key:, raise_if_missing_key:)
@@ -61,7 +67,11 @@ module ActiveSupport
     end
 
     def validate! # :nodoc:
-      deserialize(read)
+      deserialize(read).each_key do |key|
+        key.to_sym
+      rescue NoMethodError
+        raise InvalidKeyError.new(content_path, key)
+      end
     end
 
     # Returns the decrypted content as a Hash with symbolized keys.
@@ -73,7 +83,7 @@ module ActiveSupport
     #   # => { some_secret: 123, some_namespace: { another_secret: 789 } }
     #
     def config
-      @config ||= deserialize(read).deep_symbolize_keys
+      @config ||= deep_symbolize_keys(deserialize(read))
     end
 
     def inspect # :nodoc:
@@ -81,6 +91,15 @@ module ActiveSupport
     end
 
     private
+      def deep_symbolize_keys(hash)
+        hash.deep_symbolize_keys
+        hash.deep_transform_keys do |key|
+          key.to_sym
+        rescue NoMethodError
+          raise InvalidKeyError.new(content_path, key)
+        end
+      end
+
       def deep_transform(hash)
         return hash unless hash.is_a?(Hash)
 

--- a/activesupport/test/encrypted_configuration_test.rb
+++ b/activesupport/test/encrypted_configuration_test.rb
@@ -93,6 +93,42 @@ class EncryptedConfigurationTest < ActiveSupport::TestCase
     end
   end
 
+  test "raises helpful error when loading invalid content with unsupported keys" do
+    @credentials.write("42: value")
+
+    assert_raise(ActiveSupport::EncryptedConfiguration::InvalidKeyError, match: /Key '42' is invalid, it must respond to '#to_sym' from configuration in '#{@credentials_config_path}'./) do
+      @credentials.config
+    end
+
+    @credentials.write("42.0: value")
+    assert_raise(ActiveSupport::EncryptedConfiguration::InvalidKeyError, match: /Key '42.0' is invalid, it must respond to '#to_sym' from configuration in '#{@credentials_config_path}'./) do
+      @credentials.config
+    end
+
+    @credentials.write("Off: value")
+    assert_raise(ActiveSupport::EncryptedConfiguration::InvalidKeyError, match: /Key 'false' is invalid, it must respond to '#to_sym' from configuration in '#{@credentials_config_path}'./) do
+      @credentials.config
+    end
+  end
+
+  test "raises helpful error when validating invalid content with unsupported keys" do
+    @credentials.write("42: value")
+
+    assert_raise(ActiveSupport::EncryptedConfiguration::InvalidKeyError, match: /Key '42' is invalid, it must respond to '#to_sym' from configuration in '#{@credentials_config_path}'./) do
+      @credentials.validate!
+    end
+
+    @credentials.write("42.0: value")
+    assert_raise(ActiveSupport::EncryptedConfiguration::InvalidKeyError, match: /Key '42.0' is invalid, it must respond to '#to_sym' from configuration in '#{@credentials_config_path}'./) do
+      @credentials.validate!
+    end
+
+    @credentials.write("Off: value")
+    assert_raise(ActiveSupport::EncryptedConfiguration::InvalidKeyError, match: /Key 'false' is invalid, it must respond to '#to_sym' from configuration in '#{@credentials_config_path}'./) do
+      @credentials.validate!
+    end
+  end
+
   test "raises key error when accessing config via bang method" do
     assert_raise(KeyError) { @credentials.something! }
   end


### PR DESCRIPTION
As is the case when trying to use an integer as a key, which is unsupported.

This replaces the following less-friendly error:

```
NoMethodError: undefined method 'to_sym' for an instance of Integer
    lib/active_support/ordered_options.rb:38:in 'ActiveSupport::OrderedOptions#[]='
    lib/active_support/delegation.rb:167:in 'Kernel#public_send'
    lib/active_support/delegation.rb:167:in 'ActiveSupport::EncryptedConfiguration#method_missing'
```

With a more helpful error message:

```
ActiveSupport::EncryptedConfiguration::InvalidKeyError: Key '42' is invalid, it must respond to '#to_sym' from configuration in '/tmp/config-20240530-4153925-tfzzt/credentials.yml.enc'.
    lib/active_support/encrypted_configuration.rb:99:in 'block in ActiveSupport::EncryptedConfiguration#deep_symbolize_keys'
    lib/active_support/core_ext/hash/keys.rb:120:in 'block in Hash#_deep_transform_keys_in_object'
    lib/active_support/core_ext/hash/keys.rb:119:in 'Hash#each'
    lib/active_support/core_ext/hash/keys.rb:119:in 'Enumerable#each_with_object'
    lib/active_support/core_ext/hash/keys.rb:119:in 'Hash#_deep_transform_keys_in_object'
    lib/active_support/core_ext/hash/keys.rb:66:in 'Hash#deep_transform_keys'
    lib/active_support/encrypted_configuration.rb:96:in 'ActiveSupport::EncryptedConfiguration#deep_symbolize_keys'
    lib/active_support/encrypted_configuration.rb:86:in 'ActiveSupport::EncryptedConfiguration#config'
```

Fixes: #51215