### PR TITLE
Fix infinite loop in ERBTracker

### DIFF
--- a/actionview/lib/action_view/dependency_tracker/erb_tracker.rb
+++ b/actionview/lib/action_view/dependency_tracker/erb_tracker.rb
@@ -127,7 +127,8 @@ module ActionView
                 wildcard_dependency << scanner.pre_match
 
                 while unmatched_brackets > 0 && !scanner.eos?
-                  scanner.scan_until(/[{}]/)
+                  found = scanner.scan_until(/[{}]/)
+                  return unless found
 
                   case scanner.matched
                   when "{"

--- a/actionview/test/template/dependency_tracker_test.rb
+++ b/actionview/test/template/dependency_tracker_test.rb
@@ -247,6 +247,19 @@ module SharedTrackerTests
 
     assert_equal [ "*/comments" ], tracker.dependencies
   end
+
+  def test_dependencies_with_interpolation_expr
+    view_paths = ActionView::PathSet.new([File.expand_path("../fixtures/digestor", __dir__)])
+
+    template = FakeTemplate.new(%q{
+      <%= render "orders/#{variable || "default"}" %>
+    }, :erb)
+
+    tracker = make_tracker("interpolation/_string", template, view_paths)
+
+    # unsupported
+    assert_equal [], tracker.dependencies
+  end
 end
 
 class ERBTrackerTest < ActiveSupport::TestCase


### PR DESCRIPTION
Fixes #53221

When we nest strings inside ERBTracker our earlier regex only finds a partial match on the string and then it's possible to have a mismatched number of brackets. scan_until does not advance the string when it does not find a match.

Ultimately, we can't parse Ruby via regex, so this is a best effort (and even with the proper parsers this is just a best effort). We do need to make sure to fail safely.
