### PR TITLE
Update engines.md: use article :references instead of article_id :integer in Comment model generator [ci skip]

### DIFF
--- a/guides/source/engines.md
+++ b/guides/source/engines.md
@@ -440,11 +440,11 @@ model, a comment controller, and then modify the articles scaffold to display
 comments and allow people to create new ones.
 
 From the engine root, run the model generator. Tell it to generate a
-`Comment` model, with the related table having two columns: an `article_id` integer
-and `text` text column.
+`Comment` model, with the related table having two columns: an `article` references
+column and `text` text column.
 
 ```bash
-$ bin/rails generate model Comment article_id:integer text:text
+$ bin/rails generate model Comment article:references text:text
 ```
 
 This will output the following:


### PR DESCRIPTION
For Comment model generator, use article:references instead of article_id:integer


### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created because the engines.md documentation uses an `article_id:integer` column in its Comment model generator instead of an `article:references` column.

### Detail

This Pull Request changes `article_id:integer` column to `article:references` column in the example Comment model generator and updates the explanatory text to match.


### Checklist

Before submitting the PR make sure the following are checked:

* [ x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [ x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ x] Tests are added or updated if you fix a bug or add a feature.
* [ x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
