### PR TITLE
Explains that `application/pdf` is already registered by Rails [ci skip]

### DIFF
--- a/guides/source/action_controller_overview.md
+++ b/guides/source/action_controller_overview.md
@@ -1073,10 +1073,10 @@ class ClientsController < ApplicationController
 end
 ```
 
-This example works because [Rails already registers the `"application/pdf"` MIME type](https://github.com/rails/rails/blob/main/actionpack/lib/action_dispatch/http/mime_types.rb) at startup (alongside other common types). If you need additional MIME types, call [`Mime::Type.register`](https://api.rubyonrails.org/classes/Mime/Type.html#method-c-register) in the file `config/initializers/mime_types.rb`. For example:
+This example works because [Rails already registers the `"application/pdf"` MIME type](https://github.com/rails/rails/blob/b26a9fd2551a2e65e8deef10f4b5ca6b99d666fb/actionpack/lib/action_dispatch/http/mime_types.rb) at startup (alongside other common types). If you need additional MIME types, call [`Mime::Type.register`](https://api.rubyonrails.org/classes/Mime/Type.html#method-c-register) in the file `config/initializers/mime_types.rb`. For example, this is how you would register the Rich Text Format (RTF):
 
 ```ruby
-Mime::Type.register(<mime_type>, <symbol>)
+Mime::Type.register("application/rtf", :rtf)
 ```
 
 NOTE: Configuration files are not reloaded on each request, so you have to restart the server for their changes to take effect.

--- a/guides/source/action_controller_overview.md
+++ b/guides/source/action_controller_overview.md
@@ -1073,10 +1073,10 @@ class ClientsController < ApplicationController
 end
 ```
 
-For this example to work, you have to add the PDF MIME type to Rails. This can be done by adding the following line to the file `config/initializers/mime_types.rb`:
+This example works because [Rails already registers the `"application/pdf"` MIME type](https://github.com/rails/rails/blob/main/actionpack/lib/action_dispatch/http/mime_types.rb) at startup (alongside other common types). If you need additional MIME types, call [`Mime::Type.register`](https://api.rubyonrails.org/classes/Mime/Type.html#method-c-register) in the file `config/initializers/mime_types.rb`. For example:
 
 ```ruby
-Mime::Type.register "application/pdf", :pdf
+Mime::Type.register(<mime_type>, <symbol>)
 ```
 
 NOTE: Configuration files are not reloaded on each request, so you have to restart the server for their changes to take effect.

--- a/guides/source/action_controller_overview.md
+++ b/guides/source/action_controller_overview.md
@@ -1073,7 +1073,14 @@ class ClientsController < ApplicationController
 end
 ```
 
-This example works because [Rails already registers the `"application/pdf"` MIME type](https://github.com/rails/rails/blob/b26a9fd2551a2e65e8deef10f4b5ca6b99d666fb/actionpack/lib/action_dispatch/http/mime_types.rb) at startup (alongside other common types). If you need additional MIME types, call [`Mime::Type.register`](https://api.rubyonrails.org/classes/Mime/Type.html#method-c-register) in the file `config/initializers/mime_types.rb`. For example, this is how you would register the Rich Text Format (RTF):
+You can call any method on `format` that is an extension registered as a MIME type by Rails.
+Rails already registers common MIME types like `"text/html"` and `"application/pdf"`:
+```ruby
+Mime::Type.lookup_by_extension(:pdf)
+# => "application/pdf"
+```
+
+If you need additional MIME types, call [`Mime::Type.register`](https://api.rubyonrails.org/classes/Mime/Type.html#method-c-register) in the file `config/initializers/mime_types.rb`. For example, this is how you would register the Rich Text Format (RTF):
 
 ```ruby
 Mime::Type.register("application/rtf", :rtf)


### PR DESCRIPTION
### Motivation / Background

In the example about RESTful downloads and PDFs, the Guides ask to register the `application/pdf` MIME type in Rails explicitly. This step doesn't seem necessary because the [PDF type is already registered by Rails ](https://github.com/rails/rails/blob/main/actionpack/lib/action_dispatch/http/mime_types.rb) by default.

This Pull Request has been created to clarify that Rails supports the `application/pdf` type, and others, out of the box.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
