### PR TITLE
No need for explicit return of handlers

### DIFF
--- a/activerecord/lib/active_record/query_logs.rb
+++ b/activerecord/lib/active_record/query_logs.rb
@@ -181,7 +181,6 @@ module ActiveRecord
             end
           end
           handlers.sort_by! { |(key, _)| key.to_s }
-          handlers
         end
 
         def build_handler(name, handler = nil)


### PR DESCRIPTION
@byroot 
I was checking this and seems we do not need to explicitly return the handlers, as we are doing sort_by! 
Let me know if I am right and it make sense to you as well 


