### PR TITLE
Fix creating records without partial inserts and enum with database default not in the definition

### DIFF
--- a/activerecord/lib/active_record/enum.rb
+++ b/activerecord/lib/active_record/enum.rb
@@ -188,7 +188,7 @@ module ActiveRecord
       end
 
       def deserialize(value)
-        mapping.key(subtype.deserialize(value))
+        mapping.key(subtype.deserialize(value)) || value
       end
 
       def serialize(value)

--- a/activerecord/test/cases/enum_test.rb
+++ b/activerecord/test/cases/enum_test.rb
@@ -1138,4 +1138,19 @@ class EnumTest < ActiveRecord::TestCase
     assert_raises(NoMethodError) { instance.proposed? }
     assert_raises(NoMethodError) { instance.proposed! }
   end
+
+  test "without partial inserts and enum with database default not in the definition" do
+    old_inserts = ActiveRecord::Base.partial_inserts?
+    ActiveRecord::Base.partial_inserts = false
+
+    klass = Class.new(ActiveRecord::Base) do
+      self.table_name = "books"
+      enum :status, { proposed: 1, written: 2 }
+    end
+
+    instance = klass.create!
+    assert_equal 0, instance.reload.status
+  ensure
+    ActiveRecord::Base.partial_inserts = old_inserts
+  end
 end


### PR DESCRIPTION
Fixes  #52074.

Previously, when the record was created with an enum value not in the list and then retrieved from the database, it had `nil` as the enum's value. Now, it will have the actual value. 

I am not sure if this will be expected for users or not. But other methods in the `EnumType` class seems like doing similar things, like, for example, storing the original value if there is no a match in the enum definition. https://github.com/rails/rails/blob/0733ab511877d6b61932615ca7d51b069fbe5cb3/activerecord/lib/active_record/enum.rb#L180-L200
