### PR TITLE
[7-1-stable] Lower case the `link` header

### DIFF
--- a/actionpack/lib/action_dispatch/http/request.rb
+++ b/actionpack/lib/action_dispatch/http/request.rb
@@ -229,11 +229,12 @@ module ActionDispatch
     # Early Hints is an HTTP/2 status code that indicates hints to help a client start
     # making preparations for processing the final response.
     #
-    # If the env contains +rack.early_hints+ then the server accepts HTTP2 push for Link headers.
+    # If the env contains +rack.early_hints+ then the server accepts HTTP2 push for
+    # link headers.
     #
     # The +send_early_hints+ method accepts a hash of links as follows:
     #
-    #   send_early_hints("Link" => "</style.css>; rel=preload; as=style\n</script.js>; rel=preload")
+    #   send_early_hints("link" => "</style.css>; rel=preload; as=style\n</script.js>; rel=preload")
     #
     # If you are using +javascript_include_tag+ or +stylesheet_link_tag+ the
     # Early Hints headers are included by default if supported.

--- a/actionpack/test/dispatch/request_test.rb
+++ b/actionpack/test/dispatch/request_test.rb
@@ -1408,8 +1408,8 @@ class EarlyHintsRequestTest < BaseRequestTest
   end
 
   test "when early hints is set in the env link headers are sent" do
-    early_hints = @request.send_early_hints("Link" => "</style.css>; rel=preload; as=style\n</script.js>; rel=preload")
-    expected_hints = { "Link" => "</style.css>; rel=preload; as=style\n</script.js>; rel=preload" }
+    early_hints = @request.send_early_hints("link" => "</style.css>; rel=preload; as=style\n</script.js>; rel=preload")
+    expected_hints = { "link" => "</style.css>; rel=preload; as=style\n</script.js>; rel=preload" }
 
     assert_equal expected_hints, early_hints
   end

--- a/actionview/lib/action_view/helpers/asset_tag_helper.rb
+++ b/actionview/lib/action_view/helpers/asset_tag_helper.rb
@@ -645,11 +645,11 @@ module ActionView
           return if response_present && response.sending?
 
           if respond_to?(:request) && request
-            request.send_early_hints("Link" => preload_links.join("\n"))
+            request.send_early_hints("link" => preload_links.join("\n"))
           end
 
           if response_present
-            header = +response.headers["Link"].to_s
+            header = +response.headers["link"].to_s
             preload_links.each do |link|
               break if header.bytesize + link.bytesize > max_header_size
 
@@ -660,7 +660,7 @@ module ActionView
               end
             end
 
-            response.headers["Link"] = header
+            response.headers["link"] = header
           end
         end
     end

--- a/actionview/test/template/asset_tag_helper_test.rb
+++ b/actionview/test/template/asset_tag_helper_test.rb
@@ -630,7 +630,7 @@ class AssetTagHelperTest < ActionView::TestCase
       stylesheet_link_tag("http://example.com/style.css")
       javascript_include_tag("http://example.com/all.js")
       expected = "<http://example.com/style.css>; rel=preload; as=style; nopush,<http://example.com/all.js>; rel=preload; as=script; nopush"
-      assert_equal expected, @response.headers["Link"]
+      assert_equal expected, @response.headers["link"]
     end
   end
 
@@ -638,7 +638,7 @@ class AssetTagHelperTest < ActionView::TestCase
     with_preload_links_header do
       stylesheet_link_tag("data:text/css;base64,YWxlcnQoIkhlbGxvIik7")
       javascript_include_tag("data:text/javascript;base64,YWxlcnQoIkhlbGxvIik7")
-      assert_nil @response.headers["Link"]
+      assert_nil @response.headers["link"]
     end
   end
 
@@ -646,7 +646,7 @@ class AssetTagHelperTest < ActionView::TestCase
     with_preload_links_header do
       stylesheet_link_tag("http://example.com/style.css", preload_links_header: false)
       javascript_include_tag("http://example.com/all.js", preload_links_header: false)
-      assert_nil @response.headers["Link"]
+      assert_nil @response.headers["link"]
     end
   end
 
@@ -655,7 +655,7 @@ class AssetTagHelperTest < ActionView::TestCase
       stylesheet_link_tag("http://example.com/style.css", preload_links_header: true)
       javascript_include_tag("http://example.com/all.js", preload_links_header: true)
       expected = "<http://example.com/style.css>; rel=preload; as=style; nopush,<http://example.com/all.js>; rel=preload; as=script; nopush"
-      assert_equal expected, @response.headers["Link"]
+      assert_equal expected, @response.headers["link"]
     end
   end
 
@@ -665,7 +665,7 @@ class AssetTagHelperTest < ActionView::TestCase
         stylesheet_link_tag("http://example.com/style.css?#{i}")
         javascript_include_tag("http://example.com/all.js?#{i}")
       end
-      links = @response.headers["Link"].count(",")
+      links = @response.headers["link"].count(",")
       assert_equal 14, links
     end
   end
@@ -673,7 +673,7 @@ class AssetTagHelperTest < ActionView::TestCase
   def test_should_not_preload_links_with_defer
     with_preload_links_header do
       javascript_include_tag("http://example.com/all.js", defer: true)
-      assert_nil @response.headers["Link"]
+      assert_nil @response.headers["link"]
     end
   end
 
@@ -682,7 +682,7 @@ class AssetTagHelperTest < ActionView::TestCase
       stylesheet_link_tag("http://example.com/style.css", nopush: false)
       javascript_include_tag("http://example.com/all.js", nopush: false)
       expected = "<http://example.com/style.css>; rel=preload; as=style,<http://example.com/all.js>; rel=preload; as=script"
-      assert_equal expected, @response.headers["Link"]
+      assert_equal expected, @response.headers["link"]
     end
   end
 
@@ -691,7 +691,7 @@ class AssetTagHelperTest < ActionView::TestCase
       stylesheet_link_tag("http://example.com/style.css", crossorigin: "use-credentials")
       javascript_include_tag("http://example.com/all.js", crossorigin: true)
       expected = "<http://example.com/style.css>; rel=preload; as=style; crossorigin=use-credentials; nopush,<http://example.com/all.js>; rel=preload; as=script; crossorigin=anonymous; nopush"
-      assert_equal expected, @response.headers["Link"]
+      assert_equal expected, @response.headers["link"]
     end
   end
 
@@ -699,7 +699,7 @@ class AssetTagHelperTest < ActionView::TestCase
     with_preload_links_header do
       javascript_include_tag("http://example.com/all.js", type: "module")
       expected = "<http://example.com/all.js>; rel=modulepreload; as=script; nopush"
-      assert_equal expected, @response.headers["Link"]
+      assert_equal expected, @response.headers["link"]
     end
   end
 
@@ -707,7 +707,7 @@ class AssetTagHelperTest < ActionView::TestCase
     with_preload_links_header do
       preload_link_tag("http://example.com/all.js", type: "module")
       expected = "<http://example.com/all.js>; rel=modulepreload; as=script; type=module"
-      assert_equal expected, @response.headers["Link"]
+      assert_equal expected, @response.headers["link"]
     end
   end
 
@@ -716,7 +716,7 @@ class AssetTagHelperTest < ActionView::TestCase
       stylesheet_link_tag("http://example.com/style.css", integrity: "sha256-AbpHGcgLb+kRsJGnwFEktk7uzpZOCcBY74+YBdrKVGs")
       javascript_include_tag("http://example.com/all.js", integrity: "sha256-AbpHGcgLb+kRsJGnwFEktk7uzpZOCcBY74+YBdrKVGs")
       expected = "<http://example.com/style.css>; rel=preload; as=style; integrity=sha256-AbpHGcgLb+kRsJGnwFEktk7uzpZOCcBY74+YBdrKVGs; nopush,<http://example.com/all.js>; rel=preload; as=script; integrity=sha256-AbpHGcgLb+kRsJGnwFEktk7uzpZOCcBY74+YBdrKVGs; nopush"
-      assert_equal expected, @response.headers["Link"]
+      assert_equal expected, @response.headers["link"]
     end
   end
 
@@ -724,7 +724,7 @@ class AssetTagHelperTest < ActionView::TestCase
     with_preload_links_header(false) do
       stylesheet_link_tag("http://example.com/style.css")
       javascript_include_tag("http://example.com/all.js")
-      assert_nil @response.headers["Link"]
+      assert_nil @response.headers["link"]
     end
   end
 

--- a/guides/source/6_1_release_notes.md
+++ b/guides/source/6_1_release_notes.md
@@ -176,7 +176,7 @@ Please refer to the [Changelog][action-view] for detailed changes.
 
 *   Make `locals` argument required on `ActionView::Template#initialize`.
 
-*   The `javascript_include_tag` and `stylesheet_link_tag` asset helpers generate a `Link` header that gives hints to modern browsers about preloading assets. This can be disabled by setting `config.action_view.preload_links_header` to `false`.
+*   The `javascript_include_tag` and `stylesheet_link_tag` asset helpers generate a `link` header that gives hints to modern browsers about preloading assets. This can be disabled by setting `config.action_view.preload_links_header` to `false`.
 
 Action Mailer
 -------------

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -2162,7 +2162,7 @@ Determines whether to annotate rendered view with template file names. This defa
 
 #### `config.action_view.preload_links_header`
 
-Determines whether `javascript_include_tag` and `stylesheet_link_tag` will generate a `Link` header that preload assets.
+Determines whether `javascript_include_tag` and `stylesheet_link_tag` will generate a `link` header that preload assets.
 
 The default value depends on the `config.load_defaults` target version:
 

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -3351,7 +3351,7 @@ module ApplicationTests
       assert_equal false, ActionView::Helpers::AssetTagHelper.apply_stylesheet_media_default
     end
 
-    test "stylesheet_link_tag sets the Link header by default" do
+    test "stylesheet_link_tag sets the link header by default" do
       app_file "app/controllers/pages_controller.rb", <<-RUBY
       class PagesController < ApplicationController
         def index
@@ -3370,10 +3370,10 @@ module ApplicationTests
 
       get "/"
       assert_match %r[<link rel="stylesheet" href="/application.css" />], last_response.body
-      assert_equal "</application.css>; rel=preload; as=style; nopush", last_response.headers["Link"]
+      assert_equal "</application.css>; rel=preload; as=style; nopush", last_response.headers["link"]
     end
 
-    test "stylesheet_link_tag doesn't set the Link header when disabled" do
+    test "stylesheet_link_tag doesn't set the link header when disabled" do
       app_file "config/initializers/action_view.rb", <<-RUBY
         Rails.application.config.action_view.preload_links_header = false
       RUBY
@@ -3396,10 +3396,10 @@ module ApplicationTests
 
       get "/"
       assert_match %r[<link rel="stylesheet" href="/application.css" />], last_response.body
-      assert_nil last_response.headers["Link"]
+      assert_nil last_response.headers["link"]
     end
 
-    test "javascript_include_tag sets the Link header by default" do
+    test "javascript_include_tag sets the link header by default" do
       app_file "app/controllers/pages_controller.rb", <<-RUBY
       class PagesController < ApplicationController
         def index
@@ -3418,10 +3418,10 @@ module ApplicationTests
 
       get "/"
       assert_match %r[<script src="/application.js"></script>], last_response.body
-      assert_equal "</application.js>; rel=preload; as=script; nopush", last_response.headers["Link"]
+      assert_equal "</application.js>; rel=preload; as=script; nopush", last_response.headers["link"]
     end
 
-    test "javascript_include_tag doesn't set the Link header when disabled" do
+    test "javascript_include_tag doesn't set the link header when disabled" do
       app_file "config/initializers/action_view.rb", <<-RUBY
         Rails.application.config.action_view.preload_links_header = false
       RUBY
@@ -3444,7 +3444,7 @@ module ApplicationTests
 
       get "/"
       assert_match %r[<script src="/application.js"></script>], last_response.body
-      assert_nil last_response.headers["Link"]
+      assert_nil last_response.headers["link"]
     end
 
     test "ActiveJob::Base.retry_jitter is 0.15 by default for new apps" do


### PR DESCRIPTION
Backports 26a572dca11ba08b6bb97d238e6782f179701318 to `7-1-stable` by hand because it didn't apply cleanly due to rdoc->markdown change

---

Since https://github.com/rack/rack/commit/1fbcf54289b9fae2765c1167376e837fe38b543c the early hints will be checked against Rack::Link that requires all headers to be lower cased.

Fixes #51961.