### PR TITLE
Change `ActiveRecord::FinderMethods#find_sole_by` to return nil if no record is found

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,23 @@
+*   Change `ActiveRecord::FinderMethods#find_sole_by` to return nil if no record is found.
+    Add `ActiveRecord::FinderMethods#find_sole_by!` to find and assert the presence of exactly one record.
+
+    `ActiveRecord::FinderMethods#find_sole_by` behaviour is changed to return nil if no record is found and
+    the new `ActiveRecord::FinderMethods#find_sole_by!` raises `ActiveRecord::RecordNotFound` if no record is found.
+
+    ```ruby
+    user.api_keys.find_sole_by(key: key)
+    # => nil                               (if no matching api key)
+    # => #<ApiKey ...>                     (if one api key)
+    # => ActiveRecord::SoleRecordExceeded  (if more than one api key)
+
+    user.api_keys.find_sole_by!(key: key)
+    # => ActiveRecord::RecordNotFound      (if no matching api key)
+    # => #<ApiKey ...>                     (if one api key)
+    # => ActiveRecord::SoleRecordExceeded  (if more than one api key)
+    ```
+
+    *Biruk H. Tabor*
+
 *   Fix an issue where `.left_outer_joins` used with multiple associations that have
     the same child association but different parents does not join all parents.
 

--- a/activerecord/lib/active_record/querying.rb
+++ b/activerecord/lib/active_record/querying.rb
@@ -3,7 +3,7 @@
 module ActiveRecord
   module Querying
     QUERYING_METHODS = [
-      :find, :find_by, :find_by!, :take, :take!, :sole, :find_sole_by, :first, :first!, :last, :last!,
+      :find, :find_by, :find_by!, :take, :take!, :sole, :find_sole_by, :find_sole_by!, :first, :first!, :last, :last!,
       :second, :second!, :third, :third!, :fourth, :fourth!, :fifth, :fifth!,
       :forty_two, :forty_two!, :third_to_last, :third_to_last!, :second_to_last, :second_to_last!,
       :exists?, :any?, :many?, :none?, :one?,

--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -156,9 +156,16 @@ module ActiveRecord
     # record is found. Raises ActiveRecord::SoleRecordExceeded if more than one
     # record is found.
     #
-    #   Product.find_sole_by(["price = %?", price])
-    def find_sole_by(arg, *args)
+    #   Product.find_sole_by!(["price = %?", price])
+    def find_sole_by!(arg, *args)
       where(arg, *args).sole
+    end
+
+    # Like #find_sole_by!, except that if no record is found, it returns nil.
+    def find_sole_by(arg, *args)
+      find_sole_by!(arg, *args)
+    rescue ActiveRecord::RecordNotFound
+      nil
     end
 
     # Find the first record (or first N records if a parameter is supplied).

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -774,15 +774,11 @@ class FinderTest < ActiveRecord::TestCase
 
   def test_sole
     assert_equal topics(:first), Topic.where("title = 'The First Topic'").sole
-    assert_equal topics(:first), Topic.find_sole_by("title = 'The First Topic'")
   end
 
   def test_sole_failing_none
     assert_raises ActiveRecord::RecordNotFound, match: "Couldn't find Topic" do
       Topic.where("title = 'This title does not exist'").sole
-    end
-    assert_raises ActiveRecord::RecordNotFound, match: "Couldn't find Topic" do
-      Topic.find_sole_by("title = 'This title does not exist'")
     end
   end
 
@@ -790,6 +786,33 @@ class FinderTest < ActiveRecord::TestCase
     assert_raises ActiveRecord::SoleRecordExceeded, match: "Wanted only one Topic" do
       Topic.where("author_name = 'Carl'").sole
     end
+  end
+
+  def test_find_sole_by_bang
+    assert_equal topics(:first), Topic.find_sole_by!("title = 'The First Topic'")
+  end
+
+  def test_find_sole_by_bang_failing_none
+    assert_raises ActiveRecord::RecordNotFound, match: "Couldn't find Topic" do
+      Topic.find_sole_by!("title = 'This title does not exist'")
+    end
+  end
+
+  def test_find_sole_by_bang_failing_many
+    assert_raises ActiveRecord::SoleRecordExceeded, match: "Wanted only one Topic" do
+      Topic.find_sole_by!("author_name = 'Carl'")
+    end
+  end
+
+  def test_find_sole_by
+    assert_equal topics(:first), Topic.find_sole_by("title = 'The First Topic'")
+  end
+
+  def test_find_sole_by_returning_nil
+    assert_nil Topic.find_sole_by("title = 'This title does not exist'")
+  end
+
+  def test_find_sole_by_failing_many
     assert_raises ActiveRecord::SoleRecordExceeded, match: "Wanted only one Topic" do
       Topic.find_sole_by("author_name = 'Carl'")
     end


### PR DESCRIPTION
Change `#find_sole_by` to return nil if no record is found
Add `#find_sole_by!` to find and assert the presence of exactly one record

### Motivation / Background

This Pull Request addresses the issue where `#find_sole_by` currently raises an `ActiveRecord::RecordNotFound` error when no record is found. The proposed changes are similar to the behavior of `#find_by!` and `#find_by`, where if no record is found:

- `#find_sole_by` will return nil.
- `#find_sole_by!` will raise an ActiveRecord::RecordNotFound error.

### Detail

This Pull Request changes `#find_sole_by` to return nil if no record is found and adds `#find_sole_by!` to keep the current `#find_sole_by` behaviour.

### Additional information

This is a breaking change but ...
> The use case of `there should be either zero or one record matching the condition, but never more than one` is very common.

https://github.com/rails/rails/pull/40768#issuecomment-1143532090

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.