### PR TITLE
Fix a deadlock in `ConnectionPool#checkout`

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -541,12 +541,14 @@ module ActiveRecord
       # - ActiveRecord::ConnectionTimeoutError no connection can be obtained from the pool.
       def checkout(checkout_timeout = @checkout_timeout)
         if @pinned_connection
-          synchronize do
-            @pinned_connection.verify!
-            # Any leased connection must be in @connections otherwise
-            # some methods like #connected? won't behave correctly
-            unless @connections.include?(@pinned_connection)
-              @connections << @pinned_connection
+          @pinned_connection.lock.synchronize do
+            synchronize do
+              @pinned_connection.verify!
+              # Any leased connection must be in @connections otherwise
+              # some methods like #connected? won't behave correctly
+              unless @connections.include?(@pinned_connection)
+                @connections << @pinned_connection
+              end
             end
           end
           @pinned_connection


### PR DESCRIPTION
Ref https://github.com/rails/rails/pull/50999#issuecomment-2196818100

While trying to upgrade to rails 7.2, I noticed that timeouts (because of the deadlocks) started to appear when I run UI (capybara and rspec) tests.

I dumped the backtraces of the deadlocked threads. I will provide only the top portions of backtraces.

Thread 1:
```
ruby/3.3.2/lib/ruby/3.3.0/monitor.rb:201:in `synchronize'
ruby/3.3.2/lib/ruby/3.3.0/monitor.rb:201:in `mon_synchronize'
rails/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb:535:in `checkout'
rails/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb:403:in `with_connection'
rails/activerecord/lib/active_record/associations/alias_tracker.rb:10:in `create'
rails/activerecord/lib/active_record/relation.rb:1290:in `alias_tracker'
rails/activerecord/lib/active_record/associations/association_scope.rb:26:in `scope'
rails/activerecord/lib/active_record/associations/association_scope.rb:7:in `scope'
rails/activerecord/lib/active_record/associations/association.rb:275:in `association_scope'
rails/activerecord/lib/active_record/associations/association.rb:108:in `scope'
rails/activerecord/lib/active_record/associations/association.rb:225:in `find_target'
rails/activerecord/lib/active_record/associations/singular_association.rb:50:in `find_target'
rails/activerecord/lib/active_record/associations/association.rb:175:in `load_target'
.....
```

Thread 2:
```
gems/activesupport-7.2.0.beta2/lib/active_support/concurrency/load_interlock_aware_monitor.rb:55:in `lock'
gems/activesupport-7.2.0.beta2/lib/active_support/concurrency/load_interlock_aware_monitor.rb:55:in `mon_enter'
gems/activesupport-7.2.0.beta2/lib/active_support/concurrency/load_interlock_aware_monitor.rb:15:in `block in mon_enter'
gems/activesupport-7.2.0.beta2/lib/active_support/concurrency/share_lock.rb:187:in `yield_shares'
gems/activesupport-7.2.0.beta2/lib/active_support/dependencies/interlock.rb:41:in `permit_concurrent_loads'
gems/activesupport-7.2.0.beta2/lib/active_support/concurrency/load_interlock_aware_monitor.rb:15:in `mon_enter'
gems/activesupport-7.2.0.beta2/lib/active_support/concurrency/load_interlock_aware_monitor.rb:20:in `block in synchronize'
gems/activesupport-7.2.0.beta2/lib/active_support/concurrency/load_interlock_aware_monitor.rb:19:in `handle_interrupt'
gems/activesupport-7.2.0.beta2/lib/active_support/concurrency/load_interlock_aware_monitor.rb:19:in `synchronize'
rails/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb:345:in `active?'
rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:746:in `verify!'
rails/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb:536:in `block in checkout'
ruby/3.3.2/lib/ruby/3.3.0/monitor.rb:201:in `synchronize'
ruby/3.3.2/lib/ruby/3.3.0/monitor.rb:201:in `mon_synchronize'
rails/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb:535:in `checkout'
rails/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb:403:in `with_connection'
rails/activerecord/lib/active_record/associations/alias_tracker.rb:10:in `create'
rails/activerecord/lib/active_record/relation.rb:1290:in `alias_tracker'
rails/activerecord/lib/active_record/associations/association_scope.rb:26:in `scope'
.....
```

Thread 3:
```
ruby/3.3.2/lib/ruby/3.3.0/monitor.rb:201:in `synchronize'
ruby/3.3.2/lib/ruby/3.3.0/monitor.rb:201:in `mon_synchronize'
rails/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb:413:in `connected?'
rails/activerecord/lib/active_record/connection_adapters/abstract/connection_handler.rb:200:in `connected?'
rails/activerecord/lib/active_record/connection_handling.rb:338:in `connected?'
rails/activerecord/lib/active_record/query_cache.rb:29:in `uncached'
rails/activerecord/lib/active_record/relation/delegation.rb:78:in `block in uncached'
rails/activerecord/lib/active_record/relation.rb:1355:in `_scoping'
rails/activerecord/lib/active_record/relation.rb:541:in `scoping'
rails/activerecord/lib/active_record/relation/delegation.rb:78:in `uncached'
rails/activerecord/lib/active_record/relation.rb:1450:in `skip_query_cache_if_necessary'
rails/activerecord/lib/active_record/relation.rb:1386:in `exec_queries'
rails/activerecord/lib/active_record/association_relation.rb:44:in `exec_queries'
rails/activerecord/lib/active_record/relation.rb:1167:in `load'
gems/ar_lazy_preload-2.0.0/lib/ar_lazy_preload/active_record/relation.rb:27:in `load'
rails/activerecord/lib/active_record/relation.rb:336:in `records'
rails/activerecord/lib/active_record/relation/batches.rb:374:in `block in batch_on_unloaded_relation'
<internal:kernel>:187:in `loop'
rails/activerecord/lib/active_record/relation/batches.rb:372:in `batch_on_unloaded_relation'
rails/activerecord/lib/active_record/relation/batches.rb:269:in `in_batches'
rails/activerecord/lib/active_record/relation/batches.rb:157:in `find_in_batches'
rails/activerecord/lib/active_record/relation/batches.rb:81:in `find_each'
/Users/fatkodima/Desktop/work/web/app/models/user.rb:5492:in `share_welcome_folders'
/Users/fatkodima/Desktop/work/web/app/models/user.rb:5248:in `run_patient_tasks_affter_dietitian_update'
/Users/fatkodima/Desktop/work/web/app/models/user.rb:5255:in `run_provider_assignment_automations'
gems/activesupport-7.2.0.beta2/lib/active_support/callbacks.rb:362:in `block in make_lambda'
gems/activesupport-7.2.0.beta2/lib/active_support/callbacks.rb:208:in `call'
gems/activesupport-7.2.0.beta2/lib/active_support/callbacks.rb:563:in `block in invoke_after'
gems/activesupport-7.2.0.beta2/lib/active_support/callbacks.rb:563:in `each'
gems/activesupport-7.2.0.beta2/lib/active_support/callbacks.rb:563:in `invoke_after'
gems/activesupport-7.2.0.beta2/lib/active_support/callbacks.rb:111:in `run_callbacks'
gems/activesupport-7.2.0.beta2/lib/active_support/callbacks.rb:913:in `_run_commit_callbacks'
rails/activerecord/lib/active_record/transactions.rb:385:in `committed!'
rails/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb:254:in `block in commit_records'
rails/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb:286:in `run_action_on_records'
rails/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb:253:in `commit_records'
rails/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb:538:in `block in commit_transaction'
gems/activesupport-7.2.0.beta2/lib/active_support/concurrency/load_interlock_aware_monitor.rb:23:in `handle_interrupt'
gems/activesupport-7.2.0.beta2/lib/active_support/concurrency/load_interlock_aware_monitor.rb:23:in `block in synchronize'
gems/activesupport-7.2.0.beta2/lib/active_support/concurrency/load_interlock_aware_monitor.rb:19:in `handle_interrupt'
gems/activesupport-7.2.0.beta2/lib/active_support/concurrency/load_interlock_aware_monitor.rb:19:in `synchronize'
rails/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb:526:in `commit_transaction'
rails/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb:570:in `block in within_new_transaction'
gems/activesupport-7.2.0.beta2/lib/active_support/concurrency/load_interlock_aware_monitor.rb:23:in `handle_interrupt'
gems/activesupport-7.2.0.beta2/lib/active_support/concurrency/load_interlock_aware_monitor.rb:23:in `block in synchronize'
gems/activesupport-7.2.0.beta2/lib/active_support/concurrency/load_interlock_aware_monitor.rb:19:in `handle_interrupt'
gems/activesupport-7.2.0.beta2/lib/active_support/concurrency/load_interlock_aware_monitor.rb:19:in `synchronize'
rails/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb:555:in `within_new_transaction'
rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:361:in `transaction'
rails/activerecord/lib/active_record/transactions.rb:414:in `block in with_transaction_returning_status'
rails/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb:397:in `with_connection'
.....
```

Thread 3 firstly acquired the connection's lock at https://github.com/rails/rails/blob/b9d6759401c3d50a51e0a7650cb2331f4218d11f/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb#L612-L613
and then tries to acquire the pool's connection at
https://github.com/rails/rails/blob/b9d6759401c3d50a51e0a7650cb2331f4218d11f/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb#L422-L424

At the same time Thread 2 acquired pool's lock at
https://github.com/rails/rails/blob/b9d6759401c3d50a51e0a7650cb2331f4218d11f/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb#L544
and then tries to acquire connection's lock at
https://github.com/rails/rails/blob/b9d6759401c3d50a51e0a7650cb2331f4218d11f/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb#L545
https://github.com/rails/rails/blob/b9d6759401c3d50a51e0a7650cb2331f4218d11f/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb#L752-L753
https://github.com/rails/rails/blob/b9d6759401c3d50a51e0a7650cb2331f4218d11f/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb#L344-L345

Hence, the deadlock.

Thread 1 just waits to acquire the pool's lock at
https://github.com/rails/rails/blob/b9d6759401c3d50a51e0a7650cb2331f4218d11f/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb#L544

After the fix, I ran the tests ~ 100 times and no errors this time, while previously once in 2-3 runs I had a deadlock.

cc @byroot  