### PR TITLE
AllowBrowser: support method names for `:block`

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,18 @@
+*   Update `ActionController::AllowBrowser` to support passing method names to `:block`
+
+    ```ruby
+    class ApplicationController < ActionController::Base
+      allow_browser versions: :modern, block: :handle_outdated_browser
+
+      private
+        def handle_outdated_browser
+          render file: Rails.root.join("public/custom-error.html"), status: :not_acceptable
+        end
+    end
+    ```
+
+    *Sean Doyle*
+
 *   Raise an `ArgumentError` when invalid `:on` or `:except` options are passed into `#resource` and `#resources`.
 
     *Joshua Young*

--- a/actionpack/lib/action_controller/metal/allow_browser.rb
+++ b/actionpack/lib/action_controller/metal/allow_browser.rb
@@ -36,6 +36,16 @@ module ActionController # :nodoc:
       #     end
       #
       #     class ApplicationController < ActionController::Base
+      #       # Allow only browsers natively supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has
+      #       allow_browser versions: :modern, block: :handle_outdated_browser
+      #
+      #       private
+      #         def handle_outdated_browser
+      #           render file: Rails.root.join("public/custom-error.html"), status: :not_acceptable
+      #         end
+      #     end
+      #
+      #     class ApplicationController < ActionController::Base
       #       # All versions of Chrome and Opera will be allowed, but no versions of "internet explorer" (ie). Safari needs to be 16.4+ and Firefox 121+.
       #       allow_browser versions: { safari: 16.4, firefox: 121, ie: false }
       #     end
@@ -55,7 +65,7 @@ module ActionController # :nodoc:
 
         if BrowserBlocker.new(request, versions: versions).blocked?
           ActiveSupport::Notifications.instrument("browser_block.action_controller", request: request, versions: versions) do
-            instance_exec(&block)
+            block.is_a?(Symbol) ? send(block) : instance_exec(&block)
           end
         end
       end

--- a/actionpack/test/controller/allow_browser_test.rb
+++ b/actionpack/test/controller/allow_browser_test.rb
@@ -8,10 +8,20 @@ class AllowBrowserController < ActionController::Base
     head :ok
   end
 
+  allow_browser versions: { safari: "16.4", chrome: "119", firefox: "123", opera: "106", ie: false }, block: :head_upgrade_required, only: :hello_method_name
+  def hello_method_name
+    head :ok
+  end
+
   allow_browser versions: :modern, block: -> { head :upgrade_required }, only: :modern
   def modern
     head :ok
   end
+
+  private
+    def head_upgrade_required
+      head :upgrade_required
+    end
 end
 
 class AllowBrowserTest < ActionController::TestCase
@@ -25,8 +35,13 @@ class AllowBrowserTest < ActionController::TestCase
   OPERA_106     = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36 OPR/106.0.0.0"
   GOOGLE_BOT    = "Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5X Build/MMB29P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/W.X.Y.Z Mobile Safari/537.36 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)"
 
-  test "blocked browser below version limit" do
+  test "blocked browser below version limit with callable" do
     get_with_agent :hello, FIREFOX_114
+    assert_response :upgrade_required
+  end
+
+  test "blocked browser below version limit with method name" do
+    get_with_agent :hello_method_name, FIREFOX_114
     assert_response :upgrade_required
   end
 
@@ -68,9 +83,25 @@ class AllowBrowserTest < ActionController::TestCase
     assert_response :ok
   end
 
+  test "a blocked request instruments a browser_block.action_controller event" do
+    event, *rest = capture_instrumentation_events "browser_block.action_controller" do
+      get_with_agent :modern, CHROME_118
+    end
+
+    assert_equal request, event.payload[:request]
+    assert_not_empty event.payload[:versions]
+    assert_empty rest
+  end
+
   private
     def get_with_agent(action, agent)
       @request.headers["User-Agent"] = agent
       get action
+    end
+
+    def capture_instrumentation_events(pattern, &block)
+      events = []
+      ActiveSupport::Notifications.subscribed(->(e) { events << e }, pattern, &block)
+      events
     end
 end


### PR DESCRIPTION
### Motivation / Background

Prior to this commit, `:block` options only supported callables. This commit aims to bring browser blocking closer in parity to callbacks declarations like `before_action` and `after_action` by supporting instance method names as well.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
