### PR TITLE
Allow user to specify which columns should be loaded for preloaded associations

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -116,6 +116,14 @@
 
     *John Duff*
 
+*   Add `load_columns` to specify which columns to load for eager loaded associations.
+
+    ```ruby
+    Post.includes(:comments).load_columns(comments: [:body])
+    ```
+
+    *Andrii Baran*
+
 *   Introduce versions formatter for the schema dumper.
 
     It is now possible to override how schema dumper formats versions information inside the

--- a/activerecord/lib/active_record/associations/preloader.rb
+++ b/activerecord/lib/active_record/associations/preloader.rb
@@ -96,7 +96,7 @@ module ActiveRecord
       # associations before querying the database. This can save database
       # queries by reusing in-memory objects. The optimization is only applied
       # to single associations (i.e. :belongs_to, :has_one) with no scopes.
-      def initialize(records:, associations:, scope: nil, available_records: [], associate_by_default: true)
+      def initialize(records:, associations:, scope: nil, available_records: [], associate_by_default: true, load_columns: {})
         @records = records
         @associations = associations
         @scope = scope
@@ -108,7 +108,8 @@ module ActiveRecord
           association: nil,
           children: @associations,
           associate_by_default: @associate_by_default,
-          scope: @scope
+          scope: @scope,
+          load_columns: load_columns
         )
         @tree.preloaded_records = @records
       end

--- a/activerecord/lib/active_record/associations/preloader/branch.rb
+++ b/activerecord/lib/active_record/associations/preloader/branch.rb
@@ -8,7 +8,7 @@ module ActiveRecord
         attr_reader :scope, :associate_by_default
         attr_writer :preloaded_records
 
-        def initialize(association:, children:, parent:, associate_by_default:, scope:)
+        def initialize(association:, children:, parent:, associate_by_default:, scope:, load_columns: {})
           @association = if association
             begin
               @association = association.to_sym
@@ -19,7 +19,7 @@ module ActiveRecord
           @parent = parent
           @scope = scope
           @associate_by_default = associate_by_default
-
+          @load_columns = load_columns
           @children = build_children(children)
           @loaders = nil
         end
@@ -101,7 +101,15 @@ module ActiveRecord
 
             [klass, reflection_scope]
           end.map do |(rhs_klass, reflection_scope), rs|
-            preloader_for(reflection).new(rhs_klass, rs, reflection, scope, reflection_scope, associate_by_default)
+            normalize_columns_list(rhs_klass, reflection)
+            if @load_columns&.dig(rhs_klass.table_name.to_sym)&.any?
+              if reflection_scope.nil?
+                reflection_scope = rhs_klass.select(*@load_columns[rhs_klass.table_name.to_sym])
+              else
+                reflection_scope = reflection_scope.select(*@load_columns[rhs_klass.table_name.to_sym])
+              end
+            end
+            preloader_for(reflection).new(rhs_klass, rs, reflection, scope, reflection_scope, associate_by_default, load_columns: @load_columns)
           end
         end
 
@@ -131,7 +139,8 @@ module ActiveRecord
                   association: parent,
                   children: child,
                   associate_by_default: associate_by_default,
-                  scope: scope
+                  scope: scope,
+                  load_columns: @load_columns
                 )
               }
             }
@@ -145,6 +154,34 @@ module ActiveRecord
               ThroughAssociation
             else
               Association
+            end
+          end
+
+          def normalize_columns_list(rhs_klass, reflection)
+            return unless @load_columns
+
+            table_name = rhs_klass.table_name.to_sym
+            columns_list = Array(@load_columns[table_name])
+            columns_list = columns_list.map(&:to_s) & rhs_klass.column_names
+            if columns_list.any?
+              columns_list.unshift(rhs_klass.primary_key)
+              columns_list << rhs_klass.inheritance_column
+              if reflection.options[:through]
+                through_table_name = reflection.through_reflection.klass.table_name.to_sym
+                if @load_columns.key?(through_table_name)
+                  @load_columns[through_table_name] << reflection.through_reflection.foreign_key
+                  @load_columns[through_table_name] << reflection.source_reflection.foreign_key
+                end
+              end
+              columns_list << reflection.foreign_key
+              columns_list << reflection.type if reflection.options.key?(:as)
+              self.children.map(&:association).each do |association|
+                child_reflection = rhs_klass.reflect_on_association(association.to_sym)
+                columns_list << child_reflection.foreign_key if child_reflection.macro == :belongs_to
+              end
+              @load_columns[table_name] = columns_list.map(&:to_s) & rhs_klass.column_names
+            else
+              @load_columns.delete(table_name)
             end
           end
       end

--- a/activerecord/lib/active_record/associations/preloader/through_association.rb
+++ b/activerecord/lib/active_record/associations/preloader/through_association.rb
@@ -76,7 +76,7 @@ module ActiveRecord
           end
 
           def through_preloaders
-            @through_preloaders ||= ActiveRecord::Associations::Preloader.new(records: owners, associations: through_reflection.name, scope: through_scope, associate_by_default: false).loaders
+            @through_preloaders ||= ActiveRecord::Associations::Preloader.new(records: owners, associations: through_reflection.name, scope: through_scope, associate_by_default: false, load_columns: @load_columns).loaders
           end
 
           def through_reflection

--- a/activerecord/lib/active_record/querying.rb
+++ b/activerecord/lib/active_record/querying.rb
@@ -19,7 +19,7 @@ module ActiveRecord
       :count, :average, :minimum, :maximum, :sum, :calculate,
       :pluck, :pick, :ids, :async_ids, :strict_loading, :excluding, :without, :with, :with_recursive,
       :async_count, :async_average, :async_minimum, :async_maximum, :async_sum, :async_pluck, :async_pick,
-      :insert, :insert_all, :insert!, :insert_all!, :upsert, :upsert_all
+      :insert, :insert_all, :insert!, :insert_all!, :upsert, :upsert_all, :load_columns,
     ].freeze # :nodoc:
     delegate(*QUERYING_METHODS, to: :all)
 

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -57,10 +57,10 @@ module ActiveRecord
                             :with]
 
     SINGLE_VALUE_METHODS = [:limit, :offset, :lock, :readonly, :reordering, :strict_loading,
-                            :reverse_order, :distinct, :create_with, :skip_query_cache]
+                            :reverse_order, :distinct, :create_with, :skip_query_cache, :load_columns]
 
     CLAUSE_METHODS = [:where, :having, :from]
-    INVALID_METHODS_FOR_UPDATE_AND_DELETE_ALL = [:distinct, :with, :with_recursive]
+    INVALID_METHODS_FOR_UPDATE_AND_DELETE_ALL = [:distinct, :with, :with_recursive, :load_columns]
 
     VALUE_METHODS = MULTI_VALUE_METHODS + SINGLE_VALUE_METHODS + CLAUSE_METHODS
 
@@ -1334,8 +1334,9 @@ module ActiveRecord
       preload = preload_values
       preload += includes_values unless eager_loading?
       scope = strict_loading_value ? StrictLoadingScope : nil
+      load_columns = load_columns_value || {}
       preload.each do |associations|
-        ActiveRecord::Associations::Preloader.new(records: records, associations: associations, scope: scope).call
+        ActiveRecord::Associations::Preloader.new(records: records, associations: associations, scope: scope, load_columns: load_columns).call
       end
     end
 
@@ -1421,7 +1422,6 @@ module ActiveRecord
           else
             exec_main_query
           end
-
           records = instantiate_records(rows, &block)
           preload_associations(records) unless skip_preloading_value
 

--- a/activerecord/lib/active_record/relation/merger.rb
+++ b/activerecord/lib/active_record/relation/merger.rb
@@ -51,7 +51,7 @@ module ActiveRecord
 
       NORMAL_VALUES = Relation::VALUE_METHODS - Relation::CLAUSE_METHODS -
                       [
-                        :select, :includes, :preload, :joins, :left_outer_joins,
+                        :select, :includes, :preload, :joins, :left_outer_joins, :load_columns,
                         :order, :reverse_order, :lock, :create_with, :reordering
                       ]
 
@@ -76,6 +76,7 @@ module ActiveRecord
         merge_preloads
         merge_joins
         merge_outer_joins
+        merge_load_columns
 
         relation
       end
@@ -181,6 +182,17 @@ module ActiveRecord
 
           having_clause = relation.having_clause.merge(other.having_clause)
           relation.having_clause = having_clause unless having_clause.empty?
+        end
+
+        def merge_load_columns
+          return unless other.load_columns_value
+
+          relation.load_columns_value = {}
+          other.load_columns_value.each do |association, columns|
+            relation.load_columns_value[association] ||= []
+            relation.load_columns_value[association] += Array(columns)
+            relation.load_columns_value[association].uniq!
+          end
         end
 
         def replace_from_clause?


### PR DESCRIPTION

<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

There is an API [accessed_fields](https://github.com/rails/rails/blob/7fac5d14d00fcc8dc60b49729abe78223ad3bf00/activerecord/lib/active_record/attribute_methods.rb#L459) that track the columns accessed during some request. But there is no possibility to load required data only for preloaded associations.
This PR allows user to specify columns to be loaded without triggering additional database queries when used alongside eager loading.

### Detail


`load_columns` is a method in Active Record that allows for selective loading of specific columns from a database table. This method is particularly useful in scenarios where you're preloading tables that have many columns, but your current operation only requires a subset of those columns. By using load_columns, you can potentially improve both the performance and resource efficiency of your Active Record operations.

The primary_key, foreign keys, inheritance and polymorphic columns are included in loaded columns list by default.

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
