### PR TITLE
[7-0-stable] Lock json to 1.6.x to avoid ostruct removal

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,7 +41,7 @@ gem "bcrypt", "~> 3.1.11", require: false
 gem "terser", ">= 1.1.4", require: false
 
 # Explicitly avoid 1.x that doesn't support Ruby 2.4+
-gem "json", ">= 2.0.0", "!=2.7.0"
+gem "json", ">= 2.0.0", "< 2.7"
 
 # Lock rack-test to v1 until #45467 is fixed
 gem "rack-test", "< 2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -606,7 +606,7 @@ DEPENDENCIES
   image_processing (~> 1.2)
   importmap-rails (>= 1.2.3)
   jsbundling-rails
-  json (>= 2.0.0, != 2.7.0)
+  json (>= 2.0.0, < 2.7)
   libxml-ruby
   listen (~> 3.3)
   minitest (>= 5.15.0, < 5.16.0)


### PR DESCRIPTION
Newer versions of json gem remove ostruct causing us to either explicitly require ostruct where we need.

This is an alternative to depend on a stable version of json for older rubies.

```
Error:
ControllerHelperTest#test_respond_to:
NameError: uninitialized constant ControllerHelperTest::OpenStruct
    /rails/actionview/test/template/controller_helper_test.rb:25:in `test_respond_to'
```

https://buildkite.com/rails/rails/builds/108663#0190481d-cb6b-41b8-8c2a-db3d72a19964/1186-1194

The alternative is to combine commits like fractaledmind/rails@06a73b33e805b62e19e4e1831c226db4fd0e147c and fractaledmind/rails@759750b519ac952a2ea66f4575b2d77c8cb03cb0.

See also #51510, which was backported to `7-1-stable`, so that is also an option.