### PR TITLE
Unpin sqlite3 version in bug_report_templates

### DIFF
--- a/guides/bug_report_templates/action_mailbox.rb
+++ b/guides/bug_report_templates/action_mailbox.rb
@@ -9,7 +9,7 @@ gemfile(true) do
   # If you want to test against edge Rails replace the previous line with this:
   # gem "rails", github: "rails/rails", branch: "main"
 
-  gem "sqlite3", "~> 1.4"
+  gem "sqlite3"
 end
 
 require "active_record/railtie"

--- a/guides/bug_report_templates/active_record.rb
+++ b/guides/bug_report_templates/active_record.rb
@@ -9,7 +9,7 @@ gemfile(true) do
   # If you want to test against edge Rails replace the previous line with this:
   # gem "rails", github: "rails/rails", branch: "main"
 
-  gem "sqlite3", "~> 1.4"
+  gem "sqlite3"
 end
 
 require "active_record"

--- a/guides/bug_report_templates/active_record_migrations.rb
+++ b/guides/bug_report_templates/active_record_migrations.rb
@@ -9,7 +9,7 @@ gemfile(true) do
   # If you want to test against edge Rails replace the previous line with this:
   # gem "rails", github: "rails/rails", branch: "main"
 
-  gem "sqlite3", "~> 1.4"
+  gem "sqlite3"
 end
 
 require "active_record"

--- a/guides/bug_report_templates/active_storage.rb
+++ b/guides/bug_report_templates/active_storage.rb
@@ -9,7 +9,7 @@ gemfile(true) do
   # If you want to test against edge Rails replace the previous line with this:
   # gem "rails", github: "rails/rails", branch: "main"
 
-  gem "sqlite3", "~> 1.4"
+  gem "sqlite3"
 end
 
 require "active_record/railtie"


### PR DESCRIPTION
Reverts #51591 as it is not necessary anymore.

All the Rails currently supported versions (>= 7.1 as of now) support `sqlite3` 2.0, while edge Rails requires `sqlite3` 2.0 or higher.