### PR TITLE
[ci skip] Update docs and comments to prefer SSL/TLS instead of just SSL

### DIFF
--- a/actionmailbox/test/dummy/config/environments/production.rb
+++ b/actionmailbox/test/dummy/config/environments/production.rb
@@ -44,11 +44,11 @@ Rails.application.configure do
   # config.action_cable.url = "wss://example.com/cable"
   # config.action_cable.allowed_request_origins = [ "http://example.com", /http:\/\/example.*/ ]
 
-  # Assume all access to the app is happening through a SSL-terminating reverse proxy.
+  # Assume all access to the app is happening through a TLS/SSL-terminating reverse proxy.
   # Can be used together with config.force_ssl for Strict-Transport-Security and secure cookies.
   # config.assume_ssl = true
 
-  # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
+  # Force all access to the app over TLS/SSL, use Strict-Transport-Security, and use secure cookies.
   # config.force_ssl = true
 
   # Log to STDOUT by default

--- a/actionpack/lib/action_controller/metal/data_streaming.rb
+++ b/actionpack/lib/action_controller/metal/data_streaming.rb
@@ -49,7 +49,7 @@ module ActionController # :nodoc:
       # The default `Content-Type` and `Content-Disposition` headers are set to
       # download arbitrary binary files in as many browsers as possible. IE versions
       # 4, 5, 5.5, and 6 are all known to have a variety of quirks (especially when
-      # downloading over SSL).
+      # downloading over TLS/SSL).
       #
       # Simple download:
       #

--- a/actionpack/lib/action_controller/metal/request_forgery_protection.rb
+++ b/actionpack/lib/action_controller/metal/request_forgery_protection.rb
@@ -488,7 +488,7 @@ module ActionController # :nodoc:
       end
 
       # Creates a masked version of the authenticity token that varies on each
-      # request. The masking is used to mitigate SSL attacks like BREACH.
+      # request. The masking is used to mitigate TLS/SSL attacks like BREACH.
       def masked_authenticity_token(form_options: {})
         action, method = form_options.values_at(:action, :method)
 

--- a/actionpack/lib/action_dispatch/http/url.rb
+++ b/actionpack/lib/action_dispatch/http/url.rb
@@ -192,7 +192,7 @@ module ActionDispatch
         protocol + host_with_port + fullpath
       end
 
-      # Returns 'https://' if this is an SSL request and 'http://' otherwise.
+      # Returns 'https://' if this is a TLS/SSL request and 'http://' otherwise.
       #
       #     req = ActionDispatch::Request.new 'HTTP_HOST' => 'example.com'
       #     req.protocol # => "http://"

--- a/actionpack/lib/action_dispatch/middleware/assume_ssl.rb
+++ b/actionpack/lib/action_dispatch/middleware/assume_ssl.rb
@@ -5,10 +5,10 @@
 module ActionDispatch
   # # Action Dispatch AssumeSSL
   #
-  # When proxying through a load balancer that terminates SSL, the forwarded
+  # When proxying through a load balancer that terminates TLS/SSL, the forwarded
   # request will appear as though it's HTTP instead of HTTPS to the application.
   # This makes redirects and cookie security target HTTP instead of HTTPS. This
-  # middleware makes the server assume that the proxy already terminated SSL, and
+  # middleware makes the server assume that the proxy already terminated TLS/SSL, and
   # that the request really is HTTPS.
   class AssumeSSL
     def initialize(app)

--- a/actionpack/lib/action_dispatch/middleware/remote_ip.rb
+++ b/actionpack/lib/action_dispatch/middleware/remote_ip.rb
@@ -25,7 +25,7 @@ module ActionDispatch
   # IF YOU DON'T USE A PROXY, THIS MAKES YOU VULNERABLE TO IP SPOOFING. This
   # middleware assumes that there is at least one proxy sitting around and setting
   # headers with the client's remote IP address. If you don't use a proxy, because
-  # you are hosted on e.g. Heroku without SSL, any client can claim to have any IP
+  # you are hosted on e.g. Heroku without TLS/SSL, any client can claim to have any IP
   # address by setting the `X-Forwarded-For` header. If you care about that, then
   # you need to explicitly drop or ignore those headers sometime before this
   # middleware runs. Alternatively, remove this middleware to avoid inadvertently

--- a/actionpack/lib/action_dispatch/middleware/ssl.rb
+++ b/actionpack/lib/action_dispatch/middleware/ssl.rb
@@ -3,13 +3,13 @@
 # :markup: markdown
 
 module ActionDispatch
-  # # Action Dispatch SSL
+  # # Action Dispatch TLS/SSL
   #
   # This middleware is added to the stack when `config.force_ssl = true`, and is
   # passed the options set in `config.ssl_options`. It does three jobs to enforce
   # secure HTTP requests:
   #
-  # 1.  **TLS redirect**: Permanently redirects `http://` requests to `https://`
+  # 1.  **TLS/SSL redirect**: Permanently redirects `http://` requests to `https://`
   #     with the same URL host, path, etc. Enabled by default. Set
   #     `config.ssl_options` to modify the destination URL:
   #
@@ -23,10 +23,10 @@ module ActionDispatch
   #
   #     Cookies will not be flagged as secure for excluded requests.
   #
-  #     When proxying through a load balancer that terminates SSL, the forwarded
+  #     When proxying through a load balancer that terminates TLS/SSL, the forwarded
   #     request will appear as though it's HTTP instead of HTTPS to the application.
   #     This makes redirects and cookie security target HTTP instead of HTTPS.
-  #     To make the server assume that the proxy already terminated SSL, and
+  #     To make the server assume that the proxy already terminated TLS/SSL, and
   #     that the request really is HTTPS, set `config.assume_ssl` to `true`:
   #
   #         config.assume_ssl = true

--- a/actiontext/test/dummy/config/environments/production.rb
+++ b/actiontext/test/dummy/config/environments/production.rb
@@ -44,11 +44,11 @@ Rails.application.configure do
   # config.action_cable.url = "wss://example.com/cable"
   # config.action_cable.allowed_request_origins = [ "http://example.com", /http:\/\/example.*/ ]
 
-  # Assume all access to the app is happening through a SSL-terminating reverse proxy.
+  # Assume all access to the app is happening through a TLS/SSL-terminating reverse proxy.
   # Can be used together with config.force_ssl for Strict-Transport-Security and secure cookies.
   # config.assume_ssl = true
 
-  # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
+  # Force all access to the app over TLS/SSL, use Strict-Transport-Security, and use secure cookies.
   # config.force_ssl = true
 
   # Log to STDOUT by default

--- a/actionview/lib/action_view/helpers/asset_url_helper.rb
+++ b/actionview/lib/action_view/helpers/asset_url_helper.rb
@@ -49,7 +49,7 @@ module ActionView
     #
     # This may improve the asset loading performance of your application.
     # It is also possible the combination of additional connection overhead
-    # (DNS, SSL) and the overall browser connection limits may result in this
+    # (DNS, TLS/SSL) and the overall browser connection limits may result in this
     # solution being slower. You should be sure to measure your actual
     # performance across targeted browsers both before and after this change.
     #
@@ -93,10 +93,10 @@ module ActionView
     #   # => <link href="http://stylesheets.example.com/assets/application.css" rel="stylesheet" />
     #
     # Alternatively you may ask for a second parameter +request+. That one is
-    # particularly useful for serving assets from an SSL-protected page. The
+    # particularly useful for serving assets from a TLS/SSL-protected page. The
     # example proc below disables asset hosting for HTTPS connections, while
     # still sending assets for plain HTTP requests from asset hosts. If you don't
-    # have SSL certificates for each of the asset hosts this technique allows you
+    # have TLS/SSL certificates for each of the asset hosts this technique allows you
     # to avoid warnings in the client about mixed media.
     # Note that the +request+ parameter might not be supplied, e.g. when the assets
     # are precompiled with the command <tt>bin/rails assets:precompile</tt>. Make sure to use a

--- a/activestorage/test/dummy/config/environments/production.rb
+++ b/activestorage/test/dummy/config/environments/production.rb
@@ -44,11 +44,11 @@ Rails.application.configure do
   # config.action_cable.url = "wss://example.com/cable"
   # config.action_cable.allowed_request_origins = [ "http://example.com", /http:\/\/example.*/ ]
 
-  # Assume all access to the app is happening through a SSL-terminating reverse proxy.
+  # Assume all access to the app is happening through a TLS/SSL-terminating reverse proxy.
   # Can be used together with config.force_ssl for Strict-Transport-Security and secure cookies.
   # config.assume_ssl = true
 
-  # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
+  # Force all access to the app over TLS/SSL, use Strict-Transport-Security, and use secure cookies.
   # config.force_ssl = true
 
   # Log to STDOUT by default

--- a/guides/source/action_cable_overview.md
+++ b/guides/source/action_cable_overview.md
@@ -755,7 +755,7 @@ The Redis adapter requires users to provide a URL pointing to the Redis server.
 Additionally, a `channel_prefix` may be provided to avoid channel name collisions
 when using the same Redis server for multiple applications. See the [Redis Pub/Sub documentation](https://redis.io/docs/manual/pubsub/#database--scoping) for more details.
 
-The Redis adapter also supports SSL/TLS connections. The required SSL/TLS parameters can be passed in `ssl_params` key in the configuration YAML file.
+The Redis adapter also supports TLS/SSL connections. The required TLS/SSL parameters can be passed in `ssl_params` key in the configuration YAML file.
 
 ```yaml
 production:
@@ -766,10 +766,10 @@ production:
     ca_file: "/path/to/ca.crt"
 ```
 
-The options given to `ssl_params` are passed directly to the `OpenSSL::SSL::SSLContext#set_params` method and can be any valid attribute of the SSL context.
+The options given to `ssl_params` are passed directly to the `OpenSSL::SSL::SSLContext#set_params` method and can be any valid attribute of the TLS/SSL context.
 Please refer to the [OpenSSL::SSL::SSLContext documentation](https://docs.ruby-lang.org/en/master/OpenSSL/SSL/SSLContext.html) for other available attributes.
 
-If you are using self-signed certificates for redis adapter behind a firewall and opt to skip certificate check, then the ssl `verify_mode` should be set as `OpenSSL::SSL::VERIFY_NONE`.
+If you are using self-signed certificates for redis adapter behind a firewall and opt to skip certificate check, then the TLS/SSL `verify_mode` should be set as `OpenSSL::SSL::VERIFY_NONE`.
 
 WARNING: It is not recommended to use `VERIFY_NONE` in production unless you absolutely understand the security implications. In order to set this option for the Redis adapter, the config should be `ssl_params: { verify_mode: <%= OpenSSL::SSL::VERIFY_NONE %> }`.
 

--- a/guides/source/api_documentation_guidelines.md
+++ b/guides/source/api_documentation_guidelines.md
@@ -129,6 +129,7 @@ Spell software names correctly. When in doubt, please have a look at some author
 # npm
 # PostgreSQL
 # RSpec
+# TLS/SSL
 ```
 
 Use the article "an" for "SQL":

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -217,7 +217,7 @@ Sets the host for the assets. Useful when CDNs are used for hosting assets, or w
 
 #### `config.assume_ssl`
 
-Makes application believe that all requests are arriving over SSL. This is useful when proxying through a load balancer that terminates SSL, the forwarded request will appear as though it's HTTP instead of HTTPS to the application. This makes redirects and cookie security target HTTP instead of HTTPS. This middleware makes the server assume that the proxy already terminated SSL, and that the request really is HTTPS.
+Makes application believe that all requests are arriving over TLS/SSL. This is useful when proxying through a load balancer that terminates TLS/SSL, the forwarded request will appear as though it's HTTP instead of HTTPS to the application. This makes redirects and cookie security target HTTP instead of HTTPS. This middleware makes the server assume that the proxy already terminated TLS/SSL, and that the request really is HTTPS.
 
 #### `config.autoflush_log`
 
@@ -2183,7 +2183,7 @@ If set to `false`, when both headers are present, both headers are checked and b
 
 #### `config.action_dispatch.always_write_cookie`
 
-Cookies will be written at the end of a request if they marked as insecure, if the request is made over SSL, or if the request is made to an onion service.
+Cookies will be written at the end of a request if they marked as insecure, if the request is made over TLS/SSL, or if the request is made to an onion service.
 
 If set to `true`, cookies will be written even if this criteria is not met.
 

--- a/guides/source/security.md
+++ b/guides/source/security.md
@@ -257,7 +257,7 @@ Many web applications have an authentication system: a user provides a username 
 
 Hence, the cookie serves as temporary authentication for the web application. Anyone who seizes a cookie from someone else, may use the web application as this user - with possibly severe consequences. Here are some ways to hijack a session, and their countermeasures:
 
-* Sniff the cookie in an insecure network. A wireless LAN can be an example of such a network. In an unencrypted wireless LAN, it is especially easy to listen to the traffic of all connected clients. For the web application builder this means to _provide a secure connection over SSL_. In Rails 3.1 and later, this could be accomplished by always forcing SSL connection in your application config file:
+* Sniff the cookie in an insecure network. A wireless LAN can be an example of such a network. In an unencrypted wireless LAN, it is especially easy to listen to the traffic of all connected clients. For the web application builder this means to _provide a secure connection over TLS/SSL_. In Rails 3.1 and later, this could be accomplished by always forcing TLS/SSL connection in your application config file:
 
     ```ruby
     config.force_ssl = true

--- a/guides/source/upgrading_ruby_on_rails.md
+++ b/guides/source/upgrading_ruby_on_rails.md
@@ -935,7 +935,7 @@ gem "webpacker"
 $ bin/rails webpacker:install
 ```
 
-### Force SSL
+### Force TLS/SSL
 
 The `force_ssl` method on controllers has been deprecated and will be removed in
 Rails 6.1. You are encouraged to enable [`config.force_ssl`][] to enforce HTTPS
@@ -1756,7 +1756,7 @@ dumped. Set to `:all` to generate all dumps, or to `:schema_search_path` to gene
 config.active_record.dump_schemas = :all
 ```
 
-#### Configure SSL Options to Enable HSTS with Subdomains
+#### Configure TLS/SSL Options to Enable HSTS with Subdomains
 
 Set the following in your config to enable HSTS when using subdomains:
 
@@ -1948,7 +1948,7 @@ The [`TagAssertions` module](https://api.rubyonrails.org/v4.1/classes/ActionDisp
 
 ### Masked Authenticity Tokens
 
-In order to mitigate SSL attacks, `form_authenticity_token` is now masked so that it varies with each request.  Thus, tokens are validated by unmasking and then decrypting.  As a result, any strategies for verifying requests from non-rails forms that relied on a static session CSRF token have to take this into account.
+In order to mitigate TLS/SSL attacks, `form_authenticity_token` is now masked so that it varies with each request. Thus, tokens are validated by unmasking and then decrypting. As a result, any strategies for verifying requests from non-rails forms that relied on a static session CSRF token have to take this into account.
 
 ### Action Mailer
 
@@ -2897,7 +2897,7 @@ config.assets.digest = true
 # Precompile additional assets (application.js, application.css, and all non-JS/CSS are already added)
 # config.assets.precompile += %w( admin.js admin.css )
 
-# Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
+# Force all access to the app over TLS/SSL, use Strict-Transport-Security, and use secure cookies.
 # config.force_ssl = true
 ```
 

--- a/railties/lib/rails/generators/rails/app/templates/config/deploy.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/deploy.yml.tt
@@ -13,10 +13,10 @@ servers:
   #     - 192.168.0.1
   #   cmd: bin/jobs
 
-# Enable SSL auto certification via Let's Encrypt and allow for multiple apps on a single web server.
-# Remove this section when using multiple web servers and ensure you terminate SSL at your load balancer.
+# Enable TLS/SSL auto certification via Let's Encrypt and allow for multiple apps on a single web server.
+# Remove this section when using multiple web servers and ensure you terminate TLS/SSL at your load balancer.
 #
-# Note: If using Cloudflare, set encryption mode in SSL/TLS setting to "Full" to enable CF-to-app encryption.
+# Note: If using Cloudflare, set encryption mode in TLS/SSL setting to "Full" to enable CF-to-app encryption.
 proxy:
   ssl: true
   host: app.example.com

--- a/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
@@ -28,10 +28,10 @@ Rails.application.configure do
   config.active_storage.service = :local
 
   <%- end -%>
-  # Assume all access to the app is happening through a SSL-terminating reverse proxy.
+  # Assume all access to the app is happening through a TLS/SSL-terminating reverse proxy.
   config.assume_ssl = true
 
-  # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
+  # Force all access to the app over TLS/SSL, use Strict-Transport-Security, and use secure cookies.
   config.force_ssl = true
 
   # Skip http-to-https redirect for the default health check endpoint.


### PR DESCRIPTION
The acronym SSL is considered deprecated by the security community and has been replaced by TLS. While both are understood and can usually be used interchangeably, Rails might as well use the modern terminology.

For an example on this preference, see Wikipedia article https://en.wikipedia.org/wiki/Transport_Layer_Security

> TLS builds on the now-deprecated SSL (Secure Sockets Layer)
> specifications ...

In the interest of backward compatibility, this change only changes documentation and code comments. It does not alter configuration option names, class names, or other code. If it is preferable to make this change in code as well, followup work can be submitted for this.
