### PR TITLE
Use RubyVM::InstructionSequence for callable source

### DIFF
--- a/activesupport/lib/active_support/testing/assertions.rb
+++ b/activesupport/lib/active_support/testing/assertions.rb
@@ -299,17 +299,24 @@ module ActiveSupport
         end
 
         def _callable_to_source_string(callable)
-          if defined?(RubyVM::AbstractSyntaxTree) && callable.is_a?(Proc)
-            ast = begin
-              RubyVM::AbstractSyntaxTree.of(callable, keep_script_lines: true)
-            rescue SystemCallError
-              # Failed to get the source somehow
-              return callable
-            end
-            return callable unless ast
+          if defined?(RubyVM::InstructionSequence) && callable.is_a?(Proc)
+            iseq = RubyVM::InstructionSequence.of(callable)
+            source =
+              if iseq.script_lines
+                iseq.script_lines.join("\n")
+              elsif File.readable?(iseq.absolute_path)
+                File.read(iseq.absolute_path)
+              end
 
-            source = ast.source
-            source.strip!
+            return callable unless source
+
+            location = iseq.to_a[4][:code_location]
+            return callable unless location
+
+            lines = source.lines[(location[0] - 1)..(location[2] - 1)]
+            lines[-1] = lines[-1].byteslice(...location[3])
+            lines[0] = lines[0].byteslice(location[1]...)
+            source = lines.join.strip
 
             # We ignore procs defined with do/end as they are likely multi-line anyway.
             if source.start_with?("{")

--- a/activesupport/test/test_case_test.rb
+++ b/activesupport/test/test_case_test.rb
@@ -171,7 +171,7 @@ class AssertionsTest < ActiveSupport::TestCase
   end
 
   def test_assert_difference_message_with_lambda
-    skip if !defined?(RubyVM::AbstractSyntaxTree)
+    skip if !defined?(RubyVM::InstructionSequence)
 
     error = assert_raises Minitest::Assertion do
       assert_difference(-> { @object.num }, 1, "Object Changed") do
@@ -247,7 +247,7 @@ class AssertionsTest < ActiveSupport::TestCase
   end
 
   def test_assert_changes_message_with_lambda
-    skip if !defined?(RubyVM::AbstractSyntaxTree)
+    skip if !defined?(RubyVM::InstructionSequence)
 
     error = assert_raises Minitest::Assertion do
       assert_changes -> { @object.num }, to: 0 do
@@ -375,7 +375,7 @@ class AssertionsTest < ActiveSupport::TestCase
   end
 
   def test_assert_no_changes_message_with_lambda
-    skip if !defined?(RubyVM::AbstractSyntaxTree)
+    skip if !defined?(RubyVM::InstructionSequence)
 
     error = assert_raises Minitest::Assertion do
       assert_no_changes -> { @object.num } do


### PR DESCRIPTION
This ensures it works regardless of the parser, and does not require reparsing the original source.

This is in response to a ping on https://github.com/rails/rails/pull/53054.

cc @byroot 