### PR TITLE
Optimize AR::Timestamp#clear_timestamp_attributes

### DIFF
--- a/activerecord/lib/active_record/timestamp.rb
+++ b/activerecord/lib/active_record/timestamp.rb
@@ -169,8 +169,10 @@ module ActiveRecord
     # Clear attributes and changed_attributes
     def clear_timestamp_attributes
       all_timestamp_attributes_in_model.each do |attribute_name|
-        self[attribute_name] = nil
-        clear_attribute_change(attribute_name)
+        if self[attribute_name]
+          self[attribute_name] = nil
+          clear_attribute_change(attribute_name)
+        end
       end
     end
   end


### PR DESCRIPTION
If the attribute is already `nil` we can skip a lot of coslty work.

Benchmark: https://gist.github.com/casperisfine/ae56bec1e7eecbff3a696b367e2bafa2

Before:

```
ruby 3.3.4 (2024-07-09 revision be1089c8ec) +YJIT [arm64-darwin23]
Warming up --------------------------------------
        ActiveRecord     6.513k i/100ms
Calculating -------------------------------------
        ActiveRecord     66.008k (± 1.8%) i/s   (15.15 μs/i) -    332.163k in   5.033757s
```

After:

```
ruby 3.3.4 (2024-07-09 revision be1089c8ec) +YJIT [arm64-darwin23]
Warming up --------------------------------------
        ActiveRecord     7.021k i/100ms
Calculating -------------------------------------
        ActiveRecord     69.880k (± 2.1%) i/s   (14.31 μs/i) -    351.050k in   5.025927s
```
