### PR TITLE
Update Guide on Multi-Database Configuration to mention DATABASE_URL impacts [ci skip]

### DIFF
--- a/guides/CHANGELOG.md
+++ b/guides/CHANGELOG.md
@@ -7,4 +7,10 @@
 
     *Petrik de Heus*
 
+*   The guide _Active Record Multiple Databases_ has been updated to explain that
+    when you switch to a multi database setup, the DATABASE_URL environment
+    variable is no longer automatically used for the primary database.
+
+    *Hampton Lintorn-Catlin*
+
 Please check [7-2-stable](https://github.com/rails/rails/blob/7-2-stable/guides/CHANGELOG.md) for previous changes.

--- a/guides/source/active_record_multiple_databases.md
+++ b/guides/source/active_record_multiple_databases.md
@@ -102,6 +102,17 @@ Lastly, for new writer databases, you need to set the `migrations_paths` key to 
 where you will store migrations for that database. We'll look more at `migrations_paths`
 later on in this guide.
 
+NOTE: Multiple database configurations do not automatically use the
+DATABASE_URL environment variable. If you want to use the DATABASE_URL
+environment variable, you can pass it directly in the configuration file.
+
+```yaml
+production:
+   primary:
+      url: <%= ENV['DATABASE_URL'] %>
+   ...
+```
+
 You can also configure the schema dump file by setting `schema_dump` to a custom schema file name
 or completely skip the schema dumping by setting `schema_dump: false`.
 


### PR DESCRIPTION
The Guide on Multiple Databases has a NOTE added that addresses a potential gotcha (thatgotma’) where migrating to a multi-database setup means that the DATABASE_URL configuration method that is often used in simpler application stops working entirely.

The solution to this is shown if the user wants to keep using that method with an explicit `url:` configuration example.

Hopefully this will help out the next person from not being surprised!

### Motivation / Background

When you move from a single-database setup to a multi-database configuration (which is how SolidQueue recommends, even for simple apps), the DATABASE_URL autoconfiguration method of the `primary` database stops working.

This caused me to crash my production environment and I couldn't figure out what was wrong for many hours.

Hopefully this will give someone else a heads up!

### Detail

The guide is updated with a NOTE, and also some sample configuration that allows you to continue to use DATABASE_URL.


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
