### PR TITLE
Add support for ICU collations in PostgreSQL 15 or later

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add support for ICU collations in PostgreSQL 15 or later
+
+    *rono23*
+
 *   Deserialize binary data before decrypting
 
     This ensures that we call `PG::Connection.unescape_bytea` on PostgreSQL before decryption.


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because PostgreSQL 15 or later now support ICU collations.

### Detail

The following parameters are newly supported in config/database.yml for PostgreSQL 15 or later.

- `locale_provider`
  - `libc` or `icu`
- `icu_locale`
  - Find the value by `SELECT collname FROM pg_collation`, Ex: `ja-x-icu`
  - [Language tag](https://www.postgresql.org/docs/16/locale.html#ICU-LANGUAGE-TAG), Ex: `en-US-u-kn-ks-level2 `
- `icu_rules`
  - Ex: `&V <<< w <<< W`
  - https://www.postgresql.org/docs/16/collation.html#ICU-TAILORING-RULES
  - https://unicode-org.github.io/icu/userguide/collation/customization/

Refs:
- https://www.postgresql.org/docs/16/sql-createdatabase.html
- https://www.postgresql.org/docs/16/collation.html
- https://www.postgresql.org/docs/15/sql-createdatabase.html
- https://www.postgresql.org/docs/15/collation.html

The following methods are newly added to [`ActiveRecord::ConnectionAdapters::PostgreSQL::SchemaStatements`](https://github.com/rails/rails/blob/main/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb).

- `icu_locale`
  - Ex: `ActiveRecord::Base.connection.icu_locale #=> "ja-x-icu"`
- `locale_provider`
  - Ex: `ActiveRecord::Base.connection.locale_provider #=> "i"`
  - This method returns `c`, `i` or nil (c = libc, i = icu)
- `icu_rules`
  - Ex: `ActiveRecord::Base.connection.icu_rules #=> "&V <<< w <<< W"`

Refs:
- https://www.postgresql.org/docs/16/catalog-pg-database.html
- https://www.postgresql.org/docs/15/catalog-pg-database.html

#### Current

```
# config/database.yml
database: sample_development
adapter: postgresql
encoding: unicode
pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>

# \l sample_development
List of databases
-[ RECORD 1 ]-----+-------------------
Name              | sample_development
Owner             | rono23
Encoding          | UTF8
Locale Provider   | libc
Collate           | C
Ctype             | C
ICU Locale        | 
ICU Rules         | 
Access privileges | 

# SELECT title FROM posts ORDER BY title ASC;
 title 
-------
 1
 2
 A
 B
 a
 b
 あ
 い
 ア
 イ
(10 rows)
```

#### After this PR

```
# Set new parameters in config/database.yml
template: template0
locale_provider: icu
icu_locale: ja-x-icu                                                                                                                                         

# \l sample_development
List of databases
-[ RECORD 1 ]-----+-------------------
Name              | sample_development
Owner             | rono23
Encoding          | UTF8
Locale Provider   | icu
Collate           | C
Ctype             | C
ICU Locale        | ja-x-icu
ICU Rules         | 
Access privileges | 

# SELECT title FROM posts ORDER BY title ASC;
 title 
-------
 1
 2
 a
 A
 b
 B
 あ
 ア
 い
 イ
(10 rows)
```

### Additional information

#### PostgreSQL 15

> Allow [ICU](https://www.postgresql.org/docs/15/locale.html) collations to be set as the default for clusters and databases (Peter Eisentraut)
Previously, only libc-based collations could be selected at the cluster and database levels. ICU collations could only be used via explicit `COLLATE` clauses.
https://www.postgresql.org/docs/15/release-15.html

> [icu_locale](https://www.postgresql.org/docs/15/sql-createdatabase.html)
Specifies the ICU locale ID if the ICU locale provider is used.

> [locale_provider](https://www.postgresql.org/docs/15/sql-createdatabase.html)
Specifies the provider to use for the default collation in this database. Possible values are: `icu`, `libc`. `libc` is the default. The available choices depend on the operating system and build options.

#### PostgreSQL 16

> Allow custom ICU collation rules to be created (Peter Eisentraut)
This is done using [`CREATE COLLATION`](https://www.postgresql.org/docs/16/sql-createcollation.html)'s new RULES clause, as well as new options for [`CREATE DATABASE`](https://www.postgresql.org/docs/16/sql-createdatabase.html), [createdb](https://www.postgresql.org/docs/16/app-createdb.html), and [initdb](https://www.postgresql.org/docs/16/app-initdb.html).
https://www.postgresql.org/docs/16/release-16.html

> [icu_locale](https://www.postgresql.org/docs/16/sql-createdatabase.html#CREATE-DATABASE-ICU-LOCALE)
Specifies the ICU locale (see [Section 24.2.2.3.2](https://www.postgresql.org/docs/16/collation.html#COLLATION-MANAGING-CREATE-ICU)) for the database default collation order and character classification, overriding the setting [`locale`](https://www.postgresql.org/docs/16/sql-createdatabase.html#CREATE-DATABASE-LOCALE). The [locale provider](https://www.postgresql.org/docs/16/sql-createdatabase.html#CREATE-DATABASE-LOCALE-PROVIDER) must be ICU. The default is the setting of [`locale`](https://www.postgresql.org/docs/16/sql-createdatabase.html#CREATE-DATABASE-LOCALE) if specified; otherwise the same setting as the template database.

> [locale_provider](https://www.postgresql.org/docs/16/sql-createdatabase.html#CREATE-DATABASE-LOCALE-PROVIDER)
Specifies the provider to use for the default collation in this database. Possible values are `icu` (if the server was built with ICU support) or `libc`. By default, the provider is the same as that of the [template](https://www.postgresql.org/docs/16/sql-createdatabase.html#CREATE-DATABASE-TEMPLATE). See [Section 24.1.4](https://www.postgresql.org/docs/16/locale.html#LOCALE-PROVIDERS) for details.

> [icu_rules](https://www.postgresql.org/docs/16/sql-createdatabase.html#CREATE-DATABASE-ICU-RULES)
Specifies additional collation rules to customize the behavior of the default collation of this database. This is supported for ICU only. See [Section 24.2.3.4](https://www.postgresql.org/docs/16/collation.html#ICU-TAILORING-RULES) for details.

### Checklist

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.