### PR TITLE
Fix #52986 - New Rails project includes a Rubocop violation

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
@@ -109,7 +109,7 @@ Rails.application.configure do
   config.active_record.dump_schema_after_migration = false
 
   # Only use :id for inspections in production.
-  config.active_record.attributes_for_inspect = [:id]
+  config.active_record.attributes_for_inspect = [ :id ]
   <%- end -%>
 
   # Enable DNS rebinding protection and other `Host` header attacks.


### PR DESCRIPTION


<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created because a freshly generated Rails project contains a linter violation despite of its custom Rails omakase Rubocop rules.

### Detail
This Pull Request edits the offending line to be compliant with the Rubocop style a new Rails project ships with.

### Additional information
While the commented-out rule in a new Rails project’s .rubocop.yml suggests that exactly this rule is subject to some controversy, it seems odd to have `rails new` generate a project that already contains violations.

I see four options:

- Un-comment the custom rule from the generated .rubocop.yml that would not make this fail
- Exclude config/environments/production.rb from rubocop linting (of this rule)
- Disable the rule for the line in /config/environments/production.rb
- Use spaces to conform to the rule

Out of the four, this PR suggests to conform to the rules the project ships with by standard.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
