### PR TITLE
Address test_disable_extension_with_schema failure

### DIFF
--- a/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
@@ -671,7 +671,8 @@ module ActiveRecord
 
       def test_disable_extension_with_schema
         @connection.execute("CREATE SCHEMA custom_schema")
-        @connection.execute("CREATE EXTENSION IF NOT EXISTS hstore SCHEMA custom_schema")
+        @connection.execute("DROP EXTENSION IF EXISTS hstore")
+        @connection.execute("CREATE EXTENSION hstore SCHEMA custom_schema")
         result = @connection.query("SELECT extname FROM pg_extension WHERE extnamespace = (SELECT oid FROM pg_namespace WHERE nspname = 'custom_schema')")
         assert_equal [["hstore"]], result.to_a
 
@@ -684,7 +685,8 @@ module ActiveRecord
       end
 
       def test_disable_extension_without_schema
-        @connection.execute("CREATE EXTENSION IF NOT EXISTS hstore")
+        @connection.execute("DROP EXTENSION IF EXISTS hstore")
+        @connection.execute("CREATE EXTENSION hstore")
         result = @connection.query("SELECT extname FROM pg_extension")
         assert_includes result.to_a, ["hstore"]
 


### PR DESCRIPTION
### Motivation / Background

This pull request addresses the CI failure discussed at https://github.com/rails/rails/pull/52452#issuecomment-2282352093

### Detail

This commit addresses the following failure.

```ruby
$ ARCONN=postgresql bin/test test/cases/adapters/postgresql/extension_migration_test.rb test/cases/adapters/postgresql/postgresql_adapter_test.rb -n "/^(?:PostgresqlExtensionMigrationTest#(?:test_disable_extension_raises_when_dependent_objects_exist)|ActiveRecord::ConnectionAdapters::PostgreSQLAdapterTest#(?:test_disable_extension_with_schema))$/" --seed 3841 -v
Using postgresql
Run options: -n "/^(?:PostgresqlExtensionMigrationTest#(?:test_disable_extension_raises_when_dependent_objects_exist)|ActiveRecord::ConnectionAdapters::PostgreSQLAdapterTest#(?:test_disable_extension_with_schema))$/" --seed 3841 -v

PostgresqlExtensionMigrationTest#test_disable_extension_raises_when_dependent_objects_exist = 0.05 s = .
ActiveRecord::ConnectionAdapters::PostgreSQLAdapterTest#test_disable_extension_with_schema = 0.02 s = F

Failure:
ActiveRecord::ConnectionAdapters::PostgreSQLAdapterTest#test_disable_extension_with_schema [test/cases/adapters/postgresql/postgresql_adapter_test.rb:676]:
Expected: [["hstore"]]
  Actual: []

bin/test test/cases/adapters/postgresql/postgresql_adapter_test.rb:672

Finished in 0.070507s, 28.3659 runs/s, 56.7318 assertions/s.
2 runs, 4 assertions, 1 failures, 0 errors, 0 skips
```


### Additional information

Applied the same change for `test_disable_extension_without_schema`

Follow up #52528
Refer to https://github.com/rails/rails/pull/52452#issuecomment-2282352093

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.



