### PR TITLE
Do not use SyntaxError#path

### DIFF
--- a/activesupport/lib/active_support/syntax_error_proxy.rb
+++ b/activesupport/lib/active_support/syntax_error_proxy.rb
@@ -45,7 +45,7 @@ module ActiveSupport
 
     private
       def parse_message_for_trace
-        if source_location_eval?
+        if __getobj__.to_s.start_with?("(eval")
           # If the exception is coming from a call to eval, we need to keep
           # the path of the file in which eval was called to ensure we can
           # return the right source fragment to show the location of the
@@ -54,16 +54,6 @@ module ActiveSupport
           ["#{location.path}:#{location.lineno}: #{__getobj__}"]
         else
           __getobj__.to_s.split("\n")
-        end
-      end
-
-      if SyntaxError.method_defined?(:path) # Ruby 3.3+
-        def source_location_eval?
-          __getobj__.path.start_with?("(eval")
-        end
-      else # 3.2 and older versions of Ruby
-        def source_location_eval?
-          __getobj__.to_s.start_with?("(eval")
         end
       end
   end


### PR DESCRIPTION
Fixes #52089

From what I understand, `path` is only set in the context of `eval`. When explicitly raising `SyntaxError`, `path` is `nil`.

Regardless of how `SyntaxError` is raised, the "path" always exists in `SyntaxError#to_s`. Therefore, we should just use `#to_s`.

Here is an example of the difference between `path` (when it's present) and `to_s` (the first line is `path`):

```
"(eval at /Users/jko/Developer/rails/rails/actionpack/test/dispatch/debug_exceptions_test.rb:106)"
"(eval at /Users/jko/Developer/rails/rails/actionpack/test/dispatch/debug_exceptions_test.rb:106):1: syntax error, unexpected end-of-input\nbroke_syntax =\n              ^\n"
```

I see no reason to use [the convenience method](https://bugs.ruby-lang.org/issues/19138) `path` and it was [chosen because it's simpler](https://github.com/rails/rails/pull/48957#discussion_r1305358915). 

Perhaps `path` not being populated outside `eval` is a Ruby bug?

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
