### PR TITLE
Store query caches in IsolatedExecutionState to avoid memory bloat

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -630,8 +630,6 @@ module ActiveRecord
             remove conn
           end
         end
-
-        prune_thread_cache
       end
 
       # Disconnect all connections that have been idle for at least

--- a/activerecord/test/cases/query_cache_test.rb
+++ b/activerecord/test/cases/query_cache_test.rb
@@ -1026,7 +1026,7 @@ class QueryCacheExpiryTest < ActiveRecord::TestCase
   end
 
   def test_query_cache_lru_eviction
-    store = ActiveRecord::ConnectionAdapters::QueryCache::Store.new(2)
+    store = ActiveRecord::ConnectionAdapters::QueryCache::Store.new(ActiveRecord::Base.connection_pool, 2)
     store.enabled = true
 
     connection = Post.lease_connection


### PR DESCRIPTION
Fix: https://github.com/rails/rails/issues/52617
Closes: https://github.com/rails/rails/pull/52618

It isn't per say a leak because the connection reaper eventually prune these, and also it's not expected that new Threads are constantly making entries into that cache. But it's true that with Fiber it's probably a bit more common, and the default reaper frequency isn't adapted to clear this fast enough.

So instead of waiting for the reaper to trigger, which may take a long time, we keep the caches in `IsolatedExecutionState` so that when the owning thread or fiber is garbage collected its cache is too.

However since we need to be able to clear all threads caches, we keep a cache version on the pool, and bump it to invalidate all caches of a pool at once.
