### PR TITLE
make "g scaffold" with no field produce rubocop compliant code

### DIFF
--- a/activerecord/lib/rails/generators/active_record/migration/templates/create_table_migration.rb.tt
+++ b/activerecord/lib/rails/generators/active_record/migration/templates/create_table_migration.rb.tt
@@ -12,7 +12,10 @@ class <%= migration_class_name %> < ActiveRecord::Migration[<%= ActiveRecord::Mi
       t.<%= attribute.type %> :<%= attribute.name %><%= attribute.inject_options %>
 <% end -%>
 <% end -%>
-<% if options[:timestamps] %>
+<% unless attributes.empty? -%>
+
+<% end -%>
+<% if options[:timestamps] -%>
       t.timestamps
 <% end -%>
     end

--- a/railties/lib/rails/generators/test_unit/scaffold/scaffold_generator.rb
+++ b/railties/lib/rails/generators/test_unit/scaffold/scaffold_generator.rb
@@ -39,7 +39,11 @@ module TestUnit # :nodoc:
 
       private
         def attributes_string
-          attributes_hash.map { |k, v| "#{k}: #{v}" }.join(", ")
+          if attributes_hash.empty?
+            "{}"
+          else
+            "{ #{attributes_hash.map { |k, v| "#{k}: #{v}" }.join(", ")} }"
+          end
         end
 
         def attributes_hash

--- a/railties/lib/rails/generators/test_unit/scaffold/templates/api_functional_test.rb.tt
+++ b/railties/lib/rails/generators/test_unit/scaffold/templates/api_functional_test.rb.tt
@@ -17,7 +17,7 @@ class <%= controller_class_name %>ControllerTest < ActionDispatch::IntegrationTe
 
   test "should create <%= singular_table_name %>" do
     assert_difference("<%= class_name %>.count") do
-      post <%= index_helper %>_url, params: { <%= "#{singular_table_name}: { #{attributes_string} }" %> }, as: :json
+      post <%= index_helper %>_url, params: { <%= "#{singular_table_name}: #{attributes_string}" %> }, as: :json
     end
 
     assert_response :created
@@ -29,7 +29,7 @@ class <%= controller_class_name %>ControllerTest < ActionDispatch::IntegrationTe
   end
 
   test "should update <%= singular_table_name %>" do
-    patch <%= show_helper %>, params: { <%= "#{singular_table_name}: { #{attributes_string} }" %> }, as: :json
+    patch <%= show_helper %>, params: { <%= "#{singular_table_name}: #{attributes_string}" %> }, as: :json
     assert_response :success
   end
 

--- a/railties/lib/rails/generators/test_unit/scaffold/templates/functional_test.rb.tt
+++ b/railties/lib/rails/generators/test_unit/scaffold/templates/functional_test.rb.tt
@@ -22,7 +22,7 @@ class <%= controller_class_name %>ControllerTest < ActionDispatch::IntegrationTe
 
   test "should create <%= singular_table_name %>" do
     assert_difference("<%= class_name %>.count") do
-      post <%= index_helper(type: :url) %>, params: { <%= "#{singular_table_name}: { #{attributes_string} }" %> }
+      post <%= index_helper(type: :url) %>, params: { <%= "#{singular_table_name}: #{attributes_string}" %> }
     end
 
     assert_redirected_to <%= show_helper("#{class_name}.last") %>
@@ -39,7 +39,7 @@ class <%= controller_class_name %>ControllerTest < ActionDispatch::IntegrationTe
   end
 
   test "should update <%= singular_table_name %>" do
-    patch <%= show_helper %>, params: { <%= "#{singular_table_name}: { #{attributes_string} }" %> }
+    patch <%= show_helper %>, params: { <%= "#{singular_table_name}: #{attributes_string}" %> }
     assert_redirected_to <%= show_helper %>
   end
 

--- a/railties/test/generators/scaffold_controller_generator_test.rb
+++ b/railties/test/generators/scaffold_controller_generator_test.rb
@@ -159,8 +159,8 @@ class ScaffoldControllerGeneratorTest < Rails::Generators::TestCase
     assert_file "test/controllers/users_controller_test.rb" do |content|
       assert_match(/class UsersControllerTest < ActionDispatch::IntegrationTest/, content)
       assert_match(/test "should get index"/, content)
-      assert_match(/post users_url, params: \{ user: \{  \} \}/, content)
-      assert_match(/patch user_url\(@user\), params: \{ user: \{  \} \}/, content)
+      assert_match(/post users_url, params: \{ user: \{\} \}/, content)
+      assert_match(/patch user_url\(@user\), params: \{ user: \{\} \}/, content)
     end
   end
 

--- a/railties/test/generators/scaffold_generator_test.rb
+++ b/railties/test/generators/scaffold_generator_test.rb
@@ -170,8 +170,8 @@ class ScaffoldGeneratorTest < Rails::Generators::TestCase
     assert_file "test/controllers/product_lines_controller_test.rb" do |content|
       assert_match(/class ProductLinesControllerTest < ActionDispatch::IntegrationTest/, content)
       assert_match(/test "should get index"/, content)
-      assert_match(/post product_lines_url, params: \{ product_line: \{  \} \}/, content)
-      assert_match(/patch product_line_url\(@product_line\), params: \{ product_line: \{  \} \}/, content)
+      assert_match(/post product_lines_url, params: \{ product_line: \{\} \}/, content)
+      assert_match(/patch product_line_url\(@product_line\), params: \{ product_line: \{\} \}/, content)
     end
   end
 


### PR DESCRIPTION
When there are no fields:
  * Omit blank line in migration prior to "t.timestamps"
  * Omit leading and trailing spaced in empty hashes in create and update controller and api functional tests

Fixes #52158

This change should be backported to 7-2-stable.