### PR TITLE
Rename `unprocessable_entity` -> `unprocessable_content`.

### DIFF
--- a/actionpack/lib/action_controller/metal/rendering.rb
+++ b/actionpack/lib/action_controller/metal/rendering.rb
@@ -157,7 +157,7 @@ module ActionController
     #         render "posts/new", status: 422
     #         # => renders app/views/posts/new.html.erb with HTTP status code 422
     #
-    #         render "posts/new", status: :unprocessable_entity
+    #         render "posts/new", status: :unprocessable_content
     #         # => renders app/views/posts/new.html.erb with HTTP status code 422
     #
     #--

--- a/actionpack/lib/action_dispatch/middleware/exception_wrapper.rb
+++ b/actionpack/lib/action_dispatch/middleware/exception_wrapper.rb
@@ -9,6 +9,12 @@ require "rack/utils"
 
 module ActionDispatch
   class ExceptionWrapper
+    if Rack::Utils::SYMBOL_TO_STATUS_CODE[:unprocessable_content]
+      UNPROCESSABLE_CONTENT = :unprocessable_content
+    else
+      UNPROCESSABLE_CONTENT = :unprocessable_entity
+    end
+
     cattr_accessor :rescue_responses, default: Hash.new(:internal_server_error).merge!(
       "ActionController::RoutingError"                     => :not_found,
       "AbstractController::ActionNotFound"                 => :not_found,
@@ -18,8 +24,8 @@ module ActionDispatch
       "ActionController::UnknownFormat"                    => :not_acceptable,
       "ActionDispatch::Http::MimeNegotiation::InvalidType" => :not_acceptable,
       "ActionController::MissingExactTemplate"             => :not_acceptable,
-      "ActionController::InvalidAuthenticityToken"         => :unprocessable_entity,
-      "ActionController::InvalidCrossOriginRequest"        => :unprocessable_entity,
+      "ActionController::InvalidAuthenticityToken"         => UNPROCESSABLE_CONTENT,
+      "ActionController::InvalidCrossOriginRequest"        => UNPROCESSABLE_CONTENT,
       "ActionDispatch::Http::Parameters::ParseError"       => :bad_request,
       "ActionController::BadRequest"                       => :bad_request,
       "ActionController::ParameterMissing"                 => :bad_request,

--- a/actionpack/test/controller/rescue_test.rb
+++ b/actionpack/test/controller/rescue_test.rb
@@ -147,7 +147,7 @@ class RescueController < ActionController::Base
     end
 
     def show_errors(exception)
-      head :unprocessable_entity
+      head ActionDispatch::ExceptionWrapper::UNPROCESSABLE_CONTENT
     end
 end
 
@@ -289,12 +289,12 @@ class RescueControllerTest < ActionController::TestCase
 
   test "rescue when cause has more specific handler than wrapper" do
     get :exception_with_more_specific_handler_for_cause
-    assert_response :unprocessable_entity
+    assert_response ActionDispatch::ExceptionWrapper::UNPROCESSABLE_CONTENT
   end
 
   test "rescue when cause has handler, but wrapper doesn't" do
     get :exception_with_no_handler_for_wrapper
-    assert_response :unprocessable_entity
+    assert_response ActionDispatch::ExceptionWrapper::UNPROCESSABLE_CONTENT
   end
 
   test "can rescue a ParseError" do

--- a/actionpack/test/dispatch/debug_exceptions_test.rb
+++ b/actionpack/test/dispatch/debug_exceptions_test.rb
@@ -75,7 +75,7 @@ class DebugExceptionsTest < ActionDispatch::IntegrationTest
         raise ActionController::UnknownHttpMethod
       when "/not_implemented"
         raise ActionController::NotImplemented
-      when "/unprocessable_entity"
+      when "/unprocessable_content"
         raise ActionController::InvalidAuthenticityToken
       when "/invalid_mimetype"
         raise ActionDispatch::Http::MimeNegotiation::InvalidType


### PR DESCRIPTION
### Motivation / Background

In Rack 3.1, `unprocessable_entity` was renamed to `unprocessable_content` to reflect the current naming conventions. See <https://github.com/rack/rack/pull/2137> for more context.

The old status code alias/name continues to work but emits a deprecation warning, so we prefer to use the new name where possible while retaining compatibility with old versions of Rack.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [ ] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
