### PR TITLE
Revert change to exists? from #51987

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -78,12 +78,6 @@
 
     *Nony Dutton*
 
-*   Optimize `Relation#exists?` when records are loaded and the relation has no conditions.
-
-    This can avoid queries in some cases.
-
-    *fatkodima*
-
 *   Add a `filter` option to `in_order_of` to prioritize certain values in the sorting without filtering the results
     by these values.
 

--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -366,12 +366,6 @@ module ActiveRecord
 
       return false if !conditions || limit_value == 0
 
-      # Ignore if we have records which have saved changes since the load, because the
-      # relation can be a CollectionProxy and we updated the reference to the owner record.
-      if conditions == :none && loaded? && records.none?(&:saved_changes?)
-        return records.any?(&:persisted?)
-      end
-
       if eager_loading?
         relation = apply_join_dependency(eager_loading: false)
         return relation.exists?(conditions)

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -291,7 +291,7 @@ class FinderTest < ActiveRecord::TestCase
 
   def test_exists_with_loaded_relation
     topics = Topic.all.load
-    assert_no_queries do
+    assert_queries_match(/SELECT 1 AS one/i, count: 1) do
       assert_predicate topics, :exists?
     end
   end
@@ -299,7 +299,7 @@ class FinderTest < ActiveRecord::TestCase
   def test_exists_with_empty_loaded_relation
     Topic.delete_all
     topics = Topic.all.load
-    assert_no_queries do
+    assert_queries_match(/SELECT 1 AS one/i, count: 1) do
       assert_not_predicate topics, :exists?
     end
   end
@@ -310,7 +310,7 @@ class FinderTest < ActiveRecord::TestCase
     assert_not_empty posts
     posts.each(&:destroy)
 
-    assert_no_queries do
+    assert_queries_match(/SELECT 1 AS one/i) do
       assert_not_predicate posts, :exists?
     end
   end


### PR DESCRIPTION
This partially reverts commit c9075e3643ecaed3b053b0fe50799895b71474af, I kept all the tests ❤️ added but adjusted the query counts back to 1.

Per discussion in #51987, this changes a behaviour that was [documented](https://github.com/rails/rails/blob/55c4adeb36eff229972eecbb53723c1b80393091/activerecord/lib/active_record/associations/collection_proxy.rb#L854-L857) (though not quite well enough IMO, it should probably be mentioned here and not in `any?`). `exists?` should be an analogue to `count` and always make a database query, and users should have the ability to do that. We already have `any?`/`none?`/`empty?` as analogues to `size`, which intelligently picks whether to use the cached relation or to make a query, though likely all of these could be documented a little better.

cc @fatkodima @byroot 