### PR TITLE
Bug report templates should use ActiveSupport::TestCase not raw Minitest::Test

### DIFF
--- a/guides/bug_report_templates/active_record.rb
+++ b/guides/bug_report_templates/active_record.rb
@@ -37,7 +37,7 @@ class Comment < ActiveRecord::Base
   belongs_to :post
 end
 
-class BugTest < Minitest::Test
+class BugTest < ActiveSupport::TestCase
   def test_association_stuff
     post = Post.create!
     post.comments << Comment.create!

--- a/guides/bug_report_templates/active_record_migrations.rb
+++ b/guides/bug_report_templates/active_record_migrations.rb
@@ -43,7 +43,7 @@ class ChangeAmountToAddScale < ActiveRecord::Migration::Current # or use a speci
   end
 end
 
-class BugTest < Minitest::Test
+class BugTest < ActiveSupport::TestCase
   def test_migration_up
     ChangeAmountToAddScale.migrate(:up)
     Payment.reset_column_information

--- a/guides/bug_report_templates/active_storage.rb
+++ b/guides/bug_report_templates/active_storage.rb
@@ -55,7 +55,7 @@ end
 
 require "minitest/autorun"
 
-class BugTest < Minitest::Test
+class BugTest < ActiveSupport::TestCase
   def test_upload_and_download
     user = User.create!(
       profile: {

--- a/guides/bug_report_templates/generic.rb
+++ b/guides/bug_report_templates/generic.rb
@@ -14,7 +14,7 @@ require "active_support"
 require "active_support/core_ext/object/blank"
 require "minitest/autorun"
 
-class BugTest < Minitest::Test
+class BugTest < ActiveSupport::TestCase
   def test_stuff
     assert "zomg".present?
     refute "".present?


### PR DESCRIPTION
We always subclass AS::TestCase in the default scenario and it provides many nice assertions built-in, so reporter is probably more comfortable with this.