### PR TITLE
Fix `find_or_initialize_by` for finding by associations with composite primary keys

### DIFF
--- a/activerecord/lib/active_record/relation/predicate_builder/association_query_value.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder/association_query_value.rb
@@ -57,9 +57,15 @@ module ActiveRecord
         end
 
         def convert_to_id(value)
-          return primary_key.map { |pk| value.public_send(pk) } if primary_key.is_a?(Array)
-
-          if value.respond_to?(primary_key)
+          if primary_key.is_a?(Array)
+            primary_key.map do |attribute|
+              if attribute == "id"
+                value.id_value
+              else
+                value.public_send(attribute)
+              end
+            end
+          elsif value.respond_to?(primary_key)
             value.public_send(primary_key)
           else
             value

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -1676,6 +1676,14 @@ class RelationTest < ActiveRecord::TestCase
     assert_equal bird, Bird.find_or_initialize_by(name: "bob", color: "blue")
   end
 
+  def test_find_or_initialize_by_with_cpk_association
+    order1 = Cpk::Order.create!(id: [1, 1])
+    order2 = Cpk::Order.create!(id: [1, 2])
+    Cpk::Book.create!(id: [2, 1], order: order1)
+    book = Cpk::Book.find_or_initialize_by(order: order2)
+    assert_equal order2, book.order
+  end
+
   def test_explicit_create_with
     hens = Bird.where(name: "hen")
     assert_equal "hen", hens.new.name


### PR DESCRIPTION
Fixes #52358.

The problem was that when a primary key includes `"id"` column, then we should use `id_value` method to get its value.