### PR TITLE
Add down_only migration helper

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add `down_only` migration helper to execute a block only when reverting.
+
+    *Goulven Champenois*
+
 *   Allow `ActiveRecord::Base#pluck` to accept hash arguments with symbol and string values.
 
     ```ruby

--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -929,6 +929,24 @@ module ActiveRecord
       execute_block(&block) unless reverting?
     end
 
+    # Used to specify an operation that is only run when migrating down
+    # (for example, replacing a value with the previous default).
+    #
+    # In the following example, the column +published+ will be given the
+    # value +false+ for private records before removing the +private+ column.
+    #
+    #    class AddPrivateToPosts < ActiveRecord::Migration[8.0]
+    #      def change
+    #        down_only do
+    #          execute "update posts set published = 'false' where private = 'true'"
+    #        end
+    #        add_column :posts, :private, :boolean, default: false
+    #      end
+    #    end
+    def down_only(&block)
+      execute_block(&block) if reverting?
+    end
+
     # Runs the given migration classes.
     # Last argument can specify options:
     #

--- a/activerecord/test/cases/invertible_migration_test.rb
+++ b/activerecord/test/cases/invertible_migration_test.rb
@@ -220,6 +220,12 @@ module ActiveRecord
       end
     end
 
+    class DownOnlyMigration < SilentMigration
+      def change
+        down_only { execute "update horses set oldie = 2" }
+      end
+    end
+
     self.use_transactional_tests = false
 
     setup do
@@ -524,6 +530,23 @@ module ActiveRecord
       UpOnlyMigration.new.migrate(:down) # should be no error
       connection = ActiveRecord::Base.lease_connection
       assert_not connection.column_exists?(:horses, :oldie)
+      Horse.reset_column_information
+    end
+
+    def test_down_only
+      InvertibleMigration.new.migrate(:up)
+      horse1 = Horse.create
+      # populates existing horses with oldie = 1 but new ones have default 0
+      UpOnlyMigration.new.migrate(:up)
+      # sets oldie = 2 for existing records
+      DownOnlyMigration.new.migrate(:down)
+      Horse.reset_column_information
+      horse1.reload
+      horse2 = Horse.create
+
+      assert_equal 2, horse1.oldie # created before reverting
+      assert_equal 0, horse2.oldie # created after migration
+
       Horse.reset_column_information
     end
   end


### PR DESCRIPTION
## Motivation / Background

The `up_only (block)` helper allows running operations when migrating up, but sometimes a block needs to run when reverting instead. It is possible to wrap the block in `if reverting? […] end` but this is slightly less readable. Also, since there are `up` and `down` methods, and an `up_only` helper, one would expect a `down_only` helper to match.

See issue #48245 