### PR TITLE
Refactor CodeGenerator uses in Action View

### DIFF
--- a/actionview/lib/action_view/helpers/form_helper.rb
+++ b/actionview/lib/action_view/helpers/form_helper.rb
@@ -2020,20 +2020,15 @@ module ActionView
       #
       # Please refer to the documentation of the base helper for details.
 
-      ActiveSupport::CodeGenerator.batch(self, __FILE__, __LINE__) do |code_generator|
-        (field_helpers - [:label, :checkbox, :radio_button, :fields_for, :fields, :hidden_field, :file_field]).each do |selector|
-          code_generator.define_cached_method(selector, namespace: :form_builder) do |batch|
-            batch.push <<-RUBY_EVAL
-              def #{selector}(method, options = {})  # def text_field(method, options = {})
-                @template.public_send(               #   @template.public_send(
-                  #{selector.inspect},               #     :text_field,
-                  @object_name,                      #     @object_name,
-                  method,                            #     method,
-                  objectify_options(options))        #     objectify_options(options))
-              end                                    # end
-            RUBY_EVAL
+      (field_helpers - [:label, :checkbox, :radio_button, :fields_for, :fields, :hidden_field, :file_field]).each do |selector|
+        ActiveSupport::CodeGenerator.batch(self, __FILE__, __LINE__) do |code_generator|
+            code_generator.class_eval do |batch|
+              batch <<
+                "def #{selector}(method, options = {})" <<
+                "  @template.#{selector}(@object_name, method, objectify_options(options))" <<
+                "end"
+            end
           end
-        end
       end
       alias_method :text_area, :textarea
 

--- a/actionview/lib/action_view/helpers/tag_helper.rb
+++ b/actionview/lib/action_view/helpers/tag_helper.rb
@@ -48,48 +48,51 @@ module ActionView
         include CaptureHelper
         include OutputSafetyHelper
 
-        def self.define_element(name, code_generator:, method_name: name.to_s.underscore)
-          code_generator.define_cached_method(method_name, namespace: :tag_builder) do |batch|
-            batch.push(<<~RUBY) unless instance_methods.include?(method_name.to_sym)
-              def #{method_name}(content = nil, escape: true, **options, &block)
-                tag_string("#{name}", content, options, escape: escape, &block)
-              end
-            RUBY
+        def deprecated_void_content(name)
+          ActionView.deprecator.warn <<~TEXT
+            Putting content inside a void element (#{name}) is invalid
+            according to the HTML5 spec, and so it is being deprecated
+            without replacement. In Rails 8.0, passing content as a
+            positional argument will raise, and using a block will have
+            no effect.
+          TEXT
+        end
+
+        def self.define_element(name, code_generator:, method_name: name)
+          return if method_defined?(name)
+
+          code_generator.class_eval do |batch|
+            batch << "\n" <<
+              "def #{method_name}(content = nil, escape: true, **options, &block)" <<
+              "  tag_string(#{name.inspect}, content, options, escape: escape, &block)" <<
+              "end"
           end
         end
 
-        def self.define_void_element(name, code_generator:, method_name: name.to_s.underscore)
-          code_generator.define_cached_method(method_name, namespace: :tag_builder) do |batch|
-            batch.push(<<~RUBY)
-              def #{method_name}(content = nil, escape: true, **options, &block)
-                if content || block
-                  ActionView.deprecator.warn <<~TEXT
-                    Putting content inside a void element (#{name}) is invalid
-                    according to the HTML5 spec, and so it is being deprecated
-                    without replacement. In Rails 8.0, passing content as a
-                    positional argument will raise, and using a block will have
-                    no effect.
-                  TEXT
-                  tag_string("#{name}", content, options, escape: escape, &block)
-                else
-                  self_closing_tag_string("#{name}", options, escape, ">")
-                end
-              end
-            RUBY
+        def self.define_void_element(name, code_generator:, method_name: name)
+          code_generator.class_eval do |batch|
+            batch << "\n" <<
+              "def #{method_name}(content = nil, escape: true, **options, &block)" <<
+              "  p :called; if content || block" <<
+              "    deprecated_void_content(#{name.inspect})" <<
+              "    tag_string(#{name.inspect}, content, options, escape: escape, &block)" <<
+              "  else" <<
+              "    self_closing_tag_string(#{name.inspect}, options, escape, '>')" <<
+              "  end" <<
+              "end"
           end
         end
 
-        def self.define_self_closing_element(name, code_generator:, method_name: name.to_s.underscore)
-          code_generator.define_cached_method(method_name, namespace: :tag_builder) do |batch|
-            batch.push(<<~RUBY)
-              def #{method_name}(content = nil, escape: true, **options, &block)
-                if content || block
-                  tag_string("#{name}", content, options, escape: escape, &block)
-                else
-                  self_closing_tag_string("#{name}", options, escape)
-                end
-              end
-            RUBY
+        def self.define_self_closing_element(name, code_generator:, method_name: name)
+          code_generator.class_eval do |batch|
+            batch << "\n" <<
+              "def #{method_name}(content = nil, escape: true, **options, &block)" <<
+              "  if content || block" <<
+              "    tag_string(#{name.inspect}, content, options, escape: escape, &block)" <<
+              "  else" <<
+              "   self_closing_tag_string(#{name.inspect}, options, escape)" <<
+              "  end" <<
+              "end"
           end
         end
 
@@ -110,8 +113,8 @@ module ActionView
           define_void_element :wbr, code_generator: code_generator
 
           define_self_closing_element :animate, code_generator: code_generator
-          define_self_closing_element :animateMotion, code_generator: code_generator
-          define_self_closing_element :animateTransform, code_generator: code_generator
+          define_self_closing_element :animateMotion, code_generator: code_generator, method_name: :animate_motion
+          define_self_closing_element :animateTransform, code_generator: code_generator, method_name: :animate_transform
           define_self_closing_element :circle, code_generator: code_generator
           define_self_closing_element :ellipse, code_generator: code_generator
           define_self_closing_element :line, code_generator: code_generator

--- a/activesupport/lib/active_support/code_generator.rb
+++ b/activesupport/lib/active_support/code_generator.rb
@@ -55,6 +55,11 @@ module ActiveSupport
       @path = path
       @line = line
       @namespaces = Hash.new { |h, k| h[k] = MethodSet.new(k) }
+      @sources = []
+    end
+
+    def class_eval
+      yield @sources
     end
 
     def define_cached_method(canonical_name, namespace:, as: nil, &block)
@@ -64,6 +69,10 @@ module ActiveSupport
     def execute
       @namespaces.each_value do |method_set|
         method_set.apply(@owner, @path, @line - 1)
+      end
+
+      unless @sources.empty?
+        @owner.class_eval("# frozen_string_literal: true\n" + @sources.join(";"), @path, @line - 1)
       end
     end
   end


### PR DESCRIPTION
CodeGenerator has multiple purposes.

First it's too batch `class_eval` calls, because each call has a fixed cost , so by batching we're faster.

Second it's to be able to generate methods with the proper source location. So that if a user introspect a method, it's pointed to the proper macro.

And third, it is optionally to re-used generated method, typically attribute accessors are very often duplicated.

Where it's used in Action View, there is no need for deduplication, so `defined_cached_method` is just extra work.

Additionally, the source locations were incorrect because of the use of heredoc.

This commit introduce `CodeGenerator#class_eval` for cases where we don't need duplication, and fixes the source locations.
