### PR TITLE
Ignore Kamal files w/ Docker

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/dockerignore.tt
+++ b/railties/lib/rails/generators/rails/app/templates/dockerignore.tt
@@ -47,6 +47,12 @@
 /.github
 <% end -%>
 
+<% unless options.skip_kamal? -%>
+# Ignore Kamal files.
+/config/deploy*.yml
+/.kamal
+
+<% end -%>
 # Ignore development files
 /.devcontainer
 

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -1170,6 +1170,17 @@ class AppGeneratorTest < Rails::Generators::TestCase
 
     assert_file ".dockerignore" do |content|
       assert_match(/config\/master\.key/, content)
+      assert_match(/config\/deploy\*\.yml/, content)
+      assert_match(/\.kamal/, content)
+    end
+  end
+
+  def test_dockerignore_skip_kamal
+    run_generator [destination_root, "--skip-kamal"]
+
+    assert_file ".dockerignore" do |content|
+      assert_no_match(/config\/deploy\*\.yml/, content)
+      assert_no_match(/\.kamal/, content)
     end
   end
 


### PR DESCRIPTION
### Motivation / Background

The default configure includes both `.kamal/secrets` (may contain a `KAMAL_REGISTRY_PASSWORD` + `RAILS_MASTER_KEY`) and `config/deploy.yml`  in the built docker containers. This might make it easy to mistaken accidentally publish an image to a public container that contains credentials. This includes both the `.kamal` folder and `config/deploy.yml` file in  `.dockerignore` by default.

#### Without Change

```
docker build -t test .
docker run test cat .kamal/secrets
```

```
...
KAMAL_REGISTRY_PASSWORD=...
RAILS_MASTER_KEY=...
```

#### With Changes

```
docker build -t test .
docker run test cat .kamal/secrets
```

```
cat: .kamal/secrets: No such file or directory
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
