### PR TITLE
Enable schema queries to be retryable

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -32,7 +32,7 @@ module ActiveRecord
       # Returns the relation names usable to back Active Record models.
       # For most adapters this means all #tables and #views.
       def data_sources
-        query_values(data_source_sql, "SCHEMA")
+        query_values(data_source_sql, "SCHEMA", allow_retry: true)
       rescue NotImplementedError
         tables | views
       end
@@ -42,14 +42,14 @@ module ActiveRecord
       #   data_source_exists?(:ebooks)
       #
       def data_source_exists?(name)
-        query_values(data_source_sql(name), "SCHEMA").any? if name.present?
+        query_values(data_source_sql(name), "SCHEMA", allow_retry: true).any? if name.present?
       rescue NotImplementedError
         data_sources.include?(name.to_s)
       end
 
       # Returns an array of table names defined in the database.
       def tables
-        query_values(data_source_sql(type: "BASE TABLE"), "SCHEMA")
+        query_values(data_source_sql(type: "BASE TABLE"), "SCHEMA", allow_retry: true)
       end
 
       # Checks to see if the table +table_name+ exists on the database.
@@ -57,14 +57,14 @@ module ActiveRecord
       #   table_exists?(:developers)
       #
       def table_exists?(table_name)
-        query_values(data_source_sql(table_name, type: "BASE TABLE"), "SCHEMA").any? if table_name.present?
+        query_values(data_source_sql(table_name, type: "BASE TABLE"), "SCHEMA", allow_retry: true).any? if table_name.present?
       rescue NotImplementedError
         tables.include?(table_name.to_s)
       end
 
       # Returns an array of view names defined in the database.
       def views
-        query_values(data_source_sql(type: "VIEW"), "SCHEMA")
+        query_values(data_source_sql(type: "VIEW"), "SCHEMA", allow_retry: true)
       end
 
       # Checks to see if the view +view_name+ exists on the database.
@@ -72,7 +72,7 @@ module ActiveRecord
       #   view_exists?(:ebooks)
       #
       def view_exists?(view_name)
-        query_values(data_source_sql(view_name, type: "VIEW"), "SCHEMA").any? if view_name.present?
+        query_values(data_source_sql(view_name, type: "VIEW"), "SCHEMA", allow_retry: true).any? if view_name.present?
       rescue NotImplementedError
         views.include?(view_name.to_s)
       end

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -206,7 +206,7 @@ module ActiveRecord
       # REFERENTIAL INTEGRITY ====================================
 
       def disable_referential_integrity # :nodoc:
-        old = query_value("SELECT @@FOREIGN_KEY_CHECKS")
+        old = query_value("SELECT @@FOREIGN_KEY_CHECKS", allow_retry: true)
 
         begin
           update("SET FOREIGN_KEY_CHECKS = 0")
@@ -290,7 +290,7 @@ module ActiveRecord
       end
 
       def current_database
-        query_value("SELECT database()", "SCHEMA")
+        query_value("SELECT database()", "SCHEMA", allow_retry: true)
       end
 
       # Returns the database character set.
@@ -306,7 +306,7 @@ module ActiveRecord
       def table_comment(table_name) # :nodoc:
         scope = quoted_scope(table_name)
 
-        query_value(<<~SQL, "SCHEMA").presence
+        query_value(<<~SQL, "SCHEMA", allow_retry: true).presence
           SELECT table_comment
           FROM information_schema.tables
           WHERE table_schema = #{scope[:schema]}
@@ -579,7 +579,7 @@ module ActiveRecord
 
         scope = quoted_scope(table_name)
 
-        query_values(<<~SQL, "SCHEMA")
+        query_values(<<~SQL, "SCHEMA", allow_retry: true)
           SELECT column_name
           FROM information_schema.statistics
           WHERE index_name = 'PRIMARY'

--- a/activerecord/lib/active_record/connection_adapters/mysql/schema_dumper.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/schema_dumper.rb
@@ -88,7 +88,7 @@ module ActiveRecord
               # Calling .inspect leads into issues with the query result
               # which already returns escaped quotes.
               # We remove the escape sequence from the result in order to deal with double escaping issues.
-              @connection.query_value(sql, "SCHEMA").gsub("\\'", "'").inspect
+              @connection.query_value(sql, "SCHEMA", allow_retry: true).gsub("\\'", "'").inspect
             end
           end
       end

--- a/activerecord/lib/active_record/connection_adapters/mysql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/schema_statements.rb
@@ -148,7 +148,7 @@ module ActiveRecord
             return if row_format_dynamic_by_default?
 
             unless defined?(@default_row_format)
-              if query_value("SELECT @@innodb_file_per_table = 1 AND @@innodb_file_format = 'Barracuda'") == 1
+              if query_value("SELECT @@innodb_file_per_table = 1 AND @@innodb_file_format = 'Barracuda'", "SCHEMA", allow_retry: true) == 1
                 @default_row_format = "ROW_FORMAT=DYNAMIC"
               else
                 @default_row_format = nil

--- a/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
@@ -11,8 +11,8 @@ module ActiveRecord
         end
 
         # Queries the database and returns the results in an Array-like object
-        def query(sql, name = nil) # :nodoc:
-          result = internal_execute(sql, name)
+        def query(...) # :nodoc:
+          result = internal_execute(...)
           result.map_types!(@type_map_for_results).values
         end
 

--- a/activerecord/lib/active_record/connection_adapters/postgresql/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/quoting.rb
@@ -193,7 +193,7 @@ module ActiveRecord
 
         private
           def lookup_cast_type(sql_type)
-            super(query_value("SELECT #{quote(sql_type)}::regtype::oid", "SCHEMA").to_i)
+            super(query_value("SELECT #{quote(sql_type)}::regtype::oid", "SCHEMA", allow_retry: true).to_i)
           end
 
           def encode_array(array_data)

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -490,11 +490,11 @@ module ActiveRecord
       end
 
       def extension_available?(name)
-        query_value("SELECT true FROM pg_available_extensions WHERE name = #{quote(name)}", "SCHEMA")
+        query_value("SELECT true FROM pg_available_extensions WHERE name = #{quote(name)}", "SCHEMA", allow_retry: true)
       end
 
       def extension_enabled?(name)
-        query_value("SELECT installed_version IS NOT NULL FROM pg_available_extensions WHERE name = #{quote(name)}", "SCHEMA")
+        query_value("SELECT installed_version IS NOT NULL FROM pg_available_extensions WHERE name = #{quote(name)}", "SCHEMA", allow_retry: true)
       end
 
       def extensions
@@ -617,7 +617,7 @@ module ActiveRecord
 
       # Returns the configured supported identifier length supported by PostgreSQL
       def max_identifier_length
-        @max_identifier_length ||= query_value("SHOW max_identifier_length", "SCHEMA").to_i
+        @max_identifier_length ||= query_value("SHOW max_identifier_length", "SCHEMA", allow_retry: true).to_i
       end
 
       # Set the authorized user for this session

--- a/activerecord/lib/active_record/connection_adapters/sqlite3/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3/schema_statements.rb
@@ -11,7 +11,7 @@ module ActiveRecord
             # See https://www.sqlite.org/fileformat2.html#intschema
             next if row["name"].start_with?("sqlite_")
 
-            index_sql = query_value(<<~SQL, "SCHEMA")
+            index_sql = query_value(<<~SQL, "SCHEMA", allow_retry: true)
               SELECT sql
               FROM sqlite_master
               WHERE name = #{quote(row['name'])} AND type = 'index'
@@ -83,11 +83,11 @@ module ActiveRecord
         end
 
         def virtual_table_exists?(table_name)
-          query_values(data_source_sql(table_name, type: "VIRTUAL TABLE"), "SCHEMA").any?
+          query_values(data_source_sql(table_name, type: "VIRTUAL TABLE"), "SCHEMA", allow_retry: true).any?
         end
 
         def check_constraints(table_name)
-          table_sql = query_value(<<-SQL, "SCHEMA")
+          table_sql = query_value(<<-SQL, "SCHEMA", allow_retry: true)
             SELECT sql
             FROM sqlite_master
             WHERE name = #{quote(table_name)} AND type = 'table'

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -469,7 +469,7 @@ module ActiveRecord
       end
 
       def get_database_version # :nodoc:
-        SQLite3Adapter::Version.new(query_value("SELECT sqlite_version(*)", "SCHEMA"))
+        SQLite3Adapter::Version.new(query_value("SELECT sqlite_version(*)", "SCHEMA", allow_retry: true))
       end
 
       def check_version # :nodoc:
@@ -767,7 +767,7 @@ module ActiveRecord
           #                       "password_digest" varchar COLLATE "NOCASE",
           #                       "o_id" integer,
           #                       CONSTRAINT "fk_rails_78146ddd2e" FOREIGN KEY ("o_id") REFERENCES "os" ("id"));
-          result = query_value(sql, "SCHEMA")
+          result = query_value(sql, "SCHEMA", allow_retry: true)
 
           return [] unless result
 


### PR DESCRIPTION
### Motivation / Background

Closes #53425

When `permanent_connection_checkout` was [introduced][1], Active Record was changed to always use `with_connection` and [never][2] `lease_connection`. This causes apps that never call `lease_connection` on their own (or in a gem) during a request to no longer have a connection pinned to the current Thread/Fiber. By checking in/out connections as needed, the number of times a connection must be verified during a single request has significantly increased (more pings = more latency).

### Detail

The good news is that Active Record also now [defers][3] connection verification and can use retryable queries as verification instead of explicit pings.

This commit marks all(?) internal SCHEMA queries as retryable so that they can be used as connection verification. While this likely won't help as much in production for applications using a schema cache dump, it will definitely decrease latency for applications in development and those that do not use a dump in production.

(There are a few places where `query_value{,s}` modifies database state, those were not marked as retryable by this commit)

[1]: https://github.com/rails/rails/commit/4db9f512591b0188f05c0762102a3386b43c1b34
[2]: https://github.com/rails/rails/commit/7c68c5210cbc245d778daa7958cab73bc74f4669
[3]: https://github.com/rails/rails/commit/7fe221d898afe877f282b549bd8bb908ebe1843d

### Additional information

I plan to follow up with more but this PR is already relatively large.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
