### PR TITLE
Use `URI::RFC2396_PARSER` instead of `URI::DEFAULT_PARSER`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,6 +38,9 @@ gem "json", ">= 2.0.0", "!=2.7.0"
 # Workaround until Ruby ships with cgi version 0.3.6 or higher.
 gem "cgi", ">= 0.3.6", require: false
 
+# Workaround until all supported Ruby versions ship with uri version 0.13.1 or higher.
+gem "uri", ">= 0.13.1", require: false
+
 gem "prism"
 
 group :lint do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -96,6 +96,7 @@ PATH
       minitest (>= 5.1)
       securerandom (>= 0.3)
       tzinfo (~> 2.0, >= 2.0.5)
+      uri (>= 0.13.1)
     rails (8.0.0.alpha)
       actioncable (= 8.0.0.alpha)
       actionmailbox (= 8.0.0.alpha)
@@ -596,6 +597,7 @@ GEM
       concurrent-ruby (~> 1.0)
     uber (0.1.0)
     unicode-display_width (2.5.0)
+    uri (0.13.1)
     useragent (0.16.10)
     w3c_validators (1.3.7)
       json (>= 1.8)
@@ -701,6 +703,7 @@ DEPENDENCIES
   trilogy (>= 2.7.0)
   turbo-rails
   tzinfo-data
+  uri (>= 0.13.1)
   useragent
   w3c_validators (~> 1.3.6)
   wdm (>= 0.1.0)

--- a/actionpack/lib/action_dispatch/routing/inspector.rb
+++ b/actionpack/lib/action_dispatch/routing/inspector.rb
@@ -101,7 +101,7 @@ module ActionDispatch
             { controller: /#{filter[:controller].underscore.sub(/_?controller\z/, "")}/ }
           elsif filter[:grep]
             grep_pattern = Regexp.new(filter[:grep])
-            path = URI::DEFAULT_PARSER.escape(filter[:grep])
+            path = URI::RFC2396_PARSER.escape(filter[:grep])
             normalized_path = ("/" + path).squeeze("/")
 
             {

--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -2033,7 +2033,7 @@ module ActionDispatch
               name_for_action(options.delete(:as), action)
             end
 
-            path = Mapping.normalize_path URI::DEFAULT_PARSER.escape(path), formatted
+            path = Mapping.normalize_path URI::RFC2396_PARSER.escape(path), formatted
             ast = Journey::Parser.parse path
 
             mapping = Mapping.build(@scope, @set, ast, controller, default_action, to, via, formatted, options_constraints, anchor, options)

--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -929,7 +929,7 @@ module ActionDispatch
           params.each do |key, value|
             if value.is_a?(String)
               value = value.dup.force_encoding(Encoding::BINARY)
-              params[key] = URI::DEFAULT_PARSER.unescape(value)
+              params[key] = URI::RFC2396_PARSER.unescape(value)
             end
           end
           req.path_parameters = params

--- a/actionpack/test/controller/parameter_encoding_test.rb
+++ b/actionpack/test/controller/parameter_encoding_test.rb
@@ -56,7 +56,7 @@ class ParameterEncodingTest < ActionController::TestCase
   end
 
   test "does not raise an error when passed a param declared as ASCII-8BIT that contains invalid bytes" do
-    get :test_skip_parameter_encoding, params: { "bar" => URI::DEFAULT_PARSER.escape("bar\xE2baz".b) }
+    get :test_skip_parameter_encoding, params: { "bar" => URI::RFC2396_PARSER.escape("bar\xE2baz".b) }
 
     assert_response :success
     assert_equal "ASCII-8BIT", @response.body

--- a/actionpack/test/controller/routing_test.rb
+++ b/actionpack/test/controller/routing_test.rb
@@ -2179,11 +2179,11 @@ class RackMountIntegrationTests < ActiveSupport::TestCase
   end
 
   def test_unicode_path
-    assert_equal({ controller: "news", action: "index" }, @routes.recognize_path(URI::DEFAULT_PARSER.escape("こんにちは/世界"), method: :get))
+    assert_equal({ controller: "news", action: "index" }, @routes.recognize_path(URI::RFC2396_PARSER.escape("こんにちは/世界"), method: :get))
   end
 
   def test_downcased_unicode_path
-    assert_equal({ controller: "news", action: "index" }, @routes.recognize_path(URI::DEFAULT_PARSER.escape("こんにちは/世界").downcase, method: :get))
+    assert_equal({ controller: "news", action: "index" }, @routes.recognize_path(URI::RFC2396_PARSER.escape("こんにちは/世界").downcase, method: :get))
   end
 
   private

--- a/actionview/lib/action_view/helpers/url_helper.rb
+++ b/actionview/lib/action_view/helpers/url_helper.rb
@@ -556,14 +556,14 @@ module ActionView
 
         options ||= options_as_kwargs
         check_parameters ||= options.is_a?(Hash) && options.delete(:check_parameters)
-        url_string = URI::DEFAULT_PARSER.unescape(url_for(options)).force_encoding(Encoding::BINARY)
+        url_string = URI::RFC2396_PARSER.unescape(url_for(options)).force_encoding(Encoding::BINARY)
 
         # We ignore any extra parameters in the request_uri if the
         # submitted URL doesn't have any either. This lets the function
         # work with things like ?order=asc
         # the behavior can be disabled with check_parameters: true
         request_uri = url_string.index("?") || check_parameters ? request.fullpath : request.path
-        request_uri = URI::DEFAULT_PARSER.unescape(request_uri).force_encoding(Encoding::BINARY)
+        request_uri = URI::RFC2396_PARSER.unescape(request_uri).force_encoding(Encoding::BINARY)
 
         if %r{^\w+://}.match?(url_string)
           request_uri = +"#{request.protocol}#{request.host_with_port}#{request_uri}"

--- a/activerecord/lib/active_record/database_configurations/connection_url_resolver.rb
+++ b/activerecord/lib/active_record/database_configurations/connection_url_resolver.rb
@@ -45,7 +45,7 @@ module ActiveRecord
         attr_reader :uri
 
         def uri_parser
-          @uri_parser ||= URI::Parser.new
+          @uri_parser ||= URI::RFC2396_Parser.new
         end
 
         # Converts the query parameters of the URI into a hash.

--- a/activesupport/activesupport.gemspec
+++ b/activesupport/activesupport.gemspec
@@ -44,4 +44,5 @@ Gem::Specification.new do |s|
   s.add_dependency "bigdecimal"
   s.add_dependency "logger", ">= 1.4.2"
   s.add_dependency "securerandom", ">= 0.3"
+  s.add_dependency "uri", ">= 0.13.1"
 end

--- a/activesupport/lib/active_support/testing/strict_warnings.rb
+++ b/activesupport/lib/active_support/testing/strict_warnings.rb
@@ -15,9 +15,6 @@ module ActiveSupport
       /Ignoring .*\.yml because it has expired/,
       /Failed to validate the schema cache because/,
 
-      # TODO: Can be removed if https://github.com/ruby/uri/issues/118 is addressed
-      /URI::RFC3986_PARSER/,
-
       # TODO: We need to decide what to do with this.
       /Status code :unprocessable_entity is deprecated/
     )

--- a/railties/lib/rails/info_controller.rb
+++ b/railties/lib/rails/info_controller.rb
@@ -20,7 +20,7 @@ class Rails::InfoController < Rails::ApplicationController # :nodoc:
 
   def routes
     if query = params[:query]
-      query = URI::DEFAULT_PARSER.escape query
+      query = URI::RFC2396_PARSER.escape query
 
       render json: {
         exact: matching_routes(query: query, exact_match: true),
@@ -61,7 +61,7 @@ class Rails::InfoController < Rails::ApplicationController # :nodoc:
         match ||= (query === route_wrapper.verb)
 
         unless match
-          controller_action = URI::DEFAULT_PARSER.escape(route_wrapper.reqs)
+          controller_action = URI::RFC2396_PARSER.escape(route_wrapper.reqs)
           match = exact_match ? (query === controller_action) : controller_action.include?(query)
         end
 

--- a/railties/test/application/assets_test.rb
+++ b/railties/test/application/assets_test.rb
@@ -324,7 +324,7 @@ module ApplicationTests
       # Load app env
       app "development"
 
-      get "/assets/#{URI::DEFAULT_PARSER.escape(asset_path)}"
+      get "/assets/#{URI::RFC2396_PARSER.escape(asset_path)}"
       assert_match "not an image really", last_response.body
       assert_file_exists("#{app_path}/public/assets/#{asset_path}")
     end


### PR DESCRIPTION


### Motivation / Background

This pull request uses `URI::RFC2396_PARSER` instead of `URI::DEFAULT_PARSER`.

### Detail

Ruby 3.4 changes `URI::DEFAULT_PARSER` to `URI::RFC3986_Parser` and deprecates `URI::RFC3986_PARSER.make_regexp`,`URI::RFC3986_PARSER.escape`, `URI::RFC3986_PARSER.unescape` and `URI::RFC3986_PARSER.extract`.

```ruby
$ ruby -v
ruby 3.4.0dev (2024-08-22T23:47:40Z master fdba458e85) [x86_64-linux]
$ irb -w
irb(main):001> require 'uri'
=> true
irb(main):002> URI::VERSION
=> "0.13.0"
irb(main):003> URI::DEFAULT_PARSER.escape("/:controller(/:action)")
(irb):3: warning: URI::RFC3986_PARSER.escape is obsoleted. Use URI::RFC2396_PARSER.escape explicitly.
=> "/:controller(/:action)"
```

uri v0.12.2 for Ruby 3.2/3.1 and v0.13.1 for Ruby 3.3 adds `URI::RFC2396_PARSER`. As of right now there is no way to use uri v0.12.2 for Ruby 3.2/3.1 and v0.13.1 for Ruby 3.3, This commit uses v0.13.1 or higher version for all supported Ruby versions by Rails main branch.

It also reverts #52682 because the original issue has been resolved.

### Additional information
Refer to following URL for the backgrond of this change:
- URI::Generic should use URI::RFC3986_PARSER instead of URI::DEFAULT_PARSER https://bugs.ruby-lang.org/issues/19266

- Use RFC3986_Parser by default https://github.com/ruby/uri/pull/107

- Warn compatibility methods in RFC3986_PARSER https://github.com/ruby/uri/pull/114

- Also warn URI::RFC3986_PARSER.extract https://github.com/ruby/uri/pull/121

- Define RFC2396_PARSER for Ruby 3.3 https://github.com/ruby/uri/pull/119

- Define RFC2396_PARSER for Ruby 3.2 and 3.1 https://github.com/ruby/uri/pull/120


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
