### PR TITLE
Rails::ConsoleMethods deprecation warning should point to the source

### DIFF
--- a/railties/lib/rails/console/methods.rb
+++ b/railties/lib/rails/console/methods.rb
@@ -13,7 +13,7 @@ module Rails
     end
 
     def self.raise_deprecation_warning
-      Rails.deprecator.warn(<<~MSG, caller_locations(1..1))
+      Rails.deprecator.warn(<<~MSG, caller_locations(2..2))
         Extending Rails console through `Rails::ConsoleMethods` is deprecated and will be removed in Rails 7.3.
         Please directly use IRB's extension API to add new commands or helpers to the console.
         For more details, please visit: https://github.com/ruby/irb/blob/master/EXTEND_IRB.md

--- a/railties/test/application/console_test.rb
+++ b/railties/test/application/console_test.rb
@@ -215,7 +215,16 @@ class FullStackConsoleTest < ActiveSupport::TestCase
 
     spawn_console("-e development", wait_for_prompt: false)
 
+    line_number = 0
+    app = File.readlines("#{app_path}/config/application.rb")
+    app.each_with_index do |line, index|
+      if line.include?("Rails::ConsoleMethods.include(MyConsole)")
+        line_number = index + 1
+      end
+    end
+
     assert_output "Extending Rails console through `Rails::ConsoleMethods` is deprecated", @primary, 30
+    assert_output "(called from block in <class:Application> at #{app_path}/config/application.rb:#{line_number})", @primary, 30
     write_prompt "foo", "=> \"this is foo\""
   end
 


### PR DESCRIPTION
This PR replaces #52026 by fixing the `caller_locations`.

Before:

```
(called from include at /home/wojtek/.asdf/installs/ruby/3.3.2/lib/ruby/gems/3.3.0/gems/railties-7.2.0.beta2/lib/rails/console/methods.rb:6)
```

After:

```
(called from block in <class:Engine> at /home/zzak/.rbenv/versions/3.4.0/lib/ruby/gems/3.4.0+0/bundler/gems/mission_control-jobs-7295d75ed735/lib/mission_control/jobs/engine.rb:73)
```