### PR TITLE
Preserve custom predicate handlers for joins

### DIFF
--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -198,7 +198,7 @@ module ActiveRecord
       end
 
       def join_scope(table, foreign_table, foreign_klass)
-        predicate_builder = PredicateBuilder.new(TableMetadata.new(klass, table))
+        predicate_builder = klass.predicate_builder.with(TableMetadata.new(klass, table))
         scope_chain_items = join_scopes(table, predicate_builder)
         klass_scope       = klass_join_scope(table, predicate_builder)
 

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -76,7 +76,7 @@ module ActiveRecord
 
     def initialize(model, table: nil, predicate_builder: nil, values: {})
       if table
-        predicate_builder ||= PredicateBuilder.new(TableMetadata.new(model, table))
+        predicate_builder ||= model.predicate_builder.with(TableMetadata.new(model, table))
       else
         table = model.arel_table
         predicate_builder ||= model.predicate_builder

--- a/activerecord/lib/active_record/relation/predicate_builder.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder.rb
@@ -72,7 +72,15 @@ module ActiveRecord
       table.associated_table(table_name, &block).arel_table[column_name]
     end
 
+    def with(table)
+      other = dup
+      other.table = table
+      other
+    end
+
     protected
+      attr_writer :table
+
       def expand_from_hash(attributes, &block)
         return ["1=0"] if attributes.empty?
 

--- a/activerecord/lib/active_record/table_metadata.rb
+++ b/activerecord/lib/active_record/table_metadata.rb
@@ -69,9 +69,7 @@ module ActiveRecord
 
     def predicate_builder
       if klass
-        predicate_builder = klass.predicate_builder.dup
-        predicate_builder.instance_variable_set(:@table, self)
-        predicate_builder
+        klass.predicate_builder.with(self)
       else
         PredicateBuilder.new(self)
       end

--- a/activerecord/test/cases/relation/predicate_builder_test.rb
+++ b/activerecord/test/cases/relation/predicate_builder_test.rb
@@ -23,6 +23,12 @@ module ActiveRecord
       assert_match %r{#{Regexp.escape(quote_table_name("topics.title"))} ~ 'rails'}i, Reply.joins(:topic).where(topics: { title: /rails/ }).to_sql
     end
 
+    def test_registering_new_handlers_for_joins
+      Reply.belongs_to :regexp_topic, -> { where(title: /rails/) }, class_name: "Topic", foreign_key: "parent_id"
+
+      assert_match %r{#{Regexp.escape(quote_table_name("regexp_topic.title"))} ~ 'rails'}i, Reply.joins(:regexp_topic).references(Arel.sql("regexp_topic")).to_sql
+    end
+
     def test_references_with_schema
       assert_equal %w{schema.table}, ActiveRecord::PredicateBuilder.references(%w{schema.table.column})
     end


### PR DESCRIPTION
Otherwise join queries doesn't recognize the registered custom predicate handlers for the original class.
