### PR TITLE
Allow `benchmark` warnings tentatively

### DIFF
--- a/activesupport/lib/active_support/testing/strict_warnings.rb
+++ b/activesupport/lib/active_support/testing/strict_warnings.rb
@@ -16,7 +16,10 @@ module ActiveSupport
       /Failed to validate the schema cache because/,
 
       # TODO: We need to decide what to do with this.
-      /Status code :unprocessable_entity is deprecated/
+      /Status code :unprocessable_entity is deprecated/,
+
+      # TODO: Revert this change when #52746 or #52827 is merged.
+      /warning: benchmark was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0./,
     )
 
     SUPPRESSED_WARNINGS = Regexp.union(


### PR DESCRIPTION
### Motivation / Background

This commit allows `benchmark` warnings below tentatively to avoid overlooking other warnings/errors at Rails Nightly CI.

### Detail

https://buildkite.com/rails/rails-nightly/builds/995

```ruby
warning: benchmark was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
You can add benchmark to your Gemfile or gemspec to silence this warning.
```

### Additional information
This commit can be reverted when #52746 or #52827 is merged.

Refer to
ruby/ruby@0e7b6e3
https://bugs.ruby-lang.org/issues/20309

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [ ] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.





