### PR TITLE
Use the env variable in the key name for view cache

### DIFF
--- a/actionview/lib/action_view/helpers/cache_helper.rb
+++ b/actionview/lib/action_view/helpers/cache_helper.rb
@@ -166,6 +166,8 @@ module ActionView
       # This will include both records as part of the cache key and updating either of them will
       # expire the cache.
       def cache(name = {}, options = {}, &block)
+        name = "#{name}_#{Rails.env}" if (name.class == String) && !name.ends_with?("_#{Rails.env}")
+
         if controller.respond_to?(:perform_caching) && controller.perform_caching
           CachingRegistry.track_caching do
             name_options = options.slice(:skip_digest)


### PR DESCRIPTION
This is to prevent any cross contamination between the environments with regards to the cache keys.  An app  using the same redis instance for the cache between two environments and values for one were making it into the values for another.  Instead of remembering to use a different instance/db or emptying the instance, a better way would just be to specify the environment in the cache key.

<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created because I was having issues with keys in different environments cross contaminating.

### Detail

This Pull Request changes the way the cache keys are stored in the view cache.

### Additional information

### Checklist

Before submitting the PR make sure the following are checked:

* [ x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [ x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
