### PR TITLE
Edits in the dev containers guide

### DIFF
--- a/guides/source/getting_started_with_devcontainer.md
+++ b/guides/source/getting_started_with_devcontainer.md
@@ -3,10 +3,10 @@
 Getting Started with Dev Containers
 ===================================
 
-After reading this guide, you know:
+After reading this guide, you will know:
 
-* How to create a new Rails application with the `rails-new` tool
-* How to begin working with your application in a Dev Container
+* How to create a new Rails application with the `rails-new` tool.
+* How to begin working with your application in a development container.
 
 --------------------------------------------------------------------------------
 
@@ -14,9 +14,9 @@ The best way to read this guide is to follow it step by step. All steps are
 essential to run this example application and no additional code or steps are
 needed.
 
-This guide helps you get set up with [Developer Containers (or Dev Containers for short)](https://containers.dev/)
-for a full-featured development environment. Dev Containers are used to run your
-Rails application in a container, without needing to install Rails or its dependencies
+This guide helps you get set up with [development containers (or dev containers for short)](https://containers.dev/)
+for a full-featured development environment. Dev containers are used to run your
+Rails application in a container, without needing to install Ruby or Rails or its dependencies
 directly on your machine. This is the fastest way to get your Rails application up and running.
 
 This is an alternative to installing Ruby and Rails directly on your machine, which is
@@ -27,30 +27,30 @@ the Getting Started guide.
 Setup and Installation
 ----------------------
 
-To get set up, you will need to install the relevant tools; Docker, VSCode and
-`rails-new`. We'll go into detail about each one below.
+To get set up, you will need to install the relevant tools; Docker, VS Code and
+`rails-new`. We'll go into details about each one below.
 
 ### Installing Docker
 
-Dev Containers are run using Docker, an open platform for developing, shipping, and
+Dev containers are run using Docker, an open platform for developing, shipping, and
 running applications. You can install Docker by following the installation instructions
 for your operating system in the [Docker docs](https://docs.docker.com/desktop/).
 
-Once Docker has been installed, launch the Docker Application to begin running
+Once Docker has been installed, launch the Docker application to begin running
 the Docker engine on your machine.
 
-### Installing VSCode
+### Installing VS Code
 
-Visual Studio Code (VSCode) is an open source code editor developed by Microsoft. VSCode's Dev Container
+Visual Studio Code (VS Code) is an open source code editor developed by Microsoft. VS Code's Dev Containers
 extension allows you to open any folder inside (or mounted into) a container and take advantage of
 Visual Studio Code's full feature set. A [devcontainer.json](https://code.visualstudio.com/docs/devcontainers/containers#_create-a-devcontainerjson-file)
 file in your project tells VS Code how to access (or create) a development container with a
 well-defined tool and runtime stack. It allows you to quickly spin up containers, access terminal
 commands, debug code, and utilize extensions.
 
-You can install VSCode by downloading it from [the website](https://code.visualstudio.com/).
+You can install VS Code by downloading it from [the website](https://code.visualstudio.com/).
 
-You can install the Dev Container extension by downloading it from [the marketplace](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers).
+You can install the Dev Containers extension by downloading it from [the marketplace](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers).
 
 ### Installing rails-new
 
@@ -58,7 +58,7 @@ You can install the Dev Container extension by downloading it from [the marketpl
 your machine. It uses Docker to generate the Rails application, thus allowing Docker to
 take care of installing the correct Ruby and Rails versions for you.
 
-To install rails-new, follow the installation instructions [in the readme](https://github.com/rails/rails-new?tab=readme-ov-file#installation).
+To install `rails-new`, follow the installation instructions [in the README](https://github.com/rails/rails-new?tab=readme-ov-file#installation).
 
 Creating the Blog Application
 -----------------------------
@@ -99,18 +99,18 @@ see the full [Getting Started guide](getting_started.html#creating-the-blog-appl
 Opening the Blog Application in a Dev Container
 -----------------------------------------------
 
-Our new Rails application comes with a Dev Container already configured and ready to use.
-We will use VSCode to spin up and work with our Dev Container. Start by launching VSCode
+Our new Rails application comes with a dev container already configured and ready to use.
+We will use VS Code to spin up and work with our dev container. Start by launching VS Code
 and opening your application.
 
-Once the application opens, VSCode should prompt you that a it has found a Dev Container
-configuration file, and you can reopen the folder in a Dev Container. Click the green "Reopen
-in Container" button to create the Dev Container.
+Once the application opens, VS Code should prompt you that a it has found a dev container
+configuration file, and you can reopen the folder in a dev container. Click the green "Reopen
+in Container" button to create the dev container.
 
-Once the Dev Container setup is complete, your development environment is ready to use,
+Once the dev container setup is complete, your development environment is ready to use,
 with Ruby, Rails, and all your dependencies installed.
 
-You can open the terminal within VScode to verify that Rails is installed:
+You can open the terminal within VS Code to verify that Rails is installed:
 
 ```bash
 $ rails --version
@@ -118,6 +118,6 @@ Rails 8.0.0
 ```
 
 You can now continue with the [Getting Started guide](getting_started.html#hello-rails) and
-begin building your Blog application. You will be working within VSCode, which serves as
-your entry point to your application's Dev Container, where you can run code, run tests and
+begin building your Blog application. You will be working within VS Code, which serves as
+your entry point to your application's dev container, where you can run code, run tests, and
 run your application.


### PR DESCRIPTION
I did a pass on the dev containers guide. Remarks for review:

* Following the style in other guides, the intro says "you will know" (which makes sense, since it is something that happens "after").
* According to https://containers.dev "development container" and "dev container" are written in lowercase (while "The Development Container Specification" is spelled that way).
* According to https://code.visualstudio.com "VS Code" has a space.
* The VS Code extension is called "Dev Containers" (plural).
* ~Added a tip for macOS, since the OS did not allow the execution of `rails-new`. Though maybe that would be better documented in the README of `rails-new` itself?~
* ~`rails-new --help` does not list `--devcontainer` as an option, is the command `rails-new blog --devcontainer` correct?~
* ~Let me also add that `rails-new blog --devcontainer` did not create a `.devcontainer` folder and VS Code does not recognize the generated Rails application as subject to run in a container. Is the guide up to date in that sense?~