### PR TITLE
Add broadcast_to_list and stream_for_list to ActionCable API

### DIFF
--- a/actioncable/CHANGELOG.md
+++ b/actioncable/CHANGELOG.md
@@ -1,3 +1,29 @@
+*   Add `broadcast_to_list`, `stream_for_list` and `stop_stream_for_list` methods to ActionCable.
+    `broadcast_to_list` broadcasts a message to broadcastings whom name respects a specific nomenclature.
+    `stream_for_list` starts streaming the pubsub queue for a list of `model`
+    `stop_stream_for_list` stops streaming the pubsub queue for a list of `model`
+
+    ```ruby
+    # app/channels/chat_channel.rb
+    class ChatChannel < ApplicationCable::Channel
+      def subscribed
+        room_ids = [1, 2, 5, 7]
+        stream_from_list room_ids
+      end
+
+      def unsubscribed
+        room_ids = [1, 2, 5, 7]
+        stop_stream_for_list room_ids
+      end
+    end
+    ```
+
+    ```ruby
+    ChatChannel.broadcast_to_list("1", @comment)
+    ```
+
+    *xamey*
+
 *   Add an `identifier` to the event payload for the ActiveSupport::Notification `transmit_subscription_confirmation.action_cable` and `transmit_subscription_rejection.action_cable`.
 
     *Keith Schacht*

--- a/actioncable/lib/action_cable/channel/broadcasting.rb
+++ b/actioncable/lib/action_cable/channel/broadcasting.rb
@@ -9,23 +9,42 @@ module ActionCable
     module Broadcasting
       extend ActiveSupport::Concern
 
+      delegate :broadcasting_for_list, :broadcasting_for, :broadcast_to_list, :broadcast_to, to: :class
+
       module ClassMethods
         # Broadcast a hash to a unique broadcasting for this `model` in this channel.
         def broadcast_to(model, message)
           ActionCable.server.broadcast(broadcasting_for(model), message)
         end
 
-        # Returns a unique broadcasting identifier for this `model` in this channel:
-        #
-        #     CommentsChannel.broadcasting_for("all") # => "comments:all"
-        #
-        # You can pass any object as a target (e.g. Active Record model), and it would
-        # be serialized into a string under the hood.
+        # Broadcast a hash to multiple broadcasting for this `model` in this channel.
+        def broadcast_to_list(model, message)
+          ActionCable.server.broadcast_list(broadcasting_for(model), message)
+        end
+
         def broadcasting_for(model)
           serialize_broadcasting([ channel_name, model ])
         end
 
+        # Returns a unique broadcasting identifier for this `list` in this channel.
+        # If any of the elements in the list contains a "-" character,
+        # it raises an ArgumentError as it violates the nomenclature.
+        def broadcasting_for_list(list)
+          serialized_list = list.map { |broadcasting| serialize_broadcasting(broadcasting) }
+          if serialized_list.any? { |broadcasting| broadcasting.include?("-") }
+            raise ArgumentError, "Serialized broadcasting contains a '-' character"
+          end
+          broadcasting_for(serialized_list.join("-"))
+        end
+
         private
+          # Returns a unique broadcasting identifier for this `model` in this channel:
+          #
+          #    CommentsChannel.broadcasting_for("all") # => "comments:all"
+          #
+          # You can pass any object as a target (e.g. Active Record model), and it would
+          # be serialized into a string under the hood.
+
           def serialize_broadcasting(object) # :nodoc:
             case
             when object.is_a?(Array)
@@ -36,14 +55,6 @@ module ActionCable
               object.to_param
             end
           end
-      end
-
-      def broadcasting_for(model)
-        self.class.broadcasting_for(model)
-      end
-
-      def broadcast_to(model, message)
-        self.class.broadcast_to(model, message)
       end
     end
   end

--- a/actioncable/lib/action_cable/helpers/action_cable_helper.rb
+++ b/actioncable/lib/action_cable/helpers/action_cable_helper.rb
@@ -40,6 +40,27 @@ module ActionCable
           raise("No Action Cable URL configured -- please configure this at config.action_cable.url")
         )
       end
+
+      # Returns a list of channels that match the broadcast_to_list nomenclature
+      # For example, if channel is "posts:1", and channels is ["posts:1-2", "posts:2-3", "posts:1-3"],
+      # this method will return ["posts:1-2", "post:1-3"].
+      # channel attr must have parts separated by ":" and must have at least 2 parts
+      # channels must have parts separated by ":" and must have at least 2 parts, and in the last part
+      # which represents the identifiers, they must be separated by "-"
+      def find_matching_channels(channel, channels)
+        parts = channel.split(":")
+        return [] if parts.length == 1
+
+        id = parts.pop
+        base_channel = parts.join(":")
+
+        channels.filter_map do |ch|
+          if ch.start_with?(base_channel)
+            ids = ch.split(":").last
+            ch if ids != ch && ids.split("-").include?(id)
+          end
+        end
+      end
     end
   end
 end

--- a/actioncable/lib/action_cable/server/broadcasting.rb
+++ b/actioncable/lib/action_cable/server/broadcasting.rb
@@ -1,61 +1,112 @@
 # frozen_string_literal: true
 
 # :markup: markdown
-
 module ActionCable
   module Server
-    # # Action Cable Server Broadcasting
+    # Broadcasting is how other parts of your application can send messages to a channel's subscribers. As explained in Channel, most of the time, these
+    # broadcastings are streamed directly to the clients subscribed to the named broadcasting. Let's explain with a full-stack example:
     #
-    # Broadcasting is how other parts of your application can send messages to a
-    # channel's subscribers. As explained in Channel, most of the time, these
-    # broadcastings are streamed directly to the clients subscribed to the named
-    # broadcasting. Let's explain with a full-stack example:
-    #
-    #     class WebNotificationsChannel < ApplicationCable::Channel
-    #       def subscribed
-    #         stream_from "web_notifications_#{current_user.id}"
-    #       end
+    #   class WebNotificationsChannel < ApplicationCable::Channel
+    #     def subscribed
+    #       stream_from "web_notifications_#{current_user.id}"
     #     end
+    #   end
     #
-    #     # Somewhere in your app this is called, perhaps from a NewCommentJob:
-    #     ActionCable.server.broadcast \
-    #       "web_notifications_1", { title: "New things!", body: "All that's fit for print" }
+    #   # Somewhere in your app this is called, perhaps from a NewCommentJob:
+    #   ActionCable.server.broadcast \
+    #     "web_notifications_1", { title: "New things!", body: "All that's fit for print" }
     #
-    #     # Client-side CoffeeScript, which assumes you've already requested the right to send web notifications:
-    #     App.cable.subscriptions.create "WebNotificationsChannel",
-    #       received: (data) ->
-    #         new Notification data['title'], body: data['body']
+    #   # Client-side CoffeeScript, which assumes you've already requested the right to send web notifications:
+    #   App.cable.subscriptions.create "WebNotificationsChannel",
+    #     received: (data) ->
+    #       new Notification data['title'], body: data['body']
+    #
+    # Broadcasting to multiple subscribers without knowing the exact names of the broadcasting channels is also possible.
+    # For instance, if a client subscribes to a list of models and you want to broadcast a message to this client,
+    # but you only know one of the model's details on the Rails side, you can use `broadcast_list`.
+    # Let's explain this with another full-stack example:
+    #
+    #   In this example, we want to stream to a list of users who are currently connected to our Rails app.
+    #   You must follow a naming convention by specifying the list of identifiers as the last part of the channel name, separated by colons.
+    #
+    #   class WebNotificationsChannel < ApplicationCable::Channel
+    #     def subscribed
+    #       user_ids = Users.currently_connected.map(&:id)
+    #       stream_from "web_notifications:#{user_ids.join('-')}"
+    #     end
+    #   end
+    #
+    #   # Somewhere in your app, this is called (perhaps from a NewCommentJob).
+    #   # If the stream key is "web_notifications:1-5-6", for example, we can broadcast the message to this channel.
+    #   # The last part of the name contains the user IDs, separated by hyphens.
+    #   ActionCable.server.broadcast_list \
+    #     "web_notifications:1", { title: "New things!", body: "All that's fit for print" }
+    #
+    #   # Client-side CoffeeScript:
+    #   App.cable.subscriptions.create "WebNotificationsChannel",
+    #     received: (data) ->
+    #       new Notification data['title'], body: data['body']
     module Broadcasting
-      # Broadcast a hash directly to a named `broadcasting`. This will later be JSON
-      # encoded.
+      # Broadcast a hash directly to a named <tt>broadcasting</tt>. This will later be JSON encoded.
       def broadcast(broadcasting, message, coder: ActiveSupport::JSON)
         broadcaster_for(broadcasting, coder: coder).broadcast(message)
       end
 
-      # Returns a broadcaster for a named `broadcasting` that can be reused. Useful
-      # when you have an object that may need multiple spots to transmit to a specific
-      # broadcasting over and over.
+      # Broadcast a hash directly to a named <tt>broadcasting</tt> which may address multiple subscribers. This will later be JSON encoded.
+      def broadcast_list(broadcasting, message, coder: ActiveSupport::JSON)
+        broadcaster_for_list(broadcasting, coder: coder).broadcast(message)
+      end
+
+      # Returns a broadcaster for a named <tt>broadcasting</tt> that can be reused. Useful when you have an object that
+      # may need multiple spots to transmit to a specific broadcasting over and over.
       def broadcaster_for(broadcasting, coder: ActiveSupport::JSON)
         Broadcaster.new(self, String(broadcasting), coder: coder)
       end
 
+      # Returns a broadcaster for a named <tt>broadcasting</tt> which may address multiple subscribers that can be reused. Useful when you have an object that
+      # may need multiple spots to transmit to a specific broadcasting over and over.
+      def broadcaster_for_list(broadcasting, coder: ActiveSupport::JSON)
+        BroadcasterList.new(self, String(broadcasting), coder: coder)
+      end
+
       private
-        class Broadcaster
+        class BaseBroadcaster
           attr_reader :server, :broadcasting, :coder
 
           def initialize(server, broadcasting, coder:)
-            @server, @broadcasting, @coder = server, broadcasting, coder
+            @server = server
+            @broadcasting = broadcasting
+            @coder = coder
           end
 
           def broadcast(message)
-            server.logger.debug { "[ActionCable] Broadcasting to #{broadcasting}: #{message.inspect.truncate(300)}" }
+            @server.logger.debug { "[ActionCable] Broadcasting to #{@broadcasting}: #{message.inspect.truncate(300)}" }
 
-            payload = { broadcasting: broadcasting, message: message, coder: coder }
+            payload = { broadcasting: @broadcasting, message: message, coder: @coder }
             ActiveSupport::Notifications.instrument("broadcast.action_cable", payload) do
-              encoded = coder ? coder.encode(message) : message
-              server.pubsub.broadcast broadcasting, encoded
+              encoded = @coder ? @coder.encode(message) : message
+              perform_broadcast(encoded)
             end
           end
+
+          private
+            def perform_broadcast(encoded)
+              raise NotImplementedError, "Subclasses must implement `perform_broadcast`"
+            end
+        end
+
+        class BroadcasterList < BaseBroadcaster
+          private
+            def perform_broadcast(encoded)
+              @server.pubsub.broadcast_list @broadcasting, encoded
+            end
+        end
+
+        class Broadcaster < BaseBroadcaster
+          private
+            def perform_broadcast(encoded)
+              @server.pubsub.broadcast @broadcasting, encoded
+            end
         end
     end
   end

--- a/actioncable/lib/action_cable/server/configuration.rb
+++ b/actioncable/lib/action_cable/server/configuration.rb
@@ -63,6 +63,7 @@ module ActionCable
 
         adapter = adapter.camelize
         adapter = "PostgreSQL" if adapter == "Postgresql"
+
         "ActionCable::SubscriptionAdapter::#{adapter}".constantize
       end
     end

--- a/actioncable/lib/action_cable/subscription_adapter/base.rb
+++ b/actioncable/lib/action_cable/subscription_adapter/base.rb
@@ -16,6 +16,10 @@ module ActionCable
         raise NotImplementedError
       end
 
+      def broadcast_list(channel, payload)
+        raise NotImplementedError
+      end
+
       def subscribe(channel, message_callback, success_callback = nil)
         raise NotImplementedError
       end

--- a/actioncable/lib/action_cable/subscription_adapter/inline.rb
+++ b/actioncable/lib/action_cable/subscription_adapter/inline.rb
@@ -14,6 +14,10 @@ module ActionCable
         subscriber_map.broadcast(channel, payload)
       end
 
+      def broadcast_list(channel, payload)
+        subscriber_map.broadcast_list(channel, payload)
+      end
+
       def subscribe(channel, callback, success_callback = nil)
         subscriber_map.add_subscriber(channel, callback, success_callback)
       end

--- a/actioncable/test/channel/broadcasting_test.rb
+++ b/actioncable/test/channel/broadcasting_test.rb
@@ -17,7 +17,7 @@ class ActionCable::Channel::BroadcastingTest < ActionCable::TestCase
       ActionCable.server,
       :broadcast,
       [
-        "action_cable:channel:broadcasting_test:chat:Room#1-Campfire",
+        "action_cable:channel:broadcasting_test:chat:Room#1Campfire",
         "Hello World"
       ]
     ) do
@@ -25,16 +25,29 @@ class ActionCable::Channel::BroadcastingTest < ActionCable::TestCase
     end
   end
 
+  test "broadcast_to_list" do
+    assert_called_with(
+      ActionCable.server,
+      :broadcast_list,
+      [
+        "action_cable:channel:broadcasting_test:chat:Room#1Campfire",
+        "Hello World"
+      ]
+    ) do
+      ChatChannel.broadcast_to_list(Room.new(1), "Hello World")
+    end
+  end
+
   test "broadcasting_for with an object" do
     assert_equal(
-      "action_cable:channel:broadcasting_test:chat:Room#1-Campfire",
+      "action_cable:channel:broadcasting_test:chat:Room#1Campfire",
       ChatChannel.broadcasting_for(Room.new(1))
     )
   end
 
   test "broadcasting_for with an array" do
     assert_equal(
-      "action_cable:channel:broadcasting_test:chat:Room#1-Campfire:Room#2-Campfire",
+      "action_cable:channel:broadcasting_test:chat:Room#1Campfire:Room#2Campfire",
       ChatChannel.broadcasting_for([ Room.new(1), Room.new(2) ])
     )
   end
@@ -44,5 +57,25 @@ class ActionCable::Channel::BroadcastingTest < ActionCable::TestCase
       "action_cable:channel:broadcasting_test:chat:hello",
       ChatChannel.broadcasting_for("hello")
     )
+  end
+
+  test "broadcasting_for_list with an array of objects" do
+    assert_equal(
+      "action_cable:channel:broadcasting_test:chat:Room#1Campfire-Room#2Campfire",
+      ChatChannel.broadcasting_for_list([ Room.new(1), Room.new(2) ])
+    )
+  end
+
+  test "broadcasting_for_list with an of objects and string" do
+    assert_equal(
+      "action_cable:channel:broadcasting_test:chat:Room#1Campfire-Room#2Campfire-hello",
+      ChatChannel.broadcasting_for_list([ Room.new(1), Room.new(2), "hello" ])
+    )
+  end
+
+  test "broadcasting_for_list with an of objects and string with a dash" do
+    assert_raises(ArgumentError) do
+      ChatChannel.broadcasting_for_list([ Room.new(1), Room.new(2), "hello-world" ])
+    end
   end
 end

--- a/actioncable/test/channel/stream_test.rb
+++ b/actioncable/test/channel/stream_test.rb
@@ -104,7 +104,24 @@ module ActionCable::StreamTests
 
         pubsub_call = channel.pubsub.class.class_variable_get "@@subscribe_called"
 
-        assert_equal "action_cable:stream_tests:chat:Room#1-Campfire", pubsub_call[:channel]
+        assert_equal "action_cable:stream_tests:chat:Room#1Campfire", pubsub_call[:channel]
+        assert_instance_of Proc, pubsub_call[:callback]
+        assert_instance_of Proc, pubsub_call[:success_callback]
+      end
+    end
+
+    test "stream_for_list" do
+      run_in_eventmachine do
+        connection = TestConnection.new
+
+        channel = ChatChannel.new connection, ""
+        channel.subscribe_to_channel
+        channel.stream_for_list [Room.new(1), Room.new(2)]
+        wait_for_async
+
+        pubsub_call = channel.pubsub.class.class_variable_get "@@subscribe_called"
+
+        assert_equal "action_cable:stream_tests:chat:Room#1Campfire-Room#2Campfire", pubsub_call[:channel]
         assert_instance_of Proc, pubsub_call[:callback]
         assert_instance_of Proc, pubsub_call[:success_callback]
       end
@@ -121,7 +138,7 @@ module ActionCable::StreamTests
 
         pubsub_call = channel.pubsub.class.class_variable_get "@@subscribe_called"
 
-        assert_equal "action_cable:stream_tests:chat:Room#1-Campfire", pubsub_call[:channel]
+        assert_equal "action_cable:stream_tests:chat:Room#1Campfire", pubsub_call[:channel]
         assert_instance_of Proc, pubsub_call[:callback]
         assert_instance_of Proc, pubsub_call[:success_callback]
       end

--- a/actioncable/test/connection/multiple_identifiers_test.rb
+++ b/actioncable/test/connection/multiple_identifiers_test.rb
@@ -18,7 +18,7 @@ class ActionCable::Connection::MultipleIdentifiersTest < ActionCable::TestCase
     run_in_eventmachine do
       open_connection
 
-      assert_equal "Room#my-room:User#lifo", @connection.connection_identifier
+      assert_equal "Room#myroom:User#lifo", @connection.connection_identifier
     end
   end
 

--- a/actioncable/test/server/broadcasting_test.rb
+++ b/actioncable/test/server/broadcasting_test.rb
@@ -31,6 +31,25 @@ class BroadcastingTest < ActionCable::TestCase
     ActiveSupport::Notifications.unsubscribe "broadcast.action_cable"
   end
 
+  test "broadcast_list generates notification" do
+    server = TestServer.new
+
+    events = []
+    ActiveSupport::Notifications.subscribe("broadcast.action_cable") { |event| events << event }
+
+    broadcasting = "test_queue:1-2-3"
+    message = { body: "test message" }
+    server.broadcast_list(broadcasting, message)
+
+    assert_equal 1, events.length
+    assert_equal "broadcast.action_cable", events[0].name
+    assert_equal broadcasting, events[0].payload[:broadcasting]
+    assert_equal message, events[0].payload[:message]
+    assert_equal ActiveSupport::JSON, events[0].payload[:coder]
+  ensure
+    ActiveSupport::Notifications.unsubscribe "broadcast.action_cable"
+  end
+
   test "broadcaster from broadcaster_for generates notification" do
     server = TestServer.new
 

--- a/actioncable/test/stubs/room.rb
+++ b/actioncable/test/stubs/room.rb
@@ -9,7 +9,7 @@ class Room
   end
 
   def to_global_id
-    GlobalID.new("Room##{id}-#{name}")
+    GlobalID.new("Room##{id}#{name}")
   end
 
   def to_gid_param

--- a/actioncable/test/stubs/test_adapter.rb
+++ b/actioncable/test/stubs/test_adapter.rb
@@ -4,6 +4,9 @@ class SuccessAdapter < ActionCable::SubscriptionAdapter::Base
   def broadcast(channel, payload)
   end
 
+  def broadcast_list(channel, payload)
+  end
+
   def subscribe(channel, callback, success_callback = nil)
     subscriber_map[channel] << callback
     @@subscribe_called = { channel: channel, callback: callback, success_callback: success_callback }

--- a/actioncable/test/subscription_adapter/common.rb
+++ b/actioncable/test/subscription_adapter/common.rb
@@ -55,6 +55,34 @@ module CommonSubscriptionAdapterTest
     end
   end
 
+  def test_broadcast_list
+    subscribe_as_queue("channel:1-2-3") do |queue|
+      subscribe_as_queue("channel:2-3-4") do |queue2|
+        subscribe_as_queue("channel:1-4") do |queue3|
+          subscribe_as_queue("channel-1-4") do |queue4|
+            @tx_adapter.broadcast_list("channel:1", "hello world")
+            sleep WAIT_WHEN_NOT_EXPECTING_EVENT
+            assert_empty queue4
+          end
+          assert_equal "hello world", queue3.pop
+        end
+        sleep WAIT_WHEN_NOT_EXPECTING_EVENT
+        assert_empty queue2
+      end
+      assert_equal "hello world", queue.pop
+    end
+  end
+
+  def test_broadcast_list_with_invalid_channel
+    subscribe_as_queue("channel:1-2-3") do |queue|
+      @tx_adapter.broadcast_list("channel-1", "hello world")
+
+      sleep WAIT_WHEN_NOT_EXPECTING_EVENT
+      assert_empty queue
+    end
+  end
+
+
   def test_broadcast_after_unsubscribe
     keep_queue = nil
     subscribe_as_queue("channel") do |queue|

--- a/actioncable/test/subscription_adapter/postgresql_test.rb
+++ b/actioncable/test/subscription_adapter/postgresql_test.rb
@@ -60,6 +60,15 @@ class PostgresqlAdapterTest < ActionCable::TestCase
       assert_equal "hello world", queue.pop
     end
 
+    subscribe_as_queue("channel:2-3", adapter) do |queue|
+      subscribe_as_queue("channel:3-4", adapter) do |queue2|
+        adapter.broadcast_list("channel:2", "hello world")
+        sleep WAIT_WHEN_NOT_EXPECTING_EVENT
+        assert_empty queue2
+      end
+      assert_equal "hello world", queue.pop
+    end
+
     ActiveRecord::Base.connection_handler.clear_reloadable_connections!
 
     assert_predicate adapter, :active?

--- a/actioncable/test/subscription_adapter/redis_test.rb
+++ b/actioncable/test/subscription_adapter/redis_test.rb
@@ -16,6 +16,16 @@ class RedisAdapterTest < ActionCable::TestCase
     end
   end
 
+  def test_broadcast_list
+    subscribe_as_queue("queue:1-2") do |queue|
+      subscribe_as_queue("queue:2-3") do |queue_2|
+        @tx_adapter.broadcast_list("queue:1", "bonjour le monde")
+        assert_empty queue_2
+      end
+      assert_equal "bonjour le monde", queue.pop
+    end
+  end
+
   def test_reconnections
     subscribe_as_queue("channel") do |queue|
       subscribe_as_queue("other channel") do |queue_2|

--- a/guides/source/action_cable_overview.md
+++ b/guides/source/action_cable_overview.md
@@ -383,10 +383,44 @@ You can then broadcast to this channel by calling [`broadcast_to`][]:
 PostsChannel.broadcast_to(@post, @comment)
 ```
 
+In case you want to stream for multiple models or identifiers on the same subscription, and broadcast to this channel without knowing the list of models or identifiers but only one of them, you can use [`stream_from_list`][] to stream for a list of models or identifiers along with [`broadcast_to_list`][]. This allow us to subscribe once and avoid the need to subscribe to N broadcastings, which can be costly and induce locking periods as subscriptions are subjects to a mutex operation.
+
+
+Using a full-stack example, if I want to subscribe to a list of rooms:
+
+```ruby
+# app/channels/chat_channel.rb
+class ChatChannel < ApplicationCable::Channel
+  def subscribed
+    room_ids = [1, 2, 5, 7]
+    stream_from_list room_ids
+  end
+end
+```
+
+Broadcasting name must respect the following nomenclature:
+
+- identifiers must be separated with `-`
+- identifiers must be grouped after the last iteration of `:`
+
+`chat:work:1-5-6` is a correct broadcasting name.
+`chat:work/1-5-6` and `chat:work:1_5_6` are incorrect broadcasting names.
+
+You can then broadcast to this channel using one of the identifiers by calling [`broadcast_to_list`][]:
+
+```ruby
+ChatChannel.broadcast_to_list("1", @comment)
+```
+
+As the identifier "1" is included in the list of identifiers indicated in the broadcasting name (i.e., `chat:work:1-5-6`), the comment will be broadcasted to this subscriber.
+It won't be broadcasted to a subscribed which used the name `chat:work:2-5`.
+
 [`broadcast`]: https://api.rubyonrails.org/classes/ActionCable/Server/Broadcasting.html#method-i-broadcast
 [`broadcast_to`]: https://api.rubyonrails.org/classes/ActionCable/Channel/Broadcasting/ClassMethods.html#method-i-broadcast_to
+[`broadcast_to_list`]: https://api.rubyonrails.org/classes/ActionCable/Channel/Broadcasting/ClassMethods.html#method-i-broadcast_to_list
 [`stream_for`]: https://api.rubyonrails.org/classes/ActionCable/Channel/Streams.html#method-i-stream_for
 [`stream_from`]: https://api.rubyonrails.org/classes/ActionCable/Channel/Streams.html#method-i-stream_from
+[`stream_from_list`]: https://api.rubyonrails.org/classes/ActionCable/Channel/Streams.html#method-i-stream_from_list
 
 ### Broadcastings
 


### PR DESCRIPTION
### Motivation / Background

I encountered a scenario where I needed to subscribe to multiple models (N models) because the UI on the client side renders a table where each row corresponds to a specific model. My backend can broadcast updates for any of these models in real-time.

Rather than creating N individual subscriptions (and subsequently N unsubscriptions), I propose a more efficient approach: a single subscription that can handle updates for a list of models. Executing N separate pub/sub operations risks performance bottlenecks, as threads may become locked due to mutex contention.

To implement this, we would need a mechanism that allows broadcasting to a shared channel representing multiple models. For example, if a subscriber is interested in models with IDs 5, 10, and 55, it should be possible to broadcast updates to this group without requiring each model to individually track or manage this association. Requiring ActionCable users to track such relationships on the backend would introduce unnecessary complexity and be inconsistent with the simplicity expected from the ActionCable API.

### Detail

This pull request introduces multiple enhancements to the Action Cable API to support multi-model subscriptions:

`stream_for_list(broadcasting_list, callback = nil, coder: nil, &block)` which has the same interface than `stream_for`, but it takes a list of models instead of a single model.

`stop_stream_for_list(broadcasting_list)` which has the same interface than `stop_stream_for`, but it takes a list of models instead of a single model. 

`broadcast_to_list(model, message)` which has the same interface than `broadcast_to`, but it will broadcast the message to any broadcasting which includes model identifier.

Let's take a full-stack example :

- I have a `PostChannel` and a `Comment` model, and a clients want to subscribe to every `Comment` in my database. I execute `stream_for_list(Comment.all)` in `PostChannel` which executes only one subscription
- If I want to broadcast `Comment.find(5)` to this client, I can execute `PostChannel.broadcast_to_list(Comment.find(5), "updated!")`.

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [X] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
