### PR TITLE
Harden the `.current_transaction` API

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -356,7 +356,7 @@ module ActiveRecord
           if isolation
             raise ActiveRecord::TransactionIsolationError, "cannot set isolation when joining a transaction"
           end
-          yield current_transaction
+          yield current_transaction.user_transaction
         else
           within_new_transaction(isolation: isolation, joinable: joinable, &block)
         end

--- a/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb
@@ -277,7 +277,7 @@ module ActiveRecord
             type_casted_binds: -> { type_casted_binds(binds) },
             name: name,
             connection: self,
-            transaction: current_transaction.presence,
+            transaction: current_transaction.user_transaction.presence,
             cached: true
           }
         end

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -1118,7 +1118,7 @@ module ActiveRecord
             statement_name:    statement_name,
             async:             async,
             connection:        self,
-            transaction:       current_transaction.presence,
+            transaction:       current_transaction.user_transaction.presence,
             row_count:         0,
             &block
           )

--- a/activerecord/lib/active_record/transactions.rb
+++ b/activerecord/lib/active_record/transactions.rb
@@ -243,7 +243,7 @@ module ActiveRecord
       #
       # See the ActiveRecord::Transaction documentation for detailed behavior.
       def current_transaction
-        connection_pool.active_connection&.current_transaction || ConnectionAdapters::TransactionManager::NULL_TRANSACTION
+        connection_pool.active_connection&.current_transaction&.user_transaction || Transaction::NULL_TRANSACTION
       end
 
       def before_commit(*args, &block) # :nodoc:


### PR DESCRIPTION
Closes https://github.com/rails/rails/pull/52017

### `.current_transaction` lifetime

One concern raised by @fxn is users holding on the return value of `.current_transaction` beyond the point where it is committed / rolled back / invalidated.

I believe this is an invalid use of the API, just like holding `ActiveRecord::Base.connection` beyond the scope of a request is, and may even lead to terrible results.

However we can be more explicit and strict about it, so I changed the callback registration methods to raise an error when called on a finalized transaction.

### `:transaction` event payload

Another concern of @fxn was the usability of the null-object in the Active Record notification payloads, and I agree that while the null-object make sense when calling `Model.current_transaction`, it doesn't make sense to include it in the payload of events. The goal of the `.current_transaction` API is to allow implementing transaction aware code in a streamlined way. 

The goal of the `:transaction` in events however it to allow logging whether a query was inside a transaction or not, so it's much more ergonomic for it to be nilable. So I kept @matthewd 's change that passes `transaction: nil` in `sql.active_record` events when not inside a transaction. I also added test coverage to make sure it behaves consistently whether we're inside a transactional test or not.

### Refactoring

I also kept the separation between internal and "user" transaction objects, as I think it's a nice way to limit the effectively exposed API, and prevent users from abusing that API too much.

## Non addressed concerns

### Callback ordering

@fxn also raised the following concern:

```ruby
Post.current_transaction.after_commit { should_be_called_last }
Post.current_transaction.before_commit { should_be_called_first }
```

In the example above, the call order is inconsistent whether you are inside a transaction or not.

I don't have an answer to this aside from documenting it. But I really don't think it's big enough of a problem to justify returning `nil` in `.current_transaction`, because it would result in the above code turning into:

```ruby
if Post.current_transaction
  Post.current_transaction.after_commit { should_be_called_last }
  Post.current_transaction.before_commit { should_be_called_first }
else
  should_be_called_first
  should_be_called_last
end
```

Which, in my opinion, is more verbose, inelegant and ultimately more error prone, as you now have two code paths to keep in sync.

One option however could be to simply not expose `before_commit`, which arguably is much much less useful than `after_commit` and `after_callback` and which I only really included for completeness. As a matter of fact, the private API we currently use at Shopify to register callbacks on transactions only offer `after_commit` and `after_rollback`, so I can't justify a need for it, and we could always consider adding it later if users come up with use cases.
