### PR TITLE
Add datalist_tag to create datalist form elements

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,17 @@
+*   Add `datalist_tag` to create `datalist` form elements.
+
+    Example:
+
+        datalist_tag('countries_datalist', ['Argentina', ['Brazil', { class: 'brazilian_option' }],
+                     ['Chile', 'CL', { disabled: true }]], { class: 'sa-countries-sample' })
+        => <datalist id="countries_datalist" class="sa-countries-sample">
+             <option value="Argentina">Argentina</option>
+             <option value="Brazil" class="brazilian_option">Brazil</option>
+             <option value="CL" disabled="disabled">Chile</option>
+           </datalist>
+
+    *Willian Gustavo Veiga*
+
 *   Render `Hash` and keyword options as dasherized HTML attributes
 
     ```ruby
@@ -35,4 +49,4 @@
 
     *Jarrett Lusso*
 
-Please check [8-1-stable](https://github.com/rails/rails/blob/8-1-stable/actionview/CHANGELOG.md) for previous changes.
+Please check [8-0-stable](https://github.com/rails/rails/blob/8-0-stable/actionview/CHANGELOG.md) for previous changes.

--- a/actionview/lib/action_view/helpers/form_tag_helper.rb
+++ b/actionview/lib/action_view/helpers/form_tag_helper.rb
@@ -976,6 +976,24 @@ module ActionView
         number_field_tag(name, value, options.merge(type: :range))
       end
 
+      # Creates a datalist form element.
+      #
+      # The option_tags parameter has the same format as the container parameter from #options_for_select.
+      #
+      # ==== Examples
+      #
+      #   datalist_tag('countries_datalist', ['Argentina', ['Brazil', { class: 'brazilian_option' }],
+      #                ['Chile', 'CL', { disabled: true }]], { class: 'sa-countries-sample' })
+      #   # => <datalist id="countries_datalist" class="sa-countries-sample">
+      #          <option value="Argentina">Argentina</option>
+      #          <option value="Brazil" class="brazilian_option">Brazil</option>
+      #          <option value="CL" disabled="disabled">Chile</option>
+      #        </datalist>
+      def datalist_tag(id, option_tags = nil, html_options = {})
+        option_tags ||= ""
+        content_tag("datalist", options_for_select(option_tags), { "id" => id }.update(html_options.stringify_keys))
+      end
+
       # Creates the hidden UTF-8 enforcer tag. Override this method in a helper
       # to customize the tag.
       def utf8_enforcer_tag

--- a/actionview/test/template/form_tag_helper_test.rb
+++ b/actionview/test/template/form_tag_helper_test.rb
@@ -996,6 +996,79 @@ class FormTagHelperTest < ActionView::TestCase
     assert_dom_equal(expected, range_field_tag("volume", nil, in: 0..11, step: 0.1))
   end
 
+  def test_empty_datalist
+    actual = datalist_tag("countries_datalist")
+    expected = %(<datalist id="countries_datalist"></datalist>)
+    assert_dom_equal(expected, actual)
+  end
+
+  def test_datalist_with_simple_option_tags
+    actual = datalist_tag("countries_datalist", %w[Argentina Brazil Chile])
+    expected = %(
+      <datalist id="countries_datalist">
+        <option value="Argentina">Argentina</option>
+        <option value="Brazil">Brazil</option>
+        <option value="Chile">Chile</option>
+      </datalist>
+    )
+    assert_dom_equal(expected, actual)
+  end
+
+  def test_datalist_with_label_and_value_option_tags
+    actual = datalist_tag("countries_datalist", { "Argentina" => "AR", "Brazil" => "BR", "Chile" => "CL" })
+    expected = %(
+      <datalist id="countries_datalist">
+        <option value="AR">Argentina</option>
+        <option value="BR">Brazil</option>
+        <option value="CL">Chile</option>
+      </datalist>
+    )
+    assert_dom_equal(expected, actual)
+  end
+
+  def test_datalist_with_label_and_value_option_tags_as_arrays
+    actual = datalist_tag("countries_datalist", [%w[Argentina AR], %w[Brazil BR], %w[Chile CL]])
+    expected = %(
+      <datalist id="countries_datalist">
+        <option value="AR">Argentina</option>
+        <option value="BR">Brazil</option>
+        <option value="CL">Chile</option>
+      </datalist>
+    )
+    assert_dom_equal(expected, actual)
+  end
+
+  def test_datalist_with_label_value_and_html_options_option_tags
+    actual = datalist_tag(
+      "countries_datalist",
+      ["Argentina", ["Brazil", { class: "brazilian_option" }], ["Chile", "CL", { disabled: :disabled }]]
+    )
+    expected = %(
+      <datalist id="countries_datalist">
+        <option value="Argentina">Argentina</option>
+        <option value="Brazil" class="brazilian_option">Brazil</option>
+        <option value="CL" disabled="disabled">Chile</option>
+      </datalist>
+    )
+    assert_dom_equal(expected, actual)
+  end
+
+  def test_datalist_with_option_with_data_attribute
+    actual = datalist_tag("countries_datalist", [["Brazil", { data: { beverage: "capirinha" } }]])
+    expected = %(
+      <datalist id="countries_datalist">
+        <option value="Brazil" data-beverage="capirinha">Brazil</option>
+      </datalist>
+    )
+    assert_dom_equal(expected, actual)
+  end
+
+  def test_datalist_with_html_options
+    actual = datalist_tag("countries_datalist", [], { class: "south-america", data: { limit: 3 } })
+    expected = %(<datalist id="countries_datalist" class="south-america" data-limit="3"></datalist>)
+    assert_dom_equal(expected, actual)
+  end
+
   def test_field_set_tag_in_erb
     output_buffer = render_erb("<%= field_set_tag('Your details') do %>Hello world!<% end %>")
 


### PR DESCRIPTION
### Motivation / Background

In order to generate an HTML datalist element with Rails I needed the following code:

```ruby
<%= content_tag(:datalist, nil, id: :payees_datalist, 'data-autocomplete-input-target' => :datalist) do %>
  <% @payees.each do |payee| %>
    <%=
      content_tag(
        :option,
        nil,
        value: payee.name,
        data: { id: payee.id },
        'data-autocomplete-input-target' => 'datalistOption'
      )
    %>
  <% end %>
<% end %>
```

It would be great to have a simple way to do that.

### Detail

This Pull Request adds `datalist_tag`:

```ruby
  datalist_tag('countries_datalist', ['Argentina', ['Brazil', { class: 'brazilian_option' }],
               ['Chile', 'CL', { disabled: true }]], { class: 'sa-countries-sample' })

  => <datalist id="countries_datalist" class="sa-countries-sample">
       <option value="Argentina">Argentina</option>
       <option value="Brazil" class="brazilian_option">Brazil</option>
       <option value="CL" disabled="disabled">Chile</option>
     </datalist>
```