### PR TITLE
[Fix #51817] Allow Preloaded `has_one :through` Associations to be Accessed Without Additional Database Queries

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,16 @@
+*   Allow a record to access its `has_one :through` associations without querying the database
+    if the association has already been loaded.
+
+    Before the change:
+
+    ```ruby
+    member = Member.includes(current_membership: :club).first
+    member.current_membership.club # => does not query the database
+    member.club # => queries the database
+    ```
+
+    *Jay Ang*
+
 *   Add condensed `#inspect` for `ConnectionPool`, `AbstractAdapter`, and
     `DatabaseConfig`.
 

--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -34,6 +34,8 @@ module ActiveRecord
       def reader
         ensure_klass_exists!
 
+        yield if block_given?
+
         if stale_target?
           reload
         end

--- a/activerecord/lib/active_record/associations/has_many_through_association.rb
+++ b/activerecord/lib/active_record/associations/has_many_through_association.rb
@@ -34,6 +34,28 @@ module ActiveRecord
       end
 
       private
+        def source_association_target
+          if through_association.is_a?(ActiveRecord::Associations::BelongsToAssociation)
+            through_association_target.association(source_reflection.name).target
+          else
+            through_association_target.map do |target|
+              target.association(source_reflection.name).target
+            end.flatten
+          end
+        end
+
+        def source_association_loaded?
+          if through_association.is_a?(ActiveRecord::Associations::BelongsToAssociation)
+            through_association_target.association(source_reflection.name).loaded?
+          else
+            return false unless through_association_target
+
+            through_association_target.all? do |target|
+              target.association(source_reflection.name).loaded?
+            end
+          end
+        end
+
         def concat_records(records)
           ensure_not_nested
 

--- a/activerecord/lib/active_record/associations/has_many_through_association.rb
+++ b/activerecord/lib/active_record/associations/has_many_through_association.rb
@@ -34,28 +34,6 @@ module ActiveRecord
       end
 
       private
-        def source_association_target
-          if through_association.is_a?(ActiveRecord::Associations::BelongsToAssociation)
-            through_association_target.association(source_reflection.name).target
-          else
-            through_association_target.map do |target|
-              target.association(source_reflection.name).target
-            end.flatten
-          end
-        end
-
-        def source_association_loaded?
-          if through_association.is_a?(ActiveRecord::Associations::BelongsToAssociation)
-            through_association_target.association(source_reflection.name).loaded?
-          else
-            return false unless through_association_target
-
-            through_association_target.all? do |target|
-              target.association(source_reflection.name).loaded?
-            end
-          end
-        end
-
         def concat_records(records)
           ensure_not_nested
 

--- a/activerecord/lib/active_record/associations/has_one_through_association.rb
+++ b/activerecord/lib/active_record/associations/has_one_through_association.rb
@@ -8,7 +8,7 @@ module ActiveRecord
 
       private
         def source_association
-          @source_association ||= through_association_target.association(source_reflection.name)
+          @source_association ||= direct_through_association_target.association(source_reflection.name)
         end
 
         def replace(record, save = true)

--- a/activerecord/lib/active_record/associations/has_one_through_association.rb
+++ b/activerecord/lib/active_record/associations/has_one_through_association.rb
@@ -7,16 +7,8 @@ module ActiveRecord
       include ThroughAssociation
 
       private
-        def source_association_loaded?
-          source_association.loaded?
-        end
-
         def source_association
           @source_association ||= through_association_target.association(source_reflection.name)
-        end
-
-        def source_association_target
-          @source_association_target ||= source_association.target
         end
 
         def replace(record, save = true)

--- a/activerecord/lib/active_record/associations/has_one_through_association.rb
+++ b/activerecord/lib/active_record/associations/has_one_through_association.rb
@@ -6,14 +6,9 @@ module ActiveRecord
     class HasOneThroughAssociation < HasOneAssociation # :nodoc:
       include ThroughAssociation
 
-      def load_target
-        self.target = source_association_target if !loaded? && source_association_cached?
-        super
-      end
-
       private
-        def source_association_cached?
-          through_association.loaded? && through_association_target.present? && source_association.loaded?
+        def source_association_loaded?
+          source_association.loaded?
         end
 
         def source_association

--- a/activerecord/lib/active_record/associations/singular_association.rb
+++ b/activerecord/lib/active_record/associations/singular_association.rb
@@ -7,6 +7,8 @@ module ActiveRecord
       def reader
         ensure_klass_exists!
 
+        yield if block_given?
+
         if !loaded? || stale_target?
           reload
         end

--- a/activerecord/lib/active_record/associations/through_association.rb
+++ b/activerecord/lib/active_record/associations/through_association.rb
@@ -27,6 +27,10 @@ module ActiveRecord
           @through_association ||= owner.association(through_reflection.name)
         end
 
+        def through_association_target
+          @through_association_target ||= through_association.target
+        end
+
         # We merge in these scopes for two reasons:
         #
         #   1. To get the default_scope conditions for any of the other reflections in the chain

--- a/activerecord/lib/active_record/associations/through_association.rb
+++ b/activerecord/lib/active_record/associations/through_association.rb
@@ -33,29 +33,37 @@ module ActiveRecord
           @through_association ||= owner.association(through_reflection.name)
         end
 
-        def through_association_target
-          @through_association_target ||= through_association.target
+        def direct_through_reflection
+          @direct_through_reflection ||= reflection.through_reflection
+        end
+
+        def direct_through_association
+          @direct_through_association ||= owner.association(direct_through_reflection.name)
+        end
+
+        def direct_through_association_target
+          @direct_through_association_target ||= direct_through_association.target
         end
 
         def source_association_target
-          if through_association_target.is_a?(Array)
-            through_association_target.flat_map do |target|
+          if direct_through_association_target.is_a?(Array)
+            direct_through_association_target.flat_map do |target|
               target.association(source_reflection.name).target
             end
           else
-            through_association_target.association(source_reflection.name).target
+            direct_through_association_target.association(source_reflection.name).target
           end
         end
 
         def source_association_loaded?
-          targets = Array(through_association_target)
+          targets = Array(direct_through_association_target)
           targets.all? do |target|
             target.association(source_reflection.name).loaded?
           end
         end
 
         def source_association_cached?
-          through_association.loaded? && through_association_target.present? && source_association_loaded?
+          direct_through_association.loaded? && direct_through_association_target.present? && source_association_loaded?
         end
 
         # We merge in these scopes for two reasons:

--- a/activerecord/lib/active_record/associations/through_association.rb
+++ b/activerecord/lib/active_record/associations/through_association.rb
@@ -6,6 +6,12 @@ module ActiveRecord
     module ThroughAssociation # :nodoc:
       delegate :source_reflection, to: :reflection
 
+      def reader
+        super do
+          self.target = source_association_target if !loaded? && source_association_cached?
+        end
+      end
+
       private
         def transaction(&block)
           through_reflection.klass.transaction(&block)
@@ -29,6 +35,10 @@ module ActiveRecord
 
         def through_association_target
           @through_association_target ||= through_association.target
+        end
+
+        def source_association_cached?
+          through_association.loaded? && through_association_target.present? && source_association_loaded?
         end
 
         # We merge in these scopes for two reasons:

--- a/activerecord/lib/active_record/associations/through_association.rb
+++ b/activerecord/lib/active_record/associations/through_association.rb
@@ -37,6 +37,23 @@ module ActiveRecord
           @through_association_target ||= through_association.target
         end
 
+        def source_association_target
+          if through_association_target.is_a?(Array)
+            through_association_target.flat_map do |target|
+              target.association(source_reflection.name).target
+            end
+          else
+            through_association_target.association(source_reflection.name).target
+          end
+        end
+
+        def source_association_loaded?
+          targets = Array(through_association_target)
+          targets.all? do |target|
+            target.association(source_reflection.name).loaded?
+          end
+        end
+
         def source_association_cached?
           through_association.loaded? && through_association_target.present? && source_association_loaded?
         end

--- a/activerecord/lib/active_record/associations/through_association.rb
+++ b/activerecord/lib/active_record/associations/through_association.rb
@@ -33,6 +33,13 @@ module ActiveRecord
           @through_association ||= owner.association(through_reflection.name)
         end
 
+        # The difference between through_reflection and direct_through_reflection is that
+        # through_reflection returns the deepest (last) through reflection in the chain,
+        # while direct_through_reflection returns the immediate through reflection directly
+        # on the association.
+        #
+        # In most cases, they will be the same. However, if the association has nested
+        # through associations, they will be different.
         def direct_through_reflection
           @direct_through_reflection ||= reflection.through_reflection
         end


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

Fixes https://github.com/rails/rails/issues/51817

### Detail
Currently, Rails doesn't have a mechanism to allow the main record to efficiently access its `has_one :through` associations via the middle record.

When we define a `has_one :through` association, Rails creates a `HasOneThroughAssociation` object within that record. Like all other Association objects, `HasOneThroughAssociation` works independently and doesn't check the loading status of other associations. If it doesn't find the record within the object itself, it simply queries the database. And this triggers an additional query even when all associated records are preloaded.

On top of that, making another query for an already loaded association results in having two identical records in memory. This can confuse developers about which record is the single source of truth. When one record is updated, the other remains unchanged. Here is an example:

```ruby
member.membership.club.name = 'New Club'

member.membership.club.name # => 'New Club'
member.club.name            # => 'Old Club'
```
The changes prevent the additional query and ensure there is a single source of truth.



### Additional information
I tried to apply the same approach to the `has_many :through` association, but it is not as straightforward as the `has_one :through` association. All the final records are stored in each middle record's association object. So, we need to find a better way to implement this. I will look into this more and create another PR if I find a solution.


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
