### PR TITLE
Fix `NoMethodError` when content type is set to nil in tests

### DIFF
--- a/actionpack/lib/action_controller/test_case.rb
+++ b/actionpack/lib/action_controller/test_case.rb
@@ -108,7 +108,7 @@ module ActionController
             set_header k, "application/x-www-form-urlencoded"
           end
 
-          case content_mime_type.to_sym
+          case content_mime_type&.to_sym
           when nil
             raise "Unknown Content-Type: #{content_type}"
           when :json

--- a/actionpack/test/controller/test_case_test.rb
+++ b/actionpack/test/controller/test_case_test.rb
@@ -627,6 +627,13 @@ class TestCaseTest < ActionController::TestCase
     end
   end
 
+  test "nil Content-Type header with post request" do
+    @request.headers["Content-Type"] = nil
+    assert_raises(match: /Unknown Content-Type/) do
+      post :render_body
+    end
+  end
+
   def test_using_as_json_sets_request_content_type_to_json
     post :render_body, params: { bool_value: true, str_value: "string", num_value: 2 }, as: :json
 


### PR DESCRIPTION
Finishes and closes https://github.com/rails/rails/pull/47598.

### Motivation / Background

This Pull Request has been created because @rubendinho wanted someone to take over PR https://github.com/rails/rails/pull/47598.

The original problem is that if a `ActionController::TestCase` test explicitly sets the request content type to `nil` and performs a POST request, Rails raises a slightly obscure `undefined method 'to_sym' for nil` NoMethodError error.

### Detail

This Pull Request changes `ActionController::TestCase`'s content type check to account for `nil` content types, so Rails can raise a more descriptive `Unknown Content-Type` error instead of a slightly obscure `NoMethodError`.

I added tests which were missing in the original PR.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
