### PR TITLE
Improve invalid argument error for `with`

### DIFF
--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -1909,8 +1909,6 @@ module ActiveRecord
         return if with_values.empty?
 
         with_statements = with_values.map do |with_value|
-          raise ArgumentError, "Unsupported argument type: #{with_value} #{with_value.class}" unless with_value.is_a?(Hash)
-
           build_with_value_from_hash(with_value)
         end
 
@@ -2243,6 +2241,7 @@ module ActiveRecord
 
       def process_with_args(args)
         args.flat_map do |arg|
+          raise ArgumentError, "Unsupported argument type: #{arg} #{arg.class}" unless arg.is_a?(Hash)
           arg.map { |k, v| { k => v } }
         end
       end

--- a/activerecord/test/cases/relation/with_test.rb
+++ b/activerecord/test/cases/relation/with_test.rb
@@ -36,6 +36,12 @@ module ActiveRecord
         assert_equal POSTS_WITH_TAGS_AND_MULTIPLE_COMMENTS, relation.order(:id).pluck(:id)
       end
 
+      def test_with_when_invalid_argument_is_passed
+        assert_raises ArgumentError, match: /\AUnsupported argument type: #<Post:0x[0-9a-f]+> Post\z/ do
+          Post.with(Post.where("tags_count > 0"))
+        end
+      end
+
       def test_multiple_with_calls
         relation = Post
           .with(posts_with_tags: Post.where("tags_count > 0"))


### PR DESCRIPTION
Currently `with` requires a hash as an argument, if invalid argument is passed, it will raise NoMethodError in `process_with_args`.

This improves that will raise ArgumentError rather than NoMethodError.
