### PR TITLE
Turn ActionController::Base inclusions explicit

### DIFF
--- a/actionpack/lib/action_controller/base.rb
+++ b/actionpack/lib/action_controller/base.rb
@@ -231,7 +231,6 @@ module ActionController
       AbstractController::Rendering,
       AbstractController::Translation,
       AbstractController::AssetPaths,
-
       Helpers,
       UrlFor,
       Redirecting,
@@ -261,26 +260,55 @@ module ActionController
       HttpAuthentication::Token::ControllerMethods,
       DefaultHeaders,
       Logging,
-
-      # Before callbacks should also be executed as early as possible, so also include
-      # them at the bottom.
       AbstractController::Callbacks,
-
-      # Append rescue at the bottom to wrap as much as possible.
       Rescue,
-
-      # Add instrumentations hooks at the bottom, to ensure they instrument all the
-      # methods properly.
       Instrumentation,
-
-      # Params wrapper should come before instrumentation so they are properly showed
-      # in logs
       ParamsWrapper
     ]
 
-    MODULES.each do |mod|
-      include mod
-    end
+    include AbstractController::Rendering
+    include AbstractController::Translation
+    include AbstractController::AssetPaths
+    include Helpers
+    include UrlFor
+    include Redirecting
+    include ActionView::Layouts
+    include Rendering
+    include Renderers::All
+    include ConditionalGet
+    include EtagWithTemplateDigest
+    include EtagWithFlash
+    include Caching
+    include MimeResponds
+    include ImplicitRender
+    include StrongParameters
+    include ParameterEncoding
+    include Cookies
+    include Flash
+    include FormBuilder
+    include RequestForgeryProtection
+    include ContentSecurityPolicy
+    include PermissionsPolicy
+    include RateLimiting
+    include AllowBrowser
+    include Streaming
+    include DataStreaming
+    include HttpAuthentication::Basic::ControllerMethods
+    include HttpAuthentication::Digest::ControllerMethods
+    include HttpAuthentication::Token::ControllerMethods
+    include DefaultHeaders
+    include Logging
+    # Before callbacks should also be executed as early as possible, so also include
+    # them at the bottom.
+    include AbstractController::Callbacks
+    # Append rescue at the bottom to wrap as much as possible.
+    include Rescue
+    # Add instrumentations hooks at the bottom, to ensure they instrument all the
+    # methods properly.
+    include Instrumentation
+    # Params wrapper should come before instrumentation so they are properly showed
+    # in logs
+    include ParamsWrapper
     setup_renderer!
 
     # Define some internal variables that should not be propagated to the view.

--- a/actionpack/test/controller/base_test.rb
+++ b/actionpack/test/controller/base_test.rb
@@ -350,3 +350,15 @@ class EmptyUrlOptionsTest < ActionController::TestCase
     end
   end
 end
+
+class BaseTest < ActiveSupport::TestCase
+  def test_included_modules_are_tracked
+    base_content = File.read("#{__dir__}/../../lib/action_controller/base.rb")
+    included_modules = base_content.scan(/(?<=include )[A-Z].*/)
+
+    assert_equal(
+      ActionController::Base::MODULES.map { |m| m.to_s.delete_prefix("ActionController::") },
+      included_modules
+    )
+  end
+end


### PR DESCRIPTION
### Motivation / Background

We received some reports from [Ruby LSP](https://github.com/Shopify/ruby-lsp) users that method completions were not available inside controller actions - even in situations where we should be able to provide accurate suggestions.

The reason for the missing completions, go to definition, hover, signature help and other features is because all modules are included dynamically into `ActionController::Base`, which makes static analysis unable to capture the ancestors. Since `Base` doesn't actually define anything itself, not being able to analyze the ancestors means that static analysis fails to identify any methods, constants or instance variables defined in it.

After chatting with @rafaelfranca, he explained that the motivation of using dynamic inclusion in this case was to ensure that the list of `MODULES` that can be excluded was never out of sync, but that if we could guarantee that through other means we could change the inclusions to be explicit.

In this PR, I'm proposing adding a simple unit test to verify that the list of included modules matches the list of `MODULES` that can be excluded. This generates a minor inconvenience: when including a new module into `ActionController::Base`, we will need to add it both to the list of `MODULES` and in the explicit includes.

However, I believe it's an acceptable trade off given that we're likely not adding more inclusions in this class in a daily basis. The advantage is that Ruby LSP users (and users of other static analysis tools) will be able to get accurate features inside controllers, which is currently not the case.

### Detail

Instead of looping through the array of `MODULES` and dynamically including each one, I simply turned each inclusion explicit.

The test I included will read the `base.rb` file, find all inclusions with a regex and then verify that it matches what is expected in the `MODULES` array, so that they do not go out of sync.

### Note

Why not adding an ancestors check?

Instead of adding a unit test, I attempted to achieve this by checking the difference in ancestors before and after the inclusion of the modules. However, that will not match because the modules listed in `MODULES` have ancestors of their own, which are not included in the list. This was the idea I explored:

```ruby
class Base
  # ...

  original_ancestors = ancestors
  include AbstractController::Rendering
  # ...

  # This will include not only the items that currently exist in the MODULES list,
  # but also transitive ancestors (modules included by the modules in the list)
  # I could not come up with a decent way of dynamically generating the list
  MODULES = ancestors - original_ancestors
end
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
