### PR TITLE
Match destroyed_by_association for belongs_to with has_one and has_many behaviour

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   When a `belongs_to` association is destroyed by `dependent: :destroy`,
+    `destroyed_by_association` will now be set to the reflection, matching the
+    behaviour of `has_one` and `has_many` associations.
+
+    Fixes #52859
+
+    *Hans Christian Ang*
+
 *   Fix migrating multiple databases with `ActiveRecord::PendingMigration` action.
 
     *Gannon McGibbon*

--- a/activerecord/lib/active_record/associations/belongs_to_association.rb
+++ b/activerecord/lib/active_record/associations/belongs_to_association.rb
@@ -9,8 +9,11 @@ module ActiveRecord
 
         case options[:dependent]
         when :destroy
+          target.destroyed_by_association = reflection
           raise ActiveRecord::Rollback unless target.destroy
         when :destroy_async
+          target.destroyed_by_association = reflection
+
           if reflection.foreign_key.is_a?(Array)
             primary_key_column = reflection.active_record_primary_key
             id = reflection.foreign_key.map { |col| owner.public_send(col) }

--- a/activerecord/test/cases/associations/belongs_to_associations_test.rb
+++ b/activerecord/test/cases/associations/belongs_to_associations_test.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "activejob/helper"
+
 require "cases/helper"
 require "models/developer"
 require "models/project"
@@ -33,6 +35,8 @@ require "models/club"
 require "models/cpk"
 
 class BelongsToAssociationsTest < ActiveRecord::TestCase
+  include ActiveJob::TestHelper
+
   fixtures :accounts, :companies, :developers, :projects, :topics,
            :developers_projects, :computers, :authors, :author_addresses,
            :essays, :posts, :tags, :taggings, :comments, :sponsors, :members, :nodes, :cpk_books
@@ -1197,6 +1201,47 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
       Class.new(Author).belongs_to :special_author_address, dependent: :nullify
     end
     assert_equal "The :dependent option must be one of [:destroy, :delete, :destroy_async], but is :nullify", error.message
+  end
+
+  class DestroyViaBelongsToBook < ActiveRecord::Base
+    self.table_name = "books"
+    belongs_to :author, class_name: "DestroyViaBelongsToAuthor", dependent: :destroy
+  end
+
+  class DestroyAsyncViaBelongsToBook < ActiveRecord::Base
+    self.table_name = "books"
+    belongs_to :author, class_name: "DestroyViaBelongsToAuthor", dependent: :destroy_async
+  end
+
+  class DestroyViaBelongsToAuthor < ActiveRecord::Base
+    self.table_name = "authors"
+    has_one :book, class_name: "DestroyViaBelongsToBook", foreign_key: "author_id"
+    before_destroy :dont, unless: :destroyed_by_association
+
+    def dont
+      throw(:abort)
+    end
+  end
+
+  test "destroyed_by_association set in child destroy callback on parent destroy" do
+    author = DestroyViaBelongsToAuthor.create!(name: "Test")
+    book = DestroyViaBelongsToBook.create!(author: author)
+
+    book.destroy
+
+    assert_not DestroyViaBelongsToAuthor.exists?(book.id)
+  end
+
+  test "destroyed_by_association set in child destroy callback on parent destroy_async" do
+    author = DestroyViaBelongsToAuthor.create!(name: "Test")
+    book = DestroyAsyncViaBelongsToBook.create!(author: author)
+
+    assert_enqueued_jobs 1, only: ActiveRecord::DestroyAssociationAsyncJob do
+      book.destroy
+    end
+
+    perform_enqueued_jobs only: ActiveRecord::DestroyAssociationAsyncJob
+    assert_not DestroyViaBelongsToAuthor.exists?(book.id)
   end
 
   class EssayDestroy < ActiveRecord::Base


### PR DESCRIPTION
When a has_many and has_one association is destroyed by `dependent: destroy`, destroyed_by_association is set to the reflection, and this can be checked in callbacks. This change matches that behaviour for belongs_to associations.

Fixes #52859

<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created because `destroyed_by_association` is not set when a `belongs_to` associations is being destroyed through `dependent: :destroy`, unlike `has_many` and `has_one` (which was introduced in this [PR](https://github.com/rails/rails/pull/29855))

### Detail

This Pull Request changes sets the `destroyed_by_association` on a `belongs_to` association, to match the behaviour with `has_many` and `has_one`.

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->
N/A

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
