### PR TITLE
[`7-2-stable` Backport] Fix action-text-attachment HTML escaping regression test

### DIFF
--- a/actiontext/test/unit/attachment_test.rb
+++ b/actiontext/test/unit/attachment_test.rb
@@ -79,13 +79,10 @@ class ActionText::AttachmentTest < ActiveSupport::TestCase
     end
   end
 
-  test "sanitizes HTML content attachment" do
-    attachment = attachment_from_html('<action-text-attachment content-type="text/html" content="<img src=\&quot;.\&quot; onerror=alert>"></action-text-attachment>')
-    attachable = attachment.attachable
+  test "to_trix_html sanitizes action-text HTML content attachment" do
+    attachment = ActionText::Content.new("<action-text-attachment content-type=\"text/html\" content=\"<img src=. onerror='alert(location)' />\"></action-text-attachment>")
 
-    ActionText::Content.with_renderer MessagesController.renderer do
-      assert_equal "<img src=\"\\%22.\\%22\">", attachable.to_html.strip
-    end
+    assert_equal "<figure data-trix-attachment=\"{&quot;contentType&quot;:&quot;text/html&quot;,&quot;content&quot;:&quot;<img src=\\&quot;.\\&quot;>&quot;}\"></figure>", attachment.to_trix_html
   end
 
   test "defaults trix partial to model partial" do


### PR DESCRIPTION
### Motivation / Background
Backport https://github.com/rails/rails/pull/52106/commits/6678de6ce21fd9d24c93b53357ff9ab54a5638bd to `7-2-stable` as https://github.com/rails/rails/commit/1ac6d40d36a07b48a67bc7f8627fd1f92bffcb14 was also applied to `7-2-stable`.

Although https://github.com/rails/rails/commit/1ac6d40d36a07b48a67bc7f8627fd1f92bffcb14 addressed the target issue, the included regression test is not exercising the correct method.

### Detail
Modified the related test to target `to_trix_html()` instead of `to_html()`.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
