### PR TITLE
Add extract_dimensions_metadata to image analyzer

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add `extract_dimensions_metadata` to `ActiveStorage::Analyzer::ImageAnalyzer`.
+
+    *Alexandr Borisov*
+
 ## Rails 8.0.0.beta1 (September 26, 2024) ##
 
 *   Deprecate `ActiveStorage::Service::AzureStorageService`.

--- a/activestorage/lib/active_storage/analyzer/image_analyzer.rb
+++ b/activestorage/lib/active_storage/analyzer/image_analyzer.rb
@@ -18,12 +18,17 @@ module ActiveStorage
 
     def metadata
       read_image do |image|
+        extract_dimensions_metadata(image)
+      end
+    end
+
+    private
+      def extract_dimensions_metadata(image)
         if rotated_image?(image)
           { width: image.height, height: image.width }
         else
           { width: image.width, height: image.height }
         end
       end
-    end
   end
 end

--- a/activestorage/lib/active_storage/analyzer/image_analyzer.rb
+++ b/activestorage/lib/active_storage/analyzer/image_analyzer.rb
@@ -23,7 +23,7 @@ module ActiveStorage
     end
 
     private
-      def extract_dimensions_metadata(image)
+      def extract_dimensions_metadata(image) # :doc:
         if rotated_image?(image)
           { width: image.height, height: image.width }
         else


### PR DESCRIPTION
### Motivation / Background

It would be nice to rely on built-in extract dimensions logic when writing custom image analyzer like this:

```ruby
class CustomeImageAnalyzer < ActiveStorage::Analyzer::ImageAnalyzer::Vips
  def metadata
    read_image do |image|
      extract_dimensions_metadata(image).tap do |metadata|
        metadata[:aspect_ratio] = metadata[:width].to_f / metadata[:height]
      end
    end
  end
end
```

This pull request introduces `extract_dimensions_metadata`, the method idea is [similar](https://github.com/rails/rails/blob/main/activestorage/lib/active_storage/analyzer/image_analyzer.rb#L21) to`rotated_image?`. Not a big deal, but still.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
