### PR TITLE
Clarify `current_transaction` behavior.

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
@@ -109,6 +109,7 @@ module ActiveRecord
       def initialize; end
       def state; end
       def closed?; true; end
+      alias_method :blank?, :closed?
       def open?; false; end
       def joinable?; false; end
       def add_record(record, _ = true); end
@@ -272,8 +273,6 @@ module ActiveRecord
 
       def full_rollback?; true; end
       def joinable?; @joinable; end
-      def closed?; false; end
-      def open?; !closed?; end
 
       private
         def unique_records

--- a/activerecord/lib/active_record/transactions.rb
+++ b/activerecord/lib/active_record/transactions.rb
@@ -235,7 +235,13 @@ module ActiveRecord
         end
       end
 
-      # Returns the current transaction. See ActiveRecord::Transactions API docs.
+      # Returns a representation of the current transaction state,
+      # which can be a top level transaction, a savepoint, or the absence of a transaction.
+      #
+      # An object is always returned, whether or not a transaction is currently active.
+      # To check if a transaction was opened, use <tt>current_transaction.open?</tt>.
+      #
+      # See the ActiveRecord::Transaction documentation for detailed behavior.
       def current_transaction
         connection_pool.active_connection&.current_transaction || ConnectionAdapters::TransactionManager::NULL_TRANSACTION
       end


### PR DESCRIPTION
The documentation wasn't making it clear that a `NullTransaction` is returned when no transaction is active.

While we're not going to document `NullTransaction` itself, we can more explictly explain that `current_transaction` always returns an object that responds to the `ActiveRecord::Transaction` interface.

cc @fxn @matthewd 