### PR TITLE
Skip propshaft 1.0.1 to workaround circular require between Propshaft and Rails unit tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ gem "rake", ">= 13"
 gem "releaser", path: "tools/releaser"
 
 gem "sprockets-rails", ">= 2.0.0", require: false
-gem "propshaft", ">= 0.1.7"
+gem "propshaft", ">= 0.1.7", "!= 1.0.1"
 gem "capybara", ">= 3.39"
 gem "selenium-webdriver", ">= 4.20.0"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -412,7 +412,7 @@ GEM
     pg (1.5.4)
     prettier_print (1.2.1)
     prism (0.27.0)
-    propshaft (0.9.0)
+    propshaft (1.0.0)
       actionpack (>= 7.0.0)
       activesupport (>= 7.0.0)
       rack
@@ -687,7 +687,7 @@ DEPENDENCIES
   nokogiri (>= 1.8.1, != 1.11.0)
   pg (~> 1.3)
   prism
-  propshaft (>= 0.1.7)
+  propshaft (>= 0.1.7, != 1.0.1)
   puma (>= 5.0.3)
   queue_classic (>= 4.0.0)
   rack (~> 3.0)


### PR DESCRIPTION
### Motivation / Background

This commit workarounds CI failure at https://buildkite.com/rails/rails-nightly/builds/1087#01923f96-5384-4f75-b3a1-8fe2e1002c82 since Propshaft v1.0.1 released that includes https://github.com/rails/propshaft/pull/205

### Detail

#### Steps to reproduce

```ruby
export RAILS_STRICT_WARNINGS=1 # Let unit tests failed if some warnings appeared at Rails CI
git clone https://github.com/rails/rails
cd rails
bundle update propshaft --conservative
cd actionmailbox
bundle exec rake test
```

####  Expected behavior
It should pass.

#### Actual behavior
It gets the following `warning: loading in progress, circular require considered harmful` and it fails.

```ruby
$ bundle update propshaft --conservative
$ bundle info propshaft
  * propshaft (1.0.1)
	Summary: Deliver assets for Rails.
	Homepage: https://github.com/rails/propshaft
	Path: /home/yahonda/.rbenv/versions/3.2.0/lib/ruby/gems/3.2.0/gems/propshaft-1.0.1
yahonda@myryzen:~/src/github.com/rails/rails$
$ git diff
diff --git a/Gemfile.lock b/Gemfile.lock
index 15a821945e..293b3f0286 100644
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -412,7 +412,7 @@ GEM
     pg (1.5.4)
     prettier_print (1.2.1)
     prism (0.27.0)
-    propshaft (0.9.0)
+    propshaft (1.0.1)
       actionpack (>= 7.0.0)
       activesupport (>= 7.0.0)
       rack
$ cd actionmailbox
$ bundle exec rake test
/home/yahonda/.rbenv/versions/3.3.5/bin/ruby -w -I"lib:test" /home/yahonda/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/rake-13.1.0/lib/rake/rake_test_loader.rb "test/controllers/ingresses/mailgun/inbound_emails_controller_test.rb" "test/controllers/ingresses/mandrill/inbound_emails_controller_test.rb" "test/controllers/ingresses/postmark/inbound_emails_controller_test.rb" "test/controllers/ingresses/relay/inbound_emails_controller_test.rb" "test/controllers/ingresses/sendgrid/inbound_emails_controller_test.rb" "test/controllers/rails/action_mailbox/inbound_emails_controller_test.rb" "test/generators/mailbox_generator_test.rb" "test/jobs/incineration_job_test.rb" "test/migrations_test.rb" "test/models/table_name_test.rb" "test/unit/inbound_email/incineration_test.rb" "test/unit/inbound_email/message_id_test.rb" "test/unit/inbound_email_test.rb" "test/unit/mail_ext/address_equality_test.rb" "test/unit/mail_ext/address_wrapping_test.rb" "test/unit/mail_ext/addresses_test.rb" "test/unit/mailbox/bouncing_test.rb" "test/unit/mailbox/callbacks_test.rb" "test/unit/mailbox/notifications_test.rb" "test/unit/mailbox/routing_test.rb" "test/unit/mailbox/state_test.rb" "test/unit/relayer_test.rb" "test/unit/router_test.rb" "test/unit/test_helper_test.rb"
/home/yahonda/.rbenv/versions/3.3.5/lib/ruby/3.3.0/bundled_gems.rb:75: warning: /home/yahonda/.rbenv/versions/3.3.5/lib/ruby/3.3.0/bundled_gems.rb:75: warning: loading in progress, circular require considered harmful - /home/yahonda/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/propshaft-1.0.1/lib/propshaft.rb
	from /home/yahonda/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/rake-13.1.0/lib/rake/rake_test_loader.rb:6:in  `<main>'
	from /home/yahonda/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/rake-13.1.0/lib/rake/rake_test_loader.rb:6:in  `select'
	from /home/yahonda/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/rake-13.1.0/lib/rake/rake_test_loader.rb:21:in  `block in <main>'
	from /home/yahonda/.rbenv/versions/3.3.5/lib/ruby/3.3.0/bundled_gems.rb:75:in  `block (2 levels) in replace_require'
	from /home/yahonda/.rbenv/versions/3.3.5/lib/ruby/3.3.0/bundled_gems.rb:75:in  `require'
	from /home/yahonda/src/github.com/rails/rails/actionmailbox/test/controllers/ingresses/mailgun/inbound_emails_controller_test.rb:3:in  `<top (required)>'
	from /home/yahonda/.rbenv/versions/3.3.5/lib/ruby/3.3.0/bundled_gems.rb:75:in  `block (2 levels) in replace_require'
	from /home/yahonda/.rbenv/versions/3.3.5/lib/ruby/3.3.0/bundled_gems.rb:75:in  `require'
	from /home/yahonda/src/github.com/rails/rails/actionmailbox/test/test_helper.rb:8:in  `<top (required)>'
	from /home/yahonda/src/github.com/rails/rails/actionmailbox/test/test_helper.rb:8:in  `require_relative'
	from /home/yahonda/src/github.com/rails/rails/actionmailbox/test/dummy/config/environment.rb:2:in  `<top (required)>'
	from /home/yahonda/src/github.com/rails/rails/actionmailbox/test/dummy/config/environment.rb:2:in  `require_relative'
	from /home/yahonda/src/github.com/rails/rails/actionmailbox/test/dummy/config/application.rb:7:in  `<top (required)>'
	from /home/yahonda/.rbenv/versions/3.3.5/lib/ruby/3.3.0/bundler.rb:212:in  `require'
	from /home/yahonda/.rbenv/versions/3.3.5/lib/ruby/3.3.0/bundler/runtime.rb:44:in  `require'
	from /home/yahonda/.rbenv/versions/3.3.5/lib/ruby/3.3.0/bundler/runtime.rb:44:in  `each'
	from /home/yahonda/.rbenv/versions/3.3.5/lib/ruby/3.3.0/bundler/runtime.rb:55:in  `block in require'
	from /home/yahonda/.rbenv/versions/3.3.5/lib/ruby/3.3.0/bundler/runtime.rb:55:in  `each'
	from /home/yahonda/.rbenv/versions/3.3.5/lib/ruby/3.3.0/bundler/runtime.rb:60:in  `block (2 levels) in require'
	from /home/yahonda/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/zeitwerk-2.6.12/lib/zeitwerk/kernel.rb:38:in  `require'
	from /home/yahonda/.rbenv/versions/3.3.5/lib/ruby/3.3.0/bundled_gems.rb:75:in  `block (2 levels) in replace_require'
	from <internal:/home/yahonda/.rbenv/versions/3.3.5/lib/ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:37:in  `require'
	from <internal:/home/yahonda/.rbenv/versions/3.3.5/lib/ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:37:in  `require'
	from /home/yahonda/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/propshaft-1.0.1/lib/propshaft.rb:13:in  `<top (required)>'
	from /home/yahonda/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/zeitwerk-2.6.12/lib/zeitwerk/kernel.rb:38:in  `require'
	from /home/yahonda/.rbenv/versions/3.3.5/lib/ruby/3.3.0/bundled_gems.rb:75:in  `block (2 levels) in replace_require'
	from /home/yahonda/.rbenv/versions/3.3.5/lib/ruby/3.3.0/bundled_gems.rb:75:in  `require'
	from /home/yahonda/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/propshaft-1.0.1/lib/propshaft/railtie.rb:3:in  `<top (required)>'
	from /home/yahonda/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/zeitwerk-2.6.12/lib/zeitwerk/kernel.rb:38:in  `require'
	from /home/yahonda/.rbenv/versions/3.3.5/lib/ruby/3.3.0/bundled_gems.rb:75:in  `block (2 levels) in replace_require'
	from /home/yahonda/.rbenv/versions/3.3.5/lib/ruby/3.3.0/bundled_gems.rb:75:in  `require'

/home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/testing/strict_warnings.rb:38:in `warn': /home/yahonda/.rbenv/versions/3.3.5/lib/ruby/3.3.0/bundled_gems.rb:75: warning: /home/yahonda/.rbenv/versions/3.3.5/lib/ruby/3.3.0/bundled_gems.rb:75: warning: loading in progress, circular require considered harmful - /home/yahonda/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/propshaft-1.0.1/lib/propshaft.rb (ActiveSupport::RaiseWarnings::WarningError)
	from /home/yahonda/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/rake-13.1.0/lib/rake/rake_test_loader.rb:6:in  `<main>'
	from /home/yahonda/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/rake-13.1.0/lib/rake/rake_test_loader.rb:6:in  `select'
	from /home/yahonda/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/rake-13.1.0/lib/rake/rake_test_loader.rb:21:in  `block in <main>'
	from /home/yahonda/.rbenv/versions/3.3.5/lib/ruby/3.3.0/bundled_gems.rb:75:in  `block (2 levels) in replace_require'
	from /home/yahonda/.rbenv/versions/3.3.5/lib/ruby/3.3.0/bundled_gems.rb:75:in  `require'
	from /home/yahonda/src/github.com/rails/rails/actionmailbox/test/controllers/ingresses/mailgun/inbound_emails_controller_test.rb:3:in  `<top (required)>'
	from /home/yahonda/.rbenv/versions/3.3.5/lib/ruby/3.3.0/bundled_gems.rb:75:in  `block (2 levels) in replace_require'
	from /home/yahonda/.rbenv/versions/3.3.5/lib/ruby/3.3.0/bundled_gems.rb:75:in  `require'
	from /home/yahonda/src/github.com/rails/rails/actionmailbox/test/test_helper.rb:8:in  `<top (required)>'
	from /home/yahonda/src/github.com/rails/rails/actionmailbox/test/test_helper.rb:8:in  `require_relative'
	from /home/yahonda/src/github.com/rails/rails/actionmailbox/test/dummy/config/environment.rb:2:in  `<top (required)>'
	from /home/yahonda/src/github.com/rails/rails/actionmailbox/test/dummy/config/environment.rb:2:in  `require_relative'
	from /home/yahonda/src/github.com/rails/rails/actionmailbox/test/dummy/config/application.rb:7:in  `<top (required)>'
	from /home/yahonda/.rbenv/versions/3.3.5/lib/ruby/3.3.0/bundler.rb:212:in  `require'
	from /home/yahonda/.rbenv/versions/3.3.5/lib/ruby/3.3.0/bundler/runtime.rb:44:in  `require'
	from /home/yahonda/.rbenv/versions/3.3.5/lib/ruby/3.3.0/bundler/runtime.rb:44:in  `each'
	from /home/yahonda/.rbenv/versions/3.3.5/lib/ruby/3.3.0/bundler/runtime.rb:55:in  `block in require'
	from /home/yahonda/.rbenv/versions/3.3.5/lib/ruby/3.3.0/bundler/runtime.rb:55:in  `each'
	from /home/yahonda/.rbenv/versions/3.3.5/lib/ruby/3.3.0/bundler/runtime.rb:60:in  `block (2 levels) in require'
	from /home/yahonda/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/zeitwerk-2.6.12/lib/zeitwerk/kernel.rb:38:in  `require'
	from /home/yahonda/.rbenv/versions/3.3.5/lib/ruby/3.3.0/bundled_gems.rb:75:in  `block (2 levels) in replace_require'
	from <internal:/home/yahonda/.rbenv/versions/3.3.5/lib/ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:37:in  `require'
	from <internal:/home/yahonda/.rbenv/versions/3.3.5/lib/ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:37:in  `require'
	from /home/yahonda/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/propshaft-1.0.1/lib/propshaft.rb:13:in  `<top (required)>'
	from /home/yahonda/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/zeitwerk-2.6.12/lib/zeitwerk/kernel.rb:38:in  `require'
	from /home/yahonda/.rbenv/versions/3.3.5/lib/ruby/3.3.0/bundled_gems.rb:75:in  `block (2 levels) in replace_require'
	from /home/yahonda/.rbenv/versions/3.3.5/lib/ruby/3.3.0/bundled_gems.rb:75:in  `require'
	from /home/yahonda/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/propshaft-1.0.1/lib/propshaft/railtie.rb:3:in  `<top (required)>'
	from /home/yahonda/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/zeitwerk-2.6.12/lib/zeitwerk/kernel.rb:38:in  `require'
	from /home/yahonda/.rbenv/versions/3.3.5/lib/ruby/3.3.0/bundled_gems.rb:75:in  `block (2 levels) in replace_require'
	from /home/yahonda/.rbenv/versions/3.3.5/lib/ruby/3.3.0/bundled_gems.rb:75:in  `require'

	from /home/yahonda/.rbenv/versions/3.3.5/lib/ruby/3.3.0/bundled_gems.rb:75:in `require'
	from /home/yahonda/.rbenv/versions/3.3.5/lib/ruby/3.3.0/bundled_gems.rb:75:in `block (2 levels) in replace_require'
	from /home/yahonda/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/zeitwerk-2.6.12/lib/zeitwerk/kernel.rb:38:in `require'
	from /home/yahonda/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/propshaft-1.0.1/lib/propshaft/railtie.rb:3:in `<top (required)>'
	from /home/yahonda/.rbenv/versions/3.3.5/lib/ruby/3.3.0/bundled_gems.rb:75:in `require'
	from /home/yahonda/.rbenv/versions/3.3.5/lib/ruby/3.3.0/bundled_gems.rb:75:in `block (2 levels) in replace_require'
	from /home/yahonda/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/zeitwerk-2.6.12/lib/zeitwerk/kernel.rb:38:in `require'
	from /home/yahonda/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/propshaft-1.0.1/lib/propshaft.rb:13:in `<top (required)>'
	from <internal:/home/yahonda/.rbenv/versions/3.3.5/lib/ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:37:in `require'
	from <internal:/home/yahonda/.rbenv/versions/3.3.5/lib/ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:37:in `require'
	from /home/yahonda/.rbenv/versions/3.3.5/lib/ruby/3.3.0/bundled_gems.rb:75:in `block (2 levels) in replace_require'
	from /home/yahonda/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/zeitwerk-2.6.12/lib/zeitwerk/kernel.rb:38:in `require'
	from /home/yahonda/.rbenv/versions/3.3.5/lib/ruby/3.3.0/bundler/runtime.rb:60:in `block (2 levels) in require'
	from /home/yahonda/.rbenv/versions/3.3.5/lib/ruby/3.3.0/bundler/runtime.rb:55:in `each'
	from /home/yahonda/.rbenv/versions/3.3.5/lib/ruby/3.3.0/bundler/runtime.rb:55:in `block in require'
	from /home/yahonda/.rbenv/versions/3.3.5/lib/ruby/3.3.0/bundler/runtime.rb:44:in `each'
	from /home/yahonda/.rbenv/versions/3.3.5/lib/ruby/3.3.0/bundler/runtime.rb:44:in `require'
	from /home/yahonda/.rbenv/versions/3.3.5/lib/ruby/3.3.0/bundler.rb:212:in `require'
	from /home/yahonda/src/github.com/rails/rails/actionmailbox/test/dummy/config/application.rb:7:in `<top (required)>'
	from /home/yahonda/src/github.com/rails/rails/actionmailbox/test/dummy/config/environment.rb:2:in `require_relative'
	from /home/yahonda/src/github.com/rails/rails/actionmailbox/test/dummy/config/environment.rb:2:in `<top (required)>'
	from /home/yahonda/src/github.com/rails/rails/actionmailbox/test/test_helper.rb:8:in `require_relative'
	from /home/yahonda/src/github.com/rails/rails/actionmailbox/test/test_helper.rb:8:in `<top (required)>'
	from /home/yahonda/.rbenv/versions/3.3.5/lib/ruby/3.3.0/bundled_gems.rb:75:in `require'
	from /home/yahonda/.rbenv/versions/3.3.5/lib/ruby/3.3.0/bundled_gems.rb:75:in `block (2 levels) in replace_require'
	from /home/yahonda/src/github.com/rails/rails/actionmailbox/test/controllers/ingresses/mailgun/inbound_emails_controller_test.rb:3:in `<top (required)>'
	from /home/yahonda/.rbenv/versions/3.3.5/lib/ruby/3.3.0/bundled_gems.rb:75:in `require'
	from /home/yahonda/.rbenv/versions/3.3.5/lib/ruby/3.3.0/bundled_gems.rb:75:in `block (2 levels) in replace_require'
	from /home/yahonda/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/rake-13.1.0/lib/rake/rake_test_loader.rb:21:in `block in <main>'
	from /home/yahonda/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/rake-13.1.0/lib/rake/rake_test_loader.rb:6:in `select'
	from /home/yahonda/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/rake-13.1.0/lib/rake/rake_test_loader.rb:6:in `<main>'
rake aborted!
Command failed with status (1): [ruby -w -I"lib:test" /home/yahonda/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/rake-13.1.0/lib/rake/rake_test_loader.rb "test/controllers/ingresses/mailgun/inbound_emails_controller_test.rb" "test/controllers/ingresses/mandrill/inbound_emails_controller_test.rb" "test/controllers/ingresses/postmark/inbound_emails_controller_test.rb" "test/controllers/ingresses/relay/inbound_emails_controller_test.rb" "test/controllers/ingresses/sendgrid/inbound_emails_controller_test.rb" "test/controllers/rails/action_mailbox/inbound_emails_controller_test.rb" "test/generators/mailbox_generator_test.rb" "test/jobs/incineration_job_test.rb" "test/migrations_test.rb" "test/models/table_name_test.rb" "test/unit/inbound_email/incineration_test.rb" "test/unit/inbound_email/message_id_test.rb" "test/unit/inbound_email_test.rb" "test/unit/mail_ext/address_equality_test.rb" "test/unit/mail_ext/address_wrapping_test.rb" "test/unit/mail_ext/addresses_test.rb" "test/unit/mailbox/bouncing_test.rb" "test/unit/mailbox/callbacks_test.rb" "test/unit/mailbox/notifications_test.rb" "test/unit/mailbox/routing_test.rb" "test/unit/mailbox/state_test.rb" "test/unit/relayer_test.rb" "test/unit/router_test.rb" "test/unit/test_helper_test.rb" ]
/home/yahonda/.rbenv/versions/3.3.5/bin/bundle:25:in `load'
/home/yahonda/.rbenv/versions/3.3.5/bin/bundle:25:in `<main>'
Tasks: TOP => test
(See full trace by running task with --trace)
$
```

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
