### PR TITLE
[Bug] Fix inline value nil priority for date_field form builder

### DIFF
--- a/actionview/lib/action_view/helpers/tags/datetime_field.rb
+++ b/actionview/lib/action_view/helpers/tags/datetime_field.rb
@@ -6,7 +6,7 @@ module ActionView
       class DatetimeField < TextField # :nodoc:
         def render
           options = @options.stringify_keys
-          options["value"] = datetime_value(options["value"] || value)
+          options["value"] = datetime_value(options.fetch("value", value))
           options["min"] = format_datetime(parse_datetime(options["min"]))
           options["max"] = format_datetime(parse_datetime(options["max"]))
           @options = options

--- a/actionview/test/template/form_helper_test.rb
+++ b/actionview/test/template/form_helper_test.rb
@@ -1106,6 +1106,11 @@ class FormHelperTest < ActionView::TestCase
     assert_dom_equal(expected, date_field("post", "written_on", value: value))
   end
 
+  def test_date_field_with_nil_value_attr
+    expected = %{<input id="post_written_on" name="post[written_on]" type="date"/>}
+    assert_dom_equal(expected, date_field("post", "written_on", value: nil))
+  end
+
   def test_date_field_with_datetime_value_attr
     expected = %{<input id="post_written_on" name="post[written_on]" type="date" value="2013-06-29" />}
     value = DateTime.new(2013, 6, 29)


### PR DESCRIPTION
### Motivation / Background

Specifying `value: nil` for `date_field` doesn't overwrite the model attribute value, while any other non-nil value does.
Also, `value: nil` takes the priority for other field types like `text_field` or `select`.

### Detail

``` haml
= form_with(model: Post.new(written_on: Time.now) do |f|
  = f.date_field :written_on, value: nil
```

Extected:

``` html
<input id="post_written_on" name="post[written_on]" type="date"/>
```

Actual:

``` html
<input id="post_written_on" name="post[written_on]" type="date" value="2024-10-20"/>
```

### Additional information

Rails version: 7.2.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
