### PR TITLE
Update public directory during app:update command

### DIFF
--- a/railties/lib/rails/commands/app/update_command.rb
+++ b/railties/lib/rails/commands/app/update_command.rb
@@ -14,6 +14,7 @@ module Rails
         def perform
           configs
           bin
+          public_directory
           active_storage
           display_upgrade_guide_info
         end
@@ -29,6 +30,12 @@ module Rails
         def bin
           require_application!
           app_generator.update_bin_files
+        end
+
+        desc "public_directory", "Add or update files in the application public/ directory", hide: true
+        def public_directory
+          require_application!
+          app_generator.create_public_files
         end
 
         desc "active_storage", "Run the active_storage:update command", hide: true

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -226,6 +226,16 @@ class AppGeneratorTest < Rails::Generators::TestCase
     assert_file "config/initializers/cors.rb"
   end
 
+  def test_app_update_generates_public_folders
+    run_generator
+
+    FileUtils.rm_rf("#{destination_root}/public/406-unsupported-browser.html")
+
+    run_app_update
+
+    assert_file "public/406-unsupported-browser.html"
+  end
+
   def test_app_update_does_not_generate_assets_initializer_when_sprockets_and_propshaft_are_not_used
     run_generator [destination_root, "-a", "none"]
     run_app_update


### PR DESCRIPTION
### Motivation / Background

When upgrading Rails versions, the `app:update` command does not generate new files in `/public`.

For example, upgrading from Rails 7.1 to 7.2 does not create the new `406-unsupported-browser.html` file.

### Detail

This adds the public directory to be created on `app:update`.

Would this be better done like `config_when_updating` instead?

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
