### PR TITLE
Revert params.fetch to params.expect conversions in scaffold

### DIFF
--- a/railties/lib/rails/generators/rails/scaffold_controller/templates/api_controller.rb.tt
+++ b/railties/lib/rails/generators/rails/scaffold_controller/templates/api_controller.rb.tt
@@ -48,7 +48,7 @@ class <%= controller_class_name %>Controller < ApplicationController
     # Only allow a list of trusted parameters through.
     def <%= "#{singular_table_name}_params" %>
       <%- if attributes_names.empty? -%>
-      params.expect(<%= singular_table_name %>: {})
+      params.fetch(:<%= singular_table_name %>, {})
       <%- else -%>
       params.expect(<%= singular_table_name %>: [ <%= permitted_params %> ])
       <%- end -%>

--- a/railties/lib/rails/generators/rails/scaffold_controller/templates/controller.rb.tt
+++ b/railties/lib/rails/generators/rails/scaffold_controller/templates/controller.rb.tt
@@ -55,7 +55,7 @@ class <%= controller_class_name %>Controller < ApplicationController
     # Only allow a list of trusted parameters through.
     def <%= "#{singular_table_name}_params" %>
       <%- if attributes_names.empty? -%>
-      params.expect(<%= singular_table_name %>: {})
+      params.fetch(:<%= singular_table_name %>, {})
       <%- else -%>
       params.expect(<%= singular_table_name %>: [ <%= permitted_params %> ])
       <%- end -%>

--- a/railties/test/generators/scaffold_controller_generator_test.rb
+++ b/railties/test/generators/scaffold_controller_generator_test.rb
@@ -67,7 +67,7 @@ class ScaffoldControllerGeneratorTest < Rails::Generators::TestCase
 
     assert_file "app/controllers/users_controller.rb" do |content|
       assert_match(/def user_params/, content)
-      assert_match(/params\.expect\(user: \{\}\)/, content)
+      assert_match(/params\.fetch\(:user, \{\}\)/, content)
     end
   end
 
@@ -354,6 +354,15 @@ class ScaffoldControllerGeneratorTest < Rails::Generators::TestCase
     assert_file "app/controllers/messages_controller.rb" do |content|
       assert_match(/def message_params/, content)
       assert_match(/params\.expect\(message: \[ :video, photos: \[\] \]\)/, content)
+    end
+  end
+
+  def test_api_only_doesnt_use_require_or_permit_if_there_are_no_attributes
+    run_generator ["User", "--api"]
+
+    assert_file "app/controllers/users_controller.rb" do |content|
+      assert_match(/def user_params/, content)
+      assert_match(/params\.fetch\(:user, \{\}\)/, content)
     end
   end
 


### PR DESCRIPTION
### Motivation / Background

 In rails/jbuilder#573 we stumbled on the case where the scaffold was generating `params.expect(table_name: {})` which has the unintended consequence of requiring that a param is given when there are no expected params.

### Detail

This PR reverts 2 small changes to the scaffold templates introduced by #51674 so that default scaffolds don't return 400 Bad Request upon creation with no attributes.

### Additional information

Thanks to @jeromedalbert for noticing that I had made the very changes that I pointed out as problematic in his PR in jbuilder. Teamwork!

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
