### PR TITLE
Fix timezone for records created using `.insert` and `.insert_all` in MySQL database

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Fix timezone for records created using `.insert` and `.insert_all` in MySQL databases.
+
+    *David Stosik*
+
 *   Fix incorrect SQL query when passing an empty hash to `ActiveRecord::Base.insert`.
 
     *David Stosik*

--- a/activerecord/lib/active_record/connection_adapters/mysql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/database_statements.rb
@@ -10,9 +10,11 @@ module ActiveRecord
         private_constant :READ_QUERY
 
         # https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_current-timestamp
+        # https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_utc-timestamp
         # https://dev.mysql.com/doc/refman/5.7/en/date-and-time-type-syntax.html
         HIGH_PRECISION_CURRENT_TIMESTAMP = Arel.sql("CURRENT_TIMESTAMP(6)", retryable: true).freeze # :nodoc:
-        private_constant :HIGH_PRECISION_CURRENT_TIMESTAMP
+        HIGH_PRECISION_UTC_TIMESTAMP = Arel.sql("UTC_TIMESTAMP(6)", retryable: true).freeze # :nodoc:
+        private_constant :HIGH_PRECISION_CURRENT_TIMESTAMP, :HIGH_PRECISION_UTC_TIMESTAMP
 
         def write_query?(sql) # :nodoc:
           !READ_QUERY.match?(sql)
@@ -21,7 +23,10 @@ module ActiveRecord
         end
 
         def high_precision_current_timestamp
-          HIGH_PRECISION_CURRENT_TIMESTAMP
+          case ActiveRecord.default_timezone
+          when :utc   then HIGH_PRECISION_UTC_TIMESTAMP
+          when :local then HIGH_PRECISION_CURRENT_TIMESTAMP
+          end
         end
 
         def explain(arel, binds = [], options = [])


### PR DESCRIPTION
Fixes #53250.

According to MySQL's documentation, `CURRENT_TIMESTAMP()` is a synonym for `NOW()` and:

> Returns the current date and time as a value in `'YYYY-MM-DD hh:mm:ss'
> (...) The value is expressed in the session time zone.

Also:

> MySQL converts `TIMESTAMP` values from the current time zone to UTC for
> storage, and back from UTC to the current time zone for retrieval. (This
> does not occur for other types such as `DATETIME`.) By default, the
> current time zone for each connection is the server's time. The time
> zone can be set on a per-connection basis. As long as the time zone
> setting remains constant, you get back the same value you store. If you
> store a `TIMESTAMP` value, and then change the time zone and retrieve the
> value, the retrieved value is different from the value you stored.

This results in the `created_at` and `updated_at` timestamps for records created with `.insert` and `.insert_all` to be offset by as many hours as the server's timezone.

Most servers in production run in UTC, so that is not a problem, but when developing on a local machine, the timezone is usually the one for where one lives.

I live in Japan and records created with `.insert` get a `created_at` that's 9 hours in the future.

I'm not sure how to write tests in the test suite for this, but I'm welcoming suggestions!
You'll find more details and a way to reproduce in this issue: #53250.

<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created because [REPLACE ME]

### Detail

This Pull Request changes [REPLACE ME]

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
