### PR TITLE
Deprecate setting `config.active_job.enqueue_after_transaction_commit`

### DIFF
--- a/activejob/lib/active_job/enqueue_after_transaction_commit.rb
+++ b/activejob/lib/active_job/enqueue_after_transaction_commit.rb
@@ -4,13 +4,29 @@ module ActiveJob
   module EnqueueAfterTransactionCommit # :nodoc:
     private
       def raw_enqueue
+        enqueue_after_transaction_commit = self.class.enqueue_after_transaction_commit
+
         after_transaction = case self.class.enqueue_after_transaction_commit
         when :always
+          ActiveJob.deprecator.warn(<<~MSG.squish)
+            Setting `#{self.class.name}.enqueue_after_transaction_commit = :always` is deprecated and will be removed in Rails 8.1.
+            Set to `true` to always enqueue the job after the transaction is committed.
+          MSG
           true
         when :never
+          ActiveJob.deprecator.warn(<<~MSG.squish)
+            Setting #{self.class.name}.enqueue_after_transaction_commit = :never` is deprecated and will be removed in Rails 8.1.
+            Set to `false` to never enqueue the job after the transaction is committed.
+          MSG
           false
-        else # :default
-          queue_adapter.enqueue_after_transaction_commit?
+        when :default
+          ActiveJob.deprecator.warn(<<~MSG.squish)
+            Setting `#{self.class.name}.enqueue_after_transaction_commit = :default` is deprecated and will be removed in Rails 8.1.
+            Set to `false` to never enqueue the job after the transaction is committed.
+          MSG
+          false
+        else
+          enqueue_after_transaction_commit
         end
 
         if after_transaction

--- a/activejob/lib/active_job/enqueuing.rb
+++ b/activejob/lib/active_job/enqueuing.rb
@@ -48,10 +48,9 @@ module ActiveJob
       # automatically defers the enqueue to after the transaction commits.
       #
       # It can be set on a per job basis:
-      #  - `:always` forces the job to be deferred.
-      #  - `:never` forces the job to be queued immediately.
-      #  - `:default` lets the queue adapter define the behavior (recommended).
-      class_attribute :enqueue_after_transaction_commit, instance_accessor: false, instance_predicate: false, default: :never
+      #  - true forces the job to be deferred.
+      #  - false forces the job to be queued immediately.
+      class_attribute :enqueue_after_transaction_commit, instance_accessor: false, instance_predicate: false, default: false
     end
 
     # Includes the +perform_later+ method for job initialization.

--- a/activejob/lib/active_job/queue_adapters/abstract_adapter.rb
+++ b/activejob/lib/active_job/queue_adapters/abstract_adapter.rb
@@ -7,14 +7,6 @@ module ActiveJob
     # Active Job supports multiple job queue systems. ActiveJob::QueueAdapters::AbstractAdapter
     # forms the abstraction layer which makes this possible.
     class AbstractAdapter
-      # Defines whether enqueuing should happen implicitly to after commit when called
-      # from inside a transaction. Most adapters should return true, but some adapters
-      # that use the same database as Active Record and are transaction aware can return
-      # false to continue enqueuing jobs as part of the transaction.
-      def enqueue_after_transaction_commit?
-        true
-      end
-
       def enqueue(job)
         raise NotImplementedError
       end

--- a/activejob/lib/active_job/queue_adapters/delayed_job_adapter.rb
+++ b/activejob/lib/active_job/queue_adapters/delayed_job_adapter.rb
@@ -16,14 +16,6 @@ module ActiveJob
     #
     #   Rails.application.config.active_job.queue_adapter = :delayed_job
     class DelayedJobAdapter < AbstractAdapter
-      def initialize(enqueue_after_transaction_commit: false)
-        @enqueue_after_transaction_commit = enqueue_after_transaction_commit
-      end
-
-      def enqueue_after_transaction_commit? # :nodoc:
-        @enqueue_after_transaction_commit
-      end
-
       def enqueue(job) # :nodoc:
         delayed_job = Delayed::Job.enqueue(JobWrapper.new(job.serialize), queue: job.queue_name, priority: job.priority)
         job.provider_job_id = delayed_job.id

--- a/activejob/lib/active_job/queue_adapters/inline_adapter.rb
+++ b/activejob/lib/active_job/queue_adapters/inline_adapter.rb
@@ -11,10 +11,6 @@ module ActiveJob
     #
     #   Rails.application.config.active_job.queue_adapter = :inline
     class InlineAdapter < AbstractAdapter
-      def enqueue_after_transaction_commit? # :nodoc:
-        false
-      end
-
       def enqueue(job) # :nodoc:
         Base.execute(job.serialize)
       end

--- a/activejob/lib/active_job/queue_adapters/queue_classic_adapter.rb
+++ b/activejob/lib/active_job/queue_adapters/queue_classic_adapter.rb
@@ -19,14 +19,6 @@ module ActiveJob
     #
     #   Rails.application.config.active_job.queue_adapter = :queue_classic
     class QueueClassicAdapter < AbstractAdapter
-      def initialize(enqueue_after_transaction_commit: false)
-        @enqueue_after_transaction_commit = enqueue_after_transaction_commit
-      end
-
-      def enqueue_after_transaction_commit? # :nodoc:
-        @enqueue_after_transaction_commit
-      end
-
       def enqueue(job) # :nodoc:
         qc_job = build_queue(job.queue_name).enqueue("#{JobWrapper.name}.perform", job.serialize)
         job.provider_job_id = qc_job["id"] if qc_job.is_a?(Hash)

--- a/activejob/lib/active_job/queue_adapters/test_adapter.rb
+++ b/activejob/lib/active_job/queue_adapters/test_adapter.rb
@@ -12,16 +12,8 @@ module ActiveJob
     #
     #   Rails.application.config.active_job.queue_adapter = :test
     class TestAdapter < AbstractAdapter
-      attr_accessor(:perform_enqueued_jobs, :perform_enqueued_at_jobs, :filter, :reject, :queue, :at, :enqueue_after_transaction_commit)
+      attr_accessor(:perform_enqueued_jobs, :perform_enqueued_at_jobs, :filter, :reject, :queue, :at)
       attr_writer(:enqueued_jobs, :performed_jobs)
-
-      def initialize(enqueue_after_transaction_commit: true)
-        @enqueue_after_transaction_commit = enqueue_after_transaction_commit
-      end
-
-      def enqueue_after_transaction_commit? # :nodoc:
-        @enqueue_after_transaction_commit
-      end
 
       # Provides a store of all the enqueued jobs with the TestAdapter so you can check them.
       def enqueued_jobs

--- a/activejob/lib/active_job/railtie.rb
+++ b/activejob/lib/active_job/railtie.rb
@@ -31,7 +31,22 @@ module ActiveJob
           ActiveJob::Base.include EnqueueAfterTransactionCommit
 
           if app.config.active_job.key?(:enqueue_after_transaction_commit)
-            ActiveJob::Base.enqueue_after_transaction_commit = app.config.active_job.delete(:enqueue_after_transaction_commit)
+            ActiveJob.deprecator.warn(<<~MSG.squish)
+              `config.active_job.enqueue_after_transaction_commit` is deprecated and will be removed in Rails 8.1.
+              This configuration can still be set on individual jobs using `self.enqueue_after_transaction_commit=`,
+              but due the nature of this behavior, it is not recommended to be set globally.
+            MSG
+
+            value = case app.config.active_job.enqueue_after_transaction_commit
+            when :always
+              true
+            when :never
+              false
+            else
+              false
+            end
+
+            ActiveJob::Base.enqueue_after_transaction_commit = value
           end
         end
       end
@@ -54,7 +69,8 @@ module ActiveJob
         # Configs used in other initializers
         options = options.except(
           :log_query_tags_around_perform,
-          :custom_serializers
+          :custom_serializers,
+          :enqueue_after_transaction_commit
         )
 
         options.each do |k, v|

--- a/activejob/test/cases/enqueue_after_transaction_commit_test.rb
+++ b/activejob/test/cases/enqueue_after_transaction_commit_test.rb
@@ -29,7 +29,7 @@ class EnqueueAfterTransactionCommitTest < ActiveSupport::TestCase
   end
 
   class EnqueueAfterCommitJob < ActiveJob::Base
-    self.enqueue_after_transaction_commit = :always
+    self.enqueue_after_transaction_commit = true
 
     def perform
       # noop
@@ -38,10 +38,6 @@ class EnqueueAfterTransactionCommitTest < ActiveSupport::TestCase
 
   class ErrorEnqueueAfterCommitJob < EnqueueErrorJob
     class EnqueueErrorAdapter
-      def enqueue_after_transaction_commit?
-        true
-      end
-
       def enqueue(...)
         raise ActiveJob::EnqueueError, "There was an error enqueuing the job"
       end
@@ -52,7 +48,7 @@ class EnqueueAfterTransactionCommitTest < ActiveSupport::TestCase
     end
 
     self.queue_adapter = EnqueueErrorAdapter.new
-    self.enqueue_after_transaction_commit = :always
+    self.enqueue_after_transaction_commit = true
 
     def perform
       # noop

--- a/activejob/test/cases/queue_adapter_test.rb
+++ b/activejob/test/cases/queue_adapter_test.rb
@@ -5,13 +5,11 @@ require "helper"
 module ActiveJob
   module QueueAdapters
     class StubOneAdapter
-      def enqueue_after_transaction_commit?; false; end
       def enqueue(*); end
       def enqueue_at(*); end
     end
 
     class StubTwoAdapter
-      def enqueue_after_transaction_commit?; false; end
       def enqueue(*); end
       def enqueue_at(*); end
     end
@@ -74,7 +72,6 @@ class QueueAdapterTest < ActiveJob::TestCase
 
   module StubThreeAdapter
     class << self
-      def enqueue_after_transaction_commit?; false; end
       def enqueue(*); end
       def enqueue_at(*); end
     end
@@ -87,7 +84,6 @@ class QueueAdapterTest < ActiveJob::TestCase
   end
 
   class StubFourAdapter
-    def enqueue_after_transaction_commit?; false; end
     def enqueue(*); end
     def enqueue_at(*); end
     def queue_adapter_name

--- a/activejob/test/jobs/enqueue_error_job.rb
+++ b/activejob/test/jobs/enqueue_error_job.rb
@@ -7,10 +7,6 @@ class EnqueueErrorJob < ActiveJob::Base
     end
     self.should_raise_sequence = []
 
-    def enqueue_after_transaction_commit?
-      false
-    end
-
     def enqueue(*)
       raise ActiveJob::EnqueueError, "There was an error enqueuing the job" if should_raise?
     end

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -65,7 +65,6 @@ Below are the default values associated with each target version. In cases of co
 
 #### Default Values for Target Version 7.2
 
-- [`config.active_job.enqueue_after_transaction_commit`](#config-active-job-enqueue-after-transaction-commit): `:default`
 - [`config.active_record.postgresql_adapter_decode_dates`](#config-active-record-postgresql-adapter-decode-dates): `true`
 - [`config.active_record.validate_migration_timestamps`](#config-active-record-validate-migration-timestamps): `true`
 - [`config.active_storage.web_image_content_types`](#config-active-storage-web-image-content-types): `%w[image/png image/jpeg image/gif image/webp]`
@@ -2840,51 +2839,6 @@ class EncoderJob < ActiveJob::Base
   #....
 end
 ```
-
-#### `config.active_job.enqueue_after_transaction_commit`
-
-Controls whether Active Job's `#perform_later` and similar methods automatically defer
-the job queuing to after the current Active Record transaction is committed.
-
-It can be set to:
-
-* `:never` - Never defer the enqueue.
-* `:always` - Always defer the enqueue.
-* `:default` - Let the queue adapter define the behaviour.
-
-Each Active Job backend defines its own default behaviour for this, with some adapters preventing the deferring and others allowing it, so make sure to check that as well if you're opting for `:default`.
-
-Example:
-
-```ruby
-Topic.transaction do
-  topic = Topic.create(title: "New Topic")
-  NewTopicNotificationJob.perform_later(topic)
-end
-```
-
-In this example, if the configuration is set to `:never`, the job will
-be enqueued immediately, even though the `Topic` hasn't been committed yet.
-Because of this, if the job is picked up almost immediately, or if the
-transaction doesn't succeed for some reason, the job will fail to find this
-topic in the database.
-
-If it's set to `:always`, the job will be actually enqueued after the
-transaction has been committed. If the transaction is rolled back, the job
-won't be enqueued at all.
-
-This configuration can additionally be set on a per job class basis:
-
-```ruby
-class SomeJob < ApplicationJob
-  self.enqueue_after_transaction_commit = :never
-end
-```
-
-| Starting with version | The default value is |
-| --------------------- | -------------------- |
-| (original)            | `:never`             |
-| 7.2                   | `:default`           |
 
 #### `config.active_job.logger`
 

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -326,10 +326,6 @@ module Rails
 
           self.yjit = true
 
-          if respond_to?(:active_job)
-            active_job.enqueue_after_transaction_commit = :default
-          end
-
           if respond_to?(:active_storage)
             active_storage.web_image_content_types = %w( image/png image/jpeg image/gif image/webp )
           end

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -3045,6 +3045,20 @@ module ApplicationTests
       assert_not ActiveJob.verbose_enqueue_logs
     end
 
+    test "config.active_job.enqueue_after_transaction_commit is deprecated" do
+      app_file "config/initializers/custom_serializers.rb", <<-RUBY
+      Rails.application.config.active_job.enqueue_after_transaction_commit = :always
+      RUBY
+
+      app "production"
+
+      assert_nothing_raised do
+        ActiveRecord::Base
+      end
+
+      assert_equal true, ActiveJob::Base.enqueue_after_transaction_commit
+    end
+
     test "active record job queue is set" do
       app "development"
 


### PR DESCRIPTION
Also change the configuration to be a boolean instead of a symbol.

The value of this setting isn't delegated to the queue adapter anymore, since the behavior that this setting controls is too dangerous to leave this change of behavior as something that users don't control.

Fixes #52675.