### PR TITLE
Scoped associations should use a subquery join when necessary

### DIFF
--- a/activerecord/test/cases/associations/has_and_belongs_to_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_and_belongs_to_many_associations_test.rb
@@ -579,7 +579,7 @@ class HasAndBelongsToManyAssociationsTest < ActiveRecord::TestCase
 
   def test_find_should_append_to_association_order
     ordered_developers = projects(:active_record).developers.order("projects.id")
-    assert_equal ["developers.name desc, developers.id desc", "projects.id"], ordered_developers.order_values
+    assert_equal [Developer.arel_table[:name].desc, Developer.arel_table[:id].desc, "projects.id"], ordered_developers.order_values
   end
 
   def test_dynamic_find_all_should_respect_readonly_access

--- a/activerecord/test/models/post.rb
+++ b/activerecord/test/models/post.rb
@@ -58,6 +58,11 @@ class Post < ActiveRecord::Base
   end
   has_one :first_comment, -> { order("id ASC") }, class_name: "Comment"
   has_one :last_comment, -> { order("id desc") }, class_name: "Comment"
+  has_many :popular_comments, -> { select(:post_id).group(:post_id).having("count(*) >= 3") }, class_name: "Comment"
+  has_many :comments_with_select, -> { select("comments.*", "'hello' AS hello") }, class_name: "Comment"
+  has_many :comments_with_from, -> { select("all_comments.*").from("comments all_comments") }, class_name: "Comment"
+  has_many :comments_with_limit, -> { order(:id).limit(1).offset(2) }, class_name: "Comment"
+  has_many :comments_with_cte, -> { with(all_comments: Comment.all).from("all_comments comments") }, class_name: "Comment"
 
   scope :no_comments, -> { left_joins(:comments).where(comments: { id: nil }) }
   scope :with_special_comments, -> { joins(:comments).where(comments: { type: "SpecialComment" }) }

--- a/activerecord/test/models/project.rb
+++ b/activerecord/test/models/project.rb
@@ -2,7 +2,7 @@
 
 class Project < ActiveRecord::Base
   belongs_to :mentor
-  has_and_belongs_to_many :developers, -> { distinct.order "developers.name desc, developers.id desc" }
+  has_and_belongs_to_many :developers, -> { distinct.order(name: :desc, id: :desc) }
   has_and_belongs_to_many :readonly_developers, -> { readonly }, class_name: "Developer"
   has_and_belongs_to_many :non_unique_developers, -> { order "developers.name desc, developers.id desc" }, class_name: "Developer"
   has_and_belongs_to_many :limited_developers, -> { limit 1 }, class_name: "Developer"


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

When joining a scoped association, certain query methods are silently ignored.

```ruby
class Post < ApplicationRecord
  has_many :comments, -> { from('comments_view comments') }, class_name: 'Comment'
end
```

`Post.joins(:comment)` will completely disregard the `from` clause. The only query methods that apply to a join are `where` and other `joins`. Even more confusingly, these query methods are not ignored when `Post#comments` is called.

Here's a snippet to summarize:

```ruby
post = Post.find(1)
# SELECT "posts".* FROM "posts" ORDER BY "posts"."id" ASC LIMIT ?

post.comments
# SELECT "comments".* FROM comments_view comments WHERE "comments"."post_id" = 1

Post.joins(:comments) # Surprise!
# SELECT "posts".* FROM "posts" INNER JOIN "comments" ON "comments"."post_id" = "posts"."id"
```

By joining a subquery, we can make the behavior of scoped associations more consistent.

### Detail

This Pull Request changes how joins are constructed in `JoinAssociation`. If the scoped association has a `select`, `group`, `from`, `with`, `limit`, or `offset`, we'll join a subquery.

`from` clauses could probably be supported without restoring to a subquery, but a query can have multiple from expressions (e.g. `from('a, b, c')`).

You'll notice that `order` isn't included in that list. An `ORDER BY` expression in a subquery doesn't do anything by itself. An `ORDER BY` expression can change the behavior of a subquery in certain situations, for example, when used in combination with a limit.

`order` is probably the most common footgun with regard to joining scoped associations. Maybe `order` expressions in scoped associations should be hoisted to the top-level query? At the very least, it might be helpful to emit a warning when someone attempts to join a scoped association with an order.

When someone attempts to join a a scoped association with one of these clauses, maybe we should emit a warning? Should this subquery functionality require you to add an option like `join_using_subquery: true` to the association?

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
