### PR TITLE
Fix migration log message for down operations

### DIFF
--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -1536,7 +1536,8 @@ module ActiveRecord
         return if down? && !migrated.include?(migration.version.to_i)
         return if up?   &&  migrated.include?(migration.version.to_i)
 
-        Base.logger.info "Migrating to #{migration.name} (#{migration.version})" if Base.logger
+        message = up? ? "Migrating to" : "Reverting"
+        Base.logger.info "#{message} #{migration.name} (#{migration.version})" if Base.logger
 
         ddl_transaction(migration) do
           migration.migrate(@direction)


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because when **reverting** a migration I was getting the message `Migrating to AddUsernameColumnToUser (20240827174134)`, which doesn't seem like an accurate description of the operation.

### Detail

This Pull Request changes the message based on the operation.
- `up` operation: message keeps being the same (`Migrating to AddUsernameColumnToUser (20240827174134)`)
- `down` operation: message changed (`Reverting AddUsernameColumnToUser (20240827174134)`)

`AddUsernameColumnToUser` is just an example of a migration name
`20240827174134` is the timestamp

### Additional information

-

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
