### PR TITLE
Speedup ActiveModel::Type::Integer#serialize by up to 10x

### DIFF
--- a/activemodel/lib/active_model/type/big_integer.rb
+++ b/activemodel/lib/active_model/type/big_integer.rb
@@ -23,14 +23,30 @@ module ActiveModel
     # All casting and serialization are performed in the same way as the
     # standard ActiveModel::Type::Integer type.
     class BigInteger < Integer
+      def serialize(value) # :nodoc:
+        case value
+        when ::Integer
+          # noop
+        when ::String
+          int = value.to_i
+          if int.zero? && value != "0"
+            return if non_numeric_string?(value)
+          end
+          value = int
+        else
+          value = super
+        end
+
+        value
+      end
+
       def serialize_cast_value(value) # :nodoc:
         value
       end
 
-      private
-        def max_value
-          ::Float::INFINITY
-        end
+      def serializable?(value, &_)
+        true
+      end
     end
   end
 end

--- a/activemodel/lib/active_model/type/integer.rb
+++ b/activemodel/lib/active_model/type/integer.rb
@@ -50,7 +50,8 @@ module ActiveModel
 
       def initialize(**)
         super
-        @range = min_value...max_value
+        @max = max_value
+        @min = min_value
       end
 
       def type
@@ -63,38 +64,48 @@ module ActiveModel
       end
 
       def serialize(value)
-        return if value.is_a?(::String) && non_numeric_string?(value)
-        ensure_in_range(super)
+        case value
+        when ::Integer
+          # noop
+        when ::String
+          int = value.to_i
+          if int.zero? && value != "0"
+            return if non_numeric_string?(value)
+          end
+          value = int
+        else
+          value = super
+        end
+
+        if out_of_range?(value)
+          raise ActiveModel::RangeError, "#{value} is out of range for #{self.class} with limit #{_limit} bytes"
+        end
+
+        value
       end
 
       def serialize_cast_value(value) # :nodoc:
-        ensure_in_range(value)
+        if out_of_range?(value)
+          raise ActiveModel::RangeError, "#{value} is out of range for #{self.class} with limit #{_limit} bytes"
+        end
+
+        value
       end
 
       def serializable?(value)
         cast_value = cast(value)
-        in_range?(cast_value) || begin
-          yield cast_value if block_given?
-          false
-        end
+        return true unless out_of_range?(cast_value)
+        yield cast_value if block_given?
+        false
       end
 
       private
-        attr_reader :range
-
-        def in_range?(value)
-          !value || range.member?(value)
+        def out_of_range?(value)
+          value && (@max <= value || @min > value)
         end
 
         def cast_value(value)
           value.to_i rescue nil
-        end
-
-        def ensure_in_range(value)
-          unless in_range?(value)
-            raise ActiveModel::RangeError, "#{value} is out of range for #{self.class} with limit #{_limit} bytes"
-          end
-          value
         end
 
         def max_value


### PR DESCRIPTION
- Add a fast path for Integer.
- Avoid using a regexp to check for numeric strings.
- Directly compare with min/max rather than use a Range.
- Inline some methods.

```
== str ==
ruby 3.3.4 (2024-07-09 revision be1089c8ec) +YJIT [arm64-darwin23]
Warming up --------------------------------------
       int.serialize   267.586k i/100ms
   opt_int.serialize     2.262M i/100ms
Calculating -------------------------------------
       int.serialize      2.819M (± 1.4%) i/s  (354.69 ns/i) -     14.182M in   5.031217s
   opt_int.serialize     27.275M (± 1.0%) i/s   (36.66 ns/i) -    137.969M in   5.058951s

Comparison:
       int.serialize:  2819388.8 i/s
   opt_int.serialize: 27275044.9 i/s - 9.67x  faster

== int ==
ruby 3.3.4 (2024-07-09 revision be1089c8ec) +YJIT [arm64-darwin23]
Warming up --------------------------------------
       int.serialize     1.147M i/100ms
   opt_int.serialize     3.272M i/100ms
Calculating -------------------------------------
       int.serialize     15.327M (± 1.2%) i/s   (65.25 ns/i) -     76.821M in   5.012973s
   opt_int.serialize     48.652M (± 1.3%) i/s   (20.55 ns/i) -    245.397M in   5.044720s

Comparison:
       int.serialize: 15326758.3 i/s
   opt_int.serialize: 48652088.8 i/s - 3.17x  faster
```

```ruby
# frozen_string_literal: true

require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"

  gem "rails", "8.0.0.rc1"
  gem "sqlite3"
  gem "benchmark-ips"
end

require "active_record"
require "benchmark/ips"
require "logger"

module ActiveModel
  module Type
    class OptInteger < Value
      include Helpers::Numeric

      # Column storage size in bytes.
      # 4 bytes means an integer as opposed to smallint etc.
      DEFAULT_LIMIT = 4

      def initialize(**)
        super
        @max = max_value
        @min = min_value
      end

      def type
        :integer
      end

      def deserialize(value)
        return if value.blank?
        value.to_i
      end

      def serialize(value)
        case value
        when ::Integer
          # noop
        when ::String
          int = value.to_i
          if int.zero? && value != "0"
            return if non_numeric_string?(value)
          end
          value = int
        else
          value = super
        end

        if out_of_range?(value)
          raise ActiveModel::RangeError, "#{value} is out of range for #{self.class} with limit #{_limit} bytes"
        end

        value
      end

      def serialize_cast_value(value) # :nodoc:
        if out_of_range?(value)
          raise ActiveModel::RangeError, "#{value} is out of range for #{self.class} with limit #{_limit} bytes"
        end

        value
      end

      def serializable?(value)
        cast_value = cast(value)
        return true unless out_of_range?(cast_value)
        yield cast_value if block_given?
        false
      end

      private
        def out_of_range?(value)
          value && (@max <= value || @min > value)
        end

        def cast_value(value)
          value.to_i rescue nil
        end

        def max_value
          1 << (_limit * 8 - 1) # 8 bits per byte with one bit for sign
        end

        def min_value
          -max_value
        end

        def _limit
          limit || DEFAULT_LIMIT
        end
    end
  end
end

int = ActiveModel::Type::Integer.new
opt_int = ActiveModel::Type::OptInteger.new

puts "== str =="

Benchmark.ips do |x|
  x.report("int.serialize") { int.serialize("42") }
  x.report("opt_int.serialize") { opt_int.serialize("42") }
  x.compare!(order: :baseline)
end

puts "== int =="

Benchmark.ips do |x|
  x.report("int.serialize") { int.serialize(42) }
  x.report("opt_int.serialize") { opt_int.serialize(42) }
  x.compare!(order: :baseline)
end
```