### PR TITLE
Address ApplicationTests::QueryLogsTest errors

### DIFF
--- a/activerecord/lib/active_record/railtie.rb
+++ b/activerecord/lib/active_record/railtie.rb
@@ -400,7 +400,7 @@ To keep using the current cache store, you can turn off cache versioning entirel
           end
 
           if app.config.active_record.query_log_tags_format
-            ActiveRecord::QueryLogs.update_formatter(app.config.active_record.query_log_tags_format)
+            ActiveRecord::QueryLogs.tags_formatter = app.config.active_record.query_log_tags_format
           end
 
           if app.config.active_record.cache_query_log_tags

--- a/railties/test/application/query_logs_test.rb
+++ b/railties/test/application/query_logs_test.rb
@@ -277,11 +277,11 @@ module ApplicationTests
 
       get "/", {}, { "HTTPS" => "on" }
       comment = last_response.body.strip
-      assert_equal %(/*action:index,namespaced_controller:users,controller:users*/), comment
+      assert_match %(/*action:index,controller:users,namespaced_controller:users*/), comment
 
       get "/namespaced/users", {}, { "HTTPS" => "on" }
       comment = last_response.body.strip
-      assert_equal %(/*action:index,namespaced_controller:name_spaced/users,controller:users*/), comment
+      assert_match %(/*action:index,controller:users,namespaced_controller:name_spaced/users*/), comment
     end
 
     private


### PR DESCRIPTION
### Motivation / Background

This commit addresses the following test errors since #52392
https://buildkite.com/rails/rails/builds/109325#0190daa3-7401-4c4d-9980-d633ff17336e

### Detail

This commit addresses the following error.

```ruby
$ bin/test test/application/query_logs_test.rb:271
Run options: --seed 58601

# Running:

E

Error:
ApplicationTests::QueryLogsTest#test_controller_and_namespaced_controller_are_named_correctly,_legacy:
NoMethodError: undefined method `update_formatter' for module ActiveRecord::QueryLogs
    /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/railtie.rb:403:in `block (2 levels) in <class:Railtie>'
    /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/lazy_load_hooks.rb:94:in `block in execute_hook'
    /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/lazy_load_hooks.rb:87:in `with_execution_control'
    /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/lazy_load_hooks.rb:92:in `execute_hook'
    /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/lazy_load_hooks.rb:78:in `block in run_load_hooks'
    /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/lazy_load_hooks.rb:77:in `each'
    /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/lazy_load_hooks.rb:77:in `run_load_hooks'
    lib/rails/application/finisher.rb:94:in `block in <module:Finisher>'
    lib/rails/initializable.rb:32:in `instance_exec'
    lib/rails/initializable.rb:32:in `run'
    lib/rails/initializable.rb:61:in `block in run_initializers'
    /home/yahonda/.rbenv/versions/3.3.4/lib/ruby/3.3.0/tsort.rb:231:in `block in tsort_each'
    /home/yahonda/.rbenv/versions/3.3.4/lib/ruby/3.3.0/tsort.rb:353:in `block (2 levels) in each_strongly_connected_component'
    /home/yahonda/.rbenv/versions/3.3.4/lib/ruby/3.3.0/tsort.rb:434:in `each_strongly_connected_component_from'
    /home/yahonda/.rbenv/versions/3.3.4/lib/ruby/3.3.0/tsort.rb:352:in `block in each_strongly_connected_component'
    /home/yahonda/.rbenv/versions/3.3.4/lib/ruby/3.3.0/tsort.rb:350:in `each'
    /home/yahonda/.rbenv/versions/3.3.4/lib/ruby/3.3.0/tsort.rb:350:in `call'
    /home/yahonda/.rbenv/versions/3.3.4/lib/ruby/3.3.0/tsort.rb:350:in `each_strongly_connected_component'
    /home/yahonda/.rbenv/versions/3.3.4/lib/ruby/3.3.0/tsort.rb:229:in `tsort_each'
    /home/yahonda/.rbenv/versions/3.3.4/lib/ruby/3.3.0/tsort.rb:208:in `tsort_each'
    lib/rails/initializable.rb:60:in `run_initializers'
    lib/rails/application.rb:428:in `initialize!'
    /home/yahonda/src/github.com/rails/rails/tmp/d20240723-42404-te6pqz/app/config/environment.rb:5:in `<top (required)>'
    /home/yahonda/.rbenv/versions/3.3.4/lib/ruby/3.3.0/bundled_gems.rb:74:in `require'
    /home/yahonda/.rbenv/versions/3.3.4/lib/ruby/3.3.0/bundled_gems.rb:74:in `block (2 levels) in replace_require'
    /home/yahonda/.rbenv/versions/3.3.4/lib/ruby/gems/3.3.0/gems/zeitwerk-2.6.12/lib/zeitwerk/kernel.rb:38:in `require'
    test/application/query_logs_test.rb:291:in `boot_app'
    test/application/query_logs_test.rb:276:in `block in <class:QueryLogsTest>'


bin/test test/application/query_logs_test.rb:271



Finished in 4.032343s, 0.2480 runs/s, 0.0000 assertions/s.
1 runs, 0 assertions, 0 failures, 1 errors, 0 skips
$
```

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.

 

