### PR TITLE
Remove redundant requires

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -255,6 +255,9 @@ Lint/RedundantCopDisableDirective:
 Lint/RedundantCopEnableDirective:
   Enabled: true
 
+Lint/RedundantRequireStatement:
+  Enabled: true
+
 Lint/RedundantStringCoercion:
   Enabled: true
 

--- a/actionview/lib/action_view/renderer/streaming_template_renderer.rb
+++ b/actionview/lib/action_view/renderer/streaming_template_renderer.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "fiber"
 
 module ActionView
   # == TODO

--- a/actionview/lib/action_view/template.rb
+++ b/actionview/lib/action_view/template.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "thread"
 require "delegate"
 
 module ActionView

--- a/actionview/lib/action_view/template/resolver.rb
+++ b/actionview/lib/action_view/template/resolver.rb
@@ -4,7 +4,6 @@ require "pathname"
 require "active_support/core_ext/class"
 require "active_support/core_ext/module/attribute_accessors"
 require "action_view/template"
-require "thread"
 require "concurrent/map"
 
 module ActionView

--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_handler.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_handler.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "thread"
 require "concurrent/map"
 
 module ActiveRecord

--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "thread"
 require "concurrent/map"
 require "monitor"
 

--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool/queue.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool/queue.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "thread"
 require "monitor"
 
 module ActiveRecord

--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool/reaper.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool/reaper.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "thread"
 require "weakref"
 
 module ActiveRecord

--- a/activerecord/test/cases/locking_test.rb
+++ b/activerecord/test/cases/locking_test.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "thread"
 require "cases/helper"
 require "models/person"
 require "models/job"

--- a/activesupport/lib/active_support/callbacks.rb
+++ b/activesupport/lib/active_support/callbacks.rb
@@ -6,7 +6,6 @@ require "active_support/core_ext/array/extract_options"
 require "active_support/core_ext/class/attribute"
 require "active_support/core_ext/string/filters"
 require "active_support/core_ext/object/blank"
-require "thread"
 
 module ActiveSupport
   # = Active Support \Callbacks

--- a/activesupport/lib/active_support/concurrency/share_lock.rb
+++ b/activesupport/lib/active_support/concurrency/share_lock.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "thread"
 require "monitor"
 
 module ActiveSupport

--- a/activesupport/lib/active_support/isolated_execution_state.rb
+++ b/activesupport/lib/active_support/isolated_execution_state.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "fiber"
 
 module ActiveSupport
   module IsolatedExecutionState # :nodoc:

--- a/activesupport/lib/active_support/testing/isolation.rb
+++ b/activesupport/lib/active_support/testing/isolation.rb
@@ -5,8 +5,6 @@ require "active_support/testing/parallelize_executor"
 module ActiveSupport
   module Testing
     module Isolation
-      require "thread"
-
       SubprocessCrashed = Class.new(StandardError)
 
       def self.included(klass) # :nodoc:

--- a/activesupport/test/dependencies_test.rb
+++ b/activesupport/test/dependencies_test.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require_relative "abstract_unit"
-require "pp"
 require "active_support/dependencies"
 
 module ModuleWithMissing

--- a/guides/source/initialization.md
+++ b/guides/source/initialization.md
@@ -348,7 +348,6 @@ module Rack
 
       if options[:debug]
         $DEBUG = true
-        require "pp"
         p options[:server]
         pp wrapped_app
         pp app

--- a/railties/lib/rails/engine.rb
+++ b/railties/lib/rails/engine.rb
@@ -6,7 +6,6 @@ require "active_support/callbacks"
 require "active_support/core_ext/module/delegation"
 require "active_support/core_ext/object/try"
 require "pathname"
-require "thread"
 
 module Rails
   # +Rails::Engine+ allows you to wrap a specific \Rails application or subset of


### PR DESCRIPTION
I noticed a `require "thread"` in https://github.com/rails/rails/blob/0794abb6bb95f0904cb0a6a605ddb24863aa809e/activesupport/lib/active_support/testing/isolation.rb#L6

And it's no longer necessary, it's always loaded since Ruby 2.1 apparently.

So I thought I'd enable the lint and apply the fixes.