### PR TITLE
[7.1] Better handle errors in `#check_version`

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Fix an issue that could cause database connection leaks
+
+    If Active Record successfully connected to teh database, but then failed
+    to read the server informations, the connection would be leaked until the
+    Ruby garbage collector triggers.
+
+    *Jean Boussier*
+
 *   Fix an issue where the IDs reader method did not return expected results
     for preloaded associations in models using composite primary keys.
 

--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -675,7 +675,14 @@ module ActiveRecord
         def new_connection
           connection = Base.public_send(db_config.adapter_method, db_config.configuration_hash)
           connection.pool = self
-          connection.check_version
+
+          begin
+            connection.check_version
+          rescue
+            connection.disconnect!
+            raise
+          end
+
           connection
         rescue ConnectionNotEstablished => ex
           raise ex.set_pool(self)

--- a/activerecord/test/cases/connection_pool_test.rb
+++ b/activerecord/test/cases/connection_pool_test.rb
@@ -95,6 +95,21 @@ module ActiveRecord
         end
       end
 
+      def test_new_connection_error_in_check_version
+        connection_mock = AbstractAdapter.new(nil)
+        connection_mock.singleton_class.define_method(:check_version) do
+          raise "Oops"
+        end
+
+        Base.stub(@db_config.adapter_method, connection_mock) do
+          assert_called(connection_mock, :disconnect!) do
+            assert_raises RuntimeError, match: /Oops/ do
+              @pool.send(:new_connection)
+            end
+          end
+        end
+      end
+
       def test_active_connection_in_use
         assert_not_predicate pool, :active_connection?
         main_thread = pool.connection


### PR DESCRIPTION
Fix: https://github.com/rails/rails/issues/52046

If `#check_version` raises, the connection would be leaked until the GC collects the object.
