### PR TITLE
Fix deprecation horizon to be `8.0`

### DIFF
--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -253,14 +253,14 @@ module ActionController
       def allow_deprecated_parameters_hash_equality
         ActionController.deprecator.warn <<-WARNING.squish
           `Rails.application.config.action_controller.allow_deprecated_parameters_hash_equality` is
-          deprecated and will be removed in Rails 7.3.
+          deprecated and will be removed in Rails 8.0.
         WARNING
       end
 
       def allow_deprecated_parameters_hash_equality=(value)
         ActionController.deprecator.warn <<-WARNING.squish
           `Rails.application.config.action_controller.allow_deprecated_parameters_hash_equality`
-          is deprecated and will be removed in Rails 7.3.
+          is deprecated and will be removed in Rails 8.0.
         WARNING
       end
 

--- a/actionview/lib/action_view/helpers/form_helper.rb
+++ b/actionview/lib/action_view/helpers/form_helper.rb
@@ -753,7 +753,7 @@ module ActionView
       #     form_with(**options.merge(builder: LabellingFormBuilder), &block)
       #   end
       def form_with(model: false, scope: nil, url: nil, format: nil, **options, &block)
-        ActionView.deprecator.warn("Passing nil to the :model argument is deprecated and will raise in Rails 7.3") if model.nil?
+        ActionView.deprecator.warn("Passing nil to the :model argument is deprecated and will raise in Rails 8.0") if model.nil?
 
         options = { allow_method_names_outside_object: true, skip_default_ids: !form_with_generates_ids }.merge!(options)
 

--- a/actionview/lib/action_view/helpers/tag_helper.rb
+++ b/actionview/lib/action_view/helpers/tag_helper.rb
@@ -66,7 +66,7 @@ module ActionView
                   ActionView.deprecator.warn <<~TEXT
                     Putting content inside a void element (#{name}) is invalid
                     according to the HTML5 spec, and so it is being deprecated
-                    without replacement. In Rails 7.3, passing content as a
+                    without replacement. In Rails 8.0, passing content as a
                     positional argument will raise, and using a block will have
                     no effect.
                   TEXT

--- a/activejob/lib/active_job.rb
+++ b/activejob/lib/active_job.rb
@@ -51,13 +51,13 @@ module ActiveJob
 
   def self.use_big_decimal_serializer
     ActiveJob.deprecator.warn <<-WARNING.squish
-      Rails.application.config.active_job.use_big_decimal_serializer is deprecated and will be removed in Rails 7.3.
+      Rails.application.config.active_job.use_big_decimal_serializer is deprecated and will be removed in Rails 8.0.
     WARNING
   end
 
   def self.use_big_decimal_serializer=(value)
     ActiveJob.deprecator.warn <<-WARNING.squish
-      Rails.application.config.active_job.use_big_decimal_serializer is deprecated and will be removed in Rails 7.3.
+      Rails.application.config.active_job.use_big_decimal_serializer is deprecated and will be removed in Rails 8.0.
     WARNING
   end
 

--- a/activerecord/lib/active_record.rb
+++ b/activerecord/lib/active_record.rb
@@ -347,14 +347,14 @@ module ActiveRecord
   def self.commit_transaction_on_non_local_return
     ActiveRecord.deprecator.warn <<-WARNING.squish
       `Rails.application.config.active_record.commit_transaction_on_non_local_return`
-      is deprecated and will be removed in Rails 7.3.
+      is deprecated and will be removed in Rails 8.0.
     WARNING
   end
 
   def self.commit_transaction_on_non_local_return=(value)
     ActiveRecord.deprecator.warn <<-WARNING.squish
       `Rails.application.config.active_record.commit_transaction_on_non_local_return`
-      is deprecated and will be removed in Rails 7.3.
+      is deprecated and will be removed in Rails 8.0.
     WARNING
   end
 
@@ -447,14 +447,14 @@ module ActiveRecord
   def self.allow_deprecated_singular_associations_name
     ActiveRecord.deprecator.warn <<-WARNING.squish
       `Rails.application.config.active_record.allow_deprecated_singular_associations_name`
-      is deprecated and will be removed in Rails 7.3.
+      is deprecated and will be removed in Rails 8.0.
     WARNING
   end
 
   def self.allow_deprecated_singular_associations_name=(value)
     ActiveRecord.deprecator.warn <<-WARNING.squish
       `Rails.application.config.active_record.allow_deprecated_singular_associations_name`
-      is deprecated and will be removed in Rails 7.3.
+      is deprecated and will be removed in Rails 8.0.
     WARNING
   end
 

--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -305,7 +305,7 @@ module ActiveRecord
       def connection
         ActiveRecord.deprecator.warn(<<~MSG)
           ActiveRecord::ConnectionAdapters::ConnectionPool#connection is deprecated
-          and will be removed in Rails 7.3. Use #lease_connection instead.
+          and will be removed in Rails 8.0. Use #lease_connection instead.
         MSG
         lease_connection
       end

--- a/activerecord/lib/active_record/enum.rb
+++ b/activerecord/lib/active_record/enum.rb
@@ -226,7 +226,7 @@ module ActiveRecord
 
       ActiveRecord.deprecator.warn(<<~MSG)
         Defining enums with keyword arguments is deprecated and will be removed
-        in Rails 7.3. Positional arguments should be used instead:
+        in Rails 8.0. Positional arguments should be used instead:
 
         #{definitions.map { |name, values| "enum :#{name}, #{values}" }.join("\n")}
       MSG

--- a/activerecord/lib/active_record/railtie.rb
+++ b/activerecord/lib/active_record/railtie.rb
@@ -187,7 +187,7 @@ To keep using the current cache store, you can turn off cache versioning entirel
       if config.active_record.warn_on_records_fetched_greater_than
         ActiveRecord.deprecator.warn <<~MSG.squish
           `config.active_record.warn_on_records_fetched_greater_than` is deprecated and will be
-          removed in Rails 7.3.
+          removed in Rails 8.0.
           Please subscribe to `sql.active_record` notifications and access the row count field to
           detect large result set sizes.
         MSG

--- a/activerecord/lib/active_record/tasks/database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/database_tasks.rb
@@ -446,7 +446,7 @@ module ActiveRecord
             db_config_or_name.default_schema_cache_path(ActiveRecord::Tasks::DatabaseTasks.db_dir)
         else
           ActiveRecord.deprecator.warn(<<~MSG.squish)
-            Passing a database name to `cache_dump_filename` is deprecated and will be removed in Rails 7.3. Pass a
+            Passing a database name to `cache_dump_filename` is deprecated and will be removed in Rails 8.0. Pass a
             `ActiveRecord::DatabaseConfigurations::DatabaseConfig` object instead.
           MSG
 
@@ -531,7 +531,7 @@ module ActiveRecord
         def schema_cache_env
           if ENV["SCHEMA_CACHE"]
             ActiveRecord.deprecator.warn(<<~MSG.squish)
-              Setting `ENV["SCHEMA_CACHE"]` is deprecated and will be removed in Rails 7.3.
+              Setting `ENV["SCHEMA_CACHE"]` is deprecated and will be removed in Rails 8.0.
               Configure the `:schema_cache_path` in the database configuration instead.
             MSG
 

--- a/activerecord/test/cases/tasks/database_tasks_test.rb
+++ b/activerecord/test/cases/tasks/database_tasks_test.rb
@@ -389,7 +389,7 @@ module ActiveRecord
       config = DatabaseConfigurations::HashConfig.new("development", "primary", {})
 
       ActiveRecord::Tasks::DatabaseTasks.stub(:db_dir, "db") do
-        path = assert_deprecated(/Setting `ENV\["SCHEMA_CACHE"\]` is deprecated and will be removed in Rails 7\.3\. Configure the `:schema_cache_path` in the database configuration instead\. \(/, ActiveRecord.deprecator) do
+        path = assert_deprecated(/Setting `ENV\["SCHEMA_CACHE"\]` is deprecated and will be removed in Rails 8\.0\. Configure the `:schema_cache_path` in the database configuration instead\. \(/, ActiveRecord.deprecator) do
           ActiveRecord::Tasks::DatabaseTasks.cache_dump_filename(config)
         end
         assert_equal "db/schema_cache.yml", path
@@ -403,7 +403,7 @@ module ActiveRecord
       ENV["SCHEMA_CACHE"] = "tmp/something.yml"
 
       ActiveRecord::Tasks::DatabaseTasks.stub(:db_dir, "db") do
-        path = assert_deprecated(/Passing a database name to `cache_dump_filename` is deprecated and will be removed in Rails 7\.3\. Pass a `ActiveRecord::DatabaseConfigurations::DatabaseConfig` object instead\. \(/, ActiveRecord.deprecator) do
+        path = assert_deprecated(/Passing a database name to `cache_dump_filename` is deprecated and will be removed in Rails 8\.0\. Pass a `ActiveRecord::DatabaseConfigurations::DatabaseConfig` object instead\. \(/, ActiveRecord.deprecator) do
           ActiveRecord::Tasks::DatabaseTasks.cache_dump_filename("primary")
         end
         assert_equal "db/schema_cache.yml", path

--- a/activesupport/lib/active_support.rb
+++ b/activesupport/lib/active_support.rb
@@ -112,13 +112,13 @@ module ActiveSupport
 
   def self.to_time_preserves_timezone
     ActiveSupport.deprecator.warn(
-      "`config.active_support.to_time_preserves_timezone` has been deprecated and will be removed in Rails 7.3."
+      "`config.active_support.to_time_preserves_timezone` has been deprecated and will be removed in Rails 8.0."
     )
   end
 
   def self.to_time_preserves_timezone=(value)
     ActiveSupport.deprecator.warn(
-      "`config.active_support.to_time_preserves_timezone` has been deprecated and will be removed in Rails 7.3."
+      "`config.active_support.to_time_preserves_timezone` has been deprecated and will be removed in Rails 8.0."
     )
   end
 

--- a/activesupport/lib/active_support/core_ext/date_and_time/compatibility.rb
+++ b/activesupport/lib/active_support/core_ext/date_and_time/compatibility.rb
@@ -21,13 +21,13 @@ module DateAndTime
 
     def self.preserve_timezone
       ActiveSupport.deprecator.warn(
-        "`DateAndTime::Compatibility.preserve_timezone` has been deprecated and will be removed in Rails 7.3."
+        "`DateAndTime::Compatibility.preserve_timezone` has been deprecated and will be removed in Rails 8.0."
       )
     end
 
     def self.preserve_timezone=(value)
       ActiveSupport.deprecator.warn(
-        "`DateAndTime::Compatibility.preserve_timezone=` has been deprecated and will be removed in Rails 7.3."
+        "`DateAndTime::Compatibility.preserve_timezone=` has been deprecated and will be removed in Rails 8.0."
       )
     end
   end

--- a/activesupport/lib/active_support/core_ext/module/attr_internal.rb
+++ b/activesupport/lib/active_support/core_ext/module/attr_internal.rb
@@ -25,7 +25,7 @@ class Module
     def attr_internal_naming_format=(format)
       if format.start_with?("@")
         ActiveSupport.deprecator.warn <<~MESSAGE
-          Setting `attr_internal_naming_format` with a `@` prefix is deprecated and will be removed in Rails 7.3.
+          Setting `attr_internal_naming_format` with a `@` prefix is deprecated and will be removed in Rails 8.0.
 
           You can simply replace #{format.inspect} by #{format.delete_prefix("@").inspect}.
         MESSAGE

--- a/activesupport/lib/active_support/deprecation.rb
+++ b/activesupport/lib/active_support/deprecation.rb
@@ -68,7 +68,7 @@ module ActiveSupport
     # and the second is a library name.
     #
     #   ActiveSupport::Deprecation.new('2.0', 'MyLibrary')
-    def initialize(deprecation_horizon = "7.3", gem_name = "Rails")
+    def initialize(deprecation_horizon = "8.0", gem_name = "Rails")
       self.gem_name = gem_name
       self.deprecation_horizon = deprecation_horizon
       # By default, warnings are not silenced and debugging is off.

--- a/activesupport/lib/active_support/deprecation/reporting.rb
+++ b/activesupport/lib/active_support/deprecation/reporting.rb
@@ -152,7 +152,7 @@ module ActiveSupport
 
         def _extract_callstack(callstack)
           ActiveSupport.deprecator.warn(<<~MESSAGE)
-            Passing the result of `caller` to ActiveSupport::Deprecation#warn is deprecated and will be removed in Rails 7.3.
+            Passing the result of `caller` to ActiveSupport::Deprecation#warn is deprecated and will be removed in Rails 8.0.
 
             Please pass the result of `caller_locations` instead.
           MESSAGE

--- a/activesupport/lib/active_support/proxy_object.rb
+++ b/activesupport/lib/active_support/proxy_object.rb
@@ -12,7 +12,7 @@ module ActiveSupport
 
     def self.inherited(_subclass)
       ::ActiveSupport.deprecator.warn(<<~MSG)
-        ActiveSupport::ProxyObject is deprecated and will be removed in Rails 7.3.
+        ActiveSupport::ProxyObject is deprecated and will be removed in Rails 8.0.
         Use Ruby's built-in BasicObject instead.
       MSG
     end

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -353,11 +353,11 @@ module Rails
       end
 
       def read_encrypted_secrets
-        Rails.deprecator.warn("'config.read_encrypted_secrets' is deprecated and will be removed in Rails 7.3.")
+        Rails.deprecator.warn("'config.read_encrypted_secrets' is deprecated and will be removed in Rails 8.0.")
       end
 
       def read_encrypted_secrets=(value)
-        Rails.deprecator.warn("'config.read_encrypted_secrets=' is deprecated and will be removed in Rails 7.3.")
+        Rails.deprecator.warn("'config.read_encrypted_secrets=' is deprecated and will be removed in Rails 8.0.")
       end
 
       def encoding=(value)

--- a/railties/lib/rails/console/methods.rb
+++ b/railties/lib/rails/console/methods.rb
@@ -14,7 +14,7 @@ module Rails
 
     def self.raise_deprecation_warning
       Rails.deprecator.warn(<<~MSG, caller_locations(1..1))
-        Extending Rails console through `Rails::ConsoleMethods` is deprecated and will be removed in Rails 7.3.
+        Extending Rails console through `Rails::ConsoleMethods` is deprecated and will be removed in Rails 8.0.
         Please directly use IRB's extension API to add new commands or helpers to the console.
         For more details, please visit: https://github.com/ruby/irb/blob/master/EXTEND_IRB.md
       MSG


### PR DESCRIPTION
There is no need to fix this on `main`, because these will be removed in `8.0`.