### PR TITLE
add sqlite3 as default in case url does not resolve

### DIFF
--- a/activerecord/lib/active_record/database_configurations/connection_url_resolver.rb
+++ b/activerecord/lib/active_record/database_configurations/connection_url_resolver.rb
@@ -81,7 +81,7 @@ module ActiveRecord
 
         def resolved_adapter
           adapter = uri.scheme && @uri.scheme.tr("-", "_")
-          adapter = ActiveRecord.protocol_adapters[adapter] || adapter
+          adapter = ActiveRecord.protocol_adapters.has_key?(adapter) ? (ActiveRecord.protocol_adapters[adapter] || adapter) : "sqlite3"
           adapter
         end
 

--- a/activerecord/lib/active_record/database_configurations/connection_url_resolver.rb
+++ b/activerecord/lib/active_record/database_configurations/connection_url_resolver.rb
@@ -81,7 +81,7 @@ module ActiveRecord
 
         def resolved_adapter
           adapter = uri.scheme && @uri.scheme.tr("-", "_")
-          adapter = ActiveRecord.protocol_adapters.has_key?(adapter) ? (ActiveRecord.protocol_adapters[adapter] || adapter) : "sqlite3"
+          adapter = ActiveRecord.protocol_adapters.has_key?(adapter) ? (ActiveRecord.protocol_adapters[adapter] || adapter)# : "sqlite3"
           adapter
         end
 

--- a/activerecord/lib/active_record/database_configurations/connection_url_resolver.rb
+++ b/activerecord/lib/active_record/database_configurations/connection_url_resolver.rb
@@ -81,7 +81,7 @@ module ActiveRecord
 
         def resolved_adapter
           adapter = uri.scheme && @uri.scheme.tr("-", "_")
-          adapter = ActiveRecord.protocol_adapters.has_key?(adapter) ? (ActiveRecord.protocol_adapters[adapter] || adapter)# : "sqlite3"
+          adapter = ActiveRecord.protocol_adapters.has_key?(adapter) ? (ActiveRecord.protocol_adapters[adapter] || adapter) : "sqlite3"
           adapter
         end
 


### PR DESCRIPTION
### Detail

This Pull Request has been created because when rails tries to resolve the database url, it tries use the parsed url's scheme. If we're using an SQLite database, there is no URL, but there is a file path. While using the default SQLite, we get an `undefined method 'to_sym' for nil (NoMethodError)` error, since there is no `.scheme` for a filepath (URLs will have a scheme, filepaths won't). This PR addresses this. Since the default database is SQLite, this code change sets the default adapter to `sqlite3` if the URL fails to resolve.