### PR TITLE
Fix PostgresqlAdapter when prepared statements are disabled

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -1145,10 +1145,6 @@ module ActiveRecord
           end
         end
 
-        def without_prepared_statement?(binds)
-          !prepared_statements || binds.nil? || binds.empty?
-        end
-
         def column_for(table_name, column_name)
           column_name = column_name.to_s
           columns(table_name).detect { |c| c.name == column_name } ||

--- a/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
@@ -156,7 +156,7 @@ module ActiveRecord
 
                 raise
               end
-            elsif without_prepared_statement?(binds)
+            elsif binds.nil? || binds.empty?
               raw_connection.async_exec(sql)
             else
               raw_connection.exec_params(sql, type_casted_binds)

--- a/activerecord/lib/active_record/connection_adapters/sqlite3/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3/database_statements.rb
@@ -93,7 +93,7 @@ module ActiveRecord
               # Don't cache statements if they are not prepared.
               stmt = raw_connection.prepare(sql)
               begin
-                unless without_prepared_statement?(binds)
+                unless binds.nil? || binds.empty?
                   stmt.bind_params(type_casted_binds)
                 end
                 result = if stmt.column_count.zero? # No return

--- a/activerecord/test/cases/adapters/postgresql/connection_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/connection_test.rb
@@ -141,6 +141,14 @@ module ActiveRecord
       end
     end
 
+    def test_prepare_false_with_binds
+      @connection.stub(:prepared_statements, false) do
+        bind = Relation::QueryAttribute.new(nil, 42, Type::Value.new)
+        result = @connection.exec_query("SELECT $1::integer", "SQL", [bind], prepare: false)
+        assert_equal [[42]], result.rows
+      end
+    end
+
     def test_reconnection_after_actual_disconnection_with_verify
       assert_predicate @connection, :active?
       cause_server_side_disconnect


### PR DESCRIPTION
Fix: https://github.com/rails/rails/pull/52428#discussion_r1713956174

Also get rid of `without_prepared_statements?`.

FYI @robinator 