### PR TITLE
[7-2-stable] Add ensure to reset table name in tests

### DIFF
--- a/activerecord/test/cases/insert_all_test.rb
+++ b/activerecord/test/cases/insert_all_test.rb
@@ -819,6 +819,7 @@ class InsertAllTest < ActiveRecord::TestCase
       assert_nothing_raised do
         Book.insert_all! [{ name: "Rework", author_id: 1 }]
       end
+    ensure
       Book.table_name = "books"
     end
   end


### PR DESCRIPTION
This backports d36c752287 to 7-2-stable since #51969 was also backported.