### PR TITLE
Optimize ConfigurationFile when ERB is not used

### DIFF
--- a/activesupport/lib/active_support/configuration_file.rb
+++ b/activesupport/lib/active_support/configuration_file.rb
@@ -20,10 +20,18 @@ module ActiveSupport
 
     def parse(context: nil, **options)
       source = render(context)
-      if YAML.respond_to?(:unsafe_load)
-        YAML.unsafe_load(source, **options) || {}
+      if source == @content
+        if YAML.respond_to?(:unsafe_load)
+          YAML.unsafe_load_file(@content_path, **options) || {}
+        else
+          YAML.load_file(@content_path, **options) || {}
+        end
       else
-        YAML.load(source, **options) || {}
+        if YAML.respond_to?(:unsafe_load)
+          YAML.unsafe_load(source, **options) || {}
+        else
+          YAML.load(source, **options) || {}
+        end
       end
     rescue Psych::SyntaxError => error
       raise "YAML syntax error occurred while parsing #{@content_path}. " \

--- a/activesupport/test/configuration_file_test.rb
+++ b/activesupport/test/configuration_file_test.rb
@@ -6,7 +6,7 @@ class ConfigurationFileTest < ActiveSupport::TestCase
   test "backtrace contains YAML path" do
     Tempfile.create do |file|
       file.write("wrong: <%= foo %>")
-      file.rewind
+      file.flush
 
       error = assert_raises do
         ActiveSupport::ConfigurationFile.parse(file.path)
@@ -19,13 +19,23 @@ class ConfigurationFileTest < ActiveSupport::TestCase
   test "backtrace contains YAML path (when Pathname given)" do
     Tempfile.create do |file|
       file.write("wrong: <%= foo %>")
-      file.rewind
+      file.flush
 
       error = assert_raises do
         ActiveSupport::ConfigurationFile.parse(Pathname(file.path))
       end
 
       assert_match file.path, error.backtrace.first
+    end
+  end
+
+  test "load raw YAML" do
+    Tempfile.create do |file|
+      file.write("ok: 42")
+      file.flush
+
+      data = ActiveSupport::ConfigurationFile.parse(Pathname(file.path))
+      assert_equal({ "ok" => 42 }, data)
     end
   end
 end


### PR DESCRIPTION
`YAML.load` is much slower than `YAML.load_file` when Bootsnap is enabled.

As such for big file that don't use ERB, it's preferable to use `load_file`.

This is mostly useful for fixtures (which use `ConfigurationFile` under the hood)
