### PR TITLE
Temporarily allow sidekiq warning

### DIFF
--- a/activesupport/lib/active_support/testing/strict_warnings.rb
+++ b/activesupport/lib/active_support/testing/strict_warnings.rb
@@ -10,6 +10,8 @@ module ActiveSupport
     PROJECT_ROOT = File.expand_path("../../../../", __dir__)
     ALLOWED_WARNINGS = Regexp.union(
       /circular require considered harmful.*delayed_job/, # Bug in delayed job.
+      # TODO: Remove with the next sidekiq version bump
+      /circular require considered harmful.*sidekiq/,
 
       # Expected non-verbose warning emitted by Rails.
       /Ignoring .*\.yml because it has expired/,


### PR DESCRIPTION
It's already fixed on main but not released yet: https://github.com/sidekiq/sidekiq/pull/6477

Makes CI green for jobs that remove the gemfile like https://buildkite.com/rails/rails/builds/113285#0192dd58-d4f6-45dc-a1a9-89db15868afe, since they apparently do that.