### PR TITLE
Fix `CurrentAttributes#attributes` to return new object each time

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   `ActiveSupport::CurrentAttributes#attributes` now will return a new hash object on each call.
+
+    Previously, the same hash object was returned each time that method was called.
+
+    *fatkodima*
+
 *   `ActiveSupport::JSON.encode` supports CIDR notation.
 
     Previously:

--- a/activesupport/lib/active_support/current_attributes.rb
+++ b/activesupport/lib/active_support/current_attributes.rb
@@ -122,13 +122,13 @@ module ActiveSupport
             owner.define_cached_method(name, namespace: :current_attributes) do |batch|
               batch <<
                 "def #{name}" <<
-                "attributes[:#{name}]" <<
+                "@attributes[:#{name}]" <<
                 "end"
             end
             owner.define_cached_method("#{name}=", namespace: :current_attributes) do |batch|
               batch <<
                 "def #{name}=(value)" <<
-                "attributes[:#{name}] = value" <<
+                "@attributes[:#{name}] = value" <<
                 "end"
             end
           end
@@ -194,10 +194,14 @@ module ActiveSupport
 
     class_attribute :defaults, instance_writer: false, default: {}.freeze
 
-    attr_accessor :attributes
+    attr_writer :attributes
 
     def initialize
       @attributes = resolve_defaults
+    end
+
+    def attributes
+      @attributes.dup
     end
 
     # Expose one or more attributes within a block. Old values are returned after the block concludes.

--- a/activesupport/test/current_attributes_test.rb
+++ b/activesupport/test/current_attributes_test.rb
@@ -251,6 +251,10 @@ class CurrentAttributesTest < ActiveSupport::TestCase
     assert_equal({ counter_integer: 0, counter_callable: 0 }, Current.attributes)
   end
 
+  test "#attributes returns different objects each time" do
+    assert_not_same Current.attributes, Current.attributes
+  end
+
   test "CurrentAttributes restricted attribute names" do
     assert_raises ArgumentError, match: /Restricted attribute names: reset, set/ do
       class InvalidAttributeNames < ActiveSupport::CurrentAttributes


### PR DESCRIPTION
Was bitten by what I think is a bug in `CurrentAttributes`. 

We use sidekiq with reliable push feature. Basically sidekiq pushes jobs into the redis, but when redis is temporarily unavailable, it stores job payloads in a in-memory queue and pushes them when it is back up again. As part of the job payloads it stores what was `Current.attributes` at the the time the job was enqueued. But since currently `Current.attributes` is a kinda global object (it is always the same object in memory), when new objects were pushed with different `Current.set` values, old references (in the mentioned in memory queue) were mutated and contained incorrect values 😱 

Of course, this can be fixed by `Current.attributes.dup` on the calling side, but this behaviour is surprising and people will forget to do so (like in the sidekiq codebase). I think this should be fixed on the rails side and this PR does this.

I also found another surprising behavior of `CurrentAttributes`.
```ruby
Current.attributes # => {}
Current.set(foo: 1) { }
Current.attributes # => { foo: nil }   <-----
```

Probably not a bug, but at least unexpected and people might rely on the presence/absence of the key or just having `nil` value (instead of absence of the key) can lead to some unexpected behavior. Can also fix this, if agreed.

cc @byroot 