### PR TITLE
Correctly stub database configurations in test

### DIFF
--- a/activerecord/test/cases/fixtures_test.rb
+++ b/activerecord/test/cases/fixtures_test.rb
@@ -588,20 +588,21 @@ class FixturesTest < ActiveRecord::TestCase
   def test_fixtures_are_set_up_with_database_env_variable
     db_url_tmp = ENV["DATABASE_URL"]
     ENV["DATABASE_URL"] = "sqlite3::memory:"
-    ActiveRecord::Base.stub(:configurations, {}) do
-      test_case = Class.new(ActiveRecord::TestCase) do
-        fixtures :accounts
 
-        def test_fixtures
-          assert accounts(:signals37)
-        end
+    prev_configs, ActiveRecord::Base.configurations = ActiveRecord::Base.configurations, {}
+    test_case = Class.new(ActiveRecord::TestCase) do
+      fixtures :accounts
+
+      def test_fixtures
+        assert accounts(:signals37)
       end
-
-      result = test_case.new(:test_fixtures).run
-
-      assert result.passed?, "Expected #{result.name} to pass:\n#{result}"
     end
+
+    result = test_case.new(:test_fixtures).run
+
+    assert result.passed?, "Expected #{result.name} to pass:\n#{result}"
   ensure
+    ActiveRecord::Base.configurations = prev_configs
     ENV["DATABASE_URL"] = db_url_tmp
   end
 end


### PR DESCRIPTION
https://buildkite.com/rails/rails/builds/108172#018ffa37-574b-494d-ba93-de15f73c1de5

To reproduce, run:
```
$ cd activerecord
$ SEED=32138 rake test:postgresql
```

Using `.stub` does not pass the object via `configurations=` method (which converts the hash into the `ActiveRecord::DatabaseConfigurations` object), and so we get an error. We need to manually assign the value via the setter and restore it back at the end.