### PR TITLE
[6-1-stable] Bump cookiejar with stable Ruby 3.3 fix

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -185,7 +185,7 @@ GEM
     coffee-script-source (1.12.2)
     concurrent-ruby (1.1.8)
     connection_pool (2.2.5)
-    cookiejar (0.3.3)
+    cookiejar (0.3.4)
     crack (0.4.5)
       rexml
     crass (1.0.6)


### PR DESCRIPTION
This was meant to land in #52178 but GitHub was showing the version bump as a merge conflict.

I'm not sure why, but hopefully now that PR is merged a new PR will work.