### PR TITLE
Don't add `bin/brakeman` if brakeman is not in bundle

### DIFF
--- a/railties/lib/rails/commands/app/update_command.rb
+++ b/railties/lib/rails/commands/app/update_command.rb
@@ -69,7 +69,8 @@ module Rails
               skip_action_mailbox: !defined?(ActionMailbox::Engine),
               skip_action_text:    !defined?(ActionText::Engine),
               skip_action_cable:   !defined?(ActionCable::Engine),
-              skip_brakeman:       skip_brakeman?,
+              skip_brakeman:       skip_gem?("brakeman"),
+              skip_rubocop:        skip_gem?("rubocop"),
               skip_test:           !defined?(Rails::TestUnitRailtie),
               skip_system_test:    Rails.application.config.generators.system_tests.nil?,
               asset_pipeline:      asset_pipeline,
@@ -89,8 +90,8 @@ module Rails
             end
           end
 
-          def skip_brakeman?
-            require "brakeman"
+          def skip_gem?(gem_name)
+            gem gem_name
             false
           rescue LoadError
             true

--- a/railties/lib/rails/commands/app/update_command.rb
+++ b/railties/lib/rails/commands/app/update_command.rb
@@ -69,6 +69,7 @@ module Rails
               skip_action_mailbox: !defined?(ActionMailbox::Engine),
               skip_action_text:    !defined?(ActionText::Engine),
               skip_action_cable:   !defined?(ActionCable::Engine),
+              skip_brakeman:       skip_brakeman?,
               skip_test:           !defined?(Rails::TestUnitRailtie),
               skip_system_test:    Rails.application.config.generators.system_tests.nil?,
               asset_pipeline:      asset_pipeline,
@@ -86,6 +87,13 @@ module Rails
             else
               nil
             end
+          end
+
+          def skip_brakeman?
+            require "brakeman"
+            false
+          rescue LoadError
+            true
           end
       end
     end

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -286,6 +286,16 @@ class AppGeneratorTest < Rails::Generators::TestCase
     end
   end
 
+  def test_app_update_preserves_skip_brakeman
+    run_generator [ destination_root, "--skip-brakeman" ]
+
+    FileUtils.cd(destination_root) do
+      assert_no_changes -> { File.exist?("bin/brakeman") } do
+        run_app_update
+      end
+    end
+  end
+
   def test_app_update_preserves_skip_test
     run_generator [ destination_root, "--skip-test" ]
 

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -296,6 +296,16 @@ class AppGeneratorTest < Rails::Generators::TestCase
     end
   end
 
+  def test_app_update_preserves_skip_rubocop
+    run_generator [ destination_root, "--skip-rubocop" ]
+
+    FileUtils.cd(destination_root) do
+      assert_no_changes -> { File.exist?("bin/rubocop") } do
+        run_app_update
+      end
+    end
+  end
+
   def test_app_update_preserves_skip_test
     run_generator [ destination_root, "--skip-test" ]
 


### PR DESCRIPTION
Running `bin/rails app:update` with Rails 7.2.0 adds `bin/brakeman` even if it's not in the Gemfile already.

This checks whether brakeman is in the bundle (can be required), otherwise skips brakeman for the application generator.

### Motivation / Background

Fixes #52576 

### Detail

Repro repository:
https://github.com/etiennebarrie/rails-app/tree/bin-brakeman
we can see `bin/brakeman` gets added: https://github.com/etiennebarrie/rails-app/commit/4adad1519da8f7334ffd9dee0d89d7a67dcd1187

With the fix applied on top of to 7.2.0:
https://github.com/etiennebarrie/rails-app/tree/bin-brakeman-fixed-not-added `bin/brakeman` is not added in https://github.com/etiennebarrie/rails-app/commit/01f6ea5ab8c8cb7d65aeb69164ce846ee496440a
but it's still added if it's in the Gemfile:
**Edit:** with neither `bin/brakeman` nor `bin/rubocop` added:
https://github.com/etiennebarrie/rails-app/commit/39c8543c38f223747dc37c4bfd4ec496645599fd
https://github.com/etiennebarrie/rails-app/tree/bin-brakeman-fixed-added in 
https://github.com/etiennebarrie/rails-app/commit/fab069a0a9c28555fde004e3289ef0e41ef20e11


### Additional information


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
