### PR TITLE
Get rid of `with_multi_statement`

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
@@ -132,7 +132,7 @@ module ActiveRecord
           rescue PG::Error
           end
 
-          def perform_query(raw_connection, sql, binds, type_casted_binds, prepare:, notification_payload:)
+          def perform_query(raw_connection, sql, binds, type_casted_binds, prepare:, notification_payload:, batch: false)
             update_typemap_for_default_timezone
             result = if prepare
               begin
@@ -193,7 +193,7 @@ module ActiveRecord
           end
 
           def execute_batch(statements, name = nil)
-            raw_execute(combine_multi_statements(statements), name)
+            raw_execute(combine_multi_statements(statements), name, batch: true)
           end
 
           def build_truncate_statements(table_names)


### PR DESCRIPTION
It's a noop on all adapters except MySQL which doesn't allow multi statements by default.

Also `batch_execute` in Sqlite3Adapter has to use many ow level APIs because while sqlite3 allow multi statement by default, you have to use a different API for that.

So overall `with_multi_statement` was always a lie, because it wouldn't work on sqlite3 and it's simpler to pass a `batch: true` argument to `raw_execute` so that each adapter can do the necessary work to allow multi-statement.

This will simplify a future PR that @adrianna-chang-shopify will open soon.
