### PR TITLE
Use a fixed worker pool size for Action Cable server

### DIFF
--- a/actioncable/lib/action_cable/server/base.rb
+++ b/actioncable/lib/action_cable/server/base.rb
@@ -75,7 +75,7 @@ module ActionCable
       # The worker pool is where we run connection callbacks and channel actions. We
       # do as little as possible on the server's main thread. The worker pool is an
       # executor service that's backed by a pool of threads working from a task queue.
-      # The thread pool size maxes out at 4 worker threads by default. Tune the size
+      # The thread pool has a fixed size of 4 worker threads by default. Tune the size
       # yourself with `config.action_cable.worker_pool_size`.
       #
       # Using Active Record, Redis, etc within your channel actions means you'll get a
@@ -89,7 +89,7 @@ module ActionCable
       # connections. Use a smaller worker pool or a larger database connection pool
       # instead.
       def worker_pool
-        @worker_pool || @mutex.synchronize { @worker_pool ||= ActionCable::Server::Worker.new(max_size: config.worker_pool_size) }
+        @worker_pool || @mutex.synchronize { @worker_pool ||= ActionCable::Server::Worker.new(size: config.worker_pool_size) }
       end
 
       # Adapter used for all streams/broadcasting.

--- a/actioncable/lib/action_cable/server/worker.rb
+++ b/actioncable/lib/action_cable/server/worker.rb
@@ -18,11 +18,10 @@ module ActionCable
 
       attr_reader :executor
 
-      def initialize(max_size: 5)
-        @executor = Concurrent::ThreadPoolExecutor.new(
+      def initialize(size: 5)
+        @executor = Concurrent::FixedThreadPool.new(
+          size,
           name: "ActionCable",
-          min_threads: 1,
-          max_threads: max_size,
           max_queue: 0,
         )
       end

--- a/actioncable/test/stubs/test_server.rb
+++ b/actioncable/test/stubs/test_server.rb
@@ -37,6 +37,6 @@ class TestServer
   end
 
   def worker_pool
-    @worker_pool ||= ActionCable::Server::Worker.new(max_size: 5)
+    @worker_pool ||= ActionCable::Server::Worker.new(size: 5)
   end
 end


### PR DESCRIPTION
Uses `concurrent-ruby`'s `FixedThreadPool` with a default size of 4 (configurable) instead of its parent `ThreadPoolExecutor` with a min and max size of 1 and 4 (configurable) for the Action Cable server's worker pool.

Refs:
- https://github.com/ruby-concurrency/concurrent-ruby/blob/b16af1e977c20e47bbab287ae92f2d397c7694b0/lib/concurrent-ruby/concurrent/executor/ruby_thread_pool_executor.rb
- https://github.com/ruby-concurrency/concurrent-ruby/blob/b16af1e977c20e47bbab287ae92f2d397c7694b0/lib/concurrent-ruby/concurrent/executor/thread_pool_executor.rb
- https://github.com/ruby-concurrency/concurrent-ruby/blob/b16af1e977c20e47bbab287ae92f2d397c7694b0/lib/concurrent-ruby/concurrent/executor/fixed_thread_pool.rb

Why:
1. `concurrent-ruby`'s thread pool scaling behaviour (compared to puma's for example) seems to be a bit unpredictable due to the lack of a master / control event loop or trimmer thread. Scaling down / pruning the pool doesn't happen as soon as (or as soon as the idle time per-thread has elapsed after) there's less / no work, but only when the next bit of work comes in and there's an excess number of threads.

   Consider this basic simulated example where the server is idling on start, and receives work with varying gaps:
   ```ruby
   begin
     require "concurrent-ruby"
     
     pool = Concurrent::ThreadPoolExecutor.new(
       min_threads: 1,
       max_threads: 4,
       max_queue: 0,
       idletime: 3
     )
     # First thread is lazily spawned.
     puts pool.length #=> 0
     
     work = -> { sleep 2 }
     
     # Batch (gap-less individual units) of work.
     10.times { pool << work }
     # Wait for state updates.
     sleep 0.25
     # Expected scale up.
     puts pool.length #=> 4
     # Wait for all work to be processed.
     # This is sufficient cause work is I/O bound and parallel.
     sleep 10
     puts pool.length #=> 4
     # Wait until idle time of all threads has elapsed.
     # This is sufficient; only needs to be greater than the idle time of the last busy thread.
     sleep 5
     # Not scaled down.
     # Prune will only take place when next unit of work is received, despite idle time elapse.
     puts pool.length #=> 4

     # Wait for a while to show no change.
     sleep 20
     puts pool.length #=> 4
     
     # Another batch of work.
     10.times { pool << work }
     # Wait for state updates.
     sleep 0.25
     # This case is the most interesting, and might need to be addressed in concurrent-ruby.
     # If bulk work comes in when scaled up, since prune is called right after assignment / queuing, 
     # there's a race condition between when the ready workers size is checked for prune, and the
     # threads start processing the work, which is when the ready size is updated. As a result, we end
     # up with a single thread handling all the work i.e. the pool is prematurely scaled down, and stays
     # that way since all units of work have been assigned / queued.
     puts "pool should ideally be scaled up here"
     puts pool.length #=> 1
     # Wait for all work to be processed.
     # Work is now sequential.
     sleep 25
     puts pool.length #=> 1
     # Wait until idle time of all threads has elapsed.
     sleep 5
     puts pool.length #=> 1

     # Wait for a while to show no change.
     sleep 20
     puts pool.length #=> 1
     
     # Individual units of work, spaced apart.
     # No work will be completed by the time the last unit is added.
     1.times { pool << work }
     sleep 0.25
     1.times { pool << work }
     sleep 0.25
     1.times { pool << work }
     sleep 0.25
     1.times { pool << work }
     # Wait for state updates.
     sleep 0.25
     # Expected scale up.
     puts pool.length #=> 4
     # Wait for all work to be processed.
     sleep 10
     puts pool.length #=> 4
     # Wait until idle time of all threads has elapsed.
     sleep 5
     # Once again, won't scale down till the next unit.
     puts pool.length #=> 4

     # Wait for a while to show no change.
     sleep 20
     puts pool.length #=> 4
     
     # Single unit of work.
     1.times { pool << work }
     # Wait for state updates.
     sleep 0.25 
     # Expected scale down.
     puts pool.length #=> 1
     # Wait for all work to be processed.
     sleep 10
     puts pool.length #=> 1
     # Wait until idle time of all threads has elapsed.
     sleep 5
     puts pool.length #=> 1
   end
   ```

   We can see that most of the time the pool is actually idling at its max despite there being no work after a number of units equal to or exceeding its max size comes in, either in 'batches' or with gaps small enough such that a scale up / maintaining the current size is required.

   In other words, it'll always idle at the size it last scaled up / down to, until the next unit of work comes in. I think it therefore makes more sense to simply keep the pool at a sensible fixed size which users can tune to match their workload, considering it already mostly behaves that way, and that scaling for mixed workloads is quite unpredictable.

2. Auto-scaling / reaping and spawning threads has an (imo) unnecessary overhead with not much benefit. A fixed pool size also means more consistent and measurable resource usage and throughput capacity.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.