### PR TITLE
Remove obsolete Logger severity predicates

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -93,7 +93,7 @@ PATH
       connection_pool (>= 2.2.5)
       drb
       i18n (>= 1.6, < 2)
-      logger
+      logger (>= 1.4.2)
       minitest (>= 5.1)
       tzinfo (~> 2.0, >= 2.0.5)
     rails (8.0.0.alpha)

--- a/activesupport/activesupport.gemspec
+++ b/activesupport/activesupport.gemspec
@@ -42,5 +42,5 @@ Gem::Specification.new do |s|
   s.add_dependency "base64"
   s.add_dependency "drb"
   s.add_dependency "bigdecimal"
-  s.add_dependency "logger"
+  s.add_dependency "logger", ">= 1.4.2"
 end

--- a/activesupport/lib/active_support/logger_thread_safe_level.rb
+++ b/activesupport/lib/active_support/logger_thread_safe_level.rb
@@ -7,14 +7,6 @@ module ActiveSupport
   module LoggerThreadSafeLevel # :nodoc:
     extend ActiveSupport::Concern
 
-    Logger::Severity.constants.each do |severity|
-      class_eval(<<-EOT, __FILE__, __LINE__ + 1)
-        def #{severity.downcase}?                # def debug?
-          Logger::#{severity} >= level           #   DEBUG >= level
-        end                                      # end
-      EOT
-    end
-
     def local_level
       IsolatedExecutionState[local_level_key]
     end

--- a/activesupport/test/broadcast_logger_test.rb
+++ b/activesupport/test/broadcast_logger_test.rb
@@ -369,6 +369,26 @@ module ActiveSupport
         @adds << [message_level, message, progname] if message_level >= local_level
       end
 
+      def debug?
+        level <= ::Logger::DEBUG
+      end
+
+      def info?
+        level <= ::Logger::INFO
+      end
+
+      def warn?
+        level <= ::Logger::WARN
+      end
+
+      def error?
+        level <= ::Logger::ERROR
+      end
+
+      def fatal?
+        level <= ::Logger::FATAL
+      end
+
       def close
         @closed = true
       end


### PR DESCRIPTION
### Motivation / Background

The Logger severity predicates have existed since the [introduction of Logger][1]. However, these methods only looked at the `level` instance variable, so they did not work with the [thread safe implementation][2] of temporary log levels in Rails.

Since then, the Logger severity predicates were [updated][3] to use the `level` method instead of the instance variable, making Rails' severity predicate overrides obsolete.

### Detail

This commit removes Rails' custom severity predicates in favor of Logger's implementation, since the new implementation was released in Logger 1.4.2 and came bundled with Ruby 2.7.0.

[1]: https://github.com/ruby/logger/commit/525b58d97eb7dd1375f59dec6e4f34ebff0c0ecb
[2]: https://github.com/rails/rails/commit/629efb605728b31ad9644f6f0acaf3760b641a29
[3]: https://github.com/ruby/logger/commit/7365c995bfde6cc52ad6c481e4c6fff32780025c

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.

This change only touches undocumented, internal methods so a CHANGELOG entry doesn't seem necessary.