### PR TITLE
Fix query building for `where` with tuple syntax and large values list

### DIFF
--- a/activerecord/lib/active_record/relation/predicate_builder.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder.rb
@@ -147,7 +147,7 @@ module ActiveRecord
           queries.first
         else
           queries.map! { |query| query.reduce(&:and) }
-          queries = queries.reduce { |result, query| Arel::Nodes::Or.new([result, query]) }
+          queries = Arel::Nodes::Or.new(queries)
           Arel::Nodes::Grouping.new(queries)
         end
       end

--- a/activerecord/test/cases/relation/where_test.rb
+++ b/activerecord/test/cases/relation/where_test.rb
@@ -139,6 +139,16 @@ module ActiveRecord
       assert_equal [book_two], Cpk::Book.where(title: "The Alchemist", [:author_id, :id] => [[3, 4]])
     end
 
+    def test_with_tuple_syntax_and_large_values_list
+      # sqlite3 raises "Expression tree is too large (maximum depth 1000)"
+      skip if current_adapter?(:SQLite3Adapter)
+
+      assert_nothing_raised do
+        ids = [[1, 2]] * 1500
+        Cpk::Book.where([:author_id, :id] => ids).to_sql
+      end
+    end
+
     def test_belongs_to_shallow_where
       author = Author.new
       author.id = 1


### PR DESCRIPTION
Fixes #53031.

`Or` node previously was not correctly built.

Bug was introduced in https://github.com/rails/rails/pull/51492/files#diff-b8fadd6d1ec091c30f94738b9b193b78ec90681790dd3a6aa79938b4dacbe904R145