### PR TITLE
Add AS::TimeZone#standard_name method

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,15 @@
+*   Add `ActiveSupport::TimeZone#standard_name` method.
+
+    ``` ruby
+    zone = ActiveSupport::TimeZone['Hawaii']
+    # Old way
+    ActiveSupport::TimeZone::MAPPING[zone.name]
+    # New way
+    zone.standard_name # => 'Pacific/Honolulu'
+    ```
+
+    *Bogdan Gusiev*
+
 *   Add Structured Event Reporter, accessible via `Rails.event`.
 
     The Event Reporter provides a unified interface for producing structured events in Rails

--- a/activesupport/lib/active_support/values/time_zone.rb
+++ b/activesupport/lib/active_support/values/time_zone.rb
@@ -314,6 +314,12 @@ module ActiveSupport
     end
     # :startdoc:
 
+    # Returns a standard time zone name defined by IANA
+    # https://www.iana.org/time-zones
+    def standard_name
+      MAPPING[name] || name
+    end
+
     # Returns the offset of this time zone from UTC in seconds.
     def utc_offset
       @utc_offset || tzinfo&.current_period&.base_utc_offset

--- a/activesupport/test/time_zone_test.rb
+++ b/activesupport/test/time_zone_test.rb
@@ -920,4 +920,10 @@ class TimeZoneTest < ActiveSupport::TestCase
     assert_equal "EDT", time.strftime("%Z")
     assert_equal true, time.isdst
   end
+
+  def test_standard_name
+    assert_equal "America/New_York", ActiveSupport::TimeZone["Eastern Time (US & Canada)"].standard_name
+    assert_equal "America/Montevideo", ActiveSupport::TimeZone["Montevideo"].standard_name
+    assert_equal "America/Toronto", ActiveSupport::TimeZone["America/Toronto"].standard_name
+  end
 end


### PR DESCRIPTION
### Motivation / Background

AS::TimeZone exposes MAPPING as way to normalize TZ name But using it is pretty inconvinient

``` ruby
    zone = ActiveSupport::TimeZone['Hawaii']
    # Old way
    ActiveSupport::TimeZone::MAPPING[zone.name]
    # New way
    zone.standard_name
```

### Detail

This Pull Request adds `AS::TimeZone#standard_name` method

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
