### PR TITLE
Fix `:source_location` query tag option to print full source locations

### DIFF
--- a/activerecord/lib/active_record/query_logs.rb
+++ b/activerecord/lib/active_record/query_logs.rb
@@ -154,7 +154,7 @@ module ActiveRecord
 
       def query_source_location # :nodoc:
         Thread.each_caller_location do |location|
-          frame = LogSubscriber.backtrace_cleaner.clean_frame(location.path)
+          frame = LogSubscriber.backtrace_cleaner.clean_frame(location)
           return frame if frame
         end
         nil

--- a/railties/test/application/query_logs_test.rb
+++ b/railties/test/application/query_logs_test.rb
@@ -163,7 +163,7 @@ module ApplicationTests
       get "/", {}, { "HTTPS" => "on" }
       comment = last_response.body.strip
 
-      assert_match(/source_location='.*'/, comment)
+      assert_match(/source_location='.*\d+'/, comment)
     end
 
     test "controller tags are not doubled up if already configured" do


### PR DESCRIPTION
Before this change:
```
source_location:app/controllers/users_controller.rb*/
```

After:
```
source_location:app/controllers/users_controller.rb:12:in `index'*/
```