### PR TITLE
Address `PostgreSQLAdapterTest#test_disable_extension_without_schema` error

### DIFF
--- a/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
@@ -671,7 +671,7 @@ module ActiveRecord
 
       def test_disable_extension_with_schema
         @connection.execute("CREATE SCHEMA custom_schema")
-        @connection.execute("CREATE EXTENSION hstore SCHEMA custom_schema")
+        @connection.execute("CREATE EXTENSION IF NOT EXISTS hstore SCHEMA custom_schema")
         result = @connection.query("SELECT extname FROM pg_extension WHERE extnamespace = (SELECT oid FROM pg_namespace WHERE nspname = 'custom_schema')")
         assert_equal [["hstore"]], result.to_a
 
@@ -684,7 +684,7 @@ module ActiveRecord
       end
 
       def test_disable_extension_without_schema
-        @connection.execute("CREATE EXTENSION hstore")
+        @connection.execute("CREATE EXTENSION IF NOT EXISTS hstore")
         result = @connection.query("SELECT extname FROM pg_extension")
         assert_includes result.to_a, ["hstore"]
 


### PR DESCRIPTION
### Motivation / Background

This commit addresses this CI failure.
https://buildkite.com/rails/rails/builds/109886#01912bdf-2f48-47e3-af85-cbc17d9824bd/1289-1300

### Detail

```ruby
$ ARCONN=postgresql bin/test test/cases/adapters/postgresql/postgresql_adapter_test.rb test/cases/invertible_migration_test.rb -n "/^(?:ActiveRecord::InvertibleMigrationTest#(?:test_migrate_enable_and_disable_extension)|ActiveRecord::ConnectionAdapters::PostgreSQLAdapterTest#(?:test_disable_extension_without_schema))$/" --seed 45290
Using postgresql
Run options: -n "/^(?:ActiveRecord::InvertibleMigrationTest#(?:test_migrate_enable_and_disable_extension)|ActiveRecord::ConnectionAdapters::PostgreSQLAdapterTest#(?:test_disable_extension_without_schema))$/" --seed 45290

.E

Error:
ActiveRecord::ConnectionAdapters::PostgreSQLAdapterTest#test_disable_extension_without_schema:
ActiveRecord::StatementInvalid: PG::DuplicateObject: ERROR:  extension "hstore" already exists

    lib/active_record/connection_adapters/postgresql/database_statements.rb:160:in `exec'
    lib/active_record/connection_adapters/postgresql/database_statements.rb:160:in `perform_query'
    lib/active_record/connection_adapters/abstract/database_statements.rb:556:in `block (2 levels) in raw_execute'
    lib/active_record/connection_adapters/abstract_adapter.rb:1004:in `block in with_raw_connection'
    /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/concurrency/null_lock.rb:9:in `synchronize'
    lib/active_record/connection_adapters/abstract_adapter.rb:976:in `with_raw_connection'
    lib/active_record/connection_adapters/abstract/database_statements.rb:555:in `block in raw_execute'
    /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/notifications/instrumenter.rb:58:in `instrument'
    lib/active_record/connection_adapters/abstract_adapter.rb:1122:in `log'
    lib/active_record/connection_adapters/abstract/database_statements.rb:554:in `raw_execute'
    lib/active_record/connection_adapters/abstract/database_statements.rb:591:in `internal_execute'
    lib/active_record/connection_adapters/abstract/database_statements.rb:137:in `execute'
    lib/active_record/connection_adapters/abstract/query_cache.rb:26:in `execute'
    lib/active_record/connection_adapters/postgresql/database_statements.rb:40:in `execute'
    test/cases/adapters/postgresql/postgresql_adapter_test.rb:687:in `test_disable_extension_without_schema'

bin/test test/cases/adapters/postgresql/postgresql_adapter_test.rb:686

Finished in 0.127199s, 15.7234 runs/s, 39.3085 assertions/s.
2 runs, 5 assertions, 0 failures, 1 errors, 0 skips
$
```

### Additional information
It also applies to the similar `test_disable_extension_with_schema` test that did not fail yet.
Follow up #52452 #52451

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.