### PR TITLE
Fixes #52511 Display error message when uploading same email source

### DIFF
--- a/actionmailbox/app/controllers/rails/conductor/action_mailbox/inbound_emails/sources_controller.rb
+++ b/actionmailbox/app/controllers/rails/conductor/action_mailbox/inbound_emails/sources_controller.rb
@@ -9,7 +9,12 @@ module Rails
 
     def create
       inbound_email = ActionMailbox::InboundEmail.create_and_extract_message_id! params[:source]
-      redirect_to main_app.rails_conductor_inbound_email_url(inbound_email)
+      if inbound_email
+        redirect_to main_app.rails_conductor_inbound_email_url(inbound_email)
+      else
+        flash.now[:alert] = "This exact email has already been delivered"
+        render :new, status: :unprocessable_entity
+      end
     end
   end
 end

--- a/actionmailbox/app/views/rails/conductor/action_mailbox/inbound_emails/sources/new.html.erb
+++ b/actionmailbox/app/views/rails/conductor/action_mailbox/inbound_emails/sources/new.html.erb
@@ -3,9 +3,13 @@
 <h1>Deliver new inbound email by source</h1>
 
 <%= form_with(url: main_app.rails_conductor_inbound_email_sources_path, local: true) do |form| %>
+  <% if flash[:alert] %>
+    <p style="color: red" ><%= flash[:alert] %></p>
+  <% end %>
+
   <div>
     <%= form.label :source, "Source" %><br>
-    <%= form.textarea :source, size: "80x60" %>
+    <%= form.textarea :source, size: "80x60", value: params[:source] %>
   </div>
 
   <%= form.submit "Deliver inbound email" %>

--- a/actionmailbox/test/controllers/rails/action_mailbox/inbound_emails/sources_controller_test.rb
+++ b/actionmailbox/test/controllers/rails/action_mailbox/inbound_emails/sources_controller_test.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Rails::Conductor::ActionMailbox::InboundEmails::SourcesControllerTest < ActionDispatch::IntegrationTest
+  test "create inbound email from source" do
+    with_rails_env("development") do
+      assert_difference -> { ActionMailbox::InboundEmail.count }, +1 do
+        post rails_conductor_inbound_email_sources_path, params: {
+          source: file_fixture("welcome.eml").read
+        }
+      end
+
+      mail = ActionMailbox::InboundEmail.last
+      assert_response :redirect
+      assert_equal file_fixture("welcome.eml").read, mail.raw_email.download
+      assert_equal "0CB459E0-0336-41DA-BC88-E6E28C697DDB@37signals.com", mail.message_id
+    end
+  end
+
+  test "uploading same email multiple times fail" do
+    with_rails_env("development") do
+      assert_difference -> { ActionMailbox::InboundEmail.count }, +1 do
+        post rails_conductor_inbound_email_sources_path, params: {
+          source: file_fixture("welcome.eml").read
+        }
+        post rails_conductor_inbound_email_sources_path, params: {
+          source: file_fixture("welcome.eml").read
+        }
+      end
+
+      mail = ActionMailbox::InboundEmail.last
+      assert_response :unprocessable_entity
+      assert_equal file_fixture("welcome.eml").read, mail.raw_email.download
+      assert_equal "0CB459E0-0336-41DA-BC88-E6E28C697DDB@37signals.com", mail.message_id
+      assert_equal "This exact email has already been delivered", flash[:alert]
+    end
+  end
+
+  private
+    def with_rails_env(env)
+      old_rails_env = Rails.env
+      Rails.env = env
+      yield
+    ensure
+      Rails.env = old_rails_env
+    end
+end


### PR DESCRIPTION
### Motivation / Background
Fixes #52511
When uploading the same email from source twice in development, the second time fails with an 500 error not able to redirect to the mail as `create_and_extract_message_id!` returns nil.

This fix re-renders the form and displays an error message.

### Detail

This Pull Request checks if inbound email was created and redirects or renders new form if failed.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
    Comment: Do not see a reason to add to changelog as this is only in development
