### PR TITLE
Fix ActiveRecord::Encryption::KeyProvider#encryption_key documentation [ci skip]

### DIFF
--- a/activerecord/lib/active_record/encryption/key_provider.rb
+++ b/activerecord/lib/active_record/encryption/key_provider.rb
@@ -12,7 +12,7 @@ module ActiveRecord
         @keys = Array(keys)
       end
 
-      # Returns the first key in the list as the active key to perform encryptions
+      # Returns the last key in the list as the active key to perform encryptions
       #
       # When +ActiveRecord::Encryption.config.store_key_references+ is true, the key will include
       # a public tag referencing the key itself. That key will be stored in the public


### PR DESCRIPTION
A one-word RDoc update. Per the [code](https://github.com/rails/rails/blob/9c8390032c85df23d973432b67d025df05c838f7/activerecord/lib/active_record/encryption/key_provider.rb#L21) and the [Rails guides](https://edgeguides.rubyonrails.org/active_record_encryption.html#rotating-keys), the _last_ key, not the first key, is used for encryption when the provider has multiple keys.