### PR TITLE
Update dependency on sqlite3 gem to >= 2.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -158,7 +158,7 @@ platforms :ruby, :windows do
   gem "nokogiri", ">= 1.8.1", "!= 1.11.0"
 
   # Active Record.
-  gem "sqlite3", ">= 2.0"
+  gem "sqlite3", ">= 2.1"
 
   group :db do
     gem "pg", "~> 1.3"

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -11,8 +11,11 @@ require "active_record/connection_adapters/sqlite3/schema_definitions"
 require "active_record/connection_adapters/sqlite3/schema_dumper"
 require "active_record/connection_adapters/sqlite3/schema_statements"
 
-gem "sqlite3", ">= 2.0"
+gem "sqlite3", ">= 2.1"
 require "sqlite3"
+
+# Suppress the warning that SQLite3 issues when open writable connections are carried across fork()
+SQLite3::ForkSafety.suppress_warnings!
 
 module ActiveRecord
   module ConnectionAdapters # :nodoc:

--- a/railties/lib/rails/generators/database.rb
+++ b/railties/lib/rails/generators/database.rb
@@ -248,7 +248,7 @@ module Rails
         end
 
         def gem
-          ["sqlite3", [">= 2.0"]]
+          ["sqlite3", [">= 2.1"]]
         end
 
         def base_package

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -436,7 +436,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
   def test_config_database_is_added_by_default
     run_generator
     assert_file "config/database.yml", /sqlite3/
-    assert_gem "sqlite3", '">= 2.0"'
+    assert_gem "sqlite3", '">= 2.1"'
   end
 
   def test_config_mysql_database

--- a/railties/test/generators/db_system_change_generator_test.rb
+++ b/railties/test/generators/db_system_change_generator_test.rb
@@ -128,7 +128,7 @@ module Rails
 
             assert_file("Gemfile") do |content|
               assert_match "# Use sqlite3 as the database for Active Record", content
-              assert_match 'gem "sqlite3", ">= 2.0"', content
+              assert_match 'gem "sqlite3", ">= 2.1"', content
             end
 
             assert_file("Dockerfile") do |content|


### PR DESCRIPTION
### Motivation / Background

Update the sqlite3 adapter's dependency on the sqlite3-ruby gem to v2.1.

This version contains protections against sqlite's lack of fork safety.

Also, suppress the warnings related to forking with open writable connections, despite the lost
memory per-connection.



### Detail

- Update the minimum allowed version of the sqlite3-ruby gem.
- Suppress fork safety warnings from the gem.


### Additional information

For more context, see https://github.com/sparklemotion/sqlite3-ruby/blob/main/adr/2024-09-fork-safety.md


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [-] Tests are added or updated if you fix a bug or add a feature.
* [-] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
