### PR TITLE
Ensure AS::Deprecation::Reporting constants stay private

### DIFF
--- a/activesupport/lib/active_support/deprecation/reporting.rb
+++ b/activesupport/lib/active_support/deprecation/reporting.rb
@@ -168,8 +168,8 @@ module ActiveSupport
           end
         end
 
-        RAILS_GEM_ROOT = File.expand_path("../../../..", __dir__) + "/"
-        LIB_DIR = RbConfig::CONFIG["libdir"]
+        RAILS_GEM_ROOT = File.expand_path("../../../..", __dir__) + "/" # :nodoc:
+        LIB_DIR = RbConfig::CONFIG["libdir"] # :nodoc:
 
         def ignored_callstack?(path)
           path.start_with?(RAILS_GEM_ROOT, LIB_DIR) || path.include?("<internal:")


### PR DESCRIPTION
Found these when reading the docs for [AS::Deprecation::Reporting](https://edgeapi.rubyonrails.org/classes/ActiveSupport/Deprecation/Reporting.html).

We could also use `private_constant` maybe, if we really want to make it private:
https://docs.ruby-lang.org/en/master/Module.html#method-i-private_constant

cc: https://bugs.ruby-lang.org/issues/17171