### PR TITLE
Add mapping to stored attributes

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -56,6 +56,25 @@
 
     *Joshua Young*
 
+*   Add mapping to `store_accessor` when required semantics other than stored attributes names.
+
+    ```ruby
+    class User < ApplicationRecord
+      store_accessor :settings, :language, { country: :country_of_residence }
+    end
+
+    user = User.new(country: "US")
+    user.country # => "US"
+    user.settings["country_of_residence"] # => "US"
+    user.settings["country_of_residence"] = "CA"
+    user.country # => "CA"
+    user.country = "NL"
+    user.country # => "NL"
+    user.settings["country_of_residence"] # => "NL"
+    ```
+
+    *Edem Topuzov*
+
 *   Add public method for checking if a table is ignored by the schema cache.
 
     Previously, an application would need to reimplement `ignored_table?` from the schema cache class to check if a table was set to be ignored. This adds a public method to support this and updates the schema cache to use that directly.

--- a/activerecord/test/cases/json_attribute_test.rb
+++ b/activerecord/test/cases/json_attribute_test.rb
@@ -13,7 +13,7 @@ class JsonAttributeTest < ActiveRecord::TestCase
     attribute :payload,  :json
     attribute :settings, :json
 
-    store_accessor :settings, :resolution
+    store_accessor :settings, :resolution, { country: :country_of_residence }
   end
 
   def setup

--- a/activerecord/test/cases/json_shared_test_cases.rb
+++ b/activerecord/test/cases/json_shared_test_cases.rb
@@ -9,7 +9,7 @@ module JSONSharedTestCases
   class JsonDataType < ActiveRecord::Base
     self.table_name = "json_data_type"
 
-    store_accessor :settings, :resolution
+    store_accessor :settings, :resolution, { country: :country_of_residence }
   end
 
   def setup
@@ -121,35 +121,49 @@ module JSONSharedTestCases
   end
 
   def test_with_store_accessors
-    x = klass.new(resolution: "320×480")
+    x = klass.new(resolution: "320×480", country: "US")
     assert_equal "320×480", x.resolution
+    assert_equal "US", x.country
 
     x.save!
     x = klass.first
     assert_equal "320×480", x.resolution
+    assert_equal "US", x.country
 
     x.resolution = "640×1136"
+    x.country = "UK"
     x.save!
 
     x = klass.first
     assert_equal "640×1136", x.resolution
+    assert_equal "UK", x.country
+
+    x.settings["country_of_residence"] = "US"
+    assert_equal "US", x.country
+
+    x.settings = { "country_of_residence" => "UK" }
+    assert_equal "UK", x.country
   end
 
   def test_duplication_with_store_accessors
-    x = klass.new(resolution: "320×480")
+    x = klass.new(resolution: "320×480", country: "US")
     assert_equal "320×480", x.resolution
+    assert_equal "US", x.country
 
     y = x.dup
     assert_equal "320×480", y.resolution
+    assert_equal "US", y.country
   end
 
   def test_yaml_round_trip_with_store_accessors
-    x = klass.new(resolution: "320×480")
+    x = klass.new(resolution: "320×480", country: "US")
     assert_equal "320×480", x.resolution
+    assert_equal "US", x.country
 
     payload = YAML.dump(x)
     y = YAML.respond_to?(:unsafe_load) ? YAML.unsafe_load(payload) : YAML.load(payload)
     assert_equal "320×480", y.resolution
+    assert_equal "US", y.country
   end
 
   def test_changes_in_place

--- a/activerecord/test/cases/store_test.rb
+++ b/activerecord/test/cases/store_test.rb
@@ -285,19 +285,19 @@ class StoreTest < ActiveRecord::TestCase
 
   test "stored_attributes are tracked per class" do
     first_model = Class.new(ActiveRecord::Base) do
-      store_accessor :data, :color
+      store_accessor :data, :color, { size: :length }
     end
     second_model = Class.new(ActiveRecord::Base) do
-      store_accessor :data, :width, :height
+      store_accessor :data, { base: :basis }, :width, :height
     end
 
-    assert_equal [:color], first_model.stored_attributes[:data]
-    assert_equal [:width, :height], second_model.stored_attributes[:data]
+    assert_equal [:length, :color], first_model.stored_attributes[:data]
+    assert_equal [:basis, :width, :height], second_model.stored_attributes[:data]
   end
 
   test "stored_attributes are tracked per subclass" do
     first_model = Class.new(ActiveRecord::Base) do
-      store_accessor :data, :color
+      store_accessor :data, :color, { size: :length }
     end
     second_model = Class.new(first_model) do
       store_accessor :data, :width, :height
@@ -306,10 +306,10 @@ class StoreTest < ActiveRecord::TestCase
       store_accessor :data, :area, :volume
     end
 
-    assert_equal [:color], first_model.stored_attributes[:data]
-    assert_equal [:color, :width, :height], second_model.stored_attributes[:data]
-    assert_equal [:color, :area, :volume], third_model.stored_attributes[:data]
-    assert_equal [:color], first_model.stored_attributes[:data]
+    assert_equal [:length, :color], first_model.stored_attributes[:data]
+    assert_equal [:length, :color, :width, :height], second_model.stored_attributes[:data]
+    assert_equal [:length, :color, :area, :volume], third_model.stored_attributes[:data]
+    assert_equal [:length, :color], first_model.stored_attributes[:data]
   end
 
   test "YAML coder initializes the store when a Nil value is given" do


### PR DESCRIPTION
### Motivation / Background

Sometimes when call stored attribute, it requires specific naming semantics. For example when you save some data from external source. This Pull Request adds mapping for store attribute keys

### Detail

Proposed changes

```ruby
class User < ApplicationRecord
  store_accessor :settings, :language, { country: :country_of_residence }
end

user = User.new(country: "US")
user.country # => "US"
user.settings["country_of_residence"] # => "US"
user.settings["country_of_residence"] = "CA"
user.country # => "CA"
user.country = "NL"
user.country # => "NL"
user.settings["country_of_residence"] # => "NL"
```

### Additional information

This was intended as non-breaking change

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
