### PR TITLE
Change controller generator to use _path instead of _url for redirects

### DIFF
--- a/railties/lib/rails/generators/rails/scaffold_controller/templates/controller.rb.tt
+++ b/railties/lib/rails/generators/rails/scaffold_controller/templates/controller.rb.tt
@@ -43,7 +43,7 @@ class <%= controller_class_name %>Controller < ApplicationController
   # DELETE <%= route_url %>/1
   def destroy
     @<%= orm_instance.destroy %>
-    redirect_to <%= index_helper %>_url, notice: <%= %("#{human_name} was successfully destroyed.") %>, status: :see_other
+    redirect_to <%= index_helper %>_path, notice: <%= %("#{human_name} was successfully destroyed.") %>, status: :see_other
   end
 
   private

--- a/railties/test/generators/scaffold_controller_generator_test.rb
+++ b/railties/test/generators/scaffold_controller_generator_test.rb
@@ -37,16 +37,19 @@ class ScaffoldControllerGeneratorTest < Rails::Generators::TestCase
       assert_instance_method :create, content do |m|
         assert_match(/@user = User\.new\(user_params\)/, m)
         assert_match(/@user\.save/, m)
+        assert_match(/redirect_to @user/, m)
       end
 
       assert_instance_method :update, content do |m|
         assert_match(/@user\.update\(user_params\)/, m)
+        assert_match(/redirect_to @user/, m)
         assert_match(/status: :see_other/, m)
       end
 
       assert_instance_method :destroy, content do |m|
         assert_match(/@user\.destroy/, m)
         assert_match(/User was successfully destroyed/, m)
+        assert_match(/redirect_to users_path/, m)
         assert_match(/status: :see_other/, m)
       end
 


### PR DESCRIPTION
Partially addresses https://github.com/rails/rails/issues/52756.

### Motivation / Background

This Pull Request has been created because the Rails codebase is now promoting redirecting with paths instead of URLs. Namely we need to [change `redirect_to posts_url`](https://github.com/rails/rails/issues/52756#issuecomment-2323398590) in our generators.

### Detail

This Pull Request changes the scaffold controller template to use `redirect_to posts_path` instead of `redirect_to posts_url`. It also adds redirect expectations in tests.

Please note that internally paths are still converted to URLs when redirecting ([ref](https://github.com/rails/rails/issues/52756#issuecomment-2323728578)). Changing this behavior may be trickier so I am leaving it out of this PR.

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
