### PR TITLE
Don't parse response content type if value comes from Mime

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,2 +1,13 @@
+*   Allow setting content type with a symbol of the Mime type.
+
+    ```ruby
+    # Before
+    response.content_type = "text/html"
+
+    # After
+    response.content_type = :html
+    ```
+
+    *Petrik de Heus*
 
 Please check [8-0-stable](https://github.com/rails/rails/blob/8-0-stable/actionpack/CHANGELOG.md) for previous changes.

--- a/actionpack/lib/action_controller/metal/data_streaming.rb
+++ b/actionpack/lib/action_controller/metal/data_streaming.rb
@@ -132,9 +132,7 @@ module ActionController # :nodoc:
         raise ArgumentError, ":type option required" if content_type.nil?
 
         if content_type.is_a?(Symbol)
-          extension = Mime[content_type]
-          raise ArgumentError, "Unknown MIME type #{options[:type]}" unless extension
-          self.content_type = extension
+          self.content_type = content_type
         else
           if !type_provided && options[:filename]
             # If type wasn't provided, try guessing from file extension.

--- a/actionpack/lib/action_controller/metal/head.rb
+++ b/actionpack/lib/action_controller/metal/head.rb
@@ -41,7 +41,7 @@ module ActionController
 
       if include_content?(response_code)
         unless self.media_type
-          self.content_type = content_type || ((f = formats) && Mime[f.first]) || Mime[:html]
+          self.content_type = content_type || ((f = formats) && Mime[f.first]) || :html
         end
 
         response.charset = false

--- a/actionpack/lib/action_controller/metal/renderers.rb
+++ b/actionpack/lib/action_controller/metal/renderers.rb
@@ -157,23 +157,23 @@ module ActionController
 
       if options[:callback].present?
         if media_type.nil? || media_type == Mime[:json]
-          self.content_type = Mime[:js]
+          self.content_type = :js
         end
 
         "/**/#{options[:callback]}(#{json})"
       else
-        self.content_type = Mime[:json] if media_type.nil?
+        self.content_type = :json if media_type.nil?
         json
       end
     end
 
     add :js do |js, options|
-      self.content_type = Mime[:js] if media_type.nil?
+      self.content_type = :js if media_type.nil?
       js.respond_to?(:to_js) ? js.to_js(options) : js
     end
 
     add :xml do |xml, options|
-      self.content_type = Mime[:xml] if media_type.nil?
+      self.content_type = :xml if media_type.nil?
       xml.respond_to?(:to_xml) ? xml.to_xml(options) : xml
     end
   end

--- a/actionpack/lib/action_controller/metal/rendering.rb
+++ b/actionpack/lib/action_controller/metal/rendering.rb
@@ -208,7 +208,7 @@ module ActionController
       end
 
       def _set_html_content_type
-        self.content_type = Mime[:html].to_s
+        self.content_type = :html
       end
 
       def _set_rendered_content_type(format)

--- a/actionpack/lib/action_dispatch/http/response.rb
+++ b/actionpack/lib/action_dispatch/http/response.rb
@@ -263,14 +263,27 @@ module ActionDispatch # :nodoc:
     # Sets the HTTP response's content MIME type. For example, in the controller you
     # could write this:
     #
-    #     response.content_type = "text/plain"
+    #     response.content_type = "text/html"
+    #
+    # This method also accepts a symbol with the extension of the MIME type:
+    #
+    #     response.content_type = :html
     #
     # If a character set has been defined for this response (see #charset=) then the
     # character set information will also be included in the content type
     # information.
     def content_type=(content_type)
-      return unless content_type
-      new_header_info = parse_content_type(content_type.to_s)
+      case content_type
+      when NilClass
+        return
+      when Symbol
+        mime_type = Mime[content_type]
+        raise ArgumentError, "Unknown MIME type #{content_type}" unless mime_type
+        new_header_info = ContentTypeHeader.new(mime_type.to_s)
+      else
+        new_header_info = parse_content_type(content_type.to_s)
+      end
+
       prev_header_info = parsed_content_type_header
       charset = new_header_info.charset || prev_header_info.charset
       charset ||= self.class.default_charset unless prev_header_info.mime_type

--- a/actionpack/test/controller/content_type_test.rb
+++ b/actionpack/test/controller/content_type_test.rb
@@ -55,6 +55,11 @@ class OldContentTypeController < ActionController::Base
     response.content_type = "text/html; fragment; charset=utf-16"
     render body: "hello world!"
   end
+
+  def render_content_type_with_symbol
+    response.content_type = :rss
+    render body: "hello world!"
+  end
 end
 
 class ContentTypeTest < ActionController::TestCase
@@ -140,6 +145,12 @@ class ContentTypeTest < ActionController::TestCase
     get :render_content_type_with_charset
     assert_equal "text/html; fragment", @response.media_type
     assert_equal "utf-16", @response.charset
+  end
+
+  def test_content_type_with_symbol
+    get :render_content_type_with_symbol
+    assert_equal Mime[:rss], @response.media_type
+    assert_equal "utf-8", @response.charset
   end
 
   private


### PR DESCRIPTION
### Motivation / Background

Anytime `ActionDispatch::HTTP::Reponse#content_type=` is called, the `content_type` argument is [parsed](https://github.com/rails/rails/blob/aea18ea9986cb052d3e15fe9bbff5d4d5b410e83/actionpack/lib/action_dispatch/http/response.rb#L261) using the [CONTENT_TYPE_PARSER](https://github.com/rails/rails/blob/ef679c41e7b6fa04f47652b4099a10066eb0487b/actionpack/lib/action_dispatch/http/response.rb#L437-L441) regexp. If the `content_type` argument comes from `Mime`, there is no need to parse it using the regexp as we already know the result.

### Benchmark

```ruby
require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"

  gem "rails"
  gem "benchmark-ips"
end

require "action_controller/railtie"
require 'benchmark/ips'

Benchmark.ips do |x|
  x.config(:time => 5, :warmup => 2)

  response = ActionDispatch::Response.new
  x.report("main") do
    response.content_type = Mime[:html].to_s
  end

  class BranchResponse < ActionDispatch::Response
    def content_type=(content_type)
      case content_type
      when NilClass
        return
      when Symbol
        new_header_info = ContentTypeHeader.new(Mime[content_type])
      else
        new_header_info = parse_content_type(content_type.to_s)
      end

      prev_header_info = parsed_content_type_header
      charset = new_header_info.charset || prev_header_info.charset
      charset ||= self.class.default_charset unless prev_header_info.mime_type
      set_content_type new_header_info.mime_type, charset
    end
  end

  response = BranchResponse.new
  x.report("branch") do
    response.content_type = :html
  end

  x.compare!
end
```

```
Warming up --------------------------------------
                main    38.666k i/100ms
              branch    52.235k i/100ms
Calculating -------------------------------------
                main    393.529k (± 3.3%) i/s    (2.54 μs/i) -      1.972M in   5.016529s
              branch    494.789k (± 2.2%) i/s    (2.02 μs/i) -      2.507M in   5.069774s

Comparison:
              branch:   494788.6 i/s
                main:   393529.2 i/s - 1.26x  slower
```

This improves the plain json call in the TechEmpower benchmark (and will probably improve other calls as well):

### Before

<img width="1423" alt="image" src="https://github.com/user-attachments/assets/95997268-388e-4fc4-a245-6b8e3ff387e7">

### After

<img width="1462" alt="image" src="https://github.com/user-attachments/assets/db6fa441-f8f2-4d74-adb5-4e75b044aa12">

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.