### PR TITLE
Explicitly set the user to vscode in Dev Container

### DIFF
--- a/railties/lib/rails/generators/rails/devcontainer/templates/devcontainer/devcontainer.json.tt
+++ b/railties/lib/rails/generators/rails/devcontainer/templates/devcontainer/devcontainer.json.tt
@@ -24,7 +24,7 @@
   // "customizations": {},
 
   // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
-  // "remoteUser": "root",
+  "remoteUser": "vscode",
 
 <%- if !mounts.empty? -%>
   "mounts": [


### PR DESCRIPTION

### Motivation / Background

The ruby image installs ruby for the `vscode` user (which is created in the debian base image). VSCode uses this user by default. However, other dev container implementations may not do that, in which case the dev container may open as root where ruby is not available.

### Detail

Explicitly set the `remoteUser` to `vscode` in `devcontainer.json`.

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [ ] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
