### PR TITLE
Add not-null modifier to migrations

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,25 @@
+*   Add not-null type modifier to migration attributes.
+
+
+    # Generating with...
+    bin/rails generate migration CreateUsers email_address:string!:uniq password_digest:string!
+
+    # Produces:
+    class CreateUsers < ActiveRecord::Migration[8.0]
+      def change
+        create_table :users do |t|
+          t.string :email_address, null: false
+          t.string :password_digest, null: false
+
+          t.timestamps
+        end
+        add_index :users, :email_address, unique: true
+      end
+    end
+
+
+    *DHH*
+
 *   Deprecate `bin/rake stats` in favor of `bin/rails stats`.
 
     *Juan Vásquez*

--- a/railties/lib/rails/generators/generated_attribute.rb
+++ b/railties/lib/rails/generators/generated_attribute.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "active_support/time"
+require "active_support/core_ext/string/starts_ends_with"
 
 module Rails
   module Generators
@@ -102,7 +103,7 @@ module Rails
               parsed_type, parsed_options = type&.remove("!"), {}
             end
 
-            if type =~ /!$/
+            if type.ends_with?("!")
               parsed_options[:null] = false
             end
 

--- a/railties/lib/rails/generators/generated_attribute.rb
+++ b/railties/lib/rails/generators/generated_attribute.rb
@@ -89,20 +89,24 @@ module Rails
           def parse_type_and_options(type)
             case type
             when /(text|binary)\{([a-z]+)\}/
-              return $1, size: $2.to_sym
+              parsed_type, parsed_options = $1, { size: $2.to_sym }
             when /(string|text|binary|integer)\{(\d+)\}/
-              return $1, limit: $2.to_i
+              parsed_type, parsed_options = $1, { limit: $2.to_i }
             when /decimal\{(\d+)[,.-](\d+)\}/
-              return :decimal, precision: $1.to_i, scale: $2.to_i
+              parsed_type, parsed_options = :decimal, { precision: $1.to_i, scale: $2.to_i }
             when /(references|belongs_to)\{(.+)\}/
-              type = $1
+              parsed_type = $1
               provided_options = $2.split(/[,.-]/)
-              options = Hash[provided_options.map { |opt| [opt.to_sym, true] }]
-
-              return type, options
+              parsed_options = Hash[provided_options.map { |opt| [opt.to_sym, true] }]
             else
-              return type, {}
+              parsed_type, parsed_options = type&.remove("!"), {}
             end
+
+            if type =~ /!$/
+              parsed_options[:null] = false
+            end
+
+            return parsed_type, parsed_options
           end
       end
 

--- a/railties/lib/rails/generators/generated_attribute.rb
+++ b/railties/lib/rails/generators/generated_attribute.rb
@@ -103,7 +103,7 @@ module Rails
               parsed_type, parsed_options = type&.remove("!"), {}
             end
 
-            if type.ends_with?("!")
+            if type&.ends_with?("!")
               parsed_options[:null] = false
             end
 

--- a/railties/test/generators/migration_generator_test.rb
+++ b/railties/test/generators/migration_generator_test.rb
@@ -455,6 +455,29 @@ class MigrationGeneratorTest < Rails::Generators::TestCase
     end
   end
 
+  def test_create_table_migration_with_required_attributes
+    run_generator ["create_books", "title:string!", "content:text!"]
+    assert_migration "db/migrate/create_books.rb" do |content|
+      assert_method :change, content do |change|
+        assert_match(/create_table :books/, change)
+        assert_match(/  t\.string :title, null: false/, change)
+        assert_match(/  t\.text :content, null: false/, change)
+      end
+    end
+  end
+
+  def test_add_migration_with_required_attributes
+    migration = "add_title_body_to_posts"
+    run_generator [migration, "title:string!", "body:text!"]
+
+    assert_migration "db/migrate/#{migration}.rb" do |content|
+      assert_method :change, content do |change|
+        assert_match(/add_column :posts, :title, :string, null: false/, change)
+        assert_match(/add_column :posts, :body, :text, null: false/, change)
+      end
+    end
+  end
+
   private
     def with_singular_table_name
       old_state = ActiveRecord::Base.pluralize_table_names


### PR DESCRIPTION
    # Generating with...
    bin/rails generate migration CreateUsers email_address:string!:uniq password_digest:string!

    # Produces:
    class CreateUsers < ActiveRecord::Migration[8.0]
      def change
        create_table :users do |t|
          t.string :email_address, null: false
          t.string :password_digest, null: false

          t.timestamps
        end
        add_index :users, :email_address, unique: true
      end
    end