### PR TITLE
Allow Rack unprocessable_entity deprecation warnings

### DIFF
--- a/activesupport/lib/active_support/testing/strict_warnings.rb
+++ b/activesupport/lib/active_support/testing/strict_warnings.rb
@@ -17,6 +17,9 @@ module ActiveSupport
 
       # TODO: Can be removed if https://github.com/ruby/uri/issues/118 is addressed
       /URI::RFC3986_PARSER/,
+
+      # TODO: We need to decide what to do with this.
+      /Status code :unprocessable_entity is deprecated/
     )
 
     SUPPRESSED_WARNINGS = Regexp.union(


### PR DESCRIPTION
We still need to figure out what we'll do with this, in the meantime let's not fail builds because of it.
