### PR TITLE
Default Regexp.timeout to 1s

### DIFF
--- a/guides/source/8_0_release_notes.md
+++ b/guides/source/8_0_release_notes.md
@@ -40,6 +40,8 @@ Please refer to the [Changelog][railties] for detailed changes.
 
 ### Notable changes
 
+*   Set `Regexp.timeout` to `1`s by default to improve security over Regexp Denial-of-Service attacks.
+
 Action Cable
 ------------
 

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -60,6 +60,7 @@ Below are the default values associated with each target version. In cases of co
 
 #### Default Values for Target Version 8.0
 
+- [`Regexp.timeout`](#regexp-timeout): `1`
 - [`config.action_dispatch.strict_freshness`](#config-action-dispatch-strict-freshness): `true`
 - [`config.active_support.to_time_preserves_timezone`](#config-active-support-to-time-preserves-timezone): `:zone`
 
@@ -3148,6 +3149,11 @@ Configures the HTML sanitizer used by Action Text by setting `ActionText::Conten
 | 7.1                   | `Rails::HTML5::Sanitizer` (see NOTE) | HTML5                  |
 
 NOTE: `Rails::HTML5::Sanitizer` is not supported on JRuby, so on JRuby platforms Rails will fall back to `Rails::HTML4::Sanitizer`.
+
+#### `Regexp.timeout`
+
+
+See Ruby's documentation for [`Regexp.timeout=`](https://docs.ruby-lang.org/en/3.3/Regexp.html#method-c-timeout-3D).
 
 ### Configuring a Database
 

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Set `Regexp.timeout` to `1`s by default to improve security over Regexp Denial-of-Service attacks.
+
+    *Rafael Mendonça França*
+
+
 ## Rails 8.0.0.rc1 (October 19, 2024) ##
 
 *   Remove deprecated support to extend Rails console through `Rails::ConsoleMethods`.

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -344,6 +344,8 @@ module Rails
           if respond_to?(:action_dispatch)
             action_dispatch.strict_freshness = true
           end
+
+          Regexp.timeout ||= 1
         else
           raise "Unknown version #{target_version.to_s.inspect}"
         end

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_8_0.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_8_0.rb.tt
@@ -23,3 +23,8 @@
 # If set to `false` both conditions need to be satisfied.
 #++
 # Rails.application.config.action_dispatch.strict_freshness = true
+
+###
+# Set `Regexp.timeout` to `1`s by default to improve security over Regexp Denial-of-Service attacks.
+#++
+# Regexp.timeout = 1

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -4815,6 +4815,17 @@ module ApplicationTests
       assert_instance_of ActiveJob::QueueAdapters::TestAdapter, adapter
     end
 
+    test "Regexp.timeout is set to 1s by default" do
+      app "development"
+      assert_equal 1, Regexp.timeout
+    end
+
+    test "Regexp.timeout can be configured" do
+      add_to_config "Regexp.timeout = 5"
+      app "development"
+      assert_equal 5, Regexp.timeout
+    end
+
     private
       def set_custom_config(contents, config_source = "custom".inspect)
         app_file "config/custom.yml", contents

--- a/tools/rail_inspector/lib/rail_inspector/visitor/framework_default.rb
+++ b/tools/rail_inspector/lib/rail_inspector/visitor/framework_default.rb
@@ -86,6 +86,14 @@ module RailInspector
                 end
               @configs[target] = value
             end
+
+            def visit_opassign(node)
+              if node.operator.name == :"||="
+                visit_assign(node)
+              else
+                super
+              end
+            end
           end
 
           private


### PR DESCRIPTION
To avoid Denial of Service attacks of regular expressions on Rails application we are now configuring the default timeout to 1s.

If a timeout was already configured we don't override it.