### PR TITLE
Make scaffold views I18n friendly

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Make scaffold views I18n friendly
+
+    Instead of hard-coding attribute names, call `human_attribute_name`.
+
+    *Shouichi Kamiya*
+
 *   Enable query log tags by default on development env
 
     This can be used to trace troublesome SQL statements back to the application

--- a/railties/lib/rails/generators/erb/scaffold/templates/partial.html.erb.tt
+++ b/railties/lib/rails/generators/erb/scaffold/templates/partial.html.erb.tt
@@ -1,7 +1,7 @@
 <div id="<%%= dom_id <%= singular_name %> %>">
 <% attributes.reject(&:password_digest?).each do |attribute| -%>
   <p>
-    <strong><%= attribute.human_name %>:</strong>
+    <strong><%%= <%= "#{class_name(fully_qualified: true)}.human_attribute_name(:#{attribute.name})" %> %>:</strong>
 <% if attribute.attachment? -%>
     <%%= link_to <%= singular_name %>.<%= attribute.column_name %>.filename, <%= singular_name %>.<%= attribute.column_name %> if <%= singular_name %>.<%= attribute.column_name %>.attached? %>
 <% elsif attribute.attachments? -%>

--- a/railties/lib/rails/generators/named_base.rb
+++ b/railties/lib/rails/generators/named_base.rb
@@ -67,8 +67,9 @@ module Rails
           @namespaced_class_path ||= namespace_dirs + @class_path
         end
 
-        def class_name # :doc:
-          (class_path + [file_name]).map!(&:camelize).join("::")
+        def class_name(fully_qualified: false) # :doc:
+          path = (fully_qualified && namespaced?) ? namespaced_class_path : class_path
+          (path + [file_name]).map!(&:camelize).join("::")
         end
 
         def human_name # :doc:


### PR DESCRIPTION
Instead of hard-coding attribute names, call `human_attribute_name`.