### PR TITLE
Implement Http::Headers#http

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,17 @@
+*   Implement `Http::Headers#http` that returns the original HTTP headers
+
+    ```ruby
+    # Before
+    request.headers.env
+      .select { |key, _value| key.start_with?("HTTP_") }
+      .transform_keys { |key| key.sub(/^HTTP_/, "").split("_").map(&:capitalize).join("-") }
+
+    # After
+    request.headers.http
+    ```
+
+    *Matija Čupić*
+
 *   Add `:wasm_unsafe_eval` mapping for `content_security_policy`
 
     ```ruby

--- a/actionpack/lib/action_dispatch/http/headers.rb
+++ b/actionpack/lib/action_dispatch/http/headers.rb
@@ -117,6 +117,12 @@ module ActionDispatch
 
       def env; @req.env.dup; end
 
+      def http
+        filter_map do |k, v|
+          [ k.sub(/^HTTP_/, "").split("_").map(&:capitalize).join("-"), v ] if k.start_with?("HTTP_")
+        end
+      end
+
       private
         # Converts an HTTP header name to an environment variable name if it is not
         # contained within the headers hash.

--- a/actionpack/test/dispatch/request_test.rb
+++ b/actionpack/test/dispatch/request_test.rb
@@ -1405,6 +1405,20 @@ class RequestFormData < BaseRequestTest
   end
 end
 
+class RequestHeadersTest < BaseRequestTest
+  test "#http returns only the HTTP headers without the env prefix" do
+    request = stub_request(
+      "REQUEST_METHOD" => "POST", "CONTENT_TYPE" => "application/json",
+      "HTTP_X_FORWARDED_PROTO" => "https", "HTTP_X_FORWARDED_HOST" => "example.com:443"
+    )
+
+    assert_equal [
+      ["X-Forwarded-Proto", "https"],
+      ["X-Forwarded-Host", "example.com:443"]
+    ], request.headers.http
+  end
+end
+
 class EarlyHintsRequestTest < BaseRequestTest
   def setup
     super


### PR DESCRIPTION
### Motivation / Background

Sometimes in Rails application we want to forward a request elsewhere along with its original HTTP headers. There is no elegant way to do this currently, because all the header names are converted to env names in `Http::Headers`.

Here is a sample solution for the problem above prior to this change:

```ruby
request.headers.env
  .select { |key, _value| key.start_with?("HTTP_") }
  .transform_keys { |key| key.sub(/^HTTP_/, "").split("_").map(&:capitalize).join("-") }
```

This method returns only HTTP headers. This is useful when you receive a request and want to forward it elsewhere, along with the original headers.

### Detail

This Pull Request implemented a method (`Http::Headers#http`) that returns only the HTTP headers, converted back into their original format. This implementation hides the complexity further down, so the developers using the framework don't have to do it themselves.

Sample solution with this implemented:

```ruby
request.headers.http
```

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
