### PR TITLE
Remove dead code for DateTime-backed TimeWithZone

### DIFF
--- a/activesupport/lib/active_support/time_with_zone.rb
+++ b/activesupport/lib/active_support/time_with_zone.rb
@@ -300,7 +300,7 @@ module ActiveSupport
       if duration_of_variable_length?(other)
         method_missing(:+, other)
       else
-        result = utc.acts_like?(:date) ? utc.since(other) : utc + other rescue utc.since(other)
+        result = utc + other
         result.in_time_zone(time_zone)
       end
     end
@@ -336,7 +336,7 @@ module ActiveSupport
       elsif duration_of_variable_length?(other)
         method_missing(:-, other)
       else
-        result = utc.acts_like?(:date) ? utc.ago(other) : utc - other rescue utc.ago(other)
+        result = utc - other
         result.in_time_zone(time_zone)
       end
     end
@@ -537,7 +537,6 @@ module ActiveSupport
     # Ensure proxy class responds to all methods that underlying time instance
     # responds to.
     def respond_to_missing?(sym, include_priv)
-      return false if sym.to_sym == :acts_like_date?
       time.respond_to?(sym, include_priv)
     end
 

--- a/activesupport/test/core_ext/time_with_zone_test.rb
+++ b/activesupport/test/core_ext/time_with_zone_test.rb
@@ -394,9 +394,10 @@ class TimeWithZoneTest < ActiveSupport::TestCase
     assert_equal DateTime.civil(1999, 12, 31, 19, 0, 5), (twz + 5).time
   end
 
-  def test_plus_when_crossing_time_class_limit
-    twz = ActiveSupport::TimeWithZone.new(Time.utc(2038, 1, 19), @time_zone)
-    assert_equal [0, 0, 19, 19, 1, 2038], (twz + 86_400).to_a[0, 6]
+  def test_no_limit_on_times
+    twz = ActiveSupport::TimeWithZone.new(Time.utc(2000, 1, 1), @time_zone)
+    assert_equal [0, 0, 19, 31, 12, 11999], (twz + 10_000.years).to_a[0, 6]
+    assert_equal [0, 0, 19, 31, 12, -8001], (twz - 10_000.years).to_a[0, 6]
   end
 
   def test_plus_with_duration


### PR DESCRIPTION
At one point (I believe ruby 1.9.2) Time could only represent values between 1970 and the integer overflow in 2038. On modern Ruby there does not seem to be a limit.

    >> Time.at(2**128)
    => 10783118943836478994022445751222-08-06 01:04:16 -0700

`TimeWithZone` will also convert a `DateTime` to a `Time` when initialized with one, so the code we had to catch this overflow and to deal with `DateTime` is dead. This commit removes this code and adjusts the test to be more general (the old test passed but we might as well keep a better version of the test to check that we have a large both negative and positive range).

```
$ docker run -e 'ALL_RUBY_SINCE=ruby-1.8' --rm rubylang/all-ruby ./all-ruby -e 'puts Time.at(2**64)'
ruby-1.8.0            -e:1:in `at': bignum too big to convert into `int' (RangeError)
                      	from -e:1
                  exit 1
ruby-1.8.1            -e:1:in `at': bignum too big to convert into `int' (RangeError)
                      	from -e:1
                  exit 1
ruby-1.8.2-preview1   -e:1:in `at': bignum too big to convert into `long' (RangeError)
                      	from -e:1
                  exit 1
...
ruby-1.8.6-p420       -e:1:in `at': bignum too big to convert into `long' (RangeError)
                      	from -e:1
                  exit 1
ruby-1.8.7-preview1   Thu Jan 01 00:00:00 +0000 1970
...
ruby-1.8.7-p374       Thu Jan 01 00:00:00 +0000 1970
ruby-1.9.0-0          -e:1:in `at': bignum too big to convert into `long' (RangeError)
                      	from -e:1:in `<main>'
                  exit 1
...
ruby-1.9.1-p431       -e:1:in `at': bignum too big to convert into `long' (RangeError)
                      	from -e:1:in `<main>'
                  exit 1
ruby-1.9.2-preview1   584554051223-11-09 07:00:16 +0000
...
ruby-3.4.0-preview1   584554051223-11-09 07:00:16 +0000
```