### PR TITLE
[ActiveRecord] Support PG enums with names that require quote-ident

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_dumper.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_dumper.rb
@@ -91,7 +91,7 @@ module ActiveRecord
               spec = { type: schema_type(column).inspect }.merge!(spec)
             end
 
-            spec[:enum_type] = "\"#{column.sql_type}\"" if column.enum?
+            spec[:enum_type] = column.sql_type.inspect if column.enum?
 
             spec
           end

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -500,7 +500,7 @@ module ActiveRecord
       def enum_types
         query = <<~SQL
           SELECT
-            type.typname AS name,
+            quote_ident(type.typname) AS name,
             type.OID AS oid,
             n.nspname AS schema,
             string_agg(enum.enumlabel, ',' ORDER BY enum.enumsortorder) AS value

--- a/activerecord/test/cases/adapters/postgresql/enum_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/enum_test.rb
@@ -111,6 +111,16 @@ class PostgresqlEnumTest < ActiveRecord::PostgreSQLTestCase
     assert_includes output, 't.enum "good_mood", default: "happy", null: false, enum_type: "mood"'
   end
 
+  def test_schema_dump_with_dot_in_enum_name
+    @connection.create_enum('"my.mood"', ["sad", "ok", "happy"])
+    @connection.add_column "postgresql_enums", "good_mood", '"my.mood"', default: "happy", null: false
+
+    output = dump_table_schema("postgresql_enums")
+
+    assert_includes output, 'create_enum "\\"my.mood\\"", ["sad", "ok", "happy"]'
+    assert_includes output, 't.enum "good_mood", default: "happy", null: false, enum_type: "\\"my.mood\\""'
+  end
+
   def test_schema_dump_renamed_enum
     @connection.rename_enum :mood, to: :feeling
 


### PR DESCRIPTION
### Motivation / Background

There are many cases when using double quotes is necessary to properly identify type & column names in PostgreSQL. This PR aims to address one subset of cases relating to Rails's support of PG Enums in `schema.rb`.

As it stands, PG Enums that require quote identifiers can be successfully created with the migration DSL, but these type names do not currently survive the round-trip to `schema.rb`, breaking subsequent `schema:load` calls.

(If this change is accepted, I have additional cases I would propose in follow-up PRs, but I am focusing on one change at a time.)

### Detail

Note that I'm using `.` here as an example, but there are other reasons why quote identifiers can be necessary, including case sensitivity.

#### Before:

_Without_ this PR's changes, the following migration:

```ruby
create_enum '"my.status"', %w[complete in_progress]
create_table :things do |t|
  t.enum :status, enum_type: '"my.status"', default: "in_progress", null: false
end
```

Produces the following in the `schema.rb` file:

```ruby
create_enum "my.status", ["complete", "in_progress"]

create_table "things", force: :cascade do |t|
  t.enum "status", default: "in_progress", null: false, enum_type: ""my.status""
end
```

🐛 Both the `create_enum` statement and the `:enum_type` option do not function as expected. The former produces a `PG::InvalidSchemaName` error (because it assumes `my.` is a PG schema), and the latter is not even valid Ruby.

#### After:

_With_ this PR's changes, `schema.rb` contains the following:

```ruby
create_enum "\"my.status\"", ["complete", "in_progress"]

create_table "things", force: :cascade do |t|
  t.enum "status", default: "in_progress", null: false, enum_type: "\"my.status\""
end
```

This should resolve cases where quote identifiers are necessary, without impacting cases where they are not _strictly_ necessary.

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
