### PR TITLE
Sessions generator: add basic registrations

### DIFF
--- a/railties/lib/rails/generators/rails/sessions/sessions_generator.rb
+++ b/railties/lib/rails/generators/rails/sessions/sessions_generator.rb
@@ -9,6 +9,7 @@ module Rails
         template "models/current.rb", File.join("app/models/current.rb")
 
         template "controllers/sessions_controller.rb", File.join("app/controllers/sessions_controller.rb")
+        template "controllers/registrations_controller.rb", File.join("app/controllers/registrations_controller.rb")
         template "controllers/concerns/authentication.rb", File.join("app/controllers/concerns/authentication.rb")
 
         template "views/sessions/new.html.erb", File.join("app/views/sessions/new.html.erb")

--- a/railties/lib/rails/generators/rails/sessions/sessions_generator.rb
+++ b/railties/lib/rails/generators/rails/sessions/sessions_generator.rb
@@ -12,11 +12,13 @@ module Rails
         template "controllers/concerns/authentication.rb", File.join("app/controllers/concerns/authentication.rb")
 
         template "views/sessions/new.html.erb", File.join("app/views/sessions/new.html.erb")
+        template "views/registrations/new.html.erb", File.join("app/views/registrations/new.html.erb")
       end
 
       def configure_application
         gsub_file "app/controllers/application_controller.rb", /(class ApplicationController < ActionController::Base)/, "\\1\n  include Authentication"
         route "resource :session"
+        route "resource :registration, only: %i[ new create ]"
       end
 
       def enable_bcrypt

--- a/railties/lib/rails/generators/rails/sessions/templates/controllers/registrations_controller.rb
+++ b/railties/lib/rails/generators/rails/sessions/templates/controllers/registrations_controller.rb
@@ -1,0 +1,19 @@
+class RegistrationsController < ApplicationController
+  allow_unauthenticated_access
+  before_action :resume_session, only: :new
+  rate_limit to: 10, within: 3.minutes, only: :create, with: -> { redirect_to new_session_url, alert: "Try again later." }
+
+  def new
+    redirect_to root_url if authenticated?
+  end
+
+  def create
+    user = User.new(params.permit(:email_address, :password))
+    if user.save
+      start_new_session_for user
+      redirect_to after_authentication_url
+    else
+      redirect_to new_registration_url(email_address: params[:email_address]), alert: user.errors.full_messages.to_sentence
+    end
+  end
+end

--- a/railties/lib/rails/generators/rails/sessions/templates/models/user.rb
+++ b/railties/lib/rails/generators/rails/sessions/templates/models/user.rb
@@ -1,4 +1,6 @@
 class User < ApplicationRecord
   has_secure_password validations: false
   has_many :sessions, dependent: :destroy
+
+  validates :email_address, presence: true, uniqueness: true, format: { with: URI::MailTo::EMAIL_REGEXP }
 end

--- a/railties/lib/rails/generators/rails/sessions/templates/views/registrations/new.html.erb
+++ b/railties/lib/rails/generators/rails/sessions/templates/views/registrations/new.html.erb
@@ -1,0 +1,15 @@
+<%% if alert = flash[:alert] %>
+  <div style="color:red"><%%= alert %></div>
+<%% end %>
+
+<%%= form_with url: registration_url do |form| %>
+  <div>
+    <%%= form.email_field :email_address, required: true, autofocus: true, autocomplete: "username", placeholder: "Enter your email address", value: params[:email_address] %>
+  </div>
+
+  <div>
+    <%%= form.password_field :password, required: true, autocomplete: "current-password", placeholder: "Enter your password", maxlength: 72 %>
+  </div>
+
+  <%%= form.submit "Sign up" %>
+<%% end %>

--- a/railties/test/generators/sessions_generator_test.rb
+++ b/railties/test/generators/sessions_generator_test.rb
@@ -27,8 +27,10 @@ class SessionsGeneratorTest < Rails::Generators::TestCase
     assert_file "app/models/current.rb"
     assert_file "app/models/session.rb"
     assert_file "app/controllers/sessions_controller.rb"
+    assert_file "app/controllers/registrations_controller.rb"
     assert_file "app/controllers/concerns/authentication.rb"
     assert_file "app/views/sessions/new.html.erb"
+    assert_file "app/views/registrations/new.html.erb"
 
     assert_file "app/controllers/application_controller.rb" do |content|
       assert_match(/include Authentication/, content)
@@ -40,6 +42,7 @@ class SessionsGeneratorTest < Rails::Generators::TestCase
 
     assert_file "config/routes.rb" do |content|
       assert_match(/resource :session/, content)
+      assert_match(/resource :registration, only: %i\[ new create \]/, content)
     end
 
     assert_migration "db/migrate/create_sessions.rb" do |content|


### PR DESCRIPTION
https://github.com/rails/rails/pull/52328 adds sessions (existing user can **sign in**).

This PR adds registrations (new user can **sign up**).

We already have database uniqueness validation for `email_address`, now we add validations in the `User` model to display errors during registration.

****

I think the next step to make this new authentication solution viable for a real app would be adding "forgot/reset password" feature.