### PR TITLE
Use direct status code to avoid deprecation warnings.

### DIFF
--- a/actionpack/lib/action_dispatch/http/response.rb
+++ b/actionpack/lib/action_dispatch/http/response.rb
@@ -233,7 +233,16 @@ module ActionDispatch # :nodoc:
 
     # Sets the HTTP status code.
     def status=(status)
-      @status = Rack::Utils.status_code(status)
+      case status
+      # The following block is for compatibility with Rack < 3.1
+      # In Rack < 3.1, the status code is symbolically referred to as :unprocessable_entity
+      # In Rack >= 3.1, the status code is symbolically referred to as :unprocessable_content
+      # Once support for Rack < 3.1 is dropped, this check can be removed.
+      when :unprocessable_entity, :unprocessable_content
+        @status = 422
+      else
+        @status = Rack::Utils.status_code(status)
+      end
     end
 
     # Sets the HTTP response's content MIME type. For example, in the controller you

--- a/actionpack/lib/action_dispatch/middleware/exception_wrapper.rb
+++ b/actionpack/lib/action_dispatch/middleware/exception_wrapper.rb
@@ -18,8 +18,11 @@ module ActionDispatch
       "ActionController::UnknownFormat"                    => :not_acceptable,
       "ActionDispatch::Http::MimeNegotiation::InvalidType" => :not_acceptable,
       "ActionController::MissingExactTemplate"             => :not_acceptable,
-      "ActionController::InvalidAuthenticityToken"         => :unprocessable_entity,
-      "ActionController::InvalidCrossOriginRequest"        => :unprocessable_entity,
+      # In Rack < 3.1, the status code is symbolically referred to as :unprocessable_entity
+      # In Rack >= 3.1, the status code is symbolically referred to as :unprocessable_content
+      # Once support for Rack < 3.1 is dropped, this can be replaced with :unprocessable_content if desired.
+      "ActionController::InvalidAuthenticityToken"         => 422,
+      "ActionController::InvalidCrossOriginRequest"        => 422,
       "ActionDispatch::Http::Parameters::ParseError"       => :bad_request,
       "ActionController::BadRequest"                       => :bad_request,
       "ActionController::ParameterMissing"                 => :bad_request,

--- a/actionpack/lib/action_dispatch/testing/assertion_response.rb
+++ b/actionpack/lib/action_dispatch/testing/assertion_response.rb
@@ -13,7 +13,13 @@ module ActionDispatch
       success: "2XX",
       missing: "404",
       redirect: "3XX",
-      error: "5XX"
+      error: "5XX",
+
+      # In Rack < 3.1, the status code is symbolically referred to as :unprocessable_entity
+      # In Rack >= 3.1, the status code is symbolically referred to as :unprocessable_content
+      # Once support for Rack < 3.1 is dropped, these lines can be removed
+      unprocessable_entity: 422,
+      unprocessable_content: 422,
     }
 
     # Accepts a specific response status code as an Integer (404) or String ('404')


### PR DESCRIPTION
### Motivation / Background

The HTTP status code 422 was informally referred to as "unprocessable entity" by the WebDAV specifications. However, it was officially standardised as "unprocessable content" by the HTTP standards. Rack adopted this change in v3.1 and emits deprecation warnings in v3.2 (HEAD).

The current released versions of Rack work acceptably with Rails, however Rack HEAD emits warnings, causing test failures.

See <https://github.com/rack/rack/pull/2137> for more context. See <https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/422> for more details about the specifications.

### Detail

Use "422" status code directly in `exception_wrapper.rb` to avoid the deprecation warning. This change bypasses symbolic name lookup and thus the deprecation warning, by using the status code directly. We may prefer to change all the symbolic constants to integer values to avoid extra hash lookups. However, it's probably not a performance issue in practice.

Handle both `unprocessible_entity` and `unprocessible_content` in `ActionDispatch::Response` and the test assertions helper. This ensures compatibility with both symbols going forward, until Rails decides to drop support.

### Alternatives

I considered the following alternatives:

- Don’t emit the warning in Rack head, but restore it later (3.2 in about a years time?)
- Don’t make it an error if the warning is emitted in Rack head, in Rails test CI.

If there is enough interest in doing it differently, I'd be willing to consider those options.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [ ] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
