### PR TITLE
Remove `error.respond_to?(:detailed_message)` conditions

### DIFF
--- a/actionpack/test/controller/base_test.rb
+++ b/actionpack/test/controller/base_test.rb
@@ -190,11 +190,7 @@ class PerformActionTest < ActionController::TestCase
     exception = assert_raise AbstractController::ActionNotFound do
       get :ello
     end
-    if exception.respond_to?(:detailed_message)
-      assert_match "Did you mean?", exception.detailed_message
-    else
-      assert_match "Did you mean?", exception.message
-    end
+    assert_match "Did you mean?", exception.detailed_message
   end
 
   def test_action_missing_should_work

--- a/actionpack/test/controller/helper_test.rb
+++ b/actionpack/test/controller/helper_test.rb
@@ -88,11 +88,7 @@ class HelpersTypoControllerTest < ActiveSupport::TestCase
   def test_helper_typo_error_message
     e = assert_raise(NameError) { HelpersTypoController.helper "admin/users" }
     assert_includes e.message, "uninitialized constant Admin::UsersHelper"
-    if e.respond_to?(:detailed_message)
-      assert_includes e.detailed_message, "Did you mean?  Admin::UsersHelpeR"
-    else
-      assert_includes e.message, "Did you mean?  Admin::UsersHelpeR"
-    end
+    assert_includes e.detailed_message, "Did you mean?  Admin::UsersHelpeR"
   end
 end
 

--- a/actionpack/test/controller/required_params_test.rb
+++ b/actionpack/test/controller/required_params_test.rb
@@ -26,20 +26,12 @@ class ActionControllerRequiredParamsTest < ActionController::TestCase
     error = assert_raise ActionController::ParameterMissing do
       post :create, params: { boko: { name: "Mjallo!" } }
     end
-    if error.respond_to?(:detailed_message)
-      assert_match "Did you mean?", error.detailed_message
-    else
-      assert_match "Did you mean?", error.message
-    end
+    assert_match "Did you mean?", error.detailed_message
 
     error = assert_raise ActionController::ParameterMissing do
       post :create, params: { book: { naem: "Mjallo!" } }
     end
-    if error.respond_to?(:detailed_message)
-      assert_match "Did you mean?", error.detailed_message
-    else
-      assert_match "Did you mean?", error.message
-    end
+    assert_match "Did you mean?", error.detailed_message
   end
 
   test "required parameters that are present will not raise" do

--- a/actionpack/test/dispatch/routing_test.rb
+++ b/actionpack/test/dispatch/routing_test.rb
@@ -4968,11 +4968,7 @@ class TestUrlGenerationErrors < ActionDispatch::IntegrationTest
 
   test "exceptions have suggestions for fix" do
     error = assert_raises(ActionController::UrlGenerationError) { product_path(nil, "id" => "url-tested") }
-    if error.respond_to?(:detailed_message)
-      assert_match "Did you mean?", error.detailed_message
-    else
-      assert_match "Did you mean?", error.message
-    end
+    assert_match "Did you mean?", error.detailed_message
   end
 
   # FIXME: we should fix all locations that raise this exception to provide

--- a/actionview/test/template/render_test.rb
+++ b/actionview/test/template/render_test.rb
@@ -706,55 +706,32 @@ module RenderTestCases
 
   def test_render_partial_provides_spellcheck
     e = assert_raises(ActionView::MissingTemplate) { @view.render(partial: "test/partail") }
-    if e.respond_to?(:detailed_message)
-      assert_match %r{Did you mean\?  test/partial\e\[m\n\e\[1m *test/partialhtml}, e.detailed_message
-    else
-      assert_match %r{Did you mean\?  test/partial\n *test/partialhtml}, e.message
-    end
+    assert_match %r{Did you mean\?  test/partial\e\[m\n\e\[1m *test/partialhtml}, e.detailed_message
   end
 
   def test_spellcheck_doesnt_list_directories
     e = assert_raises(ActionView::MissingTemplate) { @view.render(partial: "test/directory") }
-    if e.respond_to?(:detailed_message)
-      assert_match %r{Did you mean\?}, e.detailed_message
-      assert_no_match %r{Did you mean\?  test/directory\n}, e.detailed_message # test/hello is a directory
-    else
-      assert_match %r{Did you mean\?}, e.message
-      assert_no_match %r{Did you mean\?  test/directory\n}, e.message # test/hello is a directory
-    end
+    assert_match %r{Did you mean\?}, e.detailed_message
+    assert_no_match %r{Did you mean\?  test/directory\n}, e.detailed_message # test/hello is a directory
   end
 
   def test_spellcheck_only_lists_templates
     e = assert_raises(ActionView::MissingTemplate) { @view.render(template: "test/partial") }
 
-    if e.respond_to?(:detailed_message)
-      assert_match %r{Did you mean\?}, e.detailed_message
-      assert_no_match %r{Did you mean\?  test/partial\n}, e.detailed_message
-    else
-      assert_match %r{Did you mean\?}, e.message
-      assert_no_match %r{Did you mean\?  test/partial\n}, e.message
-    end
+    assert_match %r{Did you mean\?}, e.detailed_message
+    assert_no_match %r{Did you mean\?  test/partial\n}, e.detailed_message
   end
 
   def test_spellcheck_only_lists_partials
     e = assert_raises(ActionView::MissingTemplate) { @view.render(partial: "test/template") }
 
-    if e.respond_to?(:detailed_message)
-      assert_match %r{Did you mean\?}, e.detailed_message
-      assert_no_match %r{Did you mean\?  test/template\n}, e.detailed_message
-    else
-      assert_match %r{Did you mean\?}, e.message
-      assert_no_match %r{Did you mean\?  test/template\n}, e.message
-    end
+    assert_match %r{Did you mean\?}, e.detailed_message
+    assert_no_match %r{Did you mean\?  test/template\n}, e.detailed_message
   end
 
   def test_render_partial_wrong_details_no_spellcheck
     e = assert_raises(ActionView::MissingTemplate) { @view.render(partial: "test/partial_with_only_html_version", formats: [:xml]) }
-    if e.respond_to?(:detailed_message)
-      assert_no_match %r{Did you mean\?}, e.detailed_message
-    else
-      assert_no_match %r{Did you mean\?}, e.message
-    end
+    assert_no_match %r{Did you mean\?}, e.detailed_message
   end
 
   def test_render_with_nested_layout

--- a/activerecord/test/cases/associations/eager_test.rb
+++ b/activerecord/test/cases/associations/eager_test.rb
@@ -881,11 +881,7 @@ class EagerAssociationTest < ActiveRecord::TestCase
     error = assert_raise(ActiveRecord::AssociationNotFoundError) {
       Post.all.merge!(includes: :taggingz).find(6)
     }
-    if error.respond_to?(:detailed_message)
-      assert_match "Did you mean?  tagging", error.detailed_message
-    else
-      assert_match "Did you mean?  tagging\n", error.message
-    end
+    assert_match "Did you mean?  tagging", error.detailed_message
   end
 
   def test_eager_has_many_through_with_order

--- a/activerecord/test/cases/associations/inverse_associations_test.rb
+++ b/activerecord/test/cases/associations/inverse_associations_test.rb
@@ -418,11 +418,7 @@ class InverseHasOneTests < ActiveRecord::TestCase
       Human.first.confused_face
     }
 
-    if error.respond_to?(:detailed_message)
-      assert_match "Did you mean?", error.detailed_message
-    else
-      assert_match "Did you mean?", error.message
-    end
+    assert_match "Did you mean?", error.detailed_message
     assert_equal "confused_human", error.corrections.first
   end
 end
@@ -912,11 +908,7 @@ class InverseBelongsToTests < ActiveRecord::TestCase
       Face.first.confused_human
     }
 
-    if error.respond_to?(:detailed_message)
-      assert_match "Did you mean?", error.detailed_message
-    else
-      assert_match "Did you mean?", error.message
-    end
+    assert_match "Did you mean?", error.detailed_message
     assert_equal "confused_face", error.corrections.first
   end
 

--- a/activerecord/test/cases/associations/join_model_test.rb
+++ b/activerecord/test/cases/associations/join_model_test.rb
@@ -345,11 +345,7 @@ class AssociationsJoinModelTest < ActiveRecord::TestCase
     error = assert_raise(ActiveRecord::HasManyThroughAssociationNotFoundError) {
       authors(:david).nothings
     }
-    if error.respond_to?(:detailed_message)
-      assert_match "Did you mean?", error.detailed_message
-    else
-      assert_match "Did you mean?", error.message
-    end
+    assert_match "Did you mean?", error.detailed_message
   end
 
   def test_has_many_through_join_model_with_conditions


### PR DESCRIPTION
Since `Exception#detailed_message` is available in Ruby 3.2 and Rails requires Ruby 3.2+.
