### PR TITLE
Ensure callbacks run on counter_cache increment

### DIFF
--- a/activerecord/lib/active_record/associations/belongs_to_association.rb
+++ b/activerecord/lib/active_record/associations/belongs_to_association.rb
@@ -112,7 +112,9 @@ module ActiveRecord
 
         def update_counters_via_scope(klass, foreign_key, by)
           scope = klass.unscoped.where!(primary_key(klass) => foreign_key)
-          scope.update_counters(reflection.counter_cache_column => by, touch: reflection.options[:touch])
+          scope.each do |record|
+            record.increment!(reflection.counter_cache_column, by, touch: reflection.options[:touch])
+          end
         end
 
         def find_target?

--- a/activerecord/test/cases/associations/belongs_to_associations_test.rb
+++ b/activerecord/test/cases/associations/belongs_to_associations_test.rb
@@ -762,7 +762,7 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
     debate.touch(time: time)
     debate2.touch(time: time)
 
-    assert_queries_count(5) do
+    assert_queries_count(7) do
       reply.parent_title = "debate"
       reply.save!
     end
@@ -773,7 +773,7 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
     debate.touch(time: time)
     debate2.touch(time: time)
 
-    assert_queries_count(5) do
+    assert_queries_count(6) do
       reply.topic_with_primary_key = debate2
       reply.save!
     end


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created because there are inconsistencies with touch when `counter_cache` is used. Fixes #52646 

### Detail

This Pull Request changes how we run touch callbacks when `counter_cache` is used. Currently there is lots of inconsistency in how `after_touch` works when a model uses `counter_cache` as noted in the issue script. Example: `ProjectItem.first.destroy!` does not work but `project.project_items.first.destroy!` works.

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

As mentioned on the issue, there has been a few attempts to cover this, it looks like the preferred way is to use `increment!` based on this [commit](https://github.com/rails/rails/commit/17bf62033edd4f0934c9f4a9e0c7a5f0f765975b). This was reverted due to the additional queries [here](https://github.com/rails/rails/commit/52e11e462f6114a4d12225c639c5f501f0ffec7a) but i don't think we're able to avoid the additional queries. 

Alternative solution could be to change `update_counters` to `load_target if reflection.options[:touch]` as it appears target is nil when using `counter_cache`.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
