### PR TITLE
Address `warning: the block passed to 'Pilot.generates_token_for'` warning against ruby 3.4.0dev

### DIFF
--- a/activemodel/test/models/pilot.rb
+++ b/activemodel/test/models/pilot.rb
@@ -4,7 +4,7 @@ class Pilot
   include ActiveModel::Attributes
   include ActiveModel::SecurePassword
 
-  def self.generates_token_for(purpose, expires_in: nil)
+  def self.generates_token_for(purpose, expires_in: nil, &)
     @@expires_in = expires_in
   end
 


### PR DESCRIPTION
### Motivation / Background

This commit addresses this CI failure.
https://buildkite.com/rails/rails-nightly/builds/855#019114e5-7ece-4d93-ab6e-82591c26627f/1146-1148


### Detail

- This commit addresses this error

```ruby
% ruby -v
ruby 3.4.0dev (2024-06-11T14:33:51Z master 32683aa18d) [arm64-darwin24]
% RAILS_STRICT_WARNINGS=1 bin/test test/cases/secure_password_test.rb
/Users/yahonda/src/github.com/rails/rails/activemodel/lib/active_model/secure_password.rb:163: warning: the block passed to 'Pilot.generates_token_for' defined at /Users/yahonda/src/github.com/rails/rails/activemodel/test/models/pilot.rb:7 may be ignored
/Users/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/testing/strict_warnings.rb:35:in 'ActiveSupport::RaiseWarnings#warn': /Users/yahonda/src/github.com/rails/rails/activemodel/lib/active_model/secure_password.rb:163: warning: the block passed to 'Pilot.generates_token_for' defined at /Users/yahonda/src/github.com/rails/rails/activemodel/test/models/pilot.rb:7 may be ignored (ActiveSupport::RaiseWarnings::WarningError)
        from /Users/yahonda/src/github.com/rails/rails/activemodel/lib/active_model/secure_password.rb:163:in 'ActiveModel::SecurePassword::ClassMethods#has_secure_password'
        from /Users/yahonda/src/github.com/rails/rails/activemodel/test/models/pilot.rb:24:in '<class:Pilot>'
        from /Users/yahonda/src/github.com/rails/rails/activemodel/test/models/pilot.rb:3:in '<top (required)>'
        from /Users/yahonda/.rbenv/versions/trunk/lib/ruby/3.4.0+0/bundled_gems.rb:69:in 'Kernel.require'
        from /Users/yahonda/.rbenv/versions/trunk/lib/ruby/3.4.0+0/bundled_gems.rb:69:in 'block (2 levels) in Kernel#replace_require'
        from /Users/yahonda/src/github.com/rails/rails/activemodel/test/cases/secure_password_test.rb:5:in '<top (required)>'
        from /Users/yahonda/.rbenv/versions/trunk/lib/ruby/3.4.0+0/bundled_gems.rb:69:in 'Kernel.require'
        from /Users/yahonda/.rbenv/versions/trunk/lib/ruby/3.4.0+0/bundled_gems.rb:69:in 'block (2 levels) in Kernel#replace_require'
        from /Users/yahonda/src/github.com/rails/rails/railties/lib/rails/test_unit/runner.rb:62:in 'block in Rails::TestUnit::Runner.load_tests'
        from <internal:array>:54:in 'Array#each'
        from /Users/yahonda/src/github.com/rails/rails/railties/lib/rails/test_unit/runner.rb:60:in 'Rails::TestUnit::Runner.load_tests'
        from /Users/yahonda/src/github.com/rails/rails/railties/lib/rails/test_unit/runner.rb:52:in 'Rails::TestUnit::Runner.run'
        from /Users/yahonda/src/github.com/rails/rails/tools/test.rb:18:in '<top (required)>'
        from bin/test:5:in 'Kernel#require_relative'
        from bin/test:5:in '<main>'
%
```

### Additional information
Related to https://bugs.ruby-lang.org/issues/15554
Follow up https://github.com/rails/rails/pull/52483

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.

