### PR TITLE
Reload lazy routes on recognize_path_with_request

### DIFF
--- a/railties/lib/rails/engine/lazy_route_set.rb
+++ b/railties/lib/rails/engine/lazy_route_set.rb
@@ -78,6 +78,11 @@ module Rails
         super
       end
 
+      def recognize_path_with_request(...)
+        Rails.application&.reload_routes_unless_loaded
+        super
+      end
+
       def routes
         Rails.application&.reload_routes_unless_loaded
         super

--- a/railties/test/engine/lazy_route_set_test.rb
+++ b/railties/test/engine/lazy_route_set_test.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "isolation/abstract_unit"
+require "rack/test"
 
 module Rails
   class Engine
@@ -106,6 +107,18 @@ module Rails
         assert_equal(
           { controller: "rails/engine/lazy_route_set_test/users", action: "index" },
           Rails.application.routes.recognize_path("/users")
+        )
+      end
+
+      test "reloads routes when recognize_path_with_request is called" do
+        require "#{app_path}/config/environment"
+
+        path = "/users"
+        req = ActionDispatch::Request.new(::Rack::MockRequest.env_for(path))
+
+        assert_equal(
+          { controller: "rails/engine/lazy_route_set_test/users", action: "index" },
+          Rails.application.routes.recognize_path_with_request(req, path, {})
         )
       end
 


### PR DESCRIPTION
I would argue that `recognize_path_with_request` is a private API, but unfortunately it seems to be somewhat widely used [in the wild](https://github.com/search?q=recognize_path_with_request+language%3ARuby+NOT+path%3A*.rbi&type=code)

This adds the same reloading as other methods in the LazyRouteSet.