### PR TITLE
Revisit #39134: Don’t ignore X-Forwarded-For IPs with ports attached

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   `remote_ip` will no longer ignore IPs in X-Forwarded-For headers if they
+    are accompanied by port information.
+
+    *Duncan Brown*, *Prevenios Marinos*
+
 *   Update `ActionController::AllowBrowser` to support passing method names to `:block`
 
     ```ruby

--- a/actionpack/test/dispatch/request_test.rb
+++ b/actionpack/test/dispatch/request_test.rb
@@ -105,6 +105,9 @@ class RequestIP < BaseRequestTest
     request = stub_request "HTTP_X_FORWARDED_FOR" => "3.4.5.6,127.0.0.1"
     assert_equal "3.4.5.6", request.remote_ip
 
+    request = stub_request "HTTP_X_FORWARDED_FOR" => "3.4.5.6:1234,127.0.0.1"
+    assert_equal "3.4.5.6", request.remote_ip
+
     request = stub_request "HTTP_X_FORWARDED_FOR" => "unknown,192.168.0.1"
     assert_equal "192.168.0.1", request.remote_ip
 


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created to reapply #39134.

### Detail

#39134 is once merged but reverted at https://github.com/rails/rails/commit/25bc1c013472eb95120a5912345ea25c3cbf6f89 due to dependency on rack >= 2.2.0. At that time, required minimum version of rack was [2.0.9](https://github.com/rails/rails/blob/c2077c850715b359a24a6b083d2e042565587c52/actionpack/actionpack.gemspec#L37).
Since #45997, current required minimum version of rack is 2.2.4 and we can reconsider this.

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

Original PR description

> Fixes https://github.com/rails/rails/issues/39092
> 
> Without this patch, remote_ip will ignore X-Forwarded-For IPs with ports attached and the return value is less likely to be useful.
> 
> Rack decided to tolerate proxies which choose to attach ports to X-Forwarded-For IPs by stripping the port: https://github.com/rack/rack/pull/1251. Attaching a port is rare in the wild but some proxies (notably Microsoft Azure's App Service) do it.
> 
> The stripping logic is already available in Rack::Request::Helpers, so change the X-Forwarded-For retrieval method from #x_forwarded_for (which returns the raw header) to #forwarded_for, which returns a stripped array of IP addresses, or nil.
> 
> We can't call ips_from with an array (and legislating for that inside ips_from doesn't appeal), so refactor out the bit we need to apply in both cases (verifying the IP is acceptable to IPAddr and that it's not a range) to a separate method called sanitize_ips which reduces an array of
> maybe-ips to an array of acceptable ones.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
