### PR TITLE
Define the new start_transaction.active_record event

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
@@ -91,7 +91,9 @@ module ActiveRecord
         raise InstrumentationAlreadyStartedError.new("Called start on an already started transaction") if @started
         @started = true
 
-        @payload = @base_payload.dup
+        ActiveSupport::Notifications.instrument("start_transaction.active_record", @base_payload)
+
+        @payload = @base_payload.dup # We dup because the payload for a given event is mutated later to add the outcome.
         @handle = ActiveSupport::Notifications.instrumenter.build_handle("transaction.active_record", @payload)
         @handle.start
       end

--- a/guides/source/active_support_instrumentation.md
+++ b/guides/source/active_support_instrumentation.md
@@ -410,9 +410,56 @@ This event is only emitted when [`config.active_record.action_on_strict_loading_
 }
 ```
 
+#### `start_transaction.active_record`
+
+This event is emitted when a transaction has been started.
+
+| Key                  | Value                                                |
+| -------------------- | ---------------------------------------------------- |
+| `:transaction`       | Transaction object                                   |
+| `:connection`        | Connection object                                    |
+
+Please, note that Active Record does not create the actual database transaction
+until needed:
+
+```ruby
+ActiveRecord::Base.transaction do
+  # We are inside the block, but no event has been triggered yet.
+
+  # The following line makes Active Record start the transaction.
+  User.count # Event fired here.
+end
+```
+
+Remember that ordinary nested calls do not create new transactions:
+
+```ruby
+ActiveRecord::Base.transaction do |t1|
+  User.count # Fires an event for t1.
+  ActiveRecord::Base.transaction do |t2|
+    # The next line fires no event for t2, because the only
+    # real database transaction in this example is t1.
+    User.first.touch
+  end
+end
+```
+
+However, if `requires_new: true` is passed, you get an event for the nested
+transaction too. This might be a savepoint under the hood:
+
+```ruby
+ActiveRecord::Base.transaction do |t1|
+  User.count # Fires an event for t1.
+  ActiveRecord::Base.transaction(requires_new: true) do |t2|
+    User.first.touch # Fires an event for t2.
+  end
+end
+```
+
 #### `transaction.active_record`
 
-This event is emmited for every transaction to the database.
+This event is emitted when a database transaction finishes. The state of the
+transaction can be found in the `:outcome` key.
 
 | Key                  | Value                                                |
 | -------------------- | ---------------------------------------------------- |
@@ -420,10 +467,9 @@ This event is emmited for every transaction to the database.
 | `:outcome`           | `:commit`, `:rollback`, `:restart`, or `:incomplete` |
 | `:connection`        | Connection object                                    |
 
-Please note that at this point the transaction has been finished, and its state
-is in the `:outcome` key. In practice, you cannot do much with the transaction
-object, but it may still be helpful for tracing database activity. For example,
-by tracking `transaction.uuid`.
+In practice, you cannot do much with the transaction object, but it may still be
+helpful for tracing database activity. For example, by tracking
+`transaction.uuid`.
 
 ### Action Mailer
 


### PR DESCRIPTION
We define a new event `start_transaction.active_record` that is emitted when a database transaction or savepoint starts, and complements `transaction.active_record`, which is triggered when they finish.

The documentation included in the patch has further details and examples.

I have seen two naming conventions in existing similar events. On one hand we have `start_processing.action_controller`, and on the other hand we have `perform_start.active_job`. I think `start_transaction.active_record` reads more naturally.

Will backport to `7-2-stable` and add a CHANGELOG entry there.