### PR TITLE
Allow `warning: redefining 'object_id' may cause serious problems` in the `TransactionCallbacksTest`

### DIFF
--- a/activesupport/lib/active_support/testing/strict_warnings.rb
+++ b/activesupport/lib/active_support/testing/strict_warnings.rb
@@ -16,7 +16,10 @@ module ActiveSupport
       /Failed to validate the schema cache because/,
 
       # TODO: We need to decide what to do with this.
-      /Status code :unprocessable_entity is deprecated/
+      /Status code :unprocessable_entity is deprecated/,
+
+      # Allow this warning only in the `TransactionCallbacksTest`.
+      %r{.*/rails/activerecord/test/cases/transaction_callbacks_test\.rb:\d+: warning: redefining 'object_id' may cause serious problems}
     )
 
     SUPPRESSED_WARNINGS = Regexp.union(


### PR DESCRIPTION
### Motivation / Background

This commit allows the `warning: redefining 'object_id' may cause serious problems` in the `TransactionCallbacksTest` that have been added via #38990 .

I prefer not to allow `warning: redefining 'object_id' may cause serious problems` warning everywhere because generally overriding object_id should not be done.

### Detail

This commit addresses  the following errors.

```ruby
$ ruby -v
ruby 3.4.0dev (2024-10-13T13:00:20Z master cf8388f76c) +PRISM [x86_64-linux]
$ cd activerecord
$ RAILS_STRICT_WARNINGS=1 ARCONN=sqlite3 bin/test test/cases/transaction_callbacks_test.rb -n /test_saving_two_records_that_override_object_id/
/home/yahonda/.rbenv/versions/trunk/lib/ruby/gems/3.4.0+0/gems/minitest-5.25.1/lib/minitest/mock.rb:33: warning: redefining 'object_id' may cause serious problems
Using sqlite3
Run options: -n /test_saving_two_records_that_override_object_id/ --seed 5191

# Running:

/home/yahonda/src/github.com/rails/rails/activerecord/test/cases/transaction_callbacks_test.rb:524: warning: redefining 'object_id' may cause serious problems
E

Error:
TransactionCallbacksTest#test_saving_two_records_that_override_object_id_should_run_after_rollback_callbacks_for_both:
ActiveSupport::RaiseWarnings::WarningError: /home/yahonda/src/github.com/rails/rails/activerecord/test/cases/transaction_callbacks_test.rb:524: warning: redefining 'object_id' may cause serious problems

    /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/testing/strict_warnings.rb:38:in 'ActiveSupport::RaiseWarnings#warn'
    test/cases/transaction_callbacks_test.rb:524:in 'Module#define_method'
    test/cases/transaction_callbacks_test.rb:524:in 'block in TransactionCallbacksTest#test_saving_two_records_that_override_object_id_should_run_after_rollback_callbacks_for_both'
    test/cases/transaction_callbacks_test.rb:523:in 'Class#initialize'
    test/cases/transaction_callbacks_test.rb:523:in 'Class#new'
    test/cases/transaction_callbacks_test.rb:523:in 'TransactionCallbacksTest#test_saving_two_records_that_override_object_id_should_run_after_rollback_callbacks_for_both'


bin/test test/cases/transaction_callbacks_test.rb:522

/home/yahonda/src/github.com/rails/rails/activerecord/test/cases/transaction_callbacks_test.rb:506: warning: redefining 'object_id' may cause serious problems
E

Error:
TransactionCallbacksTest#test_saving_two_records_that_override_object_id_should_run_after_commit_callbacks_for_both:
ActiveSupport::RaiseWarnings::WarningError: /home/yahonda/src/github.com/rails/rails/activerecord/test/cases/transaction_callbacks_test.rb:506: warning: redefining 'object_id' may cause serious problems

    /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/testing/strict_warnings.rb:38:in 'ActiveSupport::RaiseWarnings#warn'
    test/cases/transaction_callbacks_test.rb:506:in 'Module#define_method'
    test/cases/transaction_callbacks_test.rb:506:in 'block in TransactionCallbacksTest#test_saving_two_records_that_override_object_id_should_run_after_commit_callbacks_for_both'
    test/cases/transaction_callbacks_test.rb:505:in 'Class#initialize'
    test/cases/transaction_callbacks_test.rb:505:in 'Class#new'
    test/cases/transaction_callbacks_test.rb:505:in 'TransactionCallbacksTest#test_saving_two_records_that_override_object_id_should_run_after_commit_callbacks_for_both'


bin/test test/cases/transaction_callbacks_test.rb:504



Finished in 0.028782s, 69.4880 runs/s, 0.0000 assertions/s.
2 runs, 0 assertions, 0 failures, 2 errors, 0 skips
$
```

### Additional information

Refer to
https://github.com/ruby/ruby/pull/11834

Fix #53266

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.


