### PR TITLE
add .ruby-version file to Dockerfile template

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/Dockerfile.tt
+++ b/railties/lib/rails/generators/rails/app/templates/Dockerfile.tt
@@ -52,7 +52,7 @@ RUN curl -fsSL https://bun.sh/install | bash -s -- "bun-v${BUN_VERSION}"
 
 <% end -%>
 # Install application gems
-COPY Gemfile Gemfile.lock ./
+COPY .ruby-version Gemfile Gemfile.lock ./
 RUN bundle install && \
     rm -rf ~/.bundle/ "${BUNDLE_PATH}"/ruby/*/cache "${BUNDLE_PATH}"/ruby/*/bundler/gems/*/.git<% if depend_on_bootsnap? -%> && \
     bundle exec bootsnap precompile --gemfile<% end %>


### PR DESCRIPTION
### Motivation / Background

When deploying my Rails 8 app via Kamal, I was unable to install gems because I was defining the app's ruby version via the `file` directive in my `Gemfile` (Example: `ruby file: ".ruby-version"`), and in order for this to work, the Docker image also needs this file.

This change worked for me but please let me know if additional changes, I'm happy to adjust as necessary.
