### PR TITLE
Fix incorrect behavior of version widget on guides homepage

### DIFF
--- a/guides/source/layout.html.erb
+++ b/guides/source/layout.html.erb
@@ -58,8 +58,9 @@
             Version:
             <select class="guides-version">
               <option value="https://edgeguides.rubyonrails.org/"<%= " selected" if @edge %>>Edge</option>
-              <% %w[7.2 7.1 7.0 6.1 6.0 5.2 5.1 5.0 4.2 4.1 4.0 3.2 3.1 3.0 2.3].each do |version| %>
-                <option value="https://guides.rubyonrails.org/v<%= version %>/"<%= " selected" if @version&.start_with?(version) %>><%= version %></option>
+              <% %w[7.2 7.1 7.0 6.1 6.0 5.2 5.1 5.0 4.2 4.1 4.0 3.2 3.1 3.0 2.3].each_with_index do |version, i| %>
+                <% selected_version = @version&.start_with?(version) || (i.zero? && @version.nil?) %>
+                <option value="https://guides.rubyonrails.org/v<%= version %>/"<%= " selected" if selected_version %>><%= version %></option>
               <% end %>
             </select>
           </span>


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

Currently, if you open the [home page of the Rails guides](https://guides.rubyonrails.org/) without specifying a version, the `version` widget at the top will incorrectly output the value of `edge`. This is wrong since we will land on the latest stable-release version guides, not on the edge guides. 

![Screenshot 2024-10-08 at 17 04 11](https://github.com/user-attachments/assets/d24d8958-295d-4307-97bb-32da66aa5d49)


### Detail

This Pull Request changes the aforementioned wrong behaviour, so that when https://guides.rubyonrails.org/ is accessed without specifying a version, the latest stable-release version is shown.

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
