### PR TITLE
Extract adapter specific `quote_table_name` helper method for testing

### DIFF
--- a/activerecord/test/activejob/destroy_association_async_test.rb
+++ b/activerecord/test/activejob/destroy_association_async_test.rb
@@ -74,7 +74,7 @@ class DestroyAssociationAsyncTest < ActiveRecord::TestCase
     assert_equal 2, delete_sqls.count
 
     delete_sqls.each do |sql|
-      assert_match(/#{Regexp.escape(Sharded::Tag.lease_connection.quote_table_name("sharded_tags.blog_id"))} =/, sql)
+      assert_match(/#{Regexp.escape(quote_table_name("sharded_tags.blog_id"))} =/, sql)
     end
   ensure
     Sharded::Tag.delete_all
@@ -187,7 +187,7 @@ class DestroyAssociationAsyncTest < ActiveRecord::TestCase
 
     delete_sqls = sql.select { |sql| sql.start_with?("DELETE") }
     assert_equal 1, delete_sqls.count
-    assert_match(/#{Regexp.escape(Sharded::BlogPost.lease_connection.quote_table_name("sharded_blog_posts.blog_id"))} =/, delete_sqls.first)
+    assert_match(/#{Regexp.escape(quote_table_name("sharded_blog_posts.blog_id"))} =/, delete_sqls.first)
   ensure
     Sharded::BlogPostDestroyAsync.delete_all
     Sharded::CommentDestroyAsync.delete_all
@@ -303,7 +303,7 @@ class DestroyAssociationAsyncTest < ActiveRecord::TestCase
     assert_equal 2, delete_sqls.count
 
     delete_sqls.each do |sql|
-      assert_match(/#{Regexp.escape(Cpk::ChapterDestroyAsync.lease_connection.quote_table_name("cpk_chapters.author_id"))} =/, sql)
+      assert_match(/#{Regexp.escape(quote_table_name("cpk_chapters.author_id"))} =/, sql)
     end
   ensure
     Cpk::ChapterDestroyAsync.delete_all

--- a/activerecord/test/cases/annotate_test.rb
+++ b/activerecord/test/cases/annotate_test.rb
@@ -7,7 +7,8 @@ class AnnotateTest < ActiveRecord::TestCase
   fixtures :posts
 
   def test_annotate_wraps_content_in_an_inline_comment
-    quoted_posts_id, quoted_posts = regexp_escape_table_name("posts.id"), regexp_escape_table_name("posts")
+    quoted_posts_id = Regexp.escape(quote_table_name("posts.id"))
+    quoted_posts = Regexp.escape(quote_table_name("posts"))
 
     assert_queries_match(%r{SELECT #{quoted_posts_id} FROM #{quoted_posts} /\* foo \*/}i) do
       posts = Post.select(:id).annotate("foo")
@@ -16,7 +17,8 @@ class AnnotateTest < ActiveRecord::TestCase
   end
 
   def test_annotate_is_sanitized
-    quoted_posts_id, quoted_posts = regexp_escape_table_name("posts.id"), regexp_escape_table_name("posts")
+    quoted_posts_id = Regexp.escape(quote_table_name("posts.id"))
+    quoted_posts = Regexp.escape(quote_table_name("posts"))
 
     assert_queries_match(%r{SELECT #{quoted_posts_id} FROM #{quoted_posts} /\* \* /foo/ \* \*/}i) do
       posts = Post.select(:id).annotate("*/foo/*")
@@ -43,9 +45,4 @@ class AnnotateTest < ActiveRecord::TestCase
       assert posts.first
     end
   end
-
-  private
-    def regexp_escape_table_name(name)
-      Regexp.escape(Post.lease_connection.quote_table_name(name))
-    end
 end

--- a/activerecord/test/cases/associations/eager_test.rb
+++ b/activerecord/test/cases/associations/eager_test.rb
@@ -497,22 +497,20 @@ class EagerAssociationTest < ActiveRecord::TestCase
   end
 
   def test_eager_association_loading_with_belongs_to_and_conditions_string_with_quoted_table_name
-    quoted_posts_id = Comment.lease_connection.quote_table_name("posts") + "." + Comment.lease_connection.quote_column_name("id")
     assert_nothing_raised do
-      Comment.includes(:post).references(:posts).where("#{quoted_posts_id} = ?", 4)
+      Comment.includes(:post).references(:posts).where("#{quote_table_name("posts.id")} = ?", 4)
     end
   end
 
   def test_eager_association_loading_with_belongs_to_and_order_string_with_unquoted_table_name
     assert_nothing_raised do
-      Comment.all.merge!(includes: :post, order: "posts.id").to_a
+      Comment.includes(:post).references(:posts).order("posts.id")
     end
   end
 
   def test_eager_association_loading_with_belongs_to_and_order_string_with_quoted_table_name
-    quoted_posts_id = Comment.lease_connection.quote_table_name("posts") + "." + Comment.lease_connection.quote_column_name("id")
     assert_nothing_raised do
-      Comment.includes(:post).references(:posts).order(quoted_posts_id)
+      Comment.includes(:post).references(:posts).order(quote_table_name("posts.id"))
     end
   end
 
@@ -1699,9 +1697,8 @@ class EagerAssociationTest < ActiveRecord::TestCase
       assert_equal 3, comments_collection.size
     end.last
 
-    c = Sharded::BlogPost.lease_connection
-    quoted_blog_id = Regexp.escape(c.quote_table_name("sharded_comments.blog_id"))
-    quoted_blog_post_id = Regexp.escape(c.quote_table_name("sharded_comments.blog_post_id"))
+    quoted_blog_id = Regexp.escape(quote_table_name("sharded_comments.blog_id"))
+    quoted_blog_post_id = Regexp.escape(quote_table_name("sharded_comments.blog_post_id"))
     assert_match(/WHERE #{quoted_blog_id} IN \(.+\) AND #{quoted_blog_post_id} IN \(.+\)/, sql)
   end
 

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -1315,10 +1315,8 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
       blog_post.delete_comments.delete(comments_to_delete)
     end
 
-    c = Sharded::Comment.lease_connection
-
-    blog_id = Regexp.escape(c.quote_table_name("sharded_comments.blog_id"))
-    id = Regexp.escape(c.quote_table_name("sharded_comments.id"))
+    blog_id = Regexp.escape(quote_table_name("sharded_comments.blog_id"))
+    id = Regexp.escape(quote_table_name("sharded_comments.id"))
 
     query_constraints = /#{blog_id} = .* AND #{id} = .*/
     expectation = /DELETE.*WHERE.* \(#{query_constraints} OR #{query_constraints}\)/

--- a/activerecord/test/cases/associations/has_many_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_through_associations_test.rb
@@ -1620,9 +1620,8 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
       tag_ids = blog_post.tags.to_a.map(&:id)
     end.first
 
-    c = Sharded::Blog.lease_connection
-    quoted_tags_blog_id = Regexp.escape(c.quote_table_name("sharded_tags.blog_id"))
-    quoted_posts_tags_blog_id = Regexp.escape(c.quote_table_name("sharded_blog_posts_tags.blog_id"))
+    quoted_tags_blog_id = Regexp.escape(quote_table_name("sharded_tags.blog_id"))
+    quoted_posts_tags_blog_id = Regexp.escape(quote_table_name("sharded_blog_posts_tags.blog_id"))
     assert_match(/.* ON.* #{quoted_tags_blog_id} = #{quoted_posts_tags_blog_id} .* WHERE/, sql)
     assert_match(/.* WHERE #{quoted_posts_tags_blog_id} = .*/, sql)
 
@@ -1638,9 +1637,8 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
       blog_post_ids = tag.blog_posts.to_a.map(&:id)
     end.first
 
-    c = Sharded::Blog.lease_connection
-    quoted_blog_posts_blog_id = Regexp.escape(c.quote_table_name("sharded_blog_posts.blog_id"))
-    quoted_posts_tags_blog_id = Regexp.escape(c.quote_table_name("sharded_blog_posts_tags.blog_id"))
+    quoted_blog_posts_blog_id = Regexp.escape(quote_table_name("sharded_blog_posts.blog_id"))
+    quoted_posts_tags_blog_id = Regexp.escape(quote_table_name("sharded_blog_posts_tags.blog_id"))
     assert_match(/.* ON.* #{quoted_blog_posts_blog_id} = #{quoted_posts_tags_blog_id} .* WHERE/, sql)
     assert_match(/.* WHERE #{quoted_posts_tags_blog_id} = .*/, sql)
 

--- a/activerecord/test/cases/associations/has_one_through_disable_joins_associations_test.rb
+++ b/activerecord/test/cases/associations/has_one_through_disable_joins_associations_test.rb
@@ -77,6 +77,6 @@ class HasOneThroughDisableJoinsAssociationsTest < ActiveRecord::TestCase
       assert_no_match(/INNER JOIN/, nj)
     end
 
-    assert_match(/#{Regexp.escape(Member.lease_connection.quote_table_name('memberships.type'))}/, no_joins.first)
+    assert_match(/#{Regexp.escape(quote_table_name("memberships.type"))}/, no_joins.first)
   end
 end

--- a/activerecord/test/cases/associations/inner_join_association_test.rb
+++ b/activerecord/test/cases/associations/inner_join_association_test.rb
@@ -238,8 +238,7 @@ class InnerJoinAssociationTest < ActiveRecord::TestCase
   def test_inner_joins_includes_all_nested_associations
     sql, = capture_sql { Friendship.joins(:friend_favorite_reference_job, :follower_favorite_reference_job).to_a }
 
-    escape = -> name { Regexp.escape(Friendship.lease_connection.quote_table_name(name)) }
-    assert_match %r(#{escape["friendships.friend_id"]}), sql
-    assert_match %r(#{escape["friendships.follower_id"]}), sql
+    assert_match %r(#{Regexp.escape(quote_table_name("friendships.friend_id"))}), sql
+    assert_match %r(#{Regexp.escape(quote_table_name("friendships.follower_id"))}), sql
   end
 end

--- a/activerecord/test/cases/associations/left_outer_join_association_test.rb
+++ b/activerecord/test/cases/associations/left_outer_join_association_test.rb
@@ -127,8 +127,7 @@ class LeftOuterJoinAssociationTest < ActiveRecord::TestCase
   def test_left_outer_joins_includes_all_nested_associations
     sql, = capture_sql { Friendship.left_outer_joins(:friend_favorite_reference_job, :follower_favorite_reference_job).to_a }
 
-    escape = -> name { Regexp.escape(Friendship.lease_connection.quote_table_name(name)) }
-    assert_match %r(#{escape["friendships.friend_id"]}), sql
-    assert_match %r(#{escape["friendships.follower_id"]}), sql
+    assert_match %r(#{Regexp.escape(quote_table_name("friendships.friend_id"))}), sql
+    assert_match %r(#{Regexp.escape(quote_table_name("friendships.follower_id"))}), sql
   end
 end

--- a/activerecord/test/cases/associations_test.rb
+++ b/activerecord/test/cases/associations_test.rb
@@ -166,8 +166,8 @@ class AssociationsTest < ActiveRecord::TestCase
       comment.blog_post
     end.first
 
-    assert_match(/#{Regexp.escape(Sharded::BlogPost.lease_connection.quote_table_name("sharded_blog_posts.blog_id"))} =/, sql)
-    assert_match(/#{Regexp.escape(Sharded::BlogPost.lease_connection.quote_table_name("sharded_blog_posts.id"))} =/, sql)
+    assert_match(/#{Regexp.escape(quote_table_name("sharded_blog_posts.blog_id"))} =/, sql)
+    assert_match(/#{Regexp.escape(quote_table_name("sharded_blog_posts.id"))} =/, sql)
   end
 
   def test_querying_by_whole_associated_records_using_query_constraints
@@ -214,8 +214,8 @@ class AssociationsTest < ActiveRecord::TestCase
       assert_equal(car, review.car)
     end
 
-    assert_match(/#{Regexp.escape(Cpk::Car.lease_connection.quote_table_name("cpk_cars.make"))} =/, sql.first)
-    assert_match(/#{Regexp.escape(Cpk::Car.lease_connection.quote_table_name("cpk_cars.model"))} =/, sql.first)
+    assert_match(/#{Regexp.escape(quote_table_name("cpk_cars.make"))} =/, sql.first)
+    assert_match(/#{Regexp.escape(quote_table_name("cpk_cars.model"))} =/, sql.first)
   end
 
   def test_cpk_model_has_many_records_by_id_attribute
@@ -236,7 +236,7 @@ class AssociationsTest < ActiveRecord::TestCase
       comments = blog_post.comments.to_a
     end.first
 
-    assert_match(/WHERE .*#{Regexp.escape(Sharded::Comment.lease_connection.quote_table_name("sharded_comments.blog_id"))} =/, sql)
+    assert_match(/WHERE .*#{Regexp.escape(quote_table_name("sharded_comments.blog_id"))} =/, sql)
     assert_not_empty(comments)
     assert_equal(expected_comments.sort, comments.sort)
   end
@@ -260,8 +260,8 @@ class AssociationsTest < ActiveRecord::TestCase
       blog_post.comments.to_a
     end.first
 
-    assert_match(/#{Regexp.escape(Sharded::Comment.lease_connection.quote_table_name("sharded_comments.blog_post_id"))} =/, sql)
-    assert_match(/#{Regexp.escape(Sharded::Comment.lease_connection.quote_table_name("sharded_comments.blog_id"))} =/, sql)
+    assert_match(/#{Regexp.escape(quote_table_name("sharded_comments.blog_post_id"))} =/, sql)
+    assert_match(/#{Regexp.escape(quote_table_name("sharded_comments.blog_id"))} =/, sql)
   end
 
   def test_belongs_to_association_does_not_use_parent_query_constraints_if_not_configured_to
@@ -1505,10 +1505,8 @@ class PreloaderTest < ActiveRecord::TestCase
     assert_equal 2, sql.size
     preload_sql = sql.last
 
-    c = Cpk::OrderAgreement.lease_connection
-    order_id_column = Regexp.escape(c.quote_table_name("cpk_order_agreements.order_id"))
-    order_id_constraint = /#{order_id_column} = (\?|(\d+)|\$\d)$/
-    expectation = /SELECT.*WHERE.* #{order_id_constraint}/
+    order_id_column = Regexp.escape(quote_table_name("cpk_order_agreements.order_id"))
+    expectation = /SELECT.*WHERE.* #{order_id_column} = (\?|(\d+)|\$\d)$/
 
     assert_match(expectation, preload_sql)
     assert_equal order_agreements.sort, loaded_order.order_agreements.sort
@@ -1527,10 +1525,8 @@ class PreloaderTest < ActiveRecord::TestCase
     assert_equal 2, sql.size
     preload_sql = sql.last
 
-    c = Cpk::Order.lease_connection
-    order_id = Regexp.escape(c.quote_table_name("cpk_orders.id"))
-    order_constraint = /#{order_id} = (\?|(\d+)|\$\d)$/
-    expectation = /SELECT.*WHERE.* #{order_constraint}/
+    order_id = Regexp.escape(quote_table_name("cpk_orders.id"))
+    expectation = /SELECT.*WHERE.* #{order_id} = (\?|(\d+)|\$\d)$/
 
     assert_match(expectation, preload_sql)
     assert_equal order, loaded_order_agreement.order

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -1319,11 +1319,11 @@ class BasicsTest < ActiveRecord::TestCase
 
     klass.table_name = "foo"
     assert_equal "foo", klass.table_name
-    assert_equal klass.lease_connection.quote_table_name("foo"), klass.quoted_table_name
+    assert_equal klass.adapter_class.quote_table_name("foo"), klass.quoted_table_name
 
     klass.table_name = "bar"
     assert_equal "bar", klass.table_name
-    assert_equal klass.lease_connection.quote_table_name("bar"), klass.quoted_table_name
+    assert_equal klass.adapter_class.quote_table_name("bar"), klass.quoted_table_name
   end
 
   def test_set_table_name_with_inheritance

--- a/activerecord/test/cases/batches_test.rb
+++ b/activerecord/test/cases/batches_test.rb
@@ -151,8 +151,7 @@ class EachTest < ActiveRecord::TestCase
   end
 
   def test_find_in_batches_should_quote_batch_order
-    c = Post.lease_connection
-    assert_queries_match(/ORDER BY #{Regexp.escape(c.quote_table_name("posts.id"))}/i) do
+    assert_queries_match(/ORDER BY #{Regexp.escape(quote_table_name("posts.id"))}/i) do
       Post.find_in_batches(batch_size: 1) do |batch|
         assert_kind_of Array, batch
         assert_kind_of Post, batch.first
@@ -161,8 +160,7 @@ class EachTest < ActiveRecord::TestCase
   end
 
   def test_find_in_batches_should_quote_batch_order_with_desc_order
-    c = Post.lease_connection
-    assert_queries_match(/ORDER BY #{Regexp.escape(c.quote_table_name("posts.id"))} DESC/) do
+    assert_queries_match(/ORDER BY #{Regexp.escape(quote_table_name("posts.id"))} DESC/) do
       Post.find_in_batches(batch_size: 1, order: :desc) do |batch|
         assert_kind_of Array, batch
         assert_kind_of Post, batch.first
@@ -613,41 +611,36 @@ class EachTest < ActiveRecord::TestCase
   end
 
   def test_in_batches_executes_range_queries_when_unconstrained
-    c = Post.lease_connection
-    quoted_posts_id = Regexp.escape(c.quote_table_name("posts.id"))
+    quoted_posts_id = Regexp.escape(quote_table_name("posts.id"))
     assert_queries_match(/WHERE #{quoted_posts_id} > .+ AND #{quoted_posts_id} <= .+/i) do
       Post.in_batches(of: 2) { |relation| assert_kind_of Post, relation.first }
     end
   end
 
   def test_in_batches_executes_in_queries_when_unconstrained_and_opted_out_of_ranges
-    c = Post.lease_connection
-    quoted_posts_id = Regexp.escape(c.quote_table_name("posts.id"))
+    quoted_posts_id = Regexp.escape(quote_table_name("posts.id"))
     assert_queries_match(/#{quoted_posts_id} IN \(.+\)/i) do
       Post.in_batches(of: 2, use_ranges: false) { |relation| assert_kind_of Post, relation.first }
     end
   end
 
   def test_in_batches_executes_in_queries_when_constrained
-    c = Post.lease_connection
-    quoted_posts_id = Regexp.escape(c.quote_table_name("posts.id"))
+    quoted_posts_id = Regexp.escape(quote_table_name("posts.id"))
     assert_queries_match(/#{quoted_posts_id} IN \(.+\)/i) do
       Post.where("id < ?", 5).in_batches(of: 2) { |relation| assert_kind_of Post, relation.first }
     end
   end
 
   def test_in_batches_executes_range_queries_when_constrained_and_opted_in_into_ranges
-    c = Post.lease_connection
-    quoted_posts_id = Regexp.escape(c.quote_table_name("posts.id"))
+    quoted_posts_id = Regexp.escape(quote_table_name("posts.id"))
     assert_queries_match(/#{quoted_posts_id} > .+ AND #{quoted_posts_id} <= .+/i) do
       Post.where("id < ?", 5).in_batches(of: 2, use_ranges: true) { |relation| assert_kind_of Post, relation.first }
     end
   end
 
   def test_in_batches_no_subqueries_for_whole_tables_batching
-    c = Post.lease_connection
-    quoted_posts_id = Regexp.escape(c.quote_table_name("posts.id"))
-    assert_queries_match(/DELETE FROM #{Regexp.escape(c.quote_table_name("posts"))} WHERE #{quoted_posts_id} > .+ AND #{quoted_posts_id} <=/i) do
+    quoted_posts_id = Regexp.escape(quote_table_name("posts.id"))
+    assert_queries_match(/DELETE FROM #{Regexp.escape(quote_table_name("posts"))} WHERE #{quoted_posts_id} > .+ AND #{quoted_posts_id} <=/i) do
       Post.in_batches(of: 2).delete_all
     end
   end
@@ -663,8 +656,7 @@ class EachTest < ActiveRecord::TestCase
   end
 
   def test_in_batches_should_quote_batch_order
-    c = Post.lease_connection
-    assert_queries_match(/ORDER BY #{Regexp.escape(c.quote_table_name('posts'))}\.#{Regexp.escape(c.quote_column_name('id'))}/) do
+    assert_queries_match(/ORDER BY #{Regexp.escape(quote_table_name("posts.id"))}/) do
       Post.in_batches(of: 1) do |relation|
         assert_kind_of ActiveRecord::Relation, relation
         assert_kind_of Post, relation.first
@@ -673,8 +665,7 @@ class EachTest < ActiveRecord::TestCase
   end
 
   def test_in_batches_should_quote_batch_order_with_desc_order
-    c = Post.lease_connection
-    assert_queries_match(/ORDER BY #{Regexp.escape(c.quote_table_name("posts.id"))} DESC/) do
+    assert_queries_match(/ORDER BY #{Regexp.escape(quote_table_name("posts.id"))} DESC/) do
       Post.in_batches(of: 1, order: :desc) do |relation|
         assert_kind_of ActiveRecord::Relation, relation
         assert_kind_of Post, relation.first
@@ -683,8 +674,7 @@ class EachTest < ActiveRecord::TestCase
   end
 
   def test_in_batches_enumerator_should_quote_batch_order_with_desc_order
-    c = Post.lease_connection
-    assert_queries_match(/ORDER BY #{Regexp.escape(c.quote_table_name("posts.id"))} DESC/) do
+    assert_queries_match(/ORDER BY #{Regexp.escape(quote_table_name("posts.id"))} DESC/) do
       relation = Post.in_batches(of: 1, order: :desc).first
       assert_kind_of ActiveRecord::Relation, relation
       assert_kind_of Post, relation.first
@@ -692,8 +682,7 @@ class EachTest < ActiveRecord::TestCase
   end
 
   def test_in_batches_enumerator_each_record_should_quote_batch_order_with_desc_order
-    c = Post.lease_connection
-    assert_queries_match(/ORDER BY #{Regexp.escape(c.quote_table_name("posts.id"))} DESC/) do
+    assert_queries_match(/ORDER BY #{Regexp.escape(quote_table_name("posts.id"))} DESC/) do
       Post.in_batches(of: 1, order: :desc).each_record do |record|
         assert_kind_of Post, record
       end

--- a/activerecord/test/cases/calculations_test.rb
+++ b/activerecord/test/cases/calculations_test.rb
@@ -227,7 +227,7 @@ class CalculationsTest < ActiveRecord::TestCase
   end
 
   def test_should_not_use_alias_for_grouped_field
-    assert_queries_match(/GROUP BY #{Regexp.escape(Account.lease_connection.quote_table_name("accounts.firm_id"))}/i) do
+    assert_queries_match(/GROUP BY #{Regexp.escape(quote_table_name("accounts.firm_id"))}/i) do
       c = Account.group(:firm_id).order("accounts_firm_id").sum(:credit_limit)
       assert_equal [1, 2, 6, 9], c.keys.compact
     end
@@ -1183,9 +1183,8 @@ class CalculationsTest < ActiveRecord::TestCase
   end
 
   def test_group_by_with_quoted_count_and_order_by_alias
-    quoted_posts_id = Post.lease_connection.quote_table_name("posts.id")
     expected = { "SpecialPost" => 1, "StiPost" => 1, "Post" => 9 }
-    actual = Post.group(:type).order("count_posts_id").count(quoted_posts_id)
+    actual = Post.group(:type).order("count_posts_id").count(quote_table_name("posts.id"))
     assert_equal expected, actual
   end
 

--- a/activerecord/test/cases/excluding_test.rb
+++ b/activerecord/test/cases/excluding_test.rb
@@ -25,7 +25,7 @@ class ExcludingTest < ActiveRecord::TestCase
   def test_result_set_does_not_include_collection_of_excluded_records_from_a_query
     query = Post.where(id: @post)
 
-    assert_queries_match(/SELECT #{Regexp.escape Post.lease_connection.quote_table_name("posts.id")} FROM/) do
+    assert_queries_match(/SELECT #{Regexp.escape(quote_table_name("posts.id"))} FROM/) do
       records = Post.excluding(query).to_a
 
       assert_not_includes records, @post
@@ -72,7 +72,7 @@ class ExcludingTest < ActiveRecord::TestCase
   def test_result_set_through_association_does_not_include_collection_of_excluded_records_from_a_relation
     relation = @post.comments
 
-    assert_queries_match(/SELECT #{Regexp.escape Comment.lease_connection.quote_table_name("comments.id")} FROM/) do
+    assert_queries_match(/SELECT #{Regexp.escape(quote_table_name("comments.id"))} FROM/) do
       records = Comment.excluding(relation).to_a
 
       assert_not_empty records

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -275,8 +275,7 @@ class FinderTest < ActiveRecord::TestCase
   end
 
   def test_exists_does_not_select_columns_without_alias
-    c = Topic.lease_connection
-    assert_queries_match(/SELECT 1 AS one FROM #{Regexp.escape(c.quote_table_name("topics"))}/i) do
+    assert_queries_match(/SELECT 1 AS one FROM #{Regexp.escape(quote_table_name("topics"))}/i) do
       Topic.exists?
     end
   end
@@ -988,12 +987,11 @@ class FinderTest < ActiveRecord::TestCase
   end
 
   def test_nth_to_last_with_order_uses_limit
-    c = Topic.lease_connection
-    assert_queries_match(/ORDER BY #{Regexp.escape(c.quote_table_name("topics.id"))} DESC LIMIT/i) do
+    assert_queries_match(/ORDER BY #{Regexp.escape(quote_table_name("topics.id"))} DESC LIMIT/i) do
       Topic.second_to_last
     end
 
-    assert_queries_match(/ORDER BY #{Regexp.escape(c.quote_table_name("topics.updated_at"))} DESC LIMIT/i) do
+    assert_queries_match(/ORDER BY #{Regexp.escape(quote_table_name("topics.updated_at"))} DESC LIMIT/i) do
       Topic.order(:updated_at).second_to_last
     end
   end
@@ -1106,8 +1104,7 @@ class FinderTest < ActiveRecord::TestCase
     assert_equal topics(:fifth), Topic.first
     assert_equal topics(:third), Topic.last
 
-    c = Topic.lease_connection
-    assert_queries_match(/ORDER BY #{Regexp.escape(c.quote_table_name("topics.title"))} DESC, #{Regexp.escape(c.quote_table_name("topics.id"))} DESC LIMIT/i) {
+    assert_queries_match(/ORDER BY #{Regexp.escape(quote_table_name("topics.title"))} DESC, #{Regexp.escape(quote_table_name("topics.id"))} DESC LIMIT/i) {
       Topic.last
     }
   ensure
@@ -1118,8 +1115,7 @@ class FinderTest < ActiveRecord::TestCase
     old_implicit_order_column = Topic.implicit_order_column
     Topic.implicit_order_column = "id"
 
-    c = Topic.lease_connection
-    assert_queries_match(/ORDER BY #{Regexp.escape(c.quote_table_name("topics.id"))} DESC LIMIT/i) {
+    assert_queries_match(/ORDER BY #{Regexp.escape(quote_table_name("topics.id"))} DESC LIMIT/i) {
       Topic.last
     }
   ensure
@@ -1130,8 +1126,7 @@ class FinderTest < ActiveRecord::TestCase
     old_implicit_order_column = NonPrimaryKey.implicit_order_column
     NonPrimaryKey.implicit_order_column = "created_at"
 
-    c = NonPrimaryKey.lease_connection
-    assert_queries_match(/ORDER BY #{Regexp.escape(c.quote_table_name("non_primary_keys.created_at"))} DESC LIMIT/i) {
+    assert_queries_match(/ORDER BY #{Regexp.escape(quote_table_name("non_primary_keys.created_at"))} DESC LIMIT/i) {
       NonPrimaryKey.last
     }
   ensure
@@ -1139,10 +1134,9 @@ class FinderTest < ActiveRecord::TestCase
   end
 
   def test_implicit_order_column_reorders_query_constraints
-    c = ClothingItem.lease_connection
     ClothingItem.implicit_order_column = "color"
-    quoted_type = Regexp.escape(c.quote_table_name("clothing_items.clothing_type"))
-    quoted_color = Regexp.escape(c.quote_table_name("clothing_items.color"))
+    quoted_type = Regexp.escape(quote_table_name("clothing_items.clothing_type"))
+    quoted_color = Regexp.escape(quote_table_name("clothing_items.color"))
 
     assert_queries_match(/ORDER BY #{quoted_color} ASC, #{quoted_type} ASC LIMIT/i) do
       assert_kind_of ClothingItem, ClothingItem.first
@@ -1152,11 +1146,10 @@ class FinderTest < ActiveRecord::TestCase
   end
 
   def test_implicit_order_column_prepends_query_constraints
-    c = ClothingItem.lease_connection
     ClothingItem.implicit_order_column = "description"
-    quoted_type = Regexp.escape(c.quote_table_name("clothing_items.clothing_type"))
-    quoted_color = Regexp.escape(c.quote_table_name("clothing_items.color"))
-    quoted_description = Regexp.escape(c.quote_table_name("clothing_items.description"))
+    quoted_type = Regexp.escape(quote_table_name("clothing_items.clothing_type"))
+    quoted_color = Regexp.escape(quote_table_name("clothing_items.color"))
+    quoted_description = Regexp.escape(quote_table_name("clothing_items.description"))
 
     assert_queries_match(/ORDER BY #{quoted_description} ASC, #{quoted_type} ASC, #{quoted_color} ASC LIMIT/i) do
       assert_kind_of ClothingItem, ClothingItem.first
@@ -1864,9 +1857,8 @@ class FinderTest < ActiveRecord::TestCase
   end
 
   test "#last for a model with composite query constraints" do
-    c = ClothingItem.lease_connection
-    quoted_type = Regexp.escape(c.quote_table_name("clothing_items.clothing_type"))
-    quoted_color = Regexp.escape(c.quote_table_name("clothing_items.color"))
+    quoted_type = Regexp.escape(quote_table_name("clothing_items.clothing_type"))
+    quoted_color = Regexp.escape(quote_table_name("clothing_items.color"))
 
     assert_queries_match(/ORDER BY #{quoted_type} DESC, #{quoted_color} DESC LIMIT/i) do
       assert_kind_of ClothingItem, ClothingItem.last
@@ -1874,9 +1866,8 @@ class FinderTest < ActiveRecord::TestCase
   end
 
   test "#first for a model with composite query constraints" do
-    c = ClothingItem.lease_connection
-    quoted_type = Regexp.escape(c.quote_table_name("clothing_items.clothing_type"))
-    quoted_color = Regexp.escape(c.quote_table_name("clothing_items.color"))
+    quoted_type = Regexp.escape(quote_table_name("clothing_items.clothing_type"))
+    quoted_color = Regexp.escape(quote_table_name("clothing_items.color"))
 
     assert_queries_match(/ORDER BY #{quoted_type} ASC, #{quoted_color} ASC LIMIT/i) do
       assert_kind_of ClothingItem, ClothingItem.first

--- a/activerecord/test/cases/fixtures_test.rb
+++ b/activerecord/test/cases/fixtures_test.rb
@@ -101,9 +101,9 @@ class FixturesTest < ActiveRecord::TestCase
       create_fixtures("bulbs", "movies", "computers")
 
       expected_sql = <<~EOS.chop
-        INSERT INTO #{ActiveRecord::Base.lease_connection.quote_table_name("bulbs")} .*
-        INSERT INTO #{ActiveRecord::Base.lease_connection.quote_table_name("movies")} .*
-        INSERT INTO #{ActiveRecord::Base.lease_connection.quote_table_name("computers")} .*
+        INSERT INTO #{quote_table_name("bulbs")} .*
+        INSERT INTO #{quote_table_name("movies")} .*
+        INSERT INTO #{quote_table_name("computers")} .*
       EOS
       assert_equal 1, subscriber.events.size
       assert_match(/#{expected_sql}/, subscriber.events.first)

--- a/activerecord/test/cases/inheritance_test.rb
+++ b/activerecord/test/cases/inheritance_test.rb
@@ -477,9 +477,8 @@ class InheritanceTest < ActiveRecord::TestCase
   end
 
   def test_eager_load_belongs_to_primary_key_quoting
-    c = Account.lease_connection
     bind_param = Arel::Nodes::BindParam.new(nil)
-    assert_queries_match(/#{Regexp.escape(c.quote_table_name("companies.id"))} = (?:#{Regexp.escape(bind_param.to_sql)}|1)/i) do
+    assert_queries_match(/#{Regexp.escape(quote_table_name("companies.id"))} = (?:#{Regexp.escape(bind_param.to_sql)}|1)/i) do
       Account.all.merge!(includes: :firm).find(1)
     end
   end

--- a/activerecord/test/cases/locking_test.rb
+++ b/activerecord/test/cases/locking_test.rb
@@ -465,7 +465,7 @@ class OptimisticLockingTest < ActiveRecord::TestCase
     assert_equal "unchangeable name", s.name
   end
 
-  def test_quote_table_name
+  def test_quote_table_name_reserved_word_references
     ref = references(:michael_magician)
     ref.favorite = !ref.favorite
     assert ref.save

--- a/activerecord/test/cases/relation/delete_all_test.rb
+++ b/activerecord/test/cases/relation/delete_all_test.rb
@@ -83,9 +83,9 @@ class DeleteAllTest < ActiveRecord::TestCase
     end
 
     if current_adapter?(:Mysql2Adapter, :TrilogyAdapter)
-      assert_no_match %r/SELECT DISTINCT #{Regexp.escape(Pet.lease_connection.quote_table_name("pets.pet_id"))}/, sqls.last
+      assert_no_match %r/SELECT DISTINCT #{Regexp.escape(quote_table_name("pets.pet_id"))}/, sqls.last
     else
-      assert_match %r/SELECT #{Regexp.escape(Pet.lease_connection.quote_table_name("pets.pet_id"))}/, sqls.last
+      assert_match %r/SELECT #{Regexp.escape(quote_table_name("pets.pet_id"))}/, sqls.last
     end
   end
 

--- a/activerecord/test/cases/relation/merging_test.rb
+++ b/activerecord/test/cases/relation/merging_test.rb
@@ -139,7 +139,7 @@ class RelationMergingTest < ActiveRecord::TestCase
 
     non_mary_and_bob = Author.where.not(id: [mary, bob])
 
-    author_id = Author.lease_connection.quote_table_name("authors.id")
+    author_id = quote_table_name("authors.id")
     assert_queries_match(/WHERE #{Regexp.escape(author_id)} NOT IN \((\?|\W?\w?\d), \g<1>\)\z/) do
       assert_equal [david], non_mary_and_bob.merge(non_mary_and_bob)
     end

--- a/activerecord/test/cases/relation/predicate_builder_test.rb
+++ b/activerecord/test/cases/relation/predicate_builder_test.rb
@@ -16,11 +16,11 @@ module ActiveRecord
     end
 
     def test_registering_new_handlers
-      assert_match %r{#{Regexp.escape(topic_title)} ~ 'rails'}i, Topic.where(title: /rails/).to_sql
+      assert_match %r{#{Regexp.escape(quote_table_name("topics.title"))} ~ 'rails'}i, Topic.where(title: /rails/).to_sql
     end
 
     def test_registering_new_handlers_for_association
-      assert_match %r{#{Regexp.escape(topic_title)} ~ 'rails'}i, Reply.joins(:topic).where(topics: { title: /rails/ }).to_sql
+      assert_match %r{#{Regexp.escape(quote_table_name("topics.title"))} ~ 'rails'}i, Reply.joins(:topic).where(topics: { title: /rails/ }).to_sql
     end
 
     def test_references_with_schema
@@ -36,10 +36,5 @@ module ActiveRecord
       Topic.where(defaults).to_sql
       assert_equal({ topics: { title: "rails" }, "topics.approved" => true }, defaults)
     end
-
-    private
-      def topic_title
-        Topic.lease_connection.quote_table_name("topics.title")
-      end
   end
 end

--- a/activerecord/test/cases/relation/update_all_test.rb
+++ b/activerecord/test/cases/relation/update_all_test.rb
@@ -69,9 +69,9 @@ class UpdateAllTest < ActiveRecord::TestCase
     end
 
     if current_adapter?(:Mysql2Adapter, :TrilogyAdapter)
-      assert_no_match %r/SELECT DISTINCT #{Regexp.escape(Pet.lease_connection.quote_table_name("pets.pet_id"))}/, sqls.last
+      assert_no_match %r/SELECT DISTINCT #{Regexp.escape(quote_table_name("pets.pet_id"))}/, sqls.last
     else
-      assert_match %r/SELECT #{Regexp.escape(Pet.lease_connection.quote_table_name("pets.pet_id"))}/, sqls.last
+      assert_match %r/SELECT #{Regexp.escape(quote_table_name("pets.pet_id"))}/, sqls.last
     end
   end
 

--- a/activerecord/test/cases/relation_test.rb
+++ b/activerecord/test/cases/relation_test.rb
@@ -291,8 +291,7 @@ module ActiveRecord
 
     def test_select_quotes_when_using_from_clause
       skip_if_sqlite3_version_includes_quoting_bug
-      quoted_join = ActiveRecord::Base.lease_connection.quote_table_name("join")
-      selected = Post.select(:join).from(Post.select("id as #{quoted_join}")).map(&:join)
+      selected = Post.select(:join).from(Post.select("id as #{quote_table_name("join")}")).map(&:join)
       assert_equal Post.pluck(:id).sort, selected.sort
     end
 
@@ -373,7 +372,7 @@ module ActiveRecord
     end
 
     def test_does_not_duplicate_optimizer_hints_on_merge
-      escaped_table = Post.lease_connection.quote_table_name("posts")
+      escaped_table = quote_table_name("posts")
       expected = "SELECT /*+ OMGHINT */ #{escaped_table}.* FROM #{escaped_table}"
       query = Post.optimizer_hints("OMGHINT").merge(Post.optimizer_hints("OMGHINT")).to_sql
       assert_equal expected, query

--- a/activerecord/test/cases/schema_dumper_test.rb
+++ b/activerecord/test/cases/schema_dumper_test.rb
@@ -32,7 +32,7 @@ class SchemaDumperTest < ActiveRecord::TestCase
 
     schema_info = ActiveRecord::Base.lease_connection.dump_schema_information
     expected = <<~STR
-    INSERT INTO #{ActiveRecord::Base.lease_connection.quote_table_name("schema_migrations")} (version) VALUES
+    INSERT INTO #{quote_table_name("schema_migrations")} (version) VALUES
     ('20100301010101'),
     ('20100201010101'),
     ('20100101010101');

--- a/activerecord/test/cases/scoping/default_scoping_test.rb
+++ b/activerecord/test/cases/scoping/default_scoping_test.rb
@@ -705,11 +705,8 @@ class DefaultScopingTest < ActiveRecord::TestCase
   end
 
   def test_with_abstract_class_scope_should_be_executed_in_correct_context
-    vegetarian_pattern = /#{Regexp.escape(Lion.lease_connection.quote_table_name("lions.is_vegetarian"))}/i
-    gender_pattern     = /#{Regexp.escape(Lion.lease_connection.quote_table_name("lions.gender"))}/i
-
-    assert_match vegetarian_pattern, Lion.all.to_sql
-    assert_match gender_pattern, Lion.female.to_sql
+    assert_match %r/#{Regexp.escape(quote_table_name("lions.is_vegetarian"))}/i, Lion.all.to_sql
+    assert_match %r/#{Regexp.escape(quote_table_name("lions.gender"))}/i, Lion.female.to_sql
   end
 end
 

--- a/activerecord/test/cases/test_case.rb
+++ b/activerecord/test/cases/test_case.rb
@@ -290,6 +290,10 @@ module ActiveRecord
       end
     end
 
+    def quote_table_name(name)
+      ActiveRecord::Base.adapter_class.quote_table_name(name)
+    end
+
     # Connect to the database
     ARTest.connect
     # Load database schema

--- a/activerecord/test/cases/unsafe_raw_sql_test.rb
+++ b/activerecord/test/cases/unsafe_raw_sql_test.rb
@@ -74,8 +74,7 @@ class UnsafeRawSqlTest < ActiveRecord::TestCase
   test "order: allows quoted table and column names" do
     ids_expected = Post.order(Arel.sql("title")).pluck(:id)
 
-    quoted_title = Post.lease_connection.quote_table_name("posts.title")
-    ids = Post.order(quoted_title).pluck(:id)
+    ids = Post.order(quote_table_name("posts.title")).pluck(:id)
 
     assert_equal ids_expected, ids
   end
@@ -256,8 +255,7 @@ class UnsafeRawSqlTest < ActiveRecord::TestCase
   test "pluck: allows quoted table and column names" do
     titles_expected = Post.pluck(Arel.sql("title"))
 
-    quoted_title = Post.lease_connection.quote_table_name("posts.title")
-    titles = Post.pluck(quoted_title)
+    titles = Post.pluck(quote_table_name("posts.title"))
 
     assert_equal titles_expected, titles
   end

--- a/activerecord/test/cases/view_test.rb
+++ b/activerecord/test/cases/view_test.rb
@@ -78,11 +78,6 @@ module ViewBehavior
     schema = dump_table_schema "ebooks'"
     assert_no_match %r{create_table "ebooks'"}, schema
   end
-
-  private
-    def quote_table_name(name)
-      @connection.quote_table_name(name)
-    end
 end
 
 if ActiveRecord::Base.lease_connection.supports_views?


### PR DESCRIPTION
We frequently use `Model.lease_connection.quote_table_name(name)` to construct adapter specific quoted SQL by hand for testing. It is used over 80 times in tests and will continue to increase, so I'd like to cut it out as a hepler method for convenience, and change `lease_connection` to `adapter_class` since `quote_table_name` is connection independent after #51174.
