### PR TITLE
Allow to eager load nested nil associations

### DIFF
--- a/activerecord/lib/active_record/associations/join_dependency.rb
+++ b/activerecord/lib/active_record/associations/join_dependency.rb
@@ -61,7 +61,7 @@ module ActiveRecord
         when Hash
           associations.each do |k, v|
             cache = hash[k] ||= {}
-            walk_tree v, cache
+            walk_tree v, cache if v
           end
         else
           raise ConfigurationError, associations.inspect

--- a/activerecord/test/cases/associations/cascaded_eager_loading_test.rb
+++ b/activerecord/test/cases/associations/cascaded_eager_loading_test.rb
@@ -77,6 +77,17 @@ class CascadedEagerLoadingTest < ActiveRecord::TestCase
     assert_queries_count(3) { authors.to_a }
   end
 
+  def test_eager_association_loading_with_nil_associations
+    authors = Author.includes(nil).to_a
+    assert_equal 3, authors.size
+
+    authors = Author.includes([:posts, nil]).to_a
+    assert_equal 3, authors.size
+
+    authors = Author.includes(posts: nil).to_a
+    assert_equal 3, authors.size
+  end
+
   def test_eager_association_loading_with_cascaded_two_levels_with_two_has_many_associations
     authors = Author.all.merge!(includes: { posts: [:comments, :categorizations] }, order: "authors.id").to_a
     assert_equal 3, authors.size


### PR DESCRIPTION
Closes #52592.

It is already possible to pass plain `nil` or a an array including `nil` to eager load methods. Only the hash was left.

cc @akicho8 @byroot 