### PR TITLE
ActiveModel::Attribute: elide dup for immutable types

### DIFF
--- a/activemodel/lib/active_model/attribute.rb
+++ b/activemodel/lib/active_model/attribute.rb
@@ -96,6 +96,14 @@ module ActiveModel
       end
     end
 
+    def deep_dup # :nodoc:
+      if @type.mutable?
+        dup
+      else
+        self # If the underlying type is immutable we can get away with not duping
+      end
+    end
+
     def type_cast(*)
       raise NotImplementedError
     end

--- a/activemodel/lib/active_model/attribute/user_provided_default.rb
+++ b/activemodel/lib/active_model/attribute/user_provided_default.rb
@@ -26,6 +26,10 @@ module ActiveModel
         self.class.new(name, user_provided_value, type, original_attribute)
       end
 
+      # Can't elide dup when a default is provided.
+      # See Attribute#deep_dup
+      alias_method :deep_dup, :dup
+
       def marshal_dump
         result = [
           name,

--- a/activemodel/lib/active_model/type/string.rb
+++ b/activemodel/lib/active_model/type/string.rb
@@ -29,6 +29,10 @@ module ActiveModel
         )
       end
 
+      def mutable? # :nodoc:
+        true
+      end
+
       private
         def cast_value(value)
           case value


### PR DESCRIPTION
`Attribute` is mostly immutable, but the deserialized value is memoized, and that value can potentially be mutable, and mutated.

When the value is immutable however, we can share instances.

Benchmark: https://gist.github.com/casperisfine/ae56bec1e7eecbff3a696b367e2bafa2

Before:

```
ruby 3.4.0preview2 (2024-10-07 master 32c733f57b) +YJIT +PRISM [arm64-darwin23]
Warming up --------------------------------------
   assign_attributes     6.140k i/100ms
Calculating -------------------------------------
   assign_attributes     60.732k (± 1.9%) i/s   (16.47 μs/i) -    307.000k in   5.056757s
```

After:

```
ruby 3.4.0preview2 (2024-10-07 master 32c733f57b) +YJIT +PRISM [arm64-darwin23]
Warming up --------------------------------------
   assign_attributes     8.245k i/100ms
Calculating -------------------------------------
   assign_attributes     82.410k (± 1.3%) i/s   (12.13 μs/i) -    412.250k in   5.003220s
```

The profile now look like:

<img width="2558" alt="Capture d’écran 2024-10-16 à 14 45 10" src="https://github.com/user-attachments/assets/29c096c9-efdd-4bf3-b99b-055695678a33">


FYI: @tenderlove @Stivaros