### PR TITLE
Don't require a `updated_at` attribute for `cache_key` when cache versioning is enabled

### DIFF
--- a/activerecord/lib/active_record/integration.rb
+++ b/activerecord/lib/active_record/integration.rb
@@ -73,7 +73,7 @@ module ActiveRecord
       if new_record?
         "#{model_name.cache_key}/new"
       else
-        if cache_version
+        if cache_versioning
           "#{model_name.cache_key}/#{id}"
         else
           timestamp = max_updated_column_timestamp

--- a/activerecord/test/cases/integration_test.rb
+++ b/activerecord/test/cases/integration_test.rb
@@ -221,6 +221,14 @@ class IntegrationTest < ActiveRecord::TestCase
     end
   end
 
+  def test_cache_key_only_needs_primary_key_with_versioning_on
+    with_cache_versioning do
+      dev = Developer.select(:id).first
+
+      assert_equal "developers/#{dev.id}", dev.cache_key
+    end
+  end
+
   def test_cache_version_changes_with_versioning_on
     with_cache_versioning do
       developer     = Developer.first


### PR DESCRIPTION
### Motivation / Background

When `cache_versioning` is enabled (which is the default), `#cache_key` raises an error when there is no `updated_at` attribute on the record instance. 

However, if the attribute is there, it returns a string without the `updated_at` inside it.

```ruby
User.select(:id).first.cache_key
# => ActiveModel::MissingAttributeError: missing attribute 'updated_at' for User

User.select(:id, :updated_at).first.cache_key 
# => "users/006a09a1-c846-45e7-883b-8165391eb4ac"
```

The value of `updated_at` is not needed to generate the cache key for the record and therefore it shouldn't raise an error when it is missing. 

### Detail

This Pull Request changes the check for cache versioning in the `cache_key` method to check for `cache_versioning` instead of `cache_version`.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
