### PR TITLE
Require testing/parallelize_executor in testing/isolation

### DIFF
--- a/activesupport/lib/active_support/testing/isolation.rb
+++ b/activesupport/lib/active_support/testing/isolation.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "active_support/testing/parallelize_executor"
+
 module ActiveSupport
   module Testing
     module Isolation


### PR DESCRIPTION
The constant is referred to by this file but might not be loaded.

### Motivation / Background

We have a gem that is failing under 7.2 but wasn't under 7.1: https://github.com/Shopify/packwerk/actions/runs/10525069080/job/29163071387

It comes from 28997e4cda4cf759ba57abc559c809dbcef7cb70 which added a reference to the constant without loading it.

