### PR TITLE
Add option to allow for duplicate plugins names generated

### DIFF
--- a/railties/lib/rails/generators/rails/plugin/plugin_generator.rb
+++ b/railties/lib/rails/generators/rails/plugin/plugin_generator.rb
@@ -225,6 +225,9 @@ module Rails
       class_option :api,          type: :boolean, default: false,
                                   desc: "Generate a smaller stack for API application plugins"
 
+      class_option :duplicate_plugin, type: :boolean, default: false,
+                   desc: "Allow duplicate plugin names."
+
       def initialize(*args)
         @dummy_path = nil
         super
@@ -385,6 +388,10 @@ module Rails
         options[:skip_git]
       end
 
+      def duplicate_plugin?
+        options[:duplicate_plugin]
+      end
+
       def with_dummy_app?
         options[:skip_test].blank? || options[:dummy_path] != "test/dummy"
       end
@@ -459,7 +466,7 @@ module Rails
           raise Error, "Invalid plugin name #{original_name}. Please give a " \
                        "name which does not match one of the reserved rails " \
                        "words: #{RESERVED_NAMES.join(", ")}"
-        elsif Object.const_defined?(camelized)
+        elsif Object.const_defined?(camelized) && !duplicate_plugin?
           raise Error, "Invalid plugin name #{original_name}, constant #{camelized} is already in use. Please choose another plugin name."
         end
       end

--- a/railties/test/generators/plugin_generator_test.rb
+++ b/railties/test/generators/plugin_generator_test.rb
@@ -925,6 +925,12 @@ class PluginGeneratorTest < Rails::Generators::TestCase
     Object.send(:remove_const, "ENGINE_ROOT")
   end
 
+  def test_duplicate_plugin_with_in_use
+    content = capture(:stderr) { run_generator [File.join(destination_root, "Digest"), "--duplicate_plugin"] }
+
+    assert_empty content
+  end
+
   private
     def action(*args, &block)
       silence(:stdout) { generator.send(*args, &block) }


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created because when creating an engine in an existing Rails codebase, we want to bypass the duplicate plugin name condition.

### Detail

This Pull Request adds a flag "duplicate_option" that allows to skip the invalid plugin name error.

Use case:
In a rails monolith, when creating rails engines to better encapsulate code, the module name most likely already exists before creating the engine (as in, when not starting from scratch) so the `valid_const?` would throw an error even though it shouldn't.

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [ ] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [ ] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
