### PR TITLE
Skip solid_cable gem if skip_action_cable is set

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
@@ -16,7 +16,9 @@ gem "tzinfo-data", platforms: %i[ <%= bundler_windows_platforms %> jruby ]
 # Use the database-backed adapters for Rails.cache, Active Job, and Action Cable
 gem "solid_cache"
 gem "solid_queue"
+<% unless options.skip_action_cable? -%>
 gem "solid_cable"
+<% end -%>
 <% end -%>
 <% if depend_on_bootsnap? -%>
 


### PR DESCRIPTION
This fixes the failing test on main (probably as of the solid_cable 3.0 release a couple hours ago)

```
AppGeneratorTest#test_app_update_does_not_generate_action_cable_contents_when_skip_action_cable_is_given
```

If this isn't the right fix please don't hesitate to revert.

cc @dhh @npezza93 
