### PR TITLE
Update `config.assets` documentation in Configuring guide [ci-skip]

### DIFF
--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -637,19 +637,29 @@ deploying to a memory constrained environment you may want to set this to `false
 | (original)            | `false`              |
 | 7.2                   | `true`               |
 
-### Configuring Assets
+### Configuring the Asset Pipeline
+
+The configuration of the asset pipeline depends on the gems used. Both
+[propshaft](https://github.com/rails/propshaft) (the default) and
+[sprockets-rails](https://github.com/rails/sprockets-rails) come with their own
+defaults defined.
 
 #### `config.assets.css_compressor`
 
-Defines the CSS compressor to use. It is set by default by `sass-rails`. The unique alternative value at the moment is `:yui`, which uses the `yui-compressor` gem.
+Defines the CSS compressor to be used by `sprockets-rails`. It is set to `:sass` by `sassc-rails`. The
+unique alternative value at the moment is `:yui`, which uses the
+`yui-compressor` gem.
 
 #### `config.assets.js_compressor`
 
-Defines the JavaScript compressor to use. Possible values are `:terser`, `:closure`, `:uglifier`, and `:yui`, which require the use of the `terser`, `closure-compiler`, `uglifier`, or `yui-compressor` gems respectively.
+Defines the JavaScript compressor to be used `sprockets-rails`. Possible values are `:terser`,
+`:closure`, `:uglifier`, and `:yui`, which require the use of the `terser`,
+`closure-compiler`, `uglifier`, or `yui-compressor` gems respectively.
 
 #### `config.assets.gzip`
 
-A flag that enables the creation of gzipped version of compiled assets, along with non-gzipped assets. Set to `true` by default.
+A flag that enables the creation of gzipped version of compiled assets, along
+with non-gzipped assets. Set to `true` by `sprockets-rails`.
 
 #### `config.assets.paths`
 
@@ -672,7 +682,8 @@ The default value depends on the `config.load_defaults` target version:
 
 #### `config.assets.prefix`
 
-Defines the prefix where assets are served from. Defaults to `/assets`.
+Defines the prefix where assets are served from. Set to `/assets` by
+`propshaft` and `sprocket-rails`.
 
 #### `config.assets.manifest`
 
@@ -680,11 +691,13 @@ Defines the full path to be used for the asset precompiler's manifest file. Defa
 
 #### `config.assets.digest`
 
-Enables the use of SHA256 fingerprints in asset names. Set to `true` by default.
+Enables the use of SHA256 fingerprints in asset names. Set to `true` by
+`sprocket-rails`.
 
 #### `config.assets.debug`
 
-Disables the concatenation and compression of assets. Set to `true` by default in `development.rb`.
+Disables the concatenation and compression of assets. Set to `false` by
+`sprocket-rails`.
 
 #### `config.assets.version`
 
@@ -692,7 +705,8 @@ Is an option string that is used in SHA256 hash generation. This can be changed 
 
 #### `config.assets.compile`
 
-Is a boolean that can be used to turn on live Sprockets compilation in production.
+Is a boolean that can be used to turn on live Sprockets compilation in
+production. Set to `true` by `sprocket-rails`.
 
 #### `config.assets.logger`
 
@@ -700,7 +714,8 @@ Accepts a logger conforming to the interface of Log4r or the default Ruby `Logge
 
 #### `config.assets.quiet`
 
-Disables logging of assets requests. Set to `true` by default in `config/environments/development.rb`.
+Disables logging of assets requests. Set to `false` by `propshaft` and
+`sprocket-rails`.
 
 ### Configuring Generators
 


### PR DESCRIPTION
Commits 0f43feda04d45aec064aedc312d265a529e4915d and adec7e7ba87e3d268149d0020d54dc211eb02ada removed setting `config.assets.quiet` and `config.assets.debug` to `true` in `config/environments/development.rb`.
The guide has been updated to reflect that.

The defaults for other `config.assets` configs are set by either `propshaft` or `sprocket-rails`. So the guides should mention that.
* propshaft https://github.com/rails/propshaft/blob/993c67d843cd544927cce150cddc160b9c5607e3/lib/propshaft/railtie.rb
* sprocket-rails https://github.com/rails/sprockets-rails/blob/2c04236faaacd021b7810289cbac93e962ff14da/lib/sprockets/railtie.rb


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
