### PR TITLE
`sql_for_insert` doesn't need to concern itself about binds

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -155,7 +155,7 @@ module ActiveRecord
       # `nil` is the default value and maintains default behavior. If an array of column names is passed -
       # the result will contain values of the specified columns from the inserted row.
       def exec_insert(sql, name = nil, binds = [], pk = nil, sequence_name = nil, returning: nil)
-        sql, binds = sql_for_insert(sql, pk, binds, returning)
+        sql = sql_for_insert(sql, pk, returning)
         internal_exec_query(sql, name, binds)
       end
 
@@ -707,7 +707,7 @@ module ActiveRecord
           end
         end
 
-        def sql_for_insert(sql, pk, binds, returning) # :nodoc:
+        def sql_for_insert(sql, pk, returning) # :nodoc:
           if supports_insert_returning?
             if pk.nil?
               # Extract the table from the insert sql. Yuck.
@@ -721,7 +721,7 @@ module ActiveRecord
             sql = "#{sql} RETURNING #{returning_columns_statement}" if returning_columns.any?
           end
 
-          [sql, binds]
+          sql
         end
 
         def last_inserted_id(result)

--- a/activerecord/lib/active_record/connection_adapters/trilogy/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/trilogy/database_statements.rb
@@ -5,7 +5,7 @@ module ActiveRecord
     module Trilogy
       module DatabaseStatements
         def exec_insert(sql, name, binds, pk = nil, sequence_name = nil, returning: nil) # :nodoc:
-          sql, _binds = sql_for_insert(sql, pk, binds, returning)
+          sql = sql_for_insert(sql, pk, returning)
           internal_execute(sql, name)
         end
 


### PR DESCRIPTION
They accepted binds ever since 8571facea3b51717b3c57c50b2deae5dbf997c6e but never did anything with them.

At one point it made sense because `sql_for_insert` would take all the arguments of `insert` and have the opportunity to change either, but that's no longer the case, only the `sql` argument is sometimes changed.
