### PR TITLE
Add bundler-cache feature in dev container setup

### DIFF
--- a/railties/lib/rails/generators/rails/devcontainer/templates/devcontainer/compose.yaml.tt
+++ b/railties/lib/rails/generators/rails/devcontainer/templates/devcontainer/compose.yaml.tt
@@ -8,6 +8,7 @@ services:
 
     volumes:
     - ../../<%= app_folder %>:/workspaces/<%= app_folder %>:cached
+    - bundle-cache:/home/vscode/.local/share
 
     # Overrides default command so things don't shut down after the process ends.
     command: sleep infinity
@@ -39,8 +40,10 @@ services:
 
 <%- end -%>
   <%= devcontainer_db_service_yaml(indentation: 4) %>
-<%- if !volumes.empty? -%>
+
 volumes:
+  bundle-cache:
+<%- if !volumes.empty? -%>
 <%- volumes.each do |volume| -%>
   <%= volume %>:
 <%- end -%>

--- a/railties/test/commands/devcontainer_test.rb
+++ b/railties/test/commands/devcontainer_test.rb
@@ -40,7 +40,10 @@ class Rails::Command::DevcontainerTest < ActiveSupport::TestCase
           "context" => "..",
           "dockerfile" => ".devcontainer/Dockerfile"
         },
-        "volumes" => ["../../app:/workspaces/app:cached"],
+        "volumes" => [
+          "../../app:/workspaces/app:cached",
+          "bundle-cache:/home/vscode/.local/share"
+        ],
         "command" => "sleep infinity",
         "depends_on" => ["selenium"]
       }

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -1576,7 +1576,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
           "context" => "..",
           "dockerfile" => ".devcontainer/Dockerfile"
         },
-        "volumes" => ["../../tmp:/workspaces/tmp:cached"],
+        "volumes" => ["../../tmp:/workspaces/tmp:cached", "bundle-cache:/home/vscode/.local/share"],
         "command" => "sleep infinity",
         "depends_on" => ["selenium"]
       }
@@ -1629,7 +1629,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
     assert_compose_file do |compose_config|
       assert_not_includes compose_config["services"]["rails-app"]["depends_on"], "redis"
       assert_nil compose_config["services"]["redis"]
-      assert_nil compose_config["volumes"]
+      assert_includes compose_config["volumes"].keys, "bundle-cache"
     end
 
     assert_devcontainer_json_file do |content|

--- a/railties/test/generators/devcontainer_generator_test.rb
+++ b/railties/test/generators/devcontainer_generator_test.rb
@@ -75,6 +75,19 @@ module Rails
         end
       end
 
+      def test_app_volumes
+        run_generator
+
+        assert_compose_file do |compose|
+          expected_volumes = ["../../rails_app:/workspaces/rails_app:cached", "bundle-cache:/home/vscode/.local/share"]
+          actual_volumes = compose["services"]["rails-app"]["volumes"]
+          expected_volumes.each do |volume|
+            assert_includes actual_volumes, volume
+          end
+          assert_equal ["bundle-cache", "redis-data"], compose["volumes"].keys
+        end
+      end
+
       def test_database_default_sqlite3
         run_generator
 
@@ -100,7 +113,7 @@ module Rails
             },
           }
           assert_equal expected_mariadb_config, compose["services"]["mariadb"]
-          assert_includes compose["volumes"].keys, "mariadb-data"
+          assert_equal ["bundle-cache", "redis-data", "mariadb-data"], compose["volumes"].keys
           assert_includes compose["services"]["rails-app"]["depends_on"], "mariadb"
         end
 
@@ -127,7 +140,7 @@ module Rails
             },
           }
           assert_equal expected_mariadb_config, compose["services"]["mariadb"]
-          assert_includes compose["volumes"].keys, "mariadb-data"
+          assert_equal ["bundle-cache", "redis-data", "mariadb-data"], compose["volumes"].keys
           assert_includes compose["services"]["rails-app"]["depends_on"], "mariadb"
         end
 
@@ -154,7 +167,7 @@ module Rails
             "networks" => ["default"],
           }
           assert_equal expected_mysql_config, compose["services"]["mysql"]
-          assert_includes compose["volumes"].keys, "mysql-data"
+          assert_equal ["bundle-cache", "redis-data", "mysql-data"], compose["volumes"].keys
           assert_includes compose["services"]["rails-app"]["depends_on"], "mysql"
         end
 
@@ -188,7 +201,7 @@ module Rails
             }
           }
           assert_equal expected_postgres_config, compose["services"]["postgres"]
-          assert_includes compose["volumes"].keys, "postgres-data"
+          assert_equal ["bundle-cache", "redis-data", "postgres-data"], compose["volumes"].keys
           assert_includes compose["services"]["rails-app"]["depends_on"], "postgres"
         end
 
@@ -216,7 +229,7 @@ module Rails
             "networks" => ["default"],
           }
           assert_equal expected_mysql_config, compose["services"]["mysql"]
-          assert_includes compose["volumes"].keys, "mysql-data"
+          assert_equal ["bundle-cache", "redis-data", "mysql-data"], compose["volumes"].keys
           assert_includes compose["services"]["rails-app"]["depends_on"], "mysql"
         end
 
@@ -275,7 +288,7 @@ module Rails
             "volumes" => ["redis-data:/data"]
           }
           assert_equal expected_redis_config, compose["services"]["redis"]
-          assert_equal ["redis-data"], compose["volumes"].keys
+          assert_equal ["bundle-cache", "redis-data"], compose["volumes"].keys
         end
 
         assert_devcontainer_json_file do |devcontainer_json|
@@ -291,7 +304,7 @@ module Rails
         assert_compose_file do |compose|
           assert_not_includes compose["services"]["rails-app"]["depends_on"], "redis"
           assert_nil compose["services"]["redis"]
-          assert_nil compose["volumes"]
+          assert_equal ["bundle-cache"], compose["volumes"].keys
         end
 
         assert_devcontainer_json_file do |devcontainer_json|
@@ -380,7 +393,7 @@ module Rails
                 "context" => "..",
                 "dockerfile" => ".devcontainer/Dockerfile"
               },
-              "volumes" => ["../../#{folder_name}:/workspaces/#{folder_name}:cached"],
+              "volumes" => ["../../#{folder_name}:/workspaces/#{folder_name}:cached", "bundle-cache:/home/vscode/.local/share"],
               "command" => "sleep infinity"
             }
             actual_independent_config = compose["services"]["rails-app"].except("depends_on")


### PR DESCRIPTION
### Motivation / Background

This Pull Request addresses the issue of caching bundler dependencies in a Dev Container setup, which can significantly speed up container startup times by avoiding the need to reinstall gems on every new container creation. 

It is a follow-up to an existing PR (https://github.com/rails/rails/pull/53123) by @patriciomacadden, which introduced a similar feature using `ghcr.io/rails/devcontainer/features/bundler-cache`. 

However, as discussed in that PR, my approach offers a simpler solution by directly mounting a volume for the `.rbenv` directory, which includes bundler dependencies. This implementation minimizes additional configuration while still solving the problem effectively. 

### Detail

This Pull Request changes the `devcontainer.json` configuration by adding a volume that caches the `.rbenv` directory. 

### Additional Information

For more context, please refer to my related PR in an example Rails app repository: https://github.com/viktorianer/rails8-devcontainer-enhancements/pull/13. 

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.