### PR TITLE
Allow hidden_field(_tag) to accept a custom autocomplete value

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,2 +1,5 @@
+*   Allow `hidden_field` and `hidden_field_tag` to accept a custom autocomplete value.
+
+    *brendon*
 
 Please check [8-0-stable](https://github.com/rails/rails/blob/8-0-stable/actionview/CHANGELOG.md) for previous changes.

--- a/actionview/lib/action_view/helpers/form_tag_helper.rb
+++ b/actionview/lib/action_view/helpers/form_tag_helper.rb
@@ -306,7 +306,7 @@ module ActionView
       #   # => <input type="hidden" name="collected_input" id="collected_input"
       #        value="" onchange="alert(&#39;Input collected!&#39;)" autocomplete="off" />
       def hidden_field_tag(name, value = nil, options = {})
-        text_field_tag(name, value, options.merge(type: :hidden, autocomplete: "off"))
+        text_field_tag(name, value, options.merge(type: :hidden).with_defaults!(autocomplete: "off"))
       end
 
       # Creates a file upload field. If you are using file uploads then you will also need

--- a/actionview/lib/action_view/helpers/tags/hidden_field.rb
+++ b/actionview/lib/action_view/helpers/tags/hidden_field.rb
@@ -5,7 +5,7 @@ module ActionView
     module Tags # :nodoc:
       class HiddenField < TextField # :nodoc:
         def render
-          @options[:autocomplete] = "off"
+          @options.reverse_merge!(autocomplete: "off")
           super
         end
       end

--- a/actionview/test/template/form_helper_test.rb
+++ b/actionview/test/template/form_helper_test.rb
@@ -641,6 +641,20 @@ class FormHelperTest < ActionView::TestCase
     )
   end
 
+  def test_hidden_field_with_autocomplete
+    assert_dom_equal(
+      '<input id="session_username" name="session[username]" type="hidden" value="me@example.com" autocomplete="username" />',
+      hidden_field("session", "username", value: "me@example.com", autocomplete: "username")
+    )
+  end
+
+  def test_hidden_field_with_autocomplete_false
+    assert_dom_equal(
+      '<input id="post_title" name="post[title]" type="hidden" value="Something Else" />',
+      hidden_field("post", "title", value: "Something Else", autocomplete: nil)
+    )
+  end
+
   def test_text_field_with_custom_type
     assert_dom_equal(
       '<input id="user_email" name="user[email]" type="email" />',

--- a/actionview/test/template/form_tag_helper_test.rb
+++ b/actionview/test/template/form_tag_helper_test.rb
@@ -327,6 +327,18 @@ class FormTagHelperTest < ActionView::TestCase
     assert_dom_equal expected, actual
   end
 
+  def test_hidden_field_tag_with_autocomplete
+    actual = hidden_field_tag "username", "me@example.com", autocomplete: "username"
+    expected = %(<input id="username" name="username" type="hidden" value="me@example.com" autocomplete="username" />)
+    assert_dom_equal expected, actual
+  end
+
+  def test_hidden_field_tag_with_autocomplete_false
+    actual = hidden_field_tag "id", 3, autocomplete: nil
+    expected = %(<input id="id" name="id" type="hidden" value="3" />)
+    assert_dom_equal expected, actual
+  end
+
   def test_hidden_field_tag_id_sanitized
     input_elem = root_elem(hidden_field_tag("item[][title]"))
     assert_match VALID_HTML_ID, input_elem["id"]


### PR DESCRIPTION
https://github.com/rails/rails/pull/43280 introduced an enforced `autocomplete="off"` to all hidden inputs generated by Rails to fix a [firefox bug](https://bugzilla.mozilla.org/show_bug.cgi?id=520561).

Unfortunately it's also a legitimate use-case to specify an `autocomplete` with a value such as `username` and a value on a hidden input. This hints to the browser that (in this example) the username of a password reset form is what we've provided as the value and the password manager can store it as such.

This commit only sets `autocomplete="off"` if another `autocomplete` value isn't provided.

Supersedes https://github.com/rails/rails/pull/47798 which didn't seem to be as elegant a solution and didn't have proper tests.