### PR TITLE
Support second-level precision for `assert_enqueued_with`

### DIFF
--- a/activejob/CHANGELOG.md
+++ b/activejob/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Support second-level precision for `assert_enqueued_with`
+
+    Fixes #52478.
+
+    *Steve Polito*
+
 *   Allow queue adapters to inspect a job when deciding whether to interrupt at
     a checkpoint, and to optionally return a specific interruption reason.
 

--- a/activejob/lib/active_job/test_helper.rb
+++ b/activejob/lib/active_job/test_helper.rb
@@ -766,8 +766,9 @@ module ActiveJob
           end
 
           if arguments[:at].acts_like?(:time)
-            at_range = arguments[:at] - 1..arguments[:at] + 1
-            arguments[:at] = ->(at) { at_range.cover?(at) }
+            expected_at = arguments[:at]
+            # Tolerate sub-second drift from Float serialization round-trips.
+            arguments[:at] = ->(at) { (at - expected_at).abs < 1.second }
           end
         end
       end

--- a/activejob/test/cases/test_helper_test.rb
+++ b/activejob/test/cases/test_helper_test.rb
@@ -1902,6 +1902,18 @@ class PerformedJobsTest < ActiveJob::TestCase
       end
     end
 
+    def test_assert_performed_with_with_at_option_with_second_level_precision
+      assert_performed_with(job: HelloJob, at: Date.tomorrow.noon) do
+        HelloJob.set(wait_until: Date.tomorrow.noon).perform_later
+      end
+
+      assert_raise ActiveSupport::TestCase::Assertion do
+        assert_performed_with(job: HelloJob, at: Time.new("1989-12-31T12:00:01")) do
+          HelloJob.set(wait_until: Time.new("1989-12-31T12:00:02")).perform_later
+        end
+      end
+    end
+
     def test_assert_performed_with_with_relative_at_option
       assert_performed_with(job: HelloJob, at: 5.minutes.from_now) do
         HelloJob.set(wait: 5.minutes).perform_later


### PR DESCRIPTION
### Motivation / Background

Closes #52478

Prior to this commit, tests using [assert_enqueued_with][] asserting against the `at` argument would incorrectly pass if testing with values that used second-level precision.

```ruby
class BuggyJobTest < ActiveJob::TestCase
  def test_should_not_find_job
    at =  Time.new("1989-12-31T12:00:01")
    wait_until = Time.new("1989-12-31T12:00:02")

    assert_enqueued_with(job: BuggyJob, at:) do
      BuggyJob.set(wait_until:).perform_later
    end

    fail "Should not reach this line because assert_enqueued_with should have failed"
  end
end
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.

[assert_enqueued_with]: https://edgeapi.rubyonrails.org/classes/ActiveJob/TestHelper.html#method-i-assert_enqueued_with