### PR TITLE
Make ActionableErrors work with `config.show_exceptions :rescuable`

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Make ActionableErrors rescuable.
+
+    Make sure ActionableErrors like PendingMigrations show the actionable form
+    when setting `action_dispatch.show_exceptions` to `:rescuable`.
+
+    *Petrik de Heus*
+
 *   Fix `Request#raw_post` raising `NoMethodError` when `rack.input` is `nil`.
 
     *Hartley McGuire*

--- a/actionpack/lib/action_dispatch/middleware/exception_wrapper.rb
+++ b/actionpack/lib/action_dispatch/middleware/exception_wrapper.rb
@@ -192,7 +192,8 @@ module ActionDispatch
     end
 
     def rescue_response?
-      @@rescue_responses.key?(exception.class.name)
+      exception.is_a?(ActiveSupport::ActionableError) ||
+        @@rescue_responses.key?(exception.class.name)
     end
 
     def source_extracts

--- a/actionpack/test/dispatch/exception_wrapper_test.rb
+++ b/actionpack/test/dispatch/exception_wrapper_test.rb
@@ -28,6 +28,10 @@ module ActionDispatch
       end
     end
 
+    class ActionableError < StandardError
+      include ActiveSupport::ActionableError
+    end
+
     setup do
       @cleaner = ActiveSupport::BacktraceCleaner.new
       @cleaner.remove_filters!
@@ -251,6 +255,16 @@ module ActionDispatch
 
     test "#show? returns true when using :rescuable and the exceptions is rescuable" do
       exception = AbstractController::ActionNotFound.new("")
+      wrapper = ExceptionWrapper.new(nil, exception)
+
+      env = { "action_dispatch.show_exceptions" => :rescuable }
+      request = ActionDispatch::Request.new(env)
+
+      assert_equal true, wrapper.show?(request)
+    end
+
+    test "#show? returns true when using :rescuable and the exceptions is actionable" do
+      exception = ActionableError.new
       wrapper = ExceptionWrapper.new(nil, exception)
 
       env = { "action_dispatch.show_exceptions" => :rescuable }


### PR DESCRIPTION
PendingMigrations no longer show the actionable form when setting `action_dispatch.show_exceptions` to `:rescuable`.

As all ActionableErrors should probably be rescuable, let the ExceptionWrapper render ActionableErrors as rescueable as well.

### Before

<img width="574" alt="image" src="https://github.com/user-attachments/assets/442ccd8a-373a-4ca3-92a9-93dc0999cff6">

### After

<img width="559" alt="image" src="https://github.com/user-attachments/assets/58c79702-70a6-4568-a17e-c4d9120a3935">


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
