### PR TITLE
Add Gemfile assertions to `Rails::Generators::TestCase`

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,2 +1,5 @@
+*   Add `assert_gem`, `assert_gems`, `assert_no_gem`, and `assert_no_gems` to `Rails::Generators::TestCase`
+
+    *Sean Doyle*
 
 Please check [8-0-stable](https://github.com/rails/rails/blob/8-0-stable/railties/CHANGELOG.md) for previous changes.

--- a/railties/test/generators/actions_test.rb
+++ b/railties/test/generators/actions_test.rb
@@ -78,7 +78,7 @@ class ActionsTest < Rails::Generators::TestCase
   def test_gem_should_put_gem_dependency_in_gemfile
     run_generator
     action :gem, "will-paginate"
-    assert_file "Gemfile", /gem "will-paginate"\n\z/
+    assert_gem "will-paginate"
   end
 
   def test_gem_with_version_should_include_version_in_gemfile
@@ -88,12 +88,12 @@ class ActionsTest < Rails::Generators::TestCase
     action :gem, "nokogiri", version: ">= 1.4.2"
     action :gem, "faker", version: [">= 0.1.0", "< 0.3.0"]
 
-    assert_file "Gemfile" do |content|
-      assert_match(/gem "rspec", ">= 2\.0\.0\.a5"/, content)
-      assert_match(/gem "RedCloth", ">= 4\.1\.0", "< 4\.2\.0"/, content)
-      assert_match(/gem "nokogiri", ">= 1\.4\.2"/, content)
-      assert_match(/gem "faker", ">= 0\.1\.0", "< 0\.3\.0"/, content)
-    end
+    assert_gems(
+      rspec: ">= 2.0.0.a5",
+      RedCloth: [">= 4.1.0", "< 4.2.0"],
+      nokogiri: ">= 1.4.2",
+      faker: [">= 0.1.0", "< 0.3.0"]
+    )
   end
 
   def test_gem_should_insert_on_separate_lines
@@ -104,8 +104,7 @@ class ActionsTest < Rails::Generators::TestCase
     action :gem, "rspec"
     action :gem, "rspec-rails"
 
-    assert_file "Gemfile", /^gem "rspec"$/
-    assert_file "Gemfile", /^gem "rspec-rails"$/
+    assert_gems "rspec", "rspec-rails"
   end
 
   def test_gem_should_include_options
@@ -113,7 +112,7 @@ class ActionsTest < Rails::Generators::TestCase
 
     action :gem, "rspec", github: "dchelimsky/rspec", tag: "1.2.9.rc1"
 
-    assert_file "Gemfile", /gem "rspec", github: "dchelimsky\/rspec", tag: "1\.2\.9\.rc1"/
+    assert_gem "rspec", github: "dchelimsky/rspec", tag: "1.2.9.rc1"
   end
 
   def test_gem_should_put_the_comment_before_gem_declaration
@@ -138,8 +137,10 @@ class ActionsTest < Rails::Generators::TestCase
     action :gem, "rspec", require: false
     action :gem, "rspec-rails", group: [:development, :test]
 
-    assert_file "Gemfile", /^gem "rspec", require: false$/
-    assert_file "Gemfile", /^gem "rspec-rails", group: \[:development, :test\]$/
+    assert_gems(
+      "rspec" => { require: false },
+      "rspec-rails" => { group: [:development, :test] }
+    )
   end
 
   def test_gem_falls_back_to_inspect_if_string_contains_single_quote
@@ -147,7 +148,7 @@ class ActionsTest < Rails::Generators::TestCase
 
     action :gem, "rspec", ">=2.0.0"
 
-    assert_file "Gemfile", /^gem "rspec", ">=2\.0\.0"$/
+    assert_gem "rspec", ">=2.0.0"
   end
 
   def test_gem_works_even_if_frozen_string_is_passed_as_argument
@@ -155,7 +156,7 @@ class ActionsTest < Rails::Generators::TestCase
 
     action :gem, -"frozen_gem", -"1.0.0"
 
-    assert_file "Gemfile", /^gem "frozen_gem", "1\.0\.0"$/
+    assert_gem "frozen_gem", "1.0.0"
   end
 
   def test_gem_group_should_wrap_gems_in_a_group

--- a/railties/test/generators/api_app_generator_test.rb
+++ b/railties/test/generators/api_app_generator_test.rb
@@ -96,9 +96,7 @@ class ApiAppGeneratorTest < Rails::Generators::TestCase
   def test_generator_skip_css
     run_generator [destination_root, "--api", "--css=tailwind"]
 
-    assert_file "Gemfile" do |content|
-      assert_no_match(%r/gem "tailwindcss-rails"/, content)
-    end
+    assert_no_gem "tailwindcss-rails"
 
     assert_no_file "app/views/layouts/application.html.erb" do |content|
       assert_no_match(/tailwind/, content)

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -436,13 +436,13 @@ class AppGeneratorTest < Rails::Generators::TestCase
   def test_config_database_is_added_by_default
     run_generator
     assert_file "config/database.yml", /sqlite3/
-    assert_gem "sqlite3", '">= 2.1"'
+    assert_gem "sqlite3", ">= 2.1"
   end
 
   def test_config_mysql_database
     run_generator([destination_root, "-d", "mysql"])
     assert_file "config/database.yml", /mysql/
-    assert_gem "mysql2", '"~> 0.5"'
+    assert_gem "mysql2", "~> 0.5"
   end
 
   def test_config_database_app_name_with_period
@@ -453,7 +453,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
   def test_config_postgresql_database
     run_generator([destination_root, "-d", "postgresql"])
     assert_file "config/database.yml", /postgresql/
-    assert_gem "pg", '"~> 1.1"'
+    assert_gem "pg", "~> 1.1"
   end
 
   def test_generator_defaults_to_puma_version

--- a/railties/test/generators/authentication_generator_test.rb
+++ b/railties/test/generators/authentication_generator_test.rb
@@ -38,9 +38,7 @@ class AuthenticationGeneratorTest < Rails::Generators::TestCase
       assert_equal "  include Authentication\n", includes_line, "includes module on first line of class definition"
     end
 
-    assert_file "Gemfile" do |content|
-      assert_match(/\ngem "bcrypt"/, content)
-    end
+    assert_gem "bcrypt"
 
     assert_file "config/routes.rb" do |content|
       assert_match(/resource :session/, content)
@@ -82,9 +80,7 @@ class AuthenticationGeneratorTest < Rails::Generators::TestCase
       assert_equal "  include Authentication\n", includes_line, "includes module on first line of class definition"
     end
 
-    assert_file "Gemfile" do |content|
-      assert_match(/\ngem "bcrypt"/, content)
-    end
+    assert_gem "bcrypt"
 
     assert_file "config/routes.rb" do |content|
       assert_match(/resource :session/, content)

--- a/railties/test/generators/benchmark_generator_test.rb
+++ b/railties/test/generators/benchmark_generator_test.rb
@@ -15,9 +15,7 @@ module Rails
       test "generate benchmark" do
         run_generator ["my_benchmark"]
 
-        assert_file("Gemfile") do |content|
-          assert_match "gem \"benchmark-ips\"", content
-        end
+        assert_gem "benchmark-ips"
 
         assert_file("script/benchmarks/my_benchmark.rb") do |content|
           assert_equal <<~RUBY, content


### PR DESCRIPTION
### Motivation / Background

Extract and generalize the `assert_gem` and `assert_no_gem` methods from the internal `SharedGeneratorTests` module. Also introduce supplementary `assert_gems` and `assert_no_gems` helpers.

The `assert_gems` method asserts that the `Gemfile` includes an entry matching each of the provided gems:

```ruby
assert_gems "rails", "propshaft"
```

In addition to gem names, it accepts a `Hash` mapping gem names to constraints:

```ruby
assert_gems rails: "~> 8.0.0"
assert_gems rails: ["> 6.1", "<=8.0.0"]
assert_gems rails: {github: "rails/rails", branch: "main"}
```

Both style can be combined in a single call:

```ruby
assert_gems "propshaft", rails: "~> 8.0.0"
```

The `assert_no_gems` method asserts that the `Gemfile` does not include any entries for the provided gem names.

```ruby
assert_no_gems "sprockets", "sprockets-rails"
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
