### PR TITLE
Correction: Delegated types do not require inheritance [ci skip]

### DIFF
--- a/guides/source/association_basics.md
+++ b/guides/source/association_basics.md
@@ -2975,8 +2975,8 @@ Delegated types solves this problem, via `delegated_type`.
 
 In order to use delegated types, we have to model our data in a particular way. The requirements are as follows:
 
-* There is a superclass that stores shared attributes among all subclasses in its table.
-* Each subclass must inherit from the super class, and will have a separate table for any additional attributes specific to it.
+* There is a "superclass" that stores shared attributes among all subclasses in its table.
+* Each "subclass" will have a separate table for any additional attributes specific to it. The model class does not inherit from the "superclass".
 
 This eliminates the need to define attributes in a single table that are unintentionally shared among all subclasses.
 


### PR DESCRIPTION
As can be seen in the code example below (and also in the API documentation for `ActiveRecord::DelegatedType`), the "subclasses" do not need to inherit (on the Ruby level) from the "superclass" - in contrast to STI.

Maybe we can find a better name for these concepts instead, to avoid the confusion?

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
