### PR TITLE
Correct typo for Active Record Callbacks doc [ci skip]

### DIFF
--- a/guides/source/active_record_callbacks.md
+++ b/guides/source/active_record_callbacks.md
@@ -1035,7 +1035,7 @@ book.update(author_id: 1)
 Cascading Association Callbacks
 -------------------------------
 
-Callbacks can be performed when asssociated objects are changed. They work
+Callbacks can be performed when associated objects are changed. They work
 through the model associations whereby life cycle events can cascade on
 associations and fire callbacks.
 


### PR DESCRIPTION
Correct typo for Active Record Callbacks doc - https://github.com/rails/rails/pull/51654