### PR TITLE
Fix for Lighthouse getting a 406 page when it should be ignored as it is a bot

### DIFF
--- a/actionpack/lib/action_controller/metal/allow_browser.rb
+++ b/actionpack/lib/action_controller/metal/allow_browser.rb
@@ -61,7 +61,7 @@ module ActionController # :nodoc:
 
     private
       def allow_browser(versions:, block:)
-        require "useragent"
+        require_relative "./useragent"
 
         if BrowserBlocker.new(request, versions: versions).blocked?
           ActiveSupport::Notifications.instrument("browser_block.action_controller", request: request, versions: versions) do

--- a/actionpack/lib/action_controller/metal/useragent.rb
+++ b/actionpack/lib/action_controller/metal/useragent.rb
@@ -1,0 +1,18 @@
+require "useragent"
+
+# Monkey Patching UserAgent to handle Google PageSpeed Insights
+# Until fix in this PR is merged and gem is updated https://github.com/gshutler/useragent/pull/67
+class UserAgent
+  def bot?
+    # Google PageSpeed Insights adds "Chrome-Lighthouse" to the user agent
+    # https://stackoverflow.com/questions/16403295/what-is-the-name-of-the-google-pagespeed-user-agent
+    if detect_product("Chrome-Lighthouse")
+      true
+    else
+      original_bot?
+    end
+  end
+
+  private
+    alias_method :original_bot?, :bot?
+end

--- a/actionpack/test/controller/allow_browser_test.rb
+++ b/actionpack/test/controller/allow_browser_test.rb
@@ -34,6 +34,7 @@ class AllowBrowserTest < ActionController::TestCase
   IE_11         = "Mozilla/5.0 (Windows NT 10.0; WOW64; Trident/7.0; rv:11.0) like Gecko"
   OPERA_106     = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36 OPR/106.0.0.0"
   GOOGLE_BOT    = "Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5X Build/MMB29P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/W.X.Y.Z Mobile Safari/537.36 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)"
+  LIGHTHOUSE    = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/94.0.4590.2 Safari/537.36 Chrome-Lighthouse"
 
   test "blocked browser below version limit with callable" do
     get_with_agent :hello, FIREFOX_114
@@ -80,6 +81,9 @@ class AllowBrowserTest < ActionController::TestCase
     assert_response :ok
 
     get_with_agent :modern, GOOGLE_BOT
+    assert_response :ok
+
+    get_with_agent :modern, LIGHTHOUSE
     assert_response :ok
   end
 


### PR DESCRIPTION
### Motivation / Background

When using newer version of Rails that support `allow_browser :modern`, there is an issue rendering the page when testing with PageSpeed Insight (Formerly called Chrome Lighthouse). The tool makes a request using the following User Agent and is actually a bot making the request to the website to test out how the page performs. Since this is a bot and used for PageInsight this PR is to allow the request to go through by considering this User Agent as a bot.

![image](https://github.com/user-attachments/assets/8f572861-cf9d-4cde-90b7-b955e0a596be)

### Detail

This Pull Request changes `UserAgent` to check if the product is `Chrome-Lighthouse` and if so it will consider it as bot otherwise it will use existing logic to check for bot.

### Checklist

Before submitting the PR make sure the following are checked:

* [ ] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [ ] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
