### PR TITLE
Include the current transaction in sql.active_record event payloads

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb
@@ -277,6 +277,7 @@ module ActiveRecord
             type_casted_binds: -> { type_casted_binds(binds) },
             name: name,
             connection: self,
+            transaction: current_transaction,
             cached: true
           }
         end

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -1118,6 +1118,7 @@ module ActiveRecord
             statement_name:    statement_name,
             async:             async,
             connection:        self,
+            transaction:       current_transaction,
             row_count:         0,
             &block
           )

--- a/activerecord/test/cases/instrumentation_test.rb
+++ b/activerecord/test/cases/instrumentation_test.rb
@@ -170,5 +170,36 @@ module ActiveRecord
     ensure
       ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
     end
+
+    def test_payload_with_implicit_transaction
+      expected_transaction = Book.current_transaction
+
+      subscriber = ActiveSupport::Notifications.subscribe("sql.active_record") do |event|
+        if event.payload[:name] == "Book Count"
+          assert_same expected_transaction, event.payload[:transaction]
+        end
+      end
+
+      Book.count
+    ensure
+      ActiveSupport::Notifications.unsubscribe(subscriber)
+    end
+
+    def test_payload_with_explicit_transaction
+      expected_transaction = nil
+
+      subscriber = ActiveSupport::Notifications.subscribe("sql.active_record") do |event|
+        if event.payload[:name] == "Book Load"
+          assert_same expected_transaction, event.payload[:transaction]
+        end
+      end
+
+      Book.transaction do |transaction|
+        expected_transaction = transaction
+        Book.first
+      end
+    ensure
+      ActiveSupport::Notifications.unsubscribe(subscriber)
+    end
   end
 end

--- a/guides/source/active_support_instrumentation.md
+++ b/guides/source/active_support_instrumentation.md
@@ -360,6 +360,7 @@ The `:cache_hits` key is only included if the collection is rendered with `cache
 | `:sql`               | SQL statement                            |
 | `:name`              | Name of the operation                    |
 | `:connection`        | Connection object                        |
+| `:transaction`       | Current transaction                      |
 | `:binds`             | Bind parameters                          |
 | `:type_casted_binds` | Typecasted bind parameters               |
 | `:statement_name`    | SQL Statement name                       |
@@ -374,12 +375,17 @@ Adapters may add their own data as well.
   sql: "SELECT \"posts\".* FROM \"posts\" ",
   name: "Post Load",
   connection: <ActiveRecord::ConnectionAdapters::SQLite3Adapter:0x00007f9f7a838850>,
+  transaction: <ActiveRecord::ConnectionAdapters::RealTransaction:0x0000000121b5d3e0>
   binds: [<ActiveModel::Attribute::WithCastValue:0x00007fe19d15dc00>],
   type_casted_binds: [11],
   statement_name: nil,
   row_count: 5
 }
 ```
+
+If there is no transaction started at the moment, `:transaction` has a null
+object with UUID `00000000-0000-0000-0000-000000000000` (the nil UUID). This may
+happen, for example, issuing a `SELECT` not wrapped in a transaction.
 
 #### `strict_loading_violation.active_record`
 


### PR DESCRIPTION
After #51955, we also include the current transaction object in `sql.active_record` event payloads.

Use case is to allow tracing database activity including the ability to group queries by transaction, thanks to the recently added `ActiveRecord::Transaction#uuid`.

(I'll cherry-pick to 7-2-stable and will write a CHANGELOG entry there.)