### PR TITLE
Fix URI deprecation on ruby 3.4.0-dev

### DIFF
--- a/actionpack/lib/action_dispatch/routing/inspector.rb
+++ b/actionpack/lib/action_dispatch/routing/inspector.rb
@@ -101,7 +101,7 @@ module ActionDispatch
             { controller: /#{filter[:controller].underscore.sub(/_?controller\z/, "")}/ }
           elsif filter[:grep]
             grep_pattern = Regexp.new(filter[:grep])
-            path = URI::DEFAULT_PARSER.escape(filter[:grep])
+            path = URI::RFC2396_PARSER.escape(filter[:grep])
             normalized_path = ("/" + path).squeeze("/")
 
             {

--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -2060,7 +2060,7 @@ module ActionDispatch
               name_for_action(options.delete(:as), action)
             end
 
-            path = Mapping.normalize_path URI::DEFAULT_PARSER.escape(path), formatted
+            path = Mapping.normalize_path URI::RFC2396_PARSER.escape(path), formatted
             ast = Journey::Parser.parse path
 
             mapping = Mapping.build(@scope, @set, ast, controller, default_action, to, via, formatted, options_constraints, anchor, options)

--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -929,7 +929,7 @@ module ActionDispatch
           params.each do |key, value|
             if value.is_a?(String)
               value = value.dup.force_encoding(Encoding::BINARY)
-              params[key] = URI::DEFAULT_PARSER.unescape(value)
+              params[key] = URI::RFC2396_PARSER.unescape(value)
             end
           end
           req.path_parameters = params

--- a/actionpack/test/controller/parameter_encoding_test.rb
+++ b/actionpack/test/controller/parameter_encoding_test.rb
@@ -56,7 +56,7 @@ class ParameterEncodingTest < ActionController::TestCase
   end
 
   test "does not raise an error when passed a param declared as ASCII-8BIT that contains invalid bytes" do
-    get :test_skip_parameter_encoding, params: { "bar" => URI::DEFAULT_PARSER.escape("bar\xE2baz".b) }
+    get :test_skip_parameter_encoding, params: { "bar" => URI::RFC2396_PARSER.escape("bar\xE2baz".b) }
 
     assert_response :success
     assert_equal "ASCII-8BIT", @response.body

--- a/actionpack/test/controller/routing_test.rb
+++ b/actionpack/test/controller/routing_test.rb
@@ -2177,11 +2177,11 @@ class RackMountIntegrationTests < ActiveSupport::TestCase
   end
 
   def test_unicode_path
-    assert_equal({ controller: "news", action: "index" }, @routes.recognize_path(URI::DEFAULT_PARSER.escape("こんにちは/世界"), method: :get))
+    assert_equal({ controller: "news", action: "index" }, @routes.recognize_path(URI::RFC2396_PARSER.escape("こんにちは/世界"), method: :get))
   end
 
   def test_downcased_unicode_path
-    assert_equal({ controller: "news", action: "index" }, @routes.recognize_path(URI::DEFAULT_PARSER.escape("こんにちは/世界").downcase, method: :get))
+    assert_equal({ controller: "news", action: "index" }, @routes.recognize_path(URI::RFC2396_PARSER.escape("こんにちは/世界").downcase, method: :get))
   end
 
   private

--- a/actionview/lib/action_view/helpers/url_helper.rb
+++ b/actionview/lib/action_view/helpers/url_helper.rb
@@ -556,14 +556,14 @@ module ActionView
 
         options ||= options_as_kwargs
         check_parameters ||= options.is_a?(Hash) && options.delete(:check_parameters)
-        url_string = URI::DEFAULT_PARSER.unescape(url_for(options)).force_encoding(Encoding::BINARY)
+        url_string = URI::RFC2396_PARSER.unescape(url_for(options)).force_encoding(Encoding::BINARY)
 
         # We ignore any extra parameters in the request_uri if the
         # submitted URL doesn't have any either. This lets the function
         # work with things like ?order=asc
         # the behavior can be disabled with check_parameters: true
         request_uri = url_string.index("?") || check_parameters ? request.fullpath : request.path
-        request_uri = URI::DEFAULT_PARSER.unescape(request_uri).force_encoding(Encoding::BINARY)
+        request_uri = URI::RFC2396_PARSER.unescape(request_uri).force_encoding(Encoding::BINARY)
 
         if %r{^\w+://}.match?(url_string)
           request_uri = +"#{request.protocol}#{request.host_with_port}#{request_uri}"

--- a/railties/lib/rails/info_controller.rb
+++ b/railties/lib/rails/info_controller.rb
@@ -20,7 +20,7 @@ class Rails::InfoController < Rails::ApplicationController # :nodoc:
 
   def routes
     if query = params[:query]
-      query = URI::DEFAULT_PARSER.escape query
+      query = URI::RFC2396_PARSER.escape query
 
       render json: {
         exact: matching_routes(query: query, exact_match: true),
@@ -61,7 +61,7 @@ class Rails::InfoController < Rails::ApplicationController # :nodoc:
         match ||= (query === route_wrapper.verb)
 
         unless match
-          controller_action = URI::DEFAULT_PARSER.escape(route_wrapper.reqs)
+          controller_action = URI::RFC2396_PARSER.escape(route_wrapper.reqs)
           match = exact_match ? (query === controller_action) : controller_action.include?(query)
         end
 

--- a/railties/test/application/assets_test.rb
+++ b/railties/test/application/assets_test.rb
@@ -324,7 +324,7 @@ module ApplicationTests
       # Load app env
       app "development"
 
-      get "/assets/#{URI::DEFAULT_PARSER.escape(asset_path)}"
+      get "/assets/#{URI::RFC2396_PARSER.escape(asset_path)}"
       assert_match "not an image really", last_response.body
       assert_file_exists("#{app_path}/public/assets/#{asset_path}")
     end


### PR DESCRIPTION
```
warning: URI::RFC3986_PARSER.unescape is obsoleted. Use URI::RFC2396_PARSER.unescape explicitly.
```

Ref: https://buildkite.com/rails/rails-nightly/builds/963#01919ff1-1c22-46d7-aa82-eec9c93d2a5b