### PR TITLE
ActiveModel::Dirty: only reset original values for persisted records

### DIFF
--- a/activemodel/lib/active_model/dirty.rb
+++ b/activemodel/lib/active_model/dirty.rb
@@ -247,7 +247,7 @@ module ActiveModel
 
     def initialize_dup(other) # :nodoc:
       super
-      if self.class.respond_to?(:_default_attributes)
+      if other.persisted? && self.class.respond_to?(:_default_attributes)
         @attributes = self.class._default_attributes.map do |attr|
           attr.with_value_from_user(@attributes.fetch_value(attr.name))
         end

--- a/activemodel/test/cases/dirty_test.rb
+++ b/activemodel/test/cases/dirty_test.rb
@@ -5,6 +5,7 @@ require "active_support/json"
 
 class DirtyTest < ActiveModel::TestCase
   class DirtyModel
+    include ActiveModel::API
     include ActiveModel::Dirty
     define_attribute_methods :name, :color, :size, :status
 


### PR DESCRIPTION
If the record wasn't persisted in the first pace, this operation is useless and costly.

Benchmark: https://gist.github.com/casperisfine/ae56bec1e7eecbff3a696b367e2bafa2

Before:

```
ruby 3.4.0preview2 (2024-10-07 master 32c733f57b) +YJIT +PRISM [arm64-darwin23]
Warming up --------------------------------------
        ActiveRecord     4.048k i/100ms
Calculating -------------------------------------
        ActiveRecord     40.231k (± 2.2%) i/s   (24.86 μs/i) -    202.400k in   5.033380s
```

After:

```
ruby 3.4.0preview2 (2024-10-07 master 32c733f57b) +YJIT +PRISM [arm64-darwin23]
Warming up --------------------------------------
        ActiveRecord     6.973k i/100ms
Calculating -------------------------------------
        ActiveRecord     66.902k (± 7.1%) i/s   (14.95 μs/i) -    334.704k in   5.035269s
```

FYI: @tenderlove @Stivaros