### PR TITLE
Drop support to Ruby 3.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -172,10 +172,4 @@ end
 gem "tzinfo-data", platforms: [:windows, :jruby]
 gem "wdm", ">= 0.1.0", platforms: [:windows]
 
-# The error_highlight gem only works on CRuby 3.1 or later.
-# Also, Rails depends on a new API available since error_highlight 0.4.0.
-# (Note that Ruby 3.1 bundles error_highlight 0.3.0.)
-if RUBY_VERSION < "3.2"
-  gem "error_highlight", ">= 0.4.0", platforms: [:ruby]
-end
 gem "launchy"

--- a/actioncable/actioncable.gemspec
+++ b/actioncable/actioncable.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
   s.summary     = "WebSocket framework for Rails."
   s.description = "Structure many real-time application concerns into channels over a single WebSocket connection."
 
-  s.required_ruby_version = ">= 3.1.0"
+  s.required_ruby_version = ">= 3.2.0"
 
   s.license = "MIT"
 

--- a/actionmailbox/actionmailbox.gemspec
+++ b/actionmailbox/actionmailbox.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
   s.summary     = "Inbound email handling framework."
   s.description = "Receive and process incoming emails in Rails applications."
 
-  s.required_ruby_version = ">= 3.1.0"
+  s.required_ruby_version = ">= 3.2.0"
 
   s.license  = "MIT"
 

--- a/actionmailer/actionmailer.gemspec
+++ b/actionmailer/actionmailer.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
   s.summary     = "Email composition and delivery framework (part of Rails)."
   s.description = "Email on Rails. Compose, deliver, and test emails using the familiar controller/view pattern. First-class support for multipart email and attachments."
 
-  s.required_ruby_version = ">= 3.1.0"
+  s.required_ruby_version = ">= 3.2.0"
 
   s.license = "MIT"
 

--- a/actionpack/actionpack.gemspec
+++ b/actionpack/actionpack.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
   s.summary     = "Web-flow and rendering framework putting the VC in MVC (part of Rails)."
   s.description = "Web apps on Rails. Simple, battle-tested conventions for building and testing MVC web applications. Works with any Rack-compatible server."
 
-  s.required_ruby_version = ">= 3.1.0"
+  s.required_ruby_version = ">= 3.2.0"
 
   s.license = "MIT"
 

--- a/actiontext/actiontext.gemspec
+++ b/actiontext/actiontext.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
   s.summary     = "Rich text framework."
   s.description = "Edit and display rich text in Rails applications."
 
-  s.required_ruby_version = ">= 3.1.0"
+  s.required_ruby_version = ">= 3.2.0"
 
   s.license  = "MIT"
 

--- a/actionview/actionview.gemspec
+++ b/actionview/actionview.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
   s.summary     = "Rendering framework putting the V in MVC (part of Rails)."
   s.description = "Simple, battle-tested conventions and helpers for building web pages."
 
-  s.required_ruby_version = ">= 3.1.0"
+  s.required_ruby_version = ">= 3.2.0"
 
   s.license = "MIT"
 

--- a/actionview/test/template/render_test.rb
+++ b/actionview/test/template/render_test.rb
@@ -208,45 +208,43 @@ module RenderTestCases
     end
   end
 
-  if RUBY_VERSION >= "3.2"
-    def test_render_runtime_error
-      ex = assert_raises(ActionView::Template::Error) {
-        @view.render(template: "test/runtime_error")
-      }
-      erb_btl = ex.backtrace_locations.first
+  def test_render_runtime_error
+    ex = assert_raises(ActionView::Template::Error) {
+      @view.render(template: "test/runtime_error")
+    }
+    erb_btl = ex.backtrace_locations.first
 
-      # Get the spot information from ErrorHighlight
-      translating_frame = ActionDispatch::ExceptionWrapper::SourceMapLocation.new(erb_btl, ex.template)
-      translated_spot = translating_frame.spot(ex.cause)
+    # Get the spot information from ErrorHighlight
+    translating_frame = ActionDispatch::ExceptionWrapper::SourceMapLocation.new(erb_btl, ex.template)
+    translated_spot = translating_frame.spot(ex.cause)
 
-      assert_equal 6, translated_spot[:first_column]
-    end
+    assert_equal 6, translated_spot[:first_column]
+  end
 
-    def test_render_location_conditional_append
-      ex = assert_raises(ActionView::Template::Error) {
-        @view.render(template: "test/unparseable_runtime_error")
-      }
-      erb_btl = ex.backtrace_locations.first
+  def test_render_location_conditional_append
+    ex = assert_raises(ActionView::Template::Error) {
+      @view.render(template: "test/unparseable_runtime_error")
+    }
+    erb_btl = ex.backtrace_locations.first
 
-      # Get the spot information from ErrorHighlight
-      translating_frame = ActionDispatch::ExceptionWrapper::SourceMapLocation.new(erb_btl, ex.template)
-      translated_spot = translating_frame.spot(ex.cause)
+    # Get the spot information from ErrorHighlight
+    translating_frame = ActionDispatch::ExceptionWrapper::SourceMapLocation.new(erb_btl, ex.template)
+    translated_spot = translating_frame.spot(ex.cause)
 
-      assert_equal 8, translated_spot[:first_column]
-    end
+    assert_equal 8, translated_spot[:first_column]
+  end
 
-    def test_render_location_conditional_append_2
-      ex = assert_raises(ActionView::Template::Error) {
-        @view.render(template: "test/unparseable_runtime_error_2")
-      }
-      erb_btl = ex.backtrace_locations.first
+  def test_render_location_conditional_append_2
+    ex = assert_raises(ActionView::Template::Error) {
+      @view.render(template: "test/unparseable_runtime_error_2")
+    }
+    erb_btl = ex.backtrace_locations.first
 
-      # Get the spot information from ErrorHighlight
-      translating_frame = ActionDispatch::ExceptionWrapper::SourceMapLocation.new(erb_btl, ex.template)
-      translated_spot = translating_frame.spot(ex.cause)
+    # Get the spot information from ErrorHighlight
+    translating_frame = ActionDispatch::ExceptionWrapper::SourceMapLocation.new(erb_btl, ex.template)
+    translated_spot = translating_frame.spot(ex.cause)
 
-      assert_instance_of Integer, translated_spot[:first_column]
-    end
+    assert_instance_of Integer, translated_spot[:first_column]
   end
 
   def test_render_partial

--- a/activejob/activejob.gemspec
+++ b/activejob/activejob.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
   s.summary     = "Job framework with pluggable queues."
   s.description = "Declare job classes that can be run by a variety of queuing backends."
 
-  s.required_ruby_version = ">= 3.1.0"
+  s.required_ruby_version = ">= 3.2.0"
 
   s.license = "MIT"
 

--- a/activemodel/activemodel.gemspec
+++ b/activemodel/activemodel.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
   s.summary     = "A toolkit for building modeling frameworks (part of Rails)."
   s.description = "A toolkit for building modeling frameworks like Active Record. Rich support for attributes, callbacks, validations, serialization, internationalization, and testing."
 
-  s.required_ruby_version = ">= 3.1.0"
+  s.required_ruby_version = ">= 3.2.0"
 
   s.license = "MIT"
 

--- a/activemodel/lib/active_model/type/helpers/time_value.rb
+++ b/activemodel/lib/active_model/type/helpers/time_value.rb
@@ -69,56 +69,32 @@ module ActiveModel
             \z
           /x
 
-          if RUBY_VERSION >= "3.2"
-            if Time.new(2000, 1, 1, 0, 0, 0, "-00:00").yday != 1 # Early 3.2.x had a bug
-              # BUG: Wrapping the Time object with Time.at because Time.new with `in:` in Ruby 3.2.0
-              # used to return an invalid Time object
-              # see: https://bugs.ruby-lang.org/issues/19292
-              def fast_string_to_time(string)
-                return unless string.include?("-") #  Time.new("1234") # => 1234-01-01 00:00:00
+          if Time.new(2000, 1, 1, 0, 0, 0, "-00:00").yday != 1 # Early 3.2.x had a bug
+            # BUG: Wrapping the Time object with Time.at because Time.new with `in:` in Ruby 3.2.0
+            # used to return an invalid Time object
+            # see: https://bugs.ruby-lang.org/issues/19292
+            def fast_string_to_time(string)
+              return unless string.include?("-") #  Time.new("1234") # => 1234-01-01 00:00:00
 
-                if is_utc?
-                  ::Time.at(::Time.new(string, in: "UTC"))
-                else
-                  ::Time.new(string)
-                end
-              rescue ArgumentError
-                nil
+              if is_utc?
+                ::Time.at(::Time.new(string, in: "UTC"))
+              else
+                ::Time.new(string)
               end
-            else
-              def fast_string_to_time(string)
-                return unless string.include?("-") #  Time.new("1234") # => 1234-01-01 00:00:00
-
-                if is_utc?
-                  ::Time.new(string, in: "UTC")
-                else
-                  ::Time.new(string)
-                end
-              rescue ArgumentError
-                nil
-              end
+            rescue ArgumentError
+              nil
             end
           else
             def fast_string_to_time(string)
-              return unless ISO_DATETIME =~ string
+              return unless string.include?("-") #  Time.new("1234") # => 1234-01-01 00:00:00
 
-              usec = $7.to_i
-              usec_len = $7&.length
-              if usec_len&.< 6
-                usec *= 10**(6 - usec_len)
+              if is_utc?
+                ::Time.new(string, in: "UTC")
+              else
+                ::Time.new(string)
               end
-
-              if $8
-                offset = \
-                  if $8 == "Z"
-                    0
-                  else
-                    offset_h, offset_m = $8.to_i, $9.to_i
-                    offset_h.to_i * 3600 + (offset_h.negative? ? -1 : 1) * offset_m * 60
-                  end
-              end
-
-              new_time($1.to_i, $2.to_i, $3.to_i, $4.to_i, $5.to_i, $6.to_i, usec, offset)
+            rescue ArgumentError
+              nil
             end
           end
       end

--- a/activerecord/activerecord.gemspec
+++ b/activerecord/activerecord.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
   s.summary     = "Object-relational mapper framework (part of Rails)."
   s.description = "Databases on Rails. Build a persistent domain model by mapping database tables to Ruby classes. Strong conventions for associations, validations, aggregations, migrations, and testing come baked-in."
 
-  s.required_ruby_version = ">= 3.1.0"
+  s.required_ruby_version = ">= 3.2.0"
 
   s.license = "MIT"
 

--- a/activestorage/activestorage.gemspec
+++ b/activestorage/activestorage.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
   s.summary     = "Local and cloud file storage framework."
   s.description = "Attach cloud and local files in Rails applications."
 
-  s.required_ruby_version = ">= 3.1.0"
+  s.required_ruby_version = ">= 3.2.0"
 
   s.license = "MIT"
 

--- a/activesupport/activesupport.gemspec
+++ b/activesupport/activesupport.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
   s.summary     = "A toolkit of support libraries and Ruby core extensions extracted from the Rails framework."
   s.description = "A toolkit of support libraries and Ruby core extensions extracted from the Rails framework. Rich support for multibyte strings, internationalization, time zones, and testing."
 
-  s.required_ruby_version = ">= 3.1.0"
+  s.required_ruby_version = ">= 3.2.0"
 
   s.license = "MIT"
 

--- a/activesupport/lib/active_support/core_ext/object/json.rb
+++ b/activesupport/lib/active_support/core_ext/object/json.rb
@@ -65,11 +65,9 @@ class Object
   end
 end
 
-if RUBY_VERSION >= "3.2"
-  class Data # :nodoc:
-    def as_json(options = nil)
-      to_h.as_json(options)
-    end
+class Data # :nodoc:
+  def as_json(options = nil)
+    to_h.as_json(options)
   end
 end
 

--- a/activesupport/test/core_ext/enumerable_test.rb
+++ b/activesupport/test/core_ext/enumerable_test.rb
@@ -412,7 +412,5 @@ class EnumerableTests < ActiveSupport::TestCase
   private
     def constant_cache_invalidations
       RubyVM.stat(:constant_cache_invalidations)
-    rescue ArgumentError
-      RubyVM.stat(:global_constant_state) # RUBY_VERSION < "3.2"
     end
 end

--- a/activesupport/test/executor_test.rb
+++ b/activesupport/test/executor_test.rb
@@ -225,35 +225,6 @@ class ExecutorTest < ActiveSupport::TestCase
     assert_equal [:state_a, :state_b, :state_d, :state_c], supplied_state
   end
 
-  if RUBY_VERSION < "3.2"
-    def test_class_serial_is_unaffected
-      skip if !defined?(RubyVM) || !RubyVM.stat.has_key?(:class_serial)
-
-      hook = Class.new do
-        define_method(:run) do
-          nil
-        end
-
-        define_method(:complete) do |state|
-          nil
-        end
-      end.new
-
-      executor.register_hook(hook)
-
-      # Warm-up to trigger any pending autoloads
-      executor.wrap { }
-
-      before = RubyVM.stat(:class_serial)
-      executor.wrap { }
-      executor.wrap { }
-      executor.wrap { }
-      after = RubyVM.stat(:class_serial)
-
-      assert_equal before, after
-    end
-  end
-
   def test_separate_classes_can_wrap
     other_executor = Class.new(ActiveSupport::Executor)
 

--- a/activesupport/test/json/encoding_test.rb
+++ b/activesupport/test/json/encoding_test.rb
@@ -346,15 +346,13 @@ class TestJSONEncoding < ActiveSupport::TestCase
                  ActiveSupport::JSON.decode(json_string_and_date))
   end
 
-  if RUBY_VERSION >= "3.2"
-    def test_data_encoding
-      data = Data.define(:name, :email).new("test", "test@example.com")
+  def test_data_encoding
+    data = Data.define(:name, :email).new("test", "test@example.com")
 
-      assert_nothing_raised { data.to_json }
+    assert_nothing_raised { data.to_json }
 
-      assert_equal({ "name" => "test", "email" => "test@example.com" },
-        ActiveSupport::JSON.decode(data.to_json))
-    end
+    assert_equal({ "name" => "test", "email" => "test@example.com" },
+      ActiveSupport::JSON.decode(data.to_json))
   end
 
   def test_nil_true_and_false_represented_as_themselves

--- a/activesupport/test/time_travel_test.rb
+++ b/activesupport/test/time_travel_test.rb
@@ -35,9 +35,7 @@ class TimeTravelTest < ActiveSupport::TestCase
       assert_equal expected_time.to_datetime.to_fs(:db), DateTime.now.to_fs(:db)
 
       assert_equal expected_time.to_fs(:db), Time.new.to_fs(:db)
-      if RUBY_VERSION >= "3.2"
-        assert_not_equal expected_time.to_fs(:db), Time.new(precision: 3).to_fs(:db)
-      end
+      assert_not_equal expected_time.to_fs(:db), Time.new(precision: 3).to_fs(:db)
     ensure
       travel_back
     end
@@ -53,18 +51,14 @@ class TimeTravelTest < ActiveSupport::TestCase
         assert_equal expected_time.to_datetime.to_fs(:db), DateTime.now.to_fs(:db)
 
         assert_equal expected_time.to_fs(:db), Time.new.to_fs(:db)
-        if RUBY_VERSION >= "3.2"
-          assert_not_equal expected_time.to_fs(:db), Time.new(precision: 3).to_fs(:db)
-          assert_equal Time.new("2000-12-31 23:59:59.567"), Time.new("2000-12-31 23:59:59.56789", precision: 3)
-        end
+        assert_not_equal expected_time.to_fs(:db), Time.new(precision: 3).to_fs(:db)
+        assert_equal Time.new("2000-12-31 23:59:59.567"), Time.new("2000-12-31 23:59:59.56789", precision: 3)
       end
 
       assert_not_equal expected_time.to_fs(:db), Time.now.to_fs(:db)
       assert_not_equal expected_time.to_date, Date.today
       assert_not_equal expected_time.to_datetime.to_fs(:db), DateTime.now.to_fs(:db)
-      if RUBY_VERSION >= "3.2"
-        assert_equal Time.new("2000-12-31 23:59:59.567"), Time.new("2000-12-31 23:59:59.56789", precision: 3)
-      end
+      assert_equal Time.new("2000-12-31 23:59:59.567"), Time.new("2000-12-31 23:59:59.56789", precision: 3)
     end
   end
 
@@ -76,9 +70,7 @@ class TimeTravelTest < ActiveSupport::TestCase
       assert_equal expected_time, Time.now
       assert_equal expected_time, Time.new
       assert_not_equal expected_time, Time.new(2004, 11, 25)
-      if RUBY_VERSION >= "3.2"
-        assert_not_equal expected_time, Time.new(precision: 3)
-      end
+      assert_not_equal expected_time, Time.new(precision: 3)
       assert_equal Date.new(2004, 11, 24), Date.today
       assert_equal expected_time.to_datetime, DateTime.now
     ensure
@@ -93,9 +85,7 @@ class TimeTravelTest < ActiveSupport::TestCase
       travel_to expected_time do
         assert_equal expected_time, Time.now
         assert_equal expected_time, Time.new
-        if RUBY_VERSION >= "3.2"
-          assert_not_equal expected_time, Time.new(precision: 3)
-        end
+        assert_not_equal expected_time, Time.new(precision: 3)
         assert_not_equal expected_time, Time.new(2004, 11, 25)
         assert_equal Date.new(2004, 11, 24), Date.today
         assert_equal expected_time.to_datetime, DateTime.now

--- a/guides/source/command_line.md
+++ b/guides/source/command_line.md
@@ -512,7 +512,7 @@ $ bin/rails destroy model Oops
 $ bin/rails about
 About your application's environment
 Rails version             8.0.0
-Ruby version              3.1.0 (x86_64-linux)
+Ruby version              3.2.0 (x86_64-linux)
 RubyGems version          3.3.7
 Rack version              3.0.8
 JavaScript Runtime        Node.js (V8)

--- a/guides/source/getting_started.md
+++ b/guides/source/getting_started.md
@@ -97,7 +97,7 @@ current version of Ruby installed:
 
 ```bash
 $ ruby --version
-ruby 3.1.0
+ruby 3.2.0
 ```
 
 Rails requires Ruby version 3.1.0 or later. It is preferred to use the latest Ruby version.

--- a/guides/source/upgrading_ruby_on_rails.md
+++ b/guides/source/upgrading_ruby_on_rails.md
@@ -20,6 +20,7 @@ The best way to be sure that your application still works after upgrading is to 
 
 Rails generally stays close to the latest released Ruby version when it's released:
 
+* Rails 8.0 requires Ruby 3.2.0 or newer.
 * Rails 7.2 requires Ruby 3.1.0 or newer.
 * Rails 7.0 and 7.1 requires Ruby 2.7.0 or newer.
 * Rails 6 requires Ruby 2.5.0 or newer.

--- a/rails.gemspec
+++ b/rails.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
   s.summary     = "Full-stack web application framework."
   s.description = "Ruby on Rails is a full-stack web framework optimized for programmer happiness and sustainable productivity. It encourages beautiful code by favoring convention over configuration."
 
-  s.required_ruby_version     = ">= 3.1.0"
+  s.required_ruby_version     = ">= 3.2.0"
   s.required_rubygems_version = ">= 1.8.11"
 
   s.license = "MIT"

--- a/railties/railties.gemspec
+++ b/railties/railties.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
   s.summary     = "Tools for creating, working with, and running Rails applications."
   s.description = "Rails internals: application bootup, plugins, generators, and rake tasks."
 
-  s.required_ruby_version = ">= 3.1.0"
+  s.required_ruby_version = ">= 3.2.0"
 
   s.license = "MIT"
 

--- a/tools/rail_inspector/rail_inspector.gemspec
+++ b/tools/rail_inspector/rail_inspector.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |spec|
   spec.summary = "A collection of linters for rails/rails"
   spec.homepage = "https://github.com/skipkayhil/rail_inspector"
   spec.license = "MIT"
-  spec.required_ruby_version = ">= 3.1.0"
+  spec.required_ruby_version = ">= 3.2.0"
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = spec.homepage

--- a/tools/releaser/releaser.gemspec
+++ b/tools/releaser/releaser.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |s|
   s.summary     = "Library to release Rails"
   s.description = "A set of tasks to release Rails"
 
-  s.required_ruby_version = ">= 3.1.0"
+  s.required_ruby_version = ">= 3.2.0"
 
   s.license = "MIT"
 


### PR DESCRIPTION
Rails 8 will require Ruby 3.2.0 or newer.