### PR TITLE
[Fix #49999] properly reference from Arel::Attribute args [7-1-stable]

### DIFF
--- a/activerecord/test/cases/relation/order_test.rb
+++ b/activerecord/test/cases/relation/order_test.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+require "models/author"
+require "models/book"
+
+class OrderTest < ActiveRecord::TestCase
+  fixtures :authors, :author_addresses
+
+  def test_order_asc
+    Book.destroy_all
+    z = Book.create!(name: "Zulu", author: authors(:david))
+    y = Book.create!(name: "Yankee", author: authors(:mary))
+    x = Book.create!(name: "X-Ray", author: authors(:david))
+
+    alphabetical = [x, y, z]
+
+    assert_equal(alphabetical, Book.order(name: :asc))
+    assert_equal(alphabetical, Book.order(name: :ASC))
+    assert_equal(alphabetical, Book.order(name: "asc"))
+    assert_equal(alphabetical, Book.order(:name))
+    assert_equal(alphabetical, Book.order("name"))
+    assert_equal(alphabetical, Book.order("books.name"))
+    assert_equal(alphabetical, Book.order(Book.arel_table["name"]))
+  end
+
+  def test_order_desc
+    Book.destroy_all
+    z = Book.create!(name: "Zulu", author: authors(:david))
+    y = Book.create!(name: "Yankee", author: authors(:mary))
+    x = Book.create!(name: "X-Ray", author: authors(:david))
+
+    reverse_alphabetical = [z, y, x]
+
+    assert_equal(reverse_alphabetical, Book.order(name: :desc))
+    assert_equal(reverse_alphabetical, Book.order(name: :DESC))
+    assert_equal(reverse_alphabetical, Book.order(name: "desc"))
+    assert_equal(reverse_alphabetical, Book.order(:name).reverse_order)
+    assert_equal(reverse_alphabetical, Book.order("name desc"))
+    assert_equal(reverse_alphabetical, Book.order("books.name desc"))
+    assert_equal(reverse_alphabetical, Book.order(Book.arel_table["name"].desc))
+  end
+
+  def test_order_with_association
+    Book.destroy_all
+    z = Book.create!(name: "Zulu", author: authors(:david))
+    y = Book.create!(name: "Yankee", author: authors(:mary))
+    x = Book.create!(name: "X-Ray", author: authors(:david))
+
+    author_then_book_name = [x, z, y]
+
+    assert_equal(author_then_book_name, Book.includes(:author).order("authors.name", "books.name"))
+    assert_equal(author_then_book_name, Book.includes(:author).order(Author.arel_table[:name], Book.arel_table[:name]))
+  end
+end


### PR DESCRIPTION
### Motivation / Background

Backports #51219 to `7-1-stable`.

Fixes #49999 for 7-1-stable branch

### Detail

ActiveRecord::Relation#order now properly references Arel::Attribute arguments


### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
