### PR TITLE
Fixed failure in bin setup test

### DIFF
--- a/railties/test/application/bin_setup_test.rb
+++ b/railties/test/application/bin_setup_test.rb
@@ -47,6 +47,7 @@ module ApplicationTests
         output.sub!(/^Done in \d+\.\d+s\.\n/, "Done in 0.00s.\n")
         # Ignore warnings such as `Psych.safe_load is deprecated`
         output.gsub!(/^.*warning:\s.*\n/, "")
+        output.gsub!(/^A new release of RubyGems is available.*\n.*\n/, "")
 
         assert_equal(<<~OUTPUT, output)
           == Installing dependencies ==


### PR DESCRIPTION
### Detail
This Pull Request has been created because the test "test_bin_setup_output" for railties application was failing with error:

```
Failure:
ApplicationTests::BinSetupTest#test_bin_setup_output [test/application/bin_setup_test.rb:51]:
--- expected
+++ actual
@@ -1,4 +1,8 @@
 "== Installing dependencies ==
+
+A new release of RubyGems is available: 3.4.10 → 3.5.17!
+Run `gem update --system 3.5.17` to update your installation.
+
 The Gemfile's dependencies are satisfied
 ```

The required fix has been provided in the commit to make this test functional.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
