### PR TITLE
`ActiveRecord::Persistence#reload` set id on RecordNotFound exception

### DIFF
--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -835,11 +835,21 @@ module ActiveRecord
         all_queries = options ? options[:all_queries] : nil
         base = self.class.all(all_queries: all_queries).preload(strict_loaded_associations)
 
-        if options && options[:lock]
-          base.lock(options[:lock]).find_by!(_in_memory_query_constraints_hash)
+        record = if options && options[:lock]
+          base.lock(options[:lock]).find_by(_in_memory_query_constraints_hash)
         else
-          base.find_by!(_in_memory_query_constraints_hash)
+          base.find_by(_in_memory_query_constraints_hash)
         end
+
+        if record.nil?
+          if self.class.query_constraints_list.nil?
+            base.raise_record_not_found_exception!(_in_memory_query_constraints_hash[@primary_key], 0, 1, @primary_key)
+          else
+            base.raise_record_not_found_exception!(_in_memory_query_constraints_hash.values, 0, 1, _in_memory_query_constraints_hash.keys)
+          end
+        end
+
+        record
       end
 
       def _in_memory_query_constraints_hash

--- a/activerecord/test/cases/persistence_test.rb
+++ b/activerecord/test/cases/persistence_test.rb
@@ -1606,6 +1606,27 @@ class PersistenceTest < ActiveRecord::TestCase
     assert_match(/WHERE .*color/, sql)
   end
 
+  def test_reload_after_destroy_keeps_id
+    topic = Topic.create!(title: "New Topic")
+
+    topic.destroy!
+
+    error = assert_raises(ActiveRecord::RecordNotFound) { topic.reload }
+
+    assert_equal Topic.name, error.model
+    assert_equal topic.id, error.id
+  end
+
+  def test_reload_after_destroy_keeps_id_with_query_constraints
+    clothing_item = clothing_items(:green_t_shirt)
+    clothing_item.destroy!
+
+    error = assert_raises(ActiveRecord::RecordNotFound) { clothing_item.reload }
+
+    assert_equal ClothingItem.name, error.model
+    assert_equal [clothing_item.clothing_type, clothing_item.color], error.id
+  end
+
   def test_destroy_uses_query_constraints_config
     clothing_item = clothing_items(:green_t_shirt)
     sql = capture_sql { clothing_item.destroy }.second


### PR DESCRIPTION


This commit addresses the issue by ensuring that the id is always passed


### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

Currently, calling reload does not pass the id information to the exception when the record is not found.

Fixes #52598

### Detail

This Pull Request changes the `_find_record` method in the `Persistence` module to stop using `find_by!` and instead use `find_by`. This way if the record is not found the method can populate the exception message with the right id information.

### Additional information

It seems that the original change (#46402) was introduced to support `query_constraints_list`. I have tried to ensure that `query_constraints_list` is used in generating the error object, but I couldn't find any prior art, so I had to come up with my own approach.

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
