### PR TITLE
Correctly check whether Action Cable is enabled in `AuthenticationGenerator`

### DIFF
--- a/railties/lib/rails/generators/rails/authentication/authentication_generator.rb
+++ b/railties/lib/rails/generators/rails/authentication/authentication_generator.rb
@@ -19,7 +19,7 @@ module Rails
         template "app/controllers/concerns/authentication.rb"
         template "app/controllers/passwords_controller.rb"
 
-        template "app/channels/application_cable/connection.rb" unless options.skip_action_cable?
+        template "app/channels/application_cable/connection.rb" if defined?(ActionCable::Engine)
 
         template "app/mailers/passwords_mailer.rb"
 

--- a/railties/test/generators/authentication_generator_test.rb
+++ b/railties/test/generators/authentication_generator_test.rb
@@ -108,11 +108,14 @@ class AuthenticationGeneratorTest < Rails::Generators::TestCase
   end
 
   def test_connection_class_skipped_without_action_cable
-    generator([destination_root], skip_action_cable: true)
-
+    old_value = ActionCable.const_get(:Engine)
+    ActionCable.send(:remove_const, :Engine)
+    generator([destination_root])
     run_generator_instance
 
     assert_no_file "app/channels/application_cable/connection.rb"
+  ensure
+    ActionCable.const_set(:Engine, old_value)
   end
 
   private


### PR DESCRIPTION

### Motivation / Background


`AuthenticationGenerator` doesn't handle `skip_action_cable` option so far(`AppGenerator` only handles it).
https://github.com/rails/rails/blob/e6429269fd5a8a7d728557f4e7d7f82c0ad1478c/railties/lib/rails/generators/rails/authentication/authentication_generator.rb#L6-L8

So the current check doesn't work correctly.

Instead of depending on that option, this PR changes to check whether the engine is enabled or not. We already do the same thing. https://github.com/rails/rails/blob/e6429269fd5a8a7d728557f4e7d7f82c0ad1478c/railties/lib/rails/commands/app/update_command.rb#L71



### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
