### PR TITLE
Use sqlite3 package in default Dockerfile for apps using sqlite3

### DIFF
--- a/railties/lib/rails/generators/database.rb
+++ b/railties/lib/rails/generators/database.rb
@@ -227,7 +227,7 @@ module Rails
         end
 
         def base_package
-          "libsqlite3-0"
+          "sqlite3"
         end
 
         def build_package

--- a/railties/test/fixtures/Dockerfile.test
+++ b/railties/test/fixtures/Dockerfile.test
@@ -9,7 +9,7 @@ WORKDIR /rails
 
 # Install base packages
 RUN apt-get update -qq && \
-    apt-get install --no-install-recommends -y curl libsqlite3-0 libvips
+    apt-get install --no-install-recommends -y curl libvips sqlite3
 
 # Set production environment
 ENV RAILS_ENV="production" \

--- a/railties/test/generators/db_system_change_generator_test.rb
+++ b/railties/test/generators/db_system_change_generator_test.rb
@@ -133,7 +133,7 @@ module Rails
 
             assert_file("Dockerfile") do |content|
               assert_match "build-essential git", content
-              assert_match "curl libsqlite3-0 libvips", content
+              assert_match "curl libvips sqlite3", content
             end
 
             assert_devcontainer_json_file do |content|


### PR DESCRIPTION
Fixes #52588.

### Motivation / Background

This Pull Request has been created because `bin/rails dbconsole` does not work inside a Docker container for sqlite3 apps.

### Detail

This Pull Request changes the `Rails::Generators::Database::SQLite3#base_package` method (ultimately called by the `Dockerfile.tt` template) to use the `sqlite3` package instead of `libsqlite3-0`. `sqlite3` [depends on](https://packages.debian.org/bookworm/sqlite3) `libsqlite3-0`, so everything still works.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
