### PR TITLE
Fix markup directive in Action Cable templates

### DIFF
--- a/actioncable/lib/rails/generators/channel/templates/application_cable/channel.rb.tt
+++ b/actioncable/lib/rails/generators/channel/templates/application_cable/channel.rb.tt
@@ -1,5 +1,3 @@
-# :markup: markdown
-
 module ApplicationCable
   class Channel < ActionCable::Channel::Base
   end

--- a/actioncable/lib/rails/generators/channel/templates/application_cable/connection.rb.tt
+++ b/actioncable/lib/rails/generators/channel/templates/application_cable/connection.rb.tt
@@ -1,5 +1,3 @@
-# :markup: markdown
-
 module ApplicationCable
   class Connection < ActionCable::Connection::Base
   end


### PR DESCRIPTION
### Motivation / Background

When converting Action Cable docs from RDoc to Markdown, these two templates were accidentally included in the list of files converted (and the `:markup:` directive added) because they incorrectly had an `.rb` extension instead of `.rb.tt`.

### Detail

This commit fixes the extension and removes the `:markup:` directive.

### Checklist

Before submitting the PR make sure the following are checked:

* [ ] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [ ] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
