### PR TITLE
[DOC] Remove wrong document due to refactoring `attribute`

### DIFF
--- a/activerecord/lib/active_record/attributes.rb
+++ b/activerecord/lib/active_record/attributes.rb
@@ -210,8 +210,7 @@ module ActiveRecord
       #--
       # Implemented by ActiveModel::AttributeRegistration#attribute.
 
-      # This is the low level API which sits beneath +attribute+. It only
-      # accepts type objects, and will do its work immediately instead of
+      # This API only accepts type objects, and will do its work immediately instead of
       # waiting for the schema to load. While this method
       # is provided so it can be used by plugin authors, application code
       # should probably use ClassMethods#attribute.


### PR DESCRIPTION
### Motivation / Background

Since the current documentation contains wrong information, we need to fix it.

### Detail

The refactoring over `attribute` was done at https://github.com/rails/rails/pull/44666,
which stops `attribute` from calling `define_attribute`.

### Additional information

none

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.