### PR TITLE
Deprecate adding two Time instances with ActiveSupport::TimeWithZone

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Deprecate adding two Time instances with ActiveSupport::TimeWithZone
+    Right now adding two time instances together such as `10.days.ago + 10.days.ago` produces a nonsensical future date.
+    Includes a deprecation to remove this behaviour in Rails 8.0
+
+    *Nick Schwaderer*
+
 *   Optimize load time for `Railtie#initialize_i18n`. Filter `I18n.load_path`s passed to the file watcher to only those
     under `Rails.root`. Previously the watcher would grab all available locales, including those in gems
     which do not require a watcher because they won't change.

--- a/activesupport/lib/active_support/time_with_zone.rb
+++ b/activesupport/lib/active_support/time_with_zone.rb
@@ -303,6 +303,13 @@ module ActiveSupport
         result = utc + other
         result.in_time_zone(time_zone)
       end
+    rescue TypeError
+      ActiveSupport.deprecator.warn(
+        "Do not add an instance of #{other.class} to an instance of #{utc.class}. This behaviour will raise " \
+        "in Rails 8.0."
+      )
+      result = utc.acts_like?(:date) ? utc.since(other) : utc + other rescue utc.since(other)
+      result.in_time_zone(time_zone)
     end
     alias_method :since, :+
     alias_method :in, :+
@@ -537,6 +544,7 @@ module ActiveSupport
     # Ensure proxy class responds to all methods that underlying time instance
     # responds to.
     def respond_to_missing?(sym, include_priv)
+      return false if sym.to_sym == :acts_like_date?
       time.respond_to?(sym, include_priv)
     end
 

--- a/activesupport/test/core_ext/time_with_zone_test.rb
+++ b/activesupport/test/core_ext/time_with_zone_test.rb
@@ -400,6 +400,13 @@ class TimeWithZoneTest < ActiveSupport::TestCase
     assert_equal [0, 0, 19, 31, 12, -8001], (twz - 10_000.years).to_a[0, 6]
   end
 
+  def test_plus_two_time_instances_raises_deprecation_warning
+    twz = ActiveSupport::TimeWithZone.new(Time.utc(2000, 1, 1), @time_zone)
+    assert_deprecated(ActiveSupport.deprecator) do
+      twz + 10.days.ago
+    end
+  end
+
   def test_plus_with_duration
     assert_equal Time.utc(2000, 1, 5, 19, 0, 0), (@twz + 5.days).time
   end


### PR DESCRIPTION
Ref: #52084

Subtracting two time instances results in a Float representing the time between the instances. This is correct behaviour.

Adding two time instances should not work, but it does. It is an easily made mistake.

```ruby
10.days.ago + 10.days.ago

# => Mon, 09 Jan 2079 21:03:46.179229000 UTC +00:0
```

 [This change](https://github.com/rails/rails/pull/52084/files#diff-aa0ae5ccf92f812f874b632afe70375c52772636f927fe6e34ffeaebf54af9d1L303) removed the rescue statement that had made this possible.

Now, it is a breaking change to have made that easy mistake. This PR instead deprecates this change until Rails 8.0 and raises a deprecation warning when adding two Time instances to give people time to fix their code.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
