### PR TITLE
Fix marshalling of unsaved associated records in 7.1 format

### DIFF
--- a/activerecord/lib/active_record/marshalling.rb
+++ b/activerecord/lib/active_record/marshalling.rb
@@ -25,7 +25,10 @@ module ActiveRecord
         payload = [attributes_for_database, new_record?]
 
         cached_associations = self.class.reflect_on_all_associations.select do |reflection|
-          association_cached?(reflection.name) && association(reflection.name).loaded?
+          if association_cached?(reflection.name)
+            association = association(reflection.name)
+            association.loaded? || association.target.present?
+          end
         end
 
         unless cached_associations.empty?

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -1524,7 +1524,7 @@ class BasicsTest < ActiveRecord::TestCase
     assert_predicate post, :new_record?, "should be a new record"
   end
 
-  def test_marshalling_with_associations
+  def test_marshalling_with_associations_6_1
     post = Post.new
     post.comments.build
 
@@ -1532,6 +1532,21 @@ class BasicsTest < ActiveRecord::TestCase
     post       = Marshal.load(marshalled)
 
     assert_equal 1, post.comments.length
+  end
+
+  def test_marshalling_with_associations_7_1
+    previous_format_version = ActiveRecord::Marshalling.format_version
+    ActiveRecord::Marshalling.format_version = 7.1
+
+    post = Post.new
+    post.comments.build
+
+    marshalled = Marshal.dump(post)
+    post       = Marshal.load(marshalled)
+
+    assert_equal 1, post.comments.length
+  ensure
+    ActiveRecord::Marshalling.format_version = previous_format_version
   end
 
   if Process.respond_to?(:fork) && !in_memory_db?


### PR DESCRIPTION
I noticed this bug while trying to remove the 6.1 cache format support.

The 7.1 format would only marshal associated records if the association was loaded. But associations that would only contain unsaved records would be skipped.

This should be backported.