### PR TITLE
Split AR::Migration.load_schema_if_pending! into two methods

### DIFF
--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -715,13 +715,7 @@ module ActiveRecord
 
       def load_schema_if_pending!
         if any_schema_needs_update?
-          # Roundtrip to Rake to allow plugins to hook into database initialization.
-          root = defined?(ENGINE_ROOT) ? ENGINE_ROOT : Rails.root
-
-          FileUtils.cd(root) do
-            Base.connection_handler.clear_all_connections!(:all)
-            system("bin/rails db:test:prepare")
-          end
+          load_schema!
         end
 
         check_pending_migrations
@@ -784,6 +778,16 @@ module ActiveRecord
 
         def env
           ActiveRecord::ConnectionHandling::DEFAULT_ENV.call
+        end
+
+        def load_schema!
+          # Roundtrip to Rake to allow plugins to hook into database initialization.
+          root = defined?(ENGINE_ROOT) ? ENGINE_ROOT : Rails.root
+
+          FileUtils.cd(root) do
+            Base.connection_handler.clear_all_connections!(:all)
+            system("bin/rails db:test:prepare")
+          end
         end
     end
 


### PR DESCRIPTION
We'd like to instrument `load_schema_if_pending!`, but only in case it ends up applying the schema.

My initial stab at it looked like:

```ruby
module ActiveRecord
  class Migration
    module LogLoadSchemaIfPending
      def load_schema_if_pending!
        if any_schema_needs_update?
          instrument { super }
        else
          super
        end
      end
    end
  end
end
ActiveRecord::Migration.singleton_class.prepend(ActiveRecord::Migration::LogLoadSchemaIfPending)
```

However, that leads to `any_schema_needs_update?` being called twice, which can be somewhat expensive.

This PR moves out some logic into `load_schema!` which is the method we could instrument separately.