### PR TITLE
Show warning when load_defaults and current version are mismatched

### DIFF
--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -88,7 +88,7 @@ module Rails
       # defaults for versions prior to the target version. See the
       # {configuration guide}[https://guides.rubyonrails.org/configuring.html#versioned-default-values]
       # for the default values associated with a particular version.
-      def load_defaults(target_version)
+      def load_defaults(target_version, warning: true)
         # To introduce a change in behavior, follow these steps:
         # 1. Add an accessor on the target object (e.g. the ActiveJob class for
         #    global Active Job config).
@@ -349,6 +349,10 @@ module Rails
           end
         else
           raise "Unknown version #{target_version.to_s.inspect}"
+        end
+
+        if target_version.to_f != Rails::VERSION::STRING.to_f && warning
+          warn "config.load_defaults #{target_version} was called, but the current version is #{Rails::VERSION::STRING}. "
         end
 
         @loaded_config_version = target_version


### PR DESCRIPTION
### Motivation / Background

When I upgraded an existing app to Rails 7.1, I unintentionally left `config.load_defaults` as "7.0". Reviewers also didn't notice it. After that, the app was deployed to production. It wasn't until a month later that I realized my mistake. I wanted Rails to let me notice the version mismatch.

### Detail

With this Pull Request Rails app will warn when current Rails version and `load_defaults` version are different. If the mismatch is intentional, you can set `warning: false` option.

### Additional information

Sorry, I don't know how to write tests for this change. Any help is welcome!

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.

