### PR TITLE
Eagerly prune the query caches store

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb
@@ -148,9 +148,13 @@ module ActiveRecord
         end
 
         def query_cache
-          @thread_query_caches.compute_if_absent(ActiveSupport::IsolatedExecutionState.context) do
+          added = false
+          store = @thread_query_caches.compute_if_absent(ActiveSupport::IsolatedExecutionState.context) do
+            added = true
             Store.new(@query_cache_max_size)
           end
+          prune_thread_cache if added
+          store
         end
 
         private


### PR DESCRIPTION
Fix: https://github.com/rails/rails/issues/52617

It isn't per say a leak because the connection reaper eventually prune these, and also it's not expected that new Threads are constantly making entries into that cache. But it's true that with Fiber it's probably a bit more common, and the default reaper frequency isn't adapter to clear this fast enough.

So we should instead eagerly prune it, or use a WeakMap.
