### PR TITLE
No need to install cgi gem manually because Ruby 3.2.0 ships cgi 0.3.6 as a default gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,9 +40,6 @@ gem "terser", ">= 1.1.4", require: false
 # Explicitly avoid 1.x that doesn't support Ruby 2.4+
 gem "json", ">= 2.0.0", "!=2.7.0"
 
-# Workaround until Ruby ships with cgi version 0.3.6 or higher.
-gem "cgi", ">= 0.3.6", require: false
-
 # Workaround until all supported Ruby versions ship with uri version 0.13.1 or higher.
 gem "uri", ">= 0.13.1", require: false
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -191,7 +191,6 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
-    cgi (0.4.1)
     chef-utils (18.3.0)
       concurrent-ruby
     concurrent-ruby (1.3.3)
@@ -658,7 +657,6 @@ DEPENDENCIES
   bootsnap (>= 1.4.4)
   brakeman
   capybara (>= 3.39)
-  cgi (>= 0.3.6)
   connection_pool
   cssbundling-rails
   dalli (>= 3.0.1)


### PR DESCRIPTION
### Motivation / Background

This commit removes the workaround via https://github.com/rails/rails/pull/46595 because the current Rails main branch requires Ruby 3.2.0 that ships cgi 0.3.6 as a default gem.

### Detail

- Ruby 3.2.0 Released https://www.ruby-lang.org/en/news/2022/12/25/ruby-3-2-0-released/

> The following default gems are updated.
> cgi 0.3.6


### Additional information
Using cgi gem 0.3.6 installed with Ruby 3.2.0 as a default gem passes the test when it uses cgi 0.3.5.

```ruby
$ ruby -v
ruby 3.2.0 (2022-12-25 revision a528908271) [x86_64-linux]
$ cd rails/actionpack
$ bundle install
Bundle complete! 87 Gemfile dependencies, 237 gems now installed.
Use `bundle info [gemname]` to see where a bundled gem is installed.
$ bundle info cgi
  * cgi (0.3.6)
    Summary: Support for the Common Gateway Interface protocol.
    Homepage: https://github.com/ruby/cgi
    Source Code: https://github.com/ruby/cgi
    Path: /home/yahonda/.rbenv/versions/3.2.0/lib/ruby/gems/3.2.0/gems/cgi-0.3.6
    Default Gem: yes
$ bin/test test/dispatch/session/cookie_store_test.rb -n test_session_store_with_all_domains
Running 27 tests in a single process (parallelization threshold is 50)
Run options: -n test_session_store_with_all_domains --seed 59282

.

Finished in 0.107261s, 9.3231 runs/s, 18.6461 assertions/s.
1 runs, 2 assertions, 0 failures, 0 errors, 0 skips
$
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
