### PR TITLE
Allow to set `enqueue_after_transaction_commit` to jobs when `eager_load` is true

### DIFF
--- a/activejob/lib/active_job/enqueue_after_transaction_commit.rb
+++ b/activejob/lib/active_job/enqueue_after_transaction_commit.rb
@@ -2,22 +2,6 @@
 
 module ActiveJob
   module EnqueueAfterTransactionCommit # :nodoc:
-    extend ActiveSupport::Concern
-
-    included do
-      ##
-      # :singleton-method:
-      #
-      # Defines if enqueueing this job from inside an Active Record transaction
-      # automatically defers the enqueue to after the transaction commits.
-      #
-      # It can be set on a per job basis:
-      #  - `:always` forces the job to be deferred.
-      #  - `:never` forces the job to be queued immediately.
-      #  - `:default` lets the queue adapter define the behavior (recommended).
-      class_attribute :enqueue_after_transaction_commit, instance_accessor: false, instance_predicate: false, default: :never
-    end
-
     private
       def raw_enqueue
         after_transaction = case self.class.enqueue_after_transaction_commit

--- a/activejob/lib/active_job/enqueuing.rb
+++ b/activejob/lib/active_job/enqueuing.rb
@@ -40,6 +40,20 @@ module ActiveJob
   module Enqueuing
     extend ActiveSupport::Concern
 
+    included do
+      ##
+      # :singleton-method:
+      #
+      # Defines if enqueueing this job from inside an Active Record transaction
+      # automatically defers the enqueue to after the transaction commits.
+      #
+      # It can be set on a per job basis:
+      #  - `:always` forces the job to be deferred.
+      #  - `:never` forces the job to be queued immediately.
+      #  - `:default` lets the queue adapter define the behavior (recommended).
+      class_attribute :enqueue_after_transaction_commit, instance_accessor: false, instance_predicate: false, default: :never
+    end
+
     # Includes the +perform_later+ method for job initialization.
     module ClassMethods
       # Push a job onto the queue. By default the arguments must be either String,

--- a/activejob/lib/active_job/railtie.rb
+++ b/activejob/lib/active_job/railtie.rb
@@ -26,9 +26,9 @@ module ActiveJob
     end
 
     initializer "active_job.enqueue_after_transaction_commit" do |app|
-      ActiveSupport.on_load(:active_record) do
-        ActiveSupport.on_load(:active_job) do
-          include EnqueueAfterTransactionCommit
+      ActiveSupport.on_load(:active_job) do
+        ActiveSupport.on_load(:active_record) do
+          ActiveJob::Base.include EnqueueAfterTransactionCommit
 
           if app.config.active_job.key?(:enqueue_after_transaction_commit)
             ActiveJob::Base.enqueue_after_transaction_commit = app.config.active_job.delete(:enqueue_after_transaction_commit)

--- a/railties/test/application/active_job_railtie_test.rb
+++ b/railties/test/application/active_job_railtie_test.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require "isolation/abstract_unit"
+
+module ApplicationTests
+  class ActiveJobRailtieTest < ActiveSupport::TestCase
+    include ActiveSupport::Testing::Isolation
+
+    setup :build_app
+    teardown :teardown_app
+
+    test "jobs can set 'enqueue_after_transaction_commit' when eager_load is true" do
+      add_to_env_config "development", "config.eager_load = true"
+
+      app_file "app/jobs/foo_job.rb", <<-RUBY
+        class FooJob < ActiveJob::Base
+          self.enqueue_after_transaction_commit = :never
+        end
+      RUBY
+
+      assert_equal ":never", rails("runner", "p FooJob.enqueue_after_transaction_commit").strip
+    end
+  end
+end


### PR DESCRIPTION
### Detail

The current code expects `active_record` to be loaded before `active_job`. But I think there are no guarantees about load orders. At least, `active_job` is loaded before `active_record` in a newer application.

In that case, `EnqueueAfterTransactionCommit` isn't loaded and an application that uses `enqueue_after_transaction_commit` in jobs will fail with the following error.

 ```
 app/jobs/user_job.rb:2:in `<class:UserJob>': undefined method `enqueue_after_transaction_commit=' for class UserJob (NoMethodError)
 ```

 I removed `active_record` hook to fix this. Active Record are only used inside methods in ``EnqueueAfterTransactionCommit`. So I think it's safe to load the module without Active Record.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
