### PR TITLE
Report ActiveSupport::LogSubscriber errors to Rails.error

### DIFF
--- a/activesupport/lib/active_support/log_subscriber.rb
+++ b/activesupport/lib/active_support/log_subscriber.rb
@@ -184,6 +184,8 @@ module ActiveSupport
     end
 
     def log_exception(name, e)
+      ActiveSupport.error_reporter.report(e, source: name)
+
       if logger
         logger.error "Could not log #{name.inspect} event. #{e.class}: #{e.message} #{e.backtrace}"
       end

--- a/activesupport/test/log_subscriber_test.rb
+++ b/activesupport/test/log_subscriber_test.rb
@@ -144,10 +144,12 @@ class SyncLogSubscriberTest < ActiveSupport::TestCase
   end
 
   def test_logging_does_not_die_on_failures
-    ActiveSupport::LogSubscriber.attach_to :my_log_subscriber, @log_subscriber
-    instrument "puke.my_log_subscriber"
-    instrument "some_event.my_log_subscriber"
-    wait
+    assert_error_reported do
+      ActiveSupport::LogSubscriber.attach_to :my_log_subscriber, @log_subscriber
+      instrument "puke.my_log_subscriber"
+      instrument "some_event.my_log_subscriber"
+      wait
+    end
 
     assert_equal 1, @logger.logged(:info).size
     assert_equal "some_event.my_log_subscriber", @logger.logged(:info).last


### PR DESCRIPTION
### Motivation / Background

We put a change into production that broke one of our `LogSubscriber`, and it took us a while to realize it. We now know that an error log is issued, but to improve discoverability, it might be worth reporting an error through the ErrorReporter?

### Detail

### Additional information

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
