### PR TITLE
Fix `missing(:association)` and `associated(:association)` for composite primary keys

### DIFF
--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -92,10 +92,11 @@ module ActiveRecord
             @scope.joins!(association)
           end
 
+          association_conditions = Array(reflection.association_primary_key).index_with(nil)
           if reflection.options[:class_name]
-            self.not(association => { reflection.association_primary_key => nil })
+            self.not(association => association_conditions)
           else
-            self.not(reflection.table_name => { reflection.association_primary_key => nil })
+            self.not(reflection.table_name => association_conditions)
           end
         end
 
@@ -124,10 +125,11 @@ module ActiveRecord
         associations.each do |association|
           reflection = scope_association_reflection(association)
           @scope.left_outer_joins!(association)
+          association_conditions = Array(reflection.association_primary_key).index_with(nil)
           if reflection.options[:class_name]
-            @scope.where!(association => { reflection.association_primary_key => nil })
+            @scope.where!(association => association_conditions)
           else
-            @scope.where!(reflection.table_name => { reflection.association_primary_key => nil })
+            @scope.where!(reflection.table_name => association_conditions)
           end
         end
 

--- a/activerecord/test/cases/relation/where_chain_test.rb
+++ b/activerecord/test/cases/relation/where_chain_test.rb
@@ -8,6 +8,7 @@ require "models/essay"
 require "models/comment"
 require "models/categorization"
 require "models/book"
+require "models/cpk"
 
 module ActiveRecord
   class WhereChainTest < ActiveRecord::TestCase
@@ -113,6 +114,13 @@ module ActiveRecord
       end
     end
 
+    def test_associated_with_composite_primary_key
+      author = Cpk::Author.create!(id: [1, 2])
+      Cpk::Book.create!(id: [author.id, 2])
+
+      assert_predicate Cpk::Author.where.associated(:books), :any?
+    end
+
     def test_missing_with_association
       assert_predicate posts(:authorless).author, :blank?
       assert_equal [posts(:authorless)], Post.where.missing(:author).to_a
@@ -186,6 +194,12 @@ module ActiveRecord
 
     def test_missing_with_enum_extended_late
       assert_equal Author.find(2), Author.order(id: :desc).joins(:reading_listing).where.missing(:unread_listing).extending(Author::NamedExtension).first
+    end
+
+    def test_missing_with_composite_primary_key
+      Cpk::Book.create!(id: [1, 2])
+
+      assert_predicate Cpk::Book.where.missing(:author), :any?
     end
 
     def test_not_inverts_where_clause


### PR DESCRIPTION
Fixes #52182 

### Detail

Make a hash of the composite primary key so the where clause knows to check for multiple columns, one column per key, instead of a single column with all the key names.