### PR TITLE
Use 127.0.0.1 instead of localhost so Docker DB can be easily used

### DIFF
--- a/railties/lib/rails/generators/database.rb
+++ b/railties/lib/rails/generators/database.rb
@@ -42,7 +42,7 @@ module Rails
         end
 
         def host
-          "localhost"
+          "127.0.0.1"
         end
       end
 

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -1365,7 +1365,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
       assert_includes content["forwardPorts"], 3306
     end
     assert_file("config/database.yml") do |content|
-      assert_match(/host: <%= ENV.fetch\("DB_HOST"\) \{ "localhost" } %>/, content)
+      assert_match(/host: <%= ENV.fetch\("DB_HOST"\) \{ "127.0.0.1" } %>/, content)
     end
   end
 
@@ -1393,7 +1393,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
       assert_includes(content["forwardPorts"], 3306)
     end
     assert_file("config/database.yml") do |content|
-      assert_match(/host: <%= ENV.fetch\("DB_HOST"\) \{ "localhost" } %>/, content)
+      assert_match(/host: <%= ENV.fetch\("DB_HOST"\) \{ "127.0.0.1" } %>/, content)
     end
   end
 
@@ -1421,7 +1421,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
       assert_includes(content["forwardPorts"], 3306)
     end
     assert_file("config/database.yml") do |content|
-      assert_match(/host: <%= ENV.fetch\("DB_HOST"\) \{ "localhost" } %>/, content)
+      assert_match(/host: <%= ENV.fetch\("DB_HOST"\) \{ "127.0.0.1" } %>/, content)
     end
   end
 
@@ -1448,7 +1448,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
       assert_includes(content["forwardPorts"], 3306)
     end
     assert_file("config/database.yml") do |content|
-      assert_match(/host: <%= ENV.fetch\("DB_HOST"\) \{ "localhost" } %>/, content)
+      assert_match(/host: <%= ENV.fetch\("DB_HOST"\) \{ "127.0.0.1" } %>/, content)
     end
   end
 


### PR DESCRIPTION
It's become common practice to run the development database out of Docker. To connect to a Docker-based MySQL DB out of the box, we need to use 127.0.0.1 instead of localhost.