### PR TITLE
Fix Devcontainer generator with --dev option path error

### DIFF
--- a/railties/lib/rails/generators.rb
+++ b/railties/lib/rails/generators.rb
@@ -61,6 +61,10 @@ module Rails
       }
     }
 
+    # We need to store the RAILS_DEV_PATH in a constant, otherwise the path
+    # can change when we FileUtils.cd.
+    RAILS_DEV_PATH = File.expand_path("../../..", __dir__) # :nodoc:
+
     class << self
       def configure!(config) # :nodoc:
         api_only! if config.api_only

--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -283,10 +283,6 @@ module Rails
   end
 
   module Generators
-    # We need to store the RAILS_DEV_PATH in a constant, otherwise the path
-    # can change in Ruby 1.8.7 when we FileUtils.cd.
-    RAILS_DEV_PATH = File.expand_path("../../../../../..", __dir__)
-
     class AppGenerator < AppBase
       # :stopdoc:
 

--- a/railties/test/generators/devcontainer_generator_test.rb
+++ b/railties/test/generators/devcontainer_generator_test.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require "generators/generators_test_helper"
+require "rails/generators/rails/devcontainer/devcontainer_generator"
+
+module Rails
+  module Generators
+    class DevcontainerGeneratorTest < Rails::Generators::TestCase
+      include GeneratorsTestHelper
+
+      def test_generates_devcontainer_files
+        run_generator
+
+        assert_file ".devcontainer/compose.yaml"
+        assert_file ".devcontainer/Dockerfile"
+        assert_file ".devcontainer/devcontainer.json"
+      end
+
+      def test_default_json_has_no_mounts
+        run_generator
+
+        assert_devcontainer_json_file do |devcontainer_config|
+          assert_nil devcontainer_config["mounts"]
+        end
+      end
+
+      def test_dev_option_devcontainer_json_mounts_local_rails
+        run_generator ["--dev"]
+
+        assert_devcontainer_json_file do |devcontainer_json|
+          mounts = devcontainer_json["mounts"].sole
+
+          assert_equal "bind", mounts["type"]
+          assert_equal Rails::Generators::RAILS_DEV_PATH, mounts["source"]
+          assert_equal Rails::Generators::RAILS_DEV_PATH, mounts["target"]
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Motivation / Background
Fixes #52704 

This Pull Request has been created because the devcontainer generator with the --dev option fails (`rails g devcontainer --dev`).  The app generator --dev works just fine.

### Detail

This Pull request moves the `Rails::Generators::RAILS_DEV_PATH` definition to Rails::Generators module rather than adding it to Rails::Generators in AppGenerator definition. It also creates a DEV_RAILS_PATH constant in `railties/test/generators/generators_test_helper.rb`, so that it can be used consistently in tests.

### Additional information

- I added a generator test file, it seems the generator is not tested for the `rails generate` usage, though it is well tested via app generator. I added tests for the dev option behavior only. I can work on full specs, but will keep it separate from this.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
