### PR TITLE
Avoid repeated dup of as_json options

### DIFF
--- a/activemodel/lib/active_model/dirty.rb
+++ b/activemodel/lib/active_model/dirty.rb
@@ -256,7 +256,8 @@ module ActiveModel
     end
 
     def as_json(options = {}) # :nodoc:
-      options[:except] = [*options[:except], "mutations_from_database", "mutations_before_last_save"]
+      except = [*options[:except], "mutations_from_database", "mutations_before_last_save"]
+      options = options.merge except: except
       super(options)
     end
 

--- a/activesupport/lib/active_support/core_ext/object/json.rb
+++ b/activesupport/lib/active_support/core_ext/object/json.rb
@@ -165,7 +165,8 @@ end
 class Array
   def as_json(options = nil) # :nodoc:
     if options
-      map { |v| v.as_json(options.dup) }
+      options = options.dup.freeze unless options.frozen?
+      map { |v| v.as_json(options) }
     else
       map { |v| v.as_json }
     end
@@ -189,7 +190,8 @@ class Hash
 
     result = {}
     if options
-      subset.each { |k, v| result[k.to_s] = v.as_json(options.dup) }
+      options = options.dup.freeze unless options.frozen?
+      subset.each { |k, v| result[k.to_s] = v.as_json(options) }
     else
       subset.each { |k, v| result[k.to_s] = v.as_json }
     end

--- a/activesupport/lib/active_support/json/encoding.rb
+++ b/activesupport/lib/active_support/json/encoding.rb
@@ -36,7 +36,7 @@ module ActiveSupport
         # Encode the given object into a JSON string
         def encode(value)
           unless options.empty?
-            value = value.as_json(options.dup)
+            value = value.as_json(options.dup.freeze)
           end
           json = stringify(jsonify(value))
 


### PR DESCRIPTION
Previously for every element in an Array and every value in a Hash we would duplicate the options hash passed in. This PR avoids the duplication.

I did this very conservatively, duping and freezing the Hash when it is not already frozen so that any cases mutating the Hash should be caught. I don't feel very strongly about this and we could remove this in the future.

This should improve `to_json` performance when options are passed in (passing options is generally slower but sometimes unavoidable).

https://gist.github.com/jhawthorn/ca9e2eb38a2a982d7e30f9ab315f89a5


**Before**

```
❯ ruby benchmark_as_json.rb
ruby 3.3.2 (2024-05-30 revision e5a195edf6) [arm64-darwin23]
Calculating -------------------------------------
obj.to_json(foo: :bar)
                         35.401k (± 0.7%) i/s -    177.700k in   5.019858s
obj.as_json(foo: :bar)
                         60.774k (± 0.5%) i/s -    304.250k in   5.006362s
```

**After**

```
❯ ruby benchmark_as_json.rb
ruby 3.3.2 (2024-05-30 revision e5a195edf6) [arm64-darwin23]
Calculating -------------------------------------
obj.to_json(foo: :bar)
                         61.766k (± 0.7%) i/s -    310.250k in   5.023192s
obj.as_json(foo: :bar)
                        226.693k (± 0.8%) i/s -      1.138M in   5.018156s
```