### PR TITLE
Dockerfile - Bundle without both development & test

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/Dockerfile.tt
+++ b/railties/lib/rails/generators/rails/app/templates/Dockerfile.tt
@@ -22,7 +22,7 @@ RUN apt-get update -qq && \
 ENV RAILS_ENV="production" \
     BUNDLE_DEPLOYMENT="1" \
     BUNDLE_PATH="/usr/local/bundle" \
-    BUNDLE_WITHOUT="development"
+    BUNDLE_WITHOUT="development test"
 
 # Throw-away build stage to reduce size of final image
 FROM base as build


### PR DESCRIPTION
### Motivation / Background

Given the Dockerfile is intended for production deployment I think we should also skip the `test` group by default.

https://bundler.io/v2.5/man/bundle-config.1.html
> without
> A space-separated list of groups referencing gems to skip during installation.
