### PR TITLE
Make `kamal dbc` work with any database

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/deploy.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/deploy.yml.tt
@@ -68,9 +68,7 @@ aliases:
   console: app exec --interactive --reuse "bin/rails console"
   shell: app exec --interactive --reuse "bash"
   logs: app logs -f
-<% if sqlite3? -%>
-  dbc: app exec --interactive --reuse "sqlite3 storage/production.sqlite3"
-<% end -%>
+  dbc: app exec --interactive --reuse "bin/rails dbconsole"
 
 <% unless skip_storage? %>
 # Use a persistent storage volume for sqlite database files and local Active Storage files.


### PR DESCRIPTION
### Motivation / Background

The `kamal dbc` alias currently only works with sqlite3.

`sqlite3 storage/production.sqlite3` is virtually equivalent to doing `bin/rails dbconsole`: both have the same output. But `bin/rails dbconsole` is more generic.

### Detail

Change the alias to use `bin/rails dbconsole`, which works for any generic database, including [dockerized sqlite3 environments](https://github.com/rails/rails/pull/52589).

### Additional information

Feel free to close this PR if `kamal dbc` was intended as an example to showcase calling non-Rails commands.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
