### PR TITLE
Fix Encoding::CompatibilityError on Postgresql::Quoting

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/quoting.rb
@@ -24,7 +24,7 @@ module ActiveRecord
 
         # Quotes strings for use in SQL input.
         def quote_string(s) #:nodoc:
-          PG::Connection.escape(s)
+          @connection.escape(s)
         end
 
         # Checks the following cases:


### PR DESCRIPTION
### Motivation / Background

Fix Encoding::CompatibilityError: incompatible character encodings: ASCII-8BIT and UTF-8

### Detail

This error happens because the `quote_string` method from the `ActiveRecord::ConnectionAdapters::PostgreSQL::Quoting` module on Rails 6.1 is using PG::Connection instead of the @connection variable to escape the string the same way Rails 6.0 did.

This commit changes the `quote_string` method to use the @connection variable instead of PG::Connection.

###  Example:

```ruby
account = UserAccount.first
account.twitter="www.hölà.com".force_encoding("ASCII-8BIT")
account.facebook="www.hölà.com".force_encoding("UTF-8")
account.save!
```
### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
