### PR TITLE
ActiveSupport::Delegation needs Inflector

### DIFF
--- a/activesupport/lib/active_support/delegation.rb
+++ b/activesupport/lib/active_support/delegation.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "active_support/inflector"
+
 require "set"
 
 module ActiveSupport


### PR DESCRIPTION
### Motivation / Background

We added Inflector in https://github.com/rails/rails/pull/50926 but forgot to make it a dependency. That breaks, for example, factory_bot (when loaded without a full Rails app).

A minimal reproduction is as follows:

```ruby
require "bundler/inline"

gemfile do
  gem "activesupport", "7.2.0.beta2"
end

require "active_support/core_ext/module/delegation"

module M
  module_function

  def foo = "bar"
end

class A
  delegate :foo, to: M
end

puts A.new.foo
```

Results in:

```
/ruby/gems/3.2.0/gems/activesupport-7.2.0.beta2/lib/active_support/delegation.rb:47:in `generate': uninitialized constant #<Class:ActiveSupport::Delegation>::Inflector (NameError)

          unless Inflector.safe_constantize(to.name).equal?(to)
                 ^^^^^^^^^
        from /ruby/gems/3.2.0/gems/activesupport-7.2.0.beta2/lib/active_support/core_ext/module/delegation.rb:161:in `delegate'
        from tmp/delegation.rb:16:in `<class:A>'
        from tmp/delegation.rb:15:in `<main>'
```



### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
