### PR TITLE
Take 2 of 2: For an association scope, pass the reflection name along with the where values

### DIFF
--- a/activerecord/lib/active_record/associations/association_scope.rb
+++ b/activerecord/lib/active_record/associations/association_scope.rb
@@ -63,12 +63,12 @@ module ActiveRecord
           primary_key_foreign_key_pairs = primary_key.zip(foreign_key)
           primary_key_foreign_key_pairs.each do |join_key, foreign_key|
             value = transform_value(owner._read_attribute(foreign_key))
-            scope = apply_scope(scope, table, join_key, value)
+            scope = apply_scope(scope, table, reflection, join_key, value)
           end
 
           if reflection.type
             polymorphic_type = transform_value(owner.class.polymorphic_name)
-            scope = apply_scope(scope, table, reflection.type, polymorphic_type)
+            scope = apply_scope(scope, table, reflection, reflection.type, polymorphic_type)
           end
 
           scope
@@ -92,7 +92,7 @@ module ActiveRecord
 
           if reflection.type
             value = transform_value(next_reflection.klass.polymorphic_name)
-            scope = apply_scope(scope, table, reflection.type, value)
+            scope = apply_scope(scope, table, reflection, reflection.type, value)
           end
 
           scope.joins!(join(foreign_table, constraints))
@@ -158,11 +158,11 @@ module ActiveRecord
           scope
         end
 
-        def apply_scope(scope, table, key, value)
+        def apply_scope(scope, table, reflection, key, value)
           if scope.table == table
             scope.where!(key => value)
           else
-            scope.where!(table.name => { key => value })
+            scope.where!(table.name => { key => value, "!reflection" => reflection })
           end
         end
 

--- a/activerecord/lib/active_record/relation/predicate_builder.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder.rb
@@ -84,7 +84,9 @@ module ActiveRecord
             end
             grouping_queries(queries)
           elsif value.is_a?(Hash) && !table.has_column?(key)
-            table.associated_table(key, &block)
+            reflection = value.delete("!reflection")
+
+            table.associated_table(key, reflection.try(:name), &block)
               .predicate_builder.expand_from_hash(value.stringify_keys)
           elsif table.associated_with?(key)
             # Find the foreign key when using queries such as:

--- a/activerecord/lib/active_record/table_metadata.rb
+++ b/activerecord/lib/active_record/table_metadata.rb
@@ -26,8 +26,9 @@ module ActiveRecord
       klass&._reflect_on_association(table_name)
     end
 
-    def associated_table(table_name)
-      reflection = klass._reflect_on_association(table_name) || klass._reflect_on_association(table_name.singularize)
+    def associated_table(table_name, reflection_name = nil)
+      reflection = klass._reflect_on_association(reflection_name) if reflection_name
+      reflection ||= klass._reflect_on_association(table_name) || klass._reflect_on_association(table_name.singularize)
 
       if !reflection && table_name == arel_table.name
         return self

--- a/activerecord/test/cases/table_metadata_test.rb
+++ b/activerecord/test/cases/table_metadata_test.rb
@@ -1,16 +1,40 @@
 # frozen_string_literal: true
 
 require "cases/helper"
-require "models/developer"
 
 module ActiveRecord
   class TableMetadataTest < ActiveSupport::TestCase
-    test "#associated_table creates the right type caster for joined table with different association name" do
-      base_table_metadata = TableMetadata.new(AuditRequiredDeveloper, Arel::Table.new("developers"))
+    test "given no reflection name, #associated_table creates the right type caster for joined table with different association name" do
+      base_table_metadata = TableMetadata.new(Product, Arel::Table.new("products"))
 
-      associated_table_metadata = base_table_metadata.associated_table("audit_logs")
+      associated_table_metadata = base_table_metadata.associated_table("product_types")
 
-      assert_equal ActiveRecord::Type::String, associated_table_metadata.arel_table.type_for_attribute(:message).class
+      assert_equal ActiveModel::Type::Value, associated_table_metadata.arel_table.type_for_attribute(:nickname).class
+    end
+
+    test "given a reflection name, #associated_table creates the right type caster for joined table with different association name" do
+      base_table_metadata = TableMetadata.new(Product, Arel::Table.new("products"))
+
+      associated_table_metadata = base_table_metadata.associated_table("product_types", :custom_types)
+
+      assert_equal NicknameType, associated_table_metadata.arel_table.type_for_attribute(:nickname).class
+    end
+
+    class NicknameType < ActiveRecord::Type::String; end
+
+    class Product < ActiveRecord::Base
+      self.table_name = "products"
+      has_many :types, class_name: "ProductType"
+      has_many :custom_types, class_name: "CustomProductType"
+    end
+
+    class ProductType < ActiveRecord::Base
+      self.table_name = "product_types"
+    end
+
+    class CustomProductType < ActiveRecord::Base
+      self.table_name = "product_types"
+      attribute :nickname, NicknameType.new
     end
   end
 end


### PR DESCRIPTION
Fixes #52135

### Motivation / Background

A reflection is [currently found by table name](https://github.com/rails/rails/blame/56b83a2b4108b6d31a3b2b769e8e363640b649d6/activerecord/lib/active_record/table_metadata.rb#L30) when retrieving the associated table. Obviously, if the association name doesn't match the table name, no reflection is found. This only becomes a problem when custom types are involved. 

### Detail

This implementation puts the reflection name within the where values. It uses a key named `!reflection` that is removed before it hits the sql adapter.

### Additional information

Alternative implementation of putting the reflection name in a custom hash that represents the where values: https://github.com/rails/rails/pull/52291

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
