### PR TITLE
Fix `order` with using association name as an alias

### DIFF
--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -2131,7 +2131,7 @@ module ActiveRecord
               arg.expr.relation.name
             end
           end
-        end.compact
+        end.filter_map { |ref| Arel.sql(ref, retryable: true) if ref }
       end
 
       def extract_table_name_from(string)


### PR DESCRIPTION
Related #53064.

We need to mark user-supplied table references as possibly association names.

Fixes #53509.
