### PR TITLE
Include identifier in ActionCable channel notifications

### DIFF
--- a/actioncable/CHANGELOG.md
+++ b/actioncable/CHANGELOG.md
@@ -1,2 +1,5 @@
+*   Add an `identifier` to the event payload for the ActiveSupport::Notification `transmit_subscription_confirmation.action_cable` and `transmit_subscription_rejection.action_cable`.
+
+    *Keith Schacht*
 
 Please check [7-2-stable](https://github.com/rails/rails/blob/7-2-stable/actioncable/CHANGELOG.md) for previous changes.

--- a/actioncable/lib/action_cable/channel/base.rb
+++ b/actioncable/lib/action_cable/channel/base.rb
@@ -309,7 +309,7 @@ module ActionCable
           unless subscription_confirmation_sent?
             logger.debug "#{self.class.name} is transmitting the subscription confirmation"
 
-            ActiveSupport::Notifications.instrument("transmit_subscription_confirmation.action_cable", channel_class: self.class.name) do
+            ActiveSupport::Notifications.instrument("transmit_subscription_confirmation.action_cable", channel_class: self.class.name, identifier: @identifier) do
               connection.transmit identifier: @identifier, type: ActionCable::INTERNAL[:message_types][:confirmation]
               @subscription_confirmation_sent = true
             end
@@ -324,7 +324,7 @@ module ActionCable
         def transmit_subscription_rejection
           logger.debug "#{self.class.name} is transmitting the subscription rejection"
 
-          ActiveSupport::Notifications.instrument("transmit_subscription_rejection.action_cable", channel_class: self.class.name) do
+          ActiveSupport::Notifications.instrument("transmit_subscription_rejection.action_cable", channel_class: self.class.name, identifier: @identifier) do
             connection.transmit identifier: @identifier, type: ActionCable::INTERNAL[:message_types][:rejection]
           end
         end

--- a/actioncable/test/channel/base_test.rb
+++ b/actioncable/test/channel/base_test.rb
@@ -242,6 +242,7 @@ class ActionCable::Channel::BaseTest < ActionCable::TestCase
       assert_equal 1, events.length
       assert_equal "transmit_subscription_confirmation.action_cable", events[0].name
       assert_equal "ActionCable::Channel::BaseTest::ChatChannel", events[0].payload[:channel_class]
+      assert_equal "{id: 1}", events[0].payload[:identifier]
     end
   ensure
     ActiveSupport::Notifications.unsubscribe "transmit_subscription_confirmation.action_cable"
@@ -256,6 +257,7 @@ class ActionCable::Channel::BaseTest < ActionCable::TestCase
     assert_equal 1, events.length
     assert_equal "transmit_subscription_rejection.action_cable", events[0].name
     assert_equal "ActionCable::Channel::BaseTest::ChatChannel", events[0].payload[:channel_class]
+    assert_equal "{id: 1}", events[0].payload[:identifier]
   ensure
     ActiveSupport::Notifications.unsubscribe "transmit_subscription_rejection.action_cable"
   end


### PR DESCRIPTION
### Motivation / Background

In my app I'm using Turbo Stream. I need to know the moment that a stream channel is connected and was pleased to find there is a notification for it: `transmit_subscription_confirmation.action_cable`. However, the only information in the notification event is `channel_class: "Turbo::StreamsChannel"`. For custom ActionCable classes, this might be sufficient, but this is not very helpful for a Turbo Stream channel because you can't disambiguate them. Plus, in my particular case, I want to know the specific model that the `turbo_stream_from` was initialized for.

### Detail

This Pull Request adds `identifier:` as an additional payload field for `transmit_subscription_confirmation.action_cable` and for `transmit_subscription_rejection.action_cable`.

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [X] CHANGELOG — it does not seem worth updating the changelog for this as it's practically a bug fix.

### Addendum

The reason that I need to listen for this event is because of a bug, I think, in Turbo Stream. If I can get confirmation of the bug, I'm happy to submit a fix for it, as well. I opened an Issue https://github.com/rails/rails/issues/52420 to stay organized. But regardless of how we handle this "bug", it will be good to have an identifier on these events.