### PR TITLE
Revert rails/rails#52303

### DIFF
--- a/actionpack/lib/action_dispatch/railtie.rb
+++ b/actionpack/lib/action_dispatch/railtie.rb
@@ -68,6 +68,8 @@ module ActionDispatch
       config.action_dispatch.always_write_cookie = Rails.env.development? if config.action_dispatch.always_write_cookie.nil?
       ActionDispatch::Cookies::CookieJar.always_write_cookie = config.action_dispatch.always_write_cookie
 
+      ActionDispatch::Routing::Mapper.route_source_locations = Rails.env.development?
+
       ActionDispatch::Http::Cache::Request.strict_freshness = app.config.action_dispatch.strict_freshness
       ActionDispatch.test_app = app
     end

--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -6,7 +6,6 @@ require "active_support/core_ext/hash/slice"
 require "active_support/core_ext/enumerable"
 require "active_support/core_ext/array/extract_options"
 require "active_support/core_ext/regexp"
-require "action_dispatch/routing"
 require "action_dispatch/routing/redirection"
 require "action_dispatch/routing/endpoint"
 

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -54,11 +54,6 @@
 
     *Jerome Dalbert*, *Haroon Ahmed*
 
-*   Enable tracking route source locations only when using routes command. Previously,
-    it was enabled in development mode, but is only needed for `bin/rails routes -E`.
-
-    *Gannon McGibbon*
-
 *   Deprecate `bin/rake stats` in favor of `bin/rails stats`.
 
     *Juan Vásquez*

--- a/railties/lib/rails/commands/routes/routes_command.rb
+++ b/railties/lib/rails/commands/routes/routes_command.rb
@@ -22,8 +22,6 @@ module Rails
 
       desc "routes", "List all the defined routes"
       def perform(*)
-        require "action_dispatch/routing/mapper"
-        ActionDispatch::Routing::Mapper.route_source_locations = true
         boot_application!
         require "action_dispatch/routing/inspector"
 

--- a/railties/test/commands/routes_test.rb
+++ b/railties/test/commands/routes_test.rb
@@ -403,12 +403,6 @@ rails_conductor_inbound_email_incinerate POST /rails/conductor/action_mailbox/:i
     assert_includes(output, "No unused routes found.")
   end
 
-  test "route source locations aren't included when booted normally" do
-    output = rails "runner", "print !!ActionDispatch::Routing::Mapper.route_source_locations"
-
-    assert_equal("false", output)
-  end
-
   private
     def run_routes_command(args = [])
       rails "routes", args


### PR DESCRIPTION
### Motivation / Background

Reverts disabling source location drawing in development. It is used in `/rails/info/routes` to point to route source locations.

### Detail

I'll work on writing a proper regression test next.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
