### PR TITLE
Fix test command to exit 1 on LoadError

### DIFF
--- a/railties/lib/rails/commands/test/test_command.rb
+++ b/railties/lib/rails/commands/test/test_command.rb
@@ -32,7 +32,7 @@ module Rails
         run_prepare_task if self.args.none?(EXACT_TEST_ARGUMENT_PATTERN)
         Rails::TestUnit::Runner.run(args)
       rescue Rails::TestUnit::InvalidTestError => error
-        say error.message
+        raise ArgumentError, error.message
       end
 
       # Define Thor tasks to avoid going through Rake and booting twice when using bin/rails test:*

--- a/railties/test/application/test_runner_test.rb
+++ b/railties/test/application/test_runner_test.rb
@@ -971,6 +971,25 @@ module ApplicationTests
 
       assert_match(%r{Could not load test file.+test/models/accnt\.rb}, output)
       assert_match(%r{Did you mean?.+test/models/account_test\.rb}, output)
+      assert_not_predicate $?, :success?
+    end
+
+    def test_unrelated_load_error
+      app_file "test/models/account_test.rb", <<-RUBY
+        require "test_helper"
+
+        require "does-not-exist"
+
+        class AccountsTest < ActiveSupport::TestCase
+          def test_truth
+            assert true
+          end
+        end
+      RUBY
+
+      output = run_test_command("test/models/account_test.rb")
+      assert_match("cannot load such file -- does-not-exist", output)
+      assert_not_predicate $?, :success?
     end
 
     def test_pass_TEST_env_on_rake_test


### PR DESCRIPTION
Followup: https://github.com/rails/rails/pull/51005

We should only do the DidYouMean search if the file we failed to load was the actual test file, not an underlying `require` call.

Also we should still raise an error so that the exit code is 1, not 0.

FYI: @bensheldon @zzak 

NB: need to backport this to 7.2