### PR TITLE
Fix tiny ratelimit doc typo [ci skip]

### DIFF
--- a/actionpack/lib/action_controller/metal/rate_limiting.rb
+++ b/actionpack/lib/action_controller/metal/rate_limiting.rb
@@ -30,7 +30,7 @@ module ActionController # :nodoc:
       # parameter.
       #
       # If you want to use multiple rate limits per controller, you need to give each of
-      # them and explicit name via the `name:` option.
+      # them an explicit name via the `name:` option.
       #
       # Examples:
       #


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because a small typo was found in https://edgeapi.rubyonrails.org/

### Detail

This Pull Request changes documentation about the rate_limiting feature.

### Additional information

None

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [X] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
