### PR TITLE
Remove redundant Puma configuration settings

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/puma.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/puma.rb.tt
@@ -23,32 +23,6 @@
 threads_count = ENV.fetch("RAILS_MAX_THREADS", 3)
 threads threads_count, threads_count
 
-# Specifies the `environment` that Puma will run in.
-rails_env = ENV.fetch("RAILS_ENV", "development")
-environment rails_env
-
-case rails_env
-when "production"
-  # If you are running more than 1 thread per process, the workers count
-  # should be equal to the number of processors (CPU cores) in production.
-  #
-  # Automatically detect the number of available processors in production
-  # when WEB_CONCURRENCY is set to "auto".
-  require "concurrent-ruby"
-  workers_count = if ENV["WEB_CONCURRENCY"] == "auto"
-                    Concurrent.available_processor_count
-                  else
-                    Integer(ENV.fetch("WEB_CONCURRENCY", 1))
-                  end
-  workers workers_count if workers_count > 1
-
-  preload_app!
-when "development"
-  # Specifies a very generous `worker_timeout` so that the worker
-  # isn't killed by Puma when suspended by a debugger.
-  worker_timeout 3600
-end
-
 # Specifies the `port` that Puma will listen on to receive requests; default is 3000.
 port ENV.fetch("PORT", 3000)
 


### PR DESCRIPTION
1. Puma automatically sets its environment from RAILS_ENV
2. preload_app! is automatically set when in cluster mode
3. WEB_CONCURRENCY is automatically used and is now parsed directly so can't be extended with "auto" here.
4. worker_timeout is a cluster mode feature, and we don't run that in dev.