### PR TITLE
Implement BroadcastLogger#with_level to avoid double-invocation of passed block

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -47,4 +47,8 @@
 
     *Jonathan del Strother*
 
+*   Fix `ActiveSupport::BroadcastLogger` running blocks passed to `with_level` multiple times.
+
+    *meagar*
+
 Please check [8-0-stable](https://github.com/rails/rails/blob/8-0-stable/activesupport/CHANGELOG.md) for previous changes.

--- a/activesupport/test/broadcast_logger_test.rb
+++ b/activesupport/test/broadcast_logger_test.rb
@@ -307,6 +307,89 @@ module ActiveSupport
       assert_equal true, @logger.error("Hello")
     end
 
+    test "with_level invokes its block one time, even when broadcasting to many loggers" do
+      logs = Array.new(3) { ::Logger.new(nil) }
+
+      logger = BroadcastLogger.new(*logs)
+
+      invocations = 0
+      logger.with_level(:info) do
+        invocations += 1
+      end
+
+      assert_equal 1, invocations
+    end
+
+    test "with_level invokes its block one time, even when broadcasting to zero loggers" do
+      logger = BroadcastLogger.new()
+
+      invocations = 0
+      logger.with_level(:info) do
+        invocations += 1
+      end
+
+      assert_equal 1, invocations
+    end
+
+    test "with_level returns the value produced by the block" do
+      logger = BroadcastLogger.new(
+        ::Logger.new(StringIO.new),
+        ::Logger.new(StringIO.new)
+      )
+
+      assert_equal :foo, logger.with_level(:debug) { :foo }
+    end
+
+    test "with_level changes the logging level, and restores it afterwards" do
+      info_buf = StringIO.new
+      warn_buf = StringIO.new
+
+      info_logger = ::Logger.new(info_buf, level: Logger::INFO)
+      warn_logger = ::Logger.new(warn_buf, level: Logger::WARN)
+
+      logger = BroadcastLogger.new(info_logger, warn_logger)
+      logger.formatter = proc do |severity, time, progname, message|
+        "#{severity}:#{message}\n"
+      end
+
+      # Logs to info_logger, but not warning_logger
+      logger.info("AAA")
+      logger.debug("BBB") # skipped
+
+      logger.with_level(:debug) do
+        # Inside, debug logging should be captured
+        logger.debug("CCC") # captured
+        logger.info("DDD") # captured
+
+        logger.with_level(:error) do
+          logger.info("EEE") # skipped
+          logger.warn("FFF") # skipped
+          logger.error("GGG") # captured
+        end
+        logger.error("HHH") # captured
+      end
+
+      logger.debug("III")
+
+      want_info = <<~END
+        INFO:AAA
+        DEBUG:CCC
+        INFO:DDD
+        ERROR:GGG
+        ERROR:HHH
+      END
+
+      want_warn = <<~END
+        DEBUG:CCC
+        INFO:DDD
+        ERROR:GGG
+        ERROR:HHH
+      END
+
+      assert_equal(want_info, info_buf.string)
+      assert_equal(want_warn, warn_buf.string)
+    end
+
     Logger::Severity.constants.each do |level_name|
       method = level_name.downcase
       level = Logger::Severity.const_get(level_name)


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created because `Rails.logger.with_level` (or lack thereof) makes for a minor-to-moderate foot-gun. While the [core Ruby `Logger#with_level`](https://ruby-doc.org/3.3.5/stdliabs/logger/Logger.html#method-i-with_level) invokes its block one time with the adjusted log level, the `BroadcastLogger` invokes its block once for _each logger_ being broadcasting to.

Given a completely new Rails app, note the block executes twice:

```
$ ./bin/rails console
Loading development environment (Rails 7.1.3.4)
irb(main):001> Rails.logger.with_level(:debug) { puts "ok" }
ok
ok
=> [nil, nil]
```

For a block with a more serious side-effect, like charging a credit card or decrementing a balance of some kind, this would be a relatively serious bug. 

Note: In development it seems the default number of broadcasts is two, while in production it's one, so this shouldn't cause _production_ problems out of the gate, but it could for anybody who decides to add a second broadcast destination in production.

### Detail

Consider the following code:

```
Rails.logger.with_level(:debug) do
  user.charge_card!
end
```

Given this code works at all and appears to have correct behavior (the log level _is_ adjusted for the duration of the block), it's reasonable to assume it's _intended_ to work, and should invoke its block exactly once in all cases. However, adding a second broadcast to the logger causes the block to be invoked a second time, while removing the existing loggers causes the code to raise an exception.

This is because `BroadcastLogger` has no implementation of `with_logger`; instead, the call is handled by `method_missing`, which iterates over each of its loggers and "forwards" the call. As long as one (or more) loggers support `with_logger`, the code _runs_ but calls the block multiple times. If no loggers respond to `with_level`, the code raises an exception. 

This Pull Request changes `ActiveSupport::BroadcastLogger` to provide a real implementation of `with_level`, so  that calls to `with_logger` do the right thing: Save the current log level for each broadcast, override with the specified level, invoke the block exactly once, and then restore the old log levels before returning.

An alternate solution would be to make `BroadcastLogger` explicitly not respond to `with_level`, so that attempts to use this would fail early, but it seems relatively simple to support, and allows `BroadcastLogger` to continue being compatible with Ruby's own `Logger`.

### Additional information

We hit this when we wanted to dynamically override the log level in our jobs, based on an attribute we added to the relevant model. We introduce a Sidekiq middleware that effectively did the following:

```
  # sidekiq middleware
  def call(job_instance, job_payload, queue)
    Rails.logger.with_level(job_payload[:debug_logging] ? :debug : Rails.logger.level) do
      yield
    end
  end
```

This caused the job body to execute twice, even though only one job ran. In this particular case, the job enqueued more jobs which shared this middleware, and each of _those_ jobs also executed twice, leading to a quadrupling of output records, rather than just a doubling.

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. ~~If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`~~
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] ~~CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.~~ Given this doesn't introduce a new method, but instead provides a correct implementation for a method "exists", I don't believe a CHANGELOG entry is required
