### PR TITLE
Replace --without option with config set command on bundle install

### DIFF
--- a/guides/source/development_dependencies_install.md
+++ b/guides/source/development_dependencies_install.md
@@ -229,7 +229,8 @@ $ bundle install
 If you don't need to run Active Record tests, you can run:
 
 ```bash
-$ bundle install --without db
+$ bundle config set without db
+$ bundle install
 ```
 
 ### Contribute to Rails


### PR DESCRIPTION
### Motivation / Background

`bundle install --without` is still shown in [Installing Rails Core Development Dependencies](https://guides.rubyonrails.org/development_dependencies_install.html#installing-gem-dependencies) dev guide.

### Detail

This Pull Request replace `--without` option with `config set` sub-command on `bundle install`.

### Additional information

- https://guides.rubyonrails.org/development_dependencies_install.html#installing-gem-dependencies
   - https://guides.rubyonrails.org/v7.2/development_dependencies_install.html#installing-gem-dependencies
- With #52563 and this PR, `--without` option for `bundle install` would be expelled 🎉 

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [n/a] Tests are added or updated if you fix a bug or add a feature.
* [n/a] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
