### PR TITLE
Deprecate built-in `sidekiq` adapter

### DIFF
--- a/activejob/CHANGELOG.md
+++ b/activejob/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Deprecate built-in `sidekiq` adapter.
+
+    If you're using this adapter, upgrade to `sidekiq` 7.3.3 or later to use the `sidekiq` gem's adapter.
+
+    *fatkodima*
+
 *   Remove deprecated internal `SuckerPunch` adapter in favor of the adapter included with the `sucker_punch` gem.
 
     *Rafael Mendonça França*

--- a/activejob/lib/active_job/queue_adapters/sidekiq_adapter.rb
+++ b/activejob/lib/active_job/queue_adapters/sidekiq_adapter.rb
@@ -30,6 +30,13 @@ module ActiveJob
         end
       end
 
+      def check_adapter
+        ActiveJob.deprecator.warn <<~MSG.squish
+          The built-in `sidekiq` adapter is deprecated and will be removed in Rails 8.2.
+          Please upgrade `sidekiq` gem to version 7.3.3 or later to use the `sidekiq` gem's adapter.
+        MSG
+      end
+
       def enqueue(job) # :nodoc:
         job.provider_job_id = JobWrapper.set(
           wrapped: job.class,

--- a/activejob/test/cases/adapter_test.rb
+++ b/activejob/test/cases/adapter_test.rb
@@ -6,4 +6,20 @@ class AdapterTest < ActiveSupport::TestCase
   test "should load #{ENV['AJ_ADAPTER']} adapter" do
     assert_equal "active_job/queue_adapters/#{ENV['AJ_ADAPTER']}_adapter".classify, ActiveJob::Base.queue_adapter.class.name
   end
+
+  if adapter_is?(:sidekiq)
+    test "sidekiq adapter should be deprecated" do
+      before_adapter = ActiveJob::Base.queue_adapter
+
+      msg = <<~MSG.squish
+        The built-in `sidekiq` adapter is deprecated and will be removed in Rails 8.2.
+        Please upgrade `sidekiq` gem to version 7.3.3 or later to use the `sidekiq` gem's adapter.
+      MSG
+      assert_deprecated(msg, ActiveJob.deprecator) do
+        ActiveJob::Base.queue_adapter = :sidekiq
+      end
+    ensure
+      ActiveJob::Base.queue_adapter = before_adapter
+    end
+  end
 end


### PR DESCRIPTION
Reference #52929.

Opening this to not miss out.

The next sidekiq release will add an Active Job adapter by default - https://github.com/sidekiq/sidekiq/pull/6430.