### PR TITLE
Fix strict loading propagation even if statement cache is not used

### DIFF
--- a/activerecord/lib/active_record/association_relation.rb
+++ b/activerecord/lib/active_record/association_relation.rb
@@ -43,6 +43,7 @@ module ActiveRecord
       def exec_queries
         super do |record|
           @association.set_inverse_instance_from_queries(record)
+          @association.set_strict_loading(record)
           yield record if block_given?
         end
       end

--- a/activerecord/lib/active_record/associations/association.rb
+++ b/activerecord/lib/active_record/associations/association.rb
@@ -120,6 +120,14 @@ module ActiveRecord
         @association_scope = nil
       end
 
+      def set_strict_loading(record)
+        if owner.strict_loading_n_plus_one_only? && reflection.macro == :has_many
+          record.strict_loading!
+        else
+          record.strict_loading!(false, mode: owner.strict_loading_mode)
+        end
+      end
+
       # Set the inverse association, if possible
       def set_inverse_instance(record)
         if inverse = inverse_association_for(record)
@@ -260,11 +268,7 @@ module ActiveRecord
           klass.with_connection do |c|
             sc.execute(binds, c, async: async) do |record|
               set_inverse_instance(record)
-              if owner.strict_loading_n_plus_one_only? && reflection.macro == :has_many
-                record.strict_loading!
-              else
-                record.strict_loading!(false, mode: owner.strict_loading_mode)
-              end
+              set_strict_loading(record)
             end
           end
         end

--- a/activerecord/test/cases/strict_loading_test.rb
+++ b/activerecord/test/cases/strict_loading_test.rb
@@ -59,6 +59,15 @@ class StrictLoadingTest < ActiveRecord::TestCase
     assert_raises ActiveRecord::StrictLoadingViolationError do
       developer.projects.last.firm
     end
+
+    assert_nothing_raised do
+      developer.projects_extended_by_name.to_a
+    end
+
+    assert developer.projects_extended_by_name.all?(&:strict_loading?)
+    assert_raises ActiveRecord::StrictLoadingViolationError do
+      developer.projects_extended_by_name.last.firm
+    end
   end
 
   def test_strict_loading_n_plus_one_only_mode_with_belongs_to


### PR DESCRIPTION
Currently strict loading propagation works only if statement cache is used.

This fixes that works even if statement cache is not used.
