### PR TITLE
Fix test leak due to using class instance variables and inheritance

### DIFF
--- a/railties/test/configuration/dynamic_options_test.rb
+++ b/railties/test/configuration/dynamic_options_test.rb
@@ -7,15 +7,9 @@ require "rails/railtie/configuration"
 
 module RailtiesTest
   class DynamicOptionsTest < ActiveSupport::TestCase
-    class Configuration < Rails::Railtie::Configuration
-      def reset_options
-        @@options = {}
-      end
-    end
-
     setup do
-      @config = Configuration.new
-      @config.reset_options
+      @config = Rails::Railtie::Configuration.dup.new
+      @config.class.class_variable_set(:@@options, {})
     end
 
     test "arbitrary keys can be set, reset, and read" do


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This PR fixes a test leak caused by `dynamic_options_test.rb` when running tests locally with `bin/test`.

### Detail

Here's a simple script to illustrate the problem:

```rb
class Foo
  def initialize
    @@options ||= "@@options initialized in Foo"
  end

  def get_options = @@options
end

class Bar < Foo
  def reset_options
    @@options = "@@options reset in Bar"
  end
end

puts Foo.new.get_options
# "@@options initialized in Foo"

Bar.new.reset_options

puts Foo.new.get_options
# "@@options reset in Bar"
```

Here, the `Configuration` test class defined in `dynamic_options_test.rb` by inheritance from `Rails::Railtie::Configuration` ends up overriding the latter's `@@options` class instance variable.

I'm not sure I understand the general use of `@@` class instance variables in `Rails::Railtie::Configuration` (I problably wouldn't use them), but this fix allows me to remove the leak without changing the implementation.

To reproduce the failure and confirm the fix, run this test:

```sh-session
$ bin/test test/rails_health_controller_test.rb test/configuration/dynamic_options_test.rb --seed 15527
```

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
