### PR TITLE
[DOC] Clarify previous (type/value) in Activecord::Attributes `attribute`

### DIFF
--- a/activerecord/lib/active_record/attributes.rb
+++ b/activerecord/lib/active_record/attributes.rb
@@ -35,7 +35,7 @@ module ActiveRecord
       # The following options are accepted:
       #
       # +default+ The default value to use when no value is provided. If this option
-      # is not passed, the previously defined default value (if any) will be used.
+      # is not passed, the previously defined default value (if any) on the superclass or in the schema will be used.
       # Otherwise, the default will be +nil+.
       #
       # +array+ (PostgreSQL only) specifies that the type should be an array (see the

--- a/activerecord/lib/active_record/attributes.rb
+++ b/activerecord/lib/active_record/attributes.rb
@@ -25,15 +25,17 @@ module ActiveRecord
       # column which this will persist to.
       #
       # +cast_type+ A symbol such as +:string+ or +:integer+, or a type object
-      # to be used for this attribute. See the examples below for more
-      # information about providing custom type objects.
+      # to be used for this attribute. If this parameter is not passed, the previously
+      # defined type (if any) will be used.
+      # Otherwise, the type will be ActiveModel::Type::Value.
+      # See the examples below for more information about providing custom type objects.
       #
       # ==== Options
       #
       # The following options are accepted:
       #
       # +default+ The default value to use when no value is provided. If this option
-      # is not passed, the previous default value (if any) will be used.
+      # is not passed, the previously defined default value (if any) will be used.
       # Otherwise, the default will be +nil+.
       #
       # +array+ (PostgreSQL only) specifies that the type should be an array (see the


### PR DESCRIPTION
### Motivation / Background

When I and my colleagues saw the API document for `attribute`,
we got difficulty understanding what exactly the `previous` value.

### Detail

In order to clarify the document, I have improved the followings.

* Change the wording from `previous` to `previously defined` for clarification
* Add the similar description for `type` when not specified

### Additional information

none

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
