### PR TITLE
Fix `#inspect` for ActiveRecord singleton classes

### DIFF
--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -350,7 +350,7 @@ module ActiveRecord
 
       # Returns a string like 'Post(id:integer, title:string, body:text)'
       def inspect # :nodoc:
-        if self == Base
+        if self == Base || singleton_class?
           super
         elsif abstract_class?
           "#{super}(abstract)"

--- a/activerecord/test/cases/core_test.rb
+++ b/activerecord/test/cases/core_test.rb
@@ -47,6 +47,10 @@ class CoreTest < ActiveRecord::TestCase
     assert_match(/Topic id: nil/, Topic.new.inspect)
   end
 
+  def test_inspect_singleton_instance
+    assert_match(/#<Class:#<Topic:\w+>>/, Topic.new.singleton_class.inspect)
+  end
+
   def test_inspect_limited_select_instance
     Topic.stub(:attributes_for_inspect, [:id, :title]) do
       assert_equal %(#<Topic id: 1>), Topic.all.merge!(select: "id", where: "id = 1").first.inspect


### PR DESCRIPTION
Fixes #53013.

