### PR TITLE
Document `form_for` and `form_tag` soft deprecation in API docs

### DIFF
--- a/actionview/lib/action_view/helpers/form_helper.rb
+++ b/actionview/lib/action_view/helpers/form_helper.rb
@@ -121,6 +121,8 @@ module ActionView
 
       attr_internal :default_form_builder
 
+      # Soft deprecated. Use +form_with+ instead.
+      #
       # Creates a form that allows the user to create or update the attributes
       # of a specific model object.
       #

--- a/actionview/lib/action_view/helpers/form_tag_helper.rb
+++ b/actionview/lib/action_view/helpers/form_tag_helper.rb
@@ -28,6 +28,8 @@ module ActionView
 
       mattr_accessor :default_enforce_utf8, default: true
 
+      # Soft deprecated. Use FormHelper#form_with instead.
+      #
       # Starts a form tag that points the action to a URL configured with <tt>url_for_options</tt> just like
       # ActionController::Base#url_for. The method for the form defaults to POST.
       #


### PR DESCRIPTION
Follow-up to https://github.com/rails/rails/pull/51704.

### Motivation / Background

This Pull Request has been created because `form_for` and `form_tag` are [soft deprecated](https://guides.rubyonrails.org/form_helpers.html#using-form-tag-and-form-for) in the guides, but they are not marked as soft deprecated in the API docs, which is inconsistent.

There are precedents for explicitly documenting soft deprecation in API docs:

https://github.com/rails/rails/blob/8c7e55338df54d52d50fb4dd9e355bc8526c7611/activerecord/lib/active_record/connection_handling.rb#L273-L274

and

https://github.com/rails/rails/blob/8c7e55338df54d52d50fb4dd9e355bc8526c7611/actionpack/lib/action_controller/metal/redirecting.rb#L118-L121

<br>

Also, while PR https://github.com/rails/rails/pull/51704 was a good start and highlighted using `form_with` over `form_for`, it did not explicitly document `form_for` as soft deprecated, and it did not address `form_tag`.

### Detail

This Pull Request documents both `form_for` and `form_tag`'s soft deprecation in the API docs in a similar fashion as other soft deprecations.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
