### PR TITLE
Introduce zeitwerk:check:boot task

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Introduce `zeitwerk:check:boot` task
+
+    This task boots your application and reports if any autoloaded constants were loaded during the boot
+    process.
+
+    *Andrew Novoselac*
+
 *   Do not include redis by default in generated Dev Containers.
 
     Now that applications use the Solid Queue and Solid Cache gems by default, we do not need to include redis

--- a/railties/lib/rails/tasks/zeitwerk.rake
+++ b/railties/lib/rails/tasks/zeitwerk.rake
@@ -20,6 +20,22 @@ report_unchecked = ->(unchecked) do
   puts
 end
 
+report_autoloads_on_boot = ->(autoloads) do
+  puts
+  puts <<~EOS
+    WARNING: The following autoload constants were loaded during
+    the boot process:
+  EOS
+  puts
+
+  autoloads.each { |constant| puts "  #{constant}" }
+  puts
+
+  puts <<~EOS
+    SUMMARY: #{autoloads.count} autoload constants eagerly loaded during boot.
+  EOS
+end
+
 namespace :zeitwerk do
   desc "Check project structure for Zeitwerk compatibility"
   task check: :environment do
@@ -36,6 +52,22 @@ namespace :zeitwerk do
     else
       report_unchecked[unchecked]
       puts "Otherwise, all is good!"
+    end
+  end
+
+  namespace :check do
+    task boot: :environment do
+      begin
+        autoloads_on_boot = Rails::ZeitwerkChecker.check_boot
+      rescue Zeitwerk::NameError => e
+        abort e.message.sub(/#{Regexp.escape(Rails.root.to_s)}./, "")
+      end
+
+      if autoloads_on_boot.empty?
+        puts "All is good!"
+      else
+        report_autoloads_on_boot[autoloads_on_boot]
+      end
     end
   end
 end

--- a/railties/lib/rails/zeitwerk_checker.rb
+++ b/railties/lib/rails/zeitwerk_checker.rb
@@ -12,4 +12,8 @@ class Rails::ZeitwerkChecker # :nodoc:
     unchecked.select! { |dir| Dir.exist?(dir) && !Dir.empty?(dir)  }
     unchecked
   end
+
+  def self.check_boot
+    Zeitwerk::Registry.loaders.flat_map { |loader| loader.__to_unload.keys }
+  end
 end

--- a/railties/test/application/zeitwerk_checker_test.rb
+++ b/railties/test/application/zeitwerk_checker_test.rb
@@ -80,4 +80,23 @@ class ZeitwerkCheckerTest < ActiveSupport::TestCase
 
     assert_equal ["#{app_path}/dir1", "#{app_path}/dir2"], Rails::ZeitwerkChecker.check.sort
   end
+
+  test "booting the app does not load any autoload constants by default" do
+    boot
+
+    assert_empty Rails::ZeitwerkChecker.check_boot
+  end
+
+  test "loading an autoloaded constant during the boot process is reported" do
+    app_file "app/models/user.rb", "class User < ActiveRecord::Base; end"
+    app_file "config/initializers/extra_config.rb", <<~INITIALIZER
+      Rails.application.config.to_prepare do
+        Rails.application.config.my_favourite_model = User
+      end
+    INITIALIZER
+
+    boot
+
+    assert_equal ["User"], Rails::ZeitwerkChecker.check_boot
+  end
 end


### PR DESCRIPTION


<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

Lately I have been working on not loading constants from autoload directories during my app's boot process.

To get a list of constants that are being autoloaded during the boot process I have been doing something like:

```
bin/rails runner "puts Rails.autoloaders.main.__to_unload.keys"
```

But I think this might be useful for others so why not make it a Rake task.

### Detail

I added a new task in the `zeitwerk` namespace. It boots the app and iterates over all the autloaders and gets a list of "to unload" constants. I realize this is a private api in zeitwerk, so if it's not okay to use in a Rake task like this, or if there is an alternative way to get this info I am missing let me know.

Also I called this `zeitwerk:check:boot` but I am open to alternative suggestions.

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
