### PR TITLE
No need to consider older RubyGem versions since Rails main requires Ruby 3.2.0

### DIFF
--- a/railties/lib/rails/generators/base.rb
+++ b/railties/lib/rails/generators/base.rb
@@ -423,10 +423,6 @@ module Rails
           path = File.expand_path(File.join(base_name, generator_name), base_root)
           path if File.exist?(path)
         end
-
-        def gem_ruby_version
-          Gem::Version.new(Gem::VERSION) >= Gem::Version.new("3.3.13") ? Gem.ruby_version : RUBY_VERSION
-        end
     end
   end
 end

--- a/railties/lib/rails/generators/rails/app/templates/Dockerfile.tt
+++ b/railties/lib/rails/generators/rails/app/templates/Dockerfile.tt
@@ -8,7 +8,7 @@
 # For a containerized dev environment, see Dev Containers: https://guides.rubyonrails.org/getting_started_with_devcontainer.html
 
 # Make sure RUBY_VERSION matches the Ruby version in .ruby-version
-ARG RUBY_VERSION=<%= gem_ruby_version %>
+ARG RUBY_VERSION=<%= Gem.ruby_version %>
 FROM docker.io/library/ruby:$RUBY_VERSION-slim AS base
 
 # Rails app lives here

--- a/railties/lib/rails/generators/rails/devcontainer/templates/devcontainer/Dockerfile.tt
+++ b/railties/lib/rails/generators/rails/devcontainer/templates/devcontainer/Dockerfile.tt
@@ -1,3 +1,3 @@
 # Make sure RUBY_VERSION matches the Ruby version in .ruby-version
-ARG RUBY_VERSION=<%= gem_ruby_version %>
+ARG RUBY_VERSION=<%= Gem.ruby_version %>
 FROM ghcr.io/rails/devcontainer/images/ruby:$RUBY_VERSION

--- a/railties/test/generators/generators_test_helper.rb
+++ b/railties/test/generators/generators_test_helper.rb
@@ -151,7 +151,6 @@ module GeneratorsTestHelper
   private
     def gemfile_locals
       {
-        gem_ruby_version: RUBY_VERSION,
         rails_prerelease: false,
         skip_active_storage: true,
         depend_on_bootsnap: false,


### PR DESCRIPTION
### Motivation / Background

This pull request removes the `gem_ruby_version` method to handle RubyGem versions since Ruby 3.2.0 installs RubyGems 3.4.1 as a default gem. We can always use the `Gem.ruby_version` now.

### Detail

* Ruby 3.2.0 Released https://www.ruby-lang.org/en/news/2022/12/25/ruby-3-2-0-released/
> The following default gems are updated.
> RubyGems 3.4.1

- RubyGems version shipped with Ruby 3.2.0
```ruby
$ ruby -v
ruby 3.2.0 (2022-12-25 revision a528908271) [x86_64-linux]
$ gem -v
3.4.1
```

### Additional information
Refer to
https://github.com/rails/rails/pull/47584
https://github.com/rails/rails/pull/47669

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
