### PR TITLE
Add validations to email address field on authentication generator

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Add validations to email address field on authentication generator.
+
+    These validations reflect the database constraints present on the
+    `email_address` field in the generated migration.
+
+    *Matheus Richard*
+
 *   Do not include redis by default in generated Dev Containers.
 
     Now that applications use the Solid Queue and Solid Cache gems by default, we do not need to include redis

--- a/railties/lib/rails/generators/rails/authentication/templates/models/user.rb
+++ b/railties/lib/rails/generators/rails/authentication/templates/models/user.rb
@@ -3,4 +3,6 @@ class User < ApplicationRecord
   has_many :sessions, dependent: :destroy
 
   normalizes :email_address, with: -> e { e.strip.downcase }
+
+  validates :email_address, presence: true, uniqueness: true
 end

--- a/railties/test/generators/authentication_generator_test.rb
+++ b/railties/test/generators/authentication_generator_test.rb
@@ -24,7 +24,9 @@ class AuthenticationGeneratorTest < Rails::Generators::TestCase
   def test_authentication_generator
     run_generator
 
-    assert_file "app/models/user.rb"
+    assert_file "app/models/user.rb" do |content|
+      assert_match(/validates :email_address, presence: true, uniqueness: true/, content)
+    end
     assert_file "app/models/current.rb"
     assert_file "app/models/session.rb"
     assert_file "app/controllers/sessions_controller.rb"
@@ -55,7 +57,9 @@ class AuthenticationGeneratorTest < Rails::Generators::TestCase
   def test_authentication_generator_with_api_flag
     run_generator(["--api"])
 
-    assert_file "app/models/user.rb"
+    assert_file "app/models/user.rb" do |content|
+      assert_match(/validates :email_address, presence: true, uniqueness: true/, content)
+    end
     assert_file "app/models/current.rb"
     assert_file "app/models/session.rb"
     assert_file "app/controllers/sessions_controller.rb"


### PR DESCRIPTION


### Motivation / Background

With the default generated model, when adding a blank or duplicated email, Active Record throws a database error, instead of gracefully validating and adding errors to the model.

### Detail

These validations reflect the database constraints present on the `email_address` field in the generated migration.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
