### PR TITLE
Add ability to use multiple rate limits per controller

### DIFF
--- a/actionpack/lib/action_controller/metal/rate_limiting.rb
+++ b/actionpack/lib/action_controller/metal/rate_limiting.rb
@@ -29,6 +29,9 @@ module ActionController # :nodoc:
       # datastore as your general caches, you can pass a custom store in the `store`
       # parameter.
       #
+      # If you want to use multiple rate limits per controller, you need to give each of
+      # them and explicit name via the `name:` option.
+      #
       # Examples:
       #
       #     class SessionsController < ApplicationController
@@ -44,14 +47,19 @@ module ActionController # :nodoc:
       #       RATE_LIMIT_STORE = ActiveSupport::Cache::RedisCacheStore.new(url: ENV["REDIS_URL"])
       #       rate_limit to: 10, within: 3.minutes, store: RATE_LIMIT_STORE
       #     end
-      def rate_limit(to:, within:, by: -> { request.remote_ip }, with: -> { head :too_many_requests }, store: cache_store, **options)
-        before_action -> { rate_limiting(to: to, within: within, by: by, with: with, store: store) }, **options
+      #
+      #     class SessionsController < ApplicationController
+      #       rate_limit to: 3, within: 2.seconds, name: "short-term"
+      #       rate_limit to: 10, within: 5.minutes, name: "long-term"
+      #     end
+      def rate_limit(to:, within:, by: -> { request.remote_ip }, with: -> { head :too_many_requests }, store: cache_store, name: controller_path, **options)
+        before_action -> { rate_limiting(to: to, within: within, by: by, with: with, store: store, name: name) }, **options
       end
     end
 
     private
-      def rate_limiting(to:, within:, by:, with:, store:)
-        count = store.increment("rate-limit:#{controller_path}:#{instance_exec(&by)}", 1, expires_in: within)
+      def rate_limiting(to:, within:, by:, with:, store:, name:)
+        count = store.increment("rate-limit:#{name}:#{instance_exec(&by)}", 1, expires_in: within)
         if count && count > to
           ActiveSupport::Notifications.instrument("rate_limit.action_controller", request: request) do
             instance_exec(&with)


### PR DESCRIPTION
Fixes #52957.

Currently, when the controller have multiple rate limits, for example https://github.com/rails/rails/blob/4aa78117fa427ec6d761b81fb1d3877a20703b9e/actionpack/test/controller/rate_limiting_test.rb#L5-L17

it is not working as expected. It is expected that each rate limit applies only to the actions specified in `:only`, but since the cache key contains the controller path, the rate limiting cache key is shared between the rate limits. So sending a request to one action we actually increment rate limiting counter for other rate limit too.

I propose to add an explicit name for each rate limiter (if more than 1) via `:name`, so we use separate cache keys for each of them.