### PR TITLE
Allow railties to use lazy routes

### DIFF
--- a/railties/lib/rails/engine.rb
+++ b/railties/lib/rails/engine.rb
@@ -590,7 +590,7 @@ module Rails
       config.eager_load_paths.freeze
     end
 
-    initializer :make_routes_lazy, before: :set_routes_reloader_hook do |app|
+    initializer :make_routes_lazy, before: :bootstrap_hook do |app|
       config.route_set_class = LazyRouteSet if Rails.env.local?
     end
 


### PR DESCRIPTION
Relates to https://github.com/rails/rails/pull/52353

### Motivation / Background

This Pull Request has been created because railtie initializers currently load lazy routes early.

### Detail

This Pull Request changes the time in which the route set config is set so that this can work normally.

### Additional information

This is unreleased so we don't need a CHANGELOG.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
