### PR TITLE
Add `reset_tag` form tag helper

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,15 @@
+*   Add `reset_tag` helper method to reset the form tag state.
+
+    This method is useful when you want to reset the form tag state to the default values.
+
+    ```erb
+    <%= reset_tag %>
+    <%= reset_tag('Clear Form') %>
+    <%= reset_tag('Reset', class: 'btn btn-secondary') %>
+    ```
+
+    *Akhil G Krishnan*
+
 *   Rename `text_area` methods into `textarea`
 
     Old names are still available as aliases.

--- a/actionview/lib/action_view/helpers/form_tag_helper.rb
+++ b/actionview/lib/action_view/helpers/form_tag_helper.rb
@@ -531,6 +531,30 @@ module ActionView
         tag :input, tag_options
       end
 
+      # Creates a reset button with the text "Reset" or alternative text provided.
+      # The reset button allows users to clear form fields and return them to their default values.
+      #
+      # ==== Options
+      # * <tt>:data</tt> - This option can be used to add custom data attributes.
+      # * <tt>:disabled</tt> - If set to true, the user will not be able to use this input
+      # * Any other key creates standard HTML attributes for the tag
+      #
+      # ==== Examples
+      #   reset_tag
+      #   # => <input type="reset" name="reset" value="Reset" />
+      #
+      #   reset_tag('Reset Form')
+      #   # => <input type="reset" name="reset" value="Reset Form" />
+      #
+      #   reset_tag('Reset', class: 'form-button')
+      #   # => <input type="reset" name="reset" value="Reset" class="form-button" />
+      #
+      def reset_tag(value = "Reset", options = {})
+        options = options.deep_stringify_keys
+        tag_options = { "type" => "reset", "name" => "reset", "value" => value }.update(options)
+        tag :input, tag_options
+      end
+
       # Creates a button element that defines a <tt>submit</tt> button,
       # <tt>reset</tt> button or a generic button which can be used in
       # JavaScript, for example. You can use the button tag as a regular

--- a/actionview/test/template/form_tag_helper_test.rb
+++ b/actionview/test/template/form_tag_helper_test.rb
@@ -762,6 +762,41 @@ class FormTagHelperTest < ActionView::TestCase
     )
   end
 
+  def test_reset_tag_basic
+    assert_dom_equal(
+      '<input type="reset" name="reset" value="Reset" />',
+      reset_tag
+    )
+  end
+
+  def test_reset_tag_with_custom_value
+    assert_dom_equal(
+      '<input type="reset" name="reset" value="Clear Form" />',
+      reset_tag("Clear Form")
+    )
+  end
+
+  def test_reset_tag_with_custom_options
+    assert_dom_equal(
+      '<input type="reset" name="reset" value="Reset" class="btn" id="reset-btn" />',
+      reset_tag("Reset", class: "btn", id: "reset-btn")
+    )
+  end
+
+  def test_reset_tag_with_custom_name
+    assert_dom_equal(
+      '<input type="reset" name="clear_form" value="Reset" />',
+      reset_tag("Reset", name: "clear_form")
+    )
+  end
+
+  def test_reset_tag_disabled
+    assert_dom_equal(
+      '<input type="reset" name="reset" value="Reset" disabled="disabled" />',
+      reset_tag("Reset", disabled: true)
+    )
+  end
+
   def test_button_tag
     assert_dom_equal(
       %(<button name="button" type="submit">Button</button>),


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created to introduce a dedicated `reset_tag` helper method for creating reset buttons in forms. Currently, we are using `button_tag` for adding reset buttons, which requires additional parameters to function as a reset button. A dedicated `reset_tag` helper will provide a more intuitive and straightforward way to add reset functionality to forms.

This Pull Request has been created because [REPLACE ME]

### Detail

This Pull Request changes the way reset buttons can be created in Rails forms by introducing a new `reset_tag` helper method. The new method follows the convention of other form tag helpers like `submit_tag`, making it more consistent with the Rails API.

Example usage:
```ruby
<%= reset_tag %>
<%= reset_tag('Clear Form') %>
<%= reset_tag('Reset', class: 'btn btn-secondary') %>
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
