### PR TITLE
Use `:nodoc:` for `alias_method` instead of `:stopdoc:` [ci-skip]

### DIFF
--- a/activesupport/lib/active_support/values/time_zone.rb
+++ b/activesupport/lib/active_support/values/time_zone.rb
@@ -208,9 +208,7 @@ module ActiveSupport
         TZInfo::Timezone.get(MAPPING[name] || name)
       end
 
-      # :stopdoc:
-      alias_method :create, :new
-      # :startdoc:
+      alias_method :create, :new # :nodoc:
 
       # Returns a TimeZone instance with the given name, or +nil+ if no
       # such TimeZone instance exists. (This exists to support the use of


### PR DESCRIPTION
RDoc 6.7 now hides `alias_method`s marked with `:nodoc:`.