### PR TITLE
Change assign_attributes to assign the association's _id first. Fixes…

### DIFF
--- a/activerecord/lib/active_record/attribute_assignment.rb
+++ b/activerecord/lib/active_record/attribute_assignment.rb
@@ -4,19 +4,27 @@ module ActiveRecord
   module AttributeAssignment
     private
       def _assign_attributes(attributes)
-        multi_parameter_attributes = nil
+        multi_parameter_attributes = nested_parameter_attributes = nil
 
         attributes.each do |k, v|
           key = k.to_s
 
           if key.include?("(")
             (multi_parameter_attributes ||= {})[key] = v
+          elsif v.is_a?(Hash)
+            (nested_parameter_attributes ||= {})[key] = v
           else
             _assign_attribute(key, v)
           end
         end
 
+        assign_nested_parameter_attributes(nested_parameter_attributes) if nested_parameter_attributes
         assign_multiparameter_attributes(multi_parameter_attributes) if multi_parameter_attributes
+      end
+
+      # Assign any deferred nested attributes after the base attributes have been set.
+      def assign_nested_parameter_attributes(pairs)
+        pairs.each { |k, v| _assign_attribute(k, v) }
       end
 
       # Instantiates objects for all attribute classes that needs more than one constructor parameter. This is done

--- a/activerecord/test/cases/nested_attributes_test.rb
+++ b/activerecord/test/cases/nested_attributes_test.rb
@@ -362,6 +362,15 @@ class TestNestedAttributesOnAHasOneAssociation < ActiveRecord::TestCase
     assert_equal "Mister Pablo", @pirate.ship.name
   end
 
+  def test_should_defer_updating_nested_associations_until_after_base_attributes_are_set
+    ship = @pirate.ship
+
+    ship_part = ShipPart.new
+    ship_part.attributes = { ship_attributes: { name: "Prometheus" }, ship_id: ship.id }
+
+    assert_equal "Prometheus", ship_part.ship.name
+  end
+
   def test_should_not_destroy_the_associated_model_until_the_parent_is_saved
     @pirate.attributes = { ship_attributes: { id: @ship.id, _destroy: "1" } }
 


### PR DESCRIPTION
[Fix #52791]

### Motivation / Background

Addresses the use case where if an association's _id is later in the params than the association's _attributes, the nested attributes will not be applied.

This Pull Request has been created because the upgrade from 7.1.3.4. to 7.2.1 caused tests in our application to fail. We were assigning the association_id after the association_attributes in our parameters, and due to the order it no longer updated existing models.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
