### PR TITLE
Fix: Support for `Pathname` in `config.i18n.load_path`

### DIFF
--- a/activesupport/lib/active_support/i18n_railtie.rb
+++ b/activesupport/lib/active_support/i18n_railtie.rb
@@ -66,9 +66,9 @@ module I18n
 
       if app.config.reloading_enabled?
         directories = watched_dirs_with_extensions(reloadable_paths)
-        root_load_paths = I18n.load_path.select { |path| path.start_with?(Rails.root.to_s) }
+        root_load_paths = I18n.load_path.select { |path| path.to_s.start_with?(Rails.root.to_s) }
         reloader = app.config.file_watcher.new(root_load_paths, directories) do
-          I18n.load_path.delete_if { |p| p.start_with?(Rails.root.to_s) && !File.exist?(p) }
+          I18n.load_path.delete_if { |p| p.to_s.start_with?(Rails.root.to_s) && !File.exist?(p) }
           I18n.load_path |= reloadable_paths.flat_map(&:existent)
         end
 

--- a/railties/test/application/initializers/i18n_test.rb
+++ b/railties/test/application/initializers/i18n_test.rb
@@ -68,6 +68,22 @@ module ApplicationTests
       assert_includes I18n.load_path, "#{app_path}/config/another_locale.yml"
     end
 
+    test "load_path handles Pathname argument correctly" do
+      app_file "config/another_locale.yml", "en:\nfoo: ~"
+
+      add_to_config <<-RUBY
+        config.i18n.load_path << config.root.join("config/another_locale.yml")
+      RUBY
+
+      load_app
+      assert_equal [
+        "#{app_path}/config/locales/en.yml", Pathname.new("#{app_path}/config/another_locale.yml")
+      ], Rails.application.config.i18n.load_path
+
+      assert_includes I18n.load_path, "#{app_path}/config/locales/en.yml"
+      assert_includes I18n.load_path, Pathname.new("#{app_path}/config/another_locale.yml")
+    end
+
     test "load_path is populated before eager loaded models" do
       add_to_config <<-RUBY
         config.enable_reloading = false


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

In a previous change introduced by #52271, passing a `Pathname` object to `config.i18n.load_path` caused exception. This PR fixes it, ensuring that I18n.load_path correctly handles Pathname arguments again.

### Detail


### Additional information

`I18n.load_path` is designed to accept Pathname as a valid input. https://github.com/ruby-i18n/i18n//blob/3b65f6548245411bc9802f5a547954d370b57821/test/i18n/load_path_test.rb#L35-L38

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
