### PR TITLE
Generate errors when running a Docker build with warnings

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/Dockerfile.tt
+++ b/railties/lib/rails/generators/rails/app/templates/Dockerfile.tt
@@ -1,4 +1,5 @@
-# syntax = docker/dockerfile:1
+# syntax=docker/dockerfile:1
+# check=error=true
 
 # This Dockerfile is designed for production, not development. Use with Kamal or build'n'run by hand:
 # docker build -t my-app .


### PR DESCRIPTION
On July 29th, Docker introduced Docker build checks: https://www.docker.com/blog/introducing-docker-build-checks/.

By default, running a Docker build with warnings will not cause the build to fail (return a non-zero exit code). To raise errors on warnings `# check=error=true` declaration should be added to the Dockerfile.

Also, an official Docker guide (https://docs.docker.com/reference/dockerfile/#syntax) has syntax declaration examples without spaces, so I removed them too.