### PR TITLE
Fix edge case where ActionMailer::MailHelper#block_format caused a NoMethodError

### DIFF
--- a/actionmailer/lib/action_mailer/mail_helper.rb
+++ b/actionmailer/lib/action_mailer/mail_helper.rb
@@ -28,7 +28,7 @@ module ActionMailer
       output = +""
       splits = formatted.split(/(\*+|\#+)/)
       while line = splits.shift
-        if line.start_with?("*", "#") && splits[0].start_with?(" ")
+        if line.start_with?("*", "#") && splits.first&.start_with?(" ")
           output.chomp!(" ") while output.end_with?(" ")
           output << "  #{line} #{splits.shift.strip}\n"
         else

--- a/actionmailer/test/mail_helper_test.rb
+++ b/actionmailer/test/mail_helper_test.rb
@@ -132,5 +132,6 @@ class MailerHelperTest < ActionMailer::TestCase
     assert_equal "  * foo\n", helper.block_format("* foo")
     assert_equal "  * foo\n*bar", helper.block_format("* foo*bar")
     assert_equal "  * foo\n  * bar\n", helper.block_format("* foo * bar")
+    assert_equal "  *", helper.block_format("* ")
   end
 end


### PR DESCRIPTION
### Motivation / Background

Fixes #53338 for the `7-2-stable` branch.

### Detail

This Pull Request changes a single edge case of `ActionMailer::MailHelper#block_format`. When a bullet point is not followed by additional content for whatever reason, the method would raise an exception.

### Additional information

This regression was introduced just last week with the fix of CVE-2024-47889.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [ x Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
