### PR TITLE
Pull attribute initialization in to a function

### DIFF
--- a/activemodel/lib/active_model/dirty.rb
+++ b/activemodel/lib/active_model/dirty.rb
@@ -247,12 +247,18 @@ module ActiveModel
 
     def initialize_dup(other) # :nodoc:
       super
-      if other.persisted? && self.class.respond_to?(:_default_attributes)
-        @attributes = self.class._default_attributes.map do |attr|
-          attr.with_value_from_user(@attributes.fetch_value(attr.name))
-        end
-      end
       @mutations_from_database = nil
+    end
+
+    def init_attributes(other) # :nodoc:
+      attrs = super
+      if other.persisted? && self.class.respond_to?(:_default_attributes)
+        self.class._default_attributes.map do |attr|
+          attr.with_value_from_user(attrs.fetch_value(attr.name))
+        end
+      else
+        attrs
+      end
     end
 
     def as_json(options = {}) # :nodoc:

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -525,12 +525,7 @@ module ActiveRecord
 
     ##
     def initialize_dup(other) # :nodoc:
-      @attributes = @attributes.deep_dup
-      if self.class.composite_primary_key?
-        @primary_key.each { |key| @attributes.reset(key) }
-      else
-        @attributes.reset(@primary_key)
-      end
+      @attributes = init_attributes(other)
 
       _run_initialize_callbacks
 
@@ -540,6 +535,18 @@ module ActiveRecord
       @_start_transaction_state = nil
 
       super
+    end
+
+    def init_attributes(_) # :nodoc:
+      attrs = @attributes.deep_dup
+
+      if self.class.composite_primary_key?
+        @primary_key.each { |key| attrs.reset(key) }
+      else
+        attrs.reset(@primary_key)
+      end
+
+      attrs
     end
 
     # Populate +coder+ with attributes about this record that should be


### PR DESCRIPTION
The Dirty module had a dependency on a side-effect of Core setting a "deep duped" copy of the `@attributes` IV.  This commit pulls attribute copying to it's own function and leaves `@attribute` IV assignment as a responsibility of the `Core` module.

This is related to the AttributeSet refactoring I'm working on in #53344