### PR TITLE
Fix railties tests for Propshaft and maintain support for Sprockets

### DIFF
--- a/railties/lib/rails/commands/app/update_command.rb
+++ b/railties/lib/rails/commands/app/update_command.rb
@@ -79,14 +79,7 @@ module Rails
           end
 
           def asset_pipeline
-            case
-            when defined?(Sprockets::Railtie)
-              "sprockets"
-            when defined?(Propshaft::Railtie)
-              "propshaft"
-            else
-              nil
-            end
+            "propshaft" if defined?(Propshaft::Railtie)
           end
 
           def skip_gem?(gem_name)

--- a/railties/test/application/assets_test.rb
+++ b/railties/test/application/assets_test.rb
@@ -3,6 +3,7 @@
 require "isolation/abstract_unit"
 require "rack/test"
 require "active_support/json"
+require "propshaft"
 
 module ApplicationTests
   class AssetsTest < ActiveSupport::TestCase
@@ -49,25 +50,19 @@ module ApplicationTests
     end
 
     test "assets routes have higher priority" do
-      app_file "app/assets/images/rails.png", "notactuallyapng"
-      app_file "app/assets/javascripts/demo.js.erb", "a = <%= image_path('rails.png').inspect %>;"
-
+      app_file "app/assets/javascripts/demo-sha1_string.digested.js", "a = 1+1;"
       app_file "config/routes.rb", <<-RUBY
         Rails.application.routes.draw do
           get '*path', to: lambda { |env| [200, { "Content-Type" => "text/html" }, ["Not an asset"]] }
         end
       RUBY
 
-      add_to_env_config "development", "config.assets.digest = false"
+      get "/assets/demo-sha1_string.digested.js"
 
-      require "#{app_path}/config/environment"
-
-      get "/assets/demo.js"
-      assert_equal 'a = "/assets/rails.png";', last_response.body.strip
+      assert_equal "a = 1+1;", last_response.body.strip
     end
 
     test "precompile creates the file, gives it the original asset's content and run in production as default" do
-      app_file "app/assets/config/manifest.js", "//= link_tree ../javascripts"
       app_file "app/assets/javascripts/application.js", "alert();"
       app_file "app/assets/javascripts/foo/application.js", "alert();"
 
@@ -82,7 +77,6 @@ module ApplicationTests
     end
 
     def test_precompile_does_not_hit_the_database
-      app_file "app/assets/config/manifest.js", "//= link_tree ../javascripts"
       app_file "app/assets/javascripts/application.js", "alert();"
       app_file "app/assets/javascripts/foo/application.js", "alert();"
       app_file "app/controllers/users_controller.rb", <<-eoruby
@@ -104,80 +98,19 @@ module ApplicationTests
       end
     end
 
-    test "precompile application.js and application.css and all other non JS/CSS files if manifest requests" do
-      app_file "app/assets/javascripts/application.js", "alert();"
-      app_file "app/assets/stylesheets/application.css", "body{}"
-
-      app_file "app/assets/javascripts/someapplication.js", "alert();"
-      app_file "app/assets/stylesheets/someapplication.css", "body{}"
-
-      app_file "app/assets/javascripts/something.min.js", "alert();"
-      app_file "app/assets/stylesheets/something.min.css", "body{}"
-
-      app_file "app/assets/javascripts/something.else.js.erb", "alert();"
-      app_file "app/assets/stylesheets/something.else.css.erb", "body{}"
-
-      app_file "app/assets/config/manifest.js", <<~JS
-        //= link_tree ../images
-        //= link_directory ../stylesheets .css
-        //= link_directory ../javascripts .js
-      JS
-
-      images_should_compile = ["a.png", "happyface.png", "happy_face.png", "happy.face.png",
-                               "happy-face.png", "happy.happy_face.png", "happy_happy.face.png",
-                               "happy.happy.face.png", "-happy.png", "-happy.face.png",
-                               "_happy.face.png", "_happy.png"]
-
-      images_should_compile.each do |filename|
-        app_file "app/assets/images/#{filename}", "happy"
-      end
-
-      precompile!
-
-      images_should_compile = ["a-*.png", "happyface-*.png", "happy_face-*.png", "happy.face-*.png",
-                               "happy-face-*.png", "happy.happy_face-*.png", "happy_happy.face-*.png",
-                               "happy.happy.face-*.png", "-happy-*.png", "-happy.face-*.png",
-                               "_happy.face-*.png", "_happy-*.png"]
-
-      images_should_compile.each do |filename|
-        assert_file_exists("#{app_path}/public/assets/#{filename}")
-      end
-
-      assert_file_exists("#{app_path}/public/assets/application-*.js")
-      assert_file_exists("#{app_path}/public/assets/application-*.css")
-
-      assert_no_file_exists("#{app_path}/public/assets/someapplication-*.js")
-      assert_no_file_exists("#{app_path}/public/assets/someapplication-*.css")
-
-      assert_no_file_exists("#{app_path}/public/assets/something.min-*.js")
-      assert_no_file_exists("#{app_path}/public/assets/something.min-*.css")
-
-      assert_no_file_exists("#{app_path}/public/assets/something.else-*.js")
-      assert_no_file_exists("#{app_path}/public/assets/something.else-*.css")
-    end
-
-    test "precompile something.js for directory containing index file" do
-      add_to_config "config.assets.precompile = [ 'something.js' ]"
-      app_file "app/assets/javascripts/something/index.js.erb", "alert();"
-
-      precompile!
-
-      assert_file_exists("#{app_path}/public/assets/something-*.js")
-    end
-
     test "precompile use assets defined in app env config" do
-      add_to_env_config "production", 'config.assets.precompile = [ "something.js" ]'
-      app_file "app/assets/javascripts/something.js.erb", "alert();"
+      add_to_env_config "production", 'config.assets.paths = [ "app/assets/javascripts" ]'
+      app_file "app/assets/javascripts/something.js", "alert();"
 
       precompile! RAILS_ENV: "production"
 
       assert_file_exists("#{app_path}/public/assets/something-*.js")
     end
 
-    test "sprockets cache is not shared between environments" do
+    test "propshaft cache is not shared between environments" do
       app_file "app/assets/images/rails.png", "notactuallyapng"
       remove_file "app/assets/stylesheets/application.css"
-      app_file "app/assets/stylesheets/application.css.erb", "body { background: '<%= asset_path('rails.png') %>'; }"
+      app_file "app/assets/stylesheets/application.css", "body { background: url('rails.png'); }"
       add_to_env_config "production", 'config.assets.prefix = "production_assets"'
 
       precompile!
@@ -195,45 +128,25 @@ module ApplicationTests
       assert_match(/production_assets\/rails-([0-z]+)\.png/, File.read(file))
     end
 
-    test "precompile use assets defined in app config and reassigned in app env config" do
-      add_to_config 'config.assets.precompile = [ "something_manifest.js" ]'
-      add_to_env_config "production", 'config.assets.precompile += [ "another_manifest.js" ]'
-
-      app_file "app/assets/config/something_manifest.js", "//= link something.js"
-      app_file "app/assets/config/another_manifest.js", "//= link another.js"
-
-      app_file "app/assets/javascripts/something.js.erb", "alert();"
-      app_file "app/assets/javascripts/another.js.erb", "alert();"
-
-      precompile! RAILS_ENV: "production"
-
-      assert_file_exists("#{app_path}/public/assets/something_manifest-*.js")
-      assert_file_exists("#{app_path}/public/assets/something-*.js")
-      assert_file_exists("#{app_path}/public/assets/another_manifest-*.js")
-      assert_file_exists("#{app_path}/public/assets/another-*.js")
-    end
-
-    test "asset pipeline should use a Sprockets::CachedEnvironment when config.assets.digest is true" do
+    test "asset pipeline should use a Propshaft::Assembly" do
       add_to_config "config.action_controller.perform_caching = false"
-      add_to_env_config "production", "config.assets.compile = true"
 
-      # Load app env
       app "production"
 
-      assert_equal Sprockets::CachedEnvironment, Rails.application.assets.class
+      assert_equal Propshaft::Assembly, Rails.application.assets.class
     end
 
     test "precompile creates a manifest file with all the assets listed" do
       app_file "app/assets/images/rails.png", "notactuallyapng"
       remove_file "app/assets/stylesheets/application.css"
-      app_file "app/assets/stylesheets/application.css.erb", "<%= asset_path('rails.png') %>"
+      app_file "app/assets/stylesheets/application.css", "body { background: url('rails.png'); }"
 
       precompile!
 
-      manifest = Dir["#{app_path}/public/assets/.sprockets-manifest-*.json"].first
+      manifest = Dir["#{app_path}/public/assets/.manifest.json"].first
       assets = ActiveSupport::JSON.decode(File.read(manifest))
-      assert_match(/application-([0-z]+)\.css/, assets["assets"]["application.css"])
-      assert_match(/rails-([0-z]+)\.png/, assets["assets"]["rails.png"])
+      assert_match(/application-([0-z]+)\.css/, assets["application.css"])
+      assert_match(/rails-([0-z]+)\.png/, assets["rails.png"])
     end
 
     test "the manifest file should be saved by default in the same assets folder" do
@@ -242,9 +155,9 @@ module ApplicationTests
 
       precompile!
 
-      manifest = Dir["#{app_path}/public/x/.sprockets-manifest-*.json"].first
+      manifest = Dir["#{app_path}/public/x/.manifest.json"].first
       assets = ActiveSupport::JSON.decode(File.read(manifest))
-      assert_match(/test-([0-z]+)\.css/, assets["assets"]["test.css"])
+      assert_match(/test-([0-z]+)\.css/, assets["test.css"])
     end
 
     test "assets do not require any assets group gem when manifest file is present" do
@@ -253,24 +166,24 @@ module ApplicationTests
 
       precompile! RAILS_ENV: "production"
 
-      manifest = Dir["#{app_path}/public/assets/.sprockets-manifest-*.json"].first
+      manifest = Dir["#{app_path}/public/assets/.manifest.json"].first
       assets = ActiveSupport::JSON.decode(File.read(manifest))
-      asset_path = assets["assets"]["application.js"]
+      asset_path = assets["application.js"]
 
       # Load app env
       app "production"
 
-      # Checking if Uglifier is defined we can know if Sprockets was reached or not
+      # Checking if Uglifier is defined we can know if Propshaft was reached or not
       assert_not defined?(Uglifier)
       get("/assets/#{asset_path}", {}, "HTTPS" => "on")
       assert_match "alert()", last_response.body
       assert_not defined?(Uglifier)
     end
 
-    test "precompile properly refers files referenced with asset_path" do
+    test "precompile properly refers files referenced with url" do
       app_file "app/assets/images/rails.png", "notactuallyapng"
       remove_file "app/assets/stylesheets/application.css"
-      app_file "app/assets/stylesheets/application.css.erb", "p { background-image: url(<%= asset_path('rails.png') %>) }"
+      app_file "app/assets/stylesheets/application.css", "p { background-image: url('rails.png') }"
 
       precompile!
 
@@ -282,26 +195,26 @@ module ApplicationTests
       app_file "app/assets/images/rails.png", "notactuallyapng"
 
       remove_file "app/assets/stylesheets/application.css"
-      app_file "app/assets/stylesheets/application.css.erb", "p { background-image: url(<%= asset_path('rails.png') %>) }"
+      app_file "app/assets/stylesheets/application.css", "p { background-image: url('rails.png') }"
 
       precompile! RAILS_ENV: "production"
 
-      manifest = Dir["#{app_path}/public/assets/.sprockets-manifest-*.json"].first
+      manifest = Dir["#{app_path}/public/assets/.manifest.json"].first
       assets = ActiveSupport::JSON.decode(File.read(manifest))
-      asset_path = assets["assets"]["application.css"]
+      asset_path = assets["application.css"]
 
       app_file "app/assets/images/rails.png", "p { url: change }"
 
       precompile!
 
       assets = ActiveSupport::JSON.decode(File.read(manifest))
-      assert_not_equal asset_path, assets["assets"]["application.css"]
+      assert_not_equal asset_path, assets["application.css"]
     end
 
-    test "precompile appends the MD5 hash to files referenced with asset_path and run in production with digest true" do
+    test "precompile appends the SHA1 hash to files referenced with url and run in production" do
       app_file "app/assets/images/rails.png", "notactuallyapng"
       remove_file "app/assets/stylesheets/application.css"
-      app_file "app/assets/stylesheets/application.css.erb", "p { background-image: url(<%= asset_path('rails.png') %>) }"
+      app_file "app/assets/stylesheets/application.css", "p { background-image: url('rails.png') }"
 
       precompile! RAILS_ENV: "production"
 
@@ -312,14 +225,12 @@ module ApplicationTests
     test "precompile should handle utf8 filenames" do
       filename = "レイルズ.png"
       app_file "app/assets/images/#{filename}", "not an image really"
-      app_file "app/assets/config/manifest.js", "//= link_tree ../images"
-      add_to_config "config.assets.precompile = %w(manifest.js)"
 
       precompile!
 
-      manifest = Dir["#{app_path}/public/assets/.sprockets-manifest-*.json"].first
+      manifest = Dir["#{app_path}/public/assets/.manifest.json"].first
       assets = ActiveSupport::JSON.decode(File.read(manifest))
-      assert asset_path = assets["assets"].find { |(k, _)| /.png/.match?(k) }[1]
+      assert asset_path = assets.find { |(k, _)| /.png/.match?(k) }[1]
 
       # Load app env
       app "development"
@@ -340,30 +251,14 @@ module ApplicationTests
       assert_equal 0, files.length, "Expected no assets, but found #{files.join(', ')}"
     end
 
-    test "assets routes are not drawn when compilation is disabled" do
-      app_file "app/assets/javascripts/demo.js.erb", "<%= :alert %>();"
-      add_to_config "config.assets.compile = false"
-
-      # Load app env
-      app "production"
-
-      get("/assets/demo.js", {}, "HTTPS" => "on")
-      assert_equal 404, last_response.status
-    end
-
     test "does not stream session cookies back" do
-      app_file "app/assets/javascripts/demo.js.erb", "<%= :alert %>();"
+      app_file "app/assets/javascripts/demo-sha1_digest.digested.js", "alert();"
 
       app_file "config/routes.rb", <<-RUBY
         Rails.application.routes.draw do
           get '/omg', :to => "omg#index"
         end
       RUBY
-
-      add_to_env_config "development", "config.assets.digest = false"
-
-      # Load app env
-      app "development"
 
       class ::OmgController < ActionController::Base
         def index
@@ -375,55 +270,9 @@ module ApplicationTests
       get "/omg"
       assert_equal "ok", last_response.body
 
-      get "/assets/demo.js"
+      get "/assets/demo-sha1_digest.digested.js"
       assert_match "alert()", last_response.body
       assert_nil last_response.headers["Set-Cookie"]
-    end
-
-    test "files in any assets/ directories are not added to Sprockets" do
-      %w[app lib vendor].each do |dir|
-        app_file "#{dir}/assets/#{dir}_test.erb", "testing"
-      end
-
-      app_file "app/assets/javascripts/demo.js", "alert();"
-
-      add_to_env_config "development", "config.assets.digest = false"
-
-      # Load app env
-      app "development"
-
-      get "/assets/demo.js"
-      assert_match "alert();", last_response.body
-      assert_equal 200, last_response.status
-    end
-
-    test "assets are concatenated when debug is off and compile is off either if debug_assets param is provided" do
-      app_with_assets_in_view
-
-      # config.assets.debug and config.assets.compile are false for production environment
-      precompile! RAILS_ENV: "production"
-
-      # Load app env
-      app "production"
-
-      class ::PostsController < ActionController::Base ; end
-
-      # the debug_assets params isn't used if compile is off
-      get("/posts?debug_assets=true", {}, "HTTPS" => "on")
-      assert_match(/<script src="\/assets\/application-([0-z]+)\.js"><\/script>/, last_response.body)
-      assert_no_match(/<script src="\/assets\/xmlhr-([0-z]+)\.js"><\/script>/, last_response.body)
-    end
-
-    test "assets can access model information when precompiling" do
-      app_file "app/models/post.rb", "class Post; end"
-      app_file "app/assets/javascripts/application.js", "//= require_tree ."
-      app_file "app/assets/javascripts/xmlhr.js.erb", "<%= Post.name %>"
-      app_file "app/assets/config/manifest.js", "//= link application.js"
-
-      precompile!
-
-      assert_file_exists("#{app_path}/public/assets/application-*.js")
-      assert_match(/Post;/, File.read(Dir["#{app_path}/public/assets/application-*.js"].first))
     end
 
     test "initialization on the assets group should set assets_dir" do
@@ -440,7 +289,6 @@ module ApplicationTests
 
     test "digested assets are not mistakenly removed" do
       app_file "app/assets/application.css", "div { font-weight: bold }"
-      add_to_config "config.assets.compile = true"
 
       precompile!
 
@@ -463,53 +311,19 @@ module ApplicationTests
     test "asset URLs should use the request's protocol by default" do
       app_with_assets_in_view
       add_to_config "config.asset_host = 'example.com'"
-      add_to_env_config "development", "config.assets.digest = false"
-
-      # Load app env
-      app "development"
 
       class ::PostsController < ActionController::Base; end
 
       get "/posts", {}, { "HTTPS" => "off" }
-      assert_match('src="http://example.com/assets/application.js', last_response.body)
+      assert_match('src="http://example.com/assets/application-72d8340d.js', last_response.body)
       get "/posts", {}, { "HTTPS" => "on" }
-      assert_match('src="https://example.com/assets/application.js', last_response.body)
-    end
-
-    test "asset URLs should be protocol-relative if no request is in scope" do
-      app_file "app/assets/images/rails.png", "notreallyapng"
-      app_file "app/assets/javascripts/image_loader.js.erb", "var src='<%= image_path('rails.png') %>';"
-      add_to_config "config.assets.precompile = %w{rails.png image_loader.js}"
-      add_to_config "config.asset_host = 'example.com'"
-      add_to_env_config "development", "config.assets.digest = false"
-
-      precompile!
-
-      assert_match "src='//example.com/assets/rails.png'", File.read(Dir["#{app_path}/public/assets/image_loader-*.js"].first)
-    end
-
-    test "asset paths should use RAILS_RELATIVE_URL_ROOT by default" do
-      ENV["RAILS_RELATIVE_URL_ROOT"] = "/sub/uri"
-      app_file "app/assets/images/rails.png", "notreallyapng"
-      app_file "app/assets/javascripts/app.js.erb", "var src='<%= image_path('rails.png') %>';"
-      add_to_config "config.assets.precompile = %w{rails.png app.js}"
-      add_to_env_config "development", "config.assets.digest = false"
-
-      precompile!
-
-      assert_match "src='/sub/uri/assets/rails.png'", File.read(Dir["#{app_path}/public/assets/app-*.js"].first)
+      assert_match('src="https://example.com/assets/application-72d8340d.js', last_response.body)
     end
 
     private
       def app_with_assets_in_view
-        app_file "app/assets/javascripts/application.js", "//= require_tree ."
-        app_file "app/assets/javascripts/xmlhr.js", "function f1() { alert(); }"
+        app_file "app/assets/javascripts/application.js", "function f1() { alert(); }"
         app_file "app/views/posts/index.html.erb", "<%= javascript_include_tag 'application' %>"
-        app_file "app/assets/config/manifest.js", <<~JS
-          //= link_tree ../images
-          //= link_directory ../stylesheets .css
-          //= link_directory ../javascripts .js
-        JS
 
         app_file "config/routes.rb", <<-RUBY
         Rails.application.routes.draw do

--- a/railties/test/application/sprockets_assets_test.rb
+++ b/railties/test/application/sprockets_assets_test.rb
@@ -1,0 +1,660 @@
+# frozen_string_literal: true
+
+require "isolation/abstract_unit"
+require "rack/test"
+require "active_support/json"
+require "sprockets"
+
+module ApplicationTests
+  class SprocketsAssetsTest < ActiveSupport::TestCase
+    include ActiveSupport::Testing::Isolation
+    include Rack::Test::Methods
+
+    def tmp_path(*args)
+      @sprockets_tmp_path ||= File.realpath(Dir.mktmpdir(nil, File.join(RAILS_FRAMEWORK_ROOT, "tmp")))
+      File.join(@sprockets_tmp_path, *args)
+    end
+
+    def setup
+      build_app(initializers: true)
+
+      contents = File.read("#{app_path}/config/application.rb")
+      contents.gsub!(/propshaft/, "sprockets/railtie")
+      File.write("#{app_path}/config/application.rb", contents)
+
+      contents = File.read("#{app_path}/Gemfile")
+      contents.gsub!(/propshaft/, "sprockets-rails")
+      File.write("#{app_path}/Gemfile", contents)
+
+      remove_from_env_config :development, "config.assets.digest = false"
+
+      app_file "app/assets/config/manifest.js", <<~JS
+        //= link_tree ../images
+        //= link_directory ../stylesheets .css
+      JS
+      assert_file_exists("#{app_path}/app/assets/config/manifest.js")
+
+      add_to_env_config :production, "config.assets.compile = false"
+      add_to_env_config :development, "config.assets.quiet = true"
+    end
+
+    def teardown
+      teardown_app
+    end
+
+    def precompile!(env = nil)
+      with_env env.to_h do
+        quietly do
+          rails ["assets:precompile", "--trace"]
+        end
+      end
+    end
+
+    def run_app_update
+      quietly do
+        rails ["app:update"]
+      end
+    end
+
+    def with_env(env)
+      env.each { |k, v| ENV[k.to_s] = v }
+      yield
+    ensure
+      env.each_key { |k| ENV.delete k.to_s }
+    end
+
+    def clean_assets!
+      quietly do
+        rails ["assets:clobber"]
+      end
+    end
+
+    def assert_file_exists(filename)
+      globbed = Dir[filename]
+      assert Dir.exist?(File.dirname(filename)), "Directory #{File.dirname(filename)} does not exist"
+      assert_predicate globbed, :one?, "Found #{globbed.size} files matching #{filename}. All files in the directory: #{Dir.entries(File.dirname(filename)).inspect}"
+    end
+
+    def assert_no_file_exists(filename)
+      assert_not File.exist?(filename), "#{filename} does exist"
+    end
+
+    test "assets routes have higher priority" do
+      app_file "app/assets/images/rails.png", "notactuallyapng"
+      app_file "app/assets/javascripts/demo.js.erb", "a = <%= image_path('rails.png').inspect %>;"
+
+      app_file "config/routes.rb", <<-RUBY
+        Rails.application.routes.draw do
+          get '*path', to: lambda { |env| [200, { "Content-Type" => "text/html" }, ["Not an asset"]] }
+        end
+      RUBY
+
+      add_to_env_config "development", "config.assets.digest = false"
+
+      require "#{app_path}/config/environment"
+
+      get "/assets/demo.js"
+      assert_equal 'a = "/assets/rails.png";', last_response.body.strip
+    end
+
+    test "precompile creates the file, gives it the original asset's content and run in production as default" do
+      app_file "app/assets/config/manifest.js", "//= link_tree ../javascripts"
+      app_file "app/assets/javascripts/application.js", "alert();"
+      app_file "app/assets/javascripts/foo/application.js", "alert();"
+
+      precompile!
+
+      files = Dir["#{app_path}/public/assets/application-*.js"]
+      files << Dir["#{app_path}/public/assets/foo/application-*.js"].first
+      files.each do |file|
+        assert_not_nil file, "Expected application.js asset to be generated, but none found"
+        assert_equal "alert();\n", File.read(file)
+      end
+    end
+
+    def test_precompile_does_not_hit_the_database
+      app_file "app/assets/config/manifest.js", "//= link_tree ../javascripts"
+      app_file "app/assets/javascripts/application.js", "alert();"
+      app_file "app/assets/javascripts/foo/application.js", "alert();"
+      app_file "app/controllers/users_controller.rb", <<-eoruby
+        class UsersController < ApplicationController; end
+      eoruby
+      app_file "app/models/user.rb", <<-eoruby
+        class User < ActiveRecord::Base; raise 'should not be reached'; end
+      eoruby
+
+      precompile! \
+        RAILS_ENV: "production",
+        DATABASE_URL: "postgresql://baduser:badpass@127.0.0.1/dbname"
+
+      files = Dir["#{app_path}/public/assets/application-*.js"]
+      files << Dir["#{app_path}/public/assets/foo/application-*.js"].first
+      files.each do |file|
+        assert_not_nil file, "Expected application.js asset to be generated, but none found"
+        assert_equal "alert();".strip, File.read(file).strip
+      end
+    end
+
+    test "precompile application.js and application.css and all other non JS/CSS files if manifest requests" do
+      app_file "app/assets/javascripts/application.js", "alert();"
+      app_file "app/assets/stylesheets/application.css", "body{}"
+
+      app_file "app/assets/javascripts/someapplication.js", "alert();"
+      app_file "app/assets/stylesheets/someapplication.css", "body{}"
+
+      app_file "app/assets/javascripts/something.min.js", "alert();"
+      app_file "app/assets/stylesheets/something.min.css", "body{}"
+
+      app_file "app/assets/javascripts/something.else.js.erb", "alert();"
+      app_file "app/assets/stylesheets/something.else.css.erb", "body{}"
+
+      app_file "app/assets/config/manifest.js", <<~JS
+        //= link_tree ../images
+        //= link_directory ../stylesheets .css
+        //= link_directory ../javascripts .js
+      JS
+
+      images_should_compile = ["a.png", "happyface.png", "happy_face.png", "happy.face.png",
+                               "happy-face.png", "happy.happy_face.png", "happy_happy.face.png",
+                               "happy.happy.face.png", "-happy.png", "-happy.face.png",
+                               "_happy.face.png", "_happy.png"]
+
+      images_should_compile.each do |filename|
+        app_file "app/assets/images/#{filename}", "happy"
+      end
+
+      precompile!
+
+      images_should_compile = ["a-*.png", "happyface-*.png", "happy_face-*.png", "happy.face-*.png",
+                               "happy-face-*.png", "happy.happy_face-*.png", "happy_happy.face-*.png",
+                               "happy.happy.face-*.png", "-happy-*.png", "-happy.face-*.png",
+                               "_happy.face-*.png", "_happy-*.png"]
+
+      images_should_compile.each do |filename|
+        assert_file_exists("#{app_path}/public/assets/#{filename}")
+      end
+
+      assert_file_exists("#{app_path}/public/assets/application-*.js")
+      assert_file_exists("#{app_path}/public/assets/application-*.css")
+
+      assert_no_file_exists("#{app_path}/public/assets/someapplication-*.js")
+      assert_no_file_exists("#{app_path}/public/assets/someapplication-*.css")
+
+      assert_no_file_exists("#{app_path}/public/assets/something.min-*.js")
+      assert_no_file_exists("#{app_path}/public/assets/something.min-*.css")
+
+      assert_no_file_exists("#{app_path}/public/assets/something.else-*.js")
+      assert_no_file_exists("#{app_path}/public/assets/something.else-*.css")
+    end
+
+    test "precompile something.js for directory containing index file" do
+      add_to_config "config.assets.precompile = [ 'something.js' ]"
+      app_file "app/assets/javascripts/something/index.js.erb", "alert();"
+
+      precompile!
+
+      assert_file_exists("#{app_path}/public/assets/something-*.js")
+    end
+
+    test "precompile use assets defined in app env config" do
+      add_to_env_config "production", 'config.assets.precompile = [ "something.js" ]'
+      app_file "app/assets/javascripts/something.js.erb", "alert();"
+
+      precompile! RAILS_ENV: "production"
+
+      assert_file_exists("#{app_path}/public/assets/something-*.js")
+    end
+
+    test "sprockets cache is not shared between environments" do
+      app_file "app/assets/images/rails.png", "notactuallyapng"
+      remove_file "app/assets/stylesheets/application.css"
+      app_file "app/assets/stylesheets/application.css.erb", "body { background: '<%= asset_path('rails.png') %>'; }"
+      add_to_env_config "production", 'config.assets.prefix = "production_assets"'
+
+      precompile!
+
+      assert_file_exists("#{app_path}/public/assets/application-*.css")
+
+      file = Dir["#{app_path}/public/assets/application-*.css"].first
+      assert_match(/assets\/rails-([0-z]+)\.png/, File.read(file))
+
+      precompile! RAILS_ENV: "production"
+
+      assert_file_exists("#{app_path}/public/production_assets/application-*.css")
+
+      file = Dir["#{app_path}/public/production_assets/application-*.css"].first
+      assert_match(/production_assets\/rails-([0-z]+)\.png/, File.read(file))
+    end
+
+    test "precompile use assets defined in app config and reassigned in app env config" do
+      add_to_config 'config.assets.precompile = [ "something_manifest.js" ]'
+      add_to_env_config "production", 'config.assets.precompile += [ "another_manifest.js" ]'
+
+      app_file "app/assets/config/something_manifest.js", "//= link something.js"
+      app_file "app/assets/config/another_manifest.js", "//= link another.js"
+
+      app_file "app/assets/javascripts/something.js.erb", "alert();"
+      app_file "app/assets/javascripts/another.js.erb", "alert();"
+
+      precompile! RAILS_ENV: "production"
+
+      assert_file_exists("#{app_path}/public/assets/something_manifest-*.js")
+      assert_file_exists("#{app_path}/public/assets/something-*.js")
+      assert_file_exists("#{app_path}/public/assets/another_manifest-*.js")
+      assert_file_exists("#{app_path}/public/assets/another-*.js")
+    end
+
+    test "asset pipeline should use a Sprockets::CachedEnvironment when config.assets.digest is true" do
+      add_to_config "config.action_controller.perform_caching = false"
+      add_to_env_config "production", "config.assets.compile = true"
+
+      # Load app env
+      app "production"
+
+      assert_equal Sprockets::CachedEnvironment, Rails.application.assets.class
+    end
+
+    test "precompile creates a manifest file with all the assets listed" do
+      app_file "app/assets/images/rails.png", "notactuallyapng"
+      remove_file "app/assets/stylesheets/application.css"
+      app_file "app/assets/stylesheets/application.css.erb", "<%= asset_path('rails.png') %>"
+
+      precompile!
+
+      manifest = Dir["#{app_path}/public/assets/.sprockets-manifest-*.json"].first
+      assets = ActiveSupport::JSON.decode(File.read(manifest))
+      assert_match(/application-([0-z]+)\.css/, assets["assets"]["application.css"])
+      assert_match(/rails-([0-z]+)\.png/, assets["assets"]["rails.png"])
+    end
+
+    test "the manifest file should be saved by default in the same assets folder" do
+      app_file "app/assets/stylesheets/test.css", "a{color: red}"
+      add_to_config "config.assets.prefix = '/x'"
+
+      precompile!
+
+      manifest = Dir["#{app_path}/public/x/.sprockets-manifest-*.json"].first
+      assets = ActiveSupport::JSON.decode(File.read(manifest))
+      assert_match(/test-([0-z]+)\.css/, assets["assets"]["test.css"])
+    end
+
+    test "assets do not require any assets group gem when manifest file is present" do
+      app_file "app/assets/javascripts/application.js", "alert();"
+      app_file "app/assets/config/manifest.js", "//= link application.js"
+
+      precompile! RAILS_ENV: "production"
+
+      manifest = Dir["#{app_path}/public/assets/.sprockets-manifest-*.json"].first
+      assets = ActiveSupport::JSON.decode(File.read(manifest))
+      asset_path = assets["assets"]["application.js"]
+
+      # Load app env
+      app "production"
+
+      # Checking if Uglifier is defined we can know if Sprockets was reached or not
+      assert_not defined?(Uglifier)
+      get("/assets/#{asset_path}", {}, "HTTPS" => "on")
+      assert_match "alert()", last_response.body
+      assert_not defined?(Uglifier)
+    end
+
+    test "precompile properly refers files referenced with asset_path" do
+      app_file "app/assets/images/rails.png", "notactuallyapng"
+      remove_file "app/assets/stylesheets/application.css"
+      app_file "app/assets/stylesheets/application.css.erb", "p { background-image: url(<%= asset_path('rails.png') %>) }"
+
+      precompile!
+
+      file = Dir["#{app_path}/public/assets/application-*.css"].first
+      assert_match(/\/assets\/rails-([0-z]+)\.png/, File.read(file))
+    end
+
+    test "precompile shouldn't use the digests present in manifest.json" do
+      app_file "app/assets/images/rails.png", "notactuallyapng"
+
+      remove_file "app/assets/stylesheets/application.css"
+      app_file "app/assets/stylesheets/application.css.erb", "p { background-image: url(<%= asset_path('rails.png') %>) }"
+
+      precompile! RAILS_ENV: "production"
+
+      manifest = Dir["#{app_path}/public/assets/.sprockets-manifest-*.json"].first
+      assets = ActiveSupport::JSON.decode(File.read(manifest))
+      asset_path = assets["assets"]["application.css"]
+
+      app_file "app/assets/images/rails.png", "p { url: change }"
+
+      precompile!
+
+      assets = ActiveSupport::JSON.decode(File.read(manifest))
+      assert_not_equal asset_path, assets["assets"]["application.css"]
+    end
+
+    test "precompile appends the MD5 hash to files referenced with asset_path and run in production with digest true" do
+      app_file "app/assets/images/rails.png", "notactuallyapng"
+      remove_file "app/assets/stylesheets/application.css"
+      app_file "app/assets/stylesheets/application.css.erb", "p { background-image: url(<%= asset_path('rails.png') %>) }"
+
+      precompile! RAILS_ENV: "production"
+
+      file = Dir["#{app_path}/public/assets/application-*.css"].first
+      assert_match(/\/assets\/rails-([0-z]+)\.png/, File.read(file))
+    end
+
+    test "precompile should handle utf8 filenames" do
+      filename = "レイルズ.png"
+      app_file "app/assets/images/#{filename}", "not an image really"
+      app_file "app/assets/config/manifest.js", "//= link_tree ../images"
+      add_to_config "config.assets.precompile = %w(manifest.js)"
+
+      precompile!
+
+      manifest = Dir["#{app_path}/public/assets/.sprockets-manifest-*.json"].first
+      assets = ActiveSupport::JSON.decode(File.read(manifest))
+      assert asset_path = assets["assets"].find { |(k, _)| /.png/.match?(k) }[1]
+
+      # Load app env
+      app "development"
+
+      get "/assets/#{URI::DEFAULT_PARSER.escape(asset_path)}"
+      assert_match "not an image really", last_response.body
+      assert_file_exists("#{app_path}/public/assets/#{asset_path}")
+    end
+
+    test "assets are cleaned up properly" do
+      app_file "public/assets/application.js", "alert();"
+      app_file "public/assets/application.css", "a { color: green; }"
+      app_file "public/assets/subdir/broken.png", "not really an image file"
+
+      clean_assets!
+
+      files = Dir["#{app_path}/public/assets/**/*"]
+      assert_equal 0, files.length, "Expected no assets, but found #{files.join(', ')}"
+    end
+
+    test "assets routes are not drawn when compilation is disabled" do
+      app_file "app/assets/javascripts/demo.js.erb", "<%= :alert %>();"
+      add_to_config "config.assets.compile = false"
+
+      # Load app env
+      app "production"
+
+      get("/assets/demo.js", {}, "HTTPS" => "on")
+      assert_equal 404, last_response.status
+    end
+
+    test "does not stream session cookies back" do
+      app_file "app/assets/javascripts/demo.js.erb", "<%= :alert %>();"
+
+      app_file "config/routes.rb", <<-RUBY
+        Rails.application.routes.draw do
+          get '/omg', :to => "omg#index"
+        end
+      RUBY
+
+      add_to_env_config "development", "config.assets.digest = false"
+
+      # Load app env
+      app "development"
+
+      class ::OmgController < ActionController::Base
+        def index
+          flash[:cool_story] = true
+          render plain: "ok"
+        end
+      end
+
+      get "/omg"
+      assert_equal "ok", last_response.body
+
+      get "/assets/demo.js"
+      assert_match "alert()", last_response.body
+      assert_nil last_response.headers["Set-Cookie"]
+    end
+
+    test "files in any assets/ directories are not added to Sprockets" do
+      %w[app lib vendor].each do |dir|
+        app_file "#{dir}/assets/#{dir}_test.erb", "testing"
+      end
+
+      app_file "app/assets/javascripts/demo.js", "alert();"
+
+      add_to_env_config "development", "config.assets.digest = false"
+
+      # Load app env
+      app "development"
+
+      get "/assets/demo.js"
+      assert_match "alert();", last_response.body
+      assert_equal 200, last_response.status
+    end
+
+    test "assets are concatenated when debug is off and compile is off either if debug_assets param is provided" do
+      app_with_assets_in_view
+
+      # config.assets.debug and config.assets.compile are false for production environment
+      precompile! RAILS_ENV: "production"
+
+      # Load app env
+      app "production"
+
+      class ::PostsController < ActionController::Base ; end
+
+      # the debug_assets params isn't used if compile is off
+      get("/posts?debug_assets=true", {}, "HTTPS" => "on")
+      assert_match(/<script src="\/assets\/application-([0-z]+)\.js"><\/script>/, last_response.body)
+      assert_no_match(/<script src="\/assets\/xmlhr-([0-z]+)\.js"><\/script>/, last_response.body)
+    end
+
+    test "assets can access model information when precompiling" do
+      app_file "app/models/post.rb", "class Post; end"
+      app_file "app/assets/javascripts/application.js", "//= require_tree ."
+      app_file "app/assets/javascripts/xmlhr.js.erb", "<%= Post.name %>"
+      app_file "app/assets/config/manifest.js", "//= link application.js"
+
+      precompile!
+
+      assert_file_exists("#{app_path}/public/assets/application-*.js")
+      assert_match(/Post;/, File.read(Dir["#{app_path}/public/assets/application-*.js"].first))
+    end
+
+    test "initialization on the assets group should set assets_dir" do
+      require "#{app_path}/config/application"
+      Rails.application.initialize!(:assets)
+      assert_not_nil Rails.application.config.action_controller.assets_dir
+    end
+
+    test "enhancements to assets:precompile should only run once" do
+      app_file "lib/tasks/enhance.rake", "Rake::Task['assets:precompile'].enhance { puts 'enhancement' }"
+      output = precompile!
+      assert_equal 1, output.scan("enhancement").size
+    end
+
+    test "digested assets are not mistakenly removed" do
+      app_file "app/assets/application.css", "div { font-weight: bold }"
+      add_to_config "config.assets.compile = true"
+
+      precompile!
+
+      files = Dir["#{app_path}/public/assets/application-*.css"]
+      assert_equal 1, files.length, "Expected digested application.css asset to be generated, but none found"
+    end
+
+    test "digested assets are removed from configured path" do
+      app_file "public/production_assets/application.js", "alert();"
+      add_to_env_config "production", "config.assets.prefix = 'production_assets'"
+
+      ENV["RAILS_ENV"] = nil
+
+      clean_assets!
+
+      files = Dir["#{app_path}/public/production_assets/application-*.js"]
+      assert_equal 0, files.length, "Expected application.js asset to be removed, but still exists"
+    end
+
+    test "asset URLs should use the request's protocol by default" do
+      app_with_assets_in_view
+      add_to_config "config.asset_host = 'example.com'"
+      add_to_env_config "development", "config.assets.digest = false"
+
+      # Load app env
+      app "development"
+
+      class ::PostsController < ActionController::Base; end
+
+      get "/posts", {}, { "HTTPS" => "off" }
+      assert_match('src="http://example.com/assets/application.js', last_response.body)
+      get "/posts", {}, { "HTTPS" => "on" }
+      assert_match('src="https://example.com/assets/application.js', last_response.body)
+    end
+
+    test "asset URLs should be protocol-relative if no request is in scope" do
+      app_file "app/assets/images/rails.png", "notreallyapng"
+      app_file "app/assets/javascripts/image_loader.js.erb", "var src='<%= image_path('rails.png') %>';"
+      add_to_config "config.assets.precompile = %w{rails.png image_loader.js}"
+      add_to_config "config.asset_host = 'example.com'"
+      add_to_env_config "development", "config.assets.digest = false"
+
+      precompile!
+
+      assert_match "src='//example.com/assets/rails.png'", File.read(Dir["#{app_path}/public/assets/image_loader-*.js"].first)
+    end
+
+    test "asset paths should use RAILS_RELATIVE_URL_ROOT by default" do
+      ENV["RAILS_RELATIVE_URL_ROOT"] = "/sub/uri"
+      app_file "app/assets/images/rails.png", "notreallyapng"
+      app_file "app/assets/javascripts/app.js.erb", "var src='<%= image_path('rails.png') %>';"
+      add_to_config "config.assets.precompile = %w{rails.png app.js}"
+      add_to_env_config "development", "config.assets.digest = false"
+
+      precompile!
+
+      assert_match "src='/sub/uri/assets/rails.png'", File.read(Dir["#{app_path}/public/assets/app-*.js"].first)
+    end
+
+    test "app:update removes_sprockets" do
+      config = "#{app_path}/config/environments/production.rb"
+      assert_changes -> { File.readlines(config).grep(/config\.assets/) }, from: ["config.assets.compile = false\n"], to: [] do
+        run_app_update
+      end
+    end
+
+    test "plugin serving sprockets assets" do
+      @plugin = make_plugin
+      @plugin.write "app/assets/javascripts/engine.js.erb", "<%= :alert %>();"
+      add_to_env_config "development", "config.assets.digest = false"
+
+      require "#{app_path}/config/environment"
+
+      get "/assets/engine.js"
+      assert_match "alert()", last_response.body
+    end
+
+    test "setting priority for engines with config.railties_order" do
+      @plugin = make_plugin
+
+      @blog = engine "blog" do |plugin|
+        plugin.write "lib/blog.rb", <<-RUBY
+          module Blog
+            class Engine < ::Rails::Engine
+            end
+          end
+        RUBY
+      end
+
+      @plugin.write "lib/bukkits.rb", <<-RUBY
+        module Bukkits
+          class Engine < ::Rails::Engine
+            isolate_namespace Bukkits
+          end
+        end
+      RUBY
+      controller "main", <<-RUBY
+        class MainController < ActionController::Base
+          def foo
+            render inline: '<%= render partial: "application/foo" %>'
+          end
+          def bar
+            render inline: '<%= render partial: "application/bar" %>'
+          end
+        end
+      RUBY
+      app_file "config/routes.rb", <<-RUBY
+        Rails.application.routes.draw do
+          get "/foo" => "main#foo"
+          get "/bar" => "main#bar"
+        end
+      RUBY
+      @plugin.write "app/views/application/_foo.html.erb", <<-RUBY
+        Bukkit's foo partial
+      RUBY
+      app_file "app/views/application/_foo.html.erb", <<-RUBY
+        App's foo partial
+      RUBY
+      @blog.write "app/views/application/_bar.html.erb", <<-RUBY
+        Blog's bar partial
+      RUBY
+      app_file "app/views/application/_bar.html.erb", <<-RUBY
+        App's bar partial
+      RUBY
+      @plugin.write "app/assets/javascripts/foo.js", <<-RUBY
+        // Bukkit's foo js
+      RUBY
+      app_file "app/assets/javascripts/foo.js", <<-RUBY
+        // App's foo js
+      RUBY
+      @blog.write "app/assets/javascripts/bar.js", <<-RUBY
+        // Blog's bar js
+      RUBY
+      app_file "app/assets/javascripts/bar.js", <<-RUBY
+        // App's bar js
+      RUBY
+      add_to_config("config.railties_order = [:all, :main_app, Blog::Engine]")
+      add_to_env_config "development", "config.assets.digest = false"
+
+      require "#{app_path}/config/environment"
+
+      get("/foo")
+      assert_equal "Bukkit's foo partial", last_response.body.strip
+      get("/bar")
+      assert_equal "App's bar partial", last_response.body.strip
+
+      get("/assets/foo.js")
+      assert_match "// Bukkit's foo js", last_response.body.strip
+
+      get("/assets/bar.js")
+      assert_match "// App's bar js", last_response.body.strip
+    end
+
+    private
+      def app_with_assets_in_view
+        app_file "app/assets/javascripts/application.js", "//= require_tree ."
+        app_file "app/assets/javascripts/xmlhr.js", "function f1() { alert(); }"
+        app_file "app/views/posts/index.html.erb", "<%= javascript_include_tag 'application' %>"
+        app_file "app/assets/config/manifest.js", <<~JS
+          //= link_tree ../images
+          //= link_directory ../stylesheets .css
+          //= link_directory ../javascripts .js
+        JS
+
+        app_file "config/routes.rb", <<-RUBY
+        Rails.application.routes.draw do
+          get '/posts', :to => "posts#index"
+        end
+        RUBY
+      end
+
+      def make_plugin
+        engine "bukkits" do |plugin|
+          plugin.write "lib/bukkits.rb", <<-RUBY
+            module Bukkits
+              class Engine < ::Rails::Engine
+                railtie_name "bukkits"
+              end
+            end
+          RUBY
+
+          plugin.write "lib/another.rb", "class Another; end"
+        end
+      end
+  end
+end

--- a/railties/test/commands/routes_test.rb
+++ b/railties/test/commands/routes_test.rb
@@ -205,6 +205,7 @@ rails_blob_representation_proxy GET  /rails/active_storage/representations/proxy
 
     assert_equal <<~MESSAGE, run_routes_command
                                   Prefix Verb URI Pattern                                                                                       Controller#Action
+                                              /assets                                                                                           Propshaft::Server
            rails_postmark_inbound_emails POST /rails/action_mailbox/postmark/inbound_emails(.:format)                                           action_mailbox/ingresses/postmark/inbound_emails#create
               rails_relay_inbound_emails POST /rails/action_mailbox/relay/inbound_emails(.:format)                                              action_mailbox/ingresses/relay/inbound_emails#create
            rails_sendgrid_inbound_emails POST /rails/action_mailbox/sendgrid/inbound_emails(.:format)                                           action_mailbox/ingresses/sendgrid/inbound_emails#create
@@ -244,152 +245,160 @@ rails_conductor_inbound_email_incinerate POST /rails/conductor/action_mailbox/:i
 
     rails_gem_root = File.expand_path("../../../../", __FILE__)
 
+    # rubocop:disable Layout/TrailingWhitespace
     assert_equal <<~MESSAGE, output
       --[ Route 1 ]--------------
+      Prefix            | 
+      Verb              | 
+      URI               | /assets
+      Controller#Action | Propshaft::Server
+      Source Location   | propshaft (1.0.0) lib/propshaft/railtie.rb:43
+      --[ Route 2 ]--------------
       Prefix            | cart
       Verb              | GET
       URI               | /cart(.:format)
       Controller#Action | cart#show
       Source Location   | #{app_path}/config/routes.rb:2
-      --[ Route 2 ]--------------
+      --[ Route 3 ]--------------
       Prefix            | rails_postmark_inbound_emails
       Verb              | POST
       URI               | /rails/action_mailbox/postmark/inbound_emails(.:format)
       Controller#Action | action_mailbox/ingresses/postmark/inbound_emails#create
       Source Location   | #{rails_gem_root}/actionmailbox/config/routes.rb:5
-      --[ Route 3 ]--------------
+      --[ Route 4 ]--------------
       Prefix            | rails_relay_inbound_emails
       Verb              | POST
       URI               | /rails/action_mailbox/relay/inbound_emails(.:format)
       Controller#Action | action_mailbox/ingresses/relay/inbound_emails#create
       Source Location   | #{rails_gem_root}/actionmailbox/config/routes.rb:6
-      --[ Route 4 ]--------------
+      --[ Route 5 ]--------------
       Prefix            | rails_sendgrid_inbound_emails
       Verb              | POST
       URI               | /rails/action_mailbox/sendgrid/inbound_emails(.:format)
       Controller#Action | action_mailbox/ingresses/sendgrid/inbound_emails#create
       Source Location   | #{rails_gem_root}/actionmailbox/config/routes.rb:7
-      --[ Route 5 ]--------------
+      --[ Route 6 ]--------------
       Prefix            | rails_mandrill_inbound_health_check
       Verb              | GET
       URI               | /rails/action_mailbox/mandrill/inbound_emails(.:format)
       Controller#Action | action_mailbox/ingresses/mandrill/inbound_emails#health_check
       Source Location   | #{rails_gem_root}/actionmailbox/config/routes.rb:10
-      --[ Route 6 ]--------------
+      --[ Route 7 ]--------------
       Prefix            | rails_mandrill_inbound_emails
       Verb              | POST
       URI               | /rails/action_mailbox/mandrill/inbound_emails(.:format)
       Controller#Action | action_mailbox/ingresses/mandrill/inbound_emails#create
       Source Location   | #{rails_gem_root}/actionmailbox/config/routes.rb:11
-      --[ Route 7 ]--------------
+      --[ Route 8 ]--------------
       Prefix            | rails_mailgun_inbound_emails
       Verb              | POST
       URI               | /rails/action_mailbox/mailgun/inbound_emails/mime(.:format)
       Controller#Action | action_mailbox/ingresses/mailgun/inbound_emails#create
       Source Location   | #{rails_gem_root}/actionmailbox/config/routes.rb:14
-      --[ Route 8 ]--------------
+      --[ Route 9 ]--------------
       Prefix            | rails_conductor_inbound_emails
       Verb              | GET
       URI               | /rails/conductor/action_mailbox/inbound_emails(.:format)
       Controller#Action | rails/conductor/action_mailbox/inbound_emails#index
       Source Location   | #{rails_gem_root}/actionmailbox/config/routes.rb:19
-      --[ Route 9 ]--------------
+      --[ Route 10 ]-------------
       Prefix            |#{" "}
       Verb              | POST
       URI               | /rails/conductor/action_mailbox/inbound_emails(.:format)
       Controller#Action | rails/conductor/action_mailbox/inbound_emails#create
       Source Location   | #{rails_gem_root}/actionmailbox/config/routes.rb:19
-      --[ Route 10 ]-------------
+      --[ Route 11 ]-------------
       Prefix            | new_rails_conductor_inbound_email
       Verb              | GET
       URI               | /rails/conductor/action_mailbox/inbound_emails/new(.:format)
       Controller#Action | rails/conductor/action_mailbox/inbound_emails#new
       Source Location   | #{rails_gem_root}/actionmailbox/config/routes.rb:19
-      --[ Route 11 ]-------------
+      --[ Route 12 ]-------------
       Prefix            | rails_conductor_inbound_email
       Verb              | GET
       URI               | /rails/conductor/action_mailbox/inbound_emails/:id(.:format)
       Controller#Action | rails/conductor/action_mailbox/inbound_emails#show
       Source Location   | #{rails_gem_root}/actionmailbox/config/routes.rb:19
-      --[ Route 12 ]-------------
+      --[ Route 13 ]-------------
       Prefix            | new_rails_conductor_inbound_email_source
       Verb              | GET
       URI               | /rails/conductor/action_mailbox/inbound_emails/sources/new(.:format)
       Controller#Action | rails/conductor/action_mailbox/inbound_emails/sources#new
       Source Location   | #{rails_gem_root}/actionmailbox/config/routes.rb:20
-      --[ Route 13 ]-------------
+      --[ Route 14 ]-------------
       Prefix            | rails_conductor_inbound_email_sources
       Verb              | POST
       URI               | /rails/conductor/action_mailbox/inbound_emails/sources(.:format)
       Controller#Action | rails/conductor/action_mailbox/inbound_emails/sources#create
       Source Location   | #{rails_gem_root}/actionmailbox/config/routes.rb:21
-      --[ Route 14 ]-------------
+      --[ Route 15 ]-------------
       Prefix            | rails_conductor_inbound_email_reroute
       Verb              | POST
       URI               | /rails/conductor/action_mailbox/:inbound_email_id/reroute(.:format)
       Controller#Action | rails/conductor/action_mailbox/reroutes#create
       Source Location   | #{rails_gem_root}/actionmailbox/config/routes.rb:23
-      --[ Route 15 ]-------------
+      --[ Route 16 ]-------------
       Prefix            | rails_conductor_inbound_email_incinerate
       Verb              | POST
       URI               | /rails/conductor/action_mailbox/:inbound_email_id/incinerate(.:format)
       Controller#Action | rails/conductor/action_mailbox/incinerates#create
       Source Location   | #{rails_gem_root}/actionmailbox/config/routes.rb:24
-      --[ Route 16 ]-------------
+      --[ Route 17 ]-------------
       Prefix            | rails_service_blob
       Verb              | GET
       URI               | /rails/active_storage/blobs/redirect/:signed_id/*filename(.:format)
       Controller#Action | active_storage/blobs/redirect#show
       Source Location   | #{rails_gem_root}/activestorage/config/routes.rb:5
-      --[ Route 17 ]-------------
+      --[ Route 18 ]-------------
       Prefix            | rails_service_blob_proxy
       Verb              | GET
       URI               | /rails/active_storage/blobs/proxy/:signed_id/*filename(.:format)
       Controller#Action | active_storage/blobs/proxy#show
       Source Location   | #{rails_gem_root}/activestorage/config/routes.rb:6
-      --[ Route 18 ]-------------
+      --[ Route 19 ]-------------
       Prefix            |#{" "}
       Verb              | GET
       URI               | /rails/active_storage/blobs/:signed_id/*filename(.:format)
       Controller#Action | active_storage/blobs/redirect#show
       Source Location   | #{rails_gem_root}/activestorage/config/routes.rb:7
-      --[ Route 19 ]-------------
+      --[ Route 20 ]-------------
       Prefix            | rails_blob_representation
       Verb              | GET
       URI               | /rails/active_storage/representations/redirect/:signed_blob_id/:variation_key/*filename(.:format)
       Controller#Action | active_storage/representations/redirect#show
       Source Location   | #{rails_gem_root}/activestorage/config/routes.rb:9
-      --[ Route 20 ]-------------
+      --[ Route 21 ]-------------
       Prefix            | rails_blob_representation_proxy
       Verb              | GET
       URI               | /rails/active_storage/representations/proxy/:signed_blob_id/:variation_key/*filename(.:format)
       Controller#Action | active_storage/representations/proxy#show
       Source Location   | #{rails_gem_root}/activestorage/config/routes.rb:10
-      --[ Route 21 ]-------------
+      --[ Route 22 ]-------------
       Prefix            |#{" "}
       Verb              | GET
       URI               | /rails/active_storage/representations/:signed_blob_id/:variation_key/*filename(.:format)
       Controller#Action | active_storage/representations/redirect#show
       Source Location   | #{rails_gem_root}/activestorage/config/routes.rb:11
-      --[ Route 22 ]-------------
+      --[ Route 23 ]-------------
       Prefix            | rails_disk_service
       Verb              | GET
       URI               | /rails/active_storage/disk/:encoded_key/*filename(.:format)
       Controller#Action | active_storage/disk#show
       Source Location   | #{rails_gem_root}/activestorage/config/routes.rb:13
-      --[ Route 23 ]-------------
+      --[ Route 24 ]-------------
       Prefix            | update_rails_disk_service
       Verb              | PUT
       URI               | /rails/active_storage/disk/:encoded_token(.:format)
       Controller#Action | active_storage/disk#update
       Source Location   | #{rails_gem_root}/activestorage/config/routes.rb:14
-      --[ Route 24 ]-------------
+      --[ Route 25 ]-------------
       Prefix            | rails_direct_uploads
       Verb              | POST
       URI               | /rails/active_storage/direct_uploads(.:format)
       Controller#Action | active_storage/direct_uploads#create
       Source Location   | #{rails_gem_root}/activestorage/config/routes.rb:15
     MESSAGE
+    # rubocop:enable Layout/TrailingWhitespace
   end
 
   test "rails routes with unused option" do

--- a/railties/test/isolation/abstract_unit.rb
+++ b/railties/test/isolation/abstract_unit.rb
@@ -604,17 +604,10 @@ Module.new do
   FileUtils.rm_rf(app_template_path)
   FileUtils.mkdir_p(app_template_path)
 
-  sh "#{Gem.ruby} #{RAILS_FRAMEWORK_ROOT}/railties/exe/rails new #{app_template_path} --asset-pipeline=sprockets --skip-bundle --no-rc --quiet"
+  sh "#{Gem.ruby} #{RAILS_FRAMEWORK_ROOT}/railties/exe/rails new #{app_template_path} --skip-bundle --no-rc --quiet"
   File.open("#{app_template_path}/config/boot.rb", "w") do |f|
     f.puts 'require "bootsnap/setup" if ENV["BOOTSNAP_CACHE_DIR"]'
     f.puts 'require "rails/all"'
-  end
-
-  assets_path = "#{RAILS_FRAMEWORK_ROOT}/railties/test/isolation/assets"
-  unless Dir.exist?("#{assets_path}/node_modules")
-    Dir.chdir(assets_path) do
-      sh "yarn install"
-    end
   end
 
   FileUtils.mkdir_p "#{app_template_path}/app/javascript"

--- a/railties/test/railties/engine_test.rb
+++ b/railties/test/railties/engine_test.rb
@@ -46,16 +46,6 @@ module RailtiesTest
       ActiveRecord::MigrationContext.new(migration_root, sm, im).migrations
     end
 
-    test "serving sprocket's assets" do
-      @plugin.write "app/assets/javascripts/engine.js.erb", "<%= :alert %>();"
-      add_to_env_config "development", "config.assets.digest = false"
-
-      boot_rails
-
-      get "/assets/engine.js"
-      assert_match "alert()", last_response.body
-    end
-
     test "rake environment can be called in the engine" do
       boot_rails
 
@@ -1534,10 +1524,10 @@ en:
       assert_equal "App's bar partial", last_response.body.strip
 
       get("/assets/foo.js")
-      assert_match "// Bukkit's foo js", last_response.body.strip
+      assert_predicate last_response, :not_found?
 
       get("/assets/bar.js")
-      assert_match "// App's bar js", last_response.body.strip
+      assert_predicate last_response, :not_found?
 
       assert_equal <<~EXPECTED, Rails.application.send(:ordered_railties).flatten.map(&:class).map(&:name).join("\n") << "\n"
         I18n::Railtie


### PR DESCRIPTION
Combine #52122 and fix the remaining failures for #52887.

> Create `sprockets_assets_test.rb` file that will contain the sprockets-specific tests of `assets_test.rb` (which in turn will contain the tests common to both pipelines).

I've squashed those commits once I felt confident there was no missing cases, but it might be a useful exercise to review the commits from the other PR as well for those interested.

There is one flaky test, but I have seen this flake on main before.

**(Edit: yup, it was reported in #50364)**

```
$ bin/test test/application/sprockets_assets_test.rb

........................E, [2024-09-14T08:35:08.072799 #1983325] ERROR -- : [1ae49fc5-8c5a-48e4-ab4b-0ce5e73f79d0]
[1ae49fc5-8c5a-48e4-ab4b-0ce5e73f79d0] ActionController::RoutingError (No route matches [GET] "/assets/demo.js"):
[1ae49fc5-8c5a-48e4-ab4b-0ce5e73f79d0]
..** Invoke assets:precompile (first_time)
** Invoke assets:environment (first_time)
** Execute assets:environment
** Invoke environment (first_time)
** Execute environment
** Execute assets:precompile
F

Failure:
ApplicationTests::SprocketsAssetsTest#test_precompile_shouldn't_use_the_digests_present_in_manifest.json [test/application/sprockets_assets_test.rb:326]:
Expected "application-0a89120b13dcff9cb069311101add34ef7717de154816b01622972a4509eb5c9.css" to not be equal to "application-0a89120b13dcff9cb069311101add34ef7717de154816b01622972a4509eb5c9.css".

bin/test test/application/sprockets_assets_test.rb:307

..

Finished in 1.424157s, 20.3629 runs/s, 120.0710 assertions/s.
29 runs, 171 assertions, 1 failures, 0 errors, 0 skips

$ bin/test test/application/sprockets_assets_test.rb

........................E, [2024-09-14T08:35:12.994864 #1985849] ERROR -- : [615c9d49-d1bf-40c8-96a6-bf9c76a9a28d]
[615c9d49-d1bf-40c8-96a6-bf9c76a9a28d] ActionController::RoutingError (No route matches [GET] "/assets/demo.js"):
[615c9d49-d1bf-40c8-96a6-bf9c76a9a28d]
..** Invoke assets:precompile (first_time)
** Invoke assets:environment (first_time)
** Execute assets:environment
** Invoke environment (first_time)
** Execute environment
** Execute assets:precompile
I, [2024-09-14T08:35:13.044219 #1986490]  INFO -- : Writing /home/zzak/code/rails/tmp/d20240914-1985782-wcigrx/app/public/assets/rails-6738e33efa7b8d2036e0a0118601555f0b771ac042f6790f7538dd881a1a7f3a.png
I, [2024-09-14T08:35:13.045199 #1986490]  INFO -- : Writing /home/zzak/code/rails/tmp/d20240914-1985782-wcigrx/app/public/assets/application-f1fa81296280307c358b4bd65e4bfd705be90dc5eba7c04dcd1d76ec084c78e7.css
I, [2024-09-14T08:35:13.045508 #1986490]  INFO -- : Writing /home/zzak/code/rails/tmp/d20240914-1985782-wcigrx/app/public/assets/application-f1fa81296280307c358b4bd65e4bfd705be90dc5eba7c04dcd1d76ec084c78e7.css.gz
I, [2024-09-14T08:35:13.045767 #1986490]  INFO -- : Writing /home/zzak/code/rails/tmp/d20240914-1985782-wcigrx/app/public/assets/rails-6738e33efa7b8d2036e0a0118601555f0b771ac042f6790f7538dd881a1a7f3a.png
...

```

Thanks @tute and @fedesapuppo for the initial push here!