### PR TITLE
Deprecate calling `redirect_to` with bad status

### DIFF
--- a/actionpack/lib/action_controller/metal/redirecting.rb
+++ b/actionpack/lib/action_controller/metal/redirecting.rb
@@ -52,8 +52,8 @@ module ActionController
     # The status code can either be a standard [HTTP Status
     # code](https://www.iana.org/assignments/http-status-codes) as an integer, or a
     # symbol representing the downcased, underscored and symbolized description.
-    # Note that the status code must be a 3xx HTTP code, or redirection will not
-    # occur.
+    # Note that the status code must be a valid 3xx HTTP code, or redirection will
+    # not occur.
     #
     # If you are using XHR requests other than GET or POST and redirecting after the
     # request then some browsers will follow the redirect using the original request
@@ -105,8 +105,14 @@ module ActionController
       raise AbstractController::DoubleRenderError if response_body
 
       allow_other_host = response_options.delete(:allow_other_host) { _allow_other_host }
-
       self.status = _extract_redirect_to_status(options, response_options)
+
+      unless response.redirect?
+        ActionController.deprecator.warn(<<~MSG.squish)
+          Passing a non-3XX status to `redirect_to` is deprecated and will raise
+          an exception in Rails 8.1.
+        MSG
+      end
 
       redirect_to_location = _compute_redirect_to_location(request, options)
       _ensure_url_is_http_header_safe(redirect_to_location)

--- a/actionpack/test/controller/redirect_test.rb
+++ b/actionpack/test/controller/redirect_test.rb
@@ -44,6 +44,18 @@ class RedirectController < ActionController::Base
     redirect_to({ action: "hello_world" }, { status: 301 })
   end
 
+  def redirect_with_non_redirect_status
+    redirect_to("http://www.example.com", status: 422)
+  end
+
+  def redirect_with_non_redirect_status_by_name
+    redirect_to("http://www.example.com", status: :unprocessable_entity)
+  end
+
+  def redirect_with_3xx_yet_still_non_redirect_status
+    redirect_to("http://www.example.com", status: 304)
+  end
+
   def redirect_with_protocol
     redirect_to action: "hello_world", protocol: "https"
   end
@@ -248,6 +260,30 @@ class RedirectTest < ActionController::TestCase
     get :redirect_with_status_hash
     assert_response 301
     assert_equal "http://test.host/redirect/hello_world", redirect_to_url
+  end
+
+  def test_redirect_with_non_redirect_status
+    assert_deprecated(ActionController.deprecator) do
+      get :redirect_with_non_redirect_status
+    end
+    assert_response 422
+    assert_equal "http://www.example.com", redirect_to_url
+  end
+
+  def test_redirect_with_non_redirect_status_by_name
+    assert_deprecated(ActionController.deprecator) do
+      get :redirect_with_non_redirect_status_by_name
+    end
+    assert_response 422
+    assert_equal "http://www.example.com", redirect_to_url
+  end
+
+  def test_redirect_with_3xx_yet_still_non_redirect_status
+    assert_deprecated(ActionController.deprecator) do
+      get :redirect_with_3xx_yet_still_non_redirect_status
+    end
+    assert_response 304
+    assert_equal "http://www.example.com", redirect_to_url
   end
 
   def test_redirect_with_protocol


### PR DESCRIPTION
### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

TL;DR `redirect_to` and `assert_redirect_to` both currently accept non-redirect status codes

### Detail

Currently, `redirect_to` and `assert_redirected_to` will gladly accept "nonsensical" status values, e.g. `:bad_request`. I say nonsensical because using `redirect_to` implies that you intend to, well, redirect! But browsers (and turbo) will not process these responses as redirects because their HTTP response status falls outside the 3XX range

### Additional information
This PR adds a deprecation warning to `redirect_to` calls with non-redirect statuses. It does so by asking the response if it is a `redirect?` immediately after assigning the response status.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included
