### PR TITLE
[ci-skip] Fix rich_text_area in ActionText guide

### DIFF
--- a/guides/source/action_text_overview.md
+++ b/guides/source/action_text_overview.md
@@ -129,7 +129,7 @@ name the attribute to be something different from `content`.
 Once you have added the `has_rich_text` class method to the model, you can then
 update your views to make use of the rich text editor (Trix) for that field. To
 do so, use a
-[`rich_textarea`](https://api.rubyonrails.org/classes/ActionView/Helpers/FormHelper.html#method-i-rich_textarea)
+[`rich_text_area`](https://api.rubyonrails.org/classes/ActionView/Helpers/FormHelper.html#method-i-rich_text_area)
 for the form field.
 
 ```html+erb
@@ -137,7 +137,7 @@ for the form field.
 <%= form_with model: article do |form| %>
   <div class="field">
     <%= form.label :content %>
-    <%= form.rich_textarea :content %>
+    <%= form.rich_text_area :content %>
   </div>
 <% end %>
 ```


### PR DESCRIPTION
### Motivation / Background

I was going through the guides and noticed an outdated mention of `rich_textarea`. The hash part of the link to the api docs is broken too.

This Pull Request has been created to fix the guides to use `rich_text_area` instead.


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
