### PR TITLE
Fix `db:migrate:reset` task

### DIFF
--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -176,7 +176,7 @@ db_namespace = namespace :db do
     end
 
     # desc 'Resets your database using your migrations for the current environment'
-    task reset: ["db:drop", "db:create", "db:migrate"]
+    task reset: ["db:drop", "db:create", "db:schema:dump", "db:migrate"]
 
     desc 'Run the "up" for a given migration VERSION.'
     task up: :load_config do

--- a/railties/test/application/rake/dbs_test.rb
+++ b/railties/test/application/rake/dbs_test.rb
@@ -363,6 +363,24 @@ module ApplicationTests
         assert_equal "[\"ar_internal_metadata\", \"comments\", \"schema_migrations\"]", list_tables[]
       end
 
+      test "db:migrate:reset regenerates the schema from migrations" do
+        app_file "db/migrate/01_a_migration.rb", <<-MIGRATION
+          class AMigration < ActiveRecord::Migration::Current
+             create_table(:comments) {}
+          end
+        MIGRATION
+        rails("db:migrate")
+        app_file "db/migrate/01_a_migration.rb", <<-MIGRATION
+          class AMigration < ActiveRecord::Migration::Current
+             create_table(:comments) { |t| t.string :title }
+          end
+        MIGRATION
+
+        rails("db:migrate:reset")
+
+        assert File.read("#{app_path}/db/schema.rb").include?("title")
+      end
+
       def db_schema_dump
         Dir.chdir(app_path) do
           args = ["generate", "model", "book", "title:string"]


### PR DESCRIPTION
Fixes #53216

`db:migrate:reset` is broken, because we started to load the schema before migrating. This prevents migrations from running. This patch empties the schema before migrating, ensuring that migrations run as expected.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
