### PR TITLE
Rename check_box in checkbox

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,2 +1,7 @@
+*   Rename `check_box*` methods into `checkbox*`.
+
+    Old names are still available as aliases.
+
+    *Jean Boussier*
 
 Please check [7-2-stable](https://github.com/rails/rails/blob/7-2-stable/actionview/CHANGELOG.md) for previous changes.

--- a/actionview/lib/action_view/helpers/form_helper.rb
+++ b/actionview/lib/action_view/helpers/form_helper.rb
@@ -133,7 +133,7 @@ module ActionView
       #     First name: <%= f.text_field :first_name %><br />
       #     Last name : <%= f.text_field :last_name %><br />
       #     Biography : <%= f.text_area :biography %><br />
-      #     Admin?    : <%= f.check_box :admin %><br />
+      #     Admin?    : <%= f.checkbox :admin %><br />
       #     <%= f.submit %>
       #   <% end %>
       #
@@ -200,7 +200,7 @@ module ActionView
       #     First name: <%= f.text_field :first_name %>
       #     Last name : <%= f.text_field :last_name %>
       #     Biography : <%= text_area :person, :biography %>
-      #     Admin?    : <%= check_box_tag "person[admin]", "1", @person.company.admin? %>
+      #     Admin?    : <%= checkbox_tag "person[admin]", "1", @person.company.admin? %>
       #     <%= f.submit %>
       #   <% end %>
       #
@@ -390,7 +390,7 @@ module ActionView
       #     <%= f.text_field :first_name %>
       #     <%= f.text_field :last_name %>
       #     <%= f.text_area :biography %>
-      #     <%= f.check_box :admin %>
+      #     <%= f.checkbox :admin %>
       #     <%= f.submit %>
       #   <% end %>
       #
@@ -669,7 +669,7 @@ module ActionView
       #     <%= form.text_field :last_name %>
       #
       #     <%= text_area :person, :biography %>
-      #     <%= check_box_tag "person[admin]", "1", @person.company.admin? %>
+      #     <%= checkbox_tag "person[admin]", "1", @person.company.admin? %>
       #
       #     <%= form.submit %>
       #   <% end %>
@@ -731,7 +731,7 @@ module ActionView
       #     <%= form.text_field :first_name %>
       #     <%= form.text_field :last_name %>
       #     <%= form.text_area :biography %>
-      #     <%= form.check_box :admin %>
+      #     <%= form.checkbox :admin %>
       #     <%= form.submit %>
       #   <% end %>
       #
@@ -804,7 +804,7 @@ module ActionView
       #     Last name : <%= person_form.text_field :last_name %>
       #
       #     <%= fields_for :permission, @person.permission do |permission_fields| %>
-      #       Admin?  : <%= permission_fields.check_box :admin %>
+      #       Admin?  : <%= permission_fields.checkbox :admin %>
       #     <% end %>
       #
       #     <%= person_form.submit %>
@@ -821,7 +821,7 @@ module ActionView
       # object to +fields_for+ -
       #
       #   <%= fields_for :permission do |permission_fields| %>
-      #     Admin?: <%= permission_fields.check_box :admin %>
+      #     Admin?: <%= permission_fields.checkbox :admin %>
       #   <% end %>
       #
       # ...in which case, if <tt>:permission</tt> also happens to be the name of an
@@ -833,7 +833,7 @@ module ActionView
       # name has been omitted) -
       #
       #   <%= fields_for @person.permission do |permission_fields| %>
-      #     Admin?: <%= permission_fields.check_box :admin %>
+      #     Admin?: <%= permission_fields.checkbox :admin %>
       #   <% end %>
       #
       # and +fields_for+ will derive the required name of the field from the
@@ -914,7 +914,7 @@ module ActionView
       #     ...
       #     <%= person_form.fields_for :address do |address_fields| %>
       #       ...
-      #       Delete: <%= address_fields.check_box :_destroy %>
+      #       Delete: <%= address_fields.checkbox :_destroy %>
       #     <% end %>
       #     ...
       #   <% end %>
@@ -1002,7 +1002,7 @@ module ActionView
       #   <%= form_with model: @person do |person_form| %>
       #     ...
       #     <%= person_form.fields_for :projects do |project_fields| %>
-      #       Delete: <%= project_fields.check_box :_destroy %>
+      #       Delete: <%= project_fields.checkbox :_destroy %>
       #     <% end %>
       #     ...
       #   <% end %>
@@ -1070,7 +1070,7 @@ module ActionView
       #     <%= fields.text_field :body %>
       #
       #     <%= text_area :commenter, :biography %>
-      #     <%= check_box_tag "comment[all_caps]", "1", @comment.commenter.hulk_mode? %>
+      #     <%= checkbox_tag "comment[all_caps]", "1", @comment.commenter.hulk_mode? %>
       #   <% end %>
       #
       # Same goes for the methods in FormOptionsHelper and DateHelper designed
@@ -1316,7 +1316,7 @@ module ActionView
       # within an array-like parameter, as in
       #
       #   <%= fields_for "project[invoice_attributes][]", invoice, index: nil do |form| %>
-      #     <%= form.check_box :paid %>
+      #     <%= form.checkbox :paid %>
       #     ...
       #   <% end %>
       #
@@ -1324,27 +1324,28 @@ module ActionView
       # the elements of the array. For each item with a checked check box you
       # get an extra ghost item with only that attribute, assigned to "0".
       #
-      # In that case it is preferable to either use +check_box_tag+ or to use
+      # In that case it is preferable to either use +checkbox_tag+ or to use
       # hashes instead of arrays.
       #
       # ==== Examples
       #
       #   # Let's say that @article.validated? is 1:
-      #   check_box("article", "validated")
+      #   checkbox("article", "validated")
       #   # => <input name="article[validated]" type="hidden" value="0" />
       #   #    <input checked="checked" type="checkbox" id="article_validated" name="article[validated]" value="1" />
       #
       #   # Let's say that @puppy.gooddog is "no":
-      #   check_box("puppy", "gooddog", {}, "yes", "no")
+      #   checkbox("puppy", "gooddog", {}, "yes", "no")
       #   # => <input name="puppy[gooddog]" type="hidden" value="no" />
       #   #    <input type="checkbox" id="puppy_gooddog" name="puppy[gooddog]" value="yes" />
       #
-      #   check_box("eula", "accepted", { class: 'eula_check' }, "yes", "no")
+      #   checkbox("eula", "accepted", { class: 'eula_check' }, "yes", "no")
       #   # => <input name="eula[accepted]" type="hidden" value="no" />
       #   #    <input type="checkbox" class="eula_check" id="eula_accepted" name="eula[accepted]" value="yes" />
-      def check_box(object_name, method, options = {}, checked_value = "1", unchecked_value = "0")
+      def checkbox(object_name, method, options = {}, checked_value = "1", unchecked_value = "0")
         Tags::CheckBox.new(object_name, method, self, checked_value, unchecked_value, options).render
       end
+      alias_method :check_box, :checkbox
 
       # Returns a radio button tag for accessing a specified attribute (identified by +method+) on an object
       # assigned to the template (identified by +object+). If the current value of +method+ is +tag_value+ the
@@ -1634,12 +1635,12 @@ module ActionView
     #
     #   <%= form_with model: @person do |person_form| %>
     #     Name: <%= person_form.text_field :name %>
-    #     Admin: <%= person_form.check_box :admin %>
+    #     Admin: <%= person_form.checkbox :admin %>
     #   <% end %>
     #
     # In the above block, a +FormBuilder+ object is yielded as the
     # +person_form+ variable. This allows you to generate the +text_field+
-    # and +check_box+ fields by specifying their eponymous methods, which
+    # and +checkbox+ fields by specifying their eponymous methods, which
     # modify the underlying template and associates the <tt>@person</tt> model object
     # with the form.
     #
@@ -1681,7 +1682,7 @@ module ActionView
       # The methods which wrap a form helper call.
       class_attribute :field_helpers, default: [
         :fields_for, :fields, :label, :text_field, :password_field,
-        :hidden_field, :file_field, :text_area, :check_box,
+        :hidden_field, :file_field, :text_area, :checkbox,
         :radio_button, :color_field, :search_field,
         :telephone_field, :phone_field, :date_field,
         :time_field, :datetime_field, :datetime_local_field,
@@ -2019,7 +2020,7 @@ module ActionView
       # Please refer to the documentation of the base helper for details.
 
       ActiveSupport::CodeGenerator.batch(self, __FILE__, __LINE__) do |code_generator|
-        (field_helpers - [:label, :check_box, :radio_button, :fields_for, :fields, :hidden_field, :file_field]).each do |selector|
+        (field_helpers - [:label, :checkbox, :radio_button, :fields_for, :fields, :hidden_field, :file_field]).each do |selector|
           code_generator.define_cached_method(selector, namespace: :form_builder) do |batch|
             batch.push <<-RUBY_EVAL
               def #{selector}(method, options = {})  # def text_field(method, options = {})
@@ -2055,7 +2056,7 @@ module ActionView
       #     Last name : <%= person_form.text_field :last_name %>
       #
       #     <%= fields_for :permission, @person.permission do |permission_fields| %>
-      #       Admin?  : <%= permission_fields.check_box :admin %>
+      #       Admin?  : <%= permission_fields.checkbox :admin %>
       #     <% end %>
       #
       #     <%= person_form.submit %>
@@ -2072,7 +2073,7 @@ module ActionView
       # object to +fields_for+ -
       #
       #   <%= fields_for :permission do |permission_fields| %>
-      #     Admin?: <%= permission_fields.check_box :admin %>
+      #     Admin?: <%= permission_fields.checkbox :admin %>
       #   <% end %>
       #
       # ...in which case, if <tt>:permission</tt> also happens to be the name of an
@@ -2084,7 +2085,7 @@ module ActionView
       # name has been omitted) -
       #
       #   <%= fields_for @person.permission do |permission_fields| %>
-      #     Admin?: <%= permission_fields.check_box :admin %>
+      #     Admin?: <%= permission_fields.checkbox :admin %>
       #   <% end %>
       #
       # and +fields_for+ will derive the required name of the field from the
@@ -2102,7 +2103,7 @@ module ActionView
       #   <%= form_with model: @person do |person_form| %>
       #     ...
       #     <%= fields_for :permission, @person.permission, {} do |permission_fields| %>
-      #       Admin?: <%= check_box_tag permission_fields.field_name(:admin), @person.permission[:admin] %>
+      #       Admin?: <%= checkbox_tag permission_fields.field_name(:admin), @person.permission[:admin] %>
       #     <% end %>
       #     ...
       #   <% end %>
@@ -2177,7 +2178,7 @@ module ActionView
       #     ...
       #     <%= person_form.fields_for :address do |address_fields| %>
       #       ...
-      #       Delete: <%= address_fields.check_box :_destroy %>
+      #       Delete: <%= address_fields.checkbox :_destroy %>
       #     <% end %>
       #     ...
       #   <% end %>
@@ -2265,7 +2266,7 @@ module ActionView
       #   <%= form_with model: @person do |person_form| %>
       #     ...
       #     <%= person_form.fields_for :projects do |project_fields| %>
-      #       Delete: <%= project_fields.check_box :_destroy %>
+      #       Delete: <%= project_fields.checkbox :_destroy %>
       #     <% end %>
       #     ...
       #   <% end %>
@@ -2444,7 +2445,7 @@ module ActionView
       # within an array-like parameter, as in
       #
       #   <%= fields_for "project[invoice_attributes][]", invoice, index: nil do |form| %>
-      #     <%= form.check_box :paid %>
+      #     <%= form.checkbox :paid %>
       #     ...
       #   <% end %>
       #
@@ -2452,28 +2453,29 @@ module ActionView
       # the elements of the array. For each item with a checked check box you
       # get an extra ghost item with only that attribute, assigned to "0".
       #
-      # In that case it is preferable to either use +check_box_tag+ or to use
+      # In that case it is preferable to either use +checkbox_tag+ or to use
       # hashes instead of arrays.
       #
       # ==== Examples
       #
       #   # Let's say that @article.validated? is 1:
-      #   check_box("validated")
+      #   checkbox("validated")
       #   # => <input name="article[validated]" type="hidden" value="0" />
       #   #    <input checked="checked" type="checkbox" id="article_validated" name="article[validated]" value="1" />
       #
       #   # Let's say that @puppy.gooddog is "no":
-      #   check_box("gooddog", {}, "yes", "no")
+      #   checkbox("gooddog", {}, "yes", "no")
       #   # => <input name="puppy[gooddog]" type="hidden" value="no" />
       #   #    <input type="checkbox" id="puppy_gooddog" name="puppy[gooddog]" value="yes" />
       #
       #   # Let's say that @eula.accepted is "no":
-      #   check_box("accepted", { class: 'eula_check' }, "yes", "no")
+      #   checkbox("accepted", { class: 'eula_check' }, "yes", "no")
       #   # => <input name="eula[accepted]" type="hidden" value="no" />
       #   #    <input type="checkbox" class="eula_check" id="eula_accepted" name="eula[accepted]" value="yes" />
-      def check_box(method, options = {}, checked_value = "1", unchecked_value = "0")
-        @template.check_box(@object_name, method, objectify_options(options), checked_value, unchecked_value)
+      def checkbox(method, options = {}, checked_value = "1", unchecked_value = "0")
+        @template.checkbox(@object_name, method, objectify_options(options), checked_value, unchecked_value)
       end
+      alias_method :check_box, :checkbox
 
       # Returns a radio button tag for accessing a specified attribute (identified by +method+) on an object
       # assigned to the template (identified by +object+). If the current value of +method+ is +tag_value+ the

--- a/actionview/lib/action_view/helpers/form_options_helper.rb
+++ b/actionview/lib/action_view/helpers/form_options_helper.rb
@@ -723,7 +723,7 @@ module ActionView
       #   end
       #
       # Sample usage (selecting the associated Author for an instance of Post, <tt>@post</tt>):
-      #   collection_check_boxes(:post, :author_ids, Author.all, :id, :name_with_initial)
+      #   collection_checkboxes(:post, :author_ids, Author.all, :id, :name_with_initial)
       #
       # If <tt>@post.author_ids</tt> is already <tt>[1]</tt>, this would return:
       #   <input id="post_author_ids_1" name="post[author_ids][]" type="checkbox" value="1" checked="checked" />
@@ -736,8 +736,8 @@ module ActionView
       #
       # It is also possible to customize the way the elements will be shown by
       # giving a block to the method:
-      #   collection_check_boxes(:post, :author_ids, Author.all, :id, :name_with_initial) do |b|
-      #     b.label { b.check_box }
+      #   collection_checkboxes(:post, :author_ids, Author.all, :id, :name_with_initial) do |b|
+      #     b.label { b.checkbox }
       #   end
       #
       # The argument passed to the block is a special kind of builder for this
@@ -746,17 +746,17 @@ module ActionView
       # Using it, you can change the label and check box display order or even
       # use the label as wrapper, as in the example above.
       #
-      # The builder methods <tt>label</tt> and <tt>check_box</tt> also accept
+      # The builder methods <tt>label</tt> and <tt>checkbox</tt> also accept
       # extra HTML options:
-      #   collection_check_boxes(:post, :author_ids, Author.all, :id, :name_with_initial) do |b|
-      #     b.label(class: "check_box") { b.check_box(class: "check_box") }
+      #   collection_checkboxes(:post, :author_ids, Author.all, :id, :name_with_initial) do |b|
+      #     b.label(class: "checkbox") { b.checkbox(class: "checkbox") }
       #   end
       #
       # There are also three special methods available: <tt>object</tt>, <tt>text</tt> and
       # <tt>value</tt>, which are the current item being rendered, its text and value methods,
       # respectively. You can use them like this:
-      #   collection_check_boxes(:post, :author_ids, Author.all, :id, :name_with_initial) do |b|
-      #      b.label(:"data-value" => b.value) { b.check_box + b.text }
+      #   collection_checkboxes(:post, :author_ids, Author.all, :id, :name_with_initial) do |b|
+      #      b.label(:"data-value" => b.value) { b.checkbox + b.text }
       #   end
       #
       # ==== Gotcha
@@ -779,7 +779,7 @@ module ActionView
       #
       # In the rare case you don't want this hidden field, you can pass the
       # <tt>include_hidden: false</tt> option to the helper method.
-      def collection_check_boxes(object, method, collection, value_method, text_method, options = {}, html_options = {}, &block)
+      def collection_checkboxes(object, method, collection, value_method, text_method, options = {}, html_options = {}, &block)
         Tags::CollectionCheckBoxes.new(object, method, self, collection, value_method, text_method, options, html_options).render(&block)
       end
 
@@ -897,16 +897,16 @@ module ActionView
         @template.weekday_select(@object_name, method, objectify_options(options), @default_html_options.merge(html_options))
       end
 
-      # Wraps ActionView::Helpers::FormOptionsHelper#collection_check_boxes for form builders:
+      # Wraps ActionView::Helpers::FormOptionsHelper#collection_checkboxes for form builders:
       #
       #   <%= form_for @post do |f| %>
-      #     <%= f.collection_check_boxes :author_ids, Author.all, :id, :name_with_initial %>
+      #     <%= f.collection_checkboxes :author_ids, Author.all, :id, :name_with_initial %>
       #     <%= f.submit %>
       #   <% end %>
       #
       # Please refer to the documentation of the base helper for details.
-      def collection_check_boxes(method, collection, value_method, text_method, options = {}, html_options = {}, &block)
-        @template.collection_check_boxes(@object_name, method, collection, value_method, text_method, objectify_options(options), @default_html_options.merge(html_options), &block)
+      def collection_checkboxes(method, collection, value_method, text_method, options = {}, html_options = {}, &block)
+        @template.collection_checkboxes(@object_name, method, collection, value_method, text_method, objectify_options(options), @default_html_options.merge(html_options), &block)
       end
 
       # Wraps ActionView::Helpers::FormOptionsHelper#collection_radio_buttons for form builders:

--- a/actionview/lib/action_view/helpers/form_tag_helper.rb
+++ b/actionview/lib/action_view/helpers/form_tag_helper.rb
@@ -425,9 +425,9 @@ module ActionView
 
       ##
       # :call-seq:
-      #   check_box_tag(name, options = {})
-      #   check_box_tag(name, value, options = {})
-      #   check_box_tag(name, value, checked, options = {})
+      #   checkbox_tag(name, options = {})
+      #   checkbox_tag(name, value, options = {})
+      #   checkbox_tag(name, value, checked, options = {})
       #
       # Creates a check box form input tag.
       #
@@ -438,21 +438,21 @@ module ActionView
       # * Any other key creates standard HTML options for the tag.
       #
       # ==== Examples
-      #   check_box_tag 'accept'
+      #   checkbox_tag 'accept'
       #   # => <input id="accept" name="accept" type="checkbox" value="1" />
       #
-      #   check_box_tag 'rock', 'rock music'
+      #   checkbox_tag 'rock', 'rock music'
       #   # => <input id="rock" name="rock" type="checkbox" value="rock music" />
       #
-      #   check_box_tag 'receive_email', 'yes', true
+      #   checkbox_tag 'receive_email', 'yes', true
       #   # => <input checked="checked" id="receive_email" name="receive_email" type="checkbox" value="yes" />
       #
-      #   check_box_tag 'tos', 'yes', false, class: 'accept_tos'
+      #   checkbox_tag 'tos', 'yes', false, class: 'accept_tos'
       #   # => <input class="accept_tos" id="tos" name="tos" type="checkbox" value="yes" />
       #
-      #   check_box_tag 'eula', 'accepted', false, disabled: true
+      #   checkbox_tag 'eula', 'accepted', false, disabled: true
       #   # => <input disabled="disabled" id="eula" name="eula" type="checkbox" value="accepted" />
-      def check_box_tag(name, *args)
+      def checkbox_tag(name, *args)
         if args.length >= 4
           raise ArgumentError, "wrong number of arguments (given #{args.length + 1}, expected 1..4)"
         end
@@ -462,6 +462,7 @@ module ActionView
         html_options["checked"] = "checked" if checked
         tag :input, html_options
       end
+      alias_method :check_box_tag, :checkbox_tag
 
       ##
       # :call-seq:

--- a/actionview/lib/action_view/helpers/tags/collection_check_boxes.rb
+++ b/actionview/lib/action_view/helpers/tags/collection_check_boxes.rb
@@ -10,12 +10,13 @@ module ActionView
         include FormOptionsHelper
 
         class CheckBoxBuilder < Builder # :nodoc:
-          def check_box(extra_html_options = {})
+          def checkbox(extra_html_options = {})
             html_options = extra_html_options.merge(@input_html_options)
             html_options[:multiple] = true
             html_options[:skip_default_ids] = false
-            @template_object.check_box(@object_name, @method_name, html_options, @value, nil)
+            @template_object.checkbox(@object_name, @method_name, html_options, @value, nil)
           end
+          alias_method :check_box, :checkbox
         end
 
         def render(&block)
@@ -24,7 +25,7 @@ module ActionView
 
         private
           def render_component(builder)
-            builder.check_box + builder.label
+            builder.checkbox + builder.label
           end
 
           def hidden_field_name

--- a/actionview/test/template/active_model_helper_test.rb
+++ b/actionview/test/template/active_model_helper_test.rb
@@ -107,17 +107,17 @@ class ActiveModelHelperTest < ActionView::TestCase
     )
   end
 
-  def test_check_box_with_errors
+  def test_checkbox_with_errors
     assert_dom_equal(
       %(<input name="post[published]" type="hidden" value="0" autocomplete="off" /><div class="field_with_errors"><input type="checkbox" value="1" name="post[published]" id="post_published" /></div>),
-      check_box("post", "published")
+      checkbox("post", "published")
     )
   end
 
-  def test_check_boxes_with_errors
+  def test_checkboxes_with_errors
     assert_dom_equal(
       %(<input name="post[published]" type="hidden" value="0" autocomplete="off" /><div class="field_with_errors"><input type="checkbox" value="1" name="post[published]" id="post_published" /></div><input name="post[published]" type="hidden" value="0" autocomplete="off" /><div class="field_with_errors"><input type="checkbox" value="1" name="post[published]" id="post_published" /></div>),
-      check_box("post", "published") + check_box("post", "published")
+      checkbox("post", "published") + checkbox("post", "published")
     )
   end
 
@@ -135,10 +135,10 @@ class ActiveModelHelperTest < ActionView::TestCase
     )
   end
 
-  def test_collection_check_boxes_with_errors
+  def test_collection_checkboxes_with_errors
     assert_dom_equal(
       %(<input type="hidden" name="post[category][]" value="" autocomplete="off" /><div class="field_with_errors"><input type="checkbox" value="ruby" name="post[category][]" id="post_category_ruby" /></div><label for="post_category_ruby">ruby</label><div class="field_with_errors"><input type="checkbox" value="java" name="post[category][]" id="post_category_java" /></div><label for="post_category_java">java</label>),
-      collection_check_boxes("post", "category", [:ruby, :java], :to_s, :to_s)
+      collection_checkboxes("post", "category", [:ruby, :java], :to_s, :to_s)
     )
   end
 

--- a/actionview/test/template/form_collections_helper_test.rb
+++ b/actionview/test/template/form_collections_helper_test.rb
@@ -13,8 +13,8 @@ class FormCollectionsHelperTest < ActionView::TestCase
     @rendered = collection_radio_buttons(*args, &block)
   end
 
-  def with_collection_check_boxes(*args, &block)
-    @rendered = collection_check_boxes(*args, &block)
+  def with_collection_checkboxes(*args, &block)
+    @rendered = collection_checkboxes(*args, &block)
   end
 
   # COLLECTION RADIO BUTTONS
@@ -252,7 +252,7 @@ class FormCollectionsHelperTest < ActionView::TestCase
   # COLLECTION CHECK BOXES
   test "collection check boxes accepts a collection and generate a series of checkboxes for value method" do
     collection = [Category.new(1, "Category 1"), Category.new(2, "Category 2")]
-    with_collection_check_boxes :user, :category_ids, collection, :id, :name
+    with_collection_checkboxes :user, :category_ids, collection, :id, :name
 
     assert_select 'input#user_category_ids_1[type=checkbox][value="1"]'
     assert_select 'input#user_category_ids_2[type=checkbox][value="2"]'
@@ -260,62 +260,62 @@ class FormCollectionsHelperTest < ActionView::TestCase
 
   test "collection check boxes generates only one hidden field for the entire collection, to ensure something will be sent back to the server when posting an empty collection" do
     collection = [Category.new(1, "Category 1"), Category.new(2, "Category 2")]
-    with_collection_check_boxes :user, :category_ids, collection, :id, :name
+    with_collection_checkboxes :user, :category_ids, collection, :id, :name
 
     assert_select "input[type=hidden][name='user[category_ids][]'][value=''][autocomplete='off']", count: 1
   end
 
   test "collection check boxes generates a hidden field using the given :name in :html_options" do
     collection = [Category.new(1, "Category 1"), Category.new(2, "Category 2")]
-    with_collection_check_boxes :user, :category_ids, collection, :id, :name, {}, { name: "user[other_category_ids][]" }
+    with_collection_checkboxes :user, :category_ids, collection, :id, :name, {}, { name: "user[other_category_ids][]" }
 
     assert_select "input[type=hidden][name='user[other_category_ids][]'][value=''][autocomplete='off']", count: 1
   end
 
   test "collection check boxes generates a hidden field with index if it was provided" do
     collection = [Category.new(1, "Category 1"), Category.new(2, "Category 2")]
-    with_collection_check_boxes :user, :category_ids, collection, :id, :name, index: 322
+    with_collection_checkboxes :user, :category_ids, collection, :id, :name, index: 322
 
     assert_select "input[type=hidden][name='user[322][category_ids][]'][value=''][autocomplete='off']", count: 1
   end
 
   test "collection check boxes does not generate a hidden field if include_hidden option is false" do
     collection = [Category.new(1, "Category 1"), Category.new(2, "Category 2")]
-    with_collection_check_boxes :user, :category_ids, collection, :id, :name, include_hidden: false
+    with_collection_checkboxes :user, :category_ids, collection, :id, :name, include_hidden: false
 
     assert_select "input[type=hidden][name='user[category_ids][]'][value='']", count: 0
   end
 
   test "collection check boxes does not generate a hidden field if include_hidden option is false with key as string" do
     collection = [Category.new(1, "Category 1"), Category.new(2, "Category 2")]
-    with_collection_check_boxes :user, :category_ids, collection, :id, :name, "include_hidden" => false
+    with_collection_checkboxes :user, :category_ids, collection, :id, :name, "include_hidden" => false
 
     assert_select "input[type=hidden][name='user[category_ids][]'][value='']", count: 0
   end
 
   test "collection check boxes accepts a collection and generate a series of checkboxes with labels for label method" do
     collection = [Category.new(1, "Category 1"), Category.new(2, "Category 2")]
-    with_collection_check_boxes :user, :category_ids, collection, :id, :name
+    with_collection_checkboxes :user, :category_ids, collection, :id, :name
 
     assert_select "label[for=user_category_ids_1]", "Category 1"
     assert_select "label[for=user_category_ids_2]", "Category 2"
   end
 
   test "collection check boxes handles camelized collection values for labels correctly" do
-    with_collection_check_boxes :user, :active, ["Yes", "No"], :to_s, :to_s
+    with_collection_checkboxes :user, :active, ["Yes", "No"], :to_s, :to_s
 
     assert_select "label[for=user_active_yes]", "Yes"
     assert_select "label[for=user_active_no]", "No"
   end
 
   test "collection check box should sanitize collection values for labels correctly" do
-    with_collection_check_boxes :user, :name, ["$0.99", "$1.99"], :to_s, :to_s
+    with_collection_checkboxes :user, :name, ["$0.99", "$1.99"], :to_s, :to_s
     assert_select "label[for=user_name_0_99]", "$0.99"
     assert_select "label[for=user_name_1_99]", "$1.99"
   end
 
   test "collection check boxes correctly builds unique DOM IDs for float values" do
-    with_collection_check_boxes :user, :name, [1.0, 10], :to_s, :to_s
+    with_collection_checkboxes :user, :name, [1.0, 10], :to_s, :to_s
     assert_select "label[for=user_name_1_0]", "1.0"
     assert_select "label[for=user_name_10]", "10"
     assert_select 'input#user_name_1_0[type=checkbox][value="1.0"]'
@@ -323,7 +323,7 @@ class FormCollectionsHelperTest < ActionView::TestCase
   end
 
   test "collection check boxes generates labels for non-English values correctly" do
-    with_collection_check_boxes :user, :title, ["Господин", "Госпожа"], :to_s, :to_s
+    with_collection_checkboxes :user, :title, ["Господин", "Госпожа"], :to_s, :to_s
 
     assert_select "input[type=checkbox]#user_title_господин"
     assert_select "label[for=user_title_господин]", "Господин"
@@ -331,7 +331,7 @@ class FormCollectionsHelperTest < ActionView::TestCase
 
   test "collection check boxes accepts HTML options as the last element of array" do
     collection = [[1, "Category 1", { class: "foo" }], [2, "Category 2", { class: "bar" }]]
-    with_collection_check_boxes :user, :active, collection, :first, :second
+    with_collection_checkboxes :user, :active, collection, :first, :second
 
     assert_select 'input[type=checkbox][value="1"].foo'
     assert_select 'input[type=checkbox][value="2"].bar'
@@ -339,7 +339,7 @@ class FormCollectionsHelperTest < ActionView::TestCase
 
   test "collection check boxes propagates input id to the label for attribute" do
     collection = [[1, "Category 1", { id: "foo" }], [2, "Category 2", { id: "bar" }]]
-    with_collection_check_boxes :user, :active, collection, :first, :second
+    with_collection_checkboxes :user, :active, collection, :first, :second
 
     assert_select 'input[type=checkbox][value="1"]#foo'
     assert_select 'input[type=checkbox][value="2"]#bar'
@@ -350,17 +350,17 @@ class FormCollectionsHelperTest < ActionView::TestCase
 
   test "collection check boxes sets the label class defined inside the block" do
     collection = [[1, "Category 1", { class: "foo" }], [2, "Category 2", { class: "bar" }]]
-    with_collection_check_boxes :user, :active, collection, :second, :first do |b|
-      b.label(class: "collection_check_boxes")
+    with_collection_checkboxes :user, :active, collection, :second, :first do |b|
+      b.label(class: "collection_checkboxes")
     end
 
-    assert_select "label.collection_check_boxes[for=user_active_category_1]"
-    assert_select "label.collection_check_boxes[for=user_active_category_2]"
+    assert_select "label.collection_checkboxes[for=user_active_category_1]"
+    assert_select "label.collection_checkboxes[for=user_active_category_2]"
   end
 
   test "collection check boxes does not include the input class in the respective label" do
     collection = [[1, "Category 1", { class: "foo" }], [2, "Category 2", { class: "bar" }]]
-    with_collection_check_boxes :user, :active, collection, :second, :first
+    with_collection_checkboxes :user, :active, collection, :second, :first
 
     assert_no_select "label.foo[for=user_active_category_1]"
     assert_no_select "label.bar[for=user_active_category_2]"
@@ -368,7 +368,7 @@ class FormCollectionsHelperTest < ActionView::TestCase
 
   test "collection check boxes accepts selected values as :checked option" do
     collection = (1..3).map { |i| [i, "Category #{i}"] }
-    with_collection_check_boxes :user, :category_ids, collection, :first, :last, checked: [1, 3]
+    with_collection_checkboxes :user, :category_ids, collection, :first, :last, checked: [1, 3]
 
     assert_select 'input[type=checkbox][value="1"][checked=checked]'
     assert_select 'input[type=checkbox][value="3"][checked=checked]'
@@ -377,7 +377,7 @@ class FormCollectionsHelperTest < ActionView::TestCase
 
   test "collection check boxes accepts selected string values as :checked option" do
     collection = (1..3).map { |i| [i, "Category #{i}"] }
-    with_collection_check_boxes :user, :category_ids, collection, :first, :last, checked: ["1", "3"]
+    with_collection_checkboxes :user, :category_ids, collection, :first, :last, checked: ["1", "3"]
 
     assert_select 'input[type=checkbox][value="1"][checked=checked]'
     assert_select 'input[type=checkbox][value="3"][checked=checked]'
@@ -386,7 +386,7 @@ class FormCollectionsHelperTest < ActionView::TestCase
 
   test "collection check boxes accepts a single checked value" do
     collection = (1..3).map { |i| [i, "Category #{i}"] }
-    with_collection_check_boxes :user, :category_ids, collection, :first, :last, checked: 3
+    with_collection_checkboxes :user, :category_ids, collection, :first, :last, checked: 3
 
     assert_select 'input[type=checkbox][value="3"][checked=checked]'
     assert_no_select 'input[type=checkbox][value="1"][checked=checked]'
@@ -398,7 +398,7 @@ class FormCollectionsHelperTest < ActionView::TestCase
     collection = (1..3).map { |i| [i, "Category #{i}"] }
 
     @rendered = fields_for(:user, user) do |p|
-      p.collection_check_boxes :category_ids, collection, :first, :last, checked: [1, 3]
+      p.collection_checkboxes :category_ids, collection, :first, :last, checked: [1, 3]
     end
 
     assert_select 'input[type=checkbox][value="1"][checked=checked]'
@@ -408,7 +408,7 @@ class FormCollectionsHelperTest < ActionView::TestCase
 
   test "collection check boxes accepts multiple disabled items" do
     collection = (1..3).map { |i| [i, "Category #{i}"] }
-    with_collection_check_boxes :user, :category_ids, collection, :first, :last, disabled: [1, 3]
+    with_collection_checkboxes :user, :category_ids, collection, :first, :last, disabled: [1, 3]
 
     assert_select 'input[type=checkbox][value="1"][disabled=disabled]'
     assert_select 'input[type=checkbox][value="3"][disabled=disabled]'
@@ -417,7 +417,7 @@ class FormCollectionsHelperTest < ActionView::TestCase
 
   test "collection check boxes accepts single disabled item" do
     collection = (1..3).map { |i| [i, "Category #{i}"] }
-    with_collection_check_boxes :user, :category_ids, collection, :first, :last, disabled: 1
+    with_collection_checkboxes :user, :category_ids, collection, :first, :last, disabled: 1
 
     assert_select 'input[type=checkbox][value="1"][disabled=disabled]'
     assert_no_select 'input[type=checkbox][value="3"][disabled=disabled]'
@@ -426,7 +426,7 @@ class FormCollectionsHelperTest < ActionView::TestCase
 
   test "collection check boxes accepts a proc to disabled items" do
     collection = (1..3).map { |i| [i, "Category #{i}"] }
-    with_collection_check_boxes :user, :category_ids, collection, :first, :last, disabled: proc { |i| i.first == 1 }
+    with_collection_checkboxes :user, :category_ids, collection, :first, :last, disabled: proc { |i| i.first == 1 }
 
     assert_select 'input[type=checkbox][value="1"][disabled=disabled]'
     assert_no_select 'input[type=checkbox][value="3"][disabled=disabled]'
@@ -435,7 +435,7 @@ class FormCollectionsHelperTest < ActionView::TestCase
 
   test "collection check boxes accepts multiple readonly items" do
     collection = (1..3).map { |i| [i, "Category #{i}"] }
-    with_collection_check_boxes :user, :category_ids, collection, :first, :last, readonly: [1, 3]
+    with_collection_checkboxes :user, :category_ids, collection, :first, :last, readonly: [1, 3]
 
     assert_select 'input[type=checkbox][value="1"][readonly=readonly]'
     assert_select 'input[type=checkbox][value="3"][readonly=readonly]'
@@ -444,7 +444,7 @@ class FormCollectionsHelperTest < ActionView::TestCase
 
   test "collection check boxes accepts single readonly item" do
     collection = (1..3).map { |i| [i, "Category #{i}"] }
-    with_collection_check_boxes :user, :category_ids, collection, :first, :last, readonly: 1
+    with_collection_checkboxes :user, :category_ids, collection, :first, :last, readonly: 1
 
     assert_select 'input[type=checkbox][value="1"][readonly=readonly]'
     assert_no_select 'input[type=checkbox][value="3"][readonly=readonly]'
@@ -453,7 +453,7 @@ class FormCollectionsHelperTest < ActionView::TestCase
 
   test "collection check boxes accepts a proc to readonly items" do
     collection = (1..3).map { |i| [i, "Category #{i}"] }
-    with_collection_check_boxes :user, :category_ids, collection, :first, :last, readonly: proc { |i| i.first == 1 }
+    with_collection_checkboxes :user, :category_ids, collection, :first, :last, readonly: proc { |i| i.first == 1 }
 
     assert_select 'input[type=checkbox][value="1"][readonly=readonly]'
     assert_no_select 'input[type=checkbox][value="3"][readonly=readonly]'
@@ -462,7 +462,7 @@ class FormCollectionsHelperTest < ActionView::TestCase
 
   test "collection check boxes accepts HTML options" do
     collection = [[1, "Category 1"], [2, "Category 2"]]
-    with_collection_check_boxes :user, :category_ids, collection, :first, :last, {}, { class: "check" }
+    with_collection_checkboxes :user, :category_ids, collection, :first, :last, {}, { class: "check" }
 
     assert_select 'input.check[type=checkbox][value="1"]'
     assert_select 'input.check[type=checkbox][value="2"]'
@@ -471,7 +471,7 @@ class FormCollectionsHelperTest < ActionView::TestCase
   test "collection check boxes with fields for" do
     collection = [Category.new(1, "Category 1"), Category.new(2, "Category 2")]
     @rendered = fields_for(:post) do |p|
-      p.collection_check_boxes :category_ids, collection, :id, :name
+      p.collection_checkboxes :category_ids, collection, :id, :name
     end
 
     assert_select 'input#post_category_ids_1[type=checkbox][value="1"]'
@@ -482,15 +482,15 @@ class FormCollectionsHelperTest < ActionView::TestCase
   end
 
   test "collection check boxes does not wrap input inside the label" do
-    with_collection_check_boxes :user, :active, [true, false], :to_s, :to_s
+    with_collection_checkboxes :user, :active, [true, false], :to_s, :to_s
 
     assert_select "input[type=checkbox] + label"
     assert_no_select "label input"
   end
 
   test "collection check boxes accepts a block to render the label as check box wrapper" do
-    with_collection_check_boxes :user, :active, [true, false], :to_s, :to_s do |b|
-      b.label { b.check_box }
+    with_collection_checkboxes :user, :active, [true, false], :to_s, :to_s do |b|
+      b.label { b.checkbox }
     end
 
     assert_select "label[for=user_active_true] > input#user_active_true[type=checkbox]"
@@ -498,8 +498,8 @@ class FormCollectionsHelperTest < ActionView::TestCase
   end
 
   test "collection check boxes accepts a block to change the order of label and check box" do
-    with_collection_check_boxes :user, :active, [true, false], :to_s, :to_s do |b|
-      b.label + b.check_box
+    with_collection_checkboxes :user, :active, [true, false], :to_s, :to_s do |b|
+      b.label + b.checkbox
     end
 
     assert_select "label[for=user_active_true] + input#user_active_true[type=checkbox]"
@@ -507,17 +507,17 @@ class FormCollectionsHelperTest < ActionView::TestCase
   end
 
   test "collection check boxes with block helpers accept extra HTML options" do
-    with_collection_check_boxes :user, :active, [true, false], :to_s, :to_s do |b|
-      b.label(class: "check_box") + b.check_box(class: "check_box")
+    with_collection_checkboxes :user, :active, [true, false], :to_s, :to_s do |b|
+      b.label(class: "checkbox") + b.checkbox(class: "checkbox")
     end
 
-    assert_select "label.check_box[for=user_active_true] + input#user_active_true.check_box[type=checkbox]"
-    assert_select "label.check_box[for=user_active_false] + input#user_active_false.check_box[type=checkbox]"
+    assert_select "label.checkbox[for=user_active_true] + input#user_active_true.checkbox[type=checkbox]"
+    assert_select "label.checkbox[for=user_active_false] + input#user_active_false.checkbox[type=checkbox]"
   end
 
   test "collection check boxes with block helpers allows access to current text and value" do
-    with_collection_check_boxes :user, :active, [true, false], :to_s, :to_s do |b|
-      b.label("data-value": b.value) { b.check_box + b.text }
+    with_collection_checkboxes :user, :active, [true, false], :to_s, :to_s do |b|
+      b.label("data-value": b.value) { b.checkbox + b.text }
     end
 
     assert_select "label[for=user_active_true][data-value=true]", "true" do
@@ -529,8 +529,8 @@ class FormCollectionsHelperTest < ActionView::TestCase
   end
 
   test "collection check boxes with block helpers allows access to the current object item in the collection to access extra properties" do
-    with_collection_check_boxes :user, :active, [true, false], :to_s, :to_s do |b|
-      b.label(class: b.object) { b.check_box + b.text }
+    with_collection_checkboxes :user, :active, [true, false], :to_s, :to_s do |b|
+      b.label(class: b.object) { b.checkbox + b.text }
     end
 
     assert_select "label.true[for=user_active_true]", "true" do

--- a/actionview/test/template/form_helper/form_with_test.rb
+++ b/actionview/test/template/form_helper/form_with_test.rb
@@ -351,7 +351,7 @@ class FormWithActsLikeFormForTest < FormWithTest
       concat f.label(:title) { "The Title" }
       concat f.text_field(:title)
       concat f.text_area(:body)
-      concat f.check_box(:secret)
+      concat f.checkbox(:secret)
       concat f.select(:category, %w( animal economy sports ))
       concat f.submit("Create post")
       concat f.button("Create post")
@@ -415,7 +415,7 @@ class FormWithActsLikeFormForTest < FormWithTest
       concat f.label(:title) { "The Title" }
       concat f.text_field(:title)
       concat f.text_area(:body)
-      concat f.check_box(:secret)
+      concat f.checkbox(:secret)
       concat f.select(:category, %w( animal economy sports ))
       concat f.submit("Create post")
     end
@@ -627,12 +627,12 @@ class FormWithActsLikeFormForTest < FormWithTest
     assert_dom_equal expected, @rendered
   end
 
-  def test_form_with_with_collection_check_boxes
+  def test_form_with_with_collection_checkboxes
     post = Post.new
     def post.tag_ids; [1, 3]; end
     collection = (1..3).map { |i| [i, "Tag #{i}"] }
     form_with(model: post) do |f|
-      concat f.collection_check_boxes(:tag_ids, collection, :first, :last)
+      concat f.collection_checkboxes(:tag_ids, collection, :first, :last)
     end
 
     expected = whole_form("/posts") do
@@ -648,15 +648,15 @@ class FormWithActsLikeFormForTest < FormWithTest
     assert_dom_equal expected, @rendered
   end
 
-  def test_form_with_with_collection_check_boxes_with_custom_builder_block
+  def test_form_with_with_collection_checkboxes_with_custom_builder_block
     post = Post.new
     def post.tag_ids; [1, 3]; end
     collection = (1..3).map { |i| [i, "Tag #{i}"] }
     form_with(model: post) do |f|
-      rendered_check_boxes = f.collection_check_boxes(:tag_ids, collection, :first, :last) do |b|
-        b.label { b.check_box + b.text }
+      rendered_checkboxes = f.collection_checkboxes(:tag_ids, collection, :first, :last) do |b|
+        b.label { b.checkbox + b.text }
       end
-      concat rendered_check_boxes
+      concat rendered_checkboxes
     end
 
     expected = whole_form("/posts") do
@@ -675,17 +675,17 @@ class FormWithActsLikeFormForTest < FormWithTest
     assert_dom_equal expected, @rendered
   end
 
-  def test_form_with_with_collection_check_boxes_with_custom_builder_block_does_not_leak_the_template
+  def test_form_with_with_collection_checkboxes_with_custom_builder_block_does_not_leak_the_template
     post = Post.new
     def post.tag_ids; [1, 3]; end
     def post.id; 1; end
     collection = (1..3).map { |i| [i, "Tag #{i}"] }
 
     form_with(model: post) do |f|
-      rendered_check_boxes = f.collection_check_boxes(:tag_ids, collection, :first, :last) do |b|
-        b.label { b.check_box + b.text }
+      rendered_checkboxes = f.collection_checkboxes(:tag_ids, collection, :first, :last) do |b|
+        b.label { b.checkbox + b.text }
       end
-      concat rendered_check_boxes
+      concat rendered_checkboxes
       concat f.hidden_field :id
     end
 
@@ -706,13 +706,13 @@ class FormWithActsLikeFormForTest < FormWithTest
     assert_dom_equal expected, @rendered
   end
 
-  def test_form_with_index_and_with_collection_check_boxes
+  def test_form_with_index_and_with_collection_checkboxes
     post = Post.new
     def post.tag_ids; [1]; end
     collection = [[1, "Tag 1"]]
 
     form_with(model: post, index: "1") do |f|
-      concat f.collection_check_boxes(:tag_ids, collection, :first, :last)
+      concat f.collection_checkboxes(:tag_ids, collection, :first, :last)
     end
 
     expected = whole_form("/posts") do
@@ -795,7 +795,7 @@ class FormWithActsLikeFormForTest < FormWithTest
       concat f.label(:title, class: "post_title")
       concat f.text_field(:title)
       concat f.text_area(:body)
-      concat f.check_box(:secret)
+      concat f.checkbox(:secret)
       concat f.submit("Create post")
     end
 
@@ -815,7 +815,7 @@ class FormWithActsLikeFormForTest < FormWithTest
     form_with(model: @post, url: "/", id: "create-post", html: { method: :delete }) do |f|
       concat f.text_field(:title)
       concat f.text_area(:body)
-      concat f.check_box(:secret)
+      concat f.checkbox(:secret)
     end
 
     expected = whole_form("/", "create-post", method: "delete") do
@@ -832,7 +832,7 @@ class FormWithActsLikeFormForTest < FormWithTest
     form_with(model: @post, url: "/", method: :delete, id: "create-post") do |f|
       concat f.text_field(:title)
       concat f.text_area(:body)
-      concat f.check_box(:secret)
+      concat f.checkbox(:secret)
     end
 
     expected = whole_form("/", "create-post", method: "delete") do
@@ -863,7 +863,7 @@ class FormWithActsLikeFormForTest < FormWithTest
     form_with(model: @post, url: "/", id: "create-post", method: :patch) do |f|
       concat f.text_field(:title)
       concat f.text_area(:body)
-      concat f.check_box(:secret)
+      concat f.checkbox(:secret)
     end
 
     expected = whole_form("/", "create-post", method: "patch") do
@@ -883,7 +883,7 @@ class FormWithActsLikeFormForTest < FormWithTest
     form_with(model: @post, url: "/", id: "create-post", method: :patch) do |f|
       concat f.text_field(:title)
       concat f.text_area(:body)
-      concat f.check_box(:secret)
+      concat f.checkbox(:secret)
     end
 
     expected = whole_form("/", "create-post", method: "patch", local: true) do
@@ -954,7 +954,7 @@ class FormWithActsLikeFormForTest < FormWithTest
     form_with(scope: :post, id: "create-post") do |f|
       concat f.text_field(:title)
       concat f.text_area(:body)
-      concat f.check_box(:secret)
+      concat f.checkbox(:secret)
     end
 
     expected = whole_form("/", "create-post") do
@@ -972,7 +972,7 @@ class FormWithActsLikeFormForTest < FormWithTest
       concat f.label(:title)
       concat f.text_field(:title)
       concat f.text_area(:body)
-      concat f.check_box(:secret)
+      concat f.checkbox(:secret)
     end
 
     expected = whole_form("/posts/123", method: "patch") do
@@ -990,7 +990,7 @@ class FormWithActsLikeFormForTest < FormWithTest
     form_with(model: @post, scope: "post[]", index: nil) do |f|
       concat f.text_field(:title)
       concat f.text_area(:body)
-      concat f.check_box(:secret)
+      concat f.checkbox(:secret)
     end
 
     expected = whole_form("/posts/123", method: "patch") do
@@ -2013,7 +2013,7 @@ class FormWithActsLikeFormForTest < FormWithTest
     @rendered = fields(:post, model: @post) do |f|
       concat f.text_field(:title)
       concat f.text_area(:body)
-      concat f.check_box(:secret)
+      concat f.checkbox(:secret)
     end
 
     expected =
@@ -2029,7 +2029,7 @@ class FormWithActsLikeFormForTest < FormWithTest
     @rendered = fields("post[]", model: @post) do |f|
       concat f.text_field(:title)
       concat f.text_area(:body)
-      concat f.check_box(:secret)
+      concat f.checkbox(:secret)
     end
 
     expected =
@@ -2045,7 +2045,7 @@ class FormWithActsLikeFormForTest < FormWithTest
     @rendered = fields("post[]", model: @post, index: nil) do |f|
       concat f.text_field(:title)
       concat f.text_area(:body)
-      concat f.check_box(:secret)
+      concat f.checkbox(:secret)
     end
 
     expected =
@@ -2061,7 +2061,7 @@ class FormWithActsLikeFormForTest < FormWithTest
     @rendered = fields("post[]", model: @post, index: "abc") do |f|
       concat f.text_field(:title)
       concat f.text_area(:body)
-      concat f.check_box(:secret)
+      concat f.checkbox(:secret)
     end
 
     expected =
@@ -2077,7 +2077,7 @@ class FormWithActsLikeFormForTest < FormWithTest
     @rendered = fields(:post) do |f|
       concat f.text_field(:title)
       concat f.text_area(:body)
-      concat f.check_box(:secret)
+      concat f.checkbox(:secret)
     end
 
     expected =
@@ -2093,7 +2093,7 @@ class FormWithActsLikeFormForTest < FormWithTest
     @rendered = fields(model: @post) do |f|
       concat f.text_field(:title)
       concat f.text_area(:body)
-      concat f.check_box(:secret)
+      concat f.checkbox(:secret)
     end
 
     expected =
@@ -2147,7 +2147,7 @@ class FormWithActsLikeFormForTest < FormWithTest
       concat post_form.text_area(:body)
 
       concat fields(:parent_post, model: @post) { |parent_fields|
-        concat parent_fields.check_box(:secret)
+        concat parent_fields.checkbox(:secret)
       }
     end
 
@@ -2209,7 +2209,7 @@ class FormWithActsLikeFormForTest < FormWithTest
     form_with(model: @post, builder: LabelledFormBuilder) do |f|
       concat f.text_field(:title)
       concat f.text_area(:body)
-      concat f.check_box(:secret)
+      concat f.checkbox(:secret)
     end
 
     expected = whole_form("/posts/123", method: "patch") do
@@ -2228,7 +2228,7 @@ class FormWithActsLikeFormForTest < FormWithTest
     form_with(model: @post) do |f|
       concat f.text_field(:title)
       concat f.text_area(:body)
-      concat f.check_box(:secret)
+      concat f.checkbox(:secret)
     end
 
     expected = whole_form("/posts/123", method: "patch") do
@@ -2287,7 +2287,7 @@ class FormWithActsLikeFormForTest < FormWithTest
     @rendered = fields(:post, model: @post, builder: LabelledFormBuilder) do |f|
       concat f.text_field(:title)
       concat f.text_area(:body)
-      concat f.check_box(:secret)
+      concat f.checkbox(:secret)
     end
 
     expected =

--- a/actionview/test/template/form_helper_test.rb
+++ b/actionview/test/template/form_helper_test.rb
@@ -648,208 +648,208 @@ class FormHelperTest < ActionView::TestCase
     )
   end
 
-  def test_check_box_is_html_safe
-    assert_predicate check_box("post", "secret"), :html_safe?
+  def test_checkbox_is_html_safe
+    assert_predicate checkbox("post", "secret"), :html_safe?
   end
 
-  def test_check_box_checked_if_object_value_is_same_that_check_value
+  def test_checkbox_checked_if_object_value_is_same_that_check_value
     assert_dom_equal(
       '<input name="post[secret]" type="hidden" value="0" autocomplete="off" /><input checked="checked" id="post_secret" name="post[secret]" type="checkbox" value="1" />',
-      check_box("post", "secret")
+      checkbox("post", "secret")
     )
   end
 
-  def test_check_box_not_checked_if_object_value_is_same_that_unchecked_value
+  def test_checkbox_not_checked_if_object_value_is_same_that_unchecked_value
     @post.secret = 0
     assert_dom_equal(
       '<input name="post[secret]" type="hidden" value="0" autocomplete="off" /><input id="post_secret" name="post[secret]" type="checkbox" value="1" />',
-      check_box("post", "secret")
+      checkbox("post", "secret")
     )
   end
 
-  def test_check_box_checked_if_option_checked_is_present
+  def test_checkbox_checked_if_option_checked_is_present
     assert_dom_equal(
       '<input name="post[secret]" type="hidden" value="0" autocomplete="off" /><input checked="checked" id="post_secret" name="post[secret]" type="checkbox" value="1" />',
-      check_box("post", "secret", "checked" => "checked")
+      checkbox("post", "secret", "checked" => "checked")
     )
   end
 
-  def test_check_box_checked_if_object_value_is_true
+  def test_checkbox_checked_if_object_value_is_true
     @post.secret = true
     assert_dom_equal(
       '<input name="post[secret]" type="hidden" value="0" autocomplete="off" /><input checked="checked" id="post_secret" name="post[secret]" type="checkbox" value="1" />',
-      check_box("post", "secret")
+      checkbox("post", "secret")
     )
 
     assert_dom_equal(
       '<input name="post[secret]" type="hidden" value="0" autocomplete="off" /><input checked="checked" id="post_secret" name="post[secret]" type="checkbox" value="1" />',
-      check_box("post", "secret?")
+      checkbox("post", "secret?")
     )
   end
 
-  def test_check_box_checked_if_object_value_includes_checked_value
+  def test_checkbox_checked_if_object_value_includes_checked_value
     @post.secret = ["0"]
     assert_dom_equal(
       '<input name="post[secret]" type="hidden" value="0" autocomplete="off" /><input id="post_secret" name="post[secret]" type="checkbox" value="1" />',
-      check_box("post", "secret")
+      checkbox("post", "secret")
     )
 
     @post.secret = ["1"]
     assert_dom_equal(
       '<input name="post[secret]" type="hidden" value="0" autocomplete="off" /><input checked="checked" id="post_secret" name="post[secret]" type="checkbox" value="1" />',
-      check_box("post", "secret")
+      checkbox("post", "secret")
     )
 
     @post.secret = Set.new(["1"])
     assert_dom_equal(
       '<input name="post[secret]" type="hidden" value="0" autocomplete="off" /><input checked="checked" id="post_secret" name="post[secret]" type="checkbox" value="1" />',
-      check_box("post", "secret")
+      checkbox("post", "secret")
     )
   end
 
-  def test_check_box_with_include_hidden_false
+  def test_checkbox_with_include_hidden_false
     @post.secret = false
     assert_dom_equal(
       '<input id="post_secret" name="post[secret]" type="checkbox" value="1" />',
-      check_box("post", "secret", include_hidden: false)
+      checkbox("post", "secret", include_hidden: false)
     )
   end
 
-  def test_check_box_with_explicit_checked_and_unchecked_values_when_object_value_is_string
+  def test_checkbox_with_explicit_checked_and_unchecked_values_when_object_value_is_string
     @post.secret = "on"
     assert_dom_equal(
       '<input name="post[secret]" type="hidden" value="off" autocomplete="off" /><input checked="checked" id="post_secret" name="post[secret]" type="checkbox" value="on" />',
-      check_box("post", "secret", {}, "on", "off")
+      checkbox("post", "secret", {}, "on", "off")
     )
 
     @post.secret = "off"
     assert_dom_equal(
       '<input name="post[secret]" type="hidden" value="off" autocomplete="off" /><input id="post_secret" name="post[secret]" type="checkbox" value="on" />',
-      check_box("post", "secret", {}, "on", "off")
+      checkbox("post", "secret", {}, "on", "off")
     )
   end
 
-  def test_check_box_with_explicit_checked_and_unchecked_values_when_object_value_is_boolean
+  def test_checkbox_with_explicit_checked_and_unchecked_values_when_object_value_is_boolean
     @post.secret = false
     assert_dom_equal(
       '<input name="post[secret]" type="hidden" value="true" autocomplete="off" /><input checked="checked" id="post_secret" name="post[secret]" type="checkbox" value="false" />',
-      check_box("post", "secret", {}, false, true)
+      checkbox("post", "secret", {}, false, true)
     )
 
     @post.secret = true
     assert_dom_equal(
       '<input name="post[secret]" type="hidden" value="true" autocomplete="off" /><input id="post_secret" name="post[secret]" type="checkbox" value="false" />',
-      check_box("post", "secret", {}, false, true)
+      checkbox("post", "secret", {}, false, true)
     )
   end
 
-  def test_check_box_with_explicit_checked_and_unchecked_values_when_object_value_is_integer
+  def test_checkbox_with_explicit_checked_and_unchecked_values_when_object_value_is_integer
     @post.secret = 0
     assert_dom_equal(
       '<input name="post[secret]" type="hidden" value="1" autocomplete="off" /><input checked="checked" id="post_secret" name="post[secret]" type="checkbox" value="0" />',
-      check_box("post", "secret", {}, 0, 1)
+      checkbox("post", "secret", {}, 0, 1)
     )
 
     @post.secret = 1
     assert_dom_equal(
       '<input name="post[secret]" type="hidden" value="1" autocomplete="off" /><input id="post_secret" name="post[secret]" type="checkbox" value="0" />',
-      check_box("post", "secret", {}, 0, 1)
+      checkbox("post", "secret", {}, 0, 1)
     )
 
     @post.secret = 2
     assert_dom_equal(
       '<input name="post[secret]" type="hidden" value="1" autocomplete="off" /><input id="post_secret" name="post[secret]" type="checkbox" value="0" />',
-      check_box("post", "secret", {}, 0, 1)
+      checkbox("post", "secret", {}, 0, 1)
     )
   end
 
-  def test_check_box_with_explicit_checked_and_unchecked_values_when_object_value_is_float
+  def test_checkbox_with_explicit_checked_and_unchecked_values_when_object_value_is_float
     @post.secret = 0.0
     assert_dom_equal(
       '<input name="post[secret]" type="hidden" value="1" autocomplete="off" /><input checked="checked" id="post_secret" name="post[secret]" type="checkbox" value="0" />',
-      check_box("post", "secret", {}, 0, 1)
+      checkbox("post", "secret", {}, 0, 1)
     )
 
     @post.secret = 1.1
     assert_dom_equal(
       '<input name="post[secret]" type="hidden" value="1" autocomplete="off" /><input id="post_secret" name="post[secret]" type="checkbox" value="0" />',
-      check_box("post", "secret", {}, 0, 1)
+      checkbox("post", "secret", {}, 0, 1)
     )
 
     @post.secret = 2.2
     assert_dom_equal(
       '<input name="post[secret]" type="hidden" value="1" autocomplete="off" /><input id="post_secret" name="post[secret]" type="checkbox" value="0" />',
-      check_box("post", "secret", {}, 0, 1)
+      checkbox("post", "secret", {}, 0, 1)
     )
   end
 
-  def test_check_box_with_explicit_checked_and_unchecked_values_when_object_value_is_big_decimal
+  def test_checkbox_with_explicit_checked_and_unchecked_values_when_object_value_is_big_decimal
     @post.secret = BigDecimal(0)
     assert_dom_equal(
       '<input name="post[secret]" type="hidden" value="1" autocomplete="off" /><input checked="checked" id="post_secret" name="post[secret]" type="checkbox" value="0" />',
-      check_box("post", "secret", {}, 0, 1)
+      checkbox("post", "secret", {}, 0, 1)
     )
 
     @post.secret = BigDecimal(1)
     assert_dom_equal(
       '<input name="post[secret]" type="hidden" value="1" autocomplete="off" /><input id="post_secret" name="post[secret]" type="checkbox" value="0" />',
-      check_box("post", "secret", {}, 0, 1)
+      checkbox("post", "secret", {}, 0, 1)
     )
 
     @post.secret = BigDecimal(2.2, 1)
     assert_dom_equal(
       '<input name="post[secret]" type="hidden" value="1" autocomplete="off" /><input id="post_secret" name="post[secret]" type="checkbox" value="0" />',
-      check_box("post", "secret", {}, 0, 1)
+      checkbox("post", "secret", {}, 0, 1)
     )
   end
 
-  def test_check_box_with_nil_unchecked_value
+  def test_checkbox_with_nil_unchecked_value
     @post.secret = "on"
     assert_dom_equal(
       '<input checked="checked" id="post_secret" name="post[secret]" type="checkbox" value="on" />',
-      check_box("post", "secret", {}, "on", nil)
+      checkbox("post", "secret", {}, "on", nil)
     )
   end
 
-  def test_check_box_with_nil_unchecked_value_is_html_safe
-    assert_predicate check_box("post", "secret", {}, "on", nil), :html_safe?
+  def test_checkbox_with_nil_unchecked_value_is_html_safe
+    assert_predicate checkbox("post", "secret", {}, "on", nil), :html_safe?
   end
 
-  def test_check_box_with_multiple_behavior
+  def test_checkbox_with_multiple_behavior
     @post.comment_ids = [2, 3]
     assert_dom_equal(
       '<input name="post[comment_ids][]" type="hidden" value="0" autocomplete="off" /><input id="post_comment_ids_1" name="post[comment_ids][]" type="checkbox" value="1" />',
-      check_box("post", "comment_ids", { multiple: true }, 1)
+      checkbox("post", "comment_ids", { multiple: true }, 1)
     )
     assert_dom_equal(
       '<input name="post[comment_ids][]" type="hidden" value="0" autocomplete="off" /><input checked="checked" id="post_comment_ids_3" name="post[comment_ids][]" type="checkbox" value="3" />',
-      check_box("post", "comment_ids", { multiple: true }, 3)
+      checkbox("post", "comment_ids", { multiple: true }, 3)
     )
   end
 
-  def test_check_box_with_multiple_behavior_and_index
+  def test_checkbox_with_multiple_behavior_and_index
     @post.comment_ids = [2, 3]
     assert_dom_equal(
       '<input name="post[foo][comment_ids][]" type="hidden" value="0" autocomplete="off" /><input id="post_foo_comment_ids_1" name="post[foo][comment_ids][]" type="checkbox" value="1" />',
-      check_box("post", "comment_ids", { multiple: true, index: "foo" }, 1)
+      checkbox("post", "comment_ids", { multiple: true, index: "foo" }, 1)
     )
     assert_dom_equal(
       '<input name="post[bar][comment_ids][]" type="hidden" value="0" autocomplete="off" /><input checked="checked" id="post_bar_comment_ids_3" name="post[bar][comment_ids][]" type="checkbox" value="3" />',
-      check_box("post", "comment_ids", { multiple: true, index: "bar" }, 3)
+      checkbox("post", "comment_ids", { multiple: true, index: "bar" }, 3)
     )
   end
 
   def test_checkbox_disabled_disables_hidden_field
     assert_dom_equal(
       '<input name="post[secret]" type="hidden" value="0" disabled="disabled" autocomplete="off"/><input checked="checked" disabled="disabled" id="post_secret" name="post[secret]" type="checkbox" value="1" />',
-      check_box("post", "secret", disabled: true)
+      checkbox("post", "secret", disabled: true)
     )
   end
 
   def test_checkbox_form_html5_attribute
     assert_dom_equal(
       '<input form="new_form" name="post[secret]" type="hidden" value="0" autocomplete="off" /><input checked="checked" form="new_form" id="post_secret" name="post[secret]" type="checkbox" value="1" />',
-      check_box("post", "secret", form: "new_form")
+      checkbox("post", "secret", form: "new_form")
     )
   end
 
@@ -1408,7 +1408,7 @@ class FormHelperTest < ActionView::TestCase
     )
     assert_dom_equal(
       '<input name="i mean it" type="hidden" value="0" autocomplete="off" /><input checked="checked" id="post_secret" name="i mean it" type="checkbox" value="1" />',
-      check_box("post", "secret", "name" => "i mean it")
+      checkbox("post", "secret", "name" => "i mean it")
     )
     assert_dom_equal(
       text_field("post", "title", "name" => "dont guess"),
@@ -1419,8 +1419,8 @@ class FormHelperTest < ActionView::TestCase
       text_area("post", "body", name: "really!")
     )
     assert_dom_equal(
-      check_box("post", "secret", "name" => "i mean it"),
-      check_box("post", "secret", name: "i mean it")
+      checkbox("post", "secret", "name" => "i mean it"),
+      checkbox("post", "secret", name: "i mean it")
     )
   end
 
@@ -1435,7 +1435,7 @@ class FormHelperTest < ActionView::TestCase
     )
     assert_dom_equal(
       '<input name="post[secret]" type="hidden" value="0" autocomplete="off" /><input checked="checked" id="i mean it" name="post[secret]" type="checkbox" value="1" />',
-      check_box("post", "secret", "id" => "i mean it")
+      checkbox("post", "secret", "id" => "i mean it")
     )
     assert_dom_equal(
       text_field("post", "title", "id" => "dont guess"),
@@ -1446,8 +1446,8 @@ class FormHelperTest < ActionView::TestCase
       text_area("post", "body", id: "really!")
     )
     assert_dom_equal(
-      check_box("post", "secret", "id" => "i mean it"),
-      check_box("post", "secret", id: "i mean it")
+      checkbox("post", "secret", "id" => "i mean it"),
+      checkbox("post", "secret", id: "i mean it")
     )
   end
 
@@ -1462,7 +1462,7 @@ class FormHelperTest < ActionView::TestCase
     )
     assert_dom_equal(
       '<input name="post[secret]" type="hidden" value="0" autocomplete="off" /><input checked="checked" name="post[secret]" type="checkbox" value="1" />',
-      check_box("post", "secret", "id" => nil)
+      checkbox("post", "secret", "id" => nil)
     )
     assert_dom_equal(
       '<input type="radio" name="post[secret]" value="0" />',
@@ -1481,8 +1481,8 @@ class FormHelperTest < ActionView::TestCase
       text_area("post", "body", id: nil)
     )
     assert_dom_equal(
-      check_box("post", "secret", "id" => nil),
-      check_box("post", "secret", id: nil)
+      checkbox("post", "secret", "id" => nil),
+      checkbox("post", "secret", id: nil)
     )
     assert_dom_equal(
       radio_button("post", "secret", "0", "id" => nil),
@@ -1501,7 +1501,7 @@ class FormHelperTest < ActionView::TestCase
     )
     assert_dom_equal(
       '<input name="post[5][secret]" type="hidden" value="0" autocomplete="off" /><input checked="checked" name="post[5][secret]" type="checkbox" value="1" id="post_5_secret" />',
-      check_box("post", "secret", "index" => 5)
+      checkbox("post", "secret", "index" => 5)
     )
     assert_dom_equal(
       text_field("post", "title", "index" => 5),
@@ -1512,8 +1512,8 @@ class FormHelperTest < ActionView::TestCase
       text_area("post", "body", "index" => 5)
     )
     assert_dom_equal(
-      check_box("post", "secret", "index" => 5),
-      check_box("post", "secret", "index" => 5)
+      checkbox("post", "secret", "index" => 5),
+      checkbox("post", "secret", "index" => 5)
     )
   end
 
@@ -1528,7 +1528,7 @@ class FormHelperTest < ActionView::TestCase
     )
     assert_dom_equal(
       '<input name="post[5][secret]" type="hidden" value="0" autocomplete="off" /><input checked="checked" name="post[5][secret]" type="checkbox" value="1" />',
-      check_box("post", "secret", "index" => 5, "id" => nil)
+      checkbox("post", "secret", "index" => 5, "id" => nil)
     )
     assert_dom_equal(
       text_field("post", "title", "index" => 5, "id" => nil),
@@ -1539,8 +1539,8 @@ class FormHelperTest < ActionView::TestCase
       text_area("post", "body", index: 5, id: nil)
     )
     assert_dom_equal(
-      check_box("post", "secret", "index" => 5, "id" => nil),
-      check_box("post", "secret", index: 5, id: nil)
+      checkbox("post", "secret", "index" => 5, "id" => nil),
+      checkbox("post", "secret", index: 5, id: nil)
     )
   end
 
@@ -1560,7 +1560,7 @@ class FormHelperTest < ActionView::TestCase
     )
     assert_dom_equal(
       %{<input name="post[#{pid}][secret]" type="hidden" value="0" autocomplete="off" /><input checked="checked" id="post_#{pid}_secret" name="post[#{pid}][secret]" type="checkbox" value="1" />},
-      check_box("post[]", "secret")
+      checkbox("post[]", "secret")
     )
     assert_dom_equal(
       %{<input checked="checked" id="post_#{pid}_title_hello_world" name="post[#{pid}][title]" type="radio" value="Hello World" />},
@@ -1584,7 +1584,7 @@ class FormHelperTest < ActionView::TestCase
     )
     assert_dom_equal(
       %{<input name="post[#{pid}][secret]" type="hidden" value="0" autocomplete="off" /><input checked="checked" name="post[#{pid}][secret]" type="checkbox" value="1" />},
-      check_box("post[]", "secret", id: nil)
+      checkbox("post[]", "secret", id: nil)
     )
     assert_dom_equal(
       %{<input checked="checked" name="post[#{pid}][title]" type="radio" value="Hello World" />},
@@ -1622,7 +1622,7 @@ class FormHelperTest < ActionView::TestCase
       concat f.label(:title) { "The Title" }
       concat f.text_field(:title)
       concat f.text_area(:body)
-      concat f.check_box(:secret)
+      concat f.checkbox(:secret)
       concat f.submit("Create post")
       concat f.button("Create post")
       concat f.button {
@@ -1652,7 +1652,7 @@ class FormHelperTest < ActionView::TestCase
       concat f.label(:title) { "The Title" }
       concat f.text_field(:title)
       concat f.text_area(:body)
-      concat f.check_box(:secret)
+      concat f.checkbox(:secret)
       concat f.submit("Create post")
       concat f.button("Create post")
       concat f.button {
@@ -2056,12 +2056,12 @@ class FormHelperTest < ActionView::TestCase
     assert_dom_equal expected, @rendered
   end
 
-  def test_form_for_with_collection_check_boxes
+  def test_form_for_with_collection_checkboxes
     post = Post.new
     def post.tag_ids; [1, 3]; end
     collection = (1..3).map { |i| [i, "Tag #{i}"] }
     form_for(post) do |f|
-      concat f.collection_check_boxes(:tag_ids, collection, :first, :last)
+      concat f.collection_checkboxes(:tag_ids, collection, :first, :last)
     end
 
     expected = whole_form("/posts", "new_post", "new_post") do
@@ -2077,15 +2077,15 @@ class FormHelperTest < ActionView::TestCase
     assert_dom_equal expected, @rendered
   end
 
-  def test_form_for_with_collection_check_boxes_with_custom_builder_block
+  def test_form_for_with_collection_checkboxes_with_custom_builder_block
     post = Post.new
     def post.tag_ids; [1, 3]; end
     collection = (1..3).map { |i| [i, "Tag #{i}"] }
     form_for(post) do |f|
-      rendered_check_boxes = f.collection_check_boxes(:tag_ids, collection, :first, :last) do |b|
-        b.label { b.check_box + b.text }
+      rendered_checkboxes = f.collection_checkboxes(:tag_ids, collection, :first, :last) do |b|
+        b.label { b.checkbox + b.text }
       end
-      concat rendered_check_boxes
+      concat rendered_checkboxes
     end
 
     expected = whole_form("/posts", "new_post", "new_post") do
@@ -2104,17 +2104,17 @@ class FormHelperTest < ActionView::TestCase
     assert_dom_equal expected, @rendered
   end
 
-  def test_form_for_with_collection_check_boxes_with_custom_builder_block_does_not_leak_the_template
+  def test_form_for_with_collection_checkboxes_with_custom_builder_block_does_not_leak_the_template
     post = Post.new
     def post.tag_ids; [1, 3]; end
     def post.id; 1; end
     collection = (1..3).map { |i| [i, "Tag #{i}"] }
 
     form_for(post) do |f|
-      rendered_check_boxes = f.collection_check_boxes(:tag_ids, collection, :first, :last) do |b|
-        b.label { b.check_box + b.text }
+      rendered_checkboxes = f.collection_checkboxes(:tag_ids, collection, :first, :last) do |b|
+        b.label { b.checkbox + b.text }
       end
-      concat rendered_check_boxes
+      concat rendered_checkboxes
       concat f.hidden_field :id
     end
 
@@ -2135,13 +2135,13 @@ class FormHelperTest < ActionView::TestCase
     assert_dom_equal expected, @rendered
   end
 
-  def test_form_with_namespace_and_with_collection_check_boxes
+  def test_form_with_namespace_and_with_collection_checkboxes
     post = Post.new
     def post.tag_ids; [1]; end
     collection = [[1, "Tag 1"]]
 
     form_for(post, namespace: "foo") do |f|
-      concat f.collection_check_boxes(:tag_ids, collection, :first, :last)
+      concat f.collection_checkboxes(:tag_ids, collection, :first, :last)
     end
 
     expected = whole_form("/posts", "foo_new_post", "new_post") do
@@ -2153,13 +2153,13 @@ class FormHelperTest < ActionView::TestCase
     assert_dom_equal expected, @rendered
   end
 
-  def test_form_with_index_and_with_collection_check_boxes
+  def test_form_with_index_and_with_collection_checkboxes
     post = Post.new
     def post.tag_ids; [1]; end
     collection = [[1, "Tag 1"]]
 
     form_for(post, index: "1") do |f|
-      concat f.collection_check_boxes(:tag_ids, collection, :first, :last)
+      concat f.collection_checkboxes(:tag_ids, collection, :first, :last)
     end
 
     expected = whole_form("/posts", "new_post", "new_post") do
@@ -2262,7 +2262,7 @@ class FormHelperTest < ActionView::TestCase
       concat f.label(:title, class: "post_title")
       concat f.text_field(:title)
       concat f.text_area(:body)
-      concat f.check_box(:secret)
+      concat f.checkbox(:secret)
       concat f.submit("Create post")
     end
 
@@ -2295,7 +2295,7 @@ class FormHelperTest < ActionView::TestCase
     form_for(@post, url: "/", html: { id: "create-post", method: :delete }) do |f|
       concat f.text_field(:title)
       concat f.text_area(:body)
-      concat f.check_box(:secret)
+      concat f.checkbox(:secret)
     end
 
     expected = whole_form("/", "create-post", "edit_post", method: "delete") do
@@ -2312,7 +2312,7 @@ class FormHelperTest < ActionView::TestCase
     form_for(@post, url: "/", method: :delete, html: { id: "create-post" }) do |f|
       concat f.text_field(:title)
       concat f.text_area(:body)
-      concat f.check_box(:secret)
+      concat f.checkbox(:secret)
     end
 
     expected = whole_form("/", "create-post", "edit_post", method: "delete") do
@@ -2343,7 +2343,7 @@ class FormHelperTest < ActionView::TestCase
     form_for(@post, url: "/", remote: true, html: { id: "create-post", method: :patch }) do |f|
       concat f.text_field(:title)
       concat f.text_area(:body)
-      concat f.check_box(:secret)
+      concat f.checkbox(:secret)
     end
 
     expected = whole_form("/", "create-post", "edit_post", method: "patch", remote: true) do
@@ -2412,7 +2412,7 @@ class FormHelperTest < ActionView::TestCase
     form_for(@post, url: "/", html: { remote: true, id: "create-post", method: :patch }) do |f|
       concat f.text_field(:title)
       concat f.text_area(:body)
-      concat f.check_box(:secret)
+      concat f.checkbox(:secret)
     end
 
     expected = whole_form("/", "create-post", "edit_post", method: "patch", remote: true) do
@@ -2431,7 +2431,7 @@ class FormHelperTest < ActionView::TestCase
       form_for(@post, remote: true) do |f|
         concat f.text_field(:title)
         concat f.text_area(:body)
-        concat f.check_box(:secret)
+        concat f.checkbox(:secret)
       end
 
       expected = whole_form("/posts", "new_post", "new_post", remote: true) do
@@ -2449,7 +2449,7 @@ class FormHelperTest < ActionView::TestCase
     form_for(:post, html: { id: "create-post" }) do |f|
       concat f.text_field(:title)
       concat f.text_area(:body)
-      concat f.check_box(:secret)
+      concat f.checkbox(:secret)
     end
 
     expected = whole_form("/", "create-post") do
@@ -2467,7 +2467,7 @@ class FormHelperTest < ActionView::TestCase
       concat f.label(:title)
       concat f.text_field(:title)
       concat f.text_area(:body)
-      concat f.check_box(:secret)
+      concat f.checkbox(:secret)
     end
 
     expected = whole_form("/posts/123", "edit_post[]", "edit_post[]", method: "patch") do
@@ -2485,7 +2485,7 @@ class FormHelperTest < ActionView::TestCase
     form_for(@post, as: "post[]", index: nil) do |f|
       concat f.text_field(:title)
       concat f.text_area(:body)
-      concat f.check_box(:secret)
+      concat f.checkbox(:secret)
     end
 
     expected = whole_form("/posts/123", "edit_post[]", "edit_post[]", method: "patch") do
@@ -2550,7 +2550,7 @@ class FormHelperTest < ActionView::TestCase
     form_for(@post, namespace: "namespace") do |f|
       concat f.text_field(:title)
       concat f.text_area(:body)
-      concat f.check_box(:secret)
+      concat f.checkbox(:secret)
     end
 
     expected = whole_form("/posts/123", "namespace_edit_post_123", "edit_post", method: "patch") do
@@ -3661,7 +3661,7 @@ class FormHelperTest < ActionView::TestCase
     @rendered = fields_for(:post, @post) do |f|
       concat f.text_field(:title)
       concat f.text_area(:body)
-      concat f.check_box(:secret)
+      concat f.checkbox(:secret)
     end
 
     expected =
@@ -3683,7 +3683,7 @@ class FormHelperTest < ActionView::TestCase
     @rendered = fields_for("post[]", @post) do |f|
       concat f.text_field(:title)
       concat f.text_area(:body)
-      concat f.check_box(:secret)
+      concat f.checkbox(:secret)
     end
 
     expected =
@@ -3705,7 +3705,7 @@ class FormHelperTest < ActionView::TestCase
     @rendered = fields_for("post[]", @post, index: nil) do |f|
       concat f.text_field(:title)
       concat f.text_area(:body)
-      concat f.check_box(:secret)
+      concat f.checkbox(:secret)
     end
 
     expected =
@@ -3727,7 +3727,7 @@ class FormHelperTest < ActionView::TestCase
     @rendered = fields_for("post[]", @post, index: "abc") do |f|
       concat f.text_field(:title)
       concat f.text_area(:body)
-      concat f.check_box(:secret)
+      concat f.checkbox(:secret)
     end
 
     expected =
@@ -3743,7 +3743,7 @@ class FormHelperTest < ActionView::TestCase
     @rendered = fields_for(:post) do |f|
       concat f.text_field(:title)
       concat f.text_area(:body)
-      concat f.check_box(:secret)
+      concat f.checkbox(:secret)
     end
 
     expected =
@@ -3759,7 +3759,7 @@ class FormHelperTest < ActionView::TestCase
     @rendered = fields_for(@post) do |f|
       concat f.text_field(:title)
       concat f.text_area(:body)
-      concat f.check_box(:secret)
+      concat f.checkbox(:secret)
     end
 
     expected =
@@ -3803,7 +3803,7 @@ class FormHelperTest < ActionView::TestCase
       concat post_form.text_area(:body)
 
       concat fields_for(:parent_post, @post) { |parent_fields|
-        concat parent_fields.check_box(:secret)
+        concat parent_fields.checkbox(:secret)
       }
     end
 
@@ -3864,7 +3864,7 @@ class FormHelperTest < ActionView::TestCase
     form_for(@post, builder: LabelledFormBuilder) do |f|
       concat f.text_field(:title)
       concat f.text_area(:body)
-      concat f.check_box(:secret)
+      concat f.checkbox(:secret)
     end
 
     expected = whole_form("/posts/123", "edit_post_123", "edit_post", method: "patch") do
@@ -3883,7 +3883,7 @@ class FormHelperTest < ActionView::TestCase
     form_for(@post) do |f|
       concat f.text_field(:title)
       concat f.text_area(:body)
-      concat f.check_box(:secret)
+      concat f.checkbox(:secret)
     end
 
     expected = whole_form("/posts/123", "edit_post_123", "edit_post", method: "patch") do
@@ -3942,7 +3942,7 @@ class FormHelperTest < ActionView::TestCase
     @rendered = fields_for(:post, @post, builder: LabelledFormBuilder) do |f|
       concat f.text_field(:title)
       concat f.text_area(:body)
-      concat f.check_box(:secret)
+      concat f.checkbox(:secret)
     end
 
     expected =

--- a/actionview/test/template/form_tag_helper_test.rb
+++ b/actionview/test/template/form_tag_helper_test.rb
@@ -70,56 +70,56 @@ class FormTagHelperTest < ActionView::TestCase
 
   VALID_HTML_ID = /^[A-Za-z][-_:.A-Za-z0-9]*$/ # see http://www.w3.org/TR/html4/types.html#type-name
 
-  def test_check_box_tag
-    actual = check_box_tag "admin"
+  def test_checkbox_tag
+    actual = checkbox_tag "admin"
     expected = %(<input id="admin" name="admin" type="checkbox" value="1" />)
     assert_dom_equal expected, actual
   end
 
-  def test_check_box_tag_disabled
-    actual = check_box_tag "admin", "1", false, disabled: true
+  def test_checkbox_tag_disabled
+    actual = checkbox_tag "admin", "1", false, disabled: true
     expected = %(<input id="admin" disabled="disabled" name="admin" type="checkbox" value="1" />)
     assert_dom_equal expected, actual
   end
 
-  def test_check_box_tag_default_checked
-    actual = check_box_tag "admin", "1", true
+  def test_checkbox_tag_default_checked
+    actual = checkbox_tag "admin", "1", true
     expected = %(<input id="admin" checked="checked" name="admin" type="checkbox" value="1" />)
     assert_dom_equal expected, actual
   end
 
-  def test_check_box_tag_checked_kwarg_true
-    actual = check_box_tag "admin", "yes", checked: true
+  def test_checkbox_tag_checked_kwarg_true
+    actual = checkbox_tag "admin", "yes", checked: true
     expected = %(<input id="admin" checked="checked" name="admin" type="checkbox" value="yes" />)
     assert_dom_equal expected, actual
   end
 
-  def test_check_box_tag_checked_kwarg_false
-    actual = check_box_tag "admin", "1", checked: false
+  def test_checkbox_tag_checked_kwarg_false
+    actual = checkbox_tag "admin", "1", checked: false
     expected = %(<input id="admin" name="admin" type="checkbox" value="1" />)
     assert_dom_equal expected, actual
   end
 
-  def test_check_box_tag_checked_kwarg_false_and_disabled
-    actual = check_box_tag "admin", "1", checked: false, disabled: true
+  def test_checkbox_tag_checked_kwarg_false_and_disabled
+    actual = checkbox_tag "admin", "1", checked: false, disabled: true
     expected = %(<input id="admin" name="admin" type="checkbox" value="1" disabled="disabled" />)
     assert_dom_equal expected, actual
   end
 
-  def test_check_box_tag_checked_kwarg_true_value_argument_skipped
-    actual = check_box_tag "admin", checked: true
+  def test_checkbox_tag_checked_kwarg_true_value_argument_skipped
+    actual = checkbox_tag "admin", checked: true
     expected = %(<input id="admin" checked="checked" name="admin" type="checkbox" value="1" />)
     assert_dom_equal expected, actual
   end
 
-  def test_check_box_tag_value_kwarg
-    actual = check_box_tag "admin", value: "0", checked: true
+  def test_checkbox_tag_value_kwarg
+    actual = checkbox_tag "admin", value: "0", checked: true
     expected = %(<input id="admin" name="admin" type="checkbox" value="0" checked="checked" />)
     assert_dom_equal expected, actual
   end
 
-  def test_check_box_tag_id_sanitized
-    label_elem = root_elem(check_box_tag("project[2][admin]"))
+  def test_checkbox_tag_id_sanitized
+    label_elem = root_elem(checkbox_tag("project[2][admin]"))
     assert_match VALID_HTML_ID, label_elem["id"]
   end
 
@@ -658,8 +658,8 @@ class FormTagHelperTest < ActionView::TestCase
   end
 
   def test_boolean_options
-    assert_dom_equal %(<input checked="checked" disabled="disabled" id="admin" name="admin" readonly="readonly" type="checkbox" value="1" />), check_box_tag("admin", 1, true, "disabled" => true, :readonly => "yes")
-    assert_dom_equal %(<input checked="checked" id="admin" name="admin" type="checkbox" value="1" />), check_box_tag("admin", 1, true, disabled: false, readonly: nil)
+    assert_dom_equal %(<input checked="checked" disabled="disabled" id="admin" name="admin" readonly="readonly" type="checkbox" value="1" />), checkbox_tag("admin", 1, true, "disabled" => true, :readonly => "yes")
+    assert_dom_equal %(<input checked="checked" id="admin" name="admin" type="checkbox" value="1" />), checkbox_tag("admin", 1, true, disabled: false, readonly: nil)
     assert_dom_equal %(<input type="checkbox" />), tag(:input, type: "checkbox", checked: false)
     assert_dom_equal %(<select id="people" multiple="multiple" name="people[]"><option>david</option></select>), select_tag("people", raw("<option>david</option>"), multiple: true)
     assert_dom_equal %(<select id="people_" multiple="multiple" name="people[]"><option>david</option></select>), select_tag("people[]", raw("<option>david</option>"), multiple: true)

--- a/guides/source/2_3_release_notes.md
+++ b/guides/source/2_3_release_notes.md
@@ -365,7 +365,7 @@ You can write this view in Rails 2.3:
       <% unless order_form.object.new_record? %>
         <div>
           <%= order_form.label :_delete, 'Remove:' %>
-          <%= order_form.check_box :_delete %>
+          <%= order_form.checkbox :_delete %>
         </div>
       <% end %>
     </p>

--- a/guides/source/7_1_release_notes.md
+++ b/guides/source/7_1_release_notes.md
@@ -613,7 +613,7 @@ Please refer to the [Changelog][action-view] for detailed changes.
 
 ### Notable changes
 
-*   `check_box_tag` and `radio_button_tag` now accept `checked` as a keyword argument.
+*   `checkbox_tag` and `radio_button_tag` now accept `checked` as a keyword argument.
 
 *   Add `picture_tag` helper to generate HTML `<picture>` tags.
 

--- a/guides/source/active_support_core_extensions.md
+++ b/guides/source/active_support_core_extensions.md
@@ -2921,7 +2921,7 @@ In case of key collision, the value will be the one most recently inserted into 
 This method may be useful for example to easily accept both symbols and strings as options. For instance `ActionView::Helpers::FormHelper` defines:
 
 ```ruby
-def to_check_box_tag(options = {}, checked_value = "1", unchecked_value = "0")
+def to_checkbox_tag(options = {}, checked_value = "1", unchecked_value = "0")
   options = options.stringify_keys
   options["type"] = "checkbox"
   # ...

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -3157,7 +3157,7 @@ default to _replacing_ the current collection instead of _appending_ to it. Thus
 to support submitting an _empty_ collection, when `multiple_file_field_include_hidden`
 is `true`, the [`file_field`](https://api.rubyonrails.org/classes/ActionView/Helpers/FormBuilder.html#method-i-file_field)
 helper will render an auxiliary hidden field, similar to the auxiliary field
-rendered by the [`check_box`](https://api.rubyonrails.org/classes/ActionView/Helpers/FormBuilder.html#method-i-check_box)
+rendered by the [`checkbox`](https://api.rubyonrails.org/classes/ActionView/Helpers/FormBuilder.html#method-i-checkbox)
 helper.
 
 The default value depends on the `config.load_defaults` target version:

--- a/guides/source/form_helpers.md
+++ b/guides/source/form_helpers.md
@@ -104,11 +104,11 @@ A Checkbox is a form control that allows for a single value to be selected or de
 Here's an example with three checkboxes in a form:
 
 ```erb
-<%= form.check_box :biography %>
+<%= form.checkbox :biography %>
 <%= form.label :biography, "Biography" %>
-<%= form.check_box :romance %>
+<%= form.checkbox :romance %>
 <%= form.label :romance, "Romance" %>
-<%= form.check_box :mystery %>
+<%= form.checkbox :mystery %>
 <%= form.label :mystery, "Mystery" %>
 ```
 
@@ -123,7 +123,7 @@ The above will generate the following:
 <label for="mystery">Mystery</label>
 ```
 
-The first parameter to [`check_box`](https://api.rubyonrails.org/classes/ActionView/Helpers/FormBuilder.html#method-i-check_box) is the name of the input which can be found in the `params` hash. If the user has checked the "Biography" checkbox only, the `params` hash would contain:
+The first parameter to [`checkbox`](https://api.rubyonrails.org/classes/ActionView/Helpers/FormBuilder.html#method-i-checkbox) is the name of the input which can be found in the `params` hash. If the user has checked the "Biography" checkbox only, the `params` hash would contain:
 
 ```ruby
 {
@@ -135,9 +135,9 @@ The first parameter to [`check_box`](https://api.rubyonrails.org/classes/ActionV
 
 You can use `params[:biography]` to check if that checkbox is selected by the user.
 
-The checkbox's values (the values that will appear in `params`) can optionally be specified using the `checked_value` and `unchecked_value` parameters. See the [API documentation](https://api.rubyonrails.org/classes/ActionView/Helpers/FormHelper.html#method-i-check_box) for more details.
+The checkbox's values (the values that will appear in `params`) can optionally be specified using the `checked_value` and `unchecked_value` parameters. See the [API documentation](https://api.rubyonrails.org/classes/ActionView/Helpers/FormHelper.html#method-i-checkbox) for more details.
 
-There is also a `collection_check_boxes`, which you can learn about in the [Collection Related Helpers section](#collection-related-helpers).
+There is also a `collection_checkboxes`, which you can learn about in the [Collection Related Helpers section](#collection-related-helpers).
 
 #### Radio Buttons
 
@@ -698,7 +698,7 @@ Output:
 Collection Related Helpers
 --------------------------
 
-If you need to generate a set of choices from a collection of arbitrary objects, Rails has `collection_select`, `collection_radio_button`, and `collection_check_boxes` helpers.
+If you need to generate a set of choices from a collection of arbitrary objects, Rails has `collection_select`, `collection_radio_button`, and `collection_checkboxes` helpers.
 
 To see when these helpers are useful, suppose you have a `City` model and corresponding `belongs_to :city` association with `Person`:
 
@@ -781,12 +781,12 @@ Output:
 <label for="person_city_id_2">Madrid</label>
 ```
 
-### The `collection_check_boxes` Helper
+### The `collection_checkboxes` Helper
 
-To generate a set of check boxes — for example, to support a `has_and_belongs_to_many` association — we can use [`collection_check_boxes`](https://api.rubyonrails.org/classes/ActionView/Helpers/FormBuilder.html#method-i-collection_check_boxes):
+To generate a set of check boxes — for example, to support a `has_and_belongs_to_many` association — we can use [`collection_checkboxes`](https://api.rubyonrails.org/classes/ActionView/Helpers/FormBuilder.html#method-i-collection_checkboxes):
 
 ```erb
-<%= form.collection_check_boxes :interest_ids, Interest.order(:name), :id, :name %>
+<%= form.collection_checkboxes :interest_ids, Interest.order(:name), :id, :name %>
 ```
 
 Output:
@@ -1034,7 +1034,7 @@ This would result in `params[:person][:addresses]` being an array of hashes. Eac
 
 It's important to note that while hashes can be nested arbitrarily, only one level of "arrayness" is allowed. Arrays can usually be replaced by hashes. For example, instead of an array of model objects, you can have a hash of model objects keyed by their id or similar.
 
-WARNING: Array parameters do not play well with the `check_box` helper. According to the HTML specification unchecked checkboxes submit no value. However it is often convenient for a checkbox to always submit a value. The `check_box` helper fakes this by creating an auxiliary hidden input with the same name. If the checkbox is unchecked only the hidden input is submitted. If it is checked then both are submitted but the value submitted by the checkbox takes precedence. There is a `include_hidden` option that can be set to `false` if you want to omit this hidden field. By default, this option is `true`.
+WARNING: Array parameters do not play well with the `checkbox` helper. According to the HTML specification unchecked checkboxes submit no value. However it is often convenient for a checkbox to always submit a value. The `checkbox` helper fakes this by creating an auxiliary hidden input with the same name. If the checkbox is unchecked only the hidden input is submitted. If it is checked then both are submitted but the value submitted by the checkbox takes precedence. There is a `include_hidden` option that can be set to `false` if you want to omit this hidden field. By default, this option is `true`.
 
 ### Hashes with an Index
 
@@ -1260,7 +1260,7 @@ destroyed. This form allows users to remove addresses:
   <ul>
     <%= form.fields_for :addresses do |addresses_form| %>
       <li>
-        <%= addresses_form.check_box :_destroy %>
+        <%= addresses_form.checkbox :_destroy %>
         <%= addresses_form.label :kind %>
         <%= addresses_form.text_field :kind %>
         ...
@@ -1321,10 +1321,10 @@ At other times, the fields that can be used in the form are limited by an extern
 Using Tag Helpers without a Form Builder
 ----------------------------------------
 
-In case you need to render form fields outside of the context of a form builder, Rails provides tag helpers for common form elements. For example, [`check_box_tag`](https://api.rubyonrails.org/classes/ActionView/Helpers/FormTagHelper.html#method-i-check_box_tag):
+In case you need to render form fields outside of the context of a form builder, Rails provides tag helpers for common form elements. For example, [`checkbox_tag`](https://api.rubyonrails.org/classes/ActionView/Helpers/FormTagHelper.html#method-i-checkbox_tag):
 
 ```erb
-<%= check_box_tag "accept" %>
+<%= checkbox_tag "accept" %>
 ```
 
 Output:

--- a/railties/lib/rails/generators/generated_attribute.rb
+++ b/railties/lib/rails/generators/generated_attribute.rb
@@ -128,7 +128,7 @@ module Rails
                         when :date                     then :date_field
                         when :text                     then :text_area
                         when :rich_text                then :rich_text_area
-                        when :boolean                  then :check_box
+                        when :boolean                  then :checkbox
                         when :attachment, :attachments then :file_field
                         else
                           :text_field

--- a/railties/test/generators/generated_attribute_test.rb
+++ b/railties/test/generators/generated_attribute_test.rb
@@ -53,8 +53,8 @@ class GeneratedAttributeTest < Rails::Generators::TestCase
     assert_field_type :text, :text_area
   end
 
-  def test_field_type_returns_check_box
-    assert_field_type :boolean, :check_box
+  def test_field_type_returns_checkbox
+    assert_field_type :boolean, :checkbox
   end
 
   def test_field_type_returns_rich_text_area


### PR DESCRIPTION
But add aliases for backward compatibility.

Fix: https://github.com/rails/rails/issues/52430
