### PR TITLE
Render Partial Collection with a layout parameter

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -12,6 +12,14 @@
 
     *Hartley McGuire*
 
+*   Support of `:layout` for heterogenous collections
+
+    When rendering a collection with mixed objects, the `:layout`
+    option is now supported.
+    Fixes #49590
+
+    *Mario Caropreso*
+
 *   Rename `text_area` methods into `textarea`
 
     Old names are still available as aliases.

--- a/actionview/test/actionpack/controller/render_test.rb
+++ b/actionview/test/actionpack/controller/render_test.rb
@@ -568,6 +568,17 @@ class TestController < ActionController::Base
     partial_collection_shorthand_with_different_types_of_records
   end
 
+  def partial_collection_shorthand_with_different_types_of_records_with_layout
+    render partial: [
+      Supplier.new("mark"),
+      Customer.new("craig"),
+      Supplier.new("john"),
+      Customer.new("zach"),
+      Supplier.new("brandon"),
+      Customer.new("dan")
+    ], locals: { greeting: "Bonjour" }, layout: "layouts/record_layout"
+  end
+
   def missing_partial
     render partial: "thisFileIsntHere"
   end
@@ -682,6 +693,7 @@ class RenderTest < ActionController::TestCase
     get :partial, to: "test#partial"
     get :partial_collection, to: "test#partial_collection"
     get :partial_collection_shorthand_with_different_types_of_records, to: "test#partial_collection_shorthand_with_different_types_of_records"
+    get :partial_collection_shorthand_with_different_types_of_records_with_layout, to: "test#partial_collection_shorthand_with_different_types_of_records_with_layout"
     get :partial_collection_shorthand_with_locals, to: "test#partial_collection_shorthand_with_locals"
     get :partial_collection_with_as, to: "test#partial_collection_with_as"
     get :partial_collection_with_as_and_counter, to: "test#partial_collection_with_as_and_counter"
@@ -1451,6 +1463,11 @@ class RenderTest < ActionController::TestCase
   def test_partial_collection_shorthand_with_different_types_of_records
     get :partial_collection_shorthand_with_different_types_of_records
     assert_equal "Bonjour bad customer: mark0Bonjour good customer: craig1Bonjour bad customer: john2Bonjour good customer: zach3Bonjour good customer: brandon4Bonjour bad customer: dan5", @response.body
+  end
+
+  def test_partial_collection_shorthand_with_different_types_of_records_with_layout
+    get :partial_collection_shorthand_with_different_types_of_records_with_layout
+    assert_equal "RECORD -> Bonjour: markRECORD -> Bonjour: craigRECORD -> Bonjour: johnRECORD -> Bonjour: zachRECORD -> Bonjour: brandonRECORD -> Bonjour: dan", @response.body
   end
 
   def test_empty_partial_collection

--- a/actionview/test/fixtures/actionpack/layouts/_record_layout.erb
+++ b/actionview/test/fixtures/actionpack/layouts/_record_layout.erb
@@ -1,0 +1,1 @@
+RECORD -> <%= yield %>

--- a/actionview/test/fixtures/actionpack/suppliers/_supplier.html.erb
+++ b/actionview/test/fixtures/actionpack/suppliers/_supplier.html.erb
@@ -1,0 +1,1 @@
+<%= greeting %>: <%= supplier.name %>

--- a/actionview/test/lib/controller/fake_models.rb
+++ b/actionview/test/lib/controller/fake_models.rb
@@ -37,6 +37,38 @@ end
 class BadCustomer < Customer; end
 class GoodCustomer < Customer; end
 
+Supplier = Struct.new(:name, :id) do
+  extend ActiveModel::Naming
+  include ActiveModel::Conversion
+
+  undef_method :to_json
+
+  def to_xml(options = {})
+    if options[:builder]
+      options[:builder].name name
+    else
+      "<name>#{name}</name>"
+    end
+  end
+
+  def to_js(options = {})
+    "name: #{name.inspect}"
+  end
+  alias :to_text :to_js
+
+  def errors
+    []
+  end
+
+  def persisted?
+    id.present?
+  end
+
+  def cache_key
+    "#{name}/#{id}"
+  end
+end
+
 Post = Struct.new(:title, :author_name, :body, :secret, :persisted, :written_on, :cost) do
   extend ActiveModel::Naming
   include ActiveModel::Conversion


### PR DESCRIPTION
The current implementation does not respect the layout parameter in case of mixed collections.

This commit fixes the issue by ensuring that the code path for mixed collections render the partial inside the provided layout.

### Motivation / Background

Fixes #49590

The current implementation of `render_collection_derive_partial` ignores the layout parameter in case of mixed collections.

### Detail

This Pull Request changes`render_collection_derive_partial` to call a new `render_collection_with_no_partial` method which renders the partial inside the specified layout.

### Additional information
This is my second attempt at fixing it. I have double checked that there are no negative side effects.

1) Benchmark between rendering with a layout vs rendering without a layout:

```
ruby 3.3.2 (2024-05-30 revision e5a195edf6) [aarch64-linux]
Warming up --------------------------------------
           no layout   436.000 i/100ms
         with layout   350.000 i/100ms
Calculating -------------------------------------
           no layout      4.313k (± 3.4%) i/s -     21.800k in   5.061356s
         with layout      3.999k (± 3.9%) i/s -     20.300k in   5.083979s

Comparison:
           no layout:     4312.6 i/s
         with layout:     3999.4 i/s - 1.08x  slower
```

2) No generation of multiple layout templates

The layout template is generated only once in `render_collection_with_multiple_partials`.

3) Generation of partial templates is no different

The generation is the partial templates happen in the same way as in main and it's not affected by this change.