### PR TITLE
Add `cvv` and `cvc` as default parameters to filter out in new apps

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/filter_parameter_logging.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/filter_parameter_logging.rb.tt
@@ -4,5 +4,5 @@
 # Use this to limit dissemination of sensitive information.
 # See the ActiveSupport::ParameterFilter documentation for supported notations and behaviors.
 Rails.application.config.filter_parameters += [
-  :passw, :email, :secret, :token, :_key, :crypt, :salt, :certificate, :otp, :ssn
+  :passw, :email, :secret, :token, :_key, :crypt, :salt, :certificate, :otp, :ssn, :cvv, :cvc
 ]


### PR DESCRIPTION
In general you should not be posting credit card details to your server, you should be using a processor like Stripe or Braintree. But if you make a mistake in your form and *do* post a user's credit card number, those details will get logged by default, even if your server doesn't use them. Now you're potentially "storing card data" and so you have a whole bunch more legal requirements to do it securely.

This PR adds `cvv` and `cvc` to the defaults for [`ActiveSupport::ParameterFilter`](https://api.rubyonrails.org/v7.1.3.4/classes/ActiveSupport/ParameterFilter.html) for new apps. This means that params with those names will not get logged by default. This just changes the template for new apps; there's no changes made to existing apps.
