### PR TITLE
Avoid running console tests against users IRB config

### DIFF
--- a/railties/test/application/console_test.rb
+++ b/railties/test/application/console_test.rb
@@ -33,8 +33,11 @@ class FullStackConsoleTest < ActiveSupport::TestCase
   end
 
   def spawn_console(options, wait_for_prompt: true, env: {})
+    # Test should not depend on user's irbrc file
+    home_tmp_dir = Dir.mktmpdir
+
     pid = Process.spawn(
-      { "TERM" => "dumb" }.merge(env),
+      { "TERM" => "dumb", "HOME" => home_tmp_dir }.merge(env),
       "#{app_path}/bin/rails console #{options}",
       in: @replica, out: @replica, err: @replica
     )
@@ -44,6 +47,8 @@ class FullStackConsoleTest < ActiveSupport::TestCase
     end
 
     pid
+  ensure
+    FileUtils.remove_entry(home_tmp_dir)
   end
 
   def test_sandbox


### PR DESCRIPTION
Based off the IRB tests: https://github.com/ruby/irb/blob/master/test/irb/helper.rb#L112-L120

For example if you add this to your `~/.irbrc`:

```
IRB.conf[:PROMPT_MODE] = :SIMPLE
```

This will result in the following test failures:

```
F

Failure:
FullStackConsoleTest#test_prompt_allows_changing_irb_name [test/application/console_test.rb:32]:
"foo(test)>" expected, but got:

>> a = 1
a = 1
=> ...
>> .
Expected ">> a = 1\r\r\na = 1\r\n=> ...\r\n>> " to include "foo(test)>".

bin/test test/application/console_test.rb:120

.............F

Failure:
FullStackConsoleTest#test_test_console_prompt [test/application/console_test.rb:32]:
"app-template(test)> " expected, but got:

112123>> 123
=> 123
>> .
Expected "\r\n112123>> 123\r\r\n=> 123\r\n>> " to include "app-template(test)> ".

bin/test test/application/console_test.rb:152

...F

Failure:
FullStackConsoleTest#test_prompt_is_properly_set [test/application/console_test.rb:32]:
"app-template(test)>" expected, but got:

>> a = 1
a = 1
=> ...
>> .
Expected ">> a = 1\r\r\na = 1\r\n=> ...\r\n>> " to include "app-template(test)>".

bin/test test/application/console_test.rb:113

F

Failure:
FullStackConsoleTest#test_production_console_prompt [test/application/console_test.rb:32]:
"app-template(prod)>" expected, but got:

112123>> 123
=> 123
>> .
Expected "\r\n112123>> 123\r\r\n=> 123\r\n>> " to include "app-template(prod)>".

bin/test test/application/console_test.rb:138

...F

Failure:
FullStackConsoleTest#test_development_console_prompt [test/application/console_test.rb:32]:
"app-template(dev)> " expected, but got:

112123>> 123
=> 123
>> .
Expected "\r\n112123>> 123\r\r\n=> 123\r\n>> " to include "app-template(dev)> ".

bin/test test/application/console_test.rb:145

Finished in 137.655994s, 0.1743 runs/s, 1.8815 assertions/s.
24 runs, 259 assertions, 5 failures, 0 errors, 0 skips
```
