### PR TITLE
Improve documentation around build ActiveRecord Relations in connected_to blocks [ci skip]

### DIFF
--- a/activerecord/lib/active_record/connection_handling.rb
+++ b/activerecord/lib/active_record/connection_handling.rb
@@ -133,6 +133,17 @@ module ActiveRecord
     #   ActiveRecord::Base.connected_to(role: :reading, shard: :shard_one_replica) do
     #     Dog.first # finds first Dog record stored on the shard one replica
     #   end
+    #
+    # Note that when a `connected_to` block returns a relation, the query will be executed by calling `return_value.load`.
+    # If building multiple relations within the block, you may be surprised to see that only the last relationship is executed
+    # against the expected role.
+    #
+    #   ApplicationRecord.connected_to(role: :reading) do
+    #     @people = Person.all # Reads from writing role.
+    #     @dogs = Dog.all # Reads from reading role.
+    #   end
+    #
+    # Explicitly calling `Person.all.load` would execute the query against the expected role, however.
     def connected_to(role: nil, shard: nil, prevent_writes: false, &blk)
       if self != Base && !abstract_class
         raise NotImplementedError, "calling `connected_to` is only allowed on ActiveRecord::Base or abstract classes."

--- a/activerecord/lib/active_record/connection_handling.rb
+++ b/activerecord/lib/active_record/connection_handling.rb
@@ -138,7 +138,7 @@ module ActiveRecord
     # If building multiple relations within the block, you may be surprised to see that only the last relationship is executed
     # against the expected role.
     #
-    #   ApplicationRecord.connected_to(role: :reading) do
+    #   ActiveRecord::Base.connected_to(role: :reading) do
     #     @people = Person.all # Reads from writing role.
     #     @dogs = Dog.all # Reads from reading role.
     #   end

--- a/guides/source/active_record_multiple_databases.md
+++ b/guides/source/active_record_multiple_databases.md
@@ -387,6 +387,19 @@ The "role" in the `connected_to` call looks up the connections that are connecte
 connection handler (or role). The `reading` connection handler will hold all the connections
 that were connected via `connects_to` with the role name of `reading`.
 
+Note that when a `connected_to` block returns a relation, the query will be executed by calling `return_value.load`.
+If building multiple relations within the block, you may be surprised to see that only the last relationship is executed
+against the expected role.
+
+```ruby
+ApplicationRecord.connected_to(role: :reading) do
+  @people = Person.all # Reads from writing role.
+  @dogs = Dog.all # Reads from reading role.
+end
+```
+
+Explicitly calling `Person.all.load` would execute the query against the expected role, however.
+
 Note that `connected_to` with a role will look up an existing connection and switch
 using the connection specification name. This means that if you pass an unknown role
 like `connected_to(role: :nonexistent)` you will get an error that says

--- a/guides/source/active_record_multiple_databases.md
+++ b/guides/source/active_record_multiple_databases.md
@@ -392,7 +392,7 @@ If building multiple relations within the block, you may be surprised to see tha
 against the expected role.
 
 ```ruby
-ApplicationRecord.connected_to(role: :reading) do
+ActiveRecord::Base.connected_to(role: :reading) do
   @people = Person.all # Reads from writing role.
   @dogs = Dog.all # Reads from reading role.
 end


### PR DESCRIPTION
### Motivation / Background
This PR adds documentation around the sharp knife and unexpected behavior introduced in #38339. 

While all the examples in the current documentation execute single queries or build and return single relationships (and thus, work without surprise) one might want to use the same block to build many relationships, only to find the returning relationship is automatically loaded from the expected role, while the other relationship(s) are not.

Further, if the block does not actually return an ARel, then the user may be surprised.

### Detail

This PR updates the guides and api docs for `connected_to` to highlight this unexpected behavior.
### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
