### PR TITLE
Add script folder and generator

### DIFF
--- a/guides/source/getting_started.md
+++ b/guides/source/getting_started.md
@@ -187,6 +187,7 @@ of the files and folders that Rails creates by default:
 |public/|Contains static files and compiled assets. When your app is running, this directory will be exposed as-is.|
 |Rakefile|This file locates and loads tasks that can be run from the command line. The task definitions are defined throughout the components of Rails. Rather than changing `Rakefile`, you should add your own tasks by adding files to the `lib/tasks` directory of your application.|
 |README.md|This is a brief instruction manual for your application. You should edit this file to tell others what your application does, how to set it up, and so on.|
+|script/|Contains one-off or general purpose [scripts](https://github.com/rails/rails/blob/main/railties/lib/rails/generators/rails/script/USAGE) and [benchmarks](https://github.com/rails/rails/blob/main/railties/lib/rails/generators/rails/benchmark/USAGE).|
 |storage/|Active Storage files for Disk Service. This is covered in [Active Storage Overview](active_storage_overview.html).|
 |test/|Unit tests, fixtures, and other test apparatus. These are covered in [Testing Rails Applications](testing.html).|
 |tmp/|Temporary files (like cache and pid files).|

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,18 @@
+*   Add script folder and generator
+
+    Add a new script default folder to hold your one-off or general purpose
+    scripts, such as data migration scripts, cleanup scripts, etc.
+
+    A new script generator allows you to create such scripts:
+
+      `rails generate script my_script`
+
+    You can run the generated script using:
+
+      `ruby script/my_script.rb`
+
+    *Jerome Dalbert*, *Haroon Ahmed*
+
 *   Enable tracking route source locations only when using routes command. Previously,
     it was enabled in development mode, but is only needed for `bin/rails routes -E`.
 

--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -232,6 +232,10 @@ module Rails
       directory "public", "public", recursive: false
     end
 
+    def script
+      empty_directory_with_keep_file "script"
+    end
+
     def storage
       empty_directory_with_keep_file "storage"
       empty_directory_with_keep_file "tmp/storage"
@@ -443,6 +447,11 @@ module Rails
 
       def create_public_files
         build(:public_directory)
+      end
+
+      def create_script_folder
+        return if options[:dummy_app]
+        build(:script)
       end
 
       def create_tmp_files

--- a/railties/lib/rails/generators/rails/script/USAGE
+++ b/railties/lib/rails/generators/rails/script/USAGE
@@ -1,0 +1,18 @@
+Description:
+    Generate a one-off or general purpose script, such as a data migration
+    script, cleanup script, etc.
+
+Example:
+    `bin/rails generate script my_script`
+
+    This will create:
+        script/my_script.rb
+
+    You can run the script using:
+        `ruby script/my_script.rb`
+
+    You can specify a folder:
+        `bin/rails generate script cleanup/my_script`
+
+    This will create:
+        script/cleanup/my_script.rb

--- a/railties/lib/rails/generators/rails/script/script_generator.rb
+++ b/railties/lib/rails/generators/rails/script/script_generator.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require "rails/generators/named_base"
+
+module Rails
+  module Generators
+    class ScriptGenerator < NamedBase
+      def generate_script
+        template("script.rb.tt", "script/#{file_path}.rb")
+      end
+
+      private
+        def depth
+          class_path.size + 1
+        end
+    end
+  end
+end

--- a/railties/lib/rails/generators/rails/script/templates/script.rb.tt
+++ b/railties/lib/rails/generators/rails/script/templates/script.rb.tt
@@ -1,0 +1,3 @@
+require_relative "<%= '../' * depth %>config/environment"
+
+# Your code goes here

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -70,6 +70,7 @@ DEFAULT_APP_FILES = %w(
   public/icon.png
   public/icon.svg
   public/robots.txt
+  script/.keep
   storage/.keep
   test/application_system_test_case.rb
   test/channels/application_cable/connection_test.rb
@@ -1048,6 +1049,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
       lib/tasks
       lib/assets
       log
+      script
       test/fixtures/files
       test/controllers
       test/mailers

--- a/railties/test/generators/script_generator_test.rb
+++ b/railties/test/generators/script_generator_test.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "generators/generators_test_helper"
+require "rails/generators/rails/script/script_generator"
+
+module Rails
+  module Generators
+    class ScriptGeneratorTest < Rails::Generators::TestCase
+      include GeneratorsTestHelper
+
+      def test_generate_script
+        run_generator ["my_script"]
+
+        assert_file "script/my_script.rb" do |script|
+          assert_match('require_relative "../config/environment"', script)
+        end
+      end
+
+      def test_generate_script_with_folder
+        run_generator ["my_folder/my_script"]
+
+        assert_file "script/my_folder/my_script.rb" do |script|
+          assert_match('require_relative "../../config/environment"', script)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
New attempt at addressing [this discussion](https://discuss.rubyonrails.org/t/is-there-any-official-way-to-organize-one-off-scripts/74186) after https://github.com/rails/rails/pull/39552 fell through the cracks.

### Motivation / Background

This Pull Request has been created because it is currently not clear where to put one-off scripts, and DHH has expressed [support](https://discuss.rubyonrails.org/t/is-there-any-official-way-to-organize-one-off-scripts/74186/12) for bringing back `script/` as a default directory.

### Detail

This Pull Request changes the Rails app generator to create a new script default directory that can hold one-off scripts, data migration scripts, cleanup scripts, benchmark scripts, etc. This PR also adds a basic script generator to create such scripts.

### Additional information

- I added a script generator to this PR because:

  - there seemed to be [some support](https://github.com/rails/rails/pull/39552#issuecomment-1561969529) for it.
  - a new script directory and/or a generator seem to go hand in hand.
  - only adding a script directory with a small mention in the Getting Started guide feels a little bare. It is a good start (since it is [not clear](https://github.com/rails/rails/pull/39552#issuecomment-641614879) where else it could be documented in the guides), but adding a new generator can be an additional indirect way to document how this new directory can be used.

  I can remove the generator from this PR if it is not deemed useful. Conversely, I can keep the generator and remove the default empty script folder if only a generator is preferred.

- I think most people are interested in ruby scripts so I didn't add an option to generate bash scripts, but I can add one if needed.

- PR [39552](https://github.com/rails/rails/pull/39552) didn't go through and @hahmed expressed interest in someone else taking over, so we will see if this PR gets better luck.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
