### PR TITLE
`ActiveRecord::Base.attributes_for_inspect` should default to `:all`

### DIFF
--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -66,6 +66,7 @@ Below are the default values associated with each target version. In cases of co
 #### Default Values for Target Version 7.2
 
 - [`config.active_job.enqueue_after_transaction_commit`](#config-active-job-enqueue-after-transaction-commit): `:default`
+- [`config.active_record.attributes_for_inspect`](#config-active-record-attributes-for-inspect): `:all`
 - [`config.active_record.postgresql_adapter_decode_dates`](#config-active-record-postgresql-adapter-decode-dates): `true`
 - [`config.active_record.validate_migration_timestamps`](#config-active-record-validate-migration-timestamps): `true`
 - [`config.active_storage.web_image_content_types`](#config-active-storage-web-image-content-types): `%w[image/png image/jpeg image/gif image/webp]`
@@ -1128,6 +1129,21 @@ The default value depends on the `config.load_defaults` target version:
 | --------------------- | -------------------- |
 | (original)            | `false`              |
 | 7.2                   | `true`               |
+
+#### `config.active_record.attributes_for_inspect`
+
+Sets which attributes are included when calling `inspect` on an Active Record object. The default is `:all`.
+This can be overridden at the model level:
+
+```ruby
+class Comment < ApplicationRecord
+  self.attributes_for_inspect = [:id, :post_id]
+end
+```
+
+| Starting with version | The default value is |
+| --------------------- | -------------------- |
+| 7.2                   | :all                 |
 
 #### `config.active_record.db_warnings_action`
 

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -336,6 +336,7 @@ module Rails
           if respond_to?(:active_record)
             active_record.postgresql_adapter_decode_dates = true
             active_record.validate_migration_timestamps = true
+            active_record.attributes_for_inspect = :all
           end
         when "8.0"
           load_defaults "7.2"

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -4701,14 +4701,6 @@ module ApplicationTests
       assert_equal(:html4, Rails.application.config.dom_testing_default_html_version)
     end
 
-    test "sets ActiveRecord::Base.attributes_for_inspect to [:id] when config.consider_all_requests_local = false" do
-      add_to_config "config.consider_all_requests_local = false"
-
-      app "production"
-
-      assert_equal [:id], ActiveRecord::Base.attributes_for_inspect
-    end
-
     test "sets ActiveRecord::Base.attributes_for_inspect to :all when config.consider_all_requests_local = true" do
       add_to_config "config.consider_all_requests_local = true"
 


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

After updating to Rails 7.2, we noticed that attributes were missing when inspecting AR objects in a production-like console. We found #49765. After discussing this with @rafaelfranca and the author of the PR, @andrewn617, we came to the conclusion that this should default to `:all`. 

### Detail

This PR changes the default of `attributes_for_inspect` to `:all`. There's a commit on this branch that also updated the Rails 7.2 new defaults initializer, but I removed that as it's not on main and I'm unsure how to handle that.

### Additional information

This PR is going off of a discussion with @rafaelfranca. It's possible there is more to change here to make this work properly, and I apologize if thats the case. Happy to make more updates. I'm curious if, since we want new Rails applications to have this default set to true, if the `production.rb` environment file should be updated to include the configuration change.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
