### PR TITLE
Tweak Gemfile comment about Solid adapters

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
@@ -13,7 +13,11 @@ source "https://rubygems.org"
 gem "tzinfo-data", platforms: %i[ <%= bundler_windows_platforms %> jruby ]
 <% unless options.skip_solid? -%>
 
+<% if options.skip_action_cable? -%>
+# Use the database-backed adapters for Rails.cache and Active Job
+<% else -%>
 # Use the database-backed adapters for Rails.cache, Active Job, and Action Cable
+<% end -%>
 gem "solid_cache"
 gem "solid_queue"
 <% unless options.skip_action_cable? -%>


### PR DESCRIPTION
Follow-up to https://github.com/rails/rails/commit/1ec7b1970f8.

Do not mention Action Cable in the Gemfile if the app was generated with `--skip-action-cable`.