### PR TITLE
Fix `ActionController::Parameters` docs code block following list [ci-skip]

### DIFF
--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -95,6 +95,8 @@ module ActionController
   # *   `permit` to filter params for mass assignment.
   # *   `require` to require a parameter or raise an error.
   #
+  # Examples:
+  #
   #     params = ActionController::Parameters.new({
   #       person: {
   #         name: "Francesco",


### PR DESCRIPTION
### Motivation / Background

Fixes what appears to be a malformed code example block in the docs for `ActionController::Parameters`.

### Detail

The example code follows a list, and it appears since both are indented the resulting output is not what you'd expect. The code is not interpreted as a code block or highlighted correctly.

By inserting "Examples:" text right before the code block (similar to elsewhere in the docs), which serves as a break, `rdoc` appears to correctly interpret the it as a code block.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
