### PR TITLE
Fix running migrations on other databases when `database_tasks: false` on primary

### DIFF
--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -89,7 +89,7 @@ db_namespace = namespace :db do
   task migrate: :load_config do
     db_configs = ActiveRecord::Base.configurations.configs_for(env_name: ActiveRecord::Tasks::DatabaseTasks.env)
 
-    if db_configs.size == 1
+    if db_configs.size == 1 && db_configs.first.primary?
       ActiveRecord::Tasks::DatabaseTasks.migrate
     else
       mapped_versions = ActiveRecord::Tasks::DatabaseTasks.db_configs_with_versions(db_configs)

--- a/railties/test/application/rake/multi_dbs_test.rb
+++ b/railties/test/application/rake/multi_dbs_test.rb
@@ -1258,24 +1258,107 @@ module ApplicationTests
         YAML
 
         Dir.chdir(app_path) do
-          animals_db_exists = lambda { rails("runner", "puts !!(AnimalsBase.connection rescue false)").strip }
-
           generate_models_for_animals
 
-          assert_equal "true", animals_db_exists.call
-
-          assert_not File.exist?("db/animals_schema.yml")
+          assert_not File.exist?("storage/development_animals.sqlite3")
+          assert_not File.exist?("db/animals_schema.rb")
 
           error = assert_raises do
             rails "db:migrate:animals" ### Task not defined
           end
           assert_includes error.message, "Unrecognized command"
 
-          rails "db:schema:dump"
-          assert_not File.exist?("db/animals_schema.yml")
+          rails "db:migrate"
+          assert File.exist?("storage/default.sqlite3")
+          assert_not File.exist?("storage/development_animals.sqlite3")
+          assert File.exist?("db/schema.rb")
+          assert_not File.exist?("db/animals_schema.rb")
 
           rails "db:drop"
-          assert_equal "true", animals_db_exists.call
+          assert_not File.exist?("storage/default.sqlite3")
+          assert_not File.exist?("storage/development_animals.sqlite3")
+        end
+      end
+
+      test "when database_tasks is false on 'primary', then run the database tasks on other dbs" do
+        require "#{app_path}/config/environment"
+        app_file "config/database.yml", <<-YAML
+          development:
+            primary:
+              database: storage/development.sqlite3
+              adapter: sqlite3
+              database_tasks: false
+            animals:
+              database: storage/development_animals.sqlite3
+              adapter: sqlite3
+              migrations_paths: db/animals_migrate
+        YAML
+
+        Dir.chdir(app_path) do
+          generate_models_for_animals
+
+          assert_not File.exist?("storage/development.sqlite3")
+          assert_not File.exist?("storage/development_animals.sqlite3")
+
+          assert_not File.exist?("db/schema.rb")
+          assert_not File.exist?("db/animals_schema.rb")
+
+          error = assert_raises do
+            rails "db:migrate:animals" ### Task not defined
+          end
+          assert_includes error.message, "Unrecognized command"
+
+          rails "db:migrate"
+          assert_not File.exist?("storage/development.sqlite3")
+          assert File.exist?("storage/development_animals.sqlite3")
+          assert_not File.exist?("db/schema.rb")
+          assert File.exist?("db/animals_schema.rb")
+
+          rails "db:drop"
+
+          assert_not File.exist?("storage/development.sqlite3")
+          assert_not File.exist?("storage/development_animals.sqlite3")
+        end
+      end
+
+      test "when database_tasks is false on the implicit primary database, then run the database tasks on other dbs" do
+        require "#{app_path}/config/environment"
+        app_file "config/database.yml", <<-YAML
+          development:
+            main:
+              database: storage/development.sqlite3
+              adapter: sqlite3
+              database_tasks: false
+            animals:
+              database: storage/development_animals.sqlite3
+              adapter: sqlite3
+              migrations_paths: db/animals_migrate
+        YAML
+
+        Dir.chdir(app_path) do
+          generate_models_for_animals
+
+          assert_not File.exist?("storage/development.sqlite3")
+          assert_not File.exist?("storage/development_animals.sqlite3")
+
+          assert_not File.exist?("db/schema.rb")
+          assert_not File.exist?("db/animals_schema.rb")
+
+          error = assert_raises do
+            rails "db:migrate:animals" ### Task not defined
+          end
+          assert_includes error.message, "Unrecognized command"
+
+          rails "db:migrate"
+          assert_not File.exist?("storage/development.sqlite3")
+          assert File.exist?("storage/development_animals.sqlite3")
+          assert_not File.exist?("db/schema.rb")
+          assert File.exist?("db/animals_schema.rb")
+
+          rails "db:drop"
+
+          assert_not File.exist?("storage/development.sqlite3")
+          assert_not File.exist?("storage/development_animals.sqlite3")
         end
       end
 


### PR DESCRIPTION
This is a backport of https://github.com/rails/rails/pull/51916 to `7-1-stable`.
cc @eileencodes 