### PR TITLE
Fix `find_by_token_for` for models with composite primary keys

### DIFF
--- a/activerecord/lib/active_record/token_for.rb
+++ b/activerecord/lib/active_record/token_for.rb
@@ -40,7 +40,7 @@ module ActiveRecord
       # +nil+ if the token is invalid or the record was not found.
       def find_by_token_for(purpose, token)
         raise UnknownPrimaryKey.new(self) unless model.primary_key
-        model.token_definitions.fetch(purpose).resolve_token(token) { |id| find_by(model.primary_key => id) }
+        model.token_definitions.fetch(purpose).resolve_token(token) { |id| find_by(model.primary_key => [id]) }
       end
 
       # Finds a record using a given +token+ for a predefined +purpose+. Raises

--- a/activerecord/test/cases/token_for_test.rb
+++ b/activerecord/test/cases/token_for_test.rb
@@ -3,6 +3,7 @@
 require "cases/helper"
 require "models/matey"
 require "models/user"
+require "models/cpk"
 require "active_support/message_verifier"
 
 class TokenForTest < ActiveRecord::TestCase
@@ -142,6 +143,13 @@ class TokenForTest < ActiveRecord::TestCase
 
     assert_equal custom_pk_user, custom_pk.find_by_token_for(:lookup, custom_pk_lookup_token)
     assert_nil custom_pk.find_by_token_for(:lookup, @lookup_token)
+  end
+
+  test "finds record with a composite primary key" do
+    book = Cpk::Book.create!(id: [1, 3], shop_id: 2)
+    token = book.generate_token_for(:test)
+
+    assert_equal book, Cpk::Book.find_by_token_for(:test, token)
   end
 
   test "raises when no primary key has been declared" do

--- a/activerecord/test/models/cpk/book.rb
+++ b/activerecord/test/models/cpk/book.rb
@@ -13,6 +13,8 @@ module Cpk
 
     before_destroy :prevent_destroy_if_set
 
+    generates_token_for :test
+
     private
       def prevent_destroy_if_set
         throw(:abort) if fail_destroy


### PR DESCRIPTION
Fixes #52796.