### PR TITLE
Add scope_module option to resources

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,21 @@
+*   Add `scope_module` option to `resource(s)`.
+
+    ```ruby
+    resources :posts, scope_module: true do
+      resources :comments
+    end
+
+    # Is the same as:
+
+    resources :posts do
+      scope module: "posts" do
+        resources :comments
+      end
+    end
+    ```
+
+    *Lázaro Nixon*
+
 *   Fix `Request#raw_post` raising `NoMethodError` when `rack.input` is `nil`.
 
     *Hartley McGuire*

--- a/actionpack/test/controller/resources_test.rb
+++ b/actionpack/test/controller/resources_test.rb
@@ -8,6 +8,10 @@ class MessagesController < ResourcesController; end
 class ProductsController < ResourcesController; end
 class ThreadsController < ResourcesController; end
 
+module Threads
+  class MessagesController < ResourcesController; end
+end
+
 module Backoffice
   class ProductsController < ResourcesController; end
   class ImagesController < ResourcesController; end
@@ -455,6 +459,24 @@ class ResourcesTest < ActionController::TestCase
         name_prefix: "thread_message_",
         path_prefix: "threads/1/messages/2/",
         options: { thread_id: "1", message_id: "2" }
+    end
+  end
+
+  def test_nested_restful_routes_with_scope_module
+    with_routing do |set|
+      set.draw do
+        resources :threads, scope_module: true do
+          resources :messages
+        end
+      end
+
+      assert_simply_restful_for :threads,
+        scope_module: true
+      assert_simply_restful_for :messages,
+        controller: "threads/messages",
+        name_prefix: "thread_",
+        path_prefix: "threads/1/",
+        options: { thread_id: "1" }
     end
   end
 


### PR DESCRIPTION
### Motivation / Background

It's common practice to scope nested resources within their parents. This PR introduces a new option, `scope_module`, to the `resource/resources` methods. 

 ```ruby
 resources :posts, scope_module: true do
   resources :comments
end  

 # Is the same as:

resources :posts do
   scope module: "posts" do
     resources :comments
   end
end
```

### Detail

[I talked about it](https://x.com/matheusrich/status/1778082403673604371) with @MatheusRich months ago and [heard the same](https://github.com/cherrypush/cherrypush.com/blob/main/config/routes.rb#L31-L33) from other colleagues in the community.

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR, make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
