### PR TITLE
CI: Introduce `RAILS_MASTER_KEY` placeholder

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Introduce `RAILS_MASTER_KEY` placeholder in generated ci.yml files
+
+    *Steve Polito*
+
 *   Colorize the Rails console prompt even on non standard environments.
 
     *Lorenzo Zabot*

--- a/railties/lib/rails/generators/rails/app/templates/github/ci.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/github/ci.yml.tt
@@ -127,6 +127,7 @@ jobs:
           <%- elsif options[:database] == "postgresql" -%>
           DATABASE_URL: postgres://postgres:postgres@localhost:5432
           <%- end -%>
+          # RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_KEY }}
           # REDIS_URL: redis://localhost:6379/0
         <%- if options[:api] || options[:skip_system_test] -%>
         run: bin/rails db:test:prepare test

--- a/railties/lib/rails/generators/rails/plugin/templates/github/ci.yml.tt
+++ b/railties/lib/rails/generators/rails/plugin/templates/github/ci.yml.tt
@@ -91,6 +91,7 @@ jobs:
           <%- elsif options[:database] == "postgresql" -%>
           DATABASE_URL: postgres://postgres:postgres@localhost:5432
           <%- end -%>
+          # RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_KEY }}
           # REDIS_URL: redis://localhost:6379/0
         run: <%= test_command %>
 


### PR DESCRIPTION
### Motivation / Background

The existing CI templates do not work as expected if [custom credentials][cc] are utilized, or if [`config.require_master_key`][crmk] is enabled.

```
ActiveSupport::MessageEncryptor::InvalidMessage: ActiveSupport::MessageEncryptor::InvalidMessage
```

### Detail

Improves existing CI templates by adding an [environment variable][ev] to store the `RAILS_MASTER_KEY` which should be stored as a [secret][].

This is necessary so that [custom credentials][cc] will work as expected in CI.

Since not all applications utilize custom credentials, we comment this value out, which is consistent with how we treat Redis.

[ev]: https://docs.github.com/en/actions/learn-github-actions/variables
[cc]: https://edgeguides.rubyonrails.org/security.html#custom-credentials
[crmk]: https://guides.rubyonrails.org/configuring.html#config-require-master-key
[secret]: https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
