### PR TITLE
Address `Layout/SpaceInsideArrayLiteralBrackets` offense for Rails 7.2 and Ruby 3.1 app

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
@@ -54,7 +54,7 @@ group :development do
 <%- if RUBY_VERSION < "3.2" -%>
 
   # Highlight the fine-grained location where an error occurred [https://github.com/ruby/error_highlight]
-  gem "error_highlight", ">= 0.4.0", platforms: [:ruby]
+  gem "error_highlight", ">= 0.4.0", platforms: [ :ruby ]
 <%- end -%>
 end
 <%- end -%>


### PR DESCRIPTION
### Motivation / Background

This commit addresses the following CI failure at the 7-2-stable branch https://buildkite.com/rails/rails/builds/111646#019210c6-3574-468d-ad92-4263e0378d95/1118-1124

### Detail

This failure only happens at the 7-2-stable branch using Ruby 3.1 because of the following reasons:

- `rubocop-rails-omakase` is enabled for newly created Rails application since Rails 7.2.0

- `error_highlight` needs to be installed explicitly only if `RUBY_VERSION < "3.2"` https://github.com/rails/rails/blob/73e473e105ea17711776dd300389930a15204cf2/railties/lib/rails/generators/rails/app/templates/Gemfile.tt#L54-L60

- Rails main branch does not have this code because Rails 8 will bump the required Ruby version to higher one. https://github.com/rails/rails/commit/dc96d29d2bd64948c444c76e5aabc641da6f7aa0

This commit addresses the following failures.

```ruby
$ ruby -v
ruby 3.1.5p252 (2024-04-23 revision 1945f8dc0e) [x86_64-linux]
$ cd railties
$ bin/test test/generators/app_generator_test.rb -n test_generated_files_have_no_rubocop_warnings
$ bin/test test/generators/app_generator_test.rb -n test_generated_files_have_no_rubocop_warnings
Run options: -n test_generated_files_have_no_rubocop_warnings --seed 58776

F

Failure:
AppGeneratorTest#test_generated_files_have_no_rubocop_warnings [test/generators/shared_generator_tests.rb:413]:
bin/rubocop did not exit successfully:
Inspecting 27 files
C..........................

Offenses:

Gemfile:50:49: C: [Correctable] Layout/SpaceInsideArrayLiteralBrackets: Use space inside array brackets.
  gem "error_highlight", ">= 0.4.0", platforms: [:ruby]
                                                ^
Gemfile:50:55: C: Layout/SpaceInsideArrayLiteralBrackets: Use space inside array brackets.
  gem "error_highlight", ">= 0.4.0", platforms: [:ruby]
                                                      ^

27 files inspected, 2 offenses detected, 1 offense autocorrectable
.
Expected #<Process::Status: pid 782031 exit 1> to be success?.

bin/test test/generators/shared_generator_tests.rb:407

Finished in 2.008499s, 0.4979 runs/s, 0.4979 assertions/s.
1 runs, 1 assertions, 1 failures, 0 errors, 0 skips
$
```

### Additional information

Here is the RuboCop configuration used at `rubocop-rails-omakase`.

https://github.com/rails/rubocop-rails-omakase/blob/63a7608d668ea12f1a6d6bfabeb7d17d856a9641/rubocop.yml#L100-L105

```ruby
# Use `[ a, [ b, c ] ]` not `[a, [b, c]]`
# Use `[]` not `[ ]`
Layout/SpaceInsideArrayLiteralBrackets:
  Enabled: true
  EnforcedStyle: space
  EnforcedStyleForEmptyBrackets: no_space
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
