### PR TITLE
Use `assert_not` in bug report template TestCase

### DIFF
--- a/guides/bug_report_templates/generic.rb
+++ b/guides/bug_report_templates/generic.rb
@@ -17,6 +17,6 @@ require "minitest/autorun"
 class BugTest < ActiveSupport::TestCase
   def test_stuff
     assert "zomg".present?
-    refute "".present?
+    assert_not "".present?
   end
 end


### PR DESCRIPTION
Follow-up to https://github.com/rails/rails/pull/53171.
Addresses https://github.com/rails/rails/pull/53171#issuecomment-2394019722.

### Motivation / Background

This Pull Request has been created because `assert_not` is preferred instead of `refute`, according to the [Rails Guide](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#follow-the-coding-conventions).

Previous attempts to do this were [reverted](https://github.com/rails/rails/pull/34421#issuecomment-437641173) or [closed](https://github.com/rails/rails/pull/37915) because Rails' bug report templates were using `Minitest::Test` which didn't support `assert_not`. Now that these templates are [using](https://github.com/rails/rails/pull/53171) `ActiveSupport::TestCase`, `assert_not` works.

### Detail

This Pull Request changes `refute` to `assert_not` in bug report templates. There was only one occurrence to replace.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
