### PR TITLE
Skip test:system in Github workflow when options[:api] is passed in rails new command

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/github/ci.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/github/ci.yml.tt
@@ -126,7 +126,11 @@ jobs:
           DATABASE_URL: postgres://postgres:postgres@localhost:5432
           <%- end -%>
           # REDIS_URL: redis://localhost:6379/0
+        <%- if options[:api] -%>
+        run: bin/rails db:test:prepare test
+        <%- else -%>
         run: bin/rails db:test:prepare test test:system
+        <%- end -%>
 
       - name: Keep screenshots from failed system tests
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
### Motivation / Background

When we are running rails new with the option --api it means we don't have front and so we don't have system tests, but the github workflow setup test:system. I think we should skip it when the option is passed.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
