### PR TITLE
Reduce allocations in AS::Duration#{since,ago}

### DIFF
--- a/activesupport/lib/active_support/duration.rb
+++ b/activesupport/lib/active_support/duration.rb
@@ -491,17 +491,21 @@ module ActiveSupport
         if @parts.empty?
           time.since(sign * value)
         else
-          @parts.inject(time) do |t, (type, number)|
-            if type == :seconds
-              t.since(sign * number)
-            elsif type == :minutes
-              t.since(sign * number * 60)
-            elsif type == :hours
-              t.since(sign * number * 3600)
-            else
-              t.advance(type => sign * number)
-            end
+          @parts.each do |type, number|
+            t = time
+            time =
+              if type == :seconds
+                t.since(sign * number)
+              elsif type == :minutes
+                t.since(sign * number * 60)
+              elsif type == :hours
+                t.since(sign * number * 3600)
+              else
+                t.advance(type => sign * number)
+              end
           end
+
+          time
         end
       end
 


### PR DESCRIPTION
Using Enumerable#inject on a Hash forces an allocation of an array each
time Hash#each is called on current CRuby versions. Use Hash#each
directly.

Not as elegant, for sure, but it also doesn't require understanding how
inject/reduce works.

Casual benchmark:

```ruby
require 'active_support/all'
require 'benchmark'

p a = ActiveSupport::Duration.build(2716147)
p a.parts

time = Time.current

pre_alloc = GC.stat(:total_allocated_objects)
puts(Benchmark.measure do
  300_000.times do
    a.since(time)
  end
end)
post_alloc = GC.stat(:total_allocated_objects)
puts "alloced=#{post_alloc - pre_alloc}"
```

```diff
diff --git a/before b/after
--- a/before
+++ b/after
@@ -1,4 +1,4 @@
 1 month, 1 day, and 1 second
 {:months=>1, :days=>1, :seconds=>1}
-  2.311823   0.032300   2.344123 (  2.439997)
-alloced=14101243
+  2.223739   0.038590   2.262329 (  2.316780)
+alloced=12601105
```

So ~5% speed improvement, ~10% fewer objects.

I found this while profiling allocations in the [lobsters benchmark from
yjit-bench][1].

[1]: https://github.com/Shopify/yjit-bench/tree/main/benchmarks/lobsters


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
