### PR TITLE
Fix Action Cable loader path prefix

### DIFF
--- a/actioncable/lib/action_cable.rb
+++ b/actioncable/lib/action_cable.rb
@@ -27,18 +27,19 @@ require "active_support"
 require "active_support/rails"
 require "zeitwerk"
 
+lib = File.dirname(__FILE__)
 Zeitwerk::Loader.for_gem.tap do |loader|
   loader.ignore(
-    "#{__dir__}/rails", # Contains generators, templates, docs, etc.
-    "#{__dir__}/action_cable/gem_version.rb",
-    "#{__dir__}/action_cable/version.rb",
-    "#{__dir__}/action_cable/deprecator.rb",
+    "#{lib}/rails", # Contains generators, templates, docs, etc.
+    "#{lib}/action_cable/gem_version.rb",
+    "#{lib}/action_cable/version.rb",
+    "#{lib}/action_cable/deprecator.rb",
   )
 
   loader.do_not_eager_load(
-    "#{__dir__}/action_cable/subscription_adapter", # Adapters are required and loaded on demand.
-    "#{__dir__}/action_cable/test_helper.rb",
-    Dir["#{__dir__}/action_cable/**/test_case.rb"]
+    "#{lib}/action_cable/subscription_adapter", # Adapters are required and loaded on demand.
+    "#{lib}/action_cable/test_helper.rb",
+    Dir["#{lib}/action_cable/**/test_case.rb"]
   )
 
   loader.inflector.inflect("postgresql" => "PostgreSQL")


### PR DESCRIPTION
### Motivation / Background

Since `__dir__` uses real path, when we load the gems from a symlinked file, the Zeitwerk loader tries to load the ignored files and throws warnings or errors. Using `File.dirname(__FILE__)` gives consistency for paths.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
