### PR TITLE
Avoid recommending `form_for` in API docs

### DIFF
--- a/actionview/lib/action_view/helpers/form_helper.rb
+++ b/actionview/lib/action_view/helpers/form_helper.rb
@@ -30,8 +30,8 @@ module ActionView
     # when the form is initially displayed, input fields corresponding to attributes
     # of the resource should show the current values of those attributes.
     #
-    # In \Rails, this is usually achieved by creating the form using either
-    # +form_with+ or +form_for+ and a number of related helper methods. These
+    # In \Rails, this is usually achieved by creating the form using
+    # +form_with+ and a number of related helper methods. These
     # methods generate an appropriate <tt>form</tt> tag and yield a form
     # builder object that knows the model the form is about. Input fields are
     # created by calling methods defined on the form builder, which means they
@@ -42,7 +42,7 @@ module ActionView
     #
     # For example, to create a new person you typically set up a new instance of
     # +Person+ in the <tt>PeopleController#new</tt> action, <tt>@person</tt>, and
-    # in the view template pass that object to +form_with+ or +form_for+:
+    # in the view template pass that object to +form_with+:
     #
     #   <%= form_with model: @person do |f| %>
     #     <%= f.label :first_name %>:
@@ -414,8 +414,8 @@ module ActionView
       #     form_for(record_or_name_or_array, *(args << options.merge(builder: LabellingFormBuilder)), &block)
       #   end
       #
-      # If you don't need to attach a form to a model instance, then check out
-      # FormTagHelper#form_tag.
+      # If you don't need to attach a form to a model instance, you can instead
+      # use +form_with+ with the <tt>model</tt> option omitted or set to <tt>false</tt>.
       #
       # === Form to external resources
       #


### PR DESCRIPTION
Follow-up to https://github.com/rails/rails/pull/51704.

### Motivation / Background

This Pull Request has been created because some parts of `FormHelper`'s API docs could be seen as implicitly recommending the use of `form_for`, but it is [soft deprecated](https://guides.rubyonrails.org/form_helpers.html#using-form-tag-and-form-for), so the API docs should ideally avoid mentioning it.

### Detail

Stop recommending `form_for` in the API docs, since `form_with` can be used instead.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
