### PR TITLE
[7-0-stable] Backport #52853: Ensure AS::Deprecation::Reporting constants stay private

### DIFF
--- a/activesupport/lib/active_support/deprecation/reporting.rb
+++ b/activesupport/lib/active_support/deprecation/reporting.rb
@@ -149,8 +149,8 @@ module ActiveSupport
           end
         end
 
-        RAILS_GEM_ROOT = File.expand_path("../../../..", __dir__) + "/"
-        LIB_DIR = RbConfig::CONFIG["libdir"]
+        RAILS_GEM_ROOT = File.expand_path("../../../..", __dir__) + "/" # :nodoc:
+        LIB_DIR = RbConfig::CONFIG["libdir"] # :nodoc:
 
         def ignored_callstack?(path)
           path.start_with?(RAILS_GEM_ROOT, LIB_DIR)


### PR DESCRIPTION
Backport #52853 to `7-0-stable`.