### PR TITLE
rails console: Handle non standard application names

### DIFF
--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -135,6 +135,13 @@ module Rails
       @initialized
     end
 
+    # Returns the dhasherized application name.
+    #
+    #   MyApp::Application.new.name => "my-app"
+    def name
+      self.class.name.underscore.dasherize.delete_suffix("/application")
+    end
+
     def run_load_hooks! # :nodoc:
       return self if @ran_load_hooks
       @ran_load_hooks = true

--- a/railties/lib/rails/commands/console/irb_console.rb
+++ b/railties/lib/rails/commands/console/irb_console.rb
@@ -89,9 +89,8 @@ module Rails
         end
 
         env = colorized_env
-        app_name = @app.class.module_parent_name.underscore.dasherize
         prompt_prefix = "%N(#{env})"
-        IRB.conf[:IRB_NAME] = app_name
+        IRB.conf[:IRB_NAME] = @app.name
 
         IRB.conf[:PROMPT][:RAILS_PROMPT] = {
           PROMPT_I: "#{prompt_prefix}> ",


### PR DESCRIPTION
Fix: https://github.com/rails/rails/issues/52615
Ref: https://github.com/rails/rails/pull/50796

The code assumed the application follow the standard `Name::Application` naming, but it's possible to rename it however you like.
