### PR TITLE
Fix resolving non-existing columns for sqlite3

### DIFF
--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -2201,7 +2201,9 @@ module ActiveRecord
               arel_column("#{key}.#{column}", &:itself)
             end
           when String, Symbol
-            arel_column(key).as(columns_aliases.to_s)
+            arel_column(key) do
+              predicate_builder.resolve_arel_attribute(model.table_name, key)
+            end.as(columns_aliases.to_s)
           end
         end
       end


### PR DESCRIPTION
https://github.com/rails/rails/commit/ba468db0bdc880c694df091b5800d114e963eff0 (cc @kamipo) broke resolving of non-existing db columns to arel columns (see https://buildkite.com/rails/rails/builds/111931#01923a5a-74c1-438c-8dc2-d0038c530fef).

From sqlite docs (https://www.sqlite.org/quirks.html), section `8. Double-quoted String Literals Are Accepted`: sqlite accepts non existing column references as string literals. 

Previously, the query was: `SELECT "posts"."foo" AS post_title FROM "posts" LIMIT ?` - it explicitly references the table
Now the query is: `SELECT "foo" AS post_title FROM "posts" LIMIT ?`, so is interpreted just as a string.

CI works for a regular sqlite (non-memory) because we have `:strict` mode (https://github.com/rails/rails/pull/45346) enabled for it - https://github.com/rails/rails/blob/ba468db0bdc880c694df091b5800d114e963eff0/activerecord/test/config.example.yml#L67-L75, and so the error is raised, as expected.

Fixes #53097.