### PR TITLE
feature: Add SAX-based parser for XmlMini, using REXML

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -73,7 +73,7 @@ gem "dalli", ">= 3.0.1"
 gem "listen", "~> 3.3", require: false
 gem "libxml-ruby", platforms: :ruby
 gem "connection_pool", require: false
-gem "rexml", require: false
+gem "rexml", ">= 3.3.4", require: false
 gem "msgpack", ">= 1.7.0", require: false
 
 # for railties

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Support `REXMLSAX` backend in `ActiveSupport::XmlMini`.
+
+    *NAITOH Jun*
+
 *   Deprecate addition and since between two `Time` and `ActiveSupport::TimeWithZone`.
 
     Previously adding time instances together such as `10.days.ago + 10.days.ago` or `10.days.ago.since(10.days.ago)` produced a nonsensical future date. This behavior is deprecated and will be removed in Rails 8.1.

--- a/activesupport/lib/active_support/xml_mini/rexmlsax.rb
+++ b/activesupport/lib/active_support/xml_mini/rexmlsax.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+begin
+  require "rexml/parsers/sax2parser"
+  require "rexml/sax2listener"
+rescue LoadError => e
+  warn "You don't have rexml installed in your application. Please add it to your Gemfile and run bundle install"
+  raise e
+end
+
+require "active_support/core_ext/object/blank"
+require "stringio"
+
+module ActiveSupport
+  module XmlMini_REXMLSAX # :nodoc:
+    extend self
+
+    # Class that will build the hash while the XML document
+    # is being parsed using SAX events.
+    class HashBuilder
+      include REXML::SAX2Listener
+
+      CONTENT_KEY = "__content__"
+      HASH_SIZE_KEY = "__hash_size__"
+
+      attr_reader :hash
+
+      def current_hash
+        @hash_stack.last
+      end
+
+      def start_document
+        @hash = {}
+        @hash_stack = [@hash]
+      end
+
+      def end_document
+        raise "Parse stack not empty!" if @hash_stack.size > 1
+      end
+
+      def start_element(uri, localname, name, attrs = {})
+        new_hash = { CONTENT_KEY => +"" }.merge!(Hash[attrs])
+        new_hash[HASH_SIZE_KEY] = new_hash.size + 1
+
+        case current_hash[name]
+        when Array then current_hash[name] << new_hash
+        when Hash  then current_hash[name] = [current_hash[name], new_hash]
+        when nil   then current_hash[name] = new_hash
+        end
+
+        @hash_stack.push(new_hash)
+      end
+
+      def end_element(uri, localname, name)
+        if current_hash.length > current_hash.delete(HASH_SIZE_KEY) && current_hash[CONTENT_KEY].blank? || current_hash[CONTENT_KEY] == ""
+          current_hash.delete(CONTENT_KEY)
+        end
+        @hash_stack.pop
+      end
+
+      def characters(string)
+        current_hash[CONTENT_KEY] << string unless current_hash[CONTENT_KEY].nil?
+      end
+
+      alias_method :cdata, :characters
+    end
+
+    attr_accessor :document_class
+    self.document_class = HashBuilder
+
+    # Parse an XML Document string or IO into a simple hash.
+    # data::
+    #   XML Document string or IO to parse
+    def parse(data)
+      if !data.respond_to?(:read)
+        data = StringIO.new(data || "")
+      end
+
+      if data.eof?
+        {}
+      else
+        document = document_class.new
+        parser = REXML::Parsers::SAX2Parser.new(data)
+        parser.listen(document)
+        parser.parse
+        document.hash
+      end
+    end
+  end
+end

--- a/activesupport/test/core_ext/hash_ext_test.rb
+++ b/activesupport/test/core_ext/hash_ext_test.rb
@@ -1023,6 +1023,7 @@ class HashToXmlTest < ActiveSupport::TestCase
     expected =
       case ActiveSupport::XmlMini.backend.name
       when "ActiveSupport::XmlMini_REXML";        RuntimeError
+      when "ActiveSupport::XmlMini_REXMLSAX";     RuntimeError
       when "ActiveSupport::XmlMini_Nokogiri";     Nokogiri::XML::SyntaxError
       when "ActiveSupport::XmlMini_NokogiriSAX";  RuntimeError
       when "ActiveSupport::XmlMini_LibXML";       LibXML::XML::Error

--- a/activesupport/test/xml_mini/rexmlsax_engine_test.rb
+++ b/activesupport/test/xml_mini/rexmlsax_engine_test.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require_relative "xml_mini_engine_test"
+
+XMLMiniEngineTest.run_with_gem("rexml") do
+  class REXMLSAXEngineTest < XMLMiniEngineTest
+    private
+      def engine
+        "REXMLSAX"
+      end
+
+      def expansion_attack_error
+        RuntimeError
+      end
+  end
+end


### PR DESCRIPTION
### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This PR adds a SAX-based parser with REXML as with other XmlMini.

Use cases: Provide faster parsing than REXML(DOM) in situations where libxml-ruby or nokogiri is not available.

<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->


### Detail

This Pull Request requires the latest REXML 3.3.4 or higher to pass the XMLMiniEngineTest::EngineTests.test_exception_thrown_on_expansion_attack test.

See: https://www.ruby-lang.org/en/news/2024/08/01/dos-rexml-cve-2024-41946/


### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

- sax_bench.yaml
```
loop_count: 100
contexts:
  - name: YJIT=OFF
  - name: YJIT=ON
    prelude: |
      RubyVM::YJIT.enable

prelude: |
  $LOAD_PATH.unshift(File.expand_path("activesupport/lib"))
  require 'active_support'
  require 'active_support/core_ext'

  n_elements = 5000
  n_attributes = 10

  def build_xml(n_elements, n_attributes)
    xml = '<?xml version="1.0"?><root>'
    n_elements.times do |i|
      xml << '<child '
      n_attributes.times {|j| xml << "id#{j}=\"#{i}\" " }
      xml << '/>'
    end
    xml << '</root>'
  end
  xml = build_xml(n_elements, n_attributes)

benchmark:
  'LibXML'       : |
    ActiveSupport::XmlMini.backend = 'LibXML'
    hash = Hash.from_xml(xml)
  'LibXMLSAX'       : |
    ActiveSupport::XmlMini.backend = 'LibXMLSAX'
    hash = Hash.from_xml(xml)
  'Nokogiri'       : |
    ActiveSupport::XmlMini.backend = 'Nokogiri'
    hash = Hash.from_xml(xml)
  'NokogiriSAX'       : |
    ActiveSupport::XmlMini.backend = 'NokogiriSAX'
    hash = Hash.from_xml(xml)
  'REXML'       : |
    ActiveSupport::XmlMini.backend = 'REXML'
    hash = Hash.from_xml(xml)
  'REXMLSAX'       : |
    ActiveSupport::XmlMini.backend = 'REXMLSAX'
    hash = Hash.from_xml(xml)
```

```
$ ruby -v
ruby 3.3.3 (2024-06-12 revision f1c7b6f435) [arm64-darwin22]
$ gem list rexml libxml-ruby nokogiri

*** LOCAL GEMS ***

rexml (3.3.4)

*** LOCAL GEMS ***

libxml-ruby (5.0.3)

*** LOCAL GEMS ***

nokogiri (1.16.7 arm64-darwin, 1.16.6 arm64-darwin, 1.16.5)
```

```
$ benchmark-driver sax_bench.yaml
Calculating -------------------------------------
                       YJIT=OFF     YJIT=ON 
              LibXML     16.818      19.854 i/s -     100.000 times in 5.946048s 5.036691s
           LibXMLSAX     18.235      23.218 i/s -     100.000 times in 5.483908s 4.306973s
            Nokogiri     16.512      16.512 i/s -     100.000 times in 6.056280s 6.056372s
         NokogiriSAX     13.469      15.905 i/s -     100.000 times in 7.424489s 6.287452s
               REXML      3.341       5.426 i/s -     100.000 times in 29.928804s 18.428204s
            REXMLSAX      4.390       6.301 i/s -     100.000 times in 22.777792s 15.869573s
```

- YJIT=OFF : REXMLSAX is 1.31x  faster than REXML(DOM)
- YJIT=ON  : REXMLSAX is 1.16x  faster than REXML(DOM)

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
