### PR TITLE
Fix helper behavior on controller that don't require authentication

### DIFF
--- a/railties/lib/rails/generators/rails/authentication/templates/app/controllers/concerns/authentication.rb.tt
+++ b/railties/lib/rails/generators/rails/authentication/templates/app/controllers/concerns/authentication.rb.tt
@@ -15,7 +15,6 @@ module Authentication
   private
     def authenticated?
       resume_session
-      Current.session.present?
     end
 
     def require_authentication

--- a/railties/lib/rails/generators/rails/authentication/templates/app/controllers/concerns/authentication.rb.tt
+++ b/railties/lib/rails/generators/rails/authentication/templates/app/controllers/concerns/authentication.rb.tt
@@ -14,6 +14,7 @@ module Authentication
 
   private
     def authenticated?
+      resume_session
       Current.session.present?
     end
 
@@ -23,7 +24,7 @@ module Authentication
 
 
     def resume_session
-      Current.session = find_session_by_cookie
+      Current.session ||= find_session_by_cookie
     end
 
     def find_session_by_cookie


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

The Authentication concern generated with `rails generate authentication` contains a helper method `authenticated?`. This helper will return `false` if there is an active Session but the controller calls the `allow_unauthorized_access` filter.

This causes a weird behavior, there are reasons why I would like the helper to be useful in controllers that don't require authentication (e.g. render the user info in a header, or a "login" or "logout" link/button regardless if that specific action requires an active Session.)

### Detail

This Pull Request changes the implementation of the `authenticated?` helper method in the template used for generating the concern. It tries to resume the session before checking its presence in CurrentAttributes.

It also changes the assignment of the session to CurrentAttributes to be conditional and not trigger a query if the value is already assigned since the helper now makes the `resume_session` be potentially called several times in the same request. This avoids the lookup (even if cached).

Note: couldn't find a test for this behavior, didn't add in this PR.