### PR TITLE
Fix lazy route set `method_missing` super

### DIFF
--- a/railties/lib/rails/engine/lazy_route_set.rb
+++ b/railties/lib/rails/engine/lazy_route_set.rb
@@ -87,19 +87,19 @@ module Rails
         def method_missing_module
           @method_missing_module ||= Module.new do
             private
-              def method_missing(method_name, *args, &block)
+              def method_missing(...)
                 if Rails.application&.reload_routes_unless_loaded
-                  public_send(method_name, *args, &block)
+                  public_send(...)
                 else
-                  super(method_name, *args, &block)
+                  super
                 end
               end
 
-              def respond_to_missing?(method_name, *args)
+              def respond_to_missing?(...)
                 if Rails.application&.reload_routes_unless_loaded
-                  respond_to?(method_name, *args)
+                  respond_to?(...)
                 else
-                  super(method_name, *args)
+                  super
                 end
               end
           end


### PR DESCRIPTION
### Motivation / Background

This Pull Request fixes an issue with the lazy route set’s `method_missing`. Previously, it was calling `super` after having combined keyword arguments into a hash as a positional argument, causing other libraries to break.

### Detail

The `method_mising` call only accepted `*args`, which means any keyword arguments were combined into the args array. It then called `super` with that array, rather than passing on the original arguments.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
