### PR TITLE
PG:: Fix Build where clause with nil arguments syntax error from postgres

### DIFF
--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -1621,7 +1621,7 @@ module ActiveRecord
             parts = [Arel.sql(opts)]
           elsif rest.first.is_a?(Hash) && /:\w+/.match?(opts)
             parts = [build_named_bound_sql_literal(opts, rest.first)]
-          elsif opts.include?("?")
+          elsif opts.include?("?") && rest.compact.present?
             parts = [build_bound_sql_literal(opts, rest)]
           else
             parts = [model.sanitize_sql(rest.empty? ? opts : [opts, *rest])]

--- a/activerecord/test/cases/adapters/postgresql/bind_parameter_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/bind_parameter_test.rb
@@ -33,6 +33,15 @@ module ActiveRecord
           assert_quoted_as "0/1", Rational(0)
         end
 
+        def test_where_with_nil_for_string_column_using_bind_parameters
+          relation = Post.where("LOWER(title) = ?", nil)
+
+          expected_sql = %{SELECT "posts".* FROM "posts" WHERE LOWER("posts"."title") IS NULL}
+          assert_equal(expected_sql, relation.to_sql)
+
+          assert_empty relation.to_a
+        end
+
         private
           def assert_quoted_as(expected, value, match: 0)
             relation = Post.where("title = ?", value)

--- a/activerecord/test/cases/adapters/postgresql/bind_parameter_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/bind_parameter_test.rb
@@ -34,12 +34,12 @@ module ActiveRecord
         end
 
         def test_where_with_nil_for_string_column_using_bind_parameters
-          relation = Post.where("LOWER(title) = ?", nil)
+          post = Post.create!
+          relation = Post.where("LOWER(title) IS ?", nil)
+          assert_equal post, relation.first
 
-          expected_sql = %{SELECT "posts".* FROM "posts" WHERE (LOWER(title) = NULL)}
+          expected_sql = %{SELECT "posts".* FROM "posts" WHERE (LOWER(title) IS NULL)}
           assert_equal(expected_sql, relation.to_sql)
-
-          assert_empty relation.to_a
         end
 
         private

--- a/activerecord/test/cases/adapters/postgresql/bind_parameter_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/bind_parameter_test.rb
@@ -34,11 +34,11 @@ module ActiveRecord
         end
 
         def test_where_with_nil_for_string_column_using_bind_parameters
-          post = Post.create!
-          relation = Post.where("LOWER(title) IS ?", nil)
+          post = Post.create!(title: "Foo", body: "Bar", type: nil)
+          relation = Post.where("LOWER(type) IS ?", nil)
           assert_equal post, relation.first
 
-          expected_sql = %{SELECT "posts".* FROM "posts" WHERE (LOWER(title) IS NULL)}
+          expected_sql = %{SELECT "posts".* FROM "posts" WHERE (LOWER(type) IS NULL)}
           assert_equal(expected_sql, relation.to_sql)
         end
 

--- a/activerecord/test/cases/adapters/postgresql/bind_parameter_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/bind_parameter_test.rb
@@ -36,7 +36,7 @@ module ActiveRecord
         def test_where_with_nil_for_string_column_using_bind_parameters
           relation = Post.where("LOWER(title) = ?", nil)
 
-          expected_sql = %{SELECT "posts".* FROM "posts" WHERE LOWER("posts"."title") IS NULL}
+          expected_sql = %{SELECT "posts".* FROM "posts" WHERE (LOWER(title) = NULL)}
           assert_equal(expected_sql, relation.to_sql)
 
           assert_empty relation.to_a


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created to fix #52643 

### Detail

This Pull Request changes

**Original**
https://github.com/rails/rails/blob/16882b886e245f363cd61f5ea553fe2bc525d070/activerecord/lib/active_record/relation/query_methods.rb#L1624

**Modified**

```ruby
elsif opts.include?("?") && rest.compact.present?
```

To make sure for the nil value of the rest we are constructing the query 
```ruby
"SELECT \"users\".* FROM \"users\" WHERE (LOWER(name) IS NULL) LIMIT $1"
```

Instead of 
```ruby
"SELECT \"users\".* FROM \"users\" WHERE (LOWER(name) IS $1) LIMIT $2"
```

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
