### PR TITLE
Add back max_value to `ActiveModel::BigInteger`

### DIFF
--- a/activemodel/lib/active_model/type/big_integer.rb
+++ b/activemodel/lib/active_model/type/big_integer.rb
@@ -47,6 +47,11 @@ module ActiveModel
       def serializable?(value, &_)
         true
       end
+
+      private
+        def max_value
+          ::Float::INFINITY
+        end
     end
   end
 end

--- a/activemodel/test/cases/type/big_integer_test.rb
+++ b/activemodel/test/cases/type/big_integer_test.rb
@@ -5,6 +5,16 @@ require "cases/helper"
 module ActiveModel
   module Type
     class BigIntegerTest < ActiveModel::TestCase
+      class CustomNumber
+        attr_reader :num
+
+        def initialize(num)
+          @num = num
+        end
+
+        alias_method :to_i, :num
+      end
+
       def test_type_cast_big_integer
         type = Type::BigInteger.new
         assert_equal 1, type.cast(1)
@@ -19,6 +29,13 @@ module ActiveModel
       def test_large_values
         type = Type::BigInteger.new
         assert_equal 9999999999999999999999999999999, type.serialize(9999999999999999999999999999999)
+      end
+
+      def test_integer_like_classes_that_are_greater_than_4_bytes_still_serialize
+        type = Type::BigInteger.new
+        large_number = 9999999999999999999999999999999
+
+        assert_equal large_number, type.serialize(CustomNumber.new(large_number))
       end
 
       test "serialize_cast_value is equivalent to serialize after cast" do


### PR DESCRIPTION
## What problem are you solving?
Fixing a bug with https://github.com/rails/rails/pull/53470. This PR [removed](https://github.com/rails/rails/commit/70ca4ab91af15714cae4e8cddeb9080c6ec85378#diff-1dfdec10847763f60775b29a78fc7474cb35355d3fdd51636b7b73ae206156c9L30-L33) `max_value` off of BigInteger which breaks when a Custom Integer-like number gets serialized. 

```ruby
# typed: true
# frozen_string_literal: true

require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"

  gem "rails", github: "rails/rails", branch: "main"
end

require "active_record"
require "active_model"

module ActiveModel
  module Type
    class OldBigInteger < Integer
      def serialize(value) # :nodoc:
        case value
        when ::Integer
          # noop
        when ::String
          int = value.to_i
          if int.zero? && value != "0"
            return if non_numeric_string?(value)
          end
          value = int
        else
          value = super
        end

        value
      end

      def serialize_cast_value(value) # :nodoc:
        value
      end

      def serializable?(value, &_)
        true
      end

      private

      def max_value
        ::Float::INFINITY
      end
    end
  end
end

class CustomNumber
  attr_reader :num

  def initialize(num)
    @num = num
  end

  alias_method :to_int, :num
  alias_method :to_i, :num
end

big_int = ActiveModel::Type::BigInteger.new
old_big_int = ActiveModel::Type::OldBigInteger.new

puts "==========="

puts "BigInteger (new) behavior:"
begin
  puts big_int.serialize(CustomNumber.new(2**63))
rescue ActiveModel::RangeError => e
  puts "Out of range error: #{e.message}" # => 9223372036854775808 is out of range for ActiveModel::Type::BigInteger with limit 4 bytes
end

puts "OldBigInteger behavior:"
puts old_big_int.serialize(CustomNumber.new(2**63)) # => 9223372036854775808 (correctly handles this custom class)
```
