### PR TITLE
Avoid late require calls in potential hot spots

### DIFF
--- a/activesupport/lib/active_support/configuration_file.rb
+++ b/activesupport/lib/active_support/configuration_file.rb
@@ -33,8 +33,8 @@ module ActiveSupport
 
     private
       def read(content_path)
-        require "yaml"
-        require "erb"
+        require "yaml" unless defined?(YAML)
+        require "erb" unless defined?(ERB)
 
         File.read(content_path).tap do |content|
           if content.include?("\u00A0")


### PR DESCRIPTION
Ref: https://bugs.ruby-lang.org/issues/20641
Ref: https://github.com/ruby/psych/pull/678

Granted it's an upstream bug, but even without the bug `require` isn't cheap. `ConfigurationFile` isn't that hot of a spot in production, but in Active Record test suite it's called for almost every test so with this Ruby 3.3 bug it account for significant part of the test suite runtime.
