### PR TITLE
Do not install test gems in production Dockerfile

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/Dockerfile.tt
+++ b/railties/lib/rails/generators/rails/app/templates/Dockerfile.tt
@@ -23,7 +23,7 @@ RUN apt-get update -qq && \
 ENV RAILS_ENV="production" \
     BUNDLE_DEPLOYMENT="1" \
     BUNDLE_PATH="/usr/local/bundle" \
-    BUNDLE_WITHOUT="development"
+    BUNDLE_WITHOUT="development:test"
 
 # Throw-away build stage to reduce size of final image
 FROM base AS build

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -1175,6 +1175,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
     assert_file "Dockerfile" do |content|
       assert_match(/assets:precompile/, content)
       assert_match(/libvips/, content)
+      assert_match(/BUNDLE_WITHOUT="development:test"/, content)
       assert_no_match(/yarn/, content)
       assert_no_match(/node-gyp/, content)
     end


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because Rails' `Dockerfile`, which is [designed](https://github.com/rails/rails/blob/0df09ddb654461574dc45af5518b0cfa3a24e09e/railties/lib/rails/generators/rails/app/templates/Dockerfile.tt#L4) for production, currently installs gems from the `test` group. 

When creating a Rails app, the default Gemfile has test gems in [`group :development, :test do`](https://github.com/rails/rails/blob/0df09ddb654461574dc45af5518b0cfa3a24e09e/railties/lib/rails/generators/rails/app/templates/Gemfile.tt#L54) and [`group :test do`](https://github.com/rails/rails/blob/0df09ddb654461574dc45af5518b0cfa3a24e09e/railties/lib/rails/generators/rails/app/templates/Gemfile.tt#L78) by default. These gems are not needed for production and they slow down the Docker build.

### Detail

This Pull Request changes the `Dockerfile` template to use `BUNDLE_WITHOUT="development:test"`.

### Additional information

Thanks to Kadu Diógenes for reporting this on Discord.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
