### PR TITLE
Fixes tests with nested exception backtraces on Ruby master

### DIFF
--- a/actionpack/test/dispatch/debug_exceptions_test.rb
+++ b/actionpack/test/dispatch/debug_exceptions_test.rb
@@ -45,14 +45,25 @@ class DebugExceptionsTest < ActionDispatch::IntegrationTest
     end
 
     def raise_nested_exceptions
-      raise "First error"
-    rescue
-      begin
-        raise "Second error"
-      rescue
-        raise "Third error"
-      end
+      raise_nested_exceptions_third
     end
+
+    def raise_nested_exceptions_first
+      raise "First error"
+    end
+
+    def raise_nested_exceptions_second
+      raise_nested_exceptions_first
+    rescue
+      raise "Second error"
+    end
+
+    def raise_nested_exceptions_third
+      raise_nested_exceptions_second
+    rescue
+      raise "Third error"
+    end
+
 
     def call(env)
       env["action_dispatch.show_detailed_exceptions"] = @detailed
@@ -641,29 +652,67 @@ class DebugExceptionsTest < ActionDispatch::IntegrationTest
       Information for: RuntimeError (Third error):
     MSG
 
-    assert_match Regexp.new(<<~REGEX.strip), paragraphs[2].lines[0..2].join
-      \\A.*in `rescue in rescue in raise_nested_exceptions'
-      .*in `rescue in raise_nested_exceptions'
-      .*in `raise_nested_exceptions'
-    REGEX
+    if RUBY_VERSION >= "3.4"
+      # Changes to the format of exception backtraces
+      # https://bugs.ruby-lang.org/issues/16495 (use single quote instead of backtrace)
+      # https://bugs.ruby-lang.org/issues/20275 (don't have entry for rescue in)
+      # And probably more, they now show the class too
+      assert_match Regexp.new(<<~REGEX.strip), paragraphs[2]
+        \\A.*in '.*raise_nested_exceptions_third'
+        .*in '.*raise_nested_exceptions'
+      REGEX
 
-    assert_includes(paragraphs[3], <<~MSG.strip)
-      Information for cause: RuntimeError (Second error):
-    MSG
+      assert_includes(paragraphs[3], <<~MSG.strip)
+        Information for cause: RuntimeError (Second error):
+      MSG
 
-    assert_match Regexp.new(<<~REGEX.strip), paragraphs[4].lines[0..1].join
-      \\A.*in `rescue in raise_nested_exceptions'
-      .*in `raise_nested_exceptions'
-    REGEX
+      assert_match Regexp.new(<<~REGEX.strip), paragraphs[4]
+        \\A.*in '.*raise_nested_exceptions_second'
+        .*in '.*raise_nested_exceptions_third'
+        .*in '.*raise_nested_exceptions'
+      REGEX
 
 
-    assert_includes(paragraphs[5], <<~MSG.strip)
-      Information for cause: RuntimeError (First error):
-    MSG
+      assert_includes(paragraphs[5], <<~MSG.strip)
+        Information for cause: RuntimeError (First error):
+      MSG
 
-    assert_match Regexp.new(<<~REGEX.strip), paragraphs[6].lines[0]
-      \\A.*in `raise_nested_exceptions'
-    REGEX
+      assert_match Regexp.new(<<~REGEX.strip), paragraphs[6]
+        \\A.*in '.*raise_nested_exceptions_first'
+        .*in '.*raise_nested_exceptions_second'
+        .*in '.*raise_nested_exceptions_third'
+        .*in '.*raise_nested_exceptions'
+      REGEX
+    else
+      assert_match Regexp.new(<<~REGEX.strip), paragraphs[2]
+        \\A.*in `rescue in raise_nested_exceptions_third'
+        .*in `raise_nested_exceptions_third'
+        .*in `raise_nested_exceptions'
+      REGEX
+
+      assert_includes(paragraphs[3], <<~MSG.strip)
+        Information for cause: RuntimeError (Second error):
+      MSG
+
+      assert_match Regexp.new(<<~REGEX.strip), paragraphs[4]
+        \\A.*in `rescue in raise_nested_exceptions_second'
+        .*in `raise_nested_exceptions_second'
+        .*in `raise_nested_exceptions_third'
+        .*in `raise_nested_exceptions'
+      REGEX
+
+
+      assert_includes(paragraphs[5], <<~MSG.strip)
+        Information for cause: RuntimeError (First error):
+      MSG
+
+      assert_match Regexp.new(<<~REGEX.strip), paragraphs[6]
+        \\A.*in `raise_nested_exceptions_first'
+        .*in `raise_nested_exceptions_second'
+        .*in `raise_nested_exceptions_third'
+        .*in `raise_nested_exceptions'
+      REGEX
+    end
   end
 
   test "display backtrace when error type is SyntaxError" do
@@ -783,28 +832,28 @@ class DebugExceptionsTest < ActionDispatch::IntegrationTest
         # Possible Ruby 3.4-dev bug: https://bugs.ruby-lang.org/issues/19117#note-45
         # assert application trace refers to line that raises the last exception
         assert_select "#Application-Trace-0" do
-          assert_select "code a:first", %r{in '.*raise_nested_exceptions'}
+          assert_select "code a:first", %r{in '.*raise_nested_exceptions_third'}
         end
 
         # assert the second application trace refers to the line that raises the second exception
         assert_select "#Application-Trace-1" do
-          assert_select "code a:first", %r{in '.*raise_nested_exceptions'}
+          assert_select "code a:first", %r{in '.*raise_nested_exceptions_second'}
         end
       else
         # assert application trace refers to line that raises the last exception
         assert_select "#Application-Trace-0" do
-          assert_select "code a:first", %r{in [`']rescue in rescue in .*raise_nested_exceptions'}
+          assert_select "code a:first", %r{in [`']rescue in .*raise_nested_exceptions_third'}
         end
 
         # assert the second application trace refers to the line that raises the second exception
         assert_select "#Application-Trace-1" do
-          assert_select "code a:first", %r{in [`']rescue in .*raise_nested_exceptions'}
+          assert_select "code a:first", %r{in [`']rescue in .*raise_nested_exceptions_second'}
         end
       end
 
       # assert the third application trace refers to the line that raises the first exception
       assert_select "#Application-Trace-2" do
-        assert_select "code a:first", %r{in [`'].*raise_nested_exceptions'}
+        assert_select "code a:first", %r{in [`'].*raise_nested_exceptions_first'}
       end
     end
   end


### PR DESCRIPTION
This previous PR of mine fails when tested on Ruby Master: https://github.com/rails/rails/pull/50305

Here is a failure log: https://buildkite.com/rails/rails-nightly/builds/655#01901367-e42b-4b4e-be19-797bef5f58cd/1213-1222

The failures are causes by changes in the format of backtraces in Ruby 3.4.

There are at least these two, but I suspect there is at least another change since classes are now displayed.
https://bugs.ruby-lang.org/issues/16495
https://bugs.ruby-lang.org/issues/20275

In fixing this while still doing proper testing, I had to alter `raise_nested_exceptions` to use distinct methods to be able to test that the backtrace is the right one, since in Ruby 3.4, the backtrace of each nested exception became identical (since there is no more "rescue in" entry in the trace). This then required my to fix & improve the other test that used `raise_nested_exceptions`.

I don't know if it's possible to do a full test against master in buildkite from a PR. On my side, I installed a fresh ruby-head and tested the changes on it as well as Ruby 3.2.2 and 3.3.2. (I tested in `actionpack` only)