### PR TITLE
Simplify usage of Postgres `format` function

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/referential_integrity.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/referential_integrity.rb
@@ -45,12 +45,10 @@ Rails needs superuser privileges to disable referential integrity.
             BEGIN
             FOR r IN (
               SELECT FORMAT(
-                'UPDATE pg_constraint SET convalidated=false WHERE conname = ''%I'' AND connamespace::regnamespace = ''%I''::regnamespace; ALTER TABLE %I.%I VALIDATE CONSTRAINT %I;',
+                'UPDATE pg_catalog.pg_constraint SET convalidated=false WHERE conname = ''%1$I'' AND connamespace::regnamespace = ''%2$I''::regnamespace; ALTER TABLE %2$I.%3$I VALIDATE CONSTRAINT %1$I;',
                 constraint_name,
                 table_schema,
-                table_schema,
-                table_name,
-                constraint_name
+                table_name
               ) AS constraint_check
               FROM information_schema.table_constraints WHERE constraint_type = 'FOREIGN KEY'
             )


### PR DESCRIPTION
Postgres format function has a way to use the same argument several times inside the template string instead of repeating the same argument multiple times.

Simplified the usage by adding the argument position on the formatstr.

Reference: https://www.postgresql.org/docs/current/functions-string.html#FUNCTIONS-STRING-FORMAT
