### PR TITLE
Add TaggedLogging#logger constructor for more pleasant logging interface

### DIFF
--- a/activesupport/lib/active_support/tagged_logging.rb
+++ b/activesupport/lib/active_support/tagged_logging.rb
@@ -113,6 +113,11 @@ module ActiveSupport
       end
     end
 
+    # Returns an `ActiveSupport::Logger` that has already been wrapped with tagged logging concern.
+    def self.logger(*args, **kwargs)
+      new ActiveSupport::Logger.new(*args, **kwargs)
+    end
+
     def self.new(logger)
       logger = logger.clone
 

--- a/activesupport/test/tagged_logging_test.rb
+++ b/activesupport/test/tagged_logging_test.rb
@@ -142,6 +142,14 @@ class TaggedLoggingTest < ActiveSupport::TestCase
 
     assert_equal "[BCX] [Jason] Funky time\n[BCX] Junky time!\n", @output.string
   end
+
+  test "implicit logger instance" do
+    @output = StringIO.new
+    @logger = ActiveSupport::TaggedLogging.logger(@output)
+
+    @logger.tagged("BCX") { @logger.info "Funky time" }
+    assert_equal "[BCX] Funky time\n", @output.string
+  end
 end
 
 class TaggedLoggingWithoutBlockTest < ActiveSupport::TestCase

--- a/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
@@ -55,7 +55,7 @@ Rails.application.configure do
 
   # Log to STDOUT with the current request id as a default log tag.
   config.log_tags = [ :request_id ]
-  config.logger   = ActiveSupport::TaggedLogging.new(ActiveSupport::Logger.new(STDOUT))
+  config.logger   = ActiveSupport::TaggedLogging.logger(STDOUT)
 
   # "info" includes generic and useful information about system operation, but avoids logging too much
   # information to avoid inadvertent exposure of personally identifiable information (PII). If you


### PR DESCRIPTION
No need to expose such crude welding in a configuration file.