### PR TITLE
Revert "ActiveModel::Attribute: elide dup for immutable types"

### DIFF
--- a/activemodel/lib/active_model/attribute.rb
+++ b/activemodel/lib/active_model/attribute.rb
@@ -96,14 +96,6 @@ module ActiveModel
       end
     end
 
-    def deep_dup # :nodoc:
-      if @type.mutable?
-        dup
-      else
-        self # If the underlying type is immutable we can get away with not duping
-      end
-    end
-
     def type_cast(*)
       raise NotImplementedError
     end

--- a/activemodel/lib/active_model/attribute/user_provided_default.rb
+++ b/activemodel/lib/active_model/attribute/user_provided_default.rb
@@ -26,10 +26,6 @@ module ActiveModel
         self.class.new(name, user_provided_value, type, original_attribute)
       end
 
-      # Can't elide dup when a default is provided.
-      # See Attribute#deep_dup
-      alias_method :deep_dup, :dup
-
       def marshal_dump
         result = [
           name,

--- a/activemodel/lib/active_model/type/string.rb
+++ b/activemodel/lib/active_model/type/string.rb
@@ -29,10 +29,6 @@ module ActiveModel
         )
       end
 
-      def mutable? # :nodoc:
-        true
-      end
-
       private
         def cast_value(value)
           case value

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -1117,14 +1117,16 @@ class BasicsTest < ActiveRecord::TestCase
     end
 
     def test_default_in_local_time
-      with_timezone_config default: :local do
-        default = Default.new
+      with_env_tz do
+        with_timezone_config default: :local do
+          default = Default.new
 
-        assert_equal Date.new(2004, 1, 1), default.fixed_date
-        assert_equal Time.local(2004, 1, 1, 0, 0, 0, 0), default.fixed_time
+          assert_equal Date.new(2004, 1, 1), default.fixed_date
+          assert_equal Time.local(2004, 1, 1, 0, 0, 0, 0), default.fixed_time
 
-        if current_adapter?(:PostgreSQLAdapter)
-          assert_equal Time.utc(2004, 1, 1, 0, 0, 0, 0), default.fixed_time_with_time_zone
+          if current_adapter?(:PostgreSQLAdapter)
+            assert_equal Time.utc(2004, 1, 1, 0, 0, 0, 0), default.fixed_time_with_time_zone
+          end
         end
       end
     end
@@ -1152,6 +1154,19 @@ class BasicsTest < ActiveRecord::TestCase
 
           if current_adapter?(:PostgreSQLAdapter)
             assert_equal Time.utc(2004, 1, 1, 0, 0, 0, 0), default.fixed_time_with_time_zone
+          end
+        end
+      end
+    end
+
+    def test_switching_default_time_zone
+      with_env_tz do
+        2.times do
+          with_timezone_config default: :local do
+            assert_equal Time.local(2004, 1, 1, 0, 0, 0, 0), Default.new.fixed_time
+          end
+          with_timezone_config default: :utc do
+            assert_equal Time.utc(2004, 1, 1, 0, 0, 0, 0), Default.new.fixed_time
           end
         end
       end

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -1172,6 +1172,16 @@ class BasicsTest < ActiveRecord::TestCase
       end
     end
 
+    def test_mutating_time_objects
+      with_env_tz do
+        with_timezone_config default: :local do
+          assert_equal Time.local(2004, 1, 1, 0, 0, 0, 0), Default.new.fixed_time
+          assert_equal Time.utc(2004, 1, 1, 5, 0, 0, 0), Default.new.fixed_time.utc
+          assert_equal Time.local(2004, 1, 1, 0, 0, 0, 0), Default.new.fixed_time
+        end
+      end
+    end
+
     unless in_memory_db?
       def test_connection_in_local_time
         with_timezone_config default: :utc do


### PR DESCRIPTION
Reverts rails/rails#53337
Fixes #53343

cc @casperisfine  @tenderlove

I think the PR is a good idea but it introduces some dangerous behaviour. With not respecting AR config changes. By not deep-duping the Time attribute we end up stuck on however it is cast originally.

```
>> Default._default_attributes["fixed_time"]
=>
#<ActiveModel::Attribute::FromDatabase:0x000000012dc92d58
 @name="fixed_time",
 @original_attribute=nil,
 @type=
  #<ActiveRecord::Type::DateTime:0x000000012ad7ca50 @limit=nil, @precision=6, @scale=nil, @timezone=nil>,
 @value_before_type_cast="2004-01-01 00:00:00">
>> Default.new.fixed_time
=> 2004-01-01 00:00:00 UTC
>> Default._default_attributes["fixed_time"]
=>
#<ActiveModel::Attribute::FromDatabase:0x000000012dc92d58
 @name="fixed_time",
 @original_attribute=nil,
 @type=
  #<ActiveRecord::Type::DateTime:0x000000012ad7ca50 @limit=nil, @precision=6, @scale=nil, @timezone=nil>,
 @value=2004-01-01 00:00:00 UTC, <--- @value is now set because the attribute was shared
 @value_before_type_cast="2004-01-01 00:00:00">
```

This ends up reusing Time objects which isn't safe because they're unfortunately mutable (though the attributes API doesn't tag them as such, though maybe that's what we want as their _value_ isn't changed just their zone).

```
>> Default.new.fixed_time.localtime
=> 2003-12-31 16:00:00 -0800
>> Default.new.fixed_time
=> 2003-12-31 16:00:00 -0800
>> Default.new.fixed_time
=> 2003-12-31 16:00:00 -0800
>> Default.new.fixed_time.utc
=> 2004-01-01 00:00:00 UTC
>> Default.new.fixed_time
=> 2004-01-01 00:00:00 UTC
>> Default.new.fixed_time
=> 2004-01-01 00:00:00 UTC
```

Maybe it would be safer/more efficient to replace `deep_dup` only on the attributes we know it to be safe for as this feels like a separate (but very similar) concern to `mutable?`.