### PR TITLE
Add delete_where as alias for delete_by

### DIFF
--- a/activerecord/lib/active_record/querying.rb
+++ b/activerecord/lib/active_record/querying.rb
@@ -11,7 +11,7 @@ module ActiveRecord
       :find_or_create_by, :find_or_create_by!, :find_or_initialize_by,
       :create_or_find_by, :create_or_find_by!,
       :destroy, :destroy_all, :delete, :delete_all, :update_all, :touch_all, :destroy_by, :delete_by,
-      :find_each, :find_in_batches, :in_batches,
+      :destroy_where, :delete_where, :find_each, :find_in_batches, :in_batches,
       :select, :reselect, :order, :regroup, :in_order_of, :reorder, :group, :limit, :offset, :joins, :left_joins, :left_outer_joins,
       :where, :rewhere, :invert_where, :preload, :extract_associated, :eager_load, :includes, :from, :lock, :readonly,
       :and, :or, :annotate, :optimizer_hints, :extending,

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -1101,6 +1101,15 @@ module ActiveRecord
     end
 
     # Alias for destroy_by to make it more intuitive
+    # Finds and destroys all records matching the specified conditions.
+    # This is short-hand for <tt>relation.where(condition).destroy_all</tt>.
+    # Returns the collection of objects that were destroyed.
+    #
+    # If no record is found, returns empty array.
+    #
+    #   Person.destroy_where(id: 13)
+    #   Person.destroy_where(name: 'Spartacus', rating: 4)
+    #   Person.destroy_where("published_at < ?", 2.weeks.ago)
     def destroy_where(*args)
       destroy_by(*args)
     end
@@ -1119,6 +1128,15 @@ module ActiveRecord
     end
 
     # Alias for delete_by to make it more intuitive
+    # Finds and deletes all records matching the specified conditions.
+    # This is short-hand for <tt>relation.where(condition).delete_all</tt>.
+    # Returns the number of rows affected.
+
+    # If no record is found, returns <tt>0</tt> as zero rows were affected.
+
+    #   Person.delete_where(id: 13)
+    #   Person.delete_where(name: 'Spartacus', rating: 4)
+    #   Person.delete_where("published_at < ?", 2.weeks.ago)
     def delete_where(*args)
       delete_by(*args)
     end

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -1100,6 +1100,9 @@ module ActiveRecord
       where(*args).destroy_all
     end
 
+    # Alias for destroy_by to make it more intuitive
+    alias_method :destroy_where, :delete_by
+
     # Finds and deletes all records matching the specified conditions.
     # This is short-hand for <tt>relation.where(condition).delete_all</tt>.
     # Returns the number of rows affected.
@@ -1112,6 +1115,9 @@ module ActiveRecord
     def delete_by(*args)
       where(*args).delete_all
     end
+
+    # Alias for destroy_by to make it more intuitive
+    alias_method :delete_where, :delete_by
 
     # Schedule the query to be performed from a background thread pool.
     #

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -1101,7 +1101,9 @@ module ActiveRecord
     end
 
     # Alias for destroy_by to make it more intuitive
-    alias_method :destroy_where, :delete_by
+    def destroy_where(*args)
+      destroy_by(*args)
+    end
 
     # Finds and deletes all records matching the specified conditions.
     # This is short-hand for <tt>relation.where(condition).delete_all</tt>.
@@ -1116,8 +1118,10 @@ module ActiveRecord
       where(*args).delete_all
     end
 
-    # Alias for destroy_by to make it more intuitive
-    alias_method :delete_where, :delete_by
+    # Alias for delete_by to make it more intuitive
+    def delete_where(*args)
+      delete_by(*args)
+    end
 
     # Schedule the query to be performed from a background thread pool.
     #

--- a/activerecord/test/cases/relation/delegation_test.rb
+++ b/activerecord/test/cases/relation/delegation_test.rb
@@ -68,7 +68,8 @@ module ActiveRecord
         :find_or_create_by, :find_or_create_by!, :find_or_initialize_by,
         :create_or_find_by, :create_or_find_by!,
         :destroy, :destroy_all, :delete, :delete_all, :update_all, :touch_all, :delete_by, :destroy_by,
-        :insert, :insert_all, :insert!, :insert_all!, :upsert, :upsert_all,
+        :destroy_where, :delete_where, :insert, :insert_all, :insert!, :insert_all!,
+        :upsert, :upsert_all,
       ]
 
     def test_delegate_querying_methods

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -2017,7 +2017,7 @@ class RelationTest < ActiveRecord::TestCase
 
     assert_difference("Post.count", -3) { david.posts.destroy_where(body: "hello") }
 
-    destroyed = Author.destroy_by(id: david.id)
+    destroyed = Author.destroy_where(id: david.id)
     assert_equal [david], destroyed
   end
 

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -2003,6 +2003,24 @@ class RelationTest < ActiveRecord::TestCase
     assert_equal [david], destroyed
   end
 
+  def test_delete_where
+    david = authors(:david)
+
+    assert_difference("Post.count", -3) { david.posts.delete_where(body: "hello") }
+
+    deleted = Author.delete_where(id: david.id)
+    assert_equal 1, deleted
+  end
+
+  def test_destroy_where
+    david = authors(:david)
+
+    assert_difference("Post.count", -3) { david.posts.destroy_where(body: "hello") }
+
+    destroyed = Author.destroy_by(id: david.id)
+    assert_equal [david], destroyed
+  end
+
   test "find_by with hash conditions returns the first matching record" do
     assert_equal posts(:eager_other), Post.order(:id).find_by(author_id: 2)
   end

--- a/guides/source/active_record_callbacks.md
+++ b/guides/source/active_record_callbacks.md
@@ -750,6 +750,7 @@ to skip callbacks by using the following methods:
 * [`delete`][]
 * [`delete_all`][]
 * [`delete_by`][]
+* [`delete_where`][]
 * [`increment!`][]
 * [`increment_counter`][]
 * [`insert`][]


### PR DESCRIPTION
### Motivation / Background

Recently, I restored a very large database, around 100 GB in size. After reviewing the data, I realized I needed to delete some of it. While searching for a direct method like delete_where, I found delete_by. Therefore, I propose adding delete_where as an alias for delete_by and also adding destroy_where. These methods can be used directly for convenience.

### Additional information

@rafaelfranca @dhh @byroot 

I wanted to make more of this method, please guide and help me if we can make it asynchronous in nature 
Additionally, I would like to implement asynchronous versions of these methods (delete_where_async and destroy_where_async) to handle deletions in the background. 