### PR TITLE
Ensure authentication generator templates produce compliant code

### DIFF
--- a/railties/lib/rails/generators/rails/authentication/templates/controllers/concerns/authentication.rb
+++ b/railties/lib/rails/generators/rails/authentication/templates/controllers/concerns/authentication.rb
@@ -61,4 +61,3 @@ module Authentication
       cookies.delete(:session_token)
     end
 end
-

--- a/railties/lib/rails/generators/rails/authentication/templates/models/current.rb
+++ b/railties/lib/rails/generators/rails/authentication/templates/models/current.rb
@@ -2,4 +2,3 @@ class Current < ActiveSupport::CurrentAttributes
   attribute :session
   delegate :user, to: :session, allow_nil: true
 end
-

--- a/railties/lib/rails/generators/rails/authentication/templates/models/session.rb
+++ b/railties/lib/rails/generators/rails/authentication/templates/models/session.rb
@@ -2,4 +2,3 @@ class Session < ApplicationRecord
   has_secure_token
   belongs_to :user
 end
-


### PR DESCRIPTION
These extra lines of whitespace cause failures from Rubocop's `Layout/TrailingEmptyLines` rule which is enabled by default in Rails at the time of writing.

As such creating a brand new Rails 8 app and then running `rails generate authentication` will give you Rubocop failures.

I have read the contributing guide around cosmetic changes and whitespace but this pull request is **not** a cosmetic change as the erroneous whitespace is being pulled through into generated application code and failing Rubocop rules which are enabled by default. I do not believe it should be possible to generate code which fails Rails's own default Rubocop rules on a brand new application with a simple Rails generator command.