### PR TITLE
Add bundler-cache feature in dev container

### DIFF
--- a/railties/lib/rails/generators/rails/devcontainer/devcontainer_generator.rb
+++ b/railties/lib/rails/generators/rails/devcontainer/devcontainer_generator.rb
@@ -100,7 +100,8 @@ module Rails
           return @features if @features
 
           @features = {
-            "ghcr.io/devcontainers/features/github-cli:1" => {}
+            "ghcr.io/devcontainers/features/github-cli:1" => {},
+            "ghcr.io/rails/devcontainer/features/bundler-cache" => {}
           }
 
           @features["ghcr.io/rails/devcontainer/features/activestorage"] = {} if options[:active_storage]

--- a/railties/test/generators/devcontainer_generator_test.rb
+++ b/railties/test/generators/devcontainer_generator_test.rb
@@ -332,6 +332,7 @@ module Rails
 
           assert_devcontainer_json_file do |devcontainer_json|
             assert_includes devcontainer_json["features"].keys, "ghcr.io/devcontainers/features/github-cli:1"
+            assert_includes devcontainer_json["features"].keys, "ghcr.io/rails/devcontainer/features/bundler-cache"
             assert_includes devcontainer_json["forwardPorts"], 3000
           end
 


### PR DESCRIPTION
### Motivation / Background

I've been using docker and docker compose for years to run my rails apps in development. The way I used docker + docker compose was to run a single process and remove the container after it's done (eg `docker compose run --rm ...`, or just `docker compose up` and then removing the container, etc). And when you're adding gems, trying things out, etc. it's super useful to have a volume for the installed gems so you can run `docker compose run web bundle` and have the new gems available rather than having to rebuild the image over and over.

Devcontainers approach, ie developing inside of the container, is really interesting but there's something that slows down the whole thing of bringing the container up and that is to install gems every time (if you remove containers after a period of time obviously, if you don't you're fine).

The feature in rails/devcontainer adds a volume for bundler, so if you remove the container intentionally or not, all the dependencies are kept for the next time you create the container.

### Detail

This Pull Request adds the `ghcr.io/rails/devcontainer/features/bundler-cache` feature to the generated devcontainer.json configuration.

### Additional information

Link to the devcontainer feature: https://github.com/rails/devcontainer/tree/main/features/bundler-cache

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
