### PR TITLE
[FIX] Pluck columns should correctly casts types when using postgresql

### DIFF
--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -604,7 +604,7 @@ module ActiveRecord
               model.attribute_types.fetch(name = result.columns[i]) do
                 join_dependencies ||= build_join_dependencies
                 lookup_cast_type_from_join_dependencies(name, join_dependencies) ||
-                  result.column_types[name] || Type.default_value
+                  result.column_types[i] || Type.default_value
               end
           end
         end

--- a/activerecord/test/cases/calculations_test.rb
+++ b/activerecord/test/cases/calculations_test.rb
@@ -1228,22 +1228,13 @@ class CalculationsTest < ActiveRecord::TestCase
   end
 
   def test_pluck_functions_without_alias
-    expected = if current_adapter?(:PostgreSQLAdapter)
-      # PostgreSQL returns the same name for each column in the given query, so each column is named "coalesce"
-      # As a result Rails cannot accurately type cast each value.
-      # To work around this, you should use aliases in your select statement (see test_pluck_functions_with_alias).
-      [
-        ["1", "The First Topic"], ["2", "The Second Topic of the day"],
-        ["3", "The Third Topic of the day"], ["4", "The Fourth Topic of the day"],
-        ["5", "The Fifth Topic of the day"]
-      ]
-    else
-      [
-        [1, "The First Topic"], [2, "The Second Topic of the day"],
-        [3, "The Third Topic of the day"], [4, "The Fourth Topic of the day"],
-        [5, "The Fifth Topic of the day"]
-      ]
-    end
+    expected = [
+      [1, "The First Topic"],
+      [2, "The Second Topic of the day"],
+      [3, "The Third Topic of the day"],
+      [4, "The Fourth Topic of the day"],
+      [5, "The Fifth Topic of the day"]
+    ]
 
     assert_equal expected, Topic.order(:id).pluck(
       Arel.sql("COALESCE(id, 0)"),

--- a/activerecord/test/cases/calculations_test.rb
+++ b/activerecord/test/cases/calculations_test.rb
@@ -848,7 +848,7 @@ class CalculationsTest < ActiveRecord::TestCase
     assert_equal [ topic.last_read ], relation.pluck(:last_read)
     assert_equal [ topic.written_on ], relation.pluck(:written_on)
     assert_equal(
-      [[Topic.minimum(:written_on), Topic.minimum(:replies_count)]],
+      [[topic.written_on, topic.replies_count]],
       relation.pluck("min(written_on)", "min(replies_count)")
     )
   end

--- a/activerecord/test/cases/calculations_test.rb
+++ b/activerecord/test/cases/calculations_test.rb
@@ -847,6 +847,10 @@ class CalculationsTest < ActiveRecord::TestCase
     assert_equal [ topic.approved ], relation.pluck(:approved)
     assert_equal [ topic.last_read ], relation.pluck(:last_read)
     assert_equal [ topic.written_on ], relation.pluck(:written_on)
+    assert_equal(
+      [[Topic.minimum(:written_on), Topic.minimum(:replies_count)]],
+      relation.pluck("min(written_on)", "min(replies_count)")
+    )
   end
 
   def test_pluck_type_cast_with_conflict_column_names


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created to fix #51991 

### Detail

This Pull Request changes 

https://github.com/rails/rails/blob/eddf8465f66ca4fc92ec9ca615cfa87db0910e25/activerecord/lib/active_record/relation/calculations.rb#L316-L318

Pluck method internally calls this method which is responsible for the incorrect result.

https://github.com/rails/rails/blob/eddf8465f66ca4fc92ec9ca615cfa87db0910e25/activerecord/lib/active_record/relation/calculations.rb#L592

**What's the problem with this code?**

Let me take an example:

When we execute this code the test fails:
```ruby
assert_equal [['2024/05/31/11_12.a2b3c4d5.txt', DateTime.parse('2024-05-31 11:12:00')]], FilePart.pluck('min(part_name)', 'min(part_start_at)')
```
```ruby
  1) Failure:
BugTest#test_pluck_with_multiple_min [51991.rb:61]:
--- expected
+++ actual
@@ -1 +1 @@
-[["2024/05/31/11_12.a2b3c4d5.txt", Fri, 31 May 2024 11:12:00 +0000]]
+[[2024-05-31 00:00:00 UTC, 2024-05-31 11:12:00 UTC]]
```

**Why is this test failing?**

If we examine the output, the `part_name` field is also being cast as a timestamp.

Why is `part_name` getting cast as a timestamp?

To understand this, we need to look at this piece of code 
https://github.com/rails/rails/blob/eddf8465f66ca4fc92ec9ca615cfa87db0910e25/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb#L63-L74

Here, we are creating the `types` hash for each field required in the pluck result. Each field will have a corresponding type. Correct?

However, the issue lies in the fact that in our case, both columns have the `min` function applied, so our `fields = result.fields` will have the value:

```ruby
fields == ["min", "min"]
```

Hence, when creating the key with `min`, it will be overridden by `part_start_at`.

In the following code, we are filtering out the type based on the `name`, which will give the same type (timestamp) for columns with the same name.
https://github.com/rails/rails/blob/eddf8465f66ca4fc92ec9ca615cfa87db0910e25/activerecord/lib/active_record/relation/calculations.rb#L592

**Solution:**

With [this commit](https://github.com/rails/rails/commit/100c86c00eefc69661e9abdfcb6e0a4a2b46676e), 

https://github.com/rails/rails/blob/eddf8465f66ca4fc92ec9ca615cfa87db0910e25/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb#L70-L70
since we are also storing the type based on the column or field index, it's better to utilize that for a more accurate result.

Hence we change the line to

**Before:**
```ruby
  result.column_types[name] || Type.default_value
```
**After:**
```ruby
  result.column_types[i] || Type.default_value
```


### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #51991 ]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
