### PR TITLE
Bring back `puma.rb` to target of `app:update`

### DIFF
--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -128,7 +128,7 @@ module Rails
         template "application.rb"
         template "environment.rb"
         template "cable.yml" unless options[:update] || options[:skip_action_cable]
-        template "puma.rb"   unless options[:update]
+        template "puma.rb"
         template "storage.yml" unless options[:update] || skip_active_storage?
 
         directory "environments"


### PR DESCRIPTION
### Motivation / Background

This is a partial revert of #41083.

`puma.rb` may update by users, but  Rails has improved `puma.rb` sometimes. For example, 06d614ada9e4609ff83659e842f48af3232a03a5 and f719787c582839fd2fcd886d70b43da3ddad2ceb.

To allow users to know those improvements, I think we should update `puma.rb` by `app:update`.


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`