### PR TITLE
SQLite3Adapter: Ensure fork-safety

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   SQLite3Adapter: Ensure fork-safety.
+
+    Previously, forking a Rails process with open SQLite3 database connections could result in
+    database file corruption under certain circumstances.
+
+    *Mike Dalessio*
+
 *   Add support for PostgreSQL `IF NOT EXISTS` via the `:if_not_exists` option
     on the `add_enum_value` method.
 

--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -442,6 +442,16 @@ module ActiveRecord
         end
       end
 
+      # Notify connections that a fork is imminent, to allow them to take necessary measures to
+      # ensure fork-safety.
+      #
+      # See AbstractAdapter#prepare_to_fork!
+      def prepare_to_fork! # :nodoc:
+        @connections.each do |conn|
+          conn.prepare_to_fork!
+        end
+      end
+
       # Disconnects all connections in the pool, and clears the pool.
       #
       # The pool first tries to gain ownership of all connections. If unable to

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -696,6 +696,13 @@ module ActiveRecord
         end
       end
 
+      # Prepare the connection for an imminent fork. Some database adapters are not fork-safe
+      # (specifically sqlite3), and so this gives the adapter an opportunity to close or finalize
+      # any objects that the child process should not inherit.
+      def prepare_to_fork!
+        # This should be overridden by concrete adapters.
+      end
+
       # Disconnects from the database if already connected. Otherwise, this
       # method does nothing.
       def disconnect!

--- a/activesupport/lib/active_support/evented_file_update_checker.rb
+++ b/activesupport/lib/active_support/evented_file_update_checker.rb
@@ -99,7 +99,7 @@ module ActiveSupport
       def finalizer
         proc do
           stop
-          ActiveSupport::ForkTracker.unregister(@after_fork)
+          ActiveSupport::ForkTracker.unregister_after_fork(@after_fork)
         end
       end
 

--- a/activesupport/test/fork_tracker_test.rb
+++ b/activesupport/test/fork_tracker_test.rb
@@ -3,164 +3,114 @@
 require_relative "abstract_unit"
 
 class ForkTrackerTest < ActiveSupport::TestCase
-  def test_object_fork
-    read, write = IO.pipe
-    called = false
+  def setup
+    super
 
-    handler = ActiveSupport::ForkTracker.after_fork do
-      called = true
-      write.write "forked"
+    @read, @write = IO.pipe
+    @called = false
+
+    @handler = ActiveSupport::ForkTracker.after_fork do
+      @called = true
+      @write.write "forked"
     end
+  end
 
+  def teardown
+    ActiveSupport::ForkTracker.unregister(@handler)
+
+    super
+  end
+
+  def test_object_fork
     assert_not respond_to?(:fork)
     pid = fork do
-      read.close
-      write.close
+      @read.close
+      @write.close
       exit!
     end
 
-    write.close
+    @write.close
 
     Process.waitpid(pid)
-    assert_equal "forked", read.read
-    read.close
+    assert_equal "forked", @read.read
+    @read.close
 
-    assert_not called
-  ensure
-    ActiveSupport::ForkTracker.unregister(handler)
+    assert_not @called
   end
 
   def test_object_fork_without_block
-    read, write = IO.pipe
-    called = false
-
-    handler = ActiveSupport::ForkTracker.after_fork do
-      called = true
-      write.write "forked"
-    end
-
     if pid = fork
-      write.close
+      @write.close
       Process.waitpid(pid)
-      assert_equal "forked", read.read
-      read.close
-      assert_not called
+      assert_equal "forked", @read.read
+      @read.close
+      assert_not @called
     else
-      read.close
-      write.close
+      @read.close
+      @write.close
       exit!
     end
-  ensure
-    ActiveSupport::ForkTracker.unregister(handler)
   end
 
   def test_process_fork
-    read, write = IO.pipe
-    called = false
-
-    handler = ActiveSupport::ForkTracker.after_fork do
-      called = true
-      write.write "forked"
-    end
-
     pid = Process.fork do
-      read.close
-      write.close
+      @read.close
+      @write.close
       exit!
     end
 
-    write.close
+    @write.close
 
     Process.waitpid(pid)
-    assert_equal "forked", read.read
-    read.close
-    assert_not called
-  ensure
-    ActiveSupport::ForkTracker.unregister(handler)
+    assert_equal "forked", @read.read
+    @read.close
+    assert_not @called
   end
 
   def test_process_fork_without_block
-    read, write = IO.pipe
-    called = false
-
-    handler = ActiveSupport::ForkTracker.after_fork do
-      called = true
-      write.write "forked"
-    end
-
     if pid = Process.fork
-      write.close
+      @write.close
       Process.waitpid(pid)
-      assert_equal "forked", read.read
-      read.close
-      assert_not called
+      assert_equal "forked", @read.read
+      @read.close
+      assert_not @called
     else
-      read.close
-      write.close
+      @read.close
+      @write.close
       exit!
     end
-  ensure
-    ActiveSupport::ForkTracker.unregister(handler)
   end
 
   def test_kernel_fork
-    read, write = IO.pipe
-    called = false
-
-    handler = ActiveSupport::ForkTracker.after_fork do
-      called = true
-      write.write "forked"
-    end
-
     pid = Kernel.fork do
-      read.close
-      write.close
+      @read.close
+      @write.close
       exit!
     end
 
-    write.close
+    @write.close
 
     Process.waitpid(pid)
-    assert_equal "forked", read.read
-    read.close
-    assert_not called
-  ensure
-    ActiveSupport::ForkTracker.unregister(handler)
+    assert_equal "forked", @read.read
+    @read.close
+    assert_not @called
   end
 
   def test_kernel_fork_without_block
-    read, write = IO.pipe
-    called = false
-
-    handler = ActiveSupport::ForkTracker.after_fork do
-      called = true
-      write.write "forked"
-    end
-
     if pid = Kernel.fork
-      write.close
+      @write.close
       Process.waitpid(pid)
-      assert_equal "forked", read.read
-      read.close
-      assert_not called
+      assert_equal "forked", @read.read
+      @read.close
+      assert_not @called
     else
-      read.close
-      write.close
+      @read.close
+      @write.close
       exit!
     end
-  ensure
-    ActiveSupport::ForkTracker.unregister(handler)
   end
 
   def test_basic_object_with_kernel_fork
-    read, write = IO.pipe
-    called = false
-
-    handler = ActiveSupport::ForkTracker.after_fork do
-      called = true
-      write.write "forked"
-    end
-
     klass = Class.new(BasicObject) do
       include ::Kernel
       def fark(&block)
@@ -171,19 +121,33 @@ class ForkTrackerTest < ActiveSupport::TestCase
     object = klass.new
     assert_not object.respond_to?(:fork)
     pid = object.fark do
-      read.close
-      write.close
+      @read.close
+      @write.close
       exit!
     end
 
-    write.close
+    @write.close
 
     Process.waitpid(pid)
-    assert_equal "forked", read.read
-    read.close
+    assert_equal "forked", @read.read
+    @read.close
 
-    assert_not called
-  ensure
-    ActiveSupport::ForkTracker.unregister(handler)
+    assert_not @called
+  end
+
+  def test_unregister_callback
+    ActiveSupport::ForkTracker.unregister(@handler)
+
+    if pid = Process.fork
+      @write.close
+      Process.waitpid(pid)
+      assert_equal "", @read.read
+      @read.close
+      assert_not @called
+    else
+      @read.close
+      @write.close
+      exit!
+    end
   end
 end if Process.respond_to?(:fork)


### PR DESCRIPTION
### Motivation / Background

Currently, `SQLite3Adapter` is not fork-safe and can result in database file corruption when a Rails process forks under certain circumstances.

https://github.com/rails/solid_queue/issues/324 described sqlite database corruption happening while dealing with solid_queue job management. An investigation demonstrated that a likely cause of that corruption is sqlite's lack of fork-safety, a situation which was ironically made worse when the sqlite3-ruby driver improved its memory management with https://github.com/sparklemotion/sqlite3-ruby/pull/392 in v2.0.0.

Any `SQLite3::Database` objects that are inherited from the parent process are unsafe to properly close and may impact either the parent or the child and potentially lead to database corruption.

You can read more about sqlite's lack of fork-safety in [How To Corrupt An SQLite Database File §2.6](https://www.sqlite.org/howtocorrupt.html#_carrying_an_open_database_connection_across_a_fork_), and reproduce corruption yourself with https://github.com/flavorjones/2024-09-13-sqlite-corruption.


### Detail

In this commit, a pre-fork callback `prepare_to_fork!` is introduced for the connection pools and adapters to take any necessary actions before forking. The callback is only implemented by `SQLite3Adapter` which now invokes `disconnect!` to close all open prepared statements and database connections.

This pull request has a lot going on. The commits, in order, do the following:

1. Prefactor `activesupport/test/fork_tracker_test.rb`.
2. Introduce `ActiveSupport::ForkTracker.before_fork` for registering callbacks before a Rails process forks.
3. Introduce the `prepare_to_fork!` callback and `SQLite3Adapter`'s specialized version of that method.


### Additional information

As a side effect, the parent process will end up having to re-open database connections if it continues to do work, which may be a small performance overhead for some use cases, but is necessary in order to prevent database corruption.


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
