### PR TITLE
Set allowed_ips in generated development.rb for Docker environments

### DIFF
--- a/guides/source/debugging_rails_applications.md
+++ b/guides/source/debugging_rails_applications.md
@@ -843,6 +843,13 @@ do that with `local_variables`.
 * `config.web_console.whiny_requests`: Log a message when a console rendering
   is prevented (defaults: `true`).
 
+### Development With Docker
+
+When running the application with Docker in development, `web-console` will not
+work by default. To configure `web-console` to work within a Docker network,
+set `config.web_console.allowed_ips` in development.rb to include the network
+where the application is running.
+
 Since `web-console` evaluates plain Ruby code remotely on the server, don't try
 to use it in production.
 

--- a/railties/lib/rails/generators/rails/app/templates/config/environments/development.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/development.rb.tt
@@ -14,6 +14,14 @@ Rails.application.configure do
   # Show full error reports.
   config.consider_all_requests_local = true
 
+  <%- unless options.skip_docker? || options.skip_dev_gems? -%>
+  # Allow access to web_console when running in Docker.
+  # common ranges include "172.16.0.0/12", "192.168.0.0/16", but there may be
+  # custom ranges defined by different Docker engines and by developers at the
+  # application level.
+  config.web_console.allowed_ips = ENV.fetch("WEB_CONSOLE_ALLOWED_IPS") { "172.16.0.0/12,192.168.0.0/16" }.split(",")
+  <%- end -%>
+
   # Enable server timing.
   config.server_timing = true
 

--- a/railties/lib/rails/generators/rails/app/templates/config/environments/development.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/development.rb.tt
@@ -19,7 +19,9 @@ Rails.application.configure do
   # common ranges include "172.16.0.0/12", "192.168.0.0/16", but there may be
   # custom ranges defined by different Docker engines and by developers at the
   # application level.
-  config.web_console.allowed_ips = ENV.fetch("WEB_CONSOLE_ALLOWED_IPS") { "172.16.0.0/12,192.168.0.0/16" }.split(",")
+  if ENV["WEB_CONSOLE_ALLOWED_IPS"]
+    config.web_console.allowed_ips = ENV["WEB_CONSOLE_ALLOWED_IPS"].split(",")
+  end
   <%- end -%>
 
   # Enable server timing.

--- a/railties/lib/rails/generators/rails/devcontainer/templates/devcontainer/compose.yaml.tt
+++ b/railties/lib/rails/generators/rails/devcontainer/templates/devcontainer/compose.yaml.tt
@@ -5,6 +5,8 @@ services:
     build:
       context: ..
       dockerfile: .devcontainer/Dockerfile
+    environment:
+      WEB_CONSOLE_ALLOWED_IPS: "172.16.0.0/12,192.168.0.0/16"
 
     volumes:
     - ../..:/workspaces:cached

--- a/railties/lib/rails/generators/rails/devcontainer/templates/devcontainer/compose.yaml.tt
+++ b/railties/lib/rails/generators/rails/devcontainer/templates/devcontainer/compose.yaml.tt
@@ -5,8 +5,6 @@ services:
     build:
       context: ..
       dockerfile: .devcontainer/Dockerfile
-    environment:
-      WEB_CONSOLE_ALLOWED_IPS: "172.16.0.0/12,192.168.0.0/16"
 
     volumes:
     - ../..:/workspaces:cached


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created for two reasons

1. Running the Rails application with Docker in development has become more common/standard, developers will not be able to use `web_console` to debug application without updating the `allowed_ips`. Additionally, the message doesn't  direct a developer how to make it it work without searching for the message online.
2. Because every time a Rails app is upgraded to a new version of Rails and `app:update` is run, it overwrites my changes for `allowed_ips`.

Now that Docker related files (Dockerfile and dev container) are part of the default `rails new` generation, it is fairly standard to develop and debug against a Rails app running a Docker container. Out of the box, this leads to the whiny warning:

```
 Cannot render console from 192.168.167.1! Allowed networks: 127.0.0.0/127.255.255.255, ::1
```


### Detail

This Pull Request changes the generated `development.rb` file and docker compose to allow Docker network IPs to be used in the `allowed_ips` configuration. The defaults proposed here are static and broad for simplicity, but there are other options. It could be more dynamically set, or maybe the possibilities are just too varied to provide a good default and setting the env var would be left to the developer to populate (with a doc/guide update note perhaps as well?)

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->
Discussion of various solutions for what to set the value to in https://stackoverflow.com/questions/29417328/how-to-disable-cannot-render-console-from-on-rails


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
