### PR TITLE
Sessions: Don't allow saving user without an email

### DIFF
--- a/railties/lib/rails/generators/rails/authentication/templates/models/user.rb
+++ b/railties/lib/rails/generators/rails/authentication/templates/models/user.rb
@@ -1,4 +1,6 @@
 class User < ApplicationRecord
   has_secure_password validations: false
   has_many :sessions, dependent: :destroy
+
+  validates :email_address, presence: true
 end


### PR DESCRIPTION
Currently it is possible to save user without email address. This commit adds validation to disallow saving empty email_address.
