### PR TITLE
Document test transactions w/ multiple databases

### DIFF
--- a/guides/source/testing.md
+++ b/guides/source/testing.md
@@ -429,6 +429,12 @@ class MyTest < ActiveSupport::TestCase
 end
 ```
 
+If there are [multiple writing databases](active_record_multiple_databases.html)
+in place, tests are wrapped in as many respective transactions, and all of them
+are rolled back.
+
+#### Opting-out of Test Transactions
+
 Individual test cases can opt-out:
 
 ```ruby


### PR DESCRIPTION
This patch complements #52124 by documenting transactions w/ multiple writing databases.

@eileencodes going to merge optimistically. Tried to explain this briefly, but dropping a "writing" in there to make clear we are not talking about just having replicas. Please, let me know if you'd like to revise anything!

