### PR TITLE
Fix `link_to` when passed `:rel` is a symbol

### DIFF
--- a/actionview/lib/action_view/helpers/url_helper.rb
+++ b/actionview/lib/action_view/helpers/url_helper.rb
@@ -710,7 +710,7 @@ module ActionView
         end
 
         def add_method_to_attributes!(html_options, method)
-          if method_not_get_method?(method) && !html_options["rel"]&.include?("nofollow")
+          if method_not_get_method?(method) && !html_options["rel"].to_s.include?("nofollow")
             if html_options["rel"].blank?
               html_options["rel"] = "nofollow"
             else

--- a/actionview/test/template/url_helper_test.rb
+++ b/actionview/test/template/url_helper_test.rb
@@ -579,6 +579,11 @@ class UrlHelperTest < ActiveSupport::TestCase
       %{<a href="http://www.example.com" data-method="post" rel="example nofollow">Hello</a>},
       link_to("Hello", "http://www.example.com", method: :post, rel: "example")
     )
+
+    assert_dom_equal(
+      %{<a href="http://www.example.com" data-method="post" rel="example nofollow">Hello</a>},
+      link_to("Hello", "http://www.example.com", method: :post, rel: :example)
+    )
   end
 
   def test_link_tag_using_post_javascript_and_confirm


### PR DESCRIPTION
Fixes #53046.