### PR TITLE
Docs cache quick fix [fix #52568]

### DIFF
--- a/guides/rails_guides/generator.rb
+++ b/guides/rails_guides/generator.rb
@@ -122,9 +122,9 @@ module RailsGuides
 
       def process_scss
         system "bundle exec dartsass \
-          #{@guides_dir}/assets/stylesrc/style.scss:#{@output_dir}/stylesheets/style.css \
-          #{@guides_dir}/assets/stylesrc/highlight.scss:#{@output_dir}/stylesheets/highlight.css \
-          #{@guides_dir}/assets/stylesrc/print.scss:#{@output_dir}/stylesheets/print.css"
+          #{@guides_dir}/assets/stylesrc/style.scss:#{@output_dir}/stylesheets/style-v2.css \
+          #{@guides_dir}/assets/stylesrc/highlight.scss:#{@output_dir}/stylesheets/highlight-v2.css \
+          #{@guides_dir}/assets/stylesrc/print.scss:#{@output_dir}/stylesheets/print-v2.css"
       end
 
       def copy_assets

--- a/guides/source/layout.html.erb
+++ b/guides/source/layout.html.erb
@@ -5,9 +5,9 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title><%= yield(:page_title) %></title>
-  <link rel="stylesheet" type="text/css" href="stylesheets/style.css" data-turbo-track="reload">
-  <link rel="stylesheet" type="text/css" href="stylesheets/print.css" media="print">
-  <link rel="stylesheet" type="text/css" href="stylesheets/highlight.css" data-turbo-track="reload">
+  <link rel="stylesheet" type="text/css" href="stylesheets/style-v2.css" data-turbo-track="reload">
+  <link rel="stylesheet" type="text/css" href="stylesheets/print-v2.css" media="print">
+  <link rel="stylesheet" type="text/css" href="stylesheets/highlight-v2.css" data-turbo-track="reload">
 
   <link rel="icon" href="images/favicon.ico" sizes="any">
 


### PR DESCRIPTION
### Motivation / Background

This fixes a caching issue exhibited by numerous users and reported in issues #52568 and #52575

### Detail

This PR simply manually iterates the three CSS files and the generator to add `-v2` on each name. I am working on a MD5 digest solution in https://github.com/jathayde/rails/tree/guides-cache-key but need to get that fully buttoned up. 

### Additional information

This is a quick fix as suggested by the team internally 

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
