### PR TITLE
Update API docs to recommend `form_with` over `form_tag` and `form_for` [ci skip]

### DIFF
--- a/actionview/lib/action_view/helpers/form_helper.rb
+++ b/actionview/lib/action_view/helpers/form_helper.rb
@@ -121,7 +121,8 @@ module ActionView
       attr_internal :default_form_builder
 
       # Creates a form that allows the user to create or update the attributes
-      # of a specific model object.
+      # of a specific model object. +form_for+ is soft-deprecated, it is
+      # recommended to use form_with instead.
       #
       # The method can be used in several slightly different ways, depending on
       # how much you wish to rely on \Rails to infer automatically from the model

--- a/actionview/lib/action_view/helpers/form_tag_helper.rb
+++ b/actionview/lib/action_view/helpers/form_tag_helper.rb
@@ -30,6 +30,7 @@ module ActionView
 
       # Starts a form tag that points the action to a URL configured with <tt>url_for_options</tt> just like
       # ActionController::Base#url_for. The method for the form defaults to POST.
+      # <tt>form_tag</tt> is soft-deprecated, it is recommended to use form_with instead.
       #
       # ==== Options
       # * <tt>:multipart</tt> - If set to true, the enctype is set to "multipart/form-data".


### PR DESCRIPTION
Ref: [discussion](https://discuss.rubyonrails.org/t/should-form-tag-and-form-for-be-fully-deprecated-now/86501)

### Motivation / Background

This Pull Request has been created because DHH [mentioned](https://discuss.rubyonrails.org/t/should-form-tag-and-form-for-be-fully-deprecated-now/86501/2?u=jeromedalbert) that we're better off steering folks through guides and docs towards the new `form_with` syntax. The guides already [mention](https://guides.rubyonrails.org/form_helpers.html#using-form-tag-and-form-for) that `form_tag` and `form_for` are soft-deprecated, but the API docs don't. As a result people might be unsure which one to choose if they only search in the API docs.

### Detail

This Pull Request changes the API docs to recommend `form_with` over `form_tag` and `form_for`.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
