### PR TITLE
Introduce ActiveRecord::Persistance#insert_rows

### DIFF
--- a/activerecord/lib/active_record/insert_rows.rb
+++ b/activerecord/lib/active_record/insert_rows.rb
@@ -1,0 +1,137 @@
+# frozen_string_literal: true
+
+require "active_support/core_ext/enumerable"
+
+module ActiveRecord
+  class InsertRows # :nodoc:
+    attr_reader :model, :connection, :inserts, :columns, :returning
+
+    class << self
+      def execute(model, ...)
+        model.with_connection do |c|
+          new(model, c, ...).execute
+        end
+      end
+    end
+
+    def initialize(model, connection, inserts, columns:, returning: nil)
+      @model = model
+      @connection = connection
+
+      columns = columns.map(&:to_s)
+      duplicated_columns = columns.tally.select { |_, c| c > 1 }.keys
+      if duplicated_columns.any?
+        raise ArgumentError, "Duplicate columns are not allowed, found columns: #{duplicated_columns.join(', ')}"
+      end
+
+      @columns = columns.to_set
+      @inserts = inserts
+
+      @returning = returning
+
+      disallow_raw_sql!(returning)
+
+      @returning = (connection.supports_insert_returning? ? primary_keys : false) if @returning.nil?
+      @returning = false if @returning == []
+
+      ensure_valid_options_for_connection!
+    end
+
+    def execute
+      return ActiveRecord::Result.empty if inserts.empty?
+
+      message = +"#{model} Bulk Insert"
+      connection.exec_insert_all to_sql, message
+    end
+
+    def primary_keys
+      Array(@model.schema_cache.primary_keys(model.table_name))
+    end
+
+    private
+      def ensure_valid_options_for_connection!
+        if returning && !connection.supports_insert_returning?
+          raise ArgumentError, "#{connection.class} does not support :returning"
+        end
+      end
+
+      def to_sql
+        connection.build_insert_sql(ActiveRecord::InsertRows::Builder.new(self))
+      end
+
+      def disallow_raw_sql!(value)
+        return if !value.is_a?(String) || Arel.arel_node?(value)
+
+        raise ArgumentError, "Dangerous query method (method whose arguments are used as raw " \
+                             "SQL) called: #{value}. " \
+                             "Known-safe values can be passed " \
+                             "by wrapping them in Arel.sql()."
+      end
+
+      class Builder # :nodoc:
+        attr_reader :model
+
+        delegate :columns, to: :insert_all
+
+        def initialize(insert_all)
+          @insert_all, @model, @connection = insert_all, insert_all.model, insert_all.connection
+        end
+
+        def into
+          "INTO #{model.quoted_table_name} (#{columns_list})"
+        end
+
+        def values_list
+          insert_all.inserts.each_with_index do |row, index|
+            next if row.length == columns.length
+
+            raise ArgumentError, "Number of columns (#{row.length}) does not match number of keys (#{columns.length}) at index #{index}"
+          end
+          values_list = insert_all.inserts
+
+          connection.visitor.compile(Arel::Nodes::ValuesList.new(values_list))
+        end
+
+        def returning
+          return unless insert_all.returning
+
+          if insert_all.returning.is_a?(String)
+            insert_all.returning
+          else
+            Array(insert_all.returning).map do |attribute|
+              quote_column(attribute)
+            end.join(",")
+          end
+        end
+
+        def raw_update_sql
+          insert_all.update_sql
+        end
+
+        def keys
+          columns
+        end
+
+        def skip_duplicates?
+          false
+        end
+
+        def update_duplicates?
+          false
+        end
+
+        alias raw_update_sql? raw_update_sql
+
+        private
+          attr_reader :connection, :insert_all
+
+          def columns_list
+            insert_all.columns.map { |column| quote_column(column) }.join(",")
+          end
+
+          def quote_column(column)
+            connection.quote_column_name(column)
+          end
+      end
+  end
+end

--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "active_record/insert_all"
+require "active_record/insert_rows"
 
 module ActiveRecord
   # = Active Record \Persistence
@@ -85,6 +86,26 @@ module ActiveRecord
         else
           new(attributes, &block)
         end
+      end
+
+      # Given an array of arrays, inserts records into the table bypassing ActiveRecord model layer and validations.
+      # Note that the caller is responsible for type casting attribute values.
+      # If you prefer a higher level API that provides type casting, consider using {insert_all}[rdoc-ref:Relation#insert_all].
+      #
+      # ==== Examples
+      #
+      #     Book.insert_rows([
+      #       [1, "Rework", "David"],
+      #       [2, "Eloquent Ruby", "Russ"]
+      #     ], columns: [:id, :title, :author])
+      #
+      #
+      #     Book.insert_rows([
+      #       [1, "Rework", Arel.sql("NOW()")],
+      #       [2, "Eloquent Ruby", Arel.sql("NOW()")]
+      #     ], columns: [:id, :title, :created_at], returning: [:id])
+      def insert_rows(rows, columns:, returning: nil)
+        InsertRows.execute(self, rows, columns: columns, returning: returning)
       end
 
       # Given an attributes hash, +instantiate+ returns a new instance of

--- a/activerecord/test/cases/insert_rows_test.rb
+++ b/activerecord/test/cases/insert_rows_test.rb
@@ -1,0 +1,139 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+require "models/book"
+
+class InsertRowsTest < ActiveRecord::TestCase
+  fixtures :books
+
+  def setup
+    Arel::Table.engine = nil # should not rely on the global Arel::Table.engine
+    @original_db_warnings_action = :ignore
+  end
+
+  def teardown
+    Arel::Table.engine = ActiveRecord::Base
+  end
+
+  def test_insert_rows
+    assert_difference "Book.count", +10 do
+      Book.insert_rows([
+        ["Rework", 1 ],
+        ["Patterns of Enterprise Application Architecture", 1 ],
+        ["Design of Everyday Things", 1 ],
+        ["Practical Object-Oriented Design in Ruby", 1 ],
+        ["Clean Code", 1 ],
+        ["Ruby Under a Microscope", 1 ],
+        ["The Principles of Product Development Flow", 1 ],
+        ["Peopleware", 1 ],
+        ["About Face", 1 ],
+        ["Eloquent Ruby", 1 ],
+      ], columns: %w(name author_id))
+    end
+  end
+
+  def test_insert_rows_raises_error_on_duplicate_columns
+    assert_raises(ArgumentError) do
+      Book.insert_rows([
+        ["Rework", 1, 2]
+      ], columns: %w(name author_id author_id))
+    end
+
+    assert_raises(ArgumentError) do
+      Book.insert_rows([
+        ["Rework", 1, 2]
+      ], columns: ["name", :author_id, "author_id"])
+    end
+  end
+
+  def test_insert_rows_column_mode_mismatch
+    assert_raises(ArgumentError) do
+      Book.insert_rows([
+        ["Rework", 1, 2]
+      ], columns: %w(name author_id))
+    end
+
+    assert_raises(ArgumentError) do
+      Book.insert_rows([
+        ["Rework", 1],
+        ["Rework", 1, 2]
+      ], columns: %w(name author_id))
+    end
+
+    assert_raises(ArgumentError) do
+      Book.insert_rows([
+        ["Rework", 1],
+        ["Rework", 1, 2]
+      ], columns: %w(name author_id onemore))
+    end
+  end
+
+  def test_insert_rows_with_arel_predicates
+    sql_predicate = if current_adapter?(:SQLite3Adapter)
+      "DATE('now', '+1 day')"
+    elsif current_adapter?(:PostgreSQLAdapter)
+      "NOW() + INTERVAL '1 DAY'"
+    else
+      "NOW() + INTERVAL 1 DAY"
+    end
+
+    Book.insert_rows([
+      ["Rework", 1, Arel.sql(sql_predicate) ],
+    ], columns: %w(name author_id updated_at))
+
+    book = Book.find_by(name: "Rework")
+    assert book.updated_at > Time.current, "expected #{book.updated_at} to be greater than #{Time.current}"
+  end
+
+  def test_insert_all_should_handle_empty_arrays
+    skip unless supports_insert_on_duplicate_update?
+
+    assert_empty Book.insert_rows([], columns: %w(name author_id))
+  end
+
+  def test_insert_all_returns_ActiveRecord_Result
+    result = Book.insert_rows [ [ "Rework", 1 ]], columns: %w(name author_id)
+    assert_kind_of ActiveRecord::Result, result
+  end
+
+  def test_insert_all_returns_primary_key_if_returning_is_supported
+    skip unless supports_insert_returning?
+
+    result = Book.insert_rows [ [ "Rework", 1 ]], columns: %w(name author_id)
+    assert_equal %w[ id ], result.columns
+  end
+
+  def test_insert_all_returns_nothing_if_returning_is_empty
+    skip unless supports_insert_returning?
+
+    result = Book.insert_rows [ [ "Rework", 1 ]], columns: %w(name author_id), returning: []
+    assert_equal [], result.columns
+  end
+
+  def test_insert_all_returns_nothing_if_returning_is_false
+    skip unless supports_insert_returning?
+
+    result = Book.insert_rows [ [ "Rework", 1 ]], columns: %w(name author_id), returning: false
+    assert_equal [], result.columns
+  end
+
+  def test_insert_all_returns_requested_fields
+    skip unless supports_insert_returning?
+
+    result = Book.insert_rows [ [ "Rework", 1 ]], columns: %w(name author_id), returning: [:id, :name]
+    assert_equal %w[ Rework ], result.pluck("name")
+  end
+
+  if current_adapter?(:Mysql2Adapter, :TrilogyAdapter)
+    def test_insert_all_when_table_name_contains_database
+      database_name = Book.connection_db_config.database
+      Book.table_name = "#{database_name}.books"
+
+      assert_nothing_raised do
+        Book.insert_rows [ [ "Rework", 1 ]], columns: %w(name author_id)
+      end
+    ensure
+      Book.table_name = "books"
+    end
+  end
+end


### PR DESCRIPTION
This PR is an alternative to https://github.com/rails/rails/pull/52228, exploring @byroot's idea of a separate method from `insert_all`. That way, the interface of `insert_all` does not become too crowded.

## Background

We have some performance-critical endpoints where we want to allocate least # of objects and use `insert_all` to write 1000s of rows into the database.

However, we see `insert_all` being ~2.5x slower compared to manually building `INSERT INTO <table> VALUES (...), (...)`.

I've been profiling `insert_all` and that turned out to be largely because it 1) works with arrays of hashes and each hash needs to be traversed 2) it serializes attributes via Attributes API.

That's great default behavior but if we're inserting 2000 tuples of `(<foreigh-key>, <foreigh-key>, <foreigh-key>)`, we don't want to traverse hashes and run the complexity of casting integers to integers via Attributes API.

I'd like to propose a "column mode" for inserting rows that takes arrays of arrays (no need to traverse hashes!) and makes attribute casting is the responsibility of the caller.

With that approach, we're able to make `insert_rows` as fast as direct string building:

```
ruby 3.3.1 (2024-04-23 revision c56cd86388) [arm64-darwin23]
Warming up --------------------------------------
          insert_all     4.000 i/100ms
insert_all with columns
                        11.000 i/100ms
             raw sql    13.000 i/100ms
           with Arel    12.000 i/100ms
Calculating -------------------------------------
          insert_all     41.522 (± 7.2%) i/s -    168.000 in   4.066766s
insert_all with columns
                         86.048 (±23.2%) i/s -    341.000 in   4.161382s
             raw sql    114.595 (±14.0%) i/s -    455.000 in   4.055053s
           with Arel    100.232 (±23.9%) i/s -    384.000 in   4.084465s

Comparison:
             raw sql:      114.6 i/s
           with Arel:      100.2 i/s - same-ish: difference falls within error
insert_all with columns:       86.0 i/s - same-ish: difference falls within error
          insert_all:       41.5 i/s - 2.76x  slower
```

<details><summary>Benchmark code</summary>
<p>

```ruby
# frozen_string_literal: true

require 'debug'
require "active_record"
require "benchmark/ips"

GC.disable

ROWS_COUNT = 1000

ActiveRecord::Base.establish_connection({ adapter: "sqlite3", database: ":memory:" })

class Commerce < ActiveRecord::Base
  connection.create_table :commerces, force: true do |t|
    t.string :name, :email, :title, :tags
    t.integer :variant_id, :product_id, :inventory_id, :something_id, :another_id
    t.boolean :fulfilled
    t.datetime :fulfilled_at, :deleted_at
    t.timestamps null: true
  end
end

def db_time(value)
  value.to_formatted_s(:db).inspect
end

ATTRS = {
  name: "sam",
  email: "kirs@shopify.com",
  title: "title",
  tags: "tag1,tag2,tag3",
  variant_id: 1,
  product_id: 1,
  inventory_id: 1,
  something_id: 1,
  another_id: 1,
  fulfilled: true,
  fulfilled_at: Time.now,
  deleted_at: Time.now
}

Benchmark.ips do |x|
  x.warmup = 2
  x.time   = 4

  relation = Commerce.all

  x.report("insert_all") do
    conn = Commerce.connection

    relation.insert_all(
      [ATTRS] * ROWS_COUNT
    )
  end

  x.report("insert_all with columns") do
    conn = Commerce.connection
    attrs = ATTRS.dup
    attrs[:fulfilled_at] = attrs[:fulfilled_at].to_formatted_s(:db)
    attrs[:deleted_at] = attrs[:deleted_at].to_formatted_s(:db)
    attrs[:created_at] = Time.now.to_formatted_s(:db)
    attrs[:updated_at] = attrs[:created_at]

    values = [
      attrs[:name], attrs[:email], attrs[:title], attrs[:tags], attrs[:variant_id], attrs[:product_id], attrs[:inventory_id], attrs[:something_id], attrs[:another_id], attrs[:fulfilled], attrs[:fulfilled_at], attrs[:deleted_at], attrs[:created_at], attrs[:updated_at]
    ]

    relation.insert_all(
      [values] * ROWS_COUNT,
      columns: %w[name email title tags variant_id product_id inventory_id something_id another_id fulfilled fulfilled_at deleted_at created_at updated_at],
    )
  end

  x.report("raw sql") do
    conn = Commerce.connection
    values = (1..ROWS_COUNT).map do
      attrs = ATTRS
      "(#{conn.quote(attrs[:name])}, #{conn.quote(attrs[:email])}, #{conn.quote(attrs[:title])}, #{conn.quote(attrs[:tags])}, #{attrs[:variant_id]}, #{attrs[:product_id]}, #{attrs[:inventory_id]}, #{attrs[:something_id]}, #{attrs[:another_id]}, #{attrs[:fulfilled]}, #{db_time(attrs[:fulfilled_at])}, #{db_time(attrs[:deleted_at])}, #{db_time(Time.now)}, #{db_time(Time.now)})"
    end

    conn.execute(
      "INSERT INTO commerces (name, email, title, tags, variant_id, product_id, inventory_id, something_id, another_id, fulfilled, fulfilled_at, deleted_at, created_at, updated_at) "\
      "VALUES #{values.join(',')}"
    )
  end

  x.report("with Arel") do
    conn = Commerce.connection
    columns = %w[name email title tags variant_id product_id inventory_id something_id another_id fulfilled fulfilled_at deleted_at created_at updated_at]
    attrs = ATTRS.dup
    attrs[:fulfilled_at] = (attrs[:fulfilled_at]).to_formatted_s(:db)
    attrs[:deleted_at] = (attrs[:deleted_at]).to_formatted_s(:db)
    attrs[:created_at] = (Time.now).to_formatted_s(:db)
    attrs[:updated_at] = (Time.now).to_formatted_s(:db)

    values_list = [attrs.values] * ROWS_COUNT

    sql = "INSERT INTO #{Commerce.quoted_table_name} (#{columns.join(',')}) "
    sql << conn.visitor.compile(Arel::Nodes::ValuesList.new(values_list))
    conn.execute(sql)
  end

  x.compare!
end
```

</p>
</details> 