### PR TITLE
Fix typo in `global_executor_concurrency` error message

### DIFF
--- a/activerecord/lib/active_record.rb
+++ b/activerecord/lib/active_record.rb
@@ -301,7 +301,7 @@ module ActiveRecord
   # with the global thread pool async query executor.
   def self.global_executor_concurrency=(global_executor_concurrency)
     if self.async_query_executor.nil? || self.async_query_executor == :multi_thread_pool
-      raise ArgumentError, "`global_executor_concurrency` cannot be set when using the executor is nil or set to multi_thead_pool. For multiple thread pools, please set the concurrency in your database configuration."
+      raise ArgumentError, "`global_executor_concurrency` cannot be set when using the executor is nil or set to multi_thread_pool. For multiple thread pools, please set the concurrency in your database configuration."
     end
 
     @global_executor_concurrency = global_executor_concurrency

--- a/activerecord/lib/active_record.rb
+++ b/activerecord/lib/active_record.rb
@@ -301,7 +301,7 @@ module ActiveRecord
   # with the global thread pool async query executor.
   def self.global_executor_concurrency=(global_executor_concurrency)
     if self.async_query_executor.nil? || self.async_query_executor == :multi_thread_pool
-      raise ArgumentError, "`global_executor_concurrency` cannot be set when using the executor is nil or set to multi_thread_pool. For multiple thread pools, please set the concurrency in your database configuration."
+      raise ArgumentError, "`global_executor_concurrency` cannot be set when the executor is nil or set to `:multi_thread_pool`. For multiple thread pools, please set the concurrency in your database configuration."
     end
 
     @global_executor_concurrency = global_executor_concurrency


### PR DESCRIPTION

### Detail

Correct typo in `activerecord/lib/active_record.rb`: replaced `multi_thead_pool` with `multi_thread_pool` in the error message