### PR TITLE
Allow BroadcastLogger to pass through kwargs

### DIFF
--- a/activesupport/lib/active_support/broadcast_logger.rb
+++ b/activesupport/lib/active_support/broadcast_logger.rb
@@ -113,33 +113,33 @@ module ActiveSupport
       dispatch { |logger| logger.<<(message) }
     end
 
-    def add(*args, &block)
-      dispatch { |logger| logger.add(*args, &block) }
+    def add(...)
+      dispatch { |logger| logger.add(...) }
     end
     alias_method :log, :add
 
-    def debug(*args, &block)
-      dispatch { |logger| logger.debug(*args, &block) }
+    def debug(...)
+      dispatch { |logger| logger.debug(...) }
     end
 
-    def info(*args, &block)
-      dispatch { |logger| logger.info(*args, &block) }
+    def info(...)
+      dispatch { |logger| logger.info(...) }
     end
 
-    def warn(*args, &block)
-      dispatch { |logger| logger.warn(*args, &block) }
+    def warn(...)
+      dispatch { |logger| logger.warn(...) }
     end
 
-    def error(*args, &block)
-      dispatch { |logger| logger.error(*args, &block) }
+    def error(...)
+      dispatch { |logger| logger.error(...) }
     end
 
-    def fatal(*args, &block)
-      dispatch { |logger| logger.fatal(*args, &block) }
+    def fatal(...)
+      dispatch { |logger| logger.fatal(...) }
     end
 
-    def unknown(*args, &block)
-      dispatch { |logger| logger.unknown(*args, &block) }
+    def unknown(...)
+      dispatch { |logger| logger.unknown(...) }
     end
 
     def formatter=(formatter)


### PR DESCRIPTION
### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created because logger implementations may extend the logging interface to provide optional information via keyword arguments. Upon assigning a logger instance to Rails.logger it becomes wrapped in a BroadcastLogger, which restricts the interface by not passing keyword arguments through to underlying loggers unchanged.

When BroadcastLogger is applied to a logger implementation that takes kwargs, a developer invoking a logging message while passing kwargs will run into

    ArgumentError: wrong number of arguments (given 2, expected 0..1)

This error is confusing since the 'correct' arguments are passed, and BroadcastLogger's splat unexpectedly converts the kwargs into a hash and passes that hash along as a second argument instead of forwarding along the method arguments unchanged.


### Detail

This Pull Request changes logging methods from explicit argument delegation `info(*args, &block)` to implicit argument delegation `info(...)`.

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->
https://github.com/bkuhlmann/cogger is an example of [a logging implementation that may take kwargs](https://github.com/bkuhlmann/cogger/blob/1d3d82f0f2b92b53277c8ff5ba9723671e478f98/lib/cogger/hub.rb#L53-L61), and this is a problem I have hit in practice with another logger implementation.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included. **is this a minor bugfix?**
