### PR TITLE
Allow to pass array values to `.in_order_of`

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,21 @@
+*   Allow to pass array values to `in_order_of`
+
+    Passing arrays allows to group records and order those groups with another query:
+
+    ```rb
+    Posts
+      .in_order_of(:state, [[:published, :canceled], :archived])
+      .order(created_at: :desc)
+    # =>
+    # SELECT "posts".* FROM "posts" WHERE "posts"."state" IN (1, 2, 3)
+    # ORDER BY CASE
+    #   WHEN "posts"."state" IN (1, 2) THEN 1
+    #   WHEN "posts"."state" = 3 THEN 2
+    #  END ASC, "posts"."created_at" DESC
+    ```
+
+    *Markus Doits*
+
 *   On PostgreSQL 18.4+, `disable_referential_integrity` uses `NOT ENFORCED`/`ENFORCED`
     instead of `DISABLE TRIGGER ALL`/`ENABLE TRIGGER ALL`, requiring only table ownership
     rather than superuser privileges. Only currently `ENFORCED` foreign keys are toggled;

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -679,6 +679,16 @@ module ActiveRecord
     #   #     WHEN "users"."id" = 3 THEN 3
     #   #   END ASC
     #
+    # To group values together, an array can be passed as a value.
+    #
+    #   User.in_order_of(:id, [[1, 5], 3])
+    #   # SELECT "users".* FROM "users"
+    #   #   WHERE "users"."id" IN (1, 5, 3)
+    #   #   ORDER BY CASE
+    #   #     WHEN "users"."id" IN (1, 5) THEN 1
+    #   #     WHEN "users"."id" = 3 THEN 2
+    #   #   END ASC
+    #
     # +column+ can point to an enum column; the actual query generated may be different depending
     # on the database adapter and the column definition.
     #
@@ -728,13 +738,21 @@ module ActiveRecord
 
         caster = arel_column.type_caster
         values = values.map do |value|
-          caster.serialize(value) if caster.serializable?(value)
+          if value.is_a?(Array)
+            value.map do |current_value|
+              caster.serialize(current_value) if caster.serializable?(current_value)
+            end
+          else
+            caster.serialize(value) if caster.serializable?(value)
+          end
         end
       end
 
       scope = spawn.order!(build_case_for_value_position(arel_column, values, filter: filter))
 
       if filter
+        values = values.flatten(1)
+
         where_clause =
           if values.include?(nil)
             arel_column.in(values.compact).or(arel_column.eq(nil))
@@ -2186,7 +2204,15 @@ module ActiveRecord
       def build_case_for_value_position(column, values, filter: true)
         node = Arel::Nodes::Case.new
         values.each.with_index(1) do |value, order|
-          node.when(column.eq(value)).then(order)
+          if value.is_a?(Array)
+            if value.include?(nil)
+              node.when(column.in(value.compact).or(column.eq(nil))).then(order)
+            else
+              node.when(column.in(value)).then(order)
+            end
+          else
+            node.when(column.eq(value)).then(order)
+          end
         end
 
         node = node.else(values.length + 1) unless filter

--- a/activerecord/test/cases/relation/field_ordered_values_test.rb
+++ b/activerecord/test/cases/relation/field_ordered_values_test.rb
@@ -125,4 +125,24 @@ class FieldOrderedValuesTest < ActiveRecord::TestCase
 
     assert_equal([1], posts.map(&:id))
   end
+
+  def test_in_order_of_with_array_values
+    order = [3, [5, 2], [4, 7], 1]
+    posts = Post.in_order_of(:id, order).order(id: :asc)
+
+    assert_equal([3, 2, 5, 4, 7, 1], posts.map(&:id))
+  end
+
+  def test_in_order_of_with_array_values_with_nil
+    Book.destroy_all
+    Book.create!(format: "paperback")
+    Book.create!(format: "ebook")
+    Book.create!(format: nil)
+    Book.create!(format: "letter")
+    Book.create!(format: "digital")
+
+    order = ["ebook", ["paperback", nil, "digital"], "letter"]
+    books = Book.in_order_of(:format, order).order(Book.arel_table[:format].desc.nulls_last)
+    assert_equal(["ebook", "paperback", "digital", nil, "letter"], books.map(&:format))
+  end
 end


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

This Pull Request has been created because I wanted to group records with `.in_order_of`. I makes it possible to execute a query like this:

```rb
Posts.in_order_of(:state, [[:published, :canceled], :archived]).order(created_at: :desc)
# =>
# SELECT "posts".* FROM "posts" WHERE "posts"."state" IN (1, 2, 3)
# ORDER BY CASE
#   WHEN "posts"."state" IN (1, 2) THEN 1
#   WHEN "posts"."state" = 3 THEN 2
#  END ASC, "posts"."created_at" DESC
```

This makes it possible to group records together and then order those groups again with another order clause.

### Additional information

I've touched this code for the first time, so I'm not sure if this is the best way to implement it. For example one could use `Array.wrap` instead of `values.is_a?(Array)` checks (I feel this would reduce the performance, no benchmarks yet though).

Another thing this changes is that array values or now not typecasted as a whole but each item. I'm not sure if this is OK or if there might be a case where an array value as a whole should be used for the type cast (e.g. for array typed columns).

Maybe there's even a way I've not come up yet to archive the same result with existing methods.

Feel free to request changes or hint how this can be implemented more efficiently – if you thing this is something to implement at all.

Thanks for reviewing it!

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
