### PR TITLE
Call `super` from `method_added`/`singleton_method_added` methods

### DIFF
--- a/activerecord/lib/active_record/scoping/named.rb
+++ b/activerecord/lib/active_record/scoping/named.rb
@@ -190,6 +190,7 @@ module ActiveRecord
 
         private
           def singleton_method_added(name)
+            super
             # Most Kernel extends are both singleton and instance methods so
             # respond_to is a fast check, but we don't want to define methods
             # only on the module (ex. Module#name)

--- a/activesupport/lib/active_support/current_attributes.rb
+++ b/activesupport/lib/active_support/current_attributes.rb
@@ -182,6 +182,7 @@ module ActiveSupport
         end
 
         def method_added(name)
+          super
           return if name == :initialize
           return unless public_method_defined?(name)
           return if respond_to?(name, true)

--- a/activesupport/lib/active_support/subscriber.rb
+++ b/activesupport/lib/active_support/subscriber.rb
@@ -67,6 +67,7 @@ module ActiveSupport
 
       # Adds event subscribers for all new methods added to the class.
       def method_added(event)
+        super
         # Only public methods are added as subscribers, and only if a notifier
         # has been set up. This means that subscribers will only be set up for
         # classes that call #attach_to.


### PR DESCRIPTION
### Motivation / Background

If a `method_added`/`singleton_method_added` method on a constant doesn't call `super` then none of the `method_added`/`singleton_method_added` methods on ancestors of the constant ever get called by Ruby.

This breaks any code that might want to instrument classes to collect method definition locations, or to do other things when methods are added.

In order to be a good citizen, it is best practice to call `super` from these methods.

This Pull Request has been created to fix the instances where the Rails codebase does not call `super` from these methods.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
