### PR TITLE
Remove QueAdapter autoload from AJ::QueueAdapters

### DIFF
--- a/activejob/lib/active_job/queue_adapters.rb
+++ b/activejob/lib/active_job/queue_adapters.rb
@@ -117,7 +117,6 @@ module ActiveJob
     autoload :InlineAdapter
     autoload :BackburnerAdapter
     autoload :DelayedJobAdapter
-    autoload :QueAdapter
     autoload :QueueClassicAdapter
     autoload :ResqueAdapter
     autoload :SidekiqAdapter


### PR DESCRIPTION
QueAdapter was removed in #46005, therefore we no longer need this autoload.
