### PR TITLE
Fix infinite loop computing ERB dependencies with non-trailing interpolations

### DIFF
--- a/actionview/lib/action_view/dependency_tracker/erb_tracker.rb
+++ b/actionview/lib/action_view/dependency_tracker/erb_tracker.rb
@@ -122,23 +122,26 @@ module ActionView
             wildcard_dependency = +""
 
             while !scanner.eos?
-              next unless scanner.scan_until(/\#{/)
+              if scanner.scan_until(/\#{/)
+                unmatched_brackets = 1
+                wildcard_dependency << scanner.pre_match
 
-              unmatched_brackets = 1
-              wildcard_dependency << scanner.pre_match
+                while unmatched_brackets > 0 && !scanner.eos?
+                  scanner.scan_until(/[{}]/)
 
-              while unmatched_brackets > 0 && !scanner.eos?
-                scanner.scan_until(/[{}]/)
-
-                case scanner.matched
-                when "{"
-                  unmatched_brackets += 1
-                when "}"
-                  unmatched_brackets -= 1
+                  case scanner.matched
+                  when "{"
+                    unmatched_brackets += 1
+                  when "}"
+                    unmatched_brackets -= 1
+                  end
                 end
-              end
 
-              wildcard_dependency << "*"
+                wildcard_dependency << "*"
+              else
+                wildcard_dependency << scanner.rest
+                scanner.terminate
+              end
             end
 
             dependencies << wildcard_dependency

--- a/actionview/test/template/dependency_tracker_test.rb
+++ b/actionview/test/template/dependency_tracker_test.rb
@@ -235,6 +235,18 @@ module SharedTrackerTests
 
     assert_equal ["events/_completed", "events/_event", "events/index"], tracker.dependencies
   end
+
+  def test_dependencies_with_interpolation_non_trailing
+    view_paths = ActionView::PathSet.new([File.expand_path("../fixtures/digestor", __dir__)])
+
+    template = FakeTemplate.new(%q{
+      <%= render "#{type}/comments" %>
+    }, :erb)
+
+    tracker = make_tracker("interpolation/_string", template, view_paths)
+
+    assert_equal [ "*/comments" ], tracker.dependencies
+  end
 end
 
 class ERBTrackerTest < ActiveSupport::TestCase


### PR DESCRIPTION
### Motivation / Background

Fix infinite loop computing ERB dependencies with non-trailing interpolations

### Detail

Calling
```ruby
ActionView::DependencyTracker::ERBTracker#add_static_dependency( [], "test/\#{bucket.bucketable_name.pluralize}/status/show", "\"")
```
Will loop indefinitely. I noticed it because after a Rails bump our CI timed out 😅. Fixes it by parsing only template strings with a trailing template interpolation.

From my understrading of https://github.com/rails/rails/pull/50944 this is the desired behaviour but I've a naive knowledge of this part of Rails so please correct me if I'm wrong. 

/cc @skipkayhil @jhawthorn 

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
