### PR TITLE
Fix `pluck` with qualified name on loaded relation

### DIFF
--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -311,8 +311,8 @@ module ActiveRecord
         relation.pluck(*column_names)
       else
         model.disallow_raw_sql!(flattened_args(column_names))
-        columns = arel_columns(column_names)
         relation = spawn
+        columns = relation.arel_columns(column_names)
         relation.select_values = columns
         result = skip_query_cache_if_necessary do
           if where_clause.contradiction?

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -1656,6 +1656,22 @@ module ActiveRecord
         self
       end
 
+    protected
+      def arel_columns(columns)
+        columns.flat_map do |field|
+          case field
+          when Symbol, String
+            arel_column(field)
+          when Proc
+            field.call
+          when Hash
+            arel_columns_from_hash(field)
+          else
+            field
+          end
+        end
+      end
+
     private
       def async
         spawn.async!
@@ -1941,21 +1957,6 @@ module ActiveRecord
         table.join(with_table, kind).on(
           with_table[model.model_name.to_s.foreign_key].eq(table[model.primary_key])
         ).join_sources.first
-      end
-
-      def arel_columns(columns)
-        columns.flat_map do |field|
-          case field
-          when Symbol, String
-            arel_column(field)
-          when Proc
-            field.call
-          when Hash
-            arel_columns_from_hash(field)
-          else
-            field
-          end
-        end
       end
 
       def arel_columns_from_hash(fields)

--- a/activerecord/test/cases/calculations_test.rb
+++ b/activerecord/test/cases/calculations_test.rb
@@ -1241,6 +1241,18 @@ class CalculationsTest < ActiveRecord::TestCase
     assert_equal [false, true, true, true, true], takes_relation.pluck(:approved)
   end
 
+  def test_pluck_with_qualified_name_on_loaded
+    topics = Topic.joins(:replies).order(:id)
+
+    assert_not_predicate topics, :loaded?
+    assert_equal [[1, 2], [3, 4]], topics.pluck("topics.id", "replies.id")
+
+    topics.load
+
+    assert_predicate topics, :loaded?
+    assert_equal [[1, 2], [3, 4]], topics.pluck("topics.id", "replies.id")
+  end
+
   def test_pluck_columns_with_same_name
     expected = [["The First Topic", "The Second Topic of the day"], ["The Third Topic of the day", "The Fourth Topic of the day"]]
     actual = Topic.joins(:replies).order(:id)


### PR DESCRIPTION
Since #53064 `arel_columns` is no longer a side-effect free helper method, so it runs on the spawned relation.

Fixes #53260.
