### PR TITLE
[Fix #52229] Respect `#reject` in Action Cable `before_subscribe` callbacks

### DIFF
--- a/actioncable/CHANGELOG.md
+++ b/actioncable/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Respect calls to `#reject` in `before_subscribe` callbacks.
+
+    It doesn't call `#subscribed` if a `before_subscribe` callback calls `#reject`.
+
+    *Joshua Young*
+
 *   Extract low-level Action Cable server responsibilities into `ActionCable::Server`
     abstractions.
 

--- a/actioncable/lib/action_cable/channel/base.rb
+++ b/actioncable/lib/action_cable/channel/base.rb
@@ -198,10 +198,11 @@ module ActionCable
       # confirms or rejects the subscription.
       def subscribe_to_channel
         run_callbacks :subscribe do
-          subscribed
+          subscribed unless subscription_rejected?
         end
 
         reject_subscription if subscription_rejected?
+
         ensure_confirmation_sent
       end
 

--- a/actioncable/lib/action_cable/channel/callbacks.rb
+++ b/actioncable/lib/action_cable/channel/callbacks.rb
@@ -47,6 +47,11 @@ module ActionCable
       end
 
       module ClassMethods
+        # This callback will be triggered before the Base#subscribed method is called.
+        #
+        # However, if the subscription is rejected with the Base#reject method in any
+        # such callback, the Base#subscribed method will not be called.
+        #
         def before_subscribe(*methods, &block)
           set_callback(:subscribe, :before, *methods, &block)
         end

--- a/actioncable/test/channel/base_test.rb
+++ b/actioncable/test/channel/base_test.rb
@@ -63,6 +63,10 @@ class ActionCable::Channel::BaseTest < ActionCable::TestCase
       @subscribed
     end
 
+    def after_subscribed_ran?
+      @after_subscribed_ran
+    end
+
     def get_latest
       transmit({ data: "latest" })
     end
@@ -198,7 +202,7 @@ class ActionCable::Channel::BaseTest < ActionCable::TestCase
   end
 
   test "actions available on Channel" do
-    available_actions = %w(room last_action subscribed unsubscribed toggle_subscribed leave speak subscribed? get_latest receive chatters topic error_action).to_set
+    available_actions = %w(room last_action subscribed unsubscribed toggle_subscribed leave speak subscribed? after_subscribed_ran? get_latest receive chatters topic error_action).to_set
     assert_equal available_actions, ChatChannel.action_methods
   end
 
@@ -257,6 +261,17 @@ class ActionCable::Channel::BaseTest < ActionCable::TestCase
   test "behaves like rescuable" do
     @channel.perform_action "action" => :error_action
     assert_equal [ :error_action ], @channel.last_action
+  end
+
+  class RejectBeforeSubscribeChannel < ChatChannel
+    before_subscribe { reject }
+  end
+
+  test "#reject in before_subscribe" do
+    channel = RejectBeforeSubscribeChannel.new @connection, "{id: 1}", id: 1
+    channel.subscribe_to_channel
+    assert_nil channel.room
+    assert_not channel.subscribed?
   end
 
   private

--- a/actioncable/test/stubs/test_socket.rb
+++ b/actioncable/test/stubs/test_socket.rb
@@ -14,6 +14,7 @@ class TestSocket
     @current_user = user
     @logger = ActiveSupport::TaggedLogging.new ActiveSupport::Logger.new(StringIO.new)
     @server = TestServer.new(subscription_adapter: subscription_adapter)
+    @subscriptions = ActionCable::Connection::Subscriptions.new(self)
     @transmissions = []
   end
 


### PR DESCRIPTION
### Motivation / Background

Closes https://github.com/rails/rails/issues/52229.

### Detail

Updates `ActionCable::Channel::Base#subscribe_to_channel` to not call `subscribed` if the `#reject` was called in a `before_subscribe`

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
