### PR TITLE
Make the query cache executor transactional fixtures aware

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   Properly release pinned connections with non joinable connections
+
+    Fixes #52973
+
+    When running system tests with transactional fixtures on, it could happen that
+    the connection leased by the Puma thread wouldn't be properly released back to the pool,
+    causing "Cannot expire connection, it is owned by a different thread" errors in later tests.
+
+    *Jean Boussier*
+
 *   Make Float distinguish between `float4` and `float8` in PostgreSQL.
 
     Fixes #52742

--- a/activerecord/lib/active_record/query_cache.rb
+++ b/activerecord/lib/active_record/query_cache.rb
@@ -43,10 +43,6 @@ module ActiveRecord
         pool.disable_query_cache!
         pool.clear_query_cache
       end
-
-      ActiveRecord::Base.connection_handler.each_connection_pool do |pool|
-        pool.release_connection if pool.active_connection? && !pool.lease_connection.transaction_open?
-      end
     end
 
     def self.install_executor_hooks(executor = ActiveSupport::Executor)

--- a/activerecord/lib/active_record/railtie.rb
+++ b/activerecord/lib/active_record/railtie.rb
@@ -312,6 +312,7 @@ To keep using the current cache store, you can turn off cache versioning entirel
     initializer "active_record.set_executor_hooks" do
       ActiveRecord::QueryCache.install_executor_hooks
       ActiveRecord::AsynchronousQueriesTracker.install_executor_hooks
+      ActiveRecord::ConnectionAdapters::ConnectionPool.install_executor_hooks
     end
 
     initializer "active_record.add_watchable_files" do |app|


### PR DESCRIPTION
Fix: https://github.com/rails/rails/issues/52973

Checking for `transaction_open?` only cause the Puma thread to not release the connection if we're still inside a fixture transaction.

We need to check `joinable?` too.
