### PR TITLE
Bulk insert fixtures on SQLite

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   SQLite3Adapter: Bulk insert fixtures.
+
+    Previously one insert command was executed for each fixture, now they are
+    aggregated in a single bulk insert command.
+
+    *Lázaro Nixon*
+
 *   PostgreSQLAdapter: Allow `disable_extension` to be called with schema-qualified name.
 
     For parity with `enable_extension`, the `disable_extension` method can be called with a schema-qualified

--- a/activerecord/lib/active_record/connection_adapters/sqlite3/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3/database_statements.rb
@@ -128,19 +128,16 @@ module ActiveRecord
             raw_execute(sql, name, batch: true)
           end
 
-          def build_fixture_statements(fixture_set)
-            fixture_set.flat_map do |table_name, fixtures|
-              next if fixtures.empty?
-              fixtures.map { |fixture| build_fixture_sql([fixture], table_name) }
-            end.compact
-          end
-
           def build_truncate_statement(table_name)
             "DELETE FROM #{quote_table_name(table_name)}"
           end
 
           def returning_column_values(result)
             result.rows.first
+          end
+
+          def default_insert_value(column)
+            column.default
           end
       end
     end


### PR DESCRIPTION
### Motivation / Background

SQLite supports bulk inserts, but one insert was created for each fixture. This PR makes it behave like the other adapters, creating a single bulk insert per fixture table and making tests with SQLite considerably faster.

### Detail

Before:

```SQL
INSERT INTO "people" ("id", "name", "age", "weight", "height", "created_at", "updated_at") VALUES (980190962, 'MyString', 1, 9.99, 9.99, '2024-08-11 05:51:09.160917', '2024-08-11 05:51:09.160917');
INSERT INTO "people" ("id", "name", "age", "weight", "height", "created_at", "updated_at") VALUES (298486374, 'MyString', 1, 9.99, 9.99, '2024-08-11 05:51:09.160917', '2024-08-11 05:51:09.160917')
```

Later:

```SQL
INSERT INTO "people" ("id", "name", "age", "weight", "height", "created_at", "updated_at") VALUES (980190962, 'MyString', 1, 9.99, 9.99, '2024-08-11 05:50:30.498112', '2024-08-11 05:50:30.498112'), (298486374, 'MyString', 1, 9.99, 9.99, '2024-08-11 05:50:30.498112', '2024-08-11 05:50:30.498112')
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
