### PR TITLE
Remove APP_NAME const as no longer being used in bin/setup

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/bin/setup.tt
+++ b/railties/lib/rails/generators/rails/app/templates/bin/setup.tt
@@ -1,7 +1,6 @@
 require "fileutils"
 
 APP_ROOT = File.expand_path("..", __dir__)
-APP_NAME = "<%= app_name.dasherize %>"
 
 def system!(*args)
   system(*args, exception: true)


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because I noticed the `APP_NAME` constant variable in bin/setup is no longer being used or referenced anymore.

It was previously being used to set up `puma-dev` configuration, but this has since been removed here: https://github.com/rails/rails/commit/7ed09d3a387a780278700ac6edac3e97aa41aa3a

### Detail

This Pull Request removes `APP_NAME` constant definition, as it's no longer being used in `bin/setup` generator template.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
