### PR TITLE
Unify query values deduplication for multi values

### DIFF
--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -508,7 +508,6 @@ module ActiveRecord
 
       def execute_grouped_calculation(operation, column_name, distinct) # :nodoc:
         group_fields = group_values
-        group_fields = group_fields.uniq if group_fields.size > 1
 
         if group_fields.size == 1 && group_fields.first.respond_to?(:to_sym)
           association  = model._reflect_on_association(group_fields.first)

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -576,7 +576,7 @@ module ActiveRecord
     end
 
     def group!(*args) # :nodoc:
-      self.group_values += args
+      self.group_values |= args
       self
     end
 
@@ -809,7 +809,7 @@ module ActiveRecord
     end
 
     def unscope!(*args) # :nodoc:
-      self.unscope_values += args
+      self.unscope_values |= args
 
       args.each do |scope|
         case scope
@@ -1465,7 +1465,7 @@ module ActiveRecord
       modules << Module.new(&block) if block
       modules.flatten!
 
-      self.extending_values += modules
+      self.extending_values |= modules
       extend(*extending_values) if extending_values.any?
 
       self
@@ -1533,7 +1533,7 @@ module ActiveRecord
 
     # Like #annotate, but modifies relation in place.
     def annotate!(*args) # :nodoc:
-      self.annotate_values += args
+      self.annotate_values |= args
       self
     end
 
@@ -1756,22 +1756,17 @@ module ActiveRecord
         arel.having(having_clause.ast) unless having_clause.empty?
         arel.take(build_cast_value("LIMIT", connection.sanitize_limit(limit_value))) if limit_value
         arel.skip(build_cast_value("OFFSET", offset_value.to_i)) if offset_value
-        arel.group(*arel_columns(group_values.uniq)) unless group_values.empty?
+        arel.group(*arel_columns(group_values)) unless group_values.empty?
 
         build_order(arel)
         build_with(arel)
         build_select(arel)
 
         arel.optimizer_hints(*optimizer_hints_values) unless optimizer_hints_values.empty?
+        arel.comment(*annotate_values) unless annotate_values.empty?
         arel.distinct(distinct_value)
         arel.from(build_from) unless from_clause.empty?
         arel.lock(lock_value) if lock_value
-
-        unless annotate_values.empty?
-          annotates = annotate_values
-          annotates = annotates.uniq if annotates.size > 1
-          arel.comment(*annotates)
-        end
 
         arel
       end
@@ -2261,11 +2256,11 @@ module ActiveRecord
         values = other.values
         STRUCTURAL_VALUE_METHODS.reject do |method|
           v1, v2 = @values[method], values[method]
-          if v1.is_a?(Array)
-            next true unless v2.is_a?(Array)
-            v1 = v1.uniq
-            v2 = v2.uniq
-          end
+
+          # `and`/`or` are focused to combine where-like clauses, so it relaxes
+          # the difference when other's multi values are uninitialized.
+          next true if v1.is_a?(Array) && v2.nil?
+
           v1 == v2
         end
       end

--- a/activerecord/test/cases/relation/merging_test.rb
+++ b/activerecord/test/cases/relation/merging_test.rb
@@ -94,7 +94,6 @@ class RelationMergingTest < ActiveRecord::TestCase
 
     assert_equal [david, bob], mary_and_bob.merge(Author.where(id: [david, bob]))
 
-
     assert_equal [mary, bob], david_and_mary.merge(mary_and_bob)
     assert_equal [mary], david_and_mary.and(mary_and_bob)
     assert_equal authors, david_and_mary.or(mary_and_bob)

--- a/activerecord/test/cases/relation_test.rb
+++ b/activerecord/test/cases/relation_test.rb
@@ -42,6 +42,25 @@ module ActiveRecord
       end
     end
 
+    def test_multi_values_deduplication_with_merge
+      expected = {
+        unscope:   [ :where ],
+        extending: [ Module.new ],
+        with:      [ foo: Post.all ],
+      }
+      expected.default = [ Object.new ]
+
+      Relation::MULTI_VALUE_METHODS.each do |method|
+        getter, setter = "#{method}_values", "#{method}_values="
+        values = expected[method]
+        relation = Relation.new(FakeKlass)
+        relation.public_send(setter, values)
+
+        assert_equal values, relation.public_send(getter), method
+        assert_equal values, relation.merge(relation).public_send(getter), method
+      end
+    end
+
     def test_extensions
       relation = Relation.new(FakeKlass)
       assert_equal [], relation.extensions


### PR DESCRIPTION
In the multi values normalization #39333, I also wanted to deduplicate that (#38145, 29874cc), but the lack of deduplication for some multi values was leaking into the behavior (#39171), so we had to deprecate that behavior first (#39358).

And then the newly added multi values caused an issue again due to the lack of deduplication (#53468).

To avoid such issues in the future, deduplicate all remaining multi values that are not currently deduplicated, and add a test to ensure that all multi values (including those that will be added in the future) are deduplicated.
