### PR TITLE
Fix `rails-new-docker` for 7-2-stable

### DIFF
--- a/.github/workflows/rails-new-docker.yml
+++ b/.github/workflows/rails-new-docker.yml
@@ -20,7 +20,8 @@ jobs:
     - name: Set up Ruby 3.3
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 3.3
+        # No 3.3.3 because of https://bugs.ruby-lang.org/issues/20581
+        ruby-version: 3.3.2
         bundler-cache: true
     - name: Generate --dev app
       run: |


### PR DESCRIPTION
The lockfile is removed for this workflow which triggers the following ruby bug: https://bugs.ruby-lang.org/issues/20581
https://github.com/ruby/net-pop/issues/26 also contains some info.

This is no problem for main since it currently pins to 3.3.1 for unrelated reasons. `7-1-stable` uses 3.2 which is also fine.

Sample failure: https://github.com/rails/rails/actions/runs/9645055608/job/26598478155
```
Downloading net-pop-0.1.2 revealed dependencies not in the API or the lockfile
(net-protocol (>= 0)).
Running `bundle update net-pop` should fix the problem.
Error: error building at STEP "RUN bundle install &&     rm -rf ~/.bundle/ "${BUNDLE_PATH}"/ruby/*/cache "${BUNDLE_PATH}"/ruby/*/bundler/gems/*/.git": error while running runtime: exit status 34
Error: Process completed with exit code 125.
```