### PR TITLE
Correctly output `driven_by` setting for Development Containers

### DIFF
--- a/.github/workflows/devcontainer-smoke-test.yml
+++ b/.github/workflows/devcontainer-smoke-test.yml
@@ -63,7 +63,7 @@ jobs:
           imageTag: postgresql
           push: ${{ github.repository_owner == 'rails' && 'filter' || 'never' }}
           refFilterForPush: refs/heads/main
-          runCmd: bin/rails g scaffold Post && bin/rails db:migrate && bin/rails test
+          runCmd: bin/rails g scaffold Post && bin/rails db:migrate && bin/rails test && bin/rails test:system
 
       - name: Stop all containers
         run: docker ps -q | xargs docker stop

--- a/railties/lib/rails/generators/rails/devcontainer/devcontainer_generator.rb
+++ b/railties/lib/rails/generators/rails/devcontainer/devcontainer_generator.rb
@@ -148,7 +148,7 @@ module Rails
         end
 
         def system_test_configuration
-          <<~RUBY
+          <<~'RUBY'
               if ENV["CAPYBARA_SERVER_PORT"]
                 served_by host: "rails-app", port: ENV["CAPYBARA_SERVER_PORT"]
 


### PR DESCRIPTION
### Motivation / Background

Currently, `ENV["SELENIUM_HOST"]` is evaluated when generating a file. So the result was the following.

```
  driven_by :selenium, using: :headless_chrome, screen_size: [ 1400, 1400 ], options: {
    browser: :remote,
    url: "http://:4444"
  }
```

This PR fixes to output the URL setting just as a string. The after result is the following.

```
  driven_by :selenium, using: :headless_chrome, screen_size: [ 1400, 1400 ], options: {
    browser: :remote,
    url: "http://#{ENV["SELENIUM_HOST"]}:4444"
  }

```

Also, this PR is updated to run a system test on Devcontainer smoke test. To confirm the files for Dev Containers are generated correctly.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
