### PR TITLE
Preload nested associations when calling `reload` with strict loading enabled

### DIFF
--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -817,10 +817,20 @@ module ActiveRecord
         @previously_new_record = false
       end
 
-      def strict_loaded_associations
-        @association_cache.find_all do |_, assoc|
-          assoc.owner.strict_loading? && !assoc.owner.strict_loading_n_plus_one_only?
-        end.map(&:first)
+      def strict_loaded_associations(checked = nil)
+        checked ||= Set.new
+        checked.add(self)
+        @association_cache.map do |name, assoc|
+          if assoc.owner.strict_loading? && !assoc.owner.strict_loading_n_plus_one_only?
+            target = Array.wrap(assoc.target).first
+
+            if target && !checked.include?(target)
+              { name => target.send(:strict_loaded_associations, checked) }
+            else
+              name
+            end
+          end
+        end.compact
       end
 
       def _find_record(options)

--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -820,7 +820,7 @@ module ActiveRecord
       def strict_loaded_associations(checked = nil)
         checked ||= Set.new
         checked.add(self)
-        @association_cache.map do |name, assoc|
+        @association_cache.filter_map do |name, assoc|
           if assoc.owner.strict_loading? && !assoc.owner.strict_loading_n_plus_one_only?
             target = Array.wrap(assoc.target).first
 
@@ -830,7 +830,7 @@ module ActiveRecord
               name
             end
           end
-        end.compact
+        end
       end
 
       def _find_record(options)

--- a/activerecord/test/cases/strict_loading_test.rb
+++ b/activerecord/test/cases/strict_loading_test.rb
@@ -298,6 +298,26 @@ class StrictLoadingTest < ActiveRecord::TestCase
     end
   end
 
+  def test_strict_loading_with_nested_association_reload
+    with_strict_loading_by_default(Project) do
+      with_strict_loading_by_default(Developer) do
+        with_strict_loading_by_default(AuditLog) do
+          project = Project.preload(developers: :audit_logs).first
+
+          assert_nothing_raised do
+            project.developers.first.audit_logs.to_a
+          end
+
+          project.reload
+
+          assert_nothing_raised do
+            project.developers.first.audit_logs.to_a
+          end
+        end
+      end
+    end
+  end
+
   def test_strict_loading_with_has_many_through_cascade_down_to_middle_records
     dev = Developer.first
     firm = Firm.create!(name: "NASA")


### PR DESCRIPTION
### Motivation / Background

This PR tried to fix #53017 by recursing the association cache to preload nested associations. 

### Detail

This Pull Request changes `ActiveRecord::Persistence#strict_loaded_associations` to recurse the association cache of the record. To prevent infinite recursion the method now takes an optional `Set` that keeps track of the already inspected model instances.

This is probably not the proper way of doing this inside of activerecord, but I'm not familiar enough with activerecord yet to find a better solution.

Also I'm not sure if this actually covers all cases, but I guess it should be more correct than the current behavior.

