### PR TITLE
No need to install `bundler` since it is a default gem since Ruby 2.6

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/bin/setup.tt
+++ b/railties/lib/rails/generators/rails/app/templates/bin/setup.tt
@@ -13,7 +13,6 @@ FileUtils.chdir APP_ROOT do
   # Add necessary setup steps to this file.
 
   puts "== Installing dependencies =="
-  system! "gem install bundler --conservative"
   system("bundle check") || system!("bundle install")
 <% if using_node? -%>
 


### PR DESCRIPTION
### Motivation / Background

This commit removes "gem install bundler --conservative" command from `bin/setup` command because bundler is installed as a default gem since Ruby 2.6.0.

### Detail

* Ruby 2.6.0 Released https://www.ruby-lang.org/en/news/2018/12/25/ruby-2-6-0-released/
> Bundler is now installed as a default gem.

The current Rails main branch requires Ruby 3.1.0 that is higher than 2.6.0. https://github.com/rails/rails/blob/8bac99ad7a403ef52a5c97e7afa73c7bbcc67110/rails.gemspec#L12

### Additional information

This line has been added via https://github.com/rails/rails/commit/58d3e025793bec3a97c6f3afd8d3e36040d21167 for Rails 4.2.0 that support Ruby 1.9.3. Ruby 1.9.3 did not install bundler as a default gem.
https://github.com/rails/rails/blob/7847a19f476fb9bee287681586d872ea43785e53/rails.gemspec#L10

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.