### PR TITLE
RateLimiting: support method names for `:by` and `:with`

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,18 @@
+*   Update `ActionController::Metal::RateLimiting` to support passing method names to `:by` and `:with`
+
+    ```ruby
+    class SignupsController < ApplicationController
+      rate_limit to: 10, within: 1.minute, with: :redirect_with_flash
+
+      private
+        def redirect_with_flash
+          redirect_to root_url, alert: "Too many requests!"
+        end
+    end
+    ```
+
+    *Sean Doyle*
+
 *   Optimize `ActionDispatch::Http::URL.build_host_url` when protocol is included in host.
 
     When using URL helpers with a host that includes the protocol (e.g., `{ host: "https://example.com" }`),


### PR DESCRIPTION
### Motivation / Background

Prior to this commit, `:by` and `:with` options only supported callables. This commit aims to bring rate limiting closer in parity to callbacks declarations like `before_action` and `after_action` by supporting instance method names as well.

Without this change, multi-line customized callables can make declarations difficult to read. Similarly, shared customization would require a local variable to be re-used. For example:

```ruby
rate_limiting_bucket = -> { ... }

rate_limit to: 3, within: 1.minutes, by: rate_limiting_bucket
rate_limit to: 10, within: 5.minutes, by: rate_limiting_bucket
rate_limit to: 30, within: 10.minutes,
  by: -> {
    # ...
    # multiple lines
    # ...
  }, 
  with: -> {
    # ...
    # multiple lines
    # ...
  }
```


### Detail


After this change, method names can be used and shared:

```ruby
rate_limit to: 3, within: 1.minutes, by: :rate_limiting_bucket
rate_limit to: 10, within: 5.minutes, by: :rate_limiting_bucket
rate_limit to: 30, within: 10.minutes, by: :rate_limiting_bucket, with: :rate_limit_exceeded

private
  def rate_limiting_bucket
    # ...
    # multiple lines
    # ...
  end

  def rate_limit_exceeded
    # ...
    # multiple lines
    # ...
  end
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
