### PR TITLE
Make Solid Cache the default for new Rails apps

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -18,6 +18,7 @@ AllCops:
     - 'actionmailbox/test/dummy/**/*'
     - 'activestorage/test/dummy/**/*'
     - 'actiontext/test/dummy/**/*'
+    - 'railties/test/fixtures/db/**/*'
     - 'tools/rail_inspector/test/fixtures/*'
     - guides/source/debugging_rails_applications.md
     - guides/source/active_support_instrumentation.md

--- a/Gemfile
+++ b/Gemfile
@@ -40,6 +40,8 @@ gem "cgi", ">= 0.3.6", require: false
 
 gem "prism"
 
+gem "solid_cache", ">= 1.0.0"
+
 group :lint do
   gem "syntax_tree", "6.1.1", require: false
 end

--- a/Gemfile
+++ b/Gemfile
@@ -40,7 +40,7 @@ gem "cgi", ">= 0.3.6", require: false
 
 gem "prism"
 
-gem "solid_cache", ">= 1.0.0"
+gem "solid_cache", ">= 1.0.1"
 
 group :lint do
   gem "syntax_tree", "6.1.1", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -544,6 +544,10 @@ GEM
       rake
       serverengine (~> 2.0.5)
       thor
+    solid_cache (1.0.0)
+      activejob (>= 7.2)
+      activerecord (>= 7.2)
+      railties (>= 7.2)
     sorted_set (1.0.3)
       rbtree
       set (~> 1.0)
@@ -689,6 +693,7 @@ DEPENDENCIES
   selenium-webdriver (>= 4.20.0)
   sidekiq
   sneakers
+  solid_cache (>= 1.0.0)
   sprockets-rails (>= 2.0.0)
   sqlite3 (>= 2.0)
   stackprof

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -544,7 +544,7 @@ GEM
       rake
       serverengine (~> 2.0.5)
       thor
-    solid_cache (1.0.0)
+    solid_cache (1.0.1)
       activejob (>= 7.2)
       activerecord (>= 7.2)
       railties (>= 7.2)
@@ -693,7 +693,7 @@ DEPENDENCIES
   selenium-webdriver (>= 4.20.0)
   sidekiq
   sneakers
-  solid_cache (>= 1.0.0)
+  solid_cache (>= 1.0.1)
   sprockets-rails (>= 2.0.0)
   sqlite3 (>= 2.0)
   stackprof

--- a/activejob/test/support/integration/helper.rb
+++ b/activejob/test/support/integration/helper.rb
@@ -9,7 +9,7 @@ require "tmpdir"
 dummy_app_path     = Dir.mktmpdir + "/dummy"
 dummy_app_template = File.expand_path("dummy_app_template.rb",  __dir__)
 args = Rails::Generators::ARGVScrubber.new(["new", dummy_app_path, "--skip-gemfile", "--skip-bundle",
-  "--skip-git", "-d", "sqlite3", "--skip-javascript", "--force", "--quiet",
+  "--skip-git", "-d", "sqlite3", "--skip-javascript", "--skip-solid-cache", "--force", "--quiet",
   "--template", dummy_app_template]).prepare!
 Rails::Generators::AppGenerator.start args
 

--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -114,6 +114,9 @@ module Rails
         class_option :skip_kamal,          type: :boolean, default: false,
                                            desc: "Skip Kamal setup"
 
+        class_option :skip_solid_cache,    type: :boolean, default: false,
+                                           desc: "Skip Solid Cache setup"
+
         class_option :dev,                 type: :boolean, default: nil,
                                            desc: "Set up the #{name} with Gemfile pointing to your Rails checkout"
 
@@ -158,6 +161,7 @@ module Rails
           css_gemfile_entry,
           jbuilder_gemfile_entry,
           cable_gemfile_entry,
+          solid_cache_gemfile_entry,
         ].flatten.compact.select(&@gem_filter)
       end
 
@@ -390,6 +394,10 @@ module Rails
 
       def skip_asset_pipeline? # :doc:
         options[:skip_asset_pipeline]
+      end
+
+      def skip_solid_cache?
+        options[:skip_solid_cache]
       end
 
       def skip_sprockets?
@@ -638,6 +646,13 @@ module Rails
 
         comment = "Use Redis adapter to run Action Cable in production"
         GemfileEntry.new("redis", ">= 4.0.1", comment, {}, true)
+      end
+
+      def solid_cache_gemfile_entry
+        return if options[:skip_solid_cache]
+
+        comment = "Use Solid Cache for caching (http://github.com/rails/solid_cache)"
+        GemfileEntry.new("solid_cache", ">= 1.0.0", comment, {}, false)
       end
 
       def bundle_command(command, env = {})

--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -651,7 +651,7 @@ module Rails
       def solid_cache_gemfile_entry
         return if options[:skip_solid_cache]
 
-        comment = "Use Solid Cache for caching (http://github.com/rails/solid_cache)"
+        comment = "Use Solid Cache for caching (https://github.com/rails/solid_cache)"
         GemfileEntry.new("solid_cache", ">= 1.0.1", comment, {}, false)
       end
 

--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -652,7 +652,7 @@ module Rails
         return if options[:skip_solid_cache]
 
         comment = "Use Solid Cache for caching (http://github.com/rails/solid_cache)"
-        GemfileEntry.new("solid_cache", ">= 1.0.0", comment, {}, false)
+        GemfileEntry.new("solid_cache", ">= 1.0.1", comment, {}, false)
       end
 
       def bundle_command(command, env = {})

--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -649,7 +649,7 @@ module Rails
       end
 
       def solid_cache_gemfile_entry
-        return if options[:skip_solid_cache]
+        return if skip_solid_cache?
 
         comment = "Use Solid Cache for caching (https://github.com/rails/solid_cache)"
         GemfileEntry.new("solid_cache", ">= 1.0.1", comment, {}, false)

--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -316,6 +316,7 @@ module Rails
             :skip_hotwire,
             :skip_javascript,
             :skip_jbuilder,
+            :skip_solid_cache,
             :skip_system_test,
           ],
           api: [
@@ -472,6 +473,16 @@ module Rails
       def create_devcontainer_files
         return if skip_devcontainer? || options[:dummy_app]
         build(:devcontainer)
+      end
+
+      def install_solid_cache
+        unless skip_solid_cache?
+          if options[:database] == "sqlite3"
+            rails_command "DATABASE=cache solid_cache:install", inline: false, capture: options[:quiet]
+          else
+            rails_command "solid_cache:install", inline: false, capture: options[:quiet]
+          end
+        end
       end
 
       def delete_app_assets_if_api_option

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/mysql.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/mysql.yml.tt
@@ -22,10 +22,10 @@ default: &default
 <% end -%>
 
 development:
-  primary:<% unless options[:skip_solid_cache] %> &development_primary<% end %>
+  primary:<% unless skip_solid_cache? %> &development_primary<% end %>
     <<: *default
     database: <%= app_name %>_development
-<% unless options[:skip_solid_cache] -%>
+<% unless skip_solid_cache? -%>
   cache:
     <<: *development_primary
 <% end -%>
@@ -34,10 +34,10 @@ development:
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test:
-  primary:<% unless options[:skip_solid_cache] %> &test_primary<% end %>
+  primary:<% unless skip_solid_cache? %> &test_primary<% end %>
     <<: *default
     database: <%= app_name %>_test
-<% unless options[:skip_solid_cache] -%>
+<% unless skip_solid_cache? -%>
   cache:
     <<: *test_primary
 <% end -%>
@@ -63,12 +63,12 @@ test:
 # for a full overview on how database connection configuration can be specified.
 #
 production:
-  primary:<% unless options[:skip_solid_cache] %> &production_primary<% end %>
+  primary:<% unless skip_solid_cache? %> &production_primary<% end %>
     <<: *default
     database: <%= app_name %>_production
     username: <%= app_name %>
     password: <%%= ENV["<%= app_name.upcase %>_DATABASE_PASSWORD"] %>
-<% unless options[:skip_solid_cache] -%>
+<% unless skip_solid_cache? -%>
   cache:
     <<: *production_primary
 <% end -%>

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/mysql.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/mysql.yml.tt
@@ -22,15 +22,25 @@ default: &default
 <% end -%>
 
 development:
-  <<: *default
-  database: <%= app_name %>_development
+  primary:<% unless options[:skip_solid_cache] %> &development_primary<% end %>
+    <<: *default
+    database: <%= app_name %>_development
+<% unless options[:skip_solid_cache] -%>
+  cache:
+    <<: *development_primary
+<% end -%>
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test:
-  <<: *default
-  database: <%= app_name %>_test
+  primary:<% unless options[:skip_solid_cache] %> &test_primary<% end %>
+    <<: *default
+    database: <%= app_name %>_test
+<% unless options[:skip_solid_cache] -%>
+  cache:
+    <<: *test_primary
+<% end -%>
 
 # As with config/credentials.yml, you never want to store sensitive information,
 # like your database password, in your source code. If your source code is
@@ -53,7 +63,12 @@ test:
 # for a full overview on how database connection configuration can be specified.
 #
 production:
-  <<: *default
-  database: <%= app_name %>_production
-  username: <%= app_name %>
-  password: <%%= ENV["<%= app_name.upcase %>_DATABASE_PASSWORD"] %>
+  primary:<% unless options[:skip_solid_cache] %> &production_primary<% end %>
+    <<: *default
+    database: <%= app_name %>_production
+    username: <%= app_name %>
+    password: <%%= ENV["<%= app_name.upcase %>_DATABASE_PASSWORD"] %>
+<% unless options[:skip_solid_cache] -%>
+  cache:
+    <<: *production_primary
+<% end -%>

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/postgresql.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/postgresql.yml.tt
@@ -27,42 +27,52 @@ default: &default
 <% end %>
 
 development:
-  <<: *default
-  database: <%= app_name %>_development
+  primary:<% unless options[:skip_solid_cache] %> &development_primary<% end %>
+    <<: *default
+    database: <%= app_name %>_development
 
-  # The specified database role being used to connect to PostgreSQL.
-  # To create additional roles in PostgreSQL see `$ createuser --help`.
-  # When left blank, PostgreSQL will use the default role. This is
-  # the same name as the operating system user running Rails.
-  #username: <%= app_name %>
+    # The specified database role being used to connect to PostgreSQL.
+    # To create additional roles in PostgreSQL see `$ createuser --help`.
+    # When left blank, PostgreSQL will use the default role. This is
+    # the same name as the operating system user running Rails.
+    #username: <%= app_name %>
 
-  # The password associated with the PostgreSQL role (username).
-  #password:
+    # The password associated with the PostgreSQL role (username).
+    #password:
 
-  # Connect on a TCP socket. Omitted by default since the client uses a
-  # domain socket that doesn't need configuration. Windows does not have
-  # domain sockets, so uncomment these lines.
-  #host: localhost
+    # Connect on a TCP socket. Omitted by default since the client uses a
+    # domain socket that doesn't need configuration. Windows does not have
+    # domain sockets, so uncomment these lines.
+    #host: localhost
 
-  # The TCP port the server listens on. Defaults to 5432.
-  # If your server runs on a different port number, change accordingly.
-  #port: 5432
+    # The TCP port the server listens on. Defaults to 5432.
+    # If your server runs on a different port number, change accordingly.
+    #port: 5432
 
-  # Schema search path. The server defaults to $user,public
-  #schema_search_path: myapp,sharedapp,public
+    # Schema search path. The server defaults to $user,public
+    #schema_search_path: myapp,sharedapp,public
 
-  # Minimum log levels, in increasing order:
-  #   debug5, debug4, debug3, debug2, debug1,
-  #   log, notice, warning, error, fatal, and panic
-  # Defaults to warning.
-  #min_messages: notice
+    # Minimum log levels, in increasing order:
+    #   debug5, debug4, debug3, debug2, debug1,
+    #   log, notice, warning, error, fatal, and panic
+    # Defaults to warning.
+    #min_messages: notice
+<% unless options[:skip_solid_cache] -%>
+  cache:
+    <<: *development_primary
+<% end -%>
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test:
-  <<: *default
-  database: <%= app_name %>_test
+  primary: <% unless options[:skip_solid_cache] %> &test_primary<% end %>
+    <<: *default
+    database: <%= app_name %>_test
+<% unless options[:skip_solid_cache] -%>
+  cache:
+    <<: *test_primary
+<% end -%>
 
 # As with config/credentials.yml, you never want to store sensitive information,
 # like your database password, in your source code. If your source code is
@@ -85,7 +95,12 @@ test:
 # for a full overview on how database connection configuration can be specified.
 #
 production:
-  <<: *default
-  database: <%= app_name %>_production
-  username: <%= app_name %>
-  password: <%%= ENV["<%= app_name.upcase %>_DATABASE_PASSWORD"] %>
+  primary:<% unless options[:skip_solid_cache] %> &production_primary<% end %>
+    <<: *default
+    database: <%= app_name %>_production
+    username: <%= app_name %>
+    password: <%%= ENV["<%= app_name.upcase %>_DATABASE_PASSWORD"] %>
+<% unless options[:skip_solid_cache] -%>
+  cache:
+    <<: *production_primary
+<% end -%>

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/postgresql.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/postgresql.yml.tt
@@ -27,7 +27,7 @@ default: &default
 <% end %>
 
 development:
-  primary:<% unless options[:skip_solid_cache] %> &development_primary<% end %>
+  primary:<% unless skip_solid_cache? %> &development_primary<% end %>
     <<: *default
     database: <%= app_name %>_development
 
@@ -57,7 +57,7 @@ development:
     #   log, notice, warning, error, fatal, and panic
     # Defaults to warning.
     #min_messages: notice
-<% unless options[:skip_solid_cache] -%>
+<% unless skip_solid_cache? -%>
   cache:
     <<: *development_primary
 <% end -%>
@@ -66,10 +66,10 @@ development:
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test:
-  primary: <% unless options[:skip_solid_cache] %> &test_primary<% end %>
+  primary: <% unless skip_solid_cache? %> &test_primary<% end %>
     <<: *default
     database: <%= app_name %>_test
-<% unless options[:skip_solid_cache] -%>
+<% unless skip_solid_cache? -%>
   cache:
     <<: *test_primary
 <% end -%>
@@ -95,12 +95,12 @@ test:
 # for a full overview on how database connection configuration can be specified.
 #
 production:
-  primary:<% unless options[:skip_solid_cache] %> &production_primary<% end %>
+  primary:<% unless skip_solid_cache? %> &production_primary<% end %>
     <<: *default
     database: <%= app_name %>_production
     username: <%= app_name %>
     password: <%%= ENV["<%= app_name.upcase %>_DATABASE_PASSWORD"] %>
-<% unless options[:skip_solid_cache] -%>
+<% unless skip_solid_cache? -%>
   cache:
     <<: *production_primary
 <% end -%>

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/sqlite3.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/sqlite3.yml.tt
@@ -13,7 +13,7 @@ development:
   primary:
     <<: *default
     database: storage/development.sqlite3
-<% unless options[:skip_solid_cache] -%>
+<% unless skip_solid_cache? -%>
   cache:
     <<: *default
     database: storage/development_cache.sqlite3
@@ -27,7 +27,7 @@ test:
   primary:
     <<: *default
     database: storage/test.sqlite3
-<% unless options[:skip_solid_cache] -%>
+<% unless skip_solid_cache? -%>
   cache:
     <<: *default
     database: storage/test_cache.sqlite3
@@ -45,7 +45,7 @@ production:
   primary:
     <<: *default
     # database: path/to/persistent/storage/production.sqlite3
-<% unless options[:skip_solid_cache] -%>
+<% unless skip_solid_cache? -%>
   cache:
     <<: *default
     # database: path/to/persistent/storage/production_cache.sqlite3
@@ -58,7 +58,7 @@ production:
   primary:
     <<: *default
     database: storage/production.sqlite3
-<% unless options[:skip_solid_cache] -%>
+<% unless skip_solid_cache? -%>
   cache:
     <<: *default
     database: storage/production_cache.sqlite3

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/sqlite3.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/sqlite3.yml.tt
@@ -10,16 +10,29 @@ default: &default
   timeout: 5000
 
 development:
-  <<: *default
-  database: storage/development.sqlite3
+  primary:
+    <<: *default
+    database: storage/development.sqlite3
+<% unless options[:skip_solid_cache] -%>
+  cache:
+    <<: *default
+    database: storage/development_cache.sqlite3
+    migrations_paths: "db/cache/migrate"
+<%- end -%>
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test:
-  <<: *default
-  database: storage/test.sqlite3
-
+  primary:
+    <<: *default
+    database: storage/test.sqlite3
+<% unless options[:skip_solid_cache] -%>
+  cache:
+    <<: *default
+    database: storage/test_cache.sqlite3
+    migrations_paths: "db/cache/migrate"
+<%- end -%>
 
 <%- if options.skip_kamal? -%>
 # SQLite3 write its data on the local filesystem, as such it requires
@@ -29,12 +42,26 @@ test:
 # Similarly, if you deploy your application as a Docker container, you must
 # ensure the database is located in a persisted volume.
 production:
-  <<: *default
-  # database: path/to/persistent/storage/production.sqlite3
+  primary:
+    <<: *default
+    # database: path/to/persistent/storage/production.sqlite3
+<% unless options[:skip_solid_cache] -%>
+  cache:
+    <<: *default
+    # database: path/to/persistent/storage/production_cache.sqlite3
+    # migrations_paths: "db/cache/migrate"
+<%- end -%>
 <%- else -%>
 # Store production database in the storage/ directory, which by default
 # is mounted as a persistent Docker volume in config/deploy.yml.
 production:
-  <<: *default
-  database: storage/production.sqlite3
+  primary:
+    <<: *default
+    database: storage/production.sqlite3
+<% unless options[:skip_solid_cache] -%>
+  cache:
+    <<: *default
+    database: storage/production_cache.sqlite3
+    migrations_paths: "db/cache/migrate"
+<%- end -%>
 <%- end -%>

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/trilogy.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/trilogy.yml.tt
@@ -22,10 +22,10 @@ default: &default
 <% end -%>
 
 development:
-  primary:<% unless options[:skip_solid_cache] %> &development_primary<% end %>
+  primary:<% unless skip_solid_cache? %> &development_primary<% end %>
     <<: *default
     database: <%= app_name %>_development
-<% unless options[:skip_solid_cache] -%>
+<% unless skip_solid_cache? -%>
   cache:
     <<: *development_primary
 <% end -%>
@@ -34,10 +34,10 @@ development:
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test:
-  primary:<% unless options[:skip_solid_cache] %> &test_primary<% end %>
+  primary:<% unless skip_solid_cache? %> &test_primary<% end %>
     <<: *default
     database: <%= app_name %>_test
-<% unless options[:skip_solid_cache] -%>
+<% unless skip_solid_cache? -%>
   cache:
     <<: *test_primary
 <% end -%>
@@ -63,12 +63,12 @@ test:
 # for a full overview on how database connection configuration can be specified.
 #
 production:
-  primary:<% unless options[:skip_solid_cache] %> &production_primary<% end %>
+  primary:<% unless skip_solid_cache? %> &production_primary<% end %>
     <<: *default
     database: <%= app_name %>_production
     username: <%= app_name %>
     password: <%%= ENV["<%= app_name.upcase %>_DATABASE_PASSWORD"] %>
-<% unless options[:skip_solid_cache] -%>
+<% unless skip_solid_cache? -%>
   cache:
     <<: *production_primary
 <% end -%>

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/trilogy.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/trilogy.yml.tt
@@ -22,15 +22,25 @@ default: &default
 <% end -%>
 
 development:
-  <<: *default
-  database: <%= app_name %>_development
+  primary:<% unless options[:skip_solid_cache] %> &development_primary<% end %>
+    <<: *default
+    database: <%= app_name %>_development
+<% unless options[:skip_solid_cache] -%>
+  cache:
+    <<: *development_primary
+<% end -%>
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test:
-  <<: *default
-  database: <%= app_name %>_test
+  primary:<% unless options[:skip_solid_cache] %> &test_primary<% end %>
+    <<: *default
+    database: <%= app_name %>_test
+<% unless options[:skip_solid_cache] -%>
+  cache:
+    <<: *test_primary
+<% end -%>
 
 # As with config/credentials.yml, you never want to store sensitive information,
 # like your database password, in your source code. If your source code is
@@ -53,7 +63,12 @@ test:
 # for a full overview on how database connection configuration can be specified.
 #
 production:
-  <<: *default
-  database: <%= app_name %>_production
-  username: <%= app_name %>
-  password: <%%= ENV["<%= app_name.upcase %>_DATABASE_PASSWORD"] %>
+  primary:<% unless options[:skip_solid_cache] %> &production_primary<% end %>
+    <<: *default
+    database: <%= app_name %>_production
+    username: <%= app_name %>
+    password: <%%= ENV["<%= app_name.upcase %>_DATABASE_PASSWORD"] %>
+<% unless options[:skip_solid_cache] -%>
+  cache:
+    <<: *production_primary
+<% end -%>

--- a/railties/lib/rails/generators/rails/app/templates/config/environments/development.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/development.rb.tt
@@ -30,11 +30,7 @@ Rails.application.configure do
   end
 
   # Change this to :null_store to avoid any caching
-  <%- if options[:skip_solid_cache] -%>
   config.cache_store = :memory_store
-  <%- else -%>
-  config.cache_store = :solid_cache_store
-  <% end %>
   <%- unless skip_active_storage? -%>
 
   # Store uploaded files on the local file system (see config/storage.yml for options).

--- a/railties/lib/rails/generators/rails/app/templates/config/environments/development.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/development.rb.tt
@@ -30,7 +30,11 @@ Rails.application.configure do
   end
 
   # Change this to :null_store to avoid any caching
+  <%- if options[:skip_solid_cache] -%>
   config.cache_store = :memory_store
+  <%- else -%>
+  config.cache_store = :solid_cache_store
+  <% end %>
   <%- unless skip_active_storage? -%>
 
   # Store uploaded files on the local file system (see config/storage.yml for options).

--- a/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
@@ -73,8 +73,13 @@ Rails.application.configure do
   # want to log everything, set the level to "debug".
   config.log_level = ENV.fetch("RAILS_LOG_LEVEL", "info")
 
+  <%- if options[:skip_solid_cache] -%>
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store
+  <%- else -%>
+  # Cache with Solid Cache
+  config.cache_store = :solid_cache_store
+  <% end %>
 
   <%- unless options[:skip_active_job] -%>
   # Use a real queuing backend for Active Job (and separate queues per environment).

--- a/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
@@ -73,7 +73,7 @@ Rails.application.configure do
   # want to log everything, set the level to "debug".
   config.log_level = ENV.fetch("RAILS_LOG_LEVEL", "info")
 
-  <%- if options[:skip_solid_cache] -%>
+  <%- if skip_solid_cache? -%>
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store
   <%- else -%>

--- a/railties/lib/rails/generators/rails/db/system/change/change_generator.rb
+++ b/railties/lib/rails/generators/rails/db/system/change/change_generator.rb
@@ -60,10 +60,12 @@ module Rails
           end
 
           def move_migrations
-            if database.name == "sqlite3"
-              move_solid_cache_migrations from: "db/migrate", to: "db/cache/migrate"
-            else
-              move_solid_cache_migrations from: "db/cache/migrate", to: "db/migrate"
+            unless skip_solid_cache?
+              if database.name == "sqlite3"
+                move_solid_cache_migrations from: "db/migrate", to: "db/cache/migrate"
+              else
+                move_solid_cache_migrations from: "db/cache/migrate", to: "db/migrate"
+              end
             end
           end
 
@@ -206,6 +208,14 @@ module Rails
               return @devcontainer if defined?(@devcontainer)
 
               @devcontainer = File.exist?(File.expand_path(".devcontainer", destination_root))
+            end
+
+            def skip_solid_cache?
+              return @skip_solid_cache if defined?(@skip_solid_cache)
+
+              @skip_solid_cache = \
+                Dir.glob(File.expand_path("db/cache/migrate/*.solid_cache.rb", destination_root)).empty? &&
+                Dir.glob(File.expand_path("db/migrate/*.solid_cache.rb", destination_root)).empty?
             end
 
             def move_solid_cache_migrations(from:, to:)

--- a/railties/lib/rails/generators/rails/devcontainer/devcontainer_generator.rb
+++ b/railties/lib/rails/generators/rails/devcontainer/devcontainer_generator.rb
@@ -55,6 +55,10 @@ module Rails
           true
         end
 
+        def skip_solid_cache?
+          options[:skip_solid_cache]
+        end
+
         def app_name
           options[:app_name]
         end

--- a/railties/test/application/bin_setup_test.rb
+++ b/railties/test/application/bin_setup_test.rb
@@ -48,6 +48,8 @@ module ApplicationTests
         # Ignore warnings such as `Psych.safe_load is deprecated`
         output.gsub!(/^.*warning:\s.*\n/, "")
         output.gsub!(/^A new release of RubyGems is available.*\n.*\n/, "")
+        # Ignore the Solid Cache migration messages
+        output.gsub!(/== \d{14} CreateSolidCacheEntries:.* migrating ==========================\n.*== \d{14} CreateSolidCacheEntries: migrated \([\d.]*s\) =================\n\n/m, "")
 
         assert_equal(<<~OUTPUT, output)
           == Installing dependencies ==

--- a/railties/test/fixtures/db/cache/migrate/20240821135818_create_solid_cache_entries.solid_cache.rb
+++ b/railties/test/fixtures/db/cache/migrate/20240821135818_create_solid_cache_entries.solid_cache.rb
@@ -1,0 +1,30 @@
+# This migration comes from solid_cache (originally 20240820123641)
+class CreateSolidCacheEntries < ActiveRecord::Migration[7.2]
+  def up
+    create_table :solid_cache_entries, if_not_exists: true do |t|
+      t.binary   :key,        null: false,   limit: 1024
+      t.binary   :value,      null: false,   limit: 512.megabytes
+      t.datetime :created_at, null: false
+      t.integer :key_hash,    null: false,    limit: 8
+      t.integer :byte_size,   null: false,    limit: 4
+
+      t.index  :key_hash, unique: true
+      t.index  [:key_hash, :byte_size]
+      t.index  :byte_size
+    end
+
+    raise "column \"key_hash\" does not exist" unless column_exists? :solid_cache_entries, :key_hash
+  rescue => e
+    if e.message =~ /(column "key_hash" does not exist|no such column: key_hash)/
+      raise \
+        "Could not find key_hash column on solid_cache_entries, if upgrading from v0.3 or earlier, have you followed " \
+        "the steps in https://github.com/rails/solid_cache/blob/main/upgrading_to_version_0.4.x.md?"
+    else
+      raise
+    end
+  end
+
+  def down
+    drop_table :solid_cache_entries
+  end
+end

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -63,6 +63,7 @@ DEFAULT_APP_FILES = [
   "db/seeds.rb",
   "lib/tasks/.keep",
   "log/.keep",
+  "log/test.log",
   "public/404.html",
   "public/406-unsupported-browser.html",
   "public/422.html",
@@ -82,6 +83,7 @@ DEFAULT_APP_FILES = [
   "test/system/.keep",
   "test/test_helper.rb",
   "tmp/.keep",
+  "tmp/local_secret.txt",
   "tmp/pids/.keep",
   "tmp/storage/.keep",
   "vendor/.keep"

--- a/railties/test/generators/db_system_change_generator_test.rb
+++ b/railties/test/generators/db_system_change_generator_test.rb
@@ -144,7 +144,7 @@ module Rails
               assert_not_includes content["containerEnv"].keys, "DB_HOST"
             end
 
-            assert_cache_migration_files in: "db/cache/migrate", not_in: "db/migrate"
+            assert_cache_migration_files here: "db/cache/migrate", not_here: "db/migrate"
           end
 
           test "change to trilogy" do
@@ -186,7 +186,7 @@ module Rails
               assert_equal expected_mariadb_config, compose_config["services"]["mariadb"]
               assert_includes compose_config["volumes"].keys, "mariadb-data"
 
-              assert_cache_migration_files in: "db/migrate", not_in: "db/cache/migrate"
+              assert_cache_migration_files here: "db/migrate", not_here: "db/cache/migrate"
             end
           end
 
@@ -224,9 +224,9 @@ module Rails
           end
 
           private
-            def assert_cache_migration_files(in:, not_in)
-              assert_operator Dir.glob("#{in}/*.solid_cache.rb").size, :>, 1
-              assert_equal Dir.glob("#{not_in}/*.solid_cache.rb").size, 0
+            def assert_cache_migration_files(here:, not_here:)
+              assert_operator Dir.glob("#{here}/*.solid_cache.rb").size, :>, 1
+              assert_equal Dir.glob("#{not_here}/*.solid_cache.rb").size, 0
             end
         end
       end

--- a/railties/test/generators/db_system_change_generator_test.rb
+++ b/railties/test/generators/db_system_change_generator_test.rb
@@ -18,6 +18,7 @@ module Rails
 
             copy_dockerfile
             copy_devcontainer_files
+            copy_solid_cache_migration
           end
 
           test "change to invalid database" do
@@ -75,7 +76,7 @@ module Rails
               assert_includes compose_config["volumes"].keys, "postgres-data"
             end
 
-            assert_cache_migration_files in: "db/migrate", not_in: "db/cache/migrate"
+            assert_solid_cache_migration here: "db/migrate", not_here: "db/cache/migrate"
           end
 
           test "change to mysql" do
@@ -118,7 +119,7 @@ module Rails
               assert_equal expected_mysql_config, compose_config["services"]["mysql"]
               assert_includes compose_config["volumes"].keys, "mysql-data"
 
-              assert_cache_migration_files in: "db/migrate", not_in: "db/cache/migrate"
+              assert_solid_cache_migration here: "db/migrate", not_here: "db/cache/migrate"
             end
           end
 
@@ -144,7 +145,7 @@ module Rails
               assert_not_includes content["containerEnv"].keys, "DB_HOST"
             end
 
-            assert_cache_migration_files here: "db/cache/migrate", not_here: "db/migrate"
+            assert_solid_cache_migration here: "db/cache/migrate", not_here: "db/migrate"
           end
 
           test "change to trilogy" do
@@ -186,7 +187,7 @@ module Rails
               assert_equal expected_mariadb_config, compose_config["services"]["mariadb"]
               assert_includes compose_config["volumes"].keys, "mariadb-data"
 
-              assert_cache_migration_files here: "db/migrate", not_here: "db/cache/migrate"
+              assert_solid_cache_migration here: "db/migrate", not_here: "db/cache/migrate"
             end
           end
 
@@ -222,12 +223,6 @@ module Rails
               assert_not_includes compose_config.keys, "volumes"
             end
           end
-
-          private
-            def assert_cache_migration_files(here:, not_here:)
-              assert_operator Dir.glob("#{here}/*.solid_cache.rb").size, :>, 1
-              assert_equal Dir.glob("#{not_here}/*.solid_cache.rb").size, 0
-            end
         end
       end
     end

--- a/railties/test/generators/db_system_change_generator_test.rb
+++ b/railties/test/generators/db_system_change_generator_test.rb
@@ -74,6 +74,8 @@ module Rails
               assert_equal expected_postgres_config, compose_config["services"]["postgres"]
               assert_includes compose_config["volumes"].keys, "postgres-data"
             end
+
+            assert_cache_migration_files in: "db/migrate", not_in: "db/cache/migrate"
           end
 
           test "change to mysql" do
@@ -115,6 +117,8 @@ module Rails
 
               assert_equal expected_mysql_config, compose_config["services"]["mysql"]
               assert_includes compose_config["volumes"].keys, "mysql-data"
+
+              assert_cache_migration_files in: "db/migrate", not_in: "db/cache/migrate"
             end
           end
 
@@ -139,6 +143,8 @@ module Rails
             assert_devcontainer_json_file do |content|
               assert_not_includes content["containerEnv"].keys, "DB_HOST"
             end
+
+            assert_cache_migration_files in: "db/cache/migrate", not_in: "db/migrate"
           end
 
           test "change to trilogy" do
@@ -179,6 +185,8 @@ module Rails
 
               assert_equal expected_mariadb_config, compose_config["services"]["mariadb"]
               assert_includes compose_config["volumes"].keys, "mariadb-data"
+
+              assert_cache_migration_files in: "db/migrate", not_in: "db/cache/migrate"
             end
           end
 
@@ -214,6 +222,12 @@ module Rails
               assert_not_includes compose_config.keys, "volumes"
             end
           end
+
+          private
+            def assert_cache_migration_files(in:, not_in)
+              assert_operator Dir.glob("#{in}/*.solid_cache.rb").size, :>, 1
+              assert_equal Dir.glob("#{not_in}/*.solid_cache.rb").size, 0
+            end
         end
       end
     end

--- a/railties/test/generators/generators_test_helper.rb
+++ b/railties/test/generators/generators_test_helper.rb
@@ -104,6 +104,14 @@ module GeneratorsTestHelper
     File.write File.join(destination, "compose.yaml"), compose_yaml
   end
 
+  def copy_solid_cache_migration
+    destination = File.join(destination_root, "db/cache/migrate")
+    mkdir_p(destination)
+
+    solid_cache_migration = File.read(File.expand_path("../fixtures/db/cache/migrate/20240821135818_create_solid_cache_entries.solid_cache.rb", __dir__))
+    File.write File.join(destination, "20240821135818_create_solid_cache_entries.solid_cache.rb"), solid_cache_migration
+  end
+
   def evaluate_template(file, locals = {})
     erb = ERB.new(File.read(file), trim_mode: "-", eoutvar: "@output_buffer")
     context = Class.new do
@@ -129,6 +137,11 @@ module GeneratorsTestHelper
     assert_file ".devcontainer/devcontainer.json" do |content|
       yield JSON.load(content)
     end
+  end
+
+  def assert_solid_cache_migration(here:, not_here:)
+    assert_file "#{here}/20240821135818_create_solid_cache_entries.solid_cache.rb"
+    assert_no_file "#{not_here}/20240821135818_create_solid_cache_entries.solid_cache.rb"
   end
 
   def run_app_update(app_root = destination_root, flags: "--force")

--- a/railties/test/generators/generators_test_helper.rb
+++ b/railties/test/generators/generators_test_helper.rb
@@ -144,6 +144,11 @@ module GeneratorsTestHelper
     assert_no_file "#{not_here}/20240821135818_create_solid_cache_entries.solid_cache.rb"
   end
 
+  def assert_no_solid_cache_migration
+    assert_no_file "db/migrate/20240821135818_create_solid_cache_entries.solid_cache.rb"
+    assert_no_file "db/cache/migrate/20240821135818_create_solid_cache_entries.solid_cache.rb"
+  end
+
   def run_app_update(app_root = destination_root, flags: "--force")
     Dir.chdir(app_root) do
       gemfile_contents = File.read("Gemfile")

--- a/railties/test/generators/plugin_generator_test.rb
+++ b/railties/test/generators/plugin_generator_test.rb
@@ -58,8 +58,10 @@ DEFAULT_PLUGIN_FILES = %w(
   test/dummy/config/locales/en.yml
   test/dummy/config/puma.rb
   test/dummy/config/routes.rb
+  test/dummy/config/solid_cache.yml
   test/dummy/config/storage.yml
   test/dummy/log/.keep
+  test/dummy/log/test.log
   test/dummy/public/404.html
   test/dummy/public/406-unsupported-browser.html
   test/dummy/public/422.html
@@ -68,6 +70,7 @@ DEFAULT_PLUGIN_FILES = %w(
   test/dummy/public/icon.svg
   test/dummy/storage/.keep
   test/dummy/tmp/.keep
+  test/dummy/tmp/local_secret.txt
   test/dummy/tmp/pids/.keep
   test/dummy/tmp/storage/.keep
   test/test_helper.rb


### PR DESCRIPTION
The defaults for the cache are pulled in from the [template](https://github.com/rails/solid_cache/blob/87fd0e9611237b5608b5e0f4197aec74fe333ca4/lib/generators/solid_cache/install/templates/config/solid_cache.yml.tt) in Solid Cache. Currently 1 week max age and 256MB max size.

Right now this sets up Solid Cache to be used in development and production - maybe we'd want to stick with a memory cache in development?

When using Sqlite, we'll use a separate database for the cache, with the migrations for that db going into `db/cache/migrate`. We then need to adjust the db change task to move the migrations if required.

For all databases we'll use a separate connection pool for the database even if it points to the primary database. This stops cache queries from being affected by primary database transactions.

As a result the `config/database.yml` templates have been converted to the three-tier format. We could keep the two-tier format when not using Solid Cache, but the templates would start to get messy.

Resolves #50443 cc @dhh 