### PR TITLE
Strip encrypted file contents

### DIFF
--- a/activesupport/lib/active_support/encrypted_file.rb
+++ b/activesupport/lib/active_support/encrypted_file.rb
@@ -69,7 +69,7 @@ module ActiveSupport
     #   decrypted or verified.
     def read
       if !key.nil? && content_path.exist?
-        decrypt content_path.binread
+        decrypt content_path.binread.strip
       else
         raise MissingContentError, content_path
       end


### PR DESCRIPTION
### Motivation / Background

If you accidentally add a newline to the end of an encrypted file (like Rails credentials), the content file will fail to decrypt. This is an easy mistake to introduce through your text editor or a git merge. Mine happened in a git merge on accident somehow.

I ran into this today and have seen a good handful of people run into this on [Reddit](https://www.reddit.com/r/rails/comments/1djus6u/rails_7_credentialsymlenc_has_broken_between/), Discord, etc. Debugging this can be tough because:

1. A rogue newline can be hard to spot.
2. you can copy paste the key and/or content file from GitHub to try and figure out what's going on, but your editor might introduce a new line causing it to always fail.
3. The error message is generic so you won't expect that it's a newline causing the issue.

```
/Users/chris/.local/share/mise/installs/ruby/3.3.4/lib/ruby/gems/3.3.0/gems/activesupport-7.2.0/lib/active_support/messages/codec.rb:57:in `catch_and_raise': missing separator (ActiveSupport::MessageEncryptor::InvalidMessage)
	from /Users/chris/.local/share/mise/installs/ruby/3.3.4/lib/ruby/gems/3.3.0/gems/activesupport-7.2.0/lib/active_support/message_encryptor.rb:242:in `decrypt_and_verify'
	from /Users/chris/.local/share/mise/installs/ruby/3.3.4/lib/ruby/gems/3.3.0/gems/activesupport-7.2.0/lib/active_support/encrypted_file.rb:109:in `decrypt'
	from /Users/chris/.local/share/mise/installs/ruby/3.3.4/lib/ruby/gems/3.3.0/gems/activesupport-7.2.0/lib/active_support/encrypted_file.rb:72:in `read'
	from /Users/chris/.local/share/mise/installs/ruby/3.3.4/lib/ruby/gems/3.3.0/gems/activesupport-7.2.0/lib/active_support/encrypted_configuration.rb:57:in `read'
	from /Users/chris/.local/share/mise/installs/ruby/3.3.4/lib/ruby/gems/3.3.0/gems/railties-7.2.0/lib/rails/commands/credentials/credentials_command.rb:38:in `show'
```

### Detail

This Pull Request strips the content file as well after reading to make sure it can be decrypted successfully.

### Additional information

The key file already reads and strips the contents of the file. This makes it consistent for the content file read as well.

https://github.com/rails/rails/blob/92e9b23472ac1ef642348b74564af85b24427078/activesupport/lib/active_support/encrypted_file.rb#L122

I didn't add a test for this since it's fixing a fairly uncommon edge case but it might be worth adding one.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.