### PR TITLE
Update the description of when SQLite might make sense as the configured database [ci skip]

### DIFF
--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -3336,7 +3336,7 @@ Now the behavior is clear, that we are only using the connection information in 
 
 #### Configuring an SQLite3 Database
 
-Rails comes with built-in support for [SQLite3](http://www.sqlite.org), which is a lightweight serverless database application. In Rails 7.1 and beyond, SQLite is better configured for production workloads, but a busy production environment may overload SQLite. Rails defaults to using an SQLite database when creating a new project, but you can always change it later.
+Rails comes with built-in support for [SQLite3](http://www.sqlite.org), which is a lightweight serverless database application. While Rails better configures SQLite for production workloads, a busy production environment may overload SQLite. Rails defaults to using an SQLite database when creating a new project, but you can always change it later.
 
 Here's the section of the default configuration file (`config/database.yml`) with connection information for the development environment:
 

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -3336,7 +3336,7 @@ Now the behavior is clear, that we are only using the connection information in 
 
 #### Configuring an SQLite3 Database
 
-Rails comes with built-in support for [SQLite3](http://www.sqlite.org), which is a lightweight serverless database application. While a busy production environment may overload SQLite, it works well for development and testing. Rails defaults to using an SQLite database when creating a new project, but you can always change it later.
+Rails comes with built-in support for [SQLite3](http://www.sqlite.org), which is a lightweight serverless database application. In Rails 7.1 and beyond, SQLite is better configured for production workloads, but a busy production environment may overload SQLite. Rails defaults to using an SQLite database when creating a new project, but you can always change it later.
 
 Here's the section of the default configuration file (`config/database.yml`) with connection information for the development environment:
 


### PR DESCRIPTION
### Motivation / Background

This is another tiny documentation change made as I read through the guides with an eye to missing or out-of-date documentation on using Rails with SQLite. 

### Detail

While SQLite was indeed a shaky option for any production system prior to the 7.1 release, the improved default configuration in 7.1 made SQLite a viable production database option for smaller workloads.

