### PR TITLE
Remove unused permission_policy test helpers

### DIFF
--- a/actionpack/test/dispatch/permissions_policy_test.rb
+++ b/actionpack/test/dispatch/permissions_policy_test.rb
@@ -181,18 +181,6 @@ class PermissionsPolicyIntegrationTest < ActionDispatch::IntegrationTest
   end
 
   private
-    def env_config
-      Rails.application.env_config
-    end
-
-    def permissions_policy
-      env_config["action_dispatch.permissions_policy"]
-    end
-
-    def permissions_policy=(policy)
-      env_config["action_dispatch.permissions_policy"] = policy
-    end
-
     def assert_policy(expected)
       assert_response :success
       assert_equal expected, response.headers["Feature-Policy"]
@@ -265,18 +253,6 @@ class PermissionsPolicyWithHelpersIntegrationTest < ActionDispatch::IntegrationT
   end
 
   private
-    def env_config
-      Rails.application.env_config
-    end
-
-    def permissions_policy
-      env_config["action_dispatch.permissions_policy"]
-    end
-
-    def permissions_policy=(policy)
-      env_config["action_dispatch.permissions_policy"] = policy
-    end
-
     def assert_policy(expected)
       assert_response :success
       assert_equal expected, response.headers[ActionDispatch::Constants::FEATURE_POLICY]


### PR DESCRIPTION
These were added in 0ddad32af53a241692ab5715bf4bd1ee119e4fc4 but they are unused and can be safely deleted.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
