### PR TITLE
[ci-skip][Docs][retry] Add description for CTE to querying guide

### DIFF
--- a/guides/source/active_record_querying.md
+++ b/guides/source/active_record_querying.md
@@ -1599,6 +1599,83 @@ WHERE reviews.id IS NULL
 
 Which means "return all customers that have not made any reviews".
 
+Using Common Table Expressions (CTE)
+-----------------------------
+
+[Common Table
+Expressions](https://en.wikipedia.org/wiki/Hierarchical_and_recursive_queries_in_SQL#Common_table_expression)
+are named temporary query results that are referable within a single SQL query.
+The [`with`][] method is a convenient way to access CTEs `WITH` syntax.
+
+NOTE: To use the CTEs on MySQL, MySQL version 8.0+ is required. On SQLite,
+version 3.8.3+ is required.
+
+The `with` method returns an instance of `ActiveRecord::Relation`, so you can
+chain other query methods and even refer to the CTE from them (e.g. `from`,
+`select`, `joins` or `left_outer_joins`):
+
+```ruby
+relation = Book
+  .with(reviewed_books: Review.select(:book_id).distinct)
+  .left_outer_joins(:reviewed_books)
+  .select("books.*, reviewed_books.book_id AS has_reviews")
+```
+
+The above should generate:
+
+```sql
+WITH "reviewed_books" AS (
+  SELECT DISTINCT "reviews"."book_id"
+  FROM "reviews"
+)
+SELECT books.*, reviewed_books.book_id AS has_reviews
+FROM "books"
+LEFT OUTER JOIN "reviewed_books"
+  ON "reviewed_books"."book_id" = "books"."id"
+```
+
+You can also define multiple CTEs by passing multiple key-value pairs:
+
+```ruby
+Book.with(
+  books_with_reviews: Book.where("reviews_count > ?", 0),
+  books_in_print: Book.in_print
+)
+```
+
+Or chaining multiple `with` calls:
+
+```ruby
+Book
+  .with(books_with_reviews: Book.where("reviews_count > ?", 0))
+  .with(books_in_print: Book.in_print)
+```
+
+These examples should generate:
+
+```sql
+WITH "books_with_reviews" AS (
+  SELECT "books".*
+  FROM "books"
+  WHERE (reviews_count > 0)
+),
+"books_in_print" AS (
+  SELECT "books".*
+  FROM "books"
+  WHERE "books"."in_print" = ?
+)
+SELECT "books".*
+FROM "books"
+```
+
+It is recommended to pass a query as `ActiveRecord::Relation`.
+
+WARNING: You should be very careful to avoid SQL injection vulnerabilities,
+especially when you pass non-relation values via Arel or other techniques to
+`with`. Never pass unsafe values such as unsanitized inputs.
+
+[`with`]:
+    https://api.rubyonrails.org/classes/ActiveRecord/QueryMethods.html#method-i-with
 
 Eager Loading Associations
 --------------------------

--- a/guides/source/active_record_querying.md
+++ b/guides/source/active_record_querying.md
@@ -1668,7 +1668,7 @@ SELECT "books".*
 FROM "books"
 ```
 
-It is recommended to pass a query as `ActiveRecord::Relation`.
+It is recommended to pass queries as `ActiveRecord::Relation` objects instead of raw, untrusted inputs to prevent SQL injection attacks.
 
 WARNING: You should be very careful to avoid SQL injection vulnerabilities,
 especially when you pass non-relation values via Arel or other techniques to

--- a/guides/source/active_record_querying.md
+++ b/guides/source/active_record_querying.md
@@ -1600,7 +1600,7 @@ WHERE reviews.id IS NULL
 Which means "return all customers that have not made any reviews".
 
 Using Common Table Expressions (CTE)
------------------------------
+------------------------------------
 
 [Common Table
 Expressions](https://en.wikipedia.org/wiki/Hierarchical_and_recursive_queries_in_SQL#Common_table_expression)


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because the current querying guide has no entries for CTE and the link to `with` method.

### Detail

This Pull Request adds the entry for CTE.

Note that this PR is a retry of https://github.com/rails/rails/pull/49630, including the following updates:

- Changed the code examples from `Post` and `Comment` models to `Book` and `Review` to be consistent with https://github.com/rails/rails/pull/39406
- Added the minimum version of SQLite to work with CTE
- Revised some English sentences with a little help of Claude 3.5 Sonnet

The SQL queries in this PR were actually generated using a local Rails application running Rails 7.1.3.4 and Ruby 3.3.4.

cc @zzak 

### Additional information

ref: https://github.com/rails/rails/pull/37944
ref: https://github.com/rails/rails/pull/46843

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`

