### PR TITLE
Introduce ActiveModel::Inspect

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,3 +1,30 @@
+*   Introduce ActiveModel::Inspect.
+
+    Show a formatted string with relevant
+    attributes when calling `inspect`.
+
+    ```ruby
+    class Person
+      include ActiveModel::API
+      include ActiveModel::Attributes
+      include ActiveModel::Inspect
+      attribute :name, :string
+    end
+    person = Person.new(name: "Amanda")
+    person.inspect
+    => "#<Person name: \"Amanda\">"
+    ```
+
+    Sensitive attributes can be filtered:
+
+    ```ruby
+    Person.filter_attributes = [:name]
+    person.inspect
+    => #<Person name: [FILTERED]>
+    ```
+
+    *Petrik de Heus*
+
 *   Add a default token generator for password reset tokens when using `has_secure_password`.
 
     ```ruby

--- a/activemodel/lib/active_model.rb
+++ b/activemodel/lib/active_model.rb
@@ -45,6 +45,7 @@ module ActiveModel
   autoload :Dirty
   autoload :EachValidator, "active_model/validator"
   autoload :ForbiddenAttributesProtection
+  autoload :Inspect
   autoload :Lint
   autoload :Model
   autoload :Name, "active_model/naming"

--- a/activemodel/lib/active_model/inspect.rb
+++ b/activemodel/lib/active_model/inspect.rb
@@ -1,0 +1,129 @@
+# frozen_string_literal: true
+
+require "active_support/parameter_filter"
+
+module ActiveModel
+  # = Active \Model \Inspect
+  #
+  # Show a formatted string with relevant attributes when calling `inspect`.
+  #
+  #   class Person
+  #     include ActiveModel::API
+  #     include ActiveModel::Attributes
+  #     include ActiveModel::Inspect
+  #     attribute :name, :string
+  #   end
+  #   person = Person.new(name: "Amanda")
+  #   person.inspect
+  #   => "#<Person name: \"Amanda\">"
+  #
+  # Sensitive attributes can be filtered:
+  #
+  #   Person.filter_attributes = [:name]
+  #   person.inspect
+  #   => #<Person name: [FILTERED]>
+  module Inspect
+    extend ActiveSupport::Concern
+
+    class << self
+      attr_accessor :filter_attributes # :nodoc:
+    end
+    self.filter_attributes = []
+
+    class InspectionMask < DelegateClass(::String)
+      def pretty_print(pp)
+        pp.text __getobj__
+      end
+    end
+    private_constant :InspectionMask
+
+    module ClassMethods
+      # Returns attributes which shouldn't be exposed while calling +#inspect+.
+      def filter_attributes
+        if @filter_attributes.nil?
+          Inspect.filter_attributes
+        else
+          @filter_attributes
+        end
+      end
+
+      # Specifies attributes which shouldn't be exposed while calling +#inspect+.
+      def filter_attributes=(filter_attributes)
+        @inspection_filter = nil
+        @filter_attributes = filter_attributes
+      end
+
+      def inspection_filter # :nodoc:
+        @inspection_filter ||= begin
+          mask = InspectionMask.new(ActiveSupport::ParameterFilter::FILTERED)
+          ActiveSupport::ParameterFilter.new(filter_attributes, mask: mask)
+        end
+      end
+    end
+
+    # Returns the attributes as a nicely formatted string.
+    def inspect # :nodoc:
+      inspection = attributes.keys.filter_map do |name|
+        name = name.to_s
+        "#{name}: #{attribute_for_inspect(name)}"
+      end.join(", ")
+
+      "#<#{self.class} #{inspection}>"
+    end
+
+    # Returns an <tt>#inspect</tt>-like string for the value of the
+    # attribute +attr_name+. String attributes are truncated up to 50
+    # characters. Other attributes return the value of <tt>#inspect</tt>
+    # without modification.
+    #
+    #   class Person
+    #     include ActiveModel::Attributes
+    #     include ActiveModel::Inspect
+    #     attribute :name, :string
+    #     attribute :created_at, :datetime
+    #     attribute :tag_ids
+    #   end
+    #
+    #   person = Person.new(name: 'David Heinemeier Hansson ' * 3)
+    #
+    #   person.attribute_for_inspect(:name)
+    #   # => "\"David Heinemeier Hansson David Heinemeier Hansson ...\""
+    #
+    #   person.created_at = Time.parse("2012-10-22 00:15:07")
+    #   person.attribute_for_inspect(:created_at)
+    #   # => "\"2012-10-22 00:15:07.000000000 +0000\""
+    #
+    #   person.tag_ids = [1, 2, 3]
+    #   person.attribute_for_inspect(:tag_ids)
+    #   # => "[1, 2, 3]"
+    def attribute_for_inspect(attr_name)
+      attr_name = attr_name.to_s
+      attr_name = self.class.attribute_aliases[attr_name] || attr_name
+      value = _read_attribute(attr_name)
+      format_for_inspect(attr_name, value)
+    end
+
+    private
+      def format_for_inspect(name, value)
+        if value.nil?
+          value.inspect
+        else
+          inspected_value = if value.is_a?(String) && value.length > 50
+            "#{value[0, 50]}...".inspect
+          elsif value.is_a?(Date) || value.is_a?(Time)
+            %("#{value.to_fs(:inspect)}")
+          else
+            value.inspect
+          end
+
+          inspection_filter.filter_param(name, inspected_value)
+        end
+      end
+
+      def inspection_filter
+        self.class.inspection_filter
+      end
+  end
+
+  ActiveSupport.run_load_hooks(:active_model_inspect, Inspect)
+end

--- a/activemodel/lib/active_model/railtie.rb
+++ b/activemodel/lib/active_model/railtie.rb
@@ -17,6 +17,12 @@ module ActiveModel
       ActiveModel::SecurePassword.min_cost = Rails.env.test?
     end
 
+    initializer "active_model.set_filter_attributes" do
+      ActiveSupport.on_load(:active_model_inspect) do
+        ActiveModel::Inspect.filter_attributes += Rails.application.config.filter_parameters
+      end
+    end
+
     initializer "active_model.i18n_customize_full_message" do
       ActiveModel::Error.i18n_customize_full_message = config.active_model.delete(:i18n_customize_full_message) || false
     end

--- a/activemodel/test/cases/attribute_methods_test.rb
+++ b/activemodel/test/cases/attribute_methods_test.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "cases/helper"
+require "models/topic"
 
 class ModelWithAttributes
   include ActiveModel::AttributeMethods

--- a/activemodel/test/cases/filter_attributes_test.rb
+++ b/activemodel/test/cases/filter_attributes_test.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+require "models/topic"
+
+class InspectTest < ActiveModel::TestCase
+  test "attribute_for_inspect with a string" do
+    t = Topic.new
+    t.title = "The First Topic Now Has A Title With\nNewlines And More Than 50 Characters"
+
+    assert_equal '"The First Topic Now Has A Title With\nNewlines And ..."', t.attribute_for_inspect(:title)
+  end
+
+  test "attribute_for_inspect with a date" do
+    t = Topic.new created_at: 1.hour.ago
+
+    assert_equal %("#{t.created_at.to_fs(:inspect)}"), t.attribute_for_inspect(:created_at)
+  end
+
+  test "attribute_for_inspect with an array" do
+    t = Topic.new content: ["some_value"]
+
+    assert_match %r(\["some_value"\]), t.attribute_for_inspect(:content)
+  end
+
+  test "attribute_for_inspect with a long array" do
+    t = Topic.new content: (1..11).to_a
+
+    assert_equal "[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]", t.attribute_for_inspect(:content)
+  end
+end

--- a/activemodel/test/cases/inspect_test.rb
+++ b/activemodel/test/cases/inspect_test.rb
@@ -1,0 +1,122 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+require "models/contact"
+require "models/user"
+require "pp"
+
+class FilterAttributesTest < ActiveModel::TestCase
+  setup do
+    @previous_filter_attributes = ActiveModel::Inspect.filter_attributes
+    ActiveModel::Inspect.filter_attributes = [:name]
+    Contact.filter_attributes = nil
+  end
+
+  teardown do
+    ActiveModel::Inspect.filter_attributes = @previous_filter_attributes
+    Contact.filter_attributes = nil
+  end
+
+  test "filter_attributes" do
+    contact = Contact.new(name: "37signals")
+    assert_includes contact.inspect, "name: [FILTERED]"
+    assert_equal 1, contact.inspect.scan("[FILTERED]").length
+  end
+
+  test "filter_attributes affects attribute_for_inspect" do
+    contact = Contact.new(name: "37signals")
+    assert_equal "[FILTERED]", contact.attribute_for_inspect(:name)
+  end
+
+  test "string filter_attributes perform partial match" do
+    ActiveModel::Inspect.filter_attributes = ["n"]
+    contact = Contact.new(name: "37signals")
+    assert_includes contact.inspect, "name: [FILTERED]"
+    assert_equal 1, contact.inspect.scan("[FILTERED]").length
+  end
+
+  test "regex filter_attributes are accepted" do
+    ActiveModel::Inspect.filter_attributes = [/\An\z/]
+    contact = Contact.new(name: "37signals")
+    assert_includes contact.inspect, 'name: "37signals"'
+    assert_equal 0, contact.inspect.scan("[FILTERED]").length
+
+    Contact.instance_variable_set(:@filter_attributes, nil)
+    Contact.instance_variable_set(:@inspection_filter, nil)
+    ActiveModel::Inspect.filter_attributes = [/\An/]
+    contact = Contact.new(name: "37signals")
+    assert_includes contact.inspect, "name: [FILTERED]"
+    assert_equal 1, contact.inspect.scan("[FILTERED]").length
+  end
+
+  test "proc filter_attributes are accepted" do
+    ActiveModel::Inspect.filter_attributes = [ lambda { |key, value| value.reverse! if key == "name" } ]
+    contact = Contact.new(name: "37signals")
+    assert_includes contact.inspect, 'name: "slangis73"'
+  end
+
+  test "filter_attributes could be overwritten by models" do
+    contact = Contact.new(name: "37signals")
+
+    assert_includes contact.inspect, "name: [FILTERED]"
+    assert_equal 1, contact.inspect.scan("[FILTERED]").length
+
+    Contact.filter_attributes = []
+
+    ## Above changes should not impact other models
+    user = User.new
+    user.name = "37signals"
+    assert_includes user.inspect, "name: [FILTERED]"
+    assert_equal 1, user.inspect.scan("[FILTERED]").length
+
+    contact = Contact.new(name: "37signals")
+    assert_not_includes contact.inspect, "name: [FILTERED]"
+    assert_equal 0, contact.inspect.scan("[FILTERED]").length
+  end
+
+  test "filter_attributes should not filter nil value" do
+    contact = Contact.new name: nil
+
+    assert_includes contact.inspect, "name: nil"
+    assert_not_includes contact.inspect, "name: [FILTERED]"
+    assert_equal 0, contact.inspect.scan("[FILTERED]").length
+  end
+
+  test "filter_attributes should handle [FILTERED] value properly" do
+    Contact.filter_attributes = ["age"]
+    contact = Contact.new(age: 20, name: "[FILTERED]")
+
+    assert_includes contact.inspect, "age: [FILTERED]"
+    assert_includes contact.inspect, "name: \"[FILTERED]\""
+  end
+
+  test "filter_attributes on pretty_print" do
+    contact = Contact.new(name: "37signals")
+    actual = "".dup
+    PP.pp(contact, StringIO.new(actual))
+
+    assert_includes actual, "name: [FILTERED]"
+    assert_equal 1, actual.scan("[FILTERED]").length
+  end
+
+  test "filter_attributes on pretty_print should not filter nil value" do
+    contact = Contact.new(name: nil)
+    actual = "".dup
+    PP.pp(contact, StringIO.new(actual))
+
+    assert_includes actual, "name: nil"
+    assert_not_includes actual, "name: [FILTERED]"
+    assert_equal 0, actual.scan("[FILTERED]").length
+  end
+
+  test "filter_attributes on pretty_print should handle [FILTERED] value properly" do
+    Contact.filter_attributes = ["age"]
+
+    contact = Contact.new(age: 20, name: "[FILTERED]")
+    actual = "".dup
+    PP.pp(contact, StringIO.new(actual))
+
+    assert_includes actual, "age: [FILTERED]"
+    assert_includes actual, "name: \"[FILTERED]\""
+  end
+end

--- a/activemodel/test/models/contact.rb
+++ b/activemodel/test/models/contact.rb
@@ -4,6 +4,8 @@ class Contact
   extend ActiveModel::Naming
   include ActiveModel::Conversion
   include ActiveModel::Validations
+  include ActiveModel::Attributes
+  include ActiveModel::Inspect
 
   include ActiveModel::Serializers::JSON
 

--- a/activemodel/test/models/topic.rb
+++ b/activemodel/test/models/topic.rb
@@ -4,6 +4,7 @@ class Topic
   include ActiveModel::Validations
   include ActiveModel::Validations::Callbacks
   include ActiveModel::AttributeMethods
+  include ActiveModel::Inspect
   include ActiveSupport::NumberHelper
 
   attribute_method_suffix "_before_type_cast", parameters: false

--- a/activemodel/test/models/user.rb
+++ b/activemodel/test/models/user.rb
@@ -5,6 +5,7 @@ class User
   include ActiveModel::Attributes
   include ActiveModel::Dirty
   include ActiveModel::SecurePassword
+  include ActiveModel::Inspect
 
   define_model_callbacks :create
 
@@ -13,6 +14,8 @@ class User
 
   attribute :recovery_password_digest
   has_secure_password :recovery_password, validations: false
+
+  attribute :name
 
   attr_accessor :password_called
 

--- a/activerecord/lib/active_record/attribute_methods.rb
+++ b/activerecord/lib/active_record/attribute_methods.rb
@@ -346,28 +346,6 @@ module ActiveRecord
       @attributes.to_hash
     end
 
-    # Returns an <tt>#inspect</tt>-like string for the value of the
-    # attribute +attr_name+. String attributes are truncated up to 50
-    # characters. Other attributes return the value of <tt>#inspect</tt>
-    # without modification.
-    #
-    #   person = Person.create!(name: 'David Heinemeier Hansson ' * 3)
-    #
-    #   person.attribute_for_inspect(:name)
-    #   # => "\"David Heinemeier Hansson David Heinemeier Hansson ...\""
-    #
-    #   person.attribute_for_inspect(:created_at)
-    #   # => "\"2012-10-22 00:15:07.000000000 +0000\""
-    #
-    #   person.attribute_for_inspect(:tag_ids)
-    #   # => "[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]"
-    def attribute_for_inspect(attr_name)
-      attr_name = attr_name.to_s
-      attr_name = self.class.attribute_aliases[attr_name] || attr_name
-      value = _read_attribute(attr_name)
-      format_for_inspect(attr_name, value)
-    end
-
     # Returns +true+ if the specified +attribute+ has been set by the user or by a
     # database load and is neither +nil+ nor <tt>empty?</tt> (the latter only applies
     # to objects that respond to <tt>empty?</tt>, most notably Strings). Otherwise, +false+.
@@ -516,22 +494,6 @@ module ActiveRecord
         attribute_names.delete_if do |name|
           (pk_attribute?(name) && id.nil?) ||
             column_for_attribute(name).virtual?
-        end
-      end
-
-      def format_for_inspect(name, value)
-        if value.nil?
-          value.inspect
-        else
-          inspected_value = if value.is_a?(String) && value.length > 50
-            "#{value[0, 50]}...".inspect
-          elsif value.is_a?(Date) || value.is_a?(Time)
-            %("#{value.to_fs(:inspect)}")
-          else
-            value.inspect
-          end
-
-          inspection_filter.filter_param(name, inspected_value)
         end
       end
 

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -3718,6 +3718,7 @@ module ApplicationTests
       app "development"
       assert_equal [ :password, :credit_card_number ], Rails.application.config.filter_parameters
       assert_equal [ :password, :credit_card_number ], ActiveRecord::Base.filter_attributes
+      assert_equal [ :password, :credit_card_number ], ActiveModel::Inspect.filter_attributes
     end
 
     test "encrypted attributes are added to record's filter_attributes by default" do


### PR DESCRIPTION
This moves the Active Record inspect implementation to Active Model, to allow Active Model objects to show a formatted string with relevant attributes when calling `inspect`.

```ruby
class Person
  include ActiveModel::API
  include ActiveModel::Attributes
  include ActiveModel::Inspect
  attribute :name, :string
end
person = Person.new(name: "Amanda")
person.inspect
=> "#<Person name: \"Amanda\">"
```

Sensitive attributes can be filtered, just like in Active Record:

```ruby
  Person.filter_attributes = [:name]
  person.inspect
  => #<Person name: [FILTERED]>
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
