### PR TITLE
Fix creating a CTE with 3 or more relations that are unioned together

### DIFF
--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -1915,7 +1915,7 @@ module ActiveRecord
         when Arel::Nodes::SqlLiteral then Arel::Nodes::Grouping.new(value)
         when ActiveRecord::Relation then value.arel
         when Arel::SelectManager then value
-        when Array then value.map { |q| build_with_expression_from_value(q) }.reduce { |result, value| result.union(:all, value) }
+        when Array then value.map { |q| build_with_expression_from_value(q) }.reduce { |result, value| result.union(:all, value.try(:ast) || value) }
         else
           raise ArgumentError, "Unsupported argument type: `#{value}` #{value.class}"
         end

--- a/activerecord/lib/arel/nodes/binary.rb
+++ b/activerecord/lib/arel/nodes/binary.rb
@@ -111,11 +111,23 @@ module Arel # :nodoc: all
       end
     end
 
+    class UnionAll < Binary
+      def union(operation, other = nil)
+        if other
+          node_class = Nodes.const_get("Union#{operation.to_s.capitalize}")
+        else
+          other = operation
+          node_class = Nodes::Union
+        end
+
+        node_class.new self, other
+      end
+    end
+
     %w{
       Assignment
       Join
       Union
-      UnionAll
       Intersect
       Except
     }.each do |name|

--- a/activerecord/lib/arel/select_manager.rb
+++ b/activerecord/lib/arel/select_manager.rb
@@ -203,7 +203,7 @@ module Arel # :nodoc: all
         node_class = Nodes::Union
       end
 
-      node_class.new self.ast, other.ast
+      node_class.new self.ast, other.try(:ast) || other
     end
 
     def intersect(other)

--- a/activerecord/test/cases/relation/with_test.rb
+++ b/activerecord/test/cases/relation/with_test.rb
@@ -72,6 +72,18 @@ module ActiveRecord
         assert_equal (POSTS_WITH_TAGS + POSTS_WITH_COMMENTS).sort, relation.order(:id).pluck(:id)
       end
 
+      def test_with_when_passing_3_arrays
+        relation = Post
+          .with(content_union: [
+            Comment.select(:body),
+            Post.select(:body),
+            Company.select("name as body")
+          ])
+          .from("content_union").select(:body)
+
+        assert_equal (Comment.pluck(:body) + Post.pluck(:body) + Company.pluck(:name)).sort, relation.pluck(:body).sort
+      end
+
       def test_with_recursive
         top_companies = Company.where(firm_id: nil).to_a
         child_companies = Company.where(firm_id: top_companies).to_a


### PR DESCRIPTION
### Motivation / Background

If you try to create a cte that unions for than 2 relationships you get a NoMethodError of 
```
undefined method `union' for an instance of Arel::Nodes::UnionAll
```

### Detail

This fix allows you to pass more than 2 relationships to a cte to union them together.

Im calling ast on the nodes because passing the SelectManager around caused the selects to be wrapped in parenthesis which causes a syntax error in sqlite. 

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
