### PR TITLE
[ci skip] Add example to configure ActiveRecord::Encryption

### DIFF
--- a/guides/source/active_record_encryption.md
+++ b/guides/source/active_record_encryption.md
@@ -41,6 +41,17 @@ active_record_encryption:
   key_derivation_salt: xEY0dt6TZcAMg52K7O84wYzkjvbA62Hz
 ```
 
+To use environment variables as configuration source, you can also define the initialization in the initializer file using `ActiveRecord::Encryption.configure`:
+```ruby
+# config/initializers/active_record_encryption.rb
+
+ActiveRecord::Encryption.configure(
+  primary_key: ENV["ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY"],
+  deterministic_key: ENV["ACTIVE_RECORD_ENCRYPTION_DETERMINISTIC_KEY"],
+  key_derivation_salt: ENV["ACTIVE_RECORD_ENCRYPTION_KEY_DERIVATION_SALT"],
+)
+```
+
 NOTE: These generated values are 32 bytes in length. If you generate these yourself, the minimum lengths you should use are 12 bytes for the primary key (this will be used to derive the AES 32 bytes key) and 20 bytes for the salt.
 
 ### Declaration of Encrypted Attributes


### PR DESCRIPTION
## Add example to configure ActiveRecord::Encryption via environment variable

### Motivation / Background

This Pull Request has been created because In Rails 7.1 [Configuring Encryption Guide](https://guides.rubyonrails.org/v7.1/active_record_encryption.html#setup), we are showing how we can setup using environment variables.

Documentation in Rails 7.1 (Does not work in rails 7.0
```ruby
config.active_record.encryption.primary_key = ENV['ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY']
config.active_record.encryption.deterministic_key = ENV['ACTIVE_RECORD_ENCRYPTION_DETERMINISTIC_KEY']
config.active_record.encryption.key_derivation_salt = ENV['ACTIVE_RECORD_ENCRYPTION_KEY_DERIVATION_SALT']
```

When we are using the same method for Rails 7.0, while the initializer doesn't raise an error, but it doesn't properly set the `primary_key`, `deterministic_key`, and `key_derivation_salt`. Causing the encryption not setup properly.

This PR is adding a working method, when configuring via environment variables for Rails 7.0.x

This is working in Rails 7.0
```ruby
ActiveRecord::Encryption.configure(
  primary_key: ENV["ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY"],
  deterministic_key: ENV["ACTIVE_RECORD_ENCRYPTION_DETERMINISTIC_KEY"],
  key_derivation_salt: ENV["ACTIVE_RECORD_ENCRYPTION_KEY_DERIVATION_SALT"],
)
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
