### PR TITLE
Fix: ActiveRecord::StatementInvalid on grouped queries with Postgres …

### DIFF
--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -237,7 +237,7 @@ module ActiveRecord
             relation.select_values = Array(model.primary_key || table[Arel.star])
           end
           # PostgreSQL: ORDER BY expressions must appear in SELECT list when using DISTINCT
-          relation.order_values = [] if group_values.empty?
+          relation.order_values = []
         end
 
         relation.calculate(operation, column_name)


### PR DESCRIPTION
**Edit: It seems some tests are failing. This is not regression but simply that the assertion expects a specific order that is no longer respected since I discard it. I'm checking if there is an alternative fix that could be kept without introducing that order change.**

### Motivation / Background

ActiveRecord clears `ORDER BY` when doing `COUNT(...)` operation because it also clears every `SELECT ...` statement. However, for some reasons it doesn't do it on queries that use `GROUP BY`. This appears to be a mistake.

### Detail

This Pull Request closes https://github.com/rails/rails/issues/51434 which contains reproduction exemple.

### Additional information

To make things easier to understand, let's define a simple query that is perfectly valid and working:

```ruby
@product_tags = ProductTag
                      .select(
                        ProductTag.arel_table[Arel.star],
                        ProductVariant.arel_table[:id].count.as("product_variants_count")
                      )
                      .includes(:product_variants)
                      .references(:product_variants)
                      .group(ProductTag.arel_table[:id], ProductVariant.arel_table[:id])
                      .order(:product_variants_count) 
```

```sql
SELECT "product_tags".*, COUNT("product_variants"."id") AS product_variants_count, "product_tags"."id" AS t0_r0, "product_variants"."id" AS t1_r0, "product_variants"."crm_id" AS t1_r1, "product_variants"."product_id" AS t1_r2, "product_variants"."name_fr" AS t1_r3, "product_variants"."name_en" AS t1_r4, "product_variants"."description_fr" AS t1_r5, "product_variants"."description_en" AS t1_r6, "product_variants"."price" AS t1_r7, "product_variants"."sale_price" AS t1_r8, "product_variants"."energy_kcal" AS t1_r9, "product_variants"."saturated_fat_g" AS t1_r10, "product_variants"."saturated_fat_percent" AS t1_r11, "product_variants"."trans_fat_g" AS t1_r12, "product_variants"."trans_fat_percent" AS t1_r13, "product_variants"."carbohydrates_g" AS t1_r14, "product_variants"."carbohydrates_percent" AS t1_r15, "product_variants"."fiber_g" AS t1_r16, "product_variants"."fiber_percent" AS t1_r17, "product_variants"."sugar_g" AS t1_r18, "product_variants"."sugar_percent" AS t1_r19, "product_variants"."protein_g" AS t1_r20, "product_variants"."protein_percent" AS t1_r21, "product_variants"."salt_g" AS t1_r22, "product_variants"."salt_percent" AS t1_r23, "product_variants"."potassium_g" AS t1_r24, "product_variants"."potassium_percent" AS t1_r25, "product_variants"."calcium_g" AS t1_r26, "product_variants"."calcium_percent" AS t1_r27, "product_variants"."iron_g" AS t1_r28, "product_variants"."iron_percent" AS t1_r29, "product_variants"."created_at" AS t1_r30, "product_variants"."updated_at" AS t1_r31 FROM "product_tags" LEFT OUTER JOIN "product_tag_product_variants" ON "product_tag_product_variants"."product_tag_id" = "product_tags"."id" LEFT OUTER JOIN "product_variants" ON "product_variants"."id" = "product_tag_product_variants"."product_variant_id" GROUP BY "product_tags"."id", "product_variants"."id" /* loading for pp */ ORDER BY "product_variants_count" ASC LIMIT $1
```

Now if you call count on that query we end up having

```sql
SELECT COUNT(DISTINCT "product_tags"."id") AS "count_id", "product_tags"."id" AS "product_tags_id", "product_variants"."id" AS "product_variants_id" FROM "product_tags" LEFT OUTER JOIN "product_tag_product_variants" ON "product_tag_product_variants"."product_tag_id" = "product_tags"."id" LEFT OUTER JOIN "product_variants" ON "product_variants"."id" = "product_tag_product_variants"."product_variant_id" GROUP BY "product_tags"."id", "product_variants"."id" ORDER BY "product_variants_count" ASC
```

```
(irb):18:in `<main>': PG::UndefinedColumn: ERROR:  column "product_variants_count" does not exist (ActiveRecord::StatementInvalid)
LINE 1: ...duct_tags"."id", "product_variants"."id" ORDER BY "product_v...
                                                             ^
```
