### PR TITLE
Refactor `ActionCable::TestHelper` block-wise assertions

### DIFF
--- a/actioncable/test/test_helper_test.rb
+++ b/actioncable/test/test_helper_test.rb
@@ -119,12 +119,12 @@ class TransmittedDataTest < ActionCable::TestCase
   def test_assert_broadcast_on_with_no_block
     assert_nothing_raised do
       ActionCable.server.broadcast "test", "hello"
-      assert_broadcast_on "test", "hello"
+      assert_broadcast_on "test", '"hello"'
     end
 
     assert_nothing_raised do
       ActionCable.server.broadcast "test", "world"
-      assert_broadcast_on "test", "world"
+      assert_broadcast_on "test", '"world"'
     end
   end
 
@@ -135,7 +135,7 @@ class TransmittedDataTest < ActionCable::TestCase
     end
 
     assert_match(/No messages sent/, error.message)
-    assert_match(/Message\(s\) found:\nhello/, error.message)
+    assert_match(/Message\(s\) found:\n"hello"/, error.message)
   end
 
   def test_assert_broadcast_on_message_with_empty_channel


### PR DESCRIPTION
### Motivation / Background

Implement `ActionCable::TestHelper` block-wise assertions in terms of `#capture_broadcasts`. This change inlines the private `#new_broadcasts_from` method contents into the `#capture_broadcasts` method, and uses `#capture_broadcasts` at all the previous `#new_broadcasts_from` call sites. This consolidation enables the removal of some JSON-parsing duplication across the other method implementations.

### Detail

The test file changes were necessary to account for JSON-encoded String values (for example, transforming `hello` into `"hello"`). Since the [broadcast][] documentation explicitly mentions that the `message` value <q>will later be JSON encoded</q>, this might not be considered a backwards incompatible change, since it brings *actual* behavior in-line with *documented* behavior.

[broadcast]: https://edgeapi.rubyonrails.org/classes/ActiveRecord/AttributeMethods/BeforeTypeCast.html#method-i-read_attribute_before_type_cast

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
