### PR TITLE
Improve `ActionController::TestCase` to expose a binary encoded `request.body`.

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,15 @@
+*   Improve `ActionController::TestCase` to expose a binary encoded `request.body`.
+
+    The rack spec clearly states:
+
+    > The input stream is an IO-like object which contains the raw HTTP POST data.
+    > When applicable, its external encoding must be “ASCII-8BIT” and it must be opened in binary mode.
+
+    Until now its encoding was generally UTF-8, which doesn't accurately reflect production
+    behavior.
+
+    *Jean Boussier*
+
 *   Update `ActionController::AllowBrowser` to support passing method names to `:block`
 
     ```ruby

--- a/actionpack/lib/action_controller/test_case.rb
+++ b/actionpack/lib/action_controller/test_case.rb
@@ -123,7 +123,7 @@ module ActionController
           end
         end
 
-        data_stream = StringIO.new(data)
+        data_stream = StringIO.new(data.b)
         set_header "CONTENT_LENGTH", data_stream.length.to_s
         set_header "rack.input", data_stream
       end

--- a/actionpack/test/controller/test_case_test.rb
+++ b/actionpack/test/controller/test_case_test.rb
@@ -53,6 +53,11 @@ class TestCaseTest < ActionController::TestCase
       render plain: request.body.read
     end
 
+    def render_body_encoding
+      request.body.rewind
+      render plain: request.body.read.encoding.name
+    end
+
     def test_params
       render plain: ::JSON.dump(params.to_unsafe_h)
     end
@@ -268,6 +273,14 @@ class TestCaseTest < ActionController::TestCase
     post :render_body, params: params.dup
 
     assert_equal params.to_query, @response.body
+  end
+
+  def test_body_stream_is_binary
+    params = Hash[:page, { name: "page name" }, "some key", 123]
+
+    post :render_body_encoding, params: params.dup
+
+    assert_equal Encoding::BINARY.name, @response.body
   end
 
   def test_document_body_and_params_with_post


### PR DESCRIPTION
The rack spec clearly states:

> The input stream is an IO-like object which contains the raw HTTP POST data.
> When applicable, its external encoding must be “ASCII-8BIT” and it must be opened in binary mode.

Until now its encoding was generally UTF-8, which doesn't accurately reflect production behavior.
