### PR TITLE
Don't execute i18n watcher on boot.

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Don't execute i18n watcher on boot. It shouldn't catch any file changes initially,
+    and unnecessarily slows down boot of applications with lots of translations.
+
+    *Gannon McGibbon*, *David Stosik*
+
 *   Fix `ActiveSupport::HashWithIndifferentAccess#stringify_keys` to stringify all keys not just symbols.
 
     Previously:

--- a/activesupport/lib/active_support/i18n_railtie.rb
+++ b/activesupport/lib/active_support/i18n_railtie.rb
@@ -68,7 +68,7 @@ module I18n
         directories = watched_dirs_with_extensions(reloadable_paths)
         root_load_paths = I18n.load_path.select { |path| path.to_s.start_with?(Rails.root.to_s) }
         reloader = app.config.file_watcher.new(root_load_paths, directories) do
-          I18n.load_path.delete_if { |p| p.to_s.start_with?(Rails.root.to_s) && !File.exist?(p) }
+          I18n.load_path.delete_if { |path| path.to_s.start_with?(Rails.root.to_s) && !File.exist?(path) }
           I18n.load_path |= reloadable_paths.flat_map(&:existent)
         end
 
@@ -76,7 +76,6 @@ module I18n
         app.reloader.to_run do
           reloader.execute_if_updated { require_unload_lock! }
         end
-        reloader.execute
       end
 
       @i18n_inited = true


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because my app has lots of translations, and I noticed even after https://github.com/rails/rails/pull/52271 it is still a little slow to boot.

### Detail

This Pull Request changes Active Support's I18n railtie to not execute initially. The logic inside of it only applies if files within its watched paths have beed added or deleted. I don't see that happening in any app under normal circumstances.

### Additional information

- https://github.com/rails/rails/blob/f1be11af8e4294764ece2f1bfcf7f7bb7fae43ff/activesupport/lib/active_support/i18n_railtie.rb#L71 This line only needs to run if a file is deleted.
- https://github.com/rails/rails/blob/f1be11af8e4294764ece2f1bfcf7f7bb7fae43ff/activesupport/lib/active_support/i18n_railtie.rb#L72 And this one only applies if a file has been added.

In my application, this saves ~100ms, but it depends on how many files you have in your `I18n.load_path`:

Script:

```rb
# frozen_string_literal: true

require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"

  gem "rails", github: "rails/rails"
  gem "benchmark-ips"
end

require "rails/all"

class MyApp < Rails::Application
  config.eager_load = false
end

2000.times do |n|
  path = Pathname("translation/#{n}/en.yml")
  path.dirname.mkpath
  path.write({}.to_yaml)

  I18n.load_path << path.to_s
end


Benchmark.ips do |x|
  x.report("initialize_i18n") do
    I18n::Railtie.instance_variable_set(:@i18n_inited, false)
    I18n::Railtie.initialize_i18n(MyApp)
  end
end

Pathname("translation").rmtree
```

Before:
```
ruby 3.3.4 (2024-07-09 revision be1089c8ec) [arm64-darwin23]
Warming up --------------------------------------
     initialize_i18n   131.000 i/100ms
Calculating -------------------------------------
     initialize_i18n      1.073k (± 7.4%) i/s  (932.37 μs/i) -      5.371k in   5.035272s
```

After:
```
ruby 3.3.4 (2024-07-09 revision be1089c8ec) [arm64-darwin23]
Warming up --------------------------------------
     initialize_i18n   249.000 i/100ms
Calculating -------------------------------------
     initialize_i18n      1.491k (±13.7%) i/s  (670.63 μs/i) -      7.470k in   5.100983s
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
