### PR TITLE
Do not elevate visibility of `WEB_CONCURRENCY` in `config/deploy.yml`

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/deploy.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/deploy.yml.tt
@@ -28,11 +28,7 @@ registry:
 env:
   secret:
     - RAILS_MASTER_KEY
-  clear:
-    # Set this to the number of cores you wish the application to use on each server.
-    # You can use "auto" and the app will attempt to use all available cores (but may guess wrong on some cloud hosts!)
-    WEB_CONCURRENCY: 1
-
+  # clear:
     # Match this to the database server to configure Active Record correctly
     # DB_HOST: 192.168.0.2
 


### PR DESCRIPTION
Ref: https://github.com/rails/rails/pull/52533#discussion_r1707703351
Making this follow-up PR on @rafaelfranca's request.

### Detail

Do not elevate visibility of `WEB_CONCURRENCY` in `config/deploy.yml`, since this variable won't be set up incorrectly by default (it now defaults to 1). If people are interested in tweaking worker counts, they will have read `config/puma.rb` anyways, and if they so choose will edit their `config/deploy.yml` (or other setup) accordingly. This PR is basically reverting https://github.com/rails/rails/commit/e3ec553f8c51fc646cecd7fc5efc7fae61e64827.

Alternative implementation: https://github.com/rails/rails/pull/52537. Please only merge one PR and close the other one.