### PR TITLE
Fix `ActiveSupport::HashWithIndifferentAccess#stringify_keys` to stringify all keys not just symbols.

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,22 @@
+*   Fix `ActiveSupport::HashWithIndifferentAccess#stringify_keys` to stringify all keys not just symbols.
+
+    Previously:
+
+    ```ruby
+    { 1 => 2 }.with_indifferent_access.stringify_keys[1] # => 2
+    ```
+
+    After this change:
+
+    ```ruby
+    { 1 => 2 }.with_indifferent_access.stringify_keys["1"] # => 2
+    ```
+
+    This change can be seen as a bug fix, but since it behaved like this for a very long time, we're deciding
+    to not backport the fix and to make the change in a major release.
+
+    *Jean Boussier*
+
 ## Rails 8.0.0.beta1 (September 26, 2024) ##
 
 *   Include options when instrumenting `ActiveSupport::Cache::Store#delete` and `ActiveSupport::Cache::Store#delete_multi`.

--- a/activesupport/lib/active_support/hash_with_indifferent_access.rb
+++ b/activesupport/lib/active_support/hash_with_indifferent_access.rb
@@ -313,10 +313,6 @@ module ActiveSupport
     end
     alias_method :without, :except
 
-    def stringify_keys!; self end
-    def deep_stringify_keys!; self end
-    def stringify_keys; dup end
-    def deep_stringify_keys; dup end
     undef :symbolize_keys!
     undef :deep_symbolize_keys!
     def symbolize_keys; to_hash.symbolize_keys! end

--- a/activesupport/test/hash_with_indifferent_access_test.rb
+++ b/activesupport/test/hash_with_indifferent_access_test.rb
@@ -98,6 +98,17 @@ class HashWithIndifferentAccessTest < ActiveSupport::TestCase
     assert_raise(NoMethodError) { @integers.with_indifferent_access.dup.symbolize_keys! }
   end
 
+  def test_stringify_keys_stringifies_integer_keys_for_hash_with_indifferent_access
+    assert_equal({ "0" => 1, "1" => 2 }, @integers.with_indifferent_access.stringify_keys)
+    assert_equal({ "ints" => { "0" => 1, "1" => 2 } }, { ints: @integers }.with_indifferent_access.deep_stringify_keys)
+  end
+
+  def test_stringify_keys_stringifies_non_string_keys_for_hash_with_indifferent_access
+    object = Object.new
+    hash = { object => 1 }
+    assert_equal({ object.to_s => 1 }, hash.with_indifferent_access.stringify_keys)
+  end
+
   def test_deep_symbolize_keys_preserves_integer_keys_for_hash_with_indifferent_access
     assert_equal @nested_integers, @nested_integers.with_indifferent_access.deep_symbolize_keys
     assert_raise(NoMethodError) { @nested_integers.with_indifferent_access.deep_dup.deep_symbolize_keys! }


### PR DESCRIPTION
Fix: https://github.com/rails/rails/issues/53008

```ruby
{ 1 => 2 }.with_indifferent_access.stringify_keys[1] # => 2
```

After this change:

```ruby
{ 1 => 2 }.with_indifferent_access.stringify_keys["1"] # => 2
```

This change can be seen as a bug fix, but since it behaved like this for a very long time, we're deciding  to not backport the fix.