### PR TITLE
Fix guides menu from overflowing due to hardcoded height

### DIFF
--- a/guides/assets/stylesrc/_main.scss
+++ b/guides/assets/stylesrc/_main.scss
@@ -592,7 +592,6 @@ body.guide {
     display: block;
     border-radius: $base-border-radius;
     color: $gray-900;
-    height: 61em;
     padding: 2em 2em 1.5em 2em;
     position: absolute;
       top: 25px;


### PR DESCRIPTION
### Motivation / Background

I was looking at the Edge Guides and noticed that the Guides Index menu was not tall enough for its content.

### Detail

This menu had a hardcoded height of `61em`, which is not tall enough on my computer. With the height removed, the menu automatically grows and shrinks based on its content, due to the padding on the menu.

Before. Notice "Maintenance Policy"'s "y" is overflowing the container.

<img width="1713" alt="Screenshot 2024-06-25 at 10 12 15 AM" src="https://github.com/rails/rails/assets/5104186/17e5ea5a-6ba2-433a-bcb3-8170f7b95438">


After. Notice "Maintenance Policy" now has nice consistent padding around it:

<img width="1714" alt="Screenshot 2024-06-25 at 10 13 20 AM" src="https://github.com/rails/rails/assets/5104186/75fa9b05-ce57-4016-96f8-dda94c41b537">


And here I've deleted a few link groups to demonstrate that the menu automatically resizes itself:

<img width="1716" alt="Screenshot 2024-06-25 at 10 15 51 AM" src="https://github.com/rails/rails/assets/5104186/1b4357b0-2c59-4e40-ba5e-5f678641ed74">



### Additional information

None

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [X] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
