### PR TITLE
Raise specific exception when a connection is not defined

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Raise specific exception when a connection is not defined.
+
+     The new `ConnectionNotDefined` exception provides connection name, shard and role accessors indicating the details of the connection that was requested.
+
+    *Hana Harencarova*, *Matthew Draper*
+
 *   Delete the deprecated constant `ActiveRecord::ImmutableRelation`.
 
     *Xavier Noria*

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -1044,7 +1044,8 @@ module ActiveRecord
         end
 
         def retryable_connection_error?(exception)
-          exception.is_a?(ConnectionNotEstablished) || exception.is_a?(ConnectionFailed)
+          (exception.is_a?(ConnectionNotEstablished) && !exception.is_a?(ConnectionNotDefined)) ||
+            exception.is_a?(ConnectionFailed)
         end
 
         def invalidate_transaction(exception)

--- a/activerecord/lib/active_record/errors.rb
+++ b/activerecord/lib/active_record/errors.rb
@@ -84,6 +84,19 @@ module ActiveRecord
   class ConnectionTimeoutError < ConnectionNotEstablished
   end
 
+  # Raised when a database connection pool is requested but
+  # has not been defined.
+  class ConnectionNotDefined < ConnectionNotEstablished
+    def initialize(message = nil, connection_name: nil, role: nil, shard: nil)
+      super(message)
+      @connection_name = connection_name
+      @role = role
+      @shard = shard
+    end
+
+    attr_reader :connection_name, :role, :shard
+  end
+
   # Raised when connection to the database could not been established because it was not
   # able to connect to the host or when the authorization failed.
   class DatabaseConnectionError < ConnectionNotEstablished

--- a/activerecord/test/cases/connection_adapters/connection_handlers_multi_db_test.rb
+++ b/activerecord/test/cases/connection_adapters/connection_handlers_multi_db_test.rb
@@ -359,13 +359,13 @@ module ActiveRecord
       end
 
       def test_calling_connected_to_on_a_non_existent_handler_raises
-        error = assert_raises ActiveRecord::ConnectionNotEstablished do
+        error = assert_raises ActiveRecord::ConnectionNotDefined do
           ActiveRecord::Base.connected_to(role: :non_existent) do
             Person.first
           end
         end
 
-        assert_equal "No connection pool for 'ActiveRecord::Base' found for the 'non_existent' role.", error.message
+        assert_equal "No database connection defined for 'non_existent' role.", error.message
       end
 
       def test_default_handlers_are_writing_and_reading

--- a/activerecord/test/cases/fixtures_test.rb
+++ b/activerecord/test/cases/fixtures_test.rb
@@ -1710,7 +1710,7 @@ class MultipleFixtureConnectionsTest < ActiveRecord::TestCase
 
       setup_shared_connection_pool
 
-      assert_raises(ActiveRecord::ConnectionNotEstablished) do
+      assert_raises(ActiveRecord::ConnectionNotDefined) do
         ActiveRecord::Base.connected_to(role: :reading, shard: :two) do
           ActiveRecord::Base.retrieve_connection
         end
@@ -1721,7 +1721,7 @@ class MultipleFixtureConnectionsTest < ActiveRecord::TestCase
       clean_up_connection_handler
       teardown_shared_connection_pool
 
-      assert_raises(ActiveRecord::ConnectionNotEstablished) do
+      assert_raises(ActiveRecord::ConnectionNotDefined) do
         ActiveRecord::Base.connected_to(role: :reading) do
           ActiveRecord::Base.retrieve_connection
         end

--- a/activerecord/test/cases/unconnected_test.rb
+++ b/activerecord/test/cases/unconnected_test.rb
@@ -23,21 +23,21 @@ class TestUnconnectedAdapter < ActiveRecord::TestCase
   end
 
   def test_connection_no_longer_established
-    assert_raise(ActiveRecord::ConnectionNotEstablished) do
+    assert_raise(ActiveRecord::ConnectionNotDefined) do
       TestRecord.find(1)
     end
 
-    assert_raise(ActiveRecord::ConnectionNotEstablished) do
+    assert_raise(ActiveRecord::ConnectionNotDefined) do
       TestRecord.new.save
     end
   end
 
   def test_error_message_when_connection_not_established
-    error = assert_raise(ActiveRecord::ConnectionNotEstablished) do
+    error = assert_raise(ActiveRecord::ConnectionNotDefined) do
       TestRecord.find(1)
     end
 
-    assert_equal "No connection pool for 'ActiveRecord::Base' found.", error.message
+    assert_equal "No database connection defined.", error.message
   end
 
   def test_underlying_adapter_no_longer_active


### PR DESCRIPTION
### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created to make it easier to provide programatic access to details about requested shard/role.

### Detail

- This Pull Request introduces a more specific exception `ConnectionNotDefined` as a subclass of the previously-raised ConnectionNotEstablished. The new exception is used to handle cases where a requested database connection pool has not been found.
- The `retrieve_connection_pool` method in `connection_handler.rb` has been modified to provide more specific error messages reflecting if we're missing a shard and/or a role.
- Test cases have been updated to reflect these changes.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [ ] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.

cc @matthewd 