### PR TITLE
Avoid PTY buffer deadlock in `rails server` command tests

### DIFF
--- a/railties/test/engine/commands_test.rb
+++ b/railties/test/engine/commands_test.rb
@@ -36,8 +36,7 @@ class Rails::Engine::CommandsTest < ActiveSupport::TestCase
   if available_pty?
     def test_console_command_work_inside_engine
       primary, replica = PTY.open
-      cmd = "console"
-      spawn_command(cmd, replica, env: { "TERM" => "dumb" })
+      spawn_command("console", replica, env: { "TERM" => "dumb" })
       assert_output(">", primary)
     ensure
       primary.puts "quit"
@@ -50,33 +49,42 @@ class Rails::Engine::CommandsTest < ActiveSupport::TestCase
     ensure
       primary.puts ".exit"
     end
+  end
 
-    def test_server_command_work_inside_engine
-      primary, replica = PTY.open
-      pid = spawn_command("server", replica)
-      assert_output("Listening on", primary)
-    ensure
-      kill(pid)
+  def test_server_command_work_inside_engine
+    io_read, io_write = IO.pipe
+    pid = spawn_command("server", io_write)
+    assert_output("Listening on", io_read)
+  ensure
+    io_read.close
+    io_write.close
+    kill(pid) if pid
+  end
+
+  def test_server_command_broadcast_logs
+    io_read, io_write = IO.pipe
+    pid = spawn_command("server", io_write, env: { "RAILS_ENV" => "development" })
+
+    assert_output("Listening on", io_read)
+
+    request_thread = Thread.new do
+      Net::HTTP.get("127.0.0.1", "/", 3000)
     end
 
-    def test_server_command_broadcast_logs
-      primary, replica = PTY.open
-      pid = spawn_command("server", replica, env: { "RAILS_ENV" => "development" })
-      assert_output("Listening on", primary)
+    assert_output("Processing by Rails::WelcomeController", io_read)
 
-      Net::HTTP.new("127.0.0.1", 3000).tap do |net|
-        net.get("/")
-      end
+    # Wait for the request thread to complete and reraise any errors.
+    request_thread.value
 
-      in_plugin_context(plugin_path) do
-        logs = File.read("test/dummy/log/development.log")
-        assert_match("Processing by Rails::WelcomeController", logs)
-      end
-
-      assert_output("Processing by Rails::WelcomeController", primary)
-    ensure
-      kill(pid)
+    in_plugin_context(plugin_path) do
+      logs = File.read("test/dummy/log/development.log")
+      assert_match("Processing by Rails::WelcomeController", logs)
     end
+  ensure
+    request_thread.kill if request_thread
+    io_read.close
+    io_write.close
+    kill(pid) if pid
   end
 
   private


### PR DESCRIPTION
### Motivation / Background

`railties/test/engine/commands_test.rb:62` can hang on macOS when the test starts `rails server`, waits for it to listen, then performs an HTTP request.

The server writes enough output while handling the request to fill the PTY buffer on macOS. Since the test is blocked waiting for the HTTP request to complete, it stops consuming server output, which can prevent the server from completing the response.

This is easier to reproduce on macOS because its pseudo-terminal buffer is 1 KiB, while common Linux systems provide much larger buffers.

This PR avoids the deadlock by:

- using `IO.pipe` instead PTY to spawn the `rails server` command. (Note that `IO.pipe` comes with its own limitations too: it also has a buffer size limit, though a higher one.)
- running the HTTP request in a thread, so the test can keep consuming server output while the request is in flight

I confirmed the focused test hangs on `main` locally and passes on this branch:

```sh
cd railties
bin/test test/engine/commands_test.rb:62
```

### Checklist

- [x] This Pull Request is related to one change.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated.
- [x] CHANGELOG files are updated if necessary.

<details><summary>Original wordy PR description, for the record</summary>

Alright, I'm not going to pretend that I understand exactly what's happening, but the fact is that this seems to fix something, so I'll try to explain what I understand.

 ## The problem

Running the following test hangs forever:

```sh-session
$ bin/test test/engine/commands_test.rb:62
Run options: -v --seed 4349

# Running:

Rails::Engine::CommandsTest#test_server_command_broadcast_logs = 💥 Hangs here
```

Somehow I seem to have reproduced it with the command that would run on
CI:

```sh-session
$ TEST_DIR=engine TESTOPTS="-v -n test_server_command_broadcast_logs"  bundle exec rake test

--- test/engine/commands_test.rb
/Users/sto/.rubies/ruby-3.3.5/bin/ruby -w -Itest -Ilib -I../activesupport/lib -I../actionpack/lib -I../actionview/lib -I../activemodel/lib test/engine/commands_test.rb
Run options: -v -n test_server_command_broadcast_logs --seed 59220

# Running:

Rails::Engine::CommandsTest#test_server_command_broadcast_logs = 💥 Hangs here
```

I'm gonna venture a guess and assume that maybe this test (and 3 others) do not run in CI because of this condition:

https://github.com/rails/rails/blob/aacbb5c0f5bdd11f0dee78da03bd6859f0cabeba/railties/test/engine/commands_test.rb#L36

https://github.com/rails/rails/blob/aacbb5c0f5bdd11f0dee78da03bd6859f0cabeba/railties/test/console_helpers.rb#L23-L25

Is there a way we can check if these tests ever ran on CI?

 ## What seems to be happening

I do not understand much of how `PTY` works, but what I have identified is that:

1. The test hangs at `net.get("/")`. Using a bit of debugging, I confirmed that I was not able to `curl http://localhost:3000` after spawning `rails server`.
2. It appears the process is entering a lock where:
   - it will not continue processing and complete the request until `rails server`'s output has been "consumed" (`read`, `readlines`) out of the `IO` object returned by `PTY.new`.
   - we won't be reading more output out of `primary` since `net.get("/")` is blocked

 ## The workaround

I have no idea whether this is an acceptable fix, but parallelizing, and allowing our test thread to try and read (blocking) the PTY's output, while a different thread makes the HTTP request (blocking too), seems to be fixing the problem.

You can try running any of the two commands I shared above and confirm the test will succeed now.

 ## Questions

- Is there a way we can check if these tests ever ran on CI?
- Is my fix an acceptable approach?
- Has this test ever worked in the past? (Locally/On CI)
- Has anything changed (maybe in Puma), making Puma's output blocking, and preventing it to continue processing a request until all its output has been consumed?

<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created because [REPLACE ME]

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.

</details> 
