### PR TITLE
Skip triggering "instantiation.active_record" notification when there are no records

### DIFF
--- a/activerecord/lib/active_record/querying.rb
+++ b/activerecord/lib/active_record/querying.rb
@@ -71,6 +71,8 @@ module ActiveRecord
     end
 
     def _load_from_sql(result_set, &block) # :nodoc:
+      return [] if result_set.empty?
+
       column_types = result_set.column_types
 
       unless column_types.empty?

--- a/activerecord/test/cases/instrumentation_test.rb
+++ b/activerecord/test/cases/instrumentation_test.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "cases/helper"
+require "models/author"
 require "models/book"
 require "models/clothing_item"
 
@@ -167,6 +168,22 @@ module ActiveRecord
         Book.first
         Book.first
       end
+    ensure
+      ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
+    end
+
+    def test_no_instantiation_notification_when_no_records
+      author = Author.create!(name: "David")
+
+      called = false
+      subscriber = ActiveSupport::Notifications.subscribe("instantiation.active_record") do
+        called = true
+      end
+
+      Author.where(id: 0).to_a
+      author.books.to_a
+
+      assert_equal false, called
     ensure
       ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
     end


### PR DESCRIPTION
When loading association records, Active Record unnecessary and confusingly triggers an `instantiation.active_record` notification even when there are no records. 

This is not happening when loading records from a regular empty relation
https://github.com/rails/rails/blob/4fa56814f18fd3da49c83931fa773caa727d8096/activerecord/lib/active_record/relation.rb#L1441-L1442

I found this bug when subscribed to that event and got a strange payload with 0 count:

```ruby
ActiveSupport::Notifications.subscribe("instantiation.active_record") do |*, payload|
  puts payload # => {:record_count=>0, :class_name=>"User"}
end
```