### PR TITLE
Deprecate `unsigned_float` and `unsigned_decimal` short-hand column methods

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Deprecate `unsigned_float` and `unsigned_decimal` short-hand column methods.
+
+    As of MySQL 8.0.17, the UNSIGNED attribute is deprecated for columns of type FLOAT, DOUBLE,
+    and DECIMAL. Consider using a simple CHECK constraint instead for such columns.
+
+    https://dev.mysql.com/doc/refman/8.0/en/numeric-type-syntax.html
+
+    *Ryuta Kamizono*
+
 *   Drop MySQL 5.5 support.
 
     MySQL 5.5 is the only version that does not support datetime with precision,

--- a/activerecord/lib/active_record/connection_adapters/mysql/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/schema_definitions.rb
@@ -42,18 +42,12 @@ module ActiveRecord
         # :method: unsigned_bigint
         # :call-seq: unsigned_bigint(*names, **options)
 
-        ##
-        # :method: unsigned_float
-        # :call-seq: unsigned_float(*names, **options)
-
-        ##
-        # :method: unsigned_decimal
-        # :call-seq: unsigned_decimal(*names, **options)
-
         included do
           define_column_methods :blob, :tinyblob, :mediumblob, :longblob,
             :tinytext, :mediumtext, :longtext, :unsigned_integer, :unsigned_bigint,
             :unsigned_float, :unsigned_decimal
+
+          deprecate :unsigned_float, :unsigned_decimal, deprecator: ActiveRecord.deprecator
         end
       end
 

--- a/activerecord/test/cases/adapters/abstract_mysql_adapter/unsigned_type_test.rb
+++ b/activerecord/test/cases/adapters/abstract_mysql_adapter/unsigned_type_test.rb
@@ -49,12 +49,21 @@ class UnsignedTypeTest < ActiveRecord::AbstractMysqlTestCase
     @connection.change_table("unsigned_types") do |t|
       t.unsigned_integer :unsigned_integer_t
       t.unsigned_bigint  :unsigned_bigint_t
-      t.unsigned_float   :unsigned_float_t
-      t.unsigned_decimal :unsigned_decimal_t, precision: 10, scale: 2
     end
 
     @connection.columns("unsigned_types").select { |c| /^unsigned_/.match?(c.name) }.each do |column|
       assert_predicate column, :unsigned?
+    end
+  end
+
+  test "deprecate unsigned_float and unsigned_decimal" do
+    @connection.change_table("unsigned_types") do |t|
+      assert_deprecated(ActiveRecord.deprecator) do
+        t.unsigned_float :unsigned_float_t
+      end
+      assert_deprecated(ActiveRecord.deprecator) do
+        t.unsigned_decimal :unsigned_decimal_t
+      end
     end
   end
 


### PR DESCRIPTION
As of MySQL 8.0.17, the UNSIGNED attribute is deprecated for columns of type FLOAT, DOUBLE, and DECIMAL. Consider using a simple CHECK constraint instead for such columns.

https://dev.mysql.com/doc/refman/8.0/en/numeric-type-syntax.html

Just in case existing `schema.rb` is still valid since the schema dumper dumps un unsigned attribute as `unsigned: true` option.

https://github.com/rails/rails/blob/2ae883cc162446ae8ce602c2aa0d08a3ca15c917/activerecord/test/cases/adapters/abstract_mysql_adapter/unsigned_type_test.rb#L61-L67
