### PR TITLE
Fix httpclient git source in the lockfile

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,6 +13,8 @@ GIT
   branch: master
   specs:
     httpclient (2.8.3)
+      mutex_m
+      webrick
 
 GIT
   remote: https://github.com/rails/sdoc.git
@@ -376,6 +378,7 @@ GEM
     msgpack (1.7.2)
     multi_json (1.15.0)
     multipart-post (2.3.0)
+    mutex_m (0.2.0)
     mysql2 (0.5.6)
     net-http-persistent (4.0.2)
       connection_pool (~> 2.2)


### PR DESCRIPTION
### Motivation / Background

Followup to https://github.com/rails/rails/pull/50911

Not quite sure what happened here, the commit is still the latest. I simply ran `bundle lock --update=httpclient --conservative`.

When running the railties tests:

<details><summary>Output</summary>
<p>

```rb
.........../home/earlopain/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/bundler/gems/httpclient-d57cc6d5ffee/lib/httpclient/auth.rb:11: warning: mutex_m was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.4.0.
You can add mutex_m to your Gemfile or gemspec to silence this warning.
/home/earlopain/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/bundler/gems/httpclient-d57cc6d5ffee/lib/httpclient/auth.rb:11: warning: mutex_m was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.4.0.
You can add mutex_m to your Gemfile or gemspec to silence this warning.
/home/earlopain/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/bundler/gems/httpclient-d57cc6d5ffee/lib/httpclient/auth.rb:11: warning: mutex_m was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.4.0.
You can add mutex_m to your Gemfile or gemspec to silence this warning.
/home/earlopain/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/bundler/gems/httpclient-d57cc6d5ffee/lib/httpclient/auth.rb:11: warning: mutex_m was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.4.0.
You can add mutex_m to your Gemfile or gemspec to silence this warning.
/home/earlopain/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/bundler/gems/httpclient-d57cc6d5ffee/lib/httpclient/auth.rb:11: warning: mutex_m was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.4.0.
You can add mutex_m to your Gemfile or gemspec to silence this warning.
/home/earlopain/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/bundler/gems/httpclient-d57cc6d5ffee/lib/httpclient/auth.rb:11: warning: mutex_m was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.4.0.
You can add mutex_m to your Gemfile or gemspec to silence this warning.
/home/earlopain/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/bundler/gems/httpclient-d57cc6d5ffee/lib/httpclient/auth.rb:11: warning: mutex_m was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.4.0.
You can add mutex_m to your Gemfile or gemspec to silence this warning.
/home/earlopain/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/bundler/gems/httpclient-d57cc6d5ffee/lib/httpclient/auth.rb:11: warning: mutex_m was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.4.0.
You can add mutex_m to your Gemfile or gemspec to silence this warning.
./home/earlopain/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/bundler/gems/httpclient-d57cc6d5ffee/lib/httpclient/auth.rb:11: warning: mutex_m was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.4.0.
You can add mutex_m to your Gemfile or gemspec to silence this warning.
...
```

</p>
</details> 

You get the idea. Not sure why strict warnings don't pick this up or why no one else noticed this yet.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
