### PR TITLE
Add setting for logging redirect source locations

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,16 @@
+*   Add `action_dispatch.verbose_redirect_logs` setting that logs where redirects were called from.
+
+    Similar to `active_record.verbose_query_logs` and `active_job.verbose_enqueue_logs`, this adds a line in your logs that shows where a redirect was called from.
+
+    Example:
+
+    ```
+    Redirected to http://localhost:3000/posts/1
+    ↳ app/controllers/posts_controller.rb:32:in `block (2 levels) in create'
+    ```
+
+    *Dennis Paagman*
+
 *   Add engine route filtering and better formatting in `bin/rails routes`.
 
     Allow engine routes to be filterable in the routing inspector, and

--- a/actionpack/lib/action_controller/railtie.rb
+++ b/actionpack/lib/action_controller/railtie.rb
@@ -148,5 +148,11 @@ module ActionController
         ActionController::TestCase.executor_around_each_request = app.config.active_support.executor_around_test_case
       end
     end
+
+    initializer "action_controller.backtrace_cleaner" do
+      ActiveSupport.on_load(:action_controller) do
+        ActionController::LogSubscriber.backtrace_cleaner = Rails.backtrace_cleaner
+      end
+    end
   end
 end

--- a/actionpack/lib/action_dispatch.rb
+++ b/actionpack/lib/action_dispatch.rb
@@ -138,6 +138,14 @@ module ActionDispatch
 
   autoload :SystemTestCase, "action_dispatch/system_test_case"
 
+  ##
+  # :singleton-method:
+  #
+  # Specifies if the methods calling redirects in controllers and routes should
+  #  be logged below their relevant log lines. Defaults to false.
+  singleton_class.attr_accessor :verbose_redirect_logs
+  self.verbose_redirect_logs = false
+
   def eager_load!
     super
     Routing.eager_load!

--- a/actionpack/lib/action_dispatch/log_subscriber.rb
+++ b/actionpack/lib/action_dispatch/log_subscriber.rb
@@ -2,10 +2,18 @@
 
 module ActionDispatch
   class LogSubscriber < ActiveSupport::LogSubscriber # :nodoc:
+    class_attribute :backtrace_cleaner, default: ActiveSupport::BacktraceCleaner.new
+
     def redirect(event)
       payload = event.payload
 
       info { "Redirected to #{payload[:location]}" }
+
+      info do
+        if ActionDispatch.verbose_redirect_logs && (source = redirect_source_location)
+          "↳ #{source}"
+        end
+      end
 
       info do
         status = payload[:status]
@@ -17,6 +25,11 @@ module ActionDispatch
       end
     end
     subscribe_log_level :redirect, :info
+
+    private
+      def redirect_source_location
+        backtrace_cleaner.first_clean_frame
+      end
   end
 end
 

--- a/actionpack/lib/action_dispatch/railtie.rb
+++ b/actionpack/lib/action_dispatch/railtie.rb
@@ -34,6 +34,7 @@ module ActionDispatch
 
     config.action_dispatch.ignore_leading_brackets = nil
     config.action_dispatch.strict_query_string_separator = nil
+    config.action_dispatch.verbose_redirect_logs = false
 
     config.action_dispatch.default_headers = {
       "X-Frame-Options" => "SAMEORIGIN",
@@ -67,6 +68,8 @@ module ActionDispatch
         ActionDispatch::QueryParser.strict_query_string_separator = app.config.action_dispatch.strict_query_string_separator
       end
 
+      ActionDispatch.verbose_redirect_logs = app.config.action_dispatch.verbose_redirect_logs
+
       ActiveSupport.on_load(:action_dispatch_request) do
         self.ignore_accept_header = app.config.action_dispatch.ignore_accept_header
         ActionDispatch::Request::Utils.perform_deep_munge = app.config.action_dispatch.perform_deep_munge
@@ -87,6 +90,10 @@ module ActionDispatch
 
       ActionDispatch::Http::Cache::Request.strict_freshness = app.config.action_dispatch.strict_freshness
       ActionDispatch.test_app = app
+    end
+
+    initializer "action_dispatch.backtrace_cleaner" do
+      ActionDispatch::LogSubscriber.backtrace_cleaner = Rails.backtrace_cleaner
     end
   end
 end

--- a/actionpack/test/controller/log_subscriber_test.rb
+++ b/actionpack/test/controller/log_subscriber_test.rb
@@ -317,6 +317,22 @@ class ACLogSubscriberTest < ActionController::TestCase
     assert_equal "Redirected to [FILTERED]", logs[1]
   end
 
+  def test_verbose_redirect_logs
+    old_cleaner = ActionController::LogSubscriber.backtrace_cleaner
+    ActionController::LogSubscriber.backtrace_cleaner = ActionController::LogSubscriber.backtrace_cleaner.dup
+    ActionController::LogSubscriber.backtrace_cleaner.add_silencer { |location| !location.include?(__FILE__) }
+    ActionDispatch.verbose_redirect_logs = true
+
+    get :redirector
+    wait
+
+    assert_equal 4, logs.size
+    assert_match(/↳ #{__FILE__}/, logs[2])
+  ensure
+    ActionDispatch.verbose_redirect_logs = false
+    ActionController::LogSubscriber.backtrace_cleaner = old_cleaner
+  end
+
   def test_send_data
     get :data_sender
     wait

--- a/actionpack/test/dispatch/routing/log_subscriber_test.rb
+++ b/actionpack/test/dispatch/routing/log_subscriber_test.rb
@@ -25,6 +25,26 @@ class RoutingLogSubscriberTest < ActionDispatch::IntegrationTest
     assert_match(/Completed 301/, logs.last)
   end
 
+  test "verbose redirect logs" do
+    old_cleaner = ActionDispatch::LogSubscriber.backtrace_cleaner
+    ActionDispatch::LogSubscriber.backtrace_cleaner = ActionDispatch::LogSubscriber.backtrace_cleaner.dup
+    ActionDispatch::LogSubscriber.backtrace_cleaner.add_silencer { |location| !location.include?(__FILE__) }
+    ActionDispatch.verbose_redirect_logs = true
+
+    draw do
+      get "redirect", to: redirect("/login")
+    end
+
+    get "/redirect"
+    wait
+
+    assert_equal 3, logs.size
+    assert_match(/↳ #{__FILE__}/, logs[1])
+  ensure
+    ActionDispatch.verbose_redirect_logs = false
+    ActionDispatch::LogSubscriber.backtrace_cleaner = old_cleaner
+  end
+
   private
     def draw(&block)
       self.class.stub_controllers do |routes|
@@ -32,6 +52,10 @@ class RoutingLogSubscriberTest < ActionDispatch::IntegrationTest
         routes.draw(&block)
         @app = RoutedRackApp.new routes
       end
+    end
+
+    def get(path, **options)
+      super(path, **options.merge(headers: { "action_dispatch.routes" => @app.routes }))
     end
 
     def logs

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -2329,6 +2329,10 @@ If set to `true`, cookies will be written even if this criteria is not met.
 
 This defaults to `true` in `development`, and `false` in all other environments.
 
+#### `config.action_dispatch.verbose_redirect_logs`
+
+Specifies if source locations of redirects should be logged below relevant log lines. By default, the flag is `true` in development and `false` in all other environments.
+
 #### `ActionDispatch::Callbacks.before`
 
 Takes a block of code to run before the request.

--- a/guides/source/debugging_rails_applications.md
+++ b/guides/source/debugging_rails_applications.md
@@ -250,6 +250,23 @@ ActiveJob.verbose_enqueue_logs = true
 
 WARNING: We recommend against using this setting in production environments.
 
+### Verbose redirect logs
+
+Similar to other verbose log settings above, this logs the source location of a redirect.
+
+```
+Redirected to http://localhost:3000/posts/1
+↳ app/controllers/posts_controller.rb:32:in `block (2 levels) in create'
+```
+
+It is enabled by default in development. To enable in other environments, use this configuration:
+
+```rb
+config.action_dispatch.verbose_redirect_logs = true
+```
+
+As with other verbose loggers, it is not recommended to be used in production environments.
+
 SQL Query Comments
 ------------------
 

--- a/railties/lib/rails/generators/rails/app/templates/config/environments/development.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/development.rb.tt
@@ -65,6 +65,9 @@ Rails.application.configure do
   config.active_job.verbose_enqueue_logs = true
 
   <%- end -%>
+  # Highlight code that triggered redirect in logs.
+  config.action_dispatch.verbose_redirect_logs = true
+
   <%- unless options[:skip_asset_pipeline] -%>
   # Suppress logger output for asset requests.
   config.assets.quiet = true

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -3642,6 +3642,19 @@ module ApplicationTests
       assert_equal true, ActionDispatch::Http::Cache::Request.strict_freshness
     end
 
+    test "config.action_dispatch.verbose_redirect_logs is true in development" do
+      build_app
+      app "development"
+
+      assert ActionDispatch.verbose_redirect_logs
+    end
+
+    test "config.action_dispatch.verbose_redirect_logs is false in production" do
+      build_app
+      app "production"
+
+      assert_not ActionDispatch.verbose_redirect_logs
+    end
 
     test "Rails.application.config.action_mailer.smtp_settings have open_timeout and read_timeout defined as 5 in 7.0 defaults" do
       remove_from_config '.*config\.load_defaults.*\n'


### PR DESCRIPTION
### Motivation / Background

This introduces a new config setting: `action_dispatch.verbose_redirect_logs`. It logs the source location of redirects. It works similarly to `active_record.verbose_query_logs` and `active_job.verbose_enqueue_logs`.

Redirects are of course used a lot. They are often defined in different locations. For example in your authentication code, authorization code, fallbacks for resources that can't be found, and to redirect users to a different page after performing an action, possibly with multiple redirect options in one controller action.

I think it would be beneficial to know exactly which line of code triggered a redirect. 

### Detail

This adds a config setting that logs the source location of the redirect.

There are three main use cases, they would look like this:

1. Redirects in filters (these already have a "filter chain halted" log as well, which points you in the right direction a bit, but the exact code location can still be useful):

```
Redirected to http://localhost:3000/
↳ app/controllers/posts_controller.rb:76:in `check_something'
Filter chain halted as :redirect rendered or redirected
Completed 302 Found in 18ms (ActiveRecord: 0.1ms (1 query, 0 cached) | GC: 0.0ms)
```

2. Redirects in controller actions:

```
Redirected to http://localhost:3000/posts/7
↳ app/controllers/posts_controller.rb:32:in `block (2 levels) in create'
Completed 302 Found in 36ms (ActiveRecord: 1.3ms (1 query, 0 cached) | GC: 0.0ms)
```

3. Redirects in routes:

```
Started GET "/redirect" for ::1 at 2024-07-09 12:40:23 +0200
Redirected to http://localhost:3000/
↳ /Users/dennis/Code/rails-test-app/config/routes.rb:14
Completed 301 Moved Permanently in 9ms
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.

---

There are a few points I'm not sure how to approach and like some guidance in:

1. ~~The test for for dispatch (`actionpack/test/dispatch/routing/log_subscriber_test.rb`) breaks currently. The code relies on [`request.routes`][2] to be set (which is true for actual applications), but it's `nil` in the tests. I'm not sure if going through `request.routes` is the best approach or what needs to change in the tests to make them pass or have the routes available.~~
2. The source location for redirects from the router looks slightly different. This is because it uses [the existing `source_location` implementation][1], which for example shows the absolute path. I'm not sure if that's fine, or we want to get that in line with how the backtrace cleaner is used in other places.
3. This is the 3rd very similar config setting (`verbose_query_logs`, `verbose_enqueue_logs` and now `verbose_redirect_logs`). I can imagine most people will either set all or none of them. Would it make sense to consolidate them into one setting, or maybe have a setting that sets all 3 at the same time? The code for them is also very similar. Happy to work in a direction that unifies them if that's desirable.

[1]: https://github.com/rails/rails/blob/16f1222753cac0a554a2acd8f4ffa3f23d51d945/actionpack/lib/action_dispatch/routing/mapper.rb#L378-L408
[2]: https://github.com/rails/rails/blob/16f1222753cac0a554a2acd8f4ffa3f23d51d945/actionpack/lib/action_dispatch/http/request.rb#L161-L163