### PR TITLE
Edits to the scripts entry in CHANGELOG

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -39,18 +39,20 @@
 
     *DHH*
 
-*   Add script folder and generator
+*   Add a `script` folder to applications, and a scripts generator.
 
-    Add a new script default folder to hold your one-off or general purpose
-    scripts, such as data migration scripts, cleanup scripts, etc.
+    The new `script` folder is meant to hold one-off or general purpose scripts,
+    such as data migration scripts, cleanup scripts, etc.
 
     A new script generator allows you to create such scripts:
 
-      `rails generate script my_script`
+      `bin/rails generate script my_script`
+      `bin/rails generate script data/backfill`
 
     You can run the generated script using:
 
-      `ruby script/my_script.rb`
+      `bundle exec ruby script/my_script.rb`
+      `bundle exec ruby script/data/backfill.rb`
 
     *Jerome Dalbert*, *Haroon Ahmed*
 


### PR DESCRIPTION
Some edits in passing:

* Fixed-width font for `script` when it refers to a directory.
* Punctuation added to the first sentence.
* The first line is a super short summary of the feature. Next, you get into the details. We do not have to repeat "Add" in the second paragraph, the entry has to to read like regular English.
* `rails` → `bin/rails` as per our guidelines.
* Avoids usage of "your" as per our guidelines (no big deal, but revised since I was on it).
* Adds an example with a subdirectory.