### PR TITLE
Fix a performance regression in attribute methods

### DIFF
--- a/activemodel/lib/active_model/attributes.rb
+++ b/activemodel/lib/active_model/attributes.rb
@@ -76,11 +76,11 @@ module ActiveModel
       end
 
       private
-        def define_method_attribute=(name, owner:)
+        def define_method_attribute=(canonical_name, owner:, as: canonical_name)
           ActiveModel::AttributeMethods::AttrNames.define_attribute_accessor_method(
-            owner, name, writer: true,
+            owner, canonical_name, writer: true,
           ) do |temp_method_name, attr_name_expr|
-            owner.define_cached_method("#{name}=", as: temp_method_name, namespace: :active_model) do |batch|
+            owner.define_cached_method(temp_method_name, as: "#{as}=", namespace: :active_model) do |batch|
               batch <<
                 "def #{temp_method_name}(value)" <<
                 "  _write_attribute(#{attr_name_expr}, value)" <<

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,4 +1,11 @@
-*   Fix an issue that could cause database connection leaks
+*   Fix a memory perfomance regression in attribute methods.
+
+    Attribute methods used much more memory and were slower to define than
+    they should have been.
+
+    *Jean Boussier*
+
+*   Fix an issue that could cause database connection leaks.
 
     If Active Record successfully connected to the database, but then failed
     to read the server informations, the connection would be leaked until the

--- a/activerecord/lib/active_record/attribute_methods.rb
+++ b/activerecord/lib/active_record/attribute_methods.rb
@@ -82,10 +82,16 @@ module ActiveRecord
         end
       end
 
-      def alias_attribute_method_definition(code_generator, pattern, new_name, old_name)
+      def generate_alias_attribute_methods(code_generator, new_name, old_name) # :nodoc:
+        attribute_method_patterns.each do |pattern|
+          alias_attribute_method_definition(code_generator, pattern, new_name, old_name)
+        end
+        attribute_method_patterns_cache.clear
+      end
+
+      def alias_attribute_method_definition(code_generator, pattern, new_name, old_name) # :nodoc:
         method_name = pattern.method_name(new_name).to_s
         target_name = pattern.method_name(old_name).to_s
-        parameters = pattern.parameters
         old_name = old_name.to_s
 
         method_defined = method_defined?(target_name) || private_method_defined?(target_name)
@@ -115,9 +121,7 @@ module ActiveRecord
           )
           super
         else
-          define_proxy_call(code_generator, method_name, pattern.proxy_target, parameters, old_name,
-            namespace: :proxy_alias_attribute
-          )
+          define_attribute_method_pattern(pattern, old_name, owner: code_generator, as: new_name)
         end
       end
 

--- a/activerecord/lib/active_record/attribute_methods/read.rb
+++ b/activerecord/lib/active_record/attribute_methods/read.rb
@@ -8,11 +8,11 @@ module ActiveRecord
 
       module ClassMethods # :nodoc:
         private
-          def define_method_attribute(name, owner:)
+          def define_method_attribute(canonical_name, owner:, as: canonical_name)
             ActiveModel::AttributeMethods::AttrNames.define_attribute_accessor_method(
-              owner, name
+              owner, canonical_name
             ) do |temp_method_name, attr_name_expr|
-              owner.define_cached_method(name, as: temp_method_name, namespace: :active_record) do |batch|
+              owner.define_cached_method(temp_method_name, as: as, namespace: :active_record) do |batch|
                 batch <<
                   "def #{temp_method_name}" <<
                   "  _read_attribute(#{attr_name_expr}) { |n| missing_attribute(n, caller) }" <<

--- a/activerecord/lib/active_record/attribute_methods/write.rb
+++ b/activerecord/lib/active_record/attribute_methods/write.rb
@@ -12,11 +12,11 @@ module ActiveRecord
 
       module ClassMethods # :nodoc:
         private
-          def define_method_attribute=(name, owner:)
+          def define_method_attribute=(canonical_name, owner:, as: canonical_name)
             ActiveModel::AttributeMethods::AttrNames.define_attribute_accessor_method(
-              owner, name, writer: true,
+              owner, canonical_name, writer: true,
             ) do |temp_method_name, attr_name_expr|
-              owner.define_cached_method("#{name}=", as: temp_method_name, namespace: :active_record) do |batch|
+              owner.define_cached_method(temp_method_name, as: "#{as}=", namespace: :active_record) do |batch|
                 batch <<
                   "def #{temp_method_name}(value)" <<
                   "  _write_attribute(#{attr_name_expr}, value)" <<

--- a/activerecord/test/cases/attribute_methods_test.rb
+++ b/activerecord/test/cases/attribute_methods_test.rb
@@ -1213,8 +1213,10 @@ class AttributeMethodsTest < ActiveRecord::TestCase
   test "aliases to the same attribute name do not conflict with each other" do
     first_model_object = ToBeLoadedFirst.new(author_name: "author 1")
     assert_equal("author 1", first_model_object.subject)
+    assert_equal([nil, "author 1"], first_model_object.subject_change)
     second_model_object = ToBeLoadedSecond.new(title: "foo")
     assert_equal("foo", second_model_object.subject)
+    assert_equal([nil, "foo"], second_model_object.subject_change)
   end
 
   ClassWithDeprecatedAliasAttributeBehavior = Class.new(ActiveRecord::Base) do

--- a/activesupport/lib/active_support/code_generator.rb
+++ b/activesupport/lib/active_support/code_generator.rb
@@ -9,16 +9,19 @@ module ActiveSupport
         @cache = METHOD_CACHES[namespace]
         @sources = []
         @methods = {}
+        @canonical_methods = {}
       end
 
-      def define_cached_method(name, as: name)
-        name = name.to_sym
-        as = as.to_sym
-        @methods.fetch(name) do
-          unless @cache.method_defined?(as)
+      def define_cached_method(canonical_name, as: nil)
+        canonical_name = canonical_name.to_sym
+        as = (as || canonical_name).to_sym
+
+        @methods.fetch(as) do
+          unless @cache.method_defined?(canonical_name) || @canonical_methods[canonical_name]
             yield @sources
           end
-          @methods[name] = as
+          @canonical_methods[canonical_name] = true
+          @methods[as] = canonical_name
         end
       end
 
@@ -26,8 +29,10 @@ module ActiveSupport
         unless @sources.empty?
           @cache.module_eval("# frozen_string_literal: true\n" + @sources.join(";"), path, line)
         end
-        @methods.each do |name, as|
-          owner.define_method(name, @cache.instance_method(as))
+        @canonical_methods.clear
+
+        @methods.each do |as, canonical_name|
+          owner.define_method(as, @cache.instance_method(canonical_name))
         end
       end
     end
@@ -52,8 +57,8 @@ module ActiveSupport
       @namespaces = Hash.new { |h, k| h[k] = MethodSet.new(k) }
     end
 
-    def define_cached_method(name, namespace:, as: name, &block)
-      @namespaces[namespace].define_cached_method(name, as: as, &block)
+    def define_cached_method(canonical_name, namespace:, as: nil, &block)
+      @namespaces[namespace].define_cached_method(canonical_name, as: as, &block)
     end
 
     def execute


### PR DESCRIPTION
Fix: https://github.com/rails/rails/issues/52111
Fix: https://github.com/rails/rails/commit/5dbc7b424ef2a5d562f04ebc560ddcfe573fcdb6

The above commit caused the size of the `CodeGenerator` method cache to explode, because the dynamic namespace is way too granular.

But there is actually a much better fix for that, since `alias_attribute` is now generating exactly the same code as the attribute it's aliasing, we can generated it as the canonical method in the cache, and then just define it in the model as the aliased name.

This prevent the cache from growing a lot, and even reduce memory usage further as the original attribute and its alias now share the same method cache.

Using @SamSaffron 's script:

`7-1-stable`:

```
359
121680 bytes
```

This PR:

```
20
16344 bytes
```


```ruby
# Gemfile
require "bundler/inline"
require "bundler"

rails_version = ENV.fetch("RAILS", "7.0")
gemfile do
  source "https://rubygems.org"
  gem "rails", path: "/Users/byroot/src/github.com/Shopify/rails/"
  gem "sqlite3", "~> 1.4"
end

require "active_record"
require "sqlite3"

# Establish the connection to an in-memory SQLite3 database
ActiveRecord::Base.establish_connection(
  adapter: "sqlite3",
  database: ":memory:"
)

# Define a migration
class CreateUsersTable < ActiveRecord::Migration[6.1]
  def change
    create_table :users do |t|
      t.string :name
      t.string :email
      t.string :username
      t.string :password_digest
      t.date :date_of_birth
      t.string :address
      t.string :city
      t.string :state
      t.string :zip_code
      t.string :country
      t.string :phone_number
      t.string :occupation
      t.string :company
      t.text :bio
      t.boolean :newsletter_subscribed, default: false

      t.timestamps
    end
  end
end

# Execute the migration
CreateUsersTable.new.change

# Define the User model
class User < ActiveRecord::Base
end

# Insert some records
User.create(
  name: "John Doe",
  email: "john.doe@example.com",
  username: "johndoe",
  password_digest: "password1",
  date_of_birth: "1980-01-01",
  address: "123 Main St",
  city: "Anytown",
  state: "CA",
  zip_code: "12345",
  country: "USA",
  phone_number: "555-1234",
  occupation: "Software Developer",
  company: "Tech Corp",
  bio: "A developer with a passion for coding.",
  newsletter_subscribed: true
)
User.create(
  name: "Jane Smith",
  email: "jane.smith@example.com",
  username: "janesmith",
  password_digest: "password2",
  date_of_birth: "1990-02-02",
  address: "456 Elm St",
  city: "Othertown",
  state: "NY",
  zip_code: "67890",
  country: "USA",
  phone_number: "555-5678",
  occupation: "Product Manager",
  company: "Prod Co",
  bio: "Experienced Product Manager.",
  newsletter_subscribed: false
)

# Lookup the first user
first_user = User.first
puts "First user: #{first_user.name}, #{first_user.email}, #{first_user.username}"

require 'objspace'
def deep_memsize(obj)
  size = ObjectSpace.memsize_of(obj) 
  case obj
  when Hash
    obj.each do |k, v|
      size += deep_memsize(k)
      size += deep_memsize(v)
    end
  when Array
    obj.each do |i|
      size += deep_memsize(i)
    end
  end
  size
end

puts ActiveSupport::CodeGenerator::MethodSet::METHOD_CACHES.size
puts "#{deep_memsize(ActiveSupport::CodeGenerator::MethodSet::METHOD_CACHES)} bytes"
```
