### PR TITLE
Allow users to add transaction callbacks after commit etc

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -356,7 +356,7 @@ module ActiveRecord
           if isolation
             raise ActiveRecord::TransactionIsolationError, "cannot set isolation when joining a transaction"
           end
-          yield current_transaction
+          yield current_transaction.user_transaction
         else
           within_new_transaction(isolation: isolation, joinable: joinable, &block)
         end

--- a/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb
@@ -277,7 +277,7 @@ module ActiveRecord
             type_casted_binds: -> { type_casted_binds(binds) },
             name: name,
             connection: self,
-            transaction: current_transaction.presence,
+            transaction: current_transaction.user_transaction.presence,
             cached: true
           }
         end

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -1118,7 +1118,7 @@ module ActiveRecord
             statement_name:    statement_name,
             async:             async,
             connection:        self,
-            transaction:       current_transaction.presence,
+            transaction:       current_transaction.user_transaction.presence,
             row_count:         0,
             &block
           )

--- a/activerecord/lib/active_record/transactions.rb
+++ b/activerecord/lib/active_record/transactions.rb
@@ -243,7 +243,7 @@ module ActiveRecord
       #
       # See the ActiveRecord::Transaction documentation for detailed behavior.
       def current_transaction
-        connection_pool.active_connection&.current_transaction || ConnectionAdapters::TransactionManager::NULL_TRANSACTION
+        connection_pool.active_connection&.current_transaction&.user_transaction || Transaction::NULL_TRANSACTION
       end
 
       def before_commit(*args, &block) # :nodoc:

--- a/activerecord/test/cases/transactions_test.rb
+++ b/activerecord/test/cases/transactions_test.rb
@@ -1660,23 +1660,23 @@ end if Topic.lease_connection.supports_savepoints?
 class TransactionUUIDTest < ActiveRecord::TestCase
   def test_the_uuid_is_lazily_computed
     Topic.transaction do
-      transaction = Topic.connection.current_transaction
+      transaction = Topic.current_transaction
       assert_nil transaction.instance_variable_get(:@uuid)
     end
   end
 
   def test_the_uuid_for_regular_transactions_is_generated_and_memoized
     Topic.transaction do
-      transaction = Topic.connection.current_transaction
+      transaction = Topic.current_transaction
       uuid = transaction.uuid
       assert_match(/\A[[:xdigit:]]{8}-(?:[[:xdigit:]]{4}-){3}[[:xdigit:]]{12}\z/, uuid)
       assert_equal uuid, transaction.uuid
     end
   end
 
-  def test_the_uuid_for_null_transactions_is_the_nil_uuid
-    null_transaction = ActiveRecord::ConnectionAdapters::TransactionManager::NULL_TRANSACTION
-    assert_equal Digest::UUID.nil_uuid, null_transaction.uuid
+  def test_the_uuid_for_null_transactions_is_nil
+    null_transaction = ActiveRecord::Transaction::NULL_TRANSACTION
+    assert_nil null_transaction.uuid
   end
 end
 


### PR DESCRIPTION
Alternate take on #52016 

Instead of a proxy object representing the always-instantaneous transaction state, here I'm going the other way, and giving the user an object that will always reference the _current_ state of the then-current transaction at the time of creation. 

That means it will behave reasonably even if they do something thoroughly unreasonable, like add a callback after the transaction has already committed / rolled back. 

Definitely needs some tidying to be mergeable: at minimum I've lost the callback docs by moving them into a nodoc class -- and I haven't added tests that show the ways this differs from current HEAD behaviour. 


