### PR TITLE
Keep .ruby-version in git for applications

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/gitignore.tt
+++ b/railties/lib/rails/generators/rails/app/templates/gitignore.tt
@@ -35,3 +35,6 @@
 
 /public/assets
 <% end -%>
+
+# Keep .ruby-version for apps that are using ruby version managers.
+!.ruby-version


### PR DESCRIPTION
### Motivation / Background

When creating a new Rails 8 beta application,
the .ruby-version file is not included in the
.gitignore file as something to keep.

This results in the default application build
on github due to the default github actions not
knowing which version of ruby to use.

### Additional information

<img width="1267" alt="github-ruby-version-rails-app" src="https://github.com/user-attachments/assets/5a5146a6-a37f-41f6-b4d7-22cbdc7b246c">

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
