### PR TITLE
fix text selection color in doc guides

### DIFF
--- a/guides/assets/stylesrc/vendor/_boilerplate.scss
+++ b/guides/assets/stylesrc/vendor/_boilerplate.scss
@@ -18,23 +18,6 @@
   }
   
   /*
-   * Remove text-shadow in selection highlight:
-   * https://x.com/miketaylr/status/12228805301
-   *
-   * Customize the background color to match your design.
-   */
-  
-  ::-moz-selection {
-    background: #b3d4fc;
-    text-shadow: none;
-  }
-  
-  ::selection {
-    background: #b3d4fc;
-    text-shadow: none;
-  }
-  
-  /*
    * A better looking default horizontal rule
    */
   


### PR DESCRIPTION
### Motivation / Background

this pr fixes the selection color for text because it blends with the background.

the custom styles are removed and the highlight color is now system dependent which is better because user settings can affect the selection color such as contrast settings defined by the user and we shouldn't override those for better accessibility.

fixes #52836

This Pull Request has been created because of #52836

### Detail

This Pull Request changes the selection color in the guide docs

### Additional information

before:
![image](https://github.com/user-attachments/assets/7e649f68-79db-4a8d-b532-162ea8669e0e)

after:
![image](https://github.com/user-attachments/assets/455666dc-0922-4e34-9f0a-a45217d230aa)


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
