### PR TITLE
Fix loaded relation batching with limits and reverse order

### DIFF
--- a/activerecord/lib/active_record/relation/batches.rb
+++ b/activerecord/lib/active_record/relation/batches.rb
@@ -341,7 +341,13 @@ module ActiveRecord
 
         if start || finish
           records = records.filter do |record|
-            (start.nil? || record.id >= start) && (finish.nil? || record.id <= finish)
+            id = record.id
+
+            if order == :asc
+              (start.nil? || id >= start) && (finish.nil? || id <= finish)
+            else
+              (start.nil? || id <= start) && (finish.nil? || id >= finish)
+            end
           end
         end
 

--- a/activerecord/test/cases/batches_test.rb
+++ b/activerecord/test/cases/batches_test.rb
@@ -506,6 +506,23 @@ class EachTest < ActiveRecord::TestCase
     assert_equal posts.size - 2, batch_count
   end
 
+  def test_in_batches_when_loaded_runs_no_queries_with_start_and_end_arguments_and_reverse_order
+    posts = Post.all.order(id: :asc)
+    posts.load
+    batch_count = 0
+
+    start_id = posts.map(&:id)[-2]
+    finish_id = posts.map(&:id)[1]
+    assert_queries_count(0) do
+      posts.in_batches(of: 1, start: start_id, finish: finish_id, order: :desc) do |relation|
+        batch_count += 1
+        assert_kind_of ActiveRecord::Relation, relation
+      end
+    end
+
+    assert_equal posts.size - 2, batch_count
+  end
+
   def test_in_batches_when_loaded_can_return_an_enum
     posts = Post.all
     posts.load


### PR DESCRIPTION
If we have records with ids = [1,2,3,4,5,6,7,8,9,10] and we iterate in reverse order and provide limits (e.g. `start: 9` and `finish: 2`), it will not return any results, because conditions are not correctly constructed to select the proper records.

I also noticed, that in https://github.com/rails/rails/pull/48876 (cc @HParker) support for composite primary keys was not added to `batch_on_loaded_relation`. But adding this will make the code sooooo much ugly.   