### PR TITLE
Add prefix address when IPAddr of CIDR encoded with JSON

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,2 +1,17 @@
+*   `ActiveSupport::JSON.encode` supports CIDR notation.
+
+    Previously:
+
+    ```ruby
+    ActiveSupport::JSON.encode(IPAddr.new("172.16.0.0/24")) # => "\"172.16.0.0\""
+    ```
+
+    After this change:
+
+    ```ruby
+    ActiveSupport::JSON.encode(IPAddr.new("172.16.0.0/24")) # => "\"172.16.0.0/24\""
+    ```
+
+    *Taketo Takashima*
 
 Please check [8-0-stable](https://github.com/rails/rails/blob/8-0-stable/activesupport/CHANGELOG.md) for previous changes.

--- a/activesupport/lib/active_support/core_ext/object/json.rb
+++ b/activesupport/lib/active_support/core_ext/object/json.rb
@@ -239,9 +239,18 @@ class Pathname # :nodoc:
   end
 end
 
-class IPAddr # :nodoc:
-  def as_json(options = nil)
-    to_s
+unless IPAddr.method_defined?(:as_json, false)
+  # Use `IPAddr#as_json` from the IPAddr gem if the version is 1.2.7 or higher.
+  class IPAddr # :nodoc:
+    def as_json(options = nil)
+      if ipv4? && prefix == 32
+        to_s
+      elsif ipv6? && prefix == 128
+        to_s
+      else
+        "#{self}/#{prefix}"
+      end
+    end
   end
 end
 

--- a/activesupport/test/json/encoding_test_cases.rb
+++ b/activesupport/test/json/encoding_test_cases.rb
@@ -113,7 +113,9 @@ module JSONTest
 
     PathnameTests = [[ Pathname.new("lib/index.rb"), %("lib/index.rb") ]]
 
-    IPAddrTests   = [[  IPAddr.new("127.0.0.1"), %("127.0.0.1") ]]
+    IPAddrTests       = [[ IPAddr.new("127.0.0.1"), %("127.0.0.1") ]]
+    IPAddrv4CidrTests = [[ IPAddr.new("192.0.2.0/24"), %("192.0.2.0/24") ]]
+    IPAddrv6CidrTests = [[ IPAddr.new("2001:db8::/48"), %("2001:db8::/48") ]]
 
     DateTests     = [[ Date.new(2005, 2, 1), %("2005/02/01") ]]
     TimeTests     = [[ Time.utc(2005, 2, 1, 15, 15, 10), %("2005/02/01 15:15:10 +0000") ]]


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created because JSON encoded IPAddr/CIDR is removed the prefix address.
It is unable to deserialize IPAddr/CIDR value.

This PR is re-created from #46007.
The behavior of `IPAddr#to_json` has changed which return with prefix address, so it adjusting the behavior of `IPAddr#to_json` in rails to match the native `IPAddr#to_json` of ipaddr gem.

Fix #46006

### Detail

This Pull Request changes IPAddr of CIDR is encoded with JSON add prefix address.
And it uses the native `IPAddr#as_json`, if use ipaddr gem v1.2.7+.

```ruby
ipaddr = IPAddr.new('172.16.0.0/24')
=> #<IPAddr: IPv4:172.16.0.0/255.255.255.0>

ActiveSupport::JSON.encode(ipaddr)
=> "\"172.16.0.0/24\"" # it was returned "\"172.16.0.0\"" which had been removeed address prefix (`/24`)
```

### Additional information

`IPAddr#as_json` behavior is followed:

#### ipaddr gem v1.2.7+
```ruby
require 'ipaddr'

IPAddr.new('172.16.0.0/24').to_json #=> "\"172.16.0.0/24\""
```
https://github.com/ruby/ipaddr/releases/tag/v1.2.7
https://github.com/ruby/ipaddr/pull/77

#### ipaddr gem less than v1.2.6
```ruby
require 'ipaddr'
require 'json'

IPAddr.new('172.16.0.0/24').to_json #=> "\"172.16.0.0\""
```

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
