### PR TITLE
Fix `create_table` with `:auto_increment` option for MySQL adapter

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/mysql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/schema_statements.rb
@@ -159,7 +159,7 @@ module ActiveRecord
           end
 
           def valid_primary_key_options
-            super + [:unsigned]
+            super + [:unsigned, :auto_increment]
           end
 
           def create_table_definition(name, **options)

--- a/activerecord/test/cases/adapters/abstract_mysql_adapter/auto_increment_test.rb
+++ b/activerecord/test/cases/adapters/abstract_mysql_adapter/auto_increment_test.rb
@@ -39,4 +39,10 @@ class AutoIncrementTest < ActiveRecord::AbstractMysqlTestCase
 
     assert_not_predicate @connection.columns(:auto_increments).first, :auto_increment?
   end
+
+  def test_auto_increment_false_with_create_table
+    @connection.create_table :auto_increments, auto_increment: false, force: :cascade
+
+    assert_not_predicate @connection.columns(:auto_increments).first, :auto_increment?
+  end
 end

--- a/activerecord/test/cases/migration/invalid_options_test.rb
+++ b/activerecord/test/cases/migration/invalid_options_test.rb
@@ -30,7 +30,7 @@ module ActiveRecord
         primary_keys = [":limit", ":default", ":precision"]
 
         if current_adapter?(:Mysql2Adapter, :TrilogyAdapter)
-          primary_keys.concat([":unsigned"])
+          primary_keys.concat([":unsigned", ":auto_increment"])
         elsif current_adapter?(:SQLite3Adapter)
           table_keys.concat([":rename"])
         end


### PR DESCRIPTION
Fixes #52587.