### PR TITLE
system testing: disable chrome's search engine choice modal

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   System Testing: Disable Chrome's search engine choice by default in system tests.
+
+    *glaszig*
+
 *   Fix `Request#raw_post` raising `NoMethodError` when `rack.input` is `nil`.
 
     *Hartley McGuire*

--- a/actionpack/lib/action_dispatch/system_testing/browser.rb
+++ b/actionpack/lib/action_dispatch/system_testing/browser.rb
@@ -9,7 +9,6 @@ module ActionDispatch
 
       def initialize(name)
         @name = name
-        set_default_options
       end
 
       def type
@@ -27,9 +26,9 @@ module ActionDispatch
         @options ||=
           case type
           when :chrome
-            ::Selenium::WebDriver::Chrome::Options.new
+            default_chrome_options
           when :firefox
-            ::Selenium::WebDriver::Firefox::Options.new
+            default_firefox_options
           end
       end
 
@@ -49,26 +48,18 @@ module ActionDispatch
       end
 
       private
-        def set_default_options
-          case name
-          when :headless_chrome
-            set_headless_chrome_browser_options
-          when :headless_firefox
-            set_headless_firefox_browser_options
-          end
+        def default_chrome_options
+          options = ::Selenium::WebDriver::Chrome::Options.new
+          options.add_argument("--disable-search-engine-choice-screen")
+          options.add_argument("--headless") if name == :headless_chrome
+          options.add_argument("--disable-gpu") if Gem.win_platform?
+          options
         end
 
-        def set_headless_chrome_browser_options
-          configure do |capabilities|
-            capabilities.add_argument("--headless")
-            capabilities.add_argument("--disable-gpu") if Gem.win_platform?
-          end
-        end
-
-        def set_headless_firefox_browser_options
-          configure do |capabilities|
-            capabilities.add_argument("-headless")
-          end
+        def default_firefox_options
+          options = ::Selenium::WebDriver::Firefox::Options.new
+          options.add_argument("-headless") if name == :headless_firefox
+          options
         end
 
         def resolve_driver_path(namespace)

--- a/actionpack/test/dispatch/system_testing/driver_test.rb
+++ b/actionpack/test/dispatch/system_testing/driver_test.rb
@@ -82,7 +82,7 @@ class DriverTest < ActiveSupport::TestCase
 
     expected = {
       "goog:chromeOptions" => {
-        "args" => ["start-maximized"],
+        "args" => ["--disable-search-engine-choice-screen", "start-maximized"],
         "mobileEmulation" => { "deviceName" => "iphone 6" },
         "prefs" => { "detach" => true }
       },
@@ -101,7 +101,7 @@ class DriverTest < ActiveSupport::TestCase
 
     expected = {
       "goog:chromeOptions" => {
-        "args" => ["--headless", "start-maximized"],
+        "args" => ["--disable-search-engine-choice-screen", "--headless", "start-maximized"],
         "mobileEmulation" => { "deviceName" => "iphone 6" },
         "prefs" => { "detach" => true }
       },


### PR DESCRIPTION
### Motivation / Background

starting newer chrome with a fresh profile (like it happens with selenium) shows a search engine choice screen which will break any tests. 

### Detail

passing `--disable-search-engine-choice-screen` to chrome options will disable the screen.

### Additional information

see SeleniumHQ/selenium#14431

### Checklist

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
