### PR TITLE
[ci-skip] ActionText is installed via generate command

### DIFF
--- a/guides/source/action_text_overview.md
+++ b/guides/source/action_text_overview.md
@@ -57,7 +57,7 @@ control over what happens after every keystroke and avoids the need to use
 To install Action Text and start working with rich text content, run:
 
 ```bash
-$ bin/rails action_text:install
+$ bin/rails generate action_text:install
 ```
 
 It will do the following:


### PR DESCRIPTION
### Motivation / Background
It appears that `bin/rails generate action_text:install` is the only viable way to install ActionText. I followed the guides and tried `bin/rails action_text:install`. Didn't work. Then I confirmed that [installer is indeed a generator](https://github.com/rails/rails/blob/main/actiontext/lib/generators/action_text/install/install_generator.rb). Ran `bin/rails g action_text:install` and it was smooth sailing.

This Pull Request updates the guide to instruct readers to run `bin/rails generate action_text:install` instead of `bin/rails action_text:install`. There seems to more occurrence of `bin/rails generate` over `bin/rails g`, so even though I prefer and use the `g` alias I've opted for the full command here.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`