### PR TITLE
AbstractAdapter#cast_result should return a result with columns even if empty

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/mysql2/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql2/database_statements.rb
@@ -87,7 +87,7 @@ module ActiveRecord
           end
 
           def cast_result(result)
-            if result.nil? || result.size.zero?
+            if result.nil? || result.fields.empty?
               ActiveRecord::Result.empty
             else
               ActiveRecord::Result.new(result.fields, result.to_a)

--- a/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
@@ -169,6 +169,11 @@ module ActiveRecord
           end
 
           def cast_result(result)
+            if result.fields.empty?
+              result.clear
+              return ActiveRecord::Result.empty
+            end
+
             types = {}
             fields = result.fields
             fields.each_with_index do |fname, i|

--- a/activerecord/lib/active_record/connection_adapters/trilogy/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/trilogy/database_statements.rb
@@ -30,7 +30,7 @@ module ActiveRecord
           end
 
           def cast_result(result)
-            if result.count.zero?
+            if result.fields.empty?
               ActiveRecord::Result.empty
             else
               ActiveRecord::Result.new(result.fields, result.rows)

--- a/activerecord/test/cases/adapter_test.rb
+++ b/activerecord/test/cases/adapter_test.rb
@@ -126,9 +126,18 @@ module ActiveRecord
       end
     end
 
-    def test_exec_query_returns_an_empty_result
+    test "#exec_query queries with no result set return an empty ActiveRecord::Result" do
       result = @connection.exec_query "INSERT INTO subscribers(nick) VALUES('me')"
       assert_instance_of(ActiveRecord::Result, result)
+      assert_empty result.rows
+      assert_empty result.columns
+    end
+
+    test "#exec_query queries with an empty result set still return the columns" do
+      result = @connection.exec_query "SELECT * FROM subscribers WHERE 1=0"
+      assert_instance_of(ActiveRecord::Result, result)
+      assert_empty result.rows
+      assert_not_empty result.columns
     end
 
     if current_adapter?(:Mysql2Adapter, :TrilogyAdapter)


### PR DESCRIPTION
Followup: https://github.com/rails/rails/pull/52428

There is a suble difference between a query that doesn't return a result at all, and a query that returns an empty result set.

The former doesn't have any column name, the later do.

noticed by @matthewd 