### PR TITLE
Do not set up cable database when skipping action cable

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/databases/mysql.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/mysql.yml.tt
@@ -73,8 +73,10 @@ production:
     <<: *primary_production
     database: <%= app_name %>_production_queue
     migrations_paths: db/queue_migrate
+  <%- unless options.skip_action_cable? -%>
   cable:
     <<: *primary_production
     database: <%= app_name %>_production_cable
     migrations_paths: db/cable_migrate
+  <%- end -%>
 <%- end -%>

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/postgresql.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/postgresql.yml.tt
@@ -105,8 +105,10 @@ production:
     <<: *primary_production
     database: <%= app_name %>_production_queue
     migrations_paths: db/queue_migrate
+  <%- unless options.skip_action_cable? -%>
   cable:
     <<: *primary_production
     database: <%= app_name %>_production_cable
     migrations_paths: db/cable_migrate
+  <%- end -%>
 <%- end -%>

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/sqlite3.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/sqlite3.yml.tt
@@ -62,9 +62,11 @@ production:
     <<: *default
     database: storage/production_queue.sqlite3
     migrations_paths: db/queue_migrate
+  <%- unless options.skip_action_cable? -%>
   cable:
     <<: *default
     database: storage/production_cable.sqlite3
     migrations_paths: db/cable_migrate
+  <%- end -%>
 <%- end -%>
 <%- end -%>

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/trilogy.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/trilogy.yml.tt
@@ -73,8 +73,10 @@ production:
     <<: *primary_production
     database: <%= app_name %>_production_queue
     migrations_paths: db/queue_migrate
+  <%- unless options.skip_action_cable? -%>
   cable:
     <<: *primary_production
     database: <%= app_name %>_production_cable
     migrations_paths: db/cable_migrate
+  <%- end -%>
 <%- end -%>

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -243,6 +243,9 @@ class AppGeneratorTest < Rails::Generators::TestCase
     assert_file "config/environments/production.rb" do |content|
       assert_no_match(/config\.action_cable/, content)
     end
+    assert_file "config/database.yml" do |content|
+      assert_no_match(/cable:/, content)
+    end
   end
 
   def test_app_update_does_not_generate_bootsnap_contents_when_skip_bootsnap_is_given


### PR DESCRIPTION
Follow-up to https://github.com/rails/rails/pull/52889 and https://github.com/rails/rails/pull/52919.

### Motivation / Background

This Pull Request has been created because if you currently create a new Rails Main app with the `--skip-action-cable` option, the generated `database.yml` sets up a `cable` database for the production environment.

Steps to repro the issue:

- Run `rails new myapp --main --skip-action-cable; cd myapp`
- Expected behavior: the generated `database.yml` does not set up a `cable` database.
- Actual behavior: the generated `database.yml` sets up a `cable` database:
    ```yaml
    cable:
      <<: *default
      database: storage/production_cable.sqlite3
      migrations_paths: db/cable_migrate
    ```

### Detail

This Pull Request changes the database `.yml.tt` templates to not set up the `cable` database when the `--skip-action-cable` is provided.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
