### PR TITLE
Silence healthcheck requests from the log

### DIFF
--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -593,6 +593,14 @@ config.session_store :my_custom_store
 
 The default store is a cookie store with the application name as the session key.
 
+#### config.silence_healthcheck_path
+
+Specifies the path of the healthcheck that should be silenced in the logs. Uses `Rails::Rack::SilenceRequest` to implement the silencing. All in service of keeping healthchecks from clogging the production logs, especially for early-stage applications.
+
+```
+config.silence_healthcheck_path = "/up"
+```
+
 #### `config.ssl_options`
 
 Configuration options for the [`ActionDispatch::SSL`](https://api.rubyonrails.org/classes/ActionDispatch/SSL.html) middleware.

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -593,7 +593,7 @@ config.session_store :my_custom_store
 
 The default store is a cookie store with the application name as the session key.
 
-#### config.silence_healthcheck_path
+#### `config.silence_healthcheck_path`
 
 Specifies the path of the healthcheck that should be silenced in the logs. Uses `Rails::Rack::SilenceRequest` to implement the silencing. All in service of keeping healthchecks from clogging the production logs, especially for early-stage applications.
 

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,4 +1,4 @@
-*   Add Rails::Rack::SilenceRequest middleware and use it via `config.silence_healthcheck = path`
+*   Add Rails::Rack::SilenceRequest middleware and use it via `config.silence_healthcheck_path = path`
     to silence requests to "/up". This prevents the Kamal-required healthchecks from clogging up
     the production logs.
 

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Add Rails::Rack::SilenceRequest middleware and use it via `config.silence_healthcheck = path`
+    to silence requests to "/up". This prevents the Kamal-required healthchecks from clogging up
+    the production logs.
+
+    *DHH*
+
 *   Introduce `mariadb-mysql` and `mariadb-trilogy` database options for `rails new`
 
     When used with the `--devcontainer` flag, these options will use `mariadb` as the database for the

--- a/railties/lib/rails.rb
+++ b/railties/lib/rails.rb
@@ -12,6 +12,7 @@ require "rails/version"
 require "rails/deprecator"
 require "rails/application"
 require "rails/backtrace_cleaner"
+require "rails/rack/silence_request"
 
 require "active_support/railtie"
 require "action_dispatch/railtie"

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -15,7 +15,7 @@ module Rails
                     :cache_classes, :cache_store, :consider_all_requests_local, :console,
                     :eager_load, :exceptions_app, :file_watcher, :filter_parameters, :precompile_filter_parameters,
                     :force_ssl, :helpers_paths, :hosts, :host_authorization, :logger, :log_formatter,
-                    :log_tags, :railties_order, :relative_url_root,
+                    :log_tags, :silence_healthcheck, :railties_order, :relative_url_root,
                     :ssl_options, :public_file_server,
                     :session_options, :time_zone, :reload_classes_only_on_change,
                     :beginning_of_week, :filter_redirect, :x,
@@ -62,6 +62,7 @@ module Rails
         @exceptions_app                          = nil
         @autoflush_log                           = true
         @log_formatter                           = ActiveSupport::Logger::SimpleFormatter.new
+        @silence_healthcheck                     = false
         @eager_load                              = nil
         @secret_key_base                         = nil
         @api_only                                = false

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -15,7 +15,7 @@ module Rails
                     :cache_classes, :cache_store, :consider_all_requests_local, :console,
                     :eager_load, :exceptions_app, :file_watcher, :filter_parameters, :precompile_filter_parameters,
                     :force_ssl, :helpers_paths, :hosts, :host_authorization, :logger, :log_formatter,
-                    :log_tags, :silence_healthcheck, :railties_order, :relative_url_root,
+                    :log_tags, :silence_healthcheck_path, :railties_order, :relative_url_root,
                     :ssl_options, :public_file_server,
                     :session_options, :time_zone, :reload_classes_only_on_change,
                     :beginning_of_week, :filter_redirect, :x,
@@ -62,7 +62,7 @@ module Rails
         @exceptions_app                          = nil
         @autoflush_log                           = true
         @log_formatter                           = ActiveSupport::Logger::SimpleFormatter.new
-        @silence_healthcheck                     = false
+        @silence_healthcheck_path                = nil
         @eager_load                              = nil
         @secret_key_base                         = nil
         @api_only                                = false

--- a/railties/lib/rails/application/default_middleware_stack.rb
+++ b/railties/lib/rails/application/default_middleware_stack.rb
@@ -54,6 +54,10 @@ module Rails
           middleware.use ::ActionDispatch::RequestId, header: config.action_dispatch.request_id_header
           middleware.use ::ActionDispatch::RemoteIp, config.action_dispatch.ip_spoofing_check, config.action_dispatch.trusted_proxies
 
+          if path = config.silence_healthcheck
+            middleware.use ::Rails::Rack::SilenceRequest, path: path
+          end
+
           middleware.use ::Rails::Rack::Logger, config.log_tags
           middleware.use ::ActionDispatch::ShowExceptions, show_exceptions_app
           middleware.use ::ActionDispatch::DebugExceptions, app, config.debug_exception_response_format

--- a/railties/lib/rails/application/default_middleware_stack.rb
+++ b/railties/lib/rails/application/default_middleware_stack.rb
@@ -54,7 +54,7 @@ module Rails
           middleware.use ::ActionDispatch::RequestId, header: config.action_dispatch.request_id_header
           middleware.use ::ActionDispatch::RemoteIp, config.action_dispatch.ip_spoofing_check, config.action_dispatch.trusted_proxies
 
-          if path = config.silence_healthcheck
+          if path = config.silence_healthcheck_path
             middleware.use ::Rails::Rack::SilenceRequest, path: path
           end
 

--- a/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
@@ -60,7 +60,7 @@ Rails.application.configure do
   # Skip http-to-https redirect for the default health check endpoint.
   # config.ssl_options = { redirect: { exclude: ->(request) { request.path == "/up" } } }
 
-  # Prevent healthchecks from clogging up the production log
+  # Prevent healthchecks from clogging up the logs
   config.silence_healthcheck_path = "/up"
 
   # Log to STDOUT by default

--- a/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
@@ -60,6 +60,9 @@ Rails.application.configure do
   # Skip http-to-https redirect for the default health check endpoint.
   # config.ssl_options = { redirect: { exclude: ->(request) { request.path == "/up" } } }
 
+  # Silence requests to /up from the logs
+  config.silence_healthcheck = "/up"
+
   # Log to STDOUT by default
   config.logger = ActiveSupport::Logger.new(STDOUT)
     .tap  { |logger| logger.formatter = ::Logger::Formatter.new }

--- a/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
@@ -61,7 +61,7 @@ Rails.application.configure do
   # config.ssl_options = { redirect: { exclude: ->(request) { request.path == "/up" } } }
 
   # Silence requests to /up from the logs
-  config.silence_healthcheck = "/up"
+  config.silence_healthcheck_path = "/up"
 
   # Log to STDOUT by default
   config.logger = ActiveSupport::Logger.new(STDOUT)

--- a/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
@@ -60,7 +60,7 @@ Rails.application.configure do
   # Skip http-to-https redirect for the default health check endpoint.
   # config.ssl_options = { redirect: { exclude: ->(request) { request.path == "/up" } } }
 
-  # Silence requests to /up from the logs
+  # Prevent healthchecks from clogging up the production log
   config.silence_healthcheck_path = "/up"
 
   # Log to STDOUT by default

--- a/railties/lib/rails/rack/silence_request.rb
+++ b/railties/lib/rails/rack/silence_request.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+# :markup: markdown
+
+require "active_support/logger_silence"
+
+module Rails
+  module Rack
+    # Allows you to silence requests made to a specific path and optionally by a specific remote IP.
+    # This is useful for preventing recurring requests like healthchecks from clogging the logging.
+    # This middleware is used to do just that against the path /up from localhost in production by default.
+    #
+    # Example:
+    #
+    #   config.middleware.insert_before Rails::Rack::Logger,
+    #     Rails::Rack::SilenceRequest, remote_ip: "127.0.0.1", path: "/up"
+    #
+    # Note: This should be set before the Rails::Rack::Logger middleware in order to properly silence the entire request.
+    class SilenceRequest
+      def initialize(app, path:, remote_ip: nil)
+        @app, @path, @remote_ip = app, path, remote_ip
+      end
+
+      def call(env)
+        request = ActionDispatch::Request.new(env)
+
+        if due_silencing?(request)
+          Rails.logger.silence do
+            @app.call(env)
+          end
+        else
+          @app.call(env)
+        end
+      end
+
+      private
+        def due_silencing?(request)
+          remote_ip_due_silencing?(request) && path_due_silencing?(request)
+        end
+
+        def remote_ip_due_silencing?(request)
+          @remote_ip ? request.remote_ip == @remote_ip : true
+        end
+
+        def path_due_silencing?(request)
+          request.path == @path
+        end
+    end
+  end
+end

--- a/railties/lib/rails/rack/silence_request.rb
+++ b/railties/lib/rails/rack/silence_request.rb
@@ -22,12 +22,8 @@ module Rails
       end
 
       def call(env)
-        request = ActionDispatch::Request.new(env)
-
-        if request.path == @path
-          Rails.logger.silence do
-            @app.call(env)
-          end
+        if env['PATH_INFO'] == @path
+          Rails.logger.silence { @app.call(env) }
         else
           @app.call(env)
         end

--- a/railties/lib/rails/rack/silence_request.rb
+++ b/railties/lib/rails/rack/silence_request.rb
@@ -5,16 +5,16 @@ require "active_support/logger_silence"
 
 module Rails
   module Rack
-    # Allows you to silence requests made to a specific path and optionally by a specific remote IP.
+    # Allows you to silence requests made to a specific path.
     # This is useful for preventing recurring requests like healthchecks from clogging the logging.
-    # This middleware is used to do just that against the path /up from localhost in production by default.
+    # This middleware is used to do just that against the path /up in production by default.
     #
     # Example:
     #
-    #   config.middleware.insert_before Rails::Rack::Logger,
-    #     Rails::Rack::SilenceRequest, remote_ip: "127.0.0.1", path: "/up"
+    #   config.middleware.insert_before \
+    #     Rails::Rack::Logger, Rails::Rack::SilenceRequest, path: "/up"
     #
-    # Note: This should be set before the Rails::Rack::Logger middleware in order to properly silence the entire request.
+    # This middleware can also be configured using `config.silence_healthcheck = "/up"` in Rails.
     class SilenceRequest
       def initialize(app, path:, remote_ip: nil)
         @app, @path, @remote_ip = app, path, remote_ip
@@ -23,7 +23,7 @@ module Rails
       def call(env)
         request = ActionDispatch::Request.new(env)
 
-        if due_silencing?(request)
+        if request.path == @path
           Rails.logger.silence do
             @app.call(env)
           end
@@ -31,19 +31,6 @@ module Rails
           @app.call(env)
         end
       end
-
-      private
-        def due_silencing?(request)
-          remote_ip_due_silencing?(request) && path_due_silencing?(request)
-        end
-
-        def remote_ip_due_silencing?(request)
-          @remote_ip ? request.remote_ip == @remote_ip : true
-        end
-
-        def path_due_silencing?(request)
-          request.path == @path
-        end
     end
   end
 end

--- a/railties/lib/rails/rack/silence_request.rb
+++ b/railties/lib/rails/rack/silence_request.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 # :markup: markdown
 
 require "active_support/logger_silence"

--- a/railties/lib/rails/rack/silence_request.rb
+++ b/railties/lib/rails/rack/silence_request.rb
@@ -16,8 +16,8 @@ module Rails
     #
     # This middleware can also be configured using `config.silence_healthcheck = "/up"` in Rails.
     class SilenceRequest
-      def initialize(app, path:, remote_ip: nil)
-        @app, @path, @remote_ip = app, path, remote_ip
+      def initialize(app, path:)
+        @app, @path = app, path
       end
 
       def call(env)

--- a/railties/lib/rails/rack/silence_request.rb
+++ b/railties/lib/rails/rack/silence_request.rb
@@ -22,7 +22,7 @@ module Rails
       end
 
       def call(env)
-        if env['PATH_INFO'] == @path
+        if env["PATH_INFO"] == @path
           Rails.logger.silence { @app.call(env) }
         else
           @app.call(env)

--- a/railties/test/commands/middleware_test.rb
+++ b/railties/test/commands/middleware_test.rb
@@ -197,7 +197,7 @@ class Rails::Command::MiddlewareTest < ActiveSupport::TestCase
   end
 
   test "silence healthcheck" do
-    add_to_config "config.silence_healthcheck = '/up'"
+    add_to_config "config.silence_healthcheck_path = '/up'"
     boot!
     assert_includes middleware, "Rails::Rack::SilenceRequest"
   end

--- a/railties/test/commands/middleware_test.rb
+++ b/railties/test/commands/middleware_test.rb
@@ -196,10 +196,10 @@ class Rails::Command::MiddlewareTest < ActiveSupport::TestCase
     assert_includes middleware, "ActionDispatch::AssumeSSL"
   end
 
-  test "ActionDispatch::SSL is present when force_ssl is set" do
-    add_to_config "config.force_ssl = true"
+  test "silence healthcheck" do
+    add_to_config "config.silence_healthcheck = '/up'"
     boot!
-    assert_includes middleware, "ActionDispatch::SSL"
+    assert_includes middleware, "Rails::Rack::SilenceRequest"
   end
 
   test "ActionDispatch::SSL is configured with options when given" do

--- a/railties/test/rack_silence_request_test.rb
+++ b/railties/test/rack_silence_request_test.rb
@@ -9,32 +9,13 @@ class RackSilenceRequestTest < ActiveSupport::TestCase
     mock_logger = Minitest::Mock.new
     mock_logger.expect :silence, nil
 
-    app = app_with_silence(path: "/up")
+    app = Rails::Rack::SilenceRequest.new(lambda { |env| [200, env, "app"] }, path: "/up")
 
     Rails.stub(:logger, mock_logger) do
-      app.call(Rack::MockRequest.env_for("http://example.com/up", "REMOTE_ADDR" => "127.0.0.1"))
-      app.call(Rack::MockRequest.env_for("http://example.com/down", "REMOTE_ADDR" => "127.0.0.1"))
+      app.call(Rack::MockRequest.env_for("http://example.com/up"))
+      app.call(Rack::MockRequest.env_for("http://example.com/down"))
     end
 
     assert mock_logger.verify
   end
-
-  test "silence request only to specific path with ip restriction" do
-    mock_logger = Minitest::Mock.new
-    mock_logger.expect :silence, nil
-
-    app = app_with_silence(path: "/up", remote_ip: "127.0.0.1")
-
-    Rails.stub(:logger, mock_logger) do
-      app.call(Rack::MockRequest.env_for("http://example.com/up", "REMOTE_ADDR" => "127.0.0.1"))
-      app.call(Rack::MockRequest.env_for("http://example.com/up", "REMOTE_ADDR" => "127.0.0.2"))
-    end
-
-    assert mock_logger.verify
-  end
-
-  private
-    def app_with_silence(path:, remote_ip: nil)
-      Rails::Rack::SilenceRequest.new(lambda { |env| [200, env, "app"] }, path:, remote_ip:)
-    end
 end

--- a/railties/test/rack_silence_request_test.rb
+++ b/railties/test/rack_silence_request_test.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require "abstract_unit"
+require "rack/test"
+require "minitest/mock"
+
+class RackSilenceRequestTest < ActiveSupport::TestCase
+  test "silence request only to specific path" do
+    mock_logger = Minitest::Mock.new
+    mock_logger.expect :silence, nil
+
+    app = app_with_silence(path: "/up")
+
+    Rails.stub(:logger, mock_logger) do
+      app.call(Rack::MockRequest.env_for("http://example.com/up", "REMOTE_ADDR" => "127.0.0.1"))
+      app.call(Rack::MockRequest.env_for("http://example.com/down", "REMOTE_ADDR" => "127.0.0.1"))
+    end
+
+    assert mock_logger.verify
+  end
+
+  test "silence request only to specific path with ip restriction" do
+    mock_logger = Minitest::Mock.new
+    mock_logger.expect :silence, nil
+
+    app = app_with_silence(path: "/up", remote_ip: "127.0.0.1")
+
+    Rails.stub(:logger, mock_logger) do
+      app.call(Rack::MockRequest.env_for("http://example.com/up", "REMOTE_ADDR" => "127.0.0.1"))
+      app.call(Rack::MockRequest.env_for("http://example.com/up", "REMOTE_ADDR" => "127.0.0.2"))
+    end
+
+    assert mock_logger.verify
+  end
+
+  private
+    def app_with_silence(path:, remote_ip: nil)
+      Rails::Rack::SilenceRequest.new(lambda { |env| [200, env, "app"] }, path:, remote_ip:)
+    end
+end


### PR DESCRIPTION
The default Rails health check is intended to be hit every second or so by Kamal to ensure that the application is still or has just become responsive. This clutters up the production logs and makes it hard to follow what's actually going on. This adds a new middleware called `Rails::Rack::SilenceRequest` that is used by a new config `config.silence_healthcheck = path` to prevent that.