### PR TITLE
Fix formatting in `query_assertions` docs

### DIFF
--- a/activerecord/lib/active_record/testing/query_assertions.rb
+++ b/activerecord/lib/active_record/testing/query_assertions.rb
@@ -52,7 +52,7 @@ module ActiveRecord
       #   assert_queries_match(/LIMIT \?/) { Post.first }
       #
       # If the +:include_schema+ option is provided, any queries (including schema related)
-      #   that match the matcher are considered.
+      # that match the matcher are considered.
       #
       #   assert_queries_match(/FROM pg_attribute/i, include_schema: true) { Post.columns }
       #
@@ -80,7 +80,7 @@ module ActiveRecord
       #   assert_no_queries_match(/SELECT/i) { post.comments }
       #
       # If the +:include_schema+ option is provided, any queries (including schema related)
-      #   that match the matcher are counted.
+      # that match the matcher are counted.
       #
       #   assert_no_queries_match(/FROM pg_attribute/i, include_schema: true) { Post.columns }
       #


### PR DESCRIPTION
Fixes this incorrect formatting due to incorrect indenting:

![image](https://github.com/user-attachments/assets/979f0851-04a1-48e0-8c2c-f6ac5b56e16c)
