### PR TITLE
Ensure we deserialize database values before decrypting

### DIFF
--- a/activerecord/lib/active_record/encryption/encrypted_attribute_type.rb
+++ b/activerecord/lib/active_record/encryption/encrypted_attribute_type.rb
@@ -100,7 +100,7 @@ module ActiveRecord
         end
 
         def decrypt(value)
-          text_to_database_type decrypt_as_text(value)
+          text_to_database_type decrypt_as_text(database_type_to_text(value))
         end
 
         def try_to_deserialize_with_previous_encrypted_types(value)
@@ -166,6 +166,18 @@ module ActiveRecord
         def text_to_database_type(value)
           if value && cast_type.binary?
             ActiveModel::Type::Binary::Data.new(value)
+          else
+            value
+          end
+        end
+
+        def database_type_to_text(value)
+          if value && cast_type.binary?
+            if cast_type.is_a?(ActiveRecord::Type::Serialized)
+              cast_type.subtype.deserialize(value)
+            else
+              cast_type.deserialize(value)
+            end
           else
             value
           end

--- a/activerecord/test/cases/encryption/encryptable_record_message_pack_serialized_test.rb
+++ b/activerecord/test/cases/encryption/encryptable_record_message_pack_serialized_test.rb
@@ -5,19 +5,22 @@ require "models/author_encrypted"
 require "models/book_encrypted"
 require "active_record/encryption/message_pack_message_serializer"
 
-class ActiveRecord::Encryption::EncryptableRecordTest < ActiveRecord::EncryptionTestCase
+class ActiveRecord::Encryption::EncryptableRecordMessagePackSerializedTest < ActiveRecord::EncryptionTestCase
   fixtures :encrypted_books
 
   test "binary data can be serialized with message pack" do
     all_bytes = (0..255).map(&:chr).join
-    assert_equal all_bytes, EncryptedBookWithBinaryMessagePackSerialized.create!(logo: all_bytes).logo
+    book = EncryptedBookWithBinaryMessagePackSerialized.create!(logo: all_bytes)
+    assert_encrypted_attribute(book, :logo, all_bytes)
   end
 
   test "binary data can be encrypted uncompressed and serialized with message pack" do
+    # Strings below 140 bytes are not compressed
     low_bytes = (0..127).map(&:chr).join
     high_bytes = (128..255).map(&:chr).join
-    assert_equal low_bytes, EncryptedBookWithBinaryMessagePackSerialized.create!(logo: low_bytes).logo
-    assert_equal high_bytes, EncryptedBookWithBinaryMessagePackSerialized.create!(logo: high_bytes).logo
+
+    assert_encrypted_attribute(EncryptedBookWithBinaryMessagePackSerialized.create!(logo: low_bytes), :logo, low_bytes)
+    assert_encrypted_attribute(EncryptedBookWithBinaryMessagePackSerialized.create!(logo: high_bytes), :logo, high_bytes)
   end
 
   test "text columns cannot be serialized with message pack" do

--- a/activerecord/test/cases/encryption/encryptable_record_test.rb
+++ b/activerecord/test/cases/encryption/encryptable_record_test.rb
@@ -404,13 +404,13 @@ class ActiveRecord::Encryption::EncryptableRecordTest < ActiveRecord::Encryption
   test "binary data can be encrypted uncompressed" do
     low_bytes = (0..127).map(&:chr).join
     high_bytes = (128..255).map(&:chr).join
-    assert_equal low_bytes, EncryptedBookWithBinary.create!(logo: low_bytes).logo
-    assert_equal high_bytes, EncryptedBookWithBinary.create!(logo: high_bytes).logo
+    assert_encrypted_attribute EncryptedBookWithBinary.create!(logo: low_bytes), :logo, low_bytes
+    assert_encrypted_attribute EncryptedBookWithBinary.create!(logo: high_bytes), :logo, high_bytes
   end
 
   test "serialized binary data can be encrypted" do
     json_bytes = (32..127).map(&:chr)
-    assert_equal json_bytes, EncryptedBookWithSerializedBinary.create!(logo: json_bytes).logo
+    assert_encrypted_attribute EncryptedBookWithSerializedBinary.create!(logo: json_bytes), :logo, json_bytes
   end
 
   test "can compress data with custom compressor" do


### PR DESCRIPTION
Adds the missing step of deserializing the database value before decryption. This makes encryption of binary columns work in PostgreSQL.

For string columns, this is a no-op, For binary columns this is a no-op for SQLite and MySQL, but not for [PostgreSQL](https://github.com/rails/rails/blob/b60cf01e9d076d235fdb02db1072ea2a31c94dbe/activerecord/lib/active_record/connection_adapters/postgresql/oid/bytea.rb#L11).

The deserialization is messy, because of the need to handle serialized types (those declared with something like `serialize :foo, JSON`). The docs [recommend](https://guides.rubyonrails.org/active_record_encryption.html#supported-types) that you should have that declaration before the `encrypts :foo`.

If we recommended that they were called the other way round this could be greatly simplified and we could also remove the special case handling of binary types in `ActiveRecord::Encryption::EncryptedAttributeType#text_to_database_type`.
