### PR TITLE
feat: Add `where.exists_with` methods

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -210,4 +210,12 @@
 
     *Eileen M. Uchitelle*
 
+*   Add `where.exists_with` to fetch records with atleast one associated entity
+
+    ```ruby
+    Post.where.exists_with(:author)
+    ```
+
+    *InbaKrish*
+
 Please check [7-2-stable](https://github.com/rails/rails/blob/7-2-stable/activerecord/CHANGELOG.md) for previous changes.


### PR DESCRIPTION
To filter parent model records, with any one child associated with it by semi-joins between parent and children

### Motivation / Background

To optimize the performance when filtering parent model records based on the presence of associated records, we propose using semi-joins instead of full joins. Typically, we rely on methods like `where.associated` and `where.missing`, which utilize `JOIN` clauses. However, in scenarios where we don't need the associated records joins in the result set, semi-joins offer a more efficient alternative. They help avoid the overhead of returning duplicate rows when there are multiple matches.

For example, to retrieve posts with at least one comment, we can now write:
```ruby
Post.where.exists_with(:comments)
```