### PR TITLE
Remove "Suppressing Callbacks" section from ActiveRecord guide

### DIFF
--- a/guides/source/active_record_callbacks.md
+++ b/guides/source/active_record_callbacks.md
@@ -837,59 +837,6 @@ lead to invalid data.
 [`upsert_all`]:
     https://api.rubyonrails.org/classes/ActiveRecord/Persistence/ClassMethods.html#method-i-upsert_all
 
-Suppressing Callbacks
----------------------
-
-In certain scenarios, you may need to temporarily prevent certain callbacks from
-being executed within your Rails application. This can be useful when you want
-to skip specific actions during certain operations without permanently disabling
-the callbacks.
-
-Rails provides a mechanism for suppressing callbacks using the
-[`ActiveRecord::Suppressor`
-module](https://api.rubyonrails.org/classes/ActiveRecord/Suppressor.html). By
-using this module, you can wrap a block of code where you want to suppress
-callbacks, ensuring that they are not executed during that specific operation.
-
-Let's consider a scenario where we have a `User` model with a callback that
-sends a welcome email to new users after they sign up. However, there might be
-cases where we want to create a user without sending the welcome email, such as
-during seeding the database with test data.
-
-```ruby
-class User < ApplicationRecord
-  after_create :send_welcome_email
-
-  def send_welcome_email
-    puts "Welcome email sent to #{self.email}"
-  end
-end
-```
-
-In this example, the `after_create` callback triggers the `send_welcome_email`
-method every time a new user is created.
-
-To create a user without sending the welcome email, we can use the
-`ActiveRecord::Suppressor` module as follows:
-
-```ruby
-User.suppress do
-  User.create(name: "Jane", email: "jane@example.com")
-end
-```
-
-In the above code, the `User.suppress` block ensures that the
-`send_welcome_email` callback is not executed during the creation of the "Jane"
-user, allowing us to create the user without sending the welcome email.
-
-WARNING: Using the Active Record Suppressor, while potentially beneficial for
-selectively controlling callback execution, can introduce complexity and
-unexpected behavior. Suppressing callbacks can obscure the intended flow of your
-application, leading to difficulties in understanding and maintaining the
-codebase over time. Carefully consider the implications of suppressing
-callbacks, ensuring thorough documentation and thoughtful testing to mitigate
-risks of unintended side effects, performance issues, and test failures.
-
 Halting Execution
 -----------------
 


### PR DESCRIPTION
### Motivation / Background

The recent overhaul of the ActiveRecord callbacks documentation is great, but unfortunately the section on suppressing callbacks is wrong.

### Detail

The example given in the guide is this:

> ```ruby
> class User < ApplicationRecord
>   after_create :send_welcome_email
> 
>   def send_welcome_email
>     puts "Welcome email sent to #{self.email}"
>   end
> end
> ```
> 
> In this example, the `after_create` callback triggers the `send_welcome_email`
> method every time a new user is created.
> 
> To create a user without sending the welcome email, we can use the
> `ActiveRecord::Suppressor` module as follows:
> 
> ```ruby
> User.suppress do
>   User.create(name: "Jane", email: "jane@example.com")
> end
> ```
> 
> In the above code, the `User.suppress` block ensures that the
> `send_welcome_email` callback is not executed during the creation of the "Jane"
> user, allowing us to create the user without sending the welcome email.

However, what actually happens is no user is created at all, because `ActiveRecord::Suppressor::ClassMethods#suppress` does not interact with callbacks per-se, but prevents records of the suppressed class from being saved.

I've opted to simply remove this section, as I am not particularly motivated to document it. I think the API is awkward, and the name and description given in the API docs is confusing to the point of being misleading (as evidenced by this section of the guide). I read all the "sharp knives" comments (#18847) and while it's fine to leave it in the drawer, let's not call a cleaver a paring knife.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
