### PR TITLE
Deprecate hash key path mapping

### DIFF
--- a/actioncable/lib/action_cable/engine.rb
+++ b/actioncable/lib/action_cable/engine.rb
@@ -64,7 +64,7 @@ module ActionCable
         config = app.config
         unless config.action_cable.mount_path.nil?
           app.routes.prepend do
-            mount ActionCable.server => config.action_cable.mount_path, internal: true, anchor: true
+            mount ActionCable.server, at: config.action_cable.mount_path, internal: true, anchor: true
           end
         end
       end

--- a/actionmailbox/config/routes.rb
+++ b/actionmailbox/config/routes.rb
@@ -2,16 +2,16 @@
 
 Rails.application.routes.draw do
   scope "/rails/action_mailbox", module: "action_mailbox/ingresses" do
-    post "/postmark/inbound_emails" => "postmark/inbound_emails#create", as: :rails_postmark_inbound_emails
-    post "/relay/inbound_emails"    => "relay/inbound_emails#create",    as: :rails_relay_inbound_emails
-    post "/sendgrid/inbound_emails" => "sendgrid/inbound_emails#create", as: :rails_sendgrid_inbound_emails
+    post "/postmark/inbound_emails", to: "postmark/inbound_emails#create", as: :rails_postmark_inbound_emails
+    post "/relay/inbound_emails",    to: "relay/inbound_emails#create",    as: :rails_relay_inbound_emails
+    post "/sendgrid/inbound_emails", to: "sendgrid/inbound_emails#create", as: :rails_sendgrid_inbound_emails
 
     # Mandrill checks for the existence of a URL with a HEAD request before it will create the webhook.
-    get "/mandrill/inbound_emails"  => "mandrill/inbound_emails#health_check", as: :rails_mandrill_inbound_health_check
-    post "/mandrill/inbound_emails" => "mandrill/inbound_emails#create",       as: :rails_mandrill_inbound_emails
+    get "/mandrill/inbound_emails",  to: "mandrill/inbound_emails#health_check", as: :rails_mandrill_inbound_health_check
+    post "/mandrill/inbound_emails", to: "mandrill/inbound_emails#create",       as: :rails_mandrill_inbound_emails
 
     # Mailgun requires that a webhook's URL end in 'mime' for it to receive the raw contents of emails.
-    post "/mailgun/inbound_emails/mime" => "mailgun/inbound_emails#create", as: :rails_mailgun_inbound_emails
+    post "/mailgun/inbound_emails/mime", to: "mailgun/inbound_emails#create", as: :rails_mailgun_inbound_emails
   end
 
   # TODO: Should these be mounted within the engine only?
@@ -20,7 +20,7 @@ Rails.application.routes.draw do
     get  "inbound_emails/sources/new", to: "inbound_emails/sources#new", as: :new_rails_conductor_inbound_email_source
     post "inbound_emails/sources", to: "inbound_emails/sources#create", as: :rails_conductor_inbound_email_sources
 
-    post ":inbound_email_id/reroute" => "reroutes#create", as: :rails_conductor_inbound_email_reroute
-    post ":inbound_email_id/incinerate" => "incinerates#create", as: :rails_conductor_inbound_email_incinerate
+    post ":inbound_email_id/reroute",    to: "reroutes#create",   as: :rails_conductor_inbound_email_reroute
+    post ":inbound_email_id/incinerate", to: "incinerates#create", as: :rails_conductor_inbound_email_incinerate
   end
 end

--- a/actionmailer/lib/action_mailer/railtie.rb
+++ b/actionmailer/lib/action_mailer/railtie.rb
@@ -84,9 +84,9 @@ module ActionMailer
 
       if options.show_previews
         app.routes.prepend do
-          get "/rails/mailers" => "rails/mailers#index", internal: true
-          get "/rails/mailers/download/*path" => "rails/mailers#download", internal: true
-          get "/rails/mailers/*path" => "rails/mailers#preview", internal: true
+          get "/rails/mailers", to: "rails/mailers#index", internal: true
+          get "/rails/mailers/download/*path", to: "rails/mailers#download", internal: true
+          get "/rails/mailers/*path", to: "rails/mailers#preview", internal: true
         end
       end
     end

--- a/actionmailer/test/url_test.rb
+++ b/actionmailer/test/url_test.rb
@@ -9,8 +9,8 @@ end
 AppRoutes = ActionDispatch::Routing::RouteSet.new
 
 AppRoutes.draw do
-  get "/welcome" => "foo#bar", as: "welcome"
-  get "/dummy_model" => "foo#baz", as: "dummy_model"
+  get "/welcome", to: "foo#bar", as: "welcome"
+  get "/dummy_model", to: "foo#baz", as: "dummy_model"
   get "/welcome/greeting", to: "welcome#greeting"
   get "/a/b(/:id)", to: "a#b"
 end

--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,19 @@
+*   Deprecate drawing routes with hash key paths to make routing faster.
+
+    ```ruby
+    # Before
+    get "/users" => "users#index"
+    post "/logout" => :sessions
+    mount MyApp => "/my_app"
+
+    # After
+    get "/users", to: "users#index"
+    post "/logout", to: "sessions#logout"
+    mount MyApp, at: "/my_app"
+    ```
+
+    *Gannon McGibbon*
+
 *   Deprecate drawing routes with multiple paths to make routing faster.
     You may use `with_options` or a loop to make drawing multiple paths easier.
 

--- a/actionpack/lib/action_dispatch/routing.rb
+++ b/actionpack/lib/action_dispatch/routing.rb
@@ -118,9 +118,9 @@ module ActionDispatch
   #
   #     # In config/routes.rb
   #     controller :blog do
-  #       get 'blog/show'    => :list
-  #       get 'blog/delete'  => :delete
-  #       get 'blog/edit'    => :edit
+  #       get 'blog/show',   to: :list
+  #       get 'blog/delete', to: :delete
+  #       get 'blog/edit',   to: :edit
   #     end
   #
   #     # provides named routes for show, delete, and edit

--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -636,6 +636,7 @@ module ActionDispatch
             options = app
             app, path = options.find { |k, _| k.respond_to?(:call) }
             options.delete(app) if app
+            hash_key_app = true
           end
 
           raise ArgumentError, "A rack application must be specified" unless app.respond_to?(:call)
@@ -645,6 +646,10 @@ module ActionDispatch
               mount SomeRackApp, at: "some_route"
               or
               mount(SomeRackApp => "some_route")
+          MSG
+          ActionDispatch.deprecator.warn(<<-MSG.squish) if hash_key_app
+            Mounting an engine with a hash key name is deprecated and
+            will be removed in Rails 8.1. Please use the at: option instead.
           MSG
 
           rails_app = rails_app? app
@@ -1681,6 +1686,12 @@ module ActionDispatch
             path, to = options.find { |name, _value| name.is_a?(String) }
 
             raise ArgumentError, "Route path not specified" if path.nil?
+
+            ActionDispatch.deprecator.warn(<<-MSG.squish)
+              Drawing a route with a hash key name is deprecated and
+              will be removed in Rails 8.1. Please use the to: option with
+              "controller#action" syntax instead.
+            MSG
 
             case to
             when Symbol

--- a/actionpack/lib/action_dispatch/routing/redirection.rb
+++ b/actionpack/lib/action_dispatch/routing/redirection.rb
@@ -148,7 +148,7 @@ module ActionDispatch
     module Redirection
       # Redirect any path to another path:
       #
-      #     get "/stories" => redirect("/posts")
+      #     get "/stories", to: redirect("/posts")
       #
       # This will redirect the user, while ignoring certain parts of the request,
       # including query string, etc. `/stories`, `/stories?foo=bar`, etc all redirect
@@ -157,7 +157,7 @@ module ActionDispatch
       # The redirect will use a `301 Moved Permanently` status code by default. This
       # can be overridden with the `:status` option:
       #
-      #     get "/stories" => redirect("/posts", status: 307)
+      #     get "/stories", to: redirect("/posts", status: 307)
       #
       # You can also use interpolation in the supplied redirect argument:
       #
@@ -199,7 +199,7 @@ module ActionDispatch
       # allowing you to reuse common redirect routes. The call method must accept two
       # arguments, params and request, and return a string.
       #
-      #     get 'accounts/:name' => redirect(SubdomainRedirector.new('api'))
+      #     get 'accounts/:name', to: redirect(SubdomainRedirector.new('api'))
       #
       def redirect(*args, &block)
         options = args.extract_options!

--- a/actionpack/test/controller/base_test.rb
+++ b/actionpack/test/controller/base_test.rb
@@ -215,7 +215,7 @@ class UrlOptionsTest < ActionController::TestCase
   def test_url_for_query_params_included
     rs = ActionDispatch::Routing::RouteSet.new
     rs.draw do
-      get "home" => "pages#home"
+      get "home", to: "pages#home"
     end
 
     options = {
@@ -316,7 +316,7 @@ class OptionalDefaultUrlOptionsControllerTest < ActionController::TestCase
   def test_default_url_options_override_missing_positional_arguments
     with_routing do |set|
       set.draw do
-        get "/things/:id(.:format)" => "things#show", :as => :thing
+        get "/things/:id(.:format)", to: "things#show", as: :thing
       end
       assert_equal "/things/1.atom", thing_path("1")
       assert_equal "/things/default-id.atom", thing_path

--- a/actionpack/test/controller/integration_test.rb
+++ b/actionpack/test/controller/integration_test.rb
@@ -649,7 +649,7 @@ class IntegrationProcessTest < ActionDispatch::IntegrationTest
         end
 
         set.draw do
-          get "moved" => redirect("/method")
+          get "moved", to: redirect("/method")
 
           ActionDispatch.deprecator.silence do
             match ":action", to: controller, via: [:get, :post], as: :action
@@ -784,9 +784,9 @@ class ApplicationIntegrationTest < ActionDispatch::IntegrationTest
     get "foo", to: "application_integration_test/test#index", as: :foo
     get "bar", to: "application_integration_test/test#index", as: :bar
 
-    mount MountedApp => "/mounted", :as => "mounted"
-    get "fooz" => proc { |env| [ 200, { ActionDispatch::Constants::X_CASCADE => "pass" }, [ "omg" ] ] },
-      :anchor => false
+    mount MountedApp, at: "/mounted", as: "mounted"
+    get "fooz", to: proc { |env| [ 200, { ActionDispatch::Constants::X_CASCADE => "pass" }, [ "omg" ] ] },
+      anchor: false
     get "fooz", to: "application_integration_test/test#index"
   end
 
@@ -890,7 +890,7 @@ class ControllerWithHeadersMethodIntegrationTest < ActionDispatch::IntegrationTe
   test "doesn't call controller's headers method" do
     with_routing do |routes|
       routes.draw do
-        get "/ok" => "controller_with_headers_method_integration_test/test#index"
+        get "/ok", to: "controller_with_headers_method_integration_test/test#index"
       end
 
       get "/ok"
@@ -941,10 +941,10 @@ class UrlOptionsIntegrationTest < ActionDispatch::IntegrationTest
     default_url_options host: "foo.com"
 
     scope module: "url_options_integration_test" do
-      get "/foo" => "foo#index", :as => :foos
-      get "/foo/:id" => "foo#show", :as => :foo
-      get "/foo/:id/edit" => "foo#edit", :as => :edit_foo
-      get "/bar" => "bar#index", :as => :bars
+      get "/foo", to: "foo#index", as: :foos
+      get "/foo/:id", to: "foo#show", as: :foo
+      get "/foo/:id/edit", to: "foo#edit", as: :edit_foo
+      get "/bar", to: "bar#index", as: :bars
     end
   end
 
@@ -1004,7 +1004,7 @@ class HeadWithStatusActionIntegrationTest < ActionDispatch::IntegrationTest
   end
 
   routes.draw do
-    get "/foo/status" => "head_with_status_action_integration_test/foo#status"
+    get "/foo/status", to: "head_with_status_action_integration_test/foo#status"
   end
 
   test "get /foo/status with head result does not cause stack overflow error" do
@@ -1067,7 +1067,7 @@ class IntegrationRequestsWithoutSetup < ActionDispatch::IntegrationTest
     with_routing do |routes|
       routes.draw do
         ActionDispatch.deprecator.silence do
-          get ":action" => FooController
+          get ":action", to: FooController
         end
       end
 
@@ -1115,7 +1115,7 @@ class IntegrationRequestEncodersTest < ActionDispatch::IntegrationTest
     with_routing do |routes|
       routes.draw do
         ActionDispatch.deprecator.silence do
-          post ":action" => FooController
+          post ":action", to: FooController
         end
       end
 
@@ -1142,7 +1142,7 @@ class IntegrationRequestEncodersTest < ActionDispatch::IntegrationTest
     with_routing do |routes|
       routes.draw do
         ActionDispatch.deprecator.silence do
-          post ":action" => FooController
+          post ":action", to: FooController
         end
       end
 
@@ -1203,7 +1203,7 @@ class IntegrationRequestEncodersTest < ActionDispatch::IntegrationTest
     with_routing do |routes|
       routes.draw do
         ActionDispatch.deprecator.silence do
-          get ":action" => FooController
+          get ":action", to: FooController
         end
       end
 
@@ -1217,7 +1217,7 @@ class IntegrationRequestEncodersTest < ActionDispatch::IntegrationTest
     with_routing do |routes|
       routes.draw do
         ActionDispatch.deprecator.silence do
-          get ":action" => FooController
+          get ":action", to: FooController
         end
       end
 
@@ -1231,7 +1231,7 @@ class IntegrationRequestEncodersTest < ActionDispatch::IntegrationTest
     with_routing do |routes|
       routes.draw do
         ActionDispatch.deprecator.silence do
-          get ":action" => FooController
+          get ":action", to: FooController
         end
       end
 
@@ -1247,7 +1247,7 @@ class IntegrationRequestEncodersTest < ActionDispatch::IntegrationTest
     with_routing do |routes|
       routes.draw do
         ActionDispatch.deprecator.silence do
-          get ":action" => FooController
+          get ":action", to: FooController
         end
       end
 
@@ -1262,7 +1262,7 @@ class IntegrationRequestEncodersTest < ActionDispatch::IntegrationTest
       with_routing do |routes|
         routes.draw do
           ActionDispatch.deprecator.silence do
-            post ":action" => FooController
+            post ":action", to: FooController
           end
         end
 
@@ -1358,8 +1358,8 @@ class PageDumpIntegrationTest < ActionDispatch::IntegrationTest
   end
 
   routes.draw do
-    get "/" => "page_dump_integration_test/foo#index"
-    get "/redirect" => "page_dump_integration_test/foo#redirect"
+    get "/", to: "page_dump_integration_test/foo#index"
+    get "/redirect", to: "page_dump_integration_test/foo#redirect"
   end
 
   test "save_and_open_page saves a copy of the page and call to Launchy" do

--- a/actionpack/test/controller/live_stream_test.rb
+++ b/actionpack/test/controller/live_stream_test.rb
@@ -653,7 +653,7 @@ class LiveStreamRouterTest < ActionDispatch::IntegrationTest
   end
 
   routes.draw do
-    get "/test" => "live_stream_router_test/test#index"
+    get "/test", to: "live_stream_router_test/test#index"
   end
 
   def app

--- a/actionpack/test/controller/routing_test.rb
+++ b/actionpack/test/controller/routing_test.rb
@@ -321,7 +321,7 @@ class LegacyRouteSetTests < ActiveSupport::TestCase
 
   def test_specific_controller_action_failure
     rs.draw do
-      mount lambda { } => "/foo"
+      mount lambda { }, at: "/foo"
     end
 
     assert_raises(ActionController::UrlGenerationError) do
@@ -451,7 +451,7 @@ class LegacyRouteSetTests < ActiveSupport::TestCase
 
   def test_named_route_with_option
     rs.draw do
-      get "page/:title" => "content#show_page", :as => "page"
+      get "page/:title", to: "content#show_page", as: "page"
     end
 
     assert_equal("http://test.host/page/new%20stuff",
@@ -460,7 +460,7 @@ class LegacyRouteSetTests < ActiveSupport::TestCase
 
   def test_named_route_with_default
     rs.draw do
-      get "page/:title" => "content#show_page", :title => "AboutPage", :as => "page"
+      get "page/:title", to: "content#show_page", title: "AboutPage", as: "page"
     end
 
     assert_equal("http://test.host/page/AboutRails",
@@ -470,7 +470,7 @@ class LegacyRouteSetTests < ActiveSupport::TestCase
   def test_named_route_with_path_prefix
     rs.draw do
       scope "my" do
-        get "page" => "content#show_page", :as => "page"
+        get "page", to: "content#show_page", as: "page"
       end
     end
 
@@ -480,7 +480,7 @@ class LegacyRouteSetTests < ActiveSupport::TestCase
   def test_named_route_with_blank_path_prefix
     rs.draw do
       scope "" do
-        get "page" => "content#show_page", :as => "page"
+        get "page", to: "content#show_page", as: "page"
       end
     end
 
@@ -489,7 +489,7 @@ class LegacyRouteSetTests < ActiveSupport::TestCase
 
   def test_named_route_with_nested_controller
     rs.draw do
-      get "admin/user" => "admin/user#index", :as => "users"
+      get "admin/user", to: "admin/user#index", as: "users"
     end
 
     assert_equal("http://test.host/admin/user", setup_for_named_route.users_url)
@@ -497,7 +497,7 @@ class LegacyRouteSetTests < ActiveSupport::TestCase
 
   def test_optimised_named_route_with_host
     rs.draw do
-      get "page" => "content#show_page", :as => "pages", :host => "foo.com"
+      get "page", to: "content#show_page", as: "pages", host: "foo.com"
     end
     routes = setup_for_named_route
     assert_equal "http://foo.com/page", routes.pages_url
@@ -563,8 +563,8 @@ class LegacyRouteSetTests < ActiveSupport::TestCase
 
   def test_named_route_with_regexps
     rs.draw do
-      get "page/:year/:month/:day/:title" => "page#show", :as => "article",
-        :year => /\d+/, :month => /\d+/, :day => /\d+/
+      get "page/:year/:month/:day/:title", to: "page#show", as: "article",
+        year: /\d+/, month: /\d+/, day: /\d+/
 
       ActionDispatch.deprecator.silence do
         get ":controller/:action/:id"
@@ -588,7 +588,7 @@ class LegacyRouteSetTests < ActiveSupport::TestCase
 
   def test_paths_escaped
     rs.draw do
-      get "file/*path" => "content#show_file", :as => "path"
+      get "file/*path", to: "content#show_file", as: "path"
 
       ActionDispatch.deprecator.silence do
         get ":controller/:action/:id"
@@ -608,7 +608,7 @@ class LegacyRouteSetTests < ActiveSupport::TestCase
 
   def test_paths_slashes_unescaped_with_ordered_parameters
     rs.draw do
-      get "/file/*path" => "content#index", :as => "path"
+      get "/file/*path", to: "content#index", as: "path"
     end
 
     # No / to %2F in URI, only for query params.
@@ -626,7 +626,7 @@ class LegacyRouteSetTests < ActiveSupport::TestCase
 
   def test_should_list_options_diff_when_routing_constraints_dont_match
     rs.draw do
-      get "post/:id" => "post#show", :constraints => { id: /\d+/ }, :as => "post"
+      get "post/:id", to: "post#show", constraints: { id: /\d+/ }, as: "post"
     end
     assert_raise(ActionController::UrlGenerationError) do
       url_for(rs, controller: "post", action: "show", bad_param: "foo", use_route: "post")
@@ -635,7 +635,7 @@ class LegacyRouteSetTests < ActiveSupport::TestCase
 
   def test_dynamic_path_allowed
     rs.draw do
-      get "*path" => "content#show_file"
+      get "*path", to: "content#show_file"
     end
 
     assert_equal "/pages/boo",
@@ -644,7 +644,7 @@ class LegacyRouteSetTests < ActiveSupport::TestCase
 
   def test_escapes_newline_character_for_dynamic_path
     rs.draw do
-      get "/dynamic/:dynamic_segment" => "subpath_books#show", as: :dynamic
+      get "/dynamic/:dynamic_segment", to: "subpath_books#show", as: :dynamic
 
       ActionDispatch.deprecator.silence do
         get ":controller/:action/:id"
@@ -658,7 +658,7 @@ class LegacyRouteSetTests < ActiveSupport::TestCase
 
   def test_escapes_newline_character_for_wildcard_path
     rs.draw do
-      get "/wildcard/*wildcard_segment" => "subpath_books#show", as: :wildcard
+      get "/wildcard/*wildcard_segment", to: "subpath_books#show", as: :wildcard
 
       ActionDispatch.deprecator.silence do
         get ":controller/:action/:id"
@@ -672,7 +672,7 @@ class LegacyRouteSetTests < ActiveSupport::TestCase
 
   def test_dynamic_recall_paths_allowed
     rs.draw do
-      get "*path" => "content#show_file"
+      get "*path", to: "content#show_file"
     end
 
     get URI("http://test.host/pages/boo")
@@ -686,7 +686,7 @@ class LegacyRouteSetTests < ActiveSupport::TestCase
   def test_backwards
     rs.draw do
       ActionDispatch.deprecator.silence do
-        get "page/:id(/:action)" => "pages#show"
+        get "page/:id(/:action)", to: "pages#show"
         get ":controller(/:action(/:id))"
       end
     end
@@ -699,7 +699,7 @@ class LegacyRouteSetTests < ActiveSupport::TestCase
 
   def test_route_with_integer_default
     rs.draw do
-      get "page(/:id)" => "content#show_page", :id => 1
+      get "page(/:id)", to: "content#show_page", id: 1
 
       ActionDispatch.deprecator.silence do
         get ":controller/:action/:id"
@@ -719,7 +719,7 @@ class LegacyRouteSetTests < ActiveSupport::TestCase
   # For newer revision
   def test_route_with_text_default
     rs.draw do
-      get "page/:id" => "content#show_page", :id => 1
+      get "page/:id", to: "content#show_page", id: 1
 
       ActionDispatch.deprecator.silence do
         get ":controller/:action/:id"
@@ -745,7 +745,7 @@ class LegacyRouteSetTests < ActiveSupport::TestCase
 
   def test_requirement_should_prevent_optional_id
     rs.draw do
-      get "post/:id" => "post#show", :constraints => { id: /\d+/ }, :as => "post"
+      get "post/:id", to: "post#show", constraints: { id: /\d+/ }, as: "post"
     end
 
     assert_equal "/post/10", url_for(rs, controller: "post", action: "show", id: 10)
@@ -757,9 +757,9 @@ class LegacyRouteSetTests < ActiveSupport::TestCase
 
   def test_both_requirement_and_optional
     rs.draw do
-      get("test(/:year)" => "post#show", :as => "blog",
-        :defaults => { year: nil },
-        :constraints => { year: /\d{4}/ }
+      get("test(/:year)", to: "post#show", as: "blog",
+        defaults: { year: nil },
+        constraints: { year: /\d{4}/ }
       )
 
       ActionDispatch.deprecator.silence do
@@ -775,7 +775,7 @@ class LegacyRouteSetTests < ActiveSupport::TestCase
 
   def test_set_to_nil_forgets
     rs.draw do
-      get "pages(/:year(/:month(/:day)))" => "content#list_pages", :month => nil, :day => nil
+      get "pages(/:year(/:month(/:day)))", to: "content#list_pages", month: nil, day: nil
 
       ActionDispatch.deprecator.silence do
         get ":controller/:action/:id"
@@ -825,7 +825,7 @@ class LegacyRouteSetTests < ActiveSupport::TestCase
 
   def test_named_route_method
     rs.draw do
-      get "categories" => "content#categories", :as => "categories"
+      get "categories", to: "content#categories", as: "categories"
 
       ActionDispatch.deprecator.silence do
         get ":controller(/:action(/:id))"
@@ -843,8 +843,8 @@ class LegacyRouteSetTests < ActiveSupport::TestCase
 
   def test_nil_defaults
     rs.draw do
-      get "journal" => "content#list_journal",
-        :date => nil, :user_id => nil
+      get "journal", to: "content#list_journal",
+        date: nil, user_id: nil
 
       ActionDispatch.deprecator.silence do
         get ":controller/:action/:id"
@@ -860,7 +860,7 @@ class LegacyRouteSetTests < ActiveSupport::TestCase
 
   def setup_request_method_routes_for(method)
     rs.draw do
-      match "/match" => "books##{method}", :via => method.to_sym
+      match "/match", to: "books##{method}", via: method.to_sym
     end
   end
 
@@ -874,8 +874,8 @@ class LegacyRouteSetTests < ActiveSupport::TestCase
 
   def test_recognize_array_of_methods
     rs.draw do
-      match "/match" => "books#get_or_post", :via => [:get, :post]
-      put "/match" => "books#not_get_or_post"
+      match "/match", to: "books#get_or_post", via: [:get, :post]
+      put "/match", to: "books#not_get_or_post"
     end
 
     params = rs.recognize_path("/match", method: :post)
@@ -888,10 +888,10 @@ class LegacyRouteSetTests < ActiveSupport::TestCase
   def test_subpath_recognized
     rs.draw do
       ActionDispatch.deprecator.silence do
-        get "/books/:id/edit"    => "subpath_books#edit"
-        get "/items/:id/:action" => "subpath_books"
-        get "/posts/new/:action" => "subpath_books"
-        get "/posts/:id"         => "subpath_books#show"
+        get "/books/:id/edit",    to: "subpath_books#edit"
+        get "/items/:id/complete", to: "subpath_books#complete"
+        get "/posts/new/preview", to: "subpath_books#preview"
+        get "/posts/:id",         to: "subpath_books#show"
       end
     end
 
@@ -914,11 +914,9 @@ class LegacyRouteSetTests < ActiveSupport::TestCase
 
   def test_subpath_generated
     rs.draw do
-      ActionDispatch.deprecator.silence do
-        get "/books/:id/edit"    => "subpath_books#edit"
-        get "/items/:id/:action" => "subpath_books"
-        get "/posts/new/:action" => "subpath_books"
-      end
+      get "/books/:id/edit",     to: "subpath_books#edit"
+      get "/items/:id/complete", to: "subpath_books#complete"
+      get "/posts/new/preview",  to: "subpath_books#preview"
     end
 
     assert_equal "/books/7/edit",      url_for(rs, controller: "subpath_books", id: 7, action: "edit")
@@ -928,7 +926,7 @@ class LegacyRouteSetTests < ActiveSupport::TestCase
 
   def test_failed_constraints_raises_exception_with_violated_constraints
     rs.draw do
-      get "foos/:id" => "foos#show", :as => "foo_with_requirement", :constraints => { id: /\d+/ }
+      get "foos/:id", to: "foos#show", as: "foo_with_requirement", constraints: { id: /\d+/ }
     end
 
     assert_raise(ActionController::UrlGenerationError) do
@@ -939,9 +937,9 @@ class LegacyRouteSetTests < ActiveSupport::TestCase
   def test_routes_changed_correctly_after_clear
     rs = ::ActionDispatch::Routing::RouteSet.new
     rs.draw do
-      get "ca" => "ca#aa"
-      get "cb" => "cb#ab"
-      get "cc" => "cc#ac"
+      get "ca", to: "ca#aa"
+      get "cb", to: "cb#ab"
+      get "cc", to: "cc#ac"
 
       ActionDispatch.deprecator.silence do
         get ":controller/:action/:id"
@@ -955,8 +953,8 @@ class LegacyRouteSetTests < ActiveSupport::TestCase
     assert_equal %w(cc ac), [hash[:controller], hash[:action]]
 
     rs.draw do
-      get "cb" => "cb#ab"
-      get "cc" => "cc#ac"
+      get "cb", to: "cb#ab"
+      get "cc", to: "cc#ac"
 
       ActionDispatch.deprecator.silence do
         get ":controller/:action/:id"
@@ -975,10 +973,10 @@ class LegacyRouteSetTests < ActiveSupport::TestCase
     rs.disable_clear_and_finalize = true
 
     rs.draw do
-      get "/plain" => "c#plain"
-      get "/:symbol" => "c#symbol"
-      get "/glob/*" => "c#glob"
-      get "/with#anchor" => "c#with_anchor"
+      get "/plain",       to: "c#plain"
+      get "/:symbol",     to: "c#symbol"
+      get "/glob/*",      to: "c#glob"
+      get "/with#anchor", to: "c#with_anchor"
     end
 
     hash = rs.recognize_path "/symbol"
@@ -988,10 +986,10 @@ class LegacyRouteSetTests < ActiveSupport::TestCase
     rs.eager_load!
 
     rs.draw do
-      get "/more/plain" => "c#plain"
-      get "/more/:symbol" => "c#symbol"
-      get "/more/glob/*" => "c#glob"
-      get "/more/with#anchor" => "c#with_anchor"
+      get "/more/plain",       to: "c#plain"
+      get "/more/:symbol",     to: "c#symbol"
+      get "/more/glob/*",      to: "c#glob"
+      get "/more/with#anchor", to: "c#with_anchor"
     end
 
     hash = rs.recognize_path "/symbol"
@@ -1083,7 +1081,7 @@ class RouteSetTest < ActiveSupport::TestCase
   def test_draw
     assert_equal 0, set.routes.size
     set.draw do
-      get "/hello/world" => "a#b"
+      get "/hello/world", to: "a#b"
     end
     assert_equal 1, set.routes.size
   end
@@ -1091,7 +1089,7 @@ class RouteSetTest < ActiveSupport::TestCase
   def test_draw_symbol_controller_name
     assert_equal 0, set.routes.size
     set.draw do
-      get "/users/index" => "users#index"
+      get "/users/index", to: "users#index"
     end
     set.recognize_path("/users/index", method: :get)
     assert_equal 1, set.routes.size
@@ -1100,7 +1098,7 @@ class RouteSetTest < ActiveSupport::TestCase
   def test_named_draw
     assert_equal 0, set.routes.size
     set.draw do
-      get "/hello/world" => "a#b", :as => "hello"
+      get "/hello/world", to: "a#b", as: "hello"
     end
     assert_equal 1, set.routes.size
     assert_equal set.routes.first, set.named_routes[:hello]
@@ -1109,18 +1107,18 @@ class RouteSetTest < ActiveSupport::TestCase
   def test_duplicate_named_route_raises_rather_than_pick_precedence
     assert_raise ArgumentError do
       set.draw do
-        get "/hello/world" => "a#b", :as => "hello"
-        get "/hello"       => "a#b", :as => "hello"
+        get "/hello/world", to: "a#b", as: "hello"
+        get "/hello",       to: "a#b", as: "hello"
       end
     end
   end
 
   def setup_named_route_test
     set.draw do
-      get "/people(/:id)" => "people#show", :as => "show"
-      get "/people" => "people#index", :as => "index"
-      get "/people/go/:foo/:bar/joe(/:id)" => "people#multi", :as => "multi"
-      get "/admin/users" => "admin/users#index", :as => "users"
+      get "/people(/:id)", to: "people#show", as: "show"
+      get "/people", to: "people#index", as: "index"
+      get "/people/go/:foo/:bar/joe(/:id)", to: "people#multi", as: "multi"
+      get "/admin/users", to: "admin/users#index", as: "users"
     end
 
     get URI("http://test.host/people")
@@ -1222,7 +1220,7 @@ class RouteSetTest < ActiveSupport::TestCase
 
   def test_route_with_parameter_shell
     set.draw do
-      get "page/:id" => "pages#show", :id => /\d+/
+      get "page/:id", to: "pages#show", id: /\d+/
 
       ActionDispatch.deprecator.silence do
         get "/:controller(/:action(/:id))"
@@ -1240,7 +1238,7 @@ class RouteSetTest < ActiveSupport::TestCase
   def test_route_constraints_on_request_object_with_anchors_are_valid
     assert_nothing_raised do
       set.draw do
-        get "page/:id" => "pages#show", :constraints => { host: /^foo$/ }
+        get "page/:id", to: "pages#show", constraints: { host: /^foo$/ }
       end
     end
   end
@@ -1248,27 +1246,27 @@ class RouteSetTest < ActiveSupport::TestCase
   def test_route_constraints_with_anchor_chars_are_invalid
     assert_raise ArgumentError do
       set.draw do
-        get "page/:id" => "pages#show", :id => /^\d+/
+        get "page/:id", to: "pages#show", id: /^\d+/
       end
     end
     assert_raise ArgumentError do
       set.draw do
-        get "page/:id" => "pages#show", :id => /\A\d+/
+        get "page/:id", to: "pages#show", id: /\A\d+/
       end
     end
     assert_raise ArgumentError do
       set.draw do
-        get "page/:id" => "pages#show", :id => /\d+$/
+        get "page/:id", to: "pages#show", id: /\d+$/
       end
     end
     assert_raise ArgumentError do
       set.draw do
-        get "page/:id" => "pages#show", :id => /\d+\Z/
+        get "page/:id", to: "pages#show", id: /\d+\Z/
       end
     end
     assert_raise ArgumentError do
       set.draw do
-        get "page/:id" => "pages#show", :id => /\d+\z/
+        get "page/:id", to: "pages#show", id: /\d+\z/
       end
     end
   end
@@ -1276,14 +1274,14 @@ class RouteSetTest < ActiveSupport::TestCase
   def test_route_constraints_with_options_method_condition_is_valid
     assert_nothing_raised do
       set.draw do
-        match "valid/route" => "pages#show", :via => :options
+        match "valid/route", to: "pages#show", via: :options
       end
     end
   end
 
   def test_route_error_with_missing_controller
     set.draw do
-      get    "/people" => "missing#index"
+      get "/people", to: "missing#index"
     end
 
     assert_raises(ActionController::RoutingError) { request_path_params "/people" }
@@ -1291,7 +1289,7 @@ class RouteSetTest < ActiveSupport::TestCase
 
   def test_recognize_with_encoded_id_and_regex
     set.draw do
-      get "page/:id" => "pages#show", :id => /[a-zA-Z0-9+]+/
+      get "page/:id", to: "pages#show", id: /[a-zA-Z0-9+]+/
     end
 
     assert_equal({ controller: "pages", action: "show", id: "10" }, request_path_params("/page/10"))
@@ -1300,12 +1298,12 @@ class RouteSetTest < ActiveSupport::TestCase
 
   def test_recognize_with_http_methods
     set.draw do
-      get    "/people"     => "people#index", :as => "people"
-      post   "/people"     => "people#create"
-      get    "/people/:id" => "people#show",  :as => "person"
-      put    "/people/:id" => "people#update"
-      patch  "/people/:id" => "people#update"
-      delete "/people/:id" => "people#destroy"
+      get    "/people",     to: "people#index", as: "people"
+      post   "/people",     to: "people#create"
+      get    "/people/:id", to: "people#show",  as: "person"
+      put    "/people/:id", to: "people#update"
+      patch  "/people/:id", to: "people#update"
+      delete "/people/:id", to: "people#destroy"
     end
 
     params = request_path_params("/people", method: :get)
@@ -1347,7 +1345,7 @@ class RouteSetTest < ActiveSupport::TestCase
 
   def test_recognize_with_alias_in_conditions
     set.draw do
-      match "/people" => "people#index", :as => "people", :via => :get
+      match "/people", to: "people#index", as: "people", via: :get
       root to: "people#index"
     end
 
@@ -1362,8 +1360,8 @@ class RouteSetTest < ActiveSupport::TestCase
 
   def test_typo_recognition
     set.draw do
-      get "articles/:year/:month/:day/:title" => "articles#permalink",
-             :year => /\d{4}/, :day => /\d{1,2}/, :month => /\d{1,2}/
+      get "articles/:year/:month/:day/:title", to: "articles#permalink",
+             year: /\d{4}/, day: /\d{1,2}/, month: /\d{1,2}/
     end
 
     params = request_path_params("/articles/2005/11/05/a-very-interesting-article", method: :get)
@@ -1377,7 +1375,7 @@ class RouteSetTest < ActiveSupport::TestCase
   def test_routing_traversal_does_not_load_extra_classes
     assert_not Object.const_defined?("Profiler__"), "Profiler should not be loaded"
     set.draw do
-      get "/profile" => "profile#index"
+      get "/profile", to: "profile#index"
     end
 
     request_path_params("/profile") rescue nil
@@ -1387,10 +1385,10 @@ class RouteSetTest < ActiveSupport::TestCase
 
   def test_recognize_with_conditions_and_format
     set.draw do
-      get "people/:id" => "people#show", :as => "person"
-      put "people/:id" => "people#update"
-      patch "people/:id" => "people#update"
-      get "people/:id(.:format)" => "people#show"
+      get "people/:id",           to: "people#show", as: "person"
+      put "people/:id",           to: "people#update"
+      patch "people/:id",         to: "people#update"
+      get "people/:id(.:format)", to: "people#show"
     end
 
     params = request_path_params("/people/5", method: :get)
@@ -1430,7 +1428,7 @@ class RouteSetTest < ActiveSupport::TestCase
   def test_namespace
     set.draw do
       namespace "api" do
-        get "inventory" => "products#inventory"
+        get "inventory", to: "products#inventory"
       end
     end
 
@@ -1454,7 +1452,7 @@ class RouteSetTest < ActiveSupport::TestCase
   def test_namespace_with_path_prefix
     set.draw do
       scope module: "api", path: "prefix" do
-        get "inventory" => "products#inventory"
+        get "inventory", to: "products#inventory"
       end
     end
 
@@ -1466,7 +1464,7 @@ class RouteSetTest < ActiveSupport::TestCase
   def test_namespace_with_blank_path_prefix
     set.draw do
       scope module: "api", path: "" do
-        get "inventory" => "products#inventory"
+        get "inventory", to: "products#inventory"
       end
     end
 
@@ -1493,7 +1491,7 @@ class RouteSetTest < ActiveSupport::TestCase
     @set = make_set false
 
     set.draw do
-      get "about" => "welcome#about"
+      get "about", to: "welcome#about"
 
       ActionDispatch.deprecator.silence do
         get ":controller/:id/:action"
@@ -1547,9 +1545,9 @@ class RouteSetTest < ActiveSupport::TestCase
 
     set.draw do
       ActionDispatch.deprecator.silence do
-        get "/connection/manage(/:action)" => "connection/manage#index"
-        get "/connection/connection" => "connection/connection#index"
-        get "/connection" => "connection#index", :as => "family_connection"
+        get "/connection/manage(/:action)", to: "connection/manage#index"
+        get "/connection/connection", to: "connection/connection#index"
+        get "/connection", to: "connection#index", as: "family_connection"
       end
     end
 
@@ -1584,7 +1582,7 @@ class RouteSetTest < ActiveSupport::TestCase
     @set = make_set false
 
     set.draw do
-      get "show_weblog/:parameter" => "weblog#show"
+      get "show_weblog/:parameter", to: "weblog#show"
 
       ActionDispatch.deprecator.silence do
         get ":controller(/:action(/:id))"
@@ -1597,9 +1595,9 @@ class RouteSetTest < ActiveSupport::TestCase
       action: "edit", parameter: 1, only_path: true)
   end
 
-  def test_format_is_not_inherit
+  def test_format_is_not_inherited
     set.draw do
-      get "/posts(.:format)" => "posts#index"
+      get "/posts(.:format)", to: "posts#index"
     end
 
     get URI("http://test.host/posts.xml")
@@ -1632,7 +1630,7 @@ class RouteSetTest < ActiveSupport::TestCase
     set.draw do
       resources :projects do
         member do
-          get "milestones" => "milestones#index", :as => "milestones"
+          get "milestones", to: "milestones#index", as: "milestones"
         end
       end
     end
@@ -1665,8 +1663,8 @@ class RouteSetTest < ActiveSupport::TestCase
   def test_route_constraints_with_unsupported_regexp_options_must_error
     assert_raise ArgumentError do
       set.draw do
-        get "page/:name" => "pages#show",
-          :constraints => { name: /(david|jamis)/m }
+        get "page/:name", to: "pages#show",
+          constraints: { name: /(david|jamis)/m }
       end
     end
   end
@@ -1674,19 +1672,19 @@ class RouteSetTest < ActiveSupport::TestCase
   def test_route_constraints_with_supported_options_must_not_error
     assert_nothing_raised do
       set.draw do
-        get "page/:name" => "pages#show",
-          :constraints => { name: /(david|jamis)/i }
+        get "page/:name", to: "pages#show",
+          constraints: { name: /(david|jamis)/i }
       end
     end
     assert_nothing_raised do
       set.draw do
-        get "page/:name" => "pages#show",
-          :constraints => { name: / # Desperately overcommented regexp
-                                      ( #Either
-                                       david #The Creator
-                                      | #Or
-                                        jamis #The Deployer
-                                      )/x }
+        get "page/:name", to: "pages#show",
+          constraints: { name: / # Desperately overcommented regexp
+                                ( #Either
+                                  david #The Creator
+                                | #Or
+                                  jamis #The Deployer
+                                )/x }
       end
     end
   end
@@ -1694,7 +1692,7 @@ class RouteSetTest < ActiveSupport::TestCase
   def test_route_with_subdomain_and_constraints_must_receive_params
     name_param = nil
     set.draw do
-      get "page/:name" => "pages#show", :constraints => lambda { |request|
+      get "page/:name", to: "pages#show", constraints: lambda { |request|
         name_param = request.params[:name]
         true
       }
@@ -1706,8 +1704,8 @@ class RouteSetTest < ActiveSupport::TestCase
 
   def test_route_requirement_recognize_with_ignore_case
     set.draw do
-      get "page/:name" => "pages#show",
-        :constraints => { name: /(david|jamis)/i }
+      get "page/:name", to: "pages#show",
+        constraints: { name: /(david|jamis)/i }
     end
     assert_equal({ controller: "pages", action: "show", name: "jamis" }, set.recognize_path("/page/jamis"))
     assert_raise ActionController::RoutingError do
@@ -1718,8 +1716,8 @@ class RouteSetTest < ActiveSupport::TestCase
 
   def test_route_requirement_generate_with_ignore_case
     set.draw do
-      get "page/:name" => "pages#show",
-        :constraints => { name: /(david|jamis)/i }
+      get "page/:name", to: "pages#show",
+        constraints: { name: /(david|jamis)/i }
     end
 
     url = url_for(set, controller: "pages", action: "show", name: "david")
@@ -1733,13 +1731,13 @@ class RouteSetTest < ActiveSupport::TestCase
 
   def test_route_requirement_recognize_with_extended_syntax
     set.draw do
-      get "page/:name" => "pages#show",
-        :constraints => { name: / # Desperately overcommented regexp
-                                    ( #Either
-                                     david #The Creator
-                                    | #Or
-                                      jamis #The Deployer
-                                    )/x }
+      get "page/:name", to: "pages#show",
+        constraints: { name: / # Desperately overcommented regexp
+                            ( #Either
+                              david #The Creator
+                            | #Or
+                              jamis #The Deployer
+                            )/x }
     end
     assert_equal({ controller: "pages", action: "show", name: "jamis" }, set.recognize_path("/page/jamis"))
     assert_equal({ controller: "pages", action: "show", name: "david" }, set.recognize_path("/page/david"))
@@ -1753,13 +1751,13 @@ class RouteSetTest < ActiveSupport::TestCase
 
   def test_route_requirement_with_xi_modifiers
     set.draw do
-      get "page/:name" => "pages#show",
-        :constraints => { name: / # Desperately overcommented regexp
-                                    ( #Either
-                                     david #The Creator
-                                    | #Or
-                                      jamis #The Deployer
-                                    )/xi }
+      get "page/:name", to: "pages#show",
+        constraints: { name: / # Desperately overcommented regexp
+                             ( #Either
+                               david #The Creator
+                             | #Or
+                               jamis #The Deployer
+                             )/xi }
     end
 
     assert_equal({ controller: "pages", action: "show", name: "JAMIS" },
@@ -1780,8 +1778,8 @@ class RouteSetTest < ActiveSupport::TestCase
 
   def test_regexp_chunk_should_add_question_mark_for_optionals
     set.draw do
-      get "/" => "foo#index"
-      get "/hello" => "bar#index"
+      get "/", to: "foo#index"
+      get "/hello", to: "bar#index"
     end
 
     assert_equal "/",      url_for(set, controller: "foo")
@@ -1919,11 +1917,11 @@ class RouteSetTest < ActiveSupport::TestCase
 
   def test_generate_with_default_params
     set.draw do
-      get "dummy/page/:page" => "dummy#show"
-      get "dummy/dots/page.:page" => "dummy#dots"
-      get "ibocorp(/:page)" => "ibocorp#show",
-                             :constraints => { page: /\d+/ },
-                             :defaults => { page: 1 }
+      get "dummy/page/:page", to: "dummy#show"
+      get "dummy/dots/page.:page", to: "dummy#dots"
+      get "ibocorp(/:page)", to: "ibocorp#show",
+                             constraints: { page: /\d+/ },
+                             defaults: { page: 1 }
 
       ActionDispatch.deprecator.silence do
         get ":controller/:action/:id"
@@ -2007,14 +2005,14 @@ class RackMountIntegrationTests < ActiveSupport::TestCase
       root to: "users#index"
     end
 
-    get "/blog(/:year(/:month(/:day)))" => "posts#show_date",
-      :constraints => {
+    get "/blog(/:year(/:month(/:day)))", to: "posts#show_date",
+      constraints: {
         year: /(19|20)\d\d/,
         month: /[01]?\d/,
         day: /[0-3]?\d/
       },
-      :day => nil,
-      :month => nil
+      day: nil,
+      month: nil
 
     get "archive/:year", controller: "archive", action: "index",
       defaults: { year: nil },
@@ -2022,29 +2020,29 @@ class RackMountIntegrationTests < ActiveSupport::TestCase
       as: "blog"
 
     resources :people
-    get "legacy/people" => "people#index", :legacy => "true"
+    get "legacy/people", to: "people#index", legacy: "true"
 
     get "symbols", controller: :symbols, action: :show, name: :as_symbol
-    get "id_default(/:id)" => "foo#id_default", :id => 1
-    match "get_or_post" => "foo#get_or_post", :via => [:get, :post]
-    get "optional/:optional" => "posts#index"
-    get "projects/:project_id" => "project#index", :as => "project"
-    get "clients" => "projects#index"
+    get "id_default(/:id)", to: "foo#id_default", id: 1
+    match "get_or_post", to: "foo#get_or_post", via: [:get, :post]
+    get "optional/:optional", to: "posts#index"
+    get "projects/:project_id", to: "project#index", as: "project"
+    get "clients", to: "projects#index"
 
-    get "ignorecase/geocode/:postalcode" => "geocode#show", :postalcode => /hx\d\d-\d[a-z]{2}/i
-    get "extended/geocode/:postalcode" => "geocode#show", :constraints => {
+    get "ignorecase/geocode/:postalcode", to: "geocode#show", postalcode: /hx\d\d-\d[a-z]{2}/i
+    get "extended/geocode/:postalcode", to: "geocode#show", constraints: {
                   postalcode: /# Postcode format
                                   \d{5} #Prefix
                                   (-\d{4})? #Suffix
                                   /x
-                  }, :as => "geocode"
+                  }, as: "geocode"
 
-    get "news(.:format)" => "news#index"
+    get "news(.:format)", to: "news#index"
 
     ActionDispatch.deprecator.silence do
-      get "comment/:id(/:action)" => "comments#show"
+      get "comment/:id(/:action)", to: "comments#show"
       get "ws/:controller(/:action(/:id))", ws: true
-      get "account(/:action)" => "account#subscription"
+      get "account(/:action)", to: "account#subscription"
       get "pages/:page_id/:controller(/:action(/:id))"
       get ":controller/ping", action: "ping"
     end

--- a/actionpack/test/controller/test_case_test.rb
+++ b/actionpack/test/controller/test_case_test.rb
@@ -458,7 +458,7 @@ class TestCaseTest < ActionController::TestCase
     with_routing do |set|
       set.draw do
         namespace :admin do
-          get "user" => "user#index"
+          get "user", to: "user#index"
         end
       end
 
@@ -468,7 +468,7 @@ class TestCaseTest < ActionController::TestCase
 
   def test_assert_routing_with_glob
     with_routing do |set|
-      set.draw { get("*path" => "pages#show") }
+      set.draw { get("*path", to: "pages#show") }
       assert_routing("/company/about", controller: "pages", action: "show", path: "company/about")
     end
   end
@@ -1131,7 +1131,7 @@ module EngineControllerTests
     isolate_namespace EngineControllerTests
 
     routes.draw do
-      get "/" => "bar#index"
+      get "/", to: "bar#index"
     end
   end
 

--- a/actionpack/test/controller/url_for_integration_test.rb
+++ b/actionpack/test/controller/url_for_integration_test.rb
@@ -20,14 +20,14 @@ module ActionPack
         root to: "users#index"
       end
 
-      get "/blog(/:year(/:month(/:day)))" => "posts#show_date",
-        :constraints => {
+      get "/blog(/:year(/:month(/:day)))", to: "posts#show_date",
+        constraints: {
           year: /(19|20)\d\d/,
           month: /[01]?\d/,
           day: /[0-3]?\d/
         },
-        :day => nil,
-        :month => nil
+        day: nil,
+        month: nil
 
       get "archive/:year", controller: "archive", action: "index",
         defaults: { year: nil },
@@ -37,26 +37,26 @@ module ActionPack
       resources :people
 
       get "symbols", controller: :symbols, action: :show, name: :as_symbol
-      get "id_default(/:id)" => "foo#id_default", :id => 1
-      match "get_or_post" => "foo#get_or_post", :via => [:get, :post]
-      get "optional/:optional" => "posts#index"
-      get "projects/:project_id" => "project#index", :as => "project"
-      get "clients" => "projects#index"
+      get "id_default(/:id)", to: "foo#id_default", id: 1
+      match "get_or_post", to: "foo#get_or_post", via: [:get, :post]
+      get "optional/:optional", to: "posts#index"
+      get "projects/:project_id", to: "project#index", as: "project"
+      get "clients", to: "projects#index"
 
-      get "ignorecase/geocode/:postalcode" => "geocode#show", :postalcode => /hx\d\d-\d[a-z]{2}/i
-      get "extended/geocode/:postalcode" => "geocode#show", :constraints => {
+      get "ignorecase/geocode/:postalcode", to: "geocode#show", postalcode: /hx\d\d-\d[a-z]{2}/i
+      get "extended/geocode/:postalcode", to: "geocode#show", constraints: {
         postalcode: /# Postcode format
         \d{5} #Prefix
         (-\d{4})? #Suffix
         /x
-      }, :as => "geocode"
+      }, as: "geocode"
 
-      get "news(.:format)" => "news#index"
+      get "news(.:format)", to: "news#index"
 
       ActionDispatch.deprecator.silence {
-        get "comment/:id(/:action)" => "comments#show"
+        get "comment/:id(/:action)", to: "comments#show"
         get "ws/:controller(/:action(/:id))", ws: true
-        get "account(/:action)" => "account#subscription"
+        get "account(/:action)", to: "account#subscription"
         get "pages/:page_id/:controller(/:action(/:id))"
         get ":controller/ping", action: "ping"
         get ":controller(/:action(/:id))(.:format)"

--- a/actionpack/test/controller/url_for_test.rb
+++ b/actionpack/test/controller/url_for_test.rb
@@ -325,10 +325,10 @@ module AbstractController
         with_routing do |set|
           set.draw do
             scope ":account_id" do
-              get "dashboard" => "pages#dashboard", as: :dashboard
-              get "search(/:term)" => "search#search", as: :search
+              get "dashboard", to: "pages#dashboard", as: :dashboard
+              get "search(/:term)", to: "search#search", as: :search
             end
-            delete "signout" => "sessions#destroy", as: :signout
+            delete "signout", to: "sessions#destroy", as: :signout
           end
 
           kls = Class.new do
@@ -353,10 +353,10 @@ module AbstractController
         with_routing do |set|
           set.draw do
             scope ":account_id" do
-              get "dashboard" => "pages#dashboard", as: :dashboard
-              get "search(/:term)" => "search#search", as: :search
+              get "dashboard", to: "pages#dashboard", as: :dashboard
+              get "search(/:term)", to: "search#search", as: :search
             end
-            delete "signout" => "sessions#destroy", as: :signout
+            delete "signout", to: "sessions#destroy", as: :signout
           end
 
           kls = Class.new { include set.url_helpers }
@@ -577,7 +577,7 @@ module AbstractController
       def test_default_params_first_empty
         with_routing do |set|
           set.draw do
-            get "(:param1)/test(/:param2)" => "index#index",
+            get "(:param1)/test(/:param2)", to: "index#index",
               defaults: {
                 param1: 1,
                 param2: 2

--- a/actionpack/test/dispatch/mapper_test.rb
+++ b/actionpack/test/dispatch/mapper_test.rb
@@ -177,7 +177,7 @@ module ActionDispatch
         fakeset = FakeSet.new
         mapper = Mapper.new fakeset
         app = lambda { |env| [200, {}, [""]] }
-        mapper.mount app => "/path", anchor: true
+        mapper.mount app, at: "/path", anchor: true
         assert_equal "/path", fakeset.asts.first.to_s
         assert fakeset.routes.first.path.anchored
       end

--- a/actionpack/test/dispatch/mount_test.rb
+++ b/actionpack/test/dispatch/mount_test.rb
@@ -28,7 +28,6 @@ class TestRoutingMount < ActionDispatch::IntegrationTest
 
     mount SprocketsApp, at: "/sprockets"
     mount SprocketsApp, at: "/star*"
-    mount SprocketsApp => "/shorthand"
 
     mount SinatraLikeApp, at: "/fakeengine", as: :fake
     mount SinatraLikeApp, at: "/getfake", via: :get
@@ -84,15 +83,10 @@ class TestRoutingMount < ActionDispatch::IntegrationTest
     assert_equal "/its_a/sprocket -- /omg", response.body
   end
 
-  def test_mounting_with_shorthand
-    get "/shorthand/omg"
-    assert_equal "/shorthand -- /omg", response.body
-  end
-
   def test_mounting_does_not_match_similar_paths
-    get "/shorthandomg"
-    assert_not_equal "/shorthand -- /omg", response.body
-    assert_equal " -- /shorthandomg", response.body
+    get "/sprocketsomg"
+    assert_not_equal "/sprockets -- /omg", response.body
+    assert_equal " -- /sprocketsomg", response.body
   end
 
   def test_mounting_works_with_via

--- a/actionpack/test/dispatch/prefix_generation_test.rb
+++ b/actionpack/test/dispatch/prefix_generation_test.rb
@@ -52,7 +52,7 @@ module TestGenerationPrefix
     class RailsApplication < Rails::Engine
       routes.draw do
         scope "/:omg", omg: "awesome" do
-          mount BlogEngine => "/blog", :as => "blog_engine"
+          mount BlogEngine, at: "/blog", as: "blog_engine"
         end
         get "/posts/:id", to: "outside_engine_generating#post", as: :post
         get "/generate", to: "outside_engine_generating#index"
@@ -370,7 +370,7 @@ module TestGenerationPrefix
 
     class RailsApplication < Rails::Engine
       routes.draw do
-        mount BlogEngine => "/"
+        mount BlogEngine, at: "/"
       end
     end
 

--- a/actionpack/test/dispatch/request/session_test.rb
+++ b/actionpack/test/dispatch/request/session_test.rb
@@ -201,7 +201,7 @@ module ActionDispatch
 
       Router = ActionDispatch::Routing::RouteSet.new
       Router.draw do
-        get "/mysessionapp" => MySessionApp.new
+        get "/mysessionapp", to: MySessionApp.new
       end
 
       def app

--- a/actionpack/test/dispatch/routing/inspector_test.rb
+++ b/actionpack/test/dispatch/routing/inspector_test.rb
@@ -32,7 +32,7 @@ module ActionDispatch
 
         output = draw do
           get "/custom/assets", to: "custom_assets#show"
-          mount engine => "/blog", :as => "blog"
+          mount engine, at: "/blog", as: "blog"
         end
 
         assert_equal [
@@ -55,7 +55,7 @@ module ActionDispatch
         end
 
         output = draw do
-          mount engine => "/blog", as: "blog"
+          mount engine, at: "/blog", as: "blog"
         end
 
         assert_equal [
@@ -169,7 +169,7 @@ module ActionDispatch
 
       def test_rails_routes_shows_route_with_defaults
         output = draw do
-          get "photos/:id" => "photos#show", :defaults => { format: "jpg" }
+          get "photos/:id", to: "photos#show", defaults: { format: "jpg" }
         end
 
         assert_equal [
@@ -180,7 +180,7 @@ module ActionDispatch
 
       def test_rails_routes_shows_route_with_constraints
         output = draw do
-          get "photos/:id" => "photos#show", :id => /[A-Z]\d{5}/
+          get "photos/:id", to: "photos#show", id: /[A-Z]\d{5}/
         end
 
         assert_equal [
@@ -191,7 +191,7 @@ module ActionDispatch
 
       def test_rails_routes_shows_routes_with_dashes
         output = draw do
-          get "about-us" => "pages#about_us"
+          get "about-us", to: "pages#about_us"
           get "our-work/latest"
 
           resources :photos, only: [:show] do
@@ -214,7 +214,7 @@ module ActionDispatch
 
       def test_rails_routes_shows_route_with_rack_app
         output = draw do
-          get "foo/:id" => MountedRackApp, :id => /[A-Z]\d{5}/
+          get "foo/:id", to: MountedRackApp, id: /[A-Z]\d{5}/
         end
 
         assert_equal [
@@ -225,7 +225,7 @@ module ActionDispatch
 
       def test_rails_routes_shows_named_route_with_mounted_rack_app
         output = draw do
-          mount MountedRackApp => "/foo"
+          mount MountedRackApp, at: "/foo"
         end
 
         assert_equal [
@@ -236,7 +236,7 @@ module ActionDispatch
 
       def test_rails_routes_shows_overridden_named_route_with_mounted_rack_app_with_name
         output = draw do
-          mount MountedRackApp => "/foo", as: "blog"
+          mount MountedRackApp, at: "/foo", as: "blog"
         end
 
         assert_equal [
@@ -254,7 +254,7 @@ module ActionDispatch
 
         output = draw do
           scope constraint: constraint.new do
-            mount MountedRackApp => "/foo"
+            mount MountedRackApp, at: "/foo"
           end
         end
 
@@ -266,7 +266,7 @@ module ActionDispatch
 
       def test_rails_routes_dont_show_app_mounted_in_assets_prefix
         output = draw do
-          get "/sprockets" => MountedRackApp
+          get "/sprockets", to: MountedRackApp
         end
         assert_no_match(/MountedRackApp/, output.first)
         assert_no_match(/\/sprockets/, output.first)
@@ -275,7 +275,7 @@ module ActionDispatch
       def test_rails_routes_shows_route_defined_in_under_assets_prefix
         output = draw do
           scope "/sprockets" do
-            get "/foo" => "foo#bar"
+            get "/foo", to: "foo#bar"
           end
         end
         assert_equal [
@@ -286,9 +286,9 @@ module ActionDispatch
 
       def test_redirect
         output = draw do
-          get "/foo"    => redirect("/foo/bar"), :constraints => { subdomain: "admin" }
-          get "/bar"    => redirect(path: "/foo/bar", status: 307)
-          get "/foobar" => redirect { "/foo/bar" }
+          get "/foo",    to: redirect("/foo/bar"), constraints: { subdomain: "admin" }
+          get "/bar",    to: redirect(path: "/foo/bar", status: 307)
+          get "/foobar", to: redirect { "/foo/bar" }
         end
 
         assert_equal [
@@ -332,7 +332,7 @@ module ActionDispatch
         output = draw(formatter: ActionDispatch::Routing::ConsoleFormatter::Expanded.new(width: 23)) do
           get "/custom/assets", to: "custom_assets#show"
           get "/custom/furnitures", to: "custom_furnitures#show"
-          mount engine => "/blog", :as => "blog"
+          mount engine, at: "/blog", as: "blog"
         end
 
         expected = ["--[ Route 1 ]----------",
@@ -369,7 +369,7 @@ module ActionDispatch
 
       def test_no_routes_matched_filter_when_expanded
         output = draw(grep: "rails/dummy", formatter: ActionDispatch::Routing::ConsoleFormatter::Expanded.new) do
-          get "photos/:id" => "photos#show", :id => /[A-Z]\d{5}/
+          get "photos/:id", to: "photos#show", id: /[A-Z]\d{5}/
         end
 
         assert_equal [
@@ -422,7 +422,7 @@ module ActionDispatch
 
       def test_routes_with_undefined_filter
         output = draw(controller: "Rails::MissingController") do
-          get "photos/:id" => "photos#show", :id => /[A-Z]\d{5}/
+          get "photos/:id", to: "photos#show", id: /[A-Z]\d{5}/
         end
 
         assert_equal [
@@ -433,7 +433,7 @@ module ActionDispatch
 
       def test_no_routes_matched_filter
         output = draw(grep: "rails/dummy") do
-          get "photos/:id" => "photos#show", :id => /[A-Z]\d{5}/
+          get "photos/:id", to: "photos#show", id: /[A-Z]\d{5}/
         end
 
         assert_equal [
@@ -468,7 +468,7 @@ module ActionDispatch
 
         output = draw do
           get "/custom/assets", to: "custom_assets#show"
-          mount engine => "/blog", as: "blog", internal: true
+          mount engine, at: "/blog", as: "blog", internal: true
         end
 
         assert_equal [

--- a/actionpack/test/dispatch/routing_assertions_test.rb
+++ b/actionpack/test/dispatch/routing_assertions_test.rb
@@ -62,9 +62,9 @@ module RoutingAssertionsSharedTests
         resources :articles, controller: "query_articles"
       end
 
-      mount engine => "/shelf"
+      mount engine, at: "/shelf"
 
-      mount root_engine => "/"
+      mount root_engine, at: "/"
 
       get "/shelf/foo", controller: "query_articles", action: "index"
     end

--- a/actionpack/test/dispatch/routing_test.rb
+++ b/actionpack/test/dispatch/routing_test.rb
@@ -31,7 +31,7 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
   def test_logout
     draw do
       controller :sessions do
-        delete "logout" => :destroy
+        delete "logout", action: :destroy
       end
     end
 
@@ -47,8 +47,8 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
       default_url_options host: "rubyonrails.org"
 
       controller :sessions do
-        get  "login" => :new
-        post "login" => :create
+        get  "login", action: :new
+        post "login", action: :create
       end
     end
 
@@ -77,7 +77,7 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
 
   def test_logout_redirect_without_to
     draw do
-      get "account/logout" => redirect("/logout"), :as => :logout_redirect
+      get "account/logout", to: redirect("/logout"), as: :logout_redirect
     end
 
     assert_equal "/account/logout", logout_redirect_path
@@ -272,7 +272,7 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
 
   def test_redirect_proc_with_request
     draw do
-      get "account/proc_req" => redirect { |params, req| "/#{req.method}" }
+      get "account/proc_req", to: redirect { |params, req| "/#{req.method}" }
     end
 
     get "/account/proc_req"
@@ -416,14 +416,14 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
   def test_admin
     draw do
       constraints(ip: /192\.168\.1\.\d\d\d/) do
-        get "admin" => "queenbee#index"
+        get "admin", to: "queenbee#index"
       end
 
       constraints ::TestRoutingMapper::IpRestrictor do
-        get "admin/accounts" => "queenbee#accounts"
+        get "admin/accounts", to: "queenbee#accounts"
       end
 
-      get "admin/passwords" => "queenbee#passwords", :constraints => ::TestRoutingMapper::IpRestrictor
+      get "admin/passwords", to: "queenbee#passwords", constraints: ::TestRoutingMapper::IpRestrictor
     end
 
     get "/admin", headers: { "REMOTE_ADDR" => "192.168.1.100" }
@@ -1036,7 +1036,7 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
 
   def test_sprockets
     draw do
-      get "sprockets.js" => ::TestRoutingMapper::SprocketsApp
+      get "sprockets.js", to: ::TestRoutingMapper::SprocketsApp
     end
 
     get "/sprockets.js"
@@ -1526,7 +1526,7 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
 
   def test_index
     draw do
-      get "/info" => "projects#info", :as => "info"
+      get "/info", to: "projects#info", as: "info"
     end
 
     assert_equal "/info", info_path
@@ -1656,8 +1656,8 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
     draw do
       resources :replies do
         collection do
-          get "page/:page" => "replies#index", :page => %r{\d+}
-          get ":page" => "replies#index", :page => %r{\d+}
+          get "page/:page", to: "replies#index", page: %r{\d+}
+          get ":page", to: "replies#index", page: %r{\d+}
         end
       end
     end
@@ -1694,7 +1694,7 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
 
   def test_convention_with_explicit_end
     draw do
-      get "sign_in" => "sessions#new"
+      get "sign_in", to: "sessions#new"
     end
 
     get "/sign_in"
@@ -1704,7 +1704,7 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
 
   def test_redirect_with_complete_url_and_status
     draw do
-      get "account/google" => redirect("http://www.google.com/", status: 302)
+      get "account/google", to: redirect("http://www.google.com/", status: 302)
     end
 
     get "/account/google"
@@ -1962,7 +1962,7 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
     draw do
       scope path: "api" do
         resource :me
-        get "/" => "mes#index"
+        get "/", to: "mes#index"
       end
     end
 
@@ -1979,7 +1979,7 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
       scope path: "api" do
         scope :v2 do
           resource :me, as: "v2_me"
-          get "/" => "mes#index"
+          get "/", to: "mes#index"
         end
 
         scope :v3, :admin do
@@ -2475,28 +2475,28 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
       resources :customers do
         get :recent, on: :collection
         get "profile", on: :member
-        get "secret/profile" => "customers#secret", :on => :member
-        post "preview" => "customers#preview", :as => :another_preview, :on => :new
+        get "secret/profile", to: "customers#secret", on: :member
+        post "preview", to: "customers#preview", as: :another_preview, on: :new
         resource :avatar do
-          get "thumbnail" => "avatars#thumbnail", :as => :thumbnail, :on => :member
+          get "thumbnail", to: "avatars#thumbnail", as: :thumbnail, on: :member
         end
         resources :invoices do
-          get "outstanding" => "invoices#outstanding", :on => :collection
+          get "outstanding", to: "invoices#outstanding", on: :collection
           get "overdue", action: :overdue, on: :collection
-          get "print" => "invoices#print", :as => :print, :on => :member
-          post "preview" => "invoices#preview", :as => :preview, :on => :new
+          get "print", to: "invoices#print", as: :print, on: :member
+          post "preview", to: "invoices#preview", as: :preview, on: :new
         end
         resources :notes, shallow: true do
-          get "preview" => "notes#preview", :as => :preview, :on => :new
-          get "print" => "notes#print", :as => :print, :on => :member
+          get "preview", to: "notes#preview", as: :preview, on: :new
+          get "print", to: "notes#print", as: :print, on: :member
         end
       end
 
       namespace :api do
         resources :customers do
-          get "recent" => "customers#recent", :as => :recent, :on => :collection
-          get "profile" => "customers#profile", :as => :profile, :on => :member
-          post "preview" => "customers#preview", :as => :preview, :on => :new
+          get "recent", to: "customers#recent", as: :recent, on: :collection
+          get "profile", to: "customers#profile", as: :profile, on: :member
+          post "preview", to: "customers#preview", as: :preview, on: :new
         end
       end
     end
@@ -2606,7 +2606,7 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
 
   def test_url_generator_for_optional_prefix_dynamic_segment
     draw do
-      get "(/:username)/followers" => "followers#index"
+      get "(/:username)/followers", to: "followers#index"
     end
 
     get "/bob/followers"
@@ -2622,7 +2622,7 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
 
   def test_url_generator_for_optional_suffix_static_and_dynamic_segment
     draw do
-      get "/groups(/user/:username)" => "groups#index"
+      get "/groups(/user/:username)", to: "groups#index"
     end
 
     get "/groups/user/bob"
@@ -2638,7 +2638,7 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
 
   def test_url_generator_for_optional_prefix_static_and_dynamic_segment
     draw do
-      get "(/user/:username)/photos" => "photos#index"
+      get "(/user/:username)/photos", to: "photos#index"
     end
 
     get "/user/bob/photos"
@@ -3372,7 +3372,7 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
     draw do
       resources :posts, only: [:index, :show] do
         resources :comments, except: :destroy do
-          get "views" => "comments#views", :as => :views
+          get "views", to: "comments#views", as: :views
         end
       end
     end
@@ -3460,7 +3460,7 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
 
   def test_action_from_path_is_frozen
     draw do
-      get "search" => "search"
+      get "search", to: "search#search"
     end
 
     get "/search"
@@ -3469,7 +3469,7 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
 
   def test_multiple_positional_args_with_the_same_name
     draw do
-      get "/downloads/:id/:id.tar" => "downloads#show", as: :download, format: false
+      get "/downloads/:id/:id.tar", to: "downloads#show", as: :download, format: false
     end
 
     expected_params = {
@@ -3765,7 +3765,7 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
 
   def test_head_fetch_with_mount_on_root
     draw do
-      get "/home" => "test#index"
+      get "/home", to: "test#index"
       mount lambda { |env| [200, {}, [env["REQUEST_METHOD"]]] }, at: "/"
     end
 
@@ -3968,8 +3968,8 @@ class TestAltApp < ActionDispatch::IntegrationTest
     end
   }.new
   AltRoutes.draw do
-    get "/" => TestAltApp::XHeader.new, :constraints => { x_header: /HEADER/ }
-    get "/" => TestAltApp::AltApp.new
+    get "/", to: TestAltApp::XHeader.new, constraints: { x_header: /HEADER/ }
+    get "/", to: TestAltApp::AltApp.new
   end
 
   APP = build_app AltRoutes
@@ -4004,12 +4004,12 @@ class TestAppendingRoutes < ActionDispatch::IntegrationTest
     s = self
     routes = ActionDispatch::Routing::RouteSet.new
     routes.append do
-      get "/hello"   => s.simple_app("fail")
-      get "/goodbye" => s.simple_app("goodbye")
+      get "/hello",   to: s.simple_app("fail")
+      get "/goodbye", to: s.simple_app("goodbye")
     end
 
     routes.draw do
-      get "/hello" => s.simple_app("hello")
+      get "/hello", to: s.simple_app("hello")
     end
     @app = self.class.build_app routes
   end
@@ -4196,7 +4196,7 @@ class TestHttpMethods < ActionDispatch::IntegrationTest
 
     routes.draw do
       (RFC2616 + RFC2518 + RFC3253 + RFC3648 + RFC3744 + RFC5323 + RFC4791 + RFC5789).each do |method|
-        match "/" => s.simple_app(method), :via => method.underscore.to_sym
+        match "/", to: s.simple_app(method), via: method.underscore.to_sym
       end
     end
   end
@@ -4212,15 +4212,15 @@ end
 class TestUriPathEscaping < ActionDispatch::IntegrationTest
   Routes = ActionDispatch::Routing::RouteSet.new.tap do |app|
     app.draw do
-      get "/:segment" => lambda { |env|
+      get "/:segment", to: lambda { |env|
         path_params = env["action_dispatch.request.path_parameters"]
         [200, { "Content-Type" => "text/plain" }, [path_params[:segment]]]
-      }, :as => :segment
+      }, as: :segment
 
-      get "/*splat" => lambda { |env|
+      get "/*splat", to: lambda { |env|
         path_params = env["action_dispatch.request.path_parameters"]
         [200, { "Content-Type" => "text/plain" }, [path_params[:splat]]]
-      }, :as => :splat
+      }, as: :splat
     end
   end
 
@@ -4250,9 +4250,9 @@ end
 class TestUnicodePaths < ActionDispatch::IntegrationTest
   Routes = ActionDispatch::Routing::RouteSet.new.tap do |app|
     app.draw do
-      get "/ほげ" => lambda { |env|
+      get "/ほげ", to: lambda { |env|
         [200, { "Content-Type" => "text/plain" }, []]
-      }, :as => :unicode_path
+      }, as: :unicode_path
     end
   end
 
@@ -4271,10 +4271,10 @@ class TestMultipleNestedController < ActionDispatch::IntegrationTest
     app.draw do
       namespace :foo do
         namespace :bar do
-          get "baz" => "baz#index"
+          get "baz", to: "baz#index"
         end
       end
-      get "pooh" => "pooh#index"
+      get "pooh", to: "pooh#index"
     end
   end
 
@@ -4304,8 +4304,8 @@ class TestTildeAndMinusPaths < ActionDispatch::IntegrationTest
     app.draw do
       ok = lambda { |env| [200, { "Content-Type" => "text/plain" }, []] }
 
-      get "/~user" => ok
-      get "/young-and-fine" => ok
+      get "/~user", to: ok
+      get "/young-and-fine", to: ok
     end
   end
 
@@ -4329,11 +4329,11 @@ class TestRedirectInterpolation < ActionDispatch::IntegrationTest
     app.draw do
       ok = lambda { |env| [200, { "Content-Type" => "text/plain" }, []] }
 
-      get "/foo/:id" => redirect("/foo/bar/%{id}")
-      get "/bar/:id" => redirect(path: "/foo/bar/%{id}")
-      get "/baz/:id" => redirect("/baz?id=%{id}&foo=?&bar=1#id-%{id}")
-      get "/foo/bar/:id" => ok
-      get "/baz" => ok
+      get "/foo/:id", to: redirect("/foo/bar/%{id}")
+      get "/bar/:id", to: redirect(path: "/foo/bar/%{id}")
+      get "/baz/:id", to: redirect("/baz?id=%{id}&foo=?&bar=1#id-%{id}")
+      get "/foo/bar/:id", to: ok
+      get "/baz", to: ok
     end
   end
 
@@ -4371,8 +4371,8 @@ class TestConstraintsAccessingParameters < ActionDispatch::IntegrationTest
     app.draw do
       ok = lambda { |env| [200, { "Content-Type" => "text/plain" }, []] }
 
-      get "/:foo" => ok, :constraints => lambda { |r| r.params[:foo] == "foo" }
-      get "/:bar" => ok
+      get "/:foo", to: ok, constraints: lambda { |r| r.params[:foo] == "foo" }
+      get "/:bar", to: ok
     end
   end
 
@@ -4391,8 +4391,8 @@ class TestGlobRoutingMapper < ActionDispatch::IntegrationTest
     app.draw do
       ok = lambda { |env| [200, { "Content-Type" => "text/plain" }, []] }
 
-      get "/*id" => redirect("/not_cars"), :constraints => { id: /dummy/ }
-      get "/cars" => ok
+      get "/*id", to: redirect("/not_cars"), constraints: { id: /dummy/ }
+      get "/cars", to: ok
     end
   end
 
@@ -4420,16 +4420,16 @@ class TestOptimizedNamedRoutes < ActionDispatch::IntegrationTest
   Routes = ActionDispatch::Routing::RouteSet.new.tap do |app|
     app.draw do
       ok = lambda { |env| [200, { "Content-Type" => "text/plain" }, []] }
-      get "/foo" => ok, as: :foo
+      get "/foo", to: ok, as: :foo
 
       ActionDispatch.deprecator.silence do
-        get "/post(/:action(/:id))" => ok, as: :posts
+        get "/post(/:action(/:id))", to: ok, as: :posts
       end
 
-      get "/:foo/:foo_type/bars/:id" => ok, as: :bar
-      get "/projects/:id.:format" => ok, as: :project
-      get "/pages/:id" => ok, as: :page
-      get "/wiki/*page" => ok, as: :wiki
+      get "/:foo/:foo_type/bars/:id", to: ok, as: :bar
+      get "/projects/:id.:format", to: ok, as: :project
+      get "/pages/:id", to: ok, as: :page
+      get "/wiki/*page", to: ok, as: :wiki
     end
   end
 
@@ -4501,8 +4501,8 @@ class TestNamedRouteUrlHelpers < ActionDispatch::IntegrationTest
   Routes = ActionDispatch::Routing::RouteSet.new.tap do |app|
     app.draw do
       scope module: "test_named_route_url_helpers" do
-        get "/categories/:id" => "categories#show", :as => :category
-        get "/products/:id" => "products#show", :as => :product
+        get "/categories/:id", to: "categories#show", as: :category
+        get "/products/:id", to: "products#show", as: :product
       end
     end
   end
@@ -4527,18 +4527,18 @@ class TestUrlConstraints < ActionDispatch::IntegrationTest
       ok = lambda { |env| [200, { "Content-Type" => "text/plain" }, []] }
 
       constraints subdomain: "admin" do
-        get "/" => ok, :as => :admin_root
+        get "/", to: ok, as: :admin_root
       end
 
       scope constraints: { protocol: "https://" } do
-        get "/" => ok, :as => :secure_root
+        get "/", to: ok, as: :secure_root
       end
 
-      get "/" => ok, :as => :alternate_root, :constraints => { port: 8080 }
+      get "/", to: ok, as: :alternate_root, constraints: { port: 8080 }
 
-      get "/search" => ok, :constraints => { subdomain: false }
+      get "/search", to: ok, constraints: { subdomain: false }
 
-      get "/logs" => ok, :constraints => { subdomain: true }
+      get "/logs", to: ok, constraints: { subdomain: true }
     end
   end
 
@@ -4892,7 +4892,7 @@ end
 class TestUrlGenerationErrors < ActionDispatch::IntegrationTest
   Routes = ActionDispatch::Routing::RouteSet.new.tap do |app|
     app.draw do
-      get "/products/:id" => "products#show", :as => :product
+      get "/products/:id", to: "products#show", as: :product
     end
   end
 
@@ -5168,7 +5168,7 @@ end
 class TestInternalRoutingParams < ActionDispatch::IntegrationTest
   Routes = ActionDispatch::Routing::RouteSet.new.tap do |app|
     app.draw do
-      get "/test_internal/:internal" => "internal#internal"
+      get "/test_internal/:internal", to: "internal#internal"
     end
   end
 

--- a/actionview/test/template/form_helper_test.rb
+++ b/actionview/test/template/form_helper_test.rb
@@ -10,7 +10,7 @@ class FormHelperTest < ActionView::TestCase
 
   class WithActiveStorageRoutesControllers < ActionController::Base
     test_routes do
-      post "/rails/active_storage/direct_uploads" => "active_storage/direct_uploads#create", as: :rails_direct_uploads
+      post "/rails/active_storage/direct_uploads", to: "active_storage/direct_uploads#create", as: :rails_direct_uploads
     end
 
     def url_options

--- a/actionview/test/template/form_tag_helper_test.rb
+++ b/actionview/test/template/form_tag_helper_test.rb
@@ -9,7 +9,7 @@ class FormTagHelperTest < ActionView::TestCase
 
   class WithActiveStorageRoutesControllers < ActionController::Base
     test_routes do
-      post "/rails/active_storage/direct_uploads" => "active_storage/direct_uploads#create", as: :rails_direct_uploads
+      post "/rails/active_storage/direct_uploads", to: "active_storage/direct_uploads#create", as: :rails_direct_uploads
     end
 
     def url_options

--- a/actionview/test/template/test_case_test.rb
+++ b/actionview/test/template/test_case_test.rb
@@ -273,7 +273,7 @@ module ActionView
           end
         end
 
-        set.draw { mount app => "/foo", :as => "foo_app" }
+        set.draw { mount app, at: "/foo", as: "foo_app" }
 
         singleton_class.include set.mounted_helpers
 

--- a/actionview/test/template/url_helper_test.rb
+++ b/actionview/test/template/url_helper_test.rb
@@ -31,17 +31,17 @@ class UrlHelperTest < ActiveSupport::TestCase
 
   routes = ActionDispatch::Routing::RouteSet.new
   routes.draw do
-    get "/" => "foo#bar"
-    get "/other" => "foo#other"
-    get "/article/:id" => "foo#article", :as => :article
-    get "/category/:category" => "foo#category"
+    get "/", to: "foo#bar"
+    get "/other", to: "foo#other"
+    get "/article/:id", to: "foo#article", as: :article
+    get "/category/:category", to: "foo#category"
     resources :sessions
     resources :workshops do
       resources :sessions
     end
 
     scope :engine do
-      get "/" => "foo#bar"
+      get "/", to: "foo#bar"
     end
   end
 

--- a/activestorage/config/routes.rb
+++ b/activestorage/config/routes.rb
@@ -2,17 +2,17 @@
 
 Rails.application.routes.draw do
   scope ActiveStorage.routes_prefix do
-    get "/blobs/redirect/:signed_id/*filename" => "active_storage/blobs/redirect#show", as: :rails_service_blob
-    get "/blobs/proxy/:signed_id/*filename" => "active_storage/blobs/proxy#show", as: :rails_service_blob_proxy
-    get "/blobs/:signed_id/*filename" => "active_storage/blobs/redirect#show"
+    get "/blobs/redirect/:signed_id/*filename", to: "active_storage/blobs/redirect#show", as: :rails_service_blob
+    get "/blobs/proxy/:signed_id/*filename", to: "active_storage/blobs/proxy#show", as: :rails_service_blob_proxy
+    get "/blobs/:signed_id/*filename", to: "active_storage/blobs/redirect#show"
 
-    get "/representations/redirect/:signed_blob_id/:variation_key/*filename" => "active_storage/representations/redirect#show", as: :rails_blob_representation
-    get "/representations/proxy/:signed_blob_id/:variation_key/*filename" => "active_storage/representations/proxy#show", as: :rails_blob_representation_proxy
-    get "/representations/:signed_blob_id/:variation_key/*filename" => "active_storage/representations/redirect#show"
+    get "/representations/redirect/:signed_blob_id/:variation_key/*filename", to: "active_storage/representations/redirect#show", as: :rails_blob_representation
+    get "/representations/proxy/:signed_blob_id/:variation_key/*filename", to: "active_storage/representations/proxy#show", as: :rails_blob_representation_proxy
+    get "/representations/:signed_blob_id/:variation_key/*filename", to: "active_storage/representations/redirect#show"
 
-    get  "/disk/:encoded_key/*filename" => "active_storage/disk#show", as: :rails_disk_service
-    put  "/disk/:encoded_token" => "active_storage/disk#update", as: :update_rails_disk_service
-    post "/direct_uploads" => "active_storage/direct_uploads#create", as: :rails_direct_uploads
+    get  "/disk/:encoded_key/*filename", to: "active_storage/disk#show", as: :rails_disk_service
+    put  "/disk/:encoded_token", to: "active_storage/disk#update", as: :update_rails_disk_service
+    post "/direct_uploads", to: "active_storage/direct_uploads#create", as: :rails_direct_uploads
   end
 
   direct :rails_representation do |representation, options|

--- a/guides/bug_report_templates/action_controller.rb
+++ b/guides/bug_report_templates/action_controller.rb
@@ -21,7 +21,7 @@ class TestApp < Rails::Application
   Rails.logger  = config.logger
 
   routes.draw do
-    get "/" => "test#index"
+    get "/", to: "test#index"
   end
 end
 

--- a/guides/source/action_controller_overview.md
+++ b/guides/source/action_controller_overview.md
@@ -1307,7 +1307,7 @@ While any newly generated Rails applications will have the health check at `/up`
 
 ```ruby
 Rails.application.routes.draw do
-  get "healthz" => "rails/health#show", as: :rails_health_check
+  get "healthz", to: "rails/health#show", as: :rails_health_check
 end
 ```
 

--- a/railties/lib/rails/application/finisher.rb
+++ b/railties/lib/rails/application/finisher.rb
@@ -141,15 +141,15 @@ module Rails
       initializer :add_internal_routes do |app|
         if Rails.env.development?
           app.routes.prepend do
-            get "/rails/info/properties" => "rails/info#properties", internal: true
-            get "/rails/info/routes"     => "rails/info#routes",     internal: true
-            get "/rails/info/notes"      => "rails/info#notes",      internal: true
-            get "/rails/info"            => "rails/info#index",      internal: true
+            get "/rails/info/properties", to: "rails/info#properties", internal: true
+            get "/rails/info/routes",     to: "rails/info#routes",     internal: true
+            get "/rails/info/notes",      to: "rails/info#notes",      internal: true
+            get "/rails/info",            to: "rails/info#index",      internal: true
           end
 
           routes_reloader.run_after_load_paths = -> do
             app.routes.append do
-              get "/" => "rails/welcome#index", internal: true
+              get "/", to: "rails/welcome#index", internal: true
             end
           end
         end

--- a/railties/lib/rails/engine.rb
+++ b/railties/lib/rails/engine.rb
@@ -128,7 +128,7 @@ module Rails
   # Now you can mount your engine in application's routes:
   #
   #   Rails.application.routes.draw do
-  #     mount MyEngine::Engine => "/engine"
+  #     mount MyEngine::Engine, at: "/engine"
   #   end
   #
   # == Middleware stack
@@ -149,7 +149,7 @@ module Rails
   #
   #   # ENGINE/config/routes.rb
   #   MyEngine::Engine.routes.draw do
-  #     get "/" => "posts#index"
+  #     get "/", to: "posts#index"
   #   end
   #
   # == Mount priority
@@ -158,8 +158,8 @@ module Rails
   # passing requests through many routers. Consider this situation:
   #
   #   Rails.application.routes.draw do
-  #     mount MyEngine::Engine => "/blog"
-  #     get "/blog/omg" => "main#omg"
+  #     mount MyEngine::Engine, at: "/blog"
+  #     get "/blog/omg", to: "main#omg"
   #   end
   #
   # +MyEngine+ is mounted at <tt>/blog</tt>, and <tt>/blog/omg</tt> points to application's
@@ -168,8 +168,8 @@ module Rails
   # It's much better to swap that:
   #
   #   Rails.application.routes.draw do
-  #     get "/blog/omg" => "main#omg"
-  #     mount MyEngine::Engine => "/blog"
+  #     get "/blog/omg", to: "main#omg"
+  #     mount MyEngine::Engine, at: "/blog"
   #   end
   #
   # Now, +Engine+ will get only requests that were not handled by +Application+.
@@ -178,7 +178,7 @@ module Rails
   #
   # There are some places where an Engine's name is used:
   #
-  # * routes: when you mount an Engine with <tt>mount(MyEngine::Engine => '/my_engine')</tt>,
+  # * routes: when you mount an Engine with <tt>mount(MyEngine::Engine, at: '/my_engine')</tt>,
   #   it's used as default <tt>:as</tt> option
   # * rake task for installing migrations <tt>my_engine:install:migrations</tt>
   #
@@ -264,8 +264,8 @@ module Rails
   #
   #   # config/routes.rb
   #   Rails.application.routes.draw do
-  #     mount MyEngine::Engine => "/my_engine", as: "my_engine"
-  #     get "/foo" => "foo#index"
+  #     mount MyEngine::Engine, at: "/my_engine", as: "my_engine"
+  #     get "/foo", to: "foo#index"
   #   end
   #
   # Now, you can use the <tt>my_engine</tt> helper inside your application:

--- a/railties/lib/rails/generators/rails/app/templates/config/routes.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/routes.rb.tt
@@ -3,11 +3,11 @@ Rails.application.routes.draw do
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
   # Can be used by load balancers and uptime monitors to verify that the app is live.
-  get "up" => "rails/health#show", as: :rails_health_check
+  get "up", to: "rails/health#show", as: :rails_health_check
 
   # Render dynamic PWA files from app/views/pwa/*
-  get "service-worker" => "rails/pwa#service_worker", as: :pwa_service_worker
-  get "manifest" => "rails/pwa#manifest", as: :pwa_manifest
+  get "service-worker", to: "rails/pwa#service_worker", as: :pwa_service_worker
+  get "manifest", to: "rails/pwa#manifest", as: :pwa_manifest
 
   # Defines the root path route ("/")
   # root "posts#index"

--- a/railties/lib/rails/health_controller.rb
+++ b/railties/lib/rails/health_controller.rb
@@ -18,7 +18,7 @@ module Rails
   # <tt>"config/routes.rb"</tt>:
   #
   #   Rails.application.routes.draw do
-  #     get "healthz" => "rails/health#show", as: :rails_health_check
+  #     get "healthz", to: "rails/health#show", as: :rails_health_check
   #   end
   #
   # The health check will now be accessible via the +/healthz+ path.

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -4619,8 +4619,8 @@ module ApplicationTests
 
       add_to_config <<-RUBY
         routes.prepend do
-          get "foo/controller" => "foo#controller_test"
-          get "foo/view" => "foo#view_test"
+          get "foo/controller", to: "foo#controller_test"
+          get "foo/view", to: "foo#view_test"
         end
       RUBY
 

--- a/railties/test/application/initializers/frameworks_test.rb
+++ b/railties/test/application/initializers/frameworks_test.rb
@@ -55,7 +55,7 @@ module ApplicationTests
     test "includes URL helpers as action methods" do
       app_file "config/routes.rb", <<-RUBY
         Rails.application.routes.draw do
-          get "/foo", :to => lambda { |env| [200, {}, []] }, :as => :foo
+          get "/foo", to: lambda { |env| [200, {}, []] }, as: :foo
         end
       RUBY
 

--- a/railties/test/application/middleware/session_test.rb
+++ b/railties/test/application/middleware/session_test.rb
@@ -417,9 +417,9 @@ module ApplicationTests
 
       app_file "config/routes.rb", <<-RUBY
         Rails.application.routes.draw do
-          get "/write_session" => "test#write_session"
-          get "/read_session" => "test#read_session"
-          get "/reset_session" => "test#reset_session"
+          get "/write_session", to: "test#write_session"
+          get "/read_session", to: "test#read_session"
+          get "/reset_session", to: "test#reset_session"
         end
       RUBY
 
@@ -464,7 +464,7 @@ module ApplicationTests
 
       app_file "config/routes.rb", <<-RUBY
         Rails.application.routes.draw do
-          get "/test_action" => "test#test_action"
+          get "/test_action", to: "test#test_action"
         end
       RUBY
 

--- a/railties/test/application/routing_test.rb
+++ b/railties/test/application/routing_test.rb
@@ -135,7 +135,7 @@ module ApplicationTests
 
       app_file "config/routes.rb", <<-RUBY
         Rails.application.routes.draw do
-          get "up" => "rails/health#show", as: :rails_health_check
+          get "up", to: "rails/health#show", as: :rails_health_check
         end
       RUBY
 

--- a/railties/test/application/url_generation_test.rb
+++ b/railties/test/application/url_generation_test.rb
@@ -35,7 +35,7 @@ module ApplicationTests
       end
 
       MyApp.routes.draw do
-        get "/" => "omg#index", as: :omg
+        get "/", to: "omg#index", as: :omg
       end
 
       require "rack/test"

--- a/railties/test/isolation/abstract_unit.rb
+++ b/railties/test/isolation/abstract_unit.rb
@@ -270,7 +270,7 @@ module TestHelpers
       @app.initialize!
 
       @app.routes.draw do
-        get "/" => "omg#index"
+        get "/", to: "omg#index"
       end
 
       require "rack/test"

--- a/railties/test/rails_health_controller_test.rb
+++ b/railties/test/rails_health_controller_test.rb
@@ -7,7 +7,7 @@ class HealthControllerTest < ActionController::TestCase
 
   def setup
     Rails.application.routes.draw do
-      get "/up" => "rails/health#show", as: :rails_health_check
+      get "/up", to: "rails/health#show", as: :rails_health_check
     end
     @routes = Rails.application.routes
   end

--- a/railties/test/rails_info_controller_test.rb
+++ b/railties/test/rails_info_controller_test.rb
@@ -13,11 +13,11 @@ class InfoControllerTest < ActionController::TestCase
       namespace :test do
         get :nested_route, to: "test#show"
       end
-      get "/rails/info/properties" => "rails/info#properties"
-      get "/rails/info/routes" => "rails/info#routes"
-      get "/rails/info/notes" => "rails/info#notes"
-      post "/rails/:test/properties" => "rails/info#properties"
-      put "/rails/:test/named_properties" => "rails/info#properties", as: "named_rails_info_properties"
+      get "/rails/info/properties", to: "rails/info#properties"
+      get "/rails/info/routes", to: "rails/info#routes"
+      get "/rails/info/notes", to: "rails/info#notes"
+      post "/rails/:test/properties", to: "rails/info#properties"
+      put "/rails/:test/named_properties", to: "rails/info#properties", as: "named_rails_info_properties"
     end
     @routes = Rails.application.routes
 

--- a/railties/test/railties/engine_test.rb
+++ b/railties/test/railties/engine_test.rb
@@ -477,7 +477,7 @@ module RailtiesTest
         end
 
         Rails.application.routes.draw do
-          get "/sprokkit", :to => Sprokkit
+          get "/sprokkit", to: Sprokkit
         end
       RUBY
 
@@ -498,7 +498,7 @@ module RailtiesTest
 
       app_file "config/routes.rb", <<-RUBY
         Rails.application.routes.draw do
-          get 'foo', :to => 'foo#index'
+          get 'foo', to: 'foo#index'
         end
       RUBY
 
@@ -717,7 +717,7 @@ en:
 
       app_file "config/routes.rb", <<-RUBY
         Rails.application.routes.draw do
-          mount(Bukkits::Engine => "/bukkits")
+          mount(Bukkits::Engine, at: "/bukkits")
         end
       RUBY
 
@@ -744,7 +744,7 @@ en:
 
       app_file "config/routes.rb", <<-RUBY
         Rails.application.routes.draw do
-          mount(Bukkits::Engine => "/:username")
+          mount(Bukkits::Engine, at: "/:username")
         end
       RUBY
 
@@ -764,13 +764,13 @@ en:
 
       @plugin.write "config/routes.rb", <<-RUBY
         Bukkits::Engine.routes.draw do
-          get "/foo" => lambda { |env| [200, {'Content-Type' => 'text/html'}, ['foo']] }
+          get "/foo", to: lambda { |env| [200, {'Content-Type' => 'text/html'}, ['foo']] }
         end
       RUBY
 
       app_file "config/routes.rb", <<-RUBY
         Rails.application.routes.draw do
-          mount(Bukkits::Engine => "/bukkits")
+          mount(Bukkits::Engine, at: "/bukkits")
         end
       RUBY
 
@@ -854,18 +854,18 @@ en:
 
       app_file "config/routes.rb", <<-RUBY
         Rails.application.routes.draw do
-          get "/bar" => "bar#index", as: "bar"
-          mount Bukkits::Engine => "/bukkits", as: "bukkits"
+          get "/bar", to: "bar#index", as: "bar"
+          mount Bukkits::Engine, at: "/bukkits", as: "bukkits"
         end
       RUBY
 
       @plugin.write "config/routes.rb", <<-RUBY
         Bukkits::Engine.routes.draw do
-          get "/foo" => "foo#index", as: "foo"
-          get "/foo/show" => "foo#show"
-          get "/from_app" => "foo#from_app"
-          get "/routes_helpers_in_view" => "foo#routes_helpers_in_view"
-          get "/polymorphic_path_without_namespace" => "foo#polymorphic_path_without_namespace"
+          get "/foo", to: "foo#index", as: "foo"
+          get "/foo/show", to: "foo#show"
+          get "/from_app", to: "foo#from_app"
+          get "/routes_helpers_in_view", to: "foo#routes_helpers_in_view"
+          get "/polymorphic_path_without_namespace", to: "foo#polymorphic_path_without_namespace"
           resources :posts
         end
       RUBY
@@ -1000,7 +1000,7 @@ en:
 
       app_file "config/routes.rb", <<-RUBY
         Rails.application.routes.draw do
-          mount Bukkits::Engine => "/bukkits", as: "bukkits"
+          mount Bukkits::Engine, at: "/bukkits", as: "bukkits"
         end
       RUBY
 
@@ -1044,13 +1044,13 @@ en:
 
       app_file "config/routes.rb", <<-RUBY
         Rails.application.routes.draw do
-          mount Bukkits::Awesome::Engine => "/bukkits", :as => "bukkits"
+          mount Bukkits::Awesome::Engine, at: "/bukkits", as: "bukkits"
         end
       RUBY
 
       @plugin.write "config/routes.rb", <<-RUBY
         Bukkits::Awesome::Engine.routes.draw do
-          get "/foo" => "foo#index"
+          get "/foo", to: "foo#index"
         end
       RUBY
 
@@ -1101,7 +1101,7 @@ en:
         end
 
         Bukkits::Engine.routes.draw do
-          get "/foo" => "foo#index"
+          get "/foo", to: "foo#index"
 
           mount Bukkits::Awesome::Engine, at: "/awesome"
         end
@@ -1260,8 +1260,8 @@ en:
       # file has changed
       add_to_config <<-RUBY
         routes do
-          mount lambda{|env| [200, {}, ["foo"]]} => "/foo"
-          mount Bukkits::Engine => "/bukkits"
+          mount lambda{|env| [200, {}, ["foo"]]}, at: "/foo"
+          mount Bukkits::Engine, at: "/bukkits"
         end
       RUBY
 
@@ -1269,7 +1269,7 @@ en:
 
       @plugin.write "config/routes.rb", <<-RUBY
         Bukkits::Engine.routes.draw do
-          mount lambda{|env| [200, {}, ["bar"]]} => "/bar"
+          mount lambda{|env| [200, {}, ["bar"]]}, at: "/bar"
         end
       RUBY
 
@@ -1483,8 +1483,8 @@ en:
 
       app_file "config/routes.rb", <<-RUBY
         Rails.application.routes.draw do
-          get "/foo" => "main#foo"
-          get "/bar" => "main#bar"
+          get "/foo", to: "main#foo"
+          get "/bar", to: "main#bar"
         end
       RUBY
 
@@ -1579,7 +1579,7 @@ en:
 
       app_file "config/routes.rb", <<-RUBY
         Rails.application.routes.draw do
-          get "/foo" => "main#foo"
+          get "/foo", to: "main#foo"
         end
       RUBY
 
@@ -1634,7 +1634,7 @@ en:
 
       app_file "config/routes.rb", <<-RUBY
         Rails.application.routes.draw do
-          mount Bukkits::Engine => "/"
+          mount Bukkits::Engine, at: "/"
         end
       RUBY
 
@@ -1670,14 +1670,14 @@ en:
 
       app_file "config/routes.rb", <<-RUBY
         Rails.application.routes.draw do
-          get '/bar' => 'bar#index', :as => 'bar'
-          mount Bukkits::Engine => "/bukkits", :as => "bukkits"
+          get '/bar', to: 'bar#index', as: 'bar'
+          mount Bukkits::Engine, at: "/bukkits", as: "bukkits"
         end
       RUBY
 
       @plugin.write "config/routes.rb", <<-RUBY
         Bukkits::Engine.routes.draw do
-          get '/bukkit' => 'bukkit#index'
+          get '/bukkit', to: 'bukkit#index'
         end
       RUBY
 
@@ -1723,14 +1723,14 @@ en:
 
       app_file "config/routes.rb", <<-RUBY
         Rails.application.routes.draw do
-          get '/bar' => 'bar#index', :as => 'bar'
-          mount Bukkits::Engine => "/bukkits", :as => "bukkits"
+          get '/bar', to: 'bar#index', as: 'bar'
+          mount Bukkits::Engine, at: "/bukkits", as: "bukkits"
         end
       RUBY
 
       @plugin.write "config/routes.rb", <<-RUBY
         Bukkits::Engine.routes.draw do
-          get '/bukkit' => 'bukkit#index'
+          get '/bukkit', to: 'bukkit#index'
         end
       RUBY
 
@@ -1781,15 +1781,15 @@ en:
       app_file "config/routes.rb", <<-RUBY
         Rails.application.routes.draw do
           scope "/fruits" do
-            mount Bukkits::Engine => "/bukkits", as: :fruit_bukkits
+            mount Bukkits::Engine, at: "/bukkits", as: :fruit_bukkits
           end
 
           scope "/vegetables" do
-            mount Bukkits::Engine => "/bukkits", as: :vegetable_bukkits
+            mount Bukkits::Engine, at: "/bukkits", as: :vegetable_bukkits
           end
 
-          get "/through_fruits" => "foos#through_fruits"
-          get "/through_vegetables" => "foos#through_vegetables"
+          get "/through_fruits", to: "foos#through_fruits"
+          get "/through_vegetables", to: "foos#through_vegetables"
         end
       RUBY
 
@@ -1824,15 +1824,15 @@ en:
       app_file "config/routes.rb", <<-RUBY
         Rails.application.routes.draw do
           resources :fruits do
-            mount Bukkits::Engine => "/bukkits"
+            mount Bukkits::Engine, at: "/bukkits"
           end
 
           resources :vegetables do
-            mount Bukkits::Engine => "/bukkits"
+            mount Bukkits::Engine, at: "/bukkits"
           end
 
-          get "/through_fruits" => "foos#through_fruits"
-          get "/through_vegetables" => "foos#through_vegetables"
+          get "/through_fruits", to: "foos#through_fruits"
+          get "/through_vegetables", to: "foos#through_vegetables"
         end
       RUBY
 
@@ -1863,7 +1863,7 @@ en:
       app_file "config/routes.rb", <<-RUBY
         Rails.application.routes.draw do
           resources :fruits do
-            mount Bukkits::Engine => "/bukkits"
+            mount Bukkits::Engine, at: "/bukkits"
           end
         end
       RUBY

--- a/railties/test/railties/mounted_engine_test.rb
+++ b/railties/test/railties/mounted_engine_test.rb
@@ -19,21 +19,21 @@ module ApplicationTests
 
       app_file "config/routes.rb", <<-RUBY
         Rails.application.routes.draw do
-          mount Weblog::Engine, :at => '/', :as => 'weblog'
+          mount Weblog::Engine, at: '/', as: 'weblog'
           resources :posts
-          get "/engine_route" => "application_generating#engine_route"
-          get "/engine_route_in_view" => "application_generating#engine_route_in_view"
-          get "/weblog_engine_route" => "application_generating#weblog_engine_route"
-          get "/weblog_through_metric_engine_route" => "application_generating#weblog_through_metric_engine_route"
-          get "/weblog_engine_route_in_view" => "application_generating#weblog_engine_route_in_view"
-          get "/url_for_engine_route" => "application_generating#url_for_engine_route"
-          get "/polymorphic_route" => "application_generating#polymorphic_route"
-          get "/application_polymorphic_path" => "application_generating#application_polymorphic_path"
-          scope "/:user", :user => "anonymous" do
-            mount Blog::Engine => "/blog"
+          get "/engine_route", to: "application_generating#engine_route"
+          get "/engine_route_in_view", to: "application_generating#engine_route_in_view"
+          get "/weblog_engine_route", to: "application_generating#weblog_engine_route"
+          get "/weblog_through_metric_engine_route", to: "application_generating#weblog_through_metric_engine_route"
+          get "/weblog_engine_route_in_view", to: "application_generating#weblog_engine_route_in_view"
+          get "/url_for_engine_route", to: "application_generating#url_for_engine_route"
+          get "/polymorphic_route", to: "application_generating#polymorphic_route"
+          get "/application_polymorphic_path", to: "application_generating#application_polymorphic_path"
+          scope "/:user", user: "anonymous" do
+            mount Blog::Engine, at: "/blog"
           end
-          mount Metrics::Engine => "/metrics"
-          root :to => 'main#index'
+          mount Metrics::Engine, at: "/metrics"
+          root to: 'main#index'
         end
       RUBY
 


### PR DESCRIPTION
Followup to https://github.com/rails/rails/pull/52409

### Motivation / Background

This Pull Request has been created because I'd like to deprecate paths as hash keys in route mappings:

```ruby
# Before
get "/users" => "users#index"
post "/logout" => :sessions

# After
get "/users", to: "users#index"
post "/logout", to: "sessions#logout"
```

This work moves us closer to [using keywords in the routing mapper](https://github.com/Shopify/rails/tree/routing_mapper_opt) which gives us a 1.25-1.5x speed boost (see linked PR above for benchmark).

### Detail

Drawing routes with has keys complicates route drawing enough to warrant deprecation. Transitioning the routing mapper to use keywords would result in a 1.25-1.5x improvement in speed, and it would be substantially easier to do if we drop this feature.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
