### PR TITLE
ActiveSupport::ErrorReporter#report assigns a backtrace to unraised exceptions

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   `ActiveSupport::ErrorReporter#report` now assigns a backtrace to unraised exceptions.
+
+    Previously reporting an un-raised exception would result in an error report without
+    a backtrace. Now it automatically generates one.
+
+    *Jean Boussier*
+
 *   Add `escape_html_entities` option to `ActiveSupport::JSON.encode`.
 
     This allows for overriding the global configuration found at

--- a/activesupport/test/error_reporter_test.rb
+++ b/activesupport/test/error_reporter_test.rb
@@ -161,6 +161,16 @@ class ErrorReporterTest < ActiveSupport::TestCase
     assert_equal [[error, false, :error, "application", {}]], @subscriber.events
   end
 
+  test "#report assigns a backtrace if it's missing" do
+    error = RuntimeError.new("Oops")
+    assert_nil error.backtrace
+    assert_nil error.backtrace_locations
+
+    assert_nil @reporter.report(error)
+    assert_not_predicate error.backtrace, :empty?
+    assert_not_predicate error.backtrace_locations, :empty?
+  end
+
   test "#record passes through the return value" do
     result = @reporter.record do
       2 + 2
@@ -173,6 +183,7 @@ class ErrorReporterTest < ActiveSupport::TestCase
     assert_nil @reporter.unexpected(error)
     assert_equal [[error, true, :warning, "application", {}]], @subscriber.events
     assert_not_predicate error.backtrace, :empty?
+    assert_not_predicate error.backtrace_locations, :empty?
   end
 
   test "#unexpected accepts an error message" do


### PR DESCRIPTION
Previously reporting an un-raised exception would result in an error report without a backtrace. Now it automatically generates one.
