### PR TITLE
Allow cycle detection for recursive common table expressions

### DIFF
--- a/activerecord/lib/arel/nodes/cte.rb
+++ b/activerecord/lib/arel/nodes/cte.rb
@@ -5,22 +5,24 @@ module Arel # :nodoc: all
     class Cte < Arel::Nodes::Binary
       alias :name :left
       alias :relation :right
-      attr_reader :materialized
+      attr_reader :materialized, :cycle
 
-      def initialize(name, relation, materialized: nil)
+      def initialize(name, relation, materialized: nil, cycle: nil)
         super(name, relation)
         @materialized = materialized
+        @cycle = cycle
       end
 
       def hash
-        [name, relation, materialized].hash
+        [name, relation, materialized, cycle].hash
       end
 
       def eql?(other)
         self.class == other.class &&
           self.name == other.name &&
           self.relation == other.relation &&
-          self.materialized == other.materialized
+          self.materialized == other.materialized &&
+          self.cycle == other.cycle
       end
       alias :== :eql?
 

--- a/activerecord/lib/arel/visitors/to_sql.rb
+++ b/activerecord/lib/arel/visitors/to_sql.rb
@@ -741,6 +741,12 @@ module Arel # :nodoc: all
           end
 
           visit o.relation, collector
+
+          unless o.cycle.nil?
+            collector << " #{o.cycle}"
+          end
+
+          collector
         end
 
         def visit_Arel_Attributes_Attribute(o, collector)

--- a/activerecord/test/cases/arel/visitors/to_sql_test.rb
+++ b/activerecord/test/cases/arel/visitors/to_sql_test.rb
@@ -1021,6 +1021,24 @@ module Arel
             "foo" AS NOT MATERIALIZED (SELECT * FROM "bar")
           }
         end
+
+        it "handles CTEs with a CYCLE modifier" do
+          cycle_clause = "CYCLE id SET is_cycle USING path"
+          cte = Nodes::Cte.new("foo", Table.new(:bar).project(Arel.star), cycle: cycle_clause)
+
+          _(compile(cte)).must_be_like %{
+            "foo" AS (SELECT * FROM "bar") #{cycle_clause}
+          }
+        end
+
+        it "handles CTEs with MATERIALIZED and CYCLE modifiers" do
+          cycle_clause = "CYCLE id SET is_cycle USING path"
+          cte = Nodes::Cte.new("foo", Table.new(:bar).project(Arel.star), materialized: true, cycle: cycle_clause)
+
+          _(compile(cte)).must_be_like %{
+            "foo" AS MATERIALIZED (SELECT * FROM "bar") #{cycle_clause}
+          }
+        end
       end
 
       describe "Nodes::Fragments" do


### PR DESCRIPTION
### Motivation / Background

Allow cycle detection for recursive common table expressions, using enhanced cycle mark values

Adding cycle detection to a recursive statement prevents it from running in a loop until it uses up all the database memory and crashes.  SQL:2023 introduces enhanced cycle mark values into the standard.  This is a standardized way to prevent the following of cycles in recursive CTEs which can lead to consumption of memory to the point of host failure.

### Detail

This adds a `:cycle` option to Cte instantiation, and works in a similar way to the existing `:materialized` option.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
