### PR TITLE
Suppress a RuboCop offense after running `rails new` with `--devcontainer`

### DIFF
--- a/railties/lib/rails/generators/rails/devcontainer/devcontainer_generator.rb
+++ b/railties/lib/rails/generators/rails/devcontainer/devcontainer_generator.rb
@@ -150,7 +150,7 @@ module Rails
         end
 
         def system_test_configuration
-          optimize_indentation(<<-'RUBY', 2)
+          optimize_indentation(<<-'RUBY', 2).chomp
             if ENV["CAPYBARA_SERVER_PORT"]
               served_by host: "rails-app", port: ENV["CAPYBARA_SERVER_PORT"]
 


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->


<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This PR suppresses the following RuboCop offense when running `rubocop` after generating a new Rails project with `--devcontainer`:

```console
$ rails new example --devcontainer
$ cd example
$ bin/rubocop
(snip)

Offenses:

test/application_system_test_case.rb:14:1: C: [Correctable] Layout/EmptyLinesAroundClassBody: Extra empty line detected at class body end.
```

### Detail

This PR removes the following redundant blank line by default that cause the offense:

```diff
 require "test_helper"

 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   if ENV["CAPYBARA_SERVER_PORT"]
     served_by host: "rails-app", port: ENV["CAPYBARA_SERVER_PORT"]

     driven_by :selenium, using: :headless_chrome, screen_size: [ 1400, 1400 ], options: {
       browser: :remote,
       url: "http://#{ENV["SELENIUM_HOST"]}:4444"
     }
   else
     driven_by :selenium, using: :headless_chrome, screen_size: [ 1400, 1400 ]
   end
-
 end
```

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

This is a similar issue to https://github.com/rails/rails/pull/52199

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
