### PR TITLE
Fix: JSON Column In-Place Update Issue by Adding Type Casting to changed_in_place?

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Fix `ActiveRecord::Type::Json.changed_in_place?` by casting new_value
+
+    Previously, when making in-place updates to a JSON field, the new_value was not type-casted, leading to inaccurate change detection.
+    This fix ensures that the new_value is properly casted during in-place changes, as it is when assigning the entire field.
+
+    *Ahmad Mohsen*
+
 *   Make Float distinguish between `float4` and `float8` in PostgreSQL.
 
     Fixes #52742

--- a/activerecord/lib/active_record/type/json.rb
+++ b/activerecord/lib/active_record/type/json.rb
@@ -19,7 +19,7 @@ module ActiveRecord
       end
 
       def changed_in_place?(raw_old_value, new_value)
-        deserialize(raw_old_value) != new_value
+        deserialize(raw_old_value) != cast(new_value)
       end
 
       def accessor

--- a/activerecord/test/cases/dirty_test.rb
+++ b/activerecord/test/cases/dirty_test.rb
@@ -1002,7 +1002,7 @@ class DirtyTest < ActiveRecord::TestCase
 
     admin = Admin::User.create!(name: "John", json_options: { extra_details: { nick_name: "Jo" } })
 
-    admin.json_options.merge!(extra_details: { nick_name: :Jo })
+    admin.json_options.merge!("extra_details" => { "nick_name" => :Jo })
 
     assert_empty admin.changes
   end

--- a/activerecord/test/cases/dirty_test.rb
+++ b/activerecord/test/cases/dirty_test.rb
@@ -7,6 +7,8 @@ require "models/parrot"
 require "models/person"   # For optimistic locking
 require "models/aircraft"
 require "models/numeric_data"
+require "models/admin"
+require "models/admin/user"
 
 class DirtyTest < ActiveRecord::TestCase
   include InTimeZone
@@ -993,6 +995,16 @@ class DirtyTest < ActiveRecord::TestCase
     assert parrot.breed_changed?(from: "african", to: "australian")
     assert parrot.breed_changed?(from: :african, to: :australian)
     assert parrot.breed_changed?(from: 0, to: 1)
+  end
+
+  test "changes is empty when merging equivalent symbolized values in JSON field in place" do
+    skip if current_adapter?(:Mysql2Adapter, :TrilogyAdapter) && ActiveRecord::Base.lease_connection.mariadb?
+
+    admin = Admin::User.create!(name: "John", json_options: { extra_details: { nick_name: "Jo" } })
+
+    admin.json_options.merge!(extra_details: { nick_name: :Jo })
+
+    assert_empty admin.changes
   end
 
   private

--- a/activerecord/test/cases/json_shared_test_cases.rb
+++ b/activerecord/test/cases/json_shared_test_cases.rb
@@ -192,6 +192,18 @@ module JSONSharedTestCases
     assert_not_predicate json, :changed?
   end
 
+  def test_change_in_place_equivelent_symbol_value
+    json = klass.create!(payload: { "one" => "two" })
+    json.payload["one"] = :two
+    assert_not_predicate json, :changed?
+  end
+
+  def test_change_in_place_different_symbol_value
+    json = klass.create!(payload: { "one" => "two" })
+    json.payload["one"] = :three
+    assert_predicate json, :changed?
+  end
+
   def test_changes_in_place_with_ruby_object
     time = Time.now.utc
     json = klass.create!(payload: time)


### PR DESCRIPTION
 ### Motivation / Background
 When a JSON column is partially updated in place, the new_value is not type-casted, leading to symbol values being incorrectly detected as changes.
 This PR resolves the issue by ensuring consistent behavior between ActiveRecord::Type::Json.changed_in_place? and changed?, as the new_value is type-casted by default during full attribute assignment.

 ### Detail
 This Pull Request updates the `changed_in_place?` method in `ActiveRecord::Type::Json` to type-cast the new_value before comparing it with the old_value.
 
 ### Additional information

 before:

![image](https://github.com/user-attachments/assets/fec1cbac-915b-4a2a-a7e3-def13679c159)

test: 
<img width="914" alt="image" src="https://github.com/user-attachments/assets/4c89ba7e-94c9-4456-8c63-de0e67b6c86d">

 after:
 
![image](https://github.com/user-attachments/assets/956007dd-9a86-448f-898d-163b04ec2b9f)

test:
 <img width="992" alt="image" src="https://github.com/user-attachments/assets/18aa77c1-c98f-4ea1-8376-0494f7d7be41">

 ### Checklist
 Before submitting the PR make sure the following are checked:
 
 * [x]  This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
 * [x]  Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
 * [x]  Tests are added or updated if you fix a bug or add a feature.
 * [x]  CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.

