### PR TITLE
Fix `include?` on composite key relations

### DIFF
--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -256,14 +256,16 @@ module ActiveRecord
       end
 
       def include?(record)
-        if record.is_a?(reflection.klass)
-          if record.new_record?
-            include_in_memory?(record)
-          else
-            loaded? ? target.include?(record) : scope.exists?(record.id)
-          end
+        klass = reflection.klass
+        return false unless record.is_a?(klass)
+
+        if record.new_record?
+          include_in_memory?(record)
+        elsif loaded?
+          target.include?(record)
         else
-          false
+          record_id = klass.composite_primary_key? ? klass.primary_key.zip(record.id).to_h : record.id
+          scope.exists?(record_id)
         end
       end
 

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -2029,6 +2029,13 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     assert_equal true, companies(:first_firm).clients.include?(Client.find(2))
   end
 
+  def test_included_in_collection_for_composite_keys
+    great_author = cpk_authors(:cpk_great_author)
+    book = great_author.books.first
+
+    assert great_author.books.include?(book)
+  end
+
   def test_included_in_collection_for_new_records
     client = Client.create(name: "Persisted")
     assert_nil client.client_of


### PR DESCRIPTION
Fixes #51995 

Calling `exists?` does not work with composite keys (#51295) which is used internally for `include?` here it zips the primary key values into a hash with the primary key keys, a format that is supported by `exists?` so it does not raise and returns the expected result.
