### PR TITLE
Fixes #53060, moving password reset token into session

### DIFF
--- a/railties/lib/rails/generators/erb/authentication/templates/views/passwords/edit.html.erb
+++ b/railties/lib/rails/generators/erb/authentication/templates/views/passwords/edit.html.erb
@@ -2,7 +2,7 @@
 
 <%%= tag.div(flash[:alert], style: "color:red") if flash[:alert] %>
 
-<%%= form_with url: password_path(params[:token]), method: :put do |form| %>
+<%%= form_with url: password_path, method: :put do |form| %>
   <%%= form.password_field :password, required: true, autocomplete: "new-password", placeholder: "Enter new password", maxlength: 72 %><br>
   <%%= form.password_field :password_confirmation, required: true, autocomplete: "new-password", placeholder: "Repeat new password", maxlength: 72 %><br>
   <%%= form.submit "Save" %>

--- a/railties/lib/rails/generators/erb/authentication/templates/views/passwords/new.html.erb
+++ b/railties/lib/rails/generators/erb/authentication/templates/views/passwords/new.html.erb
@@ -2,7 +2,7 @@
 
 <%%= tag.div(flash[:alert], style: "color:red") if flash[:alert] %>
 
-<%%= form_with url: passwords_path do |form| %>
+<%%= form_with url: password_path do |form| %>
   <%%= form.email_field :email_address, required: true, autofocus: true, autocomplete: "username", placeholder: "Enter your email address", value: params[:email_address] %><br>
   <%%= form.submit "Email reset instructions" %>
 <%% end %>

--- a/railties/lib/rails/generators/rails/authentication/authentication_generator.rb
+++ b/railties/lib/rails/generators/rails/authentication/authentication_generator.rb
@@ -32,7 +32,7 @@ module Rails
       end
 
       def configure_authentication_routes
-        route "resources :passwords, param: :token"
+        route "resource :password"
         route "resource :session"
       end
 

--- a/railties/lib/rails/generators/rails/authentication/templates/controllers/passwords_controller.rb
+++ b/railties/lib/rails/generators/rails/authentication/templates/controllers/passwords_controller.rb
@@ -1,5 +1,6 @@
 class PasswordsController < ApplicationController
   allow_unauthenticated_access
+  before_action :redirect_on_token, only: :edit
   before_action :set_user_by_token, only: %i[ edit update ]
 
   def new
@@ -20,14 +21,22 @@ class PasswordsController < ApplicationController
     if @user.update(params.permit(:password, :password_confirmation))
       redirect_to new_session_url, notice: "Password has been reset."
     else
-      redirect_to edit_password_url(params[:token]), alert: "Passwords did not match."
+      redirect_to edit_password_url, alert: "Passwords did not match."
     end
   end
 
   private
+    def redirect_on_token
+      if params[:token]
+        session[:token] = params[:token]
+        redirect_to edit_password_url
+      end
+    end
+
     def set_user_by_token
-      @user = User.find_by_password_reset_token!(params[:token])
+      @user = User.find_by_password_reset_token!(session[:token])
     rescue ActiveSupport::MessageVerifier::InvalidSignature
+      session.delete(:token) if session[:token]
       redirect_to new_password_url, alert: "Password reset link is invalid or has expired."
     end
 end

--- a/railties/lib/rails/generators/rails/authentication/templates/views/passwords_mailer/reset.html.erb
+++ b/railties/lib/rails/generators/rails/authentication/templates/views/passwords_mailer/reset.html.erb
@@ -1,4 +1,4 @@
 <p>
   You can reset your password within the next 15 minutes on
-  <%%= link_to "this password reset page", edit_password_url(@user.password_reset_token) %>.
+  <%%= link_to "this password reset page", edit_password_url(token: @user.password_reset_token) %>.
 </p>

--- a/railties/lib/rails/generators/rails/authentication/templates/views/passwords_mailer/reset.text.erb
+++ b/railties/lib/rails/generators/rails/authentication/templates/views/passwords_mailer/reset.text.erb
@@ -1,2 +1,2 @@
 You can reset your password within the next 15 minutes on this password reset page:
-<%%= edit_password_url(@user.password_reset_token) %>
+<%%= edit_password_url(token: @user.password_reset_token) %>


### PR DESCRIPTION
### Motivation / Background

This is a change in the code generated by the authentication generators. It aims to avoid exposing the password reset token in the URL to not give access to 3rd party scripts or off-domain images, avoiding leaking data to a referer. 

Most users using the authentication generators will probably be unaware of the consequence of putting the password reset token in the URL. This can lead them to accidentally expose it in tracking URLs or images. To prevent this, we can limit the exposure to the password reset token as much as possible by putting the password reset token in the session.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
