### PR TITLE
Guides CSS to format code tags in h2 headings [ci skip]

### DIFF
--- a/guides/assets/stylesrc/_main.scss
+++ b/guides/assets/stylesrc/_main.scss
@@ -144,6 +144,11 @@ body.guide {
     a:visited {
       color: $rf-brand;
     } // a, a:link, a:visited
+
+    code {
+      font-size: 2rem;
+      font-weight: 400;
+    }
   } // h2
 
   h3 {


### PR DESCRIPTION
### Motivation / Background

Noticed when reading the edge guides that we have some wonky formatting for the case when we use a method name in an h2 heading.

There's already a fix for h3-level headings, so I copied the font-weight (400) and eyeballed a font-size. 2.25rem looked too much to my eyes, so went with 2rem.

### Detail

This Pull Request changes CSS for the guides. To add `h2 code` formatting to bring the visual size into line.

### Additional information

#### Before:

![before](https://github.com/rails/rails/assets/2780/3af4f85c-2884-44dd-9519-362c593e9c2e)

#### After:

![after](https://github.com/rails/rails/assets/2780/d7c730e4-5636-4a26-8fd9-81676335acf5)

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
