### PR TITLE
Refactor query cache and connection lease registry for performance

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -118,26 +118,24 @@ module ActiveRecord
     # * private methods that require being called in a +synchronize+ blocks
     #   are now explicitly documented
     class ConnectionPool
-      if ObjectSpace.const_defined?(:WeakKeyMap) # RUBY_VERSION >= 3.3
-        WeakThreadKeyMap = ::ObjectSpace::WeakKeyMap # :nodoc:
-      else
-        class WeakThreadKeyMap # :nodoc:
-          def initialize
-            @map = {}
-          end
+      class WeakThreadKeyMap # :nodoc:
+        # FIXME: On 3.3 we could use ObjectSpace::WeakKeyMap
+        # but it currently cause GC crashes: https://github.com/byroot/rails/pull/3
+        def initialize
+          @map = {}
+        end
 
-          def clear
-            @map.clear
-          end
+        def clear
+          @map.clear
+        end
 
-          def [](key)
-            @map[key]
-          end
+        def [](key)
+          @map[key]
+        end
 
-          def []=(key, value)
-            @map.select! { |c, _| c.alive? }
-            @map[key] = value
-          end
+        def []=(key, value)
+          @map.select! { |c, _| c.alive? }
+          @map[key] = value
         end
       end
 


### PR DESCRIPTION
Fix: https://github.com/rails/rails/issues/52617
Followup: https://github.com/rails/rails/pull/52622

Previous fixes solved the memory issues, but our fallback implementation of WeakKeyMap actually have terrible performance, and I can't find a way to do it in a performent way.

So instead we replace it by a specialized weak map that only accept Thread or Fiber as keys, and simple purge dead threads on insertion.

This gives us reasonable performance on Ruby 3.1 and 3.2.
