### PR TITLE
Make ActionView::Template::Error work with `config.show_exceptions :rescuable`

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Make ActionView::Template::Error rescuable.
+
+    Make sure ActionView::Template::Errors show the correct error page when
+    setting `action_dispatch.show_exceptions` to `:rescuable`.
+
+    *Petrik de Heus*
+
 *   Fix `Request#raw_post` raising `NoMethodError` when `rack.input` is `nil`.
 
     *Hartley McGuire*

--- a/actionpack/lib/action_dispatch/middleware/exception_wrapper.rb
+++ b/actionpack/lib/action_dispatch/middleware/exception_wrapper.rb
@@ -10,6 +10,7 @@ require "rack/utils"
 module ActionDispatch
   class ExceptionWrapper
     cattr_accessor :rescue_responses, default: Hash.new(:internal_server_error).merge!(
+      "ActionView::Template::Error"                        => :internal_server_error,
       "ActionController::RoutingError"                     => :not_found,
       "AbstractController::ActionNotFound"                 => :not_found,
       "ActionController::MethodNotAllowed"                 => :method_not_allowed,


### PR DESCRIPTION
ActionView::Template::Errors no longer show the correct rescue response page when `action_dispatch.show_exceptions` is set to `:rescuable`.

By adding it to the rescue_responses it should render the correct error page.

### Before

<img width="746" alt="image" src="https://github.com/user-attachments/assets/5d4950b2-8cc1-4902-992c-214da7822a6b">

### After

<img width="1011" alt="image" src="https://github.com/user-attachments/assets/1f0d1064-7fea-42bd-b873-d12825a4e1c5">


### Detail

I'm not seeing test cases for each entry in rescue_responses, so I didn't add a new test case.

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
