### PR TITLE
Respect db config `query_cache` in railtie executor hook

### DIFF
--- a/activerecord/lib/active_record/query_cache.rb
+++ b/activerecord/lib/active_record/query_cache.rb
@@ -35,7 +35,10 @@ module ActiveRecord
     end
 
     def self.run
-      ActiveRecord::Base.connection_handler.each_connection_pool.reject(&:query_cache_enabled).each(&:enable_query_cache!)
+      ActiveRecord::Base.connection_handler.each_connection_pool.reject(&:query_cache_enabled).each do |pool|
+        next if pool.db_config&.query_cache == false
+        pool.enable_query_cache!
+      end
     end
 
     def self.complete(pools)


### PR DESCRIPTION
We have [documented](https://edgeguides.rubyonrails.org/configuring.html#configuring-query-cache) the ability to disable the query cache from db config, as well as implicitly being able to modify the size of the cache:

https://github.com/rails/rails/blob/8c80b02a66fb6f2cf6940027d756bf7d94d6cf53/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb#L121-L129

This was added in #48110.

When updating an app to Rails 7.1, we wanted to keep using the cache unbounded while we put in place the proper instrumentation for observing that change.

<details>
<summary>
Here is a full reproducible script:
</summary>

```yaml
# config/database.yml
development:
  adapter: sqlite3
  database: ":memory:"
  pool: 5
  timeout: 5000
  query_cache: false
```

```ruby
# bug.rb

# frozen_string_literal: true

require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"

  gem "rails"
  gem "sqlite3"
end

require "active_record"
require "active_record/railtie"
require "logger"

class TestApp < Rails::Application
  config.load_defaults Rails::VERSION::STRING.to_f

  config.root = __dir__
  config.hosts << "example.org"
  config.eager_load = false
  config.session_store :cookie_store, key: "cookie_store_key"
  config.secret_key_base = "secret_key_base"

  config.logger = Logger.new($stdout)
  Rails.logger  = config.logger
end

puts "Rails version: #{Rails.version}"

ActiveRecord::Base.pluralize_table_names = false
ActiveRecord::Base.logger = Logger.new(STDOUT)

Rails.application.initialize!

ActiveRecord::Schema.define do
  create_table :one
  create_table :two
  create_table :three
  create_table :four
  create_table :five
end

class One < ActiveRecord::Base; end
class Two < ActiveRecord::Base; end
class Three < ActiveRecord::Base; end
class Four < ActiveRecord::Base; end
class Five < ActiveRecord::Base; end

require "minitest/autorun"
require "rails/test_help"

class BugTest < ActiveSupport::TestCase
  def setup
    @mapping = {
      1 => "One",
      2 => "Two",
      3 => "Three",
      4 => "Four",
      5 => "Five",
    }
  end

  def test_association_stuff
    (1..5).each do |i|
      @mapping[i].constantize.create!
    end

    (1..5).each do |i|
      assert_queries_count(1) do
        @mapping[i].constantize.first
      end
    end

    assert_queries_count(1) do
      One.first
    end

    assert_equal 0, ActiveRecord::Base.connection.query_cache.size
  end
end
```

</details>

/cc @byroot 