### PR TITLE
authentication generator: resume session when authentication is not required to still load the current user

### DIFF
--- a/railties/lib/rails/generators/rails/authentication/templates/app/controllers/concerns/authentication.rb.tt
+++ b/railties/lib/rails/generators/rails/authentication/templates/app/controllers/concerns/authentication.rb.tt
@@ -9,6 +9,7 @@ module Authentication
   class_methods do
     def allow_unauthenticated_access(**options)
       skip_before_action :require_authentication, **options
+      before_action :resume_session
     end
   end
 


### PR DESCRIPTION
### Motivation / Background

Using the authentication generator, currently, `Current.user` is `nil` in controllers calling `allow_unauthenticated_access` because the session is not loaded. But it is pretty common to display different sections on public pages when there is a signed in user.

After this change, `resume_session` is added as a before filter when `allow_unauthenticated_access` is called.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [ ] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
