### PR TITLE
Make internal query() retryable

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -110,8 +110,8 @@ module ActiveRecord
         query(...).map(&:first)
       end
 
-      def query(...) # :nodoc:
-        internal_exec_query(...).rows
+      def query(sql, name = nil, allow_retry: true, materialize_transactions: true) # :nodoc:
+        internal_exec_query(sql, name, allow_retry:, materialize_transactions:).rows
       end
 
       # Determines whether the SQL statement is a write query.

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -320,7 +320,7 @@ module ActiveRecord
             if sequence
               quoted_sequence = quote_table_name(sequence)
 
-              query_value("SELECT setval(#{quote(quoted_sequence)}, #{value})", "SCHEMA")
+              internal_execute("SELECT setval(#{quote(quoted_sequence)}, #{value})", "SCHEMA")
             else
               @logger.warn "#{table} has primary key #{pk} with no default sequence." if @logger
             end
@@ -351,7 +351,7 @@ module ActiveRecord
               end
             end
 
-            query_value("SELECT setval(#{quote(quoted_sequence)}, #{max_pk || minvalue}, #{max_pk ? true : false})", "SCHEMA")
+            internal_execute("SELECT setval(#{quote(quoted_sequence)}, #{max_pk || minvalue}, #{max_pk ? true : false})", "SCHEMA")
           end
         end
 


### PR DESCRIPTION
### Motivation / Background

Closes #53411

When `permanent_connection_checkout` was [introduced][1], Active Record was changed to always use `with_connection` and [never][2] `lease_connection`. This causes apps that never call `lease_connection` on their own (or in a gem) during a request to no longer have a connection pinned to the current Thread/Fiber. By checking in/out connections as needed, the number of times a connection must be verified during a single request has significantly increased (more pings = more latency).

The good news is that Active Record also now [defers][3] connection verification and can use retryable queries as verification instead of explicit pings.

### Detail

This commit makes all internal SELECT `query()`s retryable so that they can be used as connection verification. While this likely won't help as much in production for applications using a schema cache dump, it will definitely decrease latency for applications in development and those that do not use a dump in production.

There are a few places where `query_value` was used to update sequences. Those have been changed to use `internal_execute` since only idempotent SELECT queries are being automatically retried and Active Record doesn't actually care about the return value of these queries anyways (so no reason to use `internal_exec_query`).

[1]: 4db9f512591b0188f05c0762102a3386b43c1b34
[2]: 7c68c5210cbc245d778daa7958cab73bc74f4669
[3]: 7fe221d898afe877f282b549bd8bb908ebe1843d

### Additional information

I plan to follow up with more but this PR is already relatively large (conceptually 😅).

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
