### PR TITLE
Don't update public directory during `app:update` command for API-only Applications

### DIFF
--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -224,6 +224,8 @@ module Rails
     end
 
     def public_directory
+      return if options[:update] && options[:api]
+
       directory "public", "public", recursive: false
     end
 

--- a/railties/test/generators/api_app_generator_test.rb
+++ b/railties/test/generators/api_app_generator_test.rb
@@ -125,6 +125,13 @@ class ApiAppGeneratorTest < Rails::Generators::TestCase
     pass
   end
 
+  def test_app_update_does_not_generate_public_files
+    run_generator
+    run_app_update
+
+    assert_no_file "public/406-unsupported-browser.html"
+  end
+
   private
     def default_files
       %w(.gitignore

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -1476,16 +1476,6 @@ class AppGeneratorTest < Rails::Generators::TestCase
       end
     end
 
-    def run_app_update(app_root = destination_root, flags: "--force")
-      Dir.chdir(app_root) do
-        gemfile_contents = File.read("Gemfile")
-        gemfile_contents.sub!(/^(gem "rails").*/, "\\1, path: #{File.expand_path("../../..", __dir__).inspect}")
-        File.write("Gemfile", gemfile_contents)
-
-        quietly { system({ "BUNDLE_GEMFILE" => "Gemfile" }, "bin/rails app:update #{flags}", exception: true) }
-      end
-    end
-
     def action(*args, &block)
       capture(:stdout) { generator.send(*args, &block) }
     end

--- a/railties/test/generators/generators_test_helper.rb
+++ b/railties/test/generators/generators_test_helper.rb
@@ -128,6 +128,16 @@ module GeneratorsTestHelper
     end
   end
 
+  def run_app_update(app_root = destination_root, flags: "--force")
+    Dir.chdir(app_root) do
+      gemfile_contents = File.read("Gemfile")
+      gemfile_contents.sub!(/^(gem "rails").*/, "\\1, path: #{File.expand_path("../../..", __dir__).inspect}")
+      File.write("Gemfile", gemfile_contents)
+
+      quietly { system({ "BUNDLE_GEMFILE" => "Gemfile" }, "bin/rails app:update #{flags}", exception: true) }
+    end
+  end
+
   private
     def gemfile_locals
       {


### PR DESCRIPTION
### Detail


We remove files under the public directory for API-only Applications. https://github.com/rails/rails/blob/a17aa6376d7974e38af90a2fe28e548b201baa63/railties/lib/rails/generators/rails/app/app_generator.rb#L500-L509

We should keep the behavior in `app:update` command too.

Follow up of #51952.


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
