### PR TITLE
Manifest link should use JSON format

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/app/views/layouts/application.html.erb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/app/views/layouts/application.html.erb.tt
@@ -11,7 +11,7 @@
     <%%= yield :head %>
 
     <%%# Enable PWA manifest for installable apps (make sure to enable in config/routes.rb too!) %>
-    <%%#= tag.link rel: "manifest", href: pwa_manifest_path %>
+    <%%#= tag.link rel: "manifest", href: pwa_manifest_path(format: :json) %>
 
     <link rel="icon" href="/icon.png" type="image/png">
     <link rel="icon" href="/icon.svg" type="image/svg+xml">


### PR DESCRIPTION
This fixes the commented manifest path to use JSON after it was refactored yesterday in https://github.com/rails/rails/blob/87bee3640b2a135a360c9af13f0e610bef8df131/railties/lib/rails/generators/rails/app/templates/app/views/layouts/application.html.erb.tt#L14

Currently, it will look for an HTML template, so this changes it to use the JSON format. 

cc @dhh 