### PR TITLE
[ci skip] Guides: Alternative Exim Relay Script for Action Mailbox

### DIFF
--- a/guides/source/action_mailbox_basics.md
+++ b/guides/source/action_mailbox_basics.md
@@ -108,6 +108,10 @@ action_mailbox:ingress:exim`, providing the `URL` of the relay ingress and the
 $ bin/rails action_mailbox:ingress:exim URL=https://example.com/rails/action_mailbox/relay/inbound_emails INGRESS_PASSWORD=...
 ```
 
+NOTE: As an alternative, task `action_mailbox:ingress:exim` can be replace
+by a [bash script](https://gist.github.com/gabriel-curtino/034aa4c9174ec21e37eb462f087c087c) 
+allowing exim and rails work independently in different servers/containers.
+
 ### Mailgun
 
 Give Action Mailbox your Mailgun Signing key (which you can find under Settings


### PR DESCRIPTION
### Motivation / Background

It seems Action Mailbox guide expects exim pipes the inbound emails to a rails task, meaning rails the Rails app must be run in that location. This task does some checks and trigger a post request to the app inbound emails path. 

This results very inconvenient when deploying in containers with Kamal or cannot install rails where the mail server is.   

### Detail

I'm adding to the guide a NOTE with an alternative for replacing that task with a bash script.

Here the link included: https://gist.github.com/gabriel-curtino/034aa4c9174ec21e37eb462f087c087c

### Additional information

It works for me :)

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
