### PR TITLE
Inherit Style/StrigLiterals cop for Guides [ci skip]

### DIFF
--- a/guides/.rubocop.yml
+++ b/guides/.rubocop.yml
@@ -1,9 +1,6 @@
 inherit_from:
   - '../.rubocop.yml'
 
-Style/StringLiterals:
-  Enabled: false
-
 Layout/IndentationConsistency:
   Enabled: false
 

--- a/guides/source/7_1_release_notes.md
+++ b/guides/source/7_1_release_notes.md
@@ -213,7 +213,7 @@ development:
 Alternatively, integration can be achieved using the `DATABASE_URL` environment variable:
 
 ```ruby
-ENV['DATABASE_URL'] # => "trilogy://localhost/blog_development?pool=5"
+ENV["DATABASE_URL"] # => "trilogy://localhost/blog_development?pool=5"
 ```
 
 ### Add `ActiveSupport::MessagePack`

--- a/guides/source/action_cable_overview.md
+++ b/guides/source/action_cable_overview.md
@@ -136,7 +136,7 @@ session, your session cookie is named `_session` and the user ID key is `user_id
 can use this approach:
 
 ```ruby
-verified_user = User.find_by(id: cookies.encrypted['_session']['user_id'])
+verified_user = User.find_by(id: cookies.encrypted["_session"]["user_id"])
 ```
 
 [`ActionCable::Connection::Base`]: https://api.rubyonrails.org/classes/ActionCable/Connection/Base.html
@@ -238,7 +238,7 @@ specific channel to handle raised exceptions:
 ```ruby
 # app/channels/chat_channel.rb
 class ChatChannel < ApplicationCable::Channel
-  rescue_from 'MyError', with: :deliver_error_message
+  rescue_from "MyError", with: :deliver_error_message
 
   private
     def deliver_error_message(e)
@@ -479,8 +479,8 @@ consumer.subscriptions.create({ channel: "ChatChannel", room: "Best Room" }, {
 ActionCable.server.broadcast(
   "chat_#{room}",
   {
-    sent_by: 'Paul',
-    body: 'This is a cool chat app.'
+    sent_by: "Paul",
+    body: "This is a cool chat app."
   }
 )
 ```
@@ -548,7 +548,7 @@ class AppearanceChannel < ApplicationCable::Channel
   end
 
   def appear(data)
-    current_user.appear(on: data['appearing_on'])
+    current_user.appear(on: data["appearing_on"])
   end
 
   def away
@@ -697,8 +697,8 @@ application:
 # Somewhere in your app this is called, perhaps from a NewCommentJob
 WebNotificationsChannel.broadcast_to(
   current_user,
-  title: 'New things!',
-  body: 'All the news fit to print'
+  title: "New things!",
+  body: "All the news fit to print"
 )
 ```
 
@@ -788,7 +788,7 @@ passed to the server config as an array. The origins can be instances of
 strings or regular expressions, against which a check for the match will be performed.
 
 ```ruby
-config.action_cable.allowed_request_origins = ['https://rubyonrails.com', %r{http://ruby.*}]
+config.action_cable.allowed_request_origins = ["https://rubyonrails.com", %r{http://ruby.*}]
 ```
 
 To disable and allow requests from any origin:
@@ -842,7 +842,7 @@ the user account id if available, else "no-account" while tagging:
 
 ```ruby
 config.action_cable.log_tags = [
-  -> request { request.env['user_account_id'] || "no-account" },
+  -> request { request.env["user_account_id"] || "no-account" },
   :action_cable,
   -> request { request.uuid }
 ]
@@ -866,7 +866,7 @@ listen for WebSocket requests on `/websocket`, specify that path to
 ```ruby
 # config/application.rb
 class Application < Rails::Application
-  config.action_cable.mount_path = '/websocket'
+  config.action_cable.mount_path = "/websocket"
 end
 ```
 

--- a/guides/source/action_controller_overview.md
+++ b/guides/source/action_controller_overview.md
@@ -181,7 +181,7 @@ NOTE: Support for parsing XML parameters has been extracted into a gem named `ac
 The `params` hash will always contain the `:controller` and `:action` keys, but you should use the methods [`controller_name`][] and [`action_name`][] instead to access these values. Any other parameters defined by the routing, such as `:id`, will also be available. As an example, consider a listing of clients where the list can show either active or inactive clients. We can add a route that captures the `:status` parameter in a "pretty" URL:
 
 ```ruby
-get '/clients/:status', to: 'clients#index', foo: 'bar'
+get "/clients/:status", to: "clients#index", foo: "bar"
 ```
 
 In this case, when a user opens the URL `/clients/active`, `params[:status]` will be set to "active". When this route is used, `params[:foo]` will also be set to "bar", as if it were passed in the query string. Your controller will also receive `params[:action]` as "index" and `params[:controller]` as "clients".
@@ -210,7 +210,7 @@ end
 And the following route:
 
 ```ruby
-get '/books/:id', to: 'books#show'
+get "/books/:id", to: "books#show"
 ```
 
 When a user opens the URL `/books/4_2`, the controller will extract the composite
@@ -469,14 +469,14 @@ Rails sets up a session key (the name of the cookie) when signing the session da
 
 ```ruby
 # Be sure to restart your server when you modify this file.
-Rails.application.config.session_store :cookie_store, key: '_your_app_session'
+Rails.application.config.session_store :cookie_store, key: "_your_app_session"
 ```
 
 You can also pass a `:domain` key and specify the domain name for the cookie:
 
 ```ruby
 # Be sure to restart your server when you modify this file.
-Rails.application.config.session_store :cookie_store, key: '_your_app_session', domain: ".example.com"
+Rails.application.config.session_store :cookie_store, key: "_your_app_session", domain: ".example.com"
 ```
 
 Rails sets up (for the CookieStore) a secret key used for signing the session data in `config/credentials.yml.enc`. This can be changed with `bin/rails credentials:edit`.
@@ -702,7 +702,7 @@ into `String`s:
 class CookiesController < ApplicationController
   def set_cookie
     cookies.encrypted[:expiration_date] = Date.tomorrow # => Thu, 20 Mar 2014
-    redirect_to action: 'read_cookie'
+    redirect_to action: "read_cookie"
   end
 
   def read_cookie
@@ -1145,7 +1145,7 @@ class MyController < ActionController::Base
   include ActionController::Live
 
   def stream
-    response.headers['Content-Type'] = 'text/event-stream'
+    response.headers["Content-Type"] = "text/event-stream"
     100.times {
       response.stream.write "hello world\n"
       sleep 1
@@ -1181,7 +1181,7 @@ class LyricsController < ActionController::Base
   include ActionController::Live
 
   def show
-    response.headers['Content-Type'] = 'text/event-stream'
+    response.headers["Content-Type"] = "text/event-stream"
     song = Song.find(params[:id])
 
     song.each do |line|
@@ -1242,13 +1242,13 @@ Sometimes it's desirable to filter out from log files some sensitive locations y
 You can do that by using the `config.filter_redirect` configuration option:
 
 ```ruby
-config.filter_redirect << 's3.amazonaws.com'
+config.filter_redirect << "s3.amazonaws.com"
 ```
 
 You can set it to a String, a Regexp, or an array of both.
 
 ```ruby
-config.filter_redirect.concat ['s3.amazonaws.com', /private_path/]
+config.filter_redirect.concat ["s3.amazonaws.com", /private_path/]
 ```
 
 Matching URLs will be replaced with '[FILTERED]'. However, if you only wish to filter the parameters, not the whole URLs,

--- a/guides/source/action_mailbox_basics.md
+++ b/guides/source/action_mailbox_basics.md
@@ -478,7 +478,7 @@ class ForwardsMailboxTest < ActionMailbox::TestCase
   test "directly recording a client forward for a forwarder and forwardee corresponding to one project" do
     assert_difference -> { people(:david).buckets.first.recordings.count } do
       receive_inbound_email_from_mail \
-        to: 'save@example.com',
+        to: "save@example.com",
         from: people(:david).email_address,
         subject: "Fwd: Status update?",
         body: <<~BODY

--- a/guides/source/action_mailer_basics.md
+++ b/guides/source/action_mailer_basics.md
@@ -71,7 +71,7 @@ used to define attributes common to all Mailers:
 # app/mailers/application_mailer.rb
 class ApplicationMailer < ActionMailer::Base
   default from: "from@example.com"
-  layout 'mailer'
+  layout "mailer"
 end
 ```
 
@@ -360,7 +360,7 @@ Action Mailer will automatically guess the `mime_type`, set the `encoding`, and
 create the attachment.
 
 ```ruby
-attachments['filename.jpg'] = File.read('/path/to/filename.jpg')
+attachments["filename.jpg"] = File.read("/path/to/filename.jpg")
 ```
 
 When the `mail` method is triggered, it will send a multipart email with an
@@ -372,10 +372,10 @@ The other way to send attachments is to specify the file name, MIME-type and
 encoding headers, and content. Action Mailer will use the settings you pass in.
 
 ```ruby
-encoded_content = SpecialEncode(File.read('/path/to/filename.jpg'))
-attachments['filename.jpg'] = {
-  mime_type: 'application/gzip',
-  encoding: 'SpecialEncoding',
+encoded_content = SpecialEncode(File.read("/path/to/filename.jpg"))
+attachments["filename.jpg"] = {
+  mime_type: "application/gzip",
+  encoding: "SpecialEncoding",
   content: encoded_content
 }
 ```
@@ -395,7 +395,7 @@ calling `#inline`:
 
 ```ruby
 def welcome
-  attachments.inline['image.jpg'] = File.read('/path/to/image.jpg')
+  attachments.inline["image.jpg"] = File.read("/path/to/image.jpg")
 end
 ```
 
@@ -461,15 +461,15 @@ There is a `template_path` and `template_name` option to the `mail` method:
 
 ```ruby
 class UserMailer < ApplicationMailer
-  default from: 'notifications@example.com'
+  default from: "notifications@example.com"
 
   def welcome_email
     @user = params[:user]
-    @url  = 'http://example.com/login'
+    @url  = "http://example.com/login"
     mail(to: @user.email,
-         subject: 'Welcome to My Awesome Site',
-         template_path: 'notifications',
-         template_name: 'hello')
+         subject: "Welcome to My Awesome Site",
+         template_path: "notifications",
+         template_name: "hello")
   end
 end
 ```
@@ -483,15 +483,15 @@ template. You can also render plain text inline without using a template file:
 
 ```ruby
 class UserMailer < ApplicationMailer
-  default from: 'notifications@example.com'
+  default from: "notifications@example.com"
 
   def welcome_email
     @user = params[:user]
-    @url  = 'http://example.com/login'
+    @url  = "http://example.com/login"
     mail(to: @user.email,
-         subject: 'Welcome to My Awesome Site') do |format|
-      format.html { render 'another_template' }
-      format.text { render plain: 'hello' }
+         subject: "Welcome to My Awesome Site") do |format|
+      format.html { render "another_template" }
+      format.text { render plain: "hello" }
     end
   end
 end
@@ -535,7 +535,7 @@ You can configure the default `host` across the application in
 `config/application.rb`:
 
 ```ruby
-config.action_mailer.default_url_options = { host: 'example.com' }
+config.action_mailer.default_url_options = { host: "example.com" }
 ```
 
 Once the `host` is configured, it is recommended that email views use the
@@ -595,7 +595,7 @@ Usually the `:asset_host` is consistent across the application, so you can
 configure it globally in `config/application.rb`:
 
 ```ruby
-config.action_mailer.asset_host = 'http://example.com'
+config.action_mailer.asset_host = "http://example.com"
 ```
 
 NOTE: Because we can't infer the protocol from the request, you'll need to
@@ -662,7 +662,7 @@ To use a different layout for a given mailer, call [`layout`][]:
 
 ```ruby
 class UserMailer < ApplicationMailer
-  layout 'awesome' # Use awesome.(html|text).erb as the layout
+  layout "awesome" # Use awesome.(html|text).erb as the layout
 end
 ```
 
@@ -673,7 +673,7 @@ To use a specific layout for a given email, you can pass in a `layout:
 class UserMailer < ApplicationMailer
   def welcome_email
     mail(to: params[:user].email) do |format|
-      format.html { render layout: 'my_layout' }
+      format.html { render layout: "my_layout" }
       format.text
     end
   end
@@ -700,7 +700,7 @@ For example, to inform all admins of a new registration:
 ```ruby
 class AdminMailer < ApplicationMailer
   default to: -> { Admin.pluck(:email) },
-          from: 'notification@example.com'
+          from: "notification@example.com"
 
   def new_registration(user)
     @user = user
@@ -726,7 +726,7 @@ def welcome_email
   @user = params[:user]
   mail(
     to: email_address_with_name(@user.email, @user.name),
-    subject: 'Welcome to My Awesome Site'
+    subject: "Welcome to My Awesome Site"
   )
 end
 ```
@@ -735,7 +735,7 @@ The same method in `from:` works to display the name of the sender:
 
 ```ruby
 class UserMailer < ApplicationMailer
-  default from: email_address_with_name('notification@example.com', 'Example Company Notifications')
+  default from: email_address_with_name("notification@example.com", "Example Company Notifications")
 end
 ```
 
@@ -904,7 +904,7 @@ class UserMailer < ApplicationMailer
 
     # An Interceptor alternative.
     def sandbox_staging
-      message.to = ['sandbox@example.com'] if Rails.env.staging?
+      message.to = ["sandbox@example.com"] if Rails.env.staging?
     end
 
     # A callback has more context than the comparable Observer example.
@@ -976,7 +976,7 @@ config.action_mailer.delivery_method = :sendmail
 # }
 config.action_mailer.perform_deliveries = true
 config.action_mailer.raise_delivery_errors = true
-config.action_mailer.default_options = { from: 'no-reply@example.com' }
+config.action_mailer.default_options = { from: "no-reply@example.com" }
 ```
 
 ### Action Mailer Configuration for Gmail
@@ -986,12 +986,12 @@ Add this to your `config/environments/$RAILS_ENV.rb` file to send via Gmail:
 ```ruby
 config.action_mailer.delivery_method = :smtp
 config.action_mailer.smtp_settings = {
-  address:         'smtp.gmail.com',
+  address:         "smtp.gmail.com",
   port:            587,
-  domain:          'example.com',
+  domain:          "example.com",
   user_name:       Rails.application.credentials.dig(:smtp, :user_name),
   password:        Rails.application.credentials.dig(:smtp, :password),
-  authentication:  'plain',
+  authentication:  "plain",
   enable_starttls: true,
   open_timeout:    5,
   read_timeout:    5 }
@@ -1084,7 +1084,7 @@ sent.
 ```ruby
 class SandboxEmailInterceptor
   def self.delivering_email(message)
-    message.to = ['sandbox@example.com']
+    message.to = ["sandbox@example.com"]
   end
 end
 ```

--- a/guides/source/action_view_overview.md
+++ b/guides/source/action_view_overview.md
@@ -790,7 +790,7 @@ Let's say you're displaying an article on a page which should be wrapped in a
 `div` for display purposes. First, you'll create a new `Article`:
 
 ```ruby
-Article.create(body: 'Partial Layouts are cool!')
+Article.create(body: "Partial Layouts are cool!")
 ```
 
 In the `show` template, you'll render the `_article` partial wrapped in the

--- a/guides/source/active_job_basics.md
+++ b/guides/source/active_job_basics.md
@@ -119,7 +119,7 @@ GuestsCleanupJob.set(wait: 1.week).perform_later(guest)
 ```ruby
 # `perform_now` and `perform_later` will call `perform` under the hood so
 # you can pass as many arguments as defined in the latter.
-GuestsCleanupJob.perform_later(guest1, guest2, filter: 'some_filter')
+GuestsCleanupJob.perform_later(guest1, guest2, filter: "some_filter")
 ```
 
 That's it!
@@ -255,7 +255,7 @@ The default queue name prefix delimiter is '\_'.  This can be changed by setting
 module YourApp
   class Application < Rails::Application
     config.active_job.queue_name_prefix = Rails.env
-    config.active_job.queue_name_delimiter = '.'
+    config.active_job.queue_name_delimiter = "."
   end
 end
 ```

--- a/guides/source/active_record_composite_primary_keys.md
+++ b/guides/source/active_record_composite_primary_keys.md
@@ -276,7 +276,7 @@ end
 And the following route:
 
 ```ruby
-get '/books/:id', to: 'books#show'
+get "/books/:id", to: "books#show"
 ```
 
 When a user opens the URL `/books/4_2`, the controller will extract the

--- a/guides/source/active_record_encryption.md
+++ b/guides/source/active_record_encryption.md
@@ -44,9 +44,9 @@ active_record_encryption:
 These values can be stored by copying and pasting the generated values into your existing [Rails credentials](/security.html#custom-credentials). Alternatively, these values can be configured from other sources, such as environment variables:
 
 ```ruby
-config.active_record.encryption.primary_key = ENV['ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY']
-config.active_record.encryption.deterministic_key = ENV['ACTIVE_RECORD_ENCRYPTION_DETERMINISTIC_KEY']
-config.active_record.encryption.key_derivation_salt = ENV['ACTIVE_RECORD_ENCRYPTION_KEY_DERIVATION_SALT']
+config.active_record.encryption.primary_key = ENV["ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY"]
+config.active_record.encryption.deterministic_key = ENV["ACTIVE_RECORD_ENCRYPTION_DETERMINISTIC_KEY"]
+config.active_record.encryption.key_derivation_salt = ENV["ACTIVE_RECORD_ENCRYPTION_KEY_DERIVATION_SALT"]
 ```
 
 NOTE: These generated values are 32 bytes in length. If you generate these yourself, the minimum lengths you should use are 12 bytes for the primary key (this will be used to derive the AES 32 bytes key) and 20 bytes for the salt.

--- a/guides/source/active_record_migrations.md
+++ b/guides/source/active_record_migrations.md
@@ -512,7 +512,7 @@ by passing `index: true` or an options hash to the `:index` option:
 ```ruby
 create_table :users do |t|
   t.string :name, index: true
-  t.string :email, index: { unique: true, name: 'unique_emails' }
+  t.string :email, index: { unique: true, name: "unique_emails" }
 end
 ```
 
@@ -1367,7 +1367,7 @@ class CreateProducts < ActiveRecord::Migration[8.1]
     suppress_messages { add_index :products, :name }
     say "and an index!", true
 
-    say_with_time 'Waiting for a while' do
+    say_with_time "Waiting for a while" do
       sleep 10
       250
     end

--- a/guides/source/active_record_postgresql.md
+++ b/guides/source/active_record_postgresql.md
@@ -39,7 +39,7 @@ that are supported by the PostgreSQL adapter.
 ```ruby
 # db/migrate/20140207133952_create_documents.rb
 create_table :documents do |t|
-  t.binary 'payload'
+  t.binary "payload"
 end
 ```
 
@@ -63,12 +63,12 @@ Document.create payload: data
 ```ruby
 # db/migrate/20140207133952_create_books.rb
 create_table :books do |t|
-  t.string 'title'
-  t.string 'tags', array: true
-  t.integer 'ratings', array: true
+  t.string "title"
+  t.string "tags", array: true
+  t.integer "ratings", array: true
 end
-add_index :books, :tags, using: 'gin'
-add_index :books, :ratings, using: 'gin'
+add_index :books, :tags, using: "gin"
+add_index :books, :ratings, using: "gin"
 ```
 
 ```ruby
@@ -103,9 +103,9 @@ NOTE: You need to enable the `hstore` extension to use hstore.
 ```ruby
 # db/migrate/20131009135255_create_profiles.rb
 class CreateProfiles < ActiveRecord::Migration[8.1]
-  enable_extension 'hstore' unless extension_enabled?('hstore')
+  enable_extension "hstore" unless extension_enabled?("hstore")
   create_table :profiles do |t|
-    t.hstore 'settings'
+    t.hstore "settings"
   end
 end
 ```
@@ -139,11 +139,11 @@ irb> Profile.where("settings->'color' = ?", "yellow")
 # db/migrate/20131220144913_create_events.rb
 # ... for json datatype:
 create_table :events do |t|
-  t.json 'payload'
+  t.json "payload"
 end
 # ... or for jsonb datatype:
 create_table :events do |t|
-  t.jsonb 'payload'
+  t.jsonb "payload"
 end
 ```
 
@@ -175,7 +175,7 @@ This type is mapped to Ruby [`Range`](https://docs.ruby-lang.org/en/master/Range
 ```ruby
 # db/migrate/20130923065404_create_events.rb
 create_table :events do |t|
-  t.daterange 'duration'
+  t.daterange "duration"
 end
 ```
 
@@ -391,7 +391,7 @@ You can use `uuid` type to define references in migrations:
 
 ```ruby
 # db/migrate/20150418012400_create_blog.rb
-enable_extension 'pgcrypto' unless extension_enabled?('pgcrypto')
+enable_extension "pgcrypto" unless extension_enabled?("pgcrypto")
 create_table :posts, id: :uuid
 
 create_table :comments, id: :uuid do |t|
@@ -456,9 +456,9 @@ objects. The `macaddr` type is mapped to normal text.
 ```ruby
 # db/migrate/20140508144913_create_devices.rb
 create_table(:devices, force: true) do |t|
-  t.inet 'ip'
-  t.cidr 'network'
-  t.macaddr 'address'
+  t.inet "ip"
+  t.cidr "network"
+  t.macaddr "address"
 end
 ```
 
@@ -498,7 +498,7 @@ This type is mapped to [`ActiveSupport::Duration`](https://api.rubyonrails.org/c
 ```ruby
 # db/migrate/20200120000000_create_events.rb
 create_table :events do |t|
-  t.interval 'duration'
+  t.interval "duration"
 end
 ```
 
@@ -524,7 +524,7 @@ extension to generate random UUIDs.
 
 ```ruby
 # db/migrate/20131220144913_create_devices.rb
-enable_extension 'pgcrypto' unless extension_enabled?('pgcrypto')
+enable_extension "pgcrypto" unless extension_enabled?("pgcrypto")
 create_table :devices, id: :uuid do |t|
   t.string :kind
 end
@@ -599,7 +599,7 @@ NOTE: Generated columns are supported since version 12.0 of PostgreSQL.
 # db/migrate/20131220144913_create_users.rb
 create_table :users do |t|
   t.string :name
-  t.virtual :name_upcased, type: :string, as: 'upper(name)', stored: true
+  t.virtual :name_upcased, type: :string, as: "upper(name)", stored: true
 end
 
 # app/models/user.rb
@@ -607,7 +607,7 @@ class User < ApplicationRecord
 end
 
 # Usage
-user = User.create(name: 'John')
+user = User.create(name: "John")
 User.last.name_upcased # => "JOHN"
 ```
 
@@ -694,7 +694,7 @@ create_table :documents do |t|
   t.string :body
 end
 
-add_index :documents, "to_tsvector('english', title || ' ' || body)", using: :gin, name: 'documents_idx'
+add_index :documents, "to_tsvector('english', title || ' ' || body)", using: :gin, name: "documents_idx"
 ```
 
 ```ruby
@@ -724,7 +724,7 @@ create_table :documents do |t|
             type: :tsvector, as: "to_tsvector('english', title || ' ' || body)", stored: true
 end
 
-add_index :documents, :textsearchable_index_col, using: :gin, name: 'documents_idx'
+add_index :documents, :textsearchable_index_col, using: :gin, name: "documents_idx"
 
 # Usage
 Document.create(title: "Cats and Dogs", body: "are nice!")

--- a/guides/source/active_record_querying.md
+++ b/guides/source/active_record_querying.md
@@ -40,13 +40,13 @@ class Book < ApplicationRecord
   belongs_to :supplier
   belongs_to :author
   has_many :reviews
-  has_and_belongs_to_many :orders, join_table: 'books_orders'
+  has_and_belongs_to_many :orders, join_table: "books_orders"
 
   scope :in_print, -> { where(out_of_print: false) }
   scope :out_of_print, -> { where(out_of_print: true) }
   scope :old, -> { where(year_published: ...50.years.ago.year) }
-  scope :out_of_print_and_expensive, -> { out_of_print.where('price > 500') }
-  scope :costs_more_than, ->(amount) { where('price > ?', amount) }
+  scope :out_of_print_and_expensive, -> { out_of_print.where("price > 500") }
+  scope :costs_more_than, ->(amount) { where("price > ?", amount) }
 end
 ```
 
@@ -60,7 +60,7 @@ end
 ```ruby
 class Order < ApplicationRecord
   belongs_to :customer
-  has_and_belongs_to_many :books, join_table: 'books_orders'
+  has_and_belongs_to_many :books, join_table: "books_orders"
 
   enum :status, [:shipped, :being_packed, :complete, :cancelled]
 
@@ -407,7 +407,7 @@ irb> Customer.find_by first_name: 'Jon'
 It is equivalent to writing:
 
 ```ruby
-Customer.where(first_name: 'Lifo').take
+Customer.where(first_name: "Lifo").take
 ```
 
 The SQL equivalent of the above is:
@@ -428,7 +428,7 @@ ActiveRecord::RecordNotFound
 This is equivalent to writing:
 
 ```ruby
-Customer.where(first_name: 'does not exist').take!
+Customer.where(first_name: "does not exist").take!
 ```
 
 [`find_by`]: https://api.rubyonrails.org/classes/ActiveRecord/FinderMethods.html#method-i-find_by
@@ -730,7 +730,7 @@ SELECT * FROM books WHERE (books.out_of_print = 1)
 The field name can also be a string:
 
 ```ruby
-Book.where('out_of_print' => true)
+Book.where("out_of_print" => true)
 ```
 
 In the case of a belongs_to relationship, an association key can be used to specify the model if an Active Record object is used as the value. This method works with polymorphic relationships as well.
@@ -833,7 +833,7 @@ Customer.where.not(nullable_country: nil)
 relation, and passing the second one as an argument.
 
 ```ruby
-Customer.where(last_name: 'Smith').or(Customer.where(orders_count: [1, 3, 5]))
+Customer.where(last_name: "Smith").or(Customer.where(orders_count: [1, 3, 5]))
 ```
 
 ```sql
@@ -847,7 +847,7 @@ SELECT * FROM customers WHERE (customers.last_name = 'Smith' OR customers.orders
 `AND` conditions can be built by chaining `where` conditions.
 
 ```ruby
-Customer.where(last_name: 'Smith').where(orders_count: [1, 3, 5])
+Customer.where(last_name: "Smith").where(orders_count: [1, 3, 5])
 ```
 
 ```sql
@@ -917,7 +917,7 @@ You can also order from a joined table
 ```ruby
 Book.includes(:author).order(books: { print_year: :desc }, authors: { name: :asc })
 # OR
-Book.includes(:author).order('books.print_year desc', 'authors.name asc')
+Book.includes(:author).order("books.print_year desc", "authors.name asc")
 ```
 
 WARNING: In most database systems, on selecting fields with `distinct` from a result set using methods like `select`, `pluck` and `ids`; the `order` method will raise an `ActiveRecord::StatementInvalid` exception unless the field(s) used in `order` clause are included in the select list. See the next section for selecting fields from the result set.
@@ -1083,7 +1083,7 @@ Overriding Conditions
 You can specify certain conditions to be removed using the [`unscope`][] method. For example:
 
 ```ruby
-Book.where('id > 100').limit(20).order('id desc').unscope(:order)
+Book.where("id > 100").limit(20).order("id desc").unscope(:order)
 ```
 
 The SQL that would be executed:
@@ -1105,7 +1105,7 @@ Book.where(id: 10, out_of_print: false).unscope(where: :id)
 A relation which has used `unscope` will affect any relation into which it is merged:
 
 ```ruby
-Book.order('id desc').merge(Book.unscope(:order))
+Book.order("id desc").merge(Book.unscope(:order))
 # SELECT books.* FROM books
 ```
 
@@ -1116,7 +1116,7 @@ Book.order('id desc').merge(Book.unscope(:order))
 You can also override conditions using the [`only`][] method. For example:
 
 ```ruby
-Book.where('id > 10').limit(20).order('id desc').only(:order, :where)
+Book.where("id > 10").limit(20).order("id desc").only(:order, :where)
 ```
 
 The SQL that would be executed:
@@ -1182,7 +1182,7 @@ SELECT * FROM books WHERE author_id = 10 ORDER BY year_published DESC
 You can using the `reorder` clause to specify a different way to order the books:
 
 ```ruby
-Author.find(10).books.reorder('year_published ASC')
+Author.find(10).books.reorder("year_published ASC")
 ```
 
 The SQL that would be executed:
@@ -1370,7 +1370,7 @@ For example:
 ```ruby
 Book.transaction do
   book = Book.lock.first
-  book.title = 'Algorithms, second edition'
+  book.title = "Algorithms, second edition"
   book.save!
 end
 ```
@@ -1510,7 +1510,7 @@ You can specify conditions on the joined tables using the regular [Array](#array
 
 ```ruby
 time_range = (Time.now.midnight - 1.day)..Time.now.midnight
-Customer.joins(:orders).where('orders.created_at' => time_range).distinct
+Customer.joins(:orders).where("orders.created_at" => time_range).distinct
 ```
 
 This will find all customers who have orders that were created yesterday, using a `BETWEEN` SQL expression to compare `created_at`.
@@ -1549,7 +1549,7 @@ If you want to select a set of records whether or not they have associated
 records you can use the [`left_outer_joins`][] method.
 
 ```ruby
-Customer.left_outer_joins(:reviews).distinct.select('customers.*, COUNT(reviews.*) AS reviews_count').group('customers.id')
+Customer.left_outer_joins(:reviews).distinct.select("customers.*, COUNT(reviews.*) AS reviews_count").group("customers.id")
 ```
 
 Which produces:
@@ -2148,9 +2148,9 @@ The query is sent only when the data is actually needed. So each example below g
 
 ```ruby
 Customer
-  .select('customers.id, customers.last_name, reviews.body')
+  .select("customers.id, customers.last_name, reviews.body")
   .joins(:reviews)
-  .where('reviews.created_at > ?', 1.week.ago)
+  .where("reviews.created_at > ?", 1.week.ago)
 ```
 
 The result should be something like this:
@@ -2167,9 +2167,9 @@ WHERE (reviews.created_at > '2019-01-08')
 
 ```ruby
 Book
-  .select('books.id, books.title, authors.first_name')
+  .select("books.id, books.title, authors.first_name")
   .joins(:author)
-  .find_by(title: 'Abstraction and Specification in Program Development')
+  .find_by(title: "Abstraction and Specification in Program Development")
 ```
 
 The above should generate:
@@ -2224,13 +2224,13 @@ exist, create a customer named "Andy" which is not locked.
 We can achieve this in two ways. The first is to use `create_with`:
 
 ```ruby
-Customer.create_with(locked: false).find_or_create_by(first_name: 'Andy')
+Customer.create_with(locked: false).find_or_create_by(first_name: "Andy")
 ```
 
 The second way is using a block:
 
 ```ruby
-Customer.find_or_create_by(first_name: 'Andy') do |c|
+Customer.find_or_create_by(first_name: "Andy") do |c|
   c.locked = false
 end
 ```
@@ -2468,13 +2468,13 @@ one of those records exists.
 ```ruby
 Customer.exists?(id: [1, 2, 3])
 # or
-Customer.exists?(first_name: ['Jane', 'Sergei'])
+Customer.exists?(first_name: ["Jane", "Sergei"])
 ```
 
 It's even possible to use `exists?` without any arguments on a model or a relation.
 
 ```ruby
-Customer.where(first_name: 'Ryan').exists?
+Customer.where(first_name: "Ryan").exists?
 ```
 
 The above returns `true` if there is at least one customer with the `first_name` 'Ryan' and `false`

--- a/guides/source/active_record_validations.md
+++ b/guides/source/active_record_validations.md
@@ -331,7 +331,7 @@ You can also pass in a custom message via the `message` option.
 
 ```ruby
 class Person < ApplicationRecord
-  validates :terms_of_service, acceptance: { message: 'must be abided' }
+  validates :terms_of_service, acceptance: { message: "must be abided" }
 end
 ```
 
@@ -341,8 +341,8 @@ easily changed.
 
 ```ruby
 class Person < ApplicationRecord
-  validates :terms_of_service, acceptance: { accept: 'yes' }
-  validates :eula, acceptance: { accept: ['TRUE', 'accepted'] }
+  validates :terms_of_service, acceptance: { accept: "yes" }
+  validates :eula, acceptance: { accept: ["TRUE", "accepted"] }
 end
 ```
 
@@ -834,7 +834,7 @@ lower case.
 ```ruby
 class Person < ApplicationRecord
   validates_each :name, :surname do |record, attr, value|
-    record.errors.add(attr, 'must start with upper case') if /\A[[:lower:]]/.match?(value)
+    record.errors.add(attr, "must start with upper case") if /\A[[:lower:]]/.match?(value)
   end
 end
 ```
@@ -1269,7 +1269,7 @@ the `validates_with` method.
 ```ruby
 class MyValidator < ActiveModel::Validator
   def validate(record)
-    unless record.name.start_with? 'X'
+    unless record.name.start_with? "X"
       record.errors.add :name, "Provide a name starting with X, please!"
     end
   end

--- a/guides/source/active_storage_overview.md
+++ b/guides/source/active_storage_overview.md
@@ -568,7 +568,7 @@ model test. To do that, provide a Hash containing at least an open IO object
 and a filename:
 
 ```ruby
-@message.images.attach(io: File.open('/path/to/file'), filename: 'file.pdf')
+@message.images.attach(io: File.open("/path/to/file"), filename: "file.pdf")
 ```
 
 When possible, provide a content type as well. Active Storage attempts to
@@ -576,7 +576,7 @@ determine a file’s content type from its data. It falls back to the content
 type you provide if it can’t do that.
 
 ```ruby
-@message.images.attach(io: File.open('/path/to/file'), filename: 'file.pdf', content_type: 'application/pdf')
+@message.images.attach(io: File.open("/path/to/file"), filename: "file.pdf", content_type: "application/pdf")
 ```
 
 You can bypass the content type inference from the data by passing in
@@ -584,9 +584,9 @@ You can bypass the content type inference from the data by passing in
 
 ```ruby
 @message.images.attach(
-  io: File.open('/path/to/file'),
-  filename: 'file.pdf',
-  content_type: 'application/pdf',
+  io: File.open("/path/to/file"),
+  filename: "file.pdf",
+  content_type: "application/pdf",
   identify: false
 )
 ```
@@ -600,9 +600,9 @@ approach is helpful if you want to organize your S3 Bucket files better.
 
 ```ruby
 @message.images.attach(
-  io: File.open('/path/to/file'),
-  filename: 'file.pdf',
-  content_type: 'application/pdf',
+  io: File.open("/path/to/file"),
+  filename: "file.pdf",
+  content_type: "application/pdf",
   key: "#{Rails.env}/blog_content/intuitive_filename.pdf",
   identify: false
 )
@@ -621,9 +621,9 @@ end
 
 ```ruby
 @message.images.attach(
-  io: File.open('/path/to/file'),
-  filename: 'file.pdf',
-  content_type: 'application/pdf',
+  io: File.open("/path/to/file"),
+  filename: "file.pdf",
+  content_type: "application/pdf",
   key: s3_file_key,
   identify: false
 )
@@ -762,7 +762,7 @@ direct :cdn_image do |model, options|
       :rails_service_blob_proxy,
       model.signed_id(expires_in: expires_in),
       model.filename,
-      options.merge(host: ENV['CDN_HOST'])
+      options.merge(host: ENV["CDN_HOST"])
     )
   else
     signed_blob_id = model.blob.signed_id(expires_in: expires_in)
@@ -774,7 +774,7 @@ direct :cdn_image do |model, options|
       signed_blob_id,
       variation_key,
       filename,
-      options.merge(host: ENV['CDN_HOST'])
+      options.merge(host: ENV["CDN_HOST"])
     )
   end
 end
@@ -854,7 +854,7 @@ a virus scanner or media transcoder) can operate on it. Use the attachment's
 
 ```ruby
 message.video.open do |file|
-  system '/path/to/virus/scanner', file.path
+  system "/path/to/virus/scanner", file.path
   # ...
 end
 ```
@@ -1391,7 +1391,7 @@ class DirectUploadsController < ActiveStorage::DirectUploadsController
   before_action :authenticate!
 
   def authenticate!
-    @token = request.headers['Authorization']&.split&.last
+    @token = request.headers["Authorization"]&.split&.last
 
     head :unauthorized unless valid_token?(@token)
   end

--- a/guides/source/active_support_core_extensions.md
+++ b/guides/source/active_support_core_extensions.md
@@ -1540,7 +1540,7 @@ INFO: As a rule of thumb you can think of `camelize` as the inverse of `undersco
 
 ```ruby
 ActiveSupport::Inflector.inflections do |inflect|
-  inflect.acronym 'SSL'
+  inflect.acronym "SSL"
 end
 
 "SSLError".underscore.camelize # => "SSLError"

--- a/guides/source/api_app.md
+++ b/guides/source/api_app.md
@@ -448,7 +448,7 @@ built (like `config/application.rb`) and pass them to your preferred middleware,
 
 ```ruby
 # This also configures session_options for use below
-config.session_store :cookie_store, key: '_your_app_session'
+config.session_store :cookie_store, key: "_your_app_session"
 
 # Required for all session management (regardless of session_store)
 config.middleware.use ActionDispatch::Cookies

--- a/guides/source/api_documentation_guidelines.md
+++ b/guides/source/api_documentation_guidelines.md
@@ -342,7 +342,7 @@ class Array
   # Calls +to_param+ on all its elements and joins the result with
   # slashes. This is used by +url_for+ in Action Pack.
   def to_param
-    collect { |e| e.to_param }.join '/'
+    collect { |e| e.to_param }.join "/"
   end
 end
 ```

--- a/guides/source/asset_pipeline.md
+++ b/guides/source/asset_pipeline.md
@@ -708,7 +708,7 @@ asset host in Rails, you need to set [`config.asset_host`][] in
 `config/environments/production.rb`:
 
 ```ruby
-config.asset_host = 'mycdnsubdomain.fictional-cdn.com'
+config.asset_host = "mycdnsubdomain.fictional-cdn.com"
 ```
 
 NOTE: You only need to provide the "host", this is the subdomain and root
@@ -721,7 +721,7 @@ variable](https://en.wikipedia.org/wiki/Environment_variable) to make running a
 staging copy of your site easier:
 
 ```ruby
-config.asset_host = ENV['CDN_HOST']
+config.asset_host = ENV["CDN_HOST"]
 ```
 
 NOTE: You would need to set `CDN_HOST` on your server to `mycdnsubdomain
@@ -832,7 +832,7 @@ year. You can do this in your Rails application by setting
 
 ```ruby
 config.public_file_server.headers = {
-  'Cache-Control' => 'public, max-age=31536000'
+  "Cache-Control" => "public, max-age=31536000"
 }
 ```
 
@@ -1035,7 +1035,7 @@ Now that you have a module that modifies the input data, it's time to register
 it as a preprocessor for your MIME type.
 
 ```ruby
-Sprockets.register_preprocessor 'text/css', AddComment
+Sprockets.register_preprocessor "text/css", AddComment
 ```
 
 

--- a/guides/source/association_basics.md
+++ b/guides/source/association_basics.md
@@ -1796,7 +1796,7 @@ Repeat the same process for `Motorcycle` and `Bicycle`.
 Creating a record for `Car`:
 
 ```ruby
-Car.create(color: 'Red', price: 10000)
+Car.create(color: "Red", price: 10000)
 ```
 
 This will generate the following SQL:
@@ -1827,7 +1827,7 @@ adding a method to the `Car` model:
 ```ruby
 class Car < Vehicle
   def honk
-    'Beep Beep'
+    "Beep Beep"
   end
 end
 ```
@@ -2470,7 +2470,7 @@ class Author < ApplicationRecord
 end
 
 class Book < ApplicationRecord
-  belongs_to :writer, class_name: 'Author', foreign_key: 'author_id'
+  belongs_to :writer, class_name: "Author", foreign_key: "author_id"
 end
 ```
 
@@ -2528,11 +2528,11 @@ using the `:inverse_of` option:
 
 ```ruby
 class Author < ApplicationRecord
-  has_many :books, inverse_of: 'writer'
+  has_many :books, inverse_of: "writer"
 end
 
 class Book < ApplicationRecord
-  belongs_to :writer, class_name: 'Author', foreign_key: 'author_id'
+  belongs_to :writer, class_name: "Author", foreign_key: "author_id"
 end
 ```
 
@@ -2663,11 +2663,11 @@ For example, if the `users` table uses `guid` as the primary key instead of
 
 ```ruby
 class User < ApplicationRecord
-  self.primary_key = 'guid' # Sets the primary key to guid instead of id
+  self.primary_key = "guid" # Sets the primary key to guid instead of id
 end
 
 class Todo < ApplicationRecord
-  belongs_to :user, primary_key: 'guid' # References the guid column in users table
+  belongs_to :user, primary_key: "guid" # References the guid column in users table
 end
 ```
 
@@ -2830,7 +2830,7 @@ You can also set conditions via a hash:
 ```ruby
 class Parts < ApplicationRecord
   has_and_belongs_to_many :assemblies,
-    -> { where factory: 'Seattle' }
+    -> { where factory: "Seattle" }
 end
 ```
 
@@ -2931,7 +2931,7 @@ also set the `:foreign_key` option to guarantee correct results. For example:
 
 ```ruby
 class Book < ApplicationRecord
-  belongs_to :author, -> { select(:id, :name) }, foreign_key: 'author_id' # Only select id and name columns
+  belongs_to :author, -> { select(:id, :name) }, foreign_key: "author_id" # Only select id and name columns
 end
 
 class Author < ApplicationRecord

--- a/guides/source/caching_with_rails.md
+++ b/guides/source/caching_with_rails.md
@@ -186,7 +186,7 @@ cache.
 It is possible to share partials and associated caching between files with different MIME types. For example shared partial caching allows template writers to share a partial between HTML and JavaScript files. When templates are collected in the template resolver file paths they only include the template language extension and not the MIME type. Because of this templates can be used for multiple MIME types. Both HTML and JavaScript requests will respond to the following code:
 
 ```ruby
-render(partial: 'hotels/hotel', collection: @hotels, cached: true)
+render(partial: "hotels/hotel", collection: @hotels, cached: true)
 ```
 
 Will load a file named `hotels/hotel.erb`.
@@ -194,7 +194,7 @@ Will load a file named `hotels/hotel.erb`.
 Another option is to include the `formats` attribute to the partial to render.
 
 ```ruby
-render(partial: 'hotels/hotel', collection: @hotels, formats: :html, cached: true)
+render(partial: "hotels/hotel", collection: @hotels, formats: :html, cached: true)
 ```
 
 Will load a file named `hotels/hotel.html.erb` in any file MIME type, for example you could include this partial in a JavaScript file.
@@ -215,8 +215,8 @@ how to decode:
 ```ruby
 render partial: "comments/comment", collection: commentable.comments
 render "comments/comments"
-render 'comments/comments'
-render('comments/comments')
+render "comments/comments"
+render("comments/comments")
 
 render "header" # translates to render("comments/header")
 
@@ -543,7 +543,7 @@ config.cache_store = :redis_cache_store, { url: cache_servers,
 
   error_handler: -> (method:, returning:, exception:) {
     # Report errors to Sentry as warnings
-    Sentry.capture_exception exception, level: 'warning',
+    Sentry.capture_exception exception, level: "warning",
       tags: { method: method, returning: returning }
   }
 }

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -35,7 +35,7 @@ In general, the work of configuring Rails means configuring the components of Ra
 For example, you could add this setting to `config/application.rb` file:
 
 ```ruby
-config.time_zone = 'Central Time (US & Canada)'
+config.time_zone = "Central Time (US & Canada)"
 ```
 
 This is a setting for Rails itself. If you want to pass settings to individual Rails components, you can do so via the same `config` object in `config/application.rb`:
@@ -189,7 +189,7 @@ Takes a block which will be run _after_ Rails has finished initializing the appl
 
 ```ruby
 config.after_initialize do
-  ActionView::Base.sanitized_allowed_tags.delete 'div'
+  ActionView::Base.sanitized_allowed_tags.delete "div"
 end
 ```
 
@@ -421,7 +421,7 @@ Parameters filter works by partial matching regular expression.
 Used for filtering out redirect urls from application logs.
 
 ```ruby
-Rails.application.config.filter_redirect += ['s3.amazonaws.com', /private-match/]
+Rails.application.config.filter_redirect += ["s3.amazonaws.com", /private-match/]
 ```
 
 The redirect filter works by testing that urls include strings or match regular
@@ -776,7 +776,7 @@ You can exclude certain requests from Host Authorization checks by setting
 ```ruby
 # Exclude requests for the /healthcheck/ path from host checking
 Rails.application.config.host_authorization = {
-  exclude: ->(request) { request.path.include?('healthcheck') }
+  exclude: ->(request) { request.path.include?("healthcheck") }
 }
 ```
 
@@ -2038,32 +2038,32 @@ Configures what exceptions are assigned to an HTTP status. It accepts a hash and
 
 ```ruby
 # It's good to use #[]= or #merge! to respect the default values
-config.action_dispatch.rescue_responses['MyAuthenticationError'] = :unauthorized
+config.action_dispatch.rescue_responses["MyAuthenticationError"] = :unauthorized
 ```
 
 Use `ActionDispatch::ExceptionWrapper.rescue_responses` to observe the configuration. By default, it is defined as:
 
 ```ruby
 {
-  'ActionController::RoutingError' => :not_found,
-  'AbstractController::ActionNotFound' => :not_found,
-  'ActionController::MethodNotAllowed' => :method_not_allowed,
-  'ActionController::UnknownHttpMethod' => :method_not_allowed,
-  'ActionController::NotImplemented' => :not_implemented,
-  'ActionController::UnknownFormat' => :not_acceptable,
-  'ActionDispatch::Http::MimeNegotiation::InvalidType' => :not_acceptable,
-  'ActionController::MissingExactTemplate' => :not_acceptable,
-  'ActionController::InvalidAuthenticityToken' => :unprocessable_entity,
-  'ActionController::InvalidCrossOriginRequest' => :unprocessable_entity,
-  'ActionDispatch::Http::Parameters::ParseError' => :bad_request,
-  'ActionController::BadRequest' => :bad_request,
-  'ActionController::ParameterMissing' => :bad_request,
-  'Rack::QueryParser::ParameterTypeError' => :bad_request,
-  'Rack::QueryParser::InvalidParameterError' => :bad_request,
-  'ActiveRecord::RecordNotFound' => :not_found,
-  'ActiveRecord::StaleObjectError' => :conflict,
-  'ActiveRecord::RecordInvalid' => :unprocessable_entity,
-  'ActiveRecord::RecordNotSaved' => :unprocessable_entity
+  "ActionController::RoutingError" => :not_found,
+  "AbstractController::ActionNotFound" => :not_found,
+  "ActionController::MethodNotAllowed" => :method_not_allowed,
+  "ActionController::UnknownHttpMethod" => :method_not_allowed,
+  "ActionController::NotImplemented" => :not_implemented,
+  "ActionController::UnknownFormat" => :not_acceptable,
+  "ActionDispatch::Http::MimeNegotiation::InvalidType" => :not_acceptable,
+  "ActionController::MissingExactTemplate" => :not_acceptable,
+  "ActionController::InvalidAuthenticityToken" => :unprocessable_entity,
+  "ActionController::InvalidCrossOriginRequest" => :unprocessable_entity,
+  "ActionDispatch::Http::Parameters::ParseError" => :bad_request,
+  "ActionController::BadRequest" => :bad_request,
+  "ActionController::ParameterMissing" => :bad_request,
+  "Rack::QueryParser::ParameterTypeError" => :bad_request,
+  "Rack::QueryParser::InvalidParameterError" => :bad_request,
+  "ActiveRecord::RecordNotFound" => :not_found,
+  "ActiveRecord::StaleObjectError" => :conflict,
+  "ActiveRecord::RecordInvalid" => :unprocessable_entity,
+  "ActiveRecord::RecordNotSaved" => :unprocessable_entity
 }
 ```
 
@@ -2831,8 +2831,8 @@ The following configuration would queue the provided job on the `video_server.lo
 
 ```ruby
 # prefix must be set for delimiter to be used
-config.active_job.queue_name_prefix = 'video_server'
-config.active_job.queue_name_delimiter = '.'
+config.active_job.queue_name_prefix = "video_server"
+config.active_job.queue_name_delimiter = "."
 ```
 
 ```ruby
@@ -2942,7 +2942,7 @@ Accepts a hash of options indicating the locations of previewer/analyzer command
 * `:ffmpeg` - The location of the ffmpeg executable.
 
 ```ruby
-config.active_storage.paths[:ffprobe] = '/usr/local/bin/ffprobe'
+config.active_storage.paths[:ffprobe] = "/usr/local/bin/ffprobe"
 ```
 
 #### `config.active_storage.variable_content_types`
@@ -3070,7 +3070,7 @@ Directs ActiveStorage::Attachments to touch its corresponding record when update
 Can be used to set the route prefix for the routes served by Active Storage. Accepts a string that will be prepended to the generated routes.
 
 ```ruby
-config.active_storage.routes_prefix = '/files'
+config.active_storage.routes_prefix = "/files"
 ```
 
 The default is `/rails/active_storage`.
@@ -3167,7 +3167,7 @@ development:
 This will connect to the database named `blog_development` using the `postgresql` adapter. This same information can be stored in a URL and provided via an environment variable like this:
 
 ```ruby
-ENV['DATABASE_URL'] # => "postgresql://localhost/blog_development?pool=5"
+ENV["DATABASE_URL"] # => "postgresql://localhost/blog_development?pool=5"
 ```
 
 The `config/database.yml` file contains sections for three different environments in which Rails can run by default:
@@ -3971,7 +3971,7 @@ end
 ```
 
 ```ruby
-Rails.configuration.payment['merchant_id'] # => production_merchant_id or development_merchant_id
+Rails.configuration.payment["merchant_id"] # => production_merchant_id or development_merchant_id
 ```
 
 `Rails::Application.config_for` supports a `shared` configuration to group common

--- a/guides/source/engines.md
+++ b/guides/source/engines.md
@@ -1176,7 +1176,7 @@ module Blorgh::Concerns::Models::Article
 
   module ClassMethods
     def some_class_method
-      'some class method string'
+      "some class method string"
     end
   end
 end

--- a/guides/source/error_reporting.md
+++ b/guides/source/error_reporting.md
@@ -126,7 +126,7 @@ the error, and the rest of your code outside the block will continue as normal.
 
 ```ruby
 result = Rails.error.handle do
-  1 + '1' # raises TypeError
+  1 + "1" # raises TypeError
 end
 result # => nil
 1 + 1 # This will be executed
@@ -151,7 +151,7 @@ the error, meaning that the rest of your code won't execute.
 
 ```ruby
 Rails.error.record do
-  1 + '1' # raises TypeError
+  1 + "1" # raises TypeError
 end
 1 + 1 # This won't be executed
 ```
@@ -252,7 +252,7 @@ report errors of certain classes. For example:
 
 ```ruby
 Rails.error.handle(IOError) do
-  1 + '1' # raises TypeError
+  1 + "1" # raises TypeError
 end
 1 + 1 # TypeErrors are not IOErrors, so this will *not* be executed
 ```
@@ -271,7 +271,7 @@ subscriber itself, or its class.
 
 ```ruby
 Rails.error.disable(ErrorSubscriber) do
-  1 + '1' # TypeError will not be reported via the ErrorSubscriber
+  1 + "1" # TypeError will not be reported via the ErrorSubscriber
 end
 ```
 

--- a/guides/source/form_helpers.md
+++ b/guides/source/form_helpers.md
@@ -389,7 +389,7 @@ If you have a [singular resource](routing.html#singular-resources), you will nee
 
 ```ruby
 resource :article
-resolve('Article') { [:article] }
+resolve("Article") { [:article] }
 ```
 
 TIP: Declaring a resource has a number of side effects. See the [Rails Routing from the Outside In](routing.html#resource-routing-the-rails-default) guide for more information on setting up and using resources.
@@ -839,7 +839,7 @@ Note that, per `form_with` conventions, the field names in the two forms above w
 When using `file_field`, the object in the `params` hash is an instance of [`ActionDispatch::Http::UploadedFile`](https://api.rubyonrails.org/classes/ActionDispatch/Http/UploadedFile.html). Here is an example of how to save data in an uploaded CSV file to records in your application:
 
 ```ruby
-  require 'csv'
+  require "csv"
 
   def upload
     uploaded_file = params[:csv_file]
@@ -966,7 +966,7 @@ Hashes mirror the syntax used for accessing the value in `params`. For example, 
 the `params` hash will contain
 
 ```ruby
-{ 'person' => { 'name' => 'Henry' } }
+{ "person" => { "name" => "Henry" } }
 ```
 
 and `params[:person][:name]` will retrieve the submitted value in the controller.
@@ -980,7 +980,7 @@ Hashes can be nested as many levels as required, for example:
 The above will result in the `params` hash being
 
 ```ruby
-{ 'person' => { 'address' => { 'city' => 'New York' } } }
+{ "person" => { "address" => { "city" => "New York" } } }
 ```
 
 The other structure is an Array. Normally Rails ignores duplicate parameter names, but if the parameter name ends with an empty set of square brackets `[]` then the parameters will be accumulated in an Array.
@@ -996,7 +996,7 @@ For example, if you want users to be able to input multiple phone numbers, you c
 This would result in `params[:person][:phone_number]` being an array containing the submitted phone numbers:
 
 ```ruby
-{ 'person' => { 'phone_number' => ['555-0123', '555-0124', '555-0125'] } }
+{ "person" => { "phone_number" => ["555-0123", "555-0124", "555-0125"] } }
 ```
 
 ### Combining Arrays and Hashes
@@ -1017,15 +1017,15 @@ You also can have an array of hashes. For example, you can create any number of 
 This would result in `params[:person][:addresses]` being an array of hashes. Each hash in the array will have the keys `line1`, `line2`, and `city`, something like this:
 
 ```ruby
-{ 'person' =>
-  { 'addresses' => [
-    { 'line1' => '1000 Fifth Avenue',
-      'line2' => '',
-      'city' => 'New York'
+{ "person" =>
+  { "addresses" => [
+    { "line1" => "1000 Fifth Avenue",
+      "line2" => "",
+      "city" => "New York"
     },
-    { 'line1' => 'Calle de Ruiz de Alarcón',
-      'line2' => '',
-      'city' => 'Madrid'
+    { "line1" => "Calle de Ruiz de Alarcón",
+      "line2" => "",
+      "city" => "Madrid"
     }
     ]
   }
@@ -1181,16 +1181,16 @@ with 2 addresses, the submitted parameters in `params` would look like this:
 
 ```ruby
 {
-  'person' => {
-    'name' => 'John Doe',
-    'addresses_attributes' => {
-      '0' => {
-        'kind' => 'Home',
-        'street' => '221b Baker Street'
+  "person" => {
+    "name" => "John Doe",
+    "addresses_attributes" => {
+      "0" => {
+        "kind" => "Home",
+        "street" => "221b Baker Street"
       },
-      '1' => {
-        'kind' => 'Office',
-        'street' => '31 Spooner Street'
+      "1" => {
+        "kind" => "Office",
+        "street" => "31 Spooner Street"
       }
     }
   }
@@ -1203,18 +1203,18 @@ If the associated object is already saved, `fields_for` autogenerates a hidden i
 
 ```ruby
 {
-  'person' => {
-    'name' => 'John Doe',
-    'addresses_attributes' => {
-      '0' => {
-        'id' => 1,
-        'kind' => 'Home',
-        'street' => '221b Baker Street'
+  "person" => {
+    "name" => "John Doe",
+    "addresses_attributes" => {
+      "0" => {
+        "id" => 1,
+        "kind" => "Home",
+        "street" => "221b Baker Street"
       },
-      '1' => {
-        'id' => '2',
-        'kind' => 'Office',
-        'street' => '31 Spooner Street'
+      "1" => {
+        "id" => "2",
+        "kind" => "Office",
+        "street" => "31 Spooner Street"
       }
     }
   }
@@ -1293,7 +1293,7 @@ It is often useful to ignore sets of fields that the user has not filled in. You
 ```ruby
 class Person < ApplicationRecord
   has_many :addresses
-  accepts_nested_attributes_for :addresses, reject_if: lambda { |attributes| attributes['kind'].blank? }
+  accepts_nested_attributes_for :addresses, reject_if: lambda { |attributes| attributes["kind"].blank? }
 end
 ```
 

--- a/guides/source/i18n.md
+++ b/guides/source/i18n.md
@@ -67,7 +67,7 @@ localize  # Localize Date and Time objects to local formats
 These have the aliases #t and #l so you can use them like this:
 
 ```ruby
-I18n.t 'store.title'
+I18n.t "store.title"
 I18n.l Time.now
 ```
 
@@ -116,7 +116,7 @@ NOTE: The backend lazy-loads these translations when a translation is looked up 
 You can change the default locale as well as configure the translations load paths in `config/application.rb` as follows:
 
 ```ruby
-config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}')]
+config.i18n.load_path += Dir[Rails.root.join("my", "locales", "*.{rb,yml}")]
 config.i18n.default_locale = :de
 ```
 
@@ -126,7 +126,7 @@ The load path must be specified before any translations are looked up. To change
 # config/initializers/locale.rb
 
 # Where the I18n library should search for translation files
-I18n.load_path += Dir[Rails.root.join('lib', 'locale', '*.{rb,yml}')]
+I18n.load_path += Dir[Rails.root.join("lib", "locale", "*.{rb,yml}")]
 
 # Permitted locales available for the application
 I18n.available_locales = [:en, :pt]
@@ -186,7 +186,7 @@ end
 #   127.0.0.1 application.pl
 # in your /etc/hosts file to try this out locally
 def extract_locale_from_tld
-  parsed_locale = request.host.split('.').last
+  parsed_locale = request.host.split(".").last
   I18n.available_locales.map(&:to_s).include?(parsed_locale) ? parsed_locale : nil
 end
 ```
@@ -270,7 +270,7 @@ You would probably need to map URLs like these:
 
 ```ruby
 # config/routes.rb
-get '/:locale' => 'dashboard#index'
+get "/:locale" => "dashboard#index"
 ```
 
 Do take special care about the **order of your routes**, so this route declaration does not "eat" other ones. (You may want to add it directly before the `root :to` declaration.)
@@ -310,7 +310,7 @@ end
 
 private
   def extract_locale_from_accept_language_header
-    request.env['HTTP_ACCEPT_LANGUAGE'].scan(/^[a-z]{2}/).first
+    request.env["HTTP_ACCEPT_LANGUAGE"].scan(/^[a-z]{2}/).first
   end
 ```
 
@@ -448,12 +448,12 @@ en:
 ```
 
 ```ruby
-I18n.t 'success.true'  # => 'True!'
-I18n.t 'success.on'    # => 'On!'
-I18n.t 'success.false' # => 'False!'
-I18n.t 'failure.false' # => Translation Missing
-I18n.t 'failure.off'   # => Translation Missing
-I18n.t 'failure.true'  # => Translation Missing
+I18n.t "success.true"  # => 'True!'
+I18n.t "success.on"    # => 'On!'
+I18n.t "success.false" # => 'False!'
+I18n.t "failure.false" # => Translation Missing
+I18n.t "failure.off"   # => Translation Missing
+I18n.t "failure.true"  # => Translation Missing
 ```
 
 ### Passing Variables to Translations
@@ -593,7 +593,7 @@ NOTE: The default locale loading mechanism in Rails does not load locale files i
 
 ```ruby
 # config/application.rb
-config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.{rb,yml}')]
+config.i18n.load_path += Dir[Rails.root.join("config", "locales", "**", "*.{rb,yml}")]
 ```
 
 Overview of the I18n API Features
@@ -621,7 +621,7 @@ Translations are looked up by keys which can be both Symbols or Strings, so thes
 
 ```ruby
 I18n.t :message
-I18n.t 'message'
+I18n.t "message"
 ```
 
 The `translate` method also takes a `:scope` option which can contain one or more additional keys that will be used to specify a "namespace" or scope for a translation key:
@@ -641,9 +641,9 @@ I18n.translate "activerecord.errors.messages.record_invalid"
 Thus the following calls are equivalent:
 
 ```ruby
-I18n.t 'activerecord.errors.messages.record_invalid'
-I18n.t 'errors.messages.record_invalid', scope: :activerecord
-I18n.t :record_invalid, scope: 'activerecord.errors.messages'
+I18n.t "activerecord.errors.messages.record_invalid"
+I18n.t "errors.messages.record_invalid", scope: :activerecord
+I18n.t :record_invalid, scope: "activerecord.errors.messages"
 I18n.t :record_invalid, scope: [:activerecord, :errors, :messages]
 ```
 
@@ -652,7 +652,7 @@ I18n.t :record_invalid, scope: [:activerecord, :errors, :messages]
 When a `:default` option is given, its value will be returned if the translation is missing:
 
 ```ruby
-I18n.t :missing, default: 'Not here'
+I18n.t :missing, default: "Not here"
 # => 'Not here'
 ```
 
@@ -661,7 +661,7 @@ If the `:default` value is a Symbol, it will be used as a key and translated. On
 E.g., the following first tries to translate the key `:missing` and then the key `:also_missing.` As both do not yield a result, the string "Not here" will be returned:
 
 ```ruby
-I18n.t :missing, default: [:also_missing, 'Not here']
+I18n.t :missing, default: [:also_missing, "Not here"]
 # => 'Not here'
 ```
 
@@ -670,14 +670,14 @@ I18n.t :missing, default: [:also_missing, 'Not here']
 To look up multiple translations at once, an array of keys can be passed:
 
 ```ruby
-I18n.t [:odd, :even], scope: 'errors.messages'
+I18n.t [:odd, :even], scope: "errors.messages"
 # => ["must be odd", "must be even"]
 ```
 
 Also, a key can translate to a (potentially nested) hash of grouped translations. E.g., one can receive _all_ Active Record error messages as a Hash with:
 
 ```ruby
-I18n.t 'errors.messages'
+I18n.t "errors.messages"
 # => {:inclusion=>"is not included in the list", :exclusion=> ... }
 ```
 
@@ -693,10 +693,10 @@ en:
 then the nested interpolation will be ignored without the setting:
 
 ```ruby
-I18n.t 'welcome', app_name: 'book store'
+I18n.t "welcome", app_name: "book store"
 # => {:title=>"Welcome!", :content=>"Welcome to the %{app_name}"}
 
-I18n.t 'welcome', deep_interpolation: true, app_name: 'book store'
+I18n.t "welcome", deep_interpolation: true, app_name: "book store"
 # => {:title=>"Welcome!", :content=>"Welcome to the book store"}
 ```
 
@@ -734,7 +734,7 @@ This is useful for setting flash messages for instance:
 class BooksController < ApplicationController
   def create
     # ...
-    redirect_to books_url, notice: t('.success')
+    redirect_to books_url, notice: t(".success")
   end
 end
 ```
@@ -749,9 +749,9 @@ pluralization backend. By default, only the English pluralization rules are appl
 
 ```ruby
 I18n.backend.store_translations :en, inbox: {
-  zero: 'no messages', # optional
-  one: 'one message',
-  other: '%{count} messages'
+  zero: "no messages", # optional
+  one: "one message",
+  other: "%{count} messages"
 }
 I18n.translate :inbox, count: 2
 # => '2 messages'
@@ -783,7 +783,7 @@ to the Simple backend, then add the localized pluralization algorithms to transl
 ```ruby
 I18n::Backend::Simple.include(I18n::Backend::Pluralization)
 I18n.backend.store_translations :pt, i18n: { plural: { rule: lambda { |n| [0, 1].include?(n) ? :one : :other } } }
-I18n.backend.store_translations :pt, apples: { one: 'one or none', other: 'more than one' }
+I18n.backend.store_translations :pt, apples: { one: "one or none", other: "more than one" }
 
 I18n.t :apples, count: 0, locale: :pt
 # => 'one or none'
@@ -1113,9 +1113,9 @@ en:
 So, all of the following equivalent lookups will return the `:short` date format `"%b %d"`:
 
 ```ruby
-I18n.t 'date.formats.short'
-I18n.t 'formats.short', scope: :date
-I18n.t :short, scope: 'date.formats'
+I18n.t "date.formats.short"
+I18n.t "formats.short", scope: :date
+I18n.t :short, scope: "date.formats"
 I18n.t :short, scope: [:date, :formats]
 ```
 

--- a/guides/source/initialization.md
+++ b/guides/source/initialization.md
@@ -40,7 +40,7 @@ This file is as follows:
 
 ```ruby
 #!/usr/bin/env ruby
-APP_PATH = File.expand_path('../config/application', __dir__)
+APP_PATH = File.expand_path("../config/application", __dir__)
 require_relative "../config/boot"
 require "rails/commands"
 ```
@@ -52,7 +52,7 @@ The `APP_PATH` constant will be used later in `rails/commands`. The `config/boot
 `config/boot.rb` contains:
 
 ```ruby
-ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
+ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../Gemfile", __dir__)
 
 require "bundler/setup" # Set up gems listed in the Gemfile.
 require "bootsnap/setup" # Speed up boot time by caching expensive operations.

--- a/guides/source/layouts_and_rendering.md
+++ b/guides/source/layouts_and_rendering.md
@@ -209,7 +209,7 @@ You can send an HTML string back to the browser by using the `:html` option to
 `render`:
 
 ```ruby
-render html: helpers.tag.strong('Not Found')
+render html: helpers.tag.strong("Not Found")
 ```
 
 TIP: This is useful when you're rendering a small snippet of HTML code.

--- a/guides/source/rails_application_templates.md
+++ b/guides/source/rails_application_templates.md
@@ -111,7 +111,7 @@ Adds a line inside the `Application` class for `config/application.rb`.
 If `options[:env]` is specified, the line is appended to the corresponding file in `config/environments`.
 
 ```ruby
-environment 'config.action_mailer.default_url_options = {host: "http://yourwebsite.example.com"}', env: 'production'
+environment 'config.action_mailer.default_url_options = {host: "http://yourwebsite.example.com"}', env: "production"
 ```
 
 A block can be used in place of the `data` argument.
@@ -123,7 +123,7 @@ Adds an initializer to the generated application's `config/initializers` directo
 Let's say you like using `Object#not_nil?` and `Object#not_blank?`:
 
 ```ruby
-initializer 'bloatlol.rb', <<-CODE
+initializer "bloatlol.rb", <<-CODE
   class Object
     def not_nil?
       !nil?
@@ -141,7 +141,7 @@ Similarly, `lib()` creates a file in the `lib/` directory and `vendor()` creates
 There is even `file()`, which accepts a relative path from `Rails.root` and creates all the directories/files needed:
 
 ```ruby
-file 'app/components/foo.rb', <<-CODE
+file "app/components/foo.rb", <<-CODE
   class Foo
   end
 CODE
@@ -194,7 +194,7 @@ rails_command "db:migrate"
 You can also run commands with a different Rails environment:
 
 ```ruby
-rails_command "db:migrate", env: 'production'
+rails_command "db:migrate", env: "production"
 ```
 
 You can also run commands as a super-user:
@@ -222,7 +222,7 @@ route "root to: 'person#index'"
 Enables you to run a command from the given directory. For example, if you have a copy of edge rails that you wish to symlink from your new apps, you can do this:
 
 ```ruby
-inside('vendor') do
+inside("vendor") do
   run "ln -s ~/commit-rails/rails rails"
 end
 ```
@@ -268,7 +268,7 @@ are generated. Useful for adding generated files to version control:
 ```ruby
 after_bundle do
   git :init
-  git add: '.'
+  git add: "."
   git commit: "-a -m 'Initial commit'"
 end
 ```

--- a/guides/source/routing.md
+++ b/guides/source/routing.md
@@ -34,7 +34,7 @@ GET /users/17
 If the first matching route is:
 
 ```ruby
-get '/users/:id', to: 'user#show'
+get "/users/:id", to: "user#show"
 ```
 
 The request is matched to the `UsersController` class's `show` action with `{ id: '17' }` in the `params` hash.
@@ -42,7 +42,7 @@ The request is matched to the `UsersController` class's `show` action with `{ id
 The `to:` option expects a `controller#action` format when passed a string. Alternatively, You can pass a symbol and use the `action:` option, instead of `to:`. You can also pass a string without a `#`, in which case the `controller:` option is used instead to `to:`. For example:
 
 ```ruby
-get '/users/:id', controller: 'users', action: :show
+get "/users/:id", controller: "users", action: :show
 ```
 
 NOTE: Rails uses snake_case for controller names when specifying routes. For example, if you have a controller named `UserProfilesController`, you would specify a route to the show action as `user_profiles#show`.
@@ -54,7 +54,7 @@ The Router automatically generates path and URL helper methods for your applicat
 For example, the `user_path` and `user_url` helper methods are available when defining the following route:
 
 ```ruby
-get '/users/:id', to: 'users#show', as: 'user'
+get "/users/:id", to: "users#show", as: "user"
 ```
 
 NOTE: The `as:` option is used to provide a custom name for a route, which is used when generating URL and path helpers.
@@ -192,7 +192,7 @@ The below resourceful route creates six routes in your application, all mapping 
 
 ```ruby
 resource :geocoder
-resolve('Geocoder') { [:geocoder] }
+resolve("Geocoder") { [:geocoder] }
 ```
 
 NOTE: The call to `resolve` is necessary for converting instances of the `Geocoder` to singular routes through [record identification](form_helpers.html#relying-on-record-identification).
@@ -247,7 +247,7 @@ Note that in the above example all of the paths have a `/admin` prefix per the d
 If you want to route `/articles` (without the prefix `/admin`) to `Admin::ArticlesController`, you can specify the module with a [`scope`][] block:
 
 ```ruby
-scope module: 'admin' do
+scope module: "admin" do
   resources :articles
 end
 ```
@@ -255,7 +255,7 @@ end
 Another way to write the above:
 
 ```ruby
-resources :articles, module: 'admin'
+resources :articles, module: "admin"
 ```
 
 #### Using Scope
@@ -263,7 +263,7 @@ resources :articles, module: 'admin'
 Alternatively, you can also route `/admin/articles` to `ArticlesController` (without the `Admin::` module prefix). You can specify the path with a `scope` block:
 
 ```ruby
-scope '/admin' do
+scope "/admin" do
   resources :articles
 end
 ```
@@ -271,7 +271,7 @@ end
 Another way to write the above:
 
 ```ruby
-resources :articles, path: '/admin/articles'
+resources :articles, path: "/admin/articles"
 ```
 
 For these alternatives (without `/admin` in path and without `Admin::` in module prefix), the named route helpers remain the same as if you did not use `scope`.
@@ -583,7 +583,7 @@ You can add a [`member`][] block into the resource block like this:
 ```ruby
 resources :photos do
   member do
-    get 'preview'
+    get "preview"
   end
 end
 ```
@@ -599,7 +599,7 @@ pass `:on` to a route, eliminating the block:
 
 ```ruby
 resources :photos do
-  get 'preview', on: :member
+  get "preview", on: :member
 end
 ```
 
@@ -620,7 +620,7 @@ To add a route to the collection, use a [`collection`][] block:
 ```ruby
 resources :photos do
   collection do
-    get 'search'
+    get "search"
   end
 end
 ```
@@ -631,7 +631,7 @@ Just as with member routes, you can pass `:on` to a route:
 
 ```ruby
 resources :photos do
-  get 'search', on: :collection
+  get "search", on: :collection
 end
 ```
 
@@ -645,7 +645,7 @@ To add an alternate new action using the `:on` shortcut:
 
 ```ruby
 resources :comments do
-  get 'preview', on: :new
+  get "preview", on: :new
 end
 ```
 
@@ -669,7 +669,7 @@ One example use case for non-resourceful routing is mapping existing legacy URLs
 When you set up a regular route, you supply a series of symbols that Rails maps to parts of an incoming HTTP request. For example, consider this route:
 
 ```ruby
-get 'photos(/:id)', to: 'photos#display'
+get "photos(/:id)", to: "photos#display"
 ```
 
 If an incoming `GET` request of `/photos/1` is processed by this route, then the result will be to invoke the `display` action of the `PhotosController`, and to make the final parameter `"1"` available as `params[:id]`. This route will also route the incoming request of `/photos` to `PhotosController#display`, since `:id` is an optional parameter, denoted by parentheses in the above example.
@@ -679,7 +679,7 @@ If an incoming `GET` request of `/photos/1` is processed by this route, then the
 You can set up as many dynamic segments within a regular route as you like. Any segment will be available to the action as part of `params`. If you set up this route:
 
 ```ruby
-get 'photos/:id/:user_id', to: 'photos#show'
+get "photos/:id/:user_id", to: "photos#show"
 ```
 
 This route will respond to paths such as `/photos/1/2`. The `params` hash will be { controller: 'photos', action: 'show', id: '1', user_id: '2' }.
@@ -691,7 +691,7 @@ TIP: By default, dynamic segments don't accept dots - this is because the dot is
 You can specify static segments when creating a route by not prepending a colon to a segment:
 
 ```ruby
-get 'photos/:id/with_user/:user_id', to: 'photos#show'
+get "photos/:id/with_user/:user_id", to: "photos#show"
 ```
 
 This route would respond to paths such as `/photos/1/with_user/2`. In this case, `params` would be `{ controller: 'photos', action: 'show', id: '1', user_id: '2' }`.
@@ -701,7 +701,7 @@ This route would respond to paths such as `/photos/1/with_user/2`. In this case,
 The `params` will also include any parameters from the query string. For example, with this route:
 
 ```ruby
-get 'photos/:id', to: 'photos#show'
+get "photos/:id", to: "photos#show"
 ```
 
 An incoming `GET` request for `/photos/1?user_id=2` will be dispatched to the `show` action of the `PhotosController` class as usual and the `params` hash will be `{ controller: 'photos', action: 'show', id: '1', user_id: '2' }`.
@@ -711,7 +711,7 @@ An incoming `GET` request for `/photos/1?user_id=2` will be dispatched to the `s
 You can define defaults in a route by supplying a hash for the `:defaults` option. This even applies to parameters that you do not specify as dynamic segments. For example:
 
 ```ruby
-get 'photos/:id', to: 'photos#show', defaults: { format: 'jpg' }
+get "photos/:id", to: "photos#show", defaults: { format: "jpg" }
 ```
 
 Rails would match `photos/12` to the `show` action of `PhotosController`, and set `params[:format]` to `"jpg"`.
@@ -734,7 +734,7 @@ NOTE: You cannot override defaults via query parameters - this is for security r
 You can specify a name that will used by the `_path` and `_url` helpers for any route using the `:as` option:
 
 ```ruby
-get 'exit', to: 'sessions#destroy', as: :logout
+get "exit", to: "sessions#destroy", as: :logout
 ```
 
 This will create `logout_path` and `logout_url` as the route helpers in your application. Calling `logout_path` will return `/exit`.
@@ -742,7 +742,7 @@ This will create `logout_path` and `logout_url` as the route helpers in your app
 You can also use `as` to override routing helper names defined by `resources` by placing a custom route definition *before* the resource is defined, like this:
 
 ```ruby
-get ':username', to: 'users#show', as: :user
+get ":username", to: "users#show", as: :user
 resources :users
 ```
 
@@ -753,7 +753,7 @@ This will define a `user_path` helper that will match `/:username` (e.g. `/jane`
 In general, you should use the [`get`][], [`post`][], [`put`][], [`patch`][], and [`delete`][] methods to constrain a route to a particular verb. There is a [`match`][] method that you could use with the `:via` option to match multiple verbs at once:
 
 ```ruby
-match 'photos', to: 'photos#show', via: [:get, :post]
+match "photos", to: "photos#show", via: [:get, :post]
 ```
 
 The above route matches GET and POST requests to the `show` action of the `PhotosController`.
@@ -761,7 +761,7 @@ The above route matches GET and POST requests to the `show` action of the `Photo
 You can match all verbs to a particular route using `via: :all`:
 
 ```ruby
-match 'photos', to: 'photos#show', via: :all
+match "photos", to: "photos#show", via: :all
 ```
 
 NOTE: Routing both `GET` and `POST` requests to a single action has security
@@ -778,19 +778,19 @@ reason.
 You can use the `:constraints` option to enforce a format for a dynamic segment:
 
 ```ruby
-get 'photos/:id', to: 'photos#show', constraints: { id: /[A-Z]\d{5}/ }
+get "photos/:id", to: "photos#show", constraints: { id: /[A-Z]\d{5}/ }
 ```
 
 The above route definition requires `id` to be 5 alphanumeric characters long. Therefore, this route would match paths such as `/photos/A12345`, but not `/photos/893`. You can more succinctly express the same route this way:
 
 ```ruby
-get 'photos/:id', to: 'photos#show', id: /[A-Z]\d{5}/
+get "photos/:id", to: "photos#show", id: /[A-Z]\d{5}/
 ```
 
 The `:constraints` option takes regular expressions (as well as any object that responds to `matches?` method) with the restriction that regexp anchors can't be used. For example, the following route will not work:
 
 ```ruby
-get '/:id', to: 'articles#show', constraints: { id: /^\d/ }
+get "/:id", to: "articles#show", constraints: { id: /^\d/ }
 ```
 
 However, note that you don't need to use anchors because all routes are anchored at the start and the end.
@@ -798,8 +798,8 @@ However, note that you don't need to use anchors because all routes are anchored
 For example:
 
 ```ruby
-get '/:id', to: 'articles#show', constraints: { id: /\d.+/ }
-get '/:username', to: 'users#show'
+get "/:id", to: "articles#show", constraints: { id: /\d.+/ }
+get "/:username", to: "users#show"
 ```
 
 The above routes would allow sharing the root namespace and:
@@ -814,7 +814,7 @@ You can also constrain a route based on any method on the [Request object](actio
 You specify a request-based constraint the same way that you specify a segment constraint. For example:
 
 ```ruby
-get 'photos', to: 'photos#index', constraints: { subdomain: 'admin' }
+get "photos", to: "photos#index", constraints: { subdomain: "admin" }
 ```
 
 Will match an incoming request with a path to `admin` subdomain.
@@ -823,7 +823,7 @@ You can also specify constraints by using a [`constraints`][] block:
 
 ```ruby
 namespace :admin do
-  constraints subdomain: 'admin' do
+  constraints subdomain: "admin" do
     resources :photos
   end
 end
@@ -857,7 +857,7 @@ class RestrictedListConstraint
 end
 
 Rails.application.routes.draw do
-  get '*path', to: 'restricted_list#index',
+  get "*path", to: "restricted_list#index",
     constraints: RestrictedListConstraint.new
 end
 ```
@@ -866,7 +866,7 @@ You can also specify constraints as a lambda:
 
 ```ruby
 Rails.application.routes.draw do
-  get '*path', to: 'restricted_list#index',
+  get "*path", to: "restricted_list#index",
     constraints: lambda { |request| RestrictedList.retrieve_ips.include?(request.remote_ip) }
 end
 ```
@@ -884,8 +884,8 @@ end
 
 Rails.application.routes.draw do
   constraints(RestrictedListConstraint.new) do
-    get '*path', to: 'restricted_list#index'
-    get '*other-path', to: 'other_restricted_list#index'
+    get "*path", to: "restricted_list#index"
+    get "*other-path", to: "other_restricted_list#index"
   end
 end
 ```
@@ -895,8 +895,8 @@ You can also use a `lambda`:
 ```ruby
 Rails.application.routes.draw do
   constraints(lambda { |request| RestrictedList.retrieve_ips.include?(request.remote_ip) }) do
-    get '*path', to: 'restricted_list#index'
-    get '*other-path', to: 'other_restricted_list#index'
+    get "*path", to: "restricted_list#index"
+    get "*other-path", to: "other_restricted_list#index"
   end
 end
 ```
@@ -906,7 +906,7 @@ end
 A route definition can have a wildcard segment, which is a segment prefixed with a star, such as `*other`:
 
 ```ruby
-get 'photos/*other', to: 'photos#unknown'
+get "photos/*other", to: "photos#unknown"
 ```
 
 Wildcard segments allow for something called "route globbing", which is a way to specify that a particular parameter (`*other` above) be matched to the remaining part of a route.
@@ -916,7 +916,7 @@ So the above route would match `photos/12` or `/photos/long/path/to/12`, setting
 Wildcard segments can occur anywhere in a route. For example:
 
 ```ruby
-get 'books/*section/:title', to: 'books#show'
+get "books/*section/:title", to: "books#show"
 ```
 
 would match `books/some/section/last-words-a-memoir` with `params[:section]` equals `'some/section'`, and `params[:title]` equals `'last-words-a-memoir'`.
@@ -924,7 +924,7 @@ would match `books/some/section/last-words-a-memoir` with `params[:section]` equ
 Technically, a route can have even more than one wildcard segment. The matcher assigns segments to parameters in the order they occur. For example:
 
 ```ruby
-get '*a/foo/*b', to: 'test#index'
+get "*a/foo/*b", to: "test#index"
 ```
 
 would match `zoo/woo/foo/bar/baz` with `params[:a]` equals `'zoo/woo'`, and `params[:b]` equals `'bar/baz'`.
@@ -934,7 +934,7 @@ would match `zoo/woo/foo/bar/baz` with `params[:a]` equals `'zoo/woo'`, and `par
 Given this route definition:
 
 ```ruby
-get '*pages', to: 'pages#show'
+get "*pages", to: "pages#show"
 ```
 
 By requesting `'/foo/bar.json'`, your `params[:pages]` will be equal to `'foo/bar'` with the request format of JSON in `params[:format]`.
@@ -944,13 +944,13 @@ The default behavior with `format` is that if included Rails automatically captu
 If you want to match URLs without an explicit format and ignore URLs that include a format extension, you could supply `format: false` like this:
 
 ```ruby
-get '*pages', to: 'pages#show', format: false
+get "*pages", to: "pages#show", format: false
 ```
 
 If you want to make the format segment mandatory, so it cannot be omitted, you can supply `format: true` like this:
 
 ```ruby
-get '*pages', to: 'pages#show', format: true
+get "*pages", to: "pages#show", format: true
 ```
 
 ### Redirection
@@ -958,26 +958,26 @@ get '*pages', to: 'pages#show', format: true
 You can redirect any path to any other path by using the [`redirect`][] helper in your router:
 
 ```ruby
-get '/stories', to: redirect('/articles')
+get "/stories", to: redirect("/articles")
 ```
 
 You can also reuse dynamic segments from the match in the path to redirect to:
 
 ```ruby
-get '/stories/:name', to: redirect('/articles/%{name}')
+get "/stories/:name", to: redirect("/articles/%{name}")
 ```
 
 You can also provide a block to `redirect`, which receives the symbolized path parameters and the request object:
 
 ```ruby
-get '/stories/:name', to: redirect { |path_params, req| "/articles/#{path_params[:name].pluralize}" }
-get '/stories', to: redirect { |path_params, req| "/articles/#{req.subdomain}" }
+get "/stories/:name", to: redirect { |path_params, req| "/articles/#{path_params[:name].pluralize}" }
+get "/stories", to: redirect { |path_params, req| "/articles/#{req.subdomain}" }
 ```
 
 Please note that default redirection is a 301 "Moved Permanently" redirect. Keep in mind that some web browsers or proxy servers will cache this type of redirect, making the old page inaccessible. You can use the `:status` option to change the response status:
 
 ```ruby
-get '/stories/:name', to: redirect('/articles/%{name}', status: 302)
+get "/stories/:name", to: redirect("/articles/%{name}", status: 302)
 ```
 
 In all of these cases, if you don't provide the host (`http://www.example.com`), Rails will take those details from the current request.
@@ -989,7 +989,7 @@ In all of these cases, if you don't provide the host (`http://www.example.com`),
 Instead of specifying `:to` as a String like `'articles#index'`, which corresponds to the `index` method in the `ArticlesController` class, you can specify any [Rack application](rails_on_rack.html) as the endpoint for a matcher:
 
 ```ruby
-match '/application.js', to: MyRackApp, via: :all
+match "/application.js", to: MyRackApp, via: :all
 ```
 
 As long as `MyRackApp` responds to `call` and returns a `[status, headers, body]`, the router won't know the difference between the Rack application and a controller action. This is an appropriate use of `via: :all`, as you will want to allow your Rack application to handle all verbs.
@@ -1003,14 +1003,14 @@ the route will be unchanged in the receiving application. With the following
 route your Rack application should expect the route to be `/admin`:
 
 ```ruby
-match '/admin', to: AdminApp, via: :all
+match "/admin", to: AdminApp, via: :all
 ```
 
 If you would prefer to have your Rack application receive requests at the root
 path instead, use [`mount`][]:
 
 ```ruby
-mount AdminApp, at: '/admin'
+mount AdminApp, at: "/admin"
 ```
 
 [`mount`]: https://api.rubyonrails.org/classes/ActionDispatch/Routing/Mapper/Base.html#method-i-mount
@@ -1020,8 +1020,8 @@ mount AdminApp, at: '/admin'
 You can specify what Rails should route `'/'` to with the [`root`][] method:
 
 ```ruby
-root to: 'pages#main'
-root 'pages#main' # shortcut for the above
+root to: "pages#main"
+root "pages#main" # shortcut for the above
 ```
 
 You typically put the `root` route at the top of the file so that it can be matched first.
@@ -1047,7 +1047,7 @@ The above will match `/admin` to the `index` action for the `AdminController` an
 You can specify unicode character routes directly. For example:
 
 ```ruby
-get 'こんにちは', to: 'welcome#index'
+get "こんにちは", to: "welcome#index"
 ```
 
 ### Direct Routes
@@ -1073,7 +1073,7 @@ end
 
 ```ruby
 direct :main do
-  { controller: 'pages', action: 'index', subdomain: 'www' }
+  { controller: "pages", action: "index", subdomain: "www" }
 end
 
 # >> main_url
@@ -1113,7 +1113,7 @@ While the default routes and helpers generated by [`resources`][] will usually s
 The `:controller` option lets you explicitly specify a controller to use for the resource. For example:
 
 ```ruby
-resources :photos, controller: 'images'
+resources :photos, controller: "images"
 ```
 
 will recognize incoming paths beginning with `/photos` but route to the `Images` controller:
@@ -1131,7 +1131,7 @@ will recognize incoming paths beginning with `/photos` but route to the `Images`
 For namespaced controllers you can use the directory notation. For example:
 
 ```ruby
-resources :user_permissions, controller: 'admin/user_permissions'
+resources :user_permissions, controller: "admin/user_permissions"
 ```
 
 This will route to the `Admin::UserPermissionsController` instance.
@@ -1167,7 +1167,7 @@ TIP: By default the `:id` parameter doesn't accept dots - this is because the do
 The `:as` option lets you override the default naming for the route helpers. For example:
 
 ```ruby
-resources :photos, as: 'images'
+resources :photos, as: "images"
 ```
 
 This will match `/photos` and route the requests to `PhotosController` as usual, *but* use the value of the `:as` option to name the helpers `images_path` etc., as shown:
@@ -1187,7 +1187,7 @@ This will match `/photos` and route the requests to `PhotosController` as usual,
 The `:path_names` option lets you override the default `new` and `edit` segment in paths. For example:
 
 ```ruby
-resources :photos, path_names: { new: 'make', edit: 'change' }
+resources :photos, path_names: { new: "make", edit: "change" }
 ```
 
 This would allow paths such as `/photos/make` and `/photos/1/change` instead of `/photos/new` and `/photos/1/edit`.
@@ -1197,7 +1197,7 @@ NOTE: The route helpers and controller action names aren't changed by this optio
 It is also possible to change this option uniformly for all of your routes by using a `scope` block:
 
 ```ruby
-scope path_names: { new: 'make' } do
+scope path_names: { new: "make" } do
   # rest of your routes
 end
 ```
@@ -1207,8 +1207,8 @@ end
 You can use the `:as` option to prefix the named route helpers that Rails generates for a route. Use this option to prevent name collisions between routes using a path scope. For example:
 
 ```ruby
-scope 'admin' do
-  resources :photos, as: 'admin_photos'
+scope "admin" do
+  resources :photos, as: "admin_photos"
 end
 
 resources :photos
@@ -1222,7 +1222,7 @@ the non-scoped `resources :photos` will not have any route helpers.
 To prefix a group of route helpers, use `:as` with `scope`:
 
 ```ruby
-scope 'admin', as: 'admin' do
+scope "admin", as: "admin" do
   resources :photos, :accounts
 end
 
@@ -1241,7 +1241,7 @@ The `:as` option can override routing helper names for resources in nested route
 
 ```ruby
 resources :magazines do
-  resources :ads, as: 'periodical_ads'
+  resources :ads, as: "periodical_ads"
 end
 ```
 
@@ -1252,7 +1252,7 @@ This will create routing helpers such as `magazine_periodical_ads_url` and `edit
 You can prefix routes with a named parameter:
 
 ```ruby
-scope ':account_id', as: 'account', constraints: { account_id: /\d+/ } do
+scope ":account_id", as: "account", constraints: { account_id: /\d+/ } do
   resources :articles
 end
 ```
@@ -1301,8 +1301,8 @@ routed](#listing-unused-routes).
 Using `scope`, we can alter path names generated by `resources`:
 
 ```ruby
-scope(path_names: { new: 'neu', edit: 'bearbeiten' }) do
-  resources :categories, path: 'kategorien'
+scope(path_names: { new: "neu", edit: "bearbeiten" }) do
+  resources :categories, path: "kategorien"
 end
 ```
 
@@ -1324,7 +1324,7 @@ If you need to override the singular form of a resource, you can add a rule to A
 
 ```ruby
 ActiveSupport::Inflector.inflections do |inflect|
-  inflect.irregular 'tooth', 'teeth'
+  inflect.irregular "tooth", "teeth"
 end
 ```
 
@@ -1496,8 +1496,8 @@ Rails offers three built-in assertions designed to make testing routes simpler:
 [`assert_generates`][] asserts that a particular set of options generate a particular path and can be used with default routes or custom routes. For example:
 
 ```ruby
-assert_generates '/photos/1', { controller: 'photos', action: 'show', id: '1' }
-assert_generates '/about', controller: 'pages', action: 'about'
+assert_generates "/photos/1", { controller: "photos", action: "show", id: "1" }
+assert_generates "/about", controller: "pages", action: "about"
 ```
 
 ### The `assert_recognizes` Assertion
@@ -1505,13 +1505,13 @@ assert_generates '/about', controller: 'pages', action: 'about'
 [`assert_recognizes`][] is the inverse of `assert_generates`. It asserts that a given path is recognized and routes it to a particular spot in your application. For example:
 
 ```ruby
-assert_recognizes({ controller: 'photos', action: 'show', id: '1' }, '/photos/1')
+assert_recognizes({ controller: "photos", action: "show", id: "1" }, "/photos/1")
 ```
 
 You can supply a `:method` argument to specify the HTTP verb:
 
 ```ruby
-assert_recognizes({ controller: 'photos', action: 'create' }, { path: 'photos', method: :post })
+assert_recognizes({ controller: "photos", action: "create" }, { path: "photos", method: :post })
 ```
 
 ### The `assert_routing` Assertion
@@ -1519,7 +1519,7 @@ assert_recognizes({ controller: 'photos', action: 'create' }, { path: 'photos', 
 The [`assert_routing`][] assertion checks the route both ways. It combines the functionality of both `assert_generates` and `assert_recognizes`. It tests that the path generates the options, and that the options generate the path:
 
 ```ruby
-assert_routing({ path: 'photos', method: :post }, { controller: 'photos', action: 'create' })
+assert_routing({ path: "photos", method: :post }, { controller: "photos", action: "create" })
 ```
 
 Breaking Up a Large Route File With `draw`
@@ -1533,7 +1533,7 @@ For example, you could add an `admin.rb` file that contains all the routes relat
 # config/routes.rb
 
 Rails.application.routes.draw do
-  get 'foo', to: 'foo#bar'
+  get "foo", to: "foo#bar"
 
   draw(:admin) # Will load another route file located in `config/routes/admin.rb`
 end

--- a/guides/source/security.md
+++ b/guides/source/security.md
@@ -362,7 +362,7 @@ Whenever the user is allowed to pass (parts of) the URL for redirection, it is p
 
 ```ruby
 def legacy
-  redirect_to(params.update(action: 'main'))
+  redirect_to(params.update(action: "main"))
 end
 ```
 
@@ -395,10 +395,10 @@ def sanitize_filename(filename)
   filename.strip.tap do |name|
     # NOTE: File.basename doesn't work right with Windows paths on Unix
     # get only the filename, not the whole path
-    name.sub!(/\A.*(\\|\/)/, '')
+    name.sub!(/\A.*(\\|\/)/, "")
     # Finally, replace all non alphanumeric, underscore
     # or periods with underscore
-    name.gsub!(/[^\w.-]/, '_')
+    name.gsub!(/[^\w.-]/, "_")
   end
 end
 ```
@@ -422,16 +422,16 @@ NOTE: _Make sure users cannot download arbitrary files._
 Just as you have to filter file names for uploads, you have to do so for downloads. The `send_file()` method sends files from the server to the client. If you use a file name, that the user entered, without filtering, any file can be downloaded:
 
 ```ruby
-send_file('/var/www/uploads/' + params[:filename])
+send_file("/var/www/uploads/" + params[:filename])
 ```
 
 Simply pass a file name like "../../../etc/passwd" to download the server's login information. A simple solution against this, is to _check that the requested file is in the expected directory_:
 
 ```ruby
-basename = File.expand_path('../../files', __dir__)
+basename = File.expand_path("../../files", __dir__)
 filename = File.expand_path(File.join(basename, @file.public_filename))
 raise if basename != File.expand_path(File.dirname(filename))
-send_file filename, disposition: 'inline'
+send_file filename, disposition: "inline"
 ```
 
 Another (additional) approach is to store the file names in the database and name the files on the disk after the ids in the database. This is also a good approach to avoid possible code in an uploaded file to be executed. The `attachment_fu` plugin does this in a similar way.
@@ -868,14 +868,14 @@ For example, RedCloth translates `_test_` to `<em>test<em>`, which makes the
 text italic. However, RedCloth doesn’t filter unsafe html tags by default:
 
 ```ruby
-RedCloth.new('<script>alert(1)</script>').to_html
+RedCloth.new("<script>alert(1)</script>").to_html
 # => "<script>alert(1)</script>"
 ```
 
 Use the `:filter_html` option to remove HTML which was not created by the Textile processor.
 
 ```ruby
-RedCloth.new('<script>alert(1)</script>', [:filter_html]).to_html
+RedCloth.new("<script>alert(1)</script>", [:filter_html]).to_html
 # => "alert(1)"
 ```
 
@@ -920,21 +920,21 @@ system("/bin/echo", "hello; rm *")
 `Kernel#open` executes OS command if the argument starts with a vertical bar (`|`).
 
 ```ruby
-open('| ls') { |file| file.read }
+open("| ls") { |file| file.read }
 # returns file list as a String via `ls` command
 ```
 
 Countermeasures are to use `File.open`, `IO.open` or `URI#open` instead. They don't execute an OS command.
 
 ```ruby
-File.open('| ls') { |file| file.read }
+File.open("| ls") { |file| file.read }
 # doesn't execute `ls` command, just opens `| ls` file if it exists
 
 IO.open(0) { |file| file.read }
 # opens stdin. doesn't accept a String as the argument
 
-require 'open-uri'
-URI('https://example.com').open { |file| file.read }
+require "open-uri"
+URI("https://example.com").open { |file| file.read }
 # opens the URI. `URI()` doesn't accept `| ls`
 ```
 
@@ -1116,19 +1116,19 @@ These headers are configured by default as follows:
 
 ```ruby
 config.action_dispatch.default_headers = {
-  'X-Frame-Options' => 'SAMEORIGIN',
-  'X-XSS-Protection' => '0',
-  'X-Content-Type-Options' => 'nosniff',
-  'X-Permitted-Cross-Domain-Policies' => 'none',
-  'Referrer-Policy' => 'strict-origin-when-cross-origin'
+  "X-Frame-Options" => "SAMEORIGIN",
+  "X-XSS-Protection" => "0",
+  "X-Content-Type-Options" => "nosniff",
+  "X-Permitted-Cross-Domain-Policies" => "none",
+  "Referrer-Policy" => "strict-origin-when-cross-origin"
 }
 ```
 
 You can override these or add extra headers in `config/application.rb`:
 
 ```ruby
-config.action_dispatch.default_headers['X-Frame-Options'] = 'DENY'
-config.action_dispatch.default_headers['Header-Name']     = 'Value'
+config.action_dispatch.default_headers["X-Frame-Options"] = "DENY"
+config.action_dispatch.default_headers["Header-Name"]     = "Value"
 ```
 
 Or you can remove them:
@@ -1363,9 +1363,9 @@ Next, add an initializer to configure the middleware:
 # config/initializers/cors.rb
 Rails.application.config.middleware.insert_before 0, Rack::Cors do
   allow do
-    origins 'example.com'
+    origins "example.com"
 
-    resource '*',
+    resource "*",
       headers: :any,
       methods: [:get, :post, :put, :patch, :delete, :options, :head]
   end

--- a/guides/source/upgrading_ruby_on_rails.md
+++ b/guides/source/upgrading_ruby_on_rails.md
@@ -797,7 +797,7 @@ This used to return a hash on which you could access values with String keys. Th
 You can call `with_indifferent_access` on the return value of `config_for` if you still want to access values with String keys, e.g.:
 
 ```ruby
-Rails.application.config_for(:example).with_indifferent_access.dig('options', 'key')
+Rails.application.config_for(:example).with_indifferent_access.dig("options", "key")
 ```
 
 ### Response's Content-Type when using `respond_to#any`
@@ -811,13 +811,13 @@ Example:
 ```ruby
 def my_action
   respond_to do |format|
-    format.any { render(json: { foo: 'bar' }) }
+    format.any { render(json: { foo: "bar" }) }
   end
 end
 ```
 
 ```ruby
-get('my_action.csv')
+get("my_action.csv")
 ```
 
 Previous behavior was returning a `text/csv` response's Content-Type which is inaccurate since a JSON response is being rendered.
@@ -1033,7 +1033,7 @@ you need to allow them like this:
 ```ruby
 # config/environments/development.rb
 
-config.hosts << 'dev.myapp.com'
+config.hosts << "dev.myapp.com"
 config.hosts << /[a-z0-9-]+\.myapp\.com/ # Optionally, regexp is allowed as well
 ```
 
@@ -1657,7 +1657,7 @@ class StreamingSupport
   def process(name)
     super(name)
   rescue ArgumentError => e
-    if e.message == 'uncaught throw :warden'
+    if e.message == "uncaught throw :warden"
       throw :warden
     else
       raise e
@@ -2094,7 +2094,7 @@ will be serialized as strings, and `Hash`es will have their keys stringified.
 class CookiesController < ApplicationController
   def set_cookie
     cookies.encrypted[:expiration_date] = Date.tomorrow # => Thu, 20 Mar 2014
-    redirect_to action: 'read_cookie'
+    redirect_to action: "read_cookie"
   end
 
   def read_cookie
@@ -2162,7 +2162,7 @@ Rails-specific features. For example:
 ```ruby
 class FooBar
   def as_json(options = nil)
-    { foo: 'bar' }
+    { foo: "bar" }
   end
 end
 ```
@@ -2255,7 +2255,7 @@ included in the newly introduced `ActiveRecord::FixtureSet.context_class`, in
 ```ruby
 module FixtureFileHelpers
   def file_sha(path)
-    OpenSSL::Digest::SHA256.hexdigest(File.read(Rails.root.join('test/fixtures', path)))
+    OpenSSL::Digest::SHA256.hexdigest(File.read(Rails.root.join("test/fixtures", path)))
   end
 end
 
@@ -2290,10 +2290,10 @@ methods directly on the `Relation`.
 
 ```ruby
 # Instead of this
-Author.where(name: 'Hank Moody').compact!
+Author.where(name: "Hank Moody").compact!
 
 # Now you have to do this
-authors = Author.where(name: 'Hank Moody').to_a
+authors = Author.where(name: "Hank Moody").to_a
 authors.compact!
 ```
 
@@ -2309,9 +2309,9 @@ Before:
 
 ```ruby
 class User < ActiveRecord::Base
-  default_scope { where state: 'pending' }
-  scope :active, -> { where state: 'active' }
-  scope :inactive, -> { where state: 'inactive' }
+  default_scope { where state: "pending" }
+  scope :active, -> { where state: "active" }
+  scope :inactive, -> { where state: "inactive" }
 end
 
 User.all
@@ -2320,7 +2320,7 @@ User.all
 User.active
 # SELECT "users".* FROM "users" WHERE "users"."state" = 'active'
 
-User.where(state: 'inactive')
+User.where(state: "inactive")
 # SELECT "users".* FROM "users" WHERE "users"."state" = 'inactive'
 ```
 
@@ -2328,9 +2328,9 @@ After:
 
 ```ruby
 class User < ActiveRecord::Base
-  default_scope { where state: 'pending' }
-  scope :active, -> { where state: 'active' }
-  scope :inactive, -> { where state: 'inactive' }
+  default_scope { where state: "pending" }
+  scope :active, -> { where state: "active" }
+  scope :inactive, -> { where state: "inactive" }
 end
 
 User.all
@@ -2339,7 +2339,7 @@ User.all
 User.active
 # SELECT "users".* FROM "users" WHERE "users"."state" = 'pending' AND "users"."state" = 'active'
 
-User.where(state: 'inactive')
+User.where(state: "inactive")
 # SELECT "users".* FROM "users" WHERE "users"."state" = 'pending' AND "users"."state" = 'inactive'
 ```
 
@@ -2349,9 +2349,9 @@ To get the previous behavior it is needed to explicitly remove the
 
 ```ruby
 class User < ActiveRecord::Base
-  default_scope { where state: 'pending' }
-  scope :active, -> { unscope(where: :state).where(state: 'active') }
-  scope :inactive, -> { rewhere state: 'inactive' }
+  default_scope { where state: "pending" }
+  scope :active, -> { unscope(where: :state).where(state: "active") }
+  scope :inactive, -> { rewhere state: "inactive" }
 end
 
 User.all
@@ -2504,7 +2504,7 @@ end
 
 ```ruby
 # config/initializers/json_patch.rb
-Mime::Type.register 'application/json-patch+json', :json_patch
+Mime::Type.register "application/json-patch+json", :json_patch
 ```
 
 As JSON Patch was only recently made into an RFC, there aren't a lot of great
@@ -2581,11 +2581,11 @@ Rails 4.0 no longer supports loading plugins from `vendor/plugins`. You must rep
 
     ```ruby
     class CatalogCategory < ActiveRecord::Base
-      has_and_belongs_to_many :catalog_products, join_table: 'catalog_categories_catalog_products'
+      has_and_belongs_to_many :catalog_products, join_table: "catalog_categories_catalog_products"
     end
 
     class CatalogProduct < ActiveRecord::Base
-      has_and_belongs_to_many :catalog_categories, join_table: 'catalog_categories_catalog_products'
+      has_and_belongs_to_many :catalog_categories, join_table: "catalog_categories_catalog_products"
     end
     ```
 
@@ -2614,8 +2614,8 @@ Rails 4.0 extracted Active Resource to its own gem. If you still need the featur
 
     ```ruby
     # config/initializers/secret_token.rb
-    Myapp::Application.config.secret_token = 'existing secret token'
-    Myapp::Application.config.secret_key_base = 'new secret key base'
+    Myapp::Application.config.secret_token = "existing secret token"
+    Myapp::Application.config.secret_key_base = "new secret key base"
     ```
 
     Please note that you should wait to set `secret_key_base` until you have 100% of your userbase on Rails 4.x and are reasonably sure you will not need to rollback to Rails 3.x. This is because cookies signed based on the new `secret_key_base` in Rails 4.x are not backwards compatible with Rails 3.x. You are free to leave your existing `secret_token` in place, not set the new `secret_key_base`, and ignore the deprecation warnings until you are reasonably sure that your upgrade is otherwise complete.
@@ -2650,13 +2650,13 @@ Rails 4.0 extracted Active Resource to its own gem. If you still need the featur
 * Rails 4.0 raises an `ArgumentError` if clashing named routes are defined. This can be triggered by explicitly defined named routes or by the `resources` method. Here are two examples that clash with routes named `example_path`:
 
     ```ruby
-    get 'one' => 'test#example', as: :example
-    get 'two' => 'test#example', as: :example
+    get "one" => "test#example", as: :example
+    get "two" => "test#example", as: :example
     ```
 
     ```ruby
     resources :examples
-    get 'clashing/:id' => 'test#example', as: :example
+    get "clashing/:id" => "test#example", as: :example
     ```
 
     In the first case, you can simply avoid using the same name for multiple
@@ -2667,26 +2667,26 @@ Rails 4.0 extracted Active Resource to its own gem. If you still need the featur
 * Rails 4.0 also changed the way unicode character routes are drawn. Now you can draw unicode character routes directly. If you already draw such routes, you must change them, for example:
 
     ```ruby
-    get Rack::Utils.escape('こんにちは'), controller: 'welcome', action: 'index'
+    get Rack::Utils.escape("こんにちは"), controller: "welcome", action: "index"
     ```
 
     becomes
 
     ```ruby
-    get 'こんにちは', controller: 'welcome', action: 'index'
+    get "こんにちは", controller: "welcome", action: "index"
     ```
 
 * Rails 4.0 requires that routes using `match` must specify the request method. For example:
 
     ```ruby
     # Rails 3.x
-    match '/' => 'root#index'
+    match "/" => "root#index"
 
     # becomes
-    match '/' => 'root#index', via: :get
+    match "/" => "root#index", via: :get
 
     # or
-    get '/' => 'root#index'
+    get "/" => "root#index"
     ```
 
 * Rails 4.0 has removed `ActionDispatch::BestStandardsSupport` middleware, `<!DOCTYPE html>` already triggers standards mode per https://msdn.microsoft.com/en-us/library/jj676915(v=vs.85).aspx and ChromeFrame header has been moved to `config.action_dispatch.default_headers`.
@@ -2704,8 +2704,8 @@ Rails 4.0 extracted Active Resource to its own gem. If you still need the featur
 
     ```ruby
     config.action_dispatch.default_headers = {
-      'X-Frame-Options' => 'SAMEORIGIN',
-      'X-XSS-Protection' => '1; mode=block'
+      "X-Frame-Options" => "SAMEORIGIN",
+      "X-XSS-Protection" => "1; mode=block"
     }
     ```
 
@@ -2853,7 +2853,7 @@ If your application is using an "/assets" route for a resource you may want to c
 
 ```ruby
 # Defaults to '/assets'
-config.assets.prefix = '/asset-files'
+config.assets.prefix = "/asset-files"
 ```
 
 ### config/environments/development.rb
@@ -2902,7 +2902,7 @@ You can help test performance with these additions to your test environment:
 # Configure static asset server for tests with Cache-Control for performance
 config.public_file_server.enabled = true
 config.public_file_server.headers = {
-  'Cache-Control' => 'public, max-age=3600'
+  "Cache-Control" => "public, max-age=3600"
 }
 ```
 
@@ -2932,7 +2932,7 @@ You need to change your session key to something new, or remove all sessions:
 
 ```ruby
 # in config/initializers/session_store.rb
-AppName::Application.config.session_store :cookie_store, key: 'SOMETHINGNEW'
+AppName::Application.config.session_store :cookie_store, key: "SOMETHINGNEW"
 ```
 
 or

--- a/guides/source/working_with_javascript_in_rails.md
+++ b/guides/source/working_with_javascript_in_rails.md
@@ -228,7 +228,7 @@ def create
 
   respond_to do |format|
     if @post.save
-      format.turbo_stream { render turbo_stream: turbo_stream.prepend('posts', partial: 'post') }
+      format.turbo_stream { render turbo_stream: turbo_stream.prepend("posts", partial: "post") }
     else
       format.html { render :new, status: :unprocessable_entity }
     end
@@ -244,7 +244,7 @@ To broadcast a Turbo Stream from a model combine a model callback like this:
 
 ```ruby
 class Post < ApplicationRecord
-  after_create_commit { broadcast_append_to('posts') }
+  after_create_commit { broadcast_append_to("posts") }
 end
 ```
 


### PR DESCRIPTION
After #53321 it occurred to me that we can just inherit the rule from the main rubocop settings and apply this across all guides.

Probably I meant to come back to these rules, and `mdl` but forgot.

This should also reduce pull requests for "the example in this guide made my linter fail".

Another open question is should the guides follow the frameworks rules, or omakase rules. :thinking: 