### PR TITLE
Allow sessions to not be lazily loaded

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/session/abstract_store.rb
+++ b/actionpack/lib/action_dispatch/middleware/session/abstract_store.rb
@@ -22,6 +22,7 @@ module ActionDispatch
     module Compatibility
       def initialize(app, options = {})
         options[:key] ||= "_session_id"
+        options[:lazy] = true unless options.key?(:lazy)
         super
       end
 
@@ -75,7 +76,9 @@ module ActionDispatch
       end
 
       def prepare_session(req)
-        Request::Session.create(self, req, @default_options)
+        Request::Session.create(self, req, @default_options).tap do |session|
+          session.send(:load!) unless @default_options[:lazy]
+        end
       end
 
       def loaded_session?(session)

--- a/actionpack/test/dispatch/session/abstract_secure_store_test.rb
+++ b/actionpack/test/dispatch/session/abstract_secure_store_test.rb
@@ -16,7 +16,7 @@ module ActionDispatch
           end
         end
 
-        def initialize(app)
+        def initialize(app, options = {})
           @sessions = {}
           super
         end
@@ -34,6 +34,24 @@ module ActionDispatch
         def session_exists?(req)
           true
         end
+      end
+
+      def test_session_is_lazily_loaded_by_default
+        env = {}
+        as = MemoryStore.new app
+        as.call(env)
+
+        session = Request::Session.find ActionDispatch::Request.new @env
+        assert_not session.loaded?
+      end
+
+      def test_session_lazy_loading_can_be_disabled
+        env = {}
+        as = MemoryStore.new app, lazy: false
+        as.call(env)
+
+        session = Request::Session.find ActionDispatch::Request.new @env
+        assert session.loaded?
       end
 
       def test_session_is_set

--- a/actionpack/test/dispatch/session/abstract_store_test.rb
+++ b/actionpack/test/dispatch/session/abstract_store_test.rb
@@ -7,7 +7,7 @@ module ActionDispatch
   module Session
     class AbstractStoreTest < ActiveSupport::TestCase
       class MemoryStore < AbstractStore
-        def initialize(app)
+        def initialize(app, options = {})
           @sessions = {}
           super
         end
@@ -25,6 +25,24 @@ module ActionDispatch
         def session_exists?(req)
           true
         end
+      end
+
+      def test_session_is_lazily_loaded_by_default
+        env = {}
+        as = MemoryStore.new app
+        as.call(env)
+
+        session = Request::Session.find ActionDispatch::Request.new @env
+        assert_not session.loaded?
+      end
+
+      def test_session_lazy_loading_can_be_disabled
+        env = {}
+        as = MemoryStore.new app, lazy: false
+        as.call(env)
+
+        session = Request::Session.find ActionDispatch::Request.new @env
+        assert session.loaded?
       end
 
       def test_session_is_set


### PR DESCRIPTION
Fixes #48463 
Fixes #51424 

### Motivation / Background

Sessions are lazily loaded by default, which makes sense for non-cookie storages. One downside of lazy loading is the session ID isn't available until after the first page load (assuming there's some interaction with `session` that loads it).

The [default CSP that's generated](https://github.com/rails/rails/blob/fb84e13468c0e266144aa7375431fc6a243f4e8f/railties/lib/rails/generators/rails/app/templates/config/initializers/content_security_policy.rb.tt#L20) suggests to use the session ID as the nonce generator. This works great when the session is actually available/loaded!

### Detail

This pull allows the session to not be lazily loaded, which should be just fine for the cookie store:

```ruby
config.session_store :cookie_store, lazy: false
```

NOTE: this pull is not complete (needs doc and generator changes) -- I'm looking for some feedback if it's even something that the core team is open to. 

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [ ] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
