### PR TITLE
Skip loading seeds for databases that are managed by Rails

### DIFF
--- a/activerecord/lib/active_record/database_configurations/database_config.rb
+++ b/activerecord/lib/active_record/database_configurations/database_config.rb
@@ -99,6 +99,10 @@ module ActiveRecord
       def use_metadata_table?
         raise NotImplementedError
       end
+
+      def framework?
+        raise NotImplementedError
+      end
     end
   end
 end

--- a/activerecord/lib/active_record/database_configurations/hash_config.rb
+++ b/activerecord/lib/active_record/database_configurations/hash_config.rb
@@ -130,6 +130,10 @@ module ActiveRecord
         Base.configurations.primary?(name)
       end
 
+      def framework? # :nodoc:
+        configuration_hash.fetch(:framework, false)
+      end
+
       # Determines whether to dump the schema/structure files and the filename that
       # should be used.
       #

--- a/activerecord/lib/active_record/tasks/database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/database_tasks.rb
@@ -180,7 +180,7 @@ module ActiveRecord
         each_current_configuration(env) do |db_config|
           database_initialized = initialize_database(db_config)
 
-          seed = true if database_initialized
+          seed = true if database_initialized && !db_config.framework?
         end
 
         each_current_environment(env) do |environment|

--- a/activerecord/test/cases/database_configurations/hash_config_test.rb
+++ b/activerecord/test/cases/database_configurations/hash_config_test.rb
@@ -179,6 +179,17 @@ module ActiveRecord
         config = HashConfig.new("default_env", "primary", { adapter: "abstract", password: "hunter2" })
         assert_equal "#<ActiveRecord::DatabaseConfigurations::HashConfig env_name=default_env name=primary adapter_class=ActiveRecord::ConnectionAdapters::AbstractAdapter>", config.inspect
       end
+
+      def test_framework
+        config = HashConfig.new("default_env", "primary", { adapter: "abstract" })
+        assert_equal false, config.framework?
+
+        config = HashConfig.new("default_env", "primary", { adapter: "abstract", framework: false })
+        assert_equal false, config.framework?
+
+        config = HashConfig.new("default_env", "primary", { adapter: "abstract", framework: true })
+        assert_equal true, config.framework?
+      end
     end
   end
 end

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/mysql.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/mysql.yml.tt
@@ -69,14 +69,17 @@ production:
     <<: *primary_production
     database: <%= app_name %>_production_cache
     migrations_paths: db/cache_migrate
+    framework: true
   queue:
     <<: *primary_production
     database: <%= app_name %>_production_queue
     migrations_paths: db/queue_migrate
+    framework: true
   <%- unless options.skip_action_cable? -%>
   cable:
     <<: *primary_production
     database: <%= app_name %>_production_cable
     migrations_paths: db/cable_migrate
+    framework: true
   <%- end -%>
 <%- end -%>

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/postgresql.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/postgresql.yml.tt
@@ -101,14 +101,17 @@ production:
     <<: *primary_production
     database: <%= app_name %>_production_cache
     migrations_paths: db/cache_migrate
+    framework: true
   queue:
     <<: *primary_production
     database: <%= app_name %>_production_queue
     migrations_paths: db/queue_migrate
+    framework: true
   <%- unless options.skip_action_cable? -%>
   cable:
     <<: *primary_production
     database: <%= app_name %>_production_cable
     migrations_paths: db/cable_migrate
+    framework: true
   <%- end -%>
 <%- end -%>

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/sqlite3.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/sqlite3.yml.tt
@@ -41,6 +41,7 @@ production:
     <<: *default
     # database: path/to/persistent/storage/production_cache.sqlite3
     migrations_paths: db/cache_migrate
+    framework: true
 <%- end -%>
 <%- else -%>
 # Store production database in the storage/ directory, which by default
@@ -58,15 +59,18 @@ production:
     <<: *default
     database: storage/production_cache.sqlite3
     migrations_paths: db/cache_migrate
+    framework: true
   queue:
     <<: *default
     database: storage/production_queue.sqlite3
     migrations_paths: db/queue_migrate
+    framework: true
   <%- unless options.skip_action_cable? -%>
   cable:
     <<: *default
     database: storage/production_cable.sqlite3
     migrations_paths: db/cable_migrate
+    framework: true
   <%- end -%>
 <%- end -%>
 <%- end -%>

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/trilogy.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/trilogy.yml.tt
@@ -69,14 +69,17 @@ production:
     <<: *primary_production
     database: <%= app_name %>_production_cache
     migrations_paths: db/cache_migrate
+    framework: true
   queue:
     <<: *primary_production
     database: <%= app_name %>_production_queue
     migrations_paths: db/queue_migrate
+    framework: true
   <%- unless options.skip_action_cable? -%>
   cable:
     <<: *primary_production
     database: <%= app_name %>_production_cable
     migrations_paths: db/cable_migrate
+    framework: true
   <%- end -%>
 <%- end -%>


### PR DESCRIPTION
### Motivation / Background

Issue #53348 describes an issue where, after adding Solid Cache to an application, running `db:prepare` in production re-loaded the seeds, potentially leading to data loss.

This PR proposes that any databases that are managed by Rails should behave differently in this case, and seeds should not be run when a Solid {Cache,Queue,Cable} database is added to the config and initialized.

### Detail

Specifically, this PR adds a new method `DatabaseConfig#framework?` which defaults to `false`, but is set to `true` for the Solid-* databases in Rails's default production database config.


### Additional information

If this proposal is merged, the docs for the Solid-* gems should be updated to inform users to add the `framework: true` value to their database config.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [?] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
