### PR TITLE
Keep using log in DatabaseStatements#raw_execute

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -546,23 +546,10 @@ module ActiveRecord
         # Lowest level way to execute a query. Doesn't check for illegal writes, doesn't annotate queries, yields a native result object.
         def raw_execute(sql, name = nil, binds = [], prepare: false, async: false, allow_retry: false, materialize_transactions: true)
           type_casted_binds = type_casted_binds(binds)
-          notification_payload = {
-            sql: sql,
-            name: name,
-            binds: binds,
-            type_casted_binds: type_casted_binds,
-            async: async,
-            connection: self,
-            transaction: current_transaction.user_transaction.presence,
-            statement_name: nil,
-            row_count: 0,
-          }
-          @instrumenter.instrument("sql.active_record", notification_payload) do
+          log(sql, name, binds, type_casted_binds, async: async) do |notification_payload|
             with_raw_connection(allow_retry: allow_retry, materialize_transactions: materialize_transactions) do |conn|
               perform_query(conn, sql, binds, type_casted_binds, prepare: prepare, notification_payload: notification_payload)
             end
-          rescue ActiveRecord::StatementInvalid => ex
-            raise ex.set_query(sql, binds)
           end
         end
 


### PR DESCRIPTION
Follow up to #52428

The payload construction was inlined here in a previous commit, but log wasn't removed or deprecated.

We've been using this as a hook we can override to add some adapter-specific keys. If we want to remove or bypass this at a later date we should probably introduce something that can be overridden like we did for `cache_notification_info`.

cc @byroot @matthewd 