### PR TITLE
Fix indentation of the application_system_test_case with devcontainer

### DIFF
--- a/railties/lib/rails/generators/rails/devcontainer/devcontainer_generator.rb
+++ b/railties/lib/rails/generators/rails/devcontainer/devcontainer_generator.rb
@@ -40,7 +40,7 @@ module Rails
         return unless options[:system_test]
         return unless File.exist?("test/application_system_test_case.rb")
 
-        gsub_file("test/application_system_test_case.rb", /^(\s*driven_by\b.*)/, system_test_configuration)
+        gsub_file("test/application_system_test_case.rb", /^\s*driven_by\b.*/, system_test_configuration)
       end
 
       def update_database_yml
@@ -148,17 +148,17 @@ module Rails
         end
 
         def system_test_configuration
-          <<~'RUBY'
-              if ENV["CAPYBARA_SERVER_PORT"]
-                served_by host: "rails-app", port: ENV["CAPYBARA_SERVER_PORT"]
+          optimize_indentation(<<-'RUBY', 2)
+            if ENV["CAPYBARA_SERVER_PORT"]
+              served_by host: "rails-app", port: ENV["CAPYBARA_SERVER_PORT"]
 
-                driven_by :selenium, using: :headless_chrome, screen_size: [ 1400, 1400 ], options: {
-                  browser: :remote,
-                  url: "http://#{ENV["SELENIUM_HOST"]}:4444"
-                }
-              else
-                driven_by :selenium, using: :headless_chrome, screen_size: [ 1400, 1400 ]
-              end
+              driven_by :selenium, using: :headless_chrome, screen_size: [ 1400, 1400 ], options: {
+                browser: :remote,
+                url: "http://#{ENV["SELENIUM_HOST"]}:4444"
+              }
+            else
+              driven_by :selenium, using: :headless_chrome, screen_size: [ 1400, 1400 ]
+            end
           RUBY
         end
     end

--- a/railties/lib/rails/generators/rails/devcontainer/templates/devcontainer/compose.yaml.tt
+++ b/railties/lib/rails/generators/rails/devcontainer/templates/devcontainer/compose.yaml.tt
@@ -26,7 +26,7 @@ services:
 <%- if options[:system_test] -%>
 
   selenium:
-    image: seleniarm/standalone-chromium
+    image: selenium/standalone-chromium
     restart: unless-stopped
 <%- end -%>
 

--- a/railties/test/fixtures/.devcontainer/compose.yaml
+++ b/railties/test/fixtures/.devcontainer/compose.yaml
@@ -20,7 +20,7 @@ services:
     - redis
 
   selenium:
-    image: seleniarm/standalone-chromium
+    image: selenium/standalone-chromium
     restart: unless-stopped
 
   redis:

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -1258,7 +1258,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
       assert_equal expected_rails_app_config, compose_config["services"]["rails-app"]
 
       expected_selenium_conifg = {
-        "image" => "seleniarm/standalone-chromium",
+        "image" => "selenium/standalone-chromium",
         "restart" => "unless-stopped",
       }
 

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -1237,7 +1237,10 @@ class AppGeneratorTest < Rails::Generators::TestCase
       assert_match(/ARG RUBY_VERSION=#{RUBY_VERSION}/, content)
     end
     assert_file("test/application_system_test_case.rb") do |content|
-      assert_match(/served_by host: "rails-app", port: ENV\["CAPYBARA_SERVER_PORT"\]/, content)
+      assert_match(/^    served_by host: "rails-app", port: ENV\["CAPYBARA_SERVER_PORT"\]/, content)
+      assert_match(/^    driven_by :selenium, using: :headless_chrome, screen_size: \[ 1400, 1400 \], options: {$/, content)
+      assert_match(/^      browser: :remote,$/, content)
+      assert_match(/^      url: "http:\/\/\#{ENV\["SELENIUM_HOST"\]}:4444"$/, content)
     end
     assert_compose_file do |compose_config|
       assert_equal "my_app", compose_config["name"]


### PR DESCRIPTION
The `application_system_test_case` file is generated with an incorrect indentation when the devcontainer generator was used.