### PR TITLE
[Fix #52304] Avoid computing `klass` if reflection is a `belongs_to` in `ActiveRecord::AutosaveAssociation#inverse_belongs_to_association_for`

### DIFF
--- a/activerecord/lib/active_record/autosave_association.rb
+++ b/activerecord/lib/active_record/autosave_association.rb
@@ -467,7 +467,8 @@ module ActiveRecord
       end
 
       def inverse_belongs_to_association_for(reflection, record)
-        reflection.inverse_of &&
+        !reflection.belongs_to? &&
+          reflection.inverse_of &&
           reflection.inverse_of.belongs_to? &&
           record.association(reflection.inverse_of.name)
       end

--- a/activerecord/test/cases/autosave_association_test.rb
+++ b/activerecord/test/cases/autosave_association_test.rb
@@ -305,7 +305,7 @@ class TestDefaultAutosaveAssociationOnAHasOneAssociation < ActiveRecord::TestCas
   end
 
   def test_callbacks_on_child_when_parent_autosaves_child
-    eye = Eye.create(iris: Iris.new)
+    eye = Eye.create!(iris: Iris.new)
     assert_equal 1, eye.iris.before_validation_callbacks_counter
     assert_equal 1, eye.iris.before_create_callbacks_counter
     assert_equal 1, eye.iris.before_save_callbacks_counter
@@ -314,14 +314,34 @@ class TestDefaultAutosaveAssociationOnAHasOneAssociation < ActiveRecord::TestCas
     assert_equal 1, eye.iris.after_save_callbacks_counter
   end
 
+  def test_callbacks_on_child_when_parent_autosaves_polymorphic_child_with_inverse_of
+    drink_designer = DrinkDesigner.create!(chef: ChefWithPolymorphicInverseOf.new)
+    assert_equal 1, drink_designer.chef.before_validation_callbacks_counter
+    assert_equal 1, drink_designer.chef.before_create_callbacks_counter
+    assert_equal 1, drink_designer.chef.before_save_callbacks_counter
+    assert_equal 1, drink_designer.chef.after_validation_callbacks_counter
+    assert_equal 1, drink_designer.chef.after_create_callbacks_counter
+    assert_equal 1, drink_designer.chef.after_save_callbacks_counter
+  end
+
   def test_callbacks_on_child_when_child_autosaves_parent
-    iris = Iris.create(eye: Eye.new)
+    iris = Iris.create!(eye: Eye.new)
     assert_equal 1, iris.before_validation_callbacks_counter
     assert_equal 1, iris.before_create_callbacks_counter
     assert_equal 1, iris.before_save_callbacks_counter
     assert_equal 1, iris.after_validation_callbacks_counter
     assert_equal 1, iris.after_create_callbacks_counter
     assert_equal 1, iris.after_save_callbacks_counter
+  end
+
+  def test_callbacks_on_child_when_polymorphic_child_with_inverse_of_autosaves_parent
+    chef = ChefWithPolymorphicInverseOf.create!(employable: DrinkDesigner.new)
+    assert_equal 1, chef.before_validation_callbacks_counter
+    assert_equal 1, chef.before_create_callbacks_counter
+    assert_equal 1, chef.before_save_callbacks_counter
+    assert_equal 1, chef.after_validation_callbacks_counter
+    assert_equal 1, chef.after_create_callbacks_counter
+    assert_equal 1, chef.after_save_callbacks_counter
   end
 
   def test_foreign_key_attribute_is_not_set_unless_changed

--- a/activerecord/test/models/chef.rb
+++ b/activerecord/test/models/chef.rb
@@ -8,3 +8,55 @@ end
 class ChefList < Chef
   belongs_to :employable_list, polymorphic: true
 end
+
+class ChefWithPolymorphicInverseOf < Chef
+  attr_reader :before_validation_callbacks_counter
+  attr_reader :before_create_callbacks_counter
+  attr_reader :before_save_callbacks_counter
+
+  attr_reader :after_validation_callbacks_counter
+  attr_reader :after_create_callbacks_counter
+  attr_reader :after_save_callbacks_counter
+
+  belongs_to :employable, polymorphic: true, inverse_of: :chef
+  accepts_nested_attributes_for :employable
+
+  before_validation :update_before_validation_counter
+  before_create :update_before_create_counter
+  before_save :update_before_save_counter
+
+  after_validation :update_after_validation_counter
+  after_create :update_after_create_counter
+  after_save :update_after_save_counter
+
+  private
+    def update_before_validation_counter
+      @before_validation_callbacks_counter ||= 0
+      @before_validation_callbacks_counter += 1
+    end
+
+    def update_before_create_counter
+      @before_create_callbacks_counter ||= 0
+      @before_create_callbacks_counter += 1
+    end
+
+    def update_before_save_counter
+      @before_save_callbacks_counter ||= 0
+      @before_save_callbacks_counter += 1
+    end
+
+    def update_after_validation_counter
+      @after_validation_callbacks_counter ||= 0
+      @after_validation_callbacks_counter += 1
+    end
+
+    def update_after_create_counter
+      @after_create_callbacks_counter ||= 0
+      @after_create_callbacks_counter += 1
+    end
+
+    def update_after_save_counter
+      @after_save_callbacks_counter ||= 0
+      @after_save_callbacks_counter += 1
+    end
+end

--- a/activerecord/test/models/drink_designer.rb
+++ b/activerecord/test/models/drink_designer.rb
@@ -2,6 +2,7 @@
 
 class DrinkDesigner < ActiveRecord::Base
   has_one :chef, as: :employable
+  accepts_nested_attributes_for :chef
 end
 
 class DrinkDesignerWithPolymorphicDependentNullifyChef < ActiveRecord::Base


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

Fixes https://github.com/rails/rails/issues/52304
Ref: https://github.com/rails/rails/pull/49847

### Detail

Adds a condition in `ActiveRecord::AutosaveAssociation#inverse_belongs_to_association_for` to return early if the current reflection is a `belongs_to`, as the inverse can't possibly be a `belongs_to` as well. This then ensures that polymorphic `belongs_to` reflections don't have their class computed which raises an error like the one in the linked issue (see https://github.com/rails/rails/pull/31895 for why this happens).

An alternative fix, specifically for the linked issue is to simply return if `reflection.polymorphic?`, but imo what I've currently got is better since it handles non-polymorphic cases as well, and will short circuit in all cases where the inverse logic is not applicable.

**Edit:** Some more context in https://github.com/rails/rails/pull/52305#issuecomment-2222227506

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.