### PR TITLE
Add require for `ClassAttribute` in class/attribute core extension

### DIFF
--- a/activesupport/lib/active_support/core_ext/class/attribute.rb
+++ b/activesupport/lib/active_support/core_ext/class/attribute.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "active_support/core_ext/module/redefine_method"
+require "active_support/class_attribute"
 
 class Class
   # Declare a class-level attribute whose value is inheritable by subclasses.


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because rails/rails@1962e8d introduced the `ClassAttribute` class. We need to require it in the `core_ext/class/attribute.rb` or else we will get a const missing error in gems or apps that are only requiring that core extension and not all of active support ([for example](https://github.com/Shopify/app_profiler/blob/6cec5eb427b1033a0866837767fb0b344aee96ec/lib/app_profiler.rb#L3)).

### Detail

Add a require.

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
