### PR TITLE
Use Solid Queue in the production environment configuration

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Use Solid Queue commented out by default in the generated production.rb environment file.
+
+    Previously, :resque was suggested as the queue in the production.rb environment file.
+
+    *Hampton Lintorn-Catlin*
+
 ## Rails 8.0.0.beta1 (September 26, 2024) ##
 
 *   Exit `rails g` with code 1 if generator could not be found.

--- a/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
@@ -55,7 +55,8 @@ Rails.application.configure do
 
   <%- unless options[:skip_active_job] -%>
   # Replace the default in-process and non-durable queuing backend for Active Job.
-  # config.active_job.queue_adapter = :resque
+  # config.active_job.queue_adapter = :solid_queue
+  # config.solid_queue.connects_to = { database: { writing: :queue } }
 
   <%- end -%>
   <%- unless options.skip_action_mailer? -%>


### PR DESCRIPTION
Currently, :resque is still listed in the generated production.rb file.

This changes the generated `production.rb` to :solid_queue and specifies the :queue database which is how it's generated in new applications.

I noticed it when upgrading my application to 8.0 as it was nuking my :solid_queue configuration in production.

I believe this was likely intended to be included in #52804


Addresses #53141 

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
