### PR TITLE
Inject named database into DATABASE_URL (if present)

### DIFF
--- a/activerecord/lib/active_record/database_configurations.rb
+++ b/activerecord/lib/active_record/database_configurations.rb
@@ -294,6 +294,11 @@ module ActiveRecord
 
       def environment_url_config(env, name, config)
         url = environment_value_for(name)
+
+        if !url && config[:database] && ENV["DATABASE_URL"]
+          url = URI.parse(ENV["DATABASE_URL"]).tap {|uri| uri.path = "/" + config[:database] }.to_s
+        end
+
         return unless url
 
         UrlConfig.new(env, name, url, config)

--- a/activerecord/lib/active_record/database_configurations.rb
+++ b/activerecord/lib/active_record/database_configurations.rb
@@ -296,7 +296,7 @@ module ActiveRecord
         url = environment_value_for(name)
 
         if !url && config[:database] && ENV["DATABASE_URL"]
-          url = URI.parse(ENV["DATABASE_URL"]).tap {|uri| uri.path = "/" + config[:database] }.to_s
+          url = URI.parse(ENV["DATABASE_URL"]).tap { |uri| uri.path = "/" + config[:database] }.to_s
         end
 
         return unless url


### PR DESCRIPTION
Prior to Rails 8, the default was one database per app, and you didn't even need to change the configuration for production, you only had to provide a single secret: DATABASE_URL.

Sure, you could install solid_queue and others, but then you would need to update your configuration.

Now with Rails 8, the default is four databases per app.  There are a number of PaaS cloud providers which will happily provide a single secret, and the first deploy will inevitably fail with an obscure error message when postgres looks for a unix socket on local host for the other three.

This patch mitigates that by inferring the named URL by modifying the path portion of the DATABASE_URL, but only if both DATABASE_URL IS set and the named version of this environment variable is NOT set.

This is mildly not backwards compatible as it is theoretically possible that somebody could intentionally have set that combination, but that seems unlikely.  Arguably this level of backwards incompatibility is permissible on a major Rails release.

Based on glancing at the test cases, it doesn't look like this would break the existing test, but if there is interest in pursuing this change it would make sense to add an additional test.  I'll save doing that work until I get confirmation that there is interest in this change.