### PR TITLE
Deserialize auto populated columns on Active Record object creation

### DIFF
--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -930,7 +930,7 @@ module ActiveRecord
           )
 
           returning_columns.zip(returning_values).each do |column, value|
-            @attributes.write_from_database(column, value) if !_read_attribute(column)
+            _write_attribute(column, type_for_attribute(column).deserialize(value)) if !_read_attribute(column)
           end if returning_values
         end
 

--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -930,7 +930,7 @@ module ActiveRecord
           )
 
           returning_columns.zip(returning_values).each do |column, value|
-            _write_attribute(column, value) if !_read_attribute(column)
+            @attributes.write_from_database(column, value) if !_read_attribute(column)
           end if returning_values
         end
 

--- a/activerecord/test/cases/persistence_test.rb
+++ b/activerecord/test/cases/persistence_test.rb
@@ -63,6 +63,8 @@ class PersistenceTest < ActiveRecord::TestCase
       assert_not_nil record.modified_time_without_precision
       assert_not_nil record.modified_time_function
 
+      assert_equal "A", record.binary_default_function
+
       if supports_identity_columns?
         klass = Class.new(ActiveRecord::Base) do
           self.table_name = "postgresql_identity_table"

--- a/activerecord/test/schema/postgresql_specific_schema.rb
+++ b/activerecord/test/schema/postgresql_specific_schema.rb
@@ -41,6 +41,7 @@ ActiveRecord::Schema.define do
     t.string :char2, limit: 50, default: "a varchar field"
     t.text :char3, default: "a text field"
     t.bigint :bigint_default, default: -> { "0::bigint" }
+    t.binary :binary_default_function, default: -> { "convert_to('A', 'UTF8')" }
     t.text :multiline_default, default: "--- []
 
 "


### PR DESCRIPTION
### Motivation / Background

Fixes #53435

This Pull Request has been created because values returned from the databases need to be deserialized as they may use a different format, such as PostgreSQL bytea "hex" format.

### Detail

This Pull Request replaces `#write_from_user` with `#write_from_database` when assigning the auto populated values returned by the database.

### Additional information

I don't like the fact that we access `@attributes` directly, but `#reload` does it too and it's the simplest solution.

Alternatives considered:
* Adding an ad-hoc `_write_attribute_from_database` method somewhere (`ActiveRecord::AttributeMethods::Write`?).
* Deserializing the value using `attributes_builder.types[column].deserialize(value)`.
  
### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
