### PR TITLE
Update engines.md with step needed to install engine in test application [ci skip]

### DIFF
--- a/guides/source/engines.md
+++ b/guides/source/engines.md
@@ -624,8 +624,8 @@ there isn't an application handy to test this out in, generate one using the
 $ rails new unicorn
 ```
 
-Usually, specifying the engine inside the `Gemfile` would be done by specifying it
-as a normal, everyday gem.
+Usually, specifying the engine inside the `unicorn` application's `Gemfile` would 
+be done by specifying it as a normal, everyday gem.
 
 ```ruby
 gem "devise"
@@ -638,6 +638,7 @@ you will need to specify the `:path` option in your `Gemfile`:
 gem "blorgh", path: "engines/blorgh"
 ```
 
+Create an `engines` directory inside `unicorn` and copy the `blorgh` engine into it.  
 Then run `bundle` to install the gem.
 
 As described earlier, by placing the gem in the `Gemfile` it will be loaded when


### PR DESCRIPTION
Documentation doesn't mention that blorgh needs to be copied into unicorn/engines/blorgh. Fix to include that step.

<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

This Pull Request has been created because the instructions to install the engine `blorgh` into the sample application `unicorn` is missing the step of copying `blorgh` into `unicorn/engines/`.

### Detail

This Pull Request adds the step of copying `blorgh` into `unicorn/engines/` before running `bundle`.


### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [X] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
