### PR TITLE
Deprecate passing a Time object to Time#since

### DIFF
--- a/activesupport/lib/active_support/core_ext/time/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/time/calculations.rb
@@ -217,7 +217,11 @@ class Time
   # Returns a new Time representing the time a number of seconds since the instance time
   def since(seconds)
     self + seconds
-  rescue
+  rescue TypeError
+    ActiveSupport.deprecator.warn(
+      "Passing an instance of #{seconds.class} to #{self.class}#since is deprecated. This behavior will raise " \
+      "a `TypeError` in Rails 8.0."
+    )
     to_datetime.since(seconds)
   end
   alias :in :since

--- a/activesupport/test/core_ext/time_ext_test.rb
+++ b/activesupport/test/core_ext/time_ext_test.rb
@@ -282,6 +282,12 @@ class TimeExtCalculationsTest < ActiveSupport::TestCase
     end
   end
 
+  def test_since_with_instance_of_time_deprecated
+    assert_deprecated(ActiveSupport.deprecator) do
+      Time.now.since(Time.now)
+    end
+  end
+
   def test_since
     assert_equal Time.local(2005, 2, 22, 10, 10, 11), Time.local(2005, 2, 22, 10, 10, 10).since(1)
     assert_equal Time.local(2005, 2, 22, 11, 10, 10), Time.local(2005, 2, 22, 10, 10, 10).since(3600)


### PR DESCRIPTION
Ref: #52343

`Time.now.since(Time.now)` does not fail, but it returns a random future date (currently in 2079).

This commit deprecates passing a Time object to Time#since until Rails 8.0, where it will raise a TypeError.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
