### PR TITLE
Show feedback for `bin/rails boot` command

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Show feedback for `bin/rails boot` command.
+
+    *Petrik de Heus*
+
 *   Use [Solid Queue](https://github.com/rails/solid_queue) as the default Active Job backend in production, configured as a separate queue database in config/database.yml. In a single-server deployment, it'll run as a Puma plugin. This is configured in `config/deploy.yml` and can easily be changed to use a dedicated jobs machine.
 
     *DHH*

--- a/railties/lib/rails/commands/boot/boot_command.rb
+++ b/railties/lib/rails/commands/boot/boot_command.rb
@@ -8,7 +8,11 @@ module Rails
       include EnvironmentArgument
 
       desc "boot", "Boot the application and exit"
-      def perform(*) = boot_application!
+      def perform(*)
+        puts "Booting the application."
+        boot_application!
+        puts "All is good!"
+      end
     end
   end
 end

--- a/railties/test/commands/boot_test.rb
+++ b/railties/test/commands/boot_test.rb
@@ -17,7 +17,10 @@ class Rails::Command::BootTest < ActiveSupport::TestCase
       File.write(#{test_file.inspect}, Rails.env)
     RUBY
 
-    rails "boot"
+    assert_equal <<~OUTPUT, rails("boot")
+      Booting the application.
+      All is good!
+    OUTPUT
 
     assert_equal "development", File.read(test_file)
   end
@@ -29,7 +32,10 @@ class Rails::Command::BootTest < ActiveSupport::TestCase
       File.write(#{test_file.inspect}, Rails.env)
     RUBY
 
-    rails "boot", "-e", "test"
+    assert_equal <<~OUTPUT, rails("boot", "-e", "test")
+      Booting the application.
+      All is good!
+    OUTPUT
 
     assert_equal "test", File.read(test_file)
   end


### PR DESCRIPTION
### Motivation / Background
There currently is no feedback when `bin/rails boot` is successful.

### Detail
Print "Booting the application." before booting.
Print "All is good!" when boot was successful, similar to `bin/rails zeitwerk:check`.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
