### PR TITLE
Remove the default network from the devcontainer compose

### DIFF
--- a/.devcontainer/compose.yaml
+++ b/.devcontainer/compose.yaml
@@ -12,10 +12,6 @@ services:
     # Overrides default command so things don't shut down after the process ends.
     command: sleep infinity
 
-    # Runs app on the same network as the database container, allows "forwardPorts" in devcontainer.json function.
-    networks:
-      - default
-
     depends_on:
       - postgres
       - mariadb
@@ -28,8 +24,6 @@ services:
   postgres:
     image: postgres:latest
     restart: unless-stopped
-    networks:
-      - default
     volumes:
       - postgres-data:/var/lib/postgresql/data
     environment:
@@ -40,8 +34,6 @@ services:
   mariadb:
     image: mariadb:latest
     restart: unless-stopped
-    networks:
-      - default
     volumes:
       - mariadb-data:/var/lib/mysql
     environment:
@@ -50,8 +42,6 @@ services:
   redis:
     image: redis:latest
     restart: unless-stopped
-    networks:
-      - default
     volumes:
       - redis-data:/data
 
@@ -59,11 +49,6 @@ services:
     image: memcached:latest
     restart: unless-stopped
     command: ["-m", "1024"]
-    networks:
-      - default
-
-networks:
-  default:
 
 volumes:
   postgres-data:

--- a/railties/lib/rails/generators/rails/devcontainer/templates/devcontainer/compose.yaml.tt
+++ b/railties/lib/rails/generators/rails/devcontainer/templates/devcontainer/compose.yaml.tt
@@ -12,16 +12,11 @@ services:
     # Overrides default command so things don't shut down after the process ends.
     command: sleep infinity
 
-    networks:
-    - default
-
     # Uncomment the next line to use a non-root user for all processes.
     # user: vscode
 
     # Use "forwardPorts" in **devcontainer.json** to forward an app port locally.
     # (Adding the "ports" property to this file will not forward from a Codespace.)
-    ports:
-    - 45678:45678
 <%- if !dependencies.empty? -%>
     depends_on:
 <%- dependencies.each do |dependency| -%>
@@ -33,16 +28,12 @@ services:
   selenium:
     image: seleniarm/standalone-chromium
     restart: unless-stopped
-    networks:
-    - default
 <%- end -%>
 
 <%- if options[:redis] -%>
   redis:
     image: redis:7.2
     restart: unless-stopped
-    networks:
-    - default
     volumes:
     - redis-data:/data
 

--- a/railties/test/fixtures/.devcontainer/compose-minimal.yaml
+++ b/railties/test/fixtures/.devcontainer/compose-minimal.yaml
@@ -9,6 +9,3 @@ services:
 
     # Overrides default command so things don't shut down after the process ends.
     command: sleep infinity
-
-    networks:
-    - default

--- a/railties/test/fixtures/.devcontainer/compose.yaml
+++ b/railties/test/fixtures/.devcontainer/compose.yaml
@@ -10,16 +10,11 @@ services:
     # Overrides default command so things don't shut down after the process ends.
     command: sleep infinity
 
-    networks:
-    - default
-
     # Uncomment the next line to use a non-root user for all processes.
     # user: vscode
 
     # Use "forwardPorts" in **devcontainer.json** to forward an app port locally.
     # (Adding the "ports" property to this file will not forward from a Codespace.)
-    ports:
-    - 45678:45678
     depends_on:
     - selenium
     - redis
@@ -27,19 +22,12 @@ services:
   selenium:
     image: seleniarm/standalone-chromium
     restart: unless-stopped
-    networks:
-    - default
 
   redis:
     image: redis:7.2
     restart: unless-stopped
-    networks:
-    - default
     volumes:
     - redis-data:/data
-
-
-
 
 volumes:
   redis-data:

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -1240,8 +1240,6 @@ class AppGeneratorTest < Rails::Generators::TestCase
         },
         "volumes" => ["../..:/workspaces:cached"],
         "command" => "sleep infinity",
-        "networks" => ["default"],
-        "ports" => ["45678:45678"],
         "depends_on" => ["selenium", "redis"]
       }
 
@@ -1250,7 +1248,6 @@ class AppGeneratorTest < Rails::Generators::TestCase
       expected_selenium_conifg = {
         "image" => "seleniarm/standalone-chromium",
         "restart" => "unless-stopped",
-        "networks" => ["default"]
       }
 
       assert_equal expected_selenium_conifg, compose_config["services"]["selenium"]
@@ -1258,7 +1255,6 @@ class AppGeneratorTest < Rails::Generators::TestCase
       expected_redis_config = {
         "image" => "redis:7.2",
         "restart" => "unless-stopped",
-        "networks" => ["default"],
         "volumes" => ["redis-data:/data"]
       }
 


### PR DESCRIPTION
And stop exposing the capybara server port to all interfaces.

We were using this just to make sure the selenium container can access the capybara server but it can with the default bridge network.