### PR TITLE
Coerce `nil` values into column default when `null: false`

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,19 @@
+*   Write `nil` values as the column default when `null: false`
+
+    ```ruby
+    ActiveRecord::Schema.define do
+      create_table :posts, force: true do |t|
+        t.boolean :published, null: false, default: true
+      end
+    end
+
+    post = Post.create! published: nil
+
+    post.published # => true
+    ```
+
+    *Sean Doyle*
+
 *   Fix incorrect SQL query when passing an empty hash to `ActiveRecord::Base.insert`.
 
     *David Stosik*

--- a/activerecord/lib/active_record/attribute_methods/write.rb
+++ b/activerecord/lib/active_record/attribute_methods/write.rb
@@ -39,6 +39,12 @@ module ActiveRecord
       # This method exists to avoid the expensive primary_key check internally, without
       # breaking compatibility with the write_attribute API
       def _write_attribute(attr_name, value) # :nodoc:
+        column = self.class.column_for_attribute(attr_name)
+
+        if value.nil? && !column.null && column.has_default?
+          value = column.default
+        end
+
         @attributes.write_from_user(attr_name, value)
       end
 

--- a/activerecord/test/cases/defaults_test.rb
+++ b/activerecord/test/cases/defaults_test.rb
@@ -4,6 +4,7 @@ require "cases/helper"
 require "support/schema_dumping_helper"
 require "models/default"
 require "models/entrant"
+require "models/person"
 
 class DefaultTest < ActiveRecord::TestCase
   def test_nil_defaults_for_not_null_columns
@@ -12,6 +13,12 @@ class DefaultTest < ActiveRecord::TestCase
       assert_not column.null, "#{name} column should be NOT NULL"
       assert_not column.default, "#{name} column should be DEFAULT 'nil'"
     end
+  end
+
+  def test_coerces_nil_into_default_value_for_column
+    person = Person.create! first_name: "ignored", insures: nil
+
+    assert_equal 0, person.read_attribute(:insures)
   end
 
   if current_adapter?(:PostgreSQLAdapter) || current_adapter?(:SQLite3Adapter)


### PR DESCRIPTION
### Motivation / Background

Considering a schema like the following:

```ruby
ActiveRecord::Schema.define do
  create_table :posts, force: true do |t|
    t.boolean :published, null: false, default: true
  end
end
```

Prior to this change, creating a `Post` with an explicitly set `published: nil` would raise an exception:

```ruby
Post.create! published: nil # => raises ActiveRecord::NotNullViolation: SQLite3::ConstraintException: NOT NULL constraint failed: posts.published
```

### Detail

After this change, attribute assignment will coerce the `nil` into the column's default value:

```ruby
post = Post.create! published: nil

post.published # => true
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
