### PR TITLE
Make http_cache_forever use `immutable: true`

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Make `http_cache_forever` use `immutable: true`
+
+    *Nate Matykiewicz*
+
 *   Add `config.action_dispatch.strict_freshness`.
 
     When set to `true`, the `ETag` header takes precedence over the `Last-Modified` header when both are present,

--- a/actionpack/lib/action_controller/metal/conditional_get.rb
+++ b/actionpack/lib/action_controller/metal/conditional_get.rb
@@ -320,7 +320,7 @@ module ActionController
     #     user's web browser. To allow proxies to cache the response, set `true` to
     #     indicate that they can serve the cached response to all users.
     def http_cache_forever(public: false)
-      expires_in 100.years, public: public
+      expires_in 100.years, public: public, immutable: true
 
       yield if stale?(etag: request.fullpath,
                       last_modified: Time.new(2011, 1, 1).utc,

--- a/actionpack/test/controller/render_test.rb
+++ b/actionpack/test/controller/render_test.rb
@@ -1021,7 +1021,7 @@ class HttpCacheForeverTest < ActionController::TestCase
   def test_cache_with_public
     get :cache_me_forever, params: { public: true }
     assert_response :ok
-    assert_equal "max-age=#{100.years}, public", @response.headers["Cache-Control"]
+    assert_equal "max-age=#{100.years}, public, immutable", @response.headers["Cache-Control"]
     assert_not_nil @response.etag
     assert_predicate @response, :weak_etag?
   end
@@ -1029,7 +1029,7 @@ class HttpCacheForeverTest < ActionController::TestCase
   def test_cache_with_private
     get :cache_me_forever
     assert_response :ok
-    assert_equal "max-age=#{100.years}, private", @response.headers["Cache-Control"]
+    assert_equal "max-age=#{100.years}, private, immutable", @response.headers["Cache-Control"]
     assert_not_nil @response.etag
     assert_predicate @response, :weak_etag?
   end

--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,2 +1,5 @@
+*   Mark proxied files as `immutable` in their Cache-Control header
+
+    *Nate Matykiewicz*
 
 Please check [7-2-stable](https://github.com/rails/rails/blob/7-2-stable/activestorage/CHANGELOG.md) for previous changes.

--- a/activestorage/test/controllers/blobs/proxy_controller_test.rb
+++ b/activestorage/test/controllers/blobs/proxy_controller_test.rb
@@ -13,7 +13,7 @@ class ActiveStorage::Blobs::ProxyControllerTest < ActionDispatch::IntegrationTes
   test "HTTP caching" do
     get rails_storage_proxy_url(create_file_blob(filename: "racecar.jpg"))
     assert_response :success
-    assert_equal "max-age=3155695200, public", response.headers["Cache-Control"]
+    assert_equal "max-age=3155695200, public, immutable", response.headers["Cache-Control"]
   end
 
   test "invalidates cache and returns a 404 if the file is not found on download" do


### PR DESCRIPTION
### Motivation / Background

https://github.com/rails/rails/pull/52197 added an `immutable: true` option to `expires_in`. This PR sets `immutable: true` for `http_cache_forever`, which additionally affects proxied ActiveStorage files.

### Detail

Set `immutable: true` on `http_cache_forever`'s `expires_in` call.

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [X] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
