### PR TITLE
[6-1-stable] Revert "Merge pull request #47789 from yahonda/7-0-stable_ruby33"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -93,7 +93,6 @@ group :cable do
   gem "websocket-client-simple", github: "matthewd/websocket-client-simple", branch: "close-race", require: false
 
   gem "blade", require: false, platforms: [:ruby]
-  gem "cookiejar", github: "yahonda/cookiejar", branch: "ruby33", require: false, platforms: [:ruby]
   gem "blade-sauce_labs_plugin", require: false, platforms: [:ruby]
   gem "sprockets-export", require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -27,13 +27,6 @@ GIT
     redis-namespace (1.8.1)
       redis (>= 3.0.4)
 
-GIT
-  remote: https://github.com/yahonda/cookiejar.git
-  revision: ebcde134a62ec9dccbc81b71d62e0f6f91b2571f
-  branch: ruby33
-  specs:
-    cookiejar (0.3.3)
-
 PATH
   remote: .
   specs:
@@ -199,6 +192,7 @@ GEM
     coffee-script-source (1.12.2)
     concurrent-ruby (1.1.8)
     connection_pool (2.2.5)
+    cookiejar (0.3.3)
     crack (0.4.5)
       rexml
     crass (1.0.6)
@@ -570,7 +564,6 @@ DEPENDENCIES
   capybara (>= 3.26)
   cgi (>= 0.3.6)
   connection_pool
-  cookiejar!
   dalli
   delayed_job
   delayed_job_active_record


### PR DESCRIPTION
This reverts commit be197368cf7f2b555ff82cb4a5815d384de61896.

The same as #52177 but for `6-1-stable`, as the build is completely blocked in it's current state.