### PR TITLE
Optimize `fast_string_to_time`

### DIFF
--- a/activemodel/lib/active_model/type/helpers/timezone.rb
+++ b/activemodel/lib/active_model/type/helpers/timezone.rb
@@ -7,7 +7,11 @@ module ActiveModel
     module Helpers # :nodoc: all
       module Timezone
         def is_utc?
-          ::Time.zone_default.nil? || ::Time.zone_default.match?("UTC")
+          if default = ::Time.zone_default
+            default.name == "UTC"
+          else
+            true
+          end
         end
 
         def default_timezone


### PR DESCRIPTION
Ref: https://github.com/rails/rails/pull/52395

It's slower than it needs to because it contains a workaround for a bug affecting early Ruby 3.2 releases.

It also matches against a regexp which isn't necessary given that starting in Ruby 3.2, `Time.new(str)` is strict enough for this purpose.

```
ruby 3.3.3 (2024-06-12 revision f1c7b6f435) +YJIT [arm64-darwin23]
Warming up --------------------------------------
              bugged   265.827k i/100ms
                good   394.774k i/100ms
Calculating -------------------------------------
              bugged      2.759M (± 5.8%) i/s -     13.823M in   5.031296s
                good      4.128M (± 7.8%) i/s -     20.528M in   5.010538s

Comparison:
              bugged:  2758945.6 i/s
                good:  4128323.9 i/s - 1.50x  faster
```

```ruby
require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"

  gem "benchmark-ips"
end

require 'benchmark/ips'

ISO_DATETIME = /
  \A
  (\d{4})-(\d\d)-(\d\d)(?:T|\s)            # 2020-06-20T
  (\d\d):(\d\d):(\d\d)(?:\.(\d{1,6})\d*)?  # 10:20:30.123456
  (?:(Z(?=\z)|[+-]\d\d)(?::?(\d\d))?)?     # +09:00
  \z
/x

def old(string)
  return unless ISO_DATETIME.match?(string)

  ::Time.at(::Time.new(string, in: "UTC"))
end

def fast(string)
  return unless string.include?("-") #  Time.new("1234") # => 1234-01-01 00:00:00

  ::Time.new(string, in: "UTC")
end

str = "2024-01-01T12:43:13"
Benchmark.ips do |x|
  x.report("bugged") { old(str) }
  x.report("good") { fast(str) }
  x.compare!(order: :baseline)
end
```