### PR TITLE
[ci-skip][docs] Add missing period in Active Storage guide.

### DIFF
--- a/guides/source/active_storage_overview.md
+++ b/guides/source/active_storage_overview.md
@@ -1578,7 +1578,7 @@ end
 
 ### Configuring services
 
-You can add `config/storage/test.yml` to configure services to be used in test environment
+You can add `config/storage/test.yml` to configure services to be used in test environment.
 This is useful when the `service` option is used.
 
 ```ruby


### PR DESCRIPTION
Fixes a missing period that threw me off while reading :)


Before:
<img width="549" alt="Screenshot 2024-09-14 at 23 31 12" src="https://github.com/user-attachments/assets/996c1821-2809-4efb-a5d9-e68c670c56d2">

After:
<img width="549" alt="Screenshot 2024-09-14 at 23 31 40" src="https://github.com/user-attachments/assets/b065e359-f4f7-4e56-9a3a-58cc26f6b05b">
