### PR TITLE
alias_attribute: handle user defined source methods

### DIFF
--- a/activemodel/test/cases/attribute_methods_test.rb
+++ b/activemodel/test/cases/attribute_methods_test.rb
@@ -371,4 +371,44 @@ class AttributeMethodsTest < ActiveModel::TestCase
     assert_equal :model_1, NameClash::Model1.new.x_changed?
     assert_equal :model_2, NameClash::Model2.new.x_changed?
   end
+
+  test "alias attribute respects user defined method" do
+    model = Class.new do
+      include ActiveModel::AttributeMethods
+
+      attr_accessor :name
+      define_attribute_methods :name
+
+      alias_attribute :nickname, :name
+
+      def initialize(name)
+        @name = name
+      end
+    end
+
+    instance = model.new("George")
+    assert_equal "George", instance.name
+    assert_equal "George", instance.nickname
+  end
+
+  test "alias attribute respects user defined method in parent classes" do
+    model = Class.new do
+      include ActiveModel::AttributeMethods
+
+      attr_accessor :name
+      define_attribute_methods :name
+
+      def initialize(name)
+        @name = name
+      end
+    end
+
+    subclass = Class.new(model) do
+      alias_attribute :nickname, :name
+    end
+
+    instance = subclass.new("George")
+    assert_equal "George", instance.name
+    assert_equal "George", instance.nickname
+  end
 end


### PR DESCRIPTION
Redo of: https://github.com/rails/rails/pull/52822
Fix: https://github.com/rails/rails/issues/52820

alias_attribute: handle user defined source methods

`alias_attribute` used to define a "jump method", e.g.
`alias_attribute :foo, :bar` was pretty much a macro to generate

```ruby
def foo
  bar
end
```

This is convienient because it's easy, it doesn't impose an order
of declaration or anything like that.

But it's also much less efficient than a true `alias_method`.

It also used to cause cache size explosion which we fixed in
https://github.com/rails/rails/pull/52118, but making it behave
like Ruby's `alias_method`, by doing a real alias.

But this breaks some expectations (literally from the documentation):

```ruby
  attr_accessor :name
  attribute_method_suffix '_short?'
  define_attribute_methods :name

  alias_attribute :nickname, :name
```

Here we're not supposed to alias a generated method, but a user defined one.

So this assumption can only hold for Active Record, not Active Model.