### PR TITLE
Fix `ActiveRecord::Relation#exists?` with no conditions for loaded relations and updated records

### DIFF
--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -365,7 +365,12 @@ module ActiveRecord
       end
 
       return false if !conditions || limit_value == 0
-      return records.any?(&:persisted?) if conditions == :none && loaded?
+
+      # Ignore if we have records which have saved changes since the load, because the
+      # relation can be a CollectionProxy and we updated the reference to the owner record.
+      if conditions == :none && loaded? && records.none?(&:saved_changes?)
+        return records.any?(&:persisted?)
+      end
 
       if eager_loading?
         relation = apply_join_dependency(eager_loading: false)

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -310,7 +310,23 @@ class FinderTest < ActiveRecord::TestCase
     assert_not_empty posts
     posts.each(&:destroy)
 
-    assert_not_predicate posts, :exists?
+    assert_no_queries do
+      assert_not_predicate posts, :exists?
+    end
+  end
+
+  def test_exists_with_loaded_relation_having_updated_owner_record
+    author = authors(:david)
+    assert_not_empty author.posts
+
+    author.posts.each do |post|
+      post.author = nil
+      post.save!
+    end
+
+    assert_queries_count(1) do
+      assert_not_predicate author.posts, :exists?
+    end
   end
 
   # exists? should handle nil for id's that come from URLs and always return false


### PR DESCRIPTION
Follow up to https://github.com/rails/rails/pull/51987#issuecomment-2177998043.

cc @byroot (please make sure I haven't messed up with the conditions 🙂)