### PR TITLE
Add a config for preserving timezone information when calling `to_time` on TimeWithZone object

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -8,4 +8,8 @@
 
     *Richard Böhme*, *Jean Boussier*
 
+*   Add a new configuration value `:zone` for `ActiveSupport.to_time_preserves_timezone` and rename the previous `true` value to `:offset`. The new default value is `:zone`.
+
+    *Jason Kim*, *John Hawthorn*
+
 Please check [7-2-stable](https://github.com/rails/rails/blob/7-2-stable/activesupport/CHANGELOG.md) for previous changes.

--- a/activesupport/lib/active_support.rb
+++ b/activesupport/lib/active_support.rb
@@ -115,9 +115,15 @@ module ActiveSupport
   end
 
   def self.to_time_preserves_timezone=(value)
-    unless value
+    if !value
       ActiveSupport.deprecator.warn(
-        "Support for the pre-Ruby 2.4 behavior of to_time has been deprecated and will be removed in Rails 8.0."
+        "`to_time` will always preserve the receiver timezone rather than system local time in Rails 8.0." \
+        "To opt in to the new behavior, set `config.active_support.to_time_preserves_timezone = :zone`."
+      )
+    elsif value != :zone
+      ActiveSupport.deprecator.warn(
+        "`to_time` will always preserve the full timezone rather than offset of the receiver in Rails 8.0. " \
+        "To opt in to the new behavior, set `config.active_support.to_time_preserves_timezone = :zone`."
       )
     end
 

--- a/activesupport/lib/active_support/core_ext/date_and_time/compatibility.rb
+++ b/activesupport/lib/active_support/core_ext/date_and_time/compatibility.rb
@@ -26,8 +26,8 @@ module DateAndTime
         # Only warn once, the first time the value is used (which should
         # be the first time #to_time is called).
         ActiveSupport.deprecator.warn(
-          "to_time will always preserve the timezone offset of the receiver in Rails 8.0. " \
-          "To opt in to the new behavior, set `ActiveSupport.to_time_preserves_timezone = true`."
+          "`to_time` will always preserve the receiver timezone rather than system local time in Rails 8.0." \
+          "To opt in to the new behavior, set `config.active_support.to_time_preserves_timezone = :zone`."
         )
 
         @@preserve_timezone = false

--- a/activesupport/lib/active_support/railtie.rb
+++ b/activesupport/lib/active_support/railtie.rb
@@ -96,6 +96,10 @@ module ActiveSupport
       config.eager_load_namespaces << TZInfo
     end
 
+    initializer "active_support.to_time_preserves_timezone" do |app|
+      ActiveSupport.to_time_preserves_timezone = app.config.active_support.to_time_preserves_timezone
+    end
+
     # Sets the default week start
     # If assigned value is not a valid day symbol (e.g. :sunday, :monday, ...), an exception will be raised.
     initializer "active_support.initialize_beginning_of_week" do |app|

--- a/activesupport/lib/active_support/time_with_zone.rb
+++ b/activesupport/lib/active_support/time_with_zone.rb
@@ -479,11 +479,13 @@ module ActiveSupport
       @to_datetime ||= utc.to_datetime.new_offset(Rational(utc_offset, 86_400))
     end
 
-    # Returns an instance of +Time+, either with the same UTC offset
-    # as +self+ or in the local system timezone depending on the setting
-    # of +ActiveSupport.to_time_preserves_timezone+.
+    # Returns an instance of +Time+, either with the same timezone as +self+,
+    # with the same UTC offset as +self+ or in the local system timezone
+    # depending on the setting of +ActiveSupport.to_time_preserves_timezone+.
     def to_time
-      if preserve_timezone
+      if preserve_timezone == :zone
+        @to_time_with_timezone ||= getlocal(time_zone)
+      elsif preserve_timezone
         @to_time_with_instance_offset ||= getlocal(utc_offset)
       else
         @to_time_with_system_offset ||= getlocal

--- a/activesupport/test/core_ext/date_and_time_compatibility_test.rb
+++ b/activesupport/test/core_ext/date_and_time_compatibility_test.rb
@@ -280,8 +280,8 @@ class DateAndTimeCompatibilityTest < ActiveSupport::TestCase
       ActiveSupport.to_time_preserves_timezone
     end
 
-    assert_not_deprecated(ActiveSupport.deprecator) do
-      ActiveSupport.to_time_preserves_timezone = true
+    assert_deprecated(ActiveSupport.deprecator) do
+      ActiveSupport.to_time_preserves_timezone = :offset
     end
 
     assert_deprecated(ActiveSupport.deprecator) do
@@ -300,6 +300,38 @@ class DateAndTimeCompatibilityTest < ActiveSupport::TestCase
 
     assert_not_deprecated(ActiveSupport.deprecator) do
       ActiveSupport.to_time_preserves_timezone
+    end
+  ensure
+    ActiveSupport.deprecator.silence do
+      ActiveSupport.to_time_preserves_timezone = current_preserve_tz
+    end
+  end
+
+  def test_to_time_preserves_timezone_supports_new_values
+    current_preserve_tz = ActiveSupport.to_time_preserves_timezone
+
+    assert_not_deprecated(ActiveSupport.deprecator) do
+      ActiveSupport.to_time_preserves_timezone
+    end
+
+    assert_not_deprecated(ActiveSupport.deprecator) do
+      ActiveSupport.to_time_preserves_timezone = :zone
+    end
+
+    assert_deprecated(ActiveSupport.deprecator) do
+      ActiveSupport.to_time_preserves_timezone = :offset
+    end
+
+    assert_deprecated(ActiveSupport.deprecator) do
+      ActiveSupport.to_time_preserves_timezone = true
+    end
+
+    assert_deprecated(ActiveSupport.deprecator) do
+      ActiveSupport.to_time_preserves_timezone = "offset"
+    end
+
+    assert_deprecated(ActiveSupport.deprecator) do
+      ActiveSupport.to_time_preserves_timezone = :foo
     end
   ensure
     ActiveSupport.deprecator.silence do

--- a/activesupport/test/core_ext/time_with_zone_test.rb
+++ b/activesupport/test/core_ext/time_with_zone_test.rb
@@ -517,7 +517,34 @@ class TimeWithZoneTest < ActiveSupport::TestCase
     assert_equal time, Time.at(time)
   end
 
-  def test_to_time_with_preserve_timezone
+  def test_to_time_with_preserve_timezone_using_zone
+    with_preserve_timezone(:zone) do
+      time = @twz.to_time
+      local_time = with_env_tz("US/Eastern") { Time.local(1999, 12, 31, 19) }
+
+      assert_equal Time, time.class
+      assert_equal time.object_id, @twz.to_time.object_id
+      assert_equal local_time, time
+      assert_equal local_time.utc_offset, time.utc_offset
+      assert_equal @time_zone, time.zone
+    end
+  end
+
+  def test_to_time_with_preserve_timezone_using_offset
+    with_preserve_timezone(:offset) do
+      with_env_tz "US/Eastern" do
+        time = @twz.to_time
+
+        assert_equal Time, time.class
+        assert_equal time.object_id, @twz.to_time.object_id
+        assert_equal Time.local(1999, 12, 31, 19), time
+        assert_equal Time.local(1999, 12, 31, 19).utc_offset, time.utc_offset
+        assert_nil time.zone
+      end
+    end
+  end
+
+  def test_to_time_with_preserve_timezone_using_true
     with_preserve_timezone(true) do
       with_env_tz "US/Eastern" do
         time = @twz.to_time
@@ -526,6 +553,7 @@ class TimeWithZoneTest < ActiveSupport::TestCase
         assert_equal time.object_id, @twz.to_time.object_id
         assert_equal Time.local(1999, 12, 31, 19), time
         assert_equal Time.local(1999, 12, 31, 19).utc_offset, time.utc_offset
+        assert_nil time.zone
       end
     end
   end
@@ -539,6 +567,7 @@ class TimeWithZoneTest < ActiveSupport::TestCase
         assert_equal time.object_id, @twz.to_time.object_id
         assert_equal Time.local(1999, 12, 31, 19), time
         assert_equal Time.local(1999, 12, 31, 19).utc_offset, time.utc_offset
+        assert_equal Time.local(1999, 12, 31, 19).zone, time.zone
       end
     end
   end
@@ -552,6 +581,7 @@ class TimeWithZoneTest < ActiveSupport::TestCase
         assert_equal time.object_id, @twz.to_time.object_id
         assert_equal Time.local(1999, 12, 31, 19), time
         assert_equal Time.local(1999, 12, 31, 19).utc_offset, time.utc_offset
+        assert_equal Time.local(1999, 12, 31, 19).zone, time.zone
 
         assert_equal false, ActiveSupport.to_time_preserves_timezone
       end

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -58,6 +58,10 @@ NOTE: If you need to apply configuration directly to a class, use a [lazy load h
 
 Below are the default values associated with each target version. In cases of conflicting values, newer versions take precedence over older versions.
 
+#### Default Values for Target Version 8.0
+
+- [`config.active_support.to_time_preserves_timezone`](#config-active-support-to-time-preserves-timezone): `:zone`
+
 #### Default Values for Target Version 7.2
 
 - [`config.active_job.enqueue_after_transaction_commit`](#config-active-job-enqueue-after-transaction-commit): `:default`
@@ -154,10 +158,10 @@ Below are the default values associated with each target version. In cases of co
 
 #### Default Values for Target Version 5.0
 
-- [`ActiveSupport.to_time_preserves_timezone`](#activesupport-to-time-preserves-timezone): `true`
 - [`config.action_controller.forgery_protection_origin_check`](#config-action-controller-forgery-protection-origin-check): `true`
 - [`config.action_controller.per_form_csrf_tokens`](#config-action-controller-per-form-csrf-tokens): `true`
 - [`config.active_record.belongs_to_required_by_default`](#config-active-record-belongs-to-required-by-default): `true`
+- [`config.active_support.to_time_preserves_timezone`](#config-active-support-to-time-preserves-timezone): `:offset`
 - [`config.ssl_options`](#config-ssl-options): `{ hsts: { subdomains: true } }`
 
 ### Rails General Configuration
@@ -2694,6 +2698,18 @@ The default value depends on the `config.load_defaults` target version:
 | (original)            | `false`              |
 | 7.0                   | `true`               |
 
+#### `config.active_support.to_time_preserves_timezone`
+
+Specifies whether `to_time` methods preserve the UTC offset of their receivers or preserves the timezone. If set to `:zone`, `to_time` methods will use the timezone of their receivers. If set to `:offset`, `to_time` methods will use the UTC offset. If `false`, `to_time` methods will convert to the local system UTC offset instead.
+
+The default value depends on the `config.load_defaults` target version:
+
+| Starting with version | The default value is |
+| --------------------- | -------------------- |
+| (original)            | `false`              |
+| 5.0                   | `:offset`            |
+| 8.0                   | `:zone`              |
+
 #### `ActiveSupport::Logger.silencer`
 
 Is set to `false` to disable the ability to silence logging in a block. The default is `true`.
@@ -2701,17 +2717,6 @@ Is set to `false` to disable the ability to silence logging in a block. The defa
 #### `ActiveSupport::Cache::Store.logger`
 
 Specifies the logger to use within cache store operations.
-
-#### `ActiveSupport.to_time_preserves_timezone`
-
-Specifies whether `to_time` methods preserve the UTC offset of their receivers. If `false`, `to_time` methods will convert to the local system UTC offset instead.
-
-The default value depends on the `config.load_defaults` target version:
-
-| Starting with version | The default value is |
-| --------------------- | -------------------- |
-| (original)            | `false`              |
-| 5.0                   | `true`               |
 
 #### `ActiveSupport.utc_to_local_returns_utc_offset_times`
 

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -114,7 +114,9 @@ module Rails
             action_controller.forgery_protection_origin_check = true
           end
 
-          ActiveSupport.to_time_preserves_timezone = true
+          if respond_to?(:active_support)
+            active_support.to_time_preserves_timezone = :offset
+          end
 
           if respond_to?(:active_record)
             active_record.belongs_to_required_by_default = true
@@ -337,6 +339,10 @@ module Rails
           end
         when "8.0"
           load_defaults "7.2"
+
+          if respond_to?(:active_support)
+            active_support.to_time_preserves_timezone = :zone
+          end
         else
           raise "Unknown version #{target_version.to_s.inspect}"
         end

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_8_0.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_8_0.rb.tt
@@ -8,3 +8,11 @@
 #
 # Read the Guide for Upgrading Ruby on Rails for more info on each option.
 # https://guides.rubyonrails.org/upgrading_ruby_on_rails.html
+
+###
+# Specifies whether `to_time` methods preserve the UTC offset of their receivers or preserves the timezone.
+# If set to `:zone`, `to_time` methods will use the timezone of their receivers.
+# If set to `:offset`, `to_time` methods will use the UTC offset.
+# If `false`, `to_time` methods will convert to the local system UTC offset instead.
+#++
+# Rails.application.config.active_support.to_time_preserves_timezone = :zone


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created because `to_time` on TimeWithZone object does not preserve timezone information. This PR adds a config to preserve timezone information when calling `to_time` on TimeWithZone object.

### Detail

This Pull Request adds a new config value `:zone` for `ActiveSupport.to_time_preserves_timezone`. In addition, the existing `true` value for `ActiveSupport.to_time_preserves_timezone` has been changed to `:offset` and preserves the previous behavior of using UTC offset.
When it's set to `:zone`, `to_time` will return a Time object with the same timezone as the TimeWithZone object.
Default value for `ActiveSupport.to_time_preserves_timezone` is now `:zone` in 8.0.

### Additional information

cc: @jhawthorn @matthewd 

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
