### PR TITLE
Fix `alias_attribute` to ignore methods defined in parent classes

### DIFF
--- a/activerecord/lib/active_record/attribute_methods.rb
+++ b/activerecord/lib/active_record/attribute_methods.rb
@@ -91,7 +91,7 @@ module ActiveRecord
           raise ArgumentError, "#{self.name} model aliases `#{old_name}`, but `#{old_name}` is not an attribute. " \
             "Use `alias_method :#{new_name}, :#{old_name}` or define the method manually."
         else
-          define_attribute_method_pattern(pattern, old_name, owner: code_generator, as: new_name)
+          define_attribute_method_pattern(pattern, old_name, owner: code_generator, as: new_name, override: true)
         end
       end
 

--- a/activerecord/test/cases/attribute_methods_test.rb
+++ b/activerecord/test/cases/attribute_methods_test.rb
@@ -1217,6 +1217,25 @@ class AttributeMethodsTest < ActiveRecord::TestCase
     alias_attribute :subject, :title
   end
 
+  test "#alias_attribute override methods defined in parent models" do
+    parent_model = Class.new(ActiveRecord::Base) do
+      self.abstract_class = true
+
+      def subject
+        "Abstract Subject"
+      end
+    end
+
+    subclass = Class.new(parent_model) do
+      self.table_name = "topics"
+      alias_attribute :subject, :title
+    end
+
+    obj = subclass.new
+    obj.title = "hey"
+    assert_equal("hey", obj.subject)
+  end
+
   test "aliases to the same attribute name do not conflict with each other" do
     first_model_object = ToBeLoadedFirst.new(author_name: "author 1")
     assert_equal("author 1", first_model_object.subject)


### PR DESCRIPTION
Fix: https://github.com/rails/rails/issues/52144

When defining regular attributes, inherited methods aren't overriden, however when defining aliased attributes, inherited methods aren't considered.

This behavior could be debatted, but that was the behavior prior to https://github.com/rails/rails/pull/52118, so I'm restoring it.

FYI: @chaadow 