### PR TITLE
Render rdoc code example for routing `defaults` method [ci skip]

### DIFF
--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -1053,6 +1053,7 @@ module ActionDispatch
         end
 
         # Allows you to set default parameters for a route, such as this:
+        #
         #     defaults id: 'home' do
         #       match 'scoped_pages/(:id)', to: 'pages#show'
         #     end


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because I suspect we actually want this example code to be rendered as code by rdoc, and yet due to the lack of a newline, that is not what is happening.

### Detail

This Pull Request changes a code comment by adding an extra blank line.

### Additional information

Before:

<img width="1076" alt="Screenshot 2024-09-18 at 16 38 13" src="https://github.com/user-attachments/assets/ba5e2e93-db9a-4353-a469-d788c5f36a17">

After:

<img width="807" alt="Screenshot 2024-09-18 at 16 38 26" src="https://github.com/user-attachments/assets/ff55bc7d-1ee1-4f80-a3b3-dd5f447b3e6b">


### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [X] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
