### PR TITLE
Add :row_count in cached sql.active_record payload

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb
@@ -266,7 +266,7 @@ module ActiveRecord
           if result
             ActiveSupport::Notifications.instrument(
               "sql.active_record",
-              cache_notification_info(sql, name, binds)
+              cache_notification_info_result(sql, name, binds, result)
             )
           end
 
@@ -288,11 +288,17 @@ module ActiveRecord
           if hit
             ActiveSupport::Notifications.instrument(
               "sql.active_record",
-              cache_notification_info(sql, name, binds)
+              cache_notification_info_result(sql, name, binds, result)
             )
           end
 
           result.dup
+        end
+
+        def cache_notification_info_result(sql, name, binds, result)
+          payload = cache_notification_info(sql, name, binds)
+          payload[:row_count] = result.length
+          payload
         end
 
         # Database adapters can override this method to


### PR DESCRIPTION
Previously in #50887 we added `:row_count` to the instrumentation payload for sql.active_record, but only for uncached queries. This adds the same information on queries which are cached.