### PR TITLE
Load routes in `LazyRoutesSet#recognize_path`

### DIFF
--- a/railties/lib/rails/engine/lazy_route_set.rb
+++ b/railties/lib/rails/engine/lazy_route_set.rb
@@ -73,6 +73,11 @@ module Rails
         super
       end
 
+      def recognize_path(path, environment = {})
+        Rails.application&.reload_routes_unless_loaded
+        super
+      end
+
       def routes
         Rails.application&.reload_routes_unless_loaded
         super

--- a/railties/test/engine/lazy_route_set_test.rb
+++ b/railties/test/engine/lazy_route_set_test.rb
@@ -10,6 +10,9 @@ module Rails
       setup :build_app
       teardown :teardown_app
 
+      class UsersController < ActionController::Base
+      end
+
       test "app lazily loads routes when invoking url helpers" do
         require "#{app_path}/config/environment"
 
@@ -63,11 +66,11 @@ module Rails
 
         @app = Rails.application
 
-        assert_not_operator(:users_path, :in?, app_url_helpers.methods)
-        assert_equal "/users", app_url_helpers.url_for(
-          controller: :users, action: :index, only_path: true,
+        assert_not_operator(:products_path, :in?, app_url_helpers.methods)
+        assert_equal "/products", app_url_helpers.url_for(
+          controller: :products, action: :index, only_path: true,
         )
-        assert_operator(:users_path, :in?, app_url_helpers.methods)
+        assert_operator(:products_path, :in?, app_url_helpers.methods)
       end
 
       test "engine lazily loads routes when url_for is used" do
@@ -97,6 +100,15 @@ module Rails
         assert_operator(Rails.application.routes, :is_a?, Engine::LazyRouteSet)
       end
 
+      test "reloads routes when recognize_path is called" do
+        require "#{app_path}/config/environment"
+
+        assert_equal(
+          { controller: "rails/engine/lazy_route_set_test/users", action: "index" },
+          Rails.application.routes.recognize_path("/users")
+        )
+      end
+
       private
         def build_app
           super
@@ -110,7 +122,8 @@ module Rails
             Rails.application.routes.draw do
               root to: proc { [200, {}, []] }
 
-              resources(:users)
+              resources :products
+              resources :users, module: "rails/engine/lazy_route_set_test"
 
               mount Plugin::Engine, at: "/plugin"
             end


### PR DESCRIPTION
Closes https://github.com/rails/rails/issues/52881

### Motivation / Background

Background: https://github.com/rails/rails/pull/52353 deferred drawing routes to the first request

Calling `recognize_path` on the lazy route set calls through to the super implementation, which in a lazy-loaded environment may not have the route loaded yet.

This just loads the route set to fix the issue.

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
