### PR TITLE
Remove Redis mention from Gemfile

### DIFF
--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -155,7 +155,6 @@ module Rails
           hotwire_gemfile_entry,
           css_gemfile_entry,
           jbuilder_gemfile_entry,
-          cable_gemfile_entry,
         ].flatten.compact.select(&@gem_filter)
       end
 
@@ -620,13 +619,6 @@ module Rails
         else
           GemfileEntry.floats "cssbundling-rails", "Bundle and process CSS [https://github.com/rails/cssbundling-rails]"
         end
-      end
-
-      def cable_gemfile_entry
-        return if options[:skip_action_cable]
-
-        comment = "Use Redis adapter to run Action Cable in production"
-        GemfileEntry.new("redis", ">= 4.0.1", comment, {}, true)
       end
 
       def bundle_command(command, env = {})

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -458,11 +458,6 @@ class AppGeneratorTest < Rails::Generators::TestCase
     assert_gem "puma", /"\W+ \d/
   end
 
-  def test_action_cable_redis_gems
-    run_generator
-    assert_file "Gemfile", /^# gem "redis"/
-  end
-
   def test_generator_configures_decrypted_diffs_by_default
     run_generator
     assert_file ".gitattributes", /\.enc diff=/


### PR DESCRIPTION
Follow-up to https://github.com/rails/rails/pull/52889.

### Motivation / Background

This Pull Request has been created because now that the default Action Cable adapter is Solid Cache, which uses a traditional database, there is no need to mention Redis in the Gemfile. Redis was only mentioned because of Action Cable.

What's more, PR https://github.com/rails/rails/pull/52889 mentions the following:

> Solid Cable is the last piece before we can fully claim that Rails 8 only requires a database as a dependency to get access to all frameworks and functionality

So Redis should not be needed any more.

### Detail

This Pull Request removes the `cable_gemfile_entry` method from the app generator. This method was responsible for adding a commented-out Redis mention to the Gemfile.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
