### PR TITLE
Add check constraint should be invertible if invalid option provided

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -1312,6 +1312,7 @@ module ActiveRecord
       def remove_check_constraint(table_name, expression = nil, if_exists: false, **options)
         return unless supports_check_constraints?
 
+        options = remove_check_constraint_options(options)
         return if if_exists && !check_constraint_exists?(table_name, **options)
 
         chk_name_to_delete = check_constraint_for!(table_name, expression: expression, **options).name
@@ -1875,6 +1876,10 @@ module ActiveRecord
 
         def quoted_scope(name = nil, type: nil)
           raise NotImplementedError
+        end
+
+        def remove_check_constraint_options(options)
+          options.slice(:name)
         end
     end
   end

--- a/activerecord/lib/active_record/connection_adapters/sqlite3/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3/schema_statements.rb
@@ -109,6 +109,7 @@ module ActiveRecord
         end
 
         def remove_check_constraint(table_name, expression = nil, if_exists: false, **options)
+          options = remove_check_constraint_options(options)
           return if if_exists && !check_constraint_exists?(table_name, **options)
 
           check_constraints = check_constraints(table_name)

--- a/activerecord/test/cases/invertible_migration_test.rb
+++ b/activerecord/test/cases/invertible_migration_test.rb
@@ -535,6 +535,9 @@ module ActiveRecord
 
     def test_add_check_constraint_with_invalid_option
       connection = ActiveRecord::Base.lease_connection
+
+      skip unless connection.supports_check_constraints?
+
       connection.create_table(:settings) do |t|
         t.integer :value
       end

--- a/activerecord/test/cases/invertible_migration_test.rb
+++ b/activerecord/test/cases/invertible_migration_test.rb
@@ -222,7 +222,7 @@ module ActiveRecord
 
     class AddCheckConstraintWithInvalidOptionMigration < SilentMigration
       def change
-        add_check_constraint :settings, "value >= 0", name: "positive_value", invalid_option: true
+        add_check_constraint :foos, "value >= 0", name: "positive_value", invalid_option: true
       end
     end
 
@@ -536,17 +536,17 @@ module ActiveRecord
     def test_add_check_constraint_with_invalid_option
       connection = ActiveRecord::Base.lease_connection
 
-      connection.create_table(:settings2) do |t|
+      connection.create_table(:foos) do |t|
         t.integer :value
       end
 
       AddCheckConstraintWithInvalidOptionMigration.new.migrate(:up)
-      assert connection.check_constraint_exists?(:settings2, name: "positive_value")
+      assert connection.check_constraint_exists?(:foos, name: "positive_value")
 
       AddCheckConstraintWithInvalidOptionMigration.new.migrate(:down)
-      assert_not connection.check_constraint_exists?(:settings2, name: "positive_value")
+      assert_not connection.check_constraint_exists?(:foos, name: "positive_value")
     ensure
-      connection.drop_table(:settings2) rescue nil
+      connection.drop_table(:foos) rescue nil
     end
   end
 end

--- a/activerecord/test/cases/invertible_migration_test.rb
+++ b/activerecord/test/cases/invertible_migration_test.rb
@@ -536,17 +536,17 @@ module ActiveRecord
     def test_add_check_constraint_with_invalid_option
       connection = ActiveRecord::Base.lease_connection
 
-      connection.create_table(:settings) do |t|
+      connection.create_table(:settings2) do |t|
         t.integer :value
       end
 
       AddCheckConstraintWithInvalidOptionMigration.new.migrate(:up)
-      assert connection.check_constraint_exists?(:settings, name: "positive_value")
+      assert connection.check_constraint_exists?(:settings2, name: "positive_value")
 
       AddCheckConstraintWithInvalidOptionMigration.new.migrate(:down)
-      assert_not connection.check_constraint_exists?(:settings, name: "positive_value")
+      assert_not connection.check_constraint_exists?(:settings2, name: "positive_value")
     ensure
-      connection.drop_table(:settings) rescue nil
+      connection.drop_table(:settings2) rescue nil
     end
   end
 end

--- a/activerecord/test/cases/invertible_migration_test.rb
+++ b/activerecord/test/cases/invertible_migration_test.rb
@@ -536,8 +536,6 @@ module ActiveRecord
     def test_add_check_constraint_with_invalid_option
       connection = ActiveRecord::Base.lease_connection
 
-      skip unless connection.supports_check_constraints?
-
       connection.create_table(:settings) do |t|
         t.integer :value
       end
@@ -548,7 +546,7 @@ module ActiveRecord
       AddCheckConstraintWithInvalidOptionMigration.new.migrate(:down)
       assert_not connection.check_constraint_exists?(:settings, name: "positive_value")
     ensure
-      connection.drop_table(:settings)
+      connection.drop_table(:settings) rescue nil
     end
   end
 end

--- a/activerecord/test/cases/invertible_migration_test.rb
+++ b/activerecord/test/cases/invertible_migration_test.rb
@@ -222,7 +222,7 @@ module ActiveRecord
 
     class AddCheckConstraintWithInvalidOptionMigration < SilentMigration
       def change
-        add_check_constraint :discounts, "amount >= 0", name: "amount_check", invalid_option: true
+        add_check_constraint :settings, "value >= 0", name: "positive_value", invalid_option: true
       end
     end
 
@@ -535,16 +535,17 @@ module ActiveRecord
 
     def test_add_check_constraint_with_invalid_option
       connection = ActiveRecord::Base.lease_connection
-
-      assert_not connection.check_constraint_exists?(:discounts, name: "amount_check")
+      connection.create_table(:settings) do |t|
+        t.integer :value
+      end
 
       AddCheckConstraintWithInvalidOptionMigration.new.migrate(:up)
-      assert connection.check_constraint_exists?(:discounts, name: "amount_check")
+      assert connection.check_constraint_exists?(:settings, name: "positive_value")
 
       AddCheckConstraintWithInvalidOptionMigration.new.migrate(:down)
-      assert_not connection.check_constraint_exists?(:discounts, name: "amount_check")
+      assert_not connection.check_constraint_exists?(:settings, name: "positive_value")
     ensure
-      connection.remove_check_constraint(:discounts, name: "amount_check", if_exists: true)
+      connection.drop_table(:settings)
     end
   end
 end

--- a/activerecord/test/cases/invertible_migration_test.rb
+++ b/activerecord/test/cases/invertible_migration_test.rb
@@ -543,6 +543,8 @@ module ActiveRecord
 
       AddCheckConstraintWithInvalidOptionMigration.new.migrate(:down)
       assert_not connection.check_constraint_exists?(:discounts, name: "amount_check")
+    ensure
+      connection.remove_check_constraint(:discounts, name: "amount_check", if_exists: true)
     end
   end
 end


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

If you have a migration that calls `add_check_constraint` with an invalid option then the migration works in the `up` direction but fails in the `down` direction. This was opened as https://github.com/rails/rails/issues/52419

### Detail

The following migration would work in the `up` direction but fails to find the check constraint in the `down` direction. 

```ruby
class AddCheckConstraintWithInvalidOptionMigration < ActiveRecord::Migration::Current
     def change
        add_check_constraint :discounts, "amount >= 0", name: "amount_check", invalid_option: true
     end
end
```

The error for SQLite would be:

```
ArgumentError: Table 'discounts' has no check constraint for amount >= 0
    lib/active_record/connection_adapters/abstract/schema_statements.rb:1788:in `check_constraint_for!'
    lib/active_record/connection_adapters/sqlite3/schema_statements.rb:116:in `remove_check_constraint'
```

The issue affects all the database adapters.

The issue is caused by the `invalid_option` not being used in the `up` direction but being used to find the constraint in the `down` direction. Fix is to just filter the options used by `remove_check_constraint` to only valid options.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
