### PR TITLE
Make route mapping scope lookups faster

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Speed up `ActionDispatch::Routing::Mapper::Scope#[]` by merging frame hashes.
+
+    *Gannon McGibbon*
+
 *   Allow bots to ignore `allow_browser`.
 
     *Matthew Nguyen*

--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -2293,9 +2293,9 @@ module ActionDispatch
 
         attr_reader :parent, :scope_level
 
-        def initialize(hash, parent = NULL, scope_level = nil)
-          @hash = hash
+        def initialize(hash, parent = ROOT, scope_level = nil)
           @parent = parent
+          @hash = parent ? parent.frame.merge(hash) : hash
           @scope_level = scope_level
         end
 
@@ -2308,7 +2308,7 @@ module ActionDispatch
         end
 
         def root?
-          @parent.null?
+          @parent == ROOT
         end
 
         def resources?
@@ -2353,23 +2353,22 @@ module ActionDispatch
         end
 
         def [](key)
-          scope = find { |node| node.frame.key? key }
-          scope && scope.frame[key]
+          frame[key]
         end
+
+        def frame; @hash; end
 
         include Enumerable
 
         def each
           node = self
-          until node.equal? NULL
+          until node.equal? ROOT
             yield node
             node = node.parent
           end
         end
 
-        def frame; @hash; end
-
-        NULL = Scope.new(nil, nil)
+        ROOT = Scope.new({}, nil)
       end
 
       def initialize(set) # :nodoc:


### PR DESCRIPTION
### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created because while working on https://github.com/rails/rails/pull/52512, I noticed that `ActionDispatch::Routing::Mapper::Scope#[]` lookup was iterating an array, which means access time isn't constant, and doesn't actually behave like a hash. Instead, we can simply merge hashes when we create nested scopes to save us having to lookup values.

### Detail

This Pull Request changes the scope implementation. Scopes are backed by an array of hashes, but we could make lookup faster by just merging inherited values into the immediate hash. This us from needless iterations for deeply nested routes.

### Additional information

Benchmark:
```rb
# frozen_string_literal: true

require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"

  gem "rails", path: "."
  gem "benchmark-ips"
  gem "stringio"
end

require "benchmark/ips"
require "action_controller/railtie"

class TestApp < Rails::Application
  config.root = __dir__
  config.hosts << "example.org"
  config.secret_key_base = "secret_key_base"

  config.logger = Logger.new($stdout)
  Rails.logger  = config.logger
end

class TestController < ActionController::Base
  include Rails.application.routes.url_helpers

  def index
    render plain: "Home"
  end
end

Benchmark.ips do |x|
  x.report("draw") do
    Rails.application.routes.draw do
      resources(:posts) do
        get :hello
        post :goodbye
        scope(path: "/path") do
          put :test
        end
      end
    end
    Rails.application.instance_variable_set(:@routes, nil)
  end
end
```

Before:
```
ruby 3.3.1 (2024-04-23 revision c56cd86388) [arm64-darwin23]
Warming up --------------------------------------
                draw   146.000 i/100ms
Calculating -------------------------------------
                draw      1.482k (± 3.0%) i/s -      7.446k in   5.029998s
```

After:
```
ruby 3.3.1 (2024-04-23 revision c56cd86388) [arm64-darwin23]
Warming up --------------------------------------
                draw   181.000 i/100ms
Calculating -------------------------------------
                draw      1.797k (± 2.8%) i/s -      9.050k in   5.040444s
```

~1.2x faster

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
