### PR TITLE
docs: update list of methods that trigger active record callbacks [ci skip]

### DIFF
--- a/guides/source/active_record_callbacks.md
+++ b/guides/source/active_record_callbacks.md
@@ -622,6 +622,7 @@ The following methods trigger callbacks:
 * `toggle!`
 * `touch`
 * `update_attribute`
+* `update_attribute!`
 * `update`
 * `update!`
 * `valid?`


### PR DESCRIPTION
### Motivation / Background
This Pull Request has been created because the list of methods that respond to callbacks in the documentation is not complete. 

### Detail

This Pull Request adds the method `update_attribute!` to the list of methods that respond to active record callbacks. This also aligns with the [Rails Edge API Doc](https://edgeapi.rubyonrails.org/classes/ActiveRecord/Persistence.html#method-i-update_attribute-21.)

### Additional information

No additional information

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
