### PR TITLE
[Dockerfile] Fix yarn installation method for yarn > 1.x.x

### DIFF
--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -539,6 +539,11 @@ module Rails
         "latest"
       end
 
+      def yarn_through_corepack?
+        true if dockerfile_yarn_version == "latest"
+        dockerfile_yarn_version >= "2"
+      end
+
       def dockerfile_bun_version
         using_bun? and `bun --version`[/\d+\.\d+\.\d+/]
       rescue

--- a/railties/lib/rails/generators/rails/app/templates/Dockerfile.tt
+++ b/railties/lib/rails/generators/rails/app/templates/Dockerfile.tt
@@ -38,10 +38,17 @@ RUN apt-get update -qq && \
 ARG NODE_VERSION=<%= node_version %>
 ARG YARN_VERSION=<%= dockerfile_yarn_version %>
 ENV PATH=/usr/local/node/bin:$PATH
+<% if yarn_through_corepack? -%>
+RUN curl -sL https://github.com/nodenv/node-build/archive/master.tar.gz | tar xz -C /tmp/ && \
+    /tmp/node-build-master/bin/node-build "${NODE_VERSION}" /usr/local/node && \
+    rm -rf /tmp/node-build-master
+RUN corepack enable && yarn set version $YARN_VERSION
+<% else -%>
 RUN curl -sL https://github.com/nodenv/node-build/archive/master.tar.gz | tar xz -C /tmp/ && \
     /tmp/node-build-master/bin/node-build "${NODE_VERSION}" /usr/local/node && \
     npm install -g yarn@$YARN_VERSION && \
     rm -rf /tmp/node-build-master
+<% end -%>
 
 <% end -%>
 <% if using_bun? -%>
@@ -61,7 +68,7 @@ RUN bundle install && \
 <% if using_node? -%>
 # Install node modules
 COPY package.json yarn.lock ./
-RUN yarn install --frozen-lockfile
+RUN yarn install --immutable
 
 <% end -%>
 <% if using_bun? -%>


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background
I try to deploy a brand-new rails "8.0.0.beta1" app with esbuild and deploy it with the shiny Kamal V2.1.
Docker image build step fails due to yarn installation : 

**the default Dockerfile :**
```dockerfile
# syntax=docker/dockerfile:1
# check=error=true

# This Dockerfile is designed for production, not development. Use with Kamal or build'n'run by hand:
# docker build -t fix_yarn .
# docker run -d -p 80:80 -e RAILS_MASTER_KEY=<value from config/master.key> --name fix_yarn fix_yarn

# For a containerized dev environment, see Dev Containers: https://guides.rubyonrails.org/getting_started_with_devcontainer.html

# Make sure RUBY_VERSION matches the Ruby version in .ruby-version
ARG RUBY_VERSION=3.3.5
FROM docker.io/library/ruby:$RUBY_VERSION-slim AS base

# Rails app lives here
WORKDIR /rails

# Install base packages
RUN apt-get update -qq && \
    apt-get install --no-install-recommends -y curl libjemalloc2 libvips sqlite3 && \
    rm -rf /var/lib/apt/lists /var/cache/apt/archives

# Set production environment
ENV RAILS_ENV="production" \
    BUNDLE_DEPLOYMENT="1" \
    BUNDLE_PATH="/usr/local/bundle" \
    BUNDLE_WITHOUT="development"

# Throw-away build stage to reduce size of final image
FROM base AS build

# Install packages needed to build gems and node modules
RUN apt-get update -qq && \
    apt-get install --no-install-recommends -y build-essential git node-gyp pkg-config python-is-python3 && \
    rm -rf /var/lib/apt/lists /var/cache/apt/archives

# Install JavaScript dependencies
ARG NODE_VERSION=22.9.0
ARG YARN_VERSION=3.3.1
ENV PATH=/usr/local/node/bin:$PATH
RUN curl -sL https://github.com/nodenv/node-build/archive/master.tar.gz | tar xz -C /tmp/ && \
    /tmp/node-build-master/bin/node-build "${NODE_VERSION}" /usr/local/node && \
    npm install -g yarn@$YARN_VERSION && \
    rm -rf /tmp/node-build-master

# Install application gems
COPY Gemfile Gemfile.lock ./
RUN bundle install && \
    rm -rf ~/.bundle/ "${BUNDLE_PATH}"/ruby/*/cache "${BUNDLE_PATH}"/ruby/*/bundler/gems/*/.git && \
    bundle exec bootsnap precompile --gemfile

# Install node modules
COPY package.json yarn.lock ./
RUN yarn install --frozen-lockfile

# Copy application code
COPY . .

# Precompile bootsnap code for faster boot times
RUN bundle exec bootsnap precompile app/ lib/

# Precompiling assets for production without requiring secret RAILS_MASTER_KEY
RUN SECRET_KEY_BASE_DUMMY=1 ./bin/rails assets:precompile


RUN rm -rf node_modules


# Final stage for app image
FROM base

# Copy built artifacts: gems, application
COPY --from=build "${BUNDLE_PATH}" "${BUNDLE_PATH}"
COPY --from=build /rails /rails

# Run and own only the runtime files as a non-root user for security
RUN groupadd --system --gid 1000 rails && \
    useradd rails --uid 1000 --gid 1000 --create-home --shell /bin/bash && \
    chown -R rails:rails db log storage tmp
USER 1000:1000

# Entrypoint prepares the database.
ENTRYPOINT ["/rails/bin/docker-entrypoint"]

# Start server via Thruster by default, this can be overwritten at runtime
EXPOSE 80
CMD ["./bin/thrust", "./bin/rails", "server"]

```

**The failure :**

<details>
<summary>Details</summary>

```red
#11 [build  2/10] RUN curl -sL https://github.com/nodenv/node-build/archive/master.tar.gz | tar xz -C /tmp/ &&     /tmp/node-build-master/bin/node-build "22.9.0" /usr/local/node &&     npm install -g yarn@3.3.1 &&     rm -rf /tmp/node-build-master
#11 1.522 To follow progress, use 'tail -f /tmp/node-build.20241004094359.13.log' or pass --verbose
#11 1.619 Downloading node-v22.9.0-linux-x64.tar.gz...
#11 1.619 -> https://nodejs.org/dist/v22.9.0/node-v22.9.0-linux-x64.tar.gz
#11 13.82 Installing node-v22.9.0-linux-x64...
#11 21.34 Installed node-v22.9.0-linux-x64 to /usr/local/node
#11 21.34 
#11 23.34 npm error code ETARGET
#11 23.34 npm error notarget No matching version found for yarn@3.3.1.
#11 23.34 npm error notarget In most cases you or one of your dependencies are requesting
#11 23.34 npm error notarget a package version that doesn't exist.
#11 23.35 npm notice
#11 23.35 npm notice New minor version of npm available! 10.8.3 -> 10.9.0
#11 23.35 npm notice Changelog: https://github.com/npm/cli/releases/tag/v10.9.0
#11 23.35 npm notice To update run: npm install -g npm@10.9.0
#11 23.35 npm notice
#11 23.35 npm error A complete log of this run can be found in: /root/.npm/_logs/2024-10-04T09_44_19_632Z-debug-0.log
#11 ERROR: process "/bin/sh -c curl -sL https://github.com/nodenv/node-build/archive/master.tar.gz | tar xz -C /tmp/ &&     /tmp/node-build-master/bin/node-build \"${NODE_VERSION}\" /usr/local/node &&     npm install -g yarn@$YARN_VERSION &&     rm -rf /tmp/node-build-master" did not complete successfully: exit code: 1
------
 > [build  2/10] RUN curl -sL https://github.com/nodenv/node-build/archive/master.tar.gz | tar xz -C /tmp/ &&     /tmp/node-build-master/bin/node-build "22.9.0" /usr/local/node &&     npm install -g yarn@3.3.1 &&     rm -rf /tmp/node-build-master:
23.34 npm error code ETARGET
23.34 npm error notarget No matching version found for yarn@3.3.1.
23.34 npm error notarget In most cases you or one of your dependencies are requesting
23.34 npm error notarget a package version that doesn't exist.
23.35 npm notice
23.35 npm notice New minor version of npm available! 10.8.3 -> 10.9.0
23.35 npm notice Changelog: https://github.com/npm/cli/releases/tag/v10.9.0
23.35 npm notice To update run: npm install -g npm@10.9.0
23.35 npm notice
23.35 npm error A complete log of this run can be found in: /root/.npm/_logs/2024-10-04T09_44_19_632Z-debug-0.log
------
Dockerfile:40
--------------------
  39 |     ENV PATH=/usr/local/node/bin:$PATH
  40 | >>> RUN curl -sL https://github.com/nodenv/node-build/archive/master.tar.gz | tar xz -C /tmp/ && \
  41 | >>>     /tmp/node-build-master/bin/node-build "${NODE_VERSION}" /usr/local/node && \
  42 | >>>     npm install -g yarn@$YARN_VERSION && \
  43 | >>>     rm -rf /tmp/node-build-master
  44 |     
--------------------
ERROR: failed to solve: process "/bin/sh -c curl -sL https://github.com/nodenv/node-build/archive/master.tar.gz | tar xz -C /tmp/ &&     /tmp/node-build-master/bin/node-build \"${NODE_VERSION}\" /usr/local/node &&     npm install -g yarn@$YARN_VERSION &&     rm -rf /tmp/node-build-master" did not complete successfully: exit code: 1
```
</details>
So, I dig the yarn documentation and found why `npm install -g yarn@3.3.1 &&` fail.
Because Yarn > 1.x.x isn't installable through NPM since 2019. 

Extract from Yarn documentation : 
[Why is the yarn package on npm still on 1.x?](https://yarnpkg.com/getting-started/qa#why-is-the-yarn-package-on-npm-still-on-1x)

> Why is the yarn package on npm still on 1.x?
> 
> Modern releases of Yarn haven't been distributed on npm since 2019.
> 
> The reason is simple: because Yarn wasn't distributed alongside Node.js, many people relied on something like npm install -g yarn as part of their image building. It meant that any breaking change would make their way on everyone using this pattern, and break their deployments.
> 
> As a result, we decided to retire the yarn npm package and only use it for the few 1.x maintenance releases needed. Yarn is now installed directly from our website, via either Corepack or yarn set version."

After this fix, Yarn warns us that `--frozen-lockfile` is deprecated, so I've replaced it with `--immutable`.

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->


### Detail

- This Pull Request changes add a method in the app generator to check if the yarn version need installation through Corepack instead of NPM (>1.x.x).
- The yarn flag `--frozen-lockfile` is deprecated, so I've replaced it with `--immutable`

### Additional information

As it's my first rails PR, I'm sorry if this fix isn't relevant.
<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
