### PR TITLE
Do not create `scan_js` workflow for API-only apps #52900

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/github/ci.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/github/ci.yml.tt
@@ -24,7 +24,7 @@ jobs:
         run: bin/brakeman --no-pager
 
 <% end -%>
-<%- if options[:javascript] == "importmap" -%>
+<%- if options[:javascript] == "importmap"  && !options[:api] -%>
   scan_js:
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because it fixes #52900.

### Detail

This Pull Request will now only generate the `scan_js` CI workflow for the full-stack rails app using importmaps as javascript bundling. 

Previously the `scan_js` workflow was generated for the API-only apps resulting in the `bin/importmap: No such file or directory` error when pushing the code to the GitHub repo.


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
