### PR TITLE
Fix `ActiveRecord::ModelSchema.sequence_name` to work for tables with composite primary keys

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -299,6 +299,8 @@ module ActiveRecord
 
         # Returns the sequence name for a table's primary key or some other specified key.
         def default_sequence_name(table_name, pk = "id") # :nodoc:
+          return nil if pk.is_a?(Array)
+
           result = serial_sequence(table_name, pk)
           return nil unless result
           Utils.extract_schema_qualified_name(result).to_s

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -1343,6 +1343,10 @@ class BasicsTest < ActiveRecord::TestCase
     assert_equal k.reset_sequence_name, orig_name
   end
 
+  def test_sequence_name_for_cpk_model
+    assert_nil Cpk::Book.sequence_name
+  end
+
   def test_count_with_join
     res = Post.count_by_sql "SELECT COUNT(*) FROM posts LEFT JOIN comments ON posts.id=comments.post_id WHERE posts.#{QUOTED_TYPE} = 'Post'"
     res2 = Post.where("posts.#{QUOTED_TYPE} = 'Post'").joins("LEFT JOIN comments ON posts.id=comments.post_id").count


### PR DESCRIPTION
Fixes #53048.

Postgres cannot have sequences over multiple columns, so when we have a table with composite primary keys, just return nil.