### PR TITLE
Add benchmark gem as dependency for Active Support

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -87,6 +87,7 @@ PATH
       marcel (~> 1.0)
     activesupport (8.0.0.alpha)
       base64
+      benchmark
       bigdecimal
       concurrent-ruby (~> 1.0, >= 1.3.1)
       connection_pool (>= 2.2.5)
@@ -162,6 +163,7 @@ GEM
     bcrypt (3.1.20)
     bcrypt_pbkdf (1.1.0)
     beaneater (1.1.3)
+    benchmark (0.3.0)
     bigdecimal (3.1.8)
     bindex (0.8.1)
     bootsnap (1.17.0)

--- a/activesupport/activesupport.gemspec
+++ b/activesupport/activesupport.gemspec
@@ -45,4 +45,5 @@ Gem::Specification.new do |s|
   s.add_dependency "logger", ">= 1.4.2"
   s.add_dependency "securerandom", ">= 0.3"
   s.add_dependency "uri", ">= 0.13.1"
+  s.add_dependency "benchmark"
 end


### PR DESCRIPTION
### Motivation / Background

This commit addresses Rails Nightly CI at https://buildkite.com/rails/rails-nightly/builds/995

### Detail
- This commit addresses the following error.

```ruby
$ cd actioncable
$ RAILS_STRICT_WARNINGS=1 bin/test test/subscription_adapter/postgresql_test.rb
/home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/migration.rb:3: warning: benchmark was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
You can add benchmark to your Gemfile or gemspec to silence this warning.
/home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/testing/strict_warnings.rb:38:in 'ActiveSupport::RaiseWarnings#warn': /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/migration.rb:3: warning: benchmark was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0. (ActiveSupport::RaiseWarnings::WarningError)
You can add benchmark to your Gemfile or gemspec to silence this warning.

        from <internal:warning>:54:in 'Kernel.warn'
        from /home/yahonda/.rbenv/versions/trunk/lib/ruby/3.4.0+0/bundled_gems.rb:74:in 'block (2 levels) in Kernel#replace_require'
        from /home/yahonda/.gem/ruby/3.4.0+0/gems/zeitwerk-2.6.12/lib/zeitwerk/kernel.rb:38:in 'Kernel#require'
        from /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/migration.rb:3:in '<top (required)>'
        from /home/yahonda/.rbenv/versions/trunk/lib/ruby/3.4.0+0/bundled_gems.rb:79:in 'Kernel.require'
        from /home/yahonda/.rbenv/versions/trunk/lib/ruby/3.4.0+0/bundled_gems.rb:79:in 'block (2 levels) in Kernel#replace_require'
        from /home/yahonda/.gem/ruby/3.4.0+0/gems/zeitwerk-2.6.12/lib/zeitwerk/kernel.rb:38:in 'Kernel#require'
        from /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record.rb:432:in '<module:ActiveRecord>'
        from /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record.rb:40:in '<top (required)>'
        from /home/yahonda/.rbenv/versions/trunk/lib/ruby/3.4.0+0/bundled_gems.rb:79:in 'Kernel.require'
        from /home/yahonda/.rbenv/versions/trunk/lib/ruby/3.4.0+0/bundled_gems.rb:79:in 'block (2 levels) in Kernel#replace_require'
        from /home/yahonda/.gem/ruby/3.4.0+0/gems/zeitwerk-2.6.12/lib/zeitwerk/kernel.rb:38:in 'Kernel#require'
        from /home/yahonda/src/github.com/rails/rails/actioncable/test/subscription_adapter/postgresql_test.rb:7:in '<top (required)>'
        from /home/yahonda/.rbenv/versions/trunk/lib/ruby/3.4.0+0/bundled_gems.rb:79:in 'Kernel.require'
        from /home/yahonda/.rbenv/versions/trunk/lib/ruby/3.4.0+0/bundled_gems.rb:79:in 'block (2 levels) in Kernel#replace_require'
        from /home/yahonda/src/github.com/rails/rails/railties/lib/rails/test_unit/runner.rb:62:in 'block in Rails::TestUnit::Runner.load_tests'
        from <internal:array>:53:in 'Array#each'
        from /home/yahonda/src/github.com/rails/rails/railties/lib/rails/test_unit/runner.rb:60:in 'Rails::TestUnit::Runner.load_tests'
        from /home/yahonda/src/github.com/rails/rails/railties/lib/rails/test_unit/runner.rb:52:in 'Rails::TestUnit::Runner.run'
        from /home/yahonda/src/github.com/rails/rails/tools/test.rb:18:in '<top (required)>'
        from bin/test:5:in 'Kernel#require_relative'
        from bin/test:5:in '<main>'
$
```

### Additional information
- "benchmark" is required at these files. Action Pack and Active Support depends on Active Support.

```ruby
$ git grep 'require "benchmark"'
actionpack/lib/action_controller/metal/instrumentation.rb:require "benchmark"
activerecord/lib/active_record/migration.rb:require "benchmark"
activesupport/lib/active_support/core_ext/benchmark.rb:require "benchmark"
```

Refer to
https://github.com/ruby/ruby/commit/0e7b6e348fa5b85de365ab9ec62abe26d0adb0bc
https://bugs.ruby-lang.org/issues/20309

### Checklist

Before submitting the PR make sure the following are checked:

* [ ] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [ ] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
