### PR TITLE
Simplify `ActiveRecord::ModelSchema.columns` method

### DIFF
--- a/activerecord/lib/active_record/model_schema.rb
+++ b/activerecord/lib/active_record/model_schema.rb
@@ -431,7 +431,6 @@ module ActiveRecord
       end
 
       def columns
-        load_schema unless @columns
         @columns ||= columns_hash.values.freeze
       end
 


### PR DESCRIPTION
Calling `load_schema` is not necessary because `columns_hash` method already does this.

This change prevents from implementing one use case I will describe below and least to an infinite loop.

For some models having many columns I want to mark only certain fields to be updatable. I can use `attr_readonly` for this and mark all other columns as readonly. I also want avoid the need to update the list passed to `attr_readonly` when new columns are added/removed, so I also use `column_names`. Something like:
```ruby
class MyModel < ApplicationRecord
  attr_readonly column_names - [:updatable_column1, :updatable_column2]
end
```

But using `column_names` inside the model class body can establish the connection too early. So I implemented this:
```ruby
class ApplicationRecord < ActiveRecord::Base
  class_attribute :_attr_updatable, instance_accessor: false, default: []

  def self.attr_updatable(*attributes)
    self._attr_updatable |= attributes.map(&:to_s)
  end

  def self.load_schema!
    super
    if _attr_updatable.any?
      readonly_attributes = column_names - _attr_updatable  # <------- `column_names` causes infinite loop calling `load_schema!` over and over
      attr_readonly(*readonly_attributes)
    end
  end
end
```

and then:
```ruby
class MyModel < ApplicationRecord
  attr_updatable :updatable_column1, :updatable_column2
end
```

Am I doing it wrong?

We have a few classes in ActiveRecord overriding `load_schema!` method. Maybe we need some callback (or something else) for people to define some custom code to be run when model schema is loaded?

cc @byroot (we had a discussion about `load_schema!` method in another PR earlier)