### PR TITLE
Handle hash methods for `ActiveRecord::Result` rows

### DIFF
--- a/activerecord/lib/active_record/result.rb
+++ b/activerecord/lib/active_record/result.rb
@@ -87,6 +87,18 @@ module ActiveRecord
         @column_indexes.transform_values { |index| @row[index] }
       end
       alias_method :to_hash, :to_h
+
+      def method_missing(method_name, ...)
+        if method_name.end_with?("!")
+          super
+        else
+          to_hash.public_send(method_name, ...)
+        end
+      end
+
+      def respond_to_missing?(method_name, include_all = false)
+        super || (!method_name.end_with?("!") && to_hash.respond_to?(method_name, include_all))
+      end
     end
 
     attr_reader :columns, :rows, :column_types

--- a/activerecord/test/cases/result_test.rb
+++ b/activerecord/test/cases/result_test.rb
@@ -129,5 +129,24 @@ module ActiveRecord
         assert_equal "col 2", row["foo"]
       end
     end
+
+    test "hash methods on rows" do
+      result = Result.new(["col_1", "col_2"], [
+        ["row 1 col 1", "row 1 col 2"],
+        ["row 2 col 1", "row 2 col 2"],
+      ])
+
+      result.each do |row|
+        assert row.respond_to?(:transform_keys)
+        assert_equal ["COL_1", "COL_2"], row.transform_keys(&:upcase).keys
+
+        # It does not accept Hash destructive methods.
+        assert_not row.respond_to?(:transform_keys!)
+
+        assert_raises(NoMethodError, match: /undefined method `transform_keys!'/) do
+          row.transform_keys!(&:upcase)
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Fixes #53081 (see there for the discussion).

