### PR TITLE
Add support for fast smoke tests.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -34,11 +34,24 @@ task default: %w(test test:isolated)
 end
 
 desc "Smoke-test all projects"
-task :smoke do
-  (FRAMEWORKS - %w(activerecord)).each do |project|
-    system %(cd #{project} && #{$0} test:isolated --trace)
+task :smoke, [:frameworks, :isolated] do |task, args|
+  frameworks = args[:frameworks] ? args[:frameworks].split(" ") : FRAMEWORKS
+  # The arguments are positional, and users may want to specify only the isolated flag.. so we allow 'all' as a default for the first argument:
+  if frameworks.include?("all")
+    frameworks = FRAMEWORKS
   end
-  system %(cd activerecord && #{$0} sqlite3:isolated_test --trace)
+
+  isolated = args[:isolated].nil? ? true : args[:isolated] == "true"
+  test_task = isolated ? "test:isolated" : "test"
+
+  (frameworks - ["activerecord"]).each do |project|
+    system %(cd #{project} && #{$0} #{test_task} --trace)
+  end
+
+  if frameworks.include? "activerecord"
+    test_task = isolated ? "sqlite3:isolated_test" : "sqlite3:test"
+    system %(cd activerecord && #{$0} #{test_task} --trace)
+  end
 end
 
 desc "Install gems for all projects."


### PR DESCRIPTION
### Motivation / Background

I'd like to get faster feedback on compatibility between Rails and Rack. I've started working on <https://github.com/rack/rack/pull/2208>. Rack has the capacity to run external tests as part of its own test suite `rake smoke` takes 41 minutes which is pretty slow. I'd like to add a bit more control over this, so we can run it more quickly.

We introduce two arguments: the list of `frameworks` to test (or `all` to test all frameworks) and a flag `isolated` which indicates whether to use isolated tests.

You can invoke it like so:

```
-- Run all tests in isolated mode:
$ bundle exec rake smoke

-- Run all tests in isolated mode:
$ bundle exec rake smoke[all,true]

-- Run all tests in non-isolated mode:
$ bundle exec rake smoke[all,false]

-- Run a subset of tests in non-isolated mode:
$ bundle exec rake smoke[activerecord actiondispatch,false]
```

The default behaviour remains the same.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [ ] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
