### PR TITLE
MariaDB supports index sort order

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -98,7 +98,7 @@ module ActiveRecord
       end
 
       def supports_index_sort_order?
-        !mariadb? && database_version >= "8.0.1"
+        mariadb? ? database_version >= "10.8.1" : database_version >= "8.0.1"
       end
 
       def supports_expression_index?


### PR DESCRIPTION
MariaDB supports index sort order since a few years now, so this commit lets ActiveRecord know. 

### Motivation / Background

When creating a descending index within a migration, it gets ignored. This commit fixes the issue.

### Additional information
MariaDB upstream announcement:
https://jira.mariadb.org/browse/MDEV-13756

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature. (I don't think this is necessary.)
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included. (If necessary I will update it.)