### PR TITLE
Set `attributes_for_inspect` to `[:id]` in the production environment only

### DIFF
--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -104,7 +104,7 @@ module ActiveRecord
       class_attribute :shard_selector, instance_accessor: false, default: nil
 
       # Specifies the attributes that will be included in the output of the #inspect method
-      class_attribute :attributes_for_inspect, instance_accessor: false, default: [:id]
+      class_attribute :attributes_for_inspect, instance_accessor: false, default: :all
 
       def self.application_record_class? # :nodoc:
         if ActiveRecord.application_record_class
@@ -732,7 +732,7 @@ module ActiveRecord
 
     # Returns the full contents of the record as a nicely formatted string.
     def full_inspect
-      inspect_with_attributes(attribute_names)
+      inspect_with_attributes(all_attributes_for_inspect)
     end
 
     # Takes a PP and prettily prints this record to it, allowing you to get a nice result from <tt>pp record</tt>
@@ -824,7 +824,13 @@ module ActiveRecord
       end
 
       def attributes_for_inspect
-        self.class.attributes_for_inspect == :all ? attribute_names : self.class.attributes_for_inspect
+        self.class.attributes_for_inspect == :all ? all_attributes_for_inspect : self.class.attributes_for_inspect
+      end
+
+      def all_attributes_for_inspect
+        return [] unless @attributes
+
+        attribute_names
       end
   end
 end

--- a/activerecord/lib/active_record/railtie.rb
+++ b/activerecord/lib/active_record/railtie.rb
@@ -69,6 +69,7 @@ module ActiveRecord
         Rails.logger.broadcast_to(console)
       end
       ActiveRecord.verbose_query_logs = false
+      ActiveRecord::Base.attributes_for_inspect = :all if Rails.env.production?
     end
 
     runner do
@@ -432,16 +433,6 @@ To keep using the current cache store, you can turn off cache versioning entirel
         ActiveSupport.on_load(:active_record) do
           require "active_record/message_pack"
           ActiveRecord::MessagePack::Extensions.install(ActiveSupport::MessagePack::CacheSerializer)
-        end
-      end
-    end
-
-    initializer "active_record.attributes_for_inspect" do |app|
-      ActiveSupport.on_load(:active_record) do
-        if app.config.consider_all_requests_local
-          if app.config.active_record.attributes_for_inspect.nil?
-            ActiveRecord::Base.attributes_for_inspect = :all
-          end
         end
       end
     end

--- a/activerecord/test/cases/core_test.rb
+++ b/activerecord/test/cases/core_test.rb
@@ -17,9 +17,9 @@ class CoreTest < ActiveRecord::TestCase
     assert_match(/^Topic\(id: integer, title: string/, Topic.inspect)
   end
 
-  def test_inspect_instance_includes_just_id_by_default
+  def test_inspect_instance
     topic = topics(:first)
-    assert_equal %(#<Topic id: 1>), topic.inspect
+    assert_equal %(#<Topic id: 1, title: "The First Topic", author_name: "David", author_email_address: "david@loudthinking.com", written_on: "#{topic.written_on.to_fs(:inspect)}", bonus_time: "#{topic.bonus_time.to_fs(:inspect)}", last_read: "#{topic.last_read.to_fs(:inspect)}", content: "Have a nice day", important: nil, binary_content: nil, approved: false, replies_count: 1, unique_replies_count: 0, parent_id: nil, parent_title: nil, type: nil, group: nil, created_at: "#{topic.created_at.to_fs(:inspect)}", updated_at: "#{topic.updated_at.to_fs(:inspect)}">), topic.inspect
   end
 
   def test_inspect_includes_attributes_from_attributes_for_inspect
@@ -107,7 +107,26 @@ class CoreTest < ActiveRecord::TestCase
     actual = +""
     PP.pp(topic, StringIO.new(actual))
     expected = <<~PRETTY
-      #<Topic:0xXXXXXX id: nil>
+      #<Topic:0xXXXXXX
+       id: nil,
+       title: nil,
+       author_name: nil,
+       author_email_address: "test@test.com",
+       written_on: nil,
+       bonus_time: nil,
+       last_read: nil,
+       content: nil,
+       important: nil,
+       binary_content: nil,
+       approved: true,
+       replies_count: 0,
+       unique_replies_count: 0,
+       parent_id: nil,
+       parent_title: nil,
+       type: nil,
+       group: nil,
+       created_at: nil,
+       updated_at: nil>
     PRETTY
     assert actual.start_with?(expected.split("XXXXXX").first)
     assert actual.end_with?(expected.split("XXXXXX").last)
@@ -118,7 +137,26 @@ class CoreTest < ActiveRecord::TestCase
     actual = +""
     PP.pp(topic, StringIO.new(actual))
     expected = <<~PRETTY
-      #<Topic:0x\\w+ id: 1>
+      #<Topic:0x\\w+
+       id: 1,
+       title: "The First Topic",
+       author_name: "David",
+       author_email_address: "david@loudthinking.com",
+       written_on: "2003-07-16 14:28:11\\.223300000 \\+0000",
+       bonus_time: "2000-01-01 14:28:00\\.000000000 \\+0000",
+       last_read: "2004-04-15",
+       content: "Have a nice day",
+       important: nil,
+       binary_content: nil,
+       approved: false,
+       replies_count: 1,
+       unique_replies_count: 0,
+       parent_id: nil,
+       parent_title: nil,
+       type: nil,
+       group: nil,
+       created_at: [^,]+,
+       updated_at: [^,>]+>
     PRETTY
     assert_match(/\A#{expected}\z/, actual)
   end

--- a/activerecord/test/cases/filter_attributes_test.rb
+++ b/activerecord/test/cases/filter_attributes_test.rb
@@ -11,15 +11,12 @@ class FilterAttributesTest < ActiveRecord::TestCase
   fixtures :"admin/users", :"admin/accounts"
 
   setup do
-    @previous_attributes_for_inspect = ActiveRecord::Base.attributes_for_inspect
-    ActiveRecord::Base.attributes_for_inspect = :all
     @previous_filter_attributes = ActiveRecord::Base.filter_attributes
     ActiveRecord::Base.filter_attributes = [:name]
     ActiveRecord.use_yaml_unsafe_load = true
   end
 
   teardown do
-    ActiveRecord::Base.attributes_for_inspect = @previous_attributes_for_inspect
     ActiveRecord::Base.filter_attributes = @previous_filter_attributes
   end
 

--- a/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
@@ -114,6 +114,9 @@ Rails.application.configure do
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
+
+  # Only use :id for inspections in production.
+  config.active_record.attributes_for_inspect = [:id]
   <%- end -%>
 
   # Enable DNS rebinding protection and other `Host` header attacks.

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -4701,24 +4701,7 @@ module ApplicationTests
       assert_equal(:html4, Rails.application.config.dom_testing_default_html_version)
     end
 
-    test "sets ActiveRecord::Base.attributes_for_inspect to [:id] when config.consider_all_requests_local = false" do
-      add_to_config "config.consider_all_requests_local = false"
-
-      app "production"
-
-      assert_equal [:id], ActiveRecord::Base.attributes_for_inspect
-    end
-
-    test "sets ActiveRecord::Base.attributes_for_inspect to :all when config.consider_all_requests_local = true" do
-      add_to_config "config.consider_all_requests_local = true"
-
-      app "development"
-
-      assert_equal :all, ActiveRecord::Base.attributes_for_inspect
-    end
-
-    test "app configuration takes precedence over default" do
-      add_to_config "config.consider_all_requests_local = true"
+    test "app attributes_for_inspect configuration takes precedence over default" do
       add_to_config "config.active_record.attributes_for_inspect = [:foo]"
 
       app "development"
@@ -4726,8 +4709,7 @@ module ApplicationTests
       assert_equal [:foo], ActiveRecord::Base.attributes_for_inspect
     end
 
-    test "model's configuration takes precedence over default" do
-      add_to_config "config.consider_all_requests_local = true"
+    test "model's attributes_for_inspect configuration takes precedence over default" do
       app_file "app/models/foo.rb", <<-RUBY
         class Foo < ApplicationRecord
           self.attributes_for_inspect = [:foo]


### PR DESCRIPTION


### Motivation / Background

Fixes https://github.com/rails/rails/issues/52728

This Pull Request has been created because we received feedback on a few things about the `attributes_for_inspect` feature introduced in https://github.com/rails/rails/pull/49765, specifically around the default settings for this feature, which is `[:id]` in production and `:all` in test and dev. The issues are:

1. This feature should be opt in, and be `:all` in production for upgrading apps.
2. We should always use `:all` in the production console to not hinder debugging/
3. We should not use `consider_all_requests_local` to determine what to set it to

### Detail

To address 1 and 3, I changed how the defaults are set. Now the default value is `:all`, and I set it to `[:id]` in `production.rb`. This means it is also opt in as upgrading apps will need to add that line to their `production.rb`.

For 2, I used the `console` method in the active record railtie to set this it to `:all` in production in the console

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
