### PR TITLE
Mention Cable in `--skip-solid` help

### DIFF
--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -110,7 +110,7 @@ module Rails
                                            desc: "Skip Kamal setup"
 
         class_option :skip_solid,          type: :boolean, default: nil,
-                                           desc: "Skip Solid Cache & Queue setup"
+                                           desc: "Skip Solid Cable, Cache, and Queue setup"
 
         class_option :dev,                 type: :boolean, default: nil,
                                            desc: "Set up the #{name} with Gemfile pointing to your Rails checkout"


### PR DESCRIPTION
`rails new --help` currently shows this after `[--skip-solid`]: `# Skip Solid Cache & Queue setup`.

This PR adds a missing mention to `Cable`.

Alternatively the help message could just say `Skip Solid adapters`.