### PR TITLE
Cast `query_cache` value when using URL configuration

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Cast `query_cache` value when using URL configuration.
+
+    *zzak*
+
 *   NULLS NOT DISTINCT works with UNIQUE CONSTRAINT as well as UNIQUE INDEX.
 
     *Ryuta Kamizono*

--- a/activerecord/lib/active_record/database_configurations/url_config.rb
+++ b/activerecord/lib/active_record/database_configurations/url_config.rb
@@ -47,9 +47,8 @@ module ActiveRecord
           @configuration_hash[:schema_dump] = false
         end
 
-        if @configuration_hash[:query_cache] == "false"
-          @configuration_hash[:query_cache] = false
-        end
+        query_cache = parse_query_cache
+        @configuration_hash[:query_cache] = query_cache unless query_cache.nil?
 
         to_boolean!(@configuration_hash, :replica)
         to_boolean!(@configuration_hash, :database_tasks)
@@ -58,6 +57,17 @@ module ActiveRecord
       end
 
       private
+        def parse_query_cache
+          case value = @configuration_hash[:query_cache]
+          when /\A\d+\z/
+            value.to_i
+          when "false"
+            false
+          else
+            value
+          end
+        end
+
         def to_boolean!(configuration_hash, key)
           if configuration_hash[key].is_a?(String)
             configuration_hash[key] = configuration_hash[key] != "false"

--- a/activerecord/test/cases/database_configurations/url_config_test.rb
+++ b/activerecord/test/cases/database_configurations/url_config_test.rb
@@ -21,7 +21,10 @@ module ActiveRecord
         assert_equal false, config.query_cache
 
         config = UrlConfig.new("default_env", "primary", "postgres://localhost/foo?query_cache=42", {})
-        assert_equal "42", config.query_cache
+        assert_equal 42, config.query_cache
+
+        config = UrlConfig.new("default_env", "primary", "postgres://localhost/foo?query_cache=forever", {})
+        assert_equal "forever", config.query_cache
       end
 
       def test_replica_parsing


### PR DESCRIPTION
When using `DATABASE_URL`, you cannot adjust the max size of the query_cache using the parameter. Since it remains as the string `"42"` it will result in not setting a max size:

https://github.com/rails/rails/blob/1869a5aa3bdd4df746cd5da9244fd1f104c6ca98/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb#L122-L129

cc @byroot 