### PR TITLE
Require "zlib" where `Zlib` is referenced

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/schema_cache.rb
+++ b/activerecord/lib/active_record/connection_adapters/schema_cache.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "zlib"
 require "active_support/core_ext/file/atomic"
 
 module ActiveRecord

--- a/activerecord/lib/active_record/encryption/config.rb
+++ b/activerecord/lib/active_record/encryption/config.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "openssl"
+require "zlib"
 
 module ActiveRecord
   module Encryption

--- a/activerecord/lib/active_record/encryption/encryptor.rb
+++ b/activerecord/lib/active_record/encryption/encryptor.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "openssl"
-require "zlib"
 require "active_support/core_ext/numeric"
 
 module ActiveRecord

--- a/activesupport/lib/active_support/cache/file_store.rb
+++ b/activesupport/lib/active_support/cache/file_store.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "zlib"
 require "active_support/core_ext/file/atomic"
 require "active_support/core_ext/string/conversions"
 require "uri/common"


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

In https://github.com/rails/rails/pull/51735, the reference to `Zlib` was moved from [activerecord/lib/active_record/encryption/encryptor.rb](https://github.com/rails/rails/pull/51735/files#diff-ba005dd3f120df81a5c246216d66abf0922f26b6f1c2e93c9516d94b7c959213) to [activerecord/lib/active_record/encryption/config.rb](https://github.com/rails/rails/pull/51735/files#diff-be4704f10be1ac4cee2a88fda4fec863e60e7f7204e94624c5137dc8e5d151b4), but the `require "zlib"` directive stayed in the original file.

As a result, loading `ActiveRecord::Encryption::Config` can result in such errors:

```shell
/[...]/activerecord/lib/active_record/encryption/config.rb:59:in `set_defaults': uninitialized constant ActiveRecord::Encryption::Config::Zlib (NameError)

          self.compressor = Zlib
                            ^^^^
```

I encountered this issue while testing a private gem of mine against rails `main` branch (the change from https://github.com/rails/rails/pull/51735 is not released yet).

### Additional information

This was an opportunity to add `require "zlib` to two other files where it was also missing.

I've kept this additional change in a separate commit for clarity during review.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
