### PR TITLE
Remove WEB_CONCURRENCY "auto" from tuning_performance_for_deployment [ci-skip]

### DIFF
--- a/guides/source/tuning_performance_for_deployment.md
+++ b/guides/source/tuning_performance_for_deployment.md
@@ -122,16 +122,7 @@ or if the server is running multiple applications, to how many cores you want th
 If you only use one thread per worker, then you can increase it to above one per process to account for when workers are
 idle waiting for I/O operations.
 
-In the default generated configuration, it is set to use 1 worker.
-You can also modify it by setting the `WEB_CONCURRENCY` environment variable.
-
-* Setting `WEB_CONCURRENCY` to a specific number will configure Puma to use that many workers.
-* Setting `WEB_CONCURRENCY` to "auto" will make Puma use all available processor cores on the server, as determined by
-  the `Concurrent.available_processor_count` helper.
-
-Please note that using "auto" might result in incorrect configurations on some cloud hosts with shared CPUs or platforms
-that inaccurately report CPU counts.
-
+You can configure number of Puma workers by setting the `WEB_CONCURRENCY` environment variable.
 
 ### YJIT
 


### PR DESCRIPTION
### Motivation / Background

Commit https://github.com/rails/rails/commit/142e6ab2c1e3cb7df4b82e20e2a1cd676b755714 removes "auto" option for `WEB_CONCURRENCY` in puma.rb since Puma 5+ parses environment variable `WEB_CONCURRENCY` directly so it can't be extended with "auto". 

### Detail

This PR updates `guides/source/tuning_performance_for_deployment.md` to reflect that change.

### Additional information

Related references:
* https://github.com/rails/rails/pull/52541
* https://github.com/rails/rails/pull/52533
* https://github.com/rails/rails/issues/52522

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
