### PR TITLE
[ci skip] Add documentation for `nulls_not_distinct` option

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -855,6 +855,16 @@ module ActiveRecord
       #
       # Note: only supported by PostgreSQL.
       #
+      # ====== Creating an index where NULLs are treated equally
+      #
+      #   add_index(:people, :last_name, nulls_not_distinct: true)
+      #
+      # generates:
+      #
+      #   CREATE INDEX index_people_on_last_name ON people (last_name) NULLS NOT DISTINCT
+      #
+      # Note: only supported by PostgreSQL version 15.0.0 and greater.
+      #
       # ====== Creating an index with a specific method
       #
       #   add_index(:developers, :name, using: 'btree')


### PR DESCRIPTION
### Motivation / Background
Fixes #52852 

This Pull Request has been created because API documentation was missing for the `nulls_not_distinct` option from the `ActiveRecord::ConnectionAdapters::SchemaStatements.add_index` method. 

### Detail

Documentation for `nulls_not_distinct` was added to the file `abstract/schema_statements.rb` following the style of existing documentation. According to the original PR #48608, where `nulls_not_distinct` was implemented, this option only works for PostgreSQL versions of 15.0.0 or greater, so this detail was included in the note of the documentation.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
