### PR TITLE
Revert "Optimize `ActiveRecord::Relation#exists?` with no conditions for loaded relations"

### DIFF
--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -365,7 +365,6 @@ module ActiveRecord
       end
 
       return false if !conditions || limit_value == 0
-      return !records.empty? if conditions == :none && loaded?
 
       if eager_loading?
         relation = apply_join_dependency(eager_loading: false)

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -285,19 +285,6 @@ class FinderTest < ActiveRecord::TestCase
     assert_equal true, Topic.exists?
   end
 
-  def test_exists_with_loaded_relation
-    topics = Topic.all.load
-    assert_no_queries do
-      assert_equal true, topics.exists?
-    end
-
-    Topic.delete_all
-    topics = Topic.all.load
-    assert_no_queries do
-      assert_equal false, topics.exists?
-    end
-  end
-
   def test_exists_returns_false_with_false_arg
     assert_equal false, Topic.exists?(false)
   end


### PR DESCRIPTION
Reverts rails/rails#51966 (see discussion there).