### PR TITLE
Allow to set isolation level on AR connection config

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -942,6 +942,15 @@ module ActiveRecord
 
           # ...and send them all in one query
           raw_execute("SET #{encoding} #{sql_mode_assignment} #{variable_assignments}", "SCHEMA")
+
+          if @config[:isolation_level]
+            # Sending as a separate query since different spots that might intercept the query (Vitess, proxysql)
+            # may rely on SET SESSION TRANSACTION ISOLATION LEVEL as a single statement
+            raw_execute(
+              "SET SESSION TRANSACTION ISOLATION LEVEL #{transaction_isolation_levels.fetch(@config[:isolation_level])}",
+              "SCHEMA"
+            )
+          end
         end
 
         def column_definitions(table_name) # :nodoc:

--- a/activerecord/test/cases/adapters/abstract_mysql_adapter/connection_test.rb
+++ b/activerecord/test/cases/adapters/abstract_mysql_adapter/connection_test.rb
@@ -141,6 +141,14 @@ class ConnectionTest < ActiveRecord::AbstractMysqlTestCase
     end
   end
 
+  def test_mysql_config_isolation_level
+    run_without_connection do |orig_connection|
+      ActiveRecord::Base.establish_connection(orig_connection.deep_merge(isolation_level: :read_committed))
+      result = ActiveRecord::Base.lease_connection.select_value("SELECT @@SESSION.transaction_isolation")
+      assert_equal("READ-COMMITTED", result)
+    end
+  end
+
   unless current_adapter?(:TrilogyAdapter)
     def test_passing_arbitrary_flags_to_adapter
       run_without_connection do |orig_connection|


### PR DESCRIPTION
ActiveRecord provides a way to set isolation level per transaction:

```ruby
Post.transaction(isolation: :read_committed) do
  ...
end
```

Underneath, that ends up calling:

```
def begin_isolated_db_transaction(isolation) # :nodoc:
  internal_execute("SET TRANSACTION ISOLATION LEVEL #{transaction_isolation_levels.fetch(isolation)}", "TRANSACTION", allow_retry: true, materialize_transactions: false)
  begin_db_transaction
end
```

However, it's possible that `BEGIN` triggered by `begin_db_transaction` would fail for connectivity reasons. ActiveRecord's behaviour it to reestablish the connection and to retry the `BEGIN`.

But that means any `SET ISOLATION LEVEL ...` that happened prior to it would be lost.

Rather than try building isolation level awareness into reconnects, I think it's a lot more reliable to have a separate connection pool, one that runs `SET SESSION TRANSACTION ISOLATION LEVEL ...` every time it connects to the DB.

This PR allows to introduce that setting on connection config.