### PR TITLE
Add `current.rb` by default

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add `models/current.rb` to Rails new generator
+
+    *Dino Maric*
+
 *   Deprecate `bin/rake stats` in favor of `bin/rails stats`.
 
     *Juan Vásquez*

--- a/railties/lib/rails/generators/rails/app/templates/app/models/current.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/app/models/current.rb.tt
@@ -1,0 +1,3 @@
+class Current < ActiveSupport::CurrentAttributes
+  # Easy to access global, per-request attributes (https://api.rubyonrails.org/classes/ActiveSupport/CurrentAttributes.html)
+end

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -28,6 +28,7 @@ DEFAULT_APP_FILES = %w(
   app/mailers/application_mailer.rb
   app/models/application_record.rb
   app/models/concerns/.keep
+  app/models/current.rb
   app/views/layouts/application.html.erb
   app/views/layouts/mailer.html.erb
   app/views/layouts/mailer.text.erb

--- a/railties/test/generators/plugin_generator_test.rb
+++ b/railties/test/generators/plugin_generator_test.rb
@@ -36,6 +36,7 @@ DEFAULT_PLUGIN_FILES = %w(
   test/dummy/app/mailers/application_mailer.rb
   test/dummy/app/models/application_record.rb
   test/dummy/app/models/concerns/.keep
+  test/dummy/app/models/current.rb
   test/dummy/app/views/layouts/application.html.erb
   test/dummy/app/views/layouts/mailer.html.erb
   test/dummy/app/views/layouts/mailer.text.erb


### PR DESCRIPTION
Since the introduction of current attributes I didn't start any new rails project without adding this file.
From my perspective it feels that this needs to be created when creating new rails app.