### PR TITLE
Add tools/cve_announcement.rb

### DIFF
--- a/tools/cve_announcement.rb
+++ b/tools/cve_announcement.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+require "net/http"
+require "json"
+require "uri"
+
+def versions_section(advisory)
+  desc = +""
+  advisory[:vulnerabilities].each do |vuln|
+    package = vuln[:package][:name]
+    bad_versions = vuln[:vulnerable_version_range]
+    patched_versions = vuln[:patched_versions]
+    desc << "* #{package} #{bad_versions}"
+    desc << " (patched in #{patched_versions})" unless patched_versions.empty?
+    desc << "\n"
+  end
+  ["Versions affected", desc]
+end
+
+def patches_section(advisory)
+  desc = +""
+  advisory[:vulnerabilities].each do |vuln|
+    patched_versions = vuln[:patched_versions]
+    commit = IO.popen(%W[git log --format=format:%H --grep=#{advisory[:cve_id]} v#{patched_versions}], &:read)
+    raise "git log failed" unless $?.success?
+    branch = patched_versions[/^\d+\.\d+/]
+    desc << "* #{branch} - https://github.com/rails/rails/commit/#{commit}.patch\n"
+  end
+  ["Patches", desc]
+end
+
+def format_advisory(advisory)
+  text = advisory[:description].dup
+  text.gsub!("\r\n", "\n") # yuck
+
+  sections = text.split(/(?=\n[A-Z].+\n---+\n)/)
+  header = sections.shift.strip
+  header = <<EOS
+#{header}
+
+* #{advisory[:cve_id]}
+* #{advisory[:ghsa_id]}
+
+EOS
+
+  sections.map! do |section|
+    section.split(/^---+$/, 2).map(&:strip)
+  end
+
+  sections.unshift(versions_section(advisory))
+  sections.push(patches_section(advisory))
+
+  ([header.strip] + sections.map do |section|
+    title, body = section
+    "#{title}\n#{"-" * title.size}\n#{body.strip}"
+  end).join("\n\n")
+end
+
+uri = URI("https://api.github.com/repos/rails/rails/security-advisories")
+json = Net::HTTP.get(uri)
+advisories = JSON.parse(json, symbolize_names: true)
+
+should_open = ARGV.delete("--open")
+cves = ARGV
+unless cves.any? && cves.all? { |s| s.match?(/\ACVE-\d\d\d\d-\d+\z/) }
+  puts "Usage: #$0 CVE-YYYY-XXXXX..."
+  puts
+  puts "recent CVEs:"
+  advisories[0, 10].each do |advisory|
+    puts "  #{advisory[:cve_id]} - #{advisory[:summary]}"
+  end
+  exit 1
+end
+
+cves.map do |cve|
+  advisory = advisories.detect { |x| x[:cve_id] == cve }
+  raise "Can't find #{cve}" unless advisory
+  if should_open
+    format = format_advisory(advisory)
+    query = {
+      title: "[#{advisory[:cve_id]}] #{advisory[:summary]}",
+      body: format,
+      category: "security-announcements",
+      tags: "announcement,security"
+    }
+    url = "https://discuss.rubyonrails.org/new-topic?#{URI.encode_www_form(query)}"
+    system(ENV.fetch("BROWSER", "open"), url)
+  else
+    puts "# #{advisory[:summary]}"
+    puts
+    puts format_advisory(advisory)
+  end
+end


### PR DESCRIPTION
This adds a small script to format the advisories from GitHub to be more suitable to posting on our discourse mailing list rather than the manual formatting I did last time.

The most notable formatting changes from what we did previously is:
* Versions affected is generated from a different format
* The CVE and GHSA identifier are just added at the end of the summary. This should allow us to drop the "This vulnerability has been assigned the CVE identifier ..." line.
* Patches are found through the tag of the patched versions noted in the GHSA, the commit is identified by the CVE appearing in its message, and it's linked to on GitHub rather than made by `git format-patch` and made a discourse attachment.

I'm almost sure this has issues/bugs 😅, but I think they'll be easy to fix/patch as they come up in the future. This is run post-release and doesn't need to be on a specific branch to work it just needs the tags to exist in the local git repo.

An example from yesterday's security release: (Compare to [my hand-edited post](https://discuss.rubyonrails.org/t/cve-2024-47889-possible-redos-vulnerability-in-block-format-in-action-mailer/87695))

```
❯ ruby tools/cve_announcement.rb
Usage: tools/cve_announcement.rb CVE-YYYY-XXXXX...

recent CVEs:
  CVE-2024-47889 - Possible ReDoS vulnerability in block_format in Action Mailer
  CVE-2024-47888 - Possible ReDoS vulnerability in plain_text_for_blockquote_node in Action Text
----8<----

❯ ruby tools/cve_announcement.rb CVE-2024-47889
# Possible ReDoS vulnerability in block_format in Action Mailer

There is a possible ReDoS vulnerability in the block_format helper in Action Mailer. This vulnerability has been assigned the CVE identifier CVE-2024-47889.

CVE-2024-47889
GHSA-h47h-mwp9-c6q6

Versions affected
-----------------
* actionmailer >= 3.0.0, < 6.1.7.9 (patched in 6.1.7.9)
* actionmailer >= 7.0.0, < 7.0.8.5 (patched in 7.0.8.5)
* actionmailer >= 7.1.0, < 7.1.4.1 (patched in 7.1.4.1)
* actionmailer >= 7.2.0, < 7.2.1.1 (patched in 7.2.1.1)

Impact
------
Carefully crafted text can cause the block_format helper to take an unexpected amount of time, possibly resulting in a DoS vulnerability. All users running an affected release should either upgrade or apply the relevant patch immediately.

Ruby 3.2 has mitigations for this problem, so Rails applications using Ruby 3.2 or newer are unaffected. Rails 8.0.0.beta1 requires Ruby 3.2 or greater so is unaffected.

Releases
--------
The fixed releases are available at the normal locations.

Workarounds
-----------
Users can avoid calling the `block_format` helper or upgrade to Ruby 3.2

Credits
-------
Thanks to [ooooooo_q](https://hackerone.com/ooooooo_q) for the report!

Patches
-------
* 6.1 - https://github.com/rails/rails/commit/985f1923fa62806ff676e41de67c3b4552131ab9.patch
* 7.0 - https://github.com/rails/rails/commit/0e5694f4d32544532d2301a9b4084eacb6986e94.patch
* 7.1 - https://github.com/rails/rails/commit/3612e3eb3fbafed4f85e1c6ea4c7b6addbb0fdd3.patch
* 7.2 - https://github.com/rails/rails/commit/be898cc996986decfe238341d96b2a6573b8fd2e.patch
```