### PR TITLE
SQLite non-GVL-blocking, fair retry interval busy handler

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -153,7 +153,7 @@ platforms :ruby, :windows do
   gem "nokogiri", ">= 1.8.1", "!= 1.11.0"
 
   # Active Record.
-  gem "sqlite3", ">= 1.6.6"
+  gem "sqlite3", ">= 2.0"
 
   group :db do
     gem "pg", "~> 1.3"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -690,7 +690,7 @@ DEPENDENCIES
   sidekiq
   sneakers
   sprockets-rails (>= 2.0.0)
-  sqlite3 (>= 1.6.6)
+  sqlite3 (>= 2.0)
   stackprof
   stimulus-rails
   sucker_punch

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Replace `SQLite3::Database#busy_timeout` with `#busy_handler_timeout=`
+
+    Provides a non-GVL-blocking, fair retry interval busy handler implementation
+
+    *Stephen Margheim*
+
 *   SQLite3Adapter: Translate `SQLite3::BusyException` into `ActiveRecord::StatementTimeout`.
 
     *Matthew Nguyen*

--- a/railties/lib/rails/generators/database.rb
+++ b/railties/lib/rails/generators/database.rb
@@ -223,7 +223,7 @@ module Rails
         end
 
         def gem
-          ["sqlite3", [">= 1.4"]]
+          ["sqlite3", [">= 2.0"]]
         end
 
         def base_package

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -449,7 +449,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
   def test_config_database_is_added_by_default
     run_generator
     assert_file "config/database.yml", /sqlite3/
-    assert_gem "sqlite3", '">= 1.4"'
+    assert_gem "sqlite3", '">= 2.0"'
   end
 
   def test_config_mysql_database

--- a/railties/test/generators/db_system_change_generator_test.rb
+++ b/railties/test/generators/db_system_change_generator_test.rb
@@ -128,7 +128,7 @@ module Rails
 
             assert_file("Gemfile") do |content|
               assert_match "# Use sqlite3 as the database for Active Record", content
-              assert_match 'gem "sqlite3", ">= 1.4"', content
+              assert_match 'gem "sqlite3", ">= 2.0"', content
             end
 
             assert_file("Dockerfile") do |content|


### PR DESCRIPTION
### Motivation / Background

As detailed in https://github.com/rails/rails/pull/50370, the current use of SQLite's `busy_timeout` functionality leads to notable increases in tail latency as well as occasional `SQLite3::BusyException: database is locked` errors since it does not release the GVL while waiting to retry acquiring the SQLite database lock. Version 2.0 of the `sqlite3` gem introduces a new [`SQLite3::Database#busy_handler_timeout=` method](https://github.com/sparklemotion/sqlite3-ruby/pull/456), which provides a non-GVL-blocking, fair retry interval busy handler implementation.

cc: @flavorjones @tenderlove @byroot 

### Detail

This PR points the `timeout` option the `database.yml` config file at this new busy handler implementation. In order to ensure that this new method is present, I have also opened https://github.com/rails/rails/pull/51957 so that Rails 8 defaults to version >= 2.0 for the `sqlite3` gem.

### Additional information

 As detailed in [my deep dive](https://fractaledmind.github.io/2024/04/15/sqlite-on-rails-the-how-and-why-of-optimal-performance/) on this topic, having such a busy handler is essential for running production-grade Rails application using SQLite. In my benchmarks, ensuring that the busy handler doesn't hold the GVL brought p95 latency down from >5s to 0.19s. Then, ensuring that the retry interval was fair for both "old" and "new" queries brought p99.99 latency down from >1.5s to 0.5s. 

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
