### PR TITLE
[ActiveSupport] Add option `filter` on `in_order_of`

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Add a `filter` option to `in_order_of` to prioritize certain values in the sorting without filtering the results
+    by these values.
+
+    *Igor Depolli*
+
 *   Improve error message when using `assert_difference` or `assert_changes` with a
     proc by printing the proc's source code (MRI only).
 

--- a/activesupport/lib/active_support/core_ext/enumerable.rb
+++ b/activesupport/lib/active_support/core_ext/enumerable.rb
@@ -198,7 +198,7 @@ module Enumerable
     if filter
       group_by(&key).values_at(*series).flatten(1).compact
     else
-      group_by(&key).values.flatten(1).sort_by { |v| series.index(v.public_send(key)) || series.size }.compact
+      sort_by { |v| series.index(v.public_send(key)) || series.size }.compact
     end
   end
 

--- a/activesupport/lib/active_support/core_ext/enumerable.rb
+++ b/activesupport/lib/active_support/core_ext/enumerable.rb
@@ -192,9 +192,14 @@ module Enumerable
   #   # => [ Person.find(1), Person.find(5), Person.find(3) ]
   #
   # If the +series+ include keys that have no corresponding element in the Enumerable, these are ignored.
-  # If the Enumerable has additional elements that aren't named in the +series+, these are not included in the result.
-  def in_order_of(key, series)
-    group_by(&key).values_at(*series).flatten(1).compact
+  # If the Enumerable has additional elements that aren't named in the +series+, these are not included in the result, unless
+  # the +filter+ option is set to +false+.
+  def in_order_of(key, series, filter: true)
+    if filter
+      group_by(&key).values_at(*series).flatten(1).compact
+    else
+      group_by(&key).values.flatten(1).sort_by { |v| series.index(v.public_send(key)) || series.size }.compact
+    end
   end
 
   # Returns the sole item in the enumerable. If there are no items, or more

--- a/activesupport/test/core_ext/enumerable_test.rb
+++ b/activesupport/test/core_ext/enumerable_test.rb
@@ -386,6 +386,11 @@ class EnumerableTests < ActiveSupport::TestCase
     assert_equal [[:opened, { price: 2, currency: :usd }], [:paid, { price: 1, currency: :eur }]], values.in_order_of(:first, [:opened, :paid])
   end
 
+  def test_in_order_of_with_filter_false
+    values = [ Payment.new(5), Payment.new(3), Payment.new(1) ]
+    assert_equal [ Payment.new(1), Payment.new(5), Payment.new(3) ], values.in_order_of(:price, [ 1, 5 ], filter: false)
+  end
+
   def test_sole
     expected_raise = Enumerable::SoleItemExpectedError
 


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created to reflect on Enumerable the suggestion opened on ActiveRecord #51761

### Detail

This Pull Request changes:

```ruby
# Without specify option
[ Person.find(5), Person.find(3), Person.find(1) ].in_order_of(:id, [ 1, 5 ])
# => [ Person.find(1), Person.find(5) ]

# With option set to false
[ Person.find(5), Person.find(3), Person.find(1) ].in_order_of(:id, [ 1, 5 ], filter: false)
# => [ Person.find(1), Person.find(5), Person.find(3) ]
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
