### PR TITLE
Add bin/dev by default

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/bin/dev.tt
+++ b/railties/lib/rails/generators/rails/app/templates/bin/dev.tt
@@ -1,0 +1,1 @@
+exec "./bin/rails", "server", *ARGV

--- a/railties/test/generators/api_app_generator_test.rb
+++ b/railties/test/generators/api_app_generator_test.rb
@@ -141,6 +141,7 @@ class ApiAppGeneratorTest < Rails::Generators::TestCase
         app/views/layouts
         app/views/layouts/mailer.html.erb
         app/views/layouts/mailer.text.erb
+        bin/dev
         bin/docker-entrypoint
         bin/rails
         bin/rake

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -32,6 +32,7 @@ DEFAULT_APP_FILES = %w(
   app/views/pwa/manifest.json.erb
   app/views/pwa/service-worker.js
   bin/brakeman
+  bin/dev
   bin/docker-entrypoint
   bin/rails
   bin/rake

--- a/railties/test/generators/plugin_generator_test.rb
+++ b/railties/test/generators/plugin_generator_test.rb
@@ -39,6 +39,7 @@ DEFAULT_PLUGIN_FILES = %w(
   test/dummy/app/views/layouts/mailer.text.erb
   test/dummy/app/views/pwa/manifest.json.erb
   test/dummy/app/views/pwa/service-worker.js
+  test/dummy/bin/dev
   test/dummy/bin/rails
   test/dummy/bin/rake
   test/dummy/bin/setup


### PR DESCRIPTION
Then we have a uniform way of starting dev mode whether someone is using jsbundling or importmaps.

This can also be overwritten by teams using docker compose or the like to boot their dev modes.
