### PR TITLE
Bump stringio to 3.1.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -562,7 +562,7 @@ GEM
     stackprof (0.2.25)
     stimulus-rails (1.3.0)
       railties (>= 6.0.0)
-    stringio (3.1.0)
+    stringio (3.1.1)
     sucker_punch (3.2.0)
       concurrent-ruby (~> 1.0)
     syntax_tree (6.1.1)


### PR DESCRIPTION
### Motivation / Background

This commit addresses this CI failure:
https://buildkite.com/rails/rails/builds/108372#0190131e-ee1a-420b-8355-9eb08eb5c29a

### Detail

* Without this commit
```ruby
$ ruby -v
ruby 3.2.4 (2024-04-23 revision af471c0e01) [x86_64-linux]
$ cd guides/bug_report_templates
$ ruby action_controller.rb
... snip ...
Installing rails 7.1.3.4
/home/yahonda/.rbenv/versions/3.2.4/lib/ruby/gems/3.2.0/gems/bundler-2.5.4/lib/bundler/runtime.rb:304:in `check_for_activated_spec!': You have already activated stringio 3.1.0, but your Gemfile requires stringio 3.1.1. Prepending `bundle exec` to your command may solve this. (Gem::LoadError)
    from /home/yahonda/.rbenv/versions/3.2.4/lib/ruby/gems/3.2.0/gems/bundler-2.5.4/lib/bundler/runtime.rb:25:in `block in setup'
    from /home/yahonda/.rbenv/versions/3.2.4/lib/ruby/gems/3.2.0/gems/bundler-2.5.4/lib/bundler/spec_set.rb:191:in `each'
    from /home/yahonda/.rbenv/versions/3.2.4/lib/ruby/gems/3.2.0/gems/bundler-2.5.4/lib/bundler/spec_set.rb:191:in `each'
    from /home/yahonda/.rbenv/versions/3.2.4/lib/ruby/gems/3.2.0/gems/bundler-2.5.4/lib/bundler/runtime.rb:24:in `map'
    from /home/yahonda/.rbenv/versions/3.2.4/lib/ruby/gems/3.2.0/gems/bundler-2.5.4/lib/bundler/runtime.rb:24:in `setup'
    from /home/yahonda/.rbenv/versions/3.2.4/lib/ruby/gems/3.2.0/gems/bundler-2.5.4/lib/bundler/inline.rb:66:in `block (2 levels) in gemfile'
    from /home/yahonda/.rbenv/versions/3.2.4/lib/ruby/gems/3.2.0/gems/bundler-2.5.4/lib/bundler/settings.rb:158:in `temporary'
    from /home/yahonda/.rbenv/versions/3.2.4/lib/ruby/gems/3.2.0/gems/bundler-2.5.4/lib/bundler/inline.rb:51:in `block in gemfile'
    from /home/yahonda/.rbenv/versions/3.2.4/lib/ruby/gems/3.2.0/gems/bundler-2.5.4/lib/bundler.rb:403:in `block in with_unbundled_env'
    from /home/yahonda/.rbenv/versions/3.2.4/lib/ruby/gems/3.2.0/gems/bundler-2.5.4/lib/bundler.rb:658:in `with_env'
    from /home/yahonda/.rbenv/versions/3.2.4/lib/ruby/gems/3.2.0/gems/bundler-2.5.4/lib/bundler.rb:403:in `with_unbundled_env'
    from /home/yahonda/.rbenv/versions/3.2.4/lib/ruby/gems/3.2.0/gems/bundler-2.5.4/lib/bundler/inline.rb:42:in `gemfile'
    from action_controller.rb:5:in `<main>'
$
```

### Additional information

Similar pull requests:
#49962
https://github.com/rails/rails/pull/45655
https://github.com/rails/rails/pull/45052
https://github.com/rails/rails/pull/49663
### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.



