### PR TITLE
Move "avoid N+1 queries" explanation lower in the Active Storage docu…

### DIFF
--- a/activestorage/lib/active_storage/attached/model.rb
+++ b/activestorage/lib/active_storage/attached/model.rb
@@ -61,10 +61,6 @@ module ActiveStorage
       # There is no column defined on the model side, Active Storage takes
       # care of the mapping between your records and the attachment.
       #
-      # To avoid N+1 queries, you can include the attached blobs in your query like so:
-      #
-      #   User.with_attached_avatar
-      #
       # Under the covers, this relationship is implemented as a +has_one+ association to a
       # ActiveStorage::Attachment record and a +has_one-through+ association to a
       # ActiveStorage::Blob record. These associations are available as +avatar_attachment+
@@ -93,6 +89,10 @@ module ActiveStorage
       #   class User < ActiveRecord::Base
       #     has_one_attached :avatar, service: ->(user) { user.in_europe_region? ? :s3_europe : :s3_usa }
       #   end
+      #
+      # To avoid N+1 queries, you can include the attached blobs in your query like so:
+      #
+      #   User.with_attached_avatar
       #
       # If you need to enable +strict_loading+ to prevent lazy loading of attachment,
       # pass the +:strict_loading+ option. You can do:
@@ -163,10 +163,6 @@ module ActiveStorage
       # There are no columns defined on the model side, Active Storage takes
       # care of the mapping between your records and the attachments.
       #
-      # To avoid N+1 queries, you can include the attached blobs in your query like so:
-      #
-      #   Gallery.where(user: Current.user).with_attached_photos
-      #
       # Under the covers, this relationship is implemented as a +has_many+ association to a
       # ActiveStorage::Attachment record and a +has_many-through+ association to a
       # ActiveStorage::Blob record. These associations are available as +photos_attachments+
@@ -195,6 +191,10 @@ module ActiveStorage
       #   class Gallery < ActiveRecord::Base
       #     has_many_attached :photos, service: ->(gallery) { gallery.personal? ? :personal_s3 : :s3 }
       #   end
+      #
+      # To avoid N+1 queries, you can include the attached blobs in your query like so:
+      #
+      #   Gallery.where(user: Current.user).with_attached_photos
       #
       # If you need to enable +strict_loading+ to prevent lazy loading of attachments,
       # pass the +:strict_loading+ option. You can do:


### PR DESCRIPTION
…mentation

The explanations about avoinding N+1 queries seem out of place early in the documentation. The actual association hasn't been explained fully yet, but we explain performance optimizations.
It's also confusing when reading the next paragraph where "this relationship" might seem to refer to the `with_attached_avatar` scope.

Instead we can group it as a performance section together with the `strict_loading` section.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
