### PR TITLE
[ci skip] update testing guide to use assert_not instead of refute.

### DIFF
--- a/guides/source/testing.md
+++ b/guides/source/testing.md
@@ -2224,7 +2224,7 @@ class BillingJobTest < ActiveJob::TestCase
     assert_raises(InsufficientFundsError) do
       BillingJob.new(empty_account, product).perform
     end
-    refute account.reload.charged_for?(product)
+    assert_not account.reload.charged_for?(product)
   end
 end
 ```


### PR DESCRIPTION
### Motivation / Background

Follow-up to #53189 
Replaced `refute` with `assert_not` in guides.

### Detail

https://github.com/rails/rails/blob/ff42150d2f2c8df2b9fe21d97fea23fef3810949/guides/source/testing.md?plain=1#L2227
replaced with: ```assert_not account.reload.charged_for?(product)```

as `ActiveJob::TestCase` inherits from `ActiveSupport::TestCase`

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
