### PR TITLE
Call prerecord to fix verbose test runs under parallelization

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Print test names when running `rails test -v` for parallel tests.
+
+    *John Hawthorn*, *Abeid Ahmed*
+
 *   Deprecate `Benchmark.ms` core extension.
 
     The `benchmark` gem will become bundled in Ruby 3.5

--- a/activesupport/lib/active_support/testing/parallelization/server.rb
+++ b/activesupport/lib/active_support/testing/parallelization/server.rb
@@ -6,6 +6,8 @@ require "drb/unix" unless Gem.win_platform?
 module ActiveSupport
   module Testing
     class Parallelization # :nodoc:
+      PrerecordResultClass = Struct.new(:name)
+
       class Server
         include DRb::DRbUndumped
 
@@ -21,6 +23,7 @@ module ActiveSupport
           @in_flight.delete([result.klass, result.name])
 
           reporter.synchronize do
+            reporter.prerecord(PrerecordResultClass.new(result.klass), result.name)
             reporter.record(result)
           end
         end


### PR DESCRIPTION
Fixes #52697

`prerecord` is where, when tests are run in verbose mode, the name of the test is printed. Unless we call this the names of tests are missing.

This deviates from the vanilla minitest behaviour, which calls prerecord before tests are run even for parallel executors, which can result in interleaved output. We don't want this as it makes it impossible to associate the time or success of a test back to which test is responsible.

Instead this calls `prerecord` after the test has come back and immediately before calling record while holding a mutex, to ensure the correct time is associated with the correct test.

I also considered continuing to not call `prerecord` and [instead letting the reporter class deal with it](https://github.com/rails/rails/compare/main...jhawthorn:rails:prerecorded_option2) but I think this PRs approach is cleaner.

**Before**

```
0.17 s = .
0.18 s = .
0.17 s = .
```

**After**

```
CachedViewRenderTest#test_render_partial_collection_as_by_symbol = 0.17 s = .
LazyViewRenderTest#test_render_partial_collection_as_by_symbol = 0.18 s = .
FrozenStringLiteralEnabledViewRenderTest#test_render_partial_collection_as_by_symbol = 0.17 s = .
```