### PR TITLE
Rename `text_area` to `textarea` and `rich_text_area` to `rich_textarea`

### DIFF
--- a/actionmailbox/app/views/rails/conductor/action_mailbox/inbound_emails/new.html.erb
+++ b/actionmailbox/app/views/rails/conductor/action_mailbox/inbound_emails/new.html.erb
@@ -40,7 +40,7 @@
 
   <div>
     <%= form.label :body, "Body" %><br>
-    <%= form.text_area :body, size: "40x20", value: params[:body] %>
+    <%= form.textarea :body, size: "40x20", value: params[:body] %>
   </div>
 
   <div>

--- a/actionmailbox/app/views/rails/conductor/action_mailbox/inbound_emails/sources/new.html.erb
+++ b/actionmailbox/app/views/rails/conductor/action_mailbox/inbound_emails/sources/new.html.erb
@@ -5,7 +5,7 @@
 <%= form_with(url: main_app.rails_conductor_inbound_email_sources_path, local: true) do |form| %>
   <div>
     <%= form.label :source, "Source" %><br>
-    <%= form.text_area :source, size: "80x60" %>
+    <%= form.textarea :source, size: "80x60" %>
   </div>
 
   <%= form.submit "Deliver inbound email" %>

--- a/actiontext/CHANGELOG.md
+++ b/actiontext/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Rename `rich_text_area` methods into `rich_textarea`
+
+    Old names are still available as aliases.
+
+    *Sean Doyle*
+
+
 *   Only sanitize `content` attribute when present in attachments.
 
     *Petrik de Heus*

--- a/actiontext/app/helpers/action_text/tag_helper.rb
+++ b/actiontext/app/helpers/action_text/tag_helper.rb
@@ -24,10 +24,10 @@ module ActionText
     #
     # #### Example
     #
-    #     rich_text_area_tag "content", message.content
+    #     rich_textarea_tag "content", message.content
     #     # <input type="hidden" name="content" id="trix_input_post_1">
     #     # <trix-editor id="content" input="trix_input_post_1" class="trix-content" ...></trix-editor>
-    def rich_text_area_tag(name, value = nil, options = {})
+    def rich_textarea_tag(name, value = nil, options = {})
       options = options.symbolize_keys
       form = options.delete(:form)
 
@@ -43,6 +43,7 @@ module ActionText
 
       input_tag + editor_tag
     end
+    alias_method :rich_text_area_tag, :rich_textarea_tag
   end
 end
 
@@ -56,7 +57,7 @@ module ActionView::Helpers
       options = @options.stringify_keys
       add_default_name_and_id(options)
       options["input"] ||= dom_id(object, [options["id"], :trix_input].compact.join("_")) if object
-      html_tag = @template_object.rich_text_area_tag(options.delete("name"), options.fetch("value") { value }, options.except("value"))
+      html_tag = @template_object.rich_textarea_tag(options.delete("name"), options.fetch("value") { value }, options.except("value"))
       error_wrapping(html_tag)
     end
   end
@@ -76,28 +77,30 @@ module ActionView::Helpers
     #
     #
     # #### Example
-    #     rich_text_area :message, :content
+    #     rich_textarea :message, :content
     #     # <input type="hidden" name="message[content]" id="message_content_trix_input_message_1">
     #     # <trix-editor id="content" input="message_content_trix_input_message_1" class="trix-content" ...></trix-editor>
     #
-    #     rich_text_area :message, :content, value: "<h1>Default message</h1>"
+    #     rich_textarea :message, :content, value: "<h1>Default message</h1>"
     #     # <input type="hidden" name="message[content]" id="message_content_trix_input_message_1" value="<h1>Default message</h1>">
     #     # <trix-editor id="content" input="message_content_trix_input_message_1" class="trix-content" ...></trix-editor>
-    def rich_text_area(object_name, method, options = {})
+    def rich_textarea(object_name, method, options = {})
       Tags::ActionText.new(object_name, method, self, options).render
     end
+    alias_method :rich_text_area, :rich_textarea
   end
 
   class FormBuilder
-    # Wraps ActionView::Helpers::FormHelper#rich_text_area for form builders:
+    # Wraps ActionView::Helpers::FormHelper#rich_textarea for form builders:
     #
     #     <%= form_with model: @message do |f| %>
-    #       <%= f.rich_text_area :content %>
+    #       <%= f.rich_textarea :content %>
     #     <% end %>
     #
     # Please refer to the documentation of the base helper for details.
-    def rich_text_area(method, options = {})
-      @template.rich_text_area(@object_name, method, objectify_options(options))
+    def rich_textarea(method, options = {})
+      @template.rich_textarea(@object_name, method, objectify_options(options))
     end
+    alias_method :rich_text_area, :rich_textarea
   end
 end

--- a/actiontext/lib/action_text/system_test_helper.rb
+++ b/actiontext/lib/action_text/system_test_helper.rb
@@ -17,42 +17,45 @@ module ActionText
     # Examples:
     #
     #     # <trix-editor id="message_content" ...></trix-editor>
-    #     fill_in_rich_text_area "message_content", with: "Hello <em>world!</em>"
+    #     fill_in_rich_textarea "message_content", with: "Hello <em>world!</em>"
     #
     #     # <trix-editor placeholder="Your message here" ...></trix-editor>
-    #     fill_in_rich_text_area "Your message here", with: "Hello <em>world!</em>"
+    #     fill_in_rich_textarea "Your message here", with: "Hello <em>world!</em>"
     #
     #     # <label for="message_content">Message content</label>
     #     # <trix-editor id="message_content" ...></trix-editor>
-    #     fill_in_rich_text_area "Message content", with: "Hello <em>world!</em>"
+    #     fill_in_rich_textarea "Message content", with: "Hello <em>world!</em>"
     #
     #     # <trix-editor aria-label="Message content" ...></trix-editor>
-    #     fill_in_rich_text_area "Message content", with: "Hello <em>world!</em>"
+    #     fill_in_rich_textarea "Message content", with: "Hello <em>world!</em>"
     #
     #     # <input id="trix_input_1" name="message[content]" type="hidden">
     #     # <trix-editor input="trix_input_1"></trix-editor>
-    #     fill_in_rich_text_area "message[content]", with: "Hello <em>world!</em>"
-    def fill_in_rich_text_area(locator = nil, with:)
-      find(:rich_text_area, locator).execute_script("this.editor.loadHTML(arguments[0])", with.to_s)
+    #     fill_in_rich_textarea "message[content]", with: "Hello <em>world!</em>"
+    def fill_in_rich_textarea(locator = nil, with:)
+      find(:rich_textarea, locator).execute_script("this.editor.loadHTML(arguments[0])", with.to_s)
     end
+    alias_method :fill_in_rich_text_area, :fill_in_rich_textarea
   end
 end
 
-Capybara.add_selector :rich_text_area do
-  label "rich-text area"
-  xpath do |locator|
-    if locator.nil?
-      XPath.descendant(:"trix-editor")
-    else
-      input_located_by_name = XPath.anywhere(:input).where(XPath.attr(:name) == locator).attr(:id)
-      input_located_by_label = XPath.anywhere(:label).where(XPath.string.n.is(locator)).attr(:for)
+%i[rich_textarea rich_text_area].each do |rich_textarea|
+  Capybara.add_selector rich_textarea do
+    label "rich-text area"
+    xpath do |locator|
+      if locator.nil?
+        XPath.descendant(:"trix-editor")
+      else
+        input_located_by_name = XPath.anywhere(:input).where(XPath.attr(:name) == locator).attr(:id)
+        input_located_by_label = XPath.anywhere(:label).where(XPath.string.n.is(locator)).attr(:for)
 
-      XPath.descendant(:"trix-editor").where \
-        XPath.attr(:id).equals(locator) |
-        XPath.attr(:placeholder).equals(locator) |
-        XPath.attr(:"aria-label").equals(locator) |
-        XPath.attr(:input).equals(input_located_by_name) |
-        XPath.attr(:id).equals(input_located_by_label)
+        XPath.descendant(:"trix-editor").where \
+          XPath.attr(:id).equals(locator) |
+          XPath.attr(:placeholder).equals(locator) |
+          XPath.attr(:"aria-label").equals(locator) |
+          XPath.attr(:input).equals(input_located_by_name) |
+          XPath.attr(:id).equals(input_located_by_label)
+      end
     end
   end
 end

--- a/actiontext/test/dummy/app/views/messages/_form.html.erb
+++ b/actiontext/test/dummy/app/views/messages/_form.html.erb
@@ -18,7 +18,7 @@
 
   <div class="field">
     <%= form.label :content, "Message content label" %>
-    <%= form.rich_text_area :content, class: "trix-content",
+    <%= form.rich_textarea :content, class: "trix-content",
           placeholder: "Your message here", aria: { label: "Message content aria-label" } %>
   </div>
 

--- a/actiontext/test/system/system_test_helper_test.rb
+++ b/actiontext/test/system/system_test_helper_test.rb
@@ -9,36 +9,36 @@ class ActionText::SystemTestHelperTest < ApplicationSystemTestCase
 
   test "filling in a rich-text area by ID" do
     assert_selector "trix-editor#message_content"
-    fill_in_rich_text_area "message_content", with: "Hello world!"
+    fill_in_rich_textarea "message_content", with: "Hello world!"
     assert_selector :field, "message[content]", with: /Hello world!/, type: "hidden"
   end
 
   test "filling in a rich-text area by placeholder" do
     assert_selector "trix-editor[placeholder='Your message here']"
-    fill_in_rich_text_area "Your message here", with: "Hello world!"
+    fill_in_rich_textarea "Your message here", with: "Hello world!"
     assert_selector :field, "message[content]", with: /Hello world!/, type: "hidden"
   end
 
   test "filling in a rich-text area by aria-label" do
     assert_selector "trix-editor[aria-label='Message content aria-label']"
-    fill_in_rich_text_area "Message content aria-label", with: "Hello world!"
+    fill_in_rich_textarea "Message content aria-label", with: "Hello world!"
     assert_selector :field, "message[content]", with: /Hello world!/, type: "hidden"
   end
 
   test "filling in a rich-text area by label" do
     assert_selector "label", text: "Message content label"
-    fill_in_rich_text_area "Message content label", with: "Hello world!"
+    fill_in_rich_textarea "Message content label", with: "Hello world!"
     assert_selector :field, "message[content]", with: /Hello world!/, type: "hidden"
   end
 
   test "filling in a rich-text area by input name" do
     assert_selector "trix-editor[input]"
-    fill_in_rich_text_area "message[content]", with: "Hello world!"
+    fill_in_rich_textarea "message[content]", with: "Hello world!"
     assert_selector :field, "message[content]", with: /Hello world!/, type: "hidden"
   end
 
   test "filling in the only rich-text area" do
-    fill_in_rich_text_area with: "Hello world!"
+    fill_in_rich_textarea with: "Hello world!"
     assert_selector :field, "message[content]", with: /Hello world!/, type: "hidden"
   end
 end

--- a/actiontext/test/template/form_helper_test.rb
+++ b/actiontext/test/template/form_helper_test.rb
@@ -25,10 +25,10 @@ class ActionText::FormHelperTest < ActionView::TestCase
     )
   end
 
-  test "#rich_text_area_tag helper" do
+  test "#rich_textarea_tag helper" do
     message = Message.new
 
-    concat rich_text_area_tag :content, message.content, { input: "trix_input_1" }
+    concat rich_textarea_tag :content, message.content, { input: "trix_input_1" }
 
     assert_dom_equal \
       '<input type="hidden" name="content" id="trix_input_1" autocomplete="off" />' \
@@ -37,8 +37,8 @@ class ActionText::FormHelperTest < ActionView::TestCase
       output_buffer
   end
 
-  test "#rich_text_area helper" do
-    concat rich_text_area :message, :content, input: "trix_input_1"
+  test "#rich_textarea helper" do
+    concat rich_textarea :message, :content, input: "trix_input_1"
 
     assert_dom_equal \
       '<input type="hidden" name="message[content]" id="trix_input_1" autocomplete="off" />' \
@@ -47,10 +47,10 @@ class ActionText::FormHelperTest < ActionView::TestCase
       output_buffer
   end
 
-  test "#rich_text_area helper renders the :value argument into the hidden field" do
+  test "#rich_textarea helper renders the :value argument into the hidden field" do
     message = Message.new content: "<h1>hello world</h1>"
 
-    concat rich_text_area :message, :title, value: message.content, input: "trix_input_1"
+    concat rich_textarea :message, :title, value: message.content, input: "trix_input_1"
 
     assert_dom_equal \
       '<input type="hidden" name="message[title]" id="trix_input_1" value="&lt;h1&gt;hello world&lt;/h1&gt;" autocomplete="off" />' \
@@ -61,7 +61,7 @@ class ActionText::FormHelperTest < ActionView::TestCase
 
   test "form with rich text area" do
     form_with model: Message.new, scope: :message do |form|
-      form.rich_text_area :content
+      form.rich_textarea :content
     end
 
     assert_dom_equal \
@@ -75,7 +75,7 @@ class ActionText::FormHelperTest < ActionView::TestCase
 
   test "form with rich text area having class" do
     form_with model: Message.new, scope: :message do |form|
-      form.rich_text_area :content, class: "custom-class"
+      form.rich_textarea :content, class: "custom-class"
     end
 
     assert_dom_equal \
@@ -92,7 +92,7 @@ class ActionText::FormHelperTest < ActionView::TestCase
     message.errors.add(:content, :blank)
 
     form_with model: message, scope: :message do |form|
-      form.rich_text_area :content
+      form.rich_textarea :content
     end
 
     assert_dom_equal \
@@ -108,7 +108,7 @@ class ActionText::FormHelperTest < ActionView::TestCase
 
   test "form with rich text area for non-attribute" do
     form_with model: Message.new, scope: :message do |form|
-      form.rich_text_area :not_an_attribute
+      form.rich_textarea :not_an_attribute
     end
 
     assert_dom_equal \
@@ -122,7 +122,7 @@ class ActionText::FormHelperTest < ActionView::TestCase
 
   test "modelless form with rich text area" do
     form_with url: "/messages", scope: :message do |form|
-      form.rich_text_area :content, { input: "trix_input_2" }
+      form.rich_textarea :content, { input: "trix_input_2" }
     end
 
     assert_dom_equal \
@@ -136,7 +136,7 @@ class ActionText::FormHelperTest < ActionView::TestCase
 
   test "form with rich text area having placeholder without locale" do
     form_with model: Message.new, scope: :message do |form|
-      form.rich_text_area :content, placeholder: true
+      form.rich_textarea :content, placeholder: true
     end
 
     assert_dom_equal \
@@ -151,7 +151,7 @@ class ActionText::FormHelperTest < ActionView::TestCase
   test "form with rich text area having placeholder with locale" do
     I18n.with_locale :placeholder do
       form_with model: Message.new, scope: :message do |form|
-        form.rich_text_area :title, placeholder: true
+        form.rich_textarea :title, placeholder: true
       end
     end
 
@@ -166,7 +166,7 @@ class ActionText::FormHelperTest < ActionView::TestCase
 
   test "form with rich text area with value" do
     form_with model: Message.new, scope: :message do |form|
-      form.rich_text_area :title, value: "<h1>hello world</h1>"
+      form.rich_textarea :title, value: "<h1>hello world</h1>"
     end
 
     assert_dom_equal \
@@ -180,7 +180,7 @@ class ActionText::FormHelperTest < ActionView::TestCase
 
   test "form with rich text area with form attribute" do
     form_with model: Message.new, scope: :message do |form|
-      form.rich_text_area :title, form: "other_form"
+      form.rich_textarea :title, form: "other_form"
     end
 
     assert_dom_equal \
@@ -194,7 +194,7 @@ class ActionText::FormHelperTest < ActionView::TestCase
 
   test "form with rich text area with data[direct_upload_url]" do
     form_with model: Message.new, scope: :message do |form|
-      form.rich_text_area :content, data: { direct_upload_url: "http://test.host/direct_uploads" }
+      form.rich_textarea :content, data: { direct_upload_url: "http://test.host/direct_uploads" }
     end
 
     assert_dom_equal \
@@ -208,7 +208,7 @@ class ActionText::FormHelperTest < ActionView::TestCase
 
   test "form with rich text area with data[blob_url_template]" do
     form_with model: Message.new, scope: :message do |form|
-      form.rich_text_area :content, data: { blob_url_template: "http://test.host/blobs/:signed_id/:filename" }
+      form.rich_textarea :content, data: { blob_url_template: "http://test.host/blobs/:signed_id/:filename" }
     end
 
     assert_dom_equal \

--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Rename `text_area` methods into `textarea`
+
+    Old names are still available as aliases.
+
+    *Sean Doyle*
+
 *   Rename `check_box*` methods into `checkbox*`.
 
     Old names are still available as aliases.

--- a/actionview/lib/action_view/helpers/form_helper.rb
+++ b/actionview/lib/action_view/helpers/form_helper.rb
@@ -132,7 +132,7 @@ module ActionView
       #   <%= form_for :person do |f| %>
       #     First name: <%= f.text_field :first_name %><br />
       #     Last name : <%= f.text_field :last_name %><br />
-      #     Biography : <%= f.text_area :biography %><br />
+      #     Biography : <%= f.textarea :biography %><br />
       #     Admin?    : <%= f.checkbox :admin %><br />
       #     <%= f.submit %>
       #   <% end %>
@@ -199,7 +199,7 @@ module ActionView
       #   <%= form_for :person do |f| %>
       #     First name: <%= f.text_field :first_name %>
       #     Last name : <%= f.text_field :last_name %>
-      #     Biography : <%= text_area :person, :biography %>
+      #     Biography : <%= textarea :person, :biography %>
       #     Admin?    : <%= checkbox_tag "person[admin]", "1", @person.company.admin? %>
       #     <%= f.submit %>
       #   <% end %>
@@ -389,7 +389,7 @@ module ActionView
       #   <%= form_for @person, url: { action: "create" }, builder: LabellingFormBuilder do |f| %>
       #     <%= f.text_field :first_name %>
       #     <%= f.text_field :last_name %>
-      #     <%= f.text_area :biography %>
+      #     <%= f.textarea :biography %>
       #     <%= f.checkbox :admin %>
       #     <%= f.submit %>
       #   <% end %>
@@ -668,7 +668,7 @@ module ActionView
       #     <%= form.text_field :first_name %>
       #     <%= form.text_field :last_name %>
       #
-      #     <%= text_area :person, :biography %>
+      #     <%= textarea :person, :biography %>
       #     <%= checkbox_tag "person[admin]", "1", @person.company.admin? %>
       #
       #     <%= form.submit %>
@@ -730,7 +730,7 @@ module ActionView
       #   <%= form_with model: @person, url: { action: "create" }, builder: LabellingFormBuilder do |form| %>
       #     <%= form.text_field :first_name %>
       #     <%= form.text_field :last_name %>
-      #     <%= form.text_area :biography %>
+      #     <%= form.textarea :biography %>
       #     <%= form.checkbox :admin %>
       #     <%= form.submit %>
       #   <% end %>
@@ -1069,7 +1069,7 @@ module ActionView
       #   <%= fields model: @comment do |fields| %>
       #     <%= fields.text_field :body %>
       #
-      #     <%= text_area :commenter, :biography %>
+      #     <%= textarea :commenter, :biography %>
       #     <%= checkbox_tag "comment[all_caps]", "1", @comment.commenter.hulk_mode? %>
       #   <% end %>
       #
@@ -1255,28 +1255,29 @@ module ActionView
       # hash with +options+.
       #
       # ==== Examples
-      #   text_area(:article, :body, cols: 20, rows: 40)
+      #   textarea(:article, :body, cols: 20, rows: 40)
       #   # => <textarea cols="20" rows="40" id="article_body" name="article[body]">
       #   #      #{@article.body}
       #   #    </textarea>
       #
-      #   text_area(:comment, :text, size: "20x30")
+      #   textarea(:comment, :text, size: "20x30")
       #   # => <textarea cols="20" rows="30" id="comment_text" name="comment[text]">
       #   #      #{@comment.text}
       #   #    </textarea>
       #
-      #   text_area(:application, :notes, cols: 40, rows: 15, class: 'app_input')
+      #   textarea(:application, :notes, cols: 40, rows: 15, class: 'app_input')
       #   # => <textarea cols="40" rows="15" id="application_notes" name="application[notes]" class="app_input">
       #   #      #{@application.notes}
       #   #    </textarea>
       #
-      #   text_area(:entry, :body, size: "20x20", disabled: 'disabled')
+      #   textarea(:entry, :body, size: "20x20", disabled: 'disabled')
       #   # => <textarea cols="20" rows="20" id="entry_body" name="entry[body]" disabled="disabled">
       #   #      #{@entry.body}
       #   #    </textarea>
-      def text_area(object_name, method, options = {})
+      def textarea(object_name, method, options = {})
         Tags::TextArea.new(object_name, method, self, options).render
       end
+      alias_method :text_area, :textarea
 
       # Returns a checkbox tag tailored for accessing a specified attribute (identified by +method+) on an object
       # assigned to the template (identified by +object+). This object must be an instance object (@object) and not a local object.
@@ -1682,7 +1683,7 @@ module ActionView
       # The methods which wrap a form helper call.
       class_attribute :field_helpers, default: [
         :fields_for, :fields, :label, :text_field, :password_field,
-        :hidden_field, :file_field, :text_area, :checkbox,
+        :hidden_field, :file_field, :textarea, :checkbox,
         :radio_button, :color_field, :search_field,
         :telephone_field, :phone_field, :date_field,
         :time_field, :datetime_field, :datetime_local_field,
@@ -1825,14 +1826,14 @@ module ActionView
       # Please refer to the documentation of the base helper for details.
 
       ##
-      # :method: text_area
+      # :method: textarea
       #
-      # :call-seq: text_area(method, options = {})
+      # :call-seq: textarea(method, options = {})
       #
-      # Wraps ActionView::Helpers::FormHelper#text_area for form builders:
+      # Wraps ActionView::Helpers::FormHelper#textarea for form builders:
       #
       #   <%= form_with model: @user do |f| %>
-      #     <%= f.text_area :detail %>
+      #     <%= f.textarea :detail %>
       #   <% end %>
       #
       # Please refer to the documentation of the base helper for details.

--- a/actionview/lib/action_view/helpers/form_tag_helper.rb
+++ b/actionview/lib/action_view/helpers/form_tag_helper.rb
@@ -393,24 +393,24 @@ module ActionView
       # * Any other key creates standard HTML attributes for the tag.
       #
       # ==== Examples
-      #   text_area_tag 'post'
+      #   textarea_tag 'post'
       #   # => <textarea id="post" name="post"></textarea>
       #
-      #   text_area_tag 'bio', @user.bio
+      #   textarea_tag 'bio', @user.bio
       #   # => <textarea id="bio" name="bio">This is my biography.</textarea>
       #
-      #   text_area_tag 'body', nil, rows: 10, cols: 25
+      #   textarea_tag 'body', nil, rows: 10, cols: 25
       #   # => <textarea cols="25" id="body" name="body" rows="10"></textarea>
       #
-      #   text_area_tag 'body', nil, size: "25x10"
+      #   textarea_tag 'body', nil, size: "25x10"
       #   # => <textarea name="body" id="body" cols="25" rows="10"></textarea>
       #
-      #   text_area_tag 'description', "Description goes here.", disabled: true
+      #   textarea_tag 'description', "Description goes here.", disabled: true
       #   # => <textarea disabled="disabled" id="description" name="description">Description goes here.</textarea>
       #
-      #   text_area_tag 'comment', nil, class: 'comment_input'
+      #   textarea_tag 'comment', nil, class: 'comment_input'
       #   # => <textarea class="comment_input" id="comment" name="comment"></textarea>
-      def text_area_tag(name, content = nil, options = {})
+      def textarea_tag(name, content = nil, options = {})
         options = options.stringify_keys
 
         if size = options.delete("size")
@@ -422,6 +422,7 @@ module ActionView
 
         content_tag :textarea, content.to_s.html_safe, { "name" => name, "id" => sanitize_to_id(name) }.update(options)
       end
+      alias_method :text_area_tag, :textarea_tag
 
       ##
       # :call-seq:

--- a/actionview/test/template/active_model_helper_test.rb
+++ b/actionview/test/template/active_model_helper_test.rb
@@ -33,10 +33,10 @@ class ActiveModelHelperTest < ActionView::TestCase
     @post.updated_at  = Date.new(2004, 6, 15)
   end
 
-  def test_text_area_with_errors
+  def test_textarea_with_errors
     assert_dom_equal(
       %(<div class="field_with_errors"><textarea id="post_body" name="post[body]">\nBack to the hill and over it again!</textarea></div>),
-      text_area("post", "body")
+      textarea("post", "body")
     )
   end
 

--- a/actionview/test/template/form_helper/form_with_test.rb
+++ b/actionview/test/template/form_helper/form_with_test.rb
@@ -350,7 +350,7 @@ class FormWithActsLikeFormForTest < FormWithTest
     form_with(model: @post, id: "create-post") do |f|
       concat f.label(:title) { "The Title" }
       concat f.text_field(:title)
-      concat f.text_area(:body)
+      concat f.textarea(:body)
       concat f.checkbox(:secret)
       concat f.select(:category, %w( animal economy sports ))
       concat f.submit("Create post")
@@ -414,7 +414,7 @@ class FormWithActsLikeFormForTest < FormWithTest
     form_with(model: @post, id: "create-post") do |f|
       concat f.label(:title) { "The Title" }
       concat f.text_field(:title)
-      concat f.text_area(:body)
+      concat f.textarea(:body)
       concat f.checkbox(:secret)
       concat f.select(:category, %w( animal economy sports ))
       concat f.submit("Create post")
@@ -794,7 +794,7 @@ class FormWithActsLikeFormForTest < FormWithTest
     form_with(model: @post, scope: "other_name", id: "create-post") do |f|
       concat f.label(:title, class: "post_title")
       concat f.text_field(:title)
-      concat f.text_area(:body)
+      concat f.textarea(:body)
       concat f.checkbox(:secret)
       concat f.submit("Create post")
     end
@@ -814,7 +814,7 @@ class FormWithActsLikeFormForTest < FormWithTest
   def test_form_with_with_method_as_part_of_html_options
     form_with(model: @post, url: "/", id: "create-post", html: { method: :delete }) do |f|
       concat f.text_field(:title)
-      concat f.text_area(:body)
+      concat f.textarea(:body)
       concat f.checkbox(:secret)
     end
 
@@ -831,7 +831,7 @@ class FormWithActsLikeFormForTest < FormWithTest
   def test_form_with_with_method
     form_with(model: @post, url: "/", method: :delete, id: "create-post") do |f|
       concat f.text_field(:title)
-      concat f.text_area(:body)
+      concat f.textarea(:body)
       concat f.checkbox(:secret)
     end
 
@@ -862,7 +862,7 @@ class FormWithActsLikeFormForTest < FormWithTest
   def test_form_with_enables_remote_by_default
     form_with(model: @post, url: "/", id: "create-post", method: :patch) do |f|
       concat f.text_field(:title)
-      concat f.text_area(:body)
+      concat f.textarea(:body)
       concat f.checkbox(:secret)
     end
 
@@ -882,7 +882,7 @@ class FormWithActsLikeFormForTest < FormWithTest
 
     form_with(model: @post, url: "/", id: "create-post", method: :patch) do |f|
       concat f.text_field(:title)
-      concat f.text_area(:body)
+      concat f.textarea(:body)
       concat f.checkbox(:secret)
     end
 
@@ -953,7 +953,7 @@ class FormWithActsLikeFormForTest < FormWithTest
   def test_form_with_without_object
     form_with(scope: :post, id: "create-post") do |f|
       concat f.text_field(:title)
-      concat f.text_area(:body)
+      concat f.textarea(:body)
       concat f.checkbox(:secret)
     end
 
@@ -971,7 +971,7 @@ class FormWithActsLikeFormForTest < FormWithTest
     form_with(model: @post, scope: "post[]") do |f|
       concat f.label(:title)
       concat f.text_field(:title)
-      concat f.text_area(:body)
+      concat f.textarea(:body)
       concat f.checkbox(:secret)
     end
 
@@ -989,7 +989,7 @@ class FormWithActsLikeFormForTest < FormWithTest
   def test_form_with_with_nil_index_option_override
     form_with(model: @post, scope: "post[]", index: nil) do |f|
       concat f.text_field(:title)
-      concat f.text_area(:body)
+      concat f.textarea(:body)
       concat f.checkbox(:secret)
     end
 
@@ -2012,7 +2012,7 @@ class FormWithActsLikeFormForTest < FormWithTest
   def test_fields
     @rendered = fields(:post, model: @post) do |f|
       concat f.text_field(:title)
-      concat f.text_area(:body)
+      concat f.textarea(:body)
       concat f.checkbox(:secret)
     end
 
@@ -2028,7 +2028,7 @@ class FormWithActsLikeFormForTest < FormWithTest
   def test_fields_with_index
     @rendered = fields("post[]", model: @post) do |f|
       concat f.text_field(:title)
-      concat f.text_area(:body)
+      concat f.textarea(:body)
       concat f.checkbox(:secret)
     end
 
@@ -2044,7 +2044,7 @@ class FormWithActsLikeFormForTest < FormWithTest
   def test_fields_with_nil_index_option_override
     @rendered = fields("post[]", model: @post, index: nil) do |f|
       concat f.text_field(:title)
-      concat f.text_area(:body)
+      concat f.textarea(:body)
       concat f.checkbox(:secret)
     end
 
@@ -2060,7 +2060,7 @@ class FormWithActsLikeFormForTest < FormWithTest
   def test_fields_with_index_option_override
     @rendered = fields("post[]", model: @post, index: "abc") do |f|
       concat f.text_field(:title)
-      concat f.text_area(:body)
+      concat f.textarea(:body)
       concat f.checkbox(:secret)
     end
 
@@ -2076,7 +2076,7 @@ class FormWithActsLikeFormForTest < FormWithTest
   def test_fields_without_object
     @rendered = fields(:post) do |f|
       concat f.text_field(:title)
-      concat f.text_area(:body)
+      concat f.textarea(:body)
       concat f.checkbox(:secret)
     end
 
@@ -2092,7 +2092,7 @@ class FormWithActsLikeFormForTest < FormWithTest
   def test_fields_with_only_object
     @rendered = fields(model: @post) do |f|
       concat f.text_field(:title)
-      concat f.text_area(:body)
+      concat f.textarea(:body)
       concat f.checkbox(:secret)
     end
 
@@ -2144,7 +2144,7 @@ class FormWithActsLikeFormForTest < FormWithTest
   def test_form_with_and_fields
     form_with(model: @post, scope: :post, id: "create-post") do |post_form|
       concat post_form.text_field(:title)
-      concat post_form.text_area(:body)
+      concat post_form.textarea(:body)
 
       concat fields(:parent_post, model: @post) { |parent_fields|
         concat parent_fields.checkbox(:secret)
@@ -2164,7 +2164,7 @@ class FormWithActsLikeFormForTest < FormWithTest
   def test_form_with_and_fields_with_object
     form_with(model: @post, scope: :post, id: "create-post") do |post_form|
       concat post_form.text_field(:title)
-      concat post_form.text_area(:body)
+      concat post_form.textarea(:body)
 
       concat post_form.fields(model: @comment) { |comment_fields|
         concat comment_fields.text_field(:name)
@@ -2208,7 +2208,7 @@ class FormWithActsLikeFormForTest < FormWithTest
   def test_form_with_with_labelled_builder
     form_with(model: @post, builder: LabelledFormBuilder) do |f|
       concat f.text_field(:title)
-      concat f.text_area(:body)
+      concat f.textarea(:body)
       concat f.checkbox(:secret)
     end
 
@@ -2227,7 +2227,7 @@ class FormWithActsLikeFormForTest < FormWithTest
 
     form_with(model: @post) do |f|
       concat f.text_field(:title)
-      concat f.text_area(:body)
+      concat f.textarea(:body)
       concat f.checkbox(:secret)
     end
 
@@ -2286,7 +2286,7 @@ class FormWithActsLikeFormForTest < FormWithTest
   def test_fields_with_labelled_builder
     @rendered = fields(:post, model: @post, builder: LabelledFormBuilder) do |f|
       concat f.text_field(:title)
-      concat f.text_area(:body)
+      concat f.textarea(:body)
       concat f.checkbox(:secret)
     end
 

--- a/actionview/test/template/form_helper_test.rb
+++ b/actionview/test/template/form_helper_test.rb
@@ -892,65 +892,65 @@ class FormHelperTest < ActionView::TestCase
     )
   end
 
-  def test_text_area_placeholder_without_locales
+  def test_textarea_placeholder_without_locales
     I18n.with_locale :placeholder do
       assert_dom_equal(
         %{<textarea id="post_body" name="post[body]" placeholder="Body">\nBack to the hill and over it again!</textarea>},
-        text_area(:post, :body, placeholder: true)
+        textarea(:post, :body, placeholder: true)
       )
     end
   end
 
-  def test_text_area_placeholder_with_locales
+  def test_textarea_placeholder_with_locales
     I18n.with_locale :placeholder do
       assert_dom_equal(
         %{<textarea id="post_title" name="post[title]" placeholder="What is this about?">\nHello World</textarea>},
-        text_area(:post, :title, placeholder: true)
+        textarea(:post, :title, placeholder: true)
       )
     end
   end
 
-  def test_text_area_placeholder_with_human_attribute_name
+  def test_textarea_placeholder_with_human_attribute_name
     I18n.with_locale :placeholder do
       assert_dom_equal(
         %{<textarea id="post_cost" name="post[cost]" placeholder="Total cost">\n</textarea>},
-        text_area(:post, :cost, placeholder: true)
+        textarea(:post, :cost, placeholder: true)
       )
     end
   end
 
-  def test_text_area_placeholder_with_string_value
+  def test_textarea_placeholder_with_string_value
     I18n.with_locale :placeholder do
       assert_dom_equal(
         %{<textarea id="post_cost" name="post[cost]" placeholder="HOW MUCH?">\n</textarea>},
-        text_area(:post, :cost, placeholder: "HOW MUCH?")
+        textarea(:post, :cost, placeholder: "HOW MUCH?")
       )
     end
   end
 
-  def test_text_area_placeholder_with_human_attribute_name_and_value
+  def test_textarea_placeholder_with_human_attribute_name_and_value
     I18n.with_locale :placeholder do
       assert_dom_equal(
         %{<textarea id="post_cost" name="post[cost]" placeholder="Pounds">\n</textarea>},
-        text_area(:post, :cost, placeholder: :uk)
+        textarea(:post, :cost, placeholder: :uk)
       )
     end
   end
 
-  def test_text_area_placeholder_with_locales_and_value
+  def test_textarea_placeholder_with_locales_and_value
     I18n.with_locale :placeholder do
       assert_dom_equal(
         %{<textarea id="post_written_on" name="post[written_on]" placeholder="Escrito en">\n2004-06-15</textarea>},
-        text_area(:post, :written_on, placeholder: :spanish)
+        textarea(:post, :written_on, placeholder: :spanish)
       )
     end
   end
 
-  def test_text_area_placeholder_with_locales_and_nested_attributes
+  def test_textarea_placeholder_with_locales_and_nested_attributes
     I18n.with_locale :placeholder do
       form_for(@post, html: { id: "create-post" }) do |f|
         f.fields_for(:comments) do |cf|
-          concat cf.text_area(:body, placeholder: true)
+          concat cf.textarea(:body, placeholder: true)
         end
       end
 
@@ -962,11 +962,11 @@ class FormHelperTest < ActionView::TestCase
     end
   end
 
-  def test_text_area_placeholder_with_locales_fallback_and_nested_attributes
+  def test_textarea_placeholder_with_locales_fallback_and_nested_attributes
     I18n.with_locale :placeholder do
       form_for(@post, html: { id: "create-post" }) do |f|
         f.fields_for(:tags) do |cf|
-          concat cf.text_area(:value, placeholder: true)
+          concat cf.textarea(:value, placeholder: true)
         end
       end
 
@@ -978,39 +978,39 @@ class FormHelperTest < ActionView::TestCase
     end
   end
 
-  def test_text_area
+  def test_textarea
     assert_dom_equal(
       %{<textarea id="post_body" name="post[body]">\nBack to the hill and over it again!</textarea>},
-      text_area("post", "body")
+      textarea("post", "body")
     )
   end
 
-  def test_text_area_with_escapes
+  def test_textarea_with_escapes
     @post.body = "Back to <i>the</i> hill and over it again!"
     assert_dom_equal(
       %{<textarea id="post_body" name="post[body]">\nBack to &lt;i&gt;the&lt;/i&gt; hill and over it again!</textarea>},
-      text_area("post", "body")
+      textarea("post", "body")
     )
   end
 
-  def test_text_area_with_alternate_value
+  def test_textarea_with_alternate_value
     assert_dom_equal(
       %{<textarea id="post_body" name="post[body]">\nTesting alternate values.</textarea>},
-      text_area("post", "body", value: "Testing alternate values.")
+      textarea("post", "body", value: "Testing alternate values.")
     )
   end
 
-  def test_text_area_with_nil_alternate_value
+  def test_textarea_with_nil_alternate_value
     assert_dom_equal(
       %{<textarea id="post_body" name="post[body]">\n</textarea>},
-      text_area("post", "body", value: nil)
+      textarea("post", "body", value: nil)
     )
   end
 
   def test_inputs_use_before_type_cast_to_retain_information_from_validations_like_numericality
     assert_dom_equal(
       %{<textarea id="post_id" name="post[id]">\nomg</textarea>},
-      text_area("post", "id")
+      textarea("post", "id")
     )
   end
 
@@ -1022,7 +1022,7 @@ class FormHelperTest < ActionView::TestCase
 
     assert_dom_equal(
       %{<textarea id="post_id" name="post[id]">\n0</textarea>},
-      text_area("post", "id")
+      textarea("post", "id")
     )
   end
 
@@ -1030,22 +1030,22 @@ class FormHelperTest < ActionView::TestCase
     class << @post; undef id_came_from_user?; end
     assert_dom_equal(
       %{<textarea id="post_id" name="post[id]">\nomg</textarea>},
-      text_area("post", "id")
+      textarea("post", "id")
     )
   end
 
-  def test_text_area_with_html_entities
+  def test_textarea_with_html_entities
     @post.body = "The HTML Entity for & is &amp;"
     assert_dom_equal(
       %{<textarea id="post_body" name="post[body]">\nThe HTML Entity for &amp; is &amp;amp;</textarea>},
-      text_area("post", "body")
+      textarea("post", "body")
     )
   end
 
-  def test_text_area_with_size_option
+  def test_textarea_with_size_option
     assert_dom_equal(
       %{<textarea cols="183" id="post_body" name="post[body]" rows="820">\nBack to the hill and over it again!</textarea>},
-      text_area("post", "body", size: "183x820")
+      textarea("post", "body", size: "183x820")
     )
   end
 
@@ -1404,7 +1404,7 @@ class FormHelperTest < ActionView::TestCase
     )
     assert_dom_equal(
       %{<textarea id="post_body" name="really!">\nBack to the hill and over it again!</textarea>},
-      text_area("post", "body", "name" => "really!")
+      textarea("post", "body", "name" => "really!")
     )
     assert_dom_equal(
       '<input name="i mean it" type="hidden" value="0" autocomplete="off" /><input checked="checked" id="post_secret" name="i mean it" type="checkbox" value="1" />',
@@ -1415,8 +1415,8 @@ class FormHelperTest < ActionView::TestCase
       text_field("post", "title", name: "dont guess")
     )
     assert_dom_equal(
-      text_area("post", "body", "name" => "really!"),
-      text_area("post", "body", name: "really!")
+      textarea("post", "body", "name" => "really!"),
+      textarea("post", "body", name: "really!")
     )
     assert_dom_equal(
       checkbox("post", "secret", "name" => "i mean it"),
@@ -1431,7 +1431,7 @@ class FormHelperTest < ActionView::TestCase
     )
     assert_dom_equal(
       %{<textarea id="really!" name="post[body]">\nBack to the hill and over it again!</textarea>},
-      text_area("post", "body", "id" => "really!")
+      textarea("post", "body", "id" => "really!")
     )
     assert_dom_equal(
       '<input name="post[secret]" type="hidden" value="0" autocomplete="off" /><input checked="checked" id="i mean it" name="post[secret]" type="checkbox" value="1" />',
@@ -1442,8 +1442,8 @@ class FormHelperTest < ActionView::TestCase
       text_field("post", "title", id: "dont guess")
     )
     assert_dom_equal(
-      text_area("post", "body", "id" => "really!"),
-      text_area("post", "body", id: "really!")
+      textarea("post", "body", "id" => "really!"),
+      textarea("post", "body", id: "really!")
     )
     assert_dom_equal(
       checkbox("post", "secret", "id" => "i mean it"),
@@ -1458,7 +1458,7 @@ class FormHelperTest < ActionView::TestCase
     )
     assert_dom_equal(
       %{<textarea name="post[body]">\nBack to the hill and over it again!</textarea>},
-      text_area("post", "body", "id" => nil)
+      textarea("post", "body", "id" => nil)
     )
     assert_dom_equal(
       '<input name="post[secret]" type="hidden" value="0" autocomplete="off" /><input checked="checked" name="post[secret]" type="checkbox" value="1" />',
@@ -1477,8 +1477,8 @@ class FormHelperTest < ActionView::TestCase
       text_field("post", "title", id: nil)
     )
     assert_dom_equal(
-      text_area("post", "body", "id" => nil),
-      text_area("post", "body", id: nil)
+      textarea("post", "body", "id" => nil),
+      textarea("post", "body", id: nil)
     )
     assert_dom_equal(
       checkbox("post", "secret", "id" => nil),
@@ -1497,7 +1497,7 @@ class FormHelperTest < ActionView::TestCase
     )
     assert_dom_equal(
       %{<textarea name="post[5][body]" id="post_5_body">\nBack to the hill and over it again!</textarea>},
-      text_area("post", "body", "index" => 5)
+      textarea("post", "body", "index" => 5)
     )
     assert_dom_equal(
       '<input name="post[5][secret]" type="hidden" value="0" autocomplete="off" /><input checked="checked" name="post[5][secret]" type="checkbox" value="1" id="post_5_secret" />',
@@ -1508,8 +1508,8 @@ class FormHelperTest < ActionView::TestCase
       text_field("post", "title", "index" => 5)
     )
     assert_dom_equal(
-      text_area("post", "body", "index" => 5),
-      text_area("post", "body", "index" => 5)
+      textarea("post", "body", "index" => 5),
+      textarea("post", "body", "index" => 5)
     )
     assert_dom_equal(
       checkbox("post", "secret", "index" => 5),
@@ -1524,7 +1524,7 @@ class FormHelperTest < ActionView::TestCase
     )
     assert_dom_equal(
       %{<textarea name="post[5][body]">\nBack to the hill and over it again!</textarea>},
-      text_area("post", "body", "index" => 5, "id" => nil)
+      textarea("post", "body", "index" => 5, "id" => nil)
     )
     assert_dom_equal(
       '<input name="post[5][secret]" type="hidden" value="0" autocomplete="off" /><input checked="checked" name="post[5][secret]" type="checkbox" value="1" />',
@@ -1535,8 +1535,8 @@ class FormHelperTest < ActionView::TestCase
       text_field("post", "title", index: 5, id: nil)
     )
     assert_dom_equal(
-      text_area("post", "body", "index" => 5, "id" => nil),
-      text_area("post", "body", index: 5, id: nil)
+      textarea("post", "body", "index" => 5, "id" => nil),
+      textarea("post", "body", index: 5, id: nil)
     )
     assert_dom_equal(
       checkbox("post", "secret", "index" => 5, "id" => nil),
@@ -1556,7 +1556,7 @@ class FormHelperTest < ActionView::TestCase
     )
     assert_dom_equal(
       %{<textarea id="post_#{pid}_body" name="post[#{pid}][body]">\nBack to the hill and over it again!</textarea>},
-      text_area("post[]", "body")
+      textarea("post[]", "body")
     )
     assert_dom_equal(
       %{<input name="post[#{pid}][secret]" type="hidden" value="0" autocomplete="off" /><input checked="checked" id="post_#{pid}_secret" name="post[#{pid}][secret]" type="checkbox" value="1" />},
@@ -1580,7 +1580,7 @@ class FormHelperTest < ActionView::TestCase
     )
     assert_dom_equal(
       %{<textarea name="post[#{pid}][body]">\nBack to the hill and over it again!</textarea>},
-      text_area("post[]", "body", id: nil)
+      textarea("post[]", "body", id: nil)
     )
     assert_dom_equal(
       %{<input name="post[#{pid}][secret]" type="hidden" value="0" autocomplete="off" /><input checked="checked" name="post[#{pid}][secret]" type="checkbox" value="1" />},
@@ -1621,7 +1621,7 @@ class FormHelperTest < ActionView::TestCase
     form_for(@post, html: { id: "create-post" }) do |f|
       concat f.label(:title) { "The Title" }
       concat f.text_field(:title)
-      concat f.text_area(:body)
+      concat f.textarea(:body)
       concat f.checkbox(:secret)
       concat f.submit("Create post")
       concat f.button("Create post")
@@ -1651,7 +1651,7 @@ class FormHelperTest < ActionView::TestCase
     form_for(@post, html: { id: "create-post" }) do |f|
       concat f.label(:title) { "The Title" }
       concat f.text_field(:title)
-      concat f.text_area(:body)
+      concat f.textarea(:body)
       concat f.checkbox(:secret)
       concat f.submit("Create post")
       concat f.button("Create post")
@@ -2261,7 +2261,7 @@ class FormHelperTest < ActionView::TestCase
     form_for(@post, as: "other_name", html: { id: "create-post" }) do |f|
       concat f.label(:title, class: "post_title")
       concat f.text_field(:title)
-      concat f.text_area(:body)
+      concat f.textarea(:body)
       concat f.checkbox(:secret)
       concat f.submit("Create post")
     end
@@ -2294,7 +2294,7 @@ class FormHelperTest < ActionView::TestCase
   def test_form_for_with_method_as_part_of_html_options
     form_for(@post, url: "/", html: { id: "create-post", method: :delete }) do |f|
       concat f.text_field(:title)
-      concat f.text_area(:body)
+      concat f.textarea(:body)
       concat f.checkbox(:secret)
     end
 
@@ -2311,7 +2311,7 @@ class FormHelperTest < ActionView::TestCase
   def test_form_for_with_method
     form_for(@post, url: "/", method: :delete, html: { id: "create-post" }) do |f|
       concat f.text_field(:title)
-      concat f.text_area(:body)
+      concat f.textarea(:body)
       concat f.checkbox(:secret)
     end
 
@@ -2342,7 +2342,7 @@ class FormHelperTest < ActionView::TestCase
   def test_form_for_with_remote
     form_for(@post, url: "/", remote: true, html: { id: "create-post", method: :patch }) do |f|
       concat f.text_field(:title)
-      concat f.text_area(:body)
+      concat f.textarea(:body)
       concat f.checkbox(:secret)
     end
 
@@ -2411,7 +2411,7 @@ class FormHelperTest < ActionView::TestCase
   def test_form_for_with_remote_in_html
     form_for(@post, url: "/", html: { remote: true, id: "create-post", method: :patch }) do |f|
       concat f.text_field(:title)
-      concat f.text_area(:body)
+      concat f.textarea(:body)
       concat f.checkbox(:secret)
     end
 
@@ -2430,7 +2430,7 @@ class FormHelperTest < ActionView::TestCase
     @post.stub(:to_key, nil) do
       form_for(@post, remote: true) do |f|
         concat f.text_field(:title)
-        concat f.text_area(:body)
+        concat f.textarea(:body)
         concat f.checkbox(:secret)
       end
 
@@ -2448,7 +2448,7 @@ class FormHelperTest < ActionView::TestCase
   def test_form_for_without_object
     form_for(:post, html: { id: "create-post" }) do |f|
       concat f.text_field(:title)
-      concat f.text_area(:body)
+      concat f.textarea(:body)
       concat f.checkbox(:secret)
     end
 
@@ -2466,7 +2466,7 @@ class FormHelperTest < ActionView::TestCase
     form_for(@post, as: "post[]") do |f|
       concat f.label(:title)
       concat f.text_field(:title)
-      concat f.text_area(:body)
+      concat f.textarea(:body)
       concat f.checkbox(:secret)
     end
 
@@ -2484,7 +2484,7 @@ class FormHelperTest < ActionView::TestCase
   def test_form_for_with_nil_index_option_override
     form_for(@post, as: "post[]", index: nil) do |f|
       concat f.text_field(:title)
-      concat f.text_area(:body)
+      concat f.textarea(:body)
       concat f.checkbox(:secret)
     end
 
@@ -2549,7 +2549,7 @@ class FormHelperTest < ActionView::TestCase
   def test_form_for_with_namespace
     form_for(@post, namespace: "namespace") do |f|
       concat f.text_field(:title)
-      concat f.text_area(:body)
+      concat f.textarea(:body)
       concat f.checkbox(:secret)
     end
 
@@ -2627,7 +2627,7 @@ class FormHelperTest < ActionView::TestCase
     @comment.body = "Hello World"
     form_for(@post, namespace: "namespace") do |f|
       concat f.text_field(:title)
-      concat f.text_area(:body)
+      concat f.textarea(:body)
       concat f.fields_for(@comment) { |c|
         concat c.text_field(:body)
       }
@@ -3660,7 +3660,7 @@ class FormHelperTest < ActionView::TestCase
   def test_fields_for
     @rendered = fields_for(:post, @post) do |f|
       concat f.text_field(:title)
-      concat f.text_area(:body)
+      concat f.textarea(:body)
       concat f.checkbox(:secret)
     end
 
@@ -3682,7 +3682,7 @@ class FormHelperTest < ActionView::TestCase
   def test_fields_for_with_index
     @rendered = fields_for("post[]", @post) do |f|
       concat f.text_field(:title)
-      concat f.text_area(:body)
+      concat f.textarea(:body)
       concat f.checkbox(:secret)
     end
 
@@ -3704,7 +3704,7 @@ class FormHelperTest < ActionView::TestCase
   def test_fields_for_with_nil_index_option_override
     @rendered = fields_for("post[]", @post, index: nil) do |f|
       concat f.text_field(:title)
-      concat f.text_area(:body)
+      concat f.textarea(:body)
       concat f.checkbox(:secret)
     end
 
@@ -3726,7 +3726,7 @@ class FormHelperTest < ActionView::TestCase
   def test_fields_for_with_index_option_override
     @rendered = fields_for("post[]", @post, index: "abc") do |f|
       concat f.text_field(:title)
-      concat f.text_area(:body)
+      concat f.textarea(:body)
       concat f.checkbox(:secret)
     end
 
@@ -3742,7 +3742,7 @@ class FormHelperTest < ActionView::TestCase
   def test_fields_for_without_object
     @rendered = fields_for(:post) do |f|
       concat f.text_field(:title)
-      concat f.text_area(:body)
+      concat f.textarea(:body)
       concat f.checkbox(:secret)
     end
 
@@ -3758,7 +3758,7 @@ class FormHelperTest < ActionView::TestCase
   def test_fields_for_with_only_object
     @rendered = fields_for(@post) do |f|
       concat f.text_field(:title)
-      concat f.text_area(:body)
+      concat f.textarea(:body)
       concat f.checkbox(:secret)
     end
 
@@ -3800,7 +3800,7 @@ class FormHelperTest < ActionView::TestCase
   def test_form_for_and_fields_for
     form_for(@post, as: :post, html: { id: "create-post" }) do |post_form|
       concat post_form.text_field(:title)
-      concat post_form.text_area(:body)
+      concat post_form.textarea(:body)
 
       concat fields_for(:parent_post, @post) { |parent_fields|
         concat parent_fields.checkbox(:secret)
@@ -3820,7 +3820,7 @@ class FormHelperTest < ActionView::TestCase
   def test_form_for_and_fields_for_with_object
     form_for(@post, as: :post, html: { id: "create-post" }) do |post_form|
       concat post_form.text_field(:title)
-      concat post_form.text_area(:body)
+      concat post_form.textarea(:body)
 
       concat post_form.fields_for(@comment) { |comment_fields|
         concat comment_fields.text_field(:name)
@@ -3863,7 +3863,7 @@ class FormHelperTest < ActionView::TestCase
   def test_form_for_with_labelled_builder
     form_for(@post, builder: LabelledFormBuilder) do |f|
       concat f.text_field(:title)
-      concat f.text_area(:body)
+      concat f.textarea(:body)
       concat f.checkbox(:secret)
     end
 
@@ -3882,7 +3882,7 @@ class FormHelperTest < ActionView::TestCase
 
     form_for(@post) do |f|
       concat f.text_field(:title)
-      concat f.text_area(:body)
+      concat f.textarea(:body)
       concat f.checkbox(:secret)
     end
 
@@ -3941,7 +3941,7 @@ class FormHelperTest < ActionView::TestCase
   def test_fields_for_with_labelled_builder
     @rendered = fields_for(:post, @post, builder: LabelledFormBuilder) do |f|
       concat f.text_field(:title)
-      concat f.text_area(:body)
+      concat f.textarea(:body)
       concat f.checkbox(:secret)
     end
 

--- a/actionview/test/template/form_tag_helper_test.rb
+++ b/actionview/test/template/form_tag_helper_test.rb
@@ -508,43 +508,43 @@ class FormTagHelperTest < ActionView::TestCase
     assert_dom_equal expected, actual
   end
 
-  def test_text_area_tag_size_string
-    actual = text_area_tag "body", "hello world", "size" => "20x40"
+  def test_textarea_tag_size_string
+    actual = textarea_tag "body", "hello world", "size" => "20x40"
     expected = %(<textarea cols="20" id="body" name="body" rows="40">\nhello world</textarea>)
     assert_dom_equal expected, actual
   end
 
-  def test_text_area_tag_size_symbol
-    actual = text_area_tag "body", "hello world", size: "20x40"
+  def test_textarea_tag_size_symbol
+    actual = textarea_tag "body", "hello world", size: "20x40"
     expected = %(<textarea cols="20" id="body" name="body" rows="40">\nhello world</textarea>)
     assert_dom_equal expected, actual
   end
 
-  def test_text_area_tag_should_disregard_size_if_its_given_as_an_integer
-    actual = text_area_tag "body", "hello world", size: 20
+  def test_textarea_tag_should_disregard_size_if_its_given_as_an_integer
+    actual = textarea_tag "body", "hello world", size: 20
     expected = %(<textarea id="body" name="body">\nhello world</textarea>)
     assert_dom_equal expected, actual
   end
 
-  def test_text_area_tag_id_sanitized
-    input_elem = root_elem(text_area_tag("item[][description]"))
+  def test_textarea_tag_id_sanitized
+    input_elem = root_elem(textarea_tag("item[][description]"))
     assert_match VALID_HTML_ID, input_elem["id"]
   end
 
-  def test_text_area_tag_escape_content
-    actual = text_area_tag "body", "<b>hello world</b>", size: "20x40"
+  def test_textarea_tag_escape_content
+    actual = textarea_tag "body", "<b>hello world</b>", size: "20x40"
     expected = %(<textarea cols="20" id="body" name="body" rows="40">\n&lt;b&gt;hello world&lt;/b&gt;</textarea>)
     assert_dom_equal expected, actual
   end
 
-  def test_text_area_tag_unescaped_content
-    actual = text_area_tag "body", "<b>hello world</b>", size: "20x40", escape: false
+  def test_textarea_tag_unescaped_content
+    actual = textarea_tag "body", "<b>hello world</b>", size: "20x40", escape: false
     expected = %(<textarea cols="20" id="body" name="body" rows="40">\n<b>hello world</b></textarea>)
     assert_dom_equal expected, actual
   end
 
-  def test_text_area_tag_unescaped_nil_content
-    actual = text_area_tag "body", nil, escape: false
+  def test_textarea_tag_unescaped_nil_content
+    actual = textarea_tag "body", nil, escape: false
     expected = %(<textarea id="body" name="body">\n</textarea>)
     assert_dom_equal expected, actual
   end
@@ -941,9 +941,9 @@ class FormTagHelperTest < ActionView::TestCase
     assert_dom_equal expected, output_buffer
   end
 
-  def test_text_area_tag_options_symbolize_keys_side_effects
+  def test_textarea_tag_options_symbolize_keys_side_effects
     options = { option: "random_option" }
-    text_area_tag "body", "hello world", options
+    textarea_tag "body", "hello world", options
     assert_equal({ option: "random_option" }, options)
   end
 

--- a/activestorage/README.md
+++ b/activestorage/README.md
@@ -73,7 +73,7 @@ end
 ```erb
 <%= form_with model: @message, local: true do |form| %>
   <%= form.text_field :title, placeholder: "Title" %><br>
-  <%= form.text_area :content %><br><br>
+  <%= form.textarea :content %><br><br>
 
   <%= form.file_field :images, multiple: true %><br>
   <%= form.submit %>

--- a/guides/source/action_text_overview.md
+++ b/guides/source/action_text_overview.md
@@ -130,7 +130,7 @@ name the attribute to be something different from `content`.
 Once you have added the `has_rich_text` class method to the model, you can then
 update your views to make use of the rich text editor (Trix) for that field. To
 do so, use a
-[`rich_text_area`](https://api.rubyonrails.org/classes/ActionView/Helpers/FormHelper.html#method-i-rich_text_area)
+[`rich_textarea`](https://api.rubyonrails.org/classes/ActionView/Helpers/FormHelper.html#method-i-rich_textarea)
 for the form field.
 
 ```html+erb
@@ -138,7 +138,7 @@ for the form field.
 <%= form_with model: article do |form| %>
   <div class="field">
     <%= form.label :content %>
-    <%= form.rich_text_area :content %>
+    <%= form.rich_textarea :content %>
   </div>
 <% end %>
 ```

--- a/guides/source/active_support_core_extensions.md
+++ b/guides/source/active_support_core_extensions.md
@@ -2967,7 +2967,7 @@ In case of key collision, the value will be the one most recently inserted into 
 This method may be useful for example to easily accept both symbols and strings as options. For instance `ActionText::TagHelper` defines
 
 ```ruby
-def rich_text_area_tag(name, value = nil, options = {})
+def rich_textarea_tag(name, value = nil, options = {})
   options = options.symbolize_keys
 
   options[:input] ||= "trix_input_#{ActionText::TagHelper.id += 1}"

--- a/guides/source/engines.md
+++ b/guides/source/engines.md
@@ -515,7 +515,7 @@ directory at `app/views/blorgh/comments` and in it a new file called
 <%= form_with model: [@article, @article.comments.build] do |form| %>
   <p>
     <%= form.label :text %><br>
-    <%= form.text_area :text %>
+    <%= form.textarea :text %>
   </p>
   <%= form.submit %>
 <% end %>

--- a/guides/source/form_helpers.md
+++ b/guides/source/form_helpers.md
@@ -216,7 +216,7 @@ Output:
 Other common helpers:
 
 ```erb
-<%= form.text_area :message, size: "70x5" %>
+<%= form.textarea :message, size: "70x5" %>
 <%= form.hidden_field :parent_id, value: "foo" %>
 <%= form.number_field :price, in: 1.0..20.0, step: 0.5 %>
 <%= form.range_field :discount, in: 1..100 %>

--- a/guides/source/getting_started.md
+++ b/guides/source/getting_started.md
@@ -839,7 +839,7 @@ Let's create `app/views/articles/new.html.erb` with the following contents:
 
   <div>
     <%= form.label :body %><br>
-    <%= form.text_area :body %>
+    <%= form.textarea :body %>
   </div>
 
   <div>
@@ -982,7 +982,7 @@ display any error messages for `title` and `body`:
 
   <div>
     <%= form.label :body %><br>
-    <%= form.text_area :body %><br>
+    <%= form.textarea :body %><br>
     <% @article.errors.full_messages_for(:body).each do |message| %>
       <div><%= message %></div>
     <% end %>
@@ -1146,7 +1146,7 @@ the following contents:
 
   <div>
     <%= form.label :body %><br>
-    <%= form.text_area :body %><br>
+    <%= form.textarea :body %><br>
     <% article.errors.full_messages_for(:body).each do |message| %>
       <div><%= message %></div>
     <% end %>
@@ -1492,7 +1492,7 @@ So first, we'll wire up the Article show template
   </p>
   <p>
     <%= form.label :body %><br>
-    <%= form.text_area :body %>
+    <%= form.textarea :body %>
   </p>
   <p>
     <%= form.submit %>
@@ -1572,7 +1572,7 @@ add that to the `app/views/articles/show.html.erb`.
   </p>
   <p>
     <%= form.label :body %><br>
-    <%= form.text_area :body %>
+    <%= form.textarea :body %>
   </p>
   <p>
     <%= form.submit %>
@@ -1637,7 +1637,7 @@ following:
   </p>
   <p>
     <%= form.label :body %><br>
-    <%= form.text_area :body %>
+    <%= form.textarea :body %>
   </p>
   <p>
     <%= form.submit %>
@@ -1664,7 +1664,7 @@ create a file `app/views/comments/_form.html.erb` containing:
   </p>
   <p>
     <%= form.label :body %><br>
-    <%= form.text_area :body %>
+    <%= form.textarea :body %>
   </p>
   <p>
     <%= form.submit %>

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Generate form helpers to use `textarea*` methods instead of `text_area*` methods
+
+    *Sean Doyle*
+
 *   Add authentication generator to give a basic start to an authentication system using database-tracked sessions.
 
     Generate with...

--- a/railties/lib/rails/generators/generated_attribute.rb
+++ b/railties/lib/rails/generators/generated_attribute.rb
@@ -126,8 +126,8 @@ module Rails
                         when :time                     then :time_field
                         when :datetime, :timestamp     then :datetime_field
                         when :date                     then :date_field
-                        when :text                     then :text_area
-                        when :rich_text                then :rich_text_area
+                        when :text                     then :textarea
+                        when :rich_text                then :rich_textarea
                         when :boolean                  then :checkbox
                         when :attachment, :attachments then :file_field
                         else

--- a/railties/test/generators/generated_attribute_test.rb
+++ b/railties/test/generators/generated_attribute_test.rb
@@ -49,16 +49,16 @@ class GeneratedAttributeTest < Rails::Generators::TestCase
     assert_field_type :date, :date_field
   end
 
-  def test_field_type_returns_text_area
-    assert_field_type :text, :text_area
+  def test_field_type_returns_textarea
+    assert_field_type :text, :textarea
   end
 
   def test_field_type_returns_checkbox
     assert_field_type :boolean, :checkbox
   end
 
-  def test_field_type_returns_rich_text_area
-    assert_field_type :rich_text, :rich_text_area
+  def test_field_type_returns_rich_textarea
+    assert_field_type :rich_text, :rich_textarea
   end
 
   def test_field_type_returns_file_field

--- a/railties/test/generators/scaffold_generator_test.rb
+++ b/railties/test/generators/scaffold_generator_test.rb
@@ -493,7 +493,7 @@ class ScaffoldGeneratorTest < Rails::Generators::TestCase
     end
 
     assert_file "app/views/messages/_form.html.erb" do |content|
-      assert_match(/^\W{4}<%= form\.rich_text_area :content %>/, content)
+      assert_match(/^\W{4}<%= form\.rich_textarea :content %>/, content)
     end
 
     assert_file "test/system/messages_test.rb" do |content|

--- a/tasks/release.rb
+++ b/tasks/release.rb
@@ -226,8 +226,8 @@ namespace :all do
       end
     CODE
 
-    substitute.call("app/views/users/_form.html.erb", /text_area :description %>\n  <\/div>/, <<~CODE)
-      rich_text_area :description %>\n  </div>
+    substitute.call("app/views/users/_form.html.erb", /textarea :description %>\n  <\/div>/, <<~CODE)
+      rich_textarea :description %>\n  </div>
 
       <div class="field">
         Avatar: <%= form.file_field :avatar %>


### PR DESCRIPTION

### Motivation / Background

Follow-up to [#52432][]
Related to [#52430][]

Helpers like `text_area_tag` construct [textarea][] elements. This commit renames all view helper and form builder methods to replace occurrences of `text_area` with `textarea`.

### Detail

In the same style, this commit also renames the `rich_text`-prefixed helpers to utilize a `textarea` suffix instead of the existing `text_area` suffix.

To preserve backwards compatibility, this commit defines aliases for the existing `text_area` format.

[#52432]: https://github.com/rails/rails/pull/52432
[#52430]: https://github.com/rails/rails/issues/52430
[textarea]: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
