### PR TITLE
Fix incorrect database.yml with skip_solid

### DIFF
--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -271,7 +271,8 @@ module Rails
         active_storage: !options[:skip_active_storage],
         dev: options[:dev],
         node: using_node?,
-        app_name: app_name
+        app_name: app_name,
+        skip_solid: options[:skip_solid]
       }
 
       Rails::Generators::DevcontainerGenerator.new([], devcontainer_options).invoke_all

--- a/railties/lib/rails/generators/rails/devcontainer/devcontainer_generator.rb
+++ b/railties/lib/rails/generators/rails/devcontainer/devcontainer_generator.rb
@@ -29,6 +29,9 @@ module Rails
       class_option :kamal, type: :boolean, default: true,
                     desc: "Include configuration for Kamal"
 
+      class_option :skip_solid, type: :boolean, default: nil,
+                    desc: "Skip Solid Cache & Queue setup"
+
       source_paths << File.expand_path(File.join(base_name, "app", "templates"), base_root)
 
       def create_devcontainer

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -1371,6 +1371,18 @@ class AppGeneratorTest < Rails::Generators::TestCase
     end
   end
 
+
+  def test_devcontainer_postgresql_skip_solid
+    # Regression test for #53482
+    run_generator [ destination_root, "--devcontainer", "-d", "postgresql", "--skip-solid"]
+
+    assert_file("config/database.yml") do |content|
+      assert_no_match("db/queue_migrate", content)
+      assert_no_match("db/cache_migrate", content)
+      assert_no_match("db/cable_migrate", content)
+    end
+  end
+
   def test_devcontainer_mysql
     run_generator [ destination_root, "--devcontainer", "-d", "mysql" ]
 


### PR DESCRIPTION
Fixes #53482

This fix a bug that omits the `skip_solid` option when calling the devcontainer generator with from the app generator. 

Generally benign, except when overriding certain files like the `database.yml` when the postgresql flag is also active. 

Rails new with `--devcontainer --skip_solid -d postgresql` would ignore the skip_solid and insert solid databases info in the `database.yml` config. 

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
