### PR TITLE
fix incorrect notification order in raw_execute

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -551,11 +551,13 @@ module ActiveRecord
         # Lowest level way to execute a query. Doesn't check for illegal writes, doesn't annotate queries, yields a native result object.
         def raw_execute(sql, name = nil, binds = [], prepare: false, async: false, allow_retry: false, materialize_transactions: true, batch: false)
           type_casted_binds = type_casted_binds(binds)
-          log(sql, name, binds, type_casted_binds, async: async) do |notification_payload|
-            with_raw_connection(allow_retry: allow_retry, materialize_transactions: materialize_transactions) do |conn|
+          with_raw_connection(allow_retry: allow_retry, materialize_transactions: materialize_transactions) do |conn|
+            log(sql, name, binds, type_casted_binds, async: async) do |notification_payload|
               perform_query(conn, sql, binds, type_casted_binds, prepare: prepare, notification_payload: notification_payload, batch: batch)
             end
           end
+        rescue ActiveRecord::StatementInvalid => ex
+          raise ex.set_query(sql, binds)
         end
 
         def perform_query(raw_connection, sql, binds, type_casted_binds, prepare:, notification_payload:, batch:)

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -794,7 +794,7 @@ module ActiveRecord
         QUERY_CANCELED        = "57014"
 
         def translate_exception(exception, message:, sql:, binds:)
-          return exception unless exception.respond_to?(:result)
+          return super unless exception.respond_to?(:result)
 
           case exception.result.try(:error_field, PG::PG_DIAG_SQLSTATE)
           when nil

--- a/activerecord/lib/active_record/errors.rb
+++ b/activerecord/lib/active_record/errors.rb
@@ -609,6 +609,9 @@ module ActiveRecord
   # the database version cannot be determined.
   class DatabaseVersionError < ActiveRecordError
   end
+
+  class InstrumenterError < StandardError
+  end
 end
 
 require "active_record/associations/errors"

--- a/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
@@ -469,9 +469,11 @@ module ActiveRecord
       end
 
       def test_raise_error_when_cannot_translate_exception
-        assert_raise TypeError do
+        error = assert_raise ActiveRecord::StatementInvalid do
           @connection.send(:log, nil) { @connection.execute(nil) }
         end
+
+        assert(error.cause.is_a?(TypeError))
       end
 
       def test_translate_no_connection_exception_to_not_established


### PR DESCRIPTION
### Motivation / Background

Notifications emitted by `#raw_execute` are in the incorrect order.

### Detail

For ActiveSupport::Notifications tracing subscribers, the events emitted from transaction-wrapped statements appear to have the form:

- execute statement
  - begin transaction
- commit transaction

i.e., the `BEGIN TRANSACTION` seems to be nested within the statement.

This behavior changed in https://github.com/rails/rails/pull/44576. For loggers or other subscribers that receive a single notification per event, this probably did not change anything, as the 'finishes' are still in the correct order. However, for subscribers that process start and finish events individually (e.g., tracers), this ordering implies that "execute statement" is a parent event of "begin" — which is not correct in terms of how this was previously understood.

Reproduction of the issue:

```ruby
# frozen_string_literal: true

require 'bundler/inline'

gemfile(true) do
  source 'https://rubygems.org'

  git_source(:github) { |repo| "https://github.com/#{repo}.git" }

  # gem 'rails'
  # If you want to test against edge Rails replace the previous line with this:
  #
  # first bad commit:
  gem 'rails', github: 'rails/rails', ref: '723d410517'

  gem 'sqlite3'
end

require 'active_record'
require 'minitest/autorun'
require 'logger'

# This connection will do for database-independent bug reports.
ActiveRecord::Base.establish_connection(adapter: 'sqlite3', database: ':memory:')
ActiveRecord::Base.logger = Logger.new(STDOUT)

class Subscriber
  attr_reader :events

  def initialize
    @events = []
  end

  def start(_name, _id, payload)
    return if payload[:name] == 'SCHEMA'

    # substitution here to strip out the new default return on the main branch
    events << [:start, payload[:sql].sub(/ RETURNING "id"/, '')]
  end

  def finish(_name, _id, payload)
    return if payload[:name] == 'SCHEMA'

    events << [:finish, payload[:sql].sub(/ RETURNING "id"/, '')]
  end

  def publish(*); end

  def publish_event(*); end
end

ActiveRecord::Schema.define do
  create_table :posts, force: true do |t|
  end
end

class Post < ActiveRecord::Base
  has_many :comments
end

class Comment < ActiveRecord::Base
  belongs_to :post
end

class BugTest < Minitest::Test
  def test_association_stuff
    subscriber = Subscriber.new
    ActiveSupport::Notifications.subscribe('sql.active_record', subscriber)

    post = Post.create!

    post.destroy

    create_events = subscriber.events.slice!(0, 6)
    destroy_events = subscriber.events

    expected_create_order = [
      [:start, 'BEGIN immediate TRANSACTION'],
      [:finish, 'BEGIN immediate TRANSACTION'],
      [:start, 'INSERT INTO "posts" DEFAULT VALUES'],
      [:finish, 'INSERT INTO "posts" DEFAULT VALUES'],
      [:start, 'COMMIT TRANSACTION'],
      [:finish, 'COMMIT TRANSACTION']
    ]

    expected_destroy_order = [
      [:start, 'BEGIN immediate TRANSACTION'],
      [:finish, 'BEGIN immediate TRANSACTION'],
      [:start, 'DELETE FROM "posts" WHERE "posts"."id" = ?'],
      [:finish, 'DELETE FROM "posts" WHERE "posts"."id" = ?'],
      [:start, 'COMMIT TRANSACTION'],
      [:finish, 'COMMIT TRANSACTION']
    ]

    assert_equal(expected_create_order, create_events)
    assert_equal(expected_destroy_order, destroy_events)
  end
end
```

### Additional information

Fixes https://github.com/rails/rails/issues/50562

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
