### PR TITLE
Pass the transaction object to transaction.active_record subscribers

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
@@ -141,7 +141,7 @@ module ActiveRecord
         @run_commit_callbacks = run_commit_callbacks
         @lazy_enrollment_records = nil
         @dirty = false
-        @instrumenter = TransactionInstrumenter.new(connection: connection)
+        @instrumenter = TransactionInstrumenter.new(connection: connection, transaction: self)
       end
 
       def dirty!

--- a/guides/source/active_support_instrumentation.md
+++ b/guides/source/active_support_instrumentation.md
@@ -413,6 +413,7 @@ This event is emmited for every transaction to the database.
 | Key                  | Value                                                |
 | -------------------- | ---------------------------------------------------- |
 | `:connection`        | Connection object                                    |
+| `:transaction`       | Transaction object
 | `:outcome`           | `:commit`, `:rollback`, `:restart`, or `:incomplete` |
 
 ### Action Mailer


### PR DESCRIPTION
I believe it is natural that subscribers of `transaction.active_record` get the transaction the event is about in the payload.