### PR TITLE
7.2: Don't claim compatibility with unknown future Rack releases

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,7 +44,7 @@ PATH
       activesupport (= 7.2.0.beta3)
       nokogiri (>= 1.8.5)
       racc
-      rack (>= 2.2.4)
+      rack (>= 2.2.4, < 3.2)
       rack-session (>= 1.0.1)
       rack-test (>= 0.6.3)
       rails-dom-testing (~> 2.2)

--- a/actionpack/actionpack.gemspec
+++ b/actionpack/actionpack.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "nokogiri", ">= 1.8.5"
   s.add_dependency "racc"
-  s.add_dependency "rack",      ">= 2.2.4"
+  s.add_dependency "rack", ">= 2.2.4", "< 3.2"
   s.add_dependency "rack-session", ">= 1.0.1"
   s.add_dependency "rack-test", ">= 0.6.3"
   s.add_dependency "rails-html-sanitizer", "~> 1.6"


### PR DESCRIPTION
Rack wants to be able to make incompatible changes in future versions, so we should not publish an open-ended dependency.

We can revisit this for 8.0 -- I have some ideas of [more complicated, put possible] approaches to allowing some forwards compat in future. But for now, we just need to make sure that Rails users won't be at risk of walking into a subtly broken framework state due to bumping Rack.