### PR TITLE
Implement the bin/rails boot command

### DIFF
--- a/guides/source/command_line.md
+++ b/guides/source/command_line.md
@@ -668,6 +668,7 @@ The `tmp:` namespaced commands will help you clear and create the `Rails.root/tm
 * `bin/rails stats` is great for looking at statistics on your code, displaying things like KLOCs (thousands of lines of code) and your code to test ratio.
 * `bin/rails secret` will give you a pseudo-random key to use for your session secret.
 * `bin/rails time:zones:all` lists all the timezones Rails knows about.
+* `bin/rails boot` boots the application and exits.
 
 ### Custom Rake Tasks
 

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   The new `bin/rails boot` command boots the application and exits. Supports the
+    standard `-e/--environment` options.
+
+    *Xavier Noria*
+
 *   Generate form helpers to use `textarea*` methods instead of `text_area*` methods
 
     *Sean Doyle*

--- a/railties/lib/rails/commands/boot/boot_command.rb
+++ b/railties/lib/rails/commands/boot/boot_command.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require "rails/command/environment_argument"
+
+module Rails
+  module Command
+    class BootCommand < Base # :nodoc:
+      include EnvironmentArgument
+
+      desc "boot", "Boot the application and exit"
+      def perform(*) = boot_application!
+    end
+  end
+end

--- a/railties/test/commands/boot_test.rb
+++ b/railties/test/commands/boot_test.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require "isolation/abstract_unit"
+require "rails/command"
+require "rails/commands/boot/boot_command"
+
+class Rails::Command::BootTest < ActiveSupport::TestCase
+  include ActiveSupport::Testing::Isolation
+
+  setup :build_app
+  teardown :teardown_app
+
+  test "boots the application" do
+    test_file = "#{app_path}/tmp/test_file"
+
+    app_file "config/initializers/write_test_file.rb", <<-RUBY
+      File.write(#{test_file.inspect}, Rails.env)
+    RUBY
+
+    rails "boot"
+
+    assert_equal "development", File.read(test_file)
+  end
+
+  test "optionally accepts an environment" do
+    test_file = "#{app_path}/tmp/test_file"
+
+    app_file "config/initializers/write_test_file.rb", <<-RUBY
+      File.write(#{test_file.inspect}, Rails.env)
+    RUBY
+
+    rails "boot", "-e", "test"
+
+    assert_equal "test", File.read(test_file)
+  end
+end


### PR DESCRIPTION
I find myself booting applications often, to benchmark something, to understand something in their boot logic, ....

In order to do that, I normally use the `runner` command like this:

```
bin/rails r 1
```

That boots the application, invokes any existing `runner` hooks, and executes the Ruby program that consists of the integer literal `1`.

This trick has served me well for many years, but it is indirect. I miss something more concise that precisely means "boot the application and do nothing else".

Hence this new `boot` command.