### PR TITLE
Deprecate built-in snekaers adapter

### DIFF
--- a/activejob/CHANGELOG.md
+++ b/activejob/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Deprecate built-in `sneakers` adapter.
+
+    *Dino Maric*
+
 *   Fix using custom serializers with `ActiveJob::Arguments.serialize` when
     `ActiveJob::Base` hasn't been loaded.
 

--- a/activejob/lib/active_job/queue_adapters/sneakers_adapter.rb
+++ b/activejob/lib/active_job/queue_adapters/sneakers_adapter.rb
@@ -18,6 +18,13 @@ module ActiveJob
     #
     #   Rails.application.config.active_job.queue_adapter = :sneakers
     class SneakersAdapter < AbstractAdapter
+      def check_adapter
+        ActiveJob.deprecator.warn <<~MSG.squish
+          The built-in `sneakers` adapter is deprecated and will be removed in Rails 8.2.
+          Please migrate from `sneakers` gem to `kicks` gem version 3.1.1 or later to use `ActiveJob` adapter from `kicks`.
+        MSG
+      end
+
       def initialize
         @monitor = Monitor.new
       end

--- a/activejob/test/cases/adapter_test.rb
+++ b/activejob/test/cases/adapter_test.rb
@@ -22,4 +22,31 @@ class AdapterTest < ActiveSupport::TestCase
       ActiveJob::Base.queue_adapter = before_adapter
     end
   end
+
+  if adapter_is?(:sneakers)
+    test "sneakers adapter should be deprecated" do
+      before_adapter = ActiveJob::Base.queue_adapter
+
+      msg = <<~MSG.squish
+        The built-in `sneakers` adapter is deprecated and will be removed in Rails 8.2.
+        Please migrate from `sneakers` gem to `kicks` gem version 3.1.1 or later to use `ActiveJob` adapter from `kicks`.
+      MSG
+      assert_deprecated(msg, ActiveJob.deprecator) do
+        ActiveJob::Base.queue_adapter = :sneakers
+      end
+
+    ensure
+      ActiveJob::Base.queue_adapter = before_adapter
+    end
+
+    test "sneakers check_adapter should warn" do
+      msg = <<~MSG.squish
+        The built-in `sneakers` adapter is deprecated and will be removed in Rails 8.2.
+        Please migrate from `sneakers` gem to `kicks` gem version 3.1.1 or later to use `ActiveJob` adapter from `kicks`.
+      MSG
+      assert_deprecated(msg, ActiveJob.deprecator) do
+        ActiveJob::Base.queue_adapter.check_adapter
+      end
+    end
+  end
 end


### PR DESCRIPTION
[`sneakers` gem development](https://github.com/jondot/sneakers?tab=readme-ov-file#sneakers-has-a-new-home-and-a-new-name) has been moved to [kicks gem](https://github.com/ruby-amqp/kicks)

Connected to https://github.com/rails/rails/issues/52929