### PR TITLE
Fix date_field_tag examples. [ci skip]

### DIFF
--- a/actionview/lib/action_view/helpers/form_tag_helper.rb
+++ b/actionview/lib/action_view/helpers/form_tag_helper.rb
@@ -727,14 +727,14 @@ module ActionView
       #   date_field_tag 'name'
       #   # => <input id="name" name="name" type="date" />
       #
-      #   date_field_tag 'date', '01/01/2014'
-      #   # => <input id="date" name="date" type="date" value="01/01/2014" />
+      #   date_field_tag 'date', '2014-12-31'
+      #   # => <input id="date" name="date" type="date" value="2014-12-31" />
       #
       #   date_field_tag 'date', nil, class: 'special_input'
       #   # => <input class="special_input" id="date" name="date" type="date" />
       #
-      #   date_field_tag 'date', '01/01/2014', class: 'special_input', disabled: true
-      #   # => <input disabled="disabled" class="special_input" id="date" name="date" type="date" value="01/01/2014" />
+      #   date_field_tag 'date', '2014-12-31', class: 'special_input', disabled: true
+      #   # => <input disabled="disabled" class="special_input" id="date" name="date" type="date" value="2014-12-31" />
       def date_field_tag(name, value = nil, options = {})
         text_field_tag(name, value, options.merge(type: :date))
       end


### PR DESCRIPTION
According MDN, value for `<input type="date" />` should be in format "yyyy-mm-dd".

For references:

1. https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/date
2. https://www.w3schools.com/html/html_form_input_types.asp
