### PR TITLE
Fix `CURRENT_TIMESTAMP` test failure by setting time_zone correctly

### DIFF
--- a/activerecord/test/cases/date_time_test.rb
+++ b/activerecord/test/cases/date_time_test.rb
@@ -17,6 +17,15 @@ class DateTimeTest < ActiveRecord::TestCase
     ActiveRecord.default_timezone = :utc
   end
 
+  def test_high_precision_current_timestamp
+    current_timestamp = Task.with_connection { |conn| conn.high_precision_current_timestamp }
+
+    task = Task.create!
+    task = Task.select(current_timestamp => :starting).find(task.id)
+
+    assert_in_delta Time.now, task.starting, 1
+  end
+
   def test_saves_both_date_and_time
     with_env_tz "America/New_York" do
       with_timezone_config default: :utc do

--- a/activerecord/test/config.example.yml
+++ b/activerecord/test/config.example.yml
@@ -18,6 +18,8 @@ connections:
     <% if ENV['MYSQL_SOCK'] %>
       socket: "<%= ENV['MYSQL_SOCK'] %>"
     <% end %>
+      variables:
+        time_zone: '+00:00'
     arunit2:
       username: rails
       encoding: utf8mb4
@@ -52,6 +54,8 @@ connections:
     <% if ENV['MYSQL_SOCK'] %>
       socket: "<%= ENV['MYSQL_SOCK'] %>"
     <% end %>
+      variables:
+        time_zone: '+00:00'
     arunit2:
       username: rails
       encoding: utf8mb4


### PR DESCRIPTION
The following tests using `CURRENT_TIMESTAMP` currently fail when run in a timezone other than UTC.

```
% bin/test -a trilogy test/cases/dirty_test.rb -n test_partial_insert_off_with_unchanged_default_function_attribute
Using trilogy
Run options: -n test_partial_insert_off_with_unchanged_default_function_attribute --seed 35804

# Running:

F

Failure:
DirtyTest#test_partial_insert_off_with_unchanged_default_function_attribute [test/cases/dirty_test.rb:954]:
Expected 2024-10-11 15:00:23.376205 +0900..2024-10-11 15:00:25.376717 +0900 to include 2024-10-11 15:00:24 UTC.

bin/test test/cases/dirty_test.rb:943

Finished in 0.024596s, 40.6570 runs/s, 162.6281 assertions/s.
1 runs, 4 assertions, 1 failures, 0 errors, 0 skips
```

https://github.com/rails/rails/blob/57fe7e781ee37a50e54b17df24738ce6c26b22db/activerecord/test/cases/dirty_test.rb#L943-L956 https://github.com/rails/rails/blob/57fe7e781ee37a50e54b17df24738ce6c26b22db/activerecord/test/schema/schema.rb#L59-L64

And add an extra test to test `high_precision_current_timestamp` which fail without setting time_zone correctly.

```
% bin/test -a trilogy test/cases/date_time_test.rb -n test_high_precision_current_timestamp
Using trilogy
Run options: -n test_high_precision_current_timestamp --seed 33000

# Running:

F

Failure:
DateTimeTest#test_high_precision_current_timestamp [test/cases/date_time_test.rb:26]:
Expected |2024-10-11 15:45:42 +0900 - 2024-10-11 15:45:42 UTC| (32399.999882) to be <= 0.001.

bin/test test/cases/date_time_test.rb:20

Finished in 0.016253s, 61.5271 runs/s, 61.5271 assertions/s.
1 runs, 1 assertions, 1 failures, 0 errors, 0 skips
```
