### PR TITLE
Allow `rename_enum` accepts two from/to name arguments as `rename_table` does so

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -575,8 +575,10 @@ module ActiveRecord
       end
 
       # Rename an existing enum type to something else.
-      def rename_enum(name, **options)
-        new_name = options.fetch(:to) { raise ArgumentError, ":to is required" }
+      def rename_enum(name, new_name = nil, **options)
+        new_name ||= options.fetch(:to) do
+          raise ArgumentError, "rename_enum requires two from/to name positional arguments."
+        end
 
         exec_query("ALTER TYPE #{quote_table_name(name)} RENAME TO #{quote_table_name(new_name)}").tap { reload_type_map }
       end

--- a/activerecord/lib/active_record/migration/command_recorder.rb
+++ b/activerecord/lib/active_record/migration/command_recorder.rb
@@ -40,7 +40,7 @@ module ActiveRecord
     # * remove_reference
     # * remove_timestamps
     # * rename_column
-    # * rename_enum (must supply a +:to+ option)
+    # * rename_enum
     # * rename_enum_value (must supply a +:from+ and +:to+ option)
     # * rename_index
     # * rename_table
@@ -364,13 +364,13 @@ module ActiveRecord
         end
 
         def invert_rename_enum(args)
-          name, options = args
+          name, new_name, = args
 
-          unless options.is_a?(Hash) && options.has_key?(:to)
-            raise ActiveRecord::IrreversibleMigration, "rename_enum is only reversible if given a :to option."
+          if new_name.is_a?(Hash) && new_name.key?(:to)
+            new_name = new_name[:to]
           end
 
-          [:rename_enum, [options[:to], to: name]]
+          [:rename_enum, [new_name, name]]
         end
 
         def invert_rename_enum_value(args)

--- a/activerecord/test/cases/adapters/postgresql/enum_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/enum_test.rb
@@ -112,6 +112,16 @@ class PostgresqlEnumTest < ActiveRecord::PostgreSQLTestCase
   end
 
   def test_schema_dump_renamed_enum
+    @connection.rename_enum :mood, :feeling
+
+    output = dump_table_schema("postgresql_enums")
+
+    assert_includes output, 'create_enum "feeling", ["sad", "ok", "happy"]'
+
+    assert_includes output, 't.enum "current_mood", enum_type: "feeling"'
+  end
+
+  def test_schema_dump_renamed_enum_with_to_option
     @connection.rename_enum :mood, to: :feeling
 
     output = dump_table_schema("postgresql_enums")

--- a/activerecord/test/cases/migration/command_recorder_test.rb
+++ b/activerecord/test/cases/migration/command_recorder_test.rb
@@ -552,14 +552,13 @@ module ActiveRecord
       end
 
       def test_invert_rename_enum
-        enum = @recorder.inverse_of :rename_enum, [:dog_breed, to: :breed]
-        assert_equal [:rename_enum, [:breed, to: :dog_breed]], enum
+        enum = @recorder.inverse_of :rename_enum, [:dog_breed, :breed]
+        assert_equal [:rename_enum, [:breed, :dog_breed]], enum
       end
 
-      def test_invert_rename_enum_without_to
-        assert_raises(ActiveRecord::IrreversibleMigration) do
-          @recorder.inverse_of :rename_enum, [:breed]
-        end
+      def test_invert_rename_enum_with_to_option
+        enum = @recorder.inverse_of :rename_enum, [:dog_breed, to: :breed]
+        assert_equal [:rename_enum, [:breed, :dog_breed]], enum
       end
 
       def test_invert_add_enum_value

--- a/guides/source/active_record_postgresql.md
+++ b/guides/source/active_record_postgresql.md
@@ -320,7 +320,7 @@ usage:
 ```ruby
 # db/migrate/20150718144917_rename_article_status.rb
 def change
-  rename_enum :article_status, to: :article_state
+  rename_enum :article_status, :article_state
 end
 ```
 


### PR DESCRIPTION
It looks odd that `rename_enum` requires two from/to name arguments but accepts one as an option.

This allows `rename_enum` accepts two from/to name arguments as `rename_table` does so.
