### PR TITLE
refactor: remove redundant `serialize_argument(true)` call in `serialize_indifferent_hash`

### DIFF
--- a/activejob/lib/active_job/arguments.rb
+++ b/activejob/lib/active_job/arguments.rb
@@ -170,7 +170,7 @@ module ActiveJob
 
       def serialize_indifferent_hash(indifferent_hash)
         result = serialize_hash(indifferent_hash)
-        result[WITH_INDIFFERENT_ACCESS_KEY] = serialize_argument(true)
+        result[WITH_INDIFFERENT_ACCESS_KEY] = true
         result
       end
 


### PR DESCRIPTION
### Motivation / Background

Remove redundant `serialize_argument(true)` method call to improve readability.

### Detail

It seems that calling the `serialize_argument(true)` method looks redundant. It seems to me that it is enough to assign `true` to `result[WITH_INDIFFERENT_ACCESS_KEY]`, if I understood everything correctly.
