### PR TITLE
Exit status 3 when Action Cable integration tests fail due to Saucelabs error

### DIFF
--- a/actioncable/Rakefile
+++ b/actioncable/Rakefile
@@ -2,8 +2,6 @@
 
 require "base64"
 require "rake/testtask"
-require "pathname"
-require "open3"
 require "action_cable"
 
 task default: :test
@@ -28,8 +26,22 @@ namespace :test do
   end
 
   task :integration do
-    system(Hash[*Base64.decode64(ENV.fetch("ENCODED", "")).split(/[ =]/)], "yarn", "test")
-    exit($?.exitstatus) unless $?.success?
+    found_saucelabs_error = false
+
+    IO.popen(Hash[*Base64.decode64(ENV.fetch("ENCODED", "")).split(/[ =]/)], "yarn test") do |io|
+      io.each do |line|
+        puts line
+        if line.include?("The environment you requested was unavailable.")
+          found_saucelabs_error = true
+        end
+      end
+    end
+
+    if found_saucelabs_error
+      exit 3
+    end
+
+    exit $?.exitstatus unless $?.success?
   end
 end
 


### PR DESCRIPTION
This is to mitigate errors like:
https://buildkite.com/rails/rails/builds/107403#018f9917-fd63-4701-9620-f9caf2caaf2d/1163-1195

```
ERROR [karma-server]:
Error: [init({...}})] The environment you requested was unavailable.
```

We can make buildkite-config retry this status and soft-fail on exit 3.

For example,
https://buildkite.com/changelog/56-command-steps-can-now-be-made-to-soft-fail

I _think_ we can combine this with a retry policy on the exit status:
https://buildkite.com/docs/pipelines/command-step#retry-attributes-automatic-retry-attributes

/cc @matthewd 