### PR TITLE
Reallow setting secret_key_base to nil when local

### DIFF
--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -512,7 +512,7 @@ module Rails
 
       def secret_key_base
         @secret_key_base || begin
-          self.secret_key_base = if Rails.env.local? || ENV["SECRET_KEY_BASE_DUMMY"]
+          self.secret_key_base = if generate_local_secret?
             generate_local_secret
           else
             ENV["SECRET_KEY_BASE"] || Rails.application.credentials.secret_key_base
@@ -521,7 +521,9 @@ module Rails
       end
 
       def secret_key_base=(new_secret_key_base)
-        if new_secret_key_base.is_a?(String) && new_secret_key_base.present?
+        if new_secret_key_base.nil? && generate_local_secret?
+          @secret_key_base = generate_local_secret
+        elsif new_secret_key_base.is_a?(String) && new_secret_key_base.present?
           @secret_key_base = new_secret_key_base
         elsif new_secret_key_base
           raise ArgumentError, "`secret_key_base` for #{Rails.env} environment must be a type of String`"
@@ -646,6 +648,10 @@ module Rails
           end
 
           File.binread(key_file)
+        end
+
+        def generate_local_secret?
+          Rails.env.local? || ENV["SECRET_KEY_BASE_DUMMY"]
         end
     end
   end

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -790,7 +790,7 @@ module ApplicationTests
 
     test "application will generate secret_key_base in tmp file if blank in development" do
       app_file "config/initializers/secret_token.rb", <<-RUBY
-        Rails.application.credentials.secret_key_base = nil
+        Rails.application.config.secret_key_base = nil
       RUBY
 
       # For test that works even if tmp dir does not exist.
@@ -804,7 +804,7 @@ module ApplicationTests
 
     test "application will generate secret_key_base in tmp file if blank in test" do
       app_file "config/initializers/secret_token.rb", <<-RUBY
-        Rails.application.credentials.secret_key_base = nil
+        Rails.application.config.secret_key_base = nil
       RUBY
 
       # For test that works even if tmp dir does not exist.


### PR DESCRIPTION
### Motivation / Background

Ref #52062

Previously, secret_key_base was allowed to be set to `nil` in local environments (or with SECRET_KEY_BASE_DUMMY) because validation would only happen on usage and not on the setter. This was recently [changed][1] to make it easier to identify exactly where a secret_key_base was being set to an invalid value.

However, this broke some applications which unconditionally set secret_key_base to some external value in dev/test. Before the change, the set value could be `nil` and fall back to the generated local secret on usage.

### Detail

This commit restores that behavior so that applications can continue to set secret_key_base unconditionally, since the nil value will end up getting replaced by the generated local secret anyways.

[1]: https://github.com/rails/rails/commit/c2901eb084adb3d3701be157bec20d2961beb515

### Additional information

I left the condition blank for now to restore the behavior, but should we deprecate it and required applications set `credentials.secret_key_base` instead?

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
