### PR TITLE
Improve error message when passing a proc to `assert_difference` or `assert_changes`

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,6 @@
+*   Improve error message when using `assert_difference` or `assert_changes` with a
+    proc by printing the proc's source code (MRI only).
 
+    *Richard Böhme*, *Jean Boussier*
 
 Please check [7-2-stable](https://github.com/rails/rails/blob/7-2-stable/activesupport/CHANGELOG.md) for previous changes.

--- a/activesupport/lib/active_support/testing/assertions.rb
+++ b/activesupport/lib/active_support/testing/assertions.rb
@@ -118,7 +118,8 @@ module ActiveSupport
 
         expressions.zip(exps, before) do |(code, diff), exp, before_value|
           actual = exp.call
-          error  = "#{code.inspect} didn't change by #{diff}, but by #{actual - before_value}"
+          code_string = code.respond_to?(:call) ? _callable_to_source_string(code) : code
+          error  = "`#{code_string}` didn't change by #{diff}, but by #{actual - before_value}"
           error  = "#{message}.\n#{error}" if message
           assert_equal(before_value + diff, actual, error)
         end
@@ -202,7 +203,8 @@ module ActiveSupport
 
         after = exp.call
 
-        error = "#{expression.inspect} didn't change"
+        code_string = expression.respond_to?(:call) ? _callable_to_source_string(expression) : expression
+        error = "`#{code_string}` didn't change"
         error = "#{error}. It was already #{to.inspect}" if before == to
         error = "#{message}.\n#{error}" if message
         refute_equal before, after, error
@@ -249,7 +251,8 @@ module ActiveSupport
 
         after = exp.call
 
-        error = "#{expression.inspect} changed"
+        code_string = expression.respond_to?(:call) ? _callable_to_source_string(expression) : expression
+        error = "`#{code_string}` changed"
         error = "#{message}.\n#{error}" if message
 
         if before.nil?
@@ -275,6 +278,36 @@ module ActiveSupport
           end
 
           raise
+        end
+
+        def _callable_to_source_string(callable)
+          if defined?(RubyVM::AbstractSyntaxTree) && callable.is_a?(Proc)
+            ast = begin
+              RubyVM::AbstractSyntaxTree.of(callable, keep_script_lines: true)
+            rescue SystemCallError
+              # Failed to get the source somehow
+              return callable
+            end
+            return callable unless ast
+
+            source = ast.source
+            source.strip!
+
+            # We ignore procs defined with do/end as they are likely multi-line anyway.
+            if source.start_with?("{")
+              source.delete_suffix!("}")
+              source.delete_prefix!("{")
+              source.strip!
+              # It won't read nice if the callable contains multiple
+              # lines, and it should be a rare occurence anyway.
+              # Same if it takes arguments.
+              if !source.include?("\n") && !source.start_with?("|")
+                return source
+              end
+            end
+          end
+
+          callable
         end
     end
   end

--- a/activesupport/test/test_case_test.rb
+++ b/activesupport/test/test_case_test.rb
@@ -54,7 +54,7 @@ class AssertionsTest < ActiveSupport::TestCase
         @object.increment
       end
     end
-    assert_equal "\"@object.num\" didn't change by 0, but by 1.\nExpected: 0\n  Actual: 1", error.message
+    assert_equal "`@object.num` didn't change by 0, but by 1.\nExpected: 0\n  Actual: 1", error.message
   end
 
   def test_assert_no_difference_with_message_fail
@@ -63,7 +63,7 @@ class AssertionsTest < ActiveSupport::TestCase
         @object.increment
       end
     end
-    assert_equal "Object Changed.\n\"@object.num\" didn't change by 0, but by 1.\nExpected: 0\n  Actual: 1", error.message
+    assert_equal "Object Changed.\n`@object.num` didn't change by 0, but by 1.\nExpected: 0\n  Actual: 1", error.message
   end
 
   def test_assert_no_difference_with_multiple_expressions_pass
@@ -157,7 +157,7 @@ class AssertionsTest < ActiveSupport::TestCase
         @object.increment
       end
     end
-    assert_equal "Object Changed.\n\"@object.num\" didn't change by 0, but by 1.\nExpected: 0\n  Actual: 1", error.message
+    assert_equal "Object Changed.\n`@object.num` didn't change by 0, but by 1.\nExpected: 0\n  Actual: 1", error.message
   end
 
   def test_assert_difference_message_includes_change
@@ -167,7 +167,17 @@ class AssertionsTest < ActiveSupport::TestCase
         @object.increment
       end
     end
-    assert_equal "\"@object.num\" didn't change by 5, but by 2.\nExpected: 5\n  Actual: 2", error.message
+    assert_equal "`@object.num` didn't change by 5, but by 2.\nExpected: 5\n  Actual: 2", error.message
+  end
+
+  def test_assert_difference_message_with_lambda
+    skip if !defined?(RubyVM::AbstractSyntaxTree)
+
+    error = assert_raises Minitest::Assertion do
+      assert_difference(-> { @object.num }, 1, "Object Changed") do
+      end
+    end
+    assert_equal "Object Changed.\n`@object.num` didn't change by 1, but by 0.\nExpected: 1\n  Actual: 0", error.message
   end
 
   def test_hash_of_lambda_expressions
@@ -233,7 +243,19 @@ class AssertionsTest < ActiveSupport::TestCase
       end
     end
 
-    assert_equal "\"@object.num\" didn't change. It was already 0.\nExpected 0 to not be equal to 0.", error.message
+    assert_equal "`@object.num` didn't change. It was already 0.\nExpected 0 to not be equal to 0.", error.message
+  end
+
+  def test_assert_changes_message_with_lambda
+    skip if !defined?(RubyVM::AbstractSyntaxTree)
+
+    error = assert_raises Minitest::Assertion do
+      assert_changes -> { @object.num }, to: 0 do
+        # no changes
+      end
+    end
+
+    assert_equal "`@object.num` didn't change. It was already 0.\nExpected 0 to not be equal to 0.", error.message
   end
 
   def test_assert_changes_with_wrong_to_option
@@ -349,7 +371,91 @@ class AssertionsTest < ActiveSupport::TestCase
       end
     end
 
-    assert_equal "@object.num should not change.\n\"@object.num\" changed.\nExpected: 0\n  Actual: 1", error.message
+    assert_equal "@object.num should not change.\n`@object.num` changed.\nExpected: 0\n  Actual: 1", error.message
+  end
+
+  def test_assert_no_changes_message_with_lambda
+    skip if !defined?(RubyVM::AbstractSyntaxTree)
+
+    error = assert_raises Minitest::Assertion do
+      assert_no_changes -> { @object.num } do
+        @object.increment
+      end
+    end
+    assert_equal "`@object.num` changed.\nExpected: 0\n  Actual: 1", error.message
+
+    check = Proc.new {
+      @object.num
+    }
+    error = assert_raises Minitest::Assertion do
+      assert_no_changes check do
+        @object.increment
+      end
+    end
+    assert_equal "`@object.num` changed.\nExpected: 1\n  Actual: 2", error.message
+
+    check = lambda {
+      @object.num
+    }
+    error = assert_raises Minitest::Assertion do
+      assert_no_changes check do
+        @object.increment
+      end
+    end
+    assert_equal "`@object.num` changed.\nExpected: 2\n  Actual: 3", error.message
+
+    error = assert_raises Minitest::Assertion do
+      assert_no_changes -> { @object.num } do
+        @object.increment
+      end
+    end
+    assert_equal "`@object.num` changed.\nExpected: 3\n  Actual: 4", error.message
+
+    error = assert_raises Minitest::Assertion do
+      assert_no_changes ->(a = nil) { @object.num } do
+        @object.increment
+      end
+    end
+    assert_match(/#<Proc:0x.*changed/, error.message)
+  end
+
+  def test_assert_no_changes_message_with_multi_line_lambda
+    check = lambda {
+      "title".upcase
+      @object.num
+    }
+    error = assert_raises Minitest::Assertion do
+      assert_no_changes check do
+        @object.increment
+      end
+    end
+    assert_match(/#<Proc:0x.*changed/, error.message)
+
+    check = lambda {
+      "title".upcase
+      @object.num
+    }
+    error = assert_raises Minitest::Assertion do
+      assert_no_changes check do
+        @object.increment
+      end
+    end
+    assert_match(/#<Proc:0x.*changed/, error.message)
+  end
+
+  def test_assert_no_changes_message_with_not_real_callable
+    check = Object.new
+    def check.call
+      @object.num
+    end
+    check.instance_variable_set(:@object, @object)
+
+    error = assert_raises Minitest::Assertion do
+      assert_no_changes check do
+        @object.increment
+      end
+    end
+    assert_match(/#<Object:0x.*changed/, error.message)
   end
 
   def test_assert_no_changes_with_long_string_wont_output_everything
@@ -362,7 +468,7 @@ class AssertionsTest < ActiveSupport::TestCase
     end
 
     assert_match <<~output, error.message
-      "lines" changed.
+      `lines` changed.
       --- expected
       +++ actual
       @@ -10,4 +10,5 @@
@@ -403,7 +509,7 @@ class ExceptionsInsideAssertionsTest < ActiveSupport::TestCase
       run_test_that_should_fail_but_not_log_a_warning
     end
     assert_not @out.string.include?("assert_nothing_raised")
-    assert error.message.include?("(lambda)> changed")
+    assert error.message.include?("`rand` changed")
   end
 
   def test_fails_and_warning_is_logged_if_wrong_error_caught


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

In our team we often discuss if it's better to pass a string or a proc to `assert_difference`. In my opinion it's better to pass a proc because linters and IDEs can analyze the ruby code in the proc. However one disadvantage is that the error message is less clear when using a proc, because the message just prints the inspect-output of the `Proc` object. 

To fix this, I propose this PR which prints the source of the proc instead.

### Detail

This Pull Request changes the error message of `assert_difference`, `assert_no_difference`, `assert_changes` and `assert_no_changes` when using MRI and when passing a proc to those assertions. It leverages the _experimental_ `RubyVM::AbstractSyntaxTree` api to print the source code of the proc which makes it easier to spot why the test failed.

For example consider the following test:

```ruby
test "see proc output" do
  assert_difference -> { 1 } do
  end
end
```

Previous output:

```
#<Proc:0x000074357846eae8 /home/richard/my-test-app/test/models/test.rb:21 (lambda)> didn't change by 1, but by 0.
Expected: 2
  Actual: 1

```

Output with this change:
```
"-> { 1 }" didn't change by 1, but by 0.
Expected: 2
  Actual: 1
```

Note that this only works in MRI because other ruby implementations do not implement the `RubyVM::AbstractSyntaxTree` api.

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

I'm not sure if Rails wants to "depend" on an experimental api like `RubyVM::AbstractSyntaxTree` because it might not be stable and change in the future. I think this change brings value to Rails but I understand if there is a policy about not using experimental ruby apis. In this case we can close this PR.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
