### PR TITLE
Allow renderables to register for implicit rendering

### DIFF
--- a/actionpack/lib/action_controller/metal/implicit_render.rb
+++ b/actionpack/lib/action_controller/metal/implicit_render.rb
@@ -35,7 +35,9 @@ module ActionController
     include BasicImplicitRender
 
     def default_render
-      if template_exists?(action_name.to_s, _prefixes, variants: request.variant)
+      if renderable = find_renderable(action_name.to_s, _prefixes)
+        render(renderable.new)
+      elsif template_exists?(action_name.to_s, _prefixes, variants: request.variant)
         render
       elsif any_templates?(action_name.to_s, _prefixes)
         message = "#{self.class.name}\##{action_name} is missing a template " \
@@ -60,6 +62,10 @@ module ActionController
     end
 
     private
+      def find_renderable(action_name, prefixes)
+        ActionView::RenderableRegistry.get_renderables(self)[[prefixes, action_name].join("/")]
+      end
+
       def interactive_browser_request?
         request.get? && request.format == Mime[:html] && !request.xhr?
       end

--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add support for implicitly rendering renderables in controllers.
+
+    *Joel Hawksley*
+
 *   Rename `check_box*` methods into `checkbox*`.
 
     Old names are still available as aliases.

--- a/actionview/lib/action_view.rb
+++ b/actionview/lib/action_view.rb
@@ -44,6 +44,7 @@ module ActionView
     autoload :PathRegistry
     autoload :PathSet
     autoload :RecordIdentifier
+    autoload :RenderableRegistry
     autoload :Rendering
     autoload :RoutingUrlFor
     autoload :Template

--- a/actionview/lib/action_view/renderable_registry.rb
+++ b/actionview/lib/action_view/renderable_registry.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module ActionView # :nodoc:
+  module RenderableRegistry # :nodoc:
+    @renderables_by_class = Hash.new({})
+
+    def self.get_renderables(klass)
+      @renderables_by_class[klass] || get_renderables(klass.superclass)
+    end
+
+    def self.set_renderable(klass, path, renderable_klass)
+      @renderables_by_class[klass][path] = renderable_klass
+    end
+  end
+end

--- a/actionview/lib/action_view/view_paths.rb
+++ b/actionview/lib/action_view/view_paths.rb
@@ -69,6 +69,10 @@ module ActionView
         self._view_paths = _build_view_paths(paths)
       end
 
+      def register_renderable(path, renderable_klass)
+        ActionView::RenderableRegistry.set_renderable(self, path, renderable_klass)
+      end
+
       private
         # Override this method in your controller if you want to change paths prefixes for finding views.
         # Prefixes defined here will still be added to parents' <tt>._prefixes</tt>.

--- a/actionview/test/actionpack/controller/render_test.rb
+++ b/actionview/test/actionpack/controller/render_test.rb
@@ -39,6 +39,12 @@ class ValidatingPost < Post
   validates :title, presence: true
 end
 
+class ImplicitRenderable
+  def render_in(_)
+    "implicit renderable"
+  end
+end
+
 class TestController < ActionController::Base
   protect_from_forgery
 
@@ -285,6 +291,9 @@ class TestController < ActionController::Base
   end
 
   def formatted_xml_erb
+  end
+
+  def implicit_renderable
   end
 
   def render_to_string_test
@@ -662,6 +671,7 @@ class RenderTest < ActionController::TestCase
     get :empty_partial_collection, to: "test#empty_partial_collection"
     get :formatted_html_erb, to: "test#formatted_html_erb"
     get :formatted_xml_erb, to: "test#formatted_xml_erb"
+    get :implicit_renderable, to: "test#implicit_renderable"
     get :greeting, to: "test#greeting"
     get :hello_in_a_string, to: "test#hello_in_a_string"
     get :hello_world, to: "fun/games#hello_world"
@@ -771,6 +781,9 @@ class RenderTest < ActionController::TestCase
     ActionView::Base.logger = ActiveSupport::Logger.new(nil)
 
     @request.host = "www.nextangle.com"
+
+    # This would likely be handled at by the view object framework
+    ActionController::Base.register_renderable("test/implicit_renderable", ImplicitRenderable)
 
     @old_view_paths = ActionController::Base.view_paths
     ActionController::Base.view_paths = File.join(FIXTURE_LOAD_PATH, "actionpack")
@@ -1120,6 +1133,11 @@ class RenderTest < ActionController::TestCase
     @request.accept = "image/gif, image/x-xbitmap, image/jpeg, image/pjpeg, application/x-shockwave-flash, */*"
     get :formatted_xml_erb
     assert_equal "<test>passed formatted HTML erb</test>", @response.body
+  end
+
+  def test_should_render_implicit_renderable
+    get :implicit_renderable
+    assert_equal "implicit renderable", @response.body
   end
 
   def test_layout_test_with_different_layout


### PR DESCRIPTION
### Motivation / Background

In #36388, we added support for rendering objects that respond to for controller actions. This PR adds support for implicitly rendering renderables for controller actions as one can for regular templates today.

In https://github.com/rails/rails/pull/52457, I prototyped this feature using an approach that required a deeply nested namespace. @dhh I'd love your thoughts on this alternative ❤️ 

### Detail

Specifically, I've updated `ImplictRender` to look for renderables registered via `ActionController::Base.register_renderable`.

If this approach is deemed acceptable, I'll gladly flesh it out and add docs ❤️ 

### Additional information

@bradgessler's post on doing this for Phlex: https://fly.io/ruby-dispatch/hacking-rails-implicit-rendering-for-view-components/
ViewComponent thread discussing the topic: https://github.com/ViewComponent/view_component/issues/618

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.

cc @joeldrapper
