### PR TITLE
Do not generate unused routes in the authentication generator

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Do not generate unused routes in the authentication generator
+
+    *Matheus Richard*
+
 *   Do not include redis by default in generated Dev Containers.
 
     Now that applications use the Solid Queue and Solid Cache gems by default, we do not need to include redis

--- a/railties/lib/rails/generators/rails/authentication/authentication_generator.rb
+++ b/railties/lib/rails/generators/rails/authentication/authentication_generator.rb
@@ -32,8 +32,8 @@ module Rails
       end
 
       def configure_authentication_routes
-        route "resources :passwords, param: :token"
-        route "resource :session"
+        route "resources :passwords, param: :token, only: %i[new create edit update]"
+        route "resource :session, only: %i[new create destroy]"
       end
 
       def enable_bcrypt

--- a/railties/test/generators/authentication_generator_test.rb
+++ b/railties/test/generators/authentication_generator_test.rb
@@ -40,7 +40,8 @@ class AuthenticationGeneratorTest < Rails::Generators::TestCase
     end
 
     assert_file "config/routes.rb" do |content|
-      assert_match(/resource :session/, content)
+      assert_match(/resources :passwords, param: :token, only: %i\[new create edit update\]/, content)
+      assert_match(/resource :session, only: %i\[new create destroy\]/, content)
     end
 
     assert_migration "db/migrate/create_sessions.rb" do |content|
@@ -71,7 +72,8 @@ class AuthenticationGeneratorTest < Rails::Generators::TestCase
     end
 
     assert_file "config/routes.rb" do |content|
-      assert_match(/resource :session/, content)
+      assert_match(/resources :passwords, param: :token, only: %i\[new create edit update\]/, content)
+      assert_match(/resource :session, only: %i\[new create destroy\]/, content)
     end
 
     assert_migration "db/migrate/create_sessions.rb" do |content|


### PR DESCRIPTION

### Motivation / Background

I've been experimenting with running `rails routes --unused` in my CI to find unused routes. The authenticator generator doesn't restrict the routes created, so additional, unused ones are implicitly declared in the route file.

### Detail

Only generate the strictly necessary routes for the authentication generator.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
