### PR TITLE
Protect against invalid validate option on remove_check_constraint

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Protect against invalid validate option on remove_check_constraint
+
+    *Shayon Mukherjee*
+
 *   Delete the deprecated constant `ActiveRecord::ImmutableRelation`.
 
     *Xavier Noria*

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -1302,6 +1302,7 @@ module ActiveRecord
       # In that case, +expression+ will be used by #add_check_constraint.
       def remove_check_constraint(table_name, expression = nil, if_exists: false, **options)
         return unless supports_check_constraints?
+        options.delete(:validate)
 
         return if if_exists && !check_constraint_exists?(table_name, **options)
 


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

When you have a `remove_check_constraint` with `validate: false`, the Rails migration can fail, producing the error: `raise(ArgumentError, "Table '#{table_name}' has no check constraint for #{expression || options}")`.

```ruby
remove_check_constraint(
  :diagram_notes,
  "width IS NOT NULL",
  name: "diagram_notes_width_null",
  validate: false,
)
```

This occurs because `remove_check_constraint` calls `check_constraint_for!`, which filters out any validations of constraints that may have `validate: false`. Since `validate` is an acceptable option on `add_check_constraint` but not on `remove_check_constraint`.

### Detail

In this PR - I am proposing to ensure that migrations do not fail with an unrelated or hard-to-understand exception when `validate: false` is accidentally passed to `remove_check_constraint`. We are simply dropping that attribute. 

### Additional information

Have followed it up with a spec as well. 

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [X] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
