### PR TITLE
[ci skip] Update reference from db:test:prepare to use test:db instead

### DIFF
--- a/guides/source/testing.md
+++ b/guides/source/testing.md
@@ -702,7 +702,7 @@ the migrations against the development database (`bin/rails db:migrate`) will
 bring the schema up to date.
 
 NOTE: If there were modifications to existing migrations, the test database needs to
-be rebuilt. This can be done by executing `bin/rails db:test:prepare`.
+be rebuilt. This can be done by executing `bin/rails test:db`.
 
 ### The Low-Down on Fixtures
 


### PR DESCRIPTION
This reference to `db:test:prepare`, which was made private in https://github.com/rails/rails/commit/fa15111d30f05edac7e4f63264e25887a5a4ae20 and covered in https://github.com/rails/rails/issues/2560 is outdated.

We should teach users about the public task instead (using `bin/rails --help` as a guide).

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] ~Tests are added or updated if you fix a bug or add a feature.~
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
