### PR TITLE
Custom Request ID sanitizer 

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/request_id.rb
+++ b/actionpack/lib/action_dispatch/middleware/request_id.rb
@@ -22,7 +22,7 @@ module ActionDispatch
   # The unique request id can be used to trace a request end-to-end and would
   # typically end up being part of log files from multiple pieces of the stack.
   class RequestId
-    SANITIZER = ->(request_id) { request_id.gsub(/[^\w\-@]/, "").first(255) }
+    SANITIZER = ->(request_id) { request_id.gsub(/[^\w\-@]/, "") }
     mattr_accessor :sanitizer, instance_writer: false, default: SANITIZER
 
     def initialize(app, header:)
@@ -39,7 +39,7 @@ module ActionDispatch
 
     private
       def make_request_id(request_id)
-        request_id.present? ? sanitizer.(request_id) : internal_request_id
+        request_id.present? ? sanitizer.(request_id).first(255) : internal_request_id
       end
 
       def internal_request_id

--- a/actionpack/lib/action_dispatch/middleware/request_id.rb
+++ b/actionpack/lib/action_dispatch/middleware/request_id.rb
@@ -22,6 +22,9 @@ module ActionDispatch
   # The unique request id can be used to trace a request end-to-end and would
   # typically end up being part of log files from multiple pieces of the stack.
   class RequestId
+    SANITIZER = ->(request_id) { request_id.gsub(/[^\w\-@]/, "").first(255) }
+    mattr_accessor :sanitizer, instance_writer: false, default: SANITIZER
+
     def initialize(app, header:)
       @app = app
       @header = header
@@ -36,11 +39,7 @@ module ActionDispatch
 
     private
       def make_request_id(request_id)
-        if request_id.presence
-          request_id.gsub(/[^\w\-@]/, "").first(255)
-        else
-          internal_request_id
-        end
+        request_id.present? ? sanitizer.(request_id) : internal_request_id
       end
 
       def internal_request_id

--- a/actionpack/lib/action_dispatch/railtie.rb
+++ b/actionpack/lib/action_dispatch/railtie.rb
@@ -52,6 +52,10 @@ module ActionDispatch
       ActionDispatch::Http::URL.secure_protocol = app.config.force_ssl
       ActionDispatch::Http::URL.tld_length = app.config.action_dispatch.tld_length
 
+      if request_id_sanitizer = app.config.action_dispatch.request_id_sanitizer
+        ActionDispatch::RequestId.sanitizer = request_id_sanitizer
+      end
+
       ActiveSupport.on_load(:action_dispatch_request) do
         self.ignore_accept_header = app.config.action_dispatch.ignore_accept_header
         ActionDispatch::Request::Utils.perform_deep_munge = app.config.action_dispatch.perform_deep_munge

--- a/actionpack/test/dispatch/request_id_test.rb
+++ b/actionpack/test/dispatch/request_id_test.rb
@@ -32,6 +32,16 @@ class RequestIdTest < ActiveSupport::TestCase
     assert_equal "external-uu-rid", stub_request({ "HTTP_X_REQUEST_ID" => "external-uu-rid" }).uuid
   end
 
+  test "custom sanitizer" do
+    sanitizer = ActionDispatch::RequestId.sanitizer
+    ActionDispatch::RequestId.sanitizer = ->(request_id) { request_id.gsub(/[^\w\-@=]/, "") }
+
+    request_id = "sjgxAo-1K9Z_3leC_noAbpH5tb2f86FFyrGaAzp---jD7Wm2dXaJPg=="
+    assert_equal request_id, stub_request({ "HTTP_X_REQUEST_ID" => request_id }).request_id
+  ensure
+    ActionDispatch::RequestId.sanitizer = sanitizer
+  end
+
   private
     def stub_request(env = {}, header: "x-request-id")
       app = lambda { |_env| [ 200, {}, [] ] }

--- a/actionpack/test/dispatch/request_id_test.rb
+++ b/actionpack/test/dispatch/request_id_test.rb
@@ -33,13 +33,13 @@ class RequestIdTest < ActiveSupport::TestCase
   end
 
   test "custom sanitizer" do
-    sanitizer = ActionDispatch::RequestId.sanitizer
+    original_request_id_sanitizer = ActionDispatch::RequestId.sanitizer
     ActionDispatch::RequestId.sanitizer = ->(request_id) { request_id.gsub(/[^\w\-@=]/, "") }
 
     request_id = "sjgxAo-1K9Z_3leC_noAbpH5tb2f86FFyrGaAzp---jD7Wm2dXaJPg=="
     assert_equal request_id, stub_request({ "HTTP_X_REQUEST_ID" => request_id }).request_id
   ensure
-    ActionDispatch::RequestId.sanitizer = sanitizer
+    ActionDispatch::RequestId.sanitizer = original_request_id_sanitizer
   end
 
   private


### PR DESCRIPTION
Fixes #53043

### Motivation / Background

Request ID header values are getting undesirably mangled by our [default request ID sanitizer](https://github.com/rails/rails/blob/main/actionpack/lib/action_dispatch/middleware/request_id.rb#L40).

Rather than further adding to the regex, let's just allow the user to customize it. 

### Detail

Add `app.config.action_dispatch.request_id_sanitizer` that allows a proc to be passed the request ID.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [ ] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
