### PR TITLE
Add enhanced default bin/dev

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Enhanced `bin/dev` Script
+
+    Previously, `bin/dev` would only start the Rails server. Gems requiring multiple processes override the `bin/dev` script to start Foreman instead, which prevents interaction with the Rails server console (debugger).
+
+    This new `bin/dev` script starts Foreman in the background if a `Procfile.dev` is present and starts Rails in the foreground to allow debugging with breakpoints.
+
+    *Joé Dupuis*
+
 *   Add `Rails.app.revision` to provide a version identifier for error reporting, monitoring, cache keys, etc.
 
     ```ruby

--- a/railties/lib/rails/generators/rails/app/templates/bin/dev.tt
+++ b/railties/lib/rails/generators/rails/app/templates/bin/dev.tt
@@ -1,1 +1,58 @@
-exec "./bin/rails", "server", *ARGV
+ENV["PORT"] ||= "3000"
+VERBOSE = ARGV.include?("--verbose") || ARGV.include?("-v") || ENV["VERBOSE"]
+RAILS_ARGS = ARGV - ["--verbose", "-v"]
+PROCFILE = "Procfile.dev"
+FOREMAN_LOG = "log/foreman.log"
+
+# Run rails standalone if no Procfile.dev exists
+Process.exec(*%w[bundle exec rails server], *RAILS_ARGS) unless File.exist?(PROCFILE)
+
+# Ignore INT so we can handle cleanup ourselves
+Signal.trap("INT") { }
+
+# Install foreman if not present
+if system(*%w[gem list --no-installed --exact --silent foreman])
+  puts "Installing foreman..."
+  system(*%w[gem install foreman])
+end
+
+# Start foreman (background processes) and rails (foreground with logs)
+begin
+  foreman_stdin_r, foreman_stdin_w = IO.pipe
+  foreman_log = VERBOSE ? STDOUT : File.open(FOREMAN_LOG, "a")
+  foreman_pid = Process.spawn(
+    *%w[foreman start -f Procfile.dev -m all=1,web=0 --env /dev/null],
+    in: foreman_stdin_r,
+    out: foreman_log,
+    err: foreman_log,
+    pgroup: true
+  )
+  foreman_pgid = Process.getpgid(foreman_pid)
+  rails_pid = Process.spawn(*%w[bundle exec rails server], *RAILS_ARGS)
+
+  # Wait for foreman or rails to exit (ignore other subprocesses)
+  loop do
+    exited_pid, = Process.wait2(-1)
+    if exited_pid == foreman_pid
+      foreman_pid = nil
+      Process.kill("INT", rails_pid) rescue Errno::ESRCH
+      $stderr.puts "\n\e[31m!! Foreman crashed !!\e[0m\nCheck #{FOREMAN_LOG} to debug or run bin/dev --verbose"
+      break
+    elsif exited_pid == rails_pid
+      rails_pid = nil
+      break
+    end
+  end
+
+# Cleanup: terminate any remaining processes and close file handles
+ensure
+  if foreman_pid
+    Process.kill("INT", -foreman_pgid)
+    Process.wait(-foreman_pgid) rescue Errno::ECHILD
+  end
+  Process.kill("KILL", rails_pid) rescue Errno::ESRCH if rails_pid
+
+  foreman_log.close if foreman_log.is_a?(File)
+  foreman_stdin_r.close
+  foreman_stdin_w.close
+end


### PR DESCRIPTION
Fixes #52459

The current default `bin/dev` execs the Rails server directly and doesn't support Procfiles. Therefore, gems like `jsbundling-rails`, `tailwindcss-rails`, and soon `solid_queue` need to overwrite the `bin/dev` script with their own version.

With this new version, gems can skip overwriting the `bin/dev` script and add to the Procfile instead.

- It installs Foreman if needed
- Execs directly into rail server if no procfile is present
- Spawns Foreman in the background to allow breakpoints in the Rails process without Foreman eating the inputs or interleaving its output.

Here's a demo video:
https://youtu.be/mF2gq-C2GE4?si=FX-2Sa5YKmJ9zpMq

### Notes
#### Arguments
Currently all args passed (except `-v` / `--verbose`) go to Raills.

An alternative option would be to split the args for the script vs Rails  with `--`.
`bin/dev -v -- -b 0.0.0.0`
This way if we want to add more options to `bin/dev`, filtering them out won't get too messy.

#### Readability
This output is not exactly easy on the eye...
Here's what it looks like:  https://github.com/JoeDupuis/bindev-test/blob/main/bin/dev

I was balancing a couple considerations. 

Part of the complexity could be extracted to the framework, but then it's hard for dev to make it their own (say change from foreman to overmind for example).

Instead of having everything flat like I did we could extract the logic to a class.
Quick example of what it could look like https://github.com/JoeDupuis/bindev-test/blob/alternative-dev/bin/dev

I am still not a big fan of how it reads. Open to suggestions.  

### To Test
Both `--css=tailwind` and `--javascript=esbuild` would override the `bin/dev` script with their own, so to test this you must run `bin/rails app:update -f` to override back the `bin/dev` with this new version.
 I've prepped these commands to make it easy. Change the project path (`../bindev-test`) if you need. 
  
```
bundle exec rails new ../bindev-test --dev --css=tailwind --javascript=esbuild
cd ../bindev-test && git add -A && git commit -m "init"
bin/rails app:update -f
git add bin/dev && git commit -m "bin/dev"
git reset --hard &&  git clean -fd
```

This should output  https://github.com/JoeDupuis/bindev-test/blob/main/bin/dev

By adding `failing: sleep 4 && exit 1` to your procfile you can simulate a failure in foreman. 

Alternatively just copy the output to an existing project: https://github.com/JoeDupuis/bindev-test/blob/main/bin/dev

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
