### PR TITLE
Improve the docs of before_configuration

### DIFF
--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -3752,7 +3752,7 @@ Initialization Events
 
 Rails has 5 initialization events which can be hooked into (listed in the order that they are run):
 
-* `before_configuration`: This is run as soon as the application constant inherits from `Rails::Application`. The `config` calls are evaluated before this happens.
+* `before_configuration`: This is run when the application class inherits from `Rails::Application` in `config/application.rb`. Before the class body is executed. Engines may use this hook to run code before the application itself gets configured.
 
 * `before_initialize`: This is run directly before the initialization process of the application occurs with the `:bootstrap_hook` initializer near the beginning of the Rails initialization process.
 


### PR DESCRIPTION
The current docs of `before_configuration` say:

> This is run as soon as the application constant inherits from `Rails::Application`. The `config` calls are evaluated before this happens.

Remarks:

* Constants do not inherit, classes do.
* The `config` calls of the application actually run after this hook has been executed, since, as the text says, the hook is executed [when the class subclasses](https://github.com/rails/rails/blob/f9e86f1bf5de382f878ce7977381c96fcaa97451/railties/lib/rails/application.rb#L76). That event happens before the body of the class is executed. Engines are on time to use this hook if their entrypoint has been required on boot, because that happens before the application class is defined.