### PR TITLE
Session generator - NoMethodError on sign out

### DIFF
--- a/railties/lib/rails/generators/rails/sessions/sessions_generator.rb
+++ b/railties/lib/rails/generators/rails/sessions/sessions_generator.rb
@@ -16,7 +16,7 @@ module Rails
 
       def configure_application
         gsub_file "app/controllers/application_controller.rb", /(class ApplicationController < ActionController::Base)/, "\\1\n  include Authentication"
-        route "resource :session"
+        route "resource :session, only: %i[new create destroy]"
       end
 
       def enable_bcrypt

--- a/railties/lib/rails/generators/rails/sessions/templates/controllers/concerns/authentication.rb
+++ b/railties/lib/rails/generators/rails/sessions/templates/controllers/concerns/authentication.rb
@@ -37,7 +37,7 @@ module Authentication
 
     def request_authentication
       session[:return_to_after_authenticating] = request.url
-      redirect_to new_session_url, alert: "Please log in to continue."
+      redirect_to new_session_url
     end
 
     def after_authentication_url

--- a/railties/lib/rails/generators/rails/sessions/templates/controllers/concerns/authentication.rb
+++ b/railties/lib/rails/generators/rails/sessions/templates/controllers/concerns/authentication.rb
@@ -37,7 +37,7 @@ module Authentication
 
     def request_authentication
       session[:return_to_after_authenticating] = request.url
-      redirect_to new_session_url
+      redirect_to new_session_url, alert: "Please log in to continue."
     end
 
     def after_authentication_url

--- a/railties/lib/rails/generators/rails/sessions/templates/controllers/sessions_controller.rb
+++ b/railties/lib/rails/generators/rails/sessions/templates/controllers/sessions_controller.rb
@@ -1,5 +1,5 @@
 class SessionsController < ApplicationController
-  allow_unauthenticated_access(only: %i[new create])
+  allow_unauthenticated_access(only: %i[ new create ])
   rate_limit to: 10, within: 3.minutes, only: :create, with: -> { redirect_to new_session_url, alert: "Try again later." }
 
   def new

--- a/railties/lib/rails/generators/rails/sessions/templates/controllers/sessions_controller.rb
+++ b/railties/lib/rails/generators/rails/sessions/templates/controllers/sessions_controller.rb
@@ -1,5 +1,5 @@
 class SessionsController < ApplicationController
-  allow_unauthenticated_access
+  allow_unauthenticated_access(only: %i[new create])
   rate_limit to: 10, within: 3.minutes, only: :create, with: -> { redirect_to new_session_url, alert: "Try again later." }
 
   def new

--- a/railties/lib/rails/generators/rails/sessions/templates/controllers/sessions_controller.rb
+++ b/railties/lib/rails/generators/rails/sessions/templates/controllers/sessions_controller.rb
@@ -1,5 +1,6 @@
 class SessionsController < ApplicationController
   allow_unauthenticated_access(only: %i[ new create ])
+  before_action :resume_session, only: :new
   rate_limit to: 10, within: 3.minutes, only: :create, with: -> { redirect_to new_session_url, alert: "Try again later." }
 
   def new


### PR DESCRIPTION
When an authenticated user clicks `button_to 'Sign out', session_path, method: :delete>, he gets an error:

<img width="696" alt="Screenshot 2024-07-19 at 21 39 54" src="https://github.com/user-attachments/assets/7dcdd078-1767-4468-99bd-31b12642b0e3">

This will fix it. 
