### PR TITLE
Add params.permit! which raises on unpermitted params

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Introduce `params.permit!` which raises on unpermitted params.
+
+    `permit!` replaces the configuration `action_on_unpermitted_parameters`
+    so that `permit!` always raises in the presence of unpermitted params.
+    If a block is given to `permit!` then it will yield the unpermitted keys
+    instead of raising.
+
+    *Martin Emde*
+
 *   Fix `Request#raw_post` raising `NoMethodError` when `rack.input` is `nil`.
 
     *Hartley McGuire*

--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -659,7 +659,7 @@ module ActionController
       permit_filters(filters, &method(:unpermitted_parameters))
     end
 
-    # Same as permit, but raises on unpermitted parameters by default.
+    # Same as `permit`, but raises on unpermitted parameters.
     # Ignores ActionController::Parameters.action_on_unpermitted_parameters
     #
     # Accepts a block which will yield any unpermitted keys instead of raising.

--- a/actionpack/test/controller/parameters/log_on_unpermitted_params_test.rb
+++ b/actionpack/test/controller/parameters/log_on_unpermitted_params_test.rb
@@ -184,6 +184,25 @@ class LogOnUnpermittedParamsTest < ActiveSupport::TestCase
     end
   end
 
+  test "permit! overrides log on unexpected params" do
+    params = ActionController::Parameters.new(
+      book: { pages: 65 },
+      fishing: "Turnips")
+
+    assert_raises(ActionController::UnpermittedParameters) do
+      params.permit!(book: [:pages])
+    end
+  end
+
+  test "permit! overrides log on unexpected nested params" do
+    params = ActionController::Parameters.new(
+      book: { pages: 65, title: "Green Cats and where to find them." })
+
+    assert_raises(ActionController::UnpermittedParameters) do
+      params.permit!(book: [:pages])
+    end
+  end
+
   private
     def assert_logged(message)
       old_logger = ActionController::Base.logger

--- a/actionpack/test/controller/parameters/raise_on_unpermitted_params_test.rb
+++ b/actionpack/test/controller/parameters/raise_on_unpermitted_params_test.rb
@@ -24,10 +24,35 @@ class RaiseOnUnpermittedParamsTest < ActiveSupport::TestCase
 
   test "raises on unexpected nested params" do
     params = ActionController::Parameters.new(
-      book: { pages: 65, title: "Green Cats and where to find then." })
+      book: { pages: 65, title: "Green Cats and where to find them." })
 
     assert_raises(ActionController::UnpermittedParameters) do
       params.permit(book: [:pages])
     end
+  end
+
+  test "permit! with block overrides raise on unexpected params" do
+    params = ActionController::Parameters.new(
+      book: { pages: 65 },
+      fishing: "Turnips")
+    unpermitted = nil
+
+    assert_nothing_raised do
+      params.permit!(book: [:pages]) { |keys| unpermitted = keys }
+    end
+
+    assert_equal ["fishing"], unpermitted
+  end
+
+  test "permit! with block overrides raise on unexpected nested params" do
+    params = ActionController::Parameters.new(
+      book: { pages: 65, title: "Green Cats and where to find them." })
+    unpermitted = nil
+
+    assert_nothing_raised do
+      params.permit!(book: [:pages]) { |keys| unpermitted = keys }
+    end
+
+    assert_equal ["title"], unpermitted
   end
 end


### PR DESCRIPTION
### Motivation / Background

`action_on_unpermitted_parameters` only allows global control of something that often needs to be controlled on a per-action basis.

### Detail

This Pull Request introduces `params.permit!` which raises if unpermitted parameters are present. It also accepts a block which yields the array of unpermitted keys instead of raising, allowing for custom handling or logging. 

### Additional information

This was the most obvious part of #51674 that could be merged. It lays the groundwork for everything else in that PR, making the remaining code much easier to understand and review.

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [X] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
