### PR TITLE
Unscope `ORDER BY` predicate in `subquery_for_count`

### DIFF
--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -673,7 +673,11 @@ module ActiveRecord
         subquery_alias = Arel.sql("subquery_for_count", retryable: true)
         select_value = operation_over_aggregate_column(column_alias, "count", false)
 
-        relation.build_subquery(subquery_alias, select_value)
+        if column_name == :all
+          relation.unscope(:order).build_subquery(subquery_alias, select_value)
+        else
+          relation.build_subquery(subquery_alias, select_value)
+        end
       end
   end
 end

--- a/activerecord/test/cases/calculations_test.rb
+++ b/activerecord/test/cases/calculations_test.rb
@@ -309,6 +309,12 @@ class CalculationsTest < ActiveRecord::TestCase
     assert_no_match(/OFFSET/, queries.first)
   end
 
+  def test_no_order_by_when_counting_all
+    queries = capture_sql { Account.order(id: :desc).limit(10).count }
+    assert_equal 1, queries.length
+    assert_no_match(/ORDER BY/, queries.first)
+  end
+
   def test_count_on_invalid_columns_raises
     error = assert_raises(ActiveRecord::StatementInvalid) do
       Account.select("credit_limit, firm_name").count


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

Currently, for a regular count query, like `Account.order(id: :desc).count`, ActiveRecord already removes the `ORDER BY` predicate. However, it does not if it needs the `subquery_for_count` alias approach. For example, running the test case I add in https://github.com/rails/rails/commit/a8a63f73f4e5801171ee26e45c3d22c4a249de00:

```shell
Using trilogy
Run options: --seed 17113

# Running:

F

Failure:
CalculationsTest#test_no_order_by_in_subquery_for_count [test/cases/calculations_test.rb:308]:
Expected /ORDER BY/ to not match "SELECT COUNT(*) FROM (SELECT 1 AS one FROM `accounts` ORDER BY `accounts`.`id` DESC LIMIT 10) subquery_for_count".


bin/test test/cases/calculations_test.rb:305
```

### Detail

This Pull Request removes the `ORDER BY` clause when building the subquery for count and will produce a query like

```sql
SELECT COUNT(*) FROM (SELECT 1 AS one FROM `accounts` LIMIT 10) subquery_for_count
```

### Checklist

Before submitting the PR make sure the following are checked:

* [ ] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [ ] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
