### PR TITLE
Set Current.session if signed-in in unauthenticated access

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   The `allow_unauthenticated_access` before action in the authentication generator will attempt to populate `Current.session`
+
+    *Tony Drake*
+
 *   Add command `rails credentials:fetch PATH` to get the value of a credential from the credentials file.
 
     ```bash

--- a/railties/lib/rails/generators/rails/authentication/templates/app/controllers/concerns/authentication.rb.tt
+++ b/railties/lib/rails/generators/rails/authentication/templates/app/controllers/concerns/authentication.rb.tt
@@ -9,6 +9,7 @@ module Authentication
   class_methods do
     def allow_unauthenticated_access(**options)
       skip_before_action :require_authentication, **options
+      before_action :resume_session
     end
   end
 


### PR DESCRIPTION
### Motivation / Background

This is related to the authentication generator.

Currently, if you call `allow_unauthenticated_access` in a controller, `Current.session` won't be set. This can result in rendered views making the user appear to be signed out if they are already signed in.

### Detail

This updates `allow_unauthenticated_access` to set a `before_action` of `resume_session` to allow the user to still be signed in for requests that do not require authentication.

### Additional information

~~Also included in this PR are two quick fixup commits:~~

- ~~Skip querying the `Session` model needlessly if the cookie isn't set.~~
- ~~`SessionsController#destroy` should redirect with `see_other` to match existing scaffolding controller destroy actions.~~

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.

