### PR TITLE
Fix a order-dependant test failure in railties

### DIFF
--- a/railties/test/application/configuration/custom_test.rb
+++ b/railties/test/application/configuration/custom_test.rb
@@ -5,6 +5,8 @@ require "isolation/abstract_unit"
 module ApplicationTests
   module ConfigurationTests
     class CustomTest < ActiveSupport::TestCase
+      include ActiveSupport::Testing::Isolation
+
       def setup
         build_app
         FileUtils.rm_rf("#{app_path}/config/environments")


### PR DESCRIPTION
Reproduce with `bin/test --seed 27653`

Closes #53368