### PR TITLE
Let allow_browser allow bots

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Allow bots to ignore `allow_browser`.
+
+    *Matthew Nguyen*
+
 *   Deprecate drawing routes with hash key paths to make routing faster.
 
     ```ruby

--- a/actionpack/lib/action_controller/metal/allow_browser.rb
+++ b/actionpack/lib/action_controller/metal/allow_browser.rb
@@ -85,11 +85,15 @@ module ActionController # :nodoc:
           end
 
           def unsupported_browser?
-            version_guarded_browser? && version_below_minimum_required?
+            version_guarded_browser? && version_below_minimum_required? && !bot?
           end
 
           def version_guarded_browser?
             minimum_browser_version_for_browser != nil
+          end
+
+          def bot?
+            parsed_user_agent.bot?
           end
 
           def version_below_minimum_required?

--- a/actionpack/test/controller/allow_browser_test.rb
+++ b/actionpack/test/controller/allow_browser_test.rb
@@ -23,6 +23,7 @@ class AllowBrowserTest < ActionController::TestCase
   FIREFOX_114   = "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:109.0) Gecko/20100101 Firefox/114.0"
   IE_11         = "Mozilla/5.0 (Windows NT 10.0; WOW64; Trident/7.0; rv:11.0) like Gecko"
   OPERA_106     = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36 OPR/106.0.0.0"
+  GOOGLE_BOT    = "Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5X Build/MMB29P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/W.X.Y.Z Mobile Safari/537.36 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)"
 
   test "blocked browser below version limit" do
     get_with_agent :hello, FIREFOX_114
@@ -56,6 +57,14 @@ class AllowBrowserTest < ActionController::TestCase
     assert_response :ok
 
     get_with_agent :modern, OPERA_106
+    assert_response :ok
+  end
+
+  test "bots" do
+    get_with_agent :hello, GOOGLE_BOT
+    assert_response :ok
+
+    get_with_agent :modern, GOOGLE_BOT
     assert_response :ok
   end
 


### PR DESCRIPTION
As mentioned in https://github.com/rails/rails/issues/50981

> #50505 was merged a few weeks ago which blocks user agents that don't match a specific set of browser versions. Based on the PR it looks like this is the default since it's included in the generator's output.
> 
> This runs the risk of preventing your site from being crawled by various search engines. Google has a [number of specific crawlers](https://developers.google.com/search/docs/crawling-indexing/overview-google-crawlers) that won't match the agents supplied in that PR (images, videos, etc.).
> 
> It will also prevent anyone from accessing your site with `curl` or other popular HTTP clients unless they manually define an agent that mimics a modern browser. This could be an undesired effect as a default, especially without documentation stating that.

The main purpose of the `allow_browser` feature is to force users to update their browsers. It shouldn't interfere with search engine crawlers.