### PR TITLE
Include information by whom is the deprecated code called.

### DIFF
--- a/railties/lib/rails/console/methods.rb
+++ b/railties/lib/rails/console/methods.rb
@@ -2,21 +2,23 @@
 
 module Rails
   module ConsoleMethods
-    def self.include(_mod, ...)
-      raise_deprecation_warning
+    def self.include(mod, ...)
+      raise_deprecation_warning(mod)
       super
     end
 
-    def self.method_added(_method_name)
-      raise_deprecation_warning
+    def self.method_added(method_name)
+      raise_deprecation_warning(method_name)
       super
     end
 
-    def self.raise_deprecation_warning
+    def self.raise_deprecation_warning(offender)
       Rails.deprecator.warn(<<~MSG, caller_locations(1..1))
         Extending Rails console through `Rails::ConsoleMethods` is deprecated and will be removed in Rails 7.3.
         Please directly use IRB's extension API to add new commands or helpers to the console.
         For more details, please visit: https://github.com/ruby/irb/blob/master/EXTEND_IRB.md
+
+        Called via `#{offender}`
       MSG
     end
   end

--- a/railties/test/application/console_test.rb
+++ b/railties/test/application/console_test.rb
@@ -216,6 +216,7 @@ class FullStackConsoleTest < ActiveSupport::TestCase
     spawn_console("-e development", wait_for_prompt: false)
 
     assert_output "Extending Rails console through `Rails::ConsoleMethods` is deprecated", @primary, 30
+    assert_output "Called via `AppTemplate::Application::MyConsole`", @primary, 30
     write_prompt "foo", "=> \"this is foo\""
   end
 


### PR DESCRIPTION
It helps to find the code/gem that uses deprecated API.

Enhances https://github.com/rails/rails/pull/51760

Previously when running rails console:
```
DEPRECATION WARNING: Extending Rails console through `Rails::ConsoleMethods` is deprecated and will be removed in Rails 8.0.
Please directly use IRB's extension API to add new commands or helpers to the console.
For more details, please visit: https://github.com/ruby/irb/blob/master/EXTEND_IRB.md
 (called from include at /home/wojtek/.asdf/installs/ruby/3.3.2/lib/ruby/gems/3.3.0/gems/railties-7.2.0.beta2/lib/rails/console/methods.rb:6)
Loading development environment (Rails 7.2.0.beta2)
```

After:
```
DEPRECATION WARNING: Extending Rails console through `Rails::ConsoleMethods` is deprecated and will be removed in Rails 8.0.
Please directly use IRB's extension API to add new commands or helpers to the console.
For more details, please visit: https://github.com/ruby/irb/blob/master/EXTEND_IRB.md

Called via `MissionControl::Jobs::Console::Helpers`
 (called from include at /home/wojtek/.asdf/installs/ruby/3.3.2/lib/ruby/gems/3.3.0/gems/railties-7.2.0.beta2/lib/rails/console/methods.rb:6)
Loading development environment (Rails 7.2.0.beta2)
```

cc @st0012 