### PR TITLE
Address `Layout/TrailingWhitespace` offense

### DIFF
--- a/activesupport/lib/active_support/json/encoding.rb
+++ b/activesupport/lib/active_support/json/encoding.rb
@@ -31,7 +31,6 @@ module ActiveSupport
 
         def initialize(options = nil)
           @options = options || {}
-          
         end
 
         # Encode the given object into a JSON string


### PR DESCRIPTION
### Motivation / Background

This commit addresses the following RuboCop offense reported at  https://buildkite.com/rails/rails/builds/110044#019140ca-55c0-4172-9b4f-f8422dd34559/1215-1221

### Detail

```ruby
$ bundle exec rubocop -a activesupport/lib/active_support/json/encoding.rb
Inspecting 1 file
C

Offenses:

activesupport/lib/active_support/json/encoding.rb:34:1: C: [Corrected] Layout/EmptyLinesAroundMethodBody: Extra empty line detected at method body end.
activesupport/lib/active_support/json/encoding.rb:34:1: C: [Corrected] Layout/TrailingWhitespace: Trailing whitespace detected.

1 file inspected, 2 offenses detected, 2 offenses corrected
$
```

### Additional information

Follow up #51272

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
