### PR TITLE
Don’t ask for DB password when running `kamal dbc`

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/deploy.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/deploy.yml.tt
@@ -69,7 +69,7 @@ aliases:
   console: app exec --interactive --reuse "bin/rails console"
   shell: app exec --interactive --reuse "bash"
   logs: app logs -f
-  dbc: app exec --interactive --reuse "bin/rails dbconsole"
+  dbc: app exec --interactive --reuse "bin/rails dbconsole --include-password"
 
 <% unless skip_storage? %>
 # Use a persistent storage volume for sqlite database files and local Active Storage files.


### PR DESCRIPTION
Follow-up of https://github.com/rails/rails/pull/53003.

### Problem

`kamal dbc`'s `bin/rails dbconsole` works as is for sqlite3 because it doesn't need a password. But for database servers like Postgres, which are typically deployed with passwords in production, you are prompted to enter a password:

```
Password for user myapp1:
```

### Solution

Use `bin/rails dbconsole --include-password` to reuse the password from database.yml.