### PR TITLE
Rewind IO stream before computing its checksum

### DIFF
--- a/activestorage/app/models/active_storage/blob.rb
+++ b/activestorage/app/models/active_storage/blob.rb
@@ -262,6 +262,11 @@ class ActiveStorage::Blob < ActiveStorage::Record
   end
 
   def unfurl(io, identify: true) # :nodoc:
+    raise ArgumentError, "io must be rewindable" unless io.respond_to?(:rewind)
+
+    # If the stream is at end-of-stream, then rewind it on behalf of the user
+    io.rewind if io.eof?
+
     self.checksum     = compute_checksum_in_chunks(io)
     self.content_type = extract_content_type(io) if content_type.nil? || identify
     self.byte_size    = io.size
@@ -346,8 +351,6 @@ class ActiveStorage::Blob < ActiveStorage::Record
 
   private
     def compute_checksum_in_chunks(io)
-      raise ArgumentError, "io must be rewindable" unless io.respond_to?(:rewind)
-
       OpenSSL::Digest::MD5.new.tap do |checksum|
         read_buffer = "".b
         while io.read(5.megabytes, read_buffer)

--- a/activestorage/test/models/blob_test.rb
+++ b/activestorage/test/models/blob_test.rb
@@ -96,12 +96,11 @@ class ActiveStorage::BlobTest < ActiveSupport::TestCase
     end
   end
 
-  test "create_and_upload raises for an io at end-of-stream" do
-    assert_raises(ActiveStorage::IntegrityError) do
-      io = StringIO.new
-      io << "Hello world!"
-      ActiveStorage::Blob.create_and_upload!(io: io, filename: "hello.txt")
-    end
+  test "create_and_upload rewinds an io which is at end-of-stream" do
+    io = StringIO.new
+    io << "Hello world!"
+    blob = ActiveStorage::Blob.create_and_upload!(io: io, filename: "hello.txt")
+    assert_equal "Hello world!", blob.open(&:read)
   end
 
   test "create_and_upload raises for an io with an offset" do

--- a/activestorage/test/models/blob_test.rb
+++ b/activestorage/test/models/blob_test.rb
@@ -96,6 +96,22 @@ class ActiveStorage::BlobTest < ActiveSupport::TestCase
     end
   end
 
+  test "create_and_upload raises for an io at end-of-stream" do
+    assert_raises(ActiveStorage::IntegrityError) do
+      io = StringIO.new
+      io << "Hello world!"
+      ActiveStorage::Blob.create_and_upload!(io: io, filename: "hello.txt")
+    end
+  end
+
+  test "create_and_upload raises for an io with an offset" do
+    io = StringIO.new("Hello world!")
+    io.read(1)
+    assert_raises(ActiveStorage::IntegrityError) do
+      ActiveStorage::Blob.create_and_upload!(io: io, filename: "hello.txt")
+    end
+  end
+
   test "record touched after analyze" do
     user = User.create!(
       name: "Nate",


### PR DESCRIPTION
### Background

When Active Storage uploads a stream, it does the following:

  1. Compute a checksum of the stream[^1]
  2. Call the storage service to perform the actual upload
  3. Compare the checksum computed in step 1 with the checksum of the uploaded file and raise an `IntegrityError` if they don't match[^2]

The checksum in step 1 is computed from the current offset of the stream but the stream is rewound after. Thus, the whole stream is uploaded in step 2, regardless of the stream's initial offset. As a result, if the stream has an initial offset, the integrity check in step 3 fails.

A few people have run into this issue[^3] and the root cause is not immediately obvious from the error raised by Active Storage.

### Solution

If the stream is at end-of-stream (i.e. if `io.eof?` is true), then the user most likely expects the whole stream to be uploaded. So let's rewind the stream in that case.

If the stream has an offset but is not at end-of-stream, then the user could arguably expect the stream to be uploaded from the offset. In that case, rewinding the stream would be surprising behaviour. Therefore, let's preserve the existing behaviour in this scenario, i.e. raise an `IntegrityError`. Ideally, we would bail out earlier with a more helpful error but I wasn't sure where to raise so I'm leaving this as a follow-up.

### Checklist

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message.
* [x] Tests are added or updated if you fix a bug or add a feature.



[^1]: https://github.com/rails/rails/blob/v8.0.0/activestorage/app/models/active_storage/blob.rb#L348-L359
[^2]: https://github.com/rails/rails/blob/v8.0.0/activestorage/lib/active_storage/service/disk_service.rb#L163-L168
[^3]: https://stackoverflow.com/questions/52335835/when-is-activestorageintegrityerror-raised