### PR TITLE
Inherit properties from the previous encryption context

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,14 @@
+*   Inherit properties from the previous encryption context
+
+    Previously, when `ActiveRecord::Encryption.with_encryption_context` was
+    called, the new context was created with the default properties, ignoring
+    anything set in previous custom contexts.
+
+    Now, the new context inherits the properties from the previous context,
+    allowing for the composition of multiple contexts.
+
+    *Neil Carvalho*
+
 *   Make Active Record asynchronous queries compatible with transactional fixtures.
 
     Previously transactional fixtures would disable asynchronous queries, because transactional

--- a/activerecord/lib/active_record/encryption/contexts.rb
+++ b/activerecord/lib/active_record/encryption/contexts.rb
@@ -32,7 +32,7 @@ module ActiveRecord
         # Encryption contexts can be nested.
         def with_encryption_context(properties)
           self.custom_contexts ||= []
-          self.custom_contexts << default_context.dup
+          self.custom_contexts << context.dup
           properties.each do |key, value|
             self.current_custom_context.send("#{key}=", value)
           end


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

Rails supports nested encryption contexts, allowing context switching. When an inner context is closed, the properties of the previous context are restored. However, the properties of the previous context are not inherited by the inner context, which can be surprising.

### Detail

This Pull Request changes the behavior of `with_encryption_context` to inherit the properties of the previous context. This change allows composable contexts, where each context can add or override properties of the previous context.

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

This behavior is similar to other nestable blocks. For example, [`Object#with_options`](https://api.rubyonrails.org/classes/Object.html#method-i-with_options), [`Object#with`](https://api.rubyonrails.org/classes/Object.html#method-i-with), and [`ActiveRecord::Relation#scoping`](https://api.rubyonrails.org/classes/ActiveRecord/Relation.html#method-i-scoping) inherit options from the outer blocks.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
