### PR TITLE
Parameterize table_name when constructing insert alias to avoid syntax error when table_name contains the database name for mysql

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -644,7 +644,7 @@ module ActiveRecord
         # MySQL 8.0.19 replaces `VALUES(<expression>)` clauses with row and column alias names, see https://dev.mysql.com/worklog/task/?id=6312 .
         # then MySQL 8.0.20 deprecates the `VALUES(<expression>)` see https://dev.mysql.com/worklog/task/?id=13325 .
         if supports_insert_raw_alias_syntax?
-          values_alias = quote_table_name("#{insert.model.table_name}_values")
+          values_alias = quote_table_name("#{insert.model.table_name.parameterize}_values")
           sql = +"INSERT #{insert.into} #{insert.values_list} AS #{values_alias}"
 
           if insert.skip_duplicates?

--- a/activerecord/test/cases/insert_all_test.rb
+++ b/activerecord/test/cases/insert_all_test.rb
@@ -811,6 +811,18 @@ class InsertAllTest < ActiveRecord::TestCase
     assert_match "#{ActiveRecord::Base.lease_connection.class} does not support :unique_by", error.message
   end
 
+  if current_adapter?(:Mysql2Adapter, :TrilogyAdapter)
+    def test_insert_all_when_table_name_contains_database
+      database_name = Book.connection_db_config.database
+      Book.table_name = "#{database_name}.books"
+
+      assert_nothing_raised do
+        Book.insert_all! [{ name: "Rework", author_id: 1 }]
+      end
+      Book.table_name = "books"
+    end
+  end
+
   private
     def capture_log_output
       output = StringIO.new


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

Gems like apartment(https://github.com/rails-on-services/apartment) prepend the database name to a models `table_name` (i.e. my_prod_db.books). When it  goes to do an insert_all  you end up with an `AS` clause that looks like the following: 
``` 
AS `my_prod_db`.`books_values` ON DUPLICATE KEY UPDATE `author`=`my_prod_db`.`books_values`.`author` 
```
which results in a syntax error. 

This change calls parameterize on the table name to convert the period to a dash so it appears as one table name. Since this is just an alias the database name isnt needed in the name and it resolves the syntax error.


After this change the above sql changes to:
``` 
AS `my_prod_db-books_values` ON DUPLICATE KEY UPDATE `author`=`my_prod_db-books_values`.`author` 
```

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created because it resolves a possible syntax error when a models `table_name` also contains the database name. 

### Additional information

This change is due to https://github.com/rails/rails/pull/51274

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
