### PR TITLE
Add tests for streaming chunks.

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -132,4 +132,8 @@
 
     *Samuel Williams*
 
+*   Tidy up handling of streaming in `ActionDispatch::Response::Buffer` to better align with the Rack 3 specification.
+
+    *Samuel Williams*
+
 Please check [7-2-stable](https://github.com/rails/rails/blob/7-2-stable/actionpack/CHANGELOG.md) for previous changes.

--- a/actionpack/lib/action_controller/metal/live.rb
+++ b/actionpack/lib/action_controller/metal/live.rb
@@ -171,12 +171,6 @@ module ActionController
         @ignore_disconnect = false
       end
 
-      # ActionDispatch::Response delegates #to_ary to the internal
-      # ActionDispatch::Response::Buffer, defining #to_ary is an indicator that the
-      # response body can be buffered and/or cached by Rack middlewares, this is not
-      # the case for Live responses so we undefine it for this Buffer subclass.
-      undef_method :to_ary
-
       def write(string)
         unless @response.committed?
           @response.headers["Cache-Control"] ||= "no-cache"

--- a/actionpack/lib/action_dispatch/http/response.rb
+++ b/actionpack/lib/action_dispatch/http/response.rb
@@ -105,10 +105,18 @@ module ActionDispatch # :nodoc:
         @str_body = nil
       end
 
+      BODY_METHODS = { to_ary: true }
+
+      def respond_to?(method, include_private = false)
+        if BODY_METHODS.key?(method)
+          @buf.respond_to?(method)
+        else
+          super
+        end
+      end
+
       def to_ary
-        @buf.respond_to?(:to_ary) ?
-          @buf.to_ary :
-          @buf.each
+        @buf.to_ary
       end
 
       def body
@@ -498,6 +506,8 @@ module ActionDispatch # :nodoc:
       def initialize(response)
         @response = response
       end
+
+      attr :response
 
       def close
         # Rack "close" maps to Response#abort, and **not** Response#close (which is used

--- a/actionpack/test/controller/new_base/render_streaming_test.rb
+++ b/actionpack/test/controller/new_base/render_streaming_test.rb
@@ -152,6 +152,8 @@ module RenderStreaming
         assert_equal expected[index], chunk
         index += 1
       end
+
+      assert_equal expected.size, index
     end
   end
 end

--- a/actionpack/test/controller/new_base/render_streaming_test.rb
+++ b/actionpack/test/controller/new_base/render_streaming_test.rb
@@ -45,44 +45,78 @@ module RenderStreaming
 
   class StreamingTest < Rack::TestCase
     test "rendering with streaming enabled at the class level" do
+      env = Rack::MockRequest.env_for("/render_streaming/basic/hello_world")
+      status, headers, body = app.call(env)
+      assert_streaming!(status, headers, body)
+      assert_chunks ["Hello world", ", I'm here!"], body
+
       get "/render_streaming/basic/hello_world"
       assert_body "Hello world, I'm here!"
-      assert_streaming!
     end
 
     test "rendering with streaming given to render" do
+      env = Rack::MockRequest.env_for("/render_streaming/basic/explicit")
+      status, headers, body = app.call(env)
+      assert_streaming!(status, headers, body)
+      assert_chunks ["Hello world", ", I'm here!"], body
+
       get "/render_streaming/basic/explicit"
       assert_body "Hello world, I'm here!"
-      assert_streaming!
+      assert_cache_control!
     end
 
     test "rendering with streaming do not override explicit cache control given to render" do
+      env = Rack::MockRequest.env_for("/render_streaming/basic/explicit_cache")
+      status, headers, body = app.call(env)
+      assert_streaming!(status, headers, body)
+      assert_chunks ["Hello world", ", I'm here!"], body
+
       get "/render_streaming/basic/explicit_cache"
       assert_body "Hello world, I'm here!"
-      assert_streaming! "private"
+      assert_cache_control! "private"
     end
 
     test "rendering with streaming no layout" do
+      env = Rack::MockRequest.env_for("/render_streaming/basic/no_layout")
+      status, headers, body = app.call(env)
+      assert_streaming!(status, headers, body)
+      assert_chunks ["Hello world"], body
+
       get "/render_streaming/basic/no_layout"
       assert_body "Hello world"
-      assert_streaming!
+      assert_cache_control!
     end
 
     test "skip rendering with streaming at render level" do
+      env = Rack::MockRequest.env_for("/render_streaming/basic/skip")
+      status, _, body = app.call(env)
+      assert_equal 200, status
+      assert_chunks ["Hello world, I'm here!"], body
+
       get "/render_streaming/basic/skip"
       assert_body "Hello world, I'm here!"
     end
 
     test "rendering with layout exception" do
+      env = Rack::MockRequest.env_for("/render_streaming/basic/layout_exception")
+      status, headers, body = app.call(env)
+      assert_streaming!(status, headers, body)
+      assert_chunks ["<body class=\"", "\"><script>window.location = \"/500.html\"</script></html>"], body
+
       get "/render_streaming/basic/layout_exception"
       assert_body "<body class=\"\"><script>window.location = \"/500.html\"</script></html>"
-      assert_streaming!
+      assert_cache_control!
     end
 
     test "rendering with template exception" do
+      env = Rack::MockRequest.env_for("/render_streaming/basic/template_exception")
+      status, headers, body = app.call(env)
+      assert_streaming!(status, headers, body)
+      assert_chunks ["\"><script>window.location = \"/500.html\"</script></html>"], body
+
       get "/render_streaming/basic/template_exception"
       assert_body "\"><script>window.location = \"/500.html\"</script></html>"
-      assert_streaming!
+      assert_cache_control!
     end
 
     test "rendering with template exception logs the exception" do
@@ -98,9 +132,26 @@ module RenderStreaming
       end
     end
 
-    def assert_streaming!(cache = "no-cache")
-      assert_status 200
-      assert_equal cache, headers["cache-control"]
+    def assert_streaming!(status, headers, body)
+      assert_equal 200, status
+
+      # It should not have a content length
+      assert_nil headers["content-length"]
+
+      # The body should not respond to `#to_ary`
+      assert_not_respond_to body, :to_ary
+    end
+
+    def assert_cache_control!(value = "no-cache", headers: self.headers)
+      assert_equal value, headers["cache-control"]
+    end
+
+    def assert_chunks(expected, body)
+      index = 0
+      body.each do |chunk|
+        assert_equal expected[index], chunk
+        index += 1
+      end
     end
   end
 end

--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -24,4 +24,8 @@
 
     *Jean Boussier*
 
+*   Allow `render_template` to use streaming for non-layout templates.
+
+    *Samuel Williams*
+
 Please check [7-2-stable](https://github.com/rails/rails/blob/7-2-stable/actionview/CHANGELOG.md) for previous changes.

--- a/actionview/lib/action_view/renderer/streaming_template_renderer.rb
+++ b/actionview/lib/action_view/renderer/streaming_template_renderer.rb
@@ -42,7 +42,7 @@ module ActionView
     # object that responds to each. This object is initialized with a block
     # that knows how to render the template.
     def render_template(view, template, layout_name = nil, locals = {}) # :nodoc:
-      return [super.body] unless layout_name && template.supports_streaming?
+      return [super.body] unless template.supports_streaming?
 
       locals ||= {}
       layout   = find_layout(layout_name, locals.keys, [formats.first])

--- a/actionview/lib/action_view/template/raw_file.rb
+++ b/actionview/lib/action_view/template/raw_file.rb
@@ -20,6 +20,10 @@ module ActionView # :nodoc:
       def render(*args)
         ::File.read(@filename)
       end
+
+      def supports_streaming?
+        false
+      end
     end
   end
 end


### PR DESCRIPTION
### Motivation / Background

The tests for streaming responses, as modified in <https://github.com/rails/rails/pull/52094> are insufficient to determine whether the response included multiple chunks. We should ensure that this is the case, as well as ensuring that the response body conforms to an "Enumerable Body" as defined by the Rack specification when `stream: true` is requested.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
