### PR TITLE
Add `ActiveModel::Serializers::JSON.key_format`

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,3 +1,26 @@
+*   Add `ActiveModel::Serializers::JSON.key_format`
+
+    ```ruby
+    class User
+      include ActiveModel::API
+      include ActiveModel::Serializers::JSON
+
+      key_format from_json: :underscore,
+                 to_json: ->(key) { key.camelize :lower }
+
+      attr_accessor :name, :born_on
+    end
+
+    json = { name: "Ruby on Rails", bornOn: "2004-11-24" }.to_json
+
+    user = User.new.from_json(json)
+    user.name                       # => "Ruby on Rails"
+    user.born_on                    # => "2004-11-24"
+    user.to_json == json            # => true
+    ```
+
+    *Sean Doyle*
+
 *   Add a default token generator for password reset tokens when using `has_secure_password`.
 
     ```ruby

--- a/activemodel/test/cases/serializers/json_serialization_test.rb
+++ b/activemodel/test/cases/serializers/json_serialization_test.rb
@@ -14,6 +14,123 @@ class JsonSerializationTest < ActiveModel::TestCase
     @contact.preferences = { "shows" => "anime" }
   end
 
+  test ".key_format supports both :to_json and :from_json options" do
+    model_class = Class.new(Contact) do
+      key_format to_json: :dasherize, from_json: :underscore
+    end
+    json = { "created-at" => "2006-08-01T00:00:00.000Z" }.to_json
+
+    model = model_class.new.from_json(json)
+
+    assert_equal "2006-08-01T00:00:00.000Z", model.created_at
+    assert_equal json, model.to_json
+  end
+
+  test ".key_format merges subsequent calls with :to_json and :from_json options" do
+    model_class = Class.new(Contact) do
+      key_format to_json: :dasherize
+      key_format from_json: :underscore
+    end
+    json = { "created-at" => "2006-08-01T00:00:00.000Z" }.to_json
+
+    model = model_class.new.from_json(json)
+
+    assert_equal "2006-08-01T00:00:00.000Z", model.created_at
+    assert_equal json, model.to_json
+  end
+
+  test ".key_format with proc :to_json option" do
+    model_class = Class.new(Contact) do
+      key_format to_json: proc { |key| key.dasherize }
+    end
+    model = model_class.new created_at: Time.utc(2006, 8, 1)
+
+    assert_equal({ "created-at" => "2006-08-01T00:00:00.000Z" }.to_json, model.to_json)
+  end
+
+  test ".key_format with lambda :to_json option" do
+    model_class = Class.new(Contact) do
+      key_format to_json: ->(key) { key.dasherize }
+    end
+    model = model_class.new created_at: Time.utc(2006, 8, 1)
+
+    assert_equal({ "created-at" => "2006-08-01T00:00:00.000Z" }.to_json, model.to_json)
+  end
+
+  test ".key_format with Symbol :to_json option" do
+    model_class = Class.new(Contact) do
+      key_format to_json: :dasherize
+    end
+    model = model_class.new created_at: Time.utc(2006, 8, 1)
+
+    assert_equal({ "created-at" => "2006-08-01T00:00:00.000Z" }.to_json, model.to_json)
+  end
+
+  test ".key_format with Hash :to_json option" do
+    model_class = Class.new(Contact) do
+      key_format to_json: { camelize: :lower }
+    end
+    model = model_class.new created_at: Time.utc(2006, 8, 1)
+
+    to_json = model.to_json
+
+    assert_equal({ "createdAt" => "2006-08-01T00:00:00.000Z" }.to_json, to_json)
+  end
+
+  test ".key_format with proc :from_json option" do
+    model_class = Class.new(Contact) do
+      key_format from_json: proc { |key| key.underscore }
+    end
+    json = { createdAt: "2006-08-01T00:00:00.000Z" }.to_json
+
+    model = model_class.new.from_json(json)
+
+    assert_equal "2006-08-01T00:00:00.000Z", model.created_at
+  end
+
+  test ".key_format with lambda :from_json option" do
+    model_class = Class.new(Contact) do
+      key_format from_json: ->(key) { key.underscore }
+    end
+    json = { createdAt: "2006-08-01T00:00:00.000Z" }.to_json
+
+    model = model_class.new.from_json(json)
+
+    assert_equal "2006-08-01T00:00:00.000Z", model.created_at
+  end
+
+  test ".key_format with Symbol :from_json option" do
+    model_class = Class.new(Contact) do
+      key_format from_json: :underscore
+    end
+    json = { createdAt: "2006-08-01T00:00:00.000Z" }.to_json
+
+    model = model_class.new.from_json(json)
+
+    assert_equal "2006-08-01T00:00:00.000Z", model.created_at
+  end
+
+  test ".key_format with Hash :from_json option" do
+    model_class = Class.new(Contact) do
+      key_format from_json: { camelize: :lower }
+
+      attr_accessor :createdAt
+    end
+    json = { created_at: "2006-08-01T00:00:00.000Z" }.to_json
+
+    model = model_class.new.from_json(json)
+
+    assert_equal "2006-08-01T00:00:00.000Z", model.createdAt
+  end
+
+  test ".key_format without arguments raises an ArgumentError" do
+    model_class = Class.new(Contact)
+
+    assert_raises ArgumentError, match: /must pass either :to_json or :from_json/ do
+      model_class.key_format
+    end
+  end
+
   test "should not include root in JSON (class method)" do
     json = @contact.to_json
 

--- a/activemodel/test/cases/serializers/json_serialization_test.rb
+++ b/activemodel/test/cases/serializers/json_serialization_test.rb
@@ -39,18 +39,9 @@ class JsonSerializationTest < ActiveModel::TestCase
     assert_equal json, model.to_json
   end
 
-  test ".key_format with proc :to_json option" do
+  test ".key_format with Proc :to_json option" do
     model_class = Class.new(Contact) do
       key_format to_json: proc { |key| key.dasherize }
-    end
-    model = model_class.new created_at: Time.utc(2006, 8, 1)
-
-    assert_equal({ "created-at" => "2006-08-01T00:00:00.000Z" }.to_json, model.to_json)
-  end
-
-  test ".key_format with lambda :to_json option" do
-    model_class = Class.new(Contact) do
-      key_format to_json: ->(key) { key.dasherize }
     end
     model = model_class.new created_at: Time.utc(2006, 8, 1)
 
@@ -66,31 +57,9 @@ class JsonSerializationTest < ActiveModel::TestCase
     assert_equal({ "created-at" => "2006-08-01T00:00:00.000Z" }.to_json, model.to_json)
   end
 
-  test ".key_format with Hash :to_json option" do
-    model_class = Class.new(Contact) do
-      key_format to_json: { camelize: :lower }
-    end
-    model = model_class.new created_at: Time.utc(2006, 8, 1)
-
-    to_json = model.to_json
-
-    assert_equal({ "createdAt" => "2006-08-01T00:00:00.000Z" }.to_json, to_json)
-  end
-
-  test ".key_format with proc :from_json option" do
+  test ".key_format with Proc :from_json option" do
     model_class = Class.new(Contact) do
       key_format from_json: proc { |key| key.underscore }
-    end
-    json = { createdAt: "2006-08-01T00:00:00.000Z" }.to_json
-
-    model = model_class.new.from_json(json)
-
-    assert_equal "2006-08-01T00:00:00.000Z", model.created_at
-  end
-
-  test ".key_format with lambda :from_json option" do
-    model_class = Class.new(Contact) do
-      key_format from_json: ->(key) { key.underscore }
     end
     json = { createdAt: "2006-08-01T00:00:00.000Z" }.to_json
 
@@ -108,19 +77,6 @@ class JsonSerializationTest < ActiveModel::TestCase
     model = model_class.new.from_json(json)
 
     assert_equal "2006-08-01T00:00:00.000Z", model.created_at
-  end
-
-  test ".key_format with Hash :from_json option" do
-    model_class = Class.new(Contact) do
-      key_format from_json: { camelize: :lower }
-
-      attr_accessor :createdAt
-    end
-    json = { created_at: "2006-08-01T00:00:00.000Z" }.to_json
-
-    model = model_class.new.from_json(json)
-
-    assert_equal "2006-08-01T00:00:00.000Z", model.createdAt
   end
 
   test ".key_format without arguments raises an ArgumentError" do


### PR DESCRIPTION
### Motivation / Background

The problem:

Active Model support for JSON serialization and deserialization assumes underscored keys.

Support for assigning Ruby attributes from snake_case JSON properties is well supported through [ActiveModel::Serializers::JSON#from_json][]:

```ruby
class User
  include ActiveModel::API
  include ActiveModel::Serializers::JSON

  attr_accessor :name, :born_on

  def attributes
    { name: name, born_on: born_on }
  end
end

user = User.new
user.from_json(<<~JSON)
  {
    "name": "Ruby on Rails",
    "born_on": "2004-11-24"
  }
JSON

user.name       # => "Ruby on Rails"
user.born_on    # => "2004-11-24"
```

However, assigning Ruby attributes from camelCase JSON properties is incompatible with `ActiveModel::Serializers::JSON#from_json`. If the `born_on` property were `bornOn`, attribute assignment would fail for classes that also include [ActiveModel::AttributeAssignment][] (like `ActiveModel::Model` and `ActiveRecord::Base`). Since `ActiveModel::AttributeAssignment` calls `send("#{attribute}=", value)`, the most likely scenario is a `NoMethodError`.

To work around this shortcoming, models can declare aliases (`alias_method :bornOn, :born_on` in the above example). This can be tedious, and feel incomplete as _not all_ keys require aliases (for example, `:name` yields the same property name regardless of casing).

Similarly, serializing an instance to JSON assumes underscored keys. Unlike `#from_json`, there are existing seams to modify keys before they are serialized. For example, models can override either `#serializable_hash` or `#as_json`. While viable, there are issues with both approach.

Overriding `#serializable_hash` with JSON-specific details is a breach of the abstraction. In theory, `#serializable_hash` aims to transform attributes into a `Hash` that is ready to be serialized into another format (JSON, XML, or otherwise).

Overriding `#as_json` is more appropriate, but lacks a corresponding abstraction for de-serializing and assigning values in a method like `#from_json`. [#51282][] aims to introduce a corollary abstraction, but feels incomplete and awkward in comparison to what's proposed below.

### Detail

The proposal:

This commit proposes the introduction of
`ActiveModel::Serializers::JSON.key_format` to configure key transformations at the class level. The name and invocation style draw inspiration from [jbuilder][], specifically its [key_format][] and `key_format!` methods. For example, consider the following:

```ruby
class User
  include ActiveModel::API
  include ActiveModel::Serializers::JSON

  key_format from_json: :underscore,
             to_json: ->(key) { key.camelize :lower }

  attr_accessor :name, :born_on

  def attributes
    { name: name, born_on: born_on }
  end
end

json = { name: "Ruby on Rails", bornOn: "2004-11-24" }.to_json

user = User.new
user.from_json(json)
user.name                       # => "Ruby on Rails"
user.born_on                    # => "2004-11-24"
user.to_json == json            # => true
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.

[ActiveModel::Serializers::JSON#from_json]: https://edgeapi.rubyonrails.org/classes/ActiveModel/Serializers/JSON.html#method-i-from_json
[ActiveModel::AttributeAssignment]: https://edgeapi.rubyonrails.org/classes/ActiveModel/AttributeAssignment.html#method-i-attributes-3D
[#51282]: https://github.com/rails/rails/pull/51282
[jbuilder]: https://github.com/rails/jbuilder
[key_format]: https://github.com/rails/jbuilder/tree/v2.12.0?tab=readme-ov-file#formatting-keys