### PR TITLE
Infer rubocop ruby version for guides from gemspec as well

### DIFF
--- a/guides/.rubocop.yml
+++ b/guides/.rubocop.yml
@@ -1,9 +1,6 @@
 inherit_from:
   - '../.rubocop.yml'
 
-AllCops:
-  TargetRubyVersion: 3.0
-
 Style/StringLiterals:
   Enabled: false
 

--- a/guides/rails_guides/generator.rb
+++ b/guides/rails_guides/generator.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "set"
 require "fileutils"
 require "nokogiri"
 require "securerandom"


### PR DESCRIPTION
Followup to https://github.com/rails/rails/pull/53062
This was once changed to 3.0 when 2.7 was the minimum version in order to allow 3.0-specific syntax: https://github.com/rails/rails/pull/49001
