### PR TITLE
Delete obsolete version in compose.yaml

### DIFF
--- a/.devcontainer/compose.yaml
+++ b/.devcontainer/compose.yaml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
   rails:
     build:


### PR DESCRIPTION
The following warning appeared when starting devcontainer.

```
WARN[0000] /home/***/ghq/github.com/rails/rails/.devcontainer/compose.yaml: `version` is obsolete
WARN[0000] /tmp/devcontainercli-***/docker-compose/docker-compose.devcontainer.build-1720224621191.yml: `version` is obsolete
```

In fact, the top-level version element will be obsolete in the compose specification. 
https://github.com/compose-spec/compose-spec/blob/master/spec.md#version-top-level-element-obsolete