### PR TITLE
[ci skip] fix(docs): incorrect indentation in association_basics.md

### DIFF
--- a/guides/source/association_basics.md
+++ b/guides/source/association_basics.md
@@ -2602,12 +2602,12 @@ Controls what happens to the associated object when its owner is destroyed:
   Do not use this option if the association is backed by foreign key constraints
   in your database. The foreign key constraint actions will occur inside the
   same transaction that deletes its owner.
-  * `:nullify` causes the foreign key to be set to `NULL`. Polymorphic type
+* `:nullify` causes the foreign key to be set to `NULL`. Polymorphic type
     column is also nullified on polymorphic associations. Callbacks are not
     executed.
-  * `:restrict_with_exception` causes an `ActiveRecord::DeleteRestrictionError`
+* `:restrict_with_exception` causes an `ActiveRecord::DeleteRestrictionError`
     exception to be raised if there is an associated record
-  * `:restrict_with_error` causes an error to be added to the owner if there is
+* `:restrict_with_error` causes an error to be added to the owner if there is
     an associated object
 
 WARNING: You should not specify this option on a `belongs_to` association that


### PR DESCRIPTION

### Motivation / Background

This Pull Request has been created because of indentation issues.

### Detail

This Pull Request changes indentation in association_basics.md

### Additional information

Before:

<img width="400" alt="Screenshot 2024-10-17 at 18 24 25" src="https://github.com/user-attachments/assets/b34ef243-3412-40e7-b4e5-2d2fb248bf60">

<img width="250" alt="Screenshot 2024-10-17 at 18 29 38" src="https://github.com/user-attachments/assets/42040515-b6a2-47c1-8c04-7266afe7bca0">

After:

<img width="250" alt="Screenshot 2024-10-17 at 18 31 29" src="https://github.com/user-attachments/assets/6d41ba50-7a6b-429e-a13c-c996eb708a18">


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
