### PR TITLE
Fix `distinct.count` when using `select` with multiple arel expressions

### DIFF
--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -635,8 +635,12 @@ module ActiveRecord
 
           adapter_class = model.adapter_class
           select_values.map do |field|
-            column = arel_column(field.to_s) do |attr_name|
-              Arel.sql(attr_name)
+            column = if Arel.arel_node?(field)
+              field
+            else
+              arel_column(field.to_s) do |attr_name|
+                Arel.sql(attr_name)
+              end
             end
 
             if column.is_a?(Arel::Nodes::SqlLiteral)

--- a/activerecord/test/cases/calculations_test.rb
+++ b/activerecord/test/cases/calculations_test.rb
@@ -623,6 +623,13 @@ class CalculationsTest < ActiveRecord::TestCase
     assert_equal 4, Account.distinct.select(Account.arel_table[:firm_id]).count
   end
 
+  def test_count_selected_arel_attributes
+    # Only MySQL supports COUNT with multiple columns, and only with DISTINCT.
+    skip unless current_adapter?(:Mysql2Adapter, :TrilogyAdapter)
+
+    assert_equal 5, Account.distinct.select(Account.arel_table[:id], Account.arel_table[:firm_id]).count
+  end
+
   def test_count_with_column_parameter
     assert_equal 5, Account.count(:firm_id)
   end


### PR DESCRIPTION
Currently, this works across all database adapters:
```ruby
SomeModel.select(arel_table[:some_column]).count
```

MySQL also support `COUNT DISTINCT` over multiple columns, but this is not working and produces invalid SQL:
```ruby
SomeModel.select(arel_table[:column1], arel_table[:column2]).distinct.count
```

So this PR fixes that case.