### PR TITLE
NULLS NOT DISTINCT works with UNIQUE CONSTRAINT as well as UNIQUE INDEX

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   NULLS NOT DISTINCT works with UNIQUE CONSTRAINT as well as UNIQUE INDEX.
+
+    *Ryuta Kamizono*
+
 *   `PG::UnableToSend: no connection to the server` is now retryable as a connection-related exception
 
     *Kazuma Watanabe*

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_creation.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_creation.rb
@@ -52,6 +52,7 @@ module ActiveRecord
             sql = ["CONSTRAINT"]
             sql << quote_column_name(o.name)
             sql << "UNIQUE"
+            sql << "NULLS NOT DISTINCT" if supports_nulls_not_distinct? && o.nulls_not_distinct
 
             if o.using_index
               sql << "USING INDEX #{quote_column_name(o.using_index)}"

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_definitions.rb
@@ -224,6 +224,10 @@ module ActiveRecord
           options[:using_index]
         end
 
+        def nulls_not_distinct
+          options[:nulls_not_distinct]
+        end
+
         def export_name_on_schema_dump?
           !ActiveRecord::SchemaDumper.unique_ignore_pattern.match?(name) if name
         end
@@ -317,7 +321,7 @@ module ActiveRecord
 
         # Adds a unique constraint.
         #
-        #  t.unique_constraint(:position, name: 'unique_position', deferrable: :deferred)
+        #  t.unique_constraint(:position, name: 'unique_position', deferrable: :deferred, nulls_not_distinct: true)
         #
         # See {connection.add_unique_constraint}[rdoc-ref:SchemaStatements#add_unique_constraint]
         def unique_constraint(*args)

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_dumper.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_dumper.rb
@@ -68,6 +68,7 @@ module ActiveRecord
                   "t.unique_constraint #{unique_constraint.column.inspect}"
                 ]
 
+                parts << "nulls_not_distinct: #{unique_constraint.nulls_not_distinct.inspect}" if unique_constraint.nulls_not_distinct
                 parts << "deferrable: #{unique_constraint.deferrable.inspect}" if unique_constraint.deferrable
 
                 if unique_constraint.export_name_on_schema_dump?

--- a/activerecord/test/cases/migration/unique_constraint_test.rb
+++ b/activerecord/test/cases/migration/unique_constraint_test.rb
@@ -39,10 +39,16 @@ if ActiveRecord::Base.lease_connection.supports_unique_constraints?
               name: "test_unique_constraints_position_deferrable_deferred",
               deferrable: :deferred,
               column: ["position_3"]
+            }, {
+              name: "test_unique_constraints_position_nulls_not_distinct",
+              nulls_not_distinct: true,
+              column: ["position_4"]
             }
           ]
 
           assert_equal expected_constraints.size, unique_constraints.size
+
+          expected_nulls_not_distinct = expected_constraints.pop
 
           expected_constraints.each do |expected_constraint|
             constraint = unique_constraints.find { |constraint| constraint.name == expected_constraint[:name] }
@@ -50,6 +56,14 @@ if ActiveRecord::Base.lease_connection.supports_unique_constraints?
             assert_equal expected_constraint[:name], constraint.name
             assert_equal expected_constraint[:column], constraint.column
             assert_equal expected_constraint[:deferrable], constraint.deferrable
+          end
+
+          if supports_nulls_not_distinct?
+            constraint = unique_constraints.find { |constraint| constraint.name == expected_nulls_not_distinct[:name] }
+            assert_equal "test_unique_constraints", constraint.table_name
+            assert_equal expected_nulls_not_distinct[:name], constraint.name
+            assert_equal expected_nulls_not_distinct[:column], constraint.column
+            assert_equal expected_nulls_not_distinct[:nulls_not_distinct], constraint.nulls_not_distinct
           end
         end
 

--- a/activerecord/test/cases/schema_dumper_test.rb
+++ b/activerecord/test/cases/schema_dumper_test.rb
@@ -246,10 +246,11 @@ class SchemaDumperTest < ActiveRecord::TestCase
       output = dump_table_schema("test_unique_constraints")
       constraint_definitions = output.split(/\n/).grep(/t\.unique_constraint/)
 
-      assert_equal 3, constraint_definitions.size
+      assert_equal 4, constraint_definitions.size
       assert_match 't.unique_constraint ["position_1"], name: "test_unique_constraints_position_deferrable_false"', output
       assert_match 't.unique_constraint ["position_2"], deferrable: :immediate, name: "test_unique_constraints_position_deferrable_immediate"', output
       assert_match 't.unique_constraint ["position_3"], deferrable: :deferred, name: "test_unique_constraints_position_deferrable_deferred"', output
+      assert_match 't.unique_constraint ["position_4"], nulls_not_distinct: true, name: "test_unique_constraints_position_nulls_not_distinct"', output
     end
 
     def test_schema_does_not_dump_unique_constraints_as_indexes

--- a/activerecord/test/schema/postgresql_specific_schema.rb
+++ b/activerecord/test/schema/postgresql_specific_schema.rb
@@ -175,10 +175,12 @@ _SQL
     t.integer :position_1
     t.integer :position_2
     t.integer :position_3
+    t.integer :position_4
 
     t.unique_constraint :position_1, name: "test_unique_constraints_position_deferrable_false"
     t.unique_constraint :position_2, name: "test_unique_constraints_position_deferrable_immediate", deferrable: :immediate
     t.unique_constraint :position_3, name: "test_unique_constraints_position_deferrable_deferred", deferrable: :deferred
+    t.unique_constraint :position_4, name: "test_unique_constraints_position_nulls_not_distinct", nulls_not_distinct: true
   end
 
   if supports_partitioned_indexes?


### PR DESCRIPTION
#48608 implemented NULLS NOT DISTINCT for UNIQUE INDEX, but it also works for UNIQUE CONSTRAINT.
