### PR TITLE
ConnectionPool#unpin_connection! handle lazily pinned connections

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,14 @@
+*   Properly handle lazily pinned connection pools.
+
+    Fixes #53147.
+
+    When using transactional fixtures with system tests to similar tools
+    such as capybara, it could happen that a connection end up pinned by the
+    server thread rather than the test thread, causing
+    `"Cannot expire connection, it is owned by a different thread"` errors.
+
+    *Jean Boussier*
+
 *   Fix `ActiveRecord::Base.with` to accept more than two sub queries.
 
     Fixes #53110.

--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -358,6 +358,7 @@ module ActiveRecord
           end
 
           if @pinned_connection.nil?
+            connection.steal!
             connection.lock_thread = nil
             checkin(connection)
           end


### PR DESCRIPTION
Fix: https://github.com/rails/rails/issues/53147

In `setup_transactional_fixtures` we register a callback to lazily pin a connections in pools that are created after the fixtures setup.

But when this callback is used, the connection owner might be a different thread than the one that will call `teardown_transactional_fixtures`.

To handle that, we must steal the connection when doing the final unpinning.
