### PR TITLE
Rate Limiting: Allow to define shared rate limit across controllers.

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,26 @@
+*   Add `scope:` option to `rate_limit` method.
+
+    Previously, it was not possible to share a rate limit count between several controllers, since the count was by
+    default separate for each controller.
+
+    Now, the `scope:` option solves this problem.
+
+    ```ruby
+    class APIController < ActionController::API
+      rate_limit to: 2, within: 2.seconds, scope: "api"
+    end
+
+    class API::PostsController < APIController
+      # ...
+    end
+
+    class API::UsersController < APIController
+      # ...
+    end
+    ```
+
+    *ArthurPV*, *Kamil Hanus*
+
 *   Add support for `rack.response_finished` callbacks in ActionDispatch::Executor.
 
     The executor middleware now supports deferring completion callbacks to later

--- a/actionpack/lib/action_controller/metal/rate_limiting.rb
+++ b/actionpack/lib/action_controller/metal/rate_limiting.rb
@@ -57,8 +57,8 @@ module ActionController # :nodoc:
       #       rate_limit to: 3, within: 2.seconds, name: "short-term"
       #       rate_limit to: 10, within: 5.minutes, name: "long-term"
       #     end
-      def rate_limit(to:, within:, by: -> { request.remote_ip }, with: -> { head :too_many_requests }, store: cache_store, name: nil, scope: controller_path, **options)
-        before_action -> { rate_limiting(to: to, within: within, by: by, with: with, store: store, name: name, scope: scope) }, **options
+      def rate_limit(to:, within:, by: -> { request.remote_ip }, with: -> { head :too_many_requests }, store: cache_store, name: nil, scope: nil, **options)
+        before_action -> { rate_limiting(to: to, within: within, by: by, with: with, store: store, name: name, scope: scope || controller_path) }, **options
       end
     end
 

--- a/actionpack/lib/action_controller/metal/rate_limiting.rb
+++ b/actionpack/lib/action_controller/metal/rate_limiting.rb
@@ -18,6 +18,10 @@ module ActionController # :nodoc:
       # parameter. It's evaluated within the context of the controller processing the
       # request.
       #
+      # By default, rate limits are scoped to the controller's path. If you want to
+      # share rate limits across multiple controllers, you can provide your own scope,
+      # by passing value in the `scope:` parameter.
+      #
       # Requests that exceed the rate limit are refused with a `429 Too Many Requests`
       # response. You can specialize this by passing a callable in the `with:`
       # parameter. It's evaluated within the context of the controller processing the
@@ -46,21 +50,22 @@ module ActionController # :nodoc:
       #     class APIController < ApplicationController
       #       RATE_LIMIT_STORE = ActiveSupport::Cache::RedisCacheStore.new(url: ENV["REDIS_URL"])
       #       rate_limit to: 10, within: 3.minutes, store: RATE_LIMIT_STORE
+      #       rate_limit to: 100, within: 5.minutes, scope: :api_global
       #     end
       #
       #     class SessionsController < ApplicationController
       #       rate_limit to: 3, within: 2.seconds, name: "short-term"
       #       rate_limit to: 10, within: 5.minutes, name: "long-term"
       #     end
-      def rate_limit(to:, within:, by: -> { request.remote_ip }, with: -> { head :too_many_requests }, store: cache_store, name: nil, **options)
-        before_action -> { rate_limiting(to: to, within: within, by: by, with: with, store: store, name: name) }, **options
+      def rate_limit(to:, within:, by: -> { request.remote_ip }, with: -> { head :too_many_requests }, store: cache_store, name: nil, scope: controller_path, **options)
+        before_action -> { rate_limiting(to: to, within: within, by: by, with: with, store: store, name: name, scope: scope) }, **options
       end
     end
 
     private
-      def rate_limiting(to:, within:, by:, with:, store:, name:)
+      def rate_limiting(to:, within:, by:, with:, store:, name:, scope:)
         by = instance_exec(&by)
-        cache_key = ["rate-limit", controller_path, name, by].compact.join(":")
+        cache_key = ["rate-limit", scope, name, by].compact.join(":")
         count = store.increment(cache_key, 1, expires_in: within)
         if count && count > to
           ActiveSupport::Notifications.instrument("rate_limit.action_controller",
@@ -70,6 +75,7 @@ module ActionController # :nodoc:
               within: within,
               by: by,
               name: name,
+              scope: scope,
               cache_key: cache_key) do
             instance_exec(&with)
           end

--- a/guides/source/active_support_instrumentation.md
+++ b/guides/source/active_support_instrumentation.md
@@ -213,6 +213,19 @@ Additional keys may be added by the caller.
 }
 ```
 
+#### `rate_limit.action_controller`
+
+| Key          | Value                                         |
+| ------------ | --------------------------------------------- |
+| `:request`   | The [`ActionDispatch::Request`][] object      |
+| `:count`     | Number of requests made                       |
+| `:to`        | Maximum number of requests allowed            |
+| `:within`    | Time window for the rate limit                |
+| `:by`        | Identifier for the rate limit (e.g. IP)       |
+| `:name`      | Name of the rate limit                        |
+| `:scope`     | Scope of the rate limit                       |
+| `:cache_key` | The cache key used for storing the rate limit |
+
 ### Action Controller: Caching
 
 #### `write_fragment.action_controller`


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because we would like to define rate limits shared for certain controllers (e.g. for all API endpoints). At the moment, rate-limit is evaluated on controller-based level due to `controller_path` part of cache key and configuration is not flexible in this  case.

### Detail

In order to achieve cross-controller rate limits, I added option `:scope` arguments which may be passed to `rate_limit` method. It is expected to be symbol or string. 

If multiple controllers (or e.g. `ApplicationController`) defines rate-limit with `:scope` value provided, rate limit counter is incremented across controller actions, which allows user to define e.g. global rate limit to 100req/s.

```ruby
rate_limit to: 100, within: 1.minute, scope: :api_global
```

### Additional information

I am not happy from provided test case. Assigning `@controller` in `cross-controller rate limit` test feels kinda hackish, however I cannot find better solution. Feedback is really welcomed.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
