### PR TITLE
Do not include redis by default in dev container

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,14 @@
+*   Do not include redis by default in generated Dev Containers.
+
+    Now that applications use the Solid Queue and Solid Cache gems by default, we do not need to include redis
+    in the Dev Container. We will only include redis if `--skip-solid` is used when generating an app that uses
+    Active Job or Action Cable.
+
+    When generating a Dev Container for an existing app, we will not include redis if either of the solid gems
+    are in use.
+
+    *Andrew Novoselac*
+
 *   Use [Solid Cable](https://github.com/rails/solid_cable) as the default Action Cable adapter in production, configured as a separate queue database in config/database.yml. It keeps messages in a table and continuously polls for updates. This makes it possible to drop the common dependency on Redis, if it isn't needed for any other purpose. Despite polling, the performance of Solid Cable is comparable to Redis in most situations. And in all circumstances, it makes it easier to deploy Rails when Redis is no longer a required dependency for Action Cable functionality.
 
     *DHH*

--- a/railties/lib/rails/commands/devcontainer/devcontainer_command.rb
+++ b/railties/lib/rails/commands/devcontainer/devcontainer_command.rb
@@ -24,7 +24,7 @@ module Rails
             app_name: Rails.application.railtie_name.chomp("_application"),
             database: !!defined?(ActiveRecord) && database,
             active_storage: !!defined?(ActiveStorage),
-            redis: !!(defined?(ActionCable) || defined?(ActiveJob)),
+            redis: !!((defined?(ActionCable) && !defined?(SolidCable)) || (defined?(ActiveJob) && !defined?(SolidQueue))),
             system_test: File.exist?("test/application_system_test_case.rb"),
             node: File.exist?(".node-version"),
           }

--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -265,7 +265,7 @@ module Rails
     def devcontainer
       devcontainer_options = {
         database: options[:database],
-        redis: !(options[:skip_action_cable] && options[:skip_active_job]),
+        redis: options[:skip_solid] && !(options[:skip_action_cable] && options[:skip_active_job]),
         system_test: depends_on_system_test?,
         active_storage: !options[:skip_active_storage],
         dev: options[:dev],

--- a/railties/test/commands/devcontainer_test.rb
+++ b/railties/test/commands/devcontainer_test.rb
@@ -8,20 +8,31 @@ class Rails::Command::DevcontainerTest < ActiveSupport::TestCase
 
   teardown { teardown_app }
 
-  test "generates devcontainer for default app" do
+  test "generates devcontainer for default app with solid gems" do
     build_app
+
+    require "solid_cable"
+    require "solid_queue"
 
     output = rails "devcontainer"
 
     assert_match "app_name: app_template", output
     assert_match "database: sqlite3", output
     assert_match "active_storage: true", output
-    assert_match "redis: true", output
+    assert_match "redis: false", output
     assert_match "system_test: true", output
     assert_match "node: false", output
   end
 
-  test "generates devcontainer for using mysql2 app" do
+  test "generates dev container for without solid gems" do
+    build_app
+
+    output = rails "devcontainer"
+
+    assert_match "redis: true", output
+  end
+
+  test "generates dev container for using mysql2 app" do
     build_app
 
     Dir.chdir(app_path) do
@@ -29,12 +40,7 @@ class Rails::Command::DevcontainerTest < ActiveSupport::TestCase
 
       output = rails "devcontainer"
 
-      assert_match "app_name: app_template", output
       assert_match "database: mysql", output
-      assert_match "active_storage: true", output
-      assert_match "redis: true", output
-      assert_match "system_test: true", output
-      assert_match "node: false", output
 
       assert_match "ghcr.io/rails/devcontainer/features/mysql-client", read_file(".devcontainer/devcontainer.json")
     end


### PR DESCRIPTION
### Motivation / Background

Rails 8 will use the solid gems by default for job queue and action cable, which do not depend on redis. So we don't need to include redis in the dev container by default. 

### Detail

For new apps, we will not include redis by default. If the app is using `--skip-solid` and either active job or action cable, then we will include redis.

When generating a dev container for an existing app, we will check if either of the solid gems is in use to decide if redis is needed.

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
