### PR TITLE
Delay enqueue_after_transaction_commit config until ActiveJob loaded

### DIFF
--- a/activejob/lib/active_job/railtie.rb
+++ b/activejob/lib/active_job/railtie.rb
@@ -26,14 +26,12 @@ module ActiveJob
     end
 
     initializer "active_job.enqueue_after_transaction_commit" do |app|
-      if config.active_job.key?(:enqueue_after_transaction_commit)
-        enqueue_after_transaction_commit = config.active_job.delete(:enqueue_after_transaction_commit)
+      ActiveSupport.on_load(:active_record) do
+        ActiveSupport.on_load(:active_job) do
+          include EnqueueAfterTransactionCommit
 
-        ActiveSupport.on_load(:active_record) do
-          ActiveSupport.on_load(:active_job) do
-            include EnqueueAfterTransactionCommit
-
-            ActiveJob::Base.enqueue_after_transaction_commit = enqueue_after_transaction_commit
+          if app.config.active_job.key?(:enqueue_after_transaction_commit)
+            ActiveJob::Base.enqueue_after_transaction_commit = app.config.active_job.delete(:enqueue_after_transaction_commit)
           end
         end
       end


### PR DESCRIPTION
### Motivation / Background

This fixes an issue where the `enqueue_after_transaction_commit` config is ignored in app initializers.
Ref #51426 @byroot 

This should be backported for the Rails 7.2 release.

### Detail

ActiveJob's initializer for this configuration option runs before app initializers. If you upgrade from Rails 7.1 or lower to 7.2 and enable this in `config/initializers/new_framework_defaults_7_2.rb`, this config is ignored because the ActiveJob Railtie has already executed.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
