### PR TITLE
Fix unintended guide chapter scrolling when visit by turbo [skip ci]

### DIFF
--- a/guides/assets/javascripts/guides.js
+++ b/guides/assets/javascripts/guides.js
@@ -23,7 +23,7 @@
     for(var i = 0; i < array.length; i++) callback(array[i]);
   }
 
-  document.addEventListener("turbo:load", function() {
+  document.addEventListener("turbo:load", function(turbo_load_event) {
     var guidesMenu = document.getElementById("guidesMenu");
     var guides     = document.getElementById("guides");
 
@@ -158,11 +158,15 @@
 
     var PAGE_LOAD_BUFFER = 1000;
 
+    var isDirectlyVisited = function() {
+      return Object.keys(turbo_load_event.detail.timing).length === 0;
+    }
+
     var navHighlight = function (entries) {
       entries.forEach(function (entry) {
         if (entry.isIntersecting) {
           updateHighlight(matchingNavLink(entry.target));
-        } else if (entry.time >= PAGE_LOAD_BUFFER && belowBottomHalf(entry)) {
+        } else if (isDirectlyVisited() && entry.time >= PAGE_LOAD_BUFFER && belowBottomHalf(entry)) {
           updateHighlight(matchingNavLink(prevElem(entry.target)));
         }
       });


### PR DESCRIPTION
### Motivation / Background
#### step to reproduce

1. Access https://edgeguides.rubyonrails.org
2. Visit "Upgrading Ruby on Rails" or any else page by clicking guides index
3. "Chapters" scrolls end of list

https://github.com/user-attachments/assets/389ea4a9-e2a3-4f36-87a5-0209e99afcdf

When visiting a guide page by turbo, the navHighlight function fires the `scrollIntoView` API.
Then, the chapter scrolls to the end of the chapter list by the `updateHighlight` function because IntersectionObserver's time origin is the first page loaded.

### Detail

To fix this, add "is the page navigated by directly" to the condition of the call `updateHighlight` function.


### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
