### PR TITLE
Drop Hash `except` core extension

### DIFF
--- a/activesupport/lib/active_support/core_ext/hash/except.rb
+++ b/activesupport/lib/active_support/core_ext/hash/except.rb
@@ -1,18 +1,6 @@
 # frozen_string_literal: true
 
 class Hash
-  # Returns a hash that includes everything except given keys.
-  #   hash = { a: true, b: false, c: nil }
-  #   hash.except(:c)     # => { a: true, b: false }
-  #   hash.except(:a, :b) # => { c: nil }
-  #   hash                # => { a: true, b: false, c: nil }
-  #
-  # This is useful for limiting a set of parameters to everything but a few known toggles:
-  #   @person.update(params[:person].except(:admin))
-  def except(*keys)
-    slice(*self.keys - keys)
-  end unless method_defined?(:except)
-
   # Removes the given keys from hash and returns it.
   #   hash = { a: true, b: false, c: nil }
   #   hash.except!(:c) # => { a: true, b: false }

--- a/activesupport/test/core_ext/hash_ext_test.rb
+++ b/activesupport/test/core_ext/hash_ext_test.rb
@@ -46,7 +46,6 @@ class HashExtTest < ActiveSupport::TestCase
     assert_respond_to h, :deep_stringify_keys!
     assert_respond_to h, :to_options
     assert_respond_to h, :to_options!
-    assert_respond_to h, :except
     assert_respond_to h, :except!
   end
 
@@ -401,10 +400,6 @@ class HashExtTest < ActiveSupport::TestCase
     original = { a: "x", b: "y", c: 10 }
     expected = { a: "x", b: "y" }
 
-    # Should return a new hash without the given keys.
-    assert_equal expected, original.except(:c)
-    assert_not_equal expected, original
-
     # Should replace the hash without the given keys.
     assert_equal expected, original.except!(:c)
     assert_equal expected, original
@@ -414,8 +409,6 @@ class HashExtTest < ActiveSupport::TestCase
     original = { a: "x", b: "y", c: 10 }
     expected = { a: "x" }
 
-    assert_equal expected, original.except(:b, :c)
-
     assert_equal expected, original.except!(:b, :c)
     assert_equal expected, original
   end
@@ -423,16 +416,7 @@ class HashExtTest < ActiveSupport::TestCase
   def test_except_with_original_frozen
     original = { a: "x", b: "y" }
     original.freeze
-    assert_nothing_raised { original.except(:a) }
-
     assert_raise(FrozenError) { original.except!(:a) }
-  end
-
-  def test_except_does_not_delete_values_in_original
-    original = { a: "x", b: "y" }
-    assert_not_called(original, :delete) do
-      original.except(:a)
-    end
   end
 end
 

--- a/guides/source/active_support_core_extensions.md
+++ b/guides/source/active_support_core_extensions.md
@@ -2881,27 +2881,25 @@ NOTE: Defined in `active_support/core_ext/object/deep_dup.rb`.
 
 ### Working with Keys
 
-#### `except` and `except!`
+#### `except!`
 
-The method [`except`][Hash#except] returns a hash with the keys in the argument list removed, if present:
-
-```ruby
-{ a: 1, b: 2 }.except(:a) # => {:b=>2}
-```
-
-If the receiver responds to `convert_key`, the method is called on each of the arguments. This allows `except` to play nice with hashes with indifferent access for instance:
+The method [`except!`][Hash#except!] is identical to the built-in `except` method but removes keys in place, returning `self`.
 
 ```ruby
-{ a: 1 }.with_indifferent_access.except(:a)  # => {}
-{ a: 1 }.with_indifferent_access.except("a") # => {}
+{ a: 1, b: 2 }.except!(:a) # => {:b=>2}
+{ a: 1, b: 2 }.except!(:c) # => {:a=>1, :b=>2}
 ```
 
-There's also the bang variant [`except!`][Hash#except!] that removes keys in place.
+If the receiver responds to `convert_key`, the method is called on each of the arguments. This allows `except!` (and `except`) to play nice with hashes with indifferent access for instance:
+
+```ruby
+{ a: 1 }.with_indifferent_access.except!(:a)  # => {}
+{ a: 1 }.with_indifferent_access.except!("a") # => {}
+```
 
 NOTE: Defined in `active_support/core_ext/hash/except.rb`.
 
 [Hash#except!]: https://api.rubyonrails.org/classes/Hash.html#method-i-except-21
-[Hash#except]: https://api.rubyonrails.org/classes/Hash.html#method-i-except
 
 #### `stringify_keys` and `stringify_keys!`
 


### PR DESCRIPTION
### Motivation / Background

Rails 8.0 will be Ruby 3.1 or greater only
`except` natively got added in Ruby 3.0 so this is dead code now.

https://docs.ruby-lang.org/en/3.1/Hash.html#method-i-except

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
