### PR TITLE
💅 In database config, prefer simple values to blocks/procs

### DIFF
--- a/guides/source/command_line.md
+++ b/guides/source/command_line.md
@@ -109,7 +109,7 @@ default: &default
 
   # For details on connection pooling, see Rails configuration guide
   # https://guides.rubyonrails.org/configuring.html#database-pooling
-  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+  pool: <%= ENV.fetch("RAILS_MAX_THREADS", 5) %>
 
 development:
   <<: *default

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/mysql.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/mysql.yml.tt
@@ -12,7 +12,7 @@
 default: &default
   adapter: mysql2
   encoding: utf8mb4
-  pool: <%%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+  pool: <%%= ENV.fetch("RAILS_MAX_THREADS", 5) %>
   username: root
   password:
 <% if database.socket -%>

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/postgresql.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/postgresql.yml.tt
@@ -17,7 +17,7 @@ default: &default
   encoding: unicode
   # For details on connection pooling, see Rails configuration guide
   # https://guides.rubyonrails.org/configuring.html#database-pooling
-  pool: <%%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+  pool: <%%= ENV.fetch("RAILS_MAX_THREADS", 5) %>
 <% if devcontainer? -%>
   <%% if ENV["DB_HOST"] %>
   host: <%%= ENV["DB_HOST"] %>

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/sqlite3.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/sqlite3.yml.tt
@@ -6,7 +6,7 @@
 #
 default: &default
   adapter: sqlite3
-  pool: <%%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+  pool: <%%= ENV.fetch("RAILS_MAX_THREADS", 5) %>
   timeout: 5000
 
 development:

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/trilogy.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/trilogy.yml.tt
@@ -12,7 +12,7 @@
 default: &default
   adapter: trilogy
   encoding: utf8mb4
-  pool: <%%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+  pool: <%%= ENV.fetch("RAILS_MAX_THREADS", 5) %>
   username: root
   password:
 <% if database.socket -%>


### PR DESCRIPTION
### Motivation / Background

In `config/database.yml` specifically, and generally where the default/fallback value of a hash key is a simple value, we should prefer [`Hash#fetch(key, default_value)`](https://ruby-doc.org/3.2.2/Hash.html#method-i-fetch) to `Hash#fetch(key, &blk)`. 

### Detail
This PR updates the `config/database.yml` template to prefer `ENV.fetch("RAILS_MAX_THREADS", 5)` over the current block/proc approach. The block/proc approach allows us to defer computing the default value until absolutely necessary—that is, `ENV.fetch("RAILS_MAX_THREADS")` is `nil`. This makes sense when the computation can be very expensive. In this case, they're not.

The defaults are simple values (integers), not resource-intensive, and require no expensive computation (method calls, etc) to produce. Therefore, I believe they should be passed directly to the `fetch` call. I've restricted the changes to the database configuration but there are other low-hanging fruits that could be similarly refactored.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why.
