### PR TITLE
Fix guide menu overflow [ci skip]

### DIFF
--- a/guides/assets/stylesrc/_main.scss
+++ b/guides/assets/stylesrc/_main.scss
@@ -592,7 +592,6 @@ body.guide {
     display: block;
     border-radius: $base-border-radius;
     color: $gray-900;
-    height: 61em;
     padding: 2em 2em 1.5em 2em;
     position: absolute;
       top: 25px;


### PR DESCRIPTION
This is a follow-up to 92b65a0f7e8c07942547d93df4a60a64088ff53f. It's also a temporary fix until we can find a better solution.


CC @jathayde who did the last fix. From my tests, I couldn't find a problem with removing the set height of the container. We still have the problem that if a lot of pages are added in the future it will overflow, but for now they will still go to the third column for a while before overflowing.

**Before fix**
![edgeguides rubyonrails org_development_dependencies_install html](https://github.com/rails/rails/assets/923718/221b5f21-2180-473b-b4d6-cb2124f5b778)

**After fix**
![edgeguides rubyonrails org_](https://github.com/rails/rails/assets/923718/f69f8699-160b-4a74-b43c-2194e9605db6)
