### PR TITLE
Make `ActionController::AllowBrowser::BrowserBlocker` private

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Rails 8.0.0.beta1 (September 26, 2024) ##
 
+*   Make `ActionController::AllowBrowser::BrowserBlocker` private
+
+    *Sean Doyle*
+
 *   Fix non-GET requests not updating cookies in `ActionController::TestCase`.
 
     *Jon Moss*, *Hartley McGuire*

--- a/actionpack/lib/action_controller/metal/allow_browser.rb
+++ b/actionpack/lib/action_controller/metal/allow_browser.rb
@@ -60,7 +60,7 @@ module ActionController # :nodoc:
         end
       end
 
-      class BrowserBlocker
+      class BrowserBlocker # :nodoc:
         SETS = {
           modern: { safari: 17.2, chrome: 120, firefox: 121, opera: 106, ie: false }
         }


### PR DESCRIPTION
### Motivation / Background

Despite the fact that the `BrowserBlocker` class is defined after a `private` modifier, it is still a public constant and is included in the [documentation][].

To reduce the API surface area of the `allow_browser` feature, this commit marks the class with a `# :nodoc:` comment.

[documentation]: https://edgeapi.rubyonrails.org/classes/ActionController/AllowBrowser/BrowserBlocker.html

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
