### PR TITLE
[7-1-stable] Fix Dirty test supports_identity_columns?

### DIFF
--- a/activerecord/test/cases/dirty_test.rb
+++ b/activerecord/test/cases/dirty_test.rb
@@ -972,7 +972,7 @@ class DirtyTest < ActiveRecord::TestCase
     end
   end
 
-  if current_adapter?(:PostgreSQLAdapter) && supports_identity_columns?
+  if current_adapter?(:PostgreSQLAdapter) && ActiveRecord::Base.connection.supports_identity_columns?
     test "partial insert off with changed composite identity primary key attribute" do
       klass = Class.new(ActiveRecord::Base) do
         self.table_name = "cpk_postgresql_identity_table"


### PR DESCRIPTION
Fixes this [build failure](https://buildkite.com/rails/rails/builds/107916#018fd1be-20a9-4de2-9930-91123e5b0682), which I believe was caused by 47722e8b4f8fee206358e2b2d87dc728e6429544.

1. `git checkout 7-1-stable`
2. `cd activerecord && bundle exec rake db:postgresql:rebuild postgresql:test`

```
/rails/activerecord/test/cases/dirty_test.rb:975:in `<class:DirtyTest>': undefined method `supports_identity_columns?' for DirtyTest:Class (NoMethodError)
  if current_adapter?(:PostgreSQLAdapter) && supports_identity_columns?
                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
Did you mean?  supports_nulls_not_distinct?
	from /rails/activerecord/test/cases/dirty_test.rb:11:in `<top (required)>'
	from <internal:/usr/local/lib/ruby/site_ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:37:in `require'
	from <internal:/usr/local/lib/ruby/site_ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:37:in `require'
	from /usr/local/bundle/gems/rake-13.2.1/lib/rake/rake_test_loader.rb:21:in `block in <main>'
	from /usr/local/bundle/gems/rake-13.2.1/lib/rake/rake_test_loader.rb:6:in `select'
	from /usr/local/bundle/gems/rake-13.2.1/lib/rake/rake_test_loader.rb:6:in `<main>'
```

I can't explain why this only fails in `7-1-stable`, maybe @yahonda or @fatkodima knows?