### PR TITLE
Allow async queries in transactional fixtures

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   Make Active Record asynchronous queries compatible with transactional fixtures.
+
+    Previously transactional fixtures would disable asynchronous queries, because transactional
+    fixtures impose all queries use the same connection.
+
+    Now asynchronous queries will use the connection pinned by transactional fixtures, and behave
+    much closer to production.
+
+    *Jean Boussier*
+
 *   Deserialize binary data before decrypting
 
     This ensures that we call `PG::Connection.unescape_bytea` on PostgreSQL before decryption.

--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -683,7 +683,7 @@ module ActiveRecord
               binds,
               prepare: prepare,
             )
-            if supports_concurrent_connections? && current_transaction.closed?
+            if supports_concurrent_connections? && !current_transaction.joinable?
               future_result.schedule!(ActiveRecord::Base.asynchronous_queries_session)
             else
               future_result.execute!(self)

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -1124,9 +1124,6 @@ module ActiveRecord
     # for queries to actually be executed concurrently. Otherwise it defaults to
     # executing them in the foreground.
     #
-    # +load_async+ will also fall back to executing in the foreground in the test environment when transactional
-    # fixtures are enabled.
-    #
     # If the query was actually executed in the background, the Active Record logs will show
     # it by prefixing the log line with <tt>ASYNC</tt>:
     #
@@ -1136,7 +1133,7 @@ module ActiveRecord
         return load if !c.async_enabled?
 
         unless loaded?
-          result = exec_main_query(async: c.current_transaction.closed?)
+          result = exec_main_query(async: !c.current_transaction.joinable?)
 
           if result.is_a?(Array)
             @records = result

--- a/activerecord/test/cases/relation/load_async_test.rb
+++ b/activerecord/test/cases/relation/load_async_test.rb
@@ -10,8 +10,6 @@ module ActiveRecord
   class LoadAsyncTest < ActiveRecord::TestCase
     include WaitForAsyncTestHelper
 
-    self.use_transactional_tests = false
-
     fixtures :posts, :comments, :categories, :categories_posts
 
     def test_scheduled?
@@ -240,8 +238,6 @@ module ActiveRecord
 
   class LoadAsyncNullExecutorTest < ActiveRecord::TestCase
     unless in_memory_db?
-      self.use_transactional_tests = false
-
       fixtures :posts, :comments
 
       def setup
@@ -363,8 +359,6 @@ module ActiveRecord
   class LoadAsyncMultiThreadPoolExecutorTest < ActiveRecord::TestCase
     unless in_memory_db?
       include WaitForAsyncTestHelper
-
-      self.use_transactional_tests = false
 
       fixtures :posts, :comments
 
@@ -504,8 +498,6 @@ module ActiveRecord
   class LoadAsyncMixedThreadPoolExecutorTest < ActiveRecord::TestCase
     unless in_memory_db?
       include WaitForAsyncTestHelper
-
-      self.use_transactional_tests = false
 
       fixtures :posts, :comments, :other_dogs
 


### PR DESCRIPTION
This is possible since https://github.com/rails/rails/pull/50999. Now in transactional fixtures, the other threads do checkout the same connection as the same thread, it's just synchronized around performing the query.

This allow to properly test async queries without having to disable transactional fixtures.

FYI: @hcmaATshopify 