### PR TITLE
Get rid of `bundler_windows_platforms`

### DIFF
--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -659,10 +659,6 @@ module Rails
         !(options[:skip_bundle] || options[:pretend])
       end
 
-      def bundler_windows_platforms
-        Gem.rubygems_version >= Gem::Version.new("3.3.22") ? "windows" : "mswin mswin64 mingw x64_mingw"
-      end
-
       def depends_on_system_test?
         !(options[:skip_system_test] || options[:skip_test] || options[:api])
       end

--- a/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
@@ -10,7 +10,7 @@ source "https://rubygems.org"
 <% end -%>
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
-gem "tzinfo-data", platforms: %i[ <%= bundler_windows_platforms %> jruby ]
+gem "tzinfo-data", platforms: %i[ windows jruby ]
 <% unless options.skip_solid? -%>
 
 <% if options.skip_action_cable? -%>
@@ -53,7 +53,7 @@ gem "thruster", require: false
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
-  gem "debug", platforms: %i[ mri <%= bundler_windows_platforms %> ], require: "debug/prelude"
+  gem "debug", platforms: %i[ mri windows ], require: "debug/prelude"
 <%- unless options.skip_brakeman? -%>
 
   # Static analysis for security vulnerabilities [https://brakemanscanner.org/]

--- a/railties/lib/rails/generators/rails/plugin/templates/Gemfile.tt
+++ b/railties/lib/rails/generators/rails/plugin/templates/Gemfile.tt
@@ -19,5 +19,5 @@ gem "rubocop-rails-omakase", require: false
 <% end -%>
 <% if RUBY_PLATFORM.match?(/mingw|mswin|java/) -%>
 
-gem "tzinfo-data", platforms: %i[ <%= bundler_windows_platforms %> jruby ]
+gem "tzinfo-data", platforms: %i[ windows jruby ]
 <% end -%>

--- a/railties/test/generators/generators_test_helper.rb
+++ b/railties/test/generators/generators_test_helper.rb
@@ -156,7 +156,6 @@ module GeneratorsTestHelper
         depend_on_bootsnap: false,
         depends_on_system_test: false,
         options: ActiveSupport::OrderedOptions.new,
-        bundler_windows_platforms: "windows",
       }
     end
 end


### PR DESCRIPTION
Since Ruby 3.2.0 installs RubyGems 3.4.1 as a default gem.
