### PR TITLE
Add option to generate scripts with a numbered prefix

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -88,6 +88,7 @@
     ```
     bin/rails generate script my_script
     bin/rails generate script data/backfill
+    bin/rails generate script data/my_script --prefix
     ```
 
     You can run the generated script using:
@@ -95,6 +96,7 @@
     ```
     bundle exec ruby script/my_script.rb
     bundle exec ruby script/data/backfill.rb
+    bundle exec ruby script/data/001_my_script.rb
     ```
 
     *Jerome Dalbert*, *Haroon Ahmed*

--- a/railties/lib/rails/generators/rails/script/USAGE
+++ b/railties/lib/rails/generators/rails/script/USAGE
@@ -16,3 +16,11 @@ Example:
 
     This will create:
         script/cleanup/my_script.rb
+
+    You can generate the script with a numbered prefix:
+        `bin/rails generate script data/my_script --prefix`
+        `bin/rails generate script data/other_script --prefix`
+
+    This will create:
+        script/data/001_my_script.rb
+        script/data/002_other_script.rb

--- a/railties/lib/rails/generators/rails/script/script_generator.rb
+++ b/railties/lib/rails/generators/rails/script/script_generator.rb
@@ -5,11 +5,29 @@ require "rails/generators/named_base"
 module Rails
   module Generators
     class ScriptGenerator < NamedBase
+      class_option :prefix, type: :boolean, aliases: "--pre", default: false,
+                            desc: "Add a numbered prefix in script file name"
+
       def generate_script
         template("script.rb.tt", "script/#{file_path}.rb")
       end
 
       private
+        def file_name
+          [prefix, super].compact.join("_")
+        end
+
+        def prefix
+          sprintf("%.3d", current_script_number + 1) if options[:prefix]
+        end
+
+        def current_script_number
+          class_path.join("/")
+            .then { |dir_path| Dir.glob("script/#{dir_path}/[0-9]*_*.rb") }
+            .map { |file| File.basename(file).split("_").first.to_i }
+            .max.to_i
+        end
+
         def depth
           class_path.size + 1
         end

--- a/railties/test/generators/script_generator_test.rb
+++ b/railties/test/generators/script_generator_test.rb
@@ -23,6 +23,36 @@ module Rails
           assert_match('require_relative "../../config/environment"', script)
         end
       end
+
+      def test_generate_script_with_initial_prefix
+        FileUtils.cd(destination_root)
+        FileUtils.mkdir_p("script/my_folder")
+        FileUtils.touch("script/my_folder/some_script.rb")
+
+        run_generator ["my_folder/my_script", "--prefix"]
+
+        assert_file "script/my_folder/001_my_script.rb"
+      end
+
+      def test_generate_script_with_next_prefix
+        FileUtils.cd(destination_root)
+        FileUtils.mkdir_p("script/my_folder")
+        FileUtils.touch("script/my_folder/001_some_script.rb")
+
+        run_generator ["my_folder/my_script", "--prefix"]
+
+        assert_file "script/my_folder/002_my_script.rb"
+      end
+
+      def test_generate_script_with_overflowing_prefix
+        FileUtils.cd(destination_root)
+        FileUtils.mkdir_p("script/my_folder")
+        FileUtils.touch("script/my_folder/999_some_script.rb")
+
+        run_generator ["my_folder/my_script", "--prefix"]
+
+        assert_file "script/my_folder/1000_my_script.rb"
+      end
     end
   end
 end


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because when a folder has a lot of one-off scripts, it is difficult to browse them in order in your code editor.

When creating a new one-off script, it can be useful to draw inspiration from the last few existing scripts. It can also be interesting to browse scripts over time to see how they have evolved.

So it would be helpful to name scripts with a numbered prefix, similarly to Rails migrations. We have been doing it manually at my company and it has worked well for us over the years, but I think having an automated way would be useful.

### Detail

This Pull Request adds a `--prefix` option to the script generator. When provided, scripts are generated with an auto-incrementing prefix, like `001_my_script.rb`, which is padded with `0` to make it lexicographic so it shows up in order in your code editor or with `ls`.

### Additional information

- An alternative is to use a Rails migration-like timestamp prefix to generate scripts like `20240814224952_my_script.rb`. I think the `001` number format looks nicer if you need to share the file name in your team chat and it is easy to type if you don't feel like copy/pasting. But I can update this PR to use a timestamp prefix, or even allow both prefix formats, depending on what people think.
- If a project has 999 scripts, the generator will increment correctly to 1000 and above. It is a rare enough event that I leave it as an exercise for the user to mass-rename their existing `xxx_` scripts to `0xxx_` if they want to keep lexicographic ordering.
- This PR makes the script generator a little more useful as it is currently pretty basic.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
