### PR TITLE
Adds missing require to action_dispatch/http/mime_negotiation

### DIFF
--- a/actionpack/lib/action_dispatch/http/mime_negotiation.rb
+++ b/actionpack/lib/action_dispatch/http/mime_negotiation.rb
@@ -3,6 +3,7 @@
 # :markup: markdown
 
 require "active_support/core_ext/module/attribute_accessors"
+require "active_support/concern"
 
 module ActionDispatch
   module Http


### PR DESCRIPTION
Requiring `action_dispatch/http/request` outside of Rails results in an error due to `MimeNegotiation` depending on `ActiveSupport::Concern` without requiring it.