### PR TITLE
Ensure consistent sort order in `ActiveModel#serializable_hash` when using `only` option

### DIFF
--- a/activemodel/lib/active_model/serialization.rb
+++ b/activemodel/lib/active_model/serialization.rb
@@ -128,7 +128,7 @@ module ActiveModel
       return serializable_attributes(attribute_names) if options.blank?
 
       if only = options[:only]
-        attribute_names &= Array(only).map(&:to_s)
+        attribute_names = Array(only).map(&:to_s) & attribute_names
       elsif except = options[:except]
         attribute_names -= Array(except).map(&:to_s)
       end

--- a/activemodel/test/cases/serialization_test.rb
+++ b/activemodel/test/cases/serialization_test.rb
@@ -62,6 +62,11 @@ class SerializationTest < ActiveModel::TestCase
     assert_equal expected, @user.serializable_hash(only: [:name])
   end
 
+  def test_method_serializable_hash_should_work_with_only_option_with_order_of_given_keys
+    expected = { "name" => "David", "email" => "david@example.com" }
+    assert_equal expected.keys, @user.serializable_hash(only: [:name, :email]).keys
+  end
+
   def test_method_serializable_hash_should_work_with_except_option
     expected = { "gender" => "male", "email" => "david@example.com" }
     assert_equal expected, @user.serializable_hash(except: [:name])


### PR DESCRIPTION
This is a bit of a nitpick, but say you do this:

```ruby
user.as_json(only: [:email, :name]).keys
```

The result will depend on the order that the columns were added to your database (or in a test environment, the order of the columns in your `structure.sql`). ie. you might get `["email", "name"]` or `["name", "email"]`.

In the specific case that you've provided `only` you are being explicit about which fields should be returned, so we can also be explicit about the order that they are returned in. This PR implements that. Now it will always return fields based on the order they're provided to the `only` argument, so in this case it would always be `["email", "name"]`.
