### PR TITLE
Redirect with paths instead of URLs by default

### DIFF
--- a/actionpack/lib/action_dispatch/routing/url_for.rb
+++ b/actionpack/lib/action_dispatch/routing/url_for.rb
@@ -201,6 +201,28 @@ module ActionDispatch
         end
       end
 
+      def path_for(options = nil)
+        case options
+        when nil
+          _routes.path_for(url_options.symbolize_keys)
+        when Hash, ActionController::Parameters
+          route_name = options.delete :use_route
+          merged_url_options = options.to_h.symbolize_keys.reverse_merge!(url_options)
+          _routes.path_for(merged_url_options, route_name)
+        when String
+          options
+        when Symbol
+          HelperMethodBuilder.path.handle_string_call self, options
+        when Array
+          components = options.dup
+          polymorphic_path(components, components.extract_options!)
+        when Class
+          HelperMethodBuilder.path.handle_class_call self, options
+        else
+          HelperMethodBuilder.path.handle_model_call self, options
+        end
+      end
+
       # Allows calling direct or regular named route.
       #
       #     resources :buckets

--- a/actionpack/test/controller/action_pack_assertions_test.rb
+++ b/actionpack/test/controller/action_pack_assertions_test.rb
@@ -256,7 +256,7 @@ class ActionPackAssertionsControllerTest < ActionController::TestCase
       end
       process :redirect_to_top_level_named_route
       # assert_redirected_to "http://test.host/action_pack_assertions/foo" would pass because of exact match early return
-      assert_redirected_to "/action_pack_assertions/foo"
+      assert_redirected_to "http://test.host/action_pack_assertions/foo"
       assert_redirected_to %r(/action_pack_assertions/foo)
     end
   end
@@ -275,7 +275,7 @@ class ActionPackAssertionsControllerTest < ActionController::TestCase
       end
       process :redirect_to_top_level_named_route
       # assert_redirected_to top_level_url('foo') would pass because of exact match early return
-      assert_redirected_to top_level_path("foo")
+      assert_redirected_to top_level_url("foo")
     end
   end
 
@@ -329,7 +329,7 @@ class ActionPackAssertionsControllerTest < ActionController::TestCase
 
   def test_redirection_location
     process :redirect_internal
-    assert_equal "http://test.host/nothing", @response.redirect_url
+    assert_equal "/nothing", @response.redirect_url
 
     process :redirect_external
     assert_equal "http://www.rubyonrails.org", @response.redirect_url
@@ -425,12 +425,12 @@ class ActionPackAssertionsControllerTest < ActionController::TestCase
 
   def test_redirect_invalid_external_route
     process :redirect_invalid_external_route
-    assert_redirected_to "http://test.hostht_tp://www.rubyonrails.org"
+    assert_redirected_to "ht_tp://www.rubyonrails.org"
   end
 
-  def test_redirected_to_url_full_url
+  def test_redirected_to_url_full_path
     process :redirect_to_path
-    assert_redirected_to "http://test.host/some/path"
+    assert_redirected_to "/some/path"
   end
 
   def test_assert_redirection_with_symbol
@@ -454,7 +454,7 @@ class ActionPackAssertionsControllerTest < ActionController::TestCase
 
   def test_assert_redirection_with_status
     process :redirect_to_path
-    assert_redirected_to "http://test.host/some/path", status: :found
+    assert_redirected_to "/some/path", status: :found
     assert_raise ActiveSupport::TestCase::Assertion do
       assert_redirected_to "http://test.host/some/path", status: :moved_permanently
     end
@@ -463,7 +463,7 @@ class ActionPackAssertionsControllerTest < ActionController::TestCase
     end
 
     process :redirect_permanently
-    assert_redirected_to "http://test.host/some/path", status: :moved_permanently
+    assert_redirected_to "/some/path", status: :moved_permanently
     assert_raise ActiveSupport::TestCase::Assertion do
       assert_redirected_to "http://test.host/some/path", status: :found
     end

--- a/actionpack/test/controller/api/redirect_to_test.rb
+++ b/actionpack/test/controller/api/redirect_to_test.rb
@@ -16,6 +16,6 @@ class RedirectToApiTest < ActionController::TestCase
   def test_redirect_to
     get :one
     assert_response :redirect
-    assert_equal "http://test.host/redirect_to_api/two", redirect_to_url
+    assert_equal "/redirect_to_api/two", redirect_to_url
   end
 end

--- a/actionpack/test/controller/filters_test.rb
+++ b/actionpack/test/controller/filters_test.rb
@@ -748,7 +748,7 @@ class FilterTest < ActionController::TestCase
   def test_before_action_redirects_breaks_actioning_chain_for_after_action
     test_process(BeforeActionRedirectionController)
     assert_response :redirect
-    assert_equal "http://test.host/filter_test/before_action_redirection/target_of_redirection", redirect_to_url
+    assert_equal "/filter_test/before_action_redirection/target_of_redirection", redirect_to_url
     assert_equal %w( before_action_redirects ), @controller.instance_variable_get(:@ran_filter)
   end
 
@@ -761,7 +761,7 @@ class FilterTest < ActionController::TestCase
   def test_before_action_redirects_breaks_actioning_chain_for_prepend_after_action
     test_process(BeforeActionRedirectionForPrependAfterActionController)
     assert_response :redirect
-    assert_equal "http://test.host/filter_test/before_action_redirection_for_prepend_after_action/target_of_redirection", redirect_to_url
+    assert_equal "/filter_test/before_action_redirection_for_prepend_after_action/target_of_redirection", redirect_to_url
     assert_equal %w( before_action_redirects ), @controller.instance_variable_get(:@ran_filter)
   end
 

--- a/actionpack/test/controller/integration_test.rb
+++ b/actionpack/test/controller/integration_test.rb
@@ -383,7 +383,7 @@ class IntegrationProcessTest < ActionDispatch::IntegrationTest
 
       get "/moved"
       assert_response :redirect
-      assert_redirected_to "/method"
+      assert_redirected_to "http://www.example.com/method"
     end
   end
 

--- a/actionpack/test/controller/redirect_test.rb
+++ b/actionpack/test/controller/redirect_test.rb
@@ -217,37 +217,37 @@ class RedirectTest < ActionController::TestCase
   def test_simple_redirect
     get :simple_redirect
     assert_response :redirect
-    assert_equal "http://test.host/redirect/hello_world", redirect_to_url
+    assert_equal "/redirect/hello_world", redirect_to_url
   end
 
   def test_redirect_with_header_break
     get :redirect_with_header_break
     assert_response :redirect
-    assert_equal "http://test.host/lolwat", redirect_to_url
+    assert_equal "/lolwat", redirect_to_url
   end
 
   def test_redirect_with_null_bytes
     get :redirect_with_null_bytes
     assert_response :redirect
-    assert_equal "http://test.host/lolwat", redirect_to_url
+    assert_equal "/lolwat", redirect_to_url
   end
 
   def test_redirect_with_no_status
     get :simple_redirect
     assert_response 302
-    assert_equal "http://test.host/redirect/hello_world", redirect_to_url
+    assert_equal "/redirect/hello_world", redirect_to_url
   end
 
   def test_redirect_with_status
     get :redirect_with_status
     assert_response 301
-    assert_equal "http://test.host/redirect/hello_world", redirect_to_url
+    assert_equal "/redirect/hello_world", redirect_to_url
   end
 
   def test_redirect_with_status_hash
     get :redirect_with_status_hash
     assert_response 301
-    assert_equal "http://test.host/redirect/hello_world", redirect_to_url
+    assert_equal "/redirect/hello_world", redirect_to_url
   end
 
   def test_redirect_with_protocol
@@ -271,20 +271,20 @@ class RedirectTest < ActionController::TestCase
   def test_relative_url_redirect_with_status
     get :relative_url_redirect_with_status
     assert_response 302
-    assert_equal "http://test.host/things/stuff", redirect_to_url
+    assert_equal "/things/stuff", redirect_to_url
   end
 
   def test_relative_url_redirect_with_status_hash
     get :relative_url_redirect_with_status_hash
     assert_response 301
-    assert_equal "http://test.host/things/stuff", redirect_to_url
+    assert_equal "/things/stuff", redirect_to_url
   end
 
   def test_relative_url_redirect_host_with_port
     request.host = "test.host:1234"
     get :relative_url_redirect_with_status
     assert_response 302
-    assert_equal "http://test.host:1234/things/stuff", redirect_to_url
+    assert_equal "/things/stuff", redirect_to_url
   end
 
   def test_simple_redirect_using_options
@@ -296,7 +296,7 @@ class RedirectTest < ActionController::TestCase
   def test_module_redirect
     get :module_redirect
     assert_response :redirect
-    assert_redirected_to "http://test.host/module_test/module_redirect/hello_world"
+    assert_redirected_to "/module_test/module_redirect/hello_world"
   end
 
   def test_module_redirect_using_options
@@ -349,7 +349,7 @@ class RedirectTest < ActionController::TestCase
     get :redirect_back_with_status
 
     assert_response 307
-    assert_equal "http://test.host/things/stuff", redirect_to_url
+    assert_equal "/things/stuff", redirect_to_url
   end
 
   def test_redirect_back_with_no_referer_redirects_to_another_host
@@ -364,7 +364,7 @@ class RedirectTest < ActionController::TestCase
     get :safe_redirect_back_with_status
 
     assert_response 307
-    assert_equal "http://test.host/things/stuff", redirect_to_url
+    assert_equal "/things/stuff", redirect_to_url
   end
 
   def test_safe_redirect_back_from_the_same_host
@@ -380,7 +380,7 @@ class RedirectTest < ActionController::TestCase
     get :safe_redirect_back_with_status
 
     assert_response 307
-    assert_equal "http://test.host/things/stuff", redirect_to_url
+    assert_equal "/things/stuff", redirect_to_url
   end
 
   def test_safe_redirect_back_with_no_referer_redirects_to_another_host
@@ -393,7 +393,7 @@ class RedirectTest < ActionController::TestCase
   def test_safe_redirect_to_root
     get :safe_redirect_to_root
 
-    assert_equal "http://test.host/", redirect_to_url
+    assert_equal "/", redirect_to_url
   end
 
   def test_redirect_back_with_explicit_fallback_kwarg
@@ -417,11 +417,11 @@ class RedirectTest < ActionController::TestCase
       end
 
       get :redirect_to_existing_record
-      assert_equal "http://test.host/workshops/5", redirect_to_url
+      assert_equal "/workshops/5", redirect_to_url
       assert_redirected_to Workshop.new(5)
 
       get :redirect_to_new_record
-      assert_equal "http://test.host/workshops", redirect_to_url
+      assert_equal "/workshops", redirect_to_url
       assert_redirected_to Workshop.new(nil)
     end
   end
@@ -439,7 +439,7 @@ class RedirectTest < ActionController::TestCase
       end
 
       get :redirect_to_polymorphic
-      assert_equal "http://test.host/internal/workshops/5", redirect_to_url
+      assert_equal "/internal/workshops/5", redirect_to_url
       assert_redirected_to [:internal, Workshop.new(5)]
     end
   end
@@ -506,7 +506,7 @@ class RedirectTest < ActionController::TestCase
       get :redirect_to_with_block_and_options
 
       assert_response :redirect
-      assert_redirected_to "http://test.host/redirect/hello_world"
+      assert_redirected_to "/redirect/hello_world"
     end
   end
 
@@ -593,11 +593,11 @@ class RedirectTest < ActionController::TestCase
     with_raise_on_open_redirects do
       get :safe_redirect_with_fallback, params: { redirect_url: "http://www.rubyonrails.org/" }
       assert_response :redirect
-      assert_redirected_to "http://test.host/fallback"
+      assert_redirected_to "/fallback"
 
       get :safe_redirect_with_fallback, params: { redirect_url: "" }
       assert_response :redirect
-      assert_redirected_to "http://test.host/fallback"
+      assert_redirected_to "/fallback"
     end
   end
 
@@ -614,7 +614,7 @@ class RedirectTest < ActionController::TestCase
 
     assert_equal request, payload[:request]
     assert_equal 302, payload[:status]
-    assert_equal "http://test.host/redirect/hello_world", payload[:location]
+    assert_equal "/redirect/hello_world", payload[:location]
   end
 
   private
@@ -640,7 +640,7 @@ module ModuleTest
     def test_simple_redirect
       get :simple_redirect
       assert_response :redirect
-      assert_equal "http://test.host/module_test/module_redirect/hello_world", redirect_to_url
+      assert_equal "/module_test/module_redirect/hello_world", redirect_to_url
     end
 
     def test_simple_redirect_using_options
@@ -652,7 +652,7 @@ module ModuleTest
     def test_module_redirect
       get :module_redirect
       assert_response :redirect
-      assert_equal "http://test.host/redirect/hello_world", redirect_to_url
+      assert_equal "/redirect/hello_world", redirect_to_url
     end
 
     def test_module_redirect_using_options

--- a/actionpack/test/dispatch/routing/ipv6_redirect_test.rb
+++ b/actionpack/test/dispatch/routing/ipv6_redirect_test.rb
@@ -13,7 +13,7 @@ class IPv6IntegrationTest < ActionDispatch::IntegrationTest
     end
 
     def foo
-      redirect_to action: :index
+      redirect_to action: :index, only_path: false
     end
   end
 

--- a/actionview/test/template/url_helper_test.rb
+++ b/actionview/test/template/url_helper_test.rb
@@ -1175,7 +1175,7 @@ class UrlHelperControllerTest < ActionController::TestCase
   def test_recall_params_should_normalize_id
     get :show, params: { id: "123" }
     assert_equal 302, @response.status
-    assert_equal "http://test.host/url_helper_controller_test/url_helper/profile/123", @response.location
+    assert_equal "/url_helper_controller_test/url_helper/profile/123", @response.location
 
     get :show, params: { name: "123" }
     assert_equal "ok", @response.body

--- a/railties/lib/rails/generators/test_unit/scaffold/templates/functional_test.rb.tt
+++ b/railties/lib/rails/generators/test_unit/scaffold/templates/functional_test.rb.tt
@@ -25,7 +25,7 @@ class <%= controller_class_name %>ControllerTest < ActionDispatch::IntegrationTe
       post <%= index_helper(type: :url) %>, params: { <%= "#{singular_table_name}: #{attributes_string}" %> }
     end
 
-    assert_redirected_to <%= show_helper("#{class_name}.last") %>
+    assert_redirected_to <%= show_helper("#{class_name}.last", type: :path) %>
   end
 
   test "should show <%= singular_table_name %>" do
@@ -40,7 +40,7 @@ class <%= controller_class_name %>ControllerTest < ActionDispatch::IntegrationTe
 
   test "should update <%= singular_table_name %>" do
     patch <%= show_helper %>, params: { <%= "#{singular_table_name}: #{attributes_string}" %> }
-    assert_redirected_to <%= show_helper %>
+    assert_redirected_to <%= show_helper(type: :path) %>
   end
 
   test "should destroy <%= singular_table_name %>" do


### PR DESCRIPTION
Partially addresses https://github.com/rails/rails/issues/52756.

### Motivation / Background

This Pull Request has been created because we want the Rails codebase to move from redirecting with URLs to redirecting with paths. See DHH's rationale in https://github.com/rails/rails/issues/52756.

The problem is that currently, Rails converts any path redirection to a URL redirection. For example all the following:

- `redirect_to @some_record`
- `redirect_to some_path`
- `redirect_to "/some/path"`

are internally converted to URLs. Meaning that the 3xx redirect `Location` response field is a full URL, not a path.

### Detail

This Pull Request changes `_compute_redirect_to_location` (called by `redirect_to`) to truly return a path by default.

A full URL is still returned if `redirect_to` has options like `:host` which IMO means that the developer intended to use full URLs. I am uncertain about this so I am open to feedback.

I am also a bit wary of unintended side effects; I only did a quick pass on fixing tests.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
