### PR TITLE
Load schema when running db:migrate on fresh db

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   When running `db:migrate` on a fresh database, load the database schema before running migrations.
+
+    *Andrew Novoselac*
+
 *   Fix an issue where `.left_outer_joins` used with multiple associations that have
     the same child association but different parents does not join all parents.
 

--- a/railties/test/application/rake/dbs_test.rb
+++ b/railties/test/application/rake/dbs_test.rb
@@ -350,6 +350,19 @@ module ApplicationTests
         db_migrate_and_status database_url_db_name
       end
 
+      test "db:migrate on new db loads schema" do
+        app_file "db/schema.rb", <<-RUBY
+          ActiveRecord::Schema.define(version: 20140423102712) do
+            create_table(:comments) {}
+          end
+        RUBY
+
+        rails "db:migrate"
+        list_tables = lambda { rails("runner", "p ActiveRecord::Base.lease_connection.tables.sort").strip }
+
+        assert_equal "[\"ar_internal_metadata\", \"comments\", \"schema_migrations\"]", list_tables[]
+      end
+
       def db_schema_dump
         Dir.chdir(app_path) do
           args = ["generate", "model", "book", "title:string"]


### PR DESCRIPTION

### Motivation / Background

Fixes https://github.com/rails/rails/issues/52829

When we have a schema file, if we run `db:migrate` before setting up the db, we do not load the schema and then we blow away the contents of the file when we dump the schema after migrations.

You can repro by creating a fresh app and running the following commands:

```
bin/rails g model Post
bin/rails db:migrate
rm -rf db/migrate
bin/rails db:drop
bin/rails db:migrate
```

After following these steps, the schema file will be empty and the posts table will not exist.

### Detail

We should make sure the db is setup before we run migrations. This is what we do in the `db:prepare` task. So, I extracted the code from that task and reused it in the migration task.

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
