### PR TITLE
Store session_id in cookies only once

### DIFF
--- a/railties/lib/rails/generators/rails/authentication/templates/controllers/concerns/authentication.rb
+++ b/railties/lib/rails/generators/rails/authentication/templates/controllers/concerns/authentication.rb
@@ -46,12 +46,12 @@ module Authentication
     def start_new_session_for(user)
       user.sessions.create!(user_agent: request.user_agent, ip_address: request.remote_ip).tap do |session|
         set_current_session session
+        cookies.signed.permanent[:session_id] = { value: session.id, httponly: true, same_site: :lax }
       end
     end
 
     def set_current_session(session)
       Current.session = session
-      cookies.signed.permanent[:session_id] = { value: session.id, httponly: true, same_site: :lax }
     end
 
     def terminate_session


### PR DESCRIPTION
Closes https://github.com/rails/rails/issues/52832

Before this commit, while authenticated, the `set_current_session` was called on every request which resulted in setting the `session_id` in the cookies on every request.

```rb
def set_current_session(session)
  Current.session = session
  cookies.signed.permanent[:session_id] = { value: session.id, httponly: true, same_site: :lax }
end
```

Setting the `session_id` in the cookies on every request is unnecessary. Also, if developers want to set an expiration date to the cookies (for example with `expires: 1.week`), the expiration date will be reset on every request leading to the cookies never expiring.

This PR solves the issue by storing the `session_id` in the cookies only in the `start_new_session_for` method.