### PR TITLE
Update Twitter name to X in Rails release documentation

### DIFF
--- a/RELEASING_RAILS.md
+++ b/RELEASING_RAILS.md
@@ -159,7 +159,7 @@ Add some context for users as to the purpose of this release (bugfix/security).
 If this is a part of the latest release series, update `_data/version.yml` so
 that the homepage points to the latest version.
 
-### Post the announcement to the Rails Twitter account.
+### Post the announcement to the Rails X account.
 
 ## Security releases
 
@@ -179,7 +179,7 @@ and links to each patch. Some people may not be able to upgrade right away,
 so we need to give them the security fixes in patch form.
 
 * Blog announcements
-* Twitter announcements
+* X announcements
 * Merge the release branch to the stable branch
 * Drink beer (or other cocktail)
 

--- a/guides/assets/stylesrc/vendor/_boilerplate.scss
+++ b/guides/assets/stylesrc/vendor/_boilerplate.scss
@@ -19,7 +19,7 @@
   
   /*
    * Remove text-shadow in selection highlight:
-   * https://twitter.com/miketaylr/status/12228805301
+   * https://x.com/miketaylr/status/12228805301
    *
    * Customize the background color to match your design.
    */

--- a/guides/source/2_3_release_notes.md
+++ b/guides/source/2_3_release_notes.md
@@ -185,7 +185,7 @@ developers = Developer.find(:all, :group => "salary",
 
 MySQL supports a reconnect flag in its connections - if set to true, then the client will try reconnecting to the server before giving up in case of a lost connection. You can now set `reconnect = true` for your MySQL connections in `database.yml` to get this behavior from a Rails application. The default is `false`, so the behavior of existing applications doesn't change.
 
-* Lead Contributor: [Dov Murik](http://twitter.com/dubek)
+* Lead Contributor: [Dov Murik](http://x.com/dubek)
 * More information:
     * [Controlling Automatic Reconnection Behavior](http://dev.mysql.com/doc/refman/5.6/en/auto-reconnect.html)
     * [MySQL auto-reconnect revisited](http://groups.google.com/group/rubyonrails-core/browse_thread/thread/49d2a7e9c96cb9f4)

--- a/guides/source/5_0_release_notes.md
+++ b/guides/source/5_0_release_notes.md
@@ -55,7 +55,7 @@ information.
 ### API Applications
 
 Rails can now be used to create slimmed down API only applications.
-This is useful for creating and serving APIs similar to [Twitter](https://dev.twitter.com) or [GitHub](https://developer.github.com) API,
+This is useful for creating and serving APIs similar to [X](https://dev.x.com) or [GitHub](https://developer.github.com) API,
 that can be used to serve public-facing, as well as, for custom applications.
 
 You can generate a new api Rails app using:

--- a/guides/source/api_app.md
+++ b/guides/source/api_app.md
@@ -24,7 +24,7 @@ With the advent of client-side frameworks, more developers are using Rails to
 build a back-end that is shared between their web application and other native
 applications.
 
-For example, Twitter uses its [public API](https://developer.twitter.com/) in its web
+For example, X uses its [public API](https://developer.x.com/) in its web
 application, which is built as a static site that consumes JSON resources.
 
 Instead of using Rails to generate HTML that communicates with the server


### PR DESCRIPTION
### Motivation / Background

This Pull Request updates the Twitter account name in the Rails release documentation to the new name "X" to ensure that all references are current and correct.

### Detail

This Pull Request changes the Twitter account name mentioned in the Rails release documentation from the old name to "X".

### Additional information

This change is straightforward and does not require additional context or reference as it's a direct update of social media information.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] [Fix #52510 ]
* [x] Tests are not required for this change as it is a minor documentation update.
* [x] CHANGELOG files do not need an update for this change as it is minor and does not affect the functionality or the API.
