### PR TITLE
Fix test runner when name contains a `/`

### DIFF
--- a/railties/lib/rails/commands/test/test_command.rb
+++ b/railties/lib/rails/commands/test/test_command.rb
@@ -69,7 +69,8 @@ module Rails
       end
 
       private
-        EXACT_TEST_ARGUMENT_PATTERN = /^-n|^--name\b|#{Rails::TestUnit::Runner::PATH_ARGUMENT_PATTERN}/
+        EXACT_TEST_ARGUMENT_PATTERN = /^(-n\b|--name\b|[^-])/
+        private_constant :EXACT_TEST_ARGUMENT_PATTERN
 
         def run_prepare_task
           Rails::Command::RakeCommand.perform("test:prepare", [], {})

--- a/railties/test/configuration/dynamic_options_test.rb
+++ b/railties/test/configuration/dynamic_options_test.rb
@@ -7,15 +7,9 @@ require "rails/railtie/configuration"
 
 module RailtiesTest
   class DynamicOptionsTest < ActiveSupport::TestCase
-    class Configuration < Rails::Railtie::Configuration
-      def reset_options
-        @@options = {}
-      end
-    end
-
     setup do
-      @config = Configuration.new
-      @config.reset_options
+      @config = Rails::Railtie::Configuration.dup.new
+      @config.class.class_variable_set(:@@options, {})
     end
 
     test "arbitrary keys can be set, reset, and read" do


### PR DESCRIPTION
## What this fixes

Here's the scenario I'd like to fix:
```rb
class MyTest < ActiveSupport::TestCase
  test "there is a / in here" do
    assert true
  end
end
```
```sh
bin/rails test test/my_test.rb --name test_there_is_a_/_in_here
```
```
`require': cannot load such file -- /tmp/testapp/test_there_is_a_/_in_here (LoadError)
```

## What the problem is

The main problem is that the code currently considers that any arg that contains at least one slash, no spaces, and is not surrounded with slashes has to be a file path, whereas in practice, arguments that follow `--name` and `-n` will never be a file path, _even_ if they contain a `/`.

## Reproducing

I've added some tests that prove the problem and fix, but here is another way to reproduce:

```
$ cd /tmp
$ rails new --minimal testapp
$ cd testapp
$ rails g scaffold Post title:string
```

Add a test to `test/models/post_test.rb` with a slash in its label:

```rb
test "dummy test with a / slash" do
  assert true
end
```

### Failure pattern 1

The following command should only run that single test, but instead it crashes on "cannot load such file":

```
$ bin/rails test test/models/post_test.rb -n test_dummy_test_with_a_/_slash
/opt/rubies/ruby-3.3.0/lib/ruby/3.3.0/bundled_gems.rb:74:in `require': cannot load such file -- /tmp/testapp/test_dummy_test_with_a_/_slash (LoadError)
```

`test_dummy_test_with_a_/_slash` was supposed to be a test name filter but was instead seen as a file path. Yet, the following command works:

```
$ bin/rails test test/modes/post_test.rb -n /test_dummy_test_with_a_\/_slash/
```

### Failure pattern 2

Another failure, which is probably less important, but happens to get fixed by this PR, is when passing an absolute file path to a test directory in order to run all tests defined in that directory.

Because the file path starts and ends with `/`, it is seen as a regular expression instead.

This next command should only run tests located in `test/models` but it runs everything:

```
$ bin/rails test --verbose /tmp/testapp/test/models/
Running 9 tests in a single process (parallelization threshold is 50)
Run options: --verbose --seed 32902

PostTest#test_the_truth = 0.02 s = .
PostTest#test_dummy_test_with_a_/_slash = 0.00 s = .
PostsControllerTest#test_should_show_post = 0.11 s = .
PostsControllerTest#test_should_get_index = 0.00 s = .
PostsControllerTest#test_should_get_edit = 0.01 s = .
PostsControllerTest#test_should_update_post = 0.01 s = .
PostsControllerTest#test_should_create_post = 0.01 s = .
PostsControllerTest#test_should_destroy_post = 0.00 s = .
PostsControllerTest#test_should_get_new = 0.00 s = .

Finished in 0.168346s, 53.4614 runs/s, 77.2221 assertions/s.
9 runs, 13 assertions, 0 failures, 0 errors, 0 skips
```

## Caveats

The code in `railties/lib/rails/test_unit/runner.rb` is hard to adjust. It's attempting to parse arguments and change them before eventually forwarding them to Minitest. Not using `OptionParser` means the code needs to somehow reinvent the wheel and handle multiple edge cases.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
