### PR TITLE
Reapply "Merge pull request #27586 from maclover7/jm-fix-27584"

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Fix non-GET requests not updating cookies in `ActionController::TestCase`.
+
+    *Jon Moss*, *Hartley McGuire*
+
 *   Update `ActionController::Live` to use a thread-pool to reuse threads across requests.
 
     *Adam Renberg Tamm*

--- a/actionpack/lib/action_controller/test_case.rb
+++ b/actionpack/lib/action_controller/test_case.rb
@@ -429,9 +429,7 @@ module ActionController
       # Note that the request method is not verified. The different methods are
       # available to make the tests more expressive.
       def get(action, **args)
-        res = process(action, method: "GET", **args)
-        cookies.update res.cookies
-        res
+        process(action, method: "GET", **args)
       end
 
       # Simulate a POST request with the given parameters and set/volley the response.
@@ -639,6 +637,7 @@ module ActionController
               unless @request.cookie_jar.committed?
                 @request.cookie_jar.write(@response)
                 cookies.update(@request.cookie_jar.instance_variable_get(:@cookies))
+                cookies.update(@response.cookies)
               end
             end
             @response.prepare!

--- a/actionpack/test/dispatch/cookies_test.rb
+++ b/actionpack/test/dispatch/cookies_test.rb
@@ -583,6 +583,15 @@ class CookiesTest < ActionController::TestCase
     assert_equal false, cookies.deleted?("another")
   end
 
+  # Ensure all HTTP methods have their cookies updated
+  [:get, :post, :patch, :put, :delete, :head].each do |method|
+    define_method("test_deleting_cookie_#{method}") do
+      request.cookies[:user_name] = "Joe"
+      public_send method, :logout
+      assert_nil cookies[:user_name]
+    end
+  end
+
   def test_deleted_cookie_predicate_with_mismatching_options
     cookies[:user_name] = "Joe"
     cookies.delete("user_name", path: "/path")


### PR DESCRIPTION
This reverts commit 6902ca51824d5bc81e6c187ec7a58f787dfe4728.

This was originally reverted due to a reported regression, however the regression appeared to be present without this patch as well (and was fixed in a later [commit][1].

[1]: https://github.com/rails/rails/commit/ca937c59cd69c05cbb92bad4839d931061e15b69

Fixes #52302
Fixes #27584

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
