### PR TITLE
Fix Zeitwerk error when Pathname added to paths [ci-skip]

### DIFF
--- a/guides/source/active_job_basics.md
+++ b/guides/source/active_job_basics.md
@@ -636,7 +636,7 @@ to set-up serializers to be loaded only once, e.g. by amending `config/applicati
 # config/application.rb
 module YourApp
   class Application < Rails::Application
-    config.autoload_once_paths << Rails.root.join('app', 'serializers')
+    config.autoload_once_paths << "#{root}/app/serializers"
   end
 end
 ```


### PR DESCRIPTION
The previous example added a Pathname to `autoload_once_paths`, which raises an error on boot:

```
loader wants to manage directory /home/hartley/test/eight/app/serializers, which is already managed by loader
```

so the example is updated to match the one in Autoloading and Reloading Constants.

cc @fxn is this error expected if a `Pathname` is used?
