### PR TITLE
Colorize console prompt on non standard environments

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Colorize the Rails console prompt even on non standard environments.
+
+    *Lorenzo Zabot*
+
 *   Don't enable YJIT in development and test environments
 
     Development and test environment tend to reload code and redefine methods (e.g. mocking),

--- a/railties/lib/rails/commands/console/irb_console.rb
+++ b/railties/lib/rails/commands/console/irb_console.rb
@@ -120,7 +120,7 @@ module Rails
         when "production"
           IRB::Color.colorize("prod", [:RED])
         else
-          Rails.env
+          IRB::Color.colorize(Rails.env, [:MAGENTA])
         end
       end
     end

--- a/railties/test/commands/console_test.rb
+++ b/railties/test/commands/console_test.rb
@@ -71,6 +71,7 @@ class Rails::ConsoleTest < ActiveSupport::TestCase
     irb_console = Rails::Console.new(app).console
     red = "\e[31m"
     blue = "\e[34m"
+    magenta = "\e[35m"
     clear = "\e[0m"
 
     Rails.env = "development"
@@ -83,7 +84,7 @@ class Rails::ConsoleTest < ActiveSupport::TestCase
     assert_equal("#{red}prod#{clear}", irb_console.colorized_env)
 
     Rails.env = "custom_env"
-    assert_equal("custom_env", irb_console.colorized_env)
+    assert_equal("#{magenta}custom_env#{clear}", irb_console.colorized_env)
   end
 
   def test_default_environment_with_no_rails_env


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->
Relates to discussion #52677.

Currently, the Rails console prompt is colored according to the following rules:
- on dev, the prompt becomes blue
- on test, the prompt becomes blue
- on prod, the prompt becomes red
- on non-standard environments (like staging), the prompt is not colored

I believe that keeping the prompt not colored for non-standard environments is rather ugly. Thus, I have decided to open this PR.

### Detail

Looking at the [IRB code](https://github.com/ruby/irb/blob/master/lib/irb/color.rb#L8-L19), the available colors are:
- black (not suitable for obvious reasons)
- red (already in use)
- green (not suitable, see https://github.com/rails/rails/pull/50855)
- yellow (**possible candidate**)
- blue (already in use)
- magenta  (**possible candidate**)
- cyan (**possible candidate**)
- white (not suitable for obvious reasons)

The 3 possible candidates are thus yellow, magenta and cyan. Here are some screenshots:

Yellow:
![Screenshot 2024-09-24 at 14 13 03](https://github.com/user-attachments/assets/7cdf9bb1-774f-46d2-99eb-09225dc753fa)

Cyan:
![Screenshot 2024-09-24 at 14 13 52](https://github.com/user-attachments/assets/6ce2bb0e-ec5a-4fb2-8ddd-a7a03310ed3a)

Magenta:
![Screenshot 2024-09-24 at 14 14 29 1](https://github.com/user-attachments/assets/39ad5573-a922-4beb-b2b5-898c2973949d)

I have decided to go with Magenta purely for personal preferences, but I am open to other opinions, especially regarding more color blind friendly combinations.

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
