### PR TITLE
Generate the correct bin/test command for railtie CI config

### DIFF
--- a/railties/lib/rails/generators/rails/plugin/plugin_generator.rb
+++ b/railties/lib/rails/generators/rails/plugin/plugin_generator.rb
@@ -489,9 +489,11 @@ module Rails
 
       def test_command
         if engine? && !options[:skip_active_record] && with_dummy_app?
-          "db:test:prepare test"
+          "bin/rails db:test:prepare test"
+        elsif engine?
+          "bin/rails test"
         else
-          "test"
+          "bin/test"
         end
       end
     end

--- a/railties/lib/rails/generators/rails/plugin/templates/github/ci.yml.tt
+++ b/railties/lib/rails/generators/rails/plugin/templates/github/ci.yml.tt
@@ -90,7 +90,7 @@ jobs:
           DATABASE_URL: postgres://postgres:postgres@localhost:5432
           <%- end -%>
           # REDIS_URL: redis://localhost:6379/0
-        run: bin/rails <%= test_command %>
+        run: <%= test_command %>
 
       - name: Keep screenshots from failed system tests
         uses: actions/upload-artifact@v4

--- a/railties/test/generators/plugin_generator_test.rb
+++ b/railties/test/generators/plugin_generator_test.rb
@@ -915,6 +915,21 @@ class PluginGeneratorTest < Rails::Generators::TestCase
     Object.send(:remove_const, "ENGINE_ROOT")
   end
 
+  def test_railtie_test_command
+    run_generator [destination_root]
+    assert_file ".github/workflows/ci.yml", /run: bin\/test/
+  end
+
+  def test_engine_test_command
+    run_generator [destination_root, "--full"]
+    assert_file ".github/workflows/ci.yml", /run: bin\/rails db:test:prepare test/
+  end
+
+  def test_engine_without_active_record_test_command
+    run_generator [destination_root, "--full", "--skip-active-record"]
+    assert_file ".github/workflows/ci.yml", /run: bin\/rails test/
+  end
+
   private
     def action(*args, &block)
       silence(:stdout) { generator.send(*args, &block) }


### PR DESCRIPTION
When generating a Railtie plugin, the GitHub Actions ci.yml generates `bin/rails test` even though it uses `bin/test` instead. 

This makes sure that engines use `bin/rails` and railties use `bin/test`