### PR TITLE
ActiveSupport::FileUpdateChecker with symlink support

### DIFF
--- a/activesupport/lib/active_support/file_update_checker.rb
+++ b/activesupport/lib/active_support/file_update_checker.rb
@@ -146,7 +146,7 @@ module ActiveSupport
         return if hash.empty?
 
         globs = hash.map do |key, value|
-          "#{escape(key)}/**/*#{compile_ext(value)}"
+          "#{escape(key)}/**{,/*/**}/*#{compile_ext(value)}"
         end
         "{#{globs.join(",")}}"
       end

--- a/activesupport/test/file_update_checker_test.rb
+++ b/activesupport/test/file_update_checker_test.rb
@@ -14,4 +14,23 @@ class FileUpdateCheckerTest < ActiveSupport::TestCase
     sleep 0.1 # let's wait a bit to ensure there's a new mtime
     super
   end
+
+  test "should watch symlinked directories" do
+    i = 0
+
+    subdir = tmpfile("subdir")
+    subdir_with_symlink = tmpfile("subdir_with_symlink")
+    symlink = tmpfile("subdir_with_symlink/symlink")
+
+    mkdir(subdir)
+    mkdir(subdir_with_symlink)
+    File.symlink(subdir, symlink)
+
+    checker = new_checker([], subdir_with_symlink => :rb) { i += 1 }
+
+    touch(tmpfile("subdir/foo.rb"))
+
+    assert checker.execute_if_updated
+    assert_equal 1, i
+  end
 end


### PR DESCRIPTION
### Motivation / Background

Our team uses symlinks to share certain logic between projects in our monorepo. However, the current glob in `ActiveSupport::FileUpdateChecker` does not follow symlinked directories, so shared code does not reload in development. 

### Detail

`FileUpdateChecker` uses the glob pattern `**/*` to find watched files, but this pattern does not include symlinked directories in file structure like this

```sh
❯ tree .
.
├── app
│   ├── app.rb
│   └── shared -> ../shared
└── shared
    ├── shared.rb
    └── subshared
        └── subshared.rb
```

I tryed several patterns and `**{,/*/**}/*.rb` seems to be the only correct one

```ruby
irb(main):001> Dir["./app/**/*.rb"]
=> ["./app/app.rb"]
irb(main):002> Dir["./app/***/*.rb"]
=> ["./app/shared/shared.rb"]
irb(main):003> Dir["./app/**/*/**/*.rb"]
=> ["./app/shared/shared.rb", "./app/shared/subshared/subshared.rb"]
irb(main):004> Dir["./app/**{,/*/**}/*.rb"]
=> ["./app/app.rb", "./app/shared/shared.rb", "./app/shared/subshared/subshared.rb"]
```

### Additional information

The final glob was found in https://stackoverflow.com/a/2724048 and is also used in the [parallel_tests](https://github.com/grosser/parallel_tests/blob/v4.7.1/lib/parallel_tests/test/runner.rb#L263) gem

### Checklist

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
