### PR TITLE
Stop ignoring old `.env.erb` files from Kamal 1

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/dockerignore.tt
+++ b/railties/lib/rails/generators/rails/app/templates/dockerignore.tt
@@ -7,9 +7,8 @@
 # Ignore bundler config.
 /.bundle
 
-# Ignore all environment files (except templates).
+# Ignore all environment files.
 /.env*
-!/.env*.erb
 
 # Ignore all default key files.
 /config/master.key

--- a/railties/lib/rails/generators/rails/app/templates/gitignore.tt
+++ b/railties/lib/rails/generators/rails/app/templates/gitignore.tt
@@ -7,9 +7,8 @@
 # Ignore bundler config.
 /.bundle
 
-# Ignore all environment files (except templates).
+# Ignore all environment files.
 /.env*
-!/.env*.erb
 
 # Ignore all logfiles and tempfiles.
 /log/*


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because Kamal 1 `.env.erb` files are mentioned in ignore files for new Rails apps, but these files are not generated any more, because new Rails 8 apps are now using Kamal 2. So it seems that mentioning `.env.erb` is not needed any more.

### Detail

This Pull Request removes `.env.erb` exceptions from `gitignore` and `dockerignore` templates.
There is no need to replace the exceptions with a `.kamal/secrets` exception, because it is meant to be [safe for git](https://github.com/rails/rails/blob/592a52b9370df79787d74b1bac9b201891c45054/railties/lib/rails/generators/rails/app/templates/kamal-secrets.tt#L3) by default.

### Additional information

I was tempted to remove the whole environment files section (including `/.env*`) from the ignore files since dotenv files seem to be less on the forefront with Kamal 2. But as mentioned by Rafael in https://github.com/rails/rails/pull/49278, it is a common error for people to check in .env files with potentially sensitive tokens. And since `dotenv` is a dependency in new Rails apps (albeit an indirect one via Kamal), if people decide to use it more explicitly one day, keeping the `/.env*` guardrail in the gitignore files could help them.

Edit: actually after re-reading [this](https://github.com/bkeepers/dotenv?tab=readme-ov-file#should-i-commit-my-env-file) and [this](https://github.com/bkeepers/dotenv?tab=readme-ov-file#customizing-rails), it could be fine to remove the whole section.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
