### PR TITLE
Fix bcrypt gem not added by auth generator

### DIFF
--- a/railties/lib/rails/generators/rails/authentication/authentication_generator.rb
+++ b/railties/lib/rails/generators/rails/authentication/authentication_generator.rb
@@ -41,7 +41,7 @@ module Rails
           uncomment_lines "Gemfile", /gem "bcrypt"/
           Bundler.with_original_env { execute_command :bundle, "install --quiet" }
         else
-          Bundler.with_original_env { execute_command :bundle, "add bcrypt --quiet" }
+          Bundler.with_original_env { execute_command :bundle, "add bcrypt", capture: true }
         end
       end
 

--- a/railties/test/generators/authentication_generator_test.rb
+++ b/railties/test/generators/authentication_generator_test.rb
@@ -12,7 +12,7 @@ class AuthenticationGeneratorTest < Rails::Generators::TestCase
     Rails.application.config.root = Pathname(destination_root)
 
     self.class.tests Rails::Generators::AppGenerator
-    run_generator([destination_root])
+    run_generator([destination_root, "--no-skip-bundle"])
 
     self.class.tests Rails::Generators::AuthenticationGenerator
   end
@@ -49,6 +49,16 @@ class AuthenticationGeneratorTest < Rails::Generators::TestCase
 
     assert_migration "db/migrate/create_users.rb" do |content|
       assert_match(/t.string :password_digest, null: false/, content)
+    end
+  end
+
+  def test_authentication_generator_without_bcrypt_in_gemfile
+    File.write("Gemfile", File.read("Gemfile").sub(/# gem "bcrypt".*\n/, ""))
+
+    run_generator
+
+    assert_file "Gemfile" do |content|
+      assert_match(/\ngem "bcrypt"/, content)
     end
   end
 


### PR DESCRIPTION
Fixes #53082.

### Motivation / Background

This Pull Request has been created because running `bin/rails generate authentication` does not add the bcrypt gem if there is no `# gem "bcrypt"` comment in the Gemfile, and this prevents authentication from working.

This is because the authentication template does `bundle add bcrypt --quiet`, but `--quiet` is not a valid option for `bundle add`.

### Detail

This Pull Request changes the authentication template to use plain `bundle add bcrypt` with Thor's `capture: true` option.

### Additional information

I chose that solution because it was the quickest fix to still [hide output](https://www.rubydoc.info/gems/thor/Thor/Actions#run-instance_method) in the spirit of what was [originally intended](https://github.com/rails/rails/commit/a6ccd0d9c15), while keeping the style of the original code. But a side effect is that if `bundle add` fails for any reason, no error message will be shown, because stderr will also be hidden.

Alternatively we could:

- run `bundle add bcrypt` without `--quiet`, but that would result in wordier output like this:

    ```
        bundle  add bcrypt
    Fetching gem metadata from https://rubygems.org/..........
    Resolving dependencies...
    Fetching gem metadata from https://rubygems.org/..........
    Resolving dependencies...
    ```

- Add `gem bcrypt` in the Gemfile with Rails' [`gem`](https://api.rubyonrails.org/classes/Rails/Generators/Actions.html#method-i-gem) helper or Thor's [`insert_into_file`](https://www.rubydoc.info/gems/thor/Thor/Actions#insert_into_file-instance_method), followed by `bundle install --quiet`.

- use another way to run `bundle add` silently, although that would change the style of the original code. Something like:
    - `say_status :run, "bundle add bcrypt"; system('bundle add bcrypt', out: File::NULL)`
    - or copy/pasting or requiring [`bundle command` + `exec_bundle_command`](https://github.com/rails/rails/blob/8a2e28d7451d5ae4cb194fccc125a6b9554bb38b/railties/lib/rails/generators/app_base.rb#L632-L656) from the `app_base` generator, although that wouldn't work out of the box because you can't pass the `quiet` option except globally, so you would need to copy/paste and/or tweak. Feels like too much.

I can update the PR if one of these options is preferred.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
