### PR TITLE
Improve error handling on attempt to update optimistic lock version to `nil`

### DIFF
--- a/activerecord/lib/active_record/locking/optimistic.rb
+++ b/activerecord/lib/active_record/locking/optimistic.rb
@@ -101,6 +101,13 @@ module ActiveRecord
             attribute_names = attribute_names.dup if attribute_names.frozen?
             attribute_names << locking_column
 
+            if self[locking_column].nil?
+              raise(<<-MSG.squish)
+                For optimistic locking, '#{locking_column}' should not be set to `nil`/`NULL`.
+                Are you missing a default value or validation on '#{locking_column}'?
+              MSG
+            end
+
             self[locking_column] += 1
 
             affected_rows = self.class._update_record(

--- a/activerecord/test/models/person.rb
+++ b/activerecord/test/models/person.rb
@@ -148,3 +148,8 @@ class SerializedPerson < ActiveRecord::Base
 
   serialize :insures, coder: Insure
 end
+
+class LockVersionValidatedPerson < ActiveRecord::Base
+  self.table_name = "people"
+  validates :lock_version, numericality: { only_integer: true }, allow_nil: false
+end


### PR DESCRIPTION
### Summary

Optimistic locking raises `NoMethodError: undefined method '+' for nil` on an attempt to `#update` the lock column (eg `lock_version`) to `nil` (and the model has no validation to prevent it).

This PR proposes to handle this situation more gracefully, by raising a more helpful error where appropriate.

### Motivation / Background

This was happening in an app where a bug was causing an `#update` attempt with `lock_version: nil`. The model had no validations on the `lock_version` column. The raised error was not particularly helpful:

```
NoMethodError: undefined method `+' for nil
    lib/active_record/locking/optimistic.rb:104:in `_update_row'
    lib/active_record/persistence.rb:907:in `_update_record'
    ...
```

Hence, I thought a more useful error message would be nice, since it is possible that an app might contain a model whose lock has no AR validations on the lock version column. Also, other cases where the lock column has no default say are handled gracefully already by the implementation.

The proposal is to raise before attempting to increment the version, with a suggestion to check if there is a missing a validation. For example:

```
For optimistic locking, 'lock_version' should not be set to `nil`/`NULL`. Are you missing a default value or validation on 'lock_version'?
```

### Detail

Consider the model (taken from the ActiveRecord test suite)

```
create_table :lock_without_defaults, force: true do |t|
  t.column :title, :string
  t.column :lock_version, :integer
  t.timestamps null: true
end
```

```
class LockWithoutDefault < ActiveRecord::Base; end
```

One can [create a record](https://github.com/rails/rails/blob/ee661852313ff697d5f3a73a68aab99101ea3ead/activerecord/test/cases/locking_test.rb#L280) without any initial value for the `lock_version` column. If one accidentally attempts to `update` the `lock_version` to `nil`, it raises.

```
t1 = LockWithoutDefault.create!(title: "title1")
t1.update(lock_version: nil)
```

```
NoMethodError: undefined method `+' for nil
    lib/active_record/locking/optimistic.rb:104:in `_update_row'
    lib/active_record/persistence.rb:907:in `_update_record'
    ...
```

After the proposed change, the error will instead be

```
RuntimeError: For optimistic locking, 'lock_version' should not be set to `nil`/`NULL`. Are you missing a default value or validation on 'lock_version'?
    lib/active_record/locking/optimistic.rb:105:in `_update_row'
    lib/active_record/persistence.rb:907:in `_update_record'
    ...
```

### Additional information

The error I chose is a `RuntimeError`, following what is generated by [pessimistic locking here](https://github.com/stevegeek/rails/blob/2d1ec4bf09381af24a336f0e1923369eb050864a/activerecord/lib/active_record/locking/pessimistic.rb#L72).

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.


------

Let me know if this is something that might be considered useful and what other changes might be needed.

Thanks for all your work on Rails!