### PR TITLE
Add `type` attribute in source of video and audio tag

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,2 +1,15 @@
+*   Add `type` attribute in source tag of video and audio
+
+    ```ruby
+    # Before
+    video_tag("movie.mp4", "movie.webm")
+    # => <video><source src="movie.mp4" /><source src="movie.webm" /></video>
+
+    # After
+    video_tag("movie.mp4", "movie.webm")
+    # => <video><source src="movie.mp4" type="video/mp4" /><source src="movie.webm" type="video/webm" /></video>
+    ```
+
+    *heka1024*
 
 Please check [7-2-stable](https://github.com/rails/rails/blob/7-2-stable/actionview/CHANGELOG.md) for previous changes.

--- a/actionview/lib/action_view/helpers/asset_tag_helper.rb
+++ b/actionview/lib/action_view/helpers/asset_tag_helper.rb
@@ -604,7 +604,14 @@ module ActionView
 
           if sources.size > 1
             content_tag(type, options) do
-              safe_join sources.map { |source| tag("source", src: resolve_asset_source(type, source, skip_pipeline)) }
+              tags = sources.map do |source|
+                tag_options = { src: resolve_asset_source(type, source, skip_pipeline) }
+                possible_type = Template::Types[File.extname(source)[1..]]&.to_s
+                tag_options[:type] = possible_type if possible_type&.start_with?(type) # Some mime type supports both audio and video, so we need to select the correct one
+
+                tag("source", tag_options)
+              end
+              safe_join(tags)
             end
           else
             options[:src] = resolve_asset_source(type, sources.first, skip_pipeline)

--- a/actionview/test/template/asset_tag_helper_test.rb
+++ b/actionview/test/template/asset_tag_helper_test.rb
@@ -383,7 +383,8 @@ class AssetTagHelperTest < ActionView::TestCase
     %(video_tag("//media.rubyonrails.org/video/rails_blog_2.mov")) => %(<video src="//media.rubyonrails.org/video/rails_blog_2.mov"></video>),
     %(video_tag("multiple.ogg", "multiple.avi")) => %(<video><source src="/videos/multiple.ogg" /><source src="/videos/multiple.avi" /></video>),
     %(video_tag(["multiple.ogg", "multiple.avi"])) => %(<video><source src="/videos/multiple.ogg" /><source src="/videos/multiple.avi" /></video>),
-    %(video_tag(["multiple.ogg", "multiple.avi"], :size => "160x120", :controls => true)) => %(<video controls="controls" height="120" width="160"><source src="/videos/multiple.ogg" /><source src="/videos/multiple.avi" /></video>)
+    %(video_tag(["multiple.ogg", "multiple.avi"], :size => "160x120", :controls => true)) => %(<video controls="controls" height="120" width="160"><source src="/videos/multiple.ogg" /><source src="/videos/multiple.avi" /></video>),
+    %(video_tag("multiple.webm", "multiple.mp4")) => %(<video><source src="/videos/multiple.webm" type="video/webm" /><source src="/videos/multiple.mp4" type="video/mp4" /></video>),
   }
 
   AudioPathToTag = {
@@ -419,9 +420,9 @@ class AssetTagHelperTest < ActionView::TestCase
     %(audio_tag("rss.wav", :autoplay => true, :controls => true)) => %(<audio autoplay="autoplay" controls="controls" src="/audios/rss.wav"></audio>),
     %(audio_tag("http://media.rubyonrails.org/audio/rails_blog_2.mov")) => %(<audio src="http://media.rubyonrails.org/audio/rails_blog_2.mov"></audio>),
     %(audio_tag("//media.rubyonrails.org/audio/rails_blog_2.mov")) => %(<audio src="//media.rubyonrails.org/audio/rails_blog_2.mov"></audio>),
-    %(audio_tag("audio.mp3", "audio.ogg")) => %(<audio><source src="/audios/audio.mp3" /><source src="/audios/audio.ogg" /></audio>),
-    %(audio_tag(["audio.mp3", "audio.ogg"])) => %(<audio><source src="/audios/audio.mp3" /><source src="/audios/audio.ogg" /></audio>),
-    %(audio_tag(["audio.mp3", "audio.ogg"], :preload => 'none', :controls => true)) => %(<audio preload="none" controls="controls"><source src="/audios/audio.mp3" /><source src="/audios/audio.ogg" /></audio>)
+    %(audio_tag("audio.mp3", "audio.ogg")) => %(<audio><source src="/audios/audio.mp3" type="audio/mpeg" /><source src="/audios/audio.ogg" type="audio/ogg" /></audio>),
+    %(audio_tag(["audio.mp3", "audio.ogg"])) => %(<audio><source src="/audios/audio.mp3" type="audio/mpeg" /><source src="/audios/audio.ogg" type="audio/ogg" /></audio>),
+    %(audio_tag(["audio.mp3", "audio.ogg"], :preload => 'none', :controls => true)) => %(<audio preload="none" controls="controls"><source src="/audios/audio.mp3" type="audio/mpeg" /><source src="/audios/audio.ogg" type="audio/ogg" /></audio>)
   }
 
   FontPathToTag = {


### PR DESCRIPTION
### Motivation / Background

Similar to what was done in https://github.com/rails/rails/pull/48266, add `type` attribute in source of video and audio tag. 

[MDN Doc: <source> tag](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/source)

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [X] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
