### PR TITLE
Always show all attributes in the console

### DIFF
--- a/activerecord/lib/active_record/railtie.rb
+++ b/activerecord/lib/active_record/railtie.rb
@@ -69,7 +69,7 @@ module ActiveRecord
         Rails.logger.broadcast_to(console)
       end
       ActiveRecord.verbose_query_logs = false
-      ActiveRecord::Base.attributes_for_inspect = :all if Rails.env.production?
+      ActiveRecord::Base.attributes_for_inspect = :all
     end
 
     runner do


### PR DESCRIPTION
### Motivation / Background

When `ActiveRecord::Core.attributes_for_inspect` is set to `[:id]` in a non-production environment, `#inspect` will only show the `id` attribute, while it will show all attributes in production.

If `.attributes_for_inspect` is set to `:all` for production console, we probably want this behaviour in all environments.

Follow up to https://github.com/rails/rails/pull/52801

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
