### PR TITLE
Mapper with keywords

### DIFF
--- a/actionpack/test/dispatch/mapper_test.rb
+++ b/actionpack/test/dispatch/mapper_test.rb
@@ -93,7 +93,7 @@ module ActionDispatch
         options = {}
         scope = Mapper::Scope.new({})
         ast = Journey::Parser.parse "/store/:name(*rest)"
-        m = Mapper::Mapping.build(scope, FakeSet.new, ast, "foo", "bar", nil, [:get], nil, {}, true, options)
+        m = Mapper::Mapping.build(scope, FakeSet.new, ast, "foo", "bar", nil, [:get], nil, {}, true, nil, options)
         assert_equal(/.+?/m, m.requirements[:rest])
       end
 

--- a/actionpack/test/dispatch/routing_test.rb
+++ b/actionpack/test/dispatch/routing_test.rb
@@ -77,7 +77,9 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
 
   def test_logout_redirect_without_to
     draw do
-      get "account/logout", to: redirect("/logout"), as: :logout_redirect
+      ActionDispatch.deprecator.silence do
+        get "account/logout" => redirect("/logout"), as: :logout_redirect
+      end
     end
 
     assert_equal "/account/logout", logout_redirect_path

--- a/actionpack/test/journey/router_test.rb
+++ b/actionpack/test/journey/router_test.rb
@@ -219,7 +219,7 @@ module ActionDispatch
       def test_generate_slash
         params = [ [:controller, "tasks"],
                    [:action, "show"] ]
-        get "/", Hash[params]
+        get "/", **Hash[params]
 
         path, _ = _generate(nil, Hash[params], {})
         assert_equal "/", path
@@ -498,15 +498,15 @@ module ActionDispatch
           [uri.path, params]
         end
 
-        def get(*args)
+        def get(...)
           ActionDispatch.deprecator.silence do
-            mapper.get(*args)
+            mapper.get(...)
           end
         end
 
-        def match(*args)
+        def match(...)
           ActionDispatch.deprecator.silence do
-            mapper.match(*args)
+            mapper.match(...)
           end
         end
 


### PR DESCRIPTION
### Motivation / Background

Followup https://github.com/rails/rails/pull/52422

### Detail

This Pull Request changes the routing mapper to use keywords instead of hashes in most places, which results in a slight speed boost, and clearer code.

### Additional information

Using the [benchmark](https://github.com/rails/rails/pull/52409#issue-2426595281) in the initial deprecation PR:

Before:
```
ruby 3.3.1 (2024-04-23 revision c56cd86388) [arm64-darwin23]
Warming up --------------------------------------
                draw   113.000 i/100ms
Calculating -------------------------------------
                draw      1.110k (± 3.1%) i/s -      5.650k in   5.095601s
```

After:
```
ruby 3.3.1 (2024-04-23 revision c56cd86388) [arm64-darwin23]
Warming up --------------------------------------
                draw   116.000 i/100ms
Calculating -------------------------------------
                draw      1.174k (± 3.2%) i/s -      5.916k in   5.042676s
```

It turns out the real speed difference is next to nothing, which is unfortunate. There was a bug in my [initial](https://github.com/Shopify/rails/tree/routing_mapper_opt) implementation that made it faster 🤦. However, I think now that the mapper is easier to reason about, we should be able to do see optimization potential a little bit easier. I can see two in the scopes and AST parsing that I'll work on next.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
