### PR TITLE
Authenticate the action cable connection too

### DIFF
--- a/railties/lib/rails/generators/rails/authentication/authentication_generator.rb
+++ b/railties/lib/rails/generators/rails/authentication/authentication_generator.rb
@@ -19,7 +19,7 @@ module Rails
         template "app/controllers/concerns/authentication.rb"
         template "app/controllers/passwords_controller.rb"
 
-        template "app/channels/application_cable/connection.rb"
+        template "app/channels/application_cable/connection.rb" unless options.skip_action_cable?
 
         template "app/mailers/passwords_mailer.rb"
 

--- a/railties/lib/rails/generators/rails/authentication/authentication_generator.rb
+++ b/railties/lib/rails/generators/rails/authentication/authentication_generator.rb
@@ -19,6 +19,8 @@ module Rails
         template "app/controllers/concerns/authentication.rb"
         template "app/controllers/passwords_controller.rb"
 
+        template "app/channels/application_cable/connection.rb"
+
         template "app/mailers/passwords_mailer.rb"
 
         template "app/views/passwords_mailer/reset.html.erb"

--- a/railties/lib/rails/generators/rails/authentication/templates/app/channels/application_cable/connection.rb.tt
+++ b/railties/lib/rails/generators/rails/authentication/templates/app/channels/application_cable/connection.rb.tt
@@ -1,0 +1,17 @@
+module ApplicationCable
+  class Connection < ActionCable::Connection::Base
+    identified_by :current_user
+
+    def connect
+      set_current_user || reject_unauthorized_connection
+    end
+
+    private
+      def set_current_user
+        if session = Session.find_by(id: cookies.signed[:session_id])
+          self.current_user = session.user
+        end
+      end
+  end
+end
+

--- a/railties/test/generators/authentication_generator_test.rb
+++ b/railties/test/generators/authentication_generator_test.rb
@@ -30,6 +30,7 @@ class AuthenticationGeneratorTest < Rails::Generators::TestCase
     assert_file "app/controllers/sessions_controller.rb"
     assert_file "app/controllers/concerns/authentication.rb"
     assert_file "app/views/sessions/new.html.erb"
+    assert_file "app/channels/application_cable/connection.rb"
 
     assert_file "app/controllers/application_controller.rb" do |content|
       class_line, includes_line = content.lines.first(2)
@@ -104,6 +105,14 @@ class AuthenticationGeneratorTest < Rails::Generators::TestCase
 
     assert_match(/rspec \[not found\]/, content)
     assert_no_file "test/models/user_test.rb"
+  end
+
+  def test_connection_class_skipped_without_action_cable
+    generator([destination_root], skip_action_cable: true)
+
+    content = run_generator_instance
+
+    assert_no_file "app/channels/application_cable/connection.rb"
   end
 
   private

--- a/railties/test/generators/authentication_generator_test.rb
+++ b/railties/test/generators/authentication_generator_test.rb
@@ -101,7 +101,7 @@ class AuthenticationGeneratorTest < Rails::Generators::TestCase
   def test_model_test_is_skipped_if_test_framework_is_given
     generator([destination_root], ["-t", "rspec"])
 
-    run_generator_instance
+    content = run_generator_instance
 
     assert_match(/rspec \[not found\]/, content)
     assert_no_file "test/models/user_test.rb"
@@ -110,7 +110,7 @@ class AuthenticationGeneratorTest < Rails::Generators::TestCase
   def test_connection_class_skipped_without_action_cable
     generator([destination_root], skip_action_cable: true)
 
-    content = run_generator_instance
+    run_generator_instance
 
     assert_no_file "app/channels/application_cable/connection.rb"
   end

--- a/railties/test/generators/authentication_generator_test.rb
+++ b/railties/test/generators/authentication_generator_test.rb
@@ -101,7 +101,7 @@ class AuthenticationGeneratorTest < Rails::Generators::TestCase
   def test_model_test_is_skipped_if_test_framework_is_given
     generator([destination_root], ["-t", "rspec"])
 
-    content = run_generator_instance
+    run_generator_instance
 
     assert_match(/rspec \[not found\]/, content)
     assert_no_file "test/models/user_test.rb"


### PR DESCRIPTION
We can lean on the existing session model to authenticate the action cable web sockets connection too.