### PR TITLE
[7-1-stable] Skip importmap-rails 2.0.2 which won't work for Ruby version '<= 3.0'

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,7 +27,7 @@ gem "stimulus-rails"
 gem "turbo-rails"
 gem "jsbundling-rails"
 gem "cssbundling-rails"
-gem "importmap-rails", ">= 1.2.3"
+gem "importmap-rails", ">= 1.2.3", "!=2.0.2"
 gem "tailwindcss-rails"
 gem "dartsass-rails"
 # require: false so bcrypt is loaded only when has_secure_password is used.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -583,7 +583,7 @@ DEPENDENCIES
   delayed_job_active_record
   google-cloud-storage (~> 1.11)
   image_processing (~> 1.2)
-  importmap-rails (>= 1.2.3)
+  importmap-rails (>= 1.2.3, != 2.0.2)
   jbuilder
   jsbundling-rails
   json (>= 2.0.0, != 2.7.0)


### PR DESCRIPTION
https://buildkite.com/rails/rails/builds/112451#01926ea6-7db9-4435-8be0-9df2c262a6ad/1170-1191
