### PR TITLE
Fix prefixed headings in guide pages meta descriptions

### DIFF
--- a/guides/rails_guides/markdown.rb
+++ b/guides/rails_guides/markdown.rb
@@ -23,8 +23,8 @@ module RailsGuides
       @raw_body = body
       extract_raw_header_and_body
       generate_header
-      generate_description
       generate_title
+      generate_description
       generate_body
       generate_structure
       generate_index
@@ -95,7 +95,7 @@ module RailsGuides
 
       def generate_description
         sanitizer = Rails::Html::FullSanitizer.new
-        @description = sanitizer.sanitize(@header).squish
+        @description = sanitizer.sanitize(@header).squish.delete_prefix(@heading)
       end
 
       def generate_structure
@@ -167,8 +167,8 @@ module RailsGuides
       end
 
       def generate_title
-        if heading = html_fragment(@header).at(:h1)
-          @title = "#{heading.text} — Ruby on Rails Guides"
+        if @heading = html_fragment(@header).at(:h1)
+          @title = "#{@heading.text} — Ruby on Rails Guides"
         else
           @title = "Ruby on Rails Guides"
         end


### PR DESCRIPTION
All meta descriptions and og:description meta tags currently are prefixed with the specific guide's h1. This happens when sanitizing the headers html fragment.

For example:

Before this change the (og)-description of the ActionCable guide was:

```
content="Action Cable OverviewIn this guide...
```

Note the "Action Cable Overview" prefix without a whitespace.

After this change the description is:

```
content="In this guide..."
```