### PR TITLE
Fix more `with_connection` offences inside Active Record

### DIFF
--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -248,18 +248,16 @@ module ActiveRecord
 
         im = Arel::InsertManager.new(arel_table)
 
-        with_connection do |c|
-          if values.empty?
-            im.insert(connection.empty_insert_statement_value(primary_key))
-          else
-            im.insert(values.transform_keys { |name| arel_table[name] })
-          end
-
-          connection.insert(
-            im, "#{self} Create", primary_key || false, primary_key_value,
-            returning: returning
-          )
+        if values.empty?
+          im.insert(connection.empty_insert_statement_value(primary_key))
+        else
+          im.insert(values.transform_keys { |name| arel_table[name] })
         end
+
+        connection.insert(
+          im, "#{self} Create", primary_key || false, primary_key_value,
+          returning: returning
+        )
       end
 
       def _update_record(values, constraints) # :nodoc:

--- a/activerecord/lib/active_record/sanitization.rb
+++ b/activerecord/lib/active_record/sanitization.rb
@@ -105,12 +105,13 @@ module ActiveRecord
       #   sanitize_sql_hash_for_assignment({ status: nil, group_id: 1 }, "posts")
       #   # => "`posts`.`status` = NULL, `posts`.`group_id` = 1"
       def sanitize_sql_hash_for_assignment(attrs, table)
-        c = connection
-        attrs.map do |attr, value|
-          type = type_for_attribute(attr)
-          value = type.serialize(type.cast(value))
-          "#{c.quote_table_name_for_assignment(table, attr)} = #{c.quote(value)}"
-        end.join(", ")
+        with_connection do |c|
+          attrs.map do |attr, value|
+            type = type_for_attribute(attr)
+            value = type.serialize(type.cast(value))
+            "#{c.quote_table_name_for_assignment(table, attr)} = #{c.quote(value)}"
+          end.join(", ")
+        end
       end
 
       # Sanitizes a +string+ so that it is safe to use within an SQL

--- a/activerecord/lib/active_record/schema_migration.rb
+++ b/activerecord/lib/active_record/schema_migration.rb
@@ -34,7 +34,8 @@ module ActiveRecord
     end
 
     def delete_all_versions
-      @pool.with_connection do |connection|
+      # Eagerly check in connection to avoid checking in/out many times in the called method.
+      @pool.with_connection do
         versions.each do |version|
           delete_version(version)
         end


### PR DESCRIPTION
Follow up to #51349.

In 2 places the call `with_connection` is not needed, in another - just `connection` is used.

cc @byroot 