### PR TITLE
[ci skip] Update config/boot.rb contents in initialization.md 

### DIFF
--- a/guides/source/initialization.md
+++ b/guides/source/initialization.md
@@ -55,6 +55,7 @@ The `APP_PATH` constant will be used later in `rails/commands`. The `config/boot
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
 
 require "bundler/setup" # Set up gems listed in the Gemfile.
+require "bootsnap/setup" # Speed up boot time by caching expensive operations.
 ```
 
 In a standard Rails application, there's a `Gemfile` which declares all


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because the code block in the initialization documentation that contains the code in`config/boot.rb` is missing the line that requires bootsnap/setup.

### Detail

This Pull Request adds the missing line from `config/boot.rb`

```ruby
require "bootsnap/setup" # Speed up boot time by caching expensive operations.
```

### Checklist

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
