### PR TITLE
Add migrating? helper for migrations

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add `migrating?` migration helper, for one-liners that need to run only when going up
+
+    *Goulven Champenois*
+
 *   Allow `ActiveRecord::Base#pluck` to accept hash arguments with symbol and string values.
 
     ```ruby

--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -870,6 +870,10 @@ module ActiveRecord
       connection.respond_to?(:reverting) && connection.reverting
     end
 
+    def migrating?
+      !reverting?
+    end
+
     ReversibleBlockHelper = Struct.new(:reverting) do # :nodoc:
       def up
         yield unless reverting
@@ -926,7 +930,7 @@ module ActiveRecord
     #      end
     #    end
     def up_only(&block)
-      execute_block(&block) unless reverting?
+      execute_block(&block) if migrating?
     end
 
     # Runs the given migration classes.


### PR DESCRIPTION
## Motivation / Background

The `reverting?` predicate method allows running operations when reverting, but sometimes we need to run code only when migrating. It is possible to wrap the code in an `up_only […] end` block but this is slightly less readable, especially for one-liners. This helper adds the `migrating?` method to avoid using the `unless reverting?` double negation.

See issue #48245

Note: I didn't add tests because I couldn't find tests specific to `reverting?`, feel free to add them or ask me to.