### PR TITLE
Prefer ETag over Last-Modified for `fresh_when` and `stale?` according to HTTP speicification

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add `config.action_dispatch.prefer_etag_over_last_modified`. When set to `true`, the `ETag` header takes precedence over the `Last-Modified` header when both are present. Defaults to `false` to maintain compatibility with previous versions of Rails. But it is recommended to set it to `true` to better align with the HTTP specification.
+
+    *heka1024*
+
 *   Support `immutable` directive in Cache-Control
 
     ```ruby

--- a/actionpack/lib/action_dispatch/railtie.rb
+++ b/actionpack/lib/action_dispatch/railtie.rb
@@ -29,6 +29,7 @@ module ActionDispatch
     config.action_dispatch.request_id_header = ActionDispatch::Constants::X_REQUEST_ID
     config.action_dispatch.log_rescued_responses = true
     config.action_dispatch.debug_exception_log_level = :fatal
+    config.action_dispatch.prefer_etag_over_last_modified = false
 
     config.action_dispatch.default_headers = {
       "X-Frame-Options" => "SAMEORIGIN",
@@ -69,7 +70,13 @@ module ActionDispatch
 
       ActionDispatch::Routing::Mapper.route_source_locations = Rails.env.development?
 
-      ActionDispatch.test_app = app
+      ActionDispatch::Http::Cache::Request.prefer_etag_over_last_modified = app.config.action_dispatch.prefer_etag_over_last_modified
+
+      unless ActionDispatch::Http::Cache::Request.prefer_etag_over_last_modified
+        ActionDispatch.deprecator.warn(<<~MSG.squish)
+          `config.action_dispatch.prefer_etag_over_last_modified` with a value of `false` is deprecated and will be removed in Rails 8.0.
+        MSG
+      end
     end
   end
 end

--- a/actionpack/test/controller/render_test.rb
+++ b/actionpack/test/controller/render_test.rb
@@ -2,6 +2,7 @@
 
 require "abstract_unit"
 require "controller/fake_models"
+require "support/etag_helper"
 
 class TestControllerWithExtraEtags < ActionController::Base
   self.view_paths = [ActionView::FixtureResolver.new(
@@ -666,6 +667,7 @@ end
 class EtagRenderTest < ActionController::TestCase
   tests TestControllerWithExtraEtags
   include TemplateModificationHelper
+  include EtagHelper
 
   def test_strong_etag
     @request.if_none_match = strong_etag(["strong", "ab", :cde, [:f]])
@@ -738,15 +740,6 @@ class EtagRenderTest < ActionController::TestCase
       assert_not_equal etag, @response.etag
     end
   end
-
-  private
-    def weak_etag(record)
-      "W/#{strong_etag record}"
-    end
-
-    def strong_etag(record)
-      %("#{ActiveSupport::Digest.hexdigest(ActiveSupport::Cache.expand_cache_key(record))}")
-    end
 end
 
 class NamespacedEtagRenderTest < ActionController::TestCase

--- a/actionpack/test/support/etag_helper.rb
+++ b/actionpack/test/support/etag_helper.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module EtagHelper
+  def weak_etag(record)
+    "W/#{strong_etag record}"
+  end
+
+  def strong_etag(record)
+    %("#{ActiveSupport::Digest.hexdigest(ActiveSupport::Cache.expand_cache_key(record))}")
+  end
+end

--- a/guides/source/caching_with_rails.md
+++ b/guides/source/caching_with_rails.md
@@ -656,6 +656,9 @@ class ProductsController < ApplicationController
 end
 ```
 
+When both `last_modified` and `etag` are set, behavior varies depending on the value of `config.action_dispatch.prefer_etag_over_last_modified`. If set to `true`, the etag takes precedence. If set to `false`, both are used. By default, `prefer_etag_over_last_modified` is `false`. But it is recommended to set it to `true` to better align with the HTTP specification. 
+
+
 Sometimes we want to cache response, for example a static page, that never gets
 expired. To achieve this, we can use `http_cache_forever` helper and by doing
 so browser and proxies will cache it indefinitely.

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -2110,6 +2110,10 @@ Setting the value to `:none` configures Action Pack raise all exceptions.
 | (original)            | `true`                |
 | 7.1                   | `:all`                |
 
+### `config.action_dispatch.prefer_etag_over_last_modified`
+
+Configures whether the `ActionDispatch::ETag` middleware should prefer the `ETag` header over the `Last-Modified` header when both are present in the response. The default value is `false`. It is recommended to set this to `true` to align with the HTTP specification. It will be set to `true` by default later versions.
+
 #### `ActionDispatch::Callbacks.before`
 
 Takes a block of code to run before the request.

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -3358,6 +3358,23 @@ module ApplicationTests
       assert_equal 308, Rails.application.config.action_dispatch.ssl_default_redirect_status
     end
 
+    test "Rails.application.config.action_dispatch.prefer_etag_over_last_modified is false by default" do
+      app "development"
+
+      assert_equal false, Rails.application.config.action_dispatch.prefer_etag_over_last_modified
+    end
+
+    test "Rails.application.config.action_dispatch.prefer_etag_over_last_modified can be configured in an initializer" do
+      add_to_config <<-RUBY
+        config.action_dispatch.prefer_etag_over_last_modified = true
+      RUBY
+
+      app "development"
+
+      assert_equal true, ActionDispatch::Http::Cache::Request.prefer_etag_over_last_modified
+    end
+
+
     test "Rails.application.config.action_mailer.smtp_settings have open_timeout and read_timeout defined as 5 in 7.0 defaults" do
       remove_from_config '.*config\.load_defaults.*\n'
       add_to_config <<-RUBY


### PR DESCRIPTION
### Summary
This pull request modifies the HTTP cache handling behavior in Rails to better align with the HTTP specification. Specifically, the change ensures that the ETag header takes precedence over other conditions when determining if a request is fresh.

### Details
Previously, the logic required both the ETag and Last-Modified headers to match for a request to be considered fresh. The new logic prioritizes the ETag header, which is in accordance with the guidance provided in the [RFC 7232, Section 6](http://tools.ietf.org/html/rfc7232#section-6)

### Changes Made
- Refactored the HTTP cache handling code to ensure that the ETag header takes precedence over the Last-Modified header.
- Updated relevant tests to reflect this new behavior.

### Reference
- [RFC 7232, Section 6](http://tools.ietf.org/html/rfc7232#section-6)
- [MDN: If-None-Match
](https://developer.mozilla.org/ko/docs/Web/HTTP/Headers/If-None-Match)

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [X] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
