### PR TITLE
Flaky test demo

### DIFF
--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -1117,6 +1117,9 @@ class BasicsTest < ActiveRecord::TestCase
     end
 
     def test_default_in_local_time
+      # FIXME: this call ensures the type map cache is poisoned
+      test_default_in_utc
+
       with_timezone_config default: :local do
         default = Default.new
 


### PR DESCRIPTION
Seems like we have a flaky test in AR.  This commit just demonstrates the problem.  I'm not sure what to do about it.  AFAICT, we're caching the default time zone in the TypeMap on ActiveRecord.  Presumably `with_timezone_config` should clear that cache, but I'm not sure the right way to do it.

This commit just calls `test_default_in_utc` to demonstrate the problem and make the test consistently fail.  To reproduce just do:

```
ARCONN=sqlite3 bundle exec ruby -I lib:test:../activemodel/lib test/cases/base_test.rb
```

I'm not sure how to fix this.  cc @matthewd 