### PR TITLE
Wrap database seeding in a reload

### DIFF
--- a/railties/lib/rails/engine.rb
+++ b/railties/lib/rails/engine.rb
@@ -648,9 +648,9 @@ module Rails
       end
     end
 
-    initializer :wrap_executor_around_load_seed do |app|
+    initializer :wrap_reloader_around_load_seed do |app|
       self.class.set_callback(:load_seed, :around) do |engine, seeds_block|
-        app.executor.wrap(&seeds_block)
+        app.reloader.wrap(&seeds_block)
       end
     end
 


### PR DESCRIPTION
### Motivation / Background

It is possible that database seeding may run jobs inline. In that case a reload will be attempted. For an app that is set to `reload_classes_only_on_change` this would normally not initiate a reload, since no files would have been changed. However, it is common to run the seeds as part of one command that also sets up the database (eg `bin/rails db:prepare db:seed`). In that case, the `schema.rb` file may have changes. [By default that file is watched by the reloader](https://github.com/rails/rails/blob/6f7f624b84d8cfa8a1d6166878c902d1fcb0655c/activerecord/lib/active_record/railtie.rb#L318). So, the application will be reloaded at the time the first job (or other reload) occurs. Reloading the application during the middle of running seeds can lead to unexpected and buggy behaviour.

### Detail

We should wrap the entire seeds task in a reload so that the reload only occurs at the end of seeding.

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
