### PR TITLE
Introduce `ActiveModel::AttributeAssignment#attribute_writer_missing`

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,2 +1,23 @@
+*   Introduce `ActiveModel::AttributeAssignment#attribute_writer_missing`
+
+    Provide instances with an opportunity to gracefully handle assigning to an
+    unknown attribute:
+
+    ```ruby
+    class Rectangle
+      include ActiveModel::AttributeAssignment
+
+      attr_accessor :length, :width
+
+      def attribute_writer_missing(name, value)
+        Rails.logger.warn "Tried to assign to unknown attribute #{name}"
+      end
+    end
+
+    rectangle = Rectangle.new
+    rectangle.assign_attributes(height: 10) # => Logs "Tried to assign to unknown attribute 'height'"
+    ```
+
+    *Sean Doyle*
 
 Please check [7-2-stable](https://github.com/rails/rails/blob/7-2-stable/activemodel/CHANGELOG.md) for previous changes.

--- a/activemodel/lib/active_model/attribute_assignment.rb
+++ b/activemodel/lib/active_model/attribute_assignment.rb
@@ -36,6 +36,27 @@ module ActiveModel
 
     alias attributes= assign_attributes
 
+    # Like `BasicObject#method_missing`, `#attribute_writer_missing` is invoked
+    # when `#assign_attributes` is passed an unknown attribute name.
+    #
+    # By default, `#attribute_writer_missing` raises an UnknownAttributeError.
+    #
+    #   class Rectangle
+    #     include ActiveModel::AttributeAssignment
+    #
+    #     attr_accessor :length, :width
+    #
+    #     def attribute_writer_missing(name, value)
+    #       Rails.logger.warn "Tried to assign to unknown attribute #{name}"
+    #     end
+    #   end
+    #
+    #   rectangle = Rectangle.new
+    #   rectangle.assign_attributes(height: 10) # => Logs "Tried to assign to unknown attribute 'height'"
+    def attribute_writer_missing(name, value)
+      raise UnknownAttributeError.new(self, name)
+    end
+
     private
       def _assign_attributes(attributes)
         attributes.each do |k, v|
@@ -50,7 +71,7 @@ module ActiveModel
         if respond_to?(setter)
           raise
         else
-          raise UnknownAttributeError.new(self, k.to_s)
+          attribute_writer_missing(k.to_s, v)
         end
       end
   end

--- a/activemodel/test/cases/attribute_assignment_test.rb
+++ b/activemodel/test/cases/attribute_assignment_test.rb
@@ -86,6 +86,19 @@ class AttributeAssignmentTest < ActiveModel::TestCase
     assert_equal "hz", error.attribute
   end
 
+  test "assign non-existing attribute by overriding #attribute_writer_missing" do
+    model_class = Class.new(Model) do
+      attr_accessor :assigned_attributes
+
+      def attribute_writer_missing(name, value) = @assigned_attributes[name] = value
+    end
+    model = model_class.new(assigned_attributes: {})
+
+    model.assign_attributes unknown: "attribute"
+
+    assert_equal({ "unknown" => "attribute" }, model.assigned_attributes)
+  end
+
   test "assign private attribute" do
     model = Model.new
     assert_raises(ActiveModel::UnknownAttributeError) do


### PR DESCRIPTION
### Motivation / Background

Over time, Active Model instances built with data from external sources (like API calls) has the potential to become out of synchronization with older versions of that data. For example, an API might add or remove a field from a JSON response, and applications might be passing that parsed JSON directly to model constructors for mass assignment.

Without operating on the data first (to sanitize or normalize it), model instances don't have an opportunity to gracefully handle those unexpected changes to the underlying data.  In the best cases, they might be able to take corrective or coercive measures. In the worst cases, they might track or log the mismatch.

### Detail

Introduce the `ActiveModel::AttributeAssignment#attribute_writer_missing` method to provide instances with an opportunity to gracefully handle assigning to an unknown attribute:

```ruby
class Rectangle
  include ActiveModel::AttributeAssignment

  attr_accessor :length, :width

  def attribute_writer_missing(name, value)
    Rails.logger.warn "Tried to assign to unknown attribute #{name}"
  end
end

rectangle = Rectangle.new
rectangle.assign_attributes(height: 10) # => Logs "Tried to assign to unknown attribute 'height'"
```

By default, classes that do not override `#attribute_writer_missing` will raise an `ActiveModel::UnknownAttributeError`.

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->
The `attribute_writer_missing` aims to mimic the naming of `BasicObject#method_missing`. There is also an
[ActiveModel::AttributeMethods#attribute_missing][] method, but that pertains to attribute _access_.

[ActiveModel::AttributeMethods#attribute_missing]: https://edgeapi.rubyonrails.org/classes/ActiveModel/AttributeMethods.html#method-i-attribute_missing

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
