### PR TITLE
[7-1-stable] Link should be separated by comma.

### DIFF
--- a/actionpack/lib/action_dispatch/http/request.rb
+++ b/actionpack/lib/action_dispatch/http/request.rb
@@ -234,7 +234,7 @@ module ActionDispatch
     #
     # The +send_early_hints+ method accepts a hash of links as follows:
     #
-    #   send_early_hints("link" => "</style.css>; rel=preload; as=style\n</script.js>; rel=preload")
+    #   send_early_hints("link" => "</style.css>; rel=preload; as=style,</script.js>; rel=preload")
     #
     # If you are using +javascript_include_tag+ or +stylesheet_link_tag+ the
     # Early Hints headers are included by default if supported.

--- a/actionpack/test/dispatch/request_test.rb
+++ b/actionpack/test/dispatch/request_test.rb
@@ -1408,8 +1408,8 @@ class EarlyHintsRequestTest < BaseRequestTest
   end
 
   test "when early hints is set in the env link headers are sent" do
-    early_hints = @request.send_early_hints("link" => "</style.css>; rel=preload; as=style\n</script.js>; rel=preload")
-    expected_hints = { "link" => "</style.css>; rel=preload; as=style\n</script.js>; rel=preload" }
+    early_hints = @request.send_early_hints("link" => "</style.css>; rel=preload; as=style,</script.js>; rel=preload")
+    expected_hints = { "link" => "</style.css>; rel=preload; as=style,</script.js>; rel=preload" }
 
     assert_equal expected_hints, early_hints
   end

--- a/actionview/lib/action_view/helpers/asset_tag_helper.rb
+++ b/actionview/lib/action_view/helpers/asset_tag_helper.rb
@@ -645,7 +645,7 @@ module ActionView
           return if response_present && response.sending?
 
           if respond_to?(:request) && request
-            request.send_early_hints("link" => preload_links.join("\n"))
+            request.send_early_hints("link" => preload_links.join(","))
           end
 
           if response_present


### PR DESCRIPTION
Backports fcec475438cd74483acc2db2477249358b5399bb to `7-1-stable` to fix [this build failure](https://buildkite.com/rails/rails/builds/107922#018fd2e7-8da4-4968-b5f7-50512b946e00/1176-1216).

```
Error:
EarlyHintsRequestTest#test_when_early_hints_is_set_in_the_env_link_headers_are_sent:
Rack::Lint::LintError: invalid header value link: "</style.css>; rel=preload; as=style\n</script.js>; rel=preload"
    /usr/local/bundle/bundler/gems/rack-47b40d344526/lib/rack/lint.rb:721:in `check_header_value'
    /usr/local/bundle/bundler/gems/rack-47b40d344526/lib/rack/lint.rb:708:in `block in check_headers'
    /usr/local/bundle/bundler/gems/rack-47b40d344526/lib/rack/lint.rb:688:in `each'
    /usr/local/bundle/bundler/gems/rack-47b40d344526/lib/rack/lint.rb:688:in `check_headers'
    /usr/local/bundle/bundler/gems/rack-47b40d344526/lib/rack/lint.rb:656:in `block in check_early_hints'
    lib/action_dispatch/http/request.rb:244:in `send_early_hints'
    test/dispatch/request_test.rb:1411:in `block in <class:EarlyHintsRequestTest>'
```

---

See https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Link.
