### PR TITLE
Sort table columns by name when dumping schema

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   The table columns inside `schema.rb` are now sorted alphabetically.
+
+    Previously they'd be sorted by creation order, which can cause merge conflicts when two
+    branches modify the same table concurrently.
+
+    *John Duff*
+
 *   Introduce versions formatter for the schema dumper.
 
     It is now possible to override how schema dumper formats versions information inside the

--- a/activerecord/lib/active_record/schema_dumper.rb
+++ b/activerecord/lib/active_record/schema_dumper.rb
@@ -192,7 +192,7 @@ module ActiveRecord
           tbl.puts ", force: :cascade do |t|"
 
           # then dump all non-primary key columns
-          columns.each do |column|
+          columns.sort_by(&:name).each do |column|
             raise StandardError, "Unknown type '#{column.sql_type}' for column '#{column.name}'" unless @connection.valid_type?(column.type)
             next if column.name == pk
 

--- a/activerecord/test/cases/schema_dumper_test.rb
+++ b/activerecord/test/cases/schema_dumper_test.rb
@@ -167,6 +167,14 @@ class SchemaDumperTest < ActiveRecord::TestCase
     assert_no_match %r{create_table "ar_internal_metadata"}, output
   end
 
+  def test_table_columns_sorted
+    column_names = column_definition_lines(dump_table_schema("companies")).flatten.filter_map do |line|
+      $1 if line !~ /t\.index/ && line.match(/t\..*"(\w+)"/)
+    end
+
+    assert_equal %w[account_id client_of description firm_id firm_name name rating status type], column_names
+  end
+
   def test_schema_dumps_index_columns_in_right_order
     index_definition = dump_table_schema("companies").split(/\n/).grep(/t\.index.*company_index/).first.strip
     if current_adapter?(:Mysql2Adapter, :TrilogyAdapter)


### PR DESCRIPTION
### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

In projects when multiple people are creating migrations they can often be run out of order from one another, this results in each developer machine having columns added in a different order. Each time we run migrations the schema is dumped based on our local database base so the schema output has columns out of order from machine to machine resulting in noisy diffs and potentially conflicts in the schema file that make no difference overall. ex:

```
     t.string "county"
-    t.string "country_code"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "country_code"
     t.string "urn"
```

### Detail

This PR adds an option to sort the columns before outputting to the table dump. I found [this previous PR](https://github.com/rails/rails/pull/32111) which does this just for MySQL, but I decided to do this at the base schema dumper level as an option because there could be cases where teams don't want to do this (MySQL being one of them since you can add columns relative to existing columns).

### Additional information

If this approach is accepted I think making a config option to set this would be a good idea and it could be useful to make enabling this the default depending on the database you ere using (ex enabled by default for postgresql and sqlite3, not for mysql).

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
