### PR TITLE
Fix Rubocop offenses for Rails apps without Jbuilder

### DIFF
--- a/railties/lib/rails/generators/rails/scaffold_controller/templates/api_controller.rb.tt
+++ b/railties/lib/rails/generators/rails/scaffold_controller/templates/api_controller.rb.tt
@@ -50,7 +50,7 @@ class <%= controller_class_name %>Controller < ApplicationController
       <%- if attributes_names.empty? -%>
       params.expect(<%= singular_table_name %>: {})
       <%- else -%>
-      params.expect(<%= singular_table_name %>: [<%= permitted_params %>])
+      params.expect(<%= singular_table_name %>: [ <%= permitted_params %> ])
       <%- end -%>
     end
 end

--- a/railties/lib/rails/generators/rails/scaffold_controller/templates/controller.rb.tt
+++ b/railties/lib/rails/generators/rails/scaffold_controller/templates/controller.rb.tt
@@ -57,7 +57,7 @@ class <%= controller_class_name %>Controller < ApplicationController
       <%- if attributes_names.empty? -%>
       params.expect(<%= singular_table_name %>: {})
       <%- else -%>
-      params.expect(<%= singular_table_name %>: [<%= permitted_params %>])
+      params.expect(<%= singular_table_name %>: [ <%= permitted_params %> ])
       <%- end -%>
     end
 end

--- a/railties/test/generators/scaffold_controller_generator_test.rb
+++ b/railties/test/generators/scaffold_controller_generator_test.rb
@@ -58,7 +58,7 @@ class ScaffoldControllerGeneratorTest < Rails::Generators::TestCase
       end
 
       assert_match(/def user_params/, content)
-      assert_match(/params\.expect\(user: \[:name, :age\]\)/, content)
+      assert_match(/params\.expect\(user: \[ :name, :age \]\)/, content)
     end
   end
 
@@ -76,7 +76,7 @@ class ScaffoldControllerGeneratorTest < Rails::Generators::TestCase
 
     assert_file "app/controllers/line_items_controller.rb" do |content|
       assert_match(/def line_item_params/, content)
-      assert_match(/params\.expect\(line_item: \[:product_id, :cart_id\]\)/, content)
+      assert_match(/params\.expect\(line_item: \[ :product_id, :cart_id \]\)/, content)
     end
   end
 
@@ -85,7 +85,7 @@ class ScaffoldControllerGeneratorTest < Rails::Generators::TestCase
 
     assert_file "app/controllers/line_items_controller.rb" do |content|
       assert_match(/def line_item_params/, content)
-      assert_match(/params\.expect\(line_item: \[:product_id, :product_type\]\)/, content)
+      assert_match(/params\.expect\(line_item: \[ :product_id, :product_type \]\)/, content)
     end
   end
 
@@ -94,7 +94,7 @@ class ScaffoldControllerGeneratorTest < Rails::Generators::TestCase
 
     assert_file "app/controllers/messages_controller.rb" do |content|
       assert_match(/def message_params/, content)
-      assert_match(/params\.expect\(message: \[:video, photos: \[\]\]\)/, content)
+      assert_match(/params\.expect\(message: \[ :video, photos: \[\] \]\)/, content)
     end
   end
 
@@ -103,7 +103,7 @@ class ScaffoldControllerGeneratorTest < Rails::Generators::TestCase
 
     assert_file "app/controllers/messages_controller.rb" do |content|
       assert_match(/def message_params/, content)
-      assert_match(/params\.expect\(message: \[photos: \[\]\]\)/, content)
+      assert_match(/params\.expect\(message: \[ photos: \[\] \]\)/, content)
     end
   end
 
@@ -353,7 +353,7 @@ class ScaffoldControllerGeneratorTest < Rails::Generators::TestCase
 
     assert_file "app/controllers/messages_controller.rb" do |content|
       assert_match(/def message_params/, content)
-      assert_match(/params\.expect\(message: \[:video, photos: \[\]\]\)/, content)
+      assert_match(/params\.expect\(message: \[ :video, photos: \[\] \]\)/, content)
     end
   end
 

--- a/railties/test/generators/scaffold_generator_test.rb
+++ b/railties/test/generators/scaffold_generator_test.rb
@@ -430,7 +430,7 @@ class ScaffoldGeneratorTest < Rails::Generators::TestCase
 
     assert_file "app/controllers/accounts_controller.rb" do |content|
       assert_instance_method :account_params, content do |m|
-        assert_match(/expect\(account: \[:name, :currency_id, :user_id\]\)/, m)
+        assert_match(/expect\(account: \[ :name, :currency_id, :user_id \]\)/, m)
       end
     end
 
@@ -461,7 +461,7 @@ class ScaffoldGeneratorTest < Rails::Generators::TestCase
 
     assert_file "app/controllers/messages_controller.rb" do |content|
       assert_instance_method :message_params, content do |m|
-        assert_match(/expect\(message: \[:video, photos: \[\], images: \[\]\]\)/, m)
+        assert_match(/expect\(message: \[ :video, photos: \[\], images: \[\] \]\)/, m)
       end
     end
 
@@ -488,7 +488,7 @@ class ScaffoldGeneratorTest < Rails::Generators::TestCase
 
     assert_file "app/controllers/messages_controller.rb" do |content|
       assert_instance_method :message_params, content do |m|
-        assert_match(/expect\(message: \[:content\]\)/, m)
+        assert_match(/expect\(message: \[ :content \]\)/, m)
       end
     end
 
@@ -536,7 +536,7 @@ class ScaffoldGeneratorTest < Rails::Generators::TestCase
 
     assert_file "app/controllers/users_controller.rb" do |content|
       assert_instance_method :user_params, content do |m|
-        assert_match(/expect\(user: \[:name, :password, :password_confirmation\]\)/, m)
+        assert_match(/expect\(user: \[ :name, :password, :password_confirmation \]\)/, m)
       end
     end
 


### PR DESCRIPTION
Follow-up to https://github.com/rails/rails/pull/51674.

### Motivation / Background

This Pull Request has been created because if you currently create a new Rails main app with the `--skip-jbuilder` option, scaffolded controllers do not comply with `rubocop-rails-omakase` rules.

Steps to repro the issue:

- Run the following
    ```
    rails new myapp --main --skip-jbuilder; cd myapp
    rails generate scaffold post title
    bundle exec rubocop
    ```
- Expected behavior: there should be no Rubocop offenses
- Actual behavior: the are Rubocop offenses:
    ```
    Inspecting 31 files
    ...C...........................

    Offenses:

    app/controllers/posts_controller.rb:56:27: C: [Correctable] Layout/SpaceInsideArrayLiteralBrackets: Use space inside array brackets.
          params.expect(post: [:title])
                              ^
    app/controllers/posts_controller.rb:56:34: C: Layout/SpaceInsideArrayLiteralBrackets: Use space inside array brackets.
          params.expect(post: [:title])
                                     ^
    ```

### Detail

This Pull Request changes the controller generators to use spaces around `[` and `]`.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
