### PR TITLE
Allow for configurable active strorage blob keys to use prefix

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Allow blob key to use a global configurable prefix.
+
+    ```ruby
+    Rails.application.configure.active_storage.key_prefix = -> { Current.tenant_id }
+    ```
+
+    *Andi Staub*
+
 *   Deprecate `ActiveStorage::Service::AzureStorageService`.
 
     *zzak*

--- a/activestorage/app/models/active_storage/blob.rb
+++ b/activestorage/app/models/active_storage/blob.rb
@@ -185,7 +185,7 @@ class ActiveStorage::Blob < ActiveStorage::Record
   # Always refer to blobs using the signed_id or a verified form of the key.
   def key
     # We can't wait until the record is first saved to have a key for it
-    self[:key] ||= self.class.generate_unique_secure_token(length: MINIMUM_TOKEN_LENGTH)
+    self[:key] ||= generate_key
   end
 
   # Returns an ActiveStorage::Filename instance of the filename that can be
@@ -390,6 +390,16 @@ class ActiveStorage::Blob < ActiveStorage::Record
 
     def update_service_metadata
       service.update_metadata key, **service_metadata if service_metadata.any?
+    end
+
+    def generate_key
+      generated_key = self.class.generate_unique_secure_token(length: MINIMUM_TOKEN_LENGTH)
+      return generated_key if ActiveStorage.key_prefix.nil?
+
+      prefix = ActiveStorage.key_prefix
+      prefix = prefix.call if prefix.respond_to?(:call)
+
+      "#{prefix}#{generated_key}"
     end
 end
 

--- a/activestorage/lib/active_storage.rb
+++ b/activestorage/lib/active_storage.rb
@@ -364,6 +364,7 @@ module ActiveStorage
   mattr_accessor :track_variants, default: false
 
   mattr_accessor :video_preview_arguments, default: "-y -vframes 1 -f image2"
+  mattr_accessor :key_prefix
 
   module Transformers
     extend ActiveSupport::Autoload

--- a/activestorage/lib/active_storage/engine.rb
+++ b/activestorage/lib/active_storage/engine.rb
@@ -119,6 +119,7 @@ module ActiveStorage
         ActiveStorage.binary_content_type = app.config.active_storage.binary_content_type || "application/octet-stream"
         ActiveStorage.video_preview_arguments = app.config.active_storage.video_preview_arguments || "-y -vframes 1 -f image2"
         ActiveStorage.track_variants = app.config.active_storage.track_variants || false
+        ActiveStorage.key_prefix = app.config.active_storage.key_prefix || nil
       end
     end
 


### PR DESCRIPTION
### Motivation / Background

We use rails with multiple tenants and wanted a way to segregate stored files within a bucket by tenant id. This pull requests adds a global configuration option that allows to set this prefix on active storage blob key model:
```ruby
# Can be a string or a block
Rails.application.configure.active_storage.key_prefix = "tenant/"
```
This generates following blob key: `tenant/mh9n0fker6q7k0qjd2ctgc42n2mo`

On some s3 providers, a prefix separated with `/` is treated like a folder

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
