### PR TITLE
Improve the explanation for unsupported browsers

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/app/controllers/application_controller.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/app/controllers/application_controller.rb.tt
@@ -1,6 +1,10 @@
 class ApplicationController < ActionController::<%= options.api? ? "API" : "Base" %>
 <%- unless options.api? -%>
   # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
+  # Note: When using a desktop browser's developer tools to simulate a phone, it may be identifying itself as an older browser which
+  # is not allowed by :modern. You can customize the user agent to meet the version requirements of :modern. Instructions for Chrome:
+  #   https://developer.chrome.com/docs/devtools/device-mode
+  # The required browser versions for :modern are defined in ActionController::AllowBrowser::BrowserBlocker::SETS
   allow_browser versions: :modern
 <% end -%>
 end

--- a/railties/lib/rails/generators/rails/app/templates/public/406-unsupported-browser.html
+++ b/railties/lib/rails/generators/rails/app/templates/public/406-unsupported-browser.html
@@ -59,7 +59,7 @@
   <div class="dialog">
     <div>
       <h1>Your browser is not supported.</h1>
-      <p>Please upgrade your browser to continue.</p>
+      <p>Please upgrade your browser to continue or change your "allow_browser" setting.</p>
     </div>
   </div>
 </body>


### PR DESCRIPTION
### Motivation / Background

This is a solution to confusion around receiving "unsupported browser" as explained in an Issue, it's to Fix https://github.com/rails/rails/issues/52534

To restate succinctly here: I just got confused why my latest-updated Chrome was resulting in an "unsupported browser" error message. It took me a bit of digging to even discover that `allow_browser` is now a configurable directive so I could comment it out. But it took me even longer to figure out why my latest-updated Chrome was not being considered `:modern`.

When I read DHH's original pull request that introduced this feature, it was notable that the same confusion was discussed on there: https://github.com/rails/rails/pull/50505#issuecomment-1892965985

I think a lot of people are going to hit this issue and be confused. It would be nice if we can enable people to self-diagnose this problem.

### Detail

This Pull Request simply adds two hints to developers to help them figure out what's going on. (1) The default 406 error page that is generated now includes mention of the "allow_browser" setting, so someone knows to look for that within their code. And (2) the default "allow_browser" setting already had a comment explaining the goal of :modern, but this comment has been expanded. I tried to do it in such a way that this comment will age slowly. For example, the comment does not mention the browser versions but instead refers to `ActionController::AllowBrowser::BrowserBlocker::SETS` which someone can reference in rails console or within rails source. This way future version bumps for :modern won't cause a comment to get out of sync.

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [ X Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [X] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
