### PR TITLE
Make `.current_transaction` return a proxy rather than the real transaction

### DIFF
--- a/activerecord/lib/active_record.rb
+++ b/activerecord/lib/active_record.rb
@@ -86,7 +86,7 @@ module ActiveRecord
   autoload :Timestamp
   autoload :TokenFor
   autoload :TouchLater
-  autoload :Transaction
+  autoload :TransactionState
   autoload :Transactions
   autoload :Translation
   autoload :Validations

--- a/activerecord/lib/active_record/transactions.rb
+++ b/activerecord/lib/active_record/transactions.rb
@@ -241,9 +241,9 @@ module ActiveRecord
       # An object is always returned, whether or not a transaction is currently active.
       # To check if a transaction was opened, use <tt>current_transaction.open?</tt>.
       #
-      # See the ActiveRecord::Transaction documentation for detailed behavior.
+      # See the ActiveRecord::TransactionState documentation for detailed behavior.
       def current_transaction
-        connection_pool.active_connection&.current_transaction || ConnectionAdapters::TransactionManager::NULL_TRANSACTION
+        TransactionState.new(connection_pool)
       end
 
       def before_commit(*args, &block) # :nodoc:


### PR DESCRIPTION
Ref: https://github.com/rails/rails/pull/51968#issuecomment-2146695970

There is some concerns about the API being misused. By returning a proxy object we make this impossible.
