### PR TITLE
FIX: Sessions generator opening new and create page

### DIFF
--- a/railties/lib/rails/generators/rails/sessions/templates/controllers/sessions_controller.rb
+++ b/railties/lib/rails/generators/rails/sessions/templates/controllers/sessions_controller.rb
@@ -2,8 +2,9 @@ class SessionsController < ApplicationController
   allow_unauthenticated_access
   rate_limit to: 10, within: 3.minutes, only: :create, with: -> { redirect_to new_session_url, alert: "Try again later." }
 
+  before_action :redirect_on_resumable_session, only: %i[ new create ]
+
   def new
-    redirect_to root_url if authenticated?
   end
 
   def create
@@ -19,4 +20,9 @@ class SessionsController < ApplicationController
     terminate_session
     redirect_to new_session_url
   end
+
+  private
+    def redirect_on_resumable_session
+      redirect_to root_url if resume_session
+    end
 end


### PR DESCRIPTION
If current session is present **new or create** will pass. We can't rely on `Current.session` since authentication is skipped above, we need to check if user has a valid session cookie without using `Current.session`.

I'm not sure whether using `resume_session` is the best approach here but it was the one with the least amount of ceremony.
