### PR TITLE
[8.0] Translate `no connection to the server` to ConnectionNotEstablished

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   `PG::UnableToSend: no connection to the server` is now retryable as a connection-related exception
+
+    *Kazuma Watanabe*
+
 ## Rails 8.0.0.rc1 (October 19, 2024) ##
 
 *   Remove deprecated support to setting `ENV["SCHEMA_CACHE"]`.

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -798,7 +798,7 @@ module ActiveRecord
 
           case exception.result.try(:error_field, PG::PG_DIAG_SQLSTATE)
           when nil
-            if exception.message.match?(/connection is closed/i)
+            if exception.message.match?(/connection is closed/i) || exception.message.match?(/no connection to the server/i)
               ConnectionNotEstablished.new(exception, connection_pool: @pool)
             elsif exception.is_a?(PG::ConnectionBad)
               # libpq message style always ends with a newline; the pg gem's internal


### PR DESCRIPTION
Backport of https://github.com/rails/rails/pull/53400 to 8-0-stable