### PR TITLE
class_attribute: reduce reliance on define_method

### DIFF
--- a/activerecord/test/cases/test_case.rb
+++ b/activerecord/test/cases/test_case.rb
@@ -141,9 +141,6 @@ module ActiveRecord
       yield
     ensure
       model.has_many_inversing = old
-      if model != ActiveRecord::Base && !old
-        model.singleton_class.remove_method(:has_many_inversing) # reset the class_attribute
-      end
     end
 
     def with_automatic_scope_inversing(*reflections)

--- a/activesupport/lib/active_support.rb
+++ b/activesupport/lib/active_support.rb
@@ -62,6 +62,7 @@ module ActiveSupport
     autoload :Cache
     autoload :Callbacks
     autoload :Configurable
+    autoload :ClassAttribute
     autoload :Deprecation
     autoload :Delegation
     autoload :Digest

--- a/activesupport/lib/active_support/callbacks.rb
+++ b/activesupport/lib/active_support/callbacks.rb
@@ -66,7 +66,7 @@ module ActiveSupport
 
     included do
       extend ActiveSupport::DescendantsTracker
-      class_attribute :__callbacks, instance_writer: false, default: {}
+      class_attribute :__callbacks, instance_writer: false, instance_predicate: false, default: {}
     end
 
     CALLBACK_FILTER_TYPES = [:before, :after, :around].freeze

--- a/activesupport/lib/active_support/class_attribute.rb
+++ b/activesupport/lib/active_support/class_attribute.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module ActiveSupport
+  module ClassAttribute # :nodoc:
+    class << self
+      def redefine(owner, name, value)
+        if owner.singleton_class?
+          owner.redefine_method(name) { value }
+          owner.silence_redefinition_of_method(name)
+        end
+
+        owner.redefine_singleton_method(name) { value }
+        owner.redefine_singleton_method("#{name}=") do |new_value|
+          if owner.equal?(self)
+            value = new_value
+          else
+            ::ActiveSupport::ClassAttribute.redefine(self, name, new_value)
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Full benchmark: https://gist.github.com/casperisfine/539e310eadd0cb650fc50ca0d9782569
Followup: https://github.com/rails/rails/pull/37903

Instead of always redefining a bmethod on assignment,
if the reciever already has its own bmethod, we just
update the local variable.

This wasn't really considered before because class attributes
are mostly meant for configuration, so not really expected
to be changed at runtime, but it can happen.

This is 10 to 17x faster to assign a class attributes:

```
interpreter:
                 old:  1834149.6 i/s
                 new: 17722346.6 i/s - 9.66x  faster
yjit:
                 old:  2561173.8 i/s
                 new: 43004422.5 i/s - 16.79x  faster
```

The difference is even bigger if something is redefining
`method_added` events, e.g. sorbet...

All other cases are unchanged in performance, except definition
that is marginally faster.

One downside however is that generated accessors source location
will no longer point to the `class_attribute` callsite.