### PR TITLE
Fix issue-53229: Ambiguous column name id when count all

### DIFF
--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -2229,14 +2229,16 @@ module ActiveRecord
           case columns_aliases
           when Hash
             columns_aliases.map do |column, column_alias|
-              arel_column_with_table(table_name, column.to_s).as(column_alias.to_s)
+              arel_column_with_table(table_name, column.to_s)
+                .as(model.adapter_class.quote_column_name(column_alias.to_s))
             end
           when Array
             columns_aliases.map do |column|
               arel_column_with_table(table_name, column.to_s)
             end
           when String, Symbol
-            arel_column(key).as(columns_aliases.to_s)
+            arel_column(key)
+              .as(model.adapter_class.quote_column_name(columns_aliases.to_s))
           end
         end
       end

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -1999,7 +1999,9 @@ module ActiveRecord
       def table_name_matches?(from)
         table_name = Regexp.escape(table.name)
         quoted_table_name = Regexp.escape(model.adapter_class.quote_table_name(table.name))
-        /(?:\A|(?<!FROM)\s)(?:\b#{table_name}\b|#{quoted_table_name})(?!\.)/i.match?(from.to_s)
+        reg = /(?:\A|(?<!FROM)\s)(?:\b#{table_name}\b|#{quoted_table_name})(?!\.)/i
+        return reg.match?(from.name) if from.is_a?(Arel::Nodes::TableAlias)
+        reg.match?(from.to_s)
       end
 
       def reverse_sql_order(order_query)

--- a/activerecord/test/cases/calculations_test.rb
+++ b/activerecord/test/cases/calculations_test.rb
@@ -1639,8 +1639,8 @@ class CalculationsTest < ActiveRecord::TestCase
   end
 
   def test_count_all_with_table_alias
-    count_alias = Post.from(Post.arel_table.alias(Post.arel_table.name)).includes(:comments).merge(Comment.where(id:2)).references(:comments).count(:all)
-    count = Post.includes(:comments).merge(Comment.where(id:2)).references(:comments).count(:all)
+    count_alias = Post.from(Post.arel_table.alias(Post.arel_table.name)).includes(:comments).merge(Comment.where(id: 2)).references(:comments).count(:all)
+    count = Post.includes(:comments).merge(Comment.where(id: 2)).references(:comments).count(:all)
     assert_equal count, count_alias
   end
 

--- a/activerecord/test/cases/calculations_test.rb
+++ b/activerecord/test/cases/calculations_test.rb
@@ -1638,6 +1638,12 @@ class CalculationsTest < ActiveRecord::TestCase
     end
   end
 
+  def test_count_all_with_table_alias
+    count_alias = Post.from(Post.arel_table.alias(Post.arel_table.name)).includes(:comments).merge(Comment.where(id:2)).references(:comments).count(:all)
+    count = Post.includes(:comments).merge(Comment.where(id:2)).references(:comments).count(:all)
+    assert_equal count, count_alias
+  end
+
   test "#skip_query_cache! for #pluck" do
     Account.cache do
       assert_queries_count(1) do


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->
Fixes #53229 
This Pull Request has been created because of fixing the issue 53229.

### Detail

This Pull Request changes the method `table_name_matches?` to check matching table in ActiveReocrd::QueryMethods module. If from clause matches with main table name, it will use the corresponding field of the table as the projections of the arel. When the query is built, it will have the select statement look like "table_name"."field_name".

In the example of the issue #53229, the select statement should have been "users"."id". However, table_name_matches? = false, so the select statement is "id". As the result, ambiguous column name error happens.

To fix this issue, table_name_matches? should handle case that from clause is TableAlias

Currently, it uses from.to_s to compare to the regex. Therefore, when from is a table alias (Arel::Nodes:TableAlias), it will work incorrectly. It should have used from.name in case type of from is TableAlias.

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
