### PR TITLE
Assign id attributes first in Active Record attribute assignment

### DIFF
--- a/activerecord/lib/active_record/attribute_assignment.rb
+++ b/activerecord/lib/active_record/attribute_assignment.rb
@@ -4,27 +4,30 @@ module ActiveRecord
   module AttributeAssignment
     private
       def _assign_attributes(attributes)
-        multi_parameter_attributes = nested_parameter_attributes = nil
+        foreign_keys = foreign_key_column_names
+        foreign_key_attributes = nil
+        normal_attributes = {}
+        multi_parameter_attributes = nil
 
         attributes.each do |k, v|
           key = k.to_s
 
-          if key.include?("(")
+          if key.in?(foreign_keys)
+            (foreign_key_attributes ||= {})[key] = v
+          elsif key.include?("(")
             (multi_parameter_attributes ||= {})[key] = v
-          elsif v.is_a?(Hash)
-            (nested_parameter_attributes ||= {})[key] = v
           else
-            _assign_attribute(key, v)
+            normal_attributes[key] = v
           end
         end
 
-        assign_nested_parameter_attributes(nested_parameter_attributes) if nested_parameter_attributes
+        foreign_key_attributes.each { |key, value| _assign_attribute(key, value) } if foreign_key_attributes
+        normal_attributes.each { |key, value| _assign_attribute(key, value)  }
         assign_multiparameter_attributes(multi_parameter_attributes) if multi_parameter_attributes
       end
 
-      # Assign any deferred nested attributes after the base attributes have been set.
-      def assign_nested_parameter_attributes(pairs)
-        pairs.each { |k, v| _assign_attribute(k, v) }
+      def foreign_key_column_names
+        self.class._reflections.values.grep(Reflection::BelongsToReflection).map(&:foreign_key)
       end
 
       # Instantiates objects for all attribute classes that needs more than one constructor parameter. This is done

--- a/activerecord/test/cases/store_test.rb
+++ b/activerecord/test/cases/store_test.rb
@@ -220,6 +220,14 @@ class StoreTest < ActiveRecord::TestCase
     assert_equal "blue", user.color[:jenny]
   end
 
+  test "update store and accessor" do
+    user = Admin::User.find_by_name("Jamis")
+    user.update(settings: { homepage: "not rails" }, homepage: "rails")
+
+    assert_equal "rails", user.settings[:homepage]
+    assert_equal "rails", user.homepage
+  end
+
   def test_convert_store_attributes_from_Hash_to_HashWithIndifferentAccess_saving_the_data_and_access_attributes_indifferently
     user = Admin::User.find_by_name("Jamis")
     assert_equal "symbol",  user.settings[:symbol]


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because store assignment behaviour changed subtly since https://github.com/rails/rails/pull/52792:

```rb
# frozen_string_literal: true

require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"

  gem "rails", github: "rails/rails"

  gem "sqlite3"# , "~> 1.4"
  gem "benchmark-ips"
end

require "active_record"
require "minitest/autorun"
require "logger"

# This connection will do for database-independent bug reports.
ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")
ActiveRecord::Base.logger = Logger.new(STDOUT)

ActiveRecord::Schema.define do
  create_table :posts, force: true do |t|
    t.text :settings
  end
end

class Post < ActiveRecord::Base
  store :settings, accessors: [:a]
end

class BugTest < Minitest::Test
  def test_association_stuff
    post = Post.create!

    post.update!(settings: { a: "a" }, a: "b")

    assert_equal("b", post.a)
  end
end
```
(fails on main, passes on 7.2, and then fails on 7.1)

Instead of assigning hashes later, we can assign IDs first to maintain the same behaviour for nested attribute assignment. Deferring hash assignment causes problems in store scenarios where an attribute can be assigned two different ways, which had worked since Rails 7.2.

### Detail

This Pull Request changes attribute assignment to assign foreign keys first.

### Additional information

```rb
require "benchmark/ips"

post = Post.create!

Benchmark.ips do |x|
  x.report(:assignment) { post.assign_attributes(settings: { a: "a" }, a: "b") }
end
```

Before:
```
ruby 3.3.4 (2024-07-09 revision be1089c8ec) [arm64-darwin23]
Warming up --------------------------------------
          assignment     2.387k i/100ms
Calculating -------------------------------------
          assignment     23.466k (± 4.6%) i/s   (42.61 μs/i) -    119.350k in   5.097964s
```

After:
```
ruby 3.3.4 (2024-07-09 revision be1089c8ec) [arm64-darwin23]
Warming up --------------------------------------
          assignment     2.358k i/100ms
Calculating -------------------------------------
          assignment     22.578k (± 5.0%) i/s   (44.29 μs/i) -    113.184k in   5.026557s
```
Potentially a little slower, but not significantly.


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
