### PR TITLE
Bump sqlite3 gem dependency to version 2.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -155,7 +155,7 @@ platforms :ruby, :windows do
   gem "racc", ">=1.4.6", require: false
 
   # Active Record.
-  gem "sqlite3", ">= 1.6.6"
+  gem "sqlite3", ">= 2.0"
 
   group :db do
     gem "pg", "~> 1.3"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -682,7 +682,7 @@ DEPENDENCIES
   sidekiq
   sneakers
   sprockets-rails (>= 2.0.0)
-  sqlite3 (>= 1.6.6)
+  sqlite3 (>= 2.0)
   stackprof
   stimulus-rails
   sucker_punch

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Bump `sqlite3` gem version to `2.x`
+
+    *Stephen Margheim*
+
 *   Add `ActiveRecord::Relation#readonly?`.
 
     Reflects if the relation has been marked as readonly.

--- a/guides/bug_report_templates/action_mailbox.rb
+++ b/guides/bug_report_templates/action_mailbox.rb
@@ -9,7 +9,7 @@ gemfile(true) do
   # If you want to test against edge Rails replace the previous line with this:
   # gem "rails", github: "rails/rails", branch: "main"
 
-  gem "sqlite3", "~> 1.4"
+  gem "sqlite3", ">= 2.0"
 end
 
 require "active_record/railtie"

--- a/guides/bug_report_templates/active_record.rb
+++ b/guides/bug_report_templates/active_record.rb
@@ -9,7 +9,7 @@ gemfile(true) do
   # If you want to test against edge Rails replace the previous line with this:
   # gem "rails", github: "rails/rails", branch: "main"
 
-  gem "sqlite3", "~> 1.4"
+  gem "sqlite3", ">= 2.0"
 end
 
 require "active_record"

--- a/guides/bug_report_templates/active_record_migrations.rb
+++ b/guides/bug_report_templates/active_record_migrations.rb
@@ -9,7 +9,7 @@ gemfile(true) do
   # If you want to test against edge Rails replace the previous line with this:
   # gem "rails", github: "rails/rails", branch: "main"
 
-  gem "sqlite3", "~> 1.4"
+  gem "sqlite3", ">= 2.0"
 end
 
 require "active_record"

--- a/guides/bug_report_templates/active_storage.rb
+++ b/guides/bug_report_templates/active_storage.rb
@@ -9,7 +9,7 @@ gemfile(true) do
   # If you want to test against edge Rails replace the previous line with this:
   # gem "rails", github: "rails/rails", branch: "main"
 
-  gem "sqlite3", "~> 1.4"
+  gem "sqlite3", ">= 2.0"
 end
 
 require "active_record/railtie"

--- a/railties/lib/rails/generators/database.rb
+++ b/railties/lib/rails/generators/database.rb
@@ -223,7 +223,7 @@ module Rails
         end
 
         def gem
-          ["sqlite3", [">= 1.4"]]
+          ["sqlite3", [">= 2.0"]]
         end
 
         def base_package

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -472,7 +472,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
   def test_config_database_is_added_by_default
     run_generator
     assert_file "config/database.yml", /sqlite3/
-    assert_gem "sqlite3", '">= 1.4"'
+    assert_gem "sqlite3", '">= 2.0"'
   end
 
   def test_config_mysql_database

--- a/railties/test/generators/db_system_change_generator_test.rb
+++ b/railties/test/generators/db_system_change_generator_test.rb
@@ -128,7 +128,7 @@ module Rails
 
             assert_file("Gemfile") do |content|
               assert_match "# Use sqlite3 as the database for Active Record", content
-              assert_match 'gem "sqlite3", ">= 1.4"', content
+              assert_match 'gem "sqlite3", ">= 2.0"', content
             end
 
             assert_file("Dockerfile") do |content|


### PR DESCRIPTION
### Motivation / Background

Rails 8 needs a production-ready, out-of-the-box experience for apps relying on SQLite. Version 2.x of the `sqlite3` brings a number of improvements and enhancements necessary for production-ready SQLite on Rails apps, most importantly being the new [`SQLite3::Database#busy_handler_timeout=` method](https://github.com/sparklemotion/sqlite3-ruby/pull/456).

cc: @flavorjones @tenderlove @byroot 

### Detail

After #51592, Rails apps can use versions of the `sqlite3` gem ranging from 1.4.x to 2.x. For Rails 8, new apps should default to >= 2.0 to ensure that the improvements in that major version bump are present for Rails to rely on.

### Additional information

For Rails 8, the bug report guides should default to `sqlite3` version >= 2.0 as well (re: https://github.com/rails/rails/pull/51591)

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
