### PR TITLE
Rename `CodeStatistics.add_directory` to `CodeStatistics.register_directory`

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,13 +1,13 @@
 *   Deprecate `::STATS_DIRECTORIES`.
 
     The global constant `STATS_DIRECTORIES` has been deprecated in favor of
-    `Rails::CodeStatistics.add_directory`.
+    `Rails::CodeStatistics.register_directory`.
 
-    Add extra directories with `Rails::CodeStatistics.add_directory(label, path)`:
+    Add extra directories with `Rails::CodeStatistics.register_directory(label, path)`:
 
     ```ruby
     require "rails/code_statistics"
-    Rails::CodeStatistics.add_directory('My Directory', 'path/to/dir')
+    Rails::CodeStatistics.register_directory('My Directory', 'path/to/dir')
     ```
 
     *Petrik de Heus*

--- a/railties/lib/rails/code_statistics.rb
+++ b/railties/lib/rails/code_statistics.rb
@@ -46,8 +46,8 @@ module Rails
 
     # Add directories to the output of the `bin/rails stats` command.
     #
-    #   Rails::CodeStatistics.add_directory("My Directory", "path/to/dir")
-    def self.add_directory(label, path)
+    #   Rails::CodeStatistics.register_directory("My Directory", "path/to/dir")
+    def self.register_directory(label, path)
       self.directories << [label, path]
     end
 

--- a/railties/lib/rails/tasks/statistics.rake
+++ b/railties/lib/rails/tasks/statistics.rake
@@ -3,7 +3,7 @@
 require "rails/code_statistics"
 STATS_DIRECTORIES = ActiveSupport::Deprecation::DeprecatedObjectProxy.new(
   Rails::CodeStatistics::DIRECTORIES,
-  "`STATS_DIRECTORIES` is deprecated and will be removed in Rails 8.1! Use `Rails::CodeStatistics.add_directory('My Directory', 'path/to/dir)` instead.",
+  "`STATS_DIRECTORIES` is deprecated and will be removed in Rails 8.1! Use `Rails::CodeStatistics.register_directory('My Directory', 'path/to/dir)` instead.",
   Rails.deprecator
 )
 

--- a/railties/test/commands/stats_test.rb
+++ b/railties/test/commands/stats_test.rb
@@ -13,7 +13,7 @@ class Rails::Command::StatsTest < ActiveSupport::TestCase
 
     app_file "config/initializers/custom.rb", <<~CODE
       require "rails/code_statistics"
-      Rails::CodeStatistics.add_directory("Custom dir", "custom/dir")
+      Rails::CodeStatistics.register_directory("Custom dir", "custom/dir")
     CODE
 
     output = rails "stats"
@@ -23,7 +23,7 @@ class Rails::Command::StatsTest < ActiveSupport::TestCase
   test "`bin/rails stats` handles non-existing directories added by third parties" do
     app_file "config/initializers/custom.rb", <<~CODE
       require "rails/code_statistics"
-      Rails::CodeStatistics.add_directory("Non Existing", "app/non_existing")
+      Rails::CodeStatistics.register_directory("Non Existing", "app/non_existing")
     CODE
 
     output = rails "stats"


### PR DESCRIPTION
`register_*` seems a more common pattern in Rails, especially for third party hooks. For example:

    Rails::SourceAnnotationExtractor::Annotation.register_directories("spec", "another")

Other examples:

    ActionMailer::Base.register_preview_interceptor
    MimeType.register
    MimeType.register_alias
    ActiveModel::Type.register

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
