### PR TITLE
SQLIte: Allow deferrable foreign key on column with non-ascii characters

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -407,7 +407,7 @@ module ActiveRecord
       end
       alias :add_belongs_to :add_reference
 
-      FK_REGEX = /.*FOREIGN KEY\s+\("(\w+)"\)\s+REFERENCES\s+"(\w+)"\s+\("(\w+)"\)/
+      FK_REGEX = /.*FOREIGN KEY\s+\("([^"]+)"\)\s+REFERENCES\s+"(\w+)"\s+\("(\w+)"\)/
       DEFERRABLE_REGEX = /DEFERRABLE INITIALLY (\w+)/
       def foreign_keys(table_name)
         # SQLite returns 1 row for each column of composite foreign keys.

--- a/activerecord/test/cases/migration/foreign_key_test.rb
+++ b/activerecord/test/cases/migration/foreign_key_test.rb
@@ -601,6 +601,14 @@ if ActiveRecord::Base.lease_connection.supports_foreign_keys?
 
             assert_match %r{\s+add_foreign_key "astronauts", "rockets", deferrable: :immediate$}, output
           end
+
+          def test_schema_dumping_with_special_chars_deferrable
+            @connection.add_reference :astronauts, :røcket, foreign_key: { to_table: :rockets, deferrable: :deferred }
+
+            output = dump_table_schema "astronauts"
+
+            assert_match %r{\s+add_foreign_key "astronauts", "rockets", column: "røcket_id", deferrable: :deferred$}, output
+          end
         end
 
         def test_does_not_create_foreign_keys_when_bypassed_by_config


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because `t.references` with `deferrable: :deferred` doesn't dump correctly when a column name contains non-ascii characters.

```ruby
t.references :spørgsmål, foreign_key: { to_table: :oda_dokumenter, deferrable: :deferred }
t.references :super, foreign_key: { to_table: :oda_dagsordenspunkter, deferrable: :deferred }
# becomes
add_foreign_key "oda_dokumenter", "oda_dokumenter", column: "spørgsmål_id" # deferrable missing!
add_foreign_key "oda_dagsordenspunkter", "oda_dagsordenspunkter", column: "super_id", deferrable: :deferred
```

### Detail

I'm matching my (SQLite) db schema to an external data-source, hence the strange column names. Everything but deferred foreign keys are working.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
