### PR TITLE
Change human_attribute_name to raise an error iff in strict mode

### DIFF
--- a/activesupport/lib/active_support/i18n_railtie.rb
+++ b/activesupport/lib/active_support/i18n_railtie.rb
@@ -49,7 +49,8 @@ module I18n
         when :load_path
           I18n.load_path += value
         when :raise_on_missing_translations
-          setup_raise_on_missing_translations_config(app)
+          strict = value == :strict
+          setup_raise_on_missing_translations_config(app, strict)
         else
           I18n.public_send("#{setting}=", value)
         end
@@ -78,13 +79,13 @@ module I18n
       @i18n_inited = true
     end
 
-    def self.setup_raise_on_missing_translations_config(app)
+    def self.setup_raise_on_missing_translations_config(app, strict)
       ActiveSupport.on_load(:action_view) do
         ActionView::Helpers::TranslationHelper.raise_on_missing_translations = app.config.i18n.raise_on_missing_translations
       end
 
       ActiveSupport.on_load(:active_model_translation) do
-        ActiveModel::Translation.raise_on_missing_translations = app.config.i18n.raise_on_missing_translations
+        ActiveModel::Translation.raise_on_missing_translations = app.config.i18n.raise_on_missing_translations if strict
       end
 
       if app.config.i18n.raise_on_missing_translations &&

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -937,7 +937,7 @@ Sets the path Rails uses to look for locale files. Defaults to `config/locales/*
 
 #### `config.i18n.raise_on_missing_translations`
 
-Determines whether an error should be raised for missing translations. This defaults to `false`.
+Determines whether an error should be raised for missing translations. If `true`, views and controllers raise `I18n::MissingTranslationData`. If `:strict`, models also raise the error. This defaults to `false`.
 
 #### `config.i18n.fallbacks`
 

--- a/guides/source/i18n.md
+++ b/guides/source/i18n.md
@@ -1150,7 +1150,7 @@ The I18n API defines the following exceptions that will be raised by backends wh
 
 #### Customizing how `I18n::MissingTranslationData` is handled
 
-If `config.i18n.raise_on_missing_translations` is `true`, `I18n::MissingTranslationData` errors will be raised. It's a good idea to turn this on in your test environment, so you can catch places where missing translations are requested.
+If `config.i18n.raise_on_missing_translations` is `true`, `I18n::MissingTranslationData` errors will be raised from views and controllers. If the value is `:strict`, models also raise the error. It's a good idea to turn this on in your test environment, so you can catch places where missing translations are requested.
 
 If `config.i18n.raise_on_missing_translations` is `false` (the default in all environments), the exception's error message will be printed. This contains the missing key/scope so you can fix your code.
 

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -4633,8 +4633,8 @@ module ApplicationTests
       assert_includes last_response.body, "rescued missing translation error from view"
     end
 
-    test "raise_on_missing_translations affects human_attribute_name in model" do
-      add_to_config "config.i18n.raise_on_missing_translations = true"
+    test "raise_on_missing_translations = :strict affects human_attribute_name in model" do
+      add_to_config "config.i18n.raise_on_missing_translations = :strict"
 
       app_file "app/models/post.rb", <<-RUBY
         class Post < ActiveRecord::Base
@@ -4644,6 +4644,21 @@ module ApplicationTests
       app "development"
 
       assert_raises I18n::MissingTranslationData do
+        Post.human_attribute_name("title")
+      end
+    end
+
+    test "raise_on_missing_translations = true does not affect human_attribute_name in model" do
+      add_to_config "config.i18n.raise_on_missing_translations = true"
+
+      app_file "app/models/post.rb", <<-RUBY
+        class Post < ActiveRecord::Base
+        end
+      RUBY
+
+      app "development"
+
+      assert_nothing_raised do
         Post.human_attribute_name("title")
       end
     end


### PR DESCRIPTION
Problem:

f6c0a35b1b8b4fb4d033aa6c09c4efaaf6652bdc changed `human_attribute_name` to raise error if `raise_on_missing_translations` is `true`. This change had a major impact on existing applications (i.e., too many missing translation errors).

Solution:

Change `human_attribute_name` to raise an error iff `raise_on_missing_translations` is `:strict`.