### PR TITLE
Infer default `:inverse_of` option for `delegated_type`

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,15 @@
+*   Infer default `:inverse_of` option for `delegated_type` definitions when `config.active_record.automatic_scope_inversing = true`
+
+    ```ruby
+    class Entry < ApplicationRecord
+      # When `config.active_record.automatic_scope_inversing = true`,
+      # automatically infer `inverse_of: :entry` option
+      delegated_type :entryable, types: %w[ Message ]
+    end
+    ```
+
+    *Sean Doyle*
+
 *   Yield the transaction object to the block when using `with_lock`.
 
     *Ngan Pham*

--- a/activerecord/lib/active_record/delegated_type.rb
+++ b/activerecord/lib/active_record/delegated_type.rb
@@ -207,6 +207,15 @@ module ActiveRecord
     # The +options+ are passed directly to the +belongs_to+ call, so this is where you declare +dependent+ etc.
     # The following options can be included to specialize the behavior of the delegated type convenience methods.
     #
+    # [+:inverse_of+]
+    #   Specifies the name of the +has_one+ association on the associated object
+    #   that is the inverse of this +belongs_to+ association.
+    #   When +config.active_record.automatic_scope_inversing+ is true, the
+    #   singularized class name is inferred unless a +:foreign_key+ option is
+    #   also provided. For example, declaring <tt>delegated_type :entryable</tt>
+    #   will infer <tt>inverse_of: :entry</tt>.
+    #   See ActiveRecord::Associations::ClassMethods's overview on Bi-directional
+    #   associations for more detail.
     # [+:foreign_key+]
     #   Specify the foreign key used for the convenience methods. By default this is guessed to be the passed
     #   +role+ with an "_id" suffix. So a class that defines a
@@ -229,6 +238,10 @@ module ActiveRecord
     #   @entry.message_uuid # => returns entryable_uuid, when entryable_type == "Message", otherwise nil
     #   @entry.comment_uuid # => returns entryable_uuid, when entryable_type == "Comment", otherwise nil
     def delegated_type(role, types:, **options)
+      if automatic_scope_inversing && !(options.key?(:inverse_of) || options.key?(:foreign_key))
+        options[:inverse_of] = model_name.singular
+      end
+
       belongs_to role, options.delete(:scope), **options, polymorphic: true
       define_delegated_type_methods role, types: types, options: options
     end

--- a/activerecord/test/models/comment.rb
+++ b/activerecord/test/models/comment.rb
@@ -1,9 +1,13 @@
 # frozen_string_literal: true
 
+require "models/entryable"
+
 # `counter_cache` requires association class before `attr_readonly`.
 class Post < ActiveRecord::Base; end
 
 class Comment < ActiveRecord::Base
+  include Entryable
+
   scope :limit_by, lambda { |l| limit(l) }
   scope :containing_the_letter_e, -> { where("comments.body LIKE '%e%'") }
   scope :not_again, -> { where("comments.body NOT LIKE '%again%'") }

--- a/activerecord/test/models/entryable.rb
+++ b/activerecord/test/models/entryable.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require "models/entry"
+
+module Entryable
+  extend ActiveSupport::Concern
+
+  included do
+    has_one :entry, as: :entryable, touch: true
+  end
+end

--- a/activerecord/test/models/message.rb
+++ b/activerecord/test/models/message.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
+require "models/entryable"
+
 class Message < ActiveRecord::Base
-  has_one  :entry, as: :entryable, touch: true
+  include Entryable
+
   has_many :recipients
 end


### PR DESCRIPTION
### Motivation / Background

Prior to this commit, delegated types were unable to infer their inverse associations, so saving records built with the generated `#build_ASSOCIATION` methods weren't writing to all the necessary places. For example:

```ruby
entry = Entry.create! entryable: Message.new(subject: "Hello world!")
entry.message.subject # => "Hello world!"

entry.build_entryable(subject: "Goodbye world!").save!
entry.reload.message.subject # => "Hello world!"
```

This commit changes that behavior to automatically infer `delegated_type` declarations' `:inverse_of` options when [config.active_record.automatic_scope_inversing][] is true.

If passed either an `:inverse_of` option or a `:foreign_key` option, calls to `delegated_type` will skip automatic inference.

[#50280]: https://github.com/rails/rails/pull/50280
[config.active_record.automatic_scope_inversing]: https://edgeguides.rubyonrails.org/configuring.html#config-active-record-automatic-scope-inversing

### Additional information

Re-submission of [#50280][].

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
