### PR TITLE
Ensure errors in ActiveJob are reported to the rails Error Reporter

### DIFF
--- a/activejob/CHANGELOG.md
+++ b/activejob/CHANGELOG.md
@@ -10,4 +10,8 @@
 
     *heka1024*
 
+*   Report errors that happen to the Rails error reporter
+
+    *Nick Pezza*
+
 Please check [7-2-stable](https://github.com/rails/rails/blob/7-2-stable/activejob/CHANGELOG.md) for previous changes.

--- a/activejob/lib/active_job/base.rb
+++ b/activejob/lib/active_job/base.rb
@@ -8,6 +8,7 @@ require "active_job/enqueuing"
 require "active_job/execution"
 require "active_job/callbacks"
 require "active_job/exceptions"
+require "active_job/error_reporter"
 require "active_job/log_subscriber"
 require "active_job/logging"
 require "active_job/instrumentation"
@@ -71,6 +72,7 @@ module ActiveJob # :nodoc:
     include Exceptions
     include Instrumentation
     include Logging
+    include ErrorReporter
     include Timezones
     include Translation
 

--- a/activejob/lib/active_job/error_reporter.rb
+++ b/activejob/lib/active_job/error_reporter.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require "active_support/error_reporter"
+
+module ActiveJob
+  module ErrorReporter
+    extend ActiveSupport::Concern
+
+    included do
+      ##
+      # Accepts an error reporter
+      cattr_accessor :error_reporter, default: ActiveSupport.error_reporter
+    end
+  end
+end

--- a/activejob/lib/active_job/execution.rb
+++ b/activejob/lib/active_job/execution.rb
@@ -51,6 +51,7 @@ module ActiveJob
       _perform_job
     rescue Exception => exception
       handled = rescue_with_handler(exception)
+      ActiveJob::Base.error_reporter.report(exception, handled: handled, source: "application.active_job")
       return handled if handled
 
       run_after_discard_procs(exception)

--- a/activejob/lib/active_job/railtie.rb
+++ b/activejob/lib/active_job/railtie.rb
@@ -18,6 +18,10 @@ module ActiveJob
       ActiveSupport.on_load(:active_job) { self.logger = ::Rails.logger }
     end
 
+    initializer "active_job.error_reporter" do
+      ActiveSupport.on_load(:active_job) { self.error_reporter = ::Rails.error }
+    end
+
     initializer "active_job.custom_serializers" do |app|
       config.after_initialize do
         custom_serializers = app.config.active_job.custom_serializers


### PR DESCRIPTION
### Motivation / Background

Currently it seems as though errors that happen inside ActiveJob are not sent off to the Rails error reporter.

### Detail

This sets up ActiveJob to report errors to the Rails to make general error reporting simpler. Currently tools like sentry are [monkey patching ](https://github.com/getsentry/sentry-ruby/blob/master/sentry-rails/lib/sentry/rails/active_job.rb#L4) to get error reporting inside ActiveJob.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
