### PR TITLE
[ci-skip] Update the upgrade guides for Rails 7.1 regarding the breaking change of the location of secret_key_base in development/test environments

### DIFF
--- a/guides/source/upgrading_ruby_on_rails.md
+++ b/guides/source/upgrading_ruby_on_rails.md
@@ -102,6 +102,18 @@ Upgrading from Rails 7.0 to Rails 7.1
 
 For more information on changes made to Rails 7.1 please see the [release notes](7_1_release_notes.html).
 
+### Development and test environments secret_key_base file changed
+
+In development and test environments, the file from which Rails reads the `secret_key_base` has been renamed from `tmp/development_secret.txt` to `tmp/local_secret.txt`.
+
+You can simply rename the previous file to `local_secret.txt` to continue using the same secret, or copy the key from the previous file to the new one.
+
+Failure to do so will cause Rails to generate a new secret key in the new file `tmp/local_secret.txt` when the app loads.
+
+This will invalidate all existing sessions/cookies in development and test environments, and also cause other signatures derived from `secret_key_base` to break, such as Active Storage/Action Text attachments.
+
+Production and other environments are not affected.
+
 ### Autoloaded paths are no longer in $LOAD_PATH
 
 Starting from Rails 7.1, the directories managed by the autoloaders are no


### PR DESCRIPTION
### Motivation / Background

#48471 made a simple change for local environments: renamed the file where `secret_key_base` is read from `txt/development_secret.txt` to `txt/local_secret.txt`

However, this actually represents a breaking change from Rails 7.0 to Rails 7.1 for these environments, and it's not documented in the upgrade guides, which this pull request address.

The change causes:

- **All sessions/cookies are now invalid, development environment is logged out;**
- **All previous ActiveStorage URLs are invalid, which also affect the persisted ones in ActionText;**

### Additional information

As the file's location changed, as soon as we boot the app for the first time in Rails 7.1 (from Rails 7.0), `Rails.application.secret_key_base`'s code will generate a brand new secret and store it in `txt/local_secret.txt`:

https://github.com/rails/rails/blob/51f81267f8e2769d847cc563967feffefe6e2beb/railties/lib/rails/application.rb#L640-L655

Since this happens out of sight and with no logging, anyone upgrading their apps will then be faced with:

- **All sessions/cookies are now invalid, development environment is logged out;**
- **All previous ActiveStorage URLs are invalid, which also affect the persisted ones in ActionText;**

The implications are serious and will prompt any developer upgrading to understand what's going on, which ensues a non-trivial debug session which will end up, at least for me, manually decrypting cookies strings to figure out what's going on.

This is compounded by the fact that [the upgrade from Rails 6.1 to Rails 7.0 involved a change in the key generator digest](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html#key-generator-digest-class-change-requires-a-cookie-rotator), which caused the exact two problems listed above (invalid sessions/broken activestorage urls) unless a key rotator was installed; so the developer probably _will_ not ignore these issues and try to figure out what's going wrong. 

After discovering the issue I also stumbled upon #50925, which documents this very problem in an issue, showing this _has_ been biting people.