### PR TITLE
Fix loaded relation batching for models with composite primary keys

### DIFF
--- a/activerecord/test/cases/batches_test.rb
+++ b/activerecord/test/cases/batches_test.rb
@@ -538,6 +538,25 @@ class EachTest < ActiveRecord::TestCase
     assert_equal posts.size, batch_count
   end
 
+  def test_in_batches_when_loaded_runs_no_queries_when_batching_over_cpk_model
+    incorrectly_sorted_orders = Cpk::Order.order(shop_id: :asc, id: :desc)
+    incorrectly_sorted_orders.load
+
+    correctly_sorted_orders = Cpk::Order.order(shop_id: :desc, id: :asc).to_a
+    expected_orders = correctly_sorted_orders[1..-2]
+    start_id = expected_orders.first.id
+    finish_id = expected_orders.last.id
+    orders = []
+
+    assert_no_queries do
+      incorrectly_sorted_orders.find_each(batch_size: 1, start: start_id, finish: finish_id, order: [:desc, :asc]) do |order|
+        orders << order
+      end
+    end
+
+    assert_equal expected_orders, orders
+  end
+
   def test_in_batches_should_return_relations
     assert_queries_count(@total + 1) do
       Post.in_batches(of: 1) do |relation|


### PR DESCRIPTION
Follow up to #48876 (cc @HParker).

In https://github.com/rails/rails/pull/52322 I discovered, that support for composite primary keys was not added to `batch_on_loaded_relation` in #48876.