### PR TITLE
Set usec 0 unless with_usec

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -65,4 +65,8 @@
 
     *Frederik Erbs Spang Thomsen*
 
+*   Fix `travel_to` to set usec 0 when `with_usec` is `false` and the given argument String or DateTime.
+
+    *mopp*
+
 Please check [7-2-stable](https://github.com/rails/rails/blob/7-2-stable/activesupport/CHANGELOG.md) for previous changes.

--- a/activesupport/lib/active_support/testing/time_helpers.rb
+++ b/activesupport/lib/active_support/testing/time_helpers.rb
@@ -166,8 +166,9 @@ module ActiveSupport
         else
           now = date_or_time
           now = now.to_time unless now.is_a?(Time)
-          now = now.change(usec: 0) unless with_usec
         end
+
+        now = now.change(usec: 0) unless with_usec
 
         # +now+ must be in local system timezone, because +Time.at(now)+
         # and +now.to_date+ (see stubs below) will use +now+'s timezone too!

--- a/activesupport/test/time_travel_test.rb
+++ b/activesupport/test/time_travel_test.rb
@@ -174,6 +174,20 @@ class TimeTravelTest < ActiveSupport::TestCase
     end
   end
 
+  def test_time_helper_travel_to_with_string_and_milliseconds
+    with_env_tz "US/Eastern" do
+      with_tz_default ActiveSupport::TimeZone["UTC"] do
+        Time.stub(:now, Time.now) do
+          expected_time = Time.new(2004, 11, 24, 1, 4, 44)
+
+          travel_to "2004-11-24T01:04:44.123-05:00" do
+            assert_equal expected_time, Time.zone.now
+          end
+        end
+      end
+    end
+  end
+
   def test_time_helper_travel_to_with_separate_class
     travel_object = TravelClass.new
     date1 = Date.new(2004, 11, 24)
@@ -327,6 +341,93 @@ class TimeTravelTest < ActiveSupport::TestCase
       end
     ensure
       travel_back
+    end
+  end
+
+  def test_time_helper_travel_to_with_datetime_and_usec
+    with_env_tz "US/Eastern" do
+      with_tz_default ActiveSupport::TimeZone["UTC"] do
+        Time.stub(:now, Time.now) do
+          duration_usec = 0.1.seconds
+          traveled_time = DateTime.iso8601("2004-11-24T01:04:44.000-05:00") + duration_usec
+          expected_time = Time.new(2004, 11, 24, 1, 4, 44)
+
+          assert_nothing_raised do
+            travel_to traveled_time
+
+            assert_equal expected_time, Time.zone.now
+
+            travel_back
+          end
+        ensure
+          travel_back
+        end
+      end
+    end
+  end
+
+  def test_time_helper_travel_to_with_datetime_and_usec_true
+    with_env_tz "US/Eastern" do
+      with_tz_default ActiveSupport::TimeZone["UTC"] do
+        Time.stub(:now, Time.now) do
+          duration_usec = 0.1.seconds
+          traveled_time = DateTime.iso8601("2004-11-24T01:04:44.000-05:00") + duration_usec
+          expected_time = Time.new(2004, 11, 24, 1, 4, 44) + duration_usec
+
+          assert_nothing_raised do
+            travel_to traveled_time, with_usec: true
+
+            assert_equal expected_time, Time.now
+
+            travel_back
+          end
+        ensure
+          travel_back
+        end
+      end
+    end
+  end
+
+  def test_time_helper_travel_to_with_string_and_usec
+    with_tz_default ActiveSupport::TimeZone["UTC"] do
+      Time.stub(:now, Time.now) do
+        duration_usec = 0.1.seconds
+        traveled_time = Time.new(2004, 11, 24, 1, 4, 44) + duration_usec
+        expected_time = Time.new(2004, 11, 24, 1, 4, 44)
+
+        assert_nothing_raised do
+          travel_to traveled_time.iso8601(3)
+
+          assert_equal expected_time, Time.now
+
+          travel_back
+        end
+      ensure
+        travel_back
+      end
+    end
+  end
+
+  def  test_time_helper_travel_to_with_string_and_usec_true
+    with_tz_default ActiveSupport::TimeZone["UTC"] do
+      Time.stub(:now, Time.now) do
+        duration_usec = 0.1.seconds
+        expected_time = Time.new(2004, 11, 24, 1, 4, 44) + duration_usec
+
+        assert_nothing_raised do
+          travel_to expected_time.iso8601(3), with_usec: true
+
+          assert_equal expected_time.to_f, Time.now.to_f
+
+          travel 0.5, with_usec: true
+
+          assert_equal((expected_time + 0.5).to_f, Time.now.to_f)
+
+          travel_back
+        end
+      ensure
+        travel_back
+      end
     end
   end
 


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created because `travel_to` does not set usec to 0 depending on the argument (String and DateTime).
The behavior differs from that defined in the documentation.

### Detail

The document describes usec will be set to 0 unless `with_usec` is set to true. 

> Note that the usec for the time passed will be set to 0 to prevent rounding errors with external services, like MySQL (which will round instead of floor, leading to off-by-one-second errors), unless the with_usec argument is set to true.

But I found it does not in some cases.

```ruby
travel_to("2024-09-11 21:17:58.766491 +0900") do
  pp Time.now.iso8601(3)
end

# expected
# => 2024-09-11 21:17:58.000 +0900

# actual
# => 2024-09-11 21:17:58.766 +0900
```

Please check the test for the other cases.

I faced this behavior in the Rails matrix test (Rails 7.0 and Rails 7.1) in CI for our products.
The PR https://github.com/rails/rails/pull/44088 introduces `with_usec` option.

The `Time.now` was stubbed and uses UNIX timestamp which does not have a subsecond before the PR
```ruby
simple_stubs.stub_object(Time, :now) { at(now.to_i) }
```

It uses `to_f` and keeps the subsecond in some branches after the PR.
```ruby
simple_stubs.stub_object(Time, :now) { at(now.to_f) }
```

This PR is also breaking change.
I'm not sure whether this way is the proper way or not. Please teach me if you have another way.
In addition, my writing is not so good. please revise the CHANGELOG also 🙏 

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->
None

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
