### PR TITLE
Only sanitize `content` attribute when present in attachments

### DIFF
--- a/actiontext/CHANGELOG.md
+++ b/actiontext/CHANGELOG.md
@@ -1,2 +1,5 @@
+*   Only sanitize `content` attribute when present in attachments.
+
+    *Petrik de Heus*
 
 Please check [7-2-stable](https://github.com/rails/rails/blob/7-2-stable/actiontext/CHANGELOG.md) for previous changes.

--- a/actiontext/lib/action_text/content.rb
+++ b/actiontext/lib/action_text/content.rb
@@ -97,7 +97,9 @@ module ActionText
 
     def render_attachments(**options, &block)
       content = fragment.replace(ActionText::Attachment.tag_name) do |node|
-        node["content"] = sanitize_content_attachment(node["content"])
+        if node.key? "content"
+          node["content"] = sanitize_content_attachment(node["content"])
+        end
         block.call(attachment_for_node(node, **options))
       end
       self.class.new(content, canonicalize: false)

--- a/actiontext/test/unit/content_test.rb
+++ b/actiontext/test/unit/content_test.rb
@@ -158,6 +158,18 @@ class ActionText::ContentTest < ActiveSupport::TestCase
     ActionText::ContentHelper.allowed_attributes = old_attrs
   end
 
+  test "sanitizes attachment markup for Trix" do
+    html = '<action-text-attachment content="<img src=\&quot;.\&quot; onerror=alert>"></action-text-attachment>'
+    trix_html = '<figure data-trix-attachment="{&quot;content&quot;:&quot;<img src=\\&quot;\\\\%22.\\\\%22\\&quot;>&quot;}"></figure>'
+    assert_equal trix_html, content_from_html(html).to_trix_html.strip
+  end
+
+  test "does not add missing content attribute" do
+    html = '<action-text-attachment sgid="123"></action-text-attachment>'
+    trix_html = '<figure data-trix-attachment="{&quot;sgid&quot;:&quot;123&quot;}"></figure>'
+    assert_equal trix_html, content_from_html(html).to_trix_html.strip
+  end
+
   test "renders with layout when in a new thread" do
     html = "<h1>Hello world</h1>"
     rendered = nil


### PR DESCRIPTION
When the `content` attribute is set for Action Text attachments, Trix shows this content.

1ac6d40d36a07b48a67bc7f8627fd1f92bffcb14 introduced sanitizing the `content` attribute of ActionText::Attachable::ContentAttachment. 
However, it would also set the `content` attribute when it isn't present.
So, instead of showing the image preview, Trix would use the empty `content` attribute resulting in missing previews for images.

An issue was reported in the Basecamp repo: https://github.com/basecamp/trix/issues/1158

### Additional information

The test that was added in 1ac6d40d36a07b48a67bc7f8627fd1f92bffcb14 did
not fail when commenting out the original sanitation fix. I've added a test to fix this as well.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
