### PR TITLE
[Fix #53269] `:only` and `:except` validation incorrectly handles string values

### DIFF
--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -1268,7 +1268,7 @@ module ActionDispatch
 
           private
             def invalid_only_except_options(options, valid_actions)
-              options.values_at(:only, :except).flatten.compact.uniq - valid_actions
+              options.values_at(:only, :except).flatten.compact.uniq.map(&:to_sym) - valid_actions
             end
         end
 

--- a/actionpack/test/controller/resources_test.rb
+++ b/actionpack/test/controller/resources_test.rb
@@ -816,6 +816,17 @@ class ResourcesTest < ActionController::TestCase
     end
   end
 
+  def test_resource_has_only_show_action_with_string_value
+    with_routing do |set|
+      set.draw do
+        resources :products, only: "show"
+      end
+
+      assert_resource_allowed_routes("products", {}, { id: "1" }, :show, [:index, :new, :create, :edit, :update, :destroy])
+      assert_resource_allowed_routes("products", { format: "xml" }, { id: "1" }, :show, [:index, :new, :create, :edit, :update, :destroy])
+    end
+  end
+
   def test_singleton_resource_has_only_show_action
     with_routing do |set|
       set.draw do
@@ -824,6 +835,17 @@ class ResourcesTest < ActionController::TestCase
 
       assert_singleton_resource_allowed_routes("accounts", {},                    :show, [:index, :new, :create, :edit, :update, :destroy])
       assert_singleton_resource_allowed_routes("accounts", { format: "xml" },  :show, [:index, :new, :create, :edit, :update, :destroy])
+    end
+  end
+
+  def test_singleton_resource_has_only_show_action_with_string_value
+    with_routing do |set|
+      set.draw do
+        resource :account, only: "show"
+      end
+
+      assert_singleton_resource_allowed_routes("accounts", {}, :show, [:index, :new, :create, :edit, :update, :destroy])
+      assert_singleton_resource_allowed_routes("accounts", { format: "xml" }, :show, [:index, :new, :create, :edit, :update, :destroy])
     end
   end
 
@@ -1113,7 +1135,7 @@ class ResourcesTest < ActionController::TestCase
     assert_raise(ArgumentError, match: expected_message) do
       with_routing do |set|
         set.draw do
-          resources :products, only: [:foo, :bar]
+          resources :products, only: [:foo, "bar"]
         end
       end
     end
@@ -1124,7 +1146,7 @@ class ResourcesTest < ActionController::TestCase
     assert_raise(ArgumentError, match: expected_message) do
       with_routing do |set|
         set.draw do
-          resource :products, only: [:foo, :bar]
+          resource :products, only: [:foo, "bar"]
         end
       end
     end


### PR DESCRIPTION
Follow-up for https://github.com/rails/rails/pull/51464
Fixes https://github.com/rails/rails/issues/53269

Casts the `:only` and `:except` arguments to symbols before validating them.

cc/ @byroot because you merged the previous PR.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.