### PR TITLE
Add support for implicitly rendering renderables

### DIFF
--- a/actionpack/lib/action_controller/metal/implicit_render.rb
+++ b/actionpack/lib/action_controller/metal/implicit_render.rb
@@ -63,7 +63,7 @@ module ActionController
 
     private
       def renderable_name(action_name, prefixes)
-        ["Views", *prefixes, action_name].map(&:camelize).join("::")
+        [*prefixes, "#{action_name}_view"].map(&:camelize).join("::")
       end
 
       def interactive_browser_request?

--- a/actionpack/lib/action_controller/metal/implicit_render.rb
+++ b/actionpack/lib/action_controller/metal/implicit_render.rb
@@ -35,7 +35,9 @@ module ActionController
     include BasicImplicitRender
 
     def default_render
-      if template_exists?(action_name.to_s, _prefixes, variants: request.variant)
+      if Object.const_defined?(const_name = renderable_name(action_name.to_s.underscore, _prefixes))
+        render(const_name.constantize.new)
+      elsif template_exists?(action_name.to_s, _prefixes, variants: request.variant)
         render
       elsif any_templates?(action_name.to_s, _prefixes)
         message = "#{self.class.name}\##{action_name} is missing a template " \
@@ -60,6 +62,10 @@ module ActionController
     end
 
     private
+      def renderable_name(action_name, prefixes)
+        ["Views", *prefixes, action_name].map(&:camelize).join("::")
+      end
+
       def interactive_browser_request?
         request.get? && request.format == Mime[:html] && !request.xhr?
       end

--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add support for implicitly rendering renderables in controllers.
+
+    *Joel Hawksley*
+
 *   Rename `check_box*` methods into `checkbox*`.
 
     Old names are still available as aliases.

--- a/actionview/test/actionpack/controller/render_test.rb
+++ b/actionview/test/actionpack/controller/render_test.rb
@@ -33,12 +33,10 @@ module Fun
   end
 end
 
-module Views
-  module Test
-    class ImplicitRenderable
-      def render_in(_)
-        "implicit renderable"
-      end
+module Test
+  class ImplicitRenderableView
+    def render_in(_)
+      "implicit renderable"
     end
   end
 end

--- a/actionview/test/actionpack/controller/render_test.rb
+++ b/actionview/test/actionpack/controller/render_test.rb
@@ -33,6 +33,16 @@ module Fun
   end
 end
 
+module Views
+  module Test
+    class ImplicitRenderable
+      def render_in(_)
+        "implicit renderable"
+      end
+    end
+  end
+end
+
 class ValidatingPost < Post
   include ActiveModel::Validations
 
@@ -285,6 +295,9 @@ class TestController < ActionController::Base
   end
 
   def formatted_xml_erb
+  end
+
+  def implicit_renderable
   end
 
   def render_to_string_test
@@ -662,6 +675,7 @@ class RenderTest < ActionController::TestCase
     get :empty_partial_collection, to: "test#empty_partial_collection"
     get :formatted_html_erb, to: "test#formatted_html_erb"
     get :formatted_xml_erb, to: "test#formatted_xml_erb"
+    get :implicit_renderable, to: "test#implicit_renderable"
     get :greeting, to: "test#greeting"
     get :hello_in_a_string, to: "test#hello_in_a_string"
     get :hello_world, to: "fun/games#hello_world"
@@ -1120,6 +1134,11 @@ class RenderTest < ActionController::TestCase
     @request.accept = "image/gif, image/x-xbitmap, image/jpeg, image/pjpeg, application/x-shockwave-flash, */*"
     get :formatted_xml_erb
     assert_equal "<test>passed formatted HTML erb</test>", @response.body
+  end
+
+  def test_should_render_implicit_renderable
+    get :implicit_renderable
+    assert_equal "implicit renderable", @response.body
   end
 
   def test_layout_test_with_different_layout


### PR DESCRIPTION
### Motivation / Background

In #36388, we added support for rendering objects that respond to for controller actions. This PR adds support for implicitly rendering renderables for controller actions as one can for regular templates today.

### Detail

Specifically, I've updated `ImplictRender` to look for a corresponding renderable in the format `Prefixes::ActionNameView`.

If this approach is deemed acceptable, I'll gladly add docs changes to this PR ❤️ 

### Additional information

@bradgessler's post on doing this for Phlex: https://fly.io/ruby-dispatch/hacking-rails-implicit-rendering-for-view-components/
ViewComponent thread discussing the topic: https://github.com/ViewComponent/view_component/issues/618

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.

cc @joeldrapper
