### PR TITLE
Avoid passing extraneous options to Renderers like `render json:`

### DIFF
--- a/actionpack/lib/action_controller/metal/renderers.rb
+++ b/actionpack/lib/action_controller/metal/renderers.rb
@@ -154,7 +154,8 @@ module ActionController
     end
 
     add :json do |json, options|
-      json = json.to_json(options) unless json.kind_of?(String)
+      json_options = options.except(:callback, :content_type, :status)
+      json = json.to_json(json_options) unless json.kind_of?(String)
 
       if options[:callback].present?
         if media_type.nil? || media_type == Mime[:json]

--- a/actionpack/test/controller/render_json_test.rb
+++ b/actionpack/test/controller/render_json_test.rb
@@ -17,6 +17,12 @@ class RenderJsonTest < ActionController::TestCase
     end
   end
 
+  class InspectOptions
+    def as_json(options = {})
+      { options: options }
+    end
+  end
+
   class TestController < ActionController::Base
     protect_from_forgery
 
@@ -58,6 +64,10 @@ class RenderJsonTest < ActionController::TestCase
 
     def render_json_without_options
       render json: JsonRenderable.new
+    end
+
+    def render_json_inspect_options
+      render json: InspectOptions.new
     end
   end
 
@@ -123,5 +133,10 @@ class RenderJsonTest < ActionController::TestCase
   def test_render_json_calls_to_json_from_object
     get :render_json_without_options
     assert_equal '{"a":"b"}', @response.body
+  end
+
+  def test_render_json_avoids_view_options
+    get :render_json_inspect_options
+    assert_equal '{"options":{}}', @response.body
   end
 end

--- a/actionview/lib/action_view/layouts.rb
+++ b/actionview/lib/action_view/layouts.rb
@@ -347,7 +347,7 @@ module ActionView
         end
     end
 
-    def _normalize_options(options) # :nodoc:
+    def _process_render_template_options(options) # :nodoc:
       super
 
       if _include_layout?(options)

--- a/actionview/lib/action_view/rendering.rb
+++ b/actionview/lib/action_view/rendering.rb
@@ -118,6 +118,7 @@ module ActionView
 
     def render_to_body(options = {})
       _process_options(options)
+      _process_render_template_options(options)
       _render_template(options)
     end
 
@@ -173,8 +174,7 @@ module ActionView
       end
 
       # Normalize options.
-      def _normalize_options(options)
-        options = super(options)
+      def _process_render_template_options(options)
         if options[:partial] == true
           options[:partial] = action_name
         end
@@ -184,7 +184,6 @@ module ActionView
         end
 
         options[:template] ||= (options[:action] || action_name).to_s
-        options
       end
   end
 end

--- a/actionview/test/actionpack/abstract/abstract_controller_test.rb
+++ b/actionview/test/actionpack/abstract/abstract_controller_test.rb
@@ -212,7 +212,6 @@ module AbstractController
         end
 
         def render_to_body(options = {})
-          options[:_layout] = options[:layout] || _default_layout({})
           super
         end
     end


### PR DESCRIPTION
`.to_json` has a fast path when we pass it no options. Previously `render json:` would pass through a bunch of Action View related options.

This aims to avoid that by only adding the additional Action View options when we are rendering a template, which _should_ be faster and more desirable anyways.

The second commit additionally skips `:callback`, `:content_type`, and `:status`, which are handled inside Action Controller (I'm less happy with this fix, but think it's a pragmatic improvement).

I'm not 100% sure nothing external would have depended on these, though I think nothing _should_.


```
class InspectOptions
  def as_json(options = {})
    options
  end
end

render json: InspectOptions.new
```

**Before:** `{"prefixes":["controller_name"],"template":"action_name","layout":{}}`
**After:** `{}`