### PR TITLE
Fix enum labels to accepts as keyword arguments

### DIFF
--- a/activerecord/lib/active_record/enum.rb
+++ b/activerecord/lib/active_record/enum.rb
@@ -213,74 +213,79 @@ module ActiveRecord
         attr_reader :name, :mapping
     end
 
-    def enum(name, values, prefix: nil, suffix: nil, scopes: true, instance_methods: true, validate: false, **options)
-      assert_valid_enum_definition_values(values)
-      assert_valid_enum_options(options)
-
-      # statuses = { }
-      enum_values = ActiveSupport::HashWithIndifferentAccess.new
-      name = name.to_s
-
-      # def self.statuses() statuses end
-      detect_enum_conflict!(name, name.pluralize, true)
-      singleton_class.define_method(name.pluralize) { enum_values }
-      defined_enums[name] = enum_values
-
-      detect_enum_conflict!(name, name)
-      detect_enum_conflict!(name, "#{name}=")
-
-      attribute(name, **options)
-
-      decorate_attributes([name]) do |_name, subtype|
-        if subtype == ActiveModel::Type.default_value
-          raise "Undeclared attribute type for enum '#{name}' in #{self.name}. Enums must be" \
-            " backed by a database column or declared with an explicit type" \
-            " via `attribute`."
-        end
-
-        subtype = subtype.subtype if EnumType === subtype
-        EnumType.new(name, enum_values, subtype, raise_on_invalid_values: !validate)
-      end
-
-      value_method_names = []
-      _enum_methods_module.module_eval do
-        prefix = if prefix
-          prefix == true ? "#{name}_" : "#{prefix}_"
-        end
-
-        suffix = if suffix
-          suffix == true ? "_#{name}" : "_#{suffix}"
-        end
-
-        pairs = values.respond_to?(:each_pair) ? values.each_pair : values.each_with_index
-        pairs.each do |label, value|
-          enum_values[label] = value
-          label = label.to_s
-
-          value_method_name = "#{prefix}#{label}#{suffix}"
-          value_method_names << value_method_name
-          define_enum_methods(name, value_method_name, value, scopes, instance_methods)
-
-          method_friendly_label = label.gsub(/[\W&&[:ascii:]]+/, "_")
-          value_method_alias = "#{prefix}#{method_friendly_label}#{suffix}"
-
-          if value_method_alias != value_method_name && !value_method_names.include?(value_method_alias)
-            value_method_names << value_method_alias
-            define_enum_methods(name, value_method_alias, value, scopes, instance_methods)
-          end
-        end
-      end
-      detect_negative_enum_conditions!(value_method_names) if scopes
-
-      if validate
-        validate = {} unless Hash === validate
-        validates_inclusion_of name, in: enum_values.keys, **validate
-      end
-
-      enum_values.freeze
+    def enum(name, values = nil, **options)
+      values, options = options, {} unless values
+      _enum(name, values, **options)
     end
 
     private
+      def _enum(name, values, prefix: nil, suffix: nil, scopes: true, instance_methods: true, validate: false, **options)
+        assert_valid_enum_definition_values(values)
+        assert_valid_enum_options(options)
+
+        # statuses = { }
+        enum_values = ActiveSupport::HashWithIndifferentAccess.new
+        name = name.to_s
+
+        # def self.statuses() statuses end
+        detect_enum_conflict!(name, name.pluralize, true)
+        singleton_class.define_method(name.pluralize) { enum_values }
+        defined_enums[name] = enum_values
+
+        detect_enum_conflict!(name, name)
+        detect_enum_conflict!(name, "#{name}=")
+
+        attribute(name, **options)
+
+        decorate_attributes([name]) do |_name, subtype|
+          if subtype == ActiveModel::Type.default_value
+            raise "Undeclared attribute type for enum '#{name}' in #{self.name}. Enums must be" \
+              " backed by a database column or declared with an explicit type" \
+              " via `attribute`."
+          end
+
+          subtype = subtype.subtype if EnumType === subtype
+          EnumType.new(name, enum_values, subtype, raise_on_invalid_values: !validate)
+        end
+
+        value_method_names = []
+        _enum_methods_module.module_eval do
+          prefix = if prefix
+            prefix == true ? "#{name}_" : "#{prefix}_"
+          end
+
+          suffix = if suffix
+            suffix == true ? "_#{name}" : "_#{suffix}"
+          end
+
+          pairs = values.respond_to?(:each_pair) ? values.each_pair : values.each_with_index
+          pairs.each do |label, value|
+            enum_values[label] = value
+            label = label.to_s
+
+            value_method_name = "#{prefix}#{label}#{suffix}"
+            value_method_names << value_method_name
+            define_enum_methods(name, value_method_name, value, scopes, instance_methods)
+
+            method_friendly_label = label.gsub(/[\W&&[:ascii:]]+/, "_")
+            value_method_alias = "#{prefix}#{method_friendly_label}#{suffix}"
+
+            if value_method_alias != value_method_name && !value_method_names.include?(value_method_alias)
+              value_method_names << value_method_alias
+              define_enum_methods(name, value_method_alias, value, scopes, instance_methods)
+            end
+          end
+        end
+        detect_negative_enum_conditions!(value_method_names) if scopes
+
+        if validate
+          validate = {} unless Hash === validate
+          validates_inclusion_of name, in: enum_values.keys, **validate
+        end
+
+        enum_values.freeze
+      end
+
       def inherited(base)
         base.defined_enums = defined_enums.deep_dup
         super

--- a/activerecord/test/cases/enum_test.rb
+++ b/activerecord/test/cases/enum_test.rb
@@ -446,7 +446,7 @@ class EnumTest < ActiveRecord::TestCase
       end
     end
 
-    assert_match(/wrong number of arguments/, e.message)
+    assert_match(/must not be empty\.$/, e.message)
 
     e = assert_raises(ArgumentError) do
       Class.new(ActiveRecord::Base) do
@@ -892,10 +892,21 @@ class EnumTest < ActiveRecord::TestCase
     assert_respond_to book, :easy_to_read?
   end
 
+  test "enum labels as keyword arguments" do
+    klass = Class.new(ActiveRecord::Base) do
+      self.table_name = "books"
+      enum :status, active: 0, archived: 1
+    end
+
+    book = klass.new
+    assert_predicate book, :active?
+    assert_not_predicate book, :archived?
+  end
+
   test "option names can be used as label" do
     klass = Class.new(ActiveRecord::Base) do
       self.table_name = "books"
-      enum :status, { default: 0, scopes: 1, prefix: 2, suffix: 3 }
+      enum :status, default: 0, scopes: 1, prefix: 2, suffix: 3
     end
 
     book = klass.new


### PR DESCRIPTION
Enum accepts labels as keyword arguments is originally intended in #41328, so I documented and covered by test that.

https://github.com/rails/rails/blob/0618d2d84a501aea93c898aec504ff9a0e09d6f2/activerecord/lib/active_record/enum.rb#L60-L65 https://github.com/rails/rails/blob/0618d2d84a501aea93c898aec504ff9a0e09d6f2/activerecord/test/cases/enum_test.rb#L702-L713

I'm not against dropping that support to simplify codebase, at least we should deprecation that before removing.

Fixes #53407.
