### PR TITLE
Fix rubocop offences for actionpack/lib/action_dispatch/journey/parser.rb

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,7 +15,6 @@ AllCops:
     - '**/tmp/**/*'
     - '**/templates/**/*'
     - '**/vendor/**/*'
-    - 'actionpack/lib/action_dispatch/journey/parser.rb'
     - 'actionmailbox/test/dummy/**/*'
     - 'activestorage/test/dummy/**/*'
     - 'actiontext/test/dummy/**/*'

--- a/actionpack/lib/action_dispatch/journey/parser.rb
+++ b/actionpack/lib/action_dispatch/journey/parser.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 
 require "action_dispatch/journey/scanner"
 require "action_dispatch/journey/nodes/node"
@@ -23,81 +24,80 @@ module ActionDispatch
       end
 
       private
+        def advance_token
+          @next_token = @scanner.next_token
+        end
 
-      def advance_token
-        @next_token = @scanner.next_token
-      end
+        def do_parse
+          parse_expressions
+        end
 
-      def do_parse
-        parse_expressions
-      end
+        def parse_expressions
+          node = parse_expression
 
-      def parse_expressions
-        node = parse_expression
+          while @next_token
+            case @next_token
+            when :RPAREN
+              break
+            when :OR
+              node = parse_or(node)
+            else
+              node = Cat.new(node, parse_expressions)
+            end
+          end
 
-        while @next_token
-          case @next_token
-          when :RPAREN
-            break
-          when :OR
-            node = parse_or(node)
+          node
+        end
+
+        def parse_or(lhs)
+          advance_token
+          node = parse_expression
+          Or.new([lhs, node])
+        end
+
+        def parse_expression
+          if @next_token == :STAR
+            parse_star
+          elsif @next_token == :LPAREN
+            parse_group
           else
-            node = Cat.new(node, parse_expressions)
+            parse_terminal
           end
         end
 
-        node
-      end
-
-      def parse_or(lhs)
-        advance_token
-        node = parse_expression
-        Or.new([lhs, node])
-      end
-
-      def parse_expression
-        if @next_token == :STAR
-          parse_star
-        elsif @next_token == :LPAREN
-          parse_group
-        else
-          parse_terminal
-        end
-      end
-
-      def parse_star
-        node = Star.new(Symbol.new(@scanner.last_string, Symbol::GREEDY_EXP))
-        advance_token
-        node
-      end
-
-      def parse_group
-        advance_token
-        node = parse_expressions
-        if @next_token == :RPAREN
-          node = Group.new(node)
+        def parse_star
+          node = Star.new(Symbol.new(@scanner.last_string, Symbol::GREEDY_EXP))
           advance_token
           node
-        else
-          raise ArgumentError, "missing right parenthesis."
-        end
-      end
-
-      def parse_terminal
-        node = case @next_token
-        when :SYMBOL
-          Symbol.new(@scanner.last_string)
-        when :LITERAL
-          Literal.new(@scanner.last_literal)
-        when :SLASH
-          Slash.new("/")
-        when :DOT
-          Dot.new(".")
         end
 
-        advance_token
-        node
-      end
+        def parse_group
+          advance_token
+          node = parse_expressions
+          if @next_token == :RPAREN
+            node = Group.new(node)
+            advance_token
+            node
+          else
+            raise ArgumentError, "missing right parenthesis."
+          end
+        end
+
+        def parse_terminal
+          node = case @next_token
+          when :SYMBOL
+            Symbol.new(@scanner.last_string)
+          when :LITERAL
+            Literal.new(@scanner.last_literal)
+          when :SLASH
+            Slash.new("/")
+          when :DOT
+            Dot.new(".")
+          end
+
+          advance_token
+          node
+        end
     end
   end
 end

--- a/guides/README.md
+++ b/guides/README.md
@@ -10,7 +10,7 @@ The editing files for the Guides rebuild reside in `stylesrc` and use SCSS to im
 
 ## Building the Guides in Development
 
-To generate new guides into static files, type `rake guides:generate` from inside the `guides` folder. If you make changes to the HTML or ERB, you'll need to remove the "output" directory before running this command. The master SCSS files (style.scss, highlight.scss) will compile as part of this process. 
+To generate new guides into static files, type `rake guides:generate` from inside the `guides` folder. If you make changes to the HTML or ERB, you'll need to remove the "output" directory before running this command. The master SCSS files (style.scss, highlight.scss) will compile as part of this process.
 
 ## FAQ
 


### PR DESCRIPTION
Enable rubocop check for the file since #52610 it is no longer automatically generated file.

```
Offenses:

actionpack/lib/action_dispatch/journey/parser.rb:1:1: C: [Corrected] Style/FrozenStringLiteralComment: Missing frozen string literal comment.
actionpack/lib/action_dispatch/journey/parser.rb:25:7: C: [Corrected] Layout/EmptyLinesAroundAccessModifier: Remove a blank line after private.
      private
      ^^^^^^^
actionpack/lib/action_dispatch/journey/parser.rb:27:7: C: [Corrected] Layout/IndentationWidth: Use 2 (not 0) spaces for indented_internal_methods indentation.
      def advance_token

actionpack/lib/action_dispatch/journey/parser.rb:31:7: C: [Corrected] Layout/IndentationConsistency: Inconsistent indentation detected.
      def do_parse ...
      ^^^^^^^^^^^^
actionpack/lib/action_dispatch/journey/parser.rb:35:7: C: [Corrected] Layout/IndentationConsistency: Inconsistent indentation detected.
      def parse_expressions ...
      ^^^^^^^^^^^^^^^^^^^^^
actionpack/lib/action_dispatch/journey/parser.rb:52:7: C: [Corrected] Layout/IndentationConsistency: Inconsistent indentation detected.
      def parse_or(lhs) ...
      ^^^^^^^^^^^^^^^^^
actionpack/lib/action_dispatch/journey/parser.rb:58:7: C: [Corrected] Layout/IndentationConsistency: Inconsistent indentation detected.
      def parse_expression ...
      ^^^^^^^^^^^^^^^^^^^^
actionpack/lib/action_dispatch/journey/parser.rb:68:7: C: [Corrected] Layout/IndentationConsistency: Inconsistent indentation detected.
      def parse_star ...
      ^^^^^^^^^^^^^^
actionpack/lib/action_dispatch/journey/parser.rb:74:7: C: [Corrected] Layout/IndentationConsistency: Inconsistent indentation detected.
      def parse_group ...
      ^^^^^^^^^^^^^^^
actionpack/lib/action_dispatch/journey/parser.rb:86:7: C: [Corrected] Layout/IndentationConsistency: Inconsistent indentation detected.
      def parse_terminal ...
      ^^^^^^^^^^^^^^^^^^
```
