### PR TITLE
Allow registering test directories for CodeStatistics

### DIFF
--- a/railties/lib/rails/code_statistics.rb
+++ b/railties/lib/rails/code_statistics.rb
@@ -43,12 +43,18 @@ module Rails
     HEADERS = { lines: " Lines", code_lines: "   LOC", classes: "Classes", methods: "Methods" }
 
     class_attribute :directories, default: DIRECTORIES
+    class_attribute :test_types, default: TEST_TYPES
 
     # Add directories to the output of the `bin/rails stats` command.
     #
     #   Rails::CodeStatistics.register_directory("My Directory", "path/to/dir")
-    def self.register_directory(label, path)
+    #
+    # For directories that contain test code, set the `test_directory` argument to true.
+    #
+    #   Rails::CodeStatistics.register_directory("Model specs", "spec/models", test_directory: true)
+    def self.register_directory(label, path, test_directory: false)
       self.directories << [label, path]
+      self.test_types << label
     end
 
     def initialize(*pairs)
@@ -99,13 +105,13 @@ module Rails
 
       def calculate_code
         code_loc = 0
-        @statistics.each { |k, v| code_loc += v.code_lines unless TEST_TYPES.include? k }
+        @statistics.each { |k, v| code_loc += v.code_lines unless test_types.include? k }
         code_loc
       end
 
       def calculate_tests
         test_loc = 0
-        @statistics.each { |k, v| test_loc += v.code_lines if TEST_TYPES.include? k }
+        @statistics.each { |k, v| test_loc += v.code_lines if test_types.include? k }
         test_loc
       end
 

--- a/railties/test/code_statistics_test.rb
+++ b/railties/test/code_statistics_test.rb
@@ -14,6 +14,20 @@ class CodeStatisticsTest < ActiveSupport::TestCase
     FileUtils.rm_rf(@tmp_path)
   end
 
+  test "register directories" do
+    Rails::CodeStatistics.register_directory("My Directory", "path/to/dir")
+    assert Rails::CodeStatistics.directories.include?(["My Directory", "path/to/dir"])
+  ensure
+    Rails::CodeStatistics.directories.delete(["My Directory", "path/to/dir"])
+  end
+
+  test "register test directories" do
+    Rails::CodeStatistics.register_directory("Model specs", "spec/models", test_directory: true)
+    assert Rails::CodeStatistics.test_types.include?("Model specs")
+  ensure
+    Rails::CodeStatistics.test_types.delete("Model specs")
+  end
+
   test "ignores directories that happen to have source files extensions" do
     assert_nothing_raised do
       @code_statistics = Rails::CodeStatistics.new(["tmp dir", @tmp_path])


### PR DESCRIPTION
Make it easier for third party gems, to register test directories.

For example `rspec-rails` currently appends to the TEST_TYPES constant:

      ::STATS_DIRECTORIES << ["#{name} specs", dir]
      ::CodeStatistics::TEST_TYPES << "#{name} specs"

https://github.com/rspec/rspec-rails/blob/418daeb0f492e693b7bd2c6bba1c2c1aee3a4d37/lib/rspec/rails/tasks/rspec.rake#L44

With this change it can be simplified to:

    ::Rails::CodeStatistics.register_directory "#{name} specs", dir, test_directory: true

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
