### PR TITLE
[7-0-stable] Require 'uri' explicitly to address NameError: uninitialized constant ToQueryTest::URI

### DIFF
--- a/activesupport/test/core_ext/object/to_query_test.rb
+++ b/activesupport/test/core_ext/object/to_query_test.rb
@@ -3,6 +3,7 @@
 require_relative "../../abstract_unit"
 require "active_support/core_ext/object/to_query"
 require "active_support/core_ext/string/output_safety"
+require "uri"
 
 class ToQueryTest < ActiveSupport::TestCase
   def test_simple_conversion


### PR DESCRIPTION
This backports #50921 to `7-0-stable` since this CI failure is also happening there.
https://buildkite.com/rails/rails/builds/108670#019048d6-64e3-4674-ab60-9b9c4f48d418/1117-1878

Require 'uri' explicitly to address `NameError: uninitialized constant ToQueryTest::URI`

```
Error:
ToQueryTest#test_hash_not_sorted_lexicographically_for_nested_structure:
NameError: uninitialized constant ToQueryTest::URI
    test/core_ext/object/to_query_test.rb:90:in `test_hash_not_sorted_lexicographically_for_nested_structure'

bin/test test/core_ext/object/to_query_test.rb:79
```