### PR TITLE
Support `immutable` directive in Cache-Control

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Support `immutable` directive in Cache-Control
+
+    ```ruby
+    expires_in 1.minute, public: true, immutable: true
+    # Cache-Control: public, max-age=60, immutable
+    ```
+
+    *heka1024*
+
 *   Add `:wasm_unsafe_eval` mapping for `content_security_policy`
 
     ```ruby

--- a/actionpack/lib/action_controller/metal/conditional_get.rb
+++ b/actionpack/lib/action_controller/metal/conditional_get.rb
@@ -293,6 +293,7 @@ module ActionController
         must_revalidate: options.delete(:must_revalidate),
         stale_while_revalidate: options.delete(:stale_while_revalidate),
         stale_if_error: options.delete(:stale_if_error),
+        immutable: options.delete(:immutable),
       )
       options.delete(:private)
 

--- a/actionpack/lib/action_dispatch/http/cache.rb
+++ b/actionpack/lib/action_dispatch/http/cache.rb
@@ -171,6 +171,7 @@ module ActionDispatch
         PUBLIC                = "public"
         PRIVATE               = "private"
         MUST_REVALIDATE       = "must-revalidate"
+        IMMUTABLE             = "immutable"
 
         def handle_conditional_get!
           # Normally default cache control setting is handled by ETag middleware. But, if
@@ -221,6 +222,7 @@ module ActionDispatch
             options << MUST_REVALIDATE if control[:must_revalidate]
             options << "stale-while-revalidate=#{stale_while_revalidate.to_i}" if stale_while_revalidate
             options << "stale-if-error=#{stale_if_error.to_i}" if stale_if_error
+            options << IMMUTABLE if control[:immutable]
             options.concat(extras) if extras
           end
 

--- a/actionpack/test/controller/render_test.rb
+++ b/actionpack/test/controller/render_test.rb
@@ -179,6 +179,11 @@ class TestController < ActionController::Base
     render action: "hello_world"
   end
 
+  def conditional_hello_with_expires_in_with_immutable
+    expires_in 1.minute, public: true, immutable: true
+    render action: "hello_world"
+  end
+
   def conditional_hello_with_expires_in_with_public_with_more_keys
     expires_in 1.minute, :public => true, "s-maxage" => 5.hours
     render action: "hello_world"
@@ -440,6 +445,11 @@ class ExpiresInRenderTest < ActionController::TestCase
   def test_expires_in_header_with_stale_if_error
     get :conditional_hello_with_expires_in_with_stale_if_error
     assert_equal "max-age=60, public, stale-if-error=300", @response.headers["Cache-Control"]
+  end
+
+  def test_expires_in_header_with_immutable
+    get :conditional_hello_with_expires_in_with_immutable
+    assert_equal "max-age=60, public, immutable", @response.headers["Cache-Control"]
   end
 
   def test_expires_in_header_with_additional_headers


### PR DESCRIPTION
### Motivation / Background

Support `immutable` directive in Cache-Control

### Detail

`immutable` cache directive can boost performance in situations with frequent refreshes. However, Rails does not support this directive currently. Therefore, I have added support for this directive.

### Additional information
- [MDN Cache directive](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#response_directives)
- https://www.keycdn.com/blog/cache-control-immutable

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [X] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
