### PR TITLE
Changelog tweak for lazy routes

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -5,6 +5,9 @@
     Previously, this was executed unconditionally on boot, which can
     slow down boot time unnecessarily for larger apps with lots of routes.
 
+    Environments like production that have `config.eager_load = true` will
+    continue to eagerly load routes on boot.
+
     *Gannon McGibbon*
 
 *   Add Rubocop and GitHub Actions to plugin generator.


### PR DESCRIPTION
### Motivation / Background

Adds context to the changelog that eager-loaded envs will draw routes eagerly like they did previously.

### Detail

Followup for https://github.com/rails/rails/pull/52012

### Additional information

Missed this from the reverted PR. Thanks @Earlopain!

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
