### PR TITLE
In association scope, always merge the joins (regardless of references_values)

### DIFF
--- a/activerecord/lib/active_record/associations/association_scope.rb
+++ b/activerecord/lib/active_record/associations/association_scope.rb
@@ -135,13 +135,15 @@ module ActiveRecord
 
               if scope_chain_item == chain_head.scope
                 scope.merge! item.except(:where, :includes, :unscope, :order)
-              elsif !item.references_values.empty?
+              else
                 scope.merge! item.only(:joins, :left_outer_joins)
 
-                associations = item.eager_load_values | item.includes_values
+                if !item.references_values.empty?
+                  associations = item.eager_load_values | item.includes_values
 
-                unless associations.empty?
-                  scope.joins! item.construct_join_dependency(associations, Arel::Nodes::OuterJoin)
+                  unless associations.empty?
+                    scope.joins! item.construct_join_dependency(associations, Arel::Nodes::OuterJoin)
+                  end
                 end
               end
 

--- a/activerecord/test/cases/associations/has_one_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_one_through_associations_test.rb
@@ -26,7 +26,8 @@ require "models/cpk"
 
 class HasOneThroughAssociationsTest < ActiveRecord::TestCase
   fixtures :member_types, :members, :clubs, :memberships, :sponsors, :organizations, :minivans,
-           :dashboards, :speedometers, :authors, :author_addresses, :posts, :comments, :categories, :essays, :owners
+           :dashboards, :speedometers, :authors, :author_addresses, :posts, :comments, :categories, :essays, :owners,
+           :categorizations
 
   def setup
     @member = members(:groucho)
@@ -366,6 +367,10 @@ class HasOneThroughAssociationsTest < ActiveRecord::TestCase
     assert_equal posts(:welcome).comments.order("id").first, authors(:david).comment_on_first_post
   end
 
+  def test_has_one_through_with_join_model_that_uses_a_scope_with_joins_and_no_where_clauses
+    assert_equal essays(:david_modest_proposal), categorizations(:david_welcome_general).general_essay
+  end
+
   def test_has_one_through_many_raises_exception
     assert_raise(ActiveRecord::HasOneThroughCantAssociateThroughCollection) do
       members(:groucho).club_through_many
@@ -427,7 +432,7 @@ class HasOneThroughAssociationsTest < ActiveRecord::TestCase
     end
   end
 
-  def test_has_one_through_do_not_cache_association_reader_if_the_though_method_has_default_scopes
+  def test_has_one_through_do_not_cache_association_reader_if_the_through_method_has_default_scopes
     customer = Customer.create!
     carrier = Carrier.create!
     customer_carrier = CustomerCarrier.create!(

--- a/activerecord/test/models/author.rb
+++ b/activerecord/test/models/author.rb
@@ -184,6 +184,7 @@ class Author < ActiveRecord::Base
 
   has_one :essay_2, primary_key: :name, class_name: "Essay", foreign_key: :author_id
   has_one :essay_category_2, through: :essay_2, source: :category
+  has_one :general_essay, -> { general }, class_name: "Essay", primary_key: :name
 
   has_many :essays, primary_key: :name, as: :writer
   has_many :essay_categories, through: :essays, source: :category

--- a/activerecord/test/models/categorization.rb
+++ b/activerecord/test/models/categorization.rb
@@ -10,6 +10,7 @@ class Categorization < ActiveRecord::Base
 
   belongs_to :author_using_custom_pk,  class_name: "Author", foreign_key: :author_id, primary_key: :author_address_extra_id
   has_many   :authors_using_custom_pk, class_name: "Author", foreign_key: :id,        primary_key: :category_id
+  has_one :general_essay, through: :author
 end
 
 class SpecialCategorization < ActiveRecord::Base

--- a/activerecord/test/models/essay.rb
+++ b/activerecord/test/models/essay.rb
@@ -5,6 +5,8 @@ class Essay < ActiveRecord::Base
   belongs_to :writer, primary_key: :name, polymorphic: true
   belongs_to :category, primary_key: :name
   has_one :owner, primary_key: :name
+
+  scope :general, -> { joins(:category).merge(Category.general) }
 end
 
 class EssaySpecial < Essay


### PR DESCRIPTION
Fixes #52081

This fixes a situation where a join table is missing in the SQL statement for a has/through relationship that utilizes a scope. It can occur when using `joins` in the scope with no where clauses (e.g. `joins(:post).where(posts: {name: "foo"})` vs `joins(:post).merge(Post.foo)`). The "chain" is cutoff and the join is left behind.

I'm guessing this bug has lingered because the majority of `joins` also utilize/chain a where clause.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
