### PR TITLE
[7.1] Fix the rails-new-docker CI step

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -193,7 +193,6 @@ GEM
     digest-crc (0.6.4)
       rake (>= 12.0.0, < 14.0.0)
     drb (2.2.1)
-    error_highlight (0.6.0)
     erubi (1.12.0)
     et-orbi (1.2.7)
       tzinfo
@@ -582,7 +581,6 @@ DEPENDENCIES
   debug (>= 1.1.0)
   delayed_job
   delayed_job_active_record
-  error_highlight (>= 0.4.0)
   google-cloud-storage (~> 1.11)
   image_processing (~> 1.2)
   importmap-rails (>= 1.2.3)


### PR DESCRIPTION
```
You are trying to install in deployment mode after changing
your Gemfile. Run `bundle install` elsewhere and add the
updated Gemfile.lock to version control.
```

This is because the Gemfile.lock is unfortunately Ruby version dependent.
