### PR TITLE
Deduplicate `with` CTE expressions

### DIFF
--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -498,7 +498,8 @@ module ActiveRecord
 
     # Like #with, but modifies relation in place.
     def with!(*args) # :nodoc:
-      self.with_values += args
+      args = process_with_args(args)
+      self.with_values |= args
       self
     end
 
@@ -521,7 +522,8 @@ module ActiveRecord
 
     # Like #with_recursive but modifies the relation in place.
     def with_recursive!(*args) # :nodoc:
-      self.with_values += args
+      args = process_with_args(args)
+      self.with_values |= args
       @with_is_recursive = true
       self
     end
@@ -2241,6 +2243,12 @@ module ActiveRecord
             arel_column(key)
               .as(model.adapter_class.quote_column_name(columns_aliases.to_s))
           end
+        end
+      end
+
+      def process_with_args(args)
+        args.flat_map do |arg|
+          arg.map { |k, v| { k => v } }
         end
       end
 

--- a/activerecord/test/cases/relation/mutation_test.rb
+++ b/activerecord/test/cases/relation/mutation_test.rb
@@ -5,7 +5,7 @@ require "models/post"
 
 module ActiveRecord
   class RelationMutationTest < ActiveRecord::TestCase
-    (Relation::MULTI_VALUE_METHODS - [:extending, :order, :unscope, :select]).each do |method|
+    (Relation::MULTI_VALUE_METHODS - [:extending, :order, :unscope, :select, :with]).each do |method|
       test "##{method}!" do
         assert relation.public_send("#{method}!", :foo).equal?(relation)
         assert_equal [:foo], relation.public_send("#{method}_values")

--- a/activerecord/test/cases/relation/with_test.rb
+++ b/activerecord/test/cases/relation/with_test.rb
@@ -45,6 +45,16 @@ module ActiveRecord
         assert_equal POSTS_WITH_TAGS_AND_COMMENTS, relation.order(:id).pluck(:id)
       end
 
+      def test_multiple_dupicate_with_calls
+        posts_with_tags = Post.where("tags_count > 0")
+        relation = Post
+          .with(posts_with_tags: posts_with_tags, one_more_posts_with_tags: posts_with_tags)
+          .with(posts_with_tags: posts_with_tags)
+          .from("posts_with_tags AS posts")
+
+        assert_equal POSTS_WITH_TAGS, relation.order(:id).pluck(:id)
+      end
+
       def test_count_after_with_call
         relation = Post.with(posts_with_comments: Post.where("legacy_comments_count > 0"))
 


### PR DESCRIPTION
Fixes #53468.

While working on this, I noticed that `Relation` class overrides `==` method https://github.com/rails/rails/blob/e6429269fd5a8a7d728557f4e7d7f82c0ad1478c/activerecord/lib/active_record/relation.rb#L1252-L1262 but not `eql?`. Thats why I needed to pass the same `post_with_tags` object in the test 2 times. Is this expected?