### PR TITLE
Fix `pluck` with using join alias

### DIFF
--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -1956,6 +1956,7 @@ module ActiveRecord
           table[field]
         elsif field.match?(/\A\w+\.\w+\z/)
           table, column = field.split(".")
+          self.references_values |= [Arel.sql(table, retryable: true)]
           predicate_builder.resolve_arel_attribute(table, column) do
             lookup_table_klass_from_join_dependencies(table)
           end

--- a/activerecord/test/cases/calculations_test.rb
+++ b/activerecord/test/cases/calculations_test.rb
@@ -1141,6 +1141,10 @@ class CalculationsTest < ActiveRecord::TestCase
     assert_equal [[2, 2], [4, 4]], Reply.includes(:topic).order(:id).pluck(:id, :"topics.id")
   end
 
+  def test_pluck_with_join_alias
+    assert_equal [[2, 1], [4, 3]], Reply.includes(:topic).order(:id).pluck(:id, :"topic.id")
+  end
+
   def test_group_by_with_order_by_virtual_count_attribute
     expected = { "SpecialPost" => 1, "StiPost" => 2 }
     actual = Post.group(:type).order(:count).limit(2).maximum(:comments_count)


### PR DESCRIPTION
Correctly adds references values when alias qualified column name is passed.

Fixes #53063.
