### PR TITLE
Make query cache registry a weak map

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -630,8 +630,6 @@ module ActiveRecord
             remove conn
           end
         end
-
-        prune_thread_cache
       end
 
       # Disconnect all connections that have been idle for at least


### PR DESCRIPTION
Fix: https://github.com/rails/rails/issues/52617
Closes: https://github.com/rails/rails/pull/52618

It isn't per say a leak because the connection reaper eventually prune these, and also it's not expected that new Threads are constantly making entries into that cache. But it's true that with Fiber it's probably a bit more common, and the default reaper frequency isn't adapted to clear this fast enough.

So we should instead eagerly prune it, or use a WeakMap.

On 3.3+ we can use `ObjectSpace::WeakKeyMap`, but on older Ruby versions we have to resort to eager clearing.
