### PR TITLE
Promote `normalizes` in `before_validation` docs

### DIFF
--- a/activemodel/lib/active_model/validations/callbacks.rb
+++ b/activemodel/lib/active_model/validations/callbacks.rb
@@ -32,26 +32,30 @@ module ActiveModel
       module ClassMethods
         # Defines a callback that will get called right before validation.
         #
-        #   class Person
+        #   class User
         #     include ActiveModel::Validations
         #     include ActiveModel::Validations::Callbacks
         #
-        #     attr_accessor :name
+        #     attr_accessor :username, :email
         #
-        #     validates_length_of :name, maximum: 6
+        #     validates :email, format: { with: /@/ }
         #
-        #     before_validation :remove_whitespaces
+        #     before_validation :ensure_username_has_value
         #
         #     private
-        #       def remove_whitespaces
-        #         name.strip!
+        #       def ensure_username_has_value
+        #         self.username = email if username.blank?
         #       end
         #   end
         #
-        #   person = Person.new
-        #   person.name = '  bob  '
-        #   person.valid? # => true
-        #   person.name   # => "bob"
+        #   user = User.new
+        #   user.email = 'john.doe@example.com'
+        #   user.valid?   # => true
+        #   user.email    # => 'john.doe@example.com'
+        #   user.username # => 'john.doe@example.com'
+        #
+        # If your goal is to normalize ActiveRecord attributes, consider using
+        # ActiveRecord::Normalization::ClassMethods.normalizes instead.
         def before_validation(*args, &block)
           options = args.extract_options!
 


### PR DESCRIPTION
It's commonly used for normalization but there is a dedicated method in AR for that. Switch it out to an example that doesn't perform normalization, and suggest `normalizes` if the user wants to do that.

I'm don't know how orthodox it is to mention ActiveRecord in ActiveModel docs. There are at least some matches right now already.