### PR TITLE
Add CHANGELOG entry for 170e6c1 [ci-skip]

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Set `.attributes_for_inspect` to `:all` by default.
+
+    For new applications it is set to `[:id]` in config/environment/production.rb.
+
+    In the console all the attributes are always shown.
+
+    *Andrew Novoselac*
+
 *   `PG::UnableToSend: no connection to the server` is now retryable as a connection-related exception
 
     *Kazuma Watanabe*


### PR DESCRIPTION
For new appliciations `.attributes_for_inspect` is set to `[:id]` in
config/environment/production.rb.

In the console all the attributes are always shown.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
