### PR TITLE
Fix `ActiveRecord::Transaction#blank?`

### DIFF
--- a/activerecord/lib/active_record/transaction.rb
+++ b/activerecord/lib/active_record/transaction.rb
@@ -111,12 +111,12 @@ module ActiveRecord
     def open?
       true
     end
-    alias_method :blank?, :open?
 
     # Returns true if no transaction is currently active.
     def closed?
       false
     end
+    alias_method :blank?, :closed?
 
     # Returns a UUID for this transaction.
     def uuid

--- a/activerecord/test/cases/transactions_test.rb
+++ b/activerecord/test/cases/transactions_test.rb
@@ -19,7 +19,14 @@ class TransactionTest < ActiveRecord::TestCase
     @first, @second = Topic.find(1, 2).sort_by(&:id)
   end
 
-  def test_after_all_transactions_committ
+  def test_blank?
+    assert_predicate Topic.current_transaction, :blank?
+    Topic.transaction do
+      assert_not_predicate Topic.current_transaction, :blank?
+    end
+  end
+
+  def test_after_all_transactions_commit
     called = 0
     ActiveRecord.after_all_transactions_commit { called += 1 }
     assert_equal 1, called


### PR DESCRIPTION
Followup: https://github.com/rails/rails/pull/51968

The wrong method was aliased.
