### PR TITLE
Document THOR_MERGE and THOR_DIFF vars during upgrade [ci skip]

### DIFF
--- a/guides/source/upgrading_ruby_on_rails.md
+++ b/guides/source/upgrading_ruby_on_rails.md
@@ -68,7 +68,7 @@ Overwrite /myapp/config/application.rb? (enter "h" for help) [Ynaqdh]
 ...
 ```
 
-Don't forget to review the difference, to see if there were any unexpected changes.
+Don't forget to review the difference, to see if there were any unexpected changes, and note that the diff and merge tools used during this processed can be defined using the `THOR_DIFF` and `THOR_MERGE` environment variables.
 
 ### Configure Framework Defaults
 


### PR DESCRIPTION
Add documentation explaining how to choose a diff/merge tool during the `rails app:update` process, as this can make the process much nicer and is not readily apparent.