### PR TITLE
Fixed assertion count in assert_playback method.

### DIFF
--- a/railties/test/configuration/middleware_stack_proxy_test.rb
+++ b/railties/test/configuration/middleware_stack_proxy_test.rb
@@ -68,10 +68,10 @@ module Rails
 
       private
         def assert_playback(msg_names, args)
-          self.assertions += 1
           mock = Minitest::Mock.new
           Array(msg_names).each do |msg_name|
             mock.expect msg_name, nil, [args]
+            self.assertions += 1
           end
           @stack.merge_into(mock)
           mock.verify


### PR DESCRIPTION
### Motivation / Background

Follow-up to #53213 
This PR fixes the assertions count in `assert_playback` method.
- Previously, calling `assert_playback([:swap, :delete], :foo)` in `test_order` would increment the assertions count by only 1, even though 2 assertions `(one for :swap, one for :delete)` were made.
- Even if the `.expect` statement failed inside `assert_playback`, the count would still be incremented. 
### Detail

This Pull Request changes:


- Calling `self.assertions += 1` inside the loop, after `.expect` so that for each `expect` the value is incremented.
- And the assertion count is incremented only if `mock.expect` succeeds.

### Updated test result: 
<img width="783" alt="image" src="https://github.com/user-attachments/assets/2e5afc06-1256-4432-8779-99632814c5fc">

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
