### PR TITLE
Revert "Assign id attributes first in Active Record attribute assignment"

### DIFF
--- a/activerecord/test/cases/store_test.rb
+++ b/activerecord/test/cases/store_test.rb
@@ -220,9 +220,9 @@ class StoreTest < ActiveRecord::TestCase
     assert_equal "blue", user.color[:jenny]
   end
 
-  test "update store and accessor" do
+  test "store takes precedence when updating store and accessor" do
     user = Admin::User.find_by_name("Jamis")
-    user.update(settings: { homepage: "not rails" }, homepage: "rails")
+    user.update(settings: { homepage: "rails" }, homepage: "not rails")
 
     assert_equal "rails", user.settings[:homepage]
     assert_equal "rails", user.homepage


### PR DESCRIPTION
Reverts rails/rails#52892

https://github.com/rails/rails/pull/49678 's behaviour I was trying to partially restore is a breaking change, and thus the reverted commit is too. We shouldn't need to crawl associations to assign attributes. Correct or not, its less problematic to make our expectations for this use-case clearer and add a regression test making sure the behaviour doesn't accidentally break any hidden contracts again.