### PR TITLE
Introduce `db:maintenance:analyze` rake task to update query planner statistics

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Introduce the `db:maintenance:analyze` rake task to update query planner statistics. Currently
+    only supported by the SQLite3 and PostgreSQL adapters.
+
+    *Mike Dalessio*
+
 *   Cast `query_cache` value when using URL configuration.
 
     *zzak*

--- a/activerecord/lib/active_record/connection_adapters.rb
+++ b/activerecord/lib/active_record/connection_adapters.rb
@@ -102,6 +102,7 @@ module ActiveRecord
       autoload :ConnectionHandler
       autoload :QueryCache
       autoload :Savepoints
+      autoload :Maintenance
     end
 
     autoload_at "active_record/connection_adapters/abstract/connection_pool" do

--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -687,6 +687,12 @@ module ActiveRecord
         Thread.pass
       end
 
+      def perform_maintenance(event) # :nodoc:
+        with_connection do |conn|
+          conn.perform_maintenance(event)
+        end
+      end
+
       private
         def connection_lease
           @leases[ActiveSupport::IsolatedExecutionState.context]

--- a/activerecord/lib/active_record/connection_adapters/abstract/maintenance.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/maintenance.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module ActiveRecord
+  module ConnectionAdapters
+    # = Active Record Connection Adapter \Maintenance
+    module Maintenance
+      # Performs maintenance on the database given the type of event passed in.
+      #
+      # Rails supports the following events, but individual adapters may support only a subset:
+      #
+      # - +:analyze+: Triggered by `bin/rails db:maintenance:analyze`, this is intended to do
+      #   ANALYZE operations that can be run frequently with minimal or no impact to a running
+      #   application.
+      #
+      def perform_maintenance(event)
+        raise NotImplementedError, "#{self.class} does not support maintenance"
+      end
+    end
+  end
+end

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -36,6 +36,7 @@ module ActiveRecord
       include DatabaseLimits
       include QueryCache
       include Savepoints
+      include Maintenance
 
       SIMPLE_INT = /\A\d+\z/
       COMMENT_REGEX = %r{(?:--.*\n)|/\*(?:[^*]|\*[^/])*\*/}

--- a/activerecord/lib/active_record/connection_adapters/postgresql/maintenance.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/maintenance.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module ActiveRecord
+  module ConnectionAdapters
+    module PostgreSQL
+      module Maintenance # :nodoc:
+        def perform_maintenance(event)
+          case event
+          when :analyze
+            postgres_analyze
+          end
+        end
+
+        private
+          def postgres_analyze
+            execute("ANALYZE", "PostgreSQL::Maintenance")
+          end
+      end
+    end
+  end
+end

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -9,6 +9,7 @@ require "active_record/connection_adapters/statement_pool"
 require "active_record/connection_adapters/postgresql/column"
 require "active_record/connection_adapters/postgresql/database_statements"
 require "active_record/connection_adapters/postgresql/explain_pretty_printer"
+require "active_record/connection_adapters/postgresql/maintenance"
 require "active_record/connection_adapters/postgresql/oid"
 require "active_record/connection_adapters/postgresql/quoting"
 require "active_record/connection_adapters/postgresql/referential_integrity"
@@ -184,6 +185,7 @@ module ActiveRecord
       include PostgreSQL::ReferentialIntegrity
       include PostgreSQL::SchemaStatements
       include PostgreSQL::DatabaseStatements
+      include PostgreSQL::Maintenance
 
       def supports_bulk_alter?
         true

--- a/activerecord/lib/active_record/connection_adapters/sqlite3/maintenance.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3/maintenance.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module ActiveRecord
+  module ConnectionAdapters
+    module SQLite3
+      module Maintenance # :nodoc:
+        def perform_maintenance(event)
+          case event
+          when :analyze
+            sqlite_optimize_all_tables_with_no_analysis_limit
+          end
+        end
+
+        private
+          def sqlite_optimize_all_tables_with_no_analysis_limit
+            execute("PRAGMA optimize = 0x10002", "SQLite3::Maintenance")
+          end
+      end
+    end
+  end
+end

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -10,6 +10,7 @@ require "active_record/connection_adapters/sqlite3/schema_creation"
 require "active_record/connection_adapters/sqlite3/schema_definitions"
 require "active_record/connection_adapters/sqlite3/schema_dumper"
 require "active_record/connection_adapters/sqlite3/schema_statements"
+require "active_record/connection_adapters/sqlite3/maintenance"
 
 gem "sqlite3", ">= 2.1"
 require "sqlite3"
@@ -55,6 +56,7 @@ module ActiveRecord
       include SQLite3::Quoting
       include SQLite3::SchemaStatements
       include SQLite3::DatabaseStatements
+      include SQLite3::Maintenance
 
       ##
       # :singleton-method:

--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -390,6 +390,14 @@ db_namespace = namespace :db do
     ActiveRecord::Tasks::DatabaseTasks.load_seed
   end
 
+  namespace :maintenance do
+    desc "Update database query planner statistics"
+    task analyze: :load_config do
+      db_namespace["abort_if_pending_migrations"].invoke
+      ActiveRecord::Tasks::DatabaseTasks.perform_maintenance(:analyze)
+    end
+  end
+
   namespace :seed do
     desc "Truncate tables of each database for current environment and load the seeds"
     task replant: [:load_config, :truncate_all, :seed]


### PR DESCRIPTION
### Motivation / Background

As a maintainer of the sqlite3-ruby gem, it was recently called to my attention[^1] that some folks who are using SQLite3 in production could improve their database performance by updating query planner statistics. This has also happened to me at points in the past with MySQL and PostgreSQL which also provide the ability to update the query planner's statistics:

- in PostgreSQL, the `ANALYZE` statement:
  - https://www.postgresql.org/docs/current/sql-analyze.html
- in MySQL/MariaDB, the `ANALYZE TABLE` statement:
  - https://dev.mysql.com/doc/refman/8.4/en/analyze-table.html
  - https://mariadb.com/kb/en/analyze-table/
- in SQLite3, the `PRAGMA optimize` and `ANALYZE` statements:
  - https://www.sqlite.org/pragma.html#pragma_optimize
  - https://www.sqlite.org/lang_analyze.html

Specifically for the problem I'm trying to solve today, the SQLite3 docs recommend running `PRAGMA optimize` relatively frequently[^2] -- multiple times a day for applications with constantly-changing data.

Rails today does not offer any generic way to perform maintenance tasks like updating statistics (or vacuuming/reclaiming empty space/defragmenting). This pull request is an exploration of an Active Record abstraction for database maintenance.

(The design is intended to be extensible for other types of maintenance in the future (e.g., vacuuming/reclaiming empty space/defragmenting), and potentially even the ability for an adapter to subscribe to Rails events (like `CREATE INDEX` statements) and perform the maintenance automatically. But that is _very_ speculative, and this PR is intentionally small to see what the Rails core team appetite is for this kind of feature.)

I'd love to hear any feedback people have, especially on whether you think this belongs in Active Record.

  [^1]: https://github.com/sparklemotion/sqlite3-ruby/pull/572
  [^2]: https://www.sqlite.org/lang_analyze.html

### Detail

A new rake task is introduced:

- `db:maintenance:analyze`

which iterates over current enviroments and their database configurations, calling `perform_maintenance(:analyze)` on the connection pool, which forwards the call to an active connection.

Implementations for `perform_maintenance(:analyze)` are offered for SQLite3 (calling `PRAGMA optimize = 0x10002` which I'm confident is the best operation for this task) and for PostgreSQL (calling `ANALYZE` which I'm less confident in).

Any connection adapter that doesn't implement `perform_maintenance` will cause the rake task to emit to stderr something like:

```
Maintenance skipped for 'development:other': ActiveRecord::ConnectionAdapters::Mysql2Adapter does not support maintenance
```

If implemented, though, the rake task will emit to stdout:

```
Maintenance performed for 'development:primary'
```

and will log something like:

```
PostgreSQL::Maintenance (72.0ms)  ANALYZE
SQLite3::Maintenance (1.5ms)  PRAGMA optimize = 0x10002
```

### Additional information

The need for something like this was validated by the upstream sqlite3-ruby PR[^1] to add a `Database#optimize` method (which runs `PRAGMA optimize`).


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
