### PR TITLE
Avoid eagerly generating Module methods on ActiveRecord::Relation delegation

### DIFF
--- a/activerecord/lib/active_record/relation/delegation.rb
+++ b/activerecord/lib/active_record/relation/delegation.rb
@@ -103,7 +103,7 @@ module ActiveRecord
              :to_sentence, :to_fs, :to_formatted_s, :as_json,
              :shuffle, :split, :slice, :index, :rindex, to: :records
 
-    delegate :primary_key, :with_connection, :connection, :table_name, :transaction, :sanitize_sql_like, :unscoped, to: :model
+    delegate :primary_key, :with_connection, :connection, :table_name, :transaction, :sanitize_sql_like, :unscoped, :name, to: :model
 
     module ClassSpecificRelation # :nodoc:
       extend ActiveSupport::Concern

--- a/activerecord/lib/active_record/scoping/named.rb
+++ b/activerecord/lib/active_record/scoping/named.rb
@@ -193,7 +193,7 @@ module ActiveRecord
             # Most Kernel extends are both singleton and instance methods so
             # respond_to is a fast check, but we don't want to define methods
             # only on the module (ex. Module#name)
-            generate_relation_method(name) if Kernel.respond_to?(name) && (Kernel.instance_methods | Kernel.private_instance_methods).include?(name) && !ActiveRecord::Relation.method_defined?(name)
+            generate_relation_method(name) if Kernel.respond_to?(name) && (Kernel.method_defined?(name) || Kernel.private_method_defined?(name)) && !ActiveRecord::Relation.method_defined?(name)
           end
       end
     end

--- a/activerecord/lib/active_record/scoping/named.rb
+++ b/activerecord/lib/active_record/scoping/named.rb
@@ -190,7 +190,10 @@ module ActiveRecord
 
         private
           def singleton_method_added(name)
-            generate_relation_method(name) if Kernel.respond_to?(name) && !ActiveRecord::Relation.method_defined?(name)
+            # Most Kernel extends are both singleton and instance methods so
+            # respond_to is a fast check, but we don't want to define methods
+            # only on the module (ex. Module#name)
+            generate_relation_method(name) if Kernel.respond_to?(name) && (Kernel.instance_methods | Kernel.private_instance_methods).include?(name) && !ActiveRecord::Relation.method_defined?(name)
           end
       end
     end


### PR DESCRIPTION
We special case singleton methods being added to ActiveRecord::Base subclasses whose names match methods on Kernel so that we can eagerly define them on the ClassSpecificRelation as otherwise we'd never hit method_missing.

Previously, this would also eagerly define methods which were on the Kernel Module's singleton class rather than being defined as instance methods inside the module, which created quite a few unnecessary methods.

Most notably this hit "name" which is defined on the anonymous HABTM classes. I think that case is worth fixing twice (it's an common error involving a complex interaction, that might only be foudn through luck) so the second commit here explicitly delegates `name`. Either commit solves the `name` issue (which I think is the only case I've seen this in the wild)