### PR TITLE
Turn SuckerPunch removal into deprecation and point to async adapter

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -104,6 +104,7 @@ group :job do
   gem "resque", require: false
   gem "resque-scheduler", require: false
   gem "sidekiq", require: false
+  gem "sucker_punch", require: false
   gem "delayed_job", require: false
   gem "queue_classic", ">= 4.0.0", require: false, platforms: :ruby
   gem "sneakers", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -585,6 +585,8 @@ GEM
     stimulus-rails (1.3.0)
       railties (>= 6.0.0)
     stringio (3.1.1)
+    sucker_punch (3.2.0)
+      concurrent-ruby (~> 1.0)
     syntax_tree (6.1.1)
       prettier_print (>= 1.2.0)
     tailwindcss-rails (2.1.0)
@@ -712,6 +714,7 @@ DEPENDENCIES
   sqlite3 (>= 2.0)
   stackprof
   stimulus-rails
+  sucker_punch
   syntax_tree (= 6.1.1)
   tailwindcss-rails
   terser (>= 1.1.4)

--- a/activejob/CHANGELOG.md
+++ b/activejob/CHANGELOG.md
@@ -1,7 +1,8 @@
-*   Remove `sucker_punch` as an adapter option [since author himself recommends using AJ's own AsyncAdapter](https://github.com/brandonhilkert/sucker_punch?tab=readme-ov-file#faq).
+*   Deprecate `sucker_punch` as an adapter option.
+
     If you're using this adapter, change to `adapter: async` for the same functionality.
 
-    *Dino Maric*
+    *Dino Maric, zzak*
 
 *   Use `RAILS_MAX_THREADS` in `ActiveJob::AsyncAdapter`. If it is not set, use 5 as default.
 

--- a/activejob/Rakefile
+++ b/activejob/Rakefile
@@ -2,7 +2,7 @@
 
 require "rake/testtask"
 
-ACTIVEJOB_ADAPTERS = %w(async inline delayed_job queue_classic resque sidekiq sneakers backburner test)
+ACTIVEJOB_ADAPTERS = %w(async inline delayed_job queue_classic resque sidekiq sneakers sucker_punch backburner test)
 ACTIVEJOB_ADAPTERS.delete("queue_classic") if defined?(JRUBY_VERSION)
 
 task default: :test

--- a/activejob/lib/active_job/queue_adapter.rb
+++ b/activejob/lib/active_job/queue_adapter.rb
@@ -50,6 +50,7 @@ module ActiveJob
         case name_or_adapter
         when Symbol, String
           queue_adapter = ActiveJob::QueueAdapters.lookup(name_or_adapter).new
+          queue_adapter.try(:check_adapter)
           assign_adapter(name_or_adapter.to_s, queue_adapter)
         else
           if queue_adapter?(name_or_adapter)

--- a/activejob/lib/active_job/queue_adapters.rb
+++ b/activejob/lib/active_job/queue_adapters.rb
@@ -121,6 +121,7 @@ module ActiveJob
     autoload :ResqueAdapter
     autoload :SidekiqAdapter
     autoload :SneakersAdapter
+    autoload :SuckerPunchAdapter
     autoload :TestAdapter
 
     ADAPTER = "Adapter"

--- a/activejob/lib/active_job/queue_adapters/sucker_punch_adapter.rb
+++ b/activejob/lib/active_job/queue_adapters/sucker_punch_adapter.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require "sucker_punch"
+
+module ActiveJob
+  module QueueAdapters
+    # = Sucker Punch adapter for Active Job
+    #
+    # Sucker Punch is a single-process Ruby asynchronous processing library.
+    # This reduces the cost of hosting on a service like Heroku along
+    # with the memory footprint of having to maintain additional jobs if
+    # hosting on a dedicated server. All queues can run within a
+    # single application (e.g. \Rails, Sinatra, etc.) process.
+    #
+    # Read more about Sucker Punch {here}[https://github.com/brandonhilkert/sucker_punch].
+    #
+    # To use Sucker Punch set the queue_adapter config to +:sucker_punch+.
+    #
+    #   Rails.application.config.active_job.queue_adapter = :sucker_punch
+    class SuckerPunchAdapter < AbstractAdapter
+      def enqueue(job) # :nodoc:
+        if JobWrapper.respond_to?(:perform_async)
+          # sucker_punch 2.0 API
+          JobWrapper.perform_async job.serialize
+        else
+          # sucker_punch 1.0 API
+          JobWrapper.new.async.perform job.serialize
+        end
+      end
+
+      def enqueue_at(job, timestamp) # :nodoc:
+        if JobWrapper.respond_to?(:perform_in)
+          delay = timestamp - Time.current.to_f
+          JobWrapper.perform_in delay, job.serialize
+        else
+          raise NotImplementedError, "sucker_punch 1.0 does not support `enqueue_at`. Please upgrade to version ~> 2.0.0 to enable this behavior."
+        end
+      end
+
+      class JobWrapper # :nodoc:
+        include SuckerPunch::Job
+
+        def perform(job_data)
+          Base.execute job_data
+        end
+      end
+    end
+  end
+end

--- a/activejob/lib/active_job/queue_adapters/sucker_punch_adapter.rb
+++ b/activejob/lib/active_job/queue_adapters/sucker_punch_adapter.rb
@@ -18,6 +18,13 @@ module ActiveJob
     #
     #   Rails.application.config.active_job.queue_adapter = :sucker_punch
     class SuckerPunchAdapter < AbstractAdapter
+      def check_adapter
+        ActiveJob.deprecator.warn <<~MSG.squish
+          The `sucker_punch` adapter is deprecated and will be removed in Rails 8.1.
+          Please use the `async` adapter instead.
+        MSG
+      end
+
       def enqueue(job) # :nodoc:
         if JobWrapper.respond_to?(:perform_async)
           # sucker_punch 2.0 API

--- a/activejob/test/adapters/sucker_punch.rb
+++ b/activejob/test/adapters/sucker_punch.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+require "sucker_punch/testing/inline"
+ActiveJob::Base.queue_adapter = :sucker_punch

--- a/activejob/test/cases/adapter_test.rb
+++ b/activejob/test/cases/adapter_test.rb
@@ -6,4 +6,31 @@ class AdapterTest < ActiveSupport::TestCase
   test "should load #{ENV['AJ_ADAPTER']} adapter" do
     assert_equal "active_job/queue_adapters/#{ENV['AJ_ADAPTER']}_adapter".classify, ActiveJob::Base.queue_adapter.class.name
   end
+
+  if adapter_is?(:sucker_punch)
+    test "sucker_punch adapter should be deprecated" do
+      before_adapter = ActiveJob::Base.queue_adapter
+
+      msg = <<~MSG.squish
+        The `sucker_punch` adapter is deprecated and will be removed in Rails 8.1.
+        Please use the `async` adapter instead.
+      MSG
+      assert_deprecated(msg, ActiveJob.deprecator) do
+        ActiveJob::Base.queue_adapter = :sucker_punch
+      end
+
+    ensure
+      ActiveJob::Base.queue_adapter = before_adapter
+    end
+
+    test "sucker_punch check_adapter should warn" do
+      msg = <<~MSG.squish
+        The `sucker_punch` adapter is deprecated and will be removed in Rails 8.1.
+        Please use the `async` adapter instead.
+      MSG
+      assert_deprecated(msg, ActiveJob.deprecator) do
+        ActiveJob::Base.queue_adapter.check_adapter
+      end
+    end
+  end
 end

--- a/activejob/test/cases/test_case_test.rb
+++ b/activejob/test/cases/test_case_test.rb
@@ -41,6 +41,8 @@ class ActiveJobTestCaseTest < ActiveJob::TestCase
                  ActiveJob::QueueAdapters::SidekiqAdapter
                when :sneakers
                  ActiveJob::QueueAdapters::SneakersAdapter
+               when :sucker_punch
+                 ActiveJob::QueueAdapters::SuckerPunchAdapter
                else
                  raise NotImplementedError.new
     end

--- a/activejob/test/integration/queuing_test.rb
+++ b/activejob/test/integration/queuing_test.rb
@@ -13,7 +13,7 @@ class QueuingTest < ActiveSupport::TestCase
     assert_job_executed
   end
 
-  unless adapter_is?(:inline, :async)
+  unless adapter_is?(:inline, :async, :sucker_punch)
     test "should not run jobs queued on a non-listening queue" do
       old_queue = TestJob.queue_name
 

--- a/activejob/test/support/integration/adapters/sucker_punch.rb
+++ b/activejob/test/support/integration/adapters/sucker_punch.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module SuckerPunchJobsManager
+  def setup
+    ActiveJob::Base.queue_adapter = :sucker_punch
+    SuckerPunch.logger = nil
+  end
+end


### PR DESCRIPTION
Follow up to #52935 as requested by @matthewd 

This gives people a chance to fix their apps while upgrading Rails, with a warning that tells them about the `async` adapter.