### PR TITLE
Change ActiveModel human_attribute_name to raise an error

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,3 +1,27 @@
+*   Add a load hook `active_model_translation` for `ActiveModel::Translation`.
+
+    *Shouichi Kamiya*
+
+*   Add `raise_on_missing_translations` option to `ActiveModel::Translation`.
+    When the option is set, `human_attribute_name` raises an error if a translation of the given attribute is missing.
+
+    ```ruby
+    # ActiveModel::Translation.raise_on_missing_translations = false
+    Post.human_attribute_name("title")
+    => "Title"
+
+    # ActiveModel::Translation.raise_on_missing_translations = true
+    Post.human_attribute_name("title")
+    => Translation missing. Options considered were: (I18n::MissingTranslationData)
+        - en.activerecord.attributes.post.title
+        - en.attributes.title
+
+                raise exception.respond_to?(:to_exception) ? exception.to_exception : exception
+                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    ```
+
+    *Shouichi Kamiya*
+
 *   Introduce `ActiveModel::AttributeAssignment#attribute_writer_missing`
 
     Provide instances with an opportunity to gracefully handle assigning to an

--- a/activemodel/lib/active_model/translation.rb
+++ b/activemodel/lib/active_model/translation.rb
@@ -22,6 +22,8 @@ module ActiveModel
   module Translation
     include ActiveModel::Naming
 
+    singleton_class.attr_accessor :raise_on_missing_translations
+
     # Returns the +i18n_scope+ for the class. Override if you want custom lookup.
     def i18n_scope
       :activemodel
@@ -60,13 +62,17 @@ module ActiveModel
         end
       end
 
+      raise_on_missing = options.fetch(:raise, Translation.raise_on_missing_translations)
+
       defaults << :"attributes.#{attribute}"
       defaults << options[:default] if options[:default]
-      defaults << MISSING_TRANSLATION
+      defaults << MISSING_TRANSLATION unless raise_on_missing
 
-      translation = I18n.translate(defaults.shift, count: 1, **options, default: defaults)
+      translation = I18n.translate(defaults.shift, count: 1, raise: raise_on_missing, **options, default: defaults)
       translation = attribute.humanize if translation == MISSING_TRANSLATION
       translation
     end
   end
+
+  ActiveSupport.run_load_hooks(:active_model_translation, Translation)
 end

--- a/activemodel/test/cases/translation_test.rb
+++ b/activemodel/test/cases/translation_test.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "active_support/core_ext/object/with"
 require "cases/helper"
 require "models/person"
 
@@ -125,5 +126,13 @@ class ActiveModelI18nTests < ActiveModel::TestCase
     options = { default: "Cool gender" }
     Person.human_attribute_name("gender", options)
     assert_equal({ default: "Cool gender" }, options)
+  end
+
+  def test_raise_on_missing_translations
+    ActiveModel::Translation.with(raise_on_missing_translations: true) do
+      assert_raises I18n::MissingTranslationData do
+        Person.human_attribute_name("name")
+      end
+    end
   end
 end

--- a/activesupport/lib/active_support/i18n_railtie.rb
+++ b/activesupport/lib/active_support/i18n_railtie.rb
@@ -83,6 +83,10 @@ module I18n
         ActionView::Helpers::TranslationHelper.raise_on_missing_translations = app.config.i18n.raise_on_missing_translations
       end
 
+      ActiveSupport.on_load(:active_model_translation) do
+        ActiveModel::Translation.raise_on_missing_translations = app.config.i18n.raise_on_missing_translations
+      end
+
       if app.config.i18n.raise_on_missing_translations &&
           I18n.exception_handler.is_a?(I18n::ExceptionHandler) # Only override the i18n gem's default exception handler.
 

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -3741,6 +3741,7 @@ These are the load hooks you can use in your own code. To hook into the initiali
 | `ActiveJob::Base`                    | `active_job`                         |
 | `ActiveJob::TestCase`                | `active_job_test_case`               |
 | `ActiveModel::Model`                 | `active_model`                       |
+| `ActiveModel::Translation`           | `active_model_translation`           |
 | `ActiveRecord::Base`                 | `active_record`                      |
 | `ActiveRecord::TestFixtures`         | `active_record_fixtures`             |
 | `ActiveRecord::ConnectionAdapters::PostgreSQLAdapter`    | `active_record_postgresqladapter`    |

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -4633,6 +4633,21 @@ module ApplicationTests
       assert_includes last_response.body, "rescued missing translation error from view"
     end
 
+    test "raise_on_missing_translations affects human_attribute_name in model" do
+      add_to_config "config.i18n.raise_on_missing_translations = true"
+
+      app_file "app/models/post.rb", <<-RUBY
+        class Post < ActiveRecord::Base
+        end
+      RUBY
+
+      app "development"
+
+      assert_raises I18n::MissingTranslationData do
+        Post.human_attribute_name("title")
+      end
+    end
+
     test "dom testing uses the HTML5 parser in new apps if it is supported" do
       app "development"
       expected = defined?(Nokogiri::HTML5) ? :html5 : :html4


### PR DESCRIPTION
### Motivation / Background

When `config.i18n.raise_on_missing_translations = true`, controllers and views raise an error on missing translations. However, models won't. This PR changes models to raise an error when `raise_on_missing_translations` is true.

### Detail

### Additional information

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.