### PR TITLE
Make sure we are using the correct connection pool when dumping the schema

### DIFF
--- a/activerecord/lib/active_record/tasks/database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/database_tasks.rb
@@ -211,7 +211,9 @@ module ActiveRecord
         # Dump schema for databases that were migrated.
         if ActiveRecord.dump_schema_after_migration
           dump_db_configs.each do |db_config|
-            dump_schema(db_config)
+            with_temporary_pool(db_config) do
+              dump_schema(db_config)
+            end
           end
         end
 

--- a/railties/test/application/rake/multi_dbs_test.rb
+++ b/railties/test/application/rake/multi_dbs_test.rb
@@ -598,11 +598,17 @@ module ApplicationTests
         require "#{app_path}/config/environment"
         app_file "db/migrate/01_one_migration.rb", <<-MIGRATION
           class OneMigration < ActiveRecord::Migration::Current
+            def change
+              create_table :posts
+            end
           end
         MIGRATION
 
         app_file "db/animals_migrate/02_two_migration.rb", <<-MIGRATION
           class TwoMigration < ActiveRecord::Migration::Current
+            def change
+              create_table :dogs
+            end
           end
         MIGRATION
 
@@ -615,6 +621,8 @@ module ApplicationTests
 
           assert File.exist?("db/schema.rb")
           assert File.exist?("db/animals_schema.rb")
+
+          assert_not_equal File.read("db/schema.rb"), File.read("db/animals_schema.rb")
 
           primary_mtime = File.mtime("db/schema.rb")
           animals_mtime = File.mtime("db/animals_schema.rb")


### PR DESCRIPTION
This was broken by https://github.com/rails/rails/commit/175bf8259a83853836657c0fbf300dfa3842e535.

Before we were switching the connection pool to use the one for the
correspondent db config, but since we moved the `dump_schema` call to
outside of the `with_temporary_pool` block, we were using the default
connection pool.

Fixes https://github.com/rails/rails/issues/52776.