### PR TITLE
Add inspect to ActiveStorage::Service, ActiveStorage::Service::Registry, and ActiveStorage::Service::Configurator

### DIFF
--- a/activestorage/lib/active_storage/service.rb
+++ b/activestorage/lib/active_storage/service.rb
@@ -148,6 +148,10 @@ module ActiveStorage
       @public
     end
 
+    def inspect # :nodoc:
+      "#<#{self.class}#{name.present? ? " name=#{name.inspect}" : ""}>"
+    end
+
     private
       def private_url(key, expires_in:, filename:, disposition:, content_type:, **)
         raise NotImplementedError

--- a/activestorage/lib/active_storage/service/configurator.rb
+++ b/activestorage/lib/active_storage/service/configurator.rb
@@ -19,6 +19,12 @@ module ActiveStorage
       )
     end
 
+    def inspect # :nodoc:
+      attrs = configurations.any? ?
+        " configurations=[#{configurations.keys.map(&:inspect).join(", ")}]" : ""
+      "#<#{self.class}#{attrs}>"
+    end
+
     private
       def config_for(name)
         configurations.fetch name do

--- a/activestorage/lib/active_storage/service/registry.rb
+++ b/activestorage/lib/active_storage/service/registry.rb
@@ -22,6 +22,12 @@ module ActiveStorage
       end
     end
 
+    def inspect # :nodoc:
+      attrs = configurations.any? ?
+        " configurations=[#{configurations.keys.map(&:inspect).join(", ")}]" : ""
+      "#<#{self.class}#{attrs}>"
+    end
+
     private
       attr_reader :configurations, :services
 

--- a/activestorage/test/service/configurator_test.rb
+++ b/activestorage/test/service/configurator_test.rb
@@ -21,6 +21,19 @@ class ActiveStorage::Service::ConfiguratorTest < ActiveSupport::TestCase
     end
   end
 
+  test "inspect attributes" do
+    config = {
+      local: { service: "Disk", root: "/tmp/active_storage_configurator_test" },
+      tmp: { service: "Disk", root: "/tmp/active_storage_configurator_test_tmp" },
+    }
+
+    configurator = ActiveStorage::Service::Configurator.new(config)
+    assert_match(/#<ActiveStorage::Service::Configurator configurations=\[:local, :tmp\]>/, configurator.inspect)
+
+    configurator = ActiveStorage::Service::Configurator.new({})
+    assert_match(/#<ActiveStorage::Service::Configurator>/, configurator.inspect)
+  end
+
   test "azure service is deprecated" do
     msg = <<~MSG.squish
       `ActiveStorage::Service::AzureStorageService` is deprecated and will be

--- a/activestorage/test/service/registry_test.rb
+++ b/activestorage/test/service/registry_test.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class ActiveStorage::Service::RegistryTest < ActiveSupport::TestCase
+  test "inspect attributes" do
+    registry = ActiveStorage::Service::Registry.new({})
+    assert_match(/#<ActiveStorage::Service::Registry>/, registry.inspect)
+  end
+
+  test "inspect attributes with config" do
+    config = {
+      local: { service: "Disk", root: "/tmp/active_storage_registry_test" },
+      tmp: { service: "Disk", root: "/tmp/active_storage_registry_test_tmp" },
+    }
+
+    registry = ActiveStorage::Service::Registry.new(config)
+    assert_match(/#<ActiveStorage::Service::Registry configurations=\[:local, :tmp\]>/, registry.inspect)
+  end
+end

--- a/activestorage/test/service_test.rb
+++ b/activestorage/test/service_test.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class ActiveStorage::ServiceTest < ActiveSupport::TestCase
+  test "inspect attributes" do
+    config = {
+      local: { service: "Disk", root: "/tmp/active_storage_service_test" },
+      tmp: { service: "Disk", root: "/tmp/active_storage_service_test_tmp" },
+    }
+
+    service = ActiveStorage::Service.configure(:local, config)
+    assert_match(/#<ActiveStorage::Service::DiskService name=:local>/, service.inspect)
+
+    service = ActiveStorage::Service.new
+    assert_match(/#<ActiveStorage::Service>/, service.inspect)
+  end
+end


### PR DESCRIPTION
This was inspired by #50405.

If you accidentally pretty print `ActiveStorage::Blob.services` and have the entire config which may contain secrets persit in logs or elsewhere.

Or in Ruby 3.2 and older, raising an exception on those objects, e.g. `ActiveStorage::Blob.services[:local]` instead of `fetch`.
For this reason, I would also like to consider this a bug-fix and backport it to 7.2 and 7.1, where the issue is even more apparent given the older versions of Ruby supported.

Before:

```ruby
pp ActiveStorage::Blob.services
  #<ActiveStorage::Service::Registry:0x00007f2a68469d28
    @configurations={
      :s3 => {
        :service=>"S3",
        :access_key_id=>"test_key",
        :secret_access_key=>"test_secret",
        :region=>"us-east-1",
        :bucket=>"rails-test"
      },
      :gcs => { :service=>"GCS", :credentials=> "secret-hash" }
    }
    @services={}>
```

After

```ruby
  #<ActiveStorage::Service::Registry configurations=[:s3, :gcs]>
```
