### PR TITLE
Pass transaction: nil in sql.active_record events if no transaction i…

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb
@@ -277,7 +277,7 @@ module ActiveRecord
             type_casted_binds: -> { type_casted_binds(binds) },
             name: name,
             connection: self,
-            transaction: current_transaction,
+            transaction: current_transaction.presence,
             cached: true
           }
         end

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -1118,7 +1118,7 @@ module ActiveRecord
             statement_name:    statement_name,
             async:             async,
             connection:        self,
-            transaction:       current_transaction,
+            transaction:       current_transaction.presence,
             row_count:         0,
             &block
           )

--- a/guides/source/active_support_instrumentation.md
+++ b/guides/source/active_support_instrumentation.md
@@ -360,7 +360,7 @@ The `:cache_hits` key is only included if the collection is rendered with `cache
 | `:sql`               | SQL statement                            |
 | `:name`              | Name of the operation                    |
 | `:connection`        | Connection object                        |
-| `:transaction`       | Current transaction                      |
+| `:transaction`       | Current transaction, if any              |
 | `:binds`             | Bind parameters                          |
 | `:type_casted_binds` | Typecasted bind parameters               |
 | `:statement_name`    | SQL Statement name                       |
@@ -383,9 +383,7 @@ Adapters may add their own data as well.
 }
 ```
 
-If there is no transaction started at the moment, `:transaction` has a null
-object with UUID `00000000-0000-0000-0000-000000000000` (the nil UUID). This may
-happen, for example, issuing a `SELECT` not wrapped in a transaction.
+If the query is not executed in the context of a transaction, `:transaction` is `nil`.
 
 #### `strict_loading_violation.active_record`
 


### PR DESCRIPTION
The purpose of the `:transaction` key in the payload of `sql.active_record` events is to pass to the subscriber the transaction the query is being executed under, if any. Better represent lack of transaction with `nil` for this purpose.