### PR TITLE
Avoid aliasing `exec_update` and `exec_delete`

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/mysql2/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql2/database_statements.rb
@@ -39,18 +39,25 @@ module ActiveRecord
         end
 
         def exec_delete(sql, name = nil, binds = []) # :nodoc:
-          if without_prepared_statement?(binds)
-            with_raw_connection do |conn|
-              @affected_rows_before_warnings = nil
-              execute_and_free(sql, name) { @affected_rows_before_warnings || conn.affected_rows }
-            end
-          else
-            exec_stmt_and_free(sql, name, binds) { |stmt| stmt.affected_rows }
-          end
+          transform_and_execute(sql, name, binds)
         end
-        alias :exec_update :exec_delete
+
+        def exec_update(sql, name = nil, binds = []) # :nodoc:
+          transform_and_execute(sql, name, binds)
+        end
 
         private
+          def transform_and_execute(sql, name, binds)
+            if without_prepared_statement?(binds)
+              with_raw_connection do |conn|
+                @affected_rows_before_warnings = nil
+                execute_and_free(sql, name) { @affected_rows_before_warnings || conn.affected_rows }
+              end
+            else
+              exec_stmt_and_free(sql, name, binds) { |stmt| stmt.affected_rows }
+            end
+          end
+
           def sync_timezone_changes(raw_connection)
             raw_connection.query_options[:database_timezone] = default_timezone
           end

--- a/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
@@ -78,7 +78,10 @@ module ActiveRecord
         def exec_delete(sql, name = nil, binds = []) # :nodoc:
           execute_and_clear(sql, name, binds) { |result| result.cmd_tuples }
         end
-        alias :exec_update :exec_delete
+
+        def exec_update(sql, name = nil, binds = []) # :nodoc:
+          execute_and_clear(sql, name, binds) { |result| result.cmd_tuples }
+        end
 
         def exec_insert(sql, name = nil, binds = [], pk = nil, sequence_name = nil, returning: nil) # :nodoc:
           if use_insert_returning? || pk == false

--- a/activerecord/lib/active_record/connection_adapters/sqlite3/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3/database_statements.rb
@@ -63,7 +63,11 @@ module ActiveRecord
           internal_exec_query(sql, name, binds)
           @raw_connection.changes
         end
-        alias :exec_update :exec_delete
+
+        def exec_update(sql, name = "SQL", binds = []) # :nodoc:
+          internal_exec_query(sql, name, binds)
+          @raw_connection.changes
+        end
 
         def begin_isolated_db_transaction(isolation) # :nodoc:
           raise TransactionIsolationError, "SQLite3 only supports the `read_uncommitted` transaction isolation level" if isolation != :read_uncommitted

--- a/activerecord/lib/active_record/connection_adapters/trilogy/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/trilogy/database_statements.rb
@@ -31,17 +31,23 @@ module ActiveRecord
         end
 
         def exec_delete(sql, name = nil, binds = []) # :nodoc:
-          sql = transform_query(sql)
-          check_if_write_query(sql)
-          mark_transaction_written_if_write(sql)
-
-          result = raw_execute(to_sql(sql, binds), name)
-          result.affected_rows
+          transform_and_execute(sql, name, binds)
         end
 
-        alias :exec_update :exec_delete # :nodoc:
+        def exec_update(sql, name = nil, binds = []) # :nodoc:
+          transform_and_execute(sql, name, binds)
+        end
 
         private
+          def transform_and_execute(sql, name, binds)
+            sql = transform_query(sql)
+            check_if_write_query(sql)
+            mark_transaction_written_if_write(sql)
+
+            result = raw_execute(to_sql(sql, binds), name)
+            result.affected_rows
+          end
+
           def raw_execute(sql, name, async: false, allow_retry: false, materialize_transactions: true)
             log(sql, name, async: async) do |notification_payload|
               with_raw_connection(allow_retry: allow_retry, materialize_transactions: materialize_transactions) do |conn|


### PR DESCRIPTION
During a recent incident, I was trying to clean up some data in a production console via an `update_all`. The query raised (due to a lock timeout), and I noticed something very surprising in the backtrace - a call to `exec_delete`!

It turns out that these methods are aliases because they both have a very simple and identical implementation. But I didn't know this at a time and so my heart skipped a beat.

I am proposing we avoid aliasing for the sake of avoid confusion in backtraces. If you call `update`, I think we should avoid showing any other SQL verbs in your backtrace.

(I realise this is a super nitpicky change so I won't be upset if it gets rejected/ignored.)
