### PR TITLE
Fix #52986

### DIFF
--- a/actionmailbox/test/test_helper.rb
+++ b/actionmailbox/test/test_helper.rb
@@ -6,7 +6,7 @@ ENV["RAILS_ENV"] = "test"
 ENV["RAILS_INBOUND_EMAIL_PASSWORD"] = "tbsy84uSV1Kt3ZJZELY2TmShPRs91E3yL4tzf96297vBCkDWgL"
 
 require_relative "../test/dummy/config/environment"
-ActiveRecord::Migrator.migrations_paths = [File.expand_path("../test/dummy/db/migrate", __dir__)]
+ActiveRecord::Migrator.migrations_paths = [ File.expand_path("../test/dummy/db/migrate", __dir__) ]
 require "rails/test_help"
 
 require "webmock/minitest"

--- a/actiontext/test/test_helper.rb
+++ b/actiontext/test/test_helper.rb
@@ -7,7 +7,7 @@ ENV["RAILS_ENV"] = "test"
 
 require_relative "../test/dummy/config/environment"
 require "active_record/testing/query_assertions"
-ActiveRecord::Migrator.migrations_paths = [File.expand_path("../test/dummy/db/migrate", __dir__)]
+ActiveRecord::Migrator.migrations_paths = [ File.expand_path("../test/dummy/db/migrate", __dir__) ]
 require "rails/test_help"
 
 require "rails/test_unit/reporter"

--- a/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
@@ -109,7 +109,7 @@ Rails.application.configure do
   config.active_record.dump_schema_after_migration = false
 
   # Only use :id for inspections in production.
-  config.active_record.attributes_for_inspect = [:id]
+  config.active_record.attributes_for_inspect = [ :id ]
   <%- end -%>
 
   # Enable DNS rebinding protection and other `Host` header attacks.

--- a/railties/lib/rails/generators/rails/plugin/templates/test/test_helper.rb.tt
+++ b/railties/lib/rails/generators/rails/plugin/templates/test/test_helper.rb.tt
@@ -3,7 +3,7 @@ ENV["RAILS_ENV"] = "test"
 
 require_relative "<%= File.join("..", options[:dummy_path], "config/environment") -%>"
 <% unless options[:skip_active_record] -%>
-ActiveRecord::Migrator.migrations_paths = [File.expand_path("../<%= options[:dummy_path] -%>/db/migrate", __dir__)]
+ActiveRecord::Migrator.migrations_paths = [ File.expand_path("../<%= options[:dummy_path] -%>/db/migrate", __dir__) ]
 <% if options[:mountable] -%>
 ActiveRecord::Migrator.migrations_paths << File.expand_path("../db/migrate", __dir__)
 <% end -%>
@@ -13,7 +13,7 @@ require "rails/test_help"
 <% unless options[:skip_active_record] -%>
 # Load fixtures from the engine
 if ActiveSupport::TestCase.respond_to?(:fixture_paths=)
-  ActiveSupport::TestCase.fixture_paths = [File.expand_path("fixtures", __dir__)]
+  ActiveSupport::TestCase.fixture_paths = [ File.expand_path("fixtures", __dir__) ]
   ActionDispatch::IntegrationTest.fixture_paths = ActiveSupport::TestCase.fixture_paths
   ActiveSupport::TestCase.file_fixture_path = File.expand_path("fixtures", __dir__) + "/files"
   ActiveSupport::TestCase.fixtures :all

--- a/railties/test/generators/shared_generator_tests.rb
+++ b/railties/test/generators/shared_generator_tests.rb
@@ -385,6 +385,16 @@ module SharedGeneratorTests
     assert_file "myproject/Gemfile", %r{^gem ["']rails["'], github: ["']rails/rails["'], branch: ["']main["']$}
   end
 
+  def test_generated_files_have_no_rubocop_warnings
+    run_generator
+
+    Dir.chdir(destination_root) do
+      output = `./bin/rubocop`
+
+      assert_predicate $?, :success?, "bin/rubocop did not exit successfully:\n#{output}"
+    end
+  end
+
   private
     def assert_load_defaults
     end


### PR DESCRIPTION

<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created because a freshly generated Rails project contains a linter violation despite of its custom Rails omakase Rubocop rules.

### Detail
This Pull Request edits the offending line to be compliant with the Rubocop style a new Rails project ships with.

### Additional information
While the commented-out rule in a new Rails project’s .rubocop.yml suggests that exactly this rule is subject to some controversy, it seems odd to have `rails new` generate a project that already contains violations.

I see four options:

- Un-comment the custom rule from the generated .rubocop.yml that would not make this fail
- Exclude config/environments/production.rb from rubocop linting (of this rule)
- Disable the rule for the line in /config/environments/production.rb
- Use spaces to conform to the rule

Out of the four, this PR suggests to conform to the rules the project ships with by standard.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
