### PR TITLE
If a job fails due to an error, it is discarded, and don't re-raise.

### DIFF
--- a/activejob/lib/active_job/execution.rb
+++ b/activejob/lib/active_job/execution.rb
@@ -53,8 +53,7 @@ module ActiveJob
       handled = rescue_with_handler(exception)
       return handled if handled
 
-      run_after_discard_procs(exception)
-      raise
+      _default_discard(exception)
     end
 
     def perform(*)
@@ -62,6 +61,12 @@ module ActiveJob
     end
 
     private
+      def _default_discard(error)
+        instrument :discard, error: error do
+          run_after_discard_procs(error)
+        end
+      end
+      
       def _perform_job
         ActiveSupport::ExecutionContext[:job] = self
         run_callbacks :perform do

--- a/activejob/lib/active_job/execution.rb
+++ b/activejob/lib/active_job/execution.rb
@@ -49,12 +49,15 @@ module ActiveJob
       deserialize_arguments_if_needed
 
       _perform_job
-    rescue Exception => exception
-      handled = rescue_with_handler(exception)
-      return handled if handled
 
-      run_after_discard_procs(exception)
-      raise
+      # The job was successfully performed:
+      performed = true
+    rescue => error
+      # The job failed for some reason, let the user handle it:
+      return rescue_with_handler(error)
+    ensure
+      # Run after discard procedures if the job was not performed:
+      run_after_discard_procs(error) unless performed
     end
 
     def perform(*)

--- a/activejob/lib/active_job/execution.rb
+++ b/activejob/lib/active_job/execution.rb
@@ -49,15 +49,12 @@ module ActiveJob
       deserialize_arguments_if_needed
 
       _perform_job
+    rescue Exception => exception
+      handled = rescue_with_handler(exception)
+      return handled if handled
 
-      # The job was successfully performed:
-      performed = true
-    rescue => error
-      # The job failed for some reason, let the user handle it:
-      return rescue_with_handler(error)
-    ensure
-      # Run after discard procedures if the job was not performed:
-      run_after_discard_procs(error) unless performed
+      run_after_discard_procs(exception)
+      raise
     end
 
     def perform(*)


### PR DESCRIPTION
### Motivation / Background

There are three cases for error handling:

1/ Normal job submission, and the job executes successfully.

```ruby
::ActiveJob::Base.execute(GoodJob.new.serialize)
```

2/ Normal job submission, but the job fails, and there is no appropriate error handler (`retry_on`). The job is discarded as expected, and the error is logged, but this method still raises an exception.

```ruby
::ActiveJob::Base.execute(BadJob.new.serialize)
```

3/ Bad job submission (or other internal error). The job is not processed, an error is raised, but there is no log.

```ruby
::ActiveJob::Base.execute({})
```

The problem is, the error raised by (2) is logged, but the error raised by (3) is not.

A job server may wrap `ActiveJob::Base.execute` like so:

```ruby
# Execute the given job.
while job = read_job
	begin
		::ActiveJob::Base.execute(job)
	rescue => error
		log_error(error)
	end
end
```

In case (2) above, this will lead to two log messages being emitted for the failure, one from ActiveJob and one from the Job runner. This is not ideal from a usability point of view, ideally only one log message should be emitted.

One way to solve the problem is this:

```ruby
# Execute the given job.
while job = read_job
	begin
		::ActiveJob::Base.execute(job)
	rescue => error
		# Ignore errors, logged by ActiveJob.
	end
end
```

Now ActiveJob is fully responsible for logging. However, there are some situations as shown in case (3) where `ActiveJob::Base.execute` can raise errors which are not logged. That is problematic as that would result in a silent failure which is a very bad user experience.

### Detail

This proposal changes case (2) to not re-raise the exception if the job is not retried. The error is still logged by ActiveJob, but the error is not propagated up, as it's normal and expected that the job is discarded in that case.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [ ] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
