### PR TITLE
Fix CTE construction when passed arrays with single items

### DIFF
--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -1921,6 +1921,8 @@ module ActiveRecord
           end
         when Arel::SelectManager then value
         when Array
+          return build_with_expression_from_value(value.first, false) if value.size == 1
+
           parts = value.map do |query|
             build_with_expression_from_value(query, true)
           end

--- a/activerecord/test/cases/relation/with_test.rb
+++ b/activerecord/test/cases/relation/with_test.rb
@@ -74,6 +74,14 @@ module ActiveRecord
         assert_equal (SPECIAL_POSTS + POSTS_WITH_TAGS + POSTS_WITH_COMMENTS).sort, relation.order(:id).pluck(:id)
       end
 
+      def test_with_when_passing_single_item_array
+        relation = Post
+          .with(posts_with_special_type_or_tags_or_comments: [Post.where(type: "SpecialPost")])
+          .from("posts_with_special_type_or_tags_or_comments AS posts")
+
+        assert_equal SPECIAL_POSTS.sort, relation.order(:id).pluck(:id)
+      end
+
       def test_with_recursive
         top_companies = Company.where(firm_id: nil).to_a
         child_companies = Company.where(firm_id: top_companies).to_a


### PR DESCRIPTION
Fixes #53242.
Follow up to #53121.

When having multiple expressions for `union` and generating sql, `union` adds the outer parens and each expression is generated without the parens. But when we have a single expression, we need to wrap it by parens.

Reminder: we fixed a strange 🤦 behaviour for sqlite in the linked PR, where for sqlite `(foo) UNION (bar)` is an invalid syntax and should be `foo UNION bar`. If not that behaviour, the code will be simpler, because we will be able to wrap queries by `()` as much as we want.