### PR TITLE
Separate specific db schema

### DIFF
--- a/activerecord/test/schema/mysql2_specific_schema.rb
+++ b/activerecord/test/schema/mysql2_specific_schema.rb
@@ -83,3 +83,18 @@ ActiveRecord::Schema.define do
     END
   SQL
 end
+
+if ActiveRecord::Base.lease_connection.supports_insert_returning?
+  ActiveRecord::Base.lease_connection.create_table :pk_autopopulated_by_a_trigger_records, force: true, id: false do |t|
+    t.integer :id, null: false
+  end
+
+  ActiveRecord::Base.lease_connection.execute(
+    <<-SQL
+      CREATE TRIGGER before_insert_trigger
+      BEFORE INSERT ON pk_autopopulated_by_a_trigger_records
+      FOR EACH ROW
+      SET NEW.id = (SELECT COALESCE(MAX(id), 0) + 1 FROM pk_autopopulated_by_a_trigger_records);
+    SQL
+  )
+end

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -1476,43 +1476,6 @@ ActiveRecord::Schema.define do
   end
 end
 
-if ActiveRecord::Base.lease_connection.supports_insert_returning? && !ActiveRecord::TestCase.current_adapter?(:SQLite3Adapter)
-  ActiveRecord::Base.lease_connection.create_table :pk_autopopulated_by_a_trigger_records, force: true, id: false do |t|
-    t.integer :id, null: false
-  end
-
-  if ActiveRecord::TestCase.current_adapter?(:PostgreSQLAdapter)
-    ActiveRecord::Base.lease_connection.execute(
-      <<-SQL
-        CREATE OR REPLACE FUNCTION populate_column()
-        RETURNS TRIGGER AS $$
-        DECLARE
-          max_value INTEGER;
-        BEGIN
-            SELECT MAX(id) INTO max_value FROM pk_autopopulated_by_a_trigger_records;
-            NEW.id = COALESCE(max_value, 0) + 1;
-            RETURN NEW;
-        END;
-        $$ LANGUAGE plpgsql;
-
-        CREATE TRIGGER before_insert_trigger
-        BEFORE INSERT ON pk_autopopulated_by_a_trigger_records
-        FOR EACH ROW
-        EXECUTE FUNCTION populate_column();
-      SQL
-    )
-  elsif ActiveRecord::TestCase.current_adapter?(:Mysql2Adapter, :TrilogyAdapter)
-    ActiveRecord::Base.lease_connection.execute(
-      <<-SQL
-        CREATE TRIGGER before_insert_trigger
-        BEFORE INSERT ON pk_autopopulated_by_a_trigger_records
-        FOR EACH ROW
-        SET NEW.id = (SELECT COALESCE(MAX(id), 0) + 1 FROM pk_autopopulated_by_a_trigger_records);
-      SQL
-    )
-  end
-end
-
 Course.lease_connection.create_table :courses, force: true do |t|
   t.column :name, :string, null: false
   t.column :college_id, :integer, index: true


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

I am maintaining two adapters : [postgis](github.com/rgeo/activerecord-postgis-adapter) and [cockroachdb](github.com/cockroachdb/activerecord-cockroachdb-adapter). For the later, we need to change the schema specific build. But since it is quite close to postgresql, we still return `true` on `current_adapter?(:PostgreSQLAdapter)`. So the actual configuration would force to replace the whole `schema.rb` trunk file.

### Detail

This Pull Request moves adapter specific schema definitions to these adapters. It is a little bit less DRY, but helps with creating external adapters.

### Additional information

We could consider having a file for what is common between trilogy and mysql2, required by both specific schemas. I'm not sure this is worth it though.