### PR TITLE
Support minitest 5.25+

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@
 source "https://rubygems.org"
 gemspec
 
-gem "minitest", ">= 5.15.0"
+gem "minitest"
 
 # We need a newish Rake since Active Job sets its test tasks' descriptions.
 gem "rake", ">= 13"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -348,7 +348,7 @@ GEM
     mini_magick (4.12.0)
     mini_mime (1.1.5)
     mini_portile2 (2.8.7)
-    minitest (5.24.1)
+    minitest (5.25.0)
     minitest-bisect (1.7.0)
       minitest-server (~> 1.0)
       path_expander (~> 1.1)
@@ -654,7 +654,7 @@ DEPENDENCIES
   libxml-ruby
   listen (~> 3.3)
   mdl (!= 0.13.0)
-  minitest (>= 5.15.0)
+  minitest
   minitest-bisect
   minitest-ci
   minitest-retry

--- a/activesupport/lib/active_support/testing/parallelization/worker.rb
+++ b/activesupport/lib/active_support/testing/parallelization/worker.rb
@@ -46,8 +46,29 @@ module ActiveSupport
 
           set_process_title("#{klass}##{method}")
 
-          result = klass.with_info_handler reporter do
-            Minitest.run_one_method(klass, method)
+          result = nil
+
+          # TODO: Remove conditional when we support on minitest 5.25+
+          if klass.method(:with_info_handler).arity == 2
+            t0 = nil
+
+            handler = lambda do
+              unless reporter.passed? then
+                warn "Current results:"
+                warn reporter.reporters.grep(SummaryReporter).first
+              end
+
+              warn "Current: %s#%s %.2fs" % [klass, method, Minitest.clock_time - t0]
+            end
+
+            result = klass.with_info_handler reporter, handler do
+              t0 = Minitest.clock_time
+              Minitest.run_one_method(klass, method)
+            end
+          else
+            result = klass.with_info_handler reporter do
+              Minitest.run_one_method(klass, method)
+            end
           end
 
           safe_record(reporter, result)


### PR DESCRIPTION
Minitest 5.25+ has a new API for `with_info_handler` that accepts an additional argument.

The code now support all versions of minitest 5.

See https://github.com/minitest/minitest/commit/8cd3b1c749c778038ead3ddf7894dc19c1fe4797