### PR TITLE
Update ActiveJob's enqueue_after_transaction_commit config

### DIFF
--- a/activejob/CHANGELOG.md
+++ b/activejob/CHANGELOG.md
@@ -10,4 +10,17 @@
 
     *heka1024*
 
+*   Now `config.active_job.enqueue_after_transaction_commit` default value is `true` and will accept only boolean values.
+
+    Adapters do not longer need to implement the `enqueue_after_transaction_commit?` method and can not use it to
+    change the global behavior.
+
+    Specific jobs can still change the value between `true` and `false`.
+
+    In general is not recommended to set the value to `false` because enqueuing jobs from inside a transaction
+    can cause them to potentially be picked and ran by another process before the transaction is committed.
+
+    *Juanjo Bazán*
+
+
 Please check [7-2-stable](https://github.com/rails/rails/blob/7-2-stable/activejob/CHANGELOG.md) for previous changes.

--- a/activejob/lib/active_job/enqueue_after_transaction_commit.rb
+++ b/activejob/lib/active_job/enqueue_after_transaction_commit.rb
@@ -4,14 +4,7 @@ module ActiveJob
   module EnqueueAfterTransactionCommit # :nodoc:
     private
       def raw_enqueue
-        after_transaction = case self.class.enqueue_after_transaction_commit
-        when :always
-          true
-        when :never
-          false
-        else # :default
-          queue_adapter.enqueue_after_transaction_commit?
-        end
+        after_transaction = !!self.class.enqueue_after_transaction_commit
 
         if after_transaction
           self.successfully_enqueued = true

--- a/activejob/lib/active_job/enqueuing.rb
+++ b/activejob/lib/active_job/enqueuing.rb
@@ -48,10 +48,9 @@ module ActiveJob
       # automatically defers the enqueue to after the transaction commits.
       #
       # It can be set on a per job basis:
-      #  - `:always` forces the job to be deferred.
-      #  - `:never` forces the job to be queued immediately.
-      #  - `:default` lets the queue adapter define the behavior (recommended).
-      class_attribute :enqueue_after_transaction_commit, instance_accessor: false, instance_predicate: false, default: :never
+      #  - `true` forces the job to be deferred (default).
+      #  - `false` forces the job to be queued immediately.
+      class_attribute :enqueue_after_transaction_commit, instance_predicate: false, default: true
     end
 
     # Includes the +perform_later+ method for job initialization.

--- a/activejob/lib/active_job/queue_adapters/abstract_adapter.rb
+++ b/activejob/lib/active_job/queue_adapters/abstract_adapter.rb
@@ -7,14 +7,6 @@ module ActiveJob
     # Active Job supports multiple job queue systems. ActiveJob::QueueAdapters::AbstractAdapter
     # forms the abstraction layer which makes this possible.
     class AbstractAdapter
-      # Defines whether enqueuing should happen implicitly to after commit when called
-      # from inside a transaction. Most adapters should return true, but some adapters
-      # that use the same database as Active Record and are transaction aware can return
-      # false to continue enqueuing jobs as part of the transaction.
-      def enqueue_after_transaction_commit?
-        true
-      end
-
       def enqueue(job)
         raise NotImplementedError
       end

--- a/activejob/lib/active_job/queue_adapters/delayed_job_adapter.rb
+++ b/activejob/lib/active_job/queue_adapters/delayed_job_adapter.rb
@@ -16,14 +16,6 @@ module ActiveJob
     #
     #   Rails.application.config.active_job.queue_adapter = :delayed_job
     class DelayedJobAdapter < AbstractAdapter
-      def initialize(enqueue_after_transaction_commit: false)
-        @enqueue_after_transaction_commit = enqueue_after_transaction_commit
-      end
-
-      def enqueue_after_transaction_commit? # :nodoc:
-        @enqueue_after_transaction_commit
-      end
-
       def enqueue(job) # :nodoc:
         delayed_job = Delayed::Job.enqueue(JobWrapper.new(job.serialize), queue: job.queue_name, priority: job.priority)
         job.provider_job_id = delayed_job.id

--- a/activejob/lib/active_job/queue_adapters/inline_adapter.rb
+++ b/activejob/lib/active_job/queue_adapters/inline_adapter.rb
@@ -11,7 +11,6 @@ module ActiveJob
     #
     #   Rails.application.config.active_job.queue_adapter = :inline
     class InlineAdapter < AbstractAdapter
-
       def enqueue(job) # :nodoc:
         job.enqueue_after_transaction_commit = false
         Base.execute(job.serialize)

--- a/activejob/lib/active_job/queue_adapters/inline_adapter.rb
+++ b/activejob/lib/active_job/queue_adapters/inline_adapter.rb
@@ -11,11 +11,9 @@ module ActiveJob
     #
     #   Rails.application.config.active_job.queue_adapter = :inline
     class InlineAdapter < AbstractAdapter
-      def enqueue_after_transaction_commit? # :nodoc:
-        false
-      end
 
       def enqueue(job) # :nodoc:
+        job.enqueue_after_transaction_commit = false
         Base.execute(job.serialize)
       end
 

--- a/activejob/lib/active_job/queue_adapters/queue_classic_adapter.rb
+++ b/activejob/lib/active_job/queue_adapters/queue_classic_adapter.rb
@@ -19,14 +19,6 @@ module ActiveJob
     #
     #   Rails.application.config.active_job.queue_adapter = :queue_classic
     class QueueClassicAdapter < AbstractAdapter
-      def initialize(enqueue_after_transaction_commit: false)
-        @enqueue_after_transaction_commit = enqueue_after_transaction_commit
-      end
-
-      def enqueue_after_transaction_commit? # :nodoc:
-        @enqueue_after_transaction_commit
-      end
-
       def enqueue(job) # :nodoc:
         qc_job = build_queue(job.queue_name).enqueue("#{JobWrapper.name}.perform", job.serialize)
         job.provider_job_id = qc_job["id"] if qc_job.is_a?(Hash)

--- a/activejob/lib/active_job/queue_adapters/test_adapter.rb
+++ b/activejob/lib/active_job/queue_adapters/test_adapter.rb
@@ -15,14 +15,6 @@ module ActiveJob
       attr_accessor(:perform_enqueued_jobs, :perform_enqueued_at_jobs, :filter, :reject, :queue, :at, :enqueue_after_transaction_commit)
       attr_writer(:enqueued_jobs, :performed_jobs)
 
-      def initialize(enqueue_after_transaction_commit: true)
-        @enqueue_after_transaction_commit = enqueue_after_transaction_commit
-      end
-
-      def enqueue_after_transaction_commit? # :nodoc:
-        @enqueue_after_transaction_commit
-      end
-
       # Provides a store of all the enqueued jobs with the TestAdapter so you can check them.
       def enqueued_jobs
         @enqueued_jobs ||= []

--- a/activejob/test/cases/enqueue_after_transaction_commit_test.rb
+++ b/activejob/test/cases/enqueue_after_transaction_commit_test.rb
@@ -38,7 +38,6 @@ class EnqueueAfterTransactionCommitTest < ActiveSupport::TestCase
 
   class ErrorEnqueueAfterCommitJob < EnqueueErrorJob
     class EnqueueErrorAdapter
-
       def enqueue(...)
         raise ActiveJob::EnqueueError, "There was an error enqueuing the job"
       end

--- a/activejob/test/cases/enqueue_after_transaction_commit_test.rb
+++ b/activejob/test/cases/enqueue_after_transaction_commit_test.rb
@@ -29,7 +29,7 @@ class EnqueueAfterTransactionCommitTest < ActiveSupport::TestCase
   end
 
   class EnqueueAfterCommitJob < ActiveJob::Base
-    self.enqueue_after_transaction_commit = :always
+    self.enqueue_after_transaction_commit = true
 
     def perform
       # noop
@@ -38,9 +38,6 @@ class EnqueueAfterTransactionCommitTest < ActiveSupport::TestCase
 
   class ErrorEnqueueAfterCommitJob < EnqueueErrorJob
     class EnqueueErrorAdapter
-      def enqueue_after_transaction_commit?
-        true
-      end
 
       def enqueue(...)
         raise ActiveJob::EnqueueError, "There was an error enqueuing the job"
@@ -52,7 +49,7 @@ class EnqueueAfterTransactionCommitTest < ActiveSupport::TestCase
     end
 
     self.queue_adapter = EnqueueErrorAdapter.new
-    self.enqueue_after_transaction_commit = :always
+    self.enqueue_after_transaction_commit = true
 
     def perform
       # noop

--- a/activejob/test/cases/queue_adapter_test.rb
+++ b/activejob/test/cases/queue_adapter_test.rb
@@ -10,7 +10,7 @@ module ActiveJob
     end
 
     class StubTwoAdapter
-       def enqueue(*); end
+      def enqueue(*); end
       def enqueue_at(*); end
     end
   end

--- a/activejob/test/cases/queue_adapter_test.rb
+++ b/activejob/test/cases/queue_adapter_test.rb
@@ -5,14 +5,12 @@ require "helper"
 module ActiveJob
   module QueueAdapters
     class StubOneAdapter
-      def enqueue_after_transaction_commit?; false; end
       def enqueue(*); end
       def enqueue_at(*); end
     end
 
     class StubTwoAdapter
-      def enqueue_after_transaction_commit?; false; end
-      def enqueue(*); end
+       def enqueue(*); end
       def enqueue_at(*); end
     end
   end
@@ -74,7 +72,6 @@ class QueueAdapterTest < ActiveJob::TestCase
 
   module StubThreeAdapter
     class << self
-      def enqueue_after_transaction_commit?; false; end
       def enqueue(*); end
       def enqueue_at(*); end
     end
@@ -87,7 +84,6 @@ class QueueAdapterTest < ActiveJob::TestCase
   end
 
   class StubFourAdapter
-    def enqueue_after_transaction_commit?; false; end
     def enqueue(*); end
     def enqueue_at(*); end
     def queue_adapter_name

--- a/activejob/test/helper.rb
+++ b/activejob/test/helper.rb
@@ -26,5 +26,3 @@ require_relative "../../tools/test_common"
 
 ActiveJob::Base.include(ActiveJob::EnqueueAfterTransactionCommit)
 ActiveJob::Base.enqueue_after_transaction_commit = false
-
-

--- a/activejob/test/helper.rb
+++ b/activejob/test/helper.rb
@@ -25,3 +25,6 @@ end
 require_relative "../../tools/test_common"
 
 ActiveJob::Base.include(ActiveJob::EnqueueAfterTransactionCommit)
+ActiveJob::Base.enqueue_after_transaction_commit = false
+
+

--- a/activejob/test/jobs/enqueue_error_job.rb
+++ b/activejob/test/jobs/enqueue_error_job.rb
@@ -7,10 +7,6 @@ class EnqueueErrorJob < ActiveJob::Base
     end
     self.should_raise_sequence = []
 
-    def enqueue_after_transaction_commit?
-      false
-    end
-
     def enqueue(*)
       raise ActiveJob::EnqueueError, "There was an error enqueuing the job" if should_raise?
     end

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -61,8 +61,8 @@ Below are the default values associated with each target version. In cases of co
 #### Default Values for Target Version 8.0
 
 - [`config.action_dispatch.strict_freshness`](#config-action-dispatch-strict-freshness): `true`
-- [`config.active_support.to_time_preserves_timezone`](#config-active-support-to-time-preserves-timezone): `:zone`
 - [`config.active_job.enqueue_after_transaction_commit`](#config-active-job-enqueue-after-transaction-commit): `true`
+- [`config.active_support.to_time_preserves_timezone`](#config-active-support-to-time-preserves-timezone): `:zone`
 
 #### Default Values for Target Version 7.2
 

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -341,6 +341,10 @@ module Rails
         when "8.0"
           load_defaults "7.2"
 
+          if respond_to?(:active_job)
+            active_job.enqueue_after_transaction_commit = true
+          end
+
           if respond_to?(:active_support)
             active_support.to_time_preserves_timezone = :zone
           end

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_8_0.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_8_0.rb.tt
@@ -10,6 +10,30 @@
 # https://guides.rubyonrails.org/upgrading_ruby_on_rails.html
 
 ###
+# Controls whether Active Job's `#perform_later` and similar methods automatically defer
+# the job queuing to after the current Active Record transaction is committed.
+#
+# Example:
+#   Topic.transaction do
+#     topic = Topic.create(...)
+#     NewTopicNotificationJob.perform_later(topic)
+#   end
+#
+# In this example, if the configuration is set to `false`, the job will
+# be enqueued immediately, even though the `Topic` hasn't been committed yet.
+# Because of this, if the job is picked up almost immediately, or if the
+# transaction doesn't succeed for some reason, the job will fail to find this
+# topic in the database. Enqueuing jobs from inside a transaction can cause
+# them to potentially be picked and ran by another process before the
+# transaction is committed.
+#
+# If `enqueue_after_transaction_commit` it's set to `true`, the job will be
+# actually enqueued after the transaction has been committed. If the transaction
+# is rolled back, the job won't be enqueued at all.
+#++
+# Rails.application.config.active_job.enqueue_after_transaction_commit = true
+
+###
 # Specifies whether `to_time` methods preserve the UTC offset of their receivers or preserves the timezone.
 # If set to `:zone`, `to_time` methods will use the timezone of their receivers.
 # If set to `:offset`, `to_time` methods will use the UTC offset.

--- a/railties/test/application/active_job_railtie_test.rb
+++ b/railties/test/application/active_job_railtie_test.rb
@@ -14,11 +14,11 @@ module ApplicationTests
 
       app_file "app/jobs/foo_job.rb", <<-RUBY
         class FooJob < ActiveJob::Base
-          self.enqueue_after_transaction_commit = :never
+          self.enqueue_after_transaction_commit = false
         end
       RUBY
 
-      assert_equal ":never", rails("runner", "p FooJob.enqueue_after_transaction_commit").strip
+      assert_equal "false", rails("runner", "p FooJob.enqueue_after_transaction_commit").strip
     end
   end
 end


### PR DESCRIPTION
This PR modifies the configuration for ActiveJob's `enqueue_after_transaction_commit` option to accept only boolean values and defaulting to `true`.

Closes #52675 