### PR TITLE
Avoid reading id twice in AR::Core#hash

### DIFF
--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -611,7 +611,7 @@ module ActiveRecord
     def hash
       id = self.id
 
-      if primary_key_values_present?
+      if self.class.composite_primary_key? ? primary_key_values_present? : id
         self.class.hash ^ id.hash
       else
         super


### PR DESCRIPTION
This can be a very hot method so we should avoid reading id twice. This restores that optimization we were using before introducing composite primary keys.

``` ruby
require "bundler/inline"

gemfile do
  source "https://rubygems.org"

  gem "rails", path: "."
  gem "benchmark-ips"
  gem "sqlite3"
end

require "active_record"
require "logger"
require "benchmark/ips"

ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")
ActiveRecord::Schema.define do
  create_table :posts, force: true do |t|
  end
end

class Post < ActiveRecord::Base
  has_many :comments
end

post = Post.create!.reload

Benchmark.ips do |x|
  x.report "post.hash" do
    post.hash
  end
end
```

**Before**
```
Warming up --------------------------------------
           post.hash   236.987k i/100ms
Calculating -------------------------------------
           post.hash      2.360M (± 1.2%) i/s  (423.76 ns/i) -     11.849M in   5.021955s
```

**After**
```
Warming up --------------------------------------
           post.hash   355.450k i/100ms
Calculating -------------------------------------
           post.hash      3.531M (± 2.3%) i/s  (283.19 ns/i) -     17.772M in   5.036145s

```