### PR TITLE
Don't try to set invalid cookies.

### DIFF
--- a/actionpack/test/dispatch/cookies_test.rb
+++ b/actionpack/test/dispatch/cookies_test.rb
@@ -115,11 +115,6 @@ class CookiesTest < ActionController::TestCase
       head :ok
     end
 
-    def set_with_with_escapable_characters
-      cookies["that & guy"] = "foo & bar => baz"
-      head :ok
-    end
-
     def authenticate_for_fourteen_days
       cookies["user_name"] = { "value" => "david", "expires" => Time.utc(2005, 10, 10, 5) }
       head :ok
@@ -491,12 +486,6 @@ class CookiesTest < ActionController::TestCase
     request.cookies[:user_name] = "Jamie"
     get :set_permanent_cookie
     assert_equal({ "user_name" => "Jamie" }, response.cookies)
-  end
-
-  def test_setting_with_escapable_characters
-    get :set_with_with_escapable_characters
-    assert_set_cookie_header "that+%26+guy=foo+%26+bar+%3D%3E+baz; path=/; SameSite=Lax"
-    assert_equal({ "that & guy" => "foo & bar => baz" }, @response.cookies)
   end
 
   def test_setting_cookie_for_fourteen_days


### PR DESCRIPTION
### Motivation / Background

In Rack 3.1, using invalid cookie keys was deprecated and in Rack 3.2, using an invalid cookie key will raise an exception.

Escaping cookie keys is non-standard behaviour and is not understood by clients, e.g. `document.cookies` will contain escaped keys. It also doesn't round-trip correctly, as in, setting a header with a given name won't have the same name in subsequent requests. In addition, the escaping / unescaping behaviour in previous versions of Rack [caused a security issue](https://github.com/advisories/GHSA-j6w9-fv6q-3q52).

### Detail

This pull request changes the test to avoid invalid cookie keys. Alternatively, Rails could continue to escape and unescape cookie keys by using a wrapper.

The issue of round tripping is particularly problematic. The following example simply doesn't work, unless the `KEY` is specified without any characters that require escaping.

```ruby
class WelcomeController < ApplicationController
  KEY = "visit counter"

  def index
    if request.cookies[KEY]
      @value = Integer(request.cookies[KEY])
    else
      @value = 0
    end

    response.set_cookie(KEY, value: @value + 1, expires: 1.year.from_now)
    
    render plain: "You have visited this page #{@value} times"
  end
end
```

The above controller will output 0 every request. If `KEY = "visit-counter"` is used, it will increment correctly. Based on this example, we can probably assume that it is unlikely code is relying on this behaviour, or if it is, it is unlikely that it is working as intended.

### Additional information

Alternatively, we could escape and unescape the cookie values. This lead to the security issue. We can reject cookies which unescape to names which are considered secure. That was explored in <https://github.com/rack/rack/pull/2188> - this approach was ultimately rejected as the current implementation is ultimately flawed as shown by the above example.

In addition, this issue is confused further by the fact that the Rails test case implementation DOES unescape cookie keys and values. I don't believe this should be considered a security issue as it's limited to testing, but the behaviour is not consistent with Rack's behaviour since the initial fix for the security issue was applied.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [ ] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
