### PR TITLE
Fix mailer templates to be rubocop compliant

### DIFF
--- a/actionmailer/lib/rails/generators/mailer/templates/mailer.rb.tt
+++ b/actionmailer/lib/rails/generators/mailer/templates/mailer.rb.tt
@@ -1,7 +1,9 @@
 <% module_namespacing do -%>
 class <%= class_name %>Mailer < ApplicationMailer
-<% actions.each do |action| -%>
+<% actions.each_with_index do |action, index| -%>
+<% if index != 0 -%>
 
+<% end -%>
   # Subject can be set in your I18n file at config/locales/en.yml
   # with the following lookup:
   #

--- a/railties/lib/rails/generators/test_unit/mailer/templates/functional_test.rb.tt
+++ b/railties/lib/rails/generators/test_unit/mailer/templates/functional_test.rb.tt
@@ -2,15 +2,17 @@ require "test_helper"
 
 <% module_namespacing do -%>
 class <%= class_name %>MailerTest < ActionMailer::TestCase
-<% actions.each do |action| -%>
+<% actions.each_with_index do |action, index| -%>
+<% if index != 0 -%>
+
+<% end -%>
   test "<%= action %>" do
     mail = <%= class_name %>Mailer.<%= action %>
     assert_equal <%= action.to_s.humanize.inspect %>, mail.subject
-    assert_equal ["to@example.org"], mail.to
-    assert_equal ["from@example.com"], mail.from
+    assert_equal [ "to@example.org" ], mail.to
+    assert_equal [ "from@example.com" ], mail.from
     assert_match "Hi", mail.body.encoded
   end
-
 <% end -%>
 <% if actions.blank? -%>
   # test "the truth" do

--- a/railties/lib/rails/generators/test_unit/mailer/templates/preview.rb.tt
+++ b/railties/lib/rails/generators/test_unit/mailer/templates/preview.rb.tt
@@ -1,13 +1,14 @@
 <% module_namespacing do -%>
 # Preview all emails at http://localhost:3000/rails/mailers/<%= file_path %>_mailer
 class <%= class_name %>MailerPreview < ActionMailer::Preview
-<% actions.each do |action| -%>
+<% actions.each_with_index do |action, index| -%>
+<% if index != 0 -%>
 
+<% end -%>
   # Preview this email at http://localhost:3000/rails/mailers/<%= file_path %>_mailer/<%= action %>
   def <%= action %>
     <%= class_name %>Mailer.<%= action %>
   end
 <% end -%>
-
 end
 <% end -%>


### PR DESCRIPTION
- spaces around array elements
- only emit blank lines between new blocks of code