### PR TITLE
PostgreSQL 18devel does not support unlogged option on partitioned tables

### DIFF
--- a/activerecord/test/cases/adapters/postgresql/partitions_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/partitions_test.rb
@@ -4,11 +4,14 @@ require "cases/helper"
 
 class PostgreSQLPartitionsTest < ActiveRecord::PostgreSQLTestCase
   def setup
+    @previous_unlogged_tables = ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.create_unlogged_tables
     @connection = ActiveRecord::Base.lease_connection
+    ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.create_unlogged_tables = false
   end
 
   def teardown
     @connection.drop_table "partitioned_events", if_exists: true
+    ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.create_unlogged_tables = @previous_unlogged_tables
   end
 
   def test_partitions_table_exists

--- a/activerecord/test/cases/adapters/postgresql/schema_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/schema_test.rb
@@ -910,13 +910,16 @@ class SchemaCreateTableOptionsTest < ActiveRecord::PostgreSQLTestCase
   include SchemaDumpingHelper
 
   setup do
+    @previous_unlogged_tables = ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.create_unlogged_tables
     @connection = ActiveRecord::Base.connection
+    ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.create_unlogged_tables = false
   end
 
   teardown do
     @connection.drop_table "trains", if_exists: true
     @connection.drop_table "transportation_modes", if_exists: true
     @connection.drop_table "vehicles", if_exists: true
+    ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.create_unlogged_tables = @previous_unlogged_tables
   end
 
   def test_list_partition_options_is_dumped

--- a/activerecord/test/schema/postgresql_specific_schema.rb
+++ b/activerecord/test/schema/postgresql_specific_schema.rb
@@ -185,17 +185,24 @@ _SQL
   end
 
   if supports_partitioned_indexes?
-    create_table(:measurements, id: false, force: true, options: "PARTITION BY LIST (city_id)") do |t|
-      t.string :city_id, null: false
-      t.date :logdate, null: false
-      t.integer :peaktemp
-      t.integer :unitsales
-      t.index [:logdate, :city_id], unique: true
+    begin
+      previous_unlogged_tables = ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.create_unlogged_tables
+      ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.create_unlogged_tables = false
+
+      create_table(:measurements, id: false, force: true, options: "PARTITION BY LIST (city_id)") do |t|
+        t.string :city_id, null: false
+        t.date :logdate, null: false
+        t.integer :peaktemp
+        t.integer :unitsales
+        t.index [:logdate, :city_id], unique: true
+      end
+      create_table(:measurements_toronto, id: false, force: true,
+                                          options: "PARTITION OF measurements FOR VALUES IN (1)")
+      create_table(:measurements_concepcion, id: false, force: true,
+                                            options: "PARTITION OF measurements FOR VALUES IN (2)")
+    ensure
+      ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.create_unlogged_tables = previous_unlogged_tables
     end
-    create_table(:measurements_toronto, id: false, force: true,
-                                        options: "PARTITION OF measurements FOR VALUES IN (1)")
-    create_table(:measurements_concepcion, id: false, force: true,
-                                           options: "PARTITION OF measurements FOR VALUES IN (2)")
   end
 
   add_index(:companies, [:firm_id, :type], name: "company_include_index", include: [:name, :account_id])


### PR DESCRIPTION
### Motivation / Background

This pull request disables UNLOGGED option for partitioned tables used in Active Record unit tests.

### Detail
https://github.com/rails/rails/pull/47499 configures the following option to use UNLOGGED tables to make unit test faster.

```ruby
ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.create_unlogged_tables
```

PostgreSQL 18 is being developed and it removes support unlogged option on partitioned table.
- Remove support for unlogged on partitioned tables https://github.com/postgres/postgres/commit/e2bab2d7920

According to this change Active Record unit tests gets the "partitioned tables cannot be unlogged" error.

```ruby
$ cd activerecord
$ ARCONN=postgresql bin/test test/cases/adapters/postgresql/partitions_test.rb -n test_partitions_table_exists
Using postgresql
Run options: -n test_partitions_table_exists --seed 35335

E

Error:
PostgreSQLPartitionsTest#test_partitions_table_exists:
ActiveRecord::StatementInvalid: PG::FeatureNotSupported: ERROR:  partitioned tables cannot be unlogged

    lib/active_record/connection_adapters/postgresql/database_statements.rb:160:in `exec'
    lib/active_record/connection_adapters/postgresql/database_statements.rb:160:in `perform_query'
    lib/active_record/connection_adapters/abstract/database_statements.rb:556:in `block (2 levels) in raw_execute'
    lib/active_record/connection_adapters/abstract_adapter.rb:1011:in `block in with_raw_connection'
    /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/concurrency/load_interlock_aware_monitor.rb:23:in `handle_interrupt'
    /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/concurrency/load_interlock_aware_monitor.rb:23:in `block in synchronize'
    /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/concurrency/load_interlock_aware_monitor.rb:19:in `handle_interrupt'
    /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/concurrency/load_interlock_aware_monitor.rb:19:in `synchronize'
    lib/active_record/connection_adapters/abstract_adapter.rb:983:in `with_raw_connection'
    lib/active_record/connection_adapters/abstract/database_statements.rb:555:in `block in raw_execute'
    /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/notifications/instrumenter.rb:58:in `instrument'
    lib/active_record/connection_adapters/abstract_adapter.rb:1129:in `log'
    lib/active_record/connection_adapters/abstract/database_statements.rb:554:in `raw_execute'
    lib/active_record/connection_adapters/abstract/database_statements.rb:591:in `internal_execute'
    lib/active_record/connection_adapters/abstract/database_statements.rb:137:in `execute'
    lib/active_record/connection_adapters/abstract/query_cache.rb:27:in `execute'
    lib/active_record/connection_adapters/postgresql/database_statements.rb:40:in `execute'
    lib/active_record/connection_adapters/abstract/schema_statements.rb:309:in `create_table'
    test/cases/adapters/postgresql/partitions_test.rb:16:in `test_partitions_table_exists'

```

### Additional information

- SQL executed without this fix
```sql
CREATE UNLOGGED TABLE "partitioned_events" ("issued_at" timestamp) partition by range (issued_at)
```

- SQL executed with this fix
```sql
CREATE TABLE "partitioned_events" ("issued_at" timestamp) partition by range (issued_at)
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
