### PR TITLE
`--skip-active-record` should imply `--skip-solid`

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   `--skip-active-record` implies `--skip-solid` when running Rails generators.
+
+    *Jon Rowe*
+
 *   Use [Solid Cache](https://github.com/rails/solid_cache) as the default Rails.cache backend in production, configured as a separate cache database in config/database.yml.
 
     *DHH*

--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -114,7 +114,7 @@ module Rails
         class_option :skip_kamal,          type: :boolean, default: false,
                                            desc: "Skip Kamal setup"
 
-        class_option :skip_solid,          type: :boolean, default: false,
+        class_option :skip_solid,          type: :boolean, default: nil,
                                            desc: "Skip Solid Cache & Queue setup"
 
         class_option :dev,                 type: :boolean, default: nil,
@@ -206,7 +206,7 @@ module Rails
 
       OPTION_IMPLICATIONS = { # :nodoc:
         skip_active_job:     [:skip_action_mailer, :skip_active_storage],
-        skip_active_record:  [:skip_active_storage],
+        skip_active_record:  [:skip_active_storage, :skip_solid],
         skip_active_storage: [:skip_action_mailbox, :skip_action_text],
         skip_javascript:     [:skip_hotwire],
       }

--- a/railties/test/generators/shared_generator_tests.rb
+++ b/railties/test/generators/shared_generator_tests.rb
@@ -279,6 +279,7 @@ module SharedGeneratorTests
     assert_gitattributes_does_not_have_schema_file
 
     assert_file "Gemfile" do |contents|
+      assert_no_match(/solid_cache/, contents)
       assert_no_match(/sqlite/, contents)
     end
   end


### PR DESCRIPTION
### Motivation / Background

Over in `rspec-rails` we have a smoke app that uses `--skip-active-record` to use that an app using Rails in this mode still works and all of our various ActiveRecord features are turned off, after the merge of #52790 this started failing because adding `solid_cache` to the Gemfile caused active record to become a dependency. We've fixed this by adding `--skip-solid` to our smoke app but this lead me to believe that similar to Active Storage, Solid Cache should be skipped when skipping Active Record.

### Detail

This Pull Request changes `OPTION_IMPLICATIONS` in the rails generator to imply `skip_solid` when `skip_active_record` is activated.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
