### PR TITLE
Fix `rake rdoc` when the timestamp file is empty

### DIFF
--- a/railties/lib/rails/api/task.rb
+++ b/railties/lib/rails/api/task.rb
@@ -160,8 +160,9 @@ module Rails
 
         # Only generate documentation for files that have been
         # changed since the API was generated.
-        if Dir.exist?(api_dir) && !ENV["ALL"]
-          last_generation = DateTime.rfc2822(File.open("#{api_dir}/created.rid", &:readline))
+        timestamp_path = "#{api_dir}/created.rid"
+        if File.exist?(timestamp_path) && !File.zero?(timestamp_path) && !ENV["ALL"]
+          last_generation = DateTime.rfc2822(File.open(timestamp_path, &:readline))
 
           rdoc_files.keep_if do |file|
             File.mtime(file).to_datetime > last_generation


### PR DESCRIPTION
This happens when rdoc fails during generation as the timestamp is only written on successful attemps. The file is created anyways though.

```
rake aborted!
EOFError: end of file reached (EOFError)
<internal:io>:134:in 'IO#readline'
/home/earlopain/Documents/rails/railties/lib/rails/api/task.rb:164:in 'IO.open'
/home/earlopain/Documents/rails/railties/lib/rails/api/task.rb:164:in 'Rails::API::Task#configure_rdoc_files'
/home/earlopain/Documents/rails/railties/lib/rails/api/task.rb:127:in 'block in Rails::API::Task#initialize'
<internal:array>:54:in 'Array#each'
<internal:array>:54:in 'Array#each'
<internal:array>:54:in 'Array#each'
/home/earlopain/.rbenv/versions/3.4-dev/bin/bundle:25:in 'Kernel#load'
/home/earlopain/.rbenv/versions/3.4-dev/bin/bundle:25:in '<main>'
Tasks: TOP => rdoc => html/created.rid
(See full trace by running task with --trace)
```

This is only relevant when it wasn't already generated in the past and if rdoc has issues generating, which it does have currently ): I'm looking into that, happens since https://github.com/rails/rails/pull/52185, but this seems fine to do on its own