### PR TITLE
docs(query_methods): fix typo

### DIFF
--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -1498,7 +1498,7 @@ module ActiveRecord
       self
     end
 
-    # Adds an SQL comment to queries generated from this relation. For example:
+    # Adds a SQL comment to queries generated from this relation. For example:
     #
     #   User.annotate("selecting user names").select(:name)
     #   # SELECT "users"."name" FROM "users" /* selecting user names */


### PR DESCRIPTION
Just a small typo fix in a comment.