### PR TITLE
Use name for Symbol#as_json

### DIFF
--- a/activesupport/lib/active_support/core_ext/object/json.rb
+++ b/activesupport/lib/active_support/core_ext/object/json.rb
@@ -105,7 +105,7 @@ end
 
 class Symbol
   def as_json(options = nil) # :nodoc:
-    to_s
+    name
   end
 end
 


### PR DESCRIPTION
`Symbol#name` is always available now that we require Ruby >= 3.1 (though plausibly this could also return `self`)