### PR TITLE
Pin `sprockets-rails` version to 3.4.2 or lower

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gem "minitest", ">= 5.15.0"
 # We need a newish Rake since Active Job sets its test tasks' descriptions.
 gem "rake", ">= 13"
 
-gem "sprockets-rails", ">= 2.0.0", require: false
+gem "sprockets-rails", ">= 2.0.0", "< 3.5.0", require: false
 gem "propshaft", ">= 0.1.7"
 gem "capybara", ">= 3.39"
 gem "selenium-webdriver", ">= 4.20.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -683,7 +683,7 @@ DEPENDENCIES
   selenium-webdriver (>= 4.20.0)
   sidekiq
   sneakers
-  sprockets-rails (>= 2.0.0)
+  sprockets-rails (>= 2.0.0, < 3.5.0)
   sqlite3 (>= 1.6.6)
   stackprof
   stimulus-rails


### PR DESCRIPTION
### Motivation / Background

This commit pins `sprockets-rails` version to 3.4.2 until https://github.com/rails/sprockets-rails/issues/524 is fixed to workaround CI failure reported at https://github.com/rails/rails/issues/52038

### Detail
None

### Additional information
None

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
