### PR TITLE
Convert values in `ActionController::Parameters#[]=`

### DIFF
--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -814,7 +814,7 @@ module ActionController
     # Assigns a value to a given `key`. The given key may still get filtered out
     # when #permit is called.
     def []=(key, value)
-      @parameters[key] = value
+      @parameters[key] = convert_value_to_parameters(value)
     end
 
     # Returns a parameter for the given `key`. If the `key` can't be found, there

--- a/actionpack/test/controller/parameters/accessors_test.rb
+++ b/actionpack/test/controller/parameters/accessors_test.rb
@@ -444,15 +444,12 @@ class ParametersAccessorsTest < ActiveSupport::TestCase
     assert_nil(params.extract_value(:non_existent_key))
   end
 
-  def test_to_h_raises_error_when_unpermitted_only_after_access
+  def test_to_h_raises_error_when_unpermitted
     params = ActionController::Parameters.new(name: "Bruce").permit(:name)
     assert_equal({ "name" => "Bruce" }, params.to_h)
 
     guitar = { "make" => "Fender", "model" => "Telecaster" }
     params[:guitar] = guitar
-    assert_equal({ "name" => "Bruce", "guitar" => guitar }, params.to_h)
-
-    assert_equal(ActionController::Parameters.new(guitar), params[:guitar])
     assert_raises(ActionController::UnfilteredParameters) { params.to_h }
   end
 end

--- a/actionpack/test/controller/parameters/accessors_test.rb
+++ b/actionpack/test/controller/parameters/accessors_test.rb
@@ -42,6 +42,15 @@ class ParametersAccessorsTest < ActiveSupport::TestCase
     assert_not_predicate @params[:person][:name], :permitted?
   end
 
+  test "[] converts hashes to parameters" do
+    params = ActionController::Parameters.new(name: "Bruce").permit(:name)
+    assert_equal({ "name" => "Bruce" }, params.to_h)
+
+    guitar = { "make" => "Fender", "model" => "Telecaster" }
+    params[:guitar] = guitar
+    assert_equal(ActionController::Parameters.new(guitar), params[:guitar])
+  end
+
   test "as_json returns the JSON representation of the parameters hash" do
     assert_not @params.as_json.key? "parameters"
     assert_not @params.as_json.key? "permitted"
@@ -433,5 +442,17 @@ class ParametersAccessorsTest < ActiveSupport::TestCase
     assert_equal(["ruby", "rails", "web"], params.extract_value(:tags, delimiter: ","))
     assert_equal(["", "ruby", "", "rails", ""], params.extract_value(:blank_tags, delimiter: ","))
     assert_nil(params.extract_value(:non_existent_key))
+  end
+
+  def test_to_h_raises_error_when_unpermitted_only_after_access
+    params = ActionController::Parameters.new(name: "Bruce").permit(:name)
+    assert_equal({ "name" => "Bruce" }, params.to_h)
+
+    guitar = { "make" => "Fender", "model" => "Telecaster" }
+    params[:guitar] = guitar
+    assert_equal({ "name" => "Bruce", "guitar" => guitar }, params.to_h)
+
+    assert_equal(ActionController::Parameters.new(guitar), params[:guitar])
+    assert_raises(ActionController::UnfilteredParameters) { params.to_h }
   end
 end

--- a/actionpack/test/controller/parameters/mutators_test.rb
+++ b/actionpack/test/controller/parameters/mutators_test.rb
@@ -218,14 +218,13 @@ class ParametersMutatorsTest < ActiveSupport::TestCase
     assert_raises(ActionController::UnfilteredParameters) { params.to_h { |key, value| [key, value] } }
   end
 
-  test "[]= does not convert hashes to parameters" do
+  test "[]= converts hashes to parameters" do
     params = ActionController::Parameters.new(name: "Bruce")
     guitar = { "make" => "Fender", "model" => "Telecaster" }
     params[:guitar] = guitar
-
     assert_equal(
-      guitar,
-      params.instance_variable_get(:@parameters)[:guitar], # bypass #Parameters#[], which itself converts hashes to parameters
+      ActionController::Parameters.new(guitar),
+      params.instance_variable_get(:@parameters)[:guitar], # bypass #Parameters#[], which also converts hashes to parameters
     )
   end
 end

--- a/actionpack/test/controller/parameters/mutators_test.rb
+++ b/actionpack/test/controller/parameters/mutators_test.rb
@@ -217,4 +217,15 @@ class ParametersMutatorsTest < ActiveSupport::TestCase
     params = ActionController::Parameters.new(name: "Alex", age: "40", location: "Beijing")
     assert_raises(ActionController::UnfilteredParameters) { params.to_h { |key, value| [key, value] } }
   end
+
+  test "[]= does not convert hashes to parameters" do
+    params = ActionController::Parameters.new(name: "Bruce")
+    guitar = { "make" => "Fender", "model" => "Telecaster" }
+    params[:guitar] = guitar
+
+    assert_equal(
+      guitar,
+      params.instance_variable_get(:@parameters)[:guitar], # bypass #Parameters#[], which itself converts hashes to parameters
+    )
+  end
 end


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

Currently, values are converted on `ActionController::Parameters#[]`, but not on `[]=`, which can cause unexpected behavior changes before and after reading a value.

```ruby
require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"
  gem "rails"
end

require "action_controller/railtie"
require "minitest/autorun"

class BugTest < Minitest::Test
  def test_accessing_subkey_does_not_break_to_h
    params = ActionController::Parameters.new(name: "Bruce").permit(:name)
    params[:guitar] = { make: "Fender", model: "Telecaster" }
    expected_params_hash = { "name" => "Bruce", "guitar" => { "make" => "Fender", "model" => "Telecaster" } }

    assert_equal(expected_params_hash, params.to_h) # works
    assert_equal("Telecaster", params[:guitar][:model])
    assert_equal(expected_params_hash, params.to_h) # raises ActionController::UnfilteredParameters
  end
end
```

### Detail

This PR starts by adding tests which document the existing behavior.

Then, `ActionController::Parameters#[]=` is updated to convert the given `value` as needed, and the tests are updated accordingly.

Keeping the commits separate makes it clear what has changed.

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
  _It is unclear if this change warrants a changelog entry._
