### PR TITLE
Security release forward ports to newer branches

### DIFF
--- a/actionmailer/lib/action_mailer/mail_helper.rb
+++ b/actionmailer/lib/action_mailer/mail_helper.rb
@@ -25,10 +25,18 @@ module ActionMailer
       }.join("\n\n")
 
       # Make list points stand on their own line
-      formatted.gsub!(/[ ]*([*]+) ([^*]*)/) { "  #{$1} #{$2.strip}\n" }
-      formatted.gsub!(/[ ]*([#]+) ([^#]*)/) { "  #{$1} #{$2.strip}\n" }
+      output = +""
+      splits = formatted.split(/(\*+|\#+)/)
+      while line = splits.shift
+        if line.start_with?("*", "#") && splits.first&.start_with?(" ")
+          output.chomp!(" ") while output.end_with?(" ")
+          output << "  #{line} #{splits.shift.strip}\n"
+        else
+          output << line
+        end
+      end
 
-      formatted
+      output
     end
 
     # Access the mailer instance.

--- a/actionmailer/test/mail_helper_test.rb
+++ b/actionmailer/test/mail_helper_test.rb
@@ -121,4 +121,17 @@ class MailerHelperTest < ActionMailer::TestCase
       assert_equal "Greetings from a cache helper block", mail.body.encoded
     end
   end
+
+  def helper
+    Object.new.extend(ActionMailer::MailHelper)
+  end
+
+  def test_block_format
+    assert_equal "  * foo\n", helper.block_format(" * foo")
+    assert_equal "  * foo\n", helper.block_format("   * foo")
+    assert_equal "  * foo\n", helper.block_format("* foo")
+    assert_equal "  * foo\n*bar", helper.block_format("* foo*bar")
+    assert_equal "  * foo\n  * bar\n", helper.block_format("* foo * bar")
+    assert_equal "  *", helper.block_format("* ")
+  end
 end

--- a/actionpack/lib/action_controller/metal/http_authentication.rb
+++ b/actionpack/lib/action_controller/metal/http_authentication.rb
@@ -513,14 +513,11 @@ module ActionController
         array_params.each { |param| (param[1] || +"").gsub! %r/^"|"$/, "" }
       end
 
-      WHITESPACED_AUTHN_PAIR_DELIMITERS = /\s*#{AUTHN_PAIR_DELIMITERS}\s*/
-      private_constant :WHITESPACED_AUTHN_PAIR_DELIMITERS
-
       # This method takes an authorization body and splits up the key-value pairs by
       # the standardized `:`, `;`, or `\t` delimiters defined in
       # `AUTHN_PAIR_DELIMITERS`.
       def raw_params(auth)
-        _raw_params = auth.sub(TOKEN_REGEX, "").split(WHITESPACED_AUTHN_PAIR_DELIMITERS)
+        _raw_params = auth.sub(TOKEN_REGEX, "").split(AUTHN_PAIR_DELIMITERS).map(&:strip)
         _raw_params.reject!(&:empty?)
 
         if !_raw_params.first&.start_with?(TOKEN_KEY)

--- a/actionpack/lib/action_dispatch/http/filter_parameters.rb
+++ b/actionpack/lib/action_dispatch/http/filter_parameters.rb
@@ -68,12 +68,17 @@ module ActionDispatch
         ActiveSupport::ParameterFilter.new(filters)
       end
 
-      KV_RE   = "[^&;=]+"
-      PAIR_RE = %r{(#{KV_RE})=(#{KV_RE})}
       def filtered_query_string # :doc:
-        query_string.gsub(PAIR_RE) do |_|
-          parameter_filter.filter($1 => $2).first.join("=")
+        parts = query_string.split(/([&;])/)
+        filtered_parts = parts.map do |part|
+          if part.include?("=")
+            key, value = part.split("=", 2)
+            parameter_filter.filter(key => value).first.join("=")
+          else
+            part
+          end
         end
+        filtered_parts.join("")
       end
     end
   end

--- a/actionpack/lib/action_dispatch/http/filter_redirect.rb
+++ b/actionpack/lib/action_dispatch/http/filter_redirect.rb
@@ -37,9 +37,16 @@ module ActionDispatch
       def parameter_filtered_location
         uri = URI.parse(location)
         unless uri.query.nil? || uri.query.empty?
-          uri.query.gsub!(FilterParameters::PAIR_RE) do
-            request.parameter_filter.filter($1 => $2).first.join("=")
+          parts = uri.query.split(/([&;])/)
+          filtered_parts = parts.map do |part|
+            if part.include?("=")
+              key, value = part.split("=", 2)
+              request.parameter_filter.filter(key => value).first.join("=")
+            else
+              part
+            end
           end
+          uri.query = filtered_parts.join("")
         end
         uri.to_s
       rescue URI::Error

--- a/actiontext/lib/action_text/plain_text_conversion.rb
+++ b/actiontext/lib/action_text/plain_text_conversion.rb
@@ -65,7 +65,12 @@ module ActionText
 
       def plain_text_for_blockquote_node(node, index)
         text = plain_text_for_block(node)
-        text.sub(/\A(\s*)(.+?)(\s*)\Z/m, '\1“\2”\3')
+        return "“”" if text.blank?
+
+        text = text.dup
+        text.insert(text.rindex(/\S/) + 1, "”")
+        text.insert(text.index(/\S/), "“")
+        text
       end
 
       def plain_text_for_li_node(node, index)

--- a/actiontext/test/unit/plain_text_conversion_test.rb
+++ b/actiontext/test/unit/plain_text_conversion_test.rb
@@ -17,6 +17,20 @@ class ActionText::PlainTextConversionTest < ActiveSupport::TestCase
     )
   end
 
+  test "<blockquote> tag with whitespace" do
+    assert_converted_to(
+      "   “Hello world!” ",
+      "<blockquote>   Hello world! </blockquote>"
+    )
+  end
+
+  test "<blockquote> tag with only whitespace" do
+    assert_converted_to(
+      "“”",
+      "<blockquote> </blockquote>"
+    )
+  end
+
   test "<ol> tags are separated by two new lines" do
     assert_converted_to(
       "Hello world!\n\n1. list1\n\n1. list2\n\nHow are you?",


### PR DESCRIPTION
This adds the commits from the recent security releases for the main branch. I will also backport this to 8-0-stable.

These aren't a security concern for the 8-0-stable or main branches, as Ruby 3.2, which is now required, runs these regular expressions in linear time. However it's best to keep these branches in sync.