### PR TITLE
Enhance ActiveModel length validation checks to catch unexpected options

### DIFF
--- a/activemodel/test/cases/validations/length_validation_test.rb
+++ b/activemodel/test/cases/validations/length_validation_test.rb
@@ -496,4 +496,9 @@ class LengthValidationTest < ActiveModel::TestCase
     t.title = ""
     assert_predicate t, :valid?
   end
+  def test_typo_in_length_options_raises_error
+    assert_raise(ArgumentError) { Topic.validates_length_of :title, minium: 5, maximum: 10 }
+    assert_raise(ArgumentError) { Topic.validates_length_of :title, mimum: 5, maximum: 10 }
+    assert_raise(ArgumentError) { Topic.validates_length_of :title, mimum: 5, maxium: 10 }
+  end
 end


### PR DESCRIPTION
### Motivation / Background

The type validation won't be captured by the length validation

For example:

```ruby
class Post < ActiveRecord::Base
  validates :title, length: { minium: 10, maximum: 20 }
end

post = Post.new(title: "Invalid")
puts post.valid? # true
```

What I want to do is like:

```ruby
class Post < ActiveRecord::Base
  validates :title, length: { minium: 10, maximum: 20 }
end

post = Post.new(title: "invalid")
ArgumentError: Range unspecified. Specify the :in, :within, :maximum, :minimum, or :is option.
```

https://discuss.rubyonrails.org/t/proposal-add-min-and-max-alias-to-lengthvalidator/82771

### Detail

1. Collect the valid option becomes a constant
2. Extract the `unexpected_keys` then raise the error like before
3. Keep the original behavior

### Additional information

Nope, Before I want to use `min` & `max`, but not a good idea. So I think this way would be better.

https://github.com/rails/rails/pull/48890

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
