### PR TITLE
ActiveRecord::Result#each to yield regular Hash

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -725,8 +725,6 @@ module ActiveRecord
             end
 
             basic_structure.map do |column|
-              column = column.to_h
-
               column_name = column["name"]
 
               if collation_hash.has_key? column_name

--- a/activerecord/lib/active_record/querying.rb
+++ b/activerecord/lib/active_record/querying.rb
@@ -86,10 +86,10 @@ module ActiveRecord
 
       message_bus.instrument("instantiation.active_record", payload) do
         if result_set.includes_column?(inheritance_column)
-          result_set.map { |record| instantiate(record, column_types, &block) }
+          result_set.indexed_rows.map { |record| instantiate(record, column_types, &block) }
         else
           # Instantiate a homogeneous set
-          result_set.map { |record| instantiate_instance_of(self, record, column_types, &block) }
+          result_set.indexed_rows.map { |record| instantiate_instance_of(self, record, column_types, &block) }
         end
       end
     end

--- a/activerecord/lib/active_record/result.rb
+++ b/activerecord/lib/active_record/result.rb
@@ -127,9 +127,9 @@ module ActiveRecord
     # Returns an +Enumerator+ if no block is given.
     def each(&block)
       if block_given?
-        indexed_rows.each(&block)
+        hash_rows.each(&block)
       else
-        indexed_rows.to_enum { @rows.size }
+        hash_rows.to_enum { @rows.size }
       end
     end
 
@@ -191,6 +191,7 @@ module ActiveRecord
     def initialize_copy(other)
       @rows = rows.dup
       @column_types = column_types.dup
+      @hash_rows    = nil
     end
 
     def freeze # :nodoc:
@@ -212,19 +213,19 @@ module ActiveRecord
       end
     end
 
+    def indexed_rows # :nodoc:
+      @indexed_rows ||= begin
+        columns = column_indexes
+        @rows.map { |row| IndexedRow.new(columns, row) }.freeze
+      end
+    end
+
     private
       def column_type(name, index, type_overrides)
         type_overrides.fetch(name) do
           column_types.fetch(index) do
             column_types.fetch(name, Type.default_value)
           end
-        end
-      end
-
-      def indexed_rows
-        @indexed_rows ||= begin
-          columns = column_indexes
-          @rows.map { |row| IndexedRow.new(columns, row) }.freeze
         end
       end
 


### PR DESCRIPTION
Followup: https://github.com/rails/rails/pull/51744
Fix: https://github.com/rails/rails/issues/53081
Closes: https://github.com/rails/rails/pull/53088

While the yielded type wasn't specified and we could always return the more efficient format, there's too many code out there that depend on this behavior.

Ultimately, queries done with `exec_query` are rare, as long as Active Record itself use the more efficient path to instantiate records, most of the gain is obtained.
