### PR TITLE
Expose connects_to configuration for ActiveStorage models

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Expose `connects_to` configuration for models.
+
+    *Nick Pezza*
+
 ## Rails 8.0.0.beta1 (September 26, 2024) ##
 
 *   Deprecate `ActiveStorage::Service::AzureStorageService`.

--- a/activestorage/app/models/active_storage/record.rb
+++ b/activestorage/app/models/active_storage/record.rb
@@ -2,6 +2,8 @@
 
 class ActiveStorage::Record < ActiveRecord::Base # :nodoc:
   self.abstract_class = true
+
+  connects_to(**ActiveStorage.connects_to) if ActiveStorage.connects_to.present?
 end
 
 ActiveSupport.run_load_hooks :active_storage_record, ActiveStorage::Record

--- a/activestorage/lib/active_storage.rb
+++ b/activestorage/lib/active_storage.rb
@@ -62,6 +62,8 @@ module ActiveStorage
   mattr_accessor :content_types_to_serve_as_binary, default: []
   mattr_accessor :content_types_allowed_inline,     default: []
 
+  mattr_accessor :connects_to
+
   mattr_accessor :supported_image_processing_methods, default: [
     "adaptive_blur",
     "adaptive_resize",

--- a/activestorage/lib/active_storage/engine.rb
+++ b/activestorage/lib/active_storage/engine.rb
@@ -161,6 +161,12 @@ module ActiveStorage
       end
     end
 
+    initializer "active_storage.connects_to" do |app|
+      ActiveSupport.on_load(:active_record) do
+        ActiveStorage.connects_to = app.config.active_storage.connects_to
+      end
+    end
+
     initializer "active_storage.reflection" do
       ActiveSupport.on_load(:active_record) do
         include Reflection::ActiveRecordExtensions


### PR DESCRIPTION
### Detail

This allows people to set where ActiveStorage tables live without having to setup an initializer in their app. This is the same setup that Solid* adopts.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
