### PR TITLE
Simplify FileUpdateCheckerSharedTests

### DIFF
--- a/activesupport/test/file_update_checker_shared_tests.rb
+++ b/activesupport/test/file_update_checker_shared_tests.rb
@@ -3,277 +3,273 @@
 require "fileutils"
 
 module FileUpdateCheckerSharedTests
-  def self.included(kls)
-    kls.class_eval do
-      extend ActiveSupport::Testing::Declarative
+  extend ActiveSupport::Testing::Declarative
 
-      def tmpdir
-        @tmpdir
-      end
+  def tmpdir
+    @tmpdir
+  end
 
-      def tmpfile(name)
-        File.join(tmpdir, name)
-      end
+  def tmpfile(name)
+    File.join(tmpdir, name)
+  end
 
-      def tmpfiles
-        @tmpfiles ||= %w(foo.rb bar.rb baz.rb).map { |f| tmpfile(f) }
-      end
+  def tmpfiles
+    @tmpfiles ||= %w(foo.rb bar.rb baz.rb).map { |f| tmpfile(f) }
+  end
 
-      def run(*args)
-        capture_exceptions do
-          Dir.mktmpdir(nil, __dir__) { |dir| @tmpdir = dir; super }
-        end
-      end
+  def run(*args)
+    capture_exceptions do
+      Dir.mktmpdir(nil, __dir__) { |dir| @tmpdir = dir; super }
+    end
+  end
 
-      test "should not execute the block if no paths are given" do
-        silence_warnings { require "listen" }
-        i = 0
+  test "should not execute the block if no paths are given" do
+    silence_warnings { require "listen" }
+    i = 0
 
-        checker = new_checker { i += 1 }
+    checker = new_checker { i += 1 }
 
-        assert_not checker.execute_if_updated
-        assert_equal 0, i
-      end
+    assert_not checker.execute_if_updated
+    assert_equal 0, i
+  end
 
-      test "should not execute the block if no files change" do
-        i = 0
+  test "should not execute the block if no files change" do
+    i = 0
 
-        FileUtils.touch(tmpfiles)
+    FileUtils.touch(tmpfiles)
 
-        checker = new_checker(tmpfiles) { i += 1 }
+    checker = new_checker(tmpfiles) { i += 1 }
 
-        assert_not checker.execute_if_updated
-        assert_equal 0, i
-      end
+    assert_not checker.execute_if_updated
+    assert_equal 0, i
+  end
 
-      test "should execute the block once when files are created" do
-        i = 0
+  test "should execute the block once when files are created" do
+    i = 0
 
-        checker = new_checker(tmpfiles) { i += 1 }
+    checker = new_checker(tmpfiles) { i += 1 }
 
-        touch(tmpfiles)
+    touch(tmpfiles)
 
-        assert checker.execute_if_updated
-        assert_equal 1, i
-      end
+    assert checker.execute_if_updated
+    assert_equal 1, i
+  end
 
-      test "should execute the block once when files are modified" do
-        i = 0
+  test "should execute the block once when files are modified" do
+    i = 0
 
-        FileUtils.touch(tmpfiles)
+    FileUtils.touch(tmpfiles)
 
-        checker = new_checker(tmpfiles) { i += 1 }
+    checker = new_checker(tmpfiles) { i += 1 }
 
-        touch(tmpfiles)
+    touch(tmpfiles)
 
-        assert checker.execute_if_updated
-        assert_equal 1, i
-      end
+    assert checker.execute_if_updated
+    assert_equal 1, i
+  end
 
-      test "should execute the block once when files are deleted" do
-        i = 0
+  test "should execute the block once when files are deleted" do
+    i = 0
 
-        FileUtils.touch(tmpfiles)
+    FileUtils.touch(tmpfiles)
 
-        checker = new_checker(tmpfiles) { i += 1 }
+    checker = new_checker(tmpfiles) { i += 1 }
 
-        rm_f(tmpfiles)
+    rm_f(tmpfiles)
 
-        assert checker.execute_if_updated
-        assert_equal 1, i
-      end
+    assert checker.execute_if_updated
+    assert_equal 1, i
+  end
 
-      test "updated should become true when watched files are created" do
-        i = 0
+  test "updated should become true when watched files are created" do
+    i = 0
 
-        checker = new_checker(tmpfiles) { i += 1 }
-        assert_not_predicate checker, :updated?
+    checker = new_checker(tmpfiles) { i += 1 }
+    assert_not_predicate checker, :updated?
 
-        touch(tmpfiles)
+    touch(tmpfiles)
 
-        assert_predicate checker, :updated?
-      end
+    assert_predicate checker, :updated?
+  end
 
-      test "updated should become true when watched files are modified" do
-        i = 0
+  test "updated should become true when watched files are modified" do
+    i = 0
 
-        FileUtils.touch(tmpfiles)
+    FileUtils.touch(tmpfiles)
 
-        checker = new_checker(tmpfiles) { i += 1 }
-        assert_not_predicate checker, :updated?
+    checker = new_checker(tmpfiles) { i += 1 }
+    assert_not_predicate checker, :updated?
 
-        touch(tmpfiles)
+    touch(tmpfiles)
 
-        assert_predicate checker, :updated?
-      end
+    assert_predicate checker, :updated?
+  end
 
-      test "updated should become true when watched files are deleted" do
-        i = 0
+  test "updated should become true when watched files are deleted" do
+    i = 0
 
-        FileUtils.touch(tmpfiles)
+    FileUtils.touch(tmpfiles)
 
-        checker = new_checker(tmpfiles) { i += 1 }
-        assert_not_predicate checker, :updated?
+    checker = new_checker(tmpfiles) { i += 1 }
+    assert_not_predicate checker, :updated?
 
-        rm_f(tmpfiles)
+    rm_f(tmpfiles)
 
-        assert_predicate checker, :updated?
-      end
+    assert_predicate checker, :updated?
+  end
 
-      test "should be robust to handle files with wrong modified time" do
-        i = 0
+  test "should be robust to handle files with wrong modified time" do
+    i = 0
 
-        FileUtils.touch(tmpfiles)
+    FileUtils.touch(tmpfiles)
 
-        now  = Time.now
-        time = Time.mktime(now.year + 1, now.month, now.day) # wrong mtime from the future
-        File.utime(time, time, tmpfiles[0])
+    now  = Time.now
+    time = Time.mktime(now.year + 1, now.month, now.day) # wrong mtime from the future
+    File.utime(time, time, tmpfiles[0])
 
-        checker = new_checker(tmpfiles) { i += 1 }
+    checker = new_checker(tmpfiles) { i += 1 }
 
-        touch(tmpfiles[1..-1])
+    touch(tmpfiles[1..-1])
 
-        assert checker.execute_if_updated
-        assert_equal 1, i
-      end
+    assert checker.execute_if_updated
+    assert_equal 1, i
+  end
 
-      test "should return max_time for files with mtime = Time.at(0)" do
-        i = 0
+  test "should return max_time for files with mtime = Time.at(0)" do
+    i = 0
 
-        FileUtils.touch(tmpfiles)
+    FileUtils.touch(tmpfiles)
 
-        time = Time.at(0) # wrong mtime from the future
-        File.utime(time, time, tmpfiles[0])
+    time = Time.at(0) # wrong mtime from the future
+    File.utime(time, time, tmpfiles[0])
 
-        checker = new_checker(tmpfiles) { i += 1 }
+    checker = new_checker(tmpfiles) { i += 1 }
 
-        touch(tmpfiles[1..-1])
+    touch(tmpfiles[1..-1])
 
-        assert checker.execute_if_updated
-        assert_equal 1, i
-      end
+    assert checker.execute_if_updated
+    assert_equal 1, i
+  end
 
-      test "should cache updated result until execute" do
-        i = 0
+  test "should cache updated result until execute" do
+    i = 0
 
-        checker = new_checker(tmpfiles) { i += 1 }
-        assert_not_predicate checker, :updated?
+    checker = new_checker(tmpfiles) { i += 1 }
+    assert_not_predicate checker, :updated?
 
-        touch(tmpfiles)
+    touch(tmpfiles)
 
-        assert_predicate checker, :updated?
-        checker.execute
-        assert_not_predicate checker, :updated?
-      end
+    assert_predicate checker, :updated?
+    checker.execute
+    assert_not_predicate checker, :updated?
+  end
 
-      test "should execute the block if files change in a watched directory one extension" do
-        i = 0
+  test "should execute the block if files change in a watched directory one extension" do
+    i = 0
 
-        checker = new_checker([], tmpdir => :rb) { i += 1 }
+    checker = new_checker([], tmpdir => :rb) { i += 1 }
 
-        touch(tmpfile("foo.rb"))
+    touch(tmpfile("foo.rb"))
 
-        assert checker.execute_if_updated
-        assert_equal 1, i
-      end
+    assert checker.execute_if_updated
+    assert_equal 1, i
+  end
 
-      test "should execute the block if files change in a watched directory any extensions" do
-        i = 0
+  test "should execute the block if files change in a watched directory any extensions" do
+    i = 0
 
-        checker = new_checker([], tmpdir => []) { i += 1 }
+    checker = new_checker([], tmpdir => []) { i += 1 }
 
-        touch(tmpfile("foo.rb"))
+    touch(tmpfile("foo.rb"))
 
-        assert checker.execute_if_updated
-        assert_equal 1, i
-      end
+    assert checker.execute_if_updated
+    assert_equal 1, i
+  end
 
-      test "should execute the block if files change in a watched directory several extensions" do
-        i = 0
+  test "should execute the block if files change in a watched directory several extensions" do
+    i = 0
 
-        checker = new_checker([], tmpdir => [:rb, :txt]) { i += 1 }
+    checker = new_checker([], tmpdir => [:rb, :txt]) { i += 1 }
 
-        touch(tmpfile("foo.rb"))
+    touch(tmpfile("foo.rb"))
 
-        assert checker.execute_if_updated
-        assert_equal 1, i
+    assert checker.execute_if_updated
+    assert_equal 1, i
 
-        touch(tmpfile("foo.txt"))
+    touch(tmpfile("foo.txt"))
 
-        assert checker.execute_if_updated
-        assert_equal 2, i
-      end
+    assert checker.execute_if_updated
+    assert_equal 2, i
+  end
 
-      test "should not execute the block if the file extension is not watched" do
-        i = 0
+  test "should not execute the block if the file extension is not watched" do
+    i = 0
 
-        checker = new_checker([], tmpdir => :txt) { i += 1 }
+    checker = new_checker([], tmpdir => :txt) { i += 1 }
 
-        touch(tmpfile("foo.rb"))
+    touch(tmpfile("foo.rb"))
 
-        assert_not checker.execute_if_updated
-        assert_equal 0, i
-      end
+    assert_not checker.execute_if_updated
+    assert_equal 0, i
+  end
 
-      test "does not assume files exist on instantiation" do
-        i = 0
+  test "does not assume files exist on instantiation" do
+    i = 0
 
-        non_existing = tmpfile("non_existing.rb")
-        checker = new_checker([non_existing]) { i += 1 }
+    non_existing = tmpfile("non_existing.rb")
+    checker = new_checker([non_existing]) { i += 1 }
 
-        touch(non_existing)
+    touch(non_existing)
 
-        assert checker.execute_if_updated
-        assert_equal 1, i
-      end
+    assert checker.execute_if_updated
+    assert_equal 1, i
+  end
 
-      test "detects files in new subdirectories" do
-        i = 0
+  test "detects files in new subdirectories" do
+    i = 0
 
-        checker = new_checker([], tmpdir => :rb) { i += 1 }
+    checker = new_checker([], tmpdir => :rb) { i += 1 }
 
-        subdir = tmpfile("subdir")
-        mkdir(subdir)
+    subdir = tmpfile("subdir")
+    mkdir(subdir)
 
-        assert_not checker.execute_if_updated
-        assert_equal 0, i
+    assert_not checker.execute_if_updated
+    assert_equal 0, i
 
-        touch(File.join(subdir, "nested.rb"))
+    touch(File.join(subdir, "nested.rb"))
 
-        assert checker.execute_if_updated
-        assert_equal 1, i
-      end
+    assert checker.execute_if_updated
+    assert_equal 1, i
+  end
 
-      test "looked up extensions are inherited in subdirectories not listening to them" do
-        i = 0
+  test "looked up extensions are inherited in subdirectories not listening to them" do
+    i = 0
 
-        subdir = tmpfile("subdir")
-        FileUtils.mkdir(subdir)
+    subdir = tmpfile("subdir")
+    FileUtils.mkdir(subdir)
 
-        checker = new_checker([], tmpdir => :rb, subdir => :txt) { i += 1 }
+    checker = new_checker([], tmpdir => :rb, subdir => :txt) { i += 1 }
 
-        touch(tmpfile("new.txt"))
+    touch(tmpfile("new.txt"))
 
-        assert_not checker.execute_if_updated
-        assert_equal 0, i
+    assert_not checker.execute_if_updated
+    assert_equal 0, i
 
-        # subdir does not look for Ruby files, but its parent tmpdir does.
-        touch(File.join(subdir, "nested.rb"))
+    # subdir does not look for Ruby files, but its parent tmpdir does.
+    touch(File.join(subdir, "nested.rb"))
 
-        assert checker.execute_if_updated
-        assert_equal 1, i
+    assert checker.execute_if_updated
+    assert_equal 1, i
 
-        touch(File.join(subdir, "nested.txt"))
+    touch(File.join(subdir, "nested.txt"))
 
-        assert checker.execute_if_updated
-        assert_equal 2, i
-      end
+    assert checker.execute_if_updated
+    assert_equal 2, i
+  end
 
-      test "initialize raises an ArgumentError if no block given" do
-        assert_raise ArgumentError do
-          new_checker([])
-        end
-      end
+  test "initialize raises an ArgumentError if no block given" do
+    assert_raise ArgumentError do
+      new_checker([])
     end
   end
 

--- a/activesupport/test/file_update_checker_test.rb
+++ b/activesupport/test/file_update_checker_test.rb
@@ -11,7 +11,7 @@ class FileUpdateCheckerTest < ActiveSupport::TestCase
   end
 
   def touch(files)
-    sleep 1 # let's wait a bit to ensure there's a new mtime
+    sleep 0.1 # let's wait a bit to ensure there's a new mtime
     super
   end
 end


### PR DESCRIPTION
There's no need to use class eval here.

Essentially a revert of f7e91c7224560fbd3e95c238a0e8bb362799bcb7

FYI: @amatsuda, I didn't find more context than the commit message, and as far as I can tell, this doesn't seem to re-introduce the issue mentioned, unless there's more to it and it happens when code is loaded in a particular order?