### PR TITLE
Add Solid Cable

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,7 @@ gem "tailwindcss-rails"
 gem "dartsass-rails"
 gem "solid_cache"
 gem "solid_queue"
+gem "solid_cable"
 gem "kamal", require: false
 gem "thruster", require: false
 # require: false so bcrypt is loaded only when has_secure_password is used.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -547,6 +547,8 @@ GEM
       rake
       serverengine (~> 2.0.5)
       thor
+    solid_cable (1.1.0)
+      rails (>= 7.2)
     solid_cache (1.0.4)
       activejob (>= 7.2)
       activerecord (>= 7.2)
@@ -704,6 +706,7 @@ DEPENDENCIES
   selenium-webdriver (>= 4.20.0)
   sidekiq
   sneakers
+  solid_cable
   solid_cache
   solid_queue
   sprockets-rails (>= 2.0.0)

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Use [Solid Cable](https://github.com/rails/solid_cable) as the default Action Cable adapter in production, configured as a separate queue database in config/database.yml. It keeps messages in a table and continously polls for updates. This makes it possible to drop the common dependency on Redis, if it isn't needed for any other purpose. Despite polling, the performance of Solid Cable is comparable to Redis in most situations. And in all circumstances, it makes it easier to deploy Rails when Redis is no longer a required dependency for Action Cable functionality.
+
+    *DHH*
+
 *   Use [Solid Queue](https://github.com/rails/solid_queue) as the default Active Job backend in production, configured as a separate queue database in config/database.yml. In a single-server deployment, it'll run as a Puma plugin. This is configured in `config/deploy.yml` and can easily be changed to use a dedicated jobs machine.
 
     *DHH*

--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -756,7 +756,10 @@ module Rails
       def run_solid
         return if skip_solid? || !bundle_install?
 
-        rails_command "solid_cache:install solid_queue:install solid_cable:install"
+        commands = "solid_cache:install solid_queue:install"
+        commands += " solid_cable:install" unless skip_action_cable?
+
+        rails_command commands
       end
 
       def add_bundler_platforms

--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -756,7 +756,7 @@ module Rails
       def run_solid
         return if skip_solid? || !bundle_install?
 
-        rails_command "solid_cache:install solid_queue:install"
+        rails_command "solid_cache:install solid_queue:install solid_cable:install"
       end
 
       def add_bundler_platforms

--- a/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
@@ -18,6 +18,9 @@ gem "solid_cache"
 
 # Use the database-backed Solid Queue adapter for Active Job [https://github.com/rails/solid_queue]
 gem "solid_queue"
+
+# Use the database-backed Solid Cable adapter for Action Cable [https://github.com/rails/solid_cable]
+gem "solid_cable"
 <% end -%>
 <% if depend_on_bootsnap? -%>
 

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/mysql.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/mysql.yml.tt
@@ -73,4 +73,8 @@ production:
     <<: *primary_production
     database: <%= app_name %>_production_queue
     migrations_paths: db/queue_migrate
+  cable:
+    <<: *primary_production
+    database: <%= app_name %>_production_cable
+    migrations_paths: db/cable_migrate
 <%- end -%>

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/postgresql.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/postgresql.yml.tt
@@ -105,4 +105,8 @@ production:
     <<: *primary_production
     database: <%= app_name %>_production_queue
     migrations_paths: db/queue_migrate
+  cable:
+    <<: *primary_production
+    database: <%= app_name %>_production_cable
+    migrations_paths: db/cable_migrate
 <%- end -%>

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/sqlite3.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/sqlite3.yml.tt
@@ -62,5 +62,9 @@ production:
     <<: *default
     database: storage/production_queue.sqlite3
     migrations_paths: db/queue_migrate
+  cable:
+    <<: *default
+    database: storage/production_cable.sqlite3
+    migrations_paths: db/cable_migrate
 <%- end -%>
 <%- end -%>

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/trilogy.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/trilogy.yml.tt
@@ -73,4 +73,8 @@ production:
     <<: *primary_production
     database: <%= app_name %>_production_queue
     migrations_paths: db/queue_migrate
+  cable:
+    <<: *primary_production
+    database: <%= app_name %>_production_cable
+    migrations_paths: db/cable_migrate
 <%- end -%>

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -645,10 +645,12 @@ class AppGeneratorTest < Rails::Generators::TestCase
 
     assert_gem "solid_cache"
     assert_gem "solid_queue"
+    assert_gem "solid_cable"
 
     assert_file "config/database.yml" do |content|
       assert_match(%r{cache:}, content)
       assert_match(%r{queue:}, content)
+      assert_match(%r{cable:}, content)
     end
   end
 
@@ -813,9 +815,10 @@ class AppGeneratorTest < Rails::Generators::TestCase
     generator([destination_root], skip_solid: true)
     run_generator_instance
 
-    assert_not_includes @rails_commands, "solid_cache:install solid_queue:install", "`solid_cache:install solid_queue:install` expected to not be called."
+    assert_not_includes @rails_commands, "solid_cache:install solid_queue:install solid_cable:install", "`solid_cache:install solid_queue:install solid_cable:install` expected to not be called."
     assert_no_gem "solid_cache"
     assert_no_gem "solid_queue"
+    assert_no_gem "solid_cable"
   end
 
   def test_skip_javascript_option
@@ -992,7 +995,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
     run_generator_instance
 
     expected_commands = [
-      "credentials:diff --enroll", "importmap:install", "turbo:install stimulus:install", "solid_cache:install solid_queue:install"
+      "credentials:diff --enroll", "importmap:install", "turbo:install stimulus:install", "solid_cache:install solid_queue:install solid_cable:install"
     ]
     assert_equal expected_commands, @rails_commands
   end


### PR DESCRIPTION
Solid Cable is the last piece before we can fully claim that Rails 8 only requires a database as a dependency to get access to all frameworks and functionality. Thanks to @npezza93 for the great work!