### PR TITLE
Allow CVE ID as valid author in the CHANGELOG

### DIFF
--- a/tools/rail_inspector/lib/rail_inspector/changelog.rb
+++ b/tools/rail_inspector/lib/rail_inspector/changelog.rb
@@ -39,7 +39,7 @@ module RailInspector
           return if no_changes?
 
           authors =
-            lines.reverse.find { |line| line.match?(/^ *\*[^*\s].*[^*\s]\*$/) }
+            lines.reverse.find { |line| line.match?(/^ *\*[^*\s].*[^*\s]\*$/) || line.match?(/\[CVE-\d{4}-\d{4,}\]/) }
 
           return if authors
 

--- a/tools/rail_inspector/test/rail_inspector/changelog_test.rb
+++ b/tools/rail_inspector/test/rail_inspector/changelog_test.rb
@@ -26,6 +26,14 @@ class TestChangelog < Minitest::Test
     CHANGELOG
   end
 
+  def test_valid_cve_entry_as_valid_author
+    assert_valid_entry <<~CHANGELOG
+      *   Some security fix.
+
+          [CVE-2099-99999]
+    CHANGELOG
+  end
+
   def test_parses_with_extra_newlines
     @changelog = changelog_fixture("action_mailbox_83d85b2.md")
 


### PR DESCRIPTION
### Motivation / Background

This commit allows CVE ID as valid author in the CHANGELOG to address these offenses at 7-2-stable.

https://buildkite.com/rails/rails/builds/112671#0192925a-d433-4c41-bdbd-5a018d4fde23

### Detail

This pull request should address these warnings below. These warnings emit at 7-2-stable only.

```ruby
$ git checkout 7-2-stable
$ tools/railspect changelogs .
..EEE........

Offenses:

actionmailer/CHANGELOG.md:1 CHANGELOG entry is missing authors.
*   Avoid regex backtracking in `block_format` helper
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
actionpack/CHANGELOG.md:6 CHANGELOG entry is missing authors.
*   Avoid regex backtracking in HTTP Token authentication
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
actionpack/CHANGELOG.md:10 CHANGELOG entry is missing authors.
*   Avoid regex backtracking in query parameter filtering
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
actiontext/CHANGELOG.md:1 CHANGELOG entry is missing authors.
*   Avoid backtracing in plain_text_for_blockquote_node
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
13 changelogs inspected, 4 offenses detected
$
```
### Additional information


According to this document, CVE ID format is defined as follows. The arbitary digits is four or more. https://www.cve.org/about/Process

> CVE IDs have the following format:
>
> CVE prefix + Year + Arbitrary Digits
>
> The “Year” portion is the year that the CVE ID was reserved or the year the vulnerability was made public.
> The year portion is not used to indicate > when the vulnerability was discovered.
>
> The “Arbitrary Digits,” or sequence number portion, can include four or more digits in the sequence number portion of the ID.
> For example, CVE-YYYY-NNNN with four digits in the sequence number,
> CVE-YYYY-NNNNNNN with seven digits in the sequence number, etc. There is no limit on the number of arbitrary digits.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
