### PR TITLE
Unify migration file name formats in "Getting Started with Rails" [ci skip]

### DIFF
--- a/guides/source/getting_started.md
+++ b/guides/source/getting_started.md
@@ -1326,7 +1326,7 @@ This command will generate four files:
 
 | File                                         | Purpose                                                                                                |
 | -------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
-| db/migrate/20140120201010_create_comments.rb | Migration to create the comments table in your database (your name will include a different timestamp) |
+| db/migrate/\<timestamp\>_create_comments.rb  | Migration to create the comments table in your database                                                |
 | app/models/comment.rb                        | The Comment model                                                                                      |
 | test/models/comment_test.rb                  | Testing harness for the comment model                                                                 |
 | test/fixtures/comments.yml                   | Sample comments for use in testing                                                                     |


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because there are two different migration file name formats as below.

- db/migrate/\<timestamp\>_create_articles.rb
- db/migrate/20140120201010_create_comments.rb with a comment: "your name will include a different timestamp"

### Detail

This Pull Request unifies the format as below.

- db/migrate/\<timestamp\>_create_articles.rb
- db/migrate/\<timestamp\>_create_comments.rb

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
