### PR TITLE
Update rails console prompts [ci skip]

### DIFF
--- a/guides/source/getting_started.md
+++ b/guides/source/getting_started.md
@@ -471,17 +471,17 @@ Let's launch the console with this command:
 $ bin/rails console
 ```
 
-You should see an `irb` prompt like:
+You should see a rails console prompt like:
 
 ```irb
 Loading development environment (Rails 8.0.0)
-irb(main):001:0>
+blog(dev)>
 ```
 
 At this prompt, we can initialize a new `Article` object:
 
 ```irb
-irb> article = Article.new(title: "Hello Rails", body: "I am on Rails!")
+blog(dev)> article = Article.new(title: "Hello Rails", body: "I am on Rails!")
 ```
 
 It's important to note that we have only *initialized* this object. This object
@@ -490,7 +490,7 @@ moment. To save the object to the database, we must call [`save`](
 https://api.rubyonrails.org/classes/ActiveRecord/Persistence.html#method-i-save):
 
 ```irb
-irb> article.save
+blog(dev)> article.save
 (0.1ms)  begin transaction
 Article Create (0.4ms)  INSERT INTO "articles" ("title", "body", "created_at", "updated_at") VALUES (?, ?, ?, ?)  [["title", "Hello Rails"], ["body", "I am on Rails!"], ["created_at", "2020-01-18 23:47:30.734416"], ["updated_at", "2020-01-18 23:47:30.734416"]]
 (0.9ms)  commit transaction
@@ -502,7 +502,7 @@ indicates that the article has been inserted into our table. And if we take a
 look at the `article` object again, we see something interesting has happened:
 
 ```irb
-irb> article
+blog(dev)> article
 => #<Article id: 1, title: "Hello Rails", body: "I am on Rails!", created_at: "2020-01-18 23:47:30", updated_at: "2020-01-18 23:47:30">
 ```
 
@@ -514,7 +514,7 @@ https://api.rubyonrails.org/classes/ActiveRecord/FinderMethods.html#method-i-fin
 on the model and pass the `id` as an argument:
 
 ```irb
-irb> Article.find(1)
+blog(dev)> Article.find(1)
 => #<Article id: 1, title: "Hello Rails", body: "I am on Rails!", created_at: "2020-01-18 23:47:30", updated_at: "2020-01-18 23:47:30">
 ```
 
@@ -523,7 +523,7 @@ https://api.rubyonrails.org/classes/ActiveRecord/Scoping/Named/ClassMethods.html
 on the model:
 
 ```irb
-irb> Article.all
+blog(dev)> Article.all
 => #<ActiveRecord::Relation [#<Article id: 1, title: "Hello Rails", body: "I am on Rails!", created_at: "2020-01-18 23:47:30", updated_at: "2020-01-18 23:47:30">]>
 ```
 


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because [rails console prompts have been changed since Rails 7.2](https://github.com/rails/rails/pull/50825).
While numerous instances of `irb>` appear in the Ruby on Rails Guides, it’s particularly important to update the prompts on the “Getting Started with Rails” page first. This page is targeted at beginners, so having prompts that match what they encounter in their hands-on activities is especially beneficial.

### Detail

This Pull Request changes prompts of `rails console`  in  "Getting Started with Rails".

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
