### PR TITLE
Document how `nil` overrides an attribute default [ci skip]

### DIFF
--- a/guides/source/active_model_basics.md
+++ b/guides/source/active_model_basics.md
@@ -199,6 +199,8 @@ irb> person.active
 Some additional methods described below are available when using
 `ActiveModel::Attributes`.
 
+NOTE: Assigning any value (including `nil`) will override an attribute's default.
+
 #### Method: `attribute_names`
 
 The `attribute_names` method returns an array of attribute names.

--- a/guides/source/active_record_migrations.md
+++ b/guides/source/active_record_migrations.md
@@ -674,10 +674,9 @@ Column modifiers can be applied when creating or changing a column:
 
 * `comment`      Adds a comment for the column.
 * `collation`    Specifies the collation for a `string` or `text` column.
-* `default`      Allows to set a default value on the column. Note that if you
-  are using a dynamic value (such as a date), the default will only be
-  calculated the first time (i.e. on the date the migration is applied). Use
-  `nil` for `NULL`.
+* `default`      Declares a default value for the column when a value is not
+  provided. Assigning any value (including `nil`) will override a column's
+  default value. Use `nil` for `NULL`.
 * `limit`        Sets the maximum number of characters for a `string` column and
   the maximum number of bytes for `text/binary/integer` columns.
 * `null`         Allows or disallows `NULL` values in the column.
@@ -694,6 +693,12 @@ for further information.
 
 NOTE: `null` and `default` cannot be specified via command line when generating
 migrations.
+
+NOTE: Declaring a `default` with a dynamic value (such as a date) will only be
+calculated the first time (on the date the migration is applied, for example).
+
+NOTE: Saving `nil` to a column with both `null: false` and a `default` value
+will raise an `ActiveRecord::NotNullViolation`.
 
 ### References
 
@@ -1779,4 +1784,3 @@ Instead, consider using the
 gem provides a framework for creating and managing data migrations and other
 maintenance tasks in a way that is safe and easy to manage without interfering
 with schema migrations.
-


### PR DESCRIPTION
### Motivation / Background

Considering a schema like the following:

```ruby
ActiveRecord::Schema.define do
  create_table :posts, force: true do |t|
    t.boolean :published, null: false, default: true
  end
end
```

Creating a Post with an explicitly set `published: nil` raises an exception:

```
Post.create! published: nil # => raises ActiveRecord::NotNullViolation: SQLite3::ConstraintException: NOT NULL constraint failed: posts.published
```

A teammate and I were recently surprised to find that our system was raising `ActiveRecord::NotNullViolation` exceptions for records that specified both `null: false` and a `default: ...` value.

> "Setting an attribute overrides its default" seems blatantly obvious to me, and I would only expect to need to give nil an individual callout if it had unique behaviour, like magically switching to the column default.

Our surprise was rooted in the fact that combining both `null: false` and `default: ...` did not sufficiently insulate our record from attempting to write a `NULL` value to the underlying database. Conceptually, we thought that the two column options would complement one another: 

* `default: ...` would provide the value to use *when an attribute is missing*
* `null: false` would provide context for Active Record to infer from while configuring the database to reject `NULL`

We've come to learn that *when an attribute is missing* only applies when the attribute's key is omitted from the persisted Hash of attributes, and *not* when the attribute itself is `nil`. My teammate and I were both surprised to learn the difference. I shared my findings with colleagues outside of my team, and they were also surprised. Personally, I have been operating under that incorrect assumption for more than a decade. I must be very lucky to have never encountered the scenario until now.

Proposed changes
---

I proposed https://github.com/rails/rails/pull/53352 to bring the behavior in this scenario closer to what we expected, since a successful save with the default value seemed more beneficial than raising an `ActiveRecord::NotNullViolation`.

That pull request's test coverage, CHANGELOG entry, and description all use `nil` directly for the sake of being explicit. However, that isn't how we encountered this issue. Like most `nil`-based surprises, we expected a value to be present and not `nil` elsewhere in the code, but were wrong.

I accept that it's the framework's stance to prefer raising the database-level exception instead of modifying a value on behalf of the caller. In response to that decision, I opened this PR to improve the guidance around this scenario.

I also accept that the current changes to the documentation do not sufficiently improve the guidance. That's ok, I'm happy to continue to workshop the prose until it's good enough. The main motivation is to describe this behavior *in the correct spots* and as *explicitly* as I can.

Script
---

Here's an executable script to demonstrate the behavior my team encountered that motivated the original PR and then this PR's changes to documentation:

<details>
  <summary>script.rb</summary>

```ruby
# frozen_string_literal: true

require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"

  gem "rails"
  # If you want to test against edge Rails replace the previous line with this:
  # gem "rails", github: "rails/rails", branch: "main"

  gem "sqlite3"
end

require "active_record"
require "minitest/autorun"
require "logger"

# This connection will do for database-independent bug reports.
ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")
ActiveRecord::Base.logger = Logger.new(STDOUT)

ActiveRecord::Schema.define do
  create_table :records, force: true do |t|
    t.boolean :bool, null: false, default: true
  end
end

class Model
  include ActiveModel::Attributes

  attribute :bool, :boolean
end

class Record < ActiveRecord::Base
end

class BugTest < ActiveSupport::TestCase
  def test_column_default_when_nil_attribute_omitted
    record = Record.create!

    assert_equal true, record.bool
  end

  def test_column_default_when_attribute_assigned
    model = Model.new
    model.bool = false
    record = Record.create! bool: model.bool

    assert_equal false, record.bool
  end

  def test_column_default_when_nil_assigned
    model = Model.new
    # skipped assignment to model.bool
    record = Record.create! bool: model.bool

    assert_equal true, record.bool # raises ActiveRecord::NotNullViolation
  end
end
```

</details>

### Detail

[#53352][] aimed to change that behavior, but was rejected. This change aims to document both Active Record and Active Model's behavior when assigning `nil` to attributes with a `default` value (and a column with both `null: false` and a `default` option).

[#53352]: https://github.com/rails/rails/pull/53352