### PR TITLE
ErrorHighlight 0.5.1+ is always available since Ruby 3.2

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/debug_view.rb
+++ b/actionpack/lib/action_dispatch/middleware/debug_view.rb
@@ -15,15 +15,10 @@ module ActionDispatch
       paths = RESCUES_TEMPLATE_PATHS.dup
       lookup_context = ActionView::LookupContext.new(paths)
       super(lookup_context, assigns, nil)
-      @exception_wrapper = assigns[:exception_wrapper]
     end
 
     def compiled_method_container
       self.class
-    end
-
-    def error_highlight_available?
-      @exception_wrapper.error_highlight_available?
     end
 
     def debug_params(params)

--- a/actionpack/lib/action_dispatch/middleware/exception_wrapper.rb
+++ b/actionpack/lib/action_dispatch/middleware/exception_wrapper.rb
@@ -201,12 +201,6 @@ module ActionDispatch
       end
     end
 
-    def error_highlight_available?
-      # ErrorHighlight.spot with backtrace_location keyword is available since
-      # error_highlight 0.4.0
-      defined?(ErrorHighlight) && Gem::Version.new(ErrorHighlight::VERSION) >= Gem::Version.new("0.4.0")
-    end
-
     def trace_to_show
       if traces["Application Trace"].empty? && rescue_template != "routing_error"
         "Full Trace"

--- a/actionpack/lib/action_dispatch/middleware/templates/rescues/_source.html.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/rescues/_source.html.erb
@@ -28,9 +28,6 @@
           </tr>
         </table>
       </div>
-      <%- unless self.error_highlight_available? -%>
-        <p class="error_highlight_tip">Tip: You may want to add <code>gem "error_highlight", "&gt;= 0.4.0"</code> into your Gemfile, which will display the fine-grained error location.</p>
-      <%- end -%>
     </div>
   <% end %>
 <% end %>

--- a/actionpack/test/dispatch/exception_wrapper_test.rb
+++ b/actionpack/test/dispatch/exception_wrapper_test.rb
@@ -91,23 +91,21 @@ module ActionDispatch
       assert_empty wrapper.source_extracts
     end
 
-    if defined?(ErrorHighlight) && Gem::Version.new(ErrorHighlight::VERSION) >= Gem::Version.new("0.4.0")
-      test "#source_extracts works with error_highlight" do
-        lineno = __LINE__
-        begin
-          1.time
-        rescue NameError => exc
-        end
-
-        wrapper = ExceptionWrapper.new(nil, exc)
-
-        code = {}
-        File.foreach(__FILE__).to_a.drop(lineno - 1).take(6).each_with_index do |line, i|
-          code[lineno + i] = line
-        end
-        code[lineno + 2] = ["          1", ".time", "\n"]
-        assert_equal({ code: code, line_number: lineno + 2 }, wrapper.source_extracts.first)
+    test "#source_extracts works with error_highlight" do
+      lineno = __LINE__
+      begin
+        1.time
+      rescue NameError => exc
       end
+
+      wrapper = ExceptionWrapper.new(nil, exc)
+
+      code = {}
+      File.foreach(__FILE__).to_a.drop(lineno - 1).take(6).each_with_index do |line, i|
+        code[lineno + i] = line
+      end
+      code[lineno + 2] = ["        1", ".time", "\n"]
+      assert_equal({ code: code, line_number: lineno + 2 }, wrapper.source_extracts.first)
     end
 
     test "#application_trace returns traces only from the application" do

--- a/activesupport/lib/active_support/core_ext/thread/backtrace/location.rb
+++ b/activesupport/lib/active_support/core_ext/thread/backtrace/location.rb
@@ -1,12 +1,7 @@
 # frozen_string_literal: true
 
 class Thread::Backtrace::Location # :nodoc:
-  if defined?(ErrorHighlight) && Gem::Version.new(ErrorHighlight::VERSION) >= Gem::Version.new("0.4.0")
-    def spot(ex)
-      ErrorHighlight.spot(ex, backtrace_location: self)
-    end
-  else
-    def spot(ex)
-    end
+  def spot(ex)
+    ErrorHighlight.spot(ex, backtrace_location: self)
   end
 end


### PR DESCRIPTION
### Motivation / Background

This commit removes conditions to see if ErrorHighligh 0.4.0 or higher version is available since ErrorHighlight 0.5.1+ is always available since Ruby 3.2 that is required by the Rails current main branch.

### Detail

- Ruby 3.2.0 Released https://www.ruby-lang.org/en/news/2022/12/25/ruby-3-2-0-released/

ErrorHighlight.spot(ex, backtrace_location: self)
> The following default gems are updated.
> error_highlight 0.5.1

### Additional information
Related to #48299 #53041

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.



