### PR TITLE
Address `DebugExceptionsTest` failures against Ruby with Prism parser

### DIFF
--- a/actionpack/test/dispatch/debug_exceptions_test.rb
+++ b/actionpack/test/dispatch/debug_exceptions_test.rb
@@ -722,7 +722,7 @@ class DebugExceptionsTest < ActionDispatch::IntegrationTest
 
     assert_response 500
     assert_select "#Application-Trace-0" do
-      assert_select "code", /syntax error, unexpected/
+      assert_select "code", /syntax error, unexpected|syntax errors found/
     end
   end
 
@@ -749,7 +749,7 @@ class DebugExceptionsTest < ActionDispatch::IntegrationTest
 
     assert_response 500
     assert_select "#Application-Trace-0" do
-      assert_select "code", /syntax error, unexpected/
+      assert_select "code", /syntax error, unexpected|syntax errors found/
     end
     assert_match %r{Showing <i>.*test/dispatch/debug_exceptions_test.rb</i>}, body
   end


### PR DESCRIPTION
### Motivation / Background

This commit addresses Rails Nightly CI failure of Action Pack. https://buildkite.com/rails/rails-nightly/builds/1023#0191ed31-1d6e-4f20-8cfd-b5f39bfa8187/1175-1217

This is due to syntax error related message differences between these two parsers. This commit allows both error messages.

- Ruby 3.4.0dev with parse.y parser raises `syntax error, unexpected end-of-input, expecting`
```ruby
$ ruby -v
ruby 3.4.0dev (2024-09-15T01:06:11Z master 532af89e3b) +PRISM [x86_64-linux]
$ RUBYOPT=--parser=parse.y ruby -w -e 'puts ("Hello, world!"'
-e:1: syntax error, unexpected end-of-input, expecting ')'
puts ("Hello, world!"
ruby: compile error (SyntaxError)
```

- Ruby 3.4.0dev with Prism parser raises `syntax errors found`
```ruby
$ ruby -v
ruby 3.4.0dev (2024-09-15T01:06:11Z master 532af89e3b) +PRISM [x86_64-linux]
$ RUBYOPT=--parser=prism ruby -w -e 'puts ("Hello, world!"'
-e:1: warning: possibly useless use of a literal in void context
-e: -e:2: syntax errors found (SyntaxError)
  1 | puts ("Hello, world!"
> 2 |
    | ^ expected a matching `)`

    | ^ unexpected end-of-input, assuming it is closing the parent top level context
```

### Detail

This commit addresses these two failures below:

```ruby
$ cd actionpack
$ bin/test test/dispatch/debug_exceptions_test.rb -n "/^(?:DebugExceptionsTest#(?:test_debug_exceptions_app_shows_all_the_nested_exceptions_in_source_view|test_display_backtrace_when_error_type_is_SyntaxError|test_display_backtrace_when_error_type_is_SyntaxError_wrapped_by_ActionView::Template::Error))$/"
/home/yahonda/.gem/ruby/3.4.0+0/gems/json-2.7.1/lib/json/generic_object.rb:2: warning: ostruct was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
You can add ostruct to your Gemfile or gemspec to silence this warning.
/home/yahonda/.gem/ruby/3.4.0+0/gems/capybara-3.39.2/lib/capybara/session/config.rb:95: warning: URI::RFC3986_PARSER.make_regexp is obsoleted. Use URI::RFC2396_PARSER.make_regexp explicitly.
/home/yahonda/.rbenv/versions/trunk/lib/ruby/gems/3.4.0+0/gems/selenium-webdriver-4.22.0/lib/selenium/webdriver/common/target_locator.rb:104: warning: possibly useless use of a variable in void context
2024-09-16 13:08:30 INFO Selenium [:logger_info] Details on how to use and modify Selenium logger:
  https://selenium.dev/documentation/webdriver/troubleshooting/logging

2024-09-16 13:08:30 WARN Selenium [:selenium_manager] The geckodriver version (0.34.0) detected in PATH at /home/yahonda/bin/geckodriver might not be compatible with the detected firefox version (130.0); currently, geckodriver 0.35.0 is recommended for firefox 130.*, so it is advised to delete the driver in PATH and retry
/home/yahonda/.rbenv/versions/trunk/lib/ruby/gems/3.4.0+0/gems/rack-3.1.7/lib/rack/lint.rb:15: warning: URI::RFC3986_PARSER.make_regexp is obsoleted. Use URI::RFC2396_PARSER.make_regexp explicitly.
Running 42 tests in a single process (parallelization threshold is 50)
Run options: -n "/^(?:DebugExceptionsTest#(?:test_debug_exceptions_app_shows_all_the_nested_exceptions_in_source_view|test_display_backtrace_when_error_type_is_SyntaxError|test_display_backtrace_when_error_type_is_SyntaxError_wrapped_by_ActionView::Template::Error))$/" --seed 16885

F

Failure:
DebugExceptionsTest#test_display_backtrace_when_error_type_is_SyntaxError [test/dispatch/debug_exceptions_test.rb:724]:
--- expected
+++ actual
@@ -1 +1,37 @@
-/syntax error, unexpected/
+"/home/yahonda/src/github.com/rails/rails/actionpack/test/dispatch/debug_exceptions_test.rb:114: (eval at /home/yahonda/src/github.com/rails/rails/actionpack/test/dispatch/debug_exceptions_test.rb:114):1: syntax errors found
+[1;31m> [m[38;5;102m1 | [mbroke_syntax =
+  [38;5;102m  | [m             [1;31m^[m expected an expression after `=`
+  [38;5;102m  | [m              [1;31m^[m unexpected end-of-input, assuming it is closing the parent top level context
+
+
+
+
+            /home/yahonda/src/github.com/rails/rails/actionpack/test/dispatch/debug_exceptions_test.rb:114:in 'Kernel#eval'
+
+
+
+            /home/yahonda/src/github.com/rails/rails/actionpack/test/dispatch/debug_exceptions_test.rb:114:in 'DebugExceptionsTest::Boomer#call'
+
+
+
+            /home/yahonda/src/github.com/rails/rails/actionpack/lib/action_dispatch/middleware/debug_exceptions.rb:31:in 'ActionDispatch::DebugExceptions#call'
+
+
+
+            /home/yahonda/src/github.com/rails/rails/actionpack/lib/action_dispatch/testing/integration.rb:287:in 'ActionDispatch::Integration::Session#process'
+
+
+
+            /home/yahonda/src/github.com/rails/rails/actionpack/lib/action_dispatch/testing/integration.rb:19:in 'ActionDispatch::Integration::RequestHelpers#get'
+
+
+
+            /home/yahonda/src/github.com/rails/rails/actionpack/lib/action_dispatch/testing/integration.rb:378:in 'ActionDispatch::Integration::Runner#get'
+
+
+
+            /home/yahonda/src/github.com/rails/rails/actionpack/test/dispatch/debug_exceptions_test.rb:721:in 'block in <class:DebugExceptionsTest>'
+
+
+
+            /home/yahonda/src/github.com/rails/rails/railties/lib/rails/test_unit/line_filtering.rb:10:in 'Rails::LineFiltering#run'"
.
Expected 0 to be >= 1.

bin/test test/dispatch/debug_exceptions_test.rb:718

.F

Failure:
DebugExceptionsTest#test_display_backtrace_when_error_type_is_SyntaxError_wrapped_by_ActionView::Template::Error [test/dispatch/debug_exceptions_test.rb:751]:
--- expected
+++ actual
@@ -1 +1,37 @@
-/syntax error, unexpected/
+"/home/yahonda/src/github.com/rails/rails/actionpack/test/dispatch/debug_exceptions_test.rb:117: (eval at /home/yahonda/src/github.com/rails/rails/actionpack/test/dispatch/debug_exceptions_test.rb:117):1: syntax errors found
+[1;31m> [m[38;5;102m1 | [mbroke_syntax =
+  [38;5;102m  | [m             [1;31m^[m expected an expression after `=`
+  [38;5;102m  | [m              [1;31m^[m unexpected end-of-input, assuming it is closing the parent top level context
+
+
+
+
+            /home/yahonda/src/github.com/rails/rails/actionpack/test/dispatch/debug_exceptions_test.rb:117:in 'Kernel#eval'
+
+
+
+            /home/yahonda/src/github.com/rails/rails/actionpack/test/dispatch/debug_exceptions_test.rb:117:in 'DebugExceptionsTest::Boomer#call'
+
+
+
+            /home/yahonda/src/github.com/rails/rails/actionpack/lib/action_dispatch/middleware/debug_exceptions.rb:31:in 'ActionDispatch::DebugExceptions#call'
+
+
+
+            /home/yahonda/src/github.com/rails/rails/actionpack/lib/action_dispatch/testing/integration.rb:287:in 'ActionDispatch::Integration::Session#process'
+
+
+
+            /home/yahonda/src/github.com/rails/rails/actionpack/lib/action_dispatch/testing/integration.rb:19:in 'ActionDispatch::Integration::RequestHelpers#get'
+
+
+
+            /home/yahonda/src/github.com/rails/rails/actionpack/lib/action_dispatch/testing/integration.rb:378:in 'ActionDispatch::Integration::Runner#get'
+
+
+
+            /home/yahonda/src/github.com/rails/rails/actionpack/test/dispatch/debug_exceptions_test.rb:748:in 'block in <class:DebugExceptionsTest>'
+
+
+
+            /home/yahonda/src/github.com/rails/rails/railties/lib/rails/test_unit/line_filtering.rb:10:in 'Rails::LineFiltering#run'"
.
Expected 0 to be >= 1.

bin/test test/dispatch/debug_exceptions_test.rb:745

Finished in 0.261984s, 11.4511 runs/s, 64.8895 assertions/s.
3 runs, 17 assertions, 2 failures, 0 errors, 0 skips
$
```

### Additional information
None

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.


