### PR TITLE
Add an explicit dependency on the `logger` gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -93,6 +93,7 @@ PATH
       connection_pool (>= 2.2.5)
       drb
       i18n (>= 1.6, < 2)
+      logger
       minitest (>= 5.1)
       tzinfo (~> 2.0, >= 2.0.5)
     rails (8.0.0.alpha)
@@ -325,6 +326,7 @@ GEM
     listen (3.8.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
+    logger (1.6.0)
     loofah (2.22.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)

--- a/actionview/test/template/template_test.rb
+++ b/actionview/test/template/template_test.rb
@@ -2,7 +2,6 @@
 # frozen_string_literal: true
 
 require "abstract_unit"
-require "logger"
 
 class TestERBTemplate < ActiveSupport::TestCase
   ERBHandler = ActionView::Template::Handlers::ERB.new

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,2 +1,5 @@
+*   Add `logger` as a dependency since it is a bundled gem candidate for Ruby 3.5
+
+    *Earlopain*
 
 Please check [7-2-stable](https://github.com/rails/rails/blob/7-2-stable/activesupport/CHANGELOG.md) for previous changes.

--- a/activesupport/activesupport.gemspec
+++ b/activesupport/activesupport.gemspec
@@ -42,4 +42,5 @@ Gem::Specification.new do |s|
   s.add_dependency "base64"
   s.add_dependency "drb"
   s.add_dependency "bigdecimal"
+  s.add_dependency "logger"
 end

--- a/activesupport/lib/active_support/tagged_logging.rb
+++ b/activesupport/lib/active_support/tagged_logging.rb
@@ -2,7 +2,6 @@
 
 require "active_support/core_ext/module/delegation"
 require "active_support/core_ext/object/blank"
-require "logger"
 require "active_support/logger"
 
 module ActiveSupport


### PR DESCRIPTION
This is getting the same treatment as `base64`, `mutex_m`, etc. In Ruby 3.4 it will start to warn: https://github.com/ruby/ruby/commit/d7e558e3c48c213d0e8bedca4fb547db55613f7c

See for example #48907 

I also removed two requires that seem unnessesary: The test doesn't access `::Logger` and the other one requires `as/logger` right after.