### PR TITLE
ConfigurationFile: skip ERB rendering unless the file seem to contain ERB

### DIFF
--- a/activesupport/lib/active_support/configuration_file.rb
+++ b/activesupport/lib/active_support/configuration_file.rb
@@ -19,7 +19,8 @@ module ActiveSupport
     end
 
     def parse(context: nil, **options)
-      source = render(context)
+      source = @content.include?("<%") ? render(context) : @content
+
       if source == @content
         if YAML.respond_to?(:unsafe_load)
           YAML.unsafe_load_file(@content_path, **options) || {}
@@ -42,7 +43,6 @@ module ActiveSupport
     private
       def read(content_path)
         require "yaml" unless defined?(YAML)
-        require "erb" unless defined?(ERB)
 
         File.read(content_path).tap do |content|
           if content.include?("\u00A0")
@@ -52,6 +52,7 @@ module ActiveSupport
       end
 
       def render(context)
+        require "erb" unless defined?(ERB)
         erb = ERB.new(@content).tap { |e| e.filename = @content_path }
         context ? erb.result(context) : erb.result
       end


### PR DESCRIPTION
Followup: https://github.com/rails/rails/pull/52665

Uncached ERB rendering is very costly, so assuming many files don't actually contain ERB, it's worth checking for it first.

For ERB files, we could consider caching the compilation, but it's more complicated.
