### PR TITLE
More robust fix for duplicate callbacks when singular child autosaves parent

### DIFF
--- a/activerecord/test/cases/autosave_association_test.rb
+++ b/activerecord/test/cases/autosave_association_test.rb
@@ -1574,6 +1574,14 @@ class TestAutosaveAssociationOnAHasOneAssociation < ActiveRecord::TestCase
     assert_equal "The Vile Serpent", @pirate.reload.ship.name
   end
 
+  def test_should_automatically_save_bang_the_associated_model_if_it_sets_the_inverse_record
+    pirate = Pirate.new(catchphrase: "Savvy?")
+    ship = Ship.new(name: "Black Pearl")
+    ship.pirate = pirate
+    pirate.save!
+    assert_equal "Black Pearl", pirate.reload.ship.name
+  end
+
   def test_should_automatically_validate_the_associated_model
     @pirate.ship.name = ""
     assert_predicate @pirate, :invalid?


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

Refs:
- Original issue: https://github.com/rails/rails/issues/48688
- Original fix: https://github.com/rails/rails/pull/49847

Implements an alternative fix to the one above.

### Detail

The original fix introduced some regressions:

1. https://github.com/rails/rails/issues/52304 which was fixed in https://github.com/rails/rails/pull/52305
2. https://github.com/rails/rails/issues/52332 which was fixed in https://github.com/rails/rails/pull/52333
3. https://github.com/rails/rails/issues/52332#issuecomment-2245522368 which will be fixed here

The root cause for 2 and 3 is that the current implementation can't differentiate between these two scenarios:

```
child saved -> child autosaves parent -> parent autosaves child # original issue
parent saved -> parent autosaves child # new regression
```

In both these cases, the current implementation avoids validating or autosaving the child if the parent association has been updated. However, it's unable to differentiate whether that update happened as a result of a direct validate/save (new regression), or an validate/autosave by the child itself (original issue).

This PR ensures that the duplicate validation/autosave of the child is only avoided if it originated from the validating/autosaving of the parent by the child.

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
