### PR TITLE
Skip tests that raises "cannot get AST for ISEQ compiled by prism" if Ruby parse is Prism

### DIFF
--- a/activesupport/test/abstract_unit.rb
+++ b/activesupport/test/abstract_unit.rb
@@ -43,6 +43,11 @@ class ActiveSupport::TestCase
 
   include ActiveSupport::Testing::MethodCallAssertions
   include ActiveSupport::Testing::ErrorReporterAssertions
+
+  private
+    def prism_skip(message = "")
+      skip message if RUBY_DESCRIPTION =~ /\+PRISM/
+    end
 end
 
 require_relative "../../tools/test_common"

--- a/activesupport/test/test_case_test.rb
+++ b/activesupport/test/test_case_test.rb
@@ -74,6 +74,8 @@ class AssertionsTest < ActiveSupport::TestCase
   end
 
   def test_assert_no_difference_with_multiple_expressions_fail
+    prism_skip
+
     another_object = @object.dup
     assert_raises(Minitest::Assertion) do
       assert_no_difference ["@object.num", -> { another_object.num }], "Another Object Changed" do
@@ -172,6 +174,7 @@ class AssertionsTest < ActiveSupport::TestCase
 
   def test_assert_difference_message_with_lambda
     skip if !defined?(RubyVM::AbstractSyntaxTree)
+    prism_skip
 
     error = assert_raises Minitest::Assertion do
       assert_difference(-> { @object.num }, 1, "Object Changed") do
@@ -248,6 +251,7 @@ class AssertionsTest < ActiveSupport::TestCase
 
   def test_assert_changes_message_with_lambda
     skip if !defined?(RubyVM::AbstractSyntaxTree)
+    prism_skip
 
     error = assert_raises Minitest::Assertion do
       assert_changes -> { @object.num }, to: 0 do
@@ -376,6 +380,7 @@ class AssertionsTest < ActiveSupport::TestCase
 
   def test_assert_no_changes_message_with_lambda
     skip if !defined?(RubyVM::AbstractSyntaxTree)
+    prism_skip
 
     error = assert_raises Minitest::Assertion do
       assert_no_changes -> { @object.num } do
@@ -420,6 +425,8 @@ class AssertionsTest < ActiveSupport::TestCase
   end
 
   def test_assert_no_changes_message_with_multi_line_lambda
+    prism_skip
+
     check = lambda {
       "title".upcase
       @object.num
@@ -505,6 +512,8 @@ class ExceptionsInsideAssertionsTest < ActiveSupport::TestCase
   end
 
   def test_warning_is_not_logged_if_assertions_are_nested_correctly
+    prism_skip
+
     error = assert_raises(Minitest::Assertion) do
       run_test_that_should_fail_but_not_log_a_warning
     end


### PR DESCRIPTION
## Motivation / Background

This commit addresses these Rails Nightly CI failures
https://buildkite.com/rails/rails-nightly/builds/1023#0191ed31-1d8d-41e5-906b-e3b88aab79da

Ruby 3.4.0dev default parser has been switched to Prism, After the default parser is switched from parse.y to Prism some of Active Support tests get failed with "cannot get AST for ISEQ compiled by prism" message.

According to https://github.com/ruby/ruby/pull/9934, this seems to be the expected behavior of Ruby with the Prism parser. This commit adds the `prism_skip` method following the naming convention of `jruby_skip` that has been removed via https://github.com/rails/rails/pull/49454 .


### Detail


- This commit addresses these failures against Ruby 3.4.0dev with Prism parser.
```ruby
$ ruby -v
ruby 3.4.0dev (2024-09-15T01:06:11Z master 532af89e3b) +PRISM [x86_64-linux]
$ cd activesupport
$ bin/test -n "/^(?:TestOrderTest#(?:test_test_order_is_global)|AssertionsTest#(?:test_assert_changes_message_with_lambda|test_assert_difference_message_with_lambda|test_assert_no_changes_message_with_lambda|test_assert_no_changes_message_with_multi_line_lambda|test_assert_no_difference_with_multiple_expressions_fail)|ExceptionsInsideAssertionsTest#(?:test_warning_is_not_logged_if_assertions_are_nested_correctly))$/"
/home/yahonda/.gem/ruby/3.4.0+0/gems/json-2.7.1/lib/json/common.rb:3: warning: ostruct was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
You can add ostruct to your Gemfile or gemspec to silence this warning.
WARNING: Nokogiri was built against libxml version 2.12.9, but has dynamically loaded 2.9.14

Run options: -n "/^(?:TestOrderTest#(?:test_test_order_is_global)|AssertionsTest#(?:test_assert_changes_message_with_lambda|test_assert_difference_message_with_lambda|test_assert_no_changes_message_with_lambda|test_assert_no_changes_message_with_multi_line_lambda|test_assert_no_difference_with_multiple_expressions_fail)|ExceptionsInsideAssertionsTest#(?:test_warning_is_not_logged_if_assertions_are_nested_correctly))$/" --seed 65502

F

Failure:
ExceptionsInsideAssertionsTest#test_warning_is_not_logged_if_assertions_are_nested_correctly [test/test_case_test.rb:508]:
[Minitest::Assertion] exception expected, not
Class: <RuntimeError>
Message: <"cannot get AST for ISEQ compiled by prism">
---Backtrace---
<internal:ast>:97:in 'RubyVM::AbstractSyntaxTree.of'
/home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/testing/assertions.rb:304:in 'ActiveSupport::Testing::Assertions#_callable_to_source_string'
/home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/testing/assertions.rb:270:in 'block in ActiveSupport::Testing::Assertions#assert_no_changes'
---------------

bin/test test/test_case_test.rb:507

F

Failure:
AssertionsTest#test_assert_changes_message_with_lambda [test/test_case_test.rb:252]:
[Minitest::Assertion] exception expected, not
Class: <RuntimeError>
Message: <"cannot get AST for ISEQ compiled by prism">
---Backtrace---
<internal:ast>:97:in 'RubyVM::AbstractSyntaxTree.of'
/home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/testing/assertions.rb:304:in 'ActiveSupport::Testing::Assertions#_callable_to_source_string'
/home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/testing/assertions.rb:213:in 'block in ActiveSupport::Testing::Assertions#assert_changes'
---------------

bin/test test/test_case_test.rb:249

F

Failure:
AssertionsTest#test_assert_no_changes_message_with_multi_line_lambda [test/test_case_test.rb:427]:
[Minitest::Assertion] exception expected, not
Class: <RuntimeError>
Message: <"cannot get AST for ISEQ compiled by prism">
---Backtrace---
<internal:ast>:97:in 'RubyVM::AbstractSyntaxTree.of'
/home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/testing/assertions.rb:304:in 'ActiveSupport::Testing::Assertions#_callable_to_source_string'
/home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/testing/assertions.rb:270:in 'block in ActiveSupport::Testing::Assertions#assert_no_changes'
---------------

bin/test test/test_case_test.rb:422

F

Failure:
AssertionsTest#test_assert_no_changes_message_with_lambda [test/test_case_test.rb:380]:
[Minitest::Assertion] exception expected, not
Class: <RuntimeError>
Message: <"cannot get AST for ISEQ compiled by prism">
---Backtrace---
<internal:ast>:97:in 'RubyVM::AbstractSyntaxTree.of'
/home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/testing/assertions.rb:304:in 'ActiveSupport::Testing::Assertions#_callable_to_source_string'
/home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/testing/assertions.rb:270:in 'block in ActiveSupport::Testing::Assertions#assert_no_changes'
---------------

bin/test test/test_case_test.rb:377

F

Failure:
AssertionsTest#test_assert_no_difference_with_multiple_expressions_fail [test/test_case_test.rb:78]:
[Minitest::Assertion] exception expected, not
Class: <RuntimeError>
Message: <"cannot get AST for ISEQ compiled by prism">
---Backtrace---
<internal:ast>:97:in 'RubyVM::AbstractSyntaxTree.of'
/home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/testing/assertions.rb:304:in 'ActiveSupport::Testing::Assertions#_callable_to_source_string'
/home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/testing/assertions.rb:122:in 'block (2 levels) in ActiveSupport::Testing::Assertions#assert_difference'
---------------

bin/test test/test_case_test.rb:76

F

Failure:
AssertionsTest#test_assert_difference_message_with_lambda [test/test_case_test.rb:176]:
[Minitest::Assertion] exception expected, not
Class: <RuntimeError>
Message: <"cannot get AST for ISEQ compiled by prism">
---Backtrace---
<internal:ast>:97:in 'RubyVM::AbstractSyntaxTree.of'
/home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/testing/assertions.rb:304:in 'ActiveSupport::Testing::Assertions#_callable_to_source_string'
/home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/testing/assertions.rb:122:in 'block (2 levels) in ActiveSupport::Testing::Assertions#assert_difference'
---------------

bin/test test/test_case_test.rb:173

.

Finished in 0.044451s, 157.4784 runs/s, 629.9136 assertions/s.
7 runs, 28 assertions, 6 failures, 0 errors, 0 skips
$
```

### Additional information

Refer to https://github.com/ruby/ruby/pull/9934
https://github.com/ruby/ruby/pull/11497/
https://bugs.ruby-lang.org/issues/20564

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [ ] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
