### PR TITLE
Improve support for using ActiveSupport::TimeZone as a ::Time object's timezone

### DIFF
--- a/activesupport/lib/active_support/values/time_zone.rb
+++ b/activesupport/lib/active_support/values/time_zone.rb
@@ -574,6 +574,12 @@ module ActiveSupport
       tzinfo.abbr(time)
     end
 
+    # Available so that TimeZone instances respond like +TZInfo::Timezone+
+    # instances.
+    def dst?(time)
+      tzinfo.dst?(time)
+    end
+
     def init_with(coder) # :nodoc:
       initialize(coder["name"])
     end

--- a/activesupport/lib/active_support/values/time_zone.rb
+++ b/activesupport/lib/active_support/values/time_zone.rb
@@ -568,6 +568,12 @@ module ActiveSupport
       tzinfo.periods_for_local(time)
     end
 
+    # Available so that TimeZone instances respond like +TZInfo::Timezone+
+    # instances.
+    def abbr(time)
+      tzinfo.abbr(time)
+    end
+
     def init_with(coder) # :nodoc:
       initialize(coder["name"])
     end

--- a/activesupport/lib/active_support/values/time_zone.rb
+++ b/activesupport/lib/active_support/values/time_zone.rb
@@ -552,15 +552,11 @@ module ActiveSupport
       tzinfo.local_to_utc(time, dst)
     end
 
-    # Available so that TimeZone instances respond like +TZInfo::Timezone+
-    # instances.
-    def period_for_utc(time)
+    def period_for_utc(time) # :nodoc:
       tzinfo.period_for_utc(time)
     end
 
-    # Available so that TimeZone instances respond like +TZInfo::Timezone+
-    # instances.
-    def period_for_local(time, dst = true)
+    def period_for_local(time, dst = true) # :nodoc:
       tzinfo.period_for_local(time, dst) { |periods| periods.last }
     end
 
@@ -568,15 +564,11 @@ module ActiveSupport
       tzinfo.periods_for_local(time)
     end
 
-    # Available so that TimeZone instances respond like +TZInfo::Timezone+
-    # instances.
-    def abbr(time)
+    def abbr(time) # :nodoc:
       tzinfo.abbr(time)
     end
 
-    # Available so that TimeZone instances respond like +TZInfo::Timezone+
-    # instances.
-    def dst?(time)
+    def dst?(time) # :nodoc:
       tzinfo.dst?(time)
     end
 

--- a/activesupport/test/time_zone_test.rb
+++ b/activesupport/test/time_zone_test.rb
@@ -886,4 +886,38 @@ class TimeZoneTest < ActiveSupport::TestCase
     assert_equal "EST", zone.abbr(Time.utc(2000, 10, 29, 6))
     assert_equal "EST", zone.abbr(Time.utc(2000, 10, 29, 7))
   end
+
+  def test_dst
+    zone = ActiveSupport::TimeZone["America/Toronto"]
+    assert_equal false, zone.dst?(Time.utc(2000, 4, 2, 6))
+    assert_equal true,  zone.dst?(Time.utc(2000, 4, 2, 7))
+    assert_equal true,  zone.dst?(Time.utc(2000, 4, 2, 8))
+    assert_equal true,  zone.dst?(Time.utc(2000, 10, 29, 5))
+    assert_equal false, zone.dst?(Time.utc(2000, 10, 29, 6))
+    assert_equal false, zone.dst?(Time.utc(2000, 10, 29, 7))
+  end
+
+  def test_works_as_ruby_time_zone
+    zone = ActiveSupport::TimeZone["America/Toronto"]
+    time = Time.new(2000, 1, 1, 1, in: zone)
+    assert_same zone, time.zone
+    assert_equal "2000-01-01T01:00:00-05:00", time.iso8601
+    assert_equal(-18000, time.utc_offset)
+    assert_equal "EST", time.strftime("%Z")
+    assert_equal false, time.isdst
+
+    time = Time.new(2000, 6, 1, 1, in: zone)
+    assert_same zone, time.zone
+    assert_equal "2000-06-01T01:00:00-04:00", time.iso8601
+    assert_equal(-14400, time.utc_offset)
+    assert_equal "EDT", time.strftime("%Z")
+    assert_equal true, time.isdst
+
+    time = Time.at(959835600, in: zone)
+    assert_same zone, time.zone
+    assert_equal "2000-06-01T01:00:00-04:00", time.iso8601
+    assert_equal(-14400, time.utc_offset)
+    assert_equal "EDT", time.strftime("%Z")
+    assert_equal true, time.isdst
+  end
 end

--- a/activesupport/test/time_zone_test.rb
+++ b/activesupport/test/time_zone_test.rb
@@ -876,4 +876,14 @@ class TimeZoneTest < ActiveSupport::TestCase
     loaded = YAML.respond_to?(:unsafe_load) ? YAML.unsafe_load(payload) : YAML.load(payload)
     assert_equal(ActiveSupport::TimeZone["Pacific/Honolulu"], loaded)
   end
+
+  def test_abbr
+    zone = ActiveSupport::TimeZone["America/Toronto"]
+    assert_equal "EST", zone.abbr(Time.utc(2000, 4, 2, 6))
+    assert_equal "EDT", zone.abbr(Time.utc(2000, 4, 2, 7))
+    assert_equal "EDT", zone.abbr(Time.utc(2000, 4, 2, 8))
+    assert_equal "EDT", zone.abbr(Time.utc(2000, 10, 29, 5))
+    assert_equal "EST", zone.abbr(Time.utc(2000, 10, 29, 6))
+    assert_equal "EST", zone.abbr(Time.utc(2000, 10, 29, 7))
+  end
 end


### PR DESCRIPTION
As of Ruby 2.6, [::Time supports rich timezone objects](https://bugs.ruby-lang.org/issues/14850) and expects them to follow a similar API to tzinfo. Mostly we already do this with ActiveSupport::TimeZone, delegating to the underlying tzinfo object so this mostly already works.

```
>> Time.new(2024, 9, 26, 10, in: ActiveSupport::TimeZone["America/Toronto"])
=> 2024-09-26 10:00:00 -0400
```

However we were missing [two optional methods Ruby would like to have used](https://ruby-doc.org/3.3.2/Time.html#class-Time-label-Timezone+Objects): `abbr` and `dist?`.

Calling strftime with "%Z" will try the following on the timezone:
* zone.abbr(time)
* zone.strftime("%Z", time)
* zone.name

Because we previously only implemented name, a `::Time` created with an `ActiveSupport::TimeZone` would "abbreviate" awkwardly to the full tz identifier (like "12:34:00 America/Vancouver" instead of "12:34:00 PDT"). This PR implements abbr to make these Times format the same way as `TimeWithZone`.

cc @jasonkim @matthewd 