### PR TITLE
Use implication for skip_active_record/skip_solid

### DIFF
--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -206,7 +206,7 @@ module Rails
 
       OPTION_IMPLICATIONS = { # :nodoc:
         skip_active_job:     [:skip_action_mailer, :skip_active_storage],
-        skip_active_record:  [:skip_active_storage],
+        skip_active_record:  [:skip_active_storage, :skip_solid],
         skip_active_storage: [:skip_action_mailbox, :skip_action_text],
         skip_javascript:     [:skip_hotwire],
       }
@@ -432,7 +432,7 @@ module Rails
       end
 
       def skip_solid?
-        options[:skip_active_record] || options[:skip_solid]
+        options[:skip_solid]
       end
 
       class GemfileEntry < Struct.new(:name, :version, :comment, :options, :commented_out)

--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -111,16 +111,16 @@ module Rails
         class_option :skip_ci,             type: :boolean, default: nil,
                                            desc: "Skip GitHub CI files"
 
-        class_option :skip_kamal,          type: :boolean, default: false,
+        class_option :skip_kamal,          type: :boolean, default: nil,
                                            desc: "Skip Kamal setup"
 
-        class_option :skip_solid,          type: :boolean, default: false,
+        class_option :skip_solid,          type: :boolean, default: nil,
                                            desc: "Skip Solid Cache & Queue setup"
 
         class_option :dev,                 type: :boolean, default: nil,
                                            desc: "Set up the #{name} with Gemfile pointing to your Rails checkout"
 
-        class_option :devcontainer,        type: :boolean, default: false,
+        class_option :devcontainer,        type: :boolean, default: nil,
                                            desc: "Generate devcontainer files"
 
         class_option :edge,                type: :boolean, default: nil,

--- a/railties/test/generators/shared_generator_tests.rb
+++ b/railties/test/generators/shared_generator_tests.rb
@@ -279,6 +279,7 @@ module SharedGeneratorTests
     assert_gitattributes_does_not_have_schema_file
 
     assert_file "Gemfile" do |contents|
+      assert_no_match(/solid_cache/, contents)
       assert_no_match(/sqlite/, contents)
     end
   end


### PR DESCRIPTION
[Generator options should default to nil for unset](https://github.com/rails/rails/pull/52802/commits/24c9c4eb4432f2bdd42da7e7a7d579ea7a1909b3)

The generator options are effectively tri-state, with true/false meaning
set by the user and nil being unset. However, some of these options were
defaulting to false, meaning they were being treated as set to false by
the user.

This commit fixes this issue by setting the values to nil by default
instead of false so that they are properly "unset" by user.

---

[Use implication for skip_active_record/skip_solid](https://github.com/rails/rails/pull/52802/commits/766dc27be1d8367f9c8a2c315c67e3d1d416553b)

When skip_solid was added, it used the "old style" option implication
where skip_*? methods delegate to all the options that should be
implied. This has a few downsides such as making it unclear to users
when conflicting options may be specified (for example,
skip_active_record and no_skip_solid).

This commit changes the skip_solid option to use the new style of
implication so that error messages are better and the predicate method
is simpler.

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [ ] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [ ] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
