### PR TITLE
Loosen time assertions

### DIFF
--- a/activesupport/test/benchmark_test.rb
+++ b/activesupport/test/benchmark_test.rb
@@ -4,12 +4,12 @@ require_relative "abstract_unit"
 
 class BenchmarkTest < ActiveSupport::TestCase
   def test_realtime
-    time = ActiveSupport::Benchmark.realtime { sleep 0.1 }
-    assert_in_delta 0.1, time, 0.0005
+    time = ActiveSupport::Benchmark.realtime { sleep 0.01 }
+    assert_includes (0.01..0.02), time
   end
 
   def test_realtime_millisecond
-    ms = ActiveSupport::Benchmark.realtime(:float_millisecond) { sleep 0.1 }
-    assert_in_delta 100, ms, 0.5
+    ms = ActiveSupport::Benchmark.realtime(:float_millisecond) { sleep 0.01 }
+    assert_includes (10..20), ms
   end
 end

--- a/activesupport/test/core_ext/benchmark_test.rb
+++ b/activesupport/test/core_ext/benchmark_test.rb
@@ -6,7 +6,7 @@ require "active_support/core_ext/benchmark"
 class BenchmarkTest < ActiveSupport::TestCase
   def test_is_deprecated
     assert_deprecated(ActiveSupport.deprecator) do
-      assert_operator Benchmark.ms { }, :>, 0
+      assert_kind_of Numeric, Benchmark.ms { }
     end
   end
 end


### PR DESCRIPTION
The time it takes to come back from sleep can be quite variable, but we can guarantee that it is _at least_ that long. On my mac the previous test assertions almost always failed.

I loosened this from a 0.5 millisecond buffer to a 10 millisecond buffer, it's possible that isn't even enough on some platforms.

I also shortened the sleep duration from 100ms each to 10ms, to make our test suite faster.