### PR TITLE
handle database urls that are missing schemas

### DIFF
--- a/activerecord/lib/active_record/database_configurations/connection_url_resolver.rb
+++ b/activerecord/lib/active_record/database_configurations/connection_url_resolver.rb
@@ -81,7 +81,7 @@ module ActiveRecord
 
         def resolved_adapter
           adapter = uri.scheme && @uri.scheme.tr("-", "_")
-          adapter = ActiveRecord.protocol_adapters[adapter] || adapter
+          adapter = ActiveRecord.protocol_adapters[adapter] || adapter if adapter
           adapter
         end
 

--- a/activerecord/test/cases/connection_adapters/merge_and_resolve_default_url_config_test.rb
+++ b/activerecord/test/cases/connection_adapters/merge_and_resolve_default_url_config_test.rb
@@ -489,6 +489,16 @@ module ActiveRecord
 
         assert_equal expected, actual.configuration_hash
       end
+
+      def test_protocol_adapter_mapping_handles_missing_scheme_in_url
+        ENV["DATABASE_URL"] = "//localhost/exampledb"
+        ENV["RAILS_ENV"] = "production"
+
+        actual = resolve_db_config(:production, { "production" => { "adapter" => "abstract" } })
+        expected = { adapter: "abstract", database: "exampledb", host: "localhost" }
+
+        assert_equal expected, actual.configuration_hash
+      end
     end
   end
 end


### PR DESCRIPTION
### Motivation / Background

When resolving the adapter. for a url that is missing the schema (for example `//root@localhost:3306/database_name`) the adapter resolution currently errors with `NoMethodError: undefined method `to_sym' for nil` when calling `ActiveRecord.protocol_adapters[]`.

I am currently using such urls to allow for the adapter to be set by the application in the database.yml instead of the ENV vars which are managed externally to the application. 

### Detail

This Pull Request prevents this error from being raised when resolving the adapter.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included. (This error is only occurring in beta releases, so I don't think a change log is required).
