### PR TITLE
Comment out Kamal `WEB_CONCURRENCY` config, since it already defaults to 1

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/deploy.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/deploy.yml.tt
@@ -28,10 +28,10 @@ registry:
 env:
   secret:
     - RAILS_MASTER_KEY
-  clear:
+  # clear:
     # Set this to the number of cores you wish the application to use on each server.
     # You can use "auto" and the app will attempt to use all available cores (but may guess wrong on some cloud hosts!)
-    WEB_CONCURRENCY: 1
+    # WEB_CONCURRENCY: 2
 
     # Match this to the database server to configure Active Record correctly
     # DB_HOST: 192.168.0.2


### PR DESCRIPTION
Ref: https://github.com/rails/rails/pull/52533#discussion_r1707703351
Making this follow-up PR on @rafaelfranca's request.

### Detail

- Comment out Kamal `WEB_CONCURRENCY` config, since it already defaults to 1. Here I have set it to `2` for no particular reason but to have a different example value. I could also set it to `auto` if that makes more sense.
- Comment out `clear:` now that the whole section is commented out again. It was already commented out before https://github.com/rails/rails/commit/e3ec553f8c51fc646cecd7fc5efc7fae61e64827.

Alternative implementation: https://github.com/rails/rails/pull/52536. Please only merge one PR and close the other one.