### PR TITLE
[7-2] Add `benchmark` to activesupport gemspec

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -80,6 +80,7 @@ PATH
       marcel (~> 1.0)
     activesupport (7.2.1)
       base64
+      benchmark (>= 0.3)
       bigdecimal
       concurrent-ruby (~> 1.0, >= 1.3.1)
       connection_pool (>= 2.2.5)
@@ -153,6 +154,7 @@ GEM
     base64 (0.2.0)
     bcrypt (3.1.20)
     beaneater (1.1.3)
+    benchmark (0.3.0)
     bigdecimal (3.1.8)
     bindex (0.8.1)
     bootsnap (1.18.3)

--- a/activesupport/activesupport.gemspec
+++ b/activesupport/activesupport.gemspec
@@ -44,4 +44,5 @@ Gem::Specification.new do |s|
   s.add_dependency "bigdecimal"
   s.add_dependency "logger", ">= 1.4.2"
   s.add_dependency "securerandom", ">= 0.3"
+  s.add_dependency "benchmark", ">= 0.3"
 end


### PR DESCRIPTION
### Motivation / Background

Ruby plans to bundle this gem, which means requiring it will emit a warning on Ruby 3.4: https://github.com/ruby/ruby/pull/11560

It is part of a core extension here: https://github.com/rails/rails/blob/v7.2.1/activesupport/lib/active_support/core_ext/benchmark.rb

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
