### PR TITLE
Support custom environments on bin/rails credentials:diff

### DIFF
--- a/railties/lib/rails/commands/credentials/credentials_command.rb
+++ b/railties/lib/rails/commands/credentials/credentials_command.rb
@@ -128,7 +128,11 @@ module Rails
         end
 
         def extract_environment_from_path(path)
-          available_environments.find { |env| path.end_with?("#{env}.yml.enc") }
+          available_environments.find { |env| path.end_with?("#{env}.yml.enc") } || extract_custom_environment(path)
+        end
+
+        def extract_custom_environment(path)
+          path =~ %r{config/credentials/(.+)\.yml\.enc} && $1
         end
     end
   end

--- a/railties/test/commands/credentials_test.rb
+++ b/railties/test/commands/credentials_test.rb
@@ -285,6 +285,20 @@ class Rails::Command::CredentialsTest < ActiveSupport::TestCase
     assert_match(raw_content, run_diff_command("config/credentials.yml.enc"))
   end
 
+  test "diff for custom environment" do
+    run_edit_command(environment: "custom")
+
+    assert_match(/access_key_id: 123/, run_diff_command("config/credentials/custom.yml.enc"))
+  end
+
+  test "diff for custom environment when key is not available" do
+    run_edit_command(environment: "custom")
+    remove_file "config/credentials/custom.key"
+
+    raw_content = File.read(app_path("config", "credentials", "custom.yml.enc"))
+    assert_match(raw_content, run_diff_command("config/credentials/custom.yml.enc"))
+  end
+
   test "diff returns raw encrypted content when errors occur" do
     run_edit_command(environment: "development")
 


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

In some cases/workflows, it may be useful to have credential files that don't match an environment name (`development`, `production`, `testing`). This is supported by all the `bin/rails credentials:*` tooling except `credentials:diff`, which shows the whole encrypted content of the file:

[on a new app]:

```
$ bin/rails credentials:edit --environment=my_custom_env
[lets me edit the yaml file and creates config/credentials/my_custom_env.yml.enc and .key]
$ bin/rails credentials:show --environment=my_custom_env
[shows its content again]
$ git add config/
$ bin/rails credentials:edit --environment=my_custom_env
[lets me edit again; I add a new key]
$ bin/rails credentials:show --environment=my_custom_env
[shows the right content, including the new key]
$ git diff config/credentials
[shows the encrypted garbage]
```

I've seen this was reported as #47570, although a workaround was found there. I think that, since it is supported in all tools but one, it makes sense to fix that one (of course maintainers decide if it _actually_ makes sense).

### Detail

This Pull Request changes the way the environment is looked up. In addition to the current lookup in the available environments, it adds a fallback and it returns the name of the file in the provided path. This is enough for the rest of the process to work correctly, and I successfully tested it on a new app, where the _"transcript"_ above can be reproduced, but getting a proper diff in the last step.

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included. **<-- I guess this qualifies as a minor fix so I didn't update it. Please let me know if I should**
