### PR TITLE
This should not be in the codeblock

### DIFF
--- a/activesupport/lib/active_support/notifications.rb
+++ b/activesupport/lib/active_support/notifications.rb
@@ -36,8 +36,8 @@ module ActiveSupport
   #     event.allocations   # => 1826 (objects)
   #   end
   #
-  #  +Event+ objects record CPU time and allocations. If you don't need this
-  #  it's also possible to pass a block that accepts five arguments:
+  # +Event+ objects record CPU time and allocations. If you don't need this
+  # it's also possible to pass a block that accepts five arguments:
   #
   #   ActiveSupport::Notifications.subscribe('render') do |name, start, finish, id, payload|
   #     name    # => String, name of the event (such as 'render' from above)


### PR DESCRIPTION
Fix the following problem:

![Screenshot](https://github.com/user-attachments/assets/282bf449-b764-47b9-bd6e-b89319c1bb50)

Found on: https://edgeapi.rubyonrails.org/classes/ActiveSupport/Notifications.html