### PR TITLE
Only enable routing source locations when using routes command

### DIFF
--- a/actionpack/lib/action_dispatch/railtie.rb
+++ b/actionpack/lib/action_dispatch/railtie.rb
@@ -68,8 +68,6 @@ module ActionDispatch
       config.action_dispatch.always_write_cookie = Rails.env.development? if config.action_dispatch.always_write_cookie.nil?
       ActionDispatch::Cookies::CookieJar.always_write_cookie = config.action_dispatch.always_write_cookie
 
-      ActionDispatch::Routing::Mapper.route_source_locations = Rails.env.development?
-
       ActionDispatch::Http::Cache::Request.strict_freshness = app.config.action_dispatch.strict_freshness
       ActionDispatch.test_app = app
     end

--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -6,6 +6,7 @@ require "active_support/core_ext/hash/slice"
 require "active_support/core_ext/enumerable"
 require "active_support/core_ext/array/extract_options"
 require "active_support/core_ext/regexp"
+require "action_dispatch/routing"
 require "action_dispatch/routing/redirection"
 require "action_dispatch/routing/endpoint"
 

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Enable tracking route source locations only when using routes command. Previously,
+    it was enabled in development mode, but is only needed for `bin/rails routes -E`.
+
+    *Gannon McGibbon*
+
 *   Deprecate `bin/rake stats` in favor of `bin/rails stats`.
 
     *Juan Vásquez*

--- a/railties/lib/rails/commands/routes/routes_command.rb
+++ b/railties/lib/rails/commands/routes/routes_command.rb
@@ -22,6 +22,8 @@ module Rails
 
       desc "routes", "List all the defined routes"
       def perform(*)
+        require "action_dispatch/routing/mapper"
+        ActionDispatch::Routing::Mapper.route_source_locations = true
         boot_application!
         require "action_dispatch/routing/inspector"
 

--- a/railties/test/commands/routes_test.rb
+++ b/railties/test/commands/routes_test.rb
@@ -403,6 +403,12 @@ rails_conductor_inbound_email_incinerate POST /rails/conductor/action_mailbox/:i
     assert_includes(output, "No unused routes found.")
   end
 
+  test "route source locations aren't included when booted normally" do
+    output = rails "runner", "print !!ActionDispatch::Routing::Mapper.route_source_locations"
+
+    assert_equal("false", output)
+  end
+
   private
     def run_routes_command(args = [])
       rails "routes", args


### PR DESCRIPTION
The overhead isn't necessary for development when not using the routes command. We can omit it entirely by checking for existence of the routes command constant.

### Motivation / Background

Here's a quick benchmark:
```rb
# frozen_string_literal: true

require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"

  gem "rails", path: "."
  gem "benchmark-ips"
end

require "benchmark/ips"
require "action_controller/railtie"

class TestApp < Rails::Application
  config.root = __dir__
  config.hosts << "example.org"
  config.secret_key_base = "secret_key_base"

  config.logger = Logger.new($stdout)
  Rails.logger  = config.logger
  config.eager_load = true
end

Rails.application.initialize!

Benchmark.ips do |x|
  x.report("draw") do
    Rails.application.routes.draw do
      300.times.each do |n|
        get "/#{n}", to: "a#a"
      end
    end
    Rails.application.instance_variable_set(:@routes, nil)
  end
end
```

Before:
```
ruby 3.3.1 (2024-04-23 revision c56cd86388) [arm64-darwin23]
Warming up --------------------------------------
                draw     8.000 i/100ms
Calculating -------------------------------------
                draw     85.752 (± 2.3%) i/s -    432.000 in   5.040986s
```
After:
```
ruby 3.3.1 (2024-04-23 revision c56cd86388) [arm64-darwin23]
Warming up --------------------------------------
                draw     9.000 i/100ms
Calculating -------------------------------------
                draw    101.938 (± 2.0%) i/s -    513.000 in   5.034786s
```

Marginally quicker. With a larger app, this shaves off around 50-100ms of draw time.

### Detail

This Pull Request changes `ActionDispatch::Routing::Mapper.route_source_locations` to true only when routing command if defined.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
