### PR TITLE
Fix text_area form method typo in getting_started.md [CI skip]

### DIFF
--- a/guides/source/getting_started.md
+++ b/guides/source/getting_started.md
@@ -1492,7 +1492,7 @@ So first, we'll wire up the Article show template
   </p>
   <p>
     <%= form.label :body %><br>
-    <%= form.textarea :body %>
+    <%= form.text_area :body %>
   </p>
   <p>
     <%= form.submit %>
@@ -1572,7 +1572,7 @@ add that to the `app/views/articles/show.html.erb`.
   </p>
   <p>
     <%= form.label :body %><br>
-    <%= form.textarea :body %>
+    <%= form.text_area :body %>
   </p>
   <p>
     <%= form.submit %>
@@ -1637,7 +1637,7 @@ following:
   </p>
   <p>
     <%= form.label :body %><br>
-    <%= form.textarea :body %>
+    <%= form.text_area :body %>
   </p>
   <p>
     <%= form.submit %>
@@ -1664,7 +1664,7 @@ create a file `app/views/comments/_form.html.erb` containing:
   </p>
   <p>
     <%= form.label :body %><br>
-    <%= form.textarea :body %>
+    <%= form.text_area :body %>
   </p>
   <p>
     <%= form.submit %>


### PR DESCRIPTION
Noticed a small typo in the edge guide getting started, where we are calling `form.textarea` instead of `form.text_area`

Wasn't able to tell If this is an intentional API change for Rails 8, so suggesting the fix