### PR TITLE
Fix raw_post raising when rack.input is nil

### DIFF
--- a/actionmailbox/app/controllers/action_mailbox/ingresses/relay/inbound_emails_controller.rb
+++ b/actionmailbox/app/controllers/action_mailbox/ingresses/relay/inbound_emails_controller.rb
@@ -52,7 +52,11 @@ module ActionMailbox
     before_action :authenticate_by_password, :require_valid_rfc822_message
 
     def create
-      ActionMailbox::InboundEmail.create_and_extract_message_id! request.body.read
+      if request.body
+        ActionMailbox::InboundEmail.create_and_extract_message_id! request.body.read
+      else
+        head :unprocessable_entity
+      end
     end
 
     private

--- a/actionmailbox/test/controllers/ingresses/relay/inbound_emails_controller_test.rb
+++ b/actionmailbox/test/controllers/ingresses/relay/inbound_emails_controller_test.rb
@@ -31,6 +31,15 @@ class ActionMailbox::Ingresses::Relay::InboundEmailsControllerTest < ActionDispa
     assert_equal "05988AA6EC0D44318855A5E39E3B6F9E@jansterba.com", inbound_email.message_id
   end
 
+  test "rejecting a request with no body" do
+    assert_no_difference -> { ActionMailbox::InboundEmail.count } do
+      post rails_relay_inbound_emails_url, headers: { "Authorization" => credentials, "Content-Type" => "message/rfc822" },
+        env: { "rack.input" => nil }
+    end
+
+    assert_response :unprocessable_entity
+  end
+
   test "rejecting an unauthorized inbound email" do
     assert_no_difference -> { ActionMailbox::InboundEmail.count } do
       post rails_relay_inbound_emails_url, headers: { "Content-Type" => "message/rfc822" },

--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Fix `Request#raw_post` raising `NoMethodError` when `rack.input` is `nil`.
+
+    *Hartley McGuire*
+
 *   Remove `racc` dependency by manually writing `ActionDispatch::Journey::Scanner`.
 
     *Gannon McGibbon*

--- a/actionpack/lib/action_dispatch/http/request.rb
+++ b/actionpack/lib/action_dispatch/http/request.rb
@@ -468,11 +468,13 @@ module ActionDispatch
       end
 
       def read_body_stream
-        reset_stream(body_stream) do
-          if has_header?(TRANSFER_ENCODING)
-            body_stream.read # Read body stream until EOF if "Transfer-Encoding" is present
-          else
-            body_stream.read(content_length)
+        if body_stream
+          reset_stream(body_stream) do
+            if has_header?(TRANSFER_ENCODING)
+              body_stream.read # Read body stream until EOF if "Transfer-Encoding" is present
+            else
+              body_stream.read(content_length)
+            end
           end
         end
       end

--- a/actionpack/test/dispatch/request_test.rb
+++ b/actionpack/test/dispatch/request_test.rb
@@ -1199,6 +1199,13 @@ class RequestParameters < BaseRequestTest
     assert_not_nil e.cause
     assert_equal e.cause.backtrace, e.backtrace
   end
+
+  test "raw_post does not raise when rack.input is nil" do
+    request = stub_request
+
+    # "" on Rack < 3.1, nil on Rack 3.1+
+    assert_predicate request.raw_post, :blank?
+  end
 end
 
 class RequestParameterFilter < BaseRequestTest


### PR DESCRIPTION
### Motivation / Background

Fixes #52125

### Detail

Starting in Rack 3.1, rack.input is optional, so `read_body_stream` (used by `raw_post`) can no longer call `read` unconditionally.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
