### PR TITLE
Revert "ActiveModel::Dirty: only reset original values for persisted records"

### DIFF
--- a/activemodel/lib/active_model/dirty.rb
+++ b/activemodel/lib/active_model/dirty.rb
@@ -252,7 +252,7 @@ module ActiveModel
 
     def init_attributes(other) # :nodoc:
       attrs = super
-      if other.persisted? && self.class.respond_to?(:_default_attributes)
+      if self.class.respond_to?(:_default_attributes)
         self.class._default_attributes.map do |attr|
           attr.with_value_from_user(attrs.fetch_value(attr.name))
         end


### PR DESCRIPTION
Reverts: https://github.com/rails/rails/pull/53330

I can't explain why just yet, but this somehow is causing some extra queries in some situations, so reverting for now, and I'll try to come back with the optimization without the degradation.

FYI @george-ma 