### PR TITLE
Add credentials:fetch command

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Add command `rails credentials:fetch PATH` to get the value of a credential from the credentials file.
+
+    ```bash
+    $ bin/rails credentials:fetch kamal_registry/password
+    ```
+
+    *Matthew Nguyen*, *Jean Boussier*
+
 *   Generate static BCrypt password digests in fixtures instead of dynamic ERB expressions.
 
     Previously, fixtures with password digest attributes used `<%= BCrypt::Password.create("secret") %>`,

--- a/railties/lib/rails/commands/credentials/credentials_command.rb
+++ b/railties/lib/rails/commands/credentials/credentials_command.rb
@@ -35,7 +35,7 @@ module Rails
       def show
         load_environment_config!
 
-        say credentials.read.presence || missing_credentials_message
+        say credentials.read.presence || missing_credentials!
       end
 
       desc "diff", "Enroll/disenroll in decrypted diffs of credentials using git"
@@ -55,6 +55,26 @@ module Rails
         end
       rescue ActiveSupport::MessageEncryptor::InvalidMessage
         say credentials.content_path.read
+      end
+
+      desc "fetch PATH", "Fetch a value in the decrypted credentials"
+      def fetch(path)
+        load_environment_config!
+
+        if (yaml = credentials.read)
+          begin
+            value = YAML.load(yaml)
+            value = path.split(".").inject(value) do |doc, key|
+              doc.fetch(key)
+            end
+            say value.to_s
+          rescue KeyError, NoMethodError
+            say_error "Invalid or missing credential path: #{path}"
+            exit 1
+          end
+        else
+          missing_credentials!
+        end
       end
 
       private
@@ -114,12 +134,13 @@ module Rails
           say "Your application will not be able to load '#{content_path}' until the error has been fixed.", :red
         end
 
-        def missing_credentials_message
+        def missing_credentials!
           if !credentials.key?
-            "Missing '#{key_path}' to decrypt credentials. See `#{executable(:help)}`."
+            say_error "Missing '#{key_path}' to decrypt credentials. See `#{executable(:help)}`."
           else
-            "File '#{content_path}' does not exist. Use `#{executable(:edit)}` to change that."
+            say_error "File '#{content_path}' does not exist. Use `#{executable(:edit)}` to change that."
           end
+          exit 1
         end
 
         def relative_path(path)

--- a/railties/lib/rails/generators/rails/app/templates/kamal-secrets.tt
+++ b/railties/lib/rails/generators/rails/app/templates/kamal-secrets.tt
@@ -7,6 +7,9 @@
 # KAMAL_REGISTRY_PASSWORD=$(kamal secrets extract KAMAL_REGISTRY_PASSWORD ${SECRETS})
 # RAILS_MASTER_KEY=$(kamal secrets extract RAILS_MASTER_KEY ${SECRETS})
 
+# Example of extracting secrets from Rails credentials
+# KAMAL_REGISTRY_PASSWORD=$(rails credentials:fetch kamal.registry_password)
+
 # Use a GITHUB_TOKEN if private repositories are needed for the image
 # GITHUB_TOKEN=$(gh config get -h github.com oauth_token)
 

--- a/railties/test/command/base_test.rb
+++ b/railties/test/command/base_test.rb
@@ -14,7 +14,7 @@ class Rails::Command::BaseTest < ActiveSupport::TestCase
   end
 
   test "printing commands returns namespaced commands" do
-    assert_equal %w(credentials:edit credentials:show credentials:diff), Rails::Command::CredentialsCommand.printing_commands.map(&:first)
+    assert_equal %w(credentials:edit credentials:show credentials:diff credentials:fetch), Rails::Command::CredentialsCommand.printing_commands.map(&:first)
     assert_equal %w(db:system:change), Rails::Command::Db::System::ChangeCommand.printing_commands.map(&:first)
   end
 

--- a/railties/test/commands/credentials_test.rb
+++ b/railties/test/commands/credentials_test.rb
@@ -170,7 +170,6 @@ class Rails::Command::CredentialsTest < ActiveSupport::TestCase
     assert_match %r/foo: bar: bad/, run_edit_command
   end
 
-
   test "show credentials" do
     assert_match DEFAULT_CREDENTIALS_PATTERN, run_show_command
   end
@@ -186,7 +185,8 @@ class Rails::Command::CredentialsTest < ActiveSupport::TestCase
     remove_file "config/master.key"
     add_to_config "config.require_master_key = false"
 
-    assert_match(/Missing 'config\/master\.key' to decrypt credentials/, run_show_command)
+    stderr_output = capture(:stderr) { run_show_command(stderr: true, allow_failure: true) }
+    assert_match(/Missing 'config\/master\.key' to decrypt credentials/, stderr_output)
   end
 
   test "show command displays content specified by environment option" do
@@ -350,6 +350,20 @@ class Rails::Command::CredentialsTest < ActiveSupport::TestCase
     assert_credentials_paths "config/credentials/production.yml.enc", key_path, environment: "production"
   end
 
+  test "fetch value for given path" do
+    write_credentials({ "foo" => { "bar" => { "baz" => 42 } } }.to_yaml)
+
+    assert_match(/42/, run_fetch_command("foo.bar.baz"))
+  end
+
+  test "fetch missing key" do
+    write_credentials({ "foo" => { "bar" => { "baz" => 42 } } }.to_yaml)
+
+
+    stderr_output = capture(:stderr) { run_fetch_command("egg.spam", stderr: true, allow_failure: true) }
+    assert_match("Invalid or missing credential path: egg.spam", stderr_output)
+  end
+
   private
     DEFAULT_CREDENTIALS_PATTERN = /access_key_id: 123\n.*secret_key_base: \h{128}\n/m
 
@@ -370,6 +384,10 @@ class Rails::Command::CredentialsTest < ActiveSupport::TestCase
     def run_diff_command(path = nil, enroll: nil, disenroll: nil, **options)
       args = [path, ("--enroll" if enroll), ("--disenroll" if disenroll)].compact
       rails "credentials:diff", args, **options
+    end
+
+    def run_fetch_command(path, **options)
+      rails "credentials:fetch", path, **options
     end
 
     def write_credentials(content, **options)


### PR DESCRIPTION
### Motivation / Background

With Kamal 2, secrets are now stored in `.kamal/secrets`. We are expected to use a 3rd party password manager such as `1password` to fetch secrets such as `KAMAL_REGISTRY_PASSWORD`.

eg. `KAMAL_REGISTRY_PASSWORD=$(kamal secrets extract KAMAL_REGISTRY_PASSWORD ${SECRETS})`

I think it would be interesting to be able to fetch the password directly from Rails credentials.

eg. `KAMAL_REGISTRY_PASSWORD=$(bin/rails credentials:fetch kamal_registry/password)`

In order to allow it, I introduce the new command `credentials:fetch`.

### Detail

Usage:

```yml
# credentials.yml.enc
secret_key_base: ****
kamal_registry:
  password: abcd1234
```

```sh
bin/rails credentials:fetch kamal_registry/password
# abcd1234
```

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
