### PR TITLE
Add user fixture to authentication generator

### DIFF
--- a/railties/lib/rails/generators/rails/authentication/authentication_generator.rb
+++ b/railties/lib/rails/generators/rails/authentication/authentication_generator.rb
@@ -49,6 +49,8 @@ module Rails
         generate "migration CreateUsers email_address:string!:uniq password_digest:string! --force"
         generate "migration CreateSessions user:references ip_address:string user_agent:string --force"
       end
+
+      hook_for :test_framework
     end
   end
 end

--- a/railties/lib/rails/generators/test_unit/authentication/authentication_generator.rb
+++ b/railties/lib/rails/generators/test_unit/authentication/authentication_generator.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require "rails/generators/test_unit"
+
+module TestUnit # :nodoc:
+  module Generators # :nodoc:
+    class AuthenticationGenerator < Rails::Generators::Base # :nodoc:
+      def create_user_test_files
+        template "test/fixtures/users.yml"
+        template "test/models/user_test.rb"
+      end
+    end
+  end
+end

--- a/railties/lib/rails/generators/test_unit/authentication/templates/test/fixtures/users.yml.tt
+++ b/railties/lib/rails/generators/test_unit/authentication/templates/test/fixtures/users.yml.tt
@@ -1,0 +1,9 @@
+<%% password_digest = BCrypt::Password.create("password") %>
+
+one:
+  email_address: one@example.com
+  password_digest: <%%= password_digest %>
+
+two:
+  email_address: two@example.com
+  password_digest: <%%= password_digest %>

--- a/railties/lib/rails/generators/test_unit/authentication/templates/test/models/user_test.rb.tt
+++ b/railties/lib/rails/generators/test_unit/authentication/templates/test/models/user_test.rb.tt
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class UserTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/railties/test/generators/authentication_generator_test.rb
+++ b/railties/test/generators/authentication_generator_test.rb
@@ -53,6 +53,9 @@ class AuthenticationGeneratorTest < Rails::Generators::TestCase
     assert_migration "db/migrate/create_users.rb" do |content|
       assert_match(/t.string :password_digest, null: false/, content)
     end
+
+    assert_file "test/models/user_test.rb"
+    assert_file "test/fixtures/users.yml"
   end
 
   def test_authentication_generator_without_bcrypt_in_gemfile
@@ -97,5 +100,14 @@ class AuthenticationGeneratorTest < Rails::Generators::TestCase
     assert_migration "db/migrate/create_users.rb" do |content|
       assert_match(/t.string :password_digest, null: false/, content)
     end
+
+    assert_file "test/models/user_test.rb"
+    assert_file "test/fixtures/users.yml"
+  end
+
+  def test_model_test_is_skipped_if_test_framework_is_given
+    content = run_generator ["authentication", "-t", "rspec"]
+    assert_match(/rspec \[not found\]/, content)
+    assert_no_file "test/models/user_test.rb"
   end
 end


### PR DESCRIPTION
### Motivation / Background

I love the new authentication generator. Since other Rails generators that create models create a test stub and fixture file, I expected the authentication generator to do the same. I think it's particularly useful in this case to smooth the learning curve for new users who may not be familiar with how to set the `password_digest`  value.

### Detail

I've used the `test_framework` and `fixture_replacement` hooks and provided a default `test_unit` implmentation.

### Checklist

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
