### PR TITLE
Respect order in Preloader::ThroughAssociation when scoped

### DIFF
--- a/activerecord/lib/active_record/associations/preloader/through_association.rb
+++ b/activerecord/lib/active_record/associations/preloader/through_association.rb
@@ -72,7 +72,7 @@ module ActiveRecord
           end
 
           def middle_records
-            through_records_by_owner.values.flatten
+            through_preloaders.flat_map(&:preloaded_records)
           end
 
           def through_preloaders

--- a/activerecord/lib/active_record/associations/preloader/through_association.rb
+++ b/activerecord/lib/active_record/associations/preloader/through_association.rb
@@ -5,7 +5,7 @@ module ActiveRecord
     class Preloader
       class ThroughAssociation < Association # :nodoc:
         def preloaded_records
-          @preloaded_records ||= source_preloaders.flat_map(&:preloaded_records)
+          @preloaded_records ||= owners_all_loaded? ? owners.flat_map { |owner| target_for(owner) } : source_preloaders.flat_map(&:preloaded_records)
         end
 
         def records_by_owner
@@ -63,8 +63,12 @@ module ActiveRecord
 
         private
           def data_available?
-            owners.all? { |owner| loaded?(owner) } ||
+            owners_all_loaded? ||
               through_preloaders.all?(&:run?) && source_preloaders.all?(&:run?)
+          end
+
+          def owners_all_loaded?
+            owners.all? { |owner| loaded?(owner) }
           end
 
           def source_preloaders

--- a/activerecord/test/cases/associations_test.rb
+++ b/activerecord/test/cases/associations_test.rb
@@ -918,6 +918,24 @@ class PreloaderTest < ActiveRecord::TestCase
     end
   end
 
+  def test_preload_through_ordered_records
+    alexandre = Author.create!(name: "Alexandre")
+    neal = Author.create!(name: "Neal")
+    victor = Author.create!(name: "Victor")
+
+    mary = authors(:mary)
+    AuthorFavorite.create!(author: mary, favorite_author: neal)
+    AuthorFavorite.create!(author: mary, favorite_author: victor)
+
+    bob = authors(:bob)
+    AuthorFavorite.create!(author: bob, favorite_author: alexandre)
+    AuthorFavorite.create!(author: bob, favorite_author: victor)
+
+    ActiveRecord::Associations::Preloader.new(records: [mary, bob], associations: :favorite_non_bob_authors).call
+    assert_equal [neal, victor], mary.favorite_non_bob_authors
+    assert_equal [alexandre, victor], bob.favorite_non_bob_authors
+  end
+
   def test_preload_with_instance_dependent_scope
     david = authors(:david)
     david2 = Author.create!(name: "David")

--- a/activerecord/test/models/author.rb
+++ b/activerecord/test/models/author.rb
@@ -154,6 +154,7 @@ class Author < ActiveRecord::Base
 
   has_many :author_favorites
   has_many :favorite_authors, -> { order("name") }, through: :author_favorites
+  has_many :favorite_non_bob_authors, -> { where.not(name: "Bob").order("name") }, through: :author_favorites, source: :favorite_author
 
   has_many :taggings,        through: :posts, source: :taggings
   has_many :taggings_2,      through: :posts, source: :tagging


### PR DESCRIPTION
### Motivation / Background

Fixes #53380

### Detail

When reflection scope has a where clause, source reflection is included. Hence source_preloaders already have all records already loaded, and thus keeps the same order than its records (ie middle_records).

Though middle_records were computed by flattening records grouped by owner, this grouping breaks the global order between all records. By computing middle_records directly from preloaded_records, we conserve the global order, hence fix the order in source_preloaders.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
