### PR TITLE
Add reload! as a IRB::HelperMethod so it can be combined with other commands in a single statement. Fixes rails/rails#52982

### DIFF
--- a/railties/lib/rails/commands/console/irb_console.rb
+++ b/railties/lib/rails/commands/console/irb_console.rb
@@ -51,7 +51,16 @@ module Rails
       end
     end
 
-    class Reloader < IRB::Command::Base
+    class ReloadHelper < RailsHelperBase
+      description "Reloads the Rails application."
+
+      def execute
+        puts "Reloading..."
+        Rails.application.reloader.reload!
+      end
+    end
+
+    class ReloadCommand < IRB::Command::Base
       include ConsoleMethods
 
       category "Rails console"
@@ -67,7 +76,8 @@ module Rails
     IRB::HelperMethod.register(:controller, ControllerInstance)
     IRB::HelperMethod.register(:new_session, NewSession)
     IRB::HelperMethod.register(:app, AppInstance)
-    IRB::Command.register(:reload!, Reloader)
+    IRB::HelperMethod.register(:reload!, ReloadHelper)
+    IRB::Command.register(:reload!, ReloadCommand)
 
     class IRBConsole
       def initialize(app)


### PR DESCRIPTION
Fixes rails/rails#52982

It is useful to iterate and test in the console by reloading and executing something in a single line command. Something like:

reload!; Post.find(123).test_a_thing

This makes it easy to quickly switch to the console, hit up and enter to re-execute after a code change.

This restores functionality that used to work until a few months ago.
