### PR TITLE
Add propshaft specs for railties new default

### DIFF
--- a/railties/test/application/assets_test.rb
+++ b/railties/test/application/assets_test.rb
@@ -272,23 +272,6 @@ module ApplicationTests
       assert_nil last_response.headers["Set-Cookie"]
     end
 
-    test "assets are concatenated when debug is off and compile is off either if debug_assets param is provided" do
-      app_with_assets_in_view
-
-      # config.assets.debug and config.assets.compile are false for production environment
-      precompile! RAILS_ENV: "production"
-
-      # Load app env
-      app "production"
-
-      class ::PostsController < ActionController::Base ; end
-
-      # the debug_assets params isn't used if compile is off
-      get("/posts?debug_assets=true", {}, "HTTPS" => "on")
-      assert_match(/<script src="\/assets\/application-([0-z]+)\.js"><\/script>/, last_response.body)
-      assert_no_match(/<script src="\/assets\/xmlhr-([0-z]+)\.js"><\/script>/, last_response.body)
-    end
-
     test "initialization on the assets group should set assets_dir" do
       require "#{app_path}/config/application"
       Rails.application.initialize!(:assets)
@@ -303,7 +286,6 @@ module ApplicationTests
 
     test "digested assets are not mistakenly removed" do
       app_file "app/assets/application.css", "div { font-weight: bold }"
-      add_to_config "config.assets.compile = true"
 
       precompile!
 

--- a/railties/test/application/assets_test.rb
+++ b/railties/test/application/assets_test.rb
@@ -354,18 +354,6 @@ module ApplicationTests
       assert_match "src='//example.com/assets/rails.png'", File.read(Dir["#{app_path}/public/assets/image_loader-*.js"].first)
     end
 
-    test "asset paths should use RAILS_RELATIVE_URL_ROOT by default" do
-      ENV["RAILS_RELATIVE_URL_ROOT"] = "/sub/uri"
-      app_file "app/assets/images/rails.png", "notreallyapng"
-      app_file "app/assets/javascripts/app.js.erb", "var src='<%= image_path('rails.png') %>';"
-      add_to_config "config.assets.precompile = %w{rails.png app.js}"
-      add_to_env_config "development", "config.assets.digest = false"
-
-      precompile!
-
-      assert_match "src='/sub/uri/assets/rails.png'", File.read(Dir["#{app_path}/public/assets/app-*.js"].first)
-    end
-
     private
       def app_with_assets_in_view
         app_file "app/assets/javascripts/application.js", "//= require_tree ."

--- a/railties/test/application/assets_test.rb
+++ b/railties/test/application/assets_test.rb
@@ -317,15 +317,6 @@ module ApplicationTests
       assert_match('src="https://example.com/assets/application-72d8340d.js', last_response.body)
     end
 
-    test "asset URLs should be protocol-relative if no request is in scope" do
-      app_file "app/assets/images/rails.png", "notreallyapng"
-      app_file "app/assets/javascripts/image_loader.js", "var src='url('rails.png')' ;"
-      add_to_config "config.asset_host = 'example.com'"
-      precompile!
-
-      assert_match "src='//example.com/assets/rails.png'", File.read(Dir["#{app_path}/public/assets/image_loader-*.js"].first)
-    end
-
     private
       def app_with_assets_in_view
         app_file "app/assets/javascripts/application.js", "function f1() { alert(); }"

--- a/railties/test/application/assets_test.rb
+++ b/railties/test/application/assets_test.rb
@@ -280,23 +280,6 @@ module ApplicationTests
       assert_nil last_response.headers["Set-Cookie"]
     end
 
-    test "files in any assets/ directories are not added to Sprockets" do
-      %w[app lib vendor].each do |dir|
-        app_file "#{dir}/assets/#{dir}_test.erb", "testing"
-      end
-
-      app_file "app/assets/javascripts/demo.js", "alert();"
-
-      add_to_env_config "development", "config.assets.digest = false"
-
-      # Load app env
-      app "development"
-
-      get "/assets/demo.js"
-      assert_match "alert();", last_response.body
-      assert_equal 200, last_response.status
-    end
-
     test "assets are concatenated when debug is off and compile is off either if debug_assets param is provided" do
       app_with_assets_in_view
 

--- a/railties/test/application/assets_test.rb
+++ b/railties/test/application/assets_test.rb
@@ -314,18 +314,6 @@ module ApplicationTests
       assert_no_match(/<script src="\/assets\/xmlhr-([0-z]+)\.js"><\/script>/, last_response.body)
     end
 
-    test "assets can access model information when precompiling" do
-      app_file "app/models/post.rb", "class Post; end"
-      app_file "app/assets/javascripts/application.js", "//= require_tree ."
-      app_file "app/assets/javascripts/xmlhr.js.erb", "<%= Post.name %>"
-      app_file "app/assets/config/manifest.js", "//= link application.js"
-
-      precompile!
-
-      assert_file_exists("#{app_path}/public/assets/application-*.js")
-      assert_match(/Post;/, File.read(Dir["#{app_path}/public/assets/application-*.js"].first))
-    end
-
     test "initialization on the assets group should set assets_dir" do
       require "#{app_path}/config/application"
       Rails.application.initialize!(:assets)
@@ -376,8 +364,7 @@ module ApplicationTests
 
     test "asset URLs should be protocol-relative if no request is in scope" do
       app_file "app/assets/images/rails.png", "notreallyapng"
-      app_file "app/assets/javascripts/image_loader.js.erb", "var src='<%= image_path('rails.png') %>';"
-      add_to_config "config.assets.precompile = %w{rails.png image_loader.js}"
+      app_file "app/assets/javascripts/image_loader.js", "var src='url('rails.png')' ;"
       add_to_config "config.asset_host = 'example.com'"
       precompile!
 

--- a/railties/test/application/assets_test.rb
+++ b/railties/test/application/assets_test.rb
@@ -214,14 +214,14 @@ module ApplicationTests
       assert_file_exists("#{app_path}/public/assets/another-*.js")
     end
 
-    test "asset pipeline should use a Sprockets::CachedEnvironment when config.assets.digest is true" do
+    test "asset pipeline should use a Propshaft::Assembly when config.assets.digest is true" do
       add_to_config "config.action_controller.perform_caching = false"
       add_to_env_config "production", "config.assets.compile = true"
 
       # Load app env
       app "production"
 
-      assert_equal Sprockets::CachedEnvironment, Rails.application.assets.class
+      assert_equal Propshaft::Assembly, Rails.application.assets.class
     end
 
     test "precompile creates a manifest file with all the assets listed" do

--- a/railties/test/application/assets_test.rb
+++ b/railties/test/application/assets_test.rb
@@ -257,9 +257,6 @@ module ApplicationTests
         end
       RUBY
 
-      # Load app env
-      app "development"
-
       class ::OmgController < ActionController::Base
         def index
           flash[:cool_story] = true
@@ -329,8 +326,6 @@ module ApplicationTests
     test "asset URLs should use the request's protocol by default" do
       app_with_assets_in_view
       add_to_config "config.asset_host = 'example.com'"
-      # Load app env
-      app "development"
 
       class ::PostsController < ActionController::Base; end
 

--- a/railties/test/application/sprockets_assets_test.rb
+++ b/railties/test/application/sprockets_assets_test.rb
@@ -3,15 +3,20 @@
 require "isolation/abstract_unit"
 require "rack/test"
 require "active_support/json"
-require "propshaft"
+require "sprockets"
 
 module ApplicationTests
-  class AssetsTest < ActiveSupport::TestCase
+  class SprocketsAssetsTest < ActiveSupport::TestCase
     include ActiveSupport::Testing::Isolation
     include Rack::Test::Methods
 
+    def tmp_path(*args)
+      @sprockets_tmp_path ||= File.realpath(Dir.mktmpdir(nil, File.join(RAILS_FRAMEWORK_ROOT, "tmp")))
+      File.join(@sprockets_tmp_path, *args)
+    end
+
     def setup
-      build_app(initializers: true)
+      build_app(initializers: true, sprockets: true)
     end
 
     def teardown


### PR DESCRIPTION
### Motivation / Background

In https://github.com/rails/rails/pull/51799 @dhh changed asset pipeline default to Propshaft in Rails 8; specs assumed sprockets though so the new default isn't being tested.

@fedesapuppo and I reconvert `test/application/assets_test.rb` to test the propshaft default (dropping several sprockets-specific tests now unneeded), and duplicated the original file into a `test/application/sprockets_assets_test.rb` to continue testing that option. Both run fine independently, but loading them together leaves the propshaft railtie loaded for both versions, messing with the sprockets configuration and tests. How could we decouple them properly?

Thanks to @rafaelfranca for helping us get started generating a template app for each asset pipeline option.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] [doesn't apply] Tests are added or updated if you fix a bug or add a feature.
* [x] [doesn't apply] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.