### PR TITLE
Use less queries when updating nested attributes

### DIFF
--- a/activerecord/lib/active_record/nested_attributes.rb
+++ b/activerecord/lib/active_record/nested_attributes.rb
@@ -524,12 +524,12 @@ module ActiveRecord
             unless reject_new_record?(association_name, attributes)
               association.reader.build(attributes.except(*UNASSIGNABLE_KEYS))
             end
-          elsif existing_record = find_record_by_id(existing_records, attributes["id"])
+          elsif existing_record = find_record_by_id(association.klass, existing_records, attributes["id"])
             unless call_reject_if(association_name, attributes)
               # Make sure we are operating on the actual object which is in the association's
               # proxy_target array (either by finding it, or adding it if not found)
               # Take into account that the proxy_target may have changed due to callbacks
-              target_record = find_record_by_id(association.target, attributes["id"])
+              target_record = find_record_by_id(association.klass, association.target, attributes["id"])
               if target_record
                 existing_record = target_record
               else
@@ -621,10 +621,8 @@ module ActiveRecord
                                  model, "id", record_id)
       end
 
-      def find_record_by_id(records, id)
-        return if records.empty?
-
-        if records.first.class.composite_primary_key?
+      def find_record_by_id(klass, records, id)
+        if klass.composite_primary_key?
           id = Array(id).map(&:to_s)
           records.find { |record| Array(record.id).map(&:to_s) == id }
         else

--- a/activerecord/test/cases/nested_attributes_test.rb
+++ b/activerecord/test/cases/nested_attributes_test.rb
@@ -238,7 +238,9 @@ class TestNestedAttributesInGeneral < ActiveRecord::TestCase
     book = Cpk::Book.create!(id: [1, 2], shop_id: 3)
     book.chapters.create!(id: [1, 3], title: "Title")
 
-    book.update!(chapters_attributes: { id: ["1", "3"], title: "New title" })
+    assert_queries_count(4) do
+      book.update!(chapters_attributes: { id: ["1", "3"], title: "New title" })
+    end
     assert_equal 1, book.reload.chapters.count
     assert_equal "New title", book.chapters.first.title
   end


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because a regression was introduced where we query unnecessarily a few times. rails/rails#52797 fixed a bug (which is great!), but I think we can refactor the code a little to be more efficient.

### Detail

This Pull Request changes nested attribute assignment to stop querying the `association.target` resulting in 2 less queries.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
