### PR TITLE
Fix migration ordering for `bin/rails db:prepare` across databases

### DIFF
--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -92,7 +92,7 @@ db_namespace = namespace :db do
     if db_configs.size == 1 && db_configs.first.primary?
       ActiveRecord::Tasks::DatabaseTasks.migrate
     else
-      mapped_versions = ActiveRecord::Tasks::DatabaseTasks.db_configs_with_versions(db_configs)
+      mapped_versions = ActiveRecord::Tasks::DatabaseTasks.db_configs_with_versions
 
       mapped_versions.sort.each do |version, db_configs|
         db_configs.each do |db_config|

--- a/railties/test/application/rake/multi_dbs_test.rb
+++ b/railties/test/application/rake/multi_dbs_test.rb
@@ -565,6 +565,35 @@ module ApplicationTests
         end
       end
 
+      test "db:prepare respects timestamp ordering across databases" do
+        require "#{app_path}/config/environment"
+        app_file "db/migrate/01_one_migration.rb", <<-MIGRATION
+          class OneMigration < ActiveRecord::Migration::Current
+          end
+        MIGRATION
+
+        app_file "db/animals_migrate/02_two_migration.rb", <<-MIGRATION
+          class TwoMigration < ActiveRecord::Migration::Current
+          end
+        MIGRATION
+
+        app_file "db/animals_migrate/04_four_migration.rb", <<-MIGRATION
+        class FourMigration < ActiveRecord::Migration::Current
+        end
+        MIGRATION
+
+        app_file "db/migrate/03_three_migration.rb", <<-MIGRATION
+          class ThreeMigration < ActiveRecord::Migration::Current
+          end
+        MIGRATION
+
+        Dir.chdir(app_path) do
+          output = rails "db:prepare"
+          entries = output.scan(/^== (\d+).+migrated/).map(&:first).map(&:to_i)
+          assert_equal [1, 2, 3, 4] * 2, entries # twice because for test env too
+        end
+      end
+
       test "migrations in different directories can have the same timestamp" do
         require "#{app_path}/config/environment"
         app_file "db/migrate/01_one_migration.rb", <<-MIGRATION


### PR DESCRIPTION
This is a backport of https://github.com/rails/rails/pull/51889 to `7-1-stable`.

cc @eileencodes 