### PR TITLE
Enable raising an error for missing translations on a per-model basis

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,3 +1,35 @@
+*   Allow each model to decide whether to raise an error on missing translations.
+
+    `ActiveModel::Translation` now allows each model to decide whether to raise
+    an error on missing translations by defining class method
+    `raise_on_missing_translations`.
+
+    ```ruby
+    class ApplicationRecord < ActiveRecord::Base
+      self.raise_on_missing_translations = true
+    end
+
+    class Post < ApplicationRecord
+    end
+
+    class User < ApplicationRecord
+      self.raise_on_missing_translations = false
+    end
+
+    Post.human_attribute_name(:title)
+    # => Translation missing. Options considered were: (I18n::MissingTranslationData)
+    #     - en.activerecord.attributes.post.title
+    #     - en.attributes.title
+    #
+    #             raise exception.respond_to?(:to_exception) ? exception.to_exception : exception
+    #                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+    User.human_attribute_name(:name)
+    # => "Name"
+    ```
+
+    *Shouichi Kamiya*
+
 *   Fix `normalizes` re-applying normalizations on every validation of an
     unpersisted record, and speed up validation of normalized attributes.
 

--- a/activemodel/lib/active_model/translation.rb
+++ b/activemodel/lib/active_model/translation.rb
@@ -24,6 +24,12 @@ module ActiveModel
 
     singleton_class.attr_accessor :raise_on_missing_translations
 
+    def self.extended(base) # :nodoc:
+      unless base.respond_to?(:raise_on_missing_translations)
+        base.class_attribute :raise_on_missing_translations, instance_accessor: false, instance_predicate: false
+      end
+    end
+
     # Returns the +i18n_scope+ for the class. Override if you want custom lookup.
     def i18n_scope
       :activemodel
@@ -71,7 +77,8 @@ module ActiveModel
         end
       end
 
-      raise_on_missing = options.fetch(:raise, Translation.raise_on_missing_translations)
+      raise_on_missing = options.fetch(:raise, raise_on_missing_translations)
+      raise_on_missing = Translation.raise_on_missing_translations if raise_on_missing.nil?
 
       defaults << :"attributes.#{attribute}"
       defaults << options[:default] if options[:default]

--- a/activemodel/test/cases/translation_test.rb
+++ b/activemodel/test/cases/translation_test.rb
@@ -155,10 +155,32 @@ class ActiveModelI18nTests < ActiveModel::TestCase
     assert_equal({ default: "Cool gender" }, options)
   end
 
-  def test_raise_on_missing_translations
+  def test_raise_on_missing_translations_global
     ActiveModel::Translation.with(raise_on_missing_translations: true) do
       assert_raises I18n::MissingTranslationData do
         Person.human_attribute_name("name")
+      end
+
+      assert_raises I18n::MissingTranslationData do
+        Person::Gender.human_attribute_name("name")
+      end
+    end
+  end
+
+  def test_raise_on_missing_translations_per_model
+    Person.with(raise_on_missing_translations: true) do
+      assert_raises I18n::MissingTranslationData do
+        Child.human_attribute_name("name")
+      end
+
+      assert_nothing_raised do
+        Child.with(raise_on_missing_translations: false) do
+          Child.human_attribute_name("name")
+
+          assert_raises I18n::MissingTranslationData do
+            Person.human_attribute_name("name")
+          end
+        end
       end
     end
   end

--- a/activemodel/test/models/person.rb
+++ b/activemodel/test/models/person.rb
@@ -2,7 +2,6 @@
 
 class Person
   include ActiveModel::Validations
-  extend  ActiveModel::Translation
 
   attr_accessor :title, :karma, :salary, :gender
 

--- a/guides/source/i18n.md
+++ b/guides/source/i18n.md
@@ -1148,6 +1148,32 @@ The I18n API defines the following exceptions that will be raised by backends wh
 
 If `config.i18n.raise_on_missing_translations` is `true`, `I18n::MissingTranslationData` errors will be raised from views and controllers. If the value is `:strict`, models also raise the error. It's a good idea to turn this on in your test environment, so you can catch places where missing translations are requested.
 
+It is also possible to decide whether to raise an error on missing translations per-model basis by defining `raise_on_missing_translations` class method.
+
+```ruby
+class ApplicationRecord < ActiveRecord::Base
+  self.raise_on_missing_translations = true
+end
+
+class Post < ApplicationRecord
+end
+
+class User < ApplicationRecord
+  self.raise_on_missing_translations = false
+end
+
+Post.human_attribute_name(:title)
+# => Translation missing. Options considered were: (I18n::MissingTranslationData)
+#     - en.activerecord.attributes.post.title
+#     - en.attributes.title
+#
+#             raise exception.respond_to?(:to_exception) ? exception.to_exception : exception
+#                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+User.human_attribute_name(:name)
+# => "Name"
+```
+
 If `config.i18n.raise_on_missing_translations` is `false` (the default in all environments), the exception's error message will be printed. This contains the missing key/scope so you can fix your code.
 
 If you want to customize this behavior further, you should set `config.i18n.raise_on_missing_translations = false` and then implement a `I18n.exception_handler`. The custom exception handler can be a proc or a class with a `call` method:


### PR DESCRIPTION
Problem:

f6c0a35b1b8b4fb4d033aa6c09c4efaaf6652bdc changed `human_attribute_name` to raise error if `raise_on_missing_translations` is `true`. This change had a major impact on existing applications (i.e., too many missing translation errors).

Solution:

Allow each model to decide whether to raise an error on missing translations.