### PR TITLE
Fix ActiveSupport::BroadcastLogger from executing a block argument for each logger (tagged, info, etc.)

### DIFF
--- a/activesupport/lib/active_support/broadcast_logger.rb
+++ b/activesupport/lib/active_support/broadcast_logger.rb
@@ -76,7 +76,6 @@ module ActiveSupport
 
     # Returns all the logger that are part of this broadcast.
     attr_reader :broadcasts
-    attr_reader :formatter
     attr_accessor :progname
 
     def initialize(*loggers)
@@ -105,62 +104,36 @@ module ActiveSupport
       @broadcasts.delete(logger)
     end
 
-    def level
-      @broadcasts.map(&:level).min
-    end
-
-    def <<(message)
-      dispatch { |logger| logger.<<(message) }
-    end
-
-    def add(...)
-      dispatch { |logger| logger.add(...) }
-    end
-    alias_method :log, :add
-
-    def debug(...)
-      dispatch { |logger| logger.debug(...) }
-    end
-
-    def info(...)
-      dispatch { |logger| logger.info(...) }
-    end
-
-    def warn(...)
-      dispatch { |logger| logger.warn(...) }
-    end
-
-    def error(...)
-      dispatch { |logger| logger.error(...) }
-    end
-
-    def fatal(...)
-      dispatch { |logger| logger.fatal(...) }
-    end
-
-    def unknown(...)
-      dispatch { |logger| logger.unknown(...) }
-    end
-
-    def formatter=(formatter)
-      dispatch { |logger| logger.formatter = formatter }
-
-      @formatter = formatter
-    end
-
-    def level=(level)
-      dispatch { |logger| logger.level = level }
-    end
-    alias_method :sev_threshold=, :level=
-
     def local_level=(level)
-      dispatch do |logger|
+      @broadcasts.each do |logger|
         logger.local_level = level if logger.respond_to?(:local_level=)
       end
     end
 
-    def close
-      dispatch { |logger| logger.close }
+    def local_level
+      loggers = @broadcasts.select { |logger| logger.respond_to?(:local_level) }
+
+      loggers.map do |logger|
+        logger.local_level
+      end.first
+    end
+
+    LOGGER_METHODS = %w[
+      << log add debug info warn error fatal unknown
+      level= sev_threshold= close
+      formatter formatter=
+    ] # :nodoc:
+    LOGGER_METHODS.each do |method|
+      class_eval <<-RUBY, __FILE__, __LINE__ + 1
+        def #{method}(...)
+          dispatch(:#{method}, ...)
+        end
+      RUBY
+    end
+
+    # Returns the lowest level of all the loggers in the broadcast.
+    def level
+      @broadcasts.map(&:level).min
     end
 
     # True if the log level allows entries with severity +Logger::DEBUG+ to be written
@@ -171,7 +144,7 @@ module ActiveSupport
 
     # Sets the log level to +Logger::DEBUG+ for the whole broadcast.
     def debug!
-      dispatch { |logger| logger.debug! }
+      dispatch(:debug!)
     end
 
     # True if the log level allows entries with severity +Logger::INFO+ to be written
@@ -182,7 +155,7 @@ module ActiveSupport
 
     # Sets the log level to +Logger::INFO+ for the whole broadcast.
     def info!
-      dispatch { |logger| logger.info! }
+      dispatch(:info!)
     end
 
     # True if the log level allows entries with severity +Logger::WARN+ to be written
@@ -193,7 +166,7 @@ module ActiveSupport
 
     # Sets the log level to +Logger::WARN+ for the whole broadcast.
     def warn!
-      dispatch { |logger| logger.warn! }
+      dispatch(:warn!)
     end
 
     # True if the log level allows entries with severity +Logger::ERROR+ to be written
@@ -204,7 +177,7 @@ module ActiveSupport
 
     # Sets the log level to +Logger::ERROR+ for the whole broadcast.
     def error!
-      dispatch { |logger| logger.error! }
+      dispatch(:error!)
     end
 
     # True if the log level allows entries with severity +Logger::FATAL+ to be written
@@ -215,21 +188,35 @@ module ActiveSupport
 
     # Sets the log level to +Logger::FATAL+ for the whole broadcast.
     def fatal!
-      dispatch { |logger| logger.fatal! }
+      dispatch(:fatal!)
     end
 
     def initialize_copy(other)
       @broadcasts = []
       @progname = other.progname.dup
-      @formatter = other.formatter.dup
 
       broadcast_to(*other.broadcasts.map(&:dup))
     end
 
     private
-      def dispatch(&block)
-        @broadcasts.each { |logger| block.call(logger) }
-        true
+      def dispatch(method, *args, **kwargs, &block)
+        if block_given?
+          # Maintain semantics that the first logger yields the block
+          # as normal, but subsequent loggers won't re-execute the block.
+          # Instead, the initial result is immediately returned.
+          called, result = false, nil
+          block = proc { |*args, **kwargs|
+            if called then result
+            else
+              called = true
+              result = yield(*args, **kwargs)
+            end
+          }
+        end
+
+        @broadcasts.map { |logger|
+          logger.send(method, *args, **kwargs, &block)
+        }.first
       end
 
       def method_missing(name, ...)

--- a/railties/lib/rails/application/bootstrap.rb
+++ b/railties/lib/rails/application/bootstrap.rb
@@ -59,9 +59,7 @@ module Rails
           end
         else
           Rails.logger.level = ActiveSupport::Logger.const_get(config.log_level.to_s.upcase)
-          broadcast_logger = ActiveSupport::BroadcastLogger.new(Rails.logger)
-          broadcast_logger.formatter = Rails.logger.formatter
-          Rails.logger = broadcast_logger
+          Rails.logger = ActiveSupport::BroadcastLogger.new(Rails.logger)
         end
       end
 


### PR DESCRIPTION
[Fixes #49745 #52876]
[Related #51883 #49771 #53105]

NB: I have a related pull request in #53105 that extends
BroadcastLogger to support TaggedLogging correctly. Both could be
merged independently of each other.

This commit refactors the implementation of dispatching method calls
to broadcasted loggers. The updated implementation ensures that any
block is only executed once. The first logger would recieve the block
as per normal, but subsequent loggers would only yield the result of
the initial execution.

The updated implementation of `dispatch` opened up an opportunity to
refactor the way each Logger method is delegatated to broadcasted
loggers - simplifying the delegator definitions.

Prior to these changes, BroadcastLoggers would iterate each broadcast
and re-execute the user provided block for each.

The consumer of any Logger would reasonably expect than when calling a
method with a block, that the block would only execute a single time.
That is, the fact that a Logger is a BroadcastLogger should be
irrelevant to consumer.

The most common example of this is when using
ActiveSupport::TaggedLogging and wrapping behaviour in a
`tagged(*tags) { }` block. But this also applies when using the block
form `info`, `warn` etc. If a BroadcastLogger is used, and there are
multiple loggers being broadcast to, then calling one of these methods
with a block would result in the block being executed multiple times.

For example:

```ruby
  broadcasts = ActiveSupport::BroadcastLogger.new(
    *Array.new(2) { ActiveSupport::Logger.new(STDOUT) }
  )
  number = 0
  broadcasts.info {
    number += 1
    "Updated number to #{number}"
  }
  # Expected:
  # Updated number to 1
  # Updated number to 1
  #
  # Actual:
  # Updated number to 1
  # Updated number to 2
```

After these changes, the behaviour of BroadcastLogger reflects the
expected behaviour above.
