### PR TITLE
Fix broken code snippet in helper doc comments

### DIFF
--- a/actionpack/lib/abstract_controller/helpers.rb
+++ b/actionpack/lib/abstract_controller/helpers.rb
@@ -104,6 +104,7 @@ module AbstractController
       # Declare a controller method as a helper. For example, the following
       # makes the `current_user` and `logged_in?` controller methods available
       # to the view:
+      #
       #     class ApplicationController < ActionController::Base
       #       helper_method :current_user, :logged_in?
       #
@@ -118,6 +119,7 @@ module AbstractController
       #     end
       #
       # In a view:
+      #
       #     <% if logged_in? -%>Welcome, <%= current_user.name %><% end -%>
       #
       # #### Parameters


### PR DESCRIPTION
See https://api.rubyonrails.org/classes/AbstractController/Helpers/ClassMethods.html#method-i-helper_method

A new line is required for the code snippets to render correctly