### PR TITLE
`"ActionMailer::DeliveryJob"` was the original default of `config.action_mailer.delivery_job`

### DIFF
--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -2553,7 +2553,7 @@ The default value depends on the `config.load_defaults` target version:
 
 | Starting with version | The default value is |
 | --------------------- | -------------------- |
-| (original)            | `ActionMailer::MailDeliveryJob` |
+| (original)            | `"ActionMailer::DeliveryJob"`     |
 | 6.0                   | `"ActionMailer::MailDeliveryJob"` |
 
 ### Configuring Active Support


### PR DESCRIPTION
### Motivation / Background
During the attempt to upgrade our Rails 5.2 application to 6.0 I have found that this documentation contains inaccuracy. I know it is rather too old an entry, but because it is tricky that the original default is incorrect while [the preference proposes it be better to stick to the original default at first](https://github.com/rails/rails/blob/v6.0.6.1/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_6_0.rb.tt#L39), I guess it should be helpful for some.

### Detail
This commit addresses the inaccurate documentation regarding the configuration upgrade between Rails 5.2 and 6.0.

The original default value of `config.action_mailer.delivery_job` before Rails 6.0 was "ActionMailer::DeliveryJob", which can be validated by the test added then: https://github.com/rails/rails/blob/v6.0.6.1/railties/test/application/configuration_test.rb#L2638

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
