### PR TITLE
Deprecate ActiveRecord::ImmutableRelation

### DIFF
--- a/activerecord/lib/active_record/errors.rb
+++ b/activerecord/lib/active_record/errors.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
+require "active_support/deprecation"
+
 module ActiveRecord
+  include ActiveSupport::Deprecation::DeprecatedConstantAccessor
+
   # = Active Record Errors
   #
   # Generic Active Record exception class.
@@ -476,10 +480,15 @@ module ActiveRecord
   #   relation.loaded? # => true
   #
   #   # Methods which try to mutate a loaded relation fail.
-  #   relation.where!(title: 'TODO')  # => ActiveRecord::ImmutableRelation
-  #   relation.limit!(5)              # => ActiveRecord::ImmutableRelation
-  class ImmutableRelation < ActiveRecordError
+  #   relation.where!(title: 'TODO')  # => ActiveRecord::UnmodifiableRelation
+  #   relation.limit!(5)              # => ActiveRecord::UnmodifiableRelation
+  class UnmodifiableRelation < ActiveRecordError
   end
+  deprecate_constant(
+    :ImmutableRelation,
+    "ActiveRecord::UnmodifiableRelation",
+    deprecator: ActiveRecord.deprecator
+  )
 
   # TransactionIsolationError will be raised under the following conditions:
   #

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -174,7 +174,7 @@ module ActiveRecord
         end                                    # end
 
         def #{method_name}=(value)             # def includes_values=(value)
-          assert_mutability!                   #   assert_mutability!
+          assert_modifiable!                   #   assert_modifiable!
           @values[:#{name}] = value            #   @values[:includes] = value
         end                                    # end
       CODE
@@ -814,7 +814,7 @@ module ActiveRecord
           if !VALID_UNSCOPING_VALUES.include?(scope)
             raise ArgumentError, "Called unscope() with invalid unscoping argument ':#{scope}'. Valid arguments are :#{VALID_UNSCOPING_VALUES.to_a.join(", :")}."
           end
-          assert_mutability!
+          assert_modifiable!
           @values.delete(scope)
         when Hash
           scope.each do |key, target_value|
@@ -1723,8 +1723,8 @@ module ActiveRecord
         )
       end
 
-      def assert_mutability!
-        raise ImmutableRelation if @loaded || @arel
+      def assert_modifiable!
+        raise UnmodifiableRelation if @loaded || @arel
       end
 
       def build_arel(connection, aliases = nil)

--- a/activerecord/test/cases/errors_test.rb
+++ b/activerecord/test/cases/errors_test.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "cases/helper"
+require "active_record/errors"
 
 class ErrorsTest < ActiveRecord::TestCase
   def test_can_be_instantiated_with_no_args
@@ -13,6 +14,13 @@ class ErrorsTest < ActiveRecord::TestCase
       rescue ArgumentError
         raise "Instance of #{error_klass} can't be initialized with no arguments"
       end
+    end
+  end
+
+  def test_active_record_immutable_relation_deprecation
+    expected_message = "ActiveRecord::ImmutableRelation is deprecated! Use ActiveRecord::UnmodifiableRelation instead"
+    assert_deprecated(expected_message, ActiveRecord.deprecator) do
+      assert_same ActiveRecord::UnmodifiableRelation, ActiveRecord::ImmutableRelation
     end
   end
 end

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -2057,7 +2057,7 @@ class RelationTest < ActiveRecord::TestCase
     relation = Post.all
     relation.to_a
 
-    assert_raises(ActiveRecord::ImmutableRelation) do
+    assert_raises(ActiveRecord::UnmodifiableRelation) do
       relation.where! "foo"
     end
   end
@@ -2066,7 +2066,7 @@ class RelationTest < ActiveRecord::TestCase
     relation = Post.all
     relation.to_a
 
-    assert_raises(ActiveRecord::ImmutableRelation) do
+    assert_raises(ActiveRecord::UnmodifiableRelation) do
       relation.limit! 5
     end
   end
@@ -2075,7 +2075,7 @@ class RelationTest < ActiveRecord::TestCase
     relation = Post.all
     relation.to_a
 
-    assert_raises(ActiveRecord::ImmutableRelation) do
+    assert_raises(ActiveRecord::UnmodifiableRelation) do
       relation.merge! where: "foo"
     end
   end
@@ -2084,7 +2084,7 @@ class RelationTest < ActiveRecord::TestCase
     relation = Post.all
     relation.to_a
 
-    assert_raises(ActiveRecord::ImmutableRelation) do
+    assert_raises(ActiveRecord::UnmodifiableRelation) do
       relation.extending! Module.new
     end
   end
@@ -2093,8 +2093,8 @@ class RelationTest < ActiveRecord::TestCase
     relation = Post.all
     relation.arel
 
-    assert_raises(ActiveRecord::ImmutableRelation) { relation.limit!(5) }
-    assert_raises(ActiveRecord::ImmutableRelation) { relation.where!("1 = 2") }
+    assert_raises(ActiveRecord::UnmodifiableRelation) { relation.limit!(5) }
+    assert_raises(ActiveRecord::UnmodifiableRelation) { relation.where!("1 = 2") }
   end
 
   test "relations show the records in #inspect" do


### PR DESCRIPTION
We want to reserve the constant `ActiveRecord::ImmutableRelation` for a stronger forthcoming feature.

This patch renames it as `ActiveRecord::UnmodifiableRelation`. The meaning is close, it has to be, but I hope it won't be confusing in practice because, typically, this exception is not referenced in client code.

After merging this I'll cherry-pick to `7-2-stable`, write a CHANGELOG entry there, and remove the deprecated constant in `main`.