### PR TITLE
`select` with hash allows aliases on expressions

### DIFF
--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -2234,9 +2234,7 @@ module ActiveRecord
               arel_column_with_table(table_name, column.to_s)
             end
           when String, Symbol
-            arel_column(key) do
-              predicate_builder.resolve_arel_attribute(model.table_name, key)
-            end.as(columns_aliases.to_s)
+            arel_column(key).as(columns_aliases.to_s)
           end
         end
       end

--- a/activerecord/test/support/adapter_helper.rb
+++ b/activerecord/test/support/adapter_helper.rb
@@ -9,8 +9,11 @@ module AdapterHelper
   end
 
   def in_memory_db?
-    current_adapter?(:SQLite3Adapter) &&
-    ActiveRecord::Base.connection_pool.db_config.database == ":memory:"
+    current_adapter?(:SQLite3Adapter) && ActiveRecord::Base.connection_pool.db_config.database == ":memory:"
+  end
+
+  def sqlite3_adapter_strict_strings_disabled?
+    current_adapter?(:SQLite3Adapter) && !ActiveRecord::Base.connection_pool.db_config.configuration_hash[:strict]
   end
 
   def mysql_enforcing_gtid_consistency?


### PR DESCRIPTION
This reverts #53095, to match `select`'s hash quotes to the original `select`'s quotes.

This allows `Post.select("UPPER(title) AS title")` to be written as `Post.select("UPPER(title)" => :title)`.