### PR TITLE
Allow `URI::RFC3986_PARSER` warnings

### DIFF
--- a/activesupport/lib/active_support/testing/strict_warnings.rb
+++ b/activesupport/lib/active_support/testing/strict_warnings.rb
@@ -14,6 +14,9 @@ module ActiveSupport
       # Expected non-verbose warning emitted by Rails.
       /Ignoring .*\.yml because it has expired/,
       /Failed to validate the schema cache because/,
+
+      # TODO: Can be removed if https://github.com/ruby/uri/issues/118 is addressed
+      /URI::RFC3986_PARSER/,
     )
 
     SUPPRESSED_WARNINGS = Regexp.union(


### PR DESCRIPTION
### Motivation / Background

This pull request allows `URI::RFC3986_PARSER` warnings appeared since https://buildkite.com/rails/rails-nightly/builds/931

### Detail
This commit allows the warning below and let Rails CI against Ruby master branch run.

```ruby
$ RAILS_STRICT_WARNINGS=1 bin/test test/abstract/callbacks_test.rb
/home/yahonda/src/github.com/rails/rails/actionpack/lib/action_dispatch/routing/mapper.rb:2063: warning: URI::RFC3986_PARSER.escape is obsoleted. Use URI::RFC2396_PARSER.escape explicitly.
/home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/testing/strict_warnings.rb:35:in 'ActiveSupport::RaiseWarnings#warn': /home/yahonda/src/github.com/rails/rails/actionpack/lib/action_dispatch/routing/mapper.rb:2063: warning: URI::RFC3986_PARSER.escape is obsoleted. Use URI::RFC2396_PARSER.escape explicitly. (ActiveSupport::RaiseWarnings::WarningError)
        from <internal:warning>:54:in 'Kernel#warn'
        from /home/yahonda/.rbenv/versions/trunk/lib/ruby/3.4.0+0/uri/rfc3986_parser.rb:156:in 'URI::RFC3986_Parser#escape'
        from /home/yahonda/src/github.com/rails/rails/actionpack/lib/action_dispatch/routing/mapper.rb:2063:in 'ActionDispatch::Routing::Mapper::Resources#add_route'
        from /home/yahonda/src/github.com/rails/rails/actionpack/lib/action_dispatch/routing/mapper.rb:2038:in 'ActionDispatch::Routing::Mapper::Resources#decomposed_match'
        from /home/yahonda/src/github.com/rails/rails/actionpack/lib/action_dispatch/routing/mapper.rb:2002:in 'block in ActionDispatch::Routing::Mapper::Resources#map_match'
        from <internal:array>:53:in 'Array#each'
        from /home/yahonda/src/github.com/rails/rails/actionpack/lib/action_dispatch/routing/mapper.rb:1996:in 'ActionDispatch::Routing::Mapper::Resources#map_match'
        from /home/yahonda/src/github.com/rails/rails/actionpack/lib/action_dispatch/routing/mapper.rb:1739:in 'ActionDispatch::Routing::Mapper::Resources#match'
        from /home/yahonda/src/github.com/rails/rails/actionpack/lib/action_dispatch/routing/mapper.rb:798:in 'ActionDispatch::Routing::Mapper::HttpHelpers#map_method'
        from /home/yahonda/src/github.com/rails/rails/actionpack/lib/action_dispatch/routing/mapper.rb:741:in 'ActionDispatch::Routing::Mapper::HttpHelpers#get'
        from /home/yahonda/src/github.com/rails/rails/actionpack/test/abstract_unit.rb:71:in 'block (2 levels) in <top (required)>'
        from /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/deprecation/reporting.rb:43:in 'ActiveSupport::Deprecation::Reporting#silence'
        from /home/yahonda/src/github.com/rails/rails/actionpack/test/abstract_unit.rb:70:in 'block in <top (required)>'
        from /home/yahonda/src/github.com/rails/rails/actionpack/lib/action_dispatch/routing/route_set.rb:479:in 'BasicObject#instance_exec'
        from /home/yahonda/src/github.com/rails/rails/actionpack/lib/action_dispatch/routing/route_set.rb:479:in 'ActionDispatch::Routing::RouteSet#eval_block'
        from /home/yahonda/src/github.com/rails/rails/actionpack/lib/action_dispatch/routing/route_set.rb:461:in 'ActionDispatch::Routing::RouteSet#draw'
        from /home/yahonda/src/github.com/rails/rails/actionpack/test/abstract_unit.rb:69:in '<top (required)>'
        from /home/yahonda/.rbenv/versions/trunk/lib/ruby/3.4.0+0/bundled_gems.rb:75:in 'Kernel.require'
        from /home/yahonda/.rbenv/versions/trunk/lib/ruby/3.4.0+0/bundled_gems.rb:75:in 'block (2 levels) in Kernel#replace_require'
        from /home/yahonda/src/github.com/rails/rails/actionpack/test/abstract/callbacks_test.rb:3:in '<top (required)>'
        from /home/yahonda/.rbenv/versions/trunk/lib/ruby/3.4.0+0/bundled_gems.rb:75:in 'Kernel.require'
        from /home/yahonda/.rbenv/versions/trunk/lib/ruby/3.4.0+0/bundled_gems.rb:75:in 'block (2 levels) in Kernel#replace_require'
        from /home/yahonda/src/github.com/rails/rails/railties/lib/rails/test_unit/runner.rb:62:in 'block in Rails::TestUnit::Runner.load_tests'
        from <internal:array>:53:in 'Array#each'
        from /home/yahonda/src/github.com/rails/rails/railties/lib/rails/test_unit/runner.rb:60:in 'Rails::TestUnit::Runner.load_tests'
        from /home/yahonda/src/github.com/rails/rails/railties/lib/rails/test_unit/runner.rb:52:in 'Rails::TestUnit::Runner.run'
        from /home/yahonda/src/github.com/rails/rails/tools/test.rb:18:in '<top (required)>'
        from bin/test:5:in 'Kernel#require_relative'
        from bin/test:5:in '<main>'
$
```

### Additional information
This warning has been implemented to Ruby master branch via https://github.com/ruby/ruby/commit/b41d79962abefbe8b70d76dee134b44a3a3d3929 and the original pull request for URI is https://github.com/ruby/uri/pull/114

We are not able to just replace `URI::DEFAULT_PARSER` with `URI::RFC2396_PARSER` because `URI::RFC2396_PARSER` gets `uninitialized constant URI::RFC2396_PARSER (NameError)` with Ruby 3.3.4 as reported https://github.com/ruby/uri/issues/118

We can revert this commit and replace `URI::DEFAULT_PARSER` with `URI::RFC2396_PARSER` once `URI::RFC2396_PARSER` is available for uri bundled with Ruby 3.3.4 or older versions.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.