### PR TITLE
Fix missing deprecator error

### DIFF
--- a/activesupport/lib/active_support/deprecation/constant_accessor.rb
+++ b/activesupport/lib/active_support/deprecation/constant_accessor.rb
@@ -62,7 +62,7 @@ module ActiveSupport
           # called and the deprecation won't work as intended. This may happen,
           # for example, if an ancestor of the enclosing namespace has a
           # constant with the same name. This is an unsupported edge case.
-          def deprecate_constant(old_constant_name, new_constant_path, deprecator:, message: nil)
+          def deprecate_constant(old_constant_name, new_constant_path, deprecator: ActiveSupport::Deprecation.new, message: nil)
             class_variable_set(:@@_deprecated_constants, {}) unless class_variable_defined?(:@@_deprecated_constants)
             class_variable_get(:@@_deprecated_constants)[old_constant_name.to_s] = { new: new_constant_path, message: message, deprecator: deprecator }
           end


### PR DESCRIPTION
I was using the latest ruby 3.3.4
and I tried upgrading the rails version to 7.2.0 following https://guides.rubyonrails.org/upgrading_ruby_on_rails.html
after updating the version in gemfile, bundle install works fine and after that every command failing 
see the below screeshot for reference 

<img width="1727" alt="Screenshot 2024-08-22 at 12 20 38 AM" src="https://github.com/user-attachments/assets/3402deb8-a974-4a65-8f1b-d05f19feb4c8">

@fxn can you take a look if this fix work or let me know your thoughts so I can fix it on root level