### PR TITLE
Deprecate `Benchmark.ms` and add `benchmark` to the gemspec

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -87,6 +87,7 @@ PATH
       marcel (~> 1.0)
     activesupport (8.0.0.alpha)
       base64
+      benchmark (>= 0.3)
       bigdecimal
       concurrent-ruby (~> 1.0, >= 1.3.1)
       connection_pool (>= 2.2.5)
@@ -162,6 +163,7 @@ GEM
     bcrypt (3.1.20)
     bcrypt_pbkdf (1.1.0)
     beaneater (1.1.3)
+    benchmark (0.3.0)
     bigdecimal (3.1.8)
     bindex (0.8.1)
     bootsnap (1.17.0)

--- a/actionpack/lib/action_controller/metal/instrumentation.rb
+++ b/actionpack/lib/action_controller/metal/instrumentation.rb
@@ -2,7 +2,6 @@
 
 # :markup: markdown
 
-require "benchmark"
 require "abstract_controller/logger"
 
 module ActionController
@@ -29,7 +28,7 @@ module ActionController
     def render(*)
       render_output = nil
       self.view_runtime = cleanup_view_runtime do
-        Benchmark.ms { render_output = super }
+        ActiveSupport::Benchmark.realtime(:float_millisecond) { render_output = super }
       end
       render_output
     end

--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "benchmark"
 require "set"
 require "active_support/core_ext/array/access"
 require "active_support/core_ext/enumerable"
@@ -975,16 +974,16 @@ module ActiveRecord
       when :down then announce "reverting"
       end
 
-      time = nil
+      time_elapsed = nil
       ActiveRecord::Tasks::DatabaseTasks.migration_connection.pool.with_connection do |conn|
-        time = Benchmark.measure do
+        time_elapsed = ActiveSupport::Benchmark.realtime do
           exec_migration(conn, direction)
         end
       end
 
       case direction
-      when :up   then announce "migrated (%.4fs)" % time.real; write
-      when :down then announce "reverted (%.4fs)" % time.real; write
+      when :up   then announce "migrated (%.4fs)" % time_elapsed; write
+      when :down then announce "reverted (%.4fs)" % time_elapsed; write
       end
     end
 
@@ -1025,8 +1024,8 @@ module ActiveRecord
     def say_with_time(message)
       say(message)
       result = nil
-      time = Benchmark.measure { result = yield }
-      say "%.4fs" % time.real, :subitem
+      time_elapsed = ActiveSupport::Benchmark.realtime { result = yield }
+      say "%.4fs" % time_elapsed, :subitem
       say("#{result} rows", :subitem) if result.is_a?(Integer)
       result
     end

--- a/activerecord/test/cases/secure_password_test.rb
+++ b/activerecord/test/cases/secure_password_test.rb
@@ -29,17 +29,17 @@ class SecurePasswordTest < ActiveRecord::TestCase
     User.authenticate_by(token: @user.token, password: @user.password)
 
     retry_flaky_test do
-      # Benchmark.realtime returns fractional seconds.  Thus, summing over 1000
+      # ActiveSupport::Benchmark.realtime returns fractional seconds. Thus, summing over 1000
       # iterations is equivalent to averaging over 1000 iterations and then
       # multiplying by 1000 to convert to milliseconds.
       found_average_time_in_ms = 1000.times.sum do
-        Benchmark.realtime do
+        ActiveSupport::Benchmark.realtime do
           User.authenticate_by(token: @user.token, password: @user.password)
         end
       end
 
       not_found_average_time_in_ms = 1000.times.sum do
-        Benchmark.realtime do
+        ActiveSupport::Benchmark.realtime do
           User.authenticate_by(token: "wrong", password: @user.password)
         end
       end

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Deprecate `Benchmark.ms` core extension.
+
+    The `benchmark` gem will become bundled in Ruby 3.5
+
+    *Earlopain*
+
 *   `ActiveSupport::TimeWithZone#inspect` now uses ISO 8601 style time like `Time#inspect`
 
     *John Hawthorn*

--- a/activesupport/activesupport.gemspec
+++ b/activesupport/activesupport.gemspec
@@ -45,4 +45,5 @@ Gem::Specification.new do |s|
   s.add_dependency "logger", ">= 1.4.2"
   s.add_dependency "securerandom", ">= 0.3"
   s.add_dependency "uri", ">= 0.13.1"
+  s.add_dependency "benchmark", ">= 0.3"
 end

--- a/activesupport/lib/active_support.rb
+++ b/activesupport/lib/active_support.rb
@@ -58,6 +58,7 @@ module ActiveSupport
   eager_autoload do
     autoload :BacktraceCleaner
     autoload :ProxyObject
+    autoload :Benchmark
     autoload :Benchmarkable
     autoload :Cache
     autoload :Callbacks

--- a/activesupport/lib/active_support/benchmark.rb
+++ b/activesupport/lib/active_support/benchmark.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module ActiveSupport
+  module Benchmark # :nodoc:
+    # Benchmark realtime in the specified time unit. By default,
+    # the returned unit is in seconds.
+    #
+    #   ActiveSupport::Benchmark.realtime { sleep 0.1 }
+    #   # => 0.10007
+    #
+    #   ActiveSupport::Benchmark.realtime(:float_millisecond) { sleep 0.1 }
+    #   # => 100.07
+    #
+    # `unit` can be any of the values accepted by Ruby's `Process.clock_gettime`.
+    def self.realtime(unit = :float_second, &block)
+      time_start = Process.clock_gettime(Process::CLOCK_MONOTONIC, unit)
+      yield
+      Process.clock_gettime(Process::CLOCK_MONOTONIC, unit) - time_start
+    end
+  end
+end

--- a/activesupport/lib/active_support/benchmarkable.rb
+++ b/activesupport/lib/active_support/benchmarkable.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "active_support/core_ext/benchmark"
 require "active_support/core_ext/hash/keys"
 
 module ActiveSupport
@@ -41,7 +40,9 @@ module ActiveSupport
         options[:level] ||= :info
 
         result = nil
-        ms = Benchmark.ms { result = options[:silence] ? logger.silence(&block) : yield }
+        ms = ActiveSupport::Benchmark.realtime(:float_millisecond) do
+          result = options[:silence] ? logger.silence(&block) : yield
+        end
         logger.public_send(options[:level], "%s (%.1fms)" % [ message, ms ])
         result
       else

--- a/activesupport/lib/active_support/core_ext/benchmark.rb
+++ b/activesupport/lib/active_support/core_ext/benchmark.rb
@@ -3,14 +3,11 @@
 require "benchmark"
 
 class << Benchmark
-  # Benchmark realtime in milliseconds.
-  #
-  #   Benchmark.realtime { User.all }
-  #   # => 8.0e-05
-  #
-  #   Benchmark.ms { User.all }
-  #   # => 0.074
-  def ms(&block)
-    1000 * realtime(&block)
+  def ms(&block) # :nodoc
+    # NOTE: Please also remove the Active Support `benchmark` dependency when removing this
+    ActiveSupport.deprecator.warn <<~TEXT
+      `Benchmark.ms` is deprecated and will be removed in Rails 8.1 without replacement.
+    TEXT
+    ActiveSupport::Benchmark.realtime(:float_millisecond, &block)
   end
 end

--- a/activesupport/test/benchmark_test.rb
+++ b/activesupport/test/benchmark_test.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require_relative "abstract_unit"
+
+class BenchmarkTest < ActiveSupport::TestCase
+  def test_realtime
+    time = ActiveSupport::Benchmark.realtime { sleep 0.1 }
+    assert_in_delta 0.1, time, 0.0005
+  end
+
+  def test_realtime_millisecond
+    ms = ActiveSupport::Benchmark.realtime(:float_millisecond) { sleep 0.1 }
+    assert_in_delta 100, ms, 0.5
+  end
+end

--- a/activesupport/test/core_ext/benchmark_test.rb
+++ b/activesupport/test/core_ext/benchmark_test.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require_relative "../abstract_unit"
+require "active_support/core_ext/benchmark"
+
+class BenchmarkTest < ActiveSupport::TestCase
+  def test_is_deprecated
+    assert_deprecated(ActiveSupport.deprecator) do
+      assert_operator Benchmark.ms { }, :>, 0
+    end
+  end
+end


### PR DESCRIPTION
### Motivation / Background

Ruby plans to make `benchmark` a bundled gem: https://github.com/ruby/ruby/pull/11492

It doesn't make much sense to keep this core extension since rails would need to add it to its gemspec to continue offering it for what basically amounts to `1000 * x`.

Since requiring it could emit a warning, add it to the gemspec until it can later be removed again with Rails 8.1

The benchmark generator will continue to work as usual: It adds `benchmark-ips` to the users Gemfile, which in turn should depend on `benchmark`: https://github.com/evanphx/benchmark-ips/pull/141

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
