### PR TITLE
Add PasswordsController tests for the authentication generator

### DIFF
--- a/railties/lib/rails/generators/test_unit/authentication/authentication_generator.rb
+++ b/railties/lib/rails/generators/test_unit/authentication/authentication_generator.rb
@@ -9,6 +9,10 @@ module TestUnit # :nodoc:
         template "test/fixtures/users.yml"
         template "test/models/user_test.rb"
       end
+
+      def create_controller_test_files
+        template "test/controllers/passwords_controller_test.rb"
+      end
     end
   end
 end

--- a/railties/lib/rails/generators/test_unit/authentication/templates/test/controllers/passwords_controller_test.rb.tt
+++ b/railties/lib/rails/generators/test_unit/authentication/templates/test/controllers/passwords_controller_test.rb.tt
@@ -1,0 +1,71 @@
+require "test_helper"
+
+class PasswordsControllerTest < ActionDispatch::IntegrationTest
+
+  setup do
+    @user = User.take
+  end
+
+  test "new" do
+    get new_password_path
+    
+    assert_response :success
+  end
+
+  test "create" do
+    post passwords_path, params: { email_address: @user.email_address }
+
+    assert_enqueued_email_with PasswordsMailer, :reset, args: [ @user ]
+    assert_redirected_to new_session_url
+    follow_redirect!
+    assert_select "div", /reset instructions sent/
+  end
+
+  test "create for an unknown user redirects but sends no mail" do
+    post passwords_path, params: { email_address: "missing-user@example.com" }
+
+    assert_enqueued_emails 0
+    assert_redirected_to new_session_url
+    follow_redirect!
+    assert_select "div", /reset instructions sent/
+  end
+
+  test "edit" do
+    get edit_password_path(@user.password_reset_token)
+
+    assert_response :success
+  end
+
+  test "edit with invalid password reset token" do
+    get edit_password_path("invalid token")
+
+    assert_redirected_to new_password_url
+    follow_redirect!
+    assert_select "div", /reset link is invalid/
+  end
+
+  test "update" do
+    assert_changes -> { @user.reload.password_digest } do
+      put password_path(@user.password_reset_token), params: {
+        password: "new-password", password_confirmation: "new-password"
+      }
+    end
+
+    assert_redirected_to new_session_url
+    follow_redirect!
+    assert_select "div", /Password has been reset/
+  end
+
+  test "update with non matching passwords" do
+    token = @user.password_reset_token
+    assert_no_changes -> { @user.reload.password_digest } do
+      put password_path(token), params: {
+        password: "A-password", password_confirmation: "B-password"
+      }
+    end
+
+    assert_redirected_to edit_password_url(token)
+    follow_redirect!
+    assert_select "div", /Passwords did not match/
+  end
+end

--- a/railties/lib/rails/generators/test_unit/authentication/templates/test/controllers/passwords_controller_test.rb.tt
+++ b/railties/lib/rails/generators/test_unit/authentication/templates/test/controllers/passwords_controller_test.rb.tt
@@ -14,7 +14,7 @@ class PasswordsControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to new_session_path
 
     follow_redirect!
-    assert_text "reset instructions sent"
+    assert_notice "reset instructions sent"
   end
 
   test "create for an unknown user redirects but sends no mail" do
@@ -23,7 +23,7 @@ class PasswordsControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to new_session_path
 
     follow_redirect!
-    assert_text "reset instructions sent"
+    assert_notice "reset instructions sent"
   end
 
   test "edit" do
@@ -36,7 +36,7 @@ class PasswordsControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to new_password_path
 
     follow_redirect!
-    assert_text "reset link is invalid"
+    assert_notice "reset link is invalid"
   end
 
   test "update" do
@@ -46,7 +46,7 @@ class PasswordsControllerTest < ActionDispatch::IntegrationTest
     end
 
     follow_redirect!
-    assert_text "Password has been reset"
+    assert_notice "Password has been reset"
   end
 
   test "update with non matching passwords" do
@@ -57,6 +57,11 @@ class PasswordsControllerTest < ActionDispatch::IntegrationTest
     end
 
     follow_redirect!
-    assert_text "Passwords did not match"
+    assert_notice "Passwords did not match"
   end
+
+  private
+    def assert_notice(text)
+      assert_select "div", /#{text}/
+    end
 end

--- a/railties/lib/rails/generators/test_unit/authentication/templates/test/controllers/passwords_controller_test.rb.tt
+++ b/railties/lib/rails/generators/test_unit/authentication/templates/test/controllers/passwords_controller_test.rb.tt
@@ -1,71 +1,62 @@
 require "test_helper"
 
 class PasswordsControllerTest < ActionDispatch::IntegrationTest
-
-  setup do
-    @user = User.take
-  end
+  setup { @user = User.take }
 
   test "new" do
     get new_password_path
-    
     assert_response :success
   end
 
   test "create" do
     post passwords_path, params: { email_address: @user.email_address }
-
     assert_enqueued_email_with PasswordsMailer, :reset, args: [ @user ]
-    assert_redirected_to new_session_url
+    assert_redirected_to new_session_path
+
     follow_redirect!
-    assert_select "div", /reset instructions sent/
+    assert_text "reset instructions sent"
   end
 
   test "create for an unknown user redirects but sends no mail" do
     post passwords_path, params: { email_address: "missing-user@example.com" }
-
     assert_enqueued_emails 0
-    assert_redirected_to new_session_url
+    assert_redirected_to new_session_path
+
     follow_redirect!
-    assert_select "div", /reset instructions sent/
+    assert_text "reset instructions sent"
   end
 
   test "edit" do
     get edit_password_path(@user.password_reset_token)
-
     assert_response :success
   end
 
   test "edit with invalid password reset token" do
     get edit_password_path("invalid token")
+    assert_redirected_to new_password_path
 
-    assert_redirected_to new_password_url
     follow_redirect!
-    assert_select "div", /reset link is invalid/
+    assert_text "reset link is invalid"
   end
 
   test "update" do
     assert_changes -> { @user.reload.password_digest } do
-      put password_path(@user.password_reset_token), params: {
-        password: "new-password", password_confirmation: "new-password"
-      }
+      put password_path(@user.password_reset_token), params: { password: "new", password_confirmation: "new" }
+      assert_redirected_to new_session_path
     end
 
-    assert_redirected_to new_session_url
     follow_redirect!
-    assert_select "div", /Password has been reset/
+    assert_text "Password has been reset"
   end
 
   test "update with non matching passwords" do
     token = @user.password_reset_token
     assert_no_changes -> { @user.reload.password_digest } do
-      put password_path(token), params: {
-        password: "A-password", password_confirmation: "B-password"
-      }
+      put password_path(token), params: { password: "no", password_confirmation: "match" }
+      assert_redirected_to edit_password_path(token)
     end
 
-    assert_redirected_to edit_password_url(token)
     follow_redirect!
-    assert_select "div", /Passwords did not match/
+    assert_text "Passwords did not match"
   end
 end

--- a/railties/test/generators/authentication_generator_test.rb
+++ b/railties/test/generators/authentication_generator_test.rb
@@ -60,6 +60,7 @@ class AuthenticationGeneratorTest < Rails::Generators::TestCase
 
     assert_file "test/models/user_test.rb"
     assert_file "test/fixtures/users.yml"
+    assert_file "test/controllers/passwords_controller_test.rb"
 
     assert_file "test/test_helper.rb" do |content|
       assert_match(/session_test_helper/, content)


### PR DESCRIPTION
### Motivation / Background

This PR changes the authentication generator to add integration tests for the `PasswordsController`. Since a user fixture is generated, I think it would make sense to generate a small set of integration test for the basic flows as well. This PR starts the generated tests with the "PasswordsController".

I can add tests for other parts in the generator as well, but I don't think this has to happen necessarily in one big PR. Also please feel free to close this PR if there's no interest in pursuing adding tests to the generator.

### Detail

Adds `passwords_controller_test.rb` to the generated files in the authentication generator.

### Additional information

I'm not sure if the `assert_select "div", "some-test"` assertions are too granular and could be omitted for the default generator.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
