### PR TITLE
Fix incorrect Method and Time API doc links [ci skip]

### DIFF
--- a/activesupport/lib/active_support/core_ext/string/multibyte.rb
+++ b/activesupport/lib/active_support/core_ext/string/multibyte.rb
@@ -19,7 +19,7 @@ class String
   #   >> "ǉ".upcase
   #   => "Ǉ"
   #
-  # == Method chaining
+  # == \Method chaining
   #
   # All the methods on the Chars proxy which normally return a string will return a Chars object. This allows
   # method chaining on the result of any of these methods.

--- a/activesupport/lib/active_support/core_ext/time/zones.rb
+++ b/activesupport/lib/active_support/core_ext/time/zones.rb
@@ -20,7 +20,7 @@ class Time
     # This method accepts any of the following:
     #
     # * A \Rails TimeZone object.
-    # * An identifier for a \Rails TimeZone object (e.g., "Eastern Time (US & Canada)", <tt>-5.hours</tt>).
+    # * An identifier for a \Rails TimeZone object (e.g., "Eastern \Time (US & Canada)", <tt>-5.hours</tt>).
     # * A +TZInfo::Timezone+ object.
     # * An identifier for a +TZInfo::Timezone+ object (e.g., "America/New_York").
     #

--- a/activesupport/lib/active_support/time_with_zone.rb
+++ b/activesupport/lib/active_support/time_with_zone.rb
@@ -85,7 +85,7 @@ module ActiveSupport
     end
     alias_method :getlocal, :localtime
 
-    # Returns true if the current time is within Daylight Savings Time for the
+    # Returns true if the current time is within Daylight Savings \Time for the
     # specified time zone.
     #
     #   Time.zone = 'Eastern Time (US & Canada)'    # => 'Eastern Time (US & Canada)'


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because I was looking at @seanpdoyle's PR https://github.com/rails/rails/pull/53367 about removing incorrect Time and Method inferences in the `ActiveSupport::TimeZone` API docs, and this gave me the idea of globally checking other places in the API docs where Time and Method might be incorrectly inferred. I found 2 or 3 such occurrences.

### Details

This PR removes the red links in the screenshots below:

- https://api.rubyonrails.org/classes/String.html#method-i-mb_chars

    ![mb_chars](https://github.com/user-attachments/assets/70b439a5-ceb8-405b-9b21-790a8a6a9030)

- https://api.rubyonrails.org/classes/Time.html#method-c-zone-3D
    
    ![zone=](https://github.com/user-attachments/assets/dc75ff58-c49f-4bf6-9786-b0fec98797a0)

- https://api.rubyonrails.org/classes/ActiveSupport/TimeWithZone.html#method-i-dst-3F. This one is arguable, but what is meant here is Daylight Savings Time (DST) as its own term and not a link to the `Time` class.

    ![dst?](https://github.com/user-attachments/assets/41288671-e0d0-42e1-aaee-9710a382b7cf)


### Additional information

I meant to provide "after" pictures but when I generate docs on my local, styles look different so it's hard to do a fair comparison. The CI-generated docs also have a different style.