### PR TITLE
[Rails 7.2.0.beta3] Fix bug with indexed nested error for singular associations

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Fixes `validates_associated` raising an exception when configured with a
+    singular association and having `index_nested_attribute_errors` enabled.
+
+    *Martin Spickermann*
+
 *   The constant `ActiveRecord::ImmutableRelation` has been deprecated because
     we want to reserve that name for a stronger sense of "immutable relation".
     Please use `ActiveRecord::UnmodifiableRelation` instead.

--- a/activerecord/lib/active_record/associations/association.rb
+++ b/activerecord/lib/active_record/associations/association.rb
@@ -210,6 +210,12 @@ module ActiveRecord
         _create_record(attributes, true, &block)
       end
 
+      # Whether the association represent a single record
+      # or a collection of records.
+      def collection?
+        false
+      end
+
       private
         # Reader and writer methods call this so that consistent errors are presented
         # when the association target class does not exist.

--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -311,6 +311,10 @@ module ActiveRecord
           target.any? { |record| record.new_record? || record.changed? }
       end
 
+      def collection?
+        true
+      end
+
       private
         def transaction(&block)
           reflection.klass.transaction(&block)

--- a/activerecord/lib/active_record/associations/nested_error.rb
+++ b/activerecord/lib/active_record/associations/nested_error.rb
@@ -18,7 +18,7 @@ module ActiveRecord
         def compute_attribute(inner_error)
           association_name = association.reflection.name
 
-          if index_errors_setting && index
+          if association.collection? && index_errors_setting && index
             "#{association_name}[#{index}].#{inner_error.attribute}".to_sym
           else
             "#{association_name}.#{inner_error.attribute}".to_sym


### PR DESCRIPTION
### Motivation / Background

When defining `validates_associated` with a singular association and when having `ActiveRecord.index_nested_attribute_errors` enabled, then calling `valid?` raises the following error

    NoMethodError: undefined method 'find_index' for an instance of <singular association class name>

This bug didn't happen with Rails `< 7.2.0.beta1` and was likely introduced in https://github.com/rails/rails/pull/48727

This PR fixes this issue by returning unindexed nested errors when an error occurs on a nested singular association.

### Detail

Test case to reproduce the error in Ruby on Rails 7.2.0.beta3:

```ruby
# frozen_string_literal: true

require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"

  gem "rails", "7.2.0.beta3"
  gem "sqlite3"
end

require "active_record"
require "minitest/autorun"
require "logger"

# This connection will do for database-independent bug reports.
ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")
ActiveRecord::Base.logger = Logger.new(STDOUT)

ActiveRecord::Schema.define do
  create_table :users, force: true do |t|
  end

  create_table :profiles, force: true do |t|
    t.integer :user_id
    t.text :handle
  end
end

ActiveRecord.index_nested_attribute_errors = true

class User < ActiveRecord::Base
  has_one :profile

  accepts_nested_attributes_for :profile
  validates_associated :profile
end

class Profile < ActiveRecord::Base
  belongs_to :user

  validates :handle, presence: true
end

class BugTest < Minitest::Test
  def test_validates_associated
    user = User.new(profile_attributes: { handle: "spickermann" })

    assert user.valid?

    user = User.new(profile_attributes: { handle: "" })

    refute user.valid?
  end
end
```

The above test case will raise the following exception in Ruby on Rails 7.2.0.beta3:

```
  1) Error:
BugTest#test_validates_associated:
NoMethodError: undefined method `find_index' for an instance of Profile
    3.3.4/lib/ruby/gems/3.3.0/gems/activemodel-7.2.0.beta3/lib/active_model/attribute_methods.rb:507:in `method_missing'
    [...]
    validate_associated.rb:53:in `test_validates_associated'
```

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
