### PR TITLE
Document undefined `local_assigns` when using Strict Locals with defaults

### DIFF
--- a/guides/source/action_view_overview.md
+++ b/guides/source/action_view_overview.md
@@ -689,6 +689,16 @@ line in the partial.
 CAUTION: Only keyword arguments are supported. Defining positional or block
 arguments will raise an Action View Error at render-time.
 
+The `local_assigns` method does not contain default values specified in the
+`local:` magic comment. To access a local variable with a default value that
+is named the same as a reserved Ruby keyword, like `class` or `if`, the values
+can be accessed through `binding.local_variable_get`:
+
+```erb
+<%# locals: (class: "message") %>
+<div class="<%= binding.local_variable_get(:class) %>">...</div>
+```
+
 Layouts
 -------
 


### PR DESCRIPTION
Redo of #52162, including language suggestions from @skipkayhil.

Now that #52205 has been merged, this documents the update behavior of `local_assigns` when using Strict Locals with defaults, and still suggests using `binding.local_variable_get` as a workaround.
