### PR TITLE
guide(dev): use BUNDLE_ONLY variable to install required deps

### DIFF
--- a/guides/source/contributing_to_ruby_on_rails.md
+++ b/guides/source/contributing_to_ruby_on_rails.md
@@ -166,10 +166,9 @@ Note that translations are not submitted to the Rails repository; your work live
 To generate the guides in HTML format, you will need to install the guides dependencies, `cd` into the *guides* directory, and then run (e.g., for it-IT):
 
 ```bash
-# only install gems necessary for the guides. To undo run: bundle config --delete without
-$ bundle install --without job cable storage test db
+$ BUNDLE_ONLY=default:doc bundle install
 $ cd guides/
-$ bundle exec rake guides:generate:html GUIDES_LANGUAGE=it-IT
+$ BUNDLE_ONLY=default:doc bundle exec rake guides:generate:html GUIDES_LANGUAGE=it-IT
 ```
 
 This will generate the guides in an *output* directory.


### PR DESCRIPTION
### Motivation / Background

- `bundle install --without` was deprecated years ago, so we would like to avoid to use it but it is still described in [4 Translating Rails Guides](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#translating-rails-guides).
- Listing `WITHOUT` group parameters bothers dev-guide maintainers.

This Pull Request has been created because we should use the current option on building translated guides.

### Detail

This Pull Request changes to use `BUNDLE_ONLY` variable to install required dependencies instead of `bundle install --without ...`.

### Additional information

- Edge: https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#translating-rails-guides
   - (or v7.2: https://guides.rubyonrails.org/v7.2/contributing_to_ruby_on_rails.html#translating-rails-guides)
- With #52564 and this PR, `--without` option for `bundle install` would be expelled 🎉 

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [n/a] Tests are added or updated if you fix a bug or add a feature.
* [n/a] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
* [x] `cp -r guides/{source,it-IT} && mv guides/it-IT guides/source && BUNDLE_ONLY=default:doc bundle install && cd guides && BUNDLE_ONLY=default:doc bundle exec rake guides:generate:html GUIDES_LANGUAGE=it-IT` looks good.