### PR TITLE
[7-1-stable] fix flaky schema dump test to prefer YAML to Marshal

### DIFF
--- a/activerecord/test/cases/connection_adapters/schema_cache_test.rb
+++ b/activerecord/test/cases/connection_adapters/schema_cache_test.rb
@@ -338,12 +338,12 @@ module ActiveRecord
         # Create an empty cache.
         cache = new_bound_reflection
 
-        tempfile_a = Tempfile.new(["schema_cache-", ".dump.gz"])
+        tempfile_a = Tempfile.new(["schema_cache-", ".yml.gz"])
         # Dump it. It should get populated before dumping.
         cache.dump_to(tempfile_a.path)
         digest_a = Digest::MD5.file(tempfile_a).hexdigest
         sleep(1) # ensure timestamp changes
-        tempfile_b = Tempfile.new(["schema_cache-", ".dump.gz"])
+        tempfile_b = Tempfile.new(["schema_cache-", ".yml.gz"])
         # Dump it. It should get populated before dumping.
         cache.dump_to(tempfile_b.path)
         digest_b = Digest::MD5.file(tempfile_b).hexdigest


### PR DESCRIPTION
This backports #51581 to `7-1-stable` branch to fix [this build failure](https://buildkite.com/rails/rails/builds/107922#018fd2e7-8e44-4bed-97ce-615fe907dddf/1111-1121).

```
Failure:
ActiveRecord::ConnectionAdapters::SchemaCacheTest#test_gzip_dumps_identical [test/cases/connection_adapters/schema_cache_test.rb:352]:
--- expected
+++ actual
@@ -1,3 +1,3 @@
 # encoding: US-ASCII
 #    valid: true
-"c6e5a4aa0bf99c80b32c8d73c26d0ec9"
+"b09eb0f057e1f6928e9de89c599f8b86"
```
