### PR TITLE
Don't make rdoc generation take an unreasonable amount of time

### DIFF
--- a/actionpack/lib/action_controller/base.rb
+++ b/actionpack/lib/action_controller/base.rb
@@ -266,6 +266,8 @@ module ActionController
       ParamsWrapper
     ]
 
+    # Note: Documenting these severely degrates the performance of rdoc
+    # :stopdoc:
     include AbstractController::Rendering
     include AbstractController::Translation
     include AbstractController::AssetPaths
@@ -309,6 +311,7 @@ module ActionController
     # Params wrapper should come before instrumentation so they are properly showed
     # in logs
     include ParamsWrapper
+    # :startdoc:
     setup_renderer!
 
     # Define some internal variables that should not be propagated to the view.


### PR DESCRIPTION
On CI, this takes about 8 hours. On my PC I canceled after 3.

I suspect this comment in rdoc to be relevant (since this method is where it is stuck): https://github.com/ruby/rdoc/blob/4b846606904cc2db3999e5482c69a27f7d96947c/lib/rdoc/mixin.rb#L68-L71 Removing a few includes eventually makes it complete in a reasonable amount of time. It doesn't seem to matter which ones you remove.

https://github.com/rails/rails/pull/52185 was the trigger for this. @vinistock, I'm not sure if the doc comments here would make `ruby-lsp` ignore it and basically undo why you did that PR in the first place. Never really thought about how that works, let me know if this is good with you.

This is probably a bug in rdoc somewhere. But I can't imagine its just including a bunch of stuff, seems like that would happen relativly often.