### PR TITLE
Silence `object_id` redefinition warnings in the test suite

### DIFF
--- a/activerecord/test/cases/transaction_callbacks_test.rb
+++ b/activerecord/test/cases/transaction_callbacks_test.rb
@@ -503,7 +503,9 @@ class TransactionCallbacksTest < ActiveRecord::TestCase
 
   def test_saving_two_records_that_override_object_id_should_run_after_commit_callbacks_for_both
     klass = Class.new(TopicWithCallbacks) do
-      define_method(:object_id) { 42 }
+      silence_warnings do
+        define_method(:object_id) { 42 }
+      end
     end
 
     records = [klass.new, klass.new]
@@ -521,7 +523,9 @@ class TransactionCallbacksTest < ActiveRecord::TestCase
 
   def test_saving_two_records_that_override_object_id_should_run_after_rollback_callbacks_for_both
     klass = Class.new(TopicWithCallbacks) do
-      define_method(:object_id) { 42 }
+      silence_warnings do
+        define_method(:object_id) { 42 }
+      end
     end
 
     records = [klass.new, klass.new]

--- a/activesupport/lib/active_support/testing/strict_warnings.rb
+++ b/activesupport/lib/active_support/testing/strict_warnings.rb
@@ -17,9 +17,6 @@ module ActiveSupport
 
       # TODO: We need to decide what to do with this.
       /Status code :unprocessable_entity is deprecated/,
-
-      # Allow this warning only in the `TransactionCallbacksTest`.
-      %r{.*/rails/activerecord/test/cases/transaction_callbacks_test\.rb:\d+: warning: redefining 'object_id' may cause serious problems}
     )
 
     SUPPRESSED_WARNINGS = Regexp.union(


### PR DESCRIPTION
Avoid tripping the strict warning code.
