### PR TITLE
Autocorrect safely with RuboCop

### DIFF
--- a/railties/lib/rails/configuration.rb
+++ b/railties/lib/rails/configuration.rb
@@ -135,7 +135,7 @@ module Rails
         after_generate do |files|
           parsable_files = files.filter { |file| File.exist?(file) && file.end_with?(".rb") }
           unless parsable_files.empty?
-            system(RbConfig.ruby, "bin/rubocop", "-A", "--fail-level=E", "--format=quiet", *parsable_files, exception: true)
+            system(RbConfig.ruby, "bin/rubocop", "-a", "--fail-level=E", "--format=quiet", *parsable_files, exception: true)
           end
         end
       end


### PR DESCRIPTION
`rubocop -A` would generate false positive fixes.
After this change we use `rubocop -a` instead.
The idea is not to change semantics with RuboCop
See https://docs.rubocop.org/rubocop/usage/auto_correct.html#safe-auto-correct