### PR TITLE
Fix ActiveRecord dirty docs

### DIFF
--- a/activerecord/lib/active_record/attribute_methods/dirty.rb
+++ b/activerecord/lib/active_record/attribute_methods/dirty.rb
@@ -31,7 +31,7 @@ module ActiveRecord
     #   person.name_in_database        # => "Alice"
     #   person.saved_change_to_name?   # => true
     #   person.saved_change_to_name    # => ["Allison", "Alice"]
-    #   person.name_before_last_change # => "Allison"
+    #   person.name_before_last_save   # => "Allison"
     #
     # Similar to ActiveModel::Dirty, methods can be invoked as
     # +saved_change_to_name?+ or by passing an argument to the generic method


### PR DESCRIPTION
The method described in this line of documentation doesn't exist, but an equivalent one does:

```ruby
user.id_before_last_change 
# => NoMethodError: undefined method `id_before_last_change' for #<User>

user.id_before_last_save
# => "030720de-cc38-4215-925f-96a5f09cde39"
```