### PR TITLE
Update doc for `quoted_table_name` and `quoted_primary_key` [ci-skip]

### DIFF
--- a/activerecord/lib/active_record/attribute_methods/primary_key.rb
+++ b/activerecord/lib/active_record/attribute_methods/primary_key.rb
@@ -87,8 +87,7 @@ module ActiveRecord
             @composite_primary_key
           end
 
-          # Returns a quoted version of the primary key name, used to construct
-          # SQL statements.
+          # Returns a quoted version of the primary key name.
           def quoted_primary_key
             adapter_class.quote_column_name(primary_key)
           end

--- a/activerecord/lib/active_record/model_schema.rb
+++ b/activerecord/lib/active_record/model_schema.rb
@@ -281,7 +281,7 @@ module ActiveRecord
         @predicate_builder = nil
       end
 
-      # Returns a quoted version of the table name, used to construct SQL statements.
+      # Returns a quoted version of the table name.
       def quoted_table_name
         adapter_class.quote_table_name(table_name)
       end


### PR DESCRIPTION
`quoted_table_name` and `quoted_primary_key` were used in earlier codebase, but since the SQL construction has been replaced by Arel they are rarely used (only in `InsertAll`) in the current codebase.
