### PR TITLE
Require zlib in top level active_record.rb file

### DIFF
--- a/activerecord/lib/active_record.rb
+++ b/activerecord/lib/active_record.rb
@@ -29,6 +29,7 @@ require "active_support/ordered_options"
 require "active_model"
 require "arel"
 require "yaml"
+require "zlib"
 
 require "active_record/version"
 require "active_record/deprecator"

--- a/activerecord/lib/active_record/encryption/encryptor.rb
+++ b/activerecord/lib/active_record/encryption/encryptor.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "openssl"
-require "zlib"
 require "active_support/core_ext/numeric"
 
 module ActiveRecord

--- a/activerecord/lib/active_record/fixtures.rb
+++ b/activerecord/lib/active_record/fixtures.rb
@@ -2,7 +2,6 @@
 
 require "erb"
 require "yaml"
-require "zlib"
 require "set"
 require "active_support/dependencies"
 require "active_support/core_ext/digest/uuid"

--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -2,7 +2,6 @@
 
 require "benchmark"
 require "set"
-require "zlib"
 require "active_support/core_ext/array/access"
 require "active_support/core_ext/enumerable"
 require "active_support/core_ext/module/attribute_accessors"


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This pull request has been created in replacement of https://github.com/rails/rails/pull/52760.

A good point was made that shared dependencies should rather be required in top level active_record.rb file (https://github.com/rails/rails/pull/52760#issuecomment-2325005602).

But this is not the case today for `require "zlib"`, which is not present in [activerecord/lib/active_record.rb](https://github.com/rails/rails/blob/main/activerecord/lib/active_record.rb) but:

* Present in [activerecord/lib/active_record/encryption/encryptor.rb](https://github.com/rails/rails/blob/main/activerecord/lib/active_record/encryption/encryptor.rb) where `Zlib` is not used (leftover from https://github.com/rails/rails/pull/51735)
* Not present in [activerecord/lib/active_record/encryption/config.rb](https://github.com/rails/rails/blob/main/activerecord/lib/active_record/encryption/config.rb) where `Zlib` is used. This does not trigger an issue because `require "zlib"` is present in [activerecord/lib/active_record/migration.rb](https://github.com/rails/rails/blob/main/activerecord/lib/active_record/migration.rb) which is usually autoloaded before when requiring the top level active_record.rb file.

Although functional, this setup seems brittle and/or accidental.

Let's rather move the `require "zlib"` directive to the top level "active_record" file as recommend for shared dependencies.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
