### PR TITLE
set `options[:javascript]` to `nil` for APi-only app

### DIFF
--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -465,6 +465,10 @@ module Rails
         build(:devcontainer)
       end
 
+      def nullify_javascript_option_if_api_option
+        options[:javascript] = nil
+      end
+
       def delete_app_assets_if_api_option
         if options[:api]
           remove_dir "app/assets"

--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -466,7 +466,9 @@ module Rails
       end
 
       def nullify_javascript_option_if_api_option
-        options[:javascript] = nil
+        if options[:api]
+          options[:javascript] = nil
+        end
       end
 
       def delete_app_assets_if_api_option


### PR DESCRIPTION
### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created because it.

### Detail

This Pull Request sets the `options[:javascript]` to `nil` for API-only apps. The reason for doing this is so that when Rails generates the CI files, it doesn't generate `scan_js` workflow. The `scan_js` workflow will only generate if the `options[javascript]` is set to `importmaps` as intended.

### Additional information

I am not yet able to figure out how to test this. 

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [ ] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
