### PR TITLE
[ci skip] Added routes PUT to the default list (doc updates).

### DIFF
--- a/guides/source/getting_started.md
+++ b/guides/source/getting_started.md
@@ -712,6 +712,7 @@ $ bin/rails routes
              POST   /articles(.:format)          articles#create
 edit_article GET    /articles/:id/edit(.:format) articles#edit
              PATCH  /articles/:id(.:format)      articles#update
+             PUT    /articles/:id(.:format)      articles#update
              DELETE /articles/:id(.:format)      articles#destroy
 ```
 


### PR DESCRIPTION
Added default route `PUT` to the docs which is generated by [resourcesful routing](https://guides.rubyonrails.org/getting_started.html#resourceful-routing).