### PR TITLE
Fix routes with `::` in the path

### DIFF
--- a/actionpack/lib/action_dispatch/journey/scanner.rb
+++ b/actionpack/lib/action_dispatch/journey/scanner.rb
@@ -55,7 +55,7 @@ module ActionDispatch
         def scan
           next_byte = @scanner.peek_byte
           case
-          when (token = STATIC_TOKENS[next_byte])
+          when (token = STATIC_TOKENS[next_byte]) && (token != :SYMBOL || next_byte_is_not_a_token?)
             @scanner.pos += 1
             @length = @scanner.skip(/\w+/).to_i + 1 if token == :SYMBOL || token == :STAR
             token
@@ -64,6 +64,10 @@ module ActionDispatch
           when @length = @scanner.skip(/./)
             :LITERAL
           end
+        end
+
+        def next_byte_is_not_a_token?
+          !STATIC_TOKENS[@scanner.string.getbyte(@scanner.pos + 1)]
         end
     end
   end

--- a/actionpack/test/dispatch/routing_test.rb
+++ b/actionpack/test/dispatch/routing_test.rb
@@ -3924,6 +3924,16 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
     assert_equal "/formats/1/items/2.json", format_item_path(1, 2, :json)
   end
 
+  def test_routes_with_double_colon
+    draw do
+      get "/sort::sort", to: "sessions#sort"
+    end
+
+    get "/sort:asc"
+    assert_equal "asc", @request.params[:sort]
+    assert_equal "sessions#sort", @response.body
+  end
+
 private
   def draw(&block)
     self.class.stub_controllers do |routes|

--- a/actionpack/test/journey/route/definition/scanner_test.rb
+++ b/actionpack/test/journey/route/definition/scanner_test.rb
@@ -60,6 +60,12 @@ module ActionDispatch
                           :SYMBOL,
                           :RPAREN,
                         ]],
+          ["/sort::sort", [
+                           :SLASH,
+                           :LITERAL,
+                           :LITERAL,
+                           :SYMBOL
+                         ]],
         ]
 
         CASES.each do |pattern, expected_tokens|


### PR DESCRIPTION
When a route has `::` in the path, the scanner was not able to parse it correctly. This was because the scanner was not checking if the next byte was a `:` when the current byte was a `:`.

This will match the behavior of the old parser.

It feels like the `#peek_byte` on the string scanner should accept a position to peek at, but it doesn't. So we have to use `#getbyte` to get the byte at the next position.

Fixes #53397.