### PR TITLE
Fix a flaky Active Record instrumentation test

### DIFF
--- a/activerecord/test/cases/instrumentation_test.rb
+++ b/activerecord/test/cases/instrumentation_test.rb
@@ -173,7 +173,7 @@ module ActiveRecord
     end
 
     def test_no_instantiation_notification_when_no_records
-      author = Author.create!(name: "David")
+      author = Author.create!(id: 100, name: "David")
 
       called = false
       subscriber = ActiveSupport::Notifications.subscribe("instantiation.active_record") do


### PR DESCRIPTION
Fixes a flaky test reported at https://github.com/rails/rails/pull/52272#issuecomment-2221950160

The problem was that when we created a new author in the test, it was created with id=1 and we already had some book fixtures already loaded for this author id.

cc @skipkayhil 