### PR TITLE
Use `deliver_now!` instead of `deliver_now`

### DIFF
--- a/actionmailer/test/callbacks_test.rb
+++ b/actionmailer/test/callbacks_test.rb
@@ -39,7 +39,7 @@ class ActionMailerCallbacksTest < ActiveSupport::TestCase
   end
 
   test "deliver_now! should call after_deliver callback" do
-    CallbackMailer.test_message.deliver_now
+    CallbackMailer.test_message.deliver_now!
 
     assert_kind_of CallbackMailer, CallbackMailer.after_deliver_instance
   end


### PR DESCRIPTION
### Motivation / Background

The description of the test did not match the actual method of execution.

### Detail

### Additional information

This has been the case since its implementation.
https://github.com/rails/rails/commit/468d80640613a3817ea2e53b24b5f39ef92a57ac#diff-6ef9cd0210c13806628a30105d875ffefdf78852084d5db06007250ccae7dff0R39-R43

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
