### PR TITLE
Fix misleading brakeman job description in CI workflow

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/github/ci.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/github/ci.yml.tt
@@ -20,7 +20,7 @@ jobs:
           ruby-version: .ruby-version
           bundler-cache: true
 
-      - name: Scan for security vulnerabilities in Ruby dependencies
+      - name: Scan for common Rails security vulnerabilities using static analysis
         run: bin/brakeman --no-pager
 
 <% end -%>


### PR DESCRIPTION
This PR is a quick fix to what was probably a copy-and-paste typo.

The GitHub Actions workflow generated by `rails new` includes a step for Brakeman with the following description:

> Scan for security vulnerabilities in Ruby dependencies

This is incorrect and misleading. The tool for scanning Ruby dependencies is [bundler-audit](https://github.com/rubysec/bundler-audit). Brakeman, on the other hand, is a static analysis tool for Rails application code.

I suggest the description be rewritten as follows:

> Scan for common Rails security vulnerabilities using static analysis

If there is a better way to phrase it, please feel free to edit the PR.

I've not included a CHANGELOG entry to the small nature of this change, but I can add it if required.