### PR TITLE
feat(docs): added authentication information to active_storage_overview docs [ci skip]

### DIFF
--- a/guides/source/active_storage_overview.md
+++ b/guides/source/active_storage_overview.md
@@ -1398,6 +1398,20 @@ class DirectUploadsController < ActiveStorage::DirectUploadsController
 end
 ```
 
+Alternatively, you can hook into an initialization event to add authentication similar to the following:
+
+```ruby
+Rails.application.config.to_prepare do
+  ActiveStorage::DirectUploadsController.class_eval do
+    before_action :authenticate!
+
+    def authenticate!
+      #auth logic
+    end
+  end
+end
+```
+
 NOTE: Using [Direct Uploads](#direct-uploads) can sometimes result in a file that uploads, but never attaches to a record. Consider [purging unattached uploads](#purging-unattached-uploads).
 
 Testing


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because Active Storage direct uploads are public and unauthenticated and there is no clear documented way of adding authentication or rate limiting

### Detail

This Pull Request changes rails/guides/source/active_storage_overview.md to add an authentication example

### Additional information


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
