### PR TITLE
Specify Rails Version 7.2.0 in rails-new  [ci skip] 

### DIFF
--- a/guides/source/getting_started_with_devcontainer.md
+++ b/guides/source/getting_started_with_devcontainer.md
@@ -77,7 +77,7 @@ To use `rails-new` to generate your app, open a terminal, navigate to a director
 rights to create files, and run:
 
 ```bash
-$ rails-new blog --devcontainer
+$ rails-new --rails-version 7.2.0 blog --devcontainer
 ```
 
 This will create a Rails application called Blog in a `blog` directory.


### PR DESCRIPTION
To generate devcontainer files using the rails-new command, it is necessary to specify that the Rails version is 7.2.0 because the default version for the rails-new command is 7.1.3. Therefore, explicitly setting this option is required.


### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [X] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
