### PR TITLE
Update PostgreSQLAdapter#extensions to include schema name

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,24 @@
+*   Include schema name in `enable_extension` statements in `db/schema.rb`.
+
+    The schema dumper will now include the schema name in generated
+    `enable_extension` statements if they differ from the current schema.
+
+    For example, if you have a migration:
+
+    ```ruby
+    enable_extension "heroku_ext.pgcrypto"
+    enable_extension "pg_stat_statements"
+    ```
+
+    then the generated schema dump will also contain:
+
+    ```ruby
+    enable_extension "heroku_ext.pgcrypto"
+    enable_extension "pg_stat_statements"
+    ```
+
+    *Tony Novak*
+
 *   Fix `ActiveRecord::Encryption::EncryptedAttributeType#type` to return
     actual cast type.
 

--- a/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
@@ -561,6 +561,24 @@ module ActiveRecord
         @connection.execute("DROP DOMAIN example_type")
       end
 
+      def test_extensions_omits_current_schema_name
+        @connection.execute("DROP EXTENSION IF EXISTS hstore")
+        @connection.execute("CREATE SCHEMA customschema")
+        @connection.execute("CREATE EXTENSION hstore SCHEMA customschema")
+        assert_includes @connection.extensions, "customschema.hstore"
+      ensure
+        @connection.execute("DROP SCHEMA IF EXISTS customschema CASCADE")
+        @connection.execute("DROP EXTENSION IF EXISTS hstore")
+      end
+
+      def test_extensions_includes_non_current_schema_name
+        @connection.execute("DROP EXTENSION IF EXISTS hstore")
+        @connection.execute("CREATE EXTENSION hstore")
+        assert_includes @connection.extensions, "hstore"
+      ensure
+        @connection.execute("DROP EXTENSION IF EXISTS hstore")
+      end
+
       def test_ignores_warnings_when_behaviour_ignore
         with_db_warnings_action(:ignore) do
           # libpq prints a warning to stderr from C, so we need to stub


### PR DESCRIPTION
This allows the schema dumper's generated `enable_extension` statements
to include the schema name, if different from `current_schema`.

### Motivation / Background

Fixes #52312.

When extensions are created within a specific schema, the `enable_extension` statement generated by the schema dumper should include the schema name.

### Detail

See #52312

### Additional information

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
