### PR TITLE
Correctly generate Devcontainer setting for applications that using mysql2 gem

### DIFF
--- a/railties/lib/rails/commands/devcontainer/devcontainer_command.rb
+++ b/railties/lib/rails/commands/devcontainer/devcontainer_command.rb
@@ -22,12 +22,17 @@ module Rails
         def devcontainer_options
           @devcontainer_options ||= {
             app_name: Rails.application.railtie_name.chomp("_application"),
-            database: !!defined?(ActiveRecord) && ActiveRecord::Base.connection_db_config.adapter,
+            database: !!defined?(ActiveRecord) && database,
             active_storage: !!defined?(ActiveStorage),
             redis: !!(defined?(ActionCable) || defined?(ActiveJob)),
             system_test: File.exist?("test/application_system_test_case.rb"),
             node: File.exist?(".node-version"),
           }
+        end
+
+        def database
+          adapter = ActiveRecord::Base.connection_db_config.adapter
+          adapter == "mysql2" ? "mysql" : adapter
         end
     end
   end

--- a/railties/test/commands/devcontainer_test.rb
+++ b/railties/test/commands/devcontainer_test.rb
@@ -20,4 +20,28 @@ class Rails::Command::DevcontainerTest < ActiveSupport::TestCase
     assert_match "system_test: true", output
     assert_match "node: false", output
   end
+
+  test "generates devcontainer for using mysql2 app" do
+    build_app
+
+    Dir.chdir(app_path) do
+      use_mysql2
+
+      output = rails "devcontainer"
+
+      assert_match "app_name: app_template", output
+      assert_match "database: mysql", output
+      assert_match "active_storage: true", output
+      assert_match "redis: true", output
+      assert_match "system_test: true", output
+      assert_match "node: false", output
+
+      assert_match "ghcr.io/rails/devcontainer/features/mysql-client", read_file(".devcontainer/devcontainer.json")
+    end
+  end
+
+  private
+    def read_file(relative)
+      File.read(app_path(relative))
+    end
 end


### PR DESCRIPTION
### Motivation / Background

Currently, `devcontainer` command sets an adapter name, but `DevcontainerGenerator` requires a database name.
https://github.com/rails/rails/blob/16d8b82d5e2aca4780c5d10b1fe9a90b33a0e84e/railties/lib/rails/generators/rails/devcontainer/devcontainer_generator.rb#L11 https://github.com/rails/rails/blob/16d8b82d5e2aca4780c5d10b1fe9a90b33a0e84e/railties/lib/rails/generators/database.rb#L6

So the `devcontainer` command doesn't generate the setting for MySQL. This fixes to generate the correct setting.


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
