### PR TITLE
Remove unused constant in `MySQLDatabaseTasks`

### DIFF
--- a/activerecord/lib/active_record/tasks/mysql_database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/mysql_database_tasks.rb
@@ -3,8 +3,6 @@
 module ActiveRecord
   module Tasks # :nodoc:
     class MySQLDatabaseTasks # :nodoc:
-      ER_DB_CREATE_EXISTS = 1007
-
       def self.using_database_configurations?
         true
       end


### PR DESCRIPTION
This constant was introduced in https://github.com/rails/rails/commit/ac41b73d97a80f2552196516e29d7e3335e2d556#diff-650415ef6a2cfebf08332595100b41c4ca6b4045e14c3d165045538f9d3223fcR3-R22, but the check was removed in https://github.com/rails/rails/commit/69700c9ee760c5880fc80af70a89b42bb791cf98. So I think this constant is unnecessary. 