### PR TITLE
Add support for SQLite3 full-text-search and other virtual tables

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Add support for SQLite3 full-text-search and other virtual tables.
+
+    Previously, adding sqlite3 virtual tables messed up `schema.rb`.
+
+    Now, virtual tables can safely be added using `create_virtual_table`.
+
+    *Zacharias Knudsen*
+
 *   Support use of alternative database interfaces via the `database_cli` ActiveRecord configuration option.
 
     ```ruby

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -595,6 +595,14 @@ module ActiveRecord
       def rename_enum_value(*) # :nodoc:
       end
 
+      # This is meant to be implemented by the adapters that support virtual tables
+      def create_virtual_table(*) # :nodoc:
+      end
+
+      # This is meant to be implemented by the adapters that support virtual tables
+      def drop_virtual_table(*) # :nodoc:
+      end
+
       def advisory_locks_enabled? # :nodoc:
         supports_advisory_locks? && @advisory_locks_enabled
       end

--- a/activerecord/lib/active_record/connection_adapters/sqlite3/schema_dumper.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3/schema_dumper.rb
@@ -5,6 +5,19 @@ module ActiveRecord
     module SQLite3
       class SchemaDumper < ConnectionAdapters::SchemaDumper # :nodoc:
         private
+          def virtual_tables(stream)
+            virtual_tables = @connection.virtual_tables
+            if virtual_tables.any?
+              stream.puts
+              stream.puts "  # Virtual tables defined in this database."
+              stream.puts "  # Note that virtual tables may not work with other database engines. Be careful if changing database."
+              virtual_tables.sort.each do |table_name, options|
+                module_name, arguments = options
+                stream.puts "  create_virtual_table #{table_name.inspect}, #{module_name.inspect}, #{arguments.split(", ").inspect}"
+              end
+            end
+          end
+
           def default_primary_key?(column)
             schema_type(column) == :integer
           end

--- a/activerecord/lib/active_record/schema_dumper.rb
+++ b/activerecord/lib/active_record/schema_dumper.rb
@@ -63,6 +63,7 @@ module ActiveRecord
       extensions(stream)
       types(stream)
       tables(stream)
+      virtual_tables(stream)
       trailer(stream)
       stream
     end
@@ -124,6 +125,10 @@ module ActiveRecord
 
       # schemas are only supported by PostgreSQL
       def schemas(stream)
+      end
+
+      # virtual tables are only supported by SQLite
+      def virtual_tables(stream)
       end
 
       def tables(stream)

--- a/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
@@ -596,7 +596,7 @@ module ActiveRecord
 
       def test_tables_logs_name
         sql = <<~SQL
-          SELECT name FROM sqlite_master WHERE name <> 'sqlite_sequence' AND type IN ('table')
+          SELECT name FROM pragma_table_list WHERE schema <> 'temp' AND name NOT IN ('sqlite_sequence', 'sqlite_schema') AND type IN ('table')
         SQL
         @conn.connect!
         assert_logged [[sql.squish, "SCHEMA", []]] do
@@ -607,7 +607,7 @@ module ActiveRecord
       def test_table_exists_logs_name
         with_example_table do
           sql = <<~SQL
-            SELECT name FROM sqlite_master WHERE name <> 'sqlite_sequence' AND name = 'ex' AND type IN ('table')
+            SELECT name FROM pragma_table_list WHERE schema <> 'temp' AND name NOT IN ('sqlite_sequence', 'sqlite_schema') AND name = 'ex' AND type IN ('table')
           SQL
           assert_logged [[sql.squish, "SCHEMA", []]] do
             assert @conn.table_exists?("ex")

--- a/activerecord/test/cases/adapters/sqlite3/virtual_table_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/virtual_table_test.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+require "support/schema_dumping_helper"
+
+class SQLite3VirtualTableTest < ActiveRecord::SQLite3TestCase
+  include SchemaDumpingHelper
+
+  def setup
+    @connection = ActiveRecord::Base.lease_connection
+    @connection.create_virtual_table :searchables, :fts5, ["content", "meta UNINDEXED", "tokenize='porter ascii'"]
+  end
+
+  def teardown
+    @connection.drop_table :searchables, if_exists: true
+  end
+
+  def test_schema_dump
+    output = dump_all_table_schema
+
+    assert_not_includes output, "searchables_docsize"
+    assert_includes output, 'create_virtual_table "searchables", "fts5", ["content", "meta UNINDEXED", "tokenize=\'porter ascii\'"]'
+  end
+
+  def test_schema_load
+    original, $stdout = $stdout, StringIO.new
+
+    ActiveRecord::Schema.define do
+      create_virtual_table :emails, :fts5, ["content", "meta UNINDEXED"]
+    end
+
+    assert @connection.virtual_table_exists?(:emails)
+  ensure
+    $stdout = original
+  end
+end

--- a/activerecord/test/cases/migration/command_recorder_test.rb
+++ b/activerecord/test/cases/migration/command_recorder_test.rb
@@ -564,6 +564,22 @@ module ActiveRecord
           @recorder.inverse_of :rename_enum_value, [:dog_breed, from: :beagle]
         end
       end
+
+      def test_invert_create_virtual_table
+        drop = @recorder.inverse_of :create_virtual_table, [:searchables, :fts5, ["content", "meta UNINDEXED", "tokenize='porter ascii'"]]
+        assert_equal [:drop_virtual_table, [:searchables, :fts5, ["content", "meta UNINDEXED", "tokenize='porter ascii'"]], nil], drop
+      end
+
+      def test_invert_drop_virtual_table
+        create = @recorder.inverse_of :drop_virtual_table, [:searchables, :fts5, ["title", "content"]]
+        assert_equal [:create_virtual_table, [:searchables, :fts5, ["title", "content"]], nil], create
+      end
+
+      def test_invert_drop_virtual_table_without_options
+        assert_raises(ActiveRecord::IrreversibleMigration) do
+          @recorder.inverse_of :drop_virtual_table, [:searchables]
+        end
+      end
     end
   end
 end

--- a/railties/test/application/bin_setup_test.rb
+++ b/railties/test/application/bin_setup_test.rb
@@ -13,7 +13,7 @@ module ApplicationTests
       Dir.chdir(app_path) do
         rails "generate", "model", "article"
 
-        list_tables = lambda { rails("runner", "p ActiveRecord::Base.lease_connection.tables").strip }
+        list_tables = lambda { rails("runner", "p ActiveRecord::Base.lease_connection.tables.sort").strip }
         File.write("log/test.log", "zomg!")
 
         assert_equal "[]", list_tables.call
@@ -22,7 +22,7 @@ module ApplicationTests
 
         `bin/setup 2>&1`
         assert_equal 0, File.size("log/test.log")
-        assert_equal '["schema_migrations", "ar_internal_metadata", "articles"]', list_tables.call
+        assert_equal '["ar_internal_metadata", "articles", "schema_migrations"]', list_tables.call
         assert File.exist?("tmp/restart.txt")
       end
     end

--- a/railties/test/application/rake/dbs_test.rb
+++ b/railties/test/application/rake/dbs_test.rb
@@ -541,11 +541,11 @@ module ApplicationTests
           end
         RUBY
 
-        list_tables = lambda { rails("runner", "p ActiveRecord::Base.lease_connection.tables").strip }
+        list_tables = lambda { rails("runner", "p ActiveRecord::Base.lease_connection.tables.sort").strip }
 
         assert_equal '["posts"]', list_tables[]
         rails "db:schema:load"
-        assert_equal '["posts", "comments", "schema_migrations", "ar_internal_metadata"]', list_tables[]
+        assert_equal '["ar_internal_metadata", "comments", "posts", "schema_migrations"]', list_tables[]
 
         add_to_config "config.active_record.schema_format = :sql"
         app_file "db/structure.sql", <<-SQL
@@ -553,7 +553,7 @@ module ApplicationTests
         SQL
 
         rails "db:schema:load"
-        assert_equal '["posts", "comments", "schema_migrations", "ar_internal_metadata", "users"]', list_tables[]
+        assert_equal '["ar_internal_metadata", "comments", "posts", "schema_migrations", "users"]', list_tables[]
       end
 
       test "db:schema:load with inflections" do

--- a/railties/test/application/rake/multi_dbs_test.rb
+++ b/railties/test/application/rake/multi_dbs_test.rb
@@ -108,11 +108,11 @@ module ApplicationTests
 
           rails "db:schema:load"
 
-          ar_tables = lambda { rails("runner", "p ActiveRecord::Base.lease_connection.tables").strip }
-          animals_tables = lambda { rails("runner", "p AnimalsBase.lease_connection.tables").strip }
+          ar_tables = lambda { rails("runner", "p ActiveRecord::Base.lease_connection.tables.sort").strip }
+          animals_tables = lambda { rails("runner", "p AnimalsBase.lease_connection.tables.sort").strip }
 
-          assert_equal '["schema_migrations", "ar_internal_metadata", "books"]', ar_tables[]
-          assert_equal '["schema_migrations", "ar_internal_metadata", "dogs"]', animals_tables[]
+          assert_equal '["ar_internal_metadata", "books", "schema_migrations"]', ar_tables[]
+          assert_equal '["ar_internal_metadata", "dogs", "schema_migrations"]', animals_tables[]
         end
       end
 
@@ -148,15 +148,15 @@ module ApplicationTests
 
           rails "db:schema:load:#{database}"
 
-          ar_tables = lambda { rails("runner", "p ActiveRecord::Base.lease_connection.tables").strip }
-          animals_tables = lambda { rails("runner", "p AnimalsBase.lease_connection.tables").strip }
+          ar_tables = lambda { rails("runner", "p ActiveRecord::Base.lease_connection.tables.sort").strip }
+          animals_tables = lambda { rails("runner", "p AnimalsBase.lease_connection.tables.sort").strip }
 
           if database == "primary"
-            assert_equal '["schema_migrations", "ar_internal_metadata", "books"]', ar_tables[]
+            assert_equal '["ar_internal_metadata", "books", "schema_migrations"]', ar_tables[]
             assert_equal "[]", animals_tables[]
           else
             assert_equal "[]", ar_tables[]
-            assert_equal '["schema_migrations", "ar_internal_metadata", "dogs"]', animals_tables[]
+            assert_equal '["ar_internal_metadata", "dogs", "schema_migrations"]', animals_tables[]
           end
         end
       end
@@ -211,15 +211,15 @@ module ApplicationTests
           output = rails("db:test:prepare:#{name}", "--trace")
           assert_match(/Execute db:test:load_schema:#{name}/, output)
 
-          ar_tables = lambda { rails("runner", "-e", "test", "p ActiveRecord::Base.lease_connection.tables").strip }
-          animals_tables = lambda { rails("runner",  "-e", "test", "p AnimalsBase.lease_connection.tables").strip }
+          ar_tables = lambda { rails("runner", "-e", "test", "p ActiveRecord::Base.lease_connection.tables.sort").strip }
+          animals_tables = lambda { rails("runner",  "-e", "test", "p AnimalsBase.lease_connection.tables.sort").strip }
 
           if name == "primary"
-            assert_equal ["schema_migrations", "ar_internal_metadata", "books"].sort, JSON.parse(ar_tables[]).sort
+            assert_equal '["ar_internal_metadata", "books", "schema_migrations"]', ar_tables[]
             assert_equal "[]", animals_tables[]
           else
             assert_equal "[]", ar_tables[]
-            assert_equal ["schema_migrations", "ar_internal_metadata", "dogs"].sort, JSON.parse(animals_tables[]).sort
+            assert_equal '["ar_internal_metadata", "dogs", "schema_migrations"]', animals_tables[]
           end
         end
       end


### PR DESCRIPTION
### Motivation / Background

As [discussed on rubyonrails-core](https://discuss.rubyonrails.org/t/proposal-sqlite3-full-text-search-and-other-virtual-tables-do-not-dump-shadow-virtual-tables/86159) with @flavorjones.

SQLite is a great default database, and even provides a [full-text-search module, `fts5`](https://www.sqlite.org/fts5.html). However, `fts5` is a [virtual table module](https://www.sqlite.org/vtab.html) which messes up `schema.rb`. For example, if you create virtual table `searchables` in a migration:

```ruby
class CreateSearchablesTable < ActiveRecord::Migration[8.0]
  def up
    execute 'CREATE VIRTUAL TABLE searchables USING fts5(content)'
  end
end
```
and run `rails db:migrate`, then 6 tables are created, 1 `virtual` and 5 "`shadow`" tables. This is what the result of `SELECT * FROM pragma_table_list ORDER BY name` (relevant part) looks like:
| schema | name | type | ncol | wr | strict |
| - | - | - | - | - | - |
| main | searchables | virtual | 3 | 0 | 0 |
| main | searchables_config | shadow | 2 | 1 | 0 |
| main | searchables_content | shadow | 2 | 0 | 0 |
| main | searchables_data | shadow | 2 | 0 | 0 |
| main | searchables_docsize | shadow | 2 | 0 | 0 |
| main | searchables_idx | shadow | 3 | 1 | 0 |

While these tables look like regular tables, they should not be dumped in the same way. In `schema.rb` there are error messages for some of them (notably the virtual table) while a few shadow tables are dumped like regular tables:

```ruby
# Could not dump table "searchables" because of following StandardError
#   Unknown type '' for column 'content'

# Could not dump table "searchables_config" because of following StandardError
#   Unknown type '' for column 'k'

# Could not dump table "searchables_content" because of following StandardError
#   Unknown type '' for column 'c0'

  create_table "searchables_data", force: :cascade do |t|
    t.binary "block"
  end

  create_table "searchables_docsize", force: :cascade do |t|
    t.binary "sz"
  end

# Could not dump table "searchables_idx" because of following StandardError
#   Unknown type '' for column 'segid'
```
This will put the app into a bad state if you run `rails db:reset`, with some shadow tables as regular tables and the virtual table missing entirely:

| schema | name | type | ncol | wr | strict |
| - | - | - | - | - | - |
| main | searchables_data | table | 2 | 0 | 0
| main | searchables_docsize | table | 2 | 0 | 0

The proper way to dump a virtual table to `schema.rb` would be to ignore the "shadow" tables and only create the virtual table (which in turn will create the shadow tables).

### Detail

This PR tries to provide general SQLite3 virtual table support using `create_virtual_table` and `drop_virtual_table`. While `drop_virtual_table` is basically `drop_table` (since dropping a virtual table also drops connected shadow tables), it allows the `CommandRecorder` to reverse `drop_virtual_table`.

It will dump virtual tables to `schema.rb` and ignore shadow tables. For example:
```sql
CREATE VIRTUAL TABLE searchables USING fts5(content, meta UNINDEXED, tokenize = 'porter ascii');
```
will append to `schema.rb`:
```ruby
create_virtual_table "searchables", "fts5", ["content", "meta UNINDEXED", "tokenize='porter ascii'"]
```

Notable changes:

* In order to filter out `virtual`/`shadow` tables from the regular table dump, I had to use `pragma_table_list` instead of `sqlite_master` in `ActiveRecord::ConnectionAdapters::SQLite3::SchemaStatements` because the schema table `sqlite_master` lacks virtual/shadow type information.
* I have added 2 new methods to the abstract adapter, but they are only used by the sqlite3 adapter. This is based on the postgresql enum implementation.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
