### PR TITLE
Don't emit to_time deprecations in known-safe contexts

### DIFF
--- a/activerecord/lib/active_record/timestamp.rb
+++ b/activerecord/lib/active_record/timestamp.rb
@@ -162,7 +162,7 @@ module ActiveRecord
 
     def max_updated_column_timestamp
       timestamp_attributes_for_update_in_model
-        .filter_map { |attr| self[attr]&.to_time }
+        .filter_map { |attr| (v = self[attr]) && (v.is_a?(::Time) ? v : v.to_time) }
         .max
     end
 

--- a/activesupport/lib/active_support/core_ext/time/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/time/calculations.rb
@@ -319,7 +319,12 @@ class Time
     if other.class == Time
       compare_without_coercion(other)
     elsif other.is_a?(Time)
-      compare_without_coercion(other.to_time)
+      # also avoid ActiveSupport::TimeWithZone#to_time before Rails 8.0
+      if other.respond_to?(:comparable_time)
+        compare_without_coercion(other.comparable_time)
+      else
+        compare_without_coercion(other.to_time)
+      end
     else
       to_datetime <=> other
     end

--- a/activesupport/lib/active_support/core_ext/time/compatibility.rb
+++ b/activesupport/lib/active_support/core_ext/time/compatibility.rb
@@ -13,4 +13,20 @@ class Time
   def to_time
     preserve_timezone ? self : getlocal
   end
+
+  def preserve_timezone # :nodoc:
+    active_support_local_zone == zone || super
+  end
+
+  private
+    @@active_support_local_tz = nil
+
+    def active_support_local_zone
+      @@active_support_local_zone = nil if @@active_support_local_tz != ENV["TZ"]
+      @@active_support_local_zone ||=
+        begin
+          @@active_support_local_tz = ENV["TZ"]
+          Time.new.zone
+        end
+    end
 end

--- a/activesupport/lib/active_support/testing/time_helpers.rb
+++ b/activesupport/lib/active_support/testing/time_helpers.rb
@@ -163,10 +163,10 @@ module ActiveSupport
           now = date_or_time.midnight.to_time
         elsif date_or_time.is_a?(String)
           now = Time.zone.parse(date_or_time)
-        elsif with_usec
-          now = date_or_time.to_time
         else
-          now = date_or_time.to_time.change(usec: 0)
+          now = date_or_time
+          now = now.to_time unless now.is_a?(Time)
+          now = now.change(usec: 0) unless with_usec
         end
 
         # +now+ must be in local system timezone, because +Time.at(now)+

--- a/activesupport/lib/active_support/time_with_zone.rb
+++ b/activesupport/lib/active_support/time_with_zone.rb
@@ -332,7 +332,7 @@ module ActiveSupport
     #
     def -(other)
       if other.acts_like?(:time)
-        to_time - other.to_time
+        getutc - other.getutc
       elsif duration_of_variable_length?(other)
         method_missing(:-, other)
       else

--- a/activesupport/test/core_ext/date_and_time_compatibility_test.rb
+++ b/activesupport/test/core_ext/date_and_time_compatibility_test.rb
@@ -43,6 +43,35 @@ class DateAndTimeCompatibilityTest < ActiveSupport::TestCase
     end
   end
 
+  def test_time_to_time_without_preserve_configured
+    with_preserve_timezone(nil) do
+      with_env_tz "US/Eastern" do
+        source = Time.new(2016, 4, 23, 15, 11, 12)
+        # No warning because it's already local
+        base_time = source.to_time
+
+        utc_time = base_time.getutc
+        converted_time = assert_deprecated(ActiveSupport.deprecator) { utc_time.to_time }
+
+        assert_equal source, base_time
+        assert_equal source, converted_time
+        assert_equal @system_offset, base_time.utc_offset
+        assert_equal @system_offset, converted_time.utc_offset
+      end
+    end
+
+    with_preserve_timezone(nil) do
+      with_env_tz "US/Eastern" do
+        foreign_time = Time.new(2016, 4, 23, 15, 11, 12, in: "-0700")
+        converted_time = assert_deprecated(ActiveSupport.deprecator) { foreign_time.to_time }
+
+        assert_equal foreign_time, converted_time
+        assert_equal @system_offset, converted_time.utc_offset
+        assert_not_equal foreign_time.utc_offset, converted_time.utc_offset
+      end
+    end
+  end
+
   def test_time_to_time_frozen_preserves_timezone
     with_preserve_timezone(true) do
       with_env_tz "US/Eastern" do

--- a/activesupport/test/core_ext/time_with_zone_test.rb
+++ b/activesupport/test/core_ext/time_with_zone_test.rb
@@ -433,6 +433,16 @@ class TimeWithZoneTest < ActiveSupport::TestCase
     assert_equal 86_400.0,  twz2 - twz1
   end
 
+  def test_minus_with_time_with_zone_without_preserve_configured
+    with_preserve_timezone(nil) do
+      twz1 = ActiveSupport::TimeWithZone.new(Time.utc(2000, 1, 1), ActiveSupport::TimeZone["UTC"])
+      twz2 = ActiveSupport::TimeWithZone.new(Time.utc(2000, 1, 2), ActiveSupport::TimeZone["UTC"])
+
+      difference = assert_not_deprecated(ActiveSupport.deprecator) { twz2 - twz1 }
+      assert_equal 86_400.0, difference
+    end
+  end
+
   def test_minus_with_time_with_zone_precision
     twz1 = ActiveSupport::TimeWithZone.new(Time.utc(2000, 1, 1, 0, 0, 0, Rational(1, 1000)), ActiveSupport::TimeZone["UTC"])
     twz2 = ActiveSupport::TimeWithZone.new(Time.utc(2000, 1, 1, 23, 59, 59, Rational(999999999, 1000)), ActiveSupport::TimeZone["UTC"])


### PR DESCRIPTION
I realised that #51994 was producing a deprecation warning while running the Active Record tests (I actually thought we'd made that fail CI, but I must be mis-remembering).

While we could just explicitly opt in to the new setting within our test suite(s), I wanted to see if we could save similar callers [i.e. those that aren't particularly concerned with time zones] from having to know about / act upon the change at all.


Mostly that comes down to the fact that for `Time#to_time`, if the value is already a local time, there's no difference in behaviour, and so no need to warn.

Correspondingly, I've avoided calling `to_time` in the handful of places we were using it internally: it's easy to do, and we know we don't care about the zone, so again won't be affected by the change.

I'm hoping this will mean that people who do see the deprecation are likely to actually be affected [or at least be genuinely at risk of being affected] by the change, thus justifying the disruption.

It's worth noting that I currently have _not_ changed `ActiveSupport::TimeWithZone#to_time`: even when its zone matches local (including the most common case where both are UTC), we will still warn. That felt like the right choice at the time, though I'm now less sure... `3.days.ago.to_time` seems like a pretty reasonable and ordinary thing to be doing, and (in the absence of any zone-related configuration) I believe it should be perfectly safe. :thinking:

