### PR TITLE
Make automatic detection of processor count in default puma config optional and non-default

### DIFF
--- a/guides/source/tuning_performance_for_deployment.md
+++ b/guides/source/tuning_performance_for_deployment.md
@@ -121,8 +121,17 @@ If you use more than one thread per process, then it should be set to how many 
 or if the server is running multiple applications, to how many cores you want the application to use.
 If you only use one thread per worker, then you can increase it to above one per process to account for when workers are
 idle waiting for I/O operations.
-In the default generated configuration, it is set to use all the available processor cores on the server via the
-`Concurrent.available_processor_count` helper. You can also modify it by setting the `WEB_CONCURRENCY` environment variable.
+
+In the default generated configuration, it is set to use 1 worker.
+You can also modify it by setting the `WEB_CONCURRENCY` environment variable.
+
+* Setting `WEB_CONCURRENCY` to a specific number will configure Puma to use that many workers.
+* Setting `WEB_CONCURRENCY` to "auto" will make Puma use all available processor cores on the server, as determined by
+  the `Concurrent.available_processor_count` helper.
+
+Please note that using "auto" might result in incorrect configurations on some cloud hosts with shared CPUs or platforms
+that inaccurately report CPU counts.
+
 
 ### YJIT
 

--- a/railties/lib/rails/generators/rails/app/templates/config/deploy.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/deploy.yml.tt
@@ -30,7 +30,7 @@ env:
     - RAILS_MASTER_KEY
   clear:
     # Set this to the number of cores you wish the application to use on each server.
-    # If not set, app will attempt to use all available cores (but may guess wrong on some cloud hosts!)
+    # You can use "auto" and the app will attempt to use all available cores (but may guess wrong on some cloud hosts!)
     WEB_CONCURRENCY: 1
 
     # Match this to the database server to configure Active Record correctly

--- a/railties/lib/rails/generators/rails/app/templates/config/puma.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/puma.rb.tt
@@ -32,9 +32,14 @@ when "production"
   # If you are running more than 1 thread per process, the workers count
   # should be equal to the number of processors (CPU cores) in production.
   #
-  # Automatically detect the number of available processors in production.
+  # Automatically detect the number of available processors in production
+  # when WEB_CONCURRENCY is set to "auto".
   require "concurrent-ruby"
-  workers_count = Integer(ENV.fetch("WEB_CONCURRENCY") { Concurrent.available_processor_count })
+  workers_count = if ENV["WEB_CONCURRENCY"] == "auto"
+                    Concurrent.available_processor_count
+                  else
+                    Integer(ENV.fetch("WEB_CONCURRENCY", 1))
+                  end
   workers workers_count if workers_count > 1
 
   preload_app!


### PR DESCRIPTION
### Motivation / Background

This Pull Request fixes #52522 

Using `Concurrent.available_processor_count` helper by default in puma.rb might result in incorrect configurations on some cloud hosts with shared CPUs or platforms that inaccurately report CPU counts.

### Detail

This Pull Request changes:
* Make puma.rb spawn only 1 worker by default if `WEB_CONCURRENCY` is not set
* Modify default puma.rb to offer "auto" as an option for `WEB_CONCURRENCY`
* Enhance comment in default deploy.yml to offer "auto" as an option for `WEB_CONCURRENCY`
* Update note to tuning_performance_for_deployment.md to explain the `WEB_CONCURRENCY`

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
