### PR TITLE
Make create_schema / drop_schema reversible in migrations

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Make `create_schema` / `drop_schema` reversible in migrations.
+
+    Previously, `create_schema` and `drop_schema` were irreversible migration operations.
+
+    *Tony Novak*
+
 *   Support batching using custom columns.
 
     ```ruby

--- a/activerecord/lib/active_record/migration/command_recorder.rb
+++ b/activerecord/lib/active_record/migration/command_recorder.rb
@@ -55,6 +55,7 @@ module ActiveRecord
         :add_exclusion_constraint, :remove_exclusion_constraint,
         :add_unique_constraint, :remove_unique_constraint,
         :create_enum, :drop_enum, :rename_enum, :add_enum_value, :rename_enum_value,
+        :create_schema, :drop_schema,
       ]
       include JoinTable
 
@@ -163,7 +164,8 @@ module ActiveRecord
               add_exclusion_constraint: :remove_exclusion_constraint,
               add_unique_constraint: :remove_unique_constraint,
               enable_extension:  :disable_extension,
-              create_enum:       :drop_enum
+              create_enum:       :drop_enum,
+              create_schema:     :drop_schema,
             }.each do |cmd, inv|
               [[inv, cmd], [cmd, inv]].uniq.each do |method, inverse|
                 class_eval <<-EOV, __FILE__, __LINE__ + 1

--- a/activerecord/test/cases/migration/command_recorder_test.rb
+++ b/activerecord/test/cases/migration/command_recorder_test.rb
@@ -376,6 +376,16 @@ module ActiveRecord
         assert_equal [:enable_extension, ["uuid-ossp"], nil], enable
       end
 
+      def test_invert_create_schema
+        disable = @recorder.inverse_of :create_schema, ["myschema"]
+        assert_equal [:drop_schema, ["myschema"], nil], disable
+      end
+
+      def test_invert_drop_schema
+        enable = @recorder.inverse_of :drop_schema, ["myschema"]
+        assert_equal [:create_schema, ["myschema"], nil], enable
+      end
+
       def test_invert_add_foreign_key
         enable = @recorder.inverse_of :add_foreign_key, [:dogs, :people]
         assert_equal [:remove_foreign_key, [:dogs, :people], nil], enable


### PR DESCRIPTION
This PR makes `create_schema` / `drop_schema` reversible in migrations. See #52312 for context.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [ ] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
