### PR TITLE
Fix an omission in the recursive CTE documentation

### DIFF
--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -506,7 +506,7 @@ module ActiveRecord
     #
     #   Post.with_recursive(post_and_replies: [Post.where(id: 42), Post.joins('JOIN post_and_replies ON posts.in_reply_to_id = post_and_replies.id')])
     #   # => ActiveRecord::Relation
-    #   # WITH post_and_replies AS (
+    #   # WITH RECURSIVE post_and_replies AS (
     #   #   (SELECT * FROM posts WHERE id = 42)
     #   #   UNION ALL
     #   #   (SELECT * FROM posts JOIN posts_and_replies ON posts.in_reply_to_id = posts_and_replies.id)


### PR DESCRIPTION
The documentation shows a regular CTE instead of a recursive CTE for `with_recursive`.

I had to verify that `with_recursive` was a recursive CTE and not an overloaded term.
This change should help clarify. 

It is still not quite the actual query, but it's easier to read. The actual query looks like: 

```sql
WITH recursive "post_and_replies"
AS
  (
         SELECT "posts".*
         FROM   "posts"
         WHERE  "posts"."id" = 42
         UNION ALL
         SELECT "posts".*
         FROM   "posts"
         JOIN   post_and_replies
         ON     posts.in_reply_to_id = post_and_replies.id )
  SELECT "posts".*
  FROM   "posts"
```


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
