### PR TITLE
Do more request parameter parsing ourselves

### DIFF
--- a/actionpack/lib/action_dispatch.rb
+++ b/actionpack/lib/action_dispatch.rb
@@ -53,7 +53,13 @@ module ActionDispatch
   eager_autoload do
     autoload_under "http" do
       autoload :ContentSecurityPolicy
+      autoload :InvalidParameterError, "action_dispatch/http/param_error"
+      autoload :ParamBuilder
+      autoload :ParamError
+      autoload :ParameterTypeError, "action_dispatch/http/param_error"
+      autoload :ParamsTooDeepError, "action_dispatch/http/param_error"
       autoload :PermissionsPolicy
+      autoload :QueryParser
       autoload :Request
       autoload :Response
     end

--- a/actionpack/lib/action_dispatch/http/param_builder.rb
+++ b/actionpack/lib/action_dispatch/http/param_builder.rb
@@ -1,0 +1,163 @@
+# frozen_string_literal: true
+
+module ActionDispatch
+  class ParamBuilder
+    def self.make_default(param_depth_limit)
+      new param_depth_limit
+    end
+
+    attr_reader :param_depth_limit
+
+    def initialize(param_depth_limit)
+      @param_depth_limit = param_depth_limit
+    end
+
+    cattr_accessor :default
+    self.default = make_default(100)
+
+    class << self
+      delegate :from_query_string, :from_pairs, :from_hash, to: :default
+    end
+
+    def from_query_string(qs, separator: nil, encoding_template: nil)
+      from_pairs QueryParser.each_pair(qs, separator), encoding_template: encoding_template
+    end
+
+    def from_pairs(pairs, encoding_template: nil)
+      params = make_params
+
+      pairs.each do |k, v|
+        if Hash === v
+          v = ActionDispatch::Http::UploadedFile.new(v)
+        end
+
+        store_nested_param(params, k, v, 0, encoding_template)
+      end
+
+      params
+    rescue ArgumentError => e
+      raise InvalidParameterError, e.message, e.backtrace
+    end
+
+    def from_hash(hash, encoding_template: nil)
+      # Force encodings from encoding template
+      hash = Request::Utils::CustomParamEncoder.encode_for_template(hash, encoding_template)
+
+      # Assert valid encoding
+      Request::Utils.check_param_encoding(hash)
+
+      # Convert hashes to HWIA (or UploadedFile), and deep-munge nils
+      # out of arrays
+      hash = Request::Utils.normalize_encode_params(hash)
+
+      hash
+    end
+
+    private
+      def store_nested_param(params, name, v, depth, encoding_template = nil)
+        raise ParamsTooDeepError if depth >= param_depth_limit
+
+        if !name
+          # nil name, treat same as empty string (required by tests)
+          k = after = ""
+        elsif depth == 0
+          # Start of parsing, don't treat [] or [ at start of string specially
+          if start = name.index("[", 1)
+            # Start of parameter nesting, use part before brackets as key
+            k = name[0, start]
+            after = name[start, name.length]
+          else
+            # Plain parameter with no nesting
+            k = name
+            after = ""
+          end
+        elsif name.start_with?("[]")
+          # Array nesting
+          k = "[]"
+          after = name[2, name.length]
+        elsif name.start_with?("[") && (start = name.index("]", 1))
+          # Hash nesting, use the part inside brackets as the key
+          k = name[1, start - 1]
+          after = name[start + 1, name.length]
+        else
+          # Probably malformed input, nested but not starting with [
+          # treat full name as key for backwards compatibility.
+          k = name
+          after = ""
+        end
+
+        return if k.empty?
+
+        if depth == 0 && String === v
+          # We have to wait until we've found the top part of the name,
+          # because that's what the encoding template is configured with
+          if encoding_template && (designated_encoding = encoding_template[k]) && !v.frozen?
+            v.force_encoding(designated_encoding)
+          end
+
+          # ... and we can't validate the encoding until after we've
+          # applied any template override
+          unless v.valid_encoding?
+            raise InvalidParameterError, "Invalid encoding for parameter: #{v.scrub}"
+          end
+        end
+
+        if after == ""
+          if k == "[]" && depth != 0
+            return (v || !ActionDispatch::Request::Utils.perform_deep_munge) ? [v] : []
+          else
+            params[k] = v
+          end
+        elsif after == "["
+          params[name] = v
+        elsif after == "[]"
+          params[k] ||= []
+          raise ParameterTypeError, "expected Array (got #{params[k].class.name}) for param `#{k}'" unless params[k].is_a?(Array)
+          params[k] << v if v || !ActionDispatch::Request::Utils.perform_deep_munge
+        elsif after.start_with?("[]")
+          # Recognize x[][y] (hash inside array) parameters
+          unless after[2] == "[" && after.end_with?("]") && (child_key = after[3, after.length - 4]) && !child_key.empty? && !child_key.index("[") && !child_key.index("]")
+            # Handle other nested array parameters
+            child_key = after[2, after.length]
+          end
+          params[k] ||= []
+          raise ParameterTypeError, "expected Array (got #{params[k].class.name}) for param `#{k}'" unless params[k].is_a?(Array)
+          if params_hash_type?(params[k].last) && !params_hash_has_key?(params[k].last, child_key)
+            store_nested_param(params[k].last, child_key, v, depth + 1)
+          else
+            params[k] << store_nested_param(make_params, child_key, v, depth + 1)
+          end
+        else
+          params[k] ||= make_params
+          raise ParameterTypeError, "expected Hash (got #{params[k].class.name}) for param `#{k}'" unless params_hash_type?(params[k])
+          params[k] = store_nested_param(params[k], after, v, depth + 1)
+        end
+
+        params
+      end
+
+      def make_params
+        ActiveSupport::HashWithIndifferentAccess.new
+      end
+
+      def new_depth_limit(param_depth_limit)
+        self.class.new @params_class, param_depth_limit
+      end
+
+      def params_hash_type?(obj)
+        Hash === obj
+      end
+
+      def params_hash_has_key?(hash, key)
+        return false if key.include?("[]")
+
+        key.split(/[\[\]]+/).inject(hash) do |h, part|
+          next h if part == ""
+          return false unless params_hash_type?(h) && h.key?(part)
+          h[part]
+        end
+
+        true
+      end
+  end
+end

--- a/actionpack/lib/action_dispatch/http/param_error.rb
+++ b/actionpack/lib/action_dispatch/http/param_error.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module ActionDispatch
+  class ParamError < ActionDispatch::Http::Parameters::ParseError
+    def initialize(message = nil)
+      super
+    end
+
+    def self.===(other)
+      super || (
+        defined?(Rack::Utils::ParameterTypeError) && Rack::Utils::ParameterTypeError === other ||
+        defined?(Rack::Utils::InvalidParameterError) && Rack::Utils::InvalidParameterError === other ||
+        defined?(Rack::QueryParser::ParamsTooDeepError) && Rack::QueryParser::ParamsTooDeepError === other
+      )
+    end
+  end
+
+  class ParameterTypeError < ParamError
+  end
+
+  class InvalidParameterError < ParamError
+  end
+
+  class ParamsTooDeepError < ParamError
+  end
+end

--- a/actionpack/lib/action_dispatch/http/query_parser.rb
+++ b/actionpack/lib/action_dispatch/http/query_parser.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "uri"
+
+module ActionDispatch
+  class QueryParser
+    DEFAULT_SEP = /& */n
+    COMMON_SEP = { ";" => /; */n, ";," => /[;,] */n, "&" => /& */n }
+
+    #--
+    # Note this departs from WHATWG's specified parsing algorithm by
+    # giving a nil value for keys that do not use '='. Callers that need
+    # the standard's interpretation can use `v.to_s`.
+    def self.each_pair(s, separator = nil)
+      return enum_for(:each_pair, s, separator) unless block_given?
+
+      (s || "").split(separator ? (COMMON_SEP[separator] || /[#{separator}] */n) : DEFAULT_SEP).each do |part|
+        next if part.empty?
+
+        k, v = part.split("=", 2)
+
+        k = URI.decode_www_form_component(k)
+        v &&= URI.decode_www_form_component(v)
+
+        yield k, v
+      end
+
+      nil
+    end
+  end
+end

--- a/actionpack/lib/action_dispatch/http/request.rb
+++ b/actionpack/lib/action_dispatch/http/request.rb
@@ -63,6 +63,9 @@ module ActionDispatch
 
     def initialize(env)
       super
+
+      @rack_request = Rack::Request.new(env)
+
       @method            = nil
       @request_method    = nil
       @remote_ip         = nil
@@ -70,6 +73,8 @@ module ActionDispatch
       @fullpath          = nil
       @ip                = nil
     end
+
+    attr_reader :rack_request
 
     def commit_cookie_jar! # :nodoc:
     end
@@ -388,15 +393,12 @@ module ActionDispatch
     # Override Rack's GET method to support indifferent access.
     def GET
       fetch_header("action_dispatch.request.query_parameters") do |k|
-        rack_query_params = super || {}
-        controller = path_parameters[:controller]
-        action = path_parameters[:action]
-        rack_query_params = Request::Utils.set_binary_encoding(self, rack_query_params, controller, action)
-        # Check for non UTF-8 parameter values, which would cause errors later
-        Request::Utils.check_param_encoding(rack_query_params)
-        set_header k, Request::Utils.normalize_encode_params(rack_query_params)
+        encoding_template = Request::Utils::CustomParamEncoder.action_encoding_template(self, path_parameters[:controller], path_parameters[:action])
+        rack_query_params = ActionDispatch::ParamBuilder.from_query_string(rack_request.query_string, encoding_template: encoding_template)
+
+        set_header k, rack_query_params
       end
-    rescue Rack::Utils::ParameterTypeError, Rack::Utils::InvalidParameterError, Rack::QueryParser::ParamsTooDeepError => e
+    rescue ActionDispatch::ParamError => e
       raise ActionController::BadRequest.new("Invalid query parameters: #{e.message}")
     end
     alias :query_parameters :GET
@@ -404,17 +406,53 @@ module ActionDispatch
     # Override Rack's POST method to support indifferent access.
     def POST
       fetch_header("action_dispatch.request.request_parameters") do
-        pr = parse_formatted_parameters(params_parsers) do |params|
-          super || {}
+        encoding_template = Request::Utils::CustomParamEncoder.action_encoding_template(self, path_parameters[:controller], path_parameters[:action])
+
+        param_list = nil
+        pr = parse_formatted_parameters(params_parsers) do
+          if param_list = request_parameters_list
+            ActionDispatch::ParamBuilder.from_pairs(param_list, encoding_template: encoding_template)
+          else
+            # We're not using a version of Rack that provides raw form
+            # pairs; we must use its hash (and thus post-process it below).
+            fallback_request_parameters
+          end
         end
-        pr = Request::Utils.set_binary_encoding(self, pr, path_parameters[:controller], path_parameters[:action])
-        Request::Utils.check_param_encoding(pr)
-        self.request_parameters = Request::Utils.normalize_encode_params(pr)
+
+        # If the request body was parsed by a custom parser like JSON
+        # (and thus the above block was not run), we need to
+        # post-process the result hash.
+        if param_list.nil?
+          pr = ActionDispatch::ParamBuilder.from_hash(pr, encoding_template: encoding_template)
+        end
+
+        self.request_parameters = pr
       end
-    rescue Rack::Utils::ParameterTypeError, Rack::Utils::InvalidParameterError, Rack::QueryParser::ParamsTooDeepError, EOFError => e
+    rescue ActionDispatch::ParamError, EOFError => e
       raise ActionController::BadRequest.new("Invalid request parameters: #{e.message}")
     end
     alias :request_parameters :POST
+
+    def request_parameters_list
+      # We don't use Rack's parse result, but we must call it so Rack
+      # can populate the rack.request.* keys we need.
+      rack_post = rack_request.POST
+
+      if form_pairs = get_header("rack.request.form_pairs")
+        # Multipart
+        form_pairs
+      elsif form_vars = get_header("rack.request.form_vars")
+        # URL-encoded
+        ActionDispatch::QueryParser.each_pair(form_vars)
+      elsif rack_post && !rack_post.empty?
+        # It was multipart, but Rack did not preserve a pair list
+        # (probably too old). Flat parameter list is not available.
+        nil
+      else
+        # No request body, or not a format Rack knows
+        []
+      end
+    end
 
     # Returns the authorization header regardless of whether it was specified
     # directly or through one of the proxy alternatives.
@@ -491,6 +529,10 @@ module ActionDispatch
         else
           yield
         end
+      end
+
+      def fallback_request_parameters
+        rack_request.POST
       end
   end
 end

--- a/actionpack/lib/action_dispatch/request/utils.rb
+++ b/actionpack/lib/action_dispatch/request/utils.rb
@@ -84,7 +84,7 @@ module ActionDispatch
 
       class CustomParamEncoder # :nodoc:
         def self.encode(request, params, controller, action)
-          return params unless controller && controller.valid_encoding? && encoding_template = action_encoding_template(request, controller, action)
+          return params unless encoding_template = action_encoding_template(request, controller, action)
           params.except(:controller, :action).each do |key, value|
             ActionDispatch::Request::Utils.each_param_value(value) do |param|
               # If `param` is frozen, it comes from the router defaults
@@ -99,7 +99,8 @@ module ActionDispatch
         end
 
         def self.action_encoding_template(request, controller, action) # :nodoc:
-          request.controller_class_for(controller).action_encoding_template(action)
+          controller && controller.valid_encoding? &&
+            request.controller_class_for(controller).action_encoding_template(action)
         rescue MissingController
           nil
         end

--- a/actionpack/lib/action_dispatch/request/utils.rb
+++ b/actionpack/lib/action_dispatch/request/utils.rb
@@ -83,8 +83,8 @@ module ActionDispatch
       end
 
       class CustomParamEncoder # :nodoc:
-        def self.encode(request, params, controller, action)
-          return params unless encoding_template = action_encoding_template(request, controller, action)
+        def self.encode_for_template(params, encoding_template)
+          return params unless encoding_template
           params.except(:controller, :action).each do |key, value|
             ActionDispatch::Request::Utils.each_param_value(value) do |param|
               # If `param` is frozen, it comes from the router defaults
@@ -96,6 +96,11 @@ module ActionDispatch
             end
           end
           params
+        end
+
+        def self.encode(request, params, controller, action)
+          encoding_template = action_encoding_template(request, controller, action)
+          encode_for_template(params, encoding_template)
         end
 
         def self.action_encoding_template(request, controller, action) # :nodoc:

--- a/actionpack/lib/action_dispatch/testing/assertions/response.rb
+++ b/actionpack/lib/action_dispatch/testing/assertions/response.rb
@@ -87,13 +87,23 @@ module ActionDispatch
         end
 
         def generate_response_message(expected, actual = @response.response_code)
-          (+"Expected response to be a <#{code_with_name(expected)}>,"\
-          " but was a <#{code_with_name(actual)}>").concat(location_if_redirected).concat(response_body_if_short)
+          lambda do
+            (+"Expected response to be a <#{code_with_name(expected)}>,"\
+             " but was a <#{code_with_name(actual)}>").
+              concat(location_if_redirected).
+              concat(exception_if_present).
+              concat(response_body_if_short)
+          end
         end
 
         def response_body_if_short
           return "" if @response.body.size > 500
           "\nResponse body: #{@response.body}"
+        end
+
+        def exception_if_present
+          return "" unless ex = @request&.env&.[]("action_dispatch.exception")
+          "\n\nException while processing request: #{Minitest::UnexpectedError.new(ex).message}\n"
         end
 
         def location_if_redirected

--- a/actionpack/lib/action_dispatch/testing/integration.rb
+++ b/actionpack/lib/action_dispatch/testing/integration.rb
@@ -284,7 +284,17 @@ module ActionDispatch
 
         # NOTE: rack-test v0.5 doesn't build a default uri correctly Make sure requested
         # path is always a full URI.
-        session.request(build_full_uri(path, request_env), request_env)
+        uri = build_full_uri(path, request_env)
+
+        if method == :get && String === request_env[:params]
+          # rack-test will needlessly parse and rebuild a :params
+          # querystring, using Rack's query parser. At best that's a
+          # waste of time; at worst it can change the value.
+
+          uri << "?" << request_env.delete(:params)
+        end
+
+        session.request(uri, request_env)
 
         @request_count += 1
         @request = ActionDispatch::Request.new(session.last_request.env)

--- a/actionpack/test/abstract_unit.rb
+++ b/actionpack/test/abstract_unit.rb
@@ -26,6 +26,8 @@ require "active_support/dependencies"
 require "active_model"
 require "zeitwerk"
 
+require_relative "support/rack_parsing_override"
+
 ActiveSupport::Cache.format_version = 7.1
 
 module Rails

--- a/actionpack/test/assertions/response_assertions_test.rb
+++ b/actionpack/test/assertions/response_assertions_test.rb
@@ -136,6 +136,19 @@ module ActionDispatch
                    " but was a <400: Bad Request>"
         assert_match expected, error.message
       end
+
+      def test_error_message_shows_rescued_exception
+        @response = ActionDispatch::Response.new
+        @response.status = 500
+
+        @request = ActionDispatch::Request.new("action_dispatch.exception" => RuntimeError.new("example error"))
+
+        error = assert_raises(Minitest::Assertion) { assert_response 200 }
+        expected = "Expected response to be a <200: OK>,"\
+                   " but was a <500: Internal Server Error>\n\n"\
+                   "Exception while processing request: RuntimeError: example error\n"
+        assert_match expected, error.message
+      end
     end
   end
 end

--- a/actionpack/test/dispatch/request/query_string_parsing_test.rb
+++ b/actionpack/test/dispatch/request/query_string_parsing_test.rb
@@ -18,9 +18,13 @@ class QueryStringParsingTest < ActionDispatch::IntegrationTest
       @app = app
     end
 
+    def populate_rack_cache(env)
+      Rack::Request.new(env).params
+    end
+
     def call(env)
       # Trigger a Rack parse so that env caches the query params
-      Rack::Request.new(env).params
+      populate_rack_cache(env)
       @app.call(env)
     end
   end

--- a/actionpack/test/dispatch/request_test.rb
+++ b/actionpack/test/dispatch/request_test.rb
@@ -1116,21 +1116,14 @@ class RequestParameters < BaseRequestTest
     end
   end
 
-  if Rack.release < "3"
-    test "parameters not accessible after rack parse error of invalid UTF8 character" do
-      request = stub_request("QUERY_STRING" => "foo%81E=1")
-      assert_raises(ActionController::BadRequest) { request.parameters }
-    end
+  test "parameters containing an invalid UTF8 character" do
+    request = stub_request("QUERY_STRING" => "foo=%81E")
+    assert_raises(ActionController::BadRequest) { request.parameters }
+  end
 
-    test "parameters containing an invalid UTF8 character" do
-      request = stub_request("QUERY_STRING" => "foo=%81E")
-      assert_raises(ActionController::BadRequest) { request.parameters }
-    end
-
-    test "parameters containing a deeply nested invalid UTF8 character" do
-      request = stub_request("QUERY_STRING" => "foo[bar]=%81E")
-      assert_raises(ActionController::BadRequest) { request.parameters }
-    end
+  test "parameters containing a deeply nested invalid UTF8 character" do
+    request = stub_request("QUERY_STRING" => "foo[bar]=%81E")
+    assert_raises(ActionController::BadRequest) { request.parameters }
   end
 
   test "POST parameters containing invalid UTF8 character" do

--- a/actionpack/test/dispatch/request_test.rb
+++ b/actionpack/test/dispatch/request_test.rb
@@ -1151,7 +1151,7 @@ class RequestParameters < BaseRequestTest
   test "query parameters specified as ASCII_8BIT encoded do not raise InvalidParameterError" do
     request = stub_request("QUERY_STRING" => "foo=%81E")
 
-    ActionDispatch::Request::Utils.stub(:set_binary_encoding, { "foo" => "\x81E".b }) do
+    ActionDispatch::Request::Utils::CustomParamEncoder.stub(:action_encoding_template, { "foo" => Encoding::ASCII_8BIT }) do
       assert_nothing_raised do
         request.parameters
       end
@@ -1167,7 +1167,7 @@ class RequestParameters < BaseRequestTest
       :input => data
     )
 
-    ActionDispatch::Request::Utils.stub(:set_binary_encoding, { "foo" => "\x81E".b }) do
+    ActionDispatch::Request::Utils::CustomParamEncoder.stub(:action_encoding_template, { "foo" => Encoding::ASCII_8BIT }) do
       assert_nothing_raised do
         request.parameters
       end

--- a/actionpack/test/journey/router_test.rb
+++ b/actionpack/test/journey/router_test.rb
@@ -494,7 +494,7 @@ module ActionDispatch
           end
           path = @route_set.path_for(options, route_name)
           uri = URI.parse path
-          params = Rack::Utils.parse_nested_query(uri.query).symbolize_keys
+          params = ActionDispatch::ParamBuilder.from_query_string(uri.query).symbolize_keys
           [uri.path, params]
         end
 

--- a/actionpack/test/support/rack_parsing_override.rb
+++ b/actionpack/test/support/rack_parsing_override.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+# Because we implement our own query string parsing, and it is extremely
+# similar to Rack's in most simple cases, it would be very easy to have
+# locations sneak in where we unknowingly depend on Rack's
+# interpretation rather than our own, potentially creating edge-case
+# incompatibilities.
+#
+# To counter that, we monkey-patch Rack in our tests to allow-list the
+# call sites that are known to be safe & appropriate.
+#
+# This file may need to change in response to future Rack changes. If
+# you're here because you're adding new code/tests to Rails, though, you
+# probably need to work out how to ensure you're using the Rails query
+# parser instead.
+module RackParsingOverride
+  UnexpectedCall = Class.new(Exception)
+
+  # The only expected calls to Rack::QueryParser#parse_nested_query are
+  # from Rack::Request#GET/POST, which are separately protected below.
+  module ParserPatch
+    def parse_nested_query(*)
+      unless caller_locations.any? { |loc| loc.path == __FILE__ && (loc.lineno == RackParsingOverride::GET_LINE || loc.lineno == RackParsingOverride::POST_LINE) }
+        raise UnexpectedCall, "Unexpected call to Rack::QueryParser#parse_nested_query"
+      end
+      super
+    end
+  end
+
+  # This is where we do the real checking, because we need to catch
+  # every caller that might _use_ the cached result of Rack's parsing,
+  # not just the first call site where parsing gets triggered.
+  module RequestPatch
+    # Single list of permitted callers -- we don't care about GET vs POST
+    def self.permitted_caller?
+      caller_locations.any? do |loc|
+        # Our parser calls Rack's to prepopulate caches
+        loc.path.end_with?("lib/action_dispatch/http/request.rb") && loc.label == "request_parameters_list" ||
+          # and as a fallback for older Rack versions
+          loc.path.end_with?("lib/action_dispatch/http/request.rb") && loc.label == "fallback_request_parameters" ||
+          # This specifically tests that a "pure" Rack middleware
+          # doesn't interfere with our parsing
+          (loc.path.end_with?("test/dispatch/request/query_string_parsing_test.rb") && loc.label == "populate_rack_cache") ||
+          # Rack::MethodOverride obviously uses Rack's parsing, and
+          # that's fine: it's looking for a simple top-level key.
+          # Checking for a specific internal method is fragile, but we
+          # don't want to ignore any app that happens to have
+          # MethodOverride on its call stack!
+          (loc.path.end_with?("lib/rack/method_override.rb") && loc.label == "method_override_param")
+      end
+    end
+
+    def params
+      unless RequestPatch.permitted_caller?
+        raise UnexpectedCall, "Unexpected call to Rack::Request#params"
+      end
+      super
+    end
+    ::RackParsingOverride::PARAMS_LINE = __LINE__ - 2
+
+    def GET
+      unless RequestPatch.permitted_caller?
+        raise UnexpectedCall, "Unexpected call to Rack::Request#GET"
+      end
+      super
+    end
+    ::RackParsingOverride::GET_LINE = __LINE__ - 2
+
+    def POST
+      unless RequestPatch.permitted_caller?
+        raise UnexpectedCall, "Unexpected call to Rack::Request#POST"
+      end
+      super
+    end
+    ::RackParsingOverride::POST_LINE = __LINE__ - 2
+  end
+
+  Rack::QueryParser.class_eval do
+    # Being careful here, as this is more internal
+    unless method_defined?(:parse_nested_query)
+      raise "Rack changed? Can't patch absent Rack::QueryParser#parse_nested_query"
+    end
+    prepend ParserPatch
+  end
+
+  Rack::Request.prepend RequestPatch
+end

--- a/railties/test/application/middleware/exceptions_test.rb
+++ b/railties/test/application/middleware/exceptions_test.rb
@@ -226,7 +226,7 @@ module ApplicationTests
       app.config.action_dispatch.show_exceptions = :all
       app.config.consider_all_requests_local = true
 
-      limit = Rack::Utils.param_depth_limit + 1
+      limit = ActionDispatch::ParamBuilder.default.param_depth_limit + 1
       malicious_url = "/foo?#{'[test]' * limit}=test"
 
       get(malicious_url, {}, "HTTPS" => "on")


### PR DESCRIPTION
Rack is looking at some minor changes to how they parse query strings, but we have learned hard-won lessons about changing even edge case behaviours.

Simultaneously, this narrow instance has highlighted a more general situation: prior to Rack 3, we always had the option to adopt our own parameter parsing strategy (e.g. if we wanted to invent some meaning for a structured parameter name of `foo[@]/bar` or something). As Rack 3 eliminated the obligation for the input body to be rewindable, only the first-to-read is guaranteed to be able to see the full set of parameters.

The Rack side of this has been alleviated via https://github.com/rack/rack/pull/2088 -- it's still true that only the first reader can parse the input, and ecosystem consistency requires that reader to be Rack... but it will now provide a more literal, less processed, view of the parameters it saw.

Here, we adopt that new raw parameter list (where available), and do the structured parsing for ourselves.

Interestingly, this allows us to be more direct in getting to a true Rails parameter set: indifferent hash access, nil munging, and string encoding controls can all be applied as we go, instead of through post-processing.

---

The intention is that there are no observable behaviour changes here: the only short-term effect will be to insulate us from future-Rack's https://github.com/rack/rack/pull/2098.

This PR _will_ result in new/different internal exception classes being raised for various invalid-parameter situations, but apart from changing spelling of some log messages, I'm not sure it's practical, let alone likely, for an application to be seeing/rescuing them: we already translate the Rack exceptions to `ActionController::BadRequest`, and here maintain that translation for the new ones.