### PR TITLE
Fix: Replace static tables names in ActiveStorage db migrations

### DIFF
--- a/activestorage/db/migrate/20170806125915_create_active_storage_tables.rb
+++ b/activestorage/db/migrate/20170806125915_create_active_storage_tables.rb
@@ -3,7 +3,7 @@ class CreateActiveStorageTables < ActiveRecord::Migration[7.0]
     # Use Active Record's configured type for primary and foreign keys
     primary_key_type, foreign_key_type = primary_and_foreign_key_types
 
-    create_table :active_storage_blobs, id: primary_key_type do |t|
+    create_table ActiveStorage::Blob.table_name, id: primary_key_type do |t|
       t.string   :key,          null: false
       t.string   :filename,     null: false
       t.string   :content_type
@@ -21,7 +21,7 @@ class CreateActiveStorageTables < ActiveRecord::Migration[7.0]
       t.index [ :key ], unique: true
     end
 
-    create_table :active_storage_attachments, id: primary_key_type do |t|
+    create_table ActiveStorage::Attachment.table_name, id: primary_key_type do |t|
       t.string     :name,     null: false
       t.references :record,   null: false, polymorphic: true, index: false, type: foreign_key_type
       t.references :blob,     null: false, type: foreign_key_type
@@ -32,16 +32,16 @@ class CreateActiveStorageTables < ActiveRecord::Migration[7.0]
         t.datetime :created_at, null: false
       end
 
-      t.index [ :record_type, :record_id, :name, :blob_id ], name: :index_active_storage_attachments_uniqueness, unique: true
-      t.foreign_key :active_storage_blobs, column: :blob_id
+      t.index [ :record_type, :record_id, :name, :blob_id ], name: "index_#{ActiveStorage::Attachment.table_name}_uniqueness", unique: true
+      t.foreign_key ActiveStorage::Blob.table_name, column: :blob_id
     end
 
-    create_table :active_storage_variant_records, id: primary_key_type do |t|
+    create_table ActiveStorage::VariantRecord.table_name, id: primary_key_type do |t|
       t.belongs_to :blob, null: false, index: false, type: foreign_key_type
       t.string :variation_digest, null: false
 
-      t.index [ :blob_id, :variation_digest ], name: :index_active_storage_variant_records_uniqueness, unique: true
-      t.foreign_key :active_storage_blobs, column: :blob_id
+      t.index [ :blob_id, :variation_digest ], name: "index_#{ActiveStorage::VariantRecord.table_name}_uniqueness", unique: true
+      t.foreign_key ActiveStorage::Blob.table_name, column: :blob_id
     end
   end
 

--- a/activestorage/db/update_migrate/20190112182829_add_service_name_to_active_storage_blobs.rb
+++ b/activestorage/db/update_migrate/20190112182829_add_service_name_to_active_storage_blobs.rb
@@ -1,21 +1,21 @@
 class AddServiceNameToActiveStorageBlobs < ActiveRecord::Migration[6.0]
   def up
-    return unless table_exists?(:active_storage_blobs)
+    return unless table_exists?(ActiveStorage::Blob.table_name)
 
-    unless column_exists?(:active_storage_blobs, :service_name)
-      add_column :active_storage_blobs, :service_name, :string
+    unless column_exists?(ActiveStorage::Blob.table_name, :service_name)
+      add_column ActiveStorage::Blob.table_name, :service_name, :string
 
       if configured_service = ActiveStorage::Blob.service.name
         ActiveStorage::Blob.unscoped.update_all(service_name: configured_service)
       end
 
-      change_column :active_storage_blobs, :service_name, :string, null: false
+      change_column ActiveStorage::Blob.table_name, :service_name, :string, null: false
     end
   end
 
   def down
-    return unless table_exists?(:active_storage_blobs)
+    return unless table_exists?(ActiveStorage::Blob.table_name)
 
-    remove_column :active_storage_blobs, :service_name
+    remove_column ActiveStorage::Blob.table_name, :service_name
   end
 end

--- a/activestorage/db/update_migrate/20191206030411_create_active_storage_variant_records.rb
+++ b/activestorage/db/update_migrate/20191206030411_create_active_storage_variant_records.rb
@@ -1,14 +1,14 @@
 class CreateActiveStorageVariantRecords < ActiveRecord::Migration[6.0]
   def change
-    return unless table_exists?(:active_storage_blobs)
+    return unless table_exists?(ActiveStorage::Blob.table_name)
 
     # Use Active Record's configured type for primary key
-    create_table :active_storage_variant_records, id: primary_key_type, if_not_exists: true do |t|
+    create_table ActiveStorage::VariantRecord.table_name, id: primary_key_type, if_not_exists: true do |t|
       t.belongs_to :blob, null: false, index: false, type: blobs_primary_key_type
       t.string :variation_digest, null: false
 
-      t.index %i[ blob_id variation_digest ], name: "index_active_storage_variant_records_uniqueness", unique: true
-      t.foreign_key :active_storage_blobs, column: :blob_id
+      t.index %i[ blob_id variation_digest ], name: "index_#{ActiveStorage::VariantRecord.table_name}_uniqueness", unique: true
+      t.foreign_key ActiveStorage::VariantRecord.table_name, column: :blob_id
     end
   end
 
@@ -19,8 +19,8 @@ class CreateActiveStorageVariantRecords < ActiveRecord::Migration[6.0]
     end
 
     def blobs_primary_key_type
-      pkey_name = connection.primary_key(:active_storage_blobs)
-      pkey_column = connection.columns(:active_storage_blobs).find { |c| c.name == pkey_name }
+      pkey_name = connection.primary_key(ActiveStorage::VariantRecord.table_name)
+      pkey_column = connection.columns(ActiveStorage::VariantRecord.table_name).find { |c| c.name == pkey_name }
       pkey_column.bigint? ? :bigint : pkey_column.type
     end
 end

--- a/activestorage/db/update_migrate/20211119233751_remove_not_null_on_active_storage_blobs_checksum.rb
+++ b/activestorage/db/update_migrate/20211119233751_remove_not_null_on_active_storage_blobs_checksum.rb
@@ -1,7 +1,7 @@
 class RemoveNotNullOnActiveStorageBlobsChecksum < ActiveRecord::Migration[6.0]
   def change
-    return unless table_exists?(:active_storage_blobs)
+    return unless table_exists?(ActiveStorage::VariantRecord.table_name)
 
-    change_column_null(:active_storage_blobs, :checksum, true)
+    change_column_null(ActiveStorage::VariantRecord.table_name, :checksum, true)
   end
 end


### PR DESCRIPTION
### Motivation / Background

The db migrations for ActiveStorage use static plural table names. If Rails runs with `config.active_record.pluralize_table_names = false`, this leads to an error as soon as ActiveStorage tries to access the DB.

### Detail

The static strings for the table names in the migrations are replaced by the `table_name` method of the corresponding model class. This ensures that the tables are named correctly in plural or singular respectively.

### Additional information

Earlier versions (prior to Rails 7.1) are not affected by this issue. However, as soon as a project is updated, the tables must be renamed with a separate database migration.

### Checklist

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.