### PR TITLE
EncryptedAttributeType#type should return cast_type's type.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Fix `ActiveRecord::Encryption::EncryptedAttributeType#type` to return
+    actual cast type.
+
+    *Vasiliy Ermolovich*
+
 *   SQLite3Adapter: Bulk insert fixtures.
 
     Previously one insert command was executed for each fixture, now they are

--- a/activerecord/lib/active_record/encryption/encrypted_attribute_type.rb
+++ b/activerecord/lib/active_record/encryption/encrypted_attribute_type.rb
@@ -7,13 +7,13 @@ module ActiveRecord
     # This is the central piece that connects the encryption system with +encrypts+ declarations in the
     # model classes. Whenever you declare an attribute as encrypted, it configures an +EncryptedAttributeType+
     # for that attribute.
-    class EncryptedAttributeType < ::ActiveRecord::Type::Text
+    class EncryptedAttributeType < ::ActiveModel::Type::Value
       include ActiveModel::Type::Helpers::Mutable
 
       attr_reader :scheme, :cast_type
 
       delegate :key_provider, :downcase?, :deterministic?, :previous_schemes, :with_context, :fixed?, to: :scheme
-      delegate :accessor, to: :cast_type
+      delegate :accessor, :type, to: :cast_type
 
       # === Options
       #

--- a/activerecord/test/cases/encryption/encryptable_record_test.rb
+++ b/activerecord/test/cases/encryption/encryptable_record_test.rb
@@ -418,6 +418,11 @@ class ActiveRecord::Encryption::EncryptableRecordTest < ActiveRecord::Encryption
     assert EncryptedBookWithCustomCompressor.create!(name: name).name.start_with?("[compressed]")
   end
 
+  test "type method returns cast type" do
+    assert_equal :string, EncryptedBook.type_for_attribute(:name).type
+    assert_equal :text, EncryptedPost.type_for_attribute(:body).type
+  end
+
   private
     def build_derived_key_provider_with(hash_digest_class)
       ActiveRecord::Encryption.with_encryption_context(key_generator: ActiveRecord::Encryption::KeyGenerator.new(hash_digest_class: hash_digest_class)) do


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because `EncryptedAttributeType#type` incorrectly always returns `:text` type since that's the type `EncryptedAttributeType` inherited from. It doesn't consider the actual `cast_type` it has.

### Detail

This Pull Request changes two things:

- it delegates `type` method to actual `cast_type` instead of using one from `::ActiveRecord::Type::Text`
- it changes type class from which `EncryptedAttributeType` is inherited to more generic `::ActiveModel::Type::Value`. We don't need this change to fix this issue but I thought it makes more sense to inherit from base type instead of specific `::ActiveRecord::Type::Text`. I tried to check git history to understand why exactly this type was chosen but it was like this when this encryption feature was implemented (without an explanation) so I'm not completely sure if that's ok to change that.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
