### PR TITLE
Bring back deleted middleware test

### DIFF
--- a/railties/test/commands/middleware_test.rb
+++ b/railties/test/commands/middleware_test.rb
@@ -196,6 +196,12 @@ class Rails::Command::MiddlewareTest < ActiveSupport::TestCase
     assert_includes middleware, "ActionDispatch::AssumeSSL"
   end
 
+  test "ActionDispatch::SSL is present when force_ssl is set" do
+    add_to_config "config.force_ssl = true"
+    boot!
+    assert_includes middleware, "ActionDispatch::SSL"
+  end
+
   test "silence healthcheck" do
     add_to_config "config.silence_healthcheck_path = '/up'"
     boot!


### PR DESCRIPTION
Fix: https://github.com/rails/rails/pull/52789/files#r1746377061