### PR TITLE
Add `after_or_equal?` and `before_or_equal?` methods

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,14 @@
+*   Add `after_or_equal?` and `before_or_equal?` methods to `Date`, `DateTime`, `Time`, and `TimeWithZone`.
+
+    These methods provide a more readable alternative to using `>=` and `<=` when comparing dates and times.
+
+    ```ruby
+    time1.after_or_equal?(time2)  # equivalent to time1 >= time2
+    time1.before_or_equal?(time2) # equivalent to time1 <= time2
+    ```
+
+    *martinfsn*
+
 *   `ActiveSupport::CurrentAttributes#attributes` now will return a new hash object on each call.
 
     Previously, the same hash object was returned each time that method was called.

--- a/activesupport/lib/active_support/core_ext/date_and_time/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/date_and_time/calculations.rb
@@ -68,9 +68,19 @@ module DateAndTime
       self < date_or_time
     end
 
+    # Returns true if the date/time falls before or equal to <tt>date_or_time</tt>.
+    def before_or_equal?(date_or_time)
+      self <= date_or_time
+    end
+
     # Returns true if the date/time falls after <tt>date_or_time</tt>.
     def after?(date_or_time)
       self > date_or_time
+    end
+
+    # Returns true if the date/time falls after or equal to <tt>date_or_time</tt>.
+    def after_or_equal?(date_or_time)
+      self >= date_or_time
     end
 
     # Returns a new date/time the specified number of days ago.

--- a/activesupport/test/core_ext/date_and_time_behavior.rb
+++ b/activesupport/test/core_ext/date_and_time_behavior.rb
@@ -346,10 +346,22 @@ module DateAndTimeBehavior
     assert_equal true, date_time_init(2017, 3, 6, 12, 0, 0).before?(date_time_init(2017, 3, 7, 12, 0, 0))
   end
 
+  def test_before_or_equal
+    assert_equal false, date_time_init(2024, 3, 6, 12, 0, 0).before_or_equal?(date_time_init(2024, 3, 5, 12, 0, 0))
+    assert_equal true, date_time_init(2024, 3, 6, 12, 0, 0).before_or_equal?(date_time_init(2024, 3, 6, 12, 0, 0))
+    assert_equal true, date_time_init(2024, 3, 6, 12, 0, 0).before_or_equal?(date_time_init(2024, 3, 7, 12, 0, 0))
+  end
+
   def test_after
     assert_equal true, date_time_init(2017, 3, 6, 12, 0, 0).after?(date_time_init(2017, 3, 5, 12, 0, 0))
     assert_equal false, date_time_init(2017, 3, 6, 12, 0, 0).after?(date_time_init(2017, 3, 6, 12, 0, 0))
     assert_equal false, date_time_init(2017, 3, 6, 12, 0, 0).after?(date_time_init(2017, 3, 7, 12, 0, 0))
+  end
+
+  def test_after_or_equal
+    assert_equal true, date_time_init(2024, 3, 6, 12, 0, 0).after_or_equal?(date_time_init(2024, 3, 5, 12, 0, 0))
+    assert_equal true, date_time_init(2024, 3, 6, 12, 0, 0).after_or_equal?(date_time_init(2024, 3, 6, 12, 0, 0))
+    assert_equal false, date_time_init(2024, 3, 6, 12, 0, 0).after_or_equal?(date_time_init(2024, 3, 7, 12, 0, 0))
   end
 
   def with_bw_default(bw = :monday)


### PR DESCRIPTION
### Motivation / Background

In our  production application, we frequently need to compare dates to determine whether one date occurs before or after another. In many cases, it’s necessary to account for dates that may also be equal, ensuring that comparisons include the possibility of two dates being the same. 

Currently, `ActiveSupport` provides standard comparison (`after?` & `before?`) methods for dates but lacks dedicated methods to explicitly check if a date is before or equal to or after or equal to another date. Therefore, we need to use `<=` and `>=`.

Adding `before_or_equal_to?` and `after_or_equal_to?` methods enhances readability and simplifies conditional logic when performing these common checks.

### Detail

This pull request adds `after_or_equal?` and `before_or_equal?` methods to `Date`, `DateTime`, `Time`, and `TimeWithZone`.

These methods provide a more readable alternative to using `>=` and `<=` when comparing dates and times.

 ```ruby
    time1.after_or_equal?(time2)  # equivalent to time1 >= time2
    time1.before_or_equal?(time2) # equivalent to time1 <= time2
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
