### PR TITLE
Fix an extra newline in `development.rb` when sprocket gets skipped

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/environments/development.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/development.rb.tt
@@ -66,8 +66,8 @@ Rails.application.configure do
   <%- unless skip_sprockets? -%>
   # Suppress logger output for asset requests.
   config.assets.quiet = true
-  <%- end -%>
 
+  <%- end -%>
   # Raises error for missing translations.
   # config.i18n.raise_on_missing_translations = true
 


### PR DESCRIPTION
Diff excerpt:

```diff
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -46,6 +46,7 @@ Rails.application.configure do
   # Highlight code that enqueued background job in logs.
   config.active_job.verbose_enqueue_logs = true
 
-
   # Raises error for missing translations.
   # config.i18n.raise_on_missing_translations = true
```

It looks as expected when sprockets is enabled:
```diff
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -46,6 +46,9 @@ Rails.application.configure do
   # Highlight code that enqueued background job in logs.
   config.active_job.verbose_enqueue_logs = true
 
+  # Suppress logger output for asset requests.
+  config.assets.quiet = true
+
   # Raises error for missing translations.
   # config.i18n.raise_on_missing_translations = true
```