### PR TITLE
Improve how the sessions generator adds `bcrypt`

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 
     # Generate with...
-    bin/rails sessions
+    bin/rails generate sessions
 
     # Generated files
     app/models/current.rb

--- a/railties/lib/rails/generators/rails/sessions/sessions_generator.rb
+++ b/railties/lib/rails/generators/rails/sessions/sessions_generator.rb
@@ -20,9 +20,12 @@ module Rails
       end
 
       def enable_bcrypt
-        # FIXME: Make more resilient in case the default comment has been removed
-        gsub_file "Gemfile", /# gem "bcrypt"/, 'gem "bcrypt"'
-        execute_command :bundle, ""
+        if File.read("Gemfile").include?('gem "bcrypt"')
+          uncomment_lines "Gemfile", /gem "bcrypt"/
+          Bundler.with_original_env { execute_command :bundle, "" }
+        else
+          Bundler.with_original_env { execute_command :bundle, "add bcrypt" }
+        end
       end
 
       def add_migrations


### PR DESCRIPTION
### Motivation / Background

Following on #52328, this PR fixes a few small things:

Use Thor's `uncomment_lines` instead of `gsub_file`.

If the Gemfile does not contain bcrypt, either commented or uncommented, then run `bundle add bcrypt`.

Make sure all bundler commands run within `Bundler.with_original_env` to avoid bundler resolution problems while trying to resolve bundler dependencies. Typically the failure mode here is seeing:

> Could not find bcrypt-3.1.20 in cached gems or installed locally (Bundler::GemNotFound)

while bootstrapping the process that will run bundle-install or bundle-add.

It also corrects the changelog entry's instructions from #52328.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [-] Tests are added or updated if you fix a bug or add a feature.
* [-] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
