### PR TITLE
`db:prepare` no longer loads seed when non-primary db is created

### DIFF
--- a/activerecord/lib/active_record/database_configurations/database_config.rb
+++ b/activerecord/lib/active_record/database_configurations/database_config.rb
@@ -99,6 +99,10 @@ module ActiveRecord
       def use_metadata_table?
         raise NotImplementedError
       end
+
+      def seeds?
+        raise NotImplementedError
+      end
     end
   end
 end

--- a/activerecord/lib/active_record/database_configurations/hash_config.rb
+++ b/activerecord/lib/active_record/database_configurations/hash_config.rb
@@ -130,6 +130,14 @@ module ActiveRecord
         Base.configurations.primary?(name)
       end
 
+      # Determines whether the db:prepare task should seed the database from db/seeds.rb.
+      #
+      # If the `seeds` key is present in the config, `seeds?` will return its value.  Otherwise, it
+      # will return `true` for the primary database and `false` for all other configs.
+      def seeds?
+        configuration_hash.fetch(:seeds, primary?)
+      end
+
       # Determines whether to dump the schema/structure files and the filename that
       # should be used.
       #

--- a/activerecord/lib/active_record/tasks/database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/database_tasks.rb
@@ -180,7 +180,7 @@ module ActiveRecord
         each_current_configuration(env) do |db_config|
           database_initialized = initialize_database(db_config)
 
-          seed = true if database_initialized
+          seed = true if database_initialized && db_config.seeds?
         end
 
         each_current_environment(env) do |environment|

--- a/activerecord/test/cases/database_configurations/hash_config_test.rb
+++ b/activerecord/test/cases/database_configurations/hash_config_test.rb
@@ -179,6 +179,32 @@ module ActiveRecord
         config = HashConfig.new("default_env", "primary", { adapter: "abstract", password: "hunter2" })
         assert_equal "#<ActiveRecord::DatabaseConfigurations::HashConfig env_name=default_env name=primary adapter_class=ActiveRecord::ConnectionAdapters::AbstractAdapter>", config.inspect
       end
+
+      def test_seeds_defaults_to_primary
+        config = HashConfig.new("default_env", "primary", { adapter: "abstract" })
+        assert_equal true, config.seeds?
+
+        config = HashConfig.new("default_env", "primary", { adapter: "abstract", seeds: false })
+        assert_equal false, config.seeds?
+
+        config = HashConfig.new("default_env", "primary", { adapter: "abstract", seeds: true })
+        assert_equal true, config.seeds?
+
+        config = HashConfig.new("default_env", "secondary", { adapter: "abstract" })
+        config.stub(:primary?, false) do # primary? will return nil without proper Base.configurations
+          assert_equal false, config.seeds?
+        end
+
+        config = HashConfig.new("default_env", "secondary", { adapter: "abstract", seeds: false })
+        config.stub(:primary?, false) do # primary? will return nil without proper Base.configurations
+          assert_equal false, config.seeds?
+        end
+
+        config = HashConfig.new("default_env", "secondary", { adapter: "abstract", seeds: true })
+        config.stub(:primary?, false) do # primary? will return nil without proper Base.configurations
+          assert_equal true, config.seeds?
+        end
+      end
     end
   end
 end

--- a/guides/source/active_record_migrations.md
+++ b/guides/source/active_record_migrations.md
@@ -1267,15 +1267,15 @@ only perform the necessary tasks once.
   load the schema, run any pending migrations, dump the updated schema, and
   finally load the seed data. See the [Seeding Data
   documentation](#migrations-and-seed-data) for more details.
-* If both the database and tables exist but the seed data has not been loaded,
-  the command will only load the seed data.
-* If the database, tables, and seed data are all in place, the command will do
-  nothing.
+* If the database and tables exist, the command will do nothing.
 
-NOTE: Once the database, tables, and seed data are all established, the command
-will not try to reload the seed data, even if the previously loaded seed data or
-the existing seed file have been altered or deleted. To reload the seed data,
-you can manually run `bin/rails db:seed`.
+Once the database and tables exist, the `db:prepare` task will not try to reload
+the seed data, even if the previously loaded seed data or the existing seed file
+have been altered or deleted. To reload the seed data, you can manually run
+`bin/rails db:seed`.
+
+NOTE: This task will only load seeds if one of the databases or tables created
+is a primary database for the environment or is configured with `seeds: true`.
 
 ### Resetting the Database
 


### PR DESCRIPTION
### Motivation / Background

Issue #53348 describes an issue where, after adding Solid Cache to an application, running db:prepare in production re-loaded the seeds, potentially leading to data loss.

Closes #53348

### Detail

This PR introduces a new database config property `seeds` to control whether seeds are loaded during `db:prepare` which defaults to `true` for primary database configs and `false` otherwise.

Previously, the `db:prepare` task would load seeds whenever a new database is created, leading to potential loss of data if a database is added to an existing environment.

Also, update the Active Record Migrations guide to more accurately describe what the `db:prepare` task does, correcting some misinformation introduced in #49480 along the way.


### Additional information

See previous rejected proposal at #53354


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
