### PR TITLE
Get rid of unused `Sqlite3Adapter#use_insert_returning?`

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -127,7 +127,6 @@ module ActiveRecord
           results_as_hash: true,
           default_transaction_mode: :immediate,
         )
-        @use_insert_returning = @config.key?(:insert_returning) ? self.class.type_cast_config_to_boolean(@config[:insert_returning]) : true
       end
 
       def database_exists?
@@ -432,10 +431,6 @@ module ActiveRecord
 
       def shared_cache? # :nodoc:
         @config.fetch(:flags, 0).anybits?(::SQLite3::Constants::Open::SHAREDCACHE)
-      end
-
-      def use_insert_returning?
-        @use_insert_returning
       end
 
       def get_database_version # :nodoc:


### PR DESCRIPTION
It was introduced in https://github.com/rails/rails/pull/49290 likely to do the same as PostgresqlAdapter, but it's not used anywhere and there not really any reason to have that option.

Postgres has it because INSERT RETURNING can't be used in some corner cases, see: https://github.com/rails/rails/pull/5698
