### PR TITLE
Revert "Make `bundle exec blade build` success with Ruby 3.3.0dev at 7-0-stable

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -117,7 +117,6 @@ gem "webmock"
 # Action View
 group :view do
   gem "blade", require: false, platforms: [:ruby]
-  gem "cookiejar", github: "yahonda/cookiejar", branch: "ruby33", require: false, platforms: [:ruby]
   gem "sprockets-export", require: false
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,13 +15,6 @@ GIT
       event_emitter
       websocket
 
-GIT
-  remote: https://github.com/yahonda/cookiejar.git
-  revision: ebcde134a62ec9dccbc81b71d62e0f6f91b2571f
-  branch: ruby33
-  specs:
-    cookiejar (0.3.3)
-
 PATH
   remote: .
   specs:
@@ -195,6 +188,7 @@ GEM
     coffee-script-source (1.12.2)
     concurrent-ruby (1.2.2)
     connection_pool (2.3.0)
+    cookiejar (0.3.4)
     crack (0.4.5)
       rexml
     crass (1.0.6)
@@ -599,7 +593,6 @@ DEPENDENCIES
   capybara (>= 3.26)
   cgi (>= 0.3.6)
   connection_pool
-  cookiejar!
   cssbundling-rails
   dalli (>= 3.0.1)
   debug (>= 1.1.0)


### PR DESCRIPTION
This reverts commit 960feca7637d12a2366d6acaf200eb3189959e2a.

```
Git error: command `git clone --bare --no-hardlinks --quiet --no-tags --depth 1 --single-branch -- https://github.com/yahonda/cookiejar.git
/home/zzak/.rbenv/versions/3.3.3/lib/ruby/gems/3.3.0/cache/bundler/git/cookiejar-38795cdcc6037257d1ca77793676561412e0ea2f` in directory
/home/zzak/.rbenv/versions/3.3.3/lib/ruby/gems/3.3.0/cache/bundler/git/cookiejar-38795cdcc6037257d1ca77793676561412e0ea2f has failed.
ERROR: Repository not found.
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
```

It also seems like the fix for Ruby 3.3 was applied and released: https://github.com/dwaite/cookiejar/commit/36332870693334ad9fb51dbfebc398b46bb1427a

cc @yahonda