### PR TITLE
Optimize ActiveRecord::QueryLogs

### DIFF
--- a/activerecord/lib/active_record/query_logs_formatter.rb
+++ b/activerecord/lib/active_record/query_logs_formatter.rb
@@ -2,40 +2,29 @@
 
 module ActiveRecord
   module QueryLogs
-    class LegacyFormatter # :nodoc:
-      def initialize
-        @key_value_separator = ":"
-      end
-
-      # Formats the key value pairs into a string.
-      def format(pairs)
-        pairs.map! do |key, value|
-          "#{key}#{key_value_separator}#{format_value(value)}"
-        end.join(",")
-      end
-
-      private
-        attr_reader :key_value_separator
-
-        def format_value(value)
-          value
+    module LegacyFormatter # :nodoc:
+      class << self
+        # Formats the key value pairs into a string.
+        def format(key, value)
+          "#{key}:#{value}"
         end
+
+        def join(pairs)
+          pairs.join(",")
+        end
+      end
     end
 
-    class SQLCommenter < LegacyFormatter # :nodoc:
-      def initialize
-        @key_value_separator = "="
-      end
-
-      def format(pairs)
-        pairs.sort_by! { |pair| pair.first.to_s }
-        super
-      end
-
-      private
-        def format_value(value)
-          "'#{ERB::Util.url_encode(value)}'"
+    class SQLCommenter # :nodoc:
+      class << self
+        def format(key, value)
+          "#{key}='#{ERB::Util.url_encode(value)}'"
         end
+
+        def join(pairs)
+          pairs.join(",")
+        end
+      end
     end
   end
 end

--- a/activerecord/test/cases/query_logs_test.rb
+++ b/activerecord/test/cases/query_logs_test.rb
@@ -33,7 +33,7 @@ class QueryLogsTest < ActiveRecord::TestCase
     ActiveRecord::QueryLogs.prepend_comment = false
     ActiveRecord::QueryLogs.cache_query_log_tags = false
     ActiveRecord::QueryLogs.clear_cache
-    ActiveRecord::QueryLogs.update_formatter(:legacy)
+    ActiveRecord::QueryLogs.tags_formatter = :legacy
 
     # ActiveSupport::ExecutionContext context is automatically reset in Rails app via an executor hooks set in railtie
     # But not in Active Record's own test suite.
@@ -45,7 +45,8 @@ class QueryLogsTest < ActiveRecord::TestCase
   end
 
   def test_escaping_good_comment_with_custom_separator
-    ActiveRecord::QueryLogs.update_formatter(:sqlcommenter)
+    ActiveRecord::QueryLogs.tags_formatter = :sqlcommenter
+
     assert_equal "app='foo'", ActiveRecord::QueryLogs.send(:escape_sql_comment, "app='foo'")
   end
 
@@ -183,7 +184,8 @@ class QueryLogsTest < ActiveRecord::TestCase
   end
 
   def test_sql_commenter_format
-    ActiveRecord::QueryLogs.update_formatter(:sqlcommenter)
+    ActiveRecord::QueryLogs.tags_formatter = :sqlcommenter
+
     assert_queries_match(%r{/\*application='active_record'\*/}) do
       Dashboard.first
     end
@@ -211,13 +213,13 @@ class QueryLogsTest < ActiveRecord::TestCase
       { custom_proc: -> { "test content" }, another_proc: -> { "more test content" } },
     ]
 
-    assert_queries_match(%r{/\*application:active_record,custom_proc:test content,another_proc:more test content\*/}) do
+    assert_queries_match(%r{/\*another_proc:more test content,application:active_record,custom_proc:test content\*/}) do
       Dashboard.first
     end
   end
 
   def test_sqlcommenter_format_value
-    ActiveRecord::QueryLogs.update_formatter(:sqlcommenter)
+    ActiveRecord::QueryLogs.tags_formatter = :sqlcommenter
 
     ActiveRecord::QueryLogs.tags = [
       :application,
@@ -230,7 +232,7 @@ class QueryLogsTest < ActiveRecord::TestCase
   end
 
   def test_sqlcommenter_format_allows_string_keys
-    ActiveRecord::QueryLogs.update_formatter(:sqlcommenter)
+    ActiveRecord::QueryLogs.tags_formatter = :sqlcommenter
 
     ActiveRecord::QueryLogs.tags = [
       :application,
@@ -247,7 +249,7 @@ class QueryLogsTest < ActiveRecord::TestCase
   end
 
   def test_sqlcommenter_format_value_string_coercible
-    ActiveRecord::QueryLogs.update_formatter(:sqlcommenter)
+    ActiveRecord::QueryLogs.tags_formatter = :sqlcommenter
 
     ActiveRecord::QueryLogs.tags = [
       :application,


### PR DESCRIPTION
I noticed it showed up quite a bit on our production allocation profiles. I tried to not break the interface, but in reality most of it is private and it should only be configured through `application.config`.

main:

```
ruby 3.3.3 (2024-06-12 revision f1c7b6f435) +YJIT [arm64-darwin23]

Total allocated: 1440 bytes (18 objects)

Calculating -------------------------------------
                 tag    521.552k (± 2.0%) i/s -      2.652M in   5.087518s
```

this branch:

```
ruby 3.3.3 (2024-06-12 revision f1c7b6f435) +YJIT [arm64-darwin23]

Total allocated: 840 bytes (7 objects)

Calculating -------------------------------------
                 tag      1.070M (± 1.9%) i/s -      5.379M in   5.026878s
```

Benchmark:

```ruby
require 'bundler/inline'

gemfile(true) do
  source "https://rubygems.org"

  gem "benchmark-ips"
  gem "memory_profiler"
  gem "rails"
end

require "active_record"

ActiveRecord::QueryLogs.taggings = {
  some_handler: -> { "Handler" }
}
ActiveRecord::QueryLogs.tags = [
  :application,
  :some_handler,
  fixed_string: "fixed string",
  callback: ->(context) { "callback" },
]

ActiveSupport::ExecutionContext[:application] = "SuperApp"

ActiveRecord::QueryLogs.singleton_class.class_eval { public(:tag_content) }

ActiveRecord::QueryLogs.tag_content(:__connection__)

report = MemoryProfiler.report do
  ActiveRecord::QueryLogs.tag_content(:__connection__)
end

report.pretty_print

Benchmark.ips do |x|
  x.report("tag") { ActiveRecord::QueryLogs.tag_content(:__connection__) }
end
```
