### PR TITLE
Defer route drawing to the first request, or when url_helpers called

### DIFF
--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -351,7 +351,7 @@ module ActionDispatch
       PATH    = ->(options) { ActionDispatch::Http::URL.path_for(options) }
       UNKNOWN = ->(options) { ActionDispatch::Http::URL.url_for(options) }
 
-      attr_accessor :formatter, :set, :named_routes, :default_scope, :router
+      attr_accessor :formatter, :set, :named_routes, :router
       attr_accessor :disable_clear_and_finalize, :resources_path_names
       attr_accessor :default_url_options, :draw_paths
       attr_reader :env_key, :polymorphic_mappings
@@ -363,7 +363,7 @@ module ActionDispatch
       end
 
       def self.new_with_config(config)
-        route_set_config = DEFAULT_CONFIG
+        route_set_config = DEFAULT_CONFIG.dup
 
         # engines apparently don't have this set
         if config.respond_to? :relative_url_root
@@ -374,14 +374,18 @@ module ActionDispatch
           route_set_config.api_only = config.api_only
         end
 
+        if config.respond_to? :default_scope
+          route_set_config.default_scope = config.default_scope
+        end
+
         new route_set_config
       end
 
-      Config = Struct.new :relative_url_root, :api_only
+      Config = Struct.new :relative_url_root, :api_only, :default_scope
 
-      DEFAULT_CONFIG = Config.new(nil, false)
+      DEFAULT_CONFIG = Config.new(nil, false, nil)
 
-      def initialize(config = DEFAULT_CONFIG)
+      def initialize(config = DEFAULT_CONFIG.dup)
         self.named_routes = NamedRouteCollection.new
         self.resources_path_names = self.class.default_resources_path_names
         self.default_url_options = {}
@@ -414,6 +418,14 @@ module ActionDispatch
 
       def api_only?
         @config.api_only
+      end
+
+      def default_scope
+        @config.default_scope
+      end
+
+      def default_scope=(new_default_scope)
+        @config.default_scope = new_default_scope
       end
 
       def request_class

--- a/actionpack/test/abstract_unit.rb
+++ b/actionpack/test/abstract_unit.rb
@@ -34,6 +34,8 @@ module Rails
       @_env ||= ActiveSupport::StringInquirer.new(ENV["RAILS_ENV"] || ENV["RACK_ENV"] || "test")
     end
 
+    def application; end
+
     def root; end
   end
 end

--- a/actionpack/test/dispatch/routing_assertions_test.rb
+++ b/actionpack/test/dispatch/routing_assertions_test.rb
@@ -4,7 +4,11 @@ require "abstract_unit"
 require "rails/engine"
 require "controller/fake_controllers"
 
-class SecureArticlesController < ArticlesController; end
+class SecureArticlesController < ArticlesController
+  def index
+    render(inline: "")
+  end
+end
 class BlockArticlesController < ArticlesController; end
 class QueryArticlesController < ArticlesController; end
 
@@ -276,6 +280,20 @@ class RoutingAssertionsControllerTest < ActionController::TestCase
 
   class WithRoutingTest < ActionController::TestCase
     include RoutingAssertionsSharedTests::WithRoutingSharedTests
+
+    test "with_routing routes are reachable" do
+      @controller = SecureArticlesController.new
+
+      with_routing do |routes|
+        routes.draw do
+          get :new_route, to: "secure_articles#index"
+        end
+
+        get :index
+
+        assert_predicate(response, :ok?)
+      end
+    end
   end
 end
 
@@ -295,6 +313,18 @@ class RoutingAssertionsIntegrationTest < ActionDispatch::IntegrationTest
 
   class WithRoutingTest < ActionDispatch::IntegrationTest
     include RoutingAssertionsSharedTests::WithRoutingSharedTests
+
+    test "with_routing routes are reachable" do
+      with_routing do |routes|
+        routes.draw do
+          get :new_route, to: "secure_articles#index"
+        end
+
+        get "/new_route"
+
+        assert_predicate(response, :ok?)
+      end
+    end
   end
 
   class WithRoutingSettingsTest < ActionDispatch::IntegrationTest

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,15 @@
+*   Defer route drawing to the first request, or when url_helpers are called
+
+    Executes the first routes reload in middleware, or when a route set's
+    url_helpers receives a route call / asked if it responds to a route.
+    Previously, this was executed unconditionally on boot, which can
+    slow down boot time unnecessarily for larger apps with lots of routes.
+
+    Environments like production that have `config.eager_load = true` will
+    continue to eagerly load routes on boot.
+
+    *Gannon McGibbon*
+
 *   Generate form helpers to use `textarea*` methods instead of `text_area*` methods
 
     *Sean Doyle*

--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -9,6 +9,7 @@ require "active_support/deprecation"
 require "active_support/encrypted_configuration"
 require "active_support/hash_with_indifferent_access"
 require "active_support/configuration_file"
+require "active_support/parameter_filter"
 require "rails/engine"
 require "rails/autoloaders"
 
@@ -151,6 +152,10 @@ module Rails
     # Reload application routes regardless if they changed or not.
     def reload_routes!
       routes_reloader.reload!
+    end
+
+    def reload_routes_unless_loaded # :nodoc:
+      initialized? && routes_reloader.execute_unless_loaded
     end
 
     # Returns a key generator (ActiveSupport::CachingKeyGenerator) for a

--- a/railties/lib/rails/application/finisher.rb
+++ b/railties/lib/rails/application/finisher.rb
@@ -160,7 +160,6 @@ module Rails
       initializer :set_routes_reloader_hook do |app|
         reloader = routes_reloader
         reloader.eager_load = app.config.eager_load
-        reloader.execute
         reloaders << reloader
 
         app.reloader.to_run do
@@ -178,7 +177,7 @@ module Rails
           ActiveSupport.run_load_hooks(:after_routes_loaded, self)
         end
 
-        ActiveSupport.run_load_hooks(:after_routes_loaded, self)
+        reloader.execute_unless_loaded if !app.routes.is_a?(Engine::LazyRouteSet) || app.config.eager_load
       end
 
       # Set clearing dependencies after the finisher hook to ensure paths

--- a/railties/lib/rails/application/routes_reloader.rb
+++ b/railties/lib/rails/application/routes_reloader.rb
@@ -7,7 +7,7 @@ module Rails
     class RoutesReloader
       include ActiveSupport::Callbacks
 
-      attr_reader :route_sets, :paths, :external_routes
+      attr_reader :route_sets, :paths, :external_routes, :loaded
       attr_accessor :eager_load
       attr_writer :run_after_load_paths # :nodoc:
       delegate :execute_if_updated, :execute, :updated?, to: :updater
@@ -17,15 +17,25 @@ module Rails
         @route_sets = []
         @external_routes = []
         @eager_load = false
+        @loaded = false
       end
 
       def reload!
+        @loaded = true
         clear!
         load_paths
         finalize!
         route_sets.each(&:eager_load!) if eager_load
       ensure
         revert
+      end
+
+      def execute_unless_loaded
+        unless @loaded
+          execute
+          ActiveSupport.run_load_hooks(:after_routes_loaded, Rails.application)
+          true
+        end
       end
 
     private

--- a/railties/lib/rails/engine/configuration.rb
+++ b/railties/lib/rails/engine/configuration.rb
@@ -6,7 +6,7 @@ module Rails
   class Engine
     class Configuration < ::Rails::Railtie::Configuration
       attr_reader :root
-      attr_accessor :middleware, :javascript_path
+      attr_accessor :middleware, :javascript_path, :route_set_class, :default_scope
       attr_writer :eager_load_paths, :autoload_once_paths, :autoload_paths
 
       # An array of custom autoload paths to be added to the ones defined
@@ -44,6 +44,8 @@ module Rails
         @generators = app_generators.dup
         @middleware = Rails::Configuration::MiddlewareStackProxy.new
         @javascript_path = "javascript"
+        @route_set_class = ActionDispatch::Routing::RouteSet
+        @default_scope = nil
 
         @autoload_paths = []
         @autoload_once_paths = []

--- a/railties/lib/rails/engine/lazy_route_set.rb
+++ b/railties/lib/rails/engine/lazy_route_set.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+# :markup: markdown
+
+require "action_dispatch/routing/route_set"
+
+module Rails
+  class Engine
+    class LazyRouteSet < ActionDispatch::Routing::RouteSet # :nodoc:
+      class NamedRouteCollection < ActionDispatch::Routing::RouteSet::NamedRouteCollection
+        def route_defined?(name)
+          Rails.application&.reload_routes_unless_loaded
+          super
+        end
+      end
+
+      module ProxyUrlHelpers
+        def url_for(options)
+          Rails.application&.reload_routes_unless_loaded
+          super
+        end
+
+        def full_url_for(options)
+          Rails.application&.reload_routes_unless_loaded
+          super
+        end
+
+        def route_for(name, *args)
+          Rails.application&.reload_routes_unless_loaded
+          super
+        end
+
+        def optimize_routes_generation?
+          Rails.application&.reload_routes_unless_loaded
+          super
+        end
+
+        def polymorphic_url(record_or_hash_or_array, options = {})
+          Rails.application&.reload_routes_unless_loaded
+          super
+        end
+
+        def polymorphic_path(record_or_hash_or_array, options = {})
+          Rails.application&.reload_routes_unless_loaded
+          super
+        end
+      end
+
+      def initialize(config = DEFAULT_CONFIG)
+        super
+        self.named_routes = NamedRouteCollection.new
+        named_routes.url_helpers_module.prepend(method_missing_module)
+        named_routes.path_helpers_module.prepend(method_missing_module)
+      end
+
+      def generate_extras(options, recall = {})
+        Rails.application&.reload_routes_unless_loaded
+
+        super(options, recall)
+      end
+
+      def generate_url_helpers(supports_path)
+        super.tap { |mod| mod.singleton_class.prepend(ProxyUrlHelpers) }
+      end
+
+      def call(req)
+        Rails.application&.reload_routes_unless_loaded
+        super
+      end
+
+      def draw(&block)
+        Rails.application&.reload_routes_unless_loaded
+        super
+      end
+
+      def routes
+        Rails.application&.reload_routes_unless_loaded
+        super
+      end
+
+      private
+        def method_missing_module
+          @method_missing_module ||= Module.new do
+            private
+              def method_missing(method_name, *args, &block)
+                if Rails.application&.reload_routes_unless_loaded
+                  public_send(method_name, *args, &block)
+                else
+                  super(method_name, *args, &block)
+                end
+              end
+
+              def respond_to_missing?(method_name, *args)
+                if Rails.application&.reload_routes_unless_loaded
+                  respond_to?(method_name, *args)
+                else
+                  super(method_name, *args)
+                end
+              end
+          end
+        end
+    end
+  end
+end

--- a/railties/test/application/action_view_test_integration_case_test.rb
+++ b/railties/test/application/action_view_test_integration_case_test.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require "isolation/abstract_unit"
+
+class ActionViewTestCaseIntegrationTest < ActionView::TestCase
+  include ActiveSupport::Testing::Isolation
+
+  class HomeController < ActionController::Base
+    def index; end
+
+    def url_options
+      {}
+    end
+  end
+
+  setup do
+    build_app
+
+    app_file "config/routes.rb", <<~RUBY
+      Rails.application.routes.draw do
+        root to: "action_view_test_case_test/home#index"
+      end
+    RUBY
+
+    require "#{app_path}/config/environment"
+
+    HomeController.include(Rails.application.routes.url_helpers)
+    @controller = HomeController.new
+  end
+
+  teardown :teardown_app
+
+  test "can use url helpers" do
+    assert_equal("/", root_path)
+  end
+end

--- a/railties/test/application/initializers/frameworks_test.rb
+++ b/railties/test/application/initializers/frameworks_test.rb
@@ -67,8 +67,8 @@ module ApplicationTests
       RUBY
 
       app("development")
-      assert Foo.method_defined?(:foo_url)
-      assert Foo.method_defined?(:main_app)
+      assert Foo.new.respond_to?(:foo_url)
+      assert Foo.new.respond_to?(:main_app)
     end
 
     test "allows to not load all helpers for controllers" do

--- a/railties/test/engine/lazy_route_set_test.rb
+++ b/railties/test/engine/lazy_route_set_test.rb
@@ -1,0 +1,140 @@
+# frozen_string_literal: true
+
+require "isolation/abstract_unit"
+
+module Rails
+  class Engine
+    class LazyRouteSetTest < ActiveSupport::TestCase
+      include ActiveSupport::Testing::Isolation
+
+      setup :build_app
+
+      teardown :teardown_app
+
+      test "app lazily loads routes when invoking url helpers" do
+        require "#{app_path}/config/environment"
+
+        assert_not_operator(:root_path, :in?, app_url_helpers.methods)
+        assert_equal("/", app_url_helpers.root_path)
+      end
+
+      test "engine lazily loads routes when invoking url helpers" do
+        require "#{app_path}/config/environment"
+
+        assert_not_operator(:root_path, :in?, engine_url_helpers.methods)
+        assert_equal("/plugin/", engine_url_helpers.root_path)
+      end
+
+      test "app lazily loads routes when checking respond_to?" do
+        require "#{app_path}/config/environment"
+
+        assert_not_operator(:root_path, :in?, app_url_helpers.methods)
+        assert_operator(app_url_helpers, :respond_to?, :root_path)
+      end
+
+      test "engine lazily loads routes when checking respond_to?" do
+        require "#{app_path}/config/environment"
+
+        assert_not_operator(:root_path, :in?, engine_url_helpers.methods)
+        assert_operator(engine_url_helpers, :respond_to?, :root_path)
+      end
+
+      test "app lazily loads routes when making a request" do
+        require "#{app_path}/config/environment"
+
+        @app = Rails.application
+
+        assert_not_operator(:root_path, :in?, app_url_helpers.methods)
+        response = get("/")
+        assert_equal(200, response.first)
+      end
+
+      test "engine lazily loads routes when making a request" do
+        require "#{app_path}/config/environment"
+
+        @app = Rails.application
+
+        assert_not_operator(:root_path, :in?, engine_url_helpers.methods)
+        response = get("/plugin/")
+        assert_equal(200, response.first)
+      end
+
+      test "app lazily loads routes when url_for is used" do
+        require "#{app_path}/config/environment"
+
+        @app = Rails.application
+
+        assert_not_operator(:users_path, :in?, app_url_helpers.methods)
+        assert_equal "/users", app_url_helpers.url_for(
+          controller: :users, action: :index, only_path: true,
+        )
+        assert_operator(:users_path, :in?, app_url_helpers.methods)
+      end
+
+      test "engine lazily loads routes when url_for is used" do
+        require "#{app_path}/config/environment"
+
+        @app = Rails.application
+
+        assert_not_operator(:plugin_posts_path, :in?, engine_url_helpers.methods)
+        assert_equal "/plugin/posts", engine_url_helpers.url_for(
+          controller: :posts, action: :index, only_path: true,
+        )
+        assert_not_operator(:plugin_posts_path, :in?, engine_url_helpers.methods)
+      end
+
+      private
+        def build_app
+          super
+
+          app_file "app/models/user.rb", <<~RUBY
+            class User < ActiveRecord::Base
+            end
+          RUBY
+
+          app_file "config/routes.rb", <<~RUBY
+            Rails.application.routes.draw do
+              root to: proc { [200, {}, []] }
+
+              resources(:users)
+
+              mount Plugin::Engine, at: "/plugin"
+            end
+          RUBY
+
+          build_engine
+        end
+
+        def build_engine
+          engine "plugin" do |plugin|
+            plugin.write "app/models/post.rb", <<~RUBY
+              class Post < ActiveRecord::Base
+              end
+            RUBY
+
+            plugin.write "lib/plugin.rb", <<~RUBY
+              module Plugin
+                class Engine < ::Rails::Engine
+                end
+              end
+            RUBY
+            plugin.write "config/routes.rb", <<~RUBY
+              Plugin::Engine.routes.draw do
+                root to: proc { [200, {}, []] }
+
+                resources(:posts)
+              end
+            RUBY
+          end
+        end
+
+        def app_url_helpers
+          Rails.application.routes.url_helpers
+        end
+
+        def engine_url_helpers
+          Plugin::Engine.routes.url_helpers
+        end
+    end
+  end
+end

--- a/railties/test/railties/engine_test.rb
+++ b/railties/test/railties/engine_test.rb
@@ -950,8 +950,8 @@ en:
       assert_equal "bukkits_", Bukkits.table_name_prefix
       assert_equal "bukkits", Bukkits::Engine.engine_name
       assert_equal Bukkits.railtie_namespace, Bukkits::Engine
-      assert ::Bukkits::MyMailer.method_defined?(:foo_url)
-      assert_not ::Bukkits::MyMailer.method_defined?(:bar_url)
+      assert ::Bukkits::MyMailer.new.respond_to?(:foo_url)
+      assert_not ::Bukkits::MyMailer.new.respond_to?(:bar_url)
 
       get("/bar")
       assert_equal "/bar", last_response.body


### PR DESCRIPTION
### Motivation / Background

Redo of https://github.com/rails/rails/pull/51614, https://github.com/rails/rails/pull/52012

Executes the first routes reload when the route set is first used to serve a request, generate a url, or otherwise. Previously, this was executed unconditionally on boot, which can slow down boot time unnecessarily for larger apps with lots of routes.

This Pull Request has been created to reduce route draw time for larger apps by deferring it until necessary. 

### Detail

This Pull Request changes previous attempts were reverted. In this one, we're depending entirely on the route set class' methods to load routes instead of littering the codebase with manual reload calls. This should help prevent loading edge cases with the lazy route set. We're also swapping out the lazy route set for the normal one in eager-loaded environments to reduce impact on production.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
