### PR TITLE
Add affected_rows to sql.active_record

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add `affected_rows` to `sql.active_record` Notification.
+
+    *Hartley McGuire*
+
 *   Fix `sum` when performing a grouped calculation.
 
     `User.group(:friendly).sum` no longer worked. This is fixed.

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -1135,6 +1135,7 @@ module ActiveRecord
             async:             async,
             connection:        self,
             transaction:       current_transaction.user_transaction.presence,
+            affected_rows:     0,
             row_count:         0,
             &block
           )

--- a/activerecord/lib/active_record/connection_adapters/mysql2/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql2/database_statements.rb
@@ -65,9 +65,11 @@ module ActiveRecord
               raw_connection.query(sql)
             end
 
+            @affected_rows_before_warnings = raw_connection.affected_rows
+
+            notification_payload[:affected_rows] = @affected_rows_before_warnings
             notification_payload[:row_count] = result&.size || 0
 
-            @affected_rows_before_warnings = raw_connection.affected_rows
             raw_connection.abandon_results!
 
             verified!

--- a/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
@@ -164,6 +164,8 @@ module ActiveRecord
 
             verified!
             handle_warnings(result)
+
+            notification_payload[:affected_rows] = result.cmd_tuples
             notification_payload[:row_count] = result.count
             result
           end

--- a/activerecord/lib/active_record/connection_adapters/sqlite3/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3/database_statements.rb
@@ -109,6 +109,7 @@ module ActiveRecord
             @last_affected_rows = raw_connection.changes
             verified!
 
+            notification_payload[:affected_rows] = @last_affected_rows
             notification_payload[:row_count] = result&.length || 0
             result
           end

--- a/activerecord/lib/active_record/connection_adapters/trilogy/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/trilogy/database_statements.rb
@@ -30,6 +30,8 @@ module ActiveRecord
             end
             verified!
             handle_warnings(sql)
+
+            notification_payload[:affected_rows] = result.affected_rows
             notification_payload[:row_count] = result.count
             result
           ensure

--- a/guides/source/active_support_instrumentation.md
+++ b/guides/source/active_support_instrumentation.md
@@ -367,6 +367,7 @@ The `:cache_hits` key is only included if the collection is rendered with `cache
 | `:async`             | `true` if query is loaded asynchronously |
 | `:cached`            | `true` is added when cached queries used |
 | `:row_count`         | Number of rows returned by the query     |
+| `:affected_rows`     | Number of rows affected by the query     |
 
 Adapters may add their own data as well.
 
@@ -379,7 +380,8 @@ Adapters may add their own data as well.
   binds: [<ActiveModel::Attribute::WithCastValue:0x00007fe19d15dc00>],
   type_casted_binds: [11],
   statement_name: nil,
-  row_count: 5
+  row_count: 5,
+  affected_rows: 0
 }
 ```
 


### PR DESCRIPTION
### Motivation / Background

The [recently added][1] `row_count` value is very useful for identifying cases where a query would return a large result set as large results can end up using a lot of memory or even be blocked by databases like Vitess.

However, somewhere that `row_count` falls short is for queries that do not necessarily return their results back to the client. These queries that affect too many rows can lead to their own set of problems, such as overwhelming replication and causing replication lag.

### Detail

This commit adds the number of `affected_rows` to the `sql.active_record` Notification so that these kinds of queries can be identified as well.

[1]: https://github.com/rails/rails/commit/e9a2288c13802cade58889af09b88be7afb85737

### Additional Information

I considered using `affected_queries(result)` for this, however `PostgresqlAdapter#affected_queries` currently `clear`s the `result` and changing that seemed like a larger refactor.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
