### PR TITLE
Include default headers in ActionController::Live responses.

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,14 @@
+*   Include default headers in `ActionController::Live` responses.
+
+    Previously, responses from `ActionController::Live` controllers, including
+    the Active Storage proxy controllers, were served over HTTP/1.1 without
+    `config.action_dispatch.default_headers` such as `X-Content-Type-Options`
+    and `X-Frame-Options`.
+
+    Fixes #53402.
+
+    *Tony Novak*
+
 *   Check `PATCH` and `QUERY` in `assert_recognizes` and `assert_routing` with `method: :all`.
 
     Both assertions only recognized the path for `GET`, `POST`, `PUT` and

--- a/actionpack/lib/action_controller/metal/live.rb
+++ b/actionpack/lib/action_controller/metal/live.rb
@@ -61,7 +61,7 @@ module ActionController
         if request.get_header("HTTP_VERSION") == "HTTP/1.0"
           super
         else
-          Live::Response.new.tap do |res|
+          Live::Response.create.tap do |res|
             res.request = request
           end
         end

--- a/actionpack/lib/action_controller/metal/live.rb
+++ b/actionpack/lib/action_controller/metal/live.rb
@@ -106,7 +106,7 @@ module ActionController
         if (request.get_header("SERVER_PROTOCOL") || request.get_header("HTTP_VERSION")) == "HTTP/1.0"
           super
         else
-          Live::Response.new.tap do |res|
+          Live::Response.create.tap do |res|
             res.request = request
           end
         end

--- a/actionpack/test/controller/integration_test.rb
+++ b/actionpack/test/controller/integration_test.rb
@@ -587,6 +587,18 @@ class IntegrationProcessTest < ActionDispatch::IntegrationTest
     assert_includes @response.headers, "c"
   end
 
+  def test_default_headers_for_live_request
+    with_test_route_set do |controller|
+      with_live_controller(controller) do
+        with_default_headers "a" => "1", "b" => "2" do
+          get "/get"
+        end
+      end
+    end
+
+    assert_includes @response.headers, "a"
+  end
+
   def test_accept_not_overridden_when_xhr_true
     with_test_route_set do
       get "/get", headers: { "Accept" => "application/json" }, xhr: true
@@ -659,8 +671,16 @@ class IntegrationProcessTest < ActionDispatch::IntegrationTest
 
         singleton_class.include(set.url_helpers)
 
-        yield
+        yield controller
       end
+    end
+
+    def with_live_controller controller
+      controller.class_eval do
+        include ActionController::Live
+      end
+
+      yield
     end
 end
 

--- a/actionpack/test/controller/integration_test.rb
+++ b/actionpack/test/controller/integration_test.rb
@@ -675,7 +675,7 @@ class IntegrationProcessTest < ActionDispatch::IntegrationTest
       end
     end
 
-    def with_live_controller controller
+    def with_live_controller(controller)
       controller.class_eval do
         include ActionController::Live
       end

--- a/actionpack/test/controller/integration_test.rb
+++ b/actionpack/test/controller/integration_test.rb
@@ -655,7 +655,7 @@ class IntegrationProcessTest < ActionDispatch::IntegrationTest
     with_test_route_set do |controller|
       with_live_controller(controller) do
         with_default_headers "a" => "1", "b" => "2" do
-          get "/get"
+          get "/get", env: { "SERVER_PROTOCOL" => "HTTP/1.1" }
         end
       end
     end

--- a/actionpack/test/controller/integration_test.rb
+++ b/actionpack/test/controller/integration_test.rb
@@ -739,7 +739,7 @@ class IntegrationProcessTest < ActionDispatch::IntegrationTest
       end
     end
 
-    def with_live_controller controller
+    def with_live_controller(controller)
       controller.class_eval do
         include ActionController::Live
       end

--- a/actionpack/test/controller/integration_test.rb
+++ b/actionpack/test/controller/integration_test.rb
@@ -651,6 +651,18 @@ class IntegrationProcessTest < ActionDispatch::IntegrationTest
     assert_includes @response.headers, "c"
   end
 
+  def test_default_headers_for_live_request
+    with_test_route_set do |controller|
+      with_live_controller(controller) do
+        with_default_headers "a" => "1", "b" => "2" do
+          get "/get"
+        end
+      end
+    end
+
+    assert_includes @response.headers, "a"
+  end
+
   def test_accept_not_overridden_when_xhr_true
     with_test_route_set do
       get "/get", headers: { "Accept" => "application/json" }, xhr: true
@@ -723,8 +735,16 @@ class IntegrationProcessTest < ActionDispatch::IntegrationTest
 
         singleton_class.include(set.url_helpers)
 
-        yield
+        yield controller
       end
+    end
+
+    def with_live_controller controller
+      controller.class_eval do
+        include ActionController::Live
+      end
+
+      yield
     end
 end
 


### PR DESCRIPTION
### Motivation / Background

Default headers are added to ActionDispatch::Response in the `.create`
method, not in `#initialize`. The `make_response!` method in
ActionController::Live calls `Live::Response.new` rather than
`Live::Response.create`, which bypasses the merging of default headers.

Fixes #53402.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
