### PR TITLE
[7.0] Fix test failures on Ruby 3.4-preview2

### DIFF
--- a/actionview/test/activerecord/polymorphic_routes_test.rb
+++ b/actionview/test/activerecord/polymorphic_routes_test.rb
@@ -213,7 +213,7 @@ class PolymorphicRoutesTest < ActionController::TestCase
         @series.save
         polymorphic_url([nil, @series])
       end
-      assert_match(/undefined method `series_url'/, exception.message)
+      assert_match(/undefined method [`']series_url'/, exception.message)
     end
   end
 

--- a/actionview/test/template/render_test.rb
+++ b/actionview/test/template/render_test.rb
@@ -328,7 +328,7 @@ module RenderTestCases
 
   def test_undefined_method_error_references_named_class
     e = assert_raises(ActionView::Template::Error) { @view.render(inline: "<%= undefined %>") }
-    assert_match(/undefined local variable or method `undefined'/, e.message)
+    assert_match(/undefined local variable or method [`']undefined'/, e.message)
   end
 
   def test_render_renderable_object

--- a/activesupport/test/callbacks_test.rb
+++ b/activesupport/test/callbacks_test.rb
@@ -474,17 +474,17 @@ module CallbacksTest
       # whatever the callbacks do themselves, of course).
 
       assert_equal [
-        "block in save",
-        "block in run_callbacks",
+        "save",
+        "run_callbacks",
         "tweedle_deedle",
-        "block in run_callbacks",
+        "run_callbacks",
         "w0tyes",
-        "block in run_callbacks",
+        "run_callbacks",
         "tweedle_dum",
-        "block in run_callbacks",
+        "run_callbacks",
         "run_callbacks",
         "save"
-      ], call_stack.map(&:label)
+      ], call_stack.map(&:base_label)
     end
 
     def test_short_call_stack
@@ -504,10 +504,10 @@ module CallbacksTest
       # back to its caller.
 
       assert_equal [
-        "block in save",
+        "save",
         "run_callbacks",
         "save"
-      ], call_stack.map(&:label)
+      ], call_stack.map(&:base_label)
     end
   end
 

--- a/activesupport/test/core_ext/module_test.rb
+++ b/activesupport/test/core_ext/module_test.rb
@@ -394,7 +394,7 @@ class ModuleTest < ActiveSupport::TestCase
       DecoratedReserved.new(@david).private_name
     end
 
-    assert_match(/undefined method `private_name' for/, e.message)
+    assert_match(/undefined method [`']private_name' for/, e.message)
   end
 
   def test_delegate_missing_to_does_not_delegate_to_fake_methods
@@ -402,7 +402,7 @@ class ModuleTest < ActiveSupport::TestCase
       DecoratedReserved.new(@david).my_fake_method
     end
 
-    assert_match(/undefined method `my_fake_method' for/, e.message)
+    assert_match(/undefined method [`']my_fake_method' for/, e.message)
   end
 
   def test_delegate_missing_to_raises_delegation_error_if_target_nil

--- a/activesupport/test/core_ext/time_with_zone_test.rb
+++ b/activesupport/test/core_ext/time_with_zone_test.rb
@@ -1113,7 +1113,7 @@ class TimeWithZoneTest < ActiveSupport::TestCase
     e = assert_raises(NoMethodError) {
       @twz.this_method_does_not_exist
     }
-    assert_match(/undefined method `this_method_does_not_exist' for.*ActiveSupport::TimeWithZone/, e.message)
+    assert_match(/undefined method [`']this_method_does_not_exist' for.*ActiveSupport::TimeWithZone/, e.message)
     assert_no_match "rescue", e.backtrace.first
   end
 end

--- a/activesupport/test/deprecation_test.rb
+++ b/activesupport/test/deprecation_test.rb
@@ -944,7 +944,7 @@ class DeprecationTest < ActiveSupport::TestCase
   test "warn deprecation can blame code generated with eval" do
     ActiveSupport::Deprecation.behavior = ->(message, *) { @message = message }
     generated_method_that_call_deprecation(ActiveSupport::Deprecation)
-    assert_equal "DEPRECATION WARNING: Here (called from generated_method_that_call_deprecation at /path/to/template.html.erb:2)", @message
+    assert_match(%r{DEPRECATION WARNING: Here \(called from .*generated_method_that_call_deprecation at /path/to/template.html.erb:2\)}, @message)
   end
 
   private

--- a/activesupport/test/test_case_test.rb
+++ b/activesupport/test/test_case_test.rb
@@ -391,8 +391,8 @@ class ExceptionsInsideAssertionsTest < ActiveSupport::TestCase
       Other block based assertions (e.g. `assert_no_changes`) can be used, as long as `assert_raises` is inside their block.
     MSG
     assert @out.string.include?(expected), @out.string
-    assert error.message.include?("ArgumentError: ArgumentError")
-    assert error.message.include?("in `block (2 levels) in run_test_that_should_fail_confusingly'")
+    assert_match "ArgumentError: ArgumentError", error.message
+    assert_match(/in .*run_test_that_should_fail_confusingly'/, error.message)
   end
 
   private

--- a/railties/test/railties/railtie_test.rb
+++ b/railties/test/railties/railtie_test.rb
@@ -243,7 +243,7 @@ module RailtiesTest
         Foo.instance.abc
       end
 
-      assert_match(/undefined method `abc' for.*RailtiesTest::RailtieTest::Foo/, error.original_message)
+      assert_match(/undefined method [`']abc' for.*RailtiesTest::RailtieTest::Foo/, error.original_message)
     end
   end
 end


### PR DESCRIPTION
Ruby 3.4.0-preview2 was added to the list of supported rubies.