### PR TITLE
Use `RAILS_MAX_THREADS` in `ActiveJob::AsyncAdapter`

### DIFF
--- a/activejob/CHANGELOG.md
+++ b/activejob/CHANGELOG.md
@@ -1,2 +1,5 @@
+*   Use `RAILS_MAX_THREADS` in `ActiveJob::AsyncAdapter`. If it is not set, use 5 as default.
+
+    *heka1024*
 
 Please check [7-2-stable](https://github.com/rails/rails/blob/7-2-stable/activejob/CHANGELOG.md) for previous changes.

--- a/activejob/lib/active_job/queue_adapters/async_adapter.rb
+++ b/activejob/lib/active_job/queue_adapters/async_adapter.rb
@@ -74,7 +74,7 @@ module ActiveJob
       class Scheduler # :nodoc:
         DEFAULT_EXECUTOR_OPTIONS = {
           min_threads:     0,
-          max_threads:     Concurrent.processor_count,
+          max_threads:     ENV.fetch("RAILS_MAX_THREADS", 5).to_i,
           auto_terminate:  true,
           idletime:        60, # 1 minute
           max_queue:       0, # unlimited


### PR DESCRIPTION
### Motivation / Background

Now that running in containers is more common, `Concurrent.available_processor_count` is more appropriate than `Concurrent.processor_count`. However, we keep a fallback for situations where available_processor cannot be retrieved. 

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
