### PR TITLE
Fix center alignment issue in guides blocks [ci skip]

### DIFF
--- a/guides/assets/stylesrc/_dark.scss
+++ b/guides/assets/stylesrc/_dark.scss
@@ -219,6 +219,8 @@
     } // #feature
 
     .interstitial {
+      display: flex;
+      align-items: center;
       &.code {
         background-color: $gray-900;
         border: 1px solid $gray-800 !important;
@@ -230,23 +232,21 @@
         border-color: $note-dark;
         background-color: $note-bkgnd-dark;
       }
-    
+
       &.info {
         border-color: $tip-dark;
         background-color: $tip-bkgnd-dark;
       }
-    
+
       &.warning {
         border-color: $stop-dark;
         background-color: $stop-bkgnd-dark;
       }
-    
+
       &.question {
         border-color: $gray-600;
         background-color: $gray-700;
       }
-    
-
-    }  
+    }
   } // body.guide
 } // @media (prefers-color-scheme: dark

--- a/guides/assets/stylesrc/print.scss
+++ b/guides/assets/stylesrc/print.scss
@@ -146,7 +146,8 @@
     }
 
     .interstitial {
-      
+      display: flex;
+      align-items: center;
       background-repeat: no-repeat !important;
       background-size: 36px 36px !important;
       background-position: 10px 10px !important;
@@ -154,20 +155,20 @@
       &.note {
         background-image: url("../images/icon_task-list-pin.svg") !important;
       }
-    
+
       &.work-in-progress,
       &.todo {
         background-image: url("../images/icon_construction-sign.svg") !important;
       }
-    
+
       &.info {
         background-image: url("../images/icon_bulb-1.svg") !important;
       }
-    
+
       &.warning {
         background-image: url("../images/icon_hand-stop.svg") !important;
       }
-    
+
       &.question {
         background-image: url("../images/icon_question-bubble.svg") !important;
       }
@@ -181,7 +182,7 @@
         border: none;
         font-size: 9.5pt !important;
       }
-      
+
       button {
         display: none;
       }


### PR DESCRIPTION
This PR will fix the center alignment issue with the tips and notes block in the guides

This will changes the below to look like 

<img width="1104" alt="Screenshot 2024-08-22 at 12 40 30 AM" src="https://github.com/user-attachments/assets/035abf0e-2378-4a90-81bb-f50931293bef">
<img width="1084" alt="Screenshot 2024-08-22 at 12 46 45 AM" src="https://github.com/user-attachments/assets/97a16bf6-f3bc-4c69-b539-c5640b8f9b0c">

To look like with fixed center alignment 

<img width="1001" alt="Screenshot 2024-08-22 at 12 39 38 AM" src="https://github.com/user-attachments/assets/ec292451-a9ff-438e-bf14-4e521c7a60f7">
<img width="1105" alt="Screenshot 2024-08-22 at 12 41 07 AM" src="https://github.com/user-attachments/assets/412243df-fa9c-4497-bcb0-872f1274a779">
