### PR TITLE
Add ago/in words to time_ago_in_words

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add the prefix `in` or the suffix `ago` to the `time_ago_in_words` helper.
+
+    *Matthew Nguyen*
+
 *   Rename `text_area` methods into `textarea`
 
     Old names are still available as aliases.

--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,5 +1,8 @@
 *   Add the prefix `in` or the suffix `ago` to the `time_ago_in_words` helper.
 
+    Use `config.action_view.include_prefix_or_suffix_to_time_ago_in_words` to control the behavior.
+    The default value is `false` to maintain compatibility with previous versions of Rails.
+
     *Matthew Nguyen*
 
 *   Rename `text_area` methods into `textarea`

--- a/actionview/lib/action_view/base.rb
+++ b/actionview/lib/action_view/base.rb
@@ -178,6 +178,9 @@ module ActionView # :nodoc:
     # Annotate rendered view with file names
     cattr_accessor :annotate_rendered_view_with_filenames, default: false
 
+    # Specify whether to include "ago" or "in" in <tt>time_ago_in_words</tt> helper method.
+    cattr_accessor :include_prefix_or_suffix_to_time_ago_in_words, default: false
+
     class_attribute :_routes
     class_attribute :logger
 

--- a/actionview/lib/action_view/helpers/date_helper.rb
+++ b/actionview/lib/action_view/helpers/date_helper.rb
@@ -175,6 +175,10 @@ module ActionView
       # Note that you cannot pass a <tt>Numeric</tt> value to <tt>time_ago_in_words</tt>.
       #
       def time_ago_in_words(from_time, options = {})
+        unless ActionView::Base.include_prefix_or_suffix_to_time_ago_in_words
+          return distance_of_time_in_words(from_time, Time.now, options)
+        end
+
         options = {
           scope: :'datetime.distance_in_words'
         }.merge!(options)

--- a/actionview/lib/action_view/helpers/date_helper.rb
+++ b/actionview/lib/action_view/helpers/date_helper.rb
@@ -157,24 +157,32 @@ module ActionView
         end
       end
 
-      # Like <tt>distance_of_time_in_words</tt>, but where <tt>to_time</tt> is fixed to <tt>Time.now</tt>.
+      # Like <tt>distance_of_time_in_words</tt>, but where <tt>to_time</tt> is fixed to <tt>Time.now</tt>
+      # and prepended by in or appended by ago.
       #
-      #   time_ago_in_words(3.minutes.from_now)                 # => 3 minutes
-      #   time_ago_in_words(3.minutes.ago)                      # => 3 minutes
-      #   time_ago_in_words(Time.now - 15.hours)                # => about 15 hours
-      #   time_ago_in_words(Time.now)                           # => less than a minute
-      #   time_ago_in_words(Time.now, include_seconds: true) # => less than 5 seconds
+      #   time_ago_in_words(3.minutes.from_now)                 # => in 3 minutes
+      #   time_ago_in_words(3.minutes.ago)                      # => 3 minutes ago
+      #   time_ago_in_words(Time.now - 15.hours)                # => about 15 hours ago
+      #   time_ago_in_words(Time.now)                           # => less than a minute ago
+      #   time_ago_in_words(Time.now, include_seconds: true) # => less than 5 seconds ago
       #
       #   from_time = Time.now - 3.days - 14.minutes - 25.seconds
-      #   time_ago_in_words(from_time)      # => 3 days
+      #   time_ago_in_words(from_time)      # => 3 days ago
       #
       #   from_time = (3.days + 14.minutes + 25.seconds).ago
-      #   time_ago_in_words(from_time)      # => 3 days
+      #   time_ago_in_words(from_time)      # => 3 days ago
       #
       # Note that you cannot pass a <tt>Numeric</tt> value to <tt>time_ago_in_words</tt>.
       #
       def time_ago_in_words(from_time, options = {})
-        distance_of_time_in_words(from_time, Time.now, options)
+        options = {
+          scope: :'datetime.distance_in_words'
+        }.merge!(options)
+
+        I18n.with_options locale: options[:locale], scope: options[:scope] do |locale|
+          key = from_time > Time.now ? :from_now : :ago
+          locale.t(key, time: distance_of_time_in_words(from_time, Time.now, options))
+        end
       end
 
       alias_method :distance_of_time_in_words_to_now, :time_ago_in_words

--- a/actionview/lib/action_view/locale/en.yml
+++ b/actionview/lib/action_view/locale/en.yml
@@ -2,6 +2,8 @@
   # Used in distance_of_time_in_words(), distance_of_time_in_words_to_now(), time_ago_in_words()
   datetime:
     distance_in_words:
+      ago:      "%{time} ago"
+      from_now: "in %{time}"
       half_a_minute: "half a minute"
       less_than_x_seconds:
         one:   "less than 1 second"

--- a/actionview/test/template/date_helper_i18n_test.rb
+++ b/actionview/test/template/date_helper_i18n_test.rb
@@ -49,9 +49,15 @@ class DateHelperDistanceOfTimeInWordsI18nTests < ActiveSupport::TestCase
   end
 
   def test_time_ago_in_words_passes_locale
-    assert_called_with(I18n, :t, [:less_than_x_minutes], scope: :'datetime.distance_in_words', count: 1, locale: "ru") do
+    mock = Minitest::Mock.new
+    expect_called_with(mock, [:less_than_x_minutes], returns: "less than a minute", scope: :'datetime.distance_in_words', count: 1, locale: "ru")
+    expect_called_with(mock, [:ago], scope: :'datetime.distance_in_words', time: "less than a minute", locale: "ru")
+
+    I18n.stub(:t, mock) do
       time_ago_in_words(15.seconds.ago, locale: "ru")
     end
+
+    assert_mock(mock)
   end
 
   def test_distance_of_time_pluralizations

--- a/actionview/test/template/date_helper_i18n_test.rb
+++ b/actionview/test/template/date_helper_i18n_test.rb
@@ -49,6 +49,14 @@ class DateHelperDistanceOfTimeInWordsI18nTests < ActiveSupport::TestCase
   end
 
   def test_time_ago_in_words_passes_locale
+    ActionView::Base.include_prefix_or_suffix_to_time_ago_in_words = false
+
+    assert_called_with(I18n, :t, [:less_than_x_minutes], scope: :'datetime.distance_in_words', count: 1, locale: "ru") do
+      time_ago_in_words(15.seconds.ago, locale: "ru")
+    end
+
+    ActionView::Base.include_prefix_or_suffix_to_time_ago_in_words = true
+
     mock = Minitest::Mock.new
     expect_called_with(mock, [:less_than_x_minutes], returns: "less than a minute", scope: :'datetime.distance_in_words', count: 1, locale: "ru")
     expect_called_with(mock, [:ago], scope: :'datetime.distance_in_words', time: "less than a minute", locale: "ru")

--- a/actionview/test/template/date_helper_test.rb
+++ b/actionview/test/template/date_helper_test.rb
@@ -144,8 +144,8 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_time_ago_in_words_passes_include_seconds
-    assert_equal "less than 20 seconds", time_ago_in_words(15.seconds.ago, include_seconds: true)
-    assert_equal "less than a minute", time_ago_in_words(15.seconds.ago, include_seconds: false)
+    assert_equal "less than 20 seconds ago", time_ago_in_words(15.seconds.ago, include_seconds: true)
+    assert_equal "less than a minute ago", time_ago_in_words(15.seconds.ago, include_seconds: false)
   end
 
   def test_distance_in_words_with_time_zones
@@ -200,7 +200,8 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_time_ago_in_words
-    assert_equal "about 1 year", time_ago_in_words(1.year.ago - 1.day)
+    assert_equal "about 1 year ago", time_ago_in_words(1.year.ago - 1.day)
+    assert_equal "in about 1 year", time_ago_in_words(1.year.from_now + 1.day)
   end
 
   def test_select_day

--- a/actionview/test/template/date_helper_test.rb
+++ b/actionview/test/template/date_helper_test.rb
@@ -144,6 +144,13 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_time_ago_in_words_passes_include_seconds
+    ActionView::Base.include_prefix_or_suffix_to_time_ago_in_words = false
+
+    assert_equal "less than 20 seconds", time_ago_in_words(15.seconds.ago, include_seconds: true)
+    assert_equal "less than a minute", time_ago_in_words(15.seconds.ago, include_seconds: false)
+
+    ActionView::Base.include_prefix_or_suffix_to_time_ago_in_words = true
+
     assert_equal "less than 20 seconds ago", time_ago_in_words(15.seconds.ago, include_seconds: true)
     assert_equal "less than a minute ago", time_ago_in_words(15.seconds.ago, include_seconds: false)
   end
@@ -200,6 +207,13 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_time_ago_in_words
+    ActionView::Base.include_prefix_or_suffix_to_time_ago_in_words = false
+
+    assert_equal "about 1 year", time_ago_in_words(1.year.ago - 1.day)
+    assert_equal "about 1 year", time_ago_in_words(1.year.from_now + 1.day)
+
+    ActionView::Base.include_prefix_or_suffix_to_time_ago_in_words = true
+
     assert_equal "about 1 year ago", time_ago_in_words(1.year.ago - 1.day)
     assert_equal "in about 1 year", time_ago_in_words(1.year.from_now + 1.day)
   end

--- a/guides/source/action_view_helpers.md
+++ b/guides/source/action_view_helpers.md
@@ -53,7 +53,7 @@ Reports the approximate distance in time between a `Time` or `Date` object, or
 integer as seconds,  and `Time.current`.
 
 ```ruby
-time_ago_in_words(3.minutes.from_now) # => 3 minutes
+time_ago_in_words(3.minutes.from_now) # => in 3 minutes
 ```
 
 See the [`time_ago_in_words` API

--- a/guides/source/command_line.md
+++ b/guides/source/command_line.md
@@ -438,7 +438,7 @@ With the `helper` method it is possible to access Rails and your application's h
 
 ```irb
 irb> helper.time_ago_in_words 30.days.ago
-=> "about 1 month"
+=> "about 1 month ago"
 
 irb> helper.my_custom_helper
 => "my custom helper"


### PR DESCRIPTION
### Motivation / Background

I recently encountered the issue https://github.com/rails/mission_control-jobs/issues/136 on mission control and I realized that Rails didn't have a way to localize the word `ago` out of the box.

~This PR will break a lot of projects but I think it's a valuable add, and the update is pretty straightforward.~

EDIT: added `config.action_view.include_prefix_or_suffix_to_time_ago_in_words` to keep retro-compatibility.

### Details

Before:

```ruby
#   time_ago_in_words(3.minutes.from_now)                 # => 3 minutes
#   time_ago_in_words(3.minutes.ago)                      # => 3 minutes
```

After:

```ruby
#   time_ago_in_words(3.minutes.from_now)                 # => in 3 minutes
#   time_ago_in_words(3.minutes.ago)                      # => 3 minutes ago
```

Example of localization:

```yml
ja:
  datetime:
    distance_in_words:
      ago: "%{time}前"
      from_now: "%{time}後"
es:
  datetime:
    distance_in_words:
      ago: "hace %{time}"
      from_now: "en %{time}"
fr:
  datetime:
    distance_in_words:
      ago: "il y a %{time}"
      from_now: "dans %{time}"
```