### PR TITLE
[ci skip] Add a note to the maintenance policy page about old releases (pre-Rails 7.2 releases)

### DIFF
--- a/guides/source/maintenance_policy.md
+++ b/guides/source/maintenance_policy.md
@@ -79,6 +79,12 @@ there could be breaking changes in the security release. A security release
 should only contain the changes needed to ensure the app is secure so that it's
 easier for applications to remain upgraded.
 
+Old releases will not follow this new policy:
+
+1. Rails 6.1 will reach end-of-life in October 2024
+2. Rails 7.0 will reach end-of-life in April 2025
+3. Rails 7.1 will reach end-of-life in October 2025
+
 End-of-life Release Series
 --------------------------
 


### PR DESCRIPTION
Hi there,

This is a follow-up to this PR: https://github.com/rails/rails/pull/52471

### Motivation / Background

This Pull Request has been created because this comment by @rafaelfranca is super valuable: https://github.com/rails/rails/pull/52471#issuecomment-2271622034

I thought it could be added to the maintenance page so that people understand that old releases don't follow the new policy.

### Detail

This Pull Request changes https://guides.rubyonrails.org/maintenance_policy.html

### Additional information

I was looking for the EOL schedule for old releases and I ended up finding Rafael's comment (not the maintenance page as I expected)

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
