### PR TITLE
Translate `no connection to the server` to ConnectionNotEstablished

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,2 +1,5 @@
+*   `PG::UnableToSend: no connection to the server` is now retryable as a connection-related exception
+
+    *Kazuma Watanabe*
 
 Please check [8-0-stable](https://github.com/rails/rails/blob/8-0-stable/activerecord/CHANGELOG.md) for previous changes.

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -798,7 +798,7 @@ module ActiveRecord
 
           case exception.result.try(:error_field, PG::PG_DIAG_SQLSTATE)
           when nil
-            if exception.message.match?(/connection is closed/i)
+            if exception.message.match?(/connection is closed/i) || exception.message.match?(/no connection to the server/i)
               ConnectionNotEstablished.new(exception, connection_pool: @pool)
             elsif exception.is_a?(PG::ConnectionBad)
               # libpq message style always ends with a newline; the pg gem's internal


### PR DESCRIPTION
### Motivation / Background

Fixes https://github.com/rails/rails/issues/53399

In PostgreSQL, if a network error occurs when submitting a query to the server, the `PG::UnableToSend: no connection to the server` error may occur.

- https://github.com/ged/ruby-pg/blob/v1.5.8/ext/pg_connection.c#L1945
- https://github.com/postgres/postgres/blob/REL_17_0/src/interfaces/libpq/fe-exec.c#L1689

The current low-level exception translator `translate_exception` primarily translates `PG::ConnectionBad` into a retryable exception, so exceptions like the one above will not be retried by `allow_retry: true`.

However, as we can see from the libpq, this query is guaranteed to return an error before being executed, so it should be safe to retry.

### Detail

This PR changes `PostgreSQLAdapter#translate_exception` to translate `PG::UnableToSend: no connection to the server` to `ConnectionNotEstablished` as same as "connection is closed".

### Additional information

This change is similar to https://github.com/rails/rails/pull/48093, but it targets "no connection to the server" instead of "server closed the connection". As @matthewd  says, the latter may not safe to retry, but the former should be.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
