### PR TITLE
Dump schema only once after database prepare

### DIFF
--- a/railties/test/application/rake/multi_dbs_test.rb
+++ b/railties/test/application/rake/multi_dbs_test.rb
@@ -556,7 +556,6 @@ module ApplicationTests
           end
         MIGRATION
 
-
         Dir.chdir(app_path) do
           rails "db:migrate:up:primary", "VERSION=01_one_migration.rb"
           rails "db:migrate:up:primary", "VERSION=03_three_migration.rb"
@@ -592,6 +591,46 @@ module ApplicationTests
           output = rails "db:prepare"
           entries = output.scan(/^== (\d+).+migrated/).map(&:first).map(&:to_i)
           assert_equal [1, 2, 3, 4] * 2, entries # twice because for test env too
+        end
+      end
+
+      test "db:prepare only dumps schema for migrated databases" do
+        require "#{app_path}/config/environment"
+        app_file "db/migrate/01_one_migration.rb", <<-MIGRATION
+          class OneMigration < ActiveRecord::Migration::Current
+          end
+        MIGRATION
+
+        app_file "db/animals_migrate/02_two_migration.rb", <<-MIGRATION
+          class TwoMigration < ActiveRecord::Migration::Current
+          end
+        MIGRATION
+
+        primary_mtime = nil
+        animals_mtime = nil
+
+        Dir.chdir(app_path) do
+          # Run the first two migrations to get the schema files.
+          rails "db:prepare"
+
+          assert File.exist?("db/schema.rb")
+          assert File.exist?("db/animals_schema.rb")
+
+          primary_mtime = File.mtime("db/schema.rb")
+          animals_mtime = File.mtime("db/animals_schema.rb")
+        end
+
+        app_file "db/animals_migrate/03_three_migration.rb", <<-MIGRATION
+          class ThreeMigration < ActiveRecord::Migration::Current
+          end
+        MIGRATION
+
+        Dir.chdir(app_path) do
+          # Run the new migration and assert that only the animals schema was updated.
+          rails "db:prepare"
+
+          assert_equal primary_mtime, File.mtime("db/schema.rb")
+          assert_not_equal animals_mtime, File.mtime("db/animals_schema.rb")
         end
       end
 


### PR DESCRIPTION
### Motivation / Background

After upgrading to Rails 7.1.4, we noticed `rails db:prepare` start to take really long time. After some investigation, I found that [this change](https://github.com/rails/rails/pull/52506) changes the behavior of migrations to dump the schema after every single migration version instead of the previous behavior of one schema dump at the very end of the migration process. I brought it up here:
https://github.com/rails/rails/pull/52506#discussion_r1729520500

### Detail

This PR changes makes it so the schema dump happens once at the end and only for the databases that ran migrations. I plan to backport this to Rails 7.1 as well.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
