### PR TITLE
Resolve model attribute types on schema load

### DIFF
--- a/activerecord/lib/active_record/model_schema.rb
+++ b/activerecord/lib/active_record/model_schema.rb
@@ -596,8 +596,6 @@ module ActiveRecord
           @columns_hash = columns_hash.freeze
 
           _default_attributes # Precompute to cache DB-dependent attribute types
-
-          super
         end
 
         # Guesses the table name, but does not decorate it with prefix and suffix information.

--- a/activerecord/lib/active_record/model_schema.rb
+++ b/activerecord/lib/active_record/model_schema.rb
@@ -595,6 +595,8 @@ module ActiveRecord
           columns_hash = columns_hash.except(*ignored_columns) unless ignored_columns.empty?
           @columns_hash = columns_hash.freeze
 
+          _default_attributes # Precompute to cache DB-dependent attribute types
+
           super
         end
 

--- a/activerecord/test/cases/enum_test.rb
+++ b/activerecord/test/cases/enum_test.rb
@@ -1157,15 +1157,28 @@ class EnumTest < ActiveRecord::TestCase
   end
 
   test "raises for attributes with undeclared type" do
-    klass = Class.new(Book) do
-      def self.name; "Book"; end
-      enum :typeless_genre, [:adventure, :comic]
+    klass = assert_deprecated(ActiveRecord.deprecator) do
+      Class.new(Book) do
+        def self.name; "Book"; end
+        enum typeless_genre: [:adventure, :comic]
+      end
     end
 
     error = assert_raises(RuntimeError) do
-      klass.type_for_attribute(:typeless_genre) # load schema
+      klass.type_for_attribute(:typeless_genre)
     end
-    assert_match "Unknown enum attribute 'typeless_genre'", error.message
+    assert_match "Undeclared attribute type for enum 'typeless_genre' in Book", error.message
+  end
+
+  test "supports attributes declared with a explicit type" do
+    klass = assert_deprecated(ActiveRecord.deprecator) do
+      Class.new(Book) do
+        attribute :my_genre, :integer
+        enum my_genre: [:adventure, :comic]
+      end
+    end
+
+    assert_equal :integer, klass.type_for_attribute(:my_genre).type
   end
 
   test "default methods can be disabled by :_instance_methods" do

--- a/railties/test/application/test_test.rb
+++ b/railties/test/application/test_test.rb
@@ -335,11 +335,14 @@ Expected: ["id", "name"]
 
       app_file "app/models/user.rb", <<-RUBY
         class User < ApplicationRecord
-          enum :type, [:admin, :user]
+          def self.load_schema!
+            super
+            raise "SCHEMA LOADED!"
+          end
         end
       RUBY
 
-      assert_unsuccessful_run "models/user_test.rb", "Unknown enum attribute 'type' for User"
+      assert_unsuccessful_run "models/user_test.rb", "SCHEMA LOADED!"
     end
 
     test "database-dependent attribute types are resolved when parallel tests are run in eager load context" do

--- a/railties/test/application/test_test.rb
+++ b/railties/test/application/test_test.rb
@@ -342,6 +342,46 @@ Expected: ["id", "name"]
       assert_unsuccessful_run "models/user_test.rb", "Unknown enum attribute 'type' for User"
     end
 
+    test "database-dependent attribute types are resolved when parallel tests are run in eager load context" do
+      use_postgresql
+      rails "db:drop", "db:create"
+
+      output = rails("generate", "model", "user")
+      version = output.match(/(\d+)_create_users\.rb/)[1]
+
+      app_file "db/schema.rb", <<~RUBY
+        ActiveRecord::Schema.define(version: #{version}) do
+          create_enum "user_favorite_color", ["red", "green", "blue"]
+
+          create_table :users do |t|
+            t.enum :favorite_color, enum_type: :user_favorite_color
+          end
+        end
+      RUBY
+
+      app_file "config/initializers/enable_eager_load.rb", <<~RUBY
+        Rails.application.config.eager_load = true
+      RUBY
+
+      app_file "test/models/user_test.rb", <<~RUBY
+        require "test_helper"
+        class UserTest < ActiveSupport::TestCase
+          ENV.delete("PARALLEL_WORKERS")
+          parallelize threshold: 1, workers: 2
+
+          2.times do |i|
+            test "favorite_color uses database type (worker \#{i})" do
+              assert_instance_of ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Enum, User.type_for_attribute("favorite_color")
+            end
+          end
+        end
+      RUBY
+
+      assert_successful_test_run "models/user_test.rb"
+    ensure
+      rails "db:drop" rescue nil
+    end
+
     private
       def assert_unsuccessful_run(name, message)
         result = run_test_file(name)


### PR DESCRIPTION
This PR contains two commits.  The 1st commit resolves model attribute types on schema load, fixing #52607, as explained below.  The 2nd commit re-applies #49769 which was previously reverted due to #52607.

When running tests in parallel, a new database is created for each test worker ([via `ActiveRecord::TestDatabases.create_and_load_schema`](https://github.com/rails/rails/blob/ec667e5f114df58087493096253541f1034815af/activerecord/lib/active_record/test_databases.rb)).  Each of these databases use different OID numbers for custom defined types such as enums.  If model schemas are loaded before forking — as done [in `railties/lib/rails/testing/maintain_test_schema.rb`](https://github.com/rails/rails/blob/ec667e5f114df58087493096253541f1034815af/railties/lib/rails/testing/maintain_test_schema.rb#L11-L15) when `eager_load` is true — Rails will hold on to the OID numbers from the original database.  Thus each test worker does not recognize the OID numbers when resolving model attribute types.

This commit sidesteps the problem by resolving model attribute types on schema load.  This does not address the conflicting OID numbers, but each test worker will inherit properly resolved attribute types.

Fixes #52607.
Fixes #49717.

/cc @rafaelfranca since you were handling #52607.