### PR TITLE
ActionText::Content - Strip `content` attribute if it is empty

### DIFF
--- a/actiontext/CHANGELOG.md
+++ b/actiontext/CHANGELOG.md
@@ -1,9 +1,12 @@
+*   Strip `content` attribute if the key is present but the value is empty
+
+    *Jeremy Green*
+
 *   Rename `rich_text_area` methods into `rich_textarea`
 
     Old names are still available as aliases.
 
     *Sean Doyle*
-
 
 *   Only sanitize `content` attribute when present in attachments.
 

--- a/actiontext/lib/action_text/content.rb
+++ b/actiontext/lib/action_text/content.rb
@@ -97,8 +97,9 @@ module ActionText
 
     def render_attachments(**options, &block)
       content = fragment.replace(ActionText::Attachment.tag_name) do |node|
-        if node.key? "content"
-          node["content"] = sanitize_content_attachment(node["content"])
+        if node.key?("content")
+          sanitized_content = sanitize_content_attachment(node.remove_attribute("content").to_s)
+          node["content"] = sanitized_content if sanitized_content.present?
         end
         block.call(attachment_for_node(node, **options))
       end

--- a/actiontext/test/unit/content_test.rb
+++ b/actiontext/test/unit/content_test.rb
@@ -164,6 +164,18 @@ class ActionText::ContentTest < ActiveSupport::TestCase
     assert_equal trix_html, content_from_html(html).to_trix_html.strip
   end
 
+  test "removes content attribute if it's value is empty" do
+    html = '<action-text-attachment sgid="123" content=""></action-text-attachment>'
+    trix_html = '<figure data-trix-attachment="{&quot;sgid&quot;:&quot;123&quot;}"></figure>'
+    assert_equal trix_html, content_from_html(html).to_trix_html.strip
+  end
+
+  test "removes content attribute if it's value is empty after sanitization" do
+    html = '<action-text-attachment sgid="123" content="<script></script>"></action-text-attachment>'
+    trix_html = '<figure data-trix-attachment="{&quot;sgid&quot;:&quot;123&quot;}"></figure>'
+    assert_equal trix_html, content_from_html(html).to_trix_html.strip
+  end
+
   test "does not add missing content attribute" do
     html = '<action-text-attachment sgid="123"></action-text-attachment>'
     trix_html = '<figure data-trix-attachment="{&quot;sgid&quot;:&quot;123&quot;}"></figure>'


### PR DESCRIPTION
### Motivation / Background

Images and other attachments added to a rich text area aren't being displayed in the editor when you go back to edit the record again.

Fixes: https://github.com/rails/rails/issues/52233

### Detail

This Pull Request makes it so that if the `action-text-attachment` element contains an empty `content` attribute, that attribute will be stripped out during the rendering of attachments.

### Additional information

None

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
