### PR TITLE
Watch `config/initializers` in engines

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   For applications using Spring, configure the Spring file watcher to watch initializers in engines defined
+    within the application.
+
+    *Andrew Novoselac* & *Gannon McGibbon*
+
 *   Add sessions generator to give a basic start to an authentication system using database-tracked sessions.
 
 

--- a/railties/lib/rails/engine.rb
+++ b/railties/lib/rails/engine.rb
@@ -649,6 +649,14 @@ module Rails
       end
     end
 
+    initializer :spring_booted do |app|
+      if config.root.to_s.start_with?(app.root.to_s)
+        ActiveSupport.on_load(:spring_booted) do
+          watcher.add config.paths["config/initializers"]
+        end
+      end
+    end
+
     initializer :engines_blank_point do
       # We need this initializer so all extra initializers added in engines are
       # consistently executed after all the initializers above across all engines.


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because Spring watches the root `config/initializers` directory and reloads the application on changes. I would also like it to watch the `config/initializers` directory of engines defined within the application so spring can reboot when they change. Otherwise spring needs to be reloaded manually when modifying configuration of engines.

### Detail

In https://github.com/rails/spring/pull/723 I introduce a `spring_booted` load hook to spring.

In this PR, I use that load hook to add `config/initializers` to the spring file watcher for each engine defined within the application.

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
