### PR TITLE
Relax the prism test parser conditions

### DIFF
--- a/railties/lib/rails/test_unit/test_parser.rb
+++ b/railties/lib/rails/test_unit/test_parser.rb
@@ -22,11 +22,11 @@ if defined?(Prism)
           while (node = queue.shift)
             case node.type
             when :def_node
-              if node.name.start_with?("test") && node.location.start_line == start_line
+              if node.location.start_line == start_line
                 return [filepath, start_line..node.location.end_line]
               end
             when :call_node
-              if node.name == :test && node.location.start_line == start_line
+              if node.location.start_line == start_line
                 return [filepath, start_line..node.location.end_line]
               end
             end

--- a/railties/test/test_unit/test_parser_test.rb
+++ b/railties/test/test_unit/test_parser_test.rb
@@ -38,6 +38,13 @@ class TestParserTestFixture < ActiveSupport::TestCase
     assert true
     assert_not false
   }
+
+  # Check that extensions can provide aliases for testing methods
+  def self.my_testing_alias(test_name, &)
+    define_method(:"test_#{test_name}", &)
+  end
+
+  my_testing_alias("method_alias") { assert true }
 end
 
 class TestParserTest < ActiveSupport::TestCase
@@ -57,7 +64,8 @@ class TestParserTest < ActiveSupport::TestCase
       [:test_declarative_explicit_receiver, __FILE__, 27..31],
       [:test_declarative_oneline, __FILE__, 33..33],
       [:test_declarative_oneline_do, __FILE__, 35..35],
-      [:"test_declarative_multiline_w/_braces", __FILE__, 37..40]
+      [:"test_declarative_multiline_w/_braces", __FILE__, 37..40],
+      [:"test_method_alias", __FILE__, 47..47],
     ]
 
     assert_equal expected, actual


### PR DESCRIPTION
### Motivation / Background

Closes #51956

### Detail

Checking explicitly against `test` break extensions that provide their own methods to generate tests, like `minitest-spec-rails` or `minitest-rails`. The ripper parser had no such checks, so I just dropped those.

cc @kddnewton

### Additional information

Needs backporting to 7.2. Maybe changelog?

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
