### PR TITLE
Fix ActiveRecord configs variable shadowing

### DIFF
--- a/activerecord/lib/active_record/railtie.rb
+++ b/activerecord/lib/active_record/railtie.rb
@@ -241,8 +241,7 @@ To keep using the current cache store, you can turn off cache versioning entirel
       end
 
       ActiveSupport.on_load(:active_record) do
-        # Configs used in other initializers
-        configs = configs.except(
+        configs_used_in_other_initializers = configs.except(
           :migration_error,
           :database_selector,
           :database_resolver,
@@ -259,7 +258,7 @@ To keep using the current cache store, you can turn off cache versioning entirel
           :postgresql_adapter_decode_dates,
         )
 
-        configs.each do |k, v|
+        configs_used_in_other_initializers.each do |k, v|
           next if k == :encryption
           setter = "#{k}="
           # Some existing initializers might rely on Active Record configuration

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -4482,6 +4482,20 @@ module ApplicationTests
       assert_equal true, ActiveRecord.run_after_transaction_callbacks_in_order_defined
     end
 
+    test "run_after_transaction_callbacks_in_order_defined can be set via framework defaults even if Active Record was previously loaded" do
+      remove_from_config '.*config\.load_defaults.*\n'
+      add_to_config 'config.load_defaults "7.0"'
+      app_file "config/initializers/01_configure_database.rb", <<-RUBY
+        ActiveRecord::Base.connected?
+      RUBY
+      app_file "config/initializers/new_framework_defaults_7_1.rb", <<-RUBY
+        Rails.application.config.active_record.run_after_transaction_callbacks_in_order_defined = true
+      RUBY
+      app "development"
+
+      assert_equal true, ActiveRecord.run_after_transaction_callbacks_in_order_defined
+    end
+
     test "raises if configuration tries to assign to an actual method" do
       remove_from_config '.*config\.load_defaults.*\n'
       add_to_config 'config.load_defaults = "7.0"'


### PR DESCRIPTION
### Motivation / Background

Fixes #52098 

This Pull Request has been created because I encountered surprising behavior when upgrading a Rails 7 application to Rails 7.1.  In `config/initializers/new_frame_defaults_7_1.rb`, I had

```ruby
Rails.application.config.active_record.run_after_transaction_callbacks_in_order_defined = true
```

but I was surprised to find that when the application booted

```ruby
ActiveRecord.run_after_transaction_callbacks_in_order_defined
=> false
```

### Detail

This Pull Request changes the name of a local variable in the ActiveRecord Railtie's `active_record.set_configs` initializer.  The name change avoids shadowing the `configs` and resetting the local variable that is initialized at the beginning of the initializer.  This way the `after_initialize` hook can run through _all_ of the config values set in `Rails.application.config.active_record` and configure `ActiveRecord` accordingly.

### Additional information

I am not certain whether the variable shadowing and resetting was indeed intentional.  It may have been and this solution may introduce other problems 😬 .

I think this problem only occurs when ActiveRecord happens to be loaded before the `new_framework_defaults` initializer runs.  I would guess that many gems might load ActiveRecord and gem Railties run before files in `config/initializers`.  That is to say that I would guess that loading ActiveRecord in a gem could be fairly commonplace.  Solving such problems may not fall under the domain of Rails, but I figured I would give this PR a try 😃 .

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
