### PR TITLE
Fix swallowing ignore order warning when batching using `BatchEnumerator`

### DIFF
--- a/activerecord/lib/active_record/relation/batches.rb
+++ b/activerecord/lib/active_record/relation/batches.rb
@@ -260,12 +260,12 @@ module ActiveRecord
       cursor = Array(cursor).map(&:to_s)
       ensure_valid_options_for_batching!(cursor, start, finish, order)
 
-      unless block
-        return BatchEnumerator.new(of: of, start: start, finish: finish, relation: self, cursor: cursor, order: order, use_ranges: use_ranges)
-      end
-
       if arel.orders.present?
         act_on_ignored_order(error_on_ignore)
+      end
+
+      unless block
+        return BatchEnumerator.new(of: of, start: start, finish: finish, relation: self, cursor: cursor, order: order, use_ranges: use_ranges)
       end
 
       batch_limit = of

--- a/activerecord/test/cases/batches_test.rb
+++ b/activerecord/test/cases/batches_test.rb
@@ -318,6 +318,16 @@ class EachTest < ActiveRecord::TestCase
     end
   end
 
+  def test_in_batches_should_error_on_ignore_the_order
+    assert_raise(ArgumentError, match: "Scoped order is ignored") do
+      PostWithDefaultScope.in_batches(error_on_ignore: true) { }
+    end
+
+    assert_raise(ArgumentError, match: "Scoped order is ignored") do
+      PostWithDefaultScope.in_batches(error_on_ignore: true).delete_all
+    end
+  end
+
   def test_in_batches_has_attribute_readers
     enumerator = Post.no_comments.in_batches(of: 2, start: 42, finish: 84)
     assert_equal Post.no_comments, enumerator.relation


### PR DESCRIPTION
Currently, `error_on_ignore` option is not passed to the `BatchEnumerator`. And when we iterate using it (via something like `Post.in_batches(error_on_ignore: true).delete_all`) it is lost. 
So we need to check for the option presence before we return the `BatchEnumerator` instance.