### PR TITLE
Include the actual ActiveJob locale when serializing rather than I18n locale

### DIFF
--- a/activejob/lib/active_job/core.rb
+++ b/activejob/lib/active_job/core.rb
@@ -114,7 +114,7 @@ module ActiveJob
         "arguments"  => serialize_arguments_if_needed(arguments),
         "executions" => executions,
         "exception_executions" => exception_executions,
-        "locale"     => I18n.locale.to_s,
+        "locale"     => locale || I18n.locale.to_s,
         "timezone"   => timezone,
         "enqueued_at" => Time.now.utc.iso8601(9),
         "scheduled_at" => scheduled_at ? scheduled_at.utc.iso8601(9) : nil,

--- a/activejob/test/cases/job_serialization_test.rb
+++ b/activejob/test/cases/job_serialization_test.rb
@@ -21,6 +21,25 @@ class JobSerializationTest < ActiveSupport::TestCase
     assert_equal "en", HelloJob.new.serialize["locale"]
   end
 
+  test "a deserialized job keeps its locale even if I18n.locale changes" do
+    old_locales = I18n.available_locales
+    begin
+      I18n.available_locales = [:en, :es]
+      I18n.locale = :es
+      payload = HelloJob.new.serialize
+      assert_equal "es", payload["locale"]
+
+      I18n.locale = :en
+
+      new_job = HelloJob.new
+      new_job.deserialize(payload)
+
+      assert_equal "es", new_job.serialize["locale"]
+    ensure
+      I18n.available_locales = old_locales
+    end
+  end
+
   test "serialize and deserialize are symmetric" do
     # Ensure `enqueued_at` does not change between serializations
     freeze_time


### PR DESCRIPTION
I realized that retrying a job from GoodJob would enqueue it in the current locale of the GoodJob dashboard, even if the job was originally enqueued in a different locale.

For instance, it was enqueued in `:fr`, and failed. When I retried it from the dashboard that was in `:en`, it was enqueued with an `:en` locale ( I noticed it because it failed again with a missing translation error)

I tracked it down to the `serialize` method of `ActiveJob` who always sets `locale` from `I18n.locale` 

This PR changes the serialize method to actually return the original local from the job if it is set, and default to the current locale if not.