### PR TITLE
Deprecate multiple path route mapping

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,17 @@
+*   Deprecate drawing routes with multiple paths to make routing faster.
+    You may use `with_options` or a loop to make drawing multiple paths easier.
+
+    ```ruby
+    # Before
+    get "/users", "/other_path", to: "users#index"
+
+    # After
+    get "/users", to: "users#index"
+    get "/other_path", to: "users#index"
+    ```
+
+    *Gannon McGibbon*
+
 *   Make `http_cache_forever` use `immutable: true`
 
     *Nate Matykiewicz*

--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -1935,6 +1935,11 @@ module ActionDispatch
           end
 
           def map_match(paths, options)
+            ActionDispatch.deprecator.warn(<<-MSG.squish) if paths.count > 1
+              Mapping a route with multiple paths is deprecated and
+              will be removed in Rails 8.1. Please use multiple method calls instead.
+            MSG
+
             if (on = options[:on]) && !VALID_ON_OPTIONS.include?(on)
               raise ArgumentError, "Unknown scope #{on.inspect} given to :on"
             end

--- a/actionpack/test/dispatch/routing_test.rb
+++ b/actionpack/test/dispatch/routing_test.rb
@@ -763,7 +763,8 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
 
           member do
             put  :accessible_projects
-            post :resend, :generate_new_password
+            post :resend
+            post :generate_new_password
           end
         end
       end
@@ -812,7 +813,8 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
     draw do
       resources :projects do
         resources :posts do
-          get  :archive, :toggle_view, on: :collection
+          get :archive, on: :collection
+          get :toggle_view, on: :collection
           post :preview, on: :member
 
           resource :subscription
@@ -1533,8 +1535,10 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
   end
 
   def test_match_with_many_paths_containing_a_slash
-    draw do
-      get "get/first", "get/second", "get/third", to: "get#show"
+    assert_deprecated(ActionDispatch.deprecator) do
+      draw do
+        get "get/first", "get/second", "get/third", to: "get#show"
+      end
     end
 
     get "/get/first"
@@ -1570,9 +1574,11 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
   end
 
   def test_match_shorthand_with_multiple_paths_inside_namespace
-    draw do
-      namespace :proposals do
-        put "activate", "inactivate"
+    assert_deprecated(ActionDispatch.deprecator) do
+      draw do
+        namespace :proposals do
+          put "activate", "inactivate"
+        end
       end
     end
 


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because I'd like to deprecate using multiple paths on route mappings:
```rb
Rails.application.routes.draw do
  get "/users", "/other_path/users", "/another_path/users", to: "users#index"
end
```
Instead, we can simply write:
```rb
Rails.application.routes.draw do
  get "/users", to: "users#index"
  get "/other_path/users",  to: "users#index"
  get "/another_path/users", to: "users#index"
end
```
This is a bit easier to read in my opinion (albeit more redundant), and it simplifies the mapper implementation for an upcoming change I'd like to propose. I'd really like to [convert hashes in the mapper to use keywords](https://github.com/Shopify/rails/tree/routing_mapper_opt). Using a benchmark like this:

```rb
# frozen_string_literal: true

require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"

  gem "rails", path: "."
  gem "benchmark-ips"
  gem "stringio"
end

require "benchmark/ips"
require "action_controller/railtie"

class TestApp < Rails::Application
  config.root = __dir__
  config.hosts << "example.org"
  config.secret_key_base = "secret_key_base"

  config.logger = Logger.new($stdout)
  Rails.logger  = config.logger
end

class TestController < ActionController::Base
  include Rails.application.routes.url_helpers

  def index
    render plain: "Home"
  end
end

Benchmark.ips do |x|
  x.report("draw") do
    Rails.application.routes.draw do
      resources :posts
      resource :user
      root to: "home#index"
      post "login", to: "sessions#login"
      delete "logout", to: "sessions#logout"
    end
    Rails.application.instance_variable_set(:@routes, nil)
  end
end
``` 

We get a 1.25-1.5x  speed boost on route draws.

On main:
```
ruby 3.3.1 (2024-04-23 revision c56cd86388) [arm64-darwin23]
Warming up --------------------------------------
                draw   114.000 i/100ms
Calculating -------------------------------------
                draw      1.150k (± 1.1%) i/s -      5.814k in   5.055991s
```
On the [feature branch](https://github.com/Shopify/rails/tree/routing_mapper_opt) with this feature removed:
```
ruby 3.3.1 (2024-04-23 revision c56cd86388) [arm64-darwin23]
Warming up --------------------------------------
                draw   141.000 i/100ms
Calculating -------------------------------------
                draw      1.496k (± 1.4%) i/s -      7.614k in   5.091321s
```

### Detail

Drawing routes with multiple paths complicates route drawing enough to warrant deprecation. Transitioning the routing mapper to use keywords would result in a 1.25-1.5x improvement in speed, and it would be substantially easier to do if we drop this feature. Most developers draw one path per route, so this feature is likely seldom used.

### Additional information

I'm planning to deprecate hash key route paths (eg. `get "/users" => "users#index"`) in a followup PR.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
