### PR TITLE
Prevent `ActiveSupport::TimeZone` documentation class inferences [ci skip]

### DIFF
--- a/activesupport/lib/active_support/values/time_zone.rb
+++ b/activesupport/lib/active_support/values/time_zone.rb
@@ -12,7 +12,7 @@ module ActiveSupport
   # * Limit the set of zones provided by TZInfo to a meaningful subset of 134
   #   zones.
   # * Retrieve and display zones with a friendlier name
-  #   (e.g., "Eastern Time (US & Canada)" instead of "America/New_York").
+  #   (e.g., "Eastern \Time (US & Canada)" instead of "America/New_York").
   # * Lazily load +TZInfo::Timezone+ instances only when they're needed.
   # * Create ActiveSupport::TimeWithZone instances via TimeZone's +local+,
   #   +parse+, +at+, and +now+ methods.
@@ -355,7 +355,7 @@ module ActiveSupport
       "(GMT#{formatted_offset}) #{name}"
     end
 
-    # Method for creating new ActiveSupport::TimeWithZone instance in time zone
+    # \Method for creating new ActiveSupport::TimeWithZone instance in time zone
     # of +self+ from given values.
     #
     #   Time.zone = 'Hawaii'                    # => "Hawaii"
@@ -365,7 +365,7 @@ module ActiveSupport
       ActiveSupport::TimeWithZone.new(nil, self, time)
     end
 
-    # Method for creating new ActiveSupport::TimeWithZone instance in time zone
+    # \Method for creating new ActiveSupport::TimeWithZone instance in time zone
     # of +self+ from number of seconds since the Unix epoch.
     #
     #   Time.zone = 'Hawaii'        # => "Hawaii"
@@ -380,7 +380,7 @@ module ActiveSupport
       Time.at(*args).utc.in_time_zone(self)
     end
 
-    # Method for creating new ActiveSupport::TimeWithZone instance in time zone
+    # \Method for creating new ActiveSupport::TimeWithZone instance in time zone
     # of +self+ from an ISO 8601 string.
     #
     #   Time.zone = 'Hawaii'                     # => "Hawaii"
@@ -432,7 +432,7 @@ module ActiveSupport
       raise ArgumentError, "invalid date"
     end
 
-    # Method for creating new ActiveSupport::TimeWithZone instance in time zone
+    # \Method for creating new ActiveSupport::TimeWithZone instance in time zone
     # of +self+ from parsed string.
     #
     #   Time.zone = 'Hawaii'                   # => "Hawaii"
@@ -454,7 +454,7 @@ module ActiveSupport
       parts_to_time(Date._parse(str, false), now)
     end
 
-    # Method for creating new ActiveSupport::TimeWithZone instance in time zone
+    # \Method for creating new ActiveSupport::TimeWithZone instance in time zone
     # of +self+ from an RFC 3339 string.
     #
     #   Time.zone = 'Hawaii'                     # => "Hawaii"


### PR DESCRIPTION
### Motivation / Background

Prior to this change, the API documentation transformed the mention of "Time" into a link to the [Time][] class, and incorrectly inferred the mention of captial M "Method" as a mention of Rails' [Method][] class extensions.

After this change, the tokens are treated as capitalized English words instead of Ruby Class names.

Before
---

![Screenshot 2024-10-18 at 11 36 13 AM](https://github.com/user-attachments/assets/18883c2f-257b-4376-8daf-ad22f04a8fa5)

![Screenshot 2024-10-18 at 11 36 42 AM](https://github.com/user-attachments/assets/8912c367-745f-4de9-9bc9-6bab5133a920)

After
---

![Screenshot 2024-10-18 at 11 43 51 AM](https://github.com/user-attachments/assets/e3764f8d-e9f6-412d-8a46-2923adc6a697)

![Screenshot 2024-10-18 at 11 44 18 AM](https://github.com/user-attachments/assets/b2241616-aea3-440f-8b25-77f08cca1f2c)


[Time]: https://api.rubyonrails.org/classes/Time.html
[Method]: https://api.rubyonrails.org/classes/Method.html