### PR TITLE
actionmailbox: Add `reply_to_address` Mail extension

### DIFF
--- a/actionmailbox/CHANGELOG.md
+++ b/actionmailbox/CHANGELOG.md
@@ -1,2 +1,5 @@
+*   Add `reply_to_address` extension method on `Mail::Message`.
+
+    *Mr0grog*
 
 Please check [8-0-stable](https://github.com/rails/rails/blob/8-0-stable/actionmailbox/CHANGELOG.md) for previous changes.

--- a/actionmailbox/lib/action_mailbox/mail_ext/addresses.rb
+++ b/actionmailbox/lib/action_mailbox/mail_ext/addresses.rb
@@ -6,6 +6,10 @@ module Mail
       address_list(header[:from])&.addresses&.first
     end
 
+    def reply_to_address
+      address_list(header[:reply_to])&.addresses&.first
+    end
+
     def recipients_addresses
       to_addresses + cc_addresses + bcc_addresses + x_original_to_addresses + x_forwarded_to_addresses
     end

--- a/actionmailbox/test/unit/mail_ext/addresses_test.rb
+++ b/actionmailbox/test/unit/mail_ext/addresses_test.rb
@@ -7,6 +7,7 @@ module MailExt
     setup do
       @mail = Mail.new \
         from: "sally@example.com",
+        reply_to: "sarah@example.com",
         to: "david@basecamp.com",
         cc: "jason@basecamp.com",
         bcc: "andrea@basecamp.com",
@@ -16,6 +17,10 @@ module MailExt
 
     test "from address uses address object" do
       assert_equal "example.com", @mail.from_address.domain
+    end
+
+    test "reply to address uses address object" do
+      assert_equal "example.com", @mail.reply_to_address.domain
     end
 
     test "recipients include everyone from to, cc, bcc, x-original-to, and x-forwarded-to" do


### PR DESCRIPTION
### Motivation / Background

I’ve been doing a bunch of work with mail recently and have gotten a lot of value out of the `*_address`/`*_addresses` extensions on `Mail::Message`. 👍   However, there isn’t one for `reply_to_address`, which I’d expected to exist. This PR adds it.

I hope this is relatively non-controversial — it seems like the obvious twin of `from_address`.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
