### PR TITLE
Revert changes to `assert_difference` and friends from #52036

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -68,11 +68,6 @@
 
     *Igor Depolli*
 
-*   Improve error message when using `assert_difference` or `assert_changes` with a
-    proc by printing the proc's source code (MRI only).
-
-    *Richard Böhme*, *Jean Boussier*
-
 *   Add a new configuration value `:zone` for `ActiveSupport.to_time_preserves_timezone` and rename the previous `true` value to `:offset`. The new default value is `:zone`.
 
     *Jason Kim*, *John Hawthorn*

--- a/activesupport/test/test_case_test.rb
+++ b/activesupport/test/test_case_test.rb
@@ -54,7 +54,7 @@ class AssertionsTest < ActiveSupport::TestCase
         @object.increment
       end
     end
-    assert_equal "`@object.num` didn't change by 0, but by 1.\nExpected: 0\n  Actual: 1", error.message
+    assert_equal "\"@object.num\" didn't change by 0, but by 1.\nExpected: 0\n  Actual: 1", error.message
   end
 
   def test_assert_no_difference_with_message_fail
@@ -63,7 +63,7 @@ class AssertionsTest < ActiveSupport::TestCase
         @object.increment
       end
     end
-    assert_equal "Object Changed.\n`@object.num` didn't change by 0, but by 1.\nExpected: 0\n  Actual: 1", error.message
+    assert_equal "Object Changed.\n\"@object.num\" didn't change by 0, but by 1.\nExpected: 0\n  Actual: 1", error.message
   end
 
   def test_assert_no_difference_with_multiple_expressions_pass
@@ -157,7 +157,7 @@ class AssertionsTest < ActiveSupport::TestCase
         @object.increment
       end
     end
-    assert_equal "Object Changed.\n`@object.num` didn't change by 0, but by 1.\nExpected: 0\n  Actual: 1", error.message
+    assert_equal "Object Changed.\n\"@object.num\" didn't change by 0, but by 1.\nExpected: 0\n  Actual: 1", error.message
   end
 
   def test_assert_difference_message_includes_change
@@ -167,17 +167,7 @@ class AssertionsTest < ActiveSupport::TestCase
         @object.increment
       end
     end
-    assert_equal "`@object.num` didn't change by 5, but by 2.\nExpected: 5\n  Actual: 2", error.message
-  end
-
-  def test_assert_difference_message_with_lambda
-    skip if !defined?(RubyVM::AbstractSyntaxTree)
-
-    error = assert_raises Minitest::Assertion do
-      assert_difference(-> { @object.num }, 1, "Object Changed") do
-      end
-    end
-    assert_equal "Object Changed.\n`@object.num` didn't change by 1, but by 0.\nExpected: 1\n  Actual: 0", error.message
+    assert_equal "\"@object.num\" didn't change by 5, but by 2.\nExpected: 5\n  Actual: 2", error.message
   end
 
   def test_hash_of_lambda_expressions
@@ -243,19 +233,7 @@ class AssertionsTest < ActiveSupport::TestCase
       end
     end
 
-    assert_equal "`@object.num` didn't change. It was already 0.\nExpected 0 to not be equal to 0.", error.message
-  end
-
-  def test_assert_changes_message_with_lambda
-    skip if !defined?(RubyVM::AbstractSyntaxTree)
-
-    error = assert_raises Minitest::Assertion do
-      assert_changes -> { @object.num }, to: 0 do
-        # no changes
-      end
-    end
-
-    assert_equal "`@object.num` didn't change. It was already 0.\nExpected 0 to not be equal to 0.", error.message
+    assert_equal "\"@object.num\" didn't change. It was already 0.\nExpected 0 to not be equal to 0.", error.message
   end
 
   def test_assert_changes_with_wrong_to_option
@@ -371,91 +349,7 @@ class AssertionsTest < ActiveSupport::TestCase
       end
     end
 
-    assert_equal "@object.num should not change.\n`@object.num` changed.\nExpected: 0\n  Actual: 1", error.message
-  end
-
-  def test_assert_no_changes_message_with_lambda
-    skip if !defined?(RubyVM::AbstractSyntaxTree)
-
-    error = assert_raises Minitest::Assertion do
-      assert_no_changes -> { @object.num } do
-        @object.increment
-      end
-    end
-    assert_equal "`@object.num` changed.\nExpected: 0\n  Actual: 1", error.message
-
-    check = Proc.new {
-      @object.num
-    }
-    error = assert_raises Minitest::Assertion do
-      assert_no_changes check do
-        @object.increment
-      end
-    end
-    assert_equal "`@object.num` changed.\nExpected: 1\n  Actual: 2", error.message
-
-    check = lambda {
-      @object.num
-    }
-    error = assert_raises Minitest::Assertion do
-      assert_no_changes check do
-        @object.increment
-      end
-    end
-    assert_equal "`@object.num` changed.\nExpected: 2\n  Actual: 3", error.message
-
-    error = assert_raises Minitest::Assertion do
-      assert_no_changes -> { @object.num } do
-        @object.increment
-      end
-    end
-    assert_equal "`@object.num` changed.\nExpected: 3\n  Actual: 4", error.message
-
-    error = assert_raises Minitest::Assertion do
-      assert_no_changes ->(a = nil) { @object.num } do
-        @object.increment
-      end
-    end
-    assert_match(/#<Proc:0x.*changed/, error.message)
-  end
-
-  def test_assert_no_changes_message_with_multi_line_lambda
-    check = lambda {
-      "title".upcase
-      @object.num
-    }
-    error = assert_raises Minitest::Assertion do
-      assert_no_changes check do
-        @object.increment
-      end
-    end
-    assert_match(/#<Proc:0x.*changed/, error.message)
-
-    check = lambda {
-      "title".upcase
-      @object.num
-    }
-    error = assert_raises Minitest::Assertion do
-      assert_no_changes check do
-        @object.increment
-      end
-    end
-    assert_match(/#<Proc:0x.*changed/, error.message)
-  end
-
-  def test_assert_no_changes_message_with_not_real_callable
-    check = Object.new
-    def check.call
-      @object.num
-    end
-    check.instance_variable_set(:@object, @object)
-
-    error = assert_raises Minitest::Assertion do
-      assert_no_changes check do
-        @object.increment
-      end
-    end
-    assert_match(/#<Object:0x.*changed/, error.message)
+    assert_equal "@object.num should not change.\n\"@object.num\" changed.\nExpected: 0\n  Actual: 1", error.message
   end
 
   def test_assert_no_changes_with_long_string_wont_output_everything
@@ -468,7 +362,7 @@ class AssertionsTest < ActiveSupport::TestCase
     end
 
     assert_match <<~output, error.message
-      `lines` changed.
+      "lines" changed.
       --- expected
       +++ actual
       @@ -10,4 +10,5 @@
@@ -509,7 +403,7 @@ class ExceptionsInsideAssertionsTest < ActiveSupport::TestCase
       run_test_that_should_fail_but_not_log_a_warning
     end
     assert_not @out.string.include?("assert_nothing_raised")
-    assert error.message.include?("`rand` changed")
+    assert error.message.include?("(lambda)> changed")
   end
 
   def test_fails_and_warning_is_logged_if_wrong_error_caught


### PR DESCRIPTION
### Motivation / Background
With prism as the default parser in Ruby 3.4, the usual method of getting a procs source does not work anymore: https://github.com/rails/rails/pull/52937

@kddnewton was so kind as to anwser some questions in https://bugs.ruby-lang.org/issues/20761 but even with that information I was not able to make it work.

@byroot's comment at https://github.com/rails/rails/pull/52036#issuecomment-2155854578 seems very relevant. Just took one (as of yet unreleased) ruby release.

### Detail

For now, I propose this revert. If someone else is able to make it work under prism that would be great but since this hasn't been part of a release yet and 8.0.0 seems somewhat close I openend this PR. cc @richardboehme

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
