### PR TITLE
Ensure ActiveRecord::Encryption.config is always ready before access

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,18 @@
+*   Ensure `ActiveRecord::Encryption.config` is always ready before access.
+
+    Previously, `ActiveRecord::Encryption` configuration was deferred until `ActiveRecord::Base`
+    was loaded. Therefore, accessing `ActiveRecord::Encryption.config` properties before
+    `ActiveRecord::Base` was loaded would give incorrect results.
+
+    `ActiveRecord::Encryption` now has its own loading hook so that its configuration is set as
+    soon as needed.
+
+    When `ActiveRecord::Base` is loaded, even lazily, it in turn triggers the loading of
+    `ActiveRecord::Encryption`, thus preserving the original behavior of having its config ready
+    before any use of `ActiveRecord::Base`.
+
+    *Maxime Réty*
+
 *   Add `TimeZoneConverter#==` method, so objects will be properly compared by
     their type, scale, limit & precision.
 

--- a/activerecord/lib/active_record/encryption.rb
+++ b/activerecord/lib/active_record/encryption.rb
@@ -53,4 +53,6 @@ module ActiveRecord
       Cipher.eager_load!
     end
   end
+
+  ActiveSupport.run_load_hooks :active_record_encryption, Encryption
 end

--- a/activerecord/lib/active_record/railtie.rb
+++ b/activerecord/lib/active_record/railtie.rb
@@ -356,16 +356,19 @@ To keep using the current cache store, you can turn off cache versioning entirel
     end
 
     initializer "active_record_encryption.configuration" do |app|
-      ActiveSupport.on_load(:active_record) do
-        ActiveRecord::Encryption.configure \
+      ActiveSupport.on_load(:active_record_encryption) do
+        ActiveRecord::Encryption.configure(
           primary_key: app.credentials.dig(:active_record_encryption, :primary_key),
           deterministic_key: app.credentials.dig(:active_record_encryption, :deterministic_key),
           key_derivation_salt: app.credentials.dig(:active_record_encryption, :key_derivation_salt),
           **app.config.active_record.encryption
+        )
 
         auto_filtered_parameters = ActiveRecord::Encryption::AutoFilteredParameters.new(app)
         auto_filtered_parameters.enable if ActiveRecord::Encryption.config.add_to_filter_parameters
+      end
 
+      ActiveSupport.on_load(:active_record) do
         # Support extended queries for deterministic attributes and validations
         if ActiveRecord::Encryption.config.extend_queries
           ActiveRecord::Encryption::ExtendedDeterministicQueries.install_support

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -3755,6 +3755,7 @@ These are the load hooks you can use in your own code. To hook into the initiali
 | `ActiveModel::Model`                 | `active_model`                       |
 | `ActiveModel::Translation`           | `active_model_translation`           |
 | `ActiveRecord::Base`                 | `active_record`                      |
+| `ActiveRecord::Encryption`           | `active_record_encryption`           |
 | `ActiveRecord::TestFixtures`         | `active_record_fixtures`             |
 | `ActiveRecord::ConnectionAdapters::PostgreSQLAdapter`    | `active_record_postgresqladapter`    |
 | `ActiveRecord::ConnectionAdapters::Mysql2Adapter`        | `active_record_mysql2adapter`        |


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created in order to fix https://github.com/rspec/rspec-rails/issues/2779.

### Detail

Previously, `ActiveRecord::Encryption` configuration was deferred until `ActiveRecord::Base` was loaded. Therefore, accessing `ActiveRecord::Encryption.config` properties before `ActiveRecord::Base` was loaded would give incorrect results.

`ActiveRecord::Encryption` now has its own loading hook so that its configuration is set as soon as needed.

When `ActiveRecord::Base` is loaded, even lazily, it in turn triggers the loading of `ActiveRecord::Encryption`, thus preserving the original behavior of having its config ready before any use of `ActiveRecord::Base`.

This fix complements one of my previous fixes in https://github.com/rails/rails/pull/50606.

Since both Rails 7.1.4 and 7.2.* versions are affected, I'd recommend backporting this fix to `7-1-stable` and `7-2-stable`. 

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
