### PR TITLE
[i18n] - Do not watch translations from gems when reloading is enabled

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Optimize load time for `Railtie#initialize_i18n`. Filter `I18n.load_path`s passed to the file watcher to only those
+    under `Rails.root`. Previously the watcher would grab all available locales, including those in gems
+    which do not require a watcher because they won't change.
+
+    *Nick Schwaderer*
+
 *   Add a `filter` option to `in_order_of` to prioritize certain values in the sorting without filtering the results
     by these values.
 

--- a/activesupport/lib/active_support/i18n_railtie.rb
+++ b/activesupport/lib/active_support/i18n_railtie.rb
@@ -62,8 +62,9 @@ module I18n
 
       if app.config.reloading_enabled?
         directories = watched_dirs_with_extensions(reloadable_paths)
-        reloader = app.config.file_watcher.new(I18n.load_path.dup, directories) do
-          I18n.load_path.keep_if { |p| File.exist?(p) }
+        root_load_paths = I18n.load_path.select { |path| path.start_with?(Rails.root.to_s) }
+        reloader = app.config.file_watcher.new(root_load_paths, directories) do
+          I18n.load_path.delete_if { |p| p.start_with?(Rails.root.to_s) && !File.exist?(p) }
           I18n.load_path |= reloadable_paths.flat_map(&:existent)
         end
 


### PR DESCRIPTION
### Motivation / Background

I18n is intialized with file watchers for all translation paths when reloading is enabled.

This includes translations contained within gems; which the user will not be editing in development. This adds unnecessary performance overhead.

### Detail

This change ensures we're only watching the files we care about.

**Before Pull Request**
`EventedFileUpdateChecker` watched all these files

```ruby
[
  "/Users/schwad/.gem/ruby/3.3.3/gems/validate_url-1.0.15/lib/locale/ar.yml",
  ...
  "/Users/schwad/path/to/my/app/config/locales/foo/en.yml"
  ...
]
```

**After Pull Request**
Now:
```
[
  "/Users/schwad/path/to/my/app/config/locales/foo/en.yml"
  ...
]
```

## Benchmark - `I18n.initialize_i18n`

I benchmarked this by running `benchmark-ips` twice; with `I18n.initialize_i18n` against `main` vs this PR. I checked against varying distributions of local translations && gem locations, up to 10000.

<details>
  <summary>
    Script
  </summary>

```ruby
require "bundler/inline"
require 'fileutils'

gemfile(true) do
  source "https://rubygems.org"

  gem "rails", github: "rails/rails", branch: "main"
  # gem "rails", github: "schwad/rails", branch: "schwad/only_watch_local_translations"
  gem "benchmark-ips"
end

require "rails/all"

class TinyApp < Rails::Application;end
TinyApp.config.eager_load = false
# TinyApp.initialize!


# Generate a sample Rails locale file content
def generate_locale_file_content(file_path, extra_lines=500)
  content = <<~YAML
    en:
      hello: "Hello, World!"
      goodbye: "Goodbye, World!"
      greeting: "Welcome, %{name}!"
  YAML

  extra_lines.times do |i|
    content += "  key_#{i}: value_#{i}\n"
  end


  File.open(file_path, "w") { |file| file.write(content) }
end

SCENARIOS = {
  "10 local 10 gem"       => [10,10],
  "10 local 0 gem"        => [10,0],
  "0 local 10 gem"        => [0,10],
  "100 local 100 gem"     => [100,100],
  "100 local 50 gem"      => [100,50],
  "100 local 0 gem"       => [100,0],
  "50 local 100 gem"      => [50,100],
  "0 local 100 gem"       => [0,100],
  "1000 local 1000 gem"   => [1000,1000],
  "1000 local 500 gem"    => [1000,500],
  "1000 local 0 gem"      => [1000,0],
  "500 local 1000 gem"    => [500,1000],
  "10000 local 10000 gem" => [10000,10000],
  "10000 local 5000 gem"  => [10000,5000],
  "10000 local 0 gem"     => [10000,0],
  "5000 local 10000 gem"  => [5000,10000],
  "0 local 10000 gem"     => [0,10000],
}

local_path = "#{TinyApp.root.to_s}/config/locales/"
gem_path = "#some_gem/config/locales/"
FileUtils.mkdir_p(local_path) unless Dir.exist?(local_path)
FileUtils.mkdir_p(gem_path) unless Dir.exist?(gem_path)



SCENARIOS.each_pair do |name, value|
  puts
  puts " #{name} ".center(80, "=")
  puts

  I18n.load_path = []

  value[0].times do |i|
    I18n.load_path << "#{TinyApp.root.to_s}/config/locales/#{i}.yml"
    file_path = "#{local_path}/#{i}.yml"
    generate_locale_file_content(file_path)
  end
  value[1].times do |x|
    I18n.load_path << "#some_gem/config/locales/#{x}.yml"
    file_path = "#{gem_path}/#{x}.yml"
    generate_locale_file_content(file_path)
  end

  Benchmark.ips do |x|
    x.report("ImprovementPR") do

      # Redeclare the Railtie class to avoid the @i18n_inited check
      module I18n
        class Railtie < Rails::Railtie
          @i18n_inited = false
        end
      end
      I18n::Railtie.initialize_i18n(TinyApp)
    end
    x.compare!
  end
end

FileUtils.rm_rf(gem_path) if File.exist?(gem_path)
File.rm_rf(local_path) if File.exist?(local_path)
```
</details>

```
=============================== 10 local 10 gem ================================
Calculating -------------------------------------
       Rails#Main      1.754k (±17.4%) i/s -      8.947k in   5.250369s
       ImprovementPR   1.812k (±17.7%) i/s -      8.928k in   5.074040s

================================ 10 local 0 gem ================================
Calculating -------------------------------------
       Rails#Main      1.114k (± 7.1%) i/s -      5.544k in   5.000581s
       ImprovementPR   1.051k (± 8.7%) i/s -      5.280k in   5.066276s

================================ 0 local 10 gem ================================
Calculating -------------------------------------
       Rails#Main    860.960 (± 4.4%) i/s -      4.312k in   5.018215s
       ImprovementPR 890.677 (± 4.2%) i/s -      4.500k in   5.060871s

============================== 100 local 100 gem ===============================
Calculating -------------------------------------
       Rails#Main    426.028 (± 1.9%) i/s -      2.150k in   5.048368s
       ImprovementPR 513.826 (± 1.9%) i/s -      2.600k in   5.062177s

=============================== 100 local 50 gem ===============================
Calculating -------------------------------------
       Rails#Main    449.178 (± 2.9%) i/s -      2.250k in   5.014045s
       ImprovementPR 487.010 (± 1.8%) i/s -      2.450k in   5.032367s

=============================== 100 local 0 gem ================================
Calculating -------------------------------------
       Rails#Main    477.125 (± 1.5%) i/s -      2.401k in   5.033304s
       ImprovementPR 459.398 (± 1.7%) i/s -      2.303k in   5.014521s

=============================== 50 local 100 gem ===============================
Calculating -------------------------------------
       Rails#Main    407.719 (± 1.7%) i/s -      2.058k in   5.049146s
       ImprovementPR 493.687 (± 1.8%) i/s -      2.499k in   5.063768s

=============================== 0 local 100 gem ================================
Calculating -------------------------------------
       Rails#Main    443.337 (± 1.8%) i/s -      2.250k in   5.077096s
       ImprovementPR 526.257 (± 7.8%) i/s -      2.632k in   5.047372s

============================= 1000 local 1000 gem ==============================
Calculating -------------------------------------
       Rails#Main     75.830 (± 6.6%) i/s -    378.000 in   5.008978s
       ImprovementPR    115.665 (± 1.7%) i/s -    583.000 in   5.042762s

============================== 1000 local 500 gem ==============================
Calculating -------------------------------------
       Rails#Main     95.604 (± 6.3%) i/s -    477.000 in   5.012849s
       ImprovementPR 118.272 (± 1.7%) i/s -    594.000 in   5.024444s

=============================== 1000 local 0 gem ===============================
Calculating -------------------------------------
       Rails#Main    127.400 (± 2.4%) i/s -    648.000 in   5.088344s
       ImprovementPR 119.764 (± 1.7%) i/s -    605.000 in   5.053437s

============================== 500 local 1000 gem ==============================
Calculating -------------------------------------
       Rails#Main    102.431 (± 2.0%) i/s -    520.000 in   5.079499s
       ImprovementPR 182.073 (± 2.2%) i/s -    918.000 in   5.044251s

============================ 10000 local 10000 gem =============================
Calculating -------------------------------------
       Rails#Main      6.085 (± 0.0%) i/s -     31.000 in   5.097722s
       ImprovementPR  11.167 (± 9.0%) i/s -     56.000 in   5.026659s

============================= 10000 local 5000 gem =============================
Calculating -------------------------------------
       Rails#Main      7.923 (± 0.0%) i/s -     40.000 in   5.056703s
       ImprovementPR  11.185 (± 8.9%) i/s -     56.000 in   5.025844s

============================== 10000 local 0 gem ===============================
Calculating -------------------------------------
       Rails#Main     11.963 (± 8.4%) i/s -     60.000 in   5.040293s
       ImprovementPR  11.823 (± 8.5%) i/s -     60.000 in   5.089172s


============================= 5000 local 10000 gem =============================
Calculating -------------------------------------
       Rails#Main      8.346 (± 0.0%) i/s -     42.000 in   5.039615s
       ImprovementPR  24.008 (± 4.2%) i/s -    120.000 in   5.012617s

============================== 0 local 10000 gem ===============================
Calculating -------------------------------------
       Rails#Main     15.497 (± 6.5%) i/s -     78.000 in   5.069015s
       ImprovementPR 185.827 (± 1.6%) i/s -    936.000 in   5.038608s
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
