### PR TITLE
Consider selenium-webdriver version for Ruby 2.7

### DIFF
--- a/actionpack/test/dispatch/system_testing/driver_test.rb
+++ b/actionpack/test/dispatch/system_testing/driver_test.rb
@@ -113,13 +113,23 @@ class DriverTest < ActiveSupport::TestCase
     end
     driver.use
 
-    expected = {
-      "moz:firefoxOptions" => {
-        "args" => ["--host=127.0.0.1"],
-        "prefs" => { "remote.active-protocols" => 3, "browser.startup.homepage" => "http://www.seleniumhq.com/" }
-      },
-      "browserName" => "firefox"
-    }
+    if RUBY_VERSION < "3"
+      expected = {
+        "moz:firefoxOptions" => {
+          "args" => ["--host=127.0.0.1"],
+          "prefs" => { "browser.startup.homepage" => "http://www.seleniumhq.com/" }
+        },
+        "browserName" => "firefox"
+      }
+    else
+      expected = {
+        "moz:firefoxOptions" => {
+          "args" => ["--host=127.0.0.1"],
+          "prefs" => { "remote.active-protocols" => 3, "browser.startup.homepage" => "http://www.seleniumhq.com/" }
+        },
+        "browserName" => "firefox"
+      }
+    end
     assert_driver_capabilities driver, expected
   end
 
@@ -130,13 +140,23 @@ class DriverTest < ActiveSupport::TestCase
     end
     driver.use
 
-    expected = {
-      "moz:firefoxOptions" => {
-        "args" => ["-headless", "--host=127.0.0.1"],
-        "prefs" => { "remote.active-protocols" => 3, "browser.startup.homepage" => "http://www.seleniumhq.com/" }
-      },
-      "browserName" => "firefox"
-    }
+    if RUBY_VERSION < "3"
+      expected = {
+        "moz:firefoxOptions" => {
+          "args" => ["-headless", "--host=127.0.0.1"],
+          "prefs" => {  "browser.startup.homepage" => "http://www.seleniumhq.com/" }
+        },
+        "browserName" => "firefox"
+      }
+    else
+      expected = {
+        "moz:firefoxOptions" => {
+          "args" => ["-headless", "--host=127.0.0.1"],
+          "prefs" => { "remote.active-protocols" => 3, "browser.startup.homepage" => "http://www.seleniumhq.com/" }
+        },
+        "browserName" => "firefox"
+      }
+    end
     assert_driver_capabilities driver, expected
   end
 


### PR DESCRIPTION
### Motivation / Background

This commit addresses the Rails CI failure at 7-1-stable branch using Ruby 2.7 https://buildkite.com/rails/rails/builds/108575#019038c9-7c19-44e9-8c90-b257a3293450/1092-1106

### Detail

Because selenium-webdriver >= 4.9.1 requires Ruby 3.0 then Gemfile of 7-1-stable branch chooses the selenium-webdriver version based on the Ruby version. https://github.com/rails/rails/pull/48847

Follow up https://github.com/rails/rails/commit/41844df3d60ff62c63d3fa48b182abacba56b021

### Additional information
None

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [ ] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
