### PR TITLE
Fix invalid syntax in TextHelper#highlight API docs example [ci skip]

### DIFF
--- a/actionview/lib/action_view/helpers/text_helper.rb
+++ b/actionview/lib/action_view/helpers/text_helper.rb
@@ -166,7 +166,7 @@ module ActionView
       #   highlight('You searched for: rails', 'rails', highlighter: '<a href="search?q=\1">\1</a>')
       #   # => "You searched for: <a href=\"search?q=rails\">rails</a>"
       #
-      #   highlight('You searched for: rails', 'rails') { |match| link_to(search_path(q: match, match)) }
+      #   highlight('You searched for: rails', 'rails') { |match| link_to(search_path(q: match)) }
       #   # => "You searched for: <a href=\"search?q=rails\">rails</a>"
       #
       #   highlight('<a href="javascript:alert(\'no!\')">ruby</a> on rails', 'rails', sanitize: false)


### PR DESCRIPTION
In the [`TextHelper#highlight`](https://api.rubyonrails.org/classes/ActionView/Helpers/TextHelper.html#method-i-highlight) API docs, one of the code examples has a typo where `match` is repeated, resulting in an invalid Ruby syntax.

This PR fixes this, which makes the example code more copy/paste-able.