### PR TITLE
lib/assets is too rare of a use case to warrant a default directory

### DIFF
--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -216,7 +216,6 @@ module Rails
     def lib
       empty_directory "lib"
       empty_directory_with_keep_file "lib/tasks"
-      empty_directory_with_keep_file "lib/assets"
     end
 
     def log
@@ -476,7 +475,6 @@ module Rails
       def delete_app_assets_if_api_option
         if options[:api]
           remove_dir "app/assets"
-          remove_dir "lib/assets"
         end
       end
 

--- a/railties/lib/rails/generators/rails/plugin/plugin_generator.rb
+++ b/railties/lib/rails/generators/rails/plugin/plugin_generator.rb
@@ -160,7 +160,7 @@ module Rails
         remove_file ".ruby-version"
         remove_dir "db"
         remove_file "Gemfile"
-        remove_file "lib/tasks"
+        remove_dir "lib"
         remove_file "public/robots.txt"
         remove_file "README.md"
         remove_file "test"

--- a/railties/test/generators/api_app_generator_test.rb
+++ b/railties/test/generators/api_app_generator_test.rb
@@ -185,7 +185,6 @@ class ApiAppGeneratorTest < Rails::Generators::TestCase
          bin/yarn
          config/initializers/assets.rb
          config/initializers/content_security_policy.rb
-         lib/assets
          test/helpers
          public/404.html
          public/422.html

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -58,7 +58,6 @@ DEFAULT_APP_FILES = %w(
   config/routes.rb
   config/storage.yml
   db/seeds.rb
-  lib/assets/.keep
   lib/tasks/.keep
   log/.keep
   public/404.html
@@ -1043,7 +1042,6 @@ class AppGeneratorTest < Rails::Generators::TestCase
       app/controllers/concerns
       app/models/concerns
       lib/tasks
-      lib/assets
       log
       script
       test/fixtures/files

--- a/railties/test/generators/plugin_generator_test.rb
+++ b/railties/test/generators/plugin_generator_test.rb
@@ -59,7 +59,6 @@ DEFAULT_PLUGIN_FILES = %w(
   test/dummy/config/puma.rb
   test/dummy/config/routes.rb
   test/dummy/config/storage.yml
-  test/dummy/lib/assets/.keep
   test/dummy/log/.keep
   test/dummy/public/404.html
   test/dummy/public/406-unsupported-browser.html


### PR DESCRIPTION
Either these assets are part of your app, and should be in app/assets, or you're getting them from a vendor, and they should be in vendor/assets.