### PR TITLE
Link to all methods from `ActiveModel::Conversion` comments [ci skip]

### DIFF
--- a/activemodel/lib/active_model/conversion.rb
+++ b/activemodel/lib/active_model/conversion.rb
@@ -3,7 +3,7 @@
 module ActiveModel
   # = Active \Model \Conversion
   #
-  # Handles default conversions: to_model, to_key, to_param, and to_partial_path.
+  # Handles default conversions: #to_model, #to_key, #to_param, and #to_partial_path.
   #
   # Let's take for example this non-persisted object.
   #


### PR DESCRIPTION
These methods are auto-linked as written, but the trailing punctuation stops the final one in the list from being linked:

<img width="788" alt="Screenshot 2024-10-02 at 20 41 04" src="https://github.com/user-attachments/assets/7423e118-88f0-4a5f-8bb8-c57f294f1634">

Explicit method link style corrects:

<img width="677" alt="Screenshot 2024-10-02 at 20 40 42" src="https://github.com/user-attachments/assets/f98cac00-d565-407e-9c2d-9efb54f62d72">

