### PR TITLE
Fix ActiveRecord::Base.inspect to correctly indicate how to load schema

### DIFF
--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -354,8 +354,8 @@ module ActiveRecord
           super
         elsif abstract_class?
           "#{super}(abstract)"
-        elsif !connected?
-          "#{super} (call '#{super}.lease_connection' to establish a connection)"
+        elsif !schema_loaded? && !connected?
+          "#{super} (call '#{super}.load_schema' to load schema informations)"
         elsif table_exists?
           attr_list = attribute_types.map { |name, type| "#{name}: #{type.type}" } * ", "
           "#{super}(#{attr_list})"

--- a/activerecord/lib/active_record/encryption/encryptable_record.rb
+++ b/activerecord/lib/active_record/encryption/encryptable_record.rb
@@ -123,7 +123,7 @@ module ActiveRecord
             end)
           end
 
-          def load_schema!
+          def load_schema! # :nodoc:
             super
 
             add_length_validation_for_encrypted_columns if ActiveRecord::Encryption.config.validate_column_size

--- a/activerecord/lib/active_record/model_schema.rb
+++ b/activerecord/lib/active_record/model_schema.rb
@@ -531,7 +531,9 @@ module ActiveRecord
         initialize_find_by_cache
       end
 
-      def load_schema # :nodoc:
+      # Load the model's schema information either from the schema cache
+      # or directly from the database.
+      def load_schema
         return if schema_loaded?
         @load_schema_monitor.synchronize do
           return if schema_loaded?

--- a/activerecord/test/cases/invalid_connection_test.rb
+++ b/activerecord/test/cases/invalid_connection_test.rb
@@ -20,7 +20,7 @@ class TestAdapterWithInvalidConnection < ActiveRecord::TestCase
     end
 
     test "inspect on Model class does not raise" do
-      assert_equal "#{Bird.name} (call '#{Bird.name}.lease_connection' to establish a connection)", Bird.inspect
+      assert_equal "#{Bird.name} (call '#{Bird.name}.load_schema' to load schema informations)", Bird.inspect
     end
   end
 end


### PR DESCRIPTION
Fix: https://github.com/rails/rails/issues/52601

Now that Active Record connections are fully lazy, just calling `.lease_connection` isn't actually enough to estalish a connection.

We might as well suggest to use a method with the actual intent.

Need to backport to 7.2.