### PR TITLE
Handle SQLite3::BusyException to raise ActiveRecord::StatementTimeout

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   SQLite3Adapter: Translate `SQLite3::BusyException` into `ActiveRecord::StatementTimeout`.
+
+    *Matthew Nguyen*
+
 *   Include schema name in `enable_extension` statements in `db/schema.rb`.
 
     The schema dumper will now include the schema name in generated

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -662,6 +662,8 @@ module ActiveRecord
             InvalidForeignKey.new(message, sql: sql, binds: binds, connection_pool: @pool)
           elsif exception.message.match?(/called on a closed database/i)
             ConnectionNotEstablished.new(exception, connection_pool: @pool)
+          elsif exception.is_a?(::SQLite3::BusyException)
+            StatementTimeout.new(message, sql: sql, binds: binds, connection_pool: @pool)
           else
             super
           end

--- a/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
@@ -928,7 +928,7 @@ module ActiveRecord
         statement.stub(:step, -> { raise ::SQLite3::BusyException.new("busy") }) do
           assert_called(statement, :close) do
             ::SQLite3::Statement.stub(:new, statement) do
-              error = assert_raises ActiveRecord::StatementInvalid do
+              error = assert_raises ActiveRecord::StatementTimeout do
                 @conn.exec_query "select * from statement_test"
               end
               assert_equal @conn.pool, error.connection_pool


### PR DESCRIPTION
### Motivation / Background

~Some jobs such as `ActiveStorage::PurgeJob` are set to retry on `ActiveRecord::Deadlocked` by default.~
I think it makes more sense to raise ~`ActiveRecord::Deadlocked`~ `ActiveRecord::StatementTimeout ` instead of `ActiveRecord::StatementInvalid` when SQLite3 raises a `SQLite3::BusyException`.

### Detail

This Pull Request translates the `SQLite3::BusyException` into a `ActiveRecord::StatementTimeout` exception.