### PR TITLE
Remove conditional `Thread.each_caller_location` usage

### DIFF
--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -375,35 +375,18 @@ module ActionDispatch
             Routing::RouteSet::Dispatcher.new raise_on_name_error
           end
 
-          if Thread.respond_to?(:each_caller_location)
-            def route_source_location
-              if Mapper.route_source_locations
-                action_dispatch_dir = File.expand_path("..", __dir__)
-                Thread.each_caller_location do |location|
-                  next if location.path.start_with?(action_dispatch_dir)
+          def route_source_location
+            if Mapper.route_source_locations
+              action_dispatch_dir = File.expand_path("..", __dir__)
+              Thread.each_caller_location do |location|
+                next if location.path.start_with?(action_dispatch_dir)
 
-                  cleaned_path = Mapper.backtrace_cleaner.clean_frame(location.path)
-                  next if cleaned_path.nil?
+                cleaned_path = Mapper.backtrace_cleaner.clean_frame(location.path)
+                next if cleaned_path.nil?
 
-                  return "#{cleaned_path}:#{location.lineno}"
-                end
-                nil
+                return "#{cleaned_path}:#{location.lineno}"
               end
-            end
-          else
-            def route_source_location
-              if Mapper.route_source_locations
-                action_dispatch_dir = File.expand_path("..", __dir__)
-                caller_locations.each do |location|
-                  next if location.path.start_with?(action_dispatch_dir)
-
-                  cleaned_path = Mapper.backtrace_cleaner.clean_frame(location.path)
-                  next if cleaned_path.nil?
-
-                  return "#{cleaned_path}:#{location.lineno}"
-                end
-                nil
-              end
+              nil
             end
           end
       end

--- a/activejob/lib/active_job/log_subscriber.rb
+++ b/activejob/lib/active_job/log_subscriber.rb
@@ -196,22 +196,12 @@ module ActiveJob
         end
       end
 
-      if Thread.respond_to?(:each_caller_location)
-        def enqueue_source_location
-          Thread.each_caller_location do |location|
-            frame = backtrace_cleaner.clean_frame(location)
-            return frame if frame
-          end
-          nil
+      def enqueue_source_location
+        Thread.each_caller_location do |location|
+          frame = backtrace_cleaner.clean_frame(location)
+          return frame if frame
         end
-      else
-        def enqueue_source_location
-          caller_locations(2).each do |location|
-            frame = backtrace_cleaner.clean_frame(location)
-            return frame if frame
-          end
-          nil
-        end
+        nil
       end
 
       def enqueued_jobs_message(adapter, enqueued_jobs)

--- a/activerecord/lib/active_record/log_subscriber.rb
+++ b/activerecord/lib/active_record/log_subscriber.rb
@@ -126,18 +126,12 @@ module ActiveRecord
         end
       end
 
-      if Thread.respond_to?(:each_caller_location)
-        def query_source_location
-          Thread.each_caller_location do |location|
-            frame = backtrace_cleaner.clean_frame(location)
-            return frame if frame
-          end
-          nil
+      def query_source_location
+        Thread.each_caller_location do |location|
+          frame = backtrace_cleaner.clean_frame(location)
+          return frame if frame
         end
-      else
-        def query_source_location
-          backtrace_cleaner.clean(caller(1).lazy).first
-        end
+        nil
       end
 
       def filter(name, value)

--- a/activerecord/lib/active_record/query_logs.rb
+++ b/activerecord/lib/active_record/query_logs.rb
@@ -152,18 +152,12 @@ module ActiveRecord
         self.cached_comment = nil
       end
 
-      if Thread.respond_to?(:each_caller_location)
-        def query_source_location # :nodoc:
-          Thread.each_caller_location do |location|
-            frame = LogSubscriber.backtrace_cleaner.clean_frame(location.path)
-            return frame if frame
-          end
-          nil
+      def query_source_location # :nodoc:
+        Thread.each_caller_location do |location|
+          frame = LogSubscriber.backtrace_cleaner.clean_frame(location.path)
+          return frame if frame
         end
-      else
-        def query_source_location # :nodoc:
-          LogSubscriber.backtrace_cleaner.clean(caller_locations(1).each).first
-        end
+        nil
       end
 
       ActiveSupport::ExecutionContext.after_change { ActiveRecord::QueryLogs.clear_cache }


### PR DESCRIPTION
Since rails now requires ruby 3.2+ and `Thread.each_caller_location` was added in ruby 3.2, we can now remove these conditional declarations.