### PR TITLE
Update min Ruby version in getting started guide

### DIFF
--- a/guides/source/getting_started.md
+++ b/guides/source/getting_started.md
@@ -100,7 +100,7 @@ $ ruby --version
 ruby 3.2.0
 ```
 
-Rails requires Ruby version 3.1.0 or later. It is preferred to use the latest Ruby version.
+Rails requires Ruby version 3.2.0 or later. It is preferred to use the latest Ruby version.
 If the version number returned is less than that number (such as 2.3.7, or 1.8.7),
 you'll need to install a fresh copy of Ruby.
 


### PR DESCRIPTION
When installing Rails 8.0.0.beta, I found that I needed to have Ruby >= 3.2., but the edge guides mention 3.1.

```
% gem install rails --version 8.0.0.beta1
ERROR:  Error installing rails:
	rails-8.0.0.beta1 requires Ruby version >= 3.2.0. The current ruby version is 3.1.3.
```
