### PR TITLE
Add support for IPv4 mapped IPv6 addresses

### DIFF
--- a/actionpack/lib/action_dispatch/http/request.rb
+++ b/actionpack/lib/action_dispatch/http/request.rb
@@ -31,7 +31,10 @@ module ActionDispatch
     autoload :Session, "action_dispatch/request/session"
     autoload :Utils,   "action_dispatch/request/utils"
 
-    LOCALHOST   = Regexp.union [/^127\.\d{1,3}\.\d{1,3}\.\d{1,3}$/, /^::1$/, /^0:0:0:0:0:0:0:1(%.*)?$/]
+    LOCALHOST   = Regexp.union [/^((::||0:0:0:0:0:)ffff:)?127\.\d{1,3}\.\d{1,3}\.\d{1,3}$/,
+      /^::1$/, /^0:0:0:0:0:0:0:1(%.*)?$/,
+      /^(::||0:0:0:0:0:)ffff:7f[0-9a-f]{2}:[0-9a-f]{1,4}$/
+      ]
 
     ENV_METHODS = %w[ AUTH_TYPE GATEWAY_INTERFACE
         PATH_TRANSLATED REMOTE_HOST

--- a/actionpack/test/dispatch/request_test.rb
+++ b/actionpack/test/dispatch/request_test.rb
@@ -588,6 +588,71 @@ class LocalhostTest < BaseRequestTest
     request = stub_request("REMOTE_IP" => "127.1.1.1", "REMOTE_ADDR" => "127.1.1.1")
     assert_predicate request, :local?
   end
+
+  test "IPs that don't match localhost" do
+    request = stub_request("REMOTE_IP" => "192.0.2.42", "REMOTE_ADDR" => "192.0.2.42")
+    assert_not_predicate request, :local?
+  end
+
+  test "IPs that match localhost IPv6" do
+    request = stub_request("REMOTE_IP" => "::1", "REMOTE_ADDR" => "::1")
+    assert_predicate request, :local?
+  end
+
+  test "IPs that don't match localhost IPv6" do
+    request = stub_request("REMOTE_IP" => "2001:db8::42", "REMOTE_ADDR" => "2001:db8::42")
+    assert_not_predicate request, :local?
+  end
+
+  test "IPs that match localhost IPv6 long form" do
+    request = stub_request("REMOTE_IP" => "0:0:0:0:0:0:0:1", "REMOTE_ADDR" => "0:0:0:0:0:0:0:1")
+    assert_predicate request, :local?
+  end
+
+  test "IPs that don't match localhost IPv6 long form" do
+    request = stub_request("REMOTE_IP" => "2001:db8:0:0:0:0:0:42", "REMOTE_ADDR" => "2001:db8:0:0:0:0:0:42")
+    assert_not_predicate request, :local?
+  end
+
+  test "IPs that match localhost v4 mapped IPv6" do
+    request = stub_request("REMOTE_IP" => "::ffff:7f01:0101", "REMOTE_ADDR" => "::ffff:7f01:0101")
+    assert_predicate request, :local?
+  end
+
+  test "IPs that don't match localhost v4 mapped IPv6" do
+    request = stub_request("REMOTE_IP" => "::ffff:c000:022a", "REMOTE_ADDR" => "::ffff:c000:022a")
+    assert_not_predicate request, :local?
+  end
+
+  test "IPs that match localhost v4 mapped IPv6 long form" do
+    request = stub_request("REMOTE_IP" => "0:0:0:0:0:ffff:7f01:0101", "REMOTE_ADDR" => "0:0:0:0:0:ffff:7f01:0101")
+    assert_predicate request, :local?
+  end
+
+  test "IPs that don't match localhost v4 mapped IPv6 long form" do
+    request = stub_request("REMOTE_IP" => "0:0:0:0:0:ffff:c000:022a", "REMOTE_ADDR" => "0:0:0:0:0:ffff:c000:022a")
+    assert_not_predicate request, :local?
+  end
+
+  test "IPs that match localhost v4 mapped IPv6 friendly format" do
+    request = stub_request("REMOTE_IP" => "::ffff:127.1.1.1", "REMOTE_ADDR" => "::ffff:127.1.1.1")
+    assert_predicate request, :local?
+  end
+
+  test "IPs that don't match localhost v4 mapped IPv6 friendly format" do
+    request = stub_request("REMOTE_IP" => "::ffff:192.0.2.42", "REMOTE_ADDR" => "::ffff:192.0.2.42")
+    assert_not_predicate request, :local?
+  end
+
+  test "IPs that match localhost v4 mapped IPv6 long form friendly format" do
+    request = stub_request("REMOTE_IP" => "0:0:0:0:0:ffff:127.1.1.1", "REMOTE_ADDR" => "0:0:0:0:0:ffff:127.1.1.1")
+    assert_predicate request, :local?
+  end
+
+  test "IPs that don't match localhost v4 mapped IPv6 long form friendly format" do
+    request = stub_request("REMOTE_IP" => "0:0:0:0:0:ffff:192.0.2.42", "REMOTE_ADDR" => "0:0:0:0:0:ffff:192.0.2.42")
+    assert_not_predicate request, :local?
+  end
 end
 
 class RequestCookie < BaseRequestTest


### PR DESCRIPTION
### Motivation / Background

We made a puma config change to bind to IPv6 in production and the change leaked to local development. It turned out Firefox on my Mac chose to connect through `::ffff:127.0.0.1` instead of `::1`. I suspect something to do with our internet connection still pending IPv6 configuration and tripping an odd edge case. However, this identified that `::ffff:127.0.0.1` is a valid local loopback address.

https://www.rfc-editor.org/rfc/rfc5952#section-5
https://en.wikipedia.org/wiki/IPv6_address#Special_addresses

### Detail

This change allows `request.local?` to recognize these addresses correctly as local. I also expanded the testing around `request.local?` a lot.

### Additional information

I'm not sold on how I broke out the multi-line but I couldn't place what the expected style is here.
