### PR TITLE
Remove skip_devcontainer? private method

### DIFF
--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -409,10 +409,6 @@ module Rails
         options[:skip_ci]
       end
 
-      def skip_devcontainer?
-        !options[:devcontainer]
-      end
-
       def devcontainer?
         options[:devcontainer]
       end

--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -466,7 +466,7 @@ module Rails
       end
 
       def create_devcontainer_files
-        return if skip_devcontainer? || options[:dummy_app]
+        return if !options[:devcontainer] || options[:dummy_app]
         build(:devcontainer)
       end
 


### PR DESCRIPTION
### Motivation / Background

In the pull request https://github.com/rails/rails/pull/51880, we removed the default generation of the devcontainer for new applications and introduced a new `--devcontainer` flag for the rails new command to generate the `.devcontainer` related files. Since we have completely removed the --skip-container option from the rails new command, using a private method like `skip_devcontainer?` is causing some confusion. This is because we have similarly named methods like `skip_brakeman?` and `skip_rubocop?`, which correspond to actual skipping options.

### Detail

This Pull Request removes the `skip_devcontainer?` private method from rails generator, and updated the occurrences of that method with `!options[:devcontainer]` 


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.

cc/ @andrewn617 
