### PR TITLE
Update script generator usage with a more real world example

### DIFF
--- a/railties/lib/rails/generators/rails/script/USAGE
+++ b/railties/lib/rails/generators/rails/script/USAGE
@@ -12,7 +12,7 @@ Example:
         `ruby script/my_script.rb`
 
     You can specify a folder:
-        `bin/rails generate script cleanup/my_script`
+        `bin/rails generate script data/backfill`
 
     This will create:
-        script/cleanup/my_script.rb
+        script/data/backfill.rb


### PR DESCRIPTION
Minor edit: in the script generator `USAGE`, use the same subdirectory example as the one in `CHANGELOG.md`, which was recently updated here: https://github.com/rails/rails/pull/52454. I also think `script/data/backfill.rb` is a better real world example.