### PR TITLE
ActiveRecord::Relation#insert_all: support column mode for highest performance

### DIFF
--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -696,6 +696,19 @@ module ActiveRecord
     # <tt>:unique_by</tt> is recommended to be paired with
     # Active Record's schema_cache.
     #
+    # [:columns]
+    #   By default, insert_all! works with array of hashes where each key matches the attribute name.
+    #   By passing columns array, you can force it to work in columnary mode. This is useful
+    #   for performance-critical areas where you want to avoid the overhead looking up keys and attributes.
+    #   Note that using this option will not type cast the values which need to be handled manually.
+    #
+    #   Example:
+    #
+    #     Book.insert_all!([
+    #       [1, "Rework", "David"],
+    #       [2, "Eloquent Ruby", "Russ"]
+    #     ], columns: [:id, :title, :author])
+    #
     # ==== Example
     #
     #   # Insert records and skip inserting any duplicates.
@@ -713,8 +726,8 @@ module ActiveRecord
     #     { id: 1, title: "Rework" },
     #     { id: 2, title: "Eloquent Ruby" }
     #   ])
-    def insert_all(attributes, returning: nil, unique_by: nil, record_timestamps: nil)
-      InsertAll.execute(self, attributes, on_duplicate: :skip, returning: returning, unique_by: unique_by, record_timestamps: record_timestamps)
+    def insert_all(attributes, returning: nil, unique_by: nil, record_timestamps: nil, columns: nil)
+      InsertAll.execute(self, attributes, on_duplicate: :skip, returning: returning, unique_by: unique_by, record_timestamps: record_timestamps, columns: columns)
     end
 
     # Inserts a single record into the database in a single SQL INSERT
@@ -766,6 +779,19 @@ module ActiveRecord
     #     record_timestamps: true  # Always set timestamps automatically
     #     record_timestamps: false # Never set timestamps automatically
     #
+    # [:columns]
+    #   By default, insert_all! works with array of hashes where each key matches the attribute name.
+    #   By passing columns array, you can force it to work in columnary mode. This is useful
+    #   for performance-critical areas where you want to avoid the overhead looking up keys and attributes.
+    #   Note that using this option will not type cast the values which need to be handled manually.
+    #
+    #   Example:
+    #
+    #     Book.insert_all!([
+    #       [1, "Rework", "David"],
+    #       [2, "Eloquent Ruby", "Russ"]
+    #     ], columns: [:id, :title, :author])
+    #
     # ==== Examples
     #
     #   # Insert multiple records
@@ -780,8 +806,8 @@ module ActiveRecord
     #     { id: 1, title: "Rework", author: "David" },
     #     { id: 1, title: "Eloquent Ruby", author: "Russ" }
     #   ])
-    def insert_all!(attributes, returning: nil, record_timestamps: nil)
-      InsertAll.execute(self, attributes, on_duplicate: :raise, returning: returning, record_timestamps: record_timestamps)
+    def insert_all!(attributes, returning: nil, record_timestamps: nil, columns: nil)
+      InsertAll.execute(self, attributes, on_duplicate: :raise, returning: returning, record_timestamps: record_timestamps, columns: columns)
     end
 
     # Updates or inserts (upserts) a single record into the database in a

--- a/activerecord/test/cases/insert_all_test.rb
+++ b/activerecord/test/cases/insert_all_test.rb
@@ -64,6 +64,46 @@ class InsertAllTest < ActiveRecord::TestCase
     end
   end
 
+
+  def test_insert_all_column_mode
+    assert_difference "Book.count", +10 do
+      Book.insert_all!([
+        ["Rework", 1],
+        ["Patterns of Enterprise Application Architecture", 1],
+        ["Design of Everyday Things", 1],
+        ["Practical Object-Oriented Design in Ruby", 1],
+        ["Clean Code", 1],
+        ["Ruby Under a Microscope", 1],
+        ["The Principles of Product Development Flow", 1],
+        ["Peopleware", 1],
+        ["About Face", 1],
+        ["Eloquent Ruby", 1],
+      ], columns: %w(name author_id))
+    end
+  end
+
+  def test_insert_all_column_mode_mismatch
+    assert_raises(ArgumentError) do
+      Book.insert_all!([
+        ["Rework", 1, 2]
+      ], columns: %w(name author_id))
+    end
+
+    assert_raises(ArgumentError) do
+      Book.insert_all!([
+        ["Rework", 1],
+        ["Rework", 1, 2]
+      ], columns: %w(name author_id))
+    end
+
+    assert_raises(ArgumentError) do
+      Book.insert_all!([
+        ["Rework", 1],
+        ["Rework", 1, 2]
+      ], columns: %w(name author_id onemore))
+    end
+  end
+
   def test_insert_all_should_handle_empty_arrays
     skip unless supports_insert_on_duplicate_update?
 


### PR DESCRIPTION
We have some performance-critical endpoints where we want to allocate least # of objects and use `insert_all` to write 1000s of rows into the database.

However, we see `insert_all` being ~2.5x slower compared to manually building `INSERT INTO <table> VALUES (...), (...)`.

I've been profiling `insert_all` and that turned out to be largely because it 1) works with arrays of hashes and each hash needs to be traversed 2) it serializes attributes via Attributes API.

That's great default behavior but if we're inserting 2000 tuples of `(<foreigh-key>, <foreigh-key>, <foreigh-key>)`, we don't want to traverse hashes and run the complexity of casting integers to integers via Attributes API.

I'd like to propose a "column mode" for `insert_all` that takes arrays of arrays (no need to traverse hashes!) and attribute casting is the responsibility of the caller.

With that approach, we're able to make `insert_all` as fast as direct string building:

```
ruby 3.3.1 (2024-04-23 revision c56cd86388) [arm64-darwin23]
Warming up --------------------------------------
          insert_all     4.000 i/100ms
insert_all with columns
                        11.000 i/100ms
             raw sql    13.000 i/100ms
           with Arel    12.000 i/100ms
Calculating -------------------------------------
          insert_all     41.522 (± 7.2%) i/s -    168.000 in   4.066766s
insert_all with columns
                         86.048 (±23.2%) i/s -    341.000 in   4.161382s
             raw sql    114.595 (±14.0%) i/s -    455.000 in   4.055053s
           with Arel    100.232 (±23.9%) i/s -    384.000 in   4.084465s

Comparison:
             raw sql:      114.6 i/s
           with Arel:      100.2 i/s - same-ish: difference falls within error
insert_all with columns:       86.0 i/s - same-ish: difference falls within error
          insert_all:       41.5 i/s - 2.76x  slower
```

<details><summary>Benchmark code</summary>
<p>

```ruby
# frozen_string_literal: true

require 'debug'
require "active_record"
require "benchmark/ips"

GC.disable

ROWS_COUNT = 1000

ActiveRecord::Base.establish_connection({ adapter: "sqlite3", database: ":memory:" })

class Commerce < ActiveRecord::Base
  connection.create_table :commerces, force: true do |t|
    t.string :name, :email, :title, :tags
    t.integer :variant_id, :product_id, :inventory_id, :something_id, :another_id
    t.boolean :fulfilled
    t.datetime :fulfilled_at, :deleted_at
    t.timestamps null: true
  end
end

def db_time(value)
  value.to_formatted_s(:db).inspect
end

ATTRS = {
  name: "sam",
  email: "kirs@shopify.com",
  title: "title",
  tags: "tag1,tag2,tag3",
  variant_id: 1,
  product_id: 1,
  inventory_id: 1,
  something_id: 1,
  another_id: 1,
  fulfilled: true,
  fulfilled_at: Time.now,
  deleted_at: Time.now
}

Benchmark.ips do |x|
  x.warmup = 2
  x.time   = 4

  relation = Commerce.all

  x.report("insert_all") do
    conn = Commerce.connection

    relation.insert_all(
      [ATTRS] * ROWS_COUNT
    )
  end

  x.report("insert_all with columns") do
    conn = Commerce.connection
    attrs = ATTRS.dup
    attrs[:fulfilled_at] = attrs[:fulfilled_at].to_formatted_s(:db)
    attrs[:deleted_at] = attrs[:deleted_at].to_formatted_s(:db)
    attrs[:created_at] = Time.now.to_formatted_s(:db)
    attrs[:updated_at] = attrs[:created_at]

    values = [
      attrs[:name], attrs[:email], attrs[:title], attrs[:tags], attrs[:variant_id], attrs[:product_id], attrs[:inventory_id], attrs[:something_id], attrs[:another_id], attrs[:fulfilled], attrs[:fulfilled_at], attrs[:deleted_at], attrs[:created_at], attrs[:updated_at]
    ]

    relation.insert_all(
      [values] * ROWS_COUNT,
      columns: %w[name email title tags variant_id product_id inventory_id something_id another_id fulfilled fulfilled_at deleted_at created_at updated_at],
    )
  end

  x.report("raw sql") do
    conn = Commerce.connection
    values = (1..ROWS_COUNT).map do
      attrs = ATTRS
      "(#{conn.quote(attrs[:name])}, #{conn.quote(attrs[:email])}, #{conn.quote(attrs[:title])}, #{conn.quote(attrs[:tags])}, #{attrs[:variant_id]}, #{attrs[:product_id]}, #{attrs[:inventory_id]}, #{attrs[:something_id]}, #{attrs[:another_id]}, #{attrs[:fulfilled]}, #{db_time(attrs[:fulfilled_at])}, #{db_time(attrs[:deleted_at])}, #{db_time(Time.now)}, #{db_time(Time.now)})"
    end

    conn.execute(
      "INSERT INTO commerces (name, email, title, tags, variant_id, product_id, inventory_id, something_id, another_id, fulfilled, fulfilled_at, deleted_at, created_at, updated_at) "\
      "VALUES #{values.join(',')}"
    )
  end

  x.report("with Arel") do
    conn = Commerce.connection
    columns = %w[name email title tags variant_id product_id inventory_id something_id another_id fulfilled fulfilled_at deleted_at created_at updated_at]
    attrs = ATTRS.dup
    attrs[:fulfilled_at] = (attrs[:fulfilled_at]).to_formatted_s(:db)
    attrs[:deleted_at] = (attrs[:deleted_at]).to_formatted_s(:db)
    attrs[:created_at] = (Time.now).to_formatted_s(:db)
    attrs[:updated_at] = (Time.now).to_formatted_s(:db)

    values_list = [attrs.values] * ROWS_COUNT

    sql = "INSERT INTO #{Commerce.quoted_table_name} (#{columns.join(',')}) "
    sql << conn.visitor.compile(Arel::Nodes::ValuesList.new(values_list))
    conn.execute(sql)
  end

  x.compare!
end
```

</p>
</details> 