### PR TITLE
Make `ActiveModel::Serialization#read_attribute_for_serialization` public

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Make `ActiveModel::Serialization#read_attribute_for_serialization` public
+
+    *Sean Doyle*
+
 *   Add a default token generator for password reset tokens when using `has_secure_password`.
 
     ```ruby

--- a/activemodel/lib/active_model/serialization.rb
+++ b/activemodel/lib/active_model/serialization.rb
@@ -29,8 +29,8 @@ module ActiveModel
   # An +attributes+ hash must be defined and should contain any attributes you
   # need to be serialized. Attributes must be strings, not symbols.
   # When called, serializable hash will use instance methods that match the name
-  # of the attributes hash's keys. In order to override this behavior, take a look
-  # at the private method +read_attribute_for_serialization+.
+  # of the attributes hash's keys. In order to override this behavior, override
+  # the +read_attribute_for_serialization+ method.
   #
   # ActiveModel::Serializers::JSON module automatically includes
   # the +ActiveModel::Serialization+ module, so there is no need to
@@ -148,28 +148,28 @@ module ActiveModel
       hash
     end
 
+    # Hook method defining how an attribute value should be retrieved for
+    # serialization. By default this is assumed to be an instance named after
+    # the attribute. Override this method in subclasses should you need to
+    # retrieve the value for a given attribute differently:
+    #
+    #   class MyClass
+    #     include ActiveModel::Serialization
+    #
+    #     def initialize(data = {})
+    #       @data = data
+    #     end
+    #
+    #     def read_attribute_for_serialization(key)
+    #       @data[key]
+    #     end
+    #   end
+    alias :read_attribute_for_serialization :send
+
     private
       def attribute_names_for_serialization
         attributes.keys
       end
-
-      # Hook method defining how an attribute value should be retrieved for
-      # serialization. By default this is assumed to be an instance named after
-      # the attribute. Override this method in subclasses should you need to
-      # retrieve the value for a given attribute differently:
-      #
-      #   class MyClass
-      #     include ActiveModel::Serialization
-      #
-      #     def initialize(data = {})
-      #       @data = data
-      #     end
-      #
-      #     def read_attribute_for_serialization(key)
-      #       @data[key]
-      #     end
-      #   end
-      alias :read_attribute_for_serialization :send
 
       def serializable_attributes(attribute_names)
         attribute_names.index_with { |n| read_attribute_for_serialization(n) }


### PR DESCRIPTION
### Motivation / Background

Despite the `#read_attribute_for_serialization` method being declared as `private`, the module-level `ActiveModel::Serialization` documentation mentions it explicitly by name.

### Detail

Mentioning the method directly and encouraging classes to override it to customize behavior breaks Rails existing `public`-`private` interface convention.

This commit promotes the method to `public` visibility.

There is already [existent test coverage](https://github.com/rails/rails/blob/3997ed6ae4e65cc092d68c8316e06a082dc9026c/activemodel/test/cases/serialization_test.rb#L94-L101) for that exercises overriding the method for custom serialization.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
