### PR TITLE
Fix running with `BACKTRACE=1` truncating gem paths

### DIFF
--- a/railties/lib/rails/backtrace_cleaner.rb
+++ b/railties/lib/rails/backtrace_cleaner.rb
@@ -27,14 +27,14 @@ module Rails
     end
 
     def clean(backtrace, kind = :silent)
-      kind = nil if ENV["BACKTRACE"]
+      return backtrace if ENV["BACKTRACE"]
 
       super(backtrace, kind)
     end
     alias_method :filter, :clean
 
     def clean_frame(frame, kind = :silent)
-      kind = nil if ENV["BACKTRACE"]
+      return frame if ENV["BACKTRACE"]
 
       super(frame, kind)
     end

--- a/railties/test/application/backtrace_cleaner_test.rb
+++ b/railties/test/application/backtrace_cleaner_test.rb
@@ -13,7 +13,7 @@ module ApplicationTests
     test "#clean silences Rails code from backtrace" do
       backtrace = [
         "app/controllers/foo_controller.rb:4:in 'index'",
-        "rails/railties/lib/rails/engine.rb:536:in `call"
+        "#{Gem.default_dir}/gems/railties-1.2.3/lib/rails/engine.rb:536:in `call"
       ]
 
       cleaned = @cleaner.clean(backtrace)
@@ -25,7 +25,7 @@ module ApplicationTests
       switch_env("BACKTRACE", "1") do
         backtrace = [
           "app/app/controllers/foo_controller.rb:4:in 'index'",
-          "/rails/railties/lib/rails/engine.rb:536:in `call"
+          "#{Gem.default_dir}/gems/railties-1.2.3/lib/rails/engine.rb:536:in `call"
         ]
 
         cleaned = @cleaner.clean(backtrace)
@@ -35,7 +35,7 @@ module ApplicationTests
     end
 
     test "#clean_frame silences Rails code" do
-      frame = "rails/railties/lib/rails/engine.rb:536:in `call"
+      frame = "#{Gem.default_dir}/gems/railties-1.2.3/lib/rails/engine.rb:536:in `call"
 
       cleaned = @cleaner.clean_frame(frame)
 
@@ -44,7 +44,7 @@ module ApplicationTests
 
     test "#clean_frame does not silence when BACKTRACE is set" do
       switch_env("BACKTRACE", "1") do
-        frame = "rails/railties/lib/rails/engine.rb:536:in `call"
+        frame = "#{Gem.default_dir}/gems/railties-1.2.3/lib/rails/engine.rb:536:in `call"
 
         cleaned = @cleaner.clean_frame(frame)
 


### PR DESCRIPTION
### Motivation / Background

https://github.com/rails/rails/pull/50563 changed the way that backtraces from gems are shown when running with `BACKTRACE=1`.

`activesupport (7.2.1) lib/active_support/executor/test_helper.rb:5:in 'block in run'` looks nice but isn't immediatly useful. This restores gem paths back to their original, full form.

### Detail

Here is sample backtrace  when running `BACKTRACE=1 bin/rails test` with a test failure somewhere in gem code:

<details><summary>Before</summary>
<p>

```rb
Error:
MyTestClass#test_0001_foobar:
IOError: closed stream
    /usr/local/lib/ruby/3.3.0/delegate.rb:349:in `rewind'
    /usr/local/lib/ruby/3.3.0/delegate.rb:349:in `block in delegating_block'
    httpx (1.3.3) lib/httpx/transcoder/multipart/encoder.rb:39:in `block in rewind'
    httpx (1.3.3) lib/httpx/transcoder/multipart/encoder.rb:37:in `each'
    httpx (1.3.3) lib/httpx/transcoder/multipart/encoder.rb:37:in `each_with_object'
    httpx (1.3.3) lib/httpx/transcoder/multipart/encoder.rb:37:in `rewind'
    httpx (1.3.3) lib/httpx/transcoder/multipart/encoder.rb:24:in `to_s'
    /usr/local/lib/ruby/3.3.0/delegate.rb:87:in `method_missing'
    httpx (1.3.3) lib/httpx/adapters/webmock.rb:23:in `build_webmock_request_signature'
    httpx (1.3.3) lib/httpx/adapters/webmock.rb:104:in `send'
    httpx (1.3.3) lib/httpx/session.rb:132:in `block in send_request'
    httpx (1.3.3) lib/httpx/session.rb:130:in `catch'
    httpx (1.3.3) lib/httpx/session.rb:130:in `send_request'
    httpx (1.3.3) lib/httpx/session.rb:254:in `block in _send_requests'
    httpx (1.3.3) lib/httpx/session.rb:253:in `each'
    httpx (1.3.3) lib/httpx/session.rb:253:in `_send_requests'
    httpx (1.3.3) lib/httpx/session.rb:245:in `send_requests'
    httpx (1.3.3) lib/httpx/session.rb:72:in `request'
    httpx (1.3.3) lib/httpx/chainable.rb:17:in `request'
    httpx (1.3.3) lib/httpx/chainable.rb:10:in `post'
    test/jobs/foo_job_test.rb:14:in `block (2 levels) in <class:FooJobTest>'
    activestorage (7.2.1) lib/active_storage/downloader.rb:15:in `block in open'
    activestorage (7.2.1) lib/active_storage/downloader.rb:24:in `open_tempfile'
    activestorage (7.2.1) lib/active_storage/downloader.rb:12:in `open'
    activestorage (7.2.1) lib/active_storage/service.rb:92:in `open'
    activestorage (7.2.1) app/models/active_storage/blob.rb:306:in `open'
    activesupport (7.2.1) lib/active_support/delegation.rb:192:in `public_send'
    activesupport (7.2.1) lib/active_support/delegation.rb:192:in `method_missing'
    activesupport (7.2.1) lib/active_support/delegation.rb:171:in `public_send'
    activesupport (7.2.1) lib/active_support/delegation.rb:171:in `method_missing'
    test/jobs/foo_job_test.rb:12:in `block in <class:FooJobTest>'
    minitest (5.25.1) lib/minitest/test.rb:94:in `block (2 levels) in run'
    minitest (5.25.1) lib/minitest/test.rb:190:in `capture_exceptions'
    minitest (5.25.1) lib/minitest/test.rb:89:in `block in run'
    minitest (5.25.1) lib/minitest.rb:367:in `time_it'
    minitest (5.25.1) lib/minitest/test.rb:88:in `run'
    activesupport (7.2.1) lib/active_support/executor/test_helper.rb:5:in `block in run'
    activesupport (7.2.1) lib/active_support/execution_wrapper.rb:104:in `perform'
    activesupport (7.2.1) lib/active_support/executor/test_helper.rb:5:in `run'
    minitest (5.25.1) lib/minitest.rb:1207:in `run_one_method'
    minitest (5.25.1) lib/minitest.rb:446:in `run_one_method'
    minitest (5.25.1) lib/minitest.rb:433:in `block (2 levels) in run'
    minitest (5.25.1) lib/minitest.rb:429:in `each'
    minitest (5.25.1) lib/minitest.rb:429:in `block in run'
    minitest (5.25.1) lib/minitest.rb:471:in `on_signal'
    minitest (5.25.1) lib/minitest.rb:458:in `with_info_handler'
    minitest (5.25.1) lib/minitest.rb:428:in `run'
    railties (7.2.1) lib/rails/test_unit/line_filtering.rb:10:in `run'
    minitest (5.25.1) lib/minitest.rb:331:in `block in __run'
    minitest (5.25.1) lib/minitest.rb:331:in `map'
    minitest (5.25.1) lib/minitest.rb:331:in `__run'
    minitest (5.25.1) lib/minitest.rb:287:in `run'
    minitest (5.25.1) lib/minitest.rb:85:in `block in autorun'
```

</p>
</details> 

<details><summary>After</summary>
<p>

```rb
Error:
MyTestClass#test_0001_foobar:
IOError: closed stream
    /usr/local/lib/ruby/3.3.0/delegate.rb:349:in `rewind'
    /usr/local/lib/ruby/3.3.0/delegate.rb:349:in `block in delegating_block'
    /usr/local/bundle/gems/httpx-1.3.3/lib/httpx/transcoder/multipart/encoder.rb:39:in `block in rewind'
    /usr/local/bundle/gems/httpx-1.3.3/lib/httpx/transcoder/multipart/encoder.rb:37:in `each'
    /usr/local/bundle/gems/httpx-1.3.3/lib/httpx/transcoder/multipart/encoder.rb:37:in `each_with_object'
    /usr/local/bundle/gems/httpx-1.3.3/lib/httpx/transcoder/multipart/encoder.rb:37:in `rewind'
    /usr/local/bundle/gems/httpx-1.3.3/lib/httpx/transcoder/multipart/encoder.rb:24:in `to_s'
    /usr/local/lib/ruby/3.3.0/delegate.rb:87:in `method_missing'
    /usr/local/bundle/gems/httpx-1.3.3/lib/httpx/adapters/webmock.rb:23:in `build_webmock_request_signature'
    /usr/local/bundle/gems/httpx-1.3.3/lib/httpx/adapters/webmock.rb:104:in `send'
    /usr/local/bundle/gems/httpx-1.3.3/lib/httpx/session.rb:132:in `block in send_request'
    /usr/local/bundle/gems/httpx-1.3.3/lib/httpx/session.rb:130:in `catch'
    /usr/local/bundle/gems/httpx-1.3.3/lib/httpx/session.rb:130:in `send_request'
    /usr/local/bundle/gems/httpx-1.3.3/lib/httpx/session.rb:254:in `block in _send_requests'
    /usr/local/bundle/gems/httpx-1.3.3/lib/httpx/session.rb:253:in `each'
    /usr/local/bundle/gems/httpx-1.3.3/lib/httpx/session.rb:253:in `_send_requests'
    /usr/local/bundle/gems/httpx-1.3.3/lib/httpx/session.rb:245:in `send_requests'
    /usr/local/bundle/gems/httpx-1.3.3/lib/httpx/session.rb:72:in `request'
    /usr/local/bundle/gems/httpx-1.3.3/lib/httpx/chainable.rb:17:in `request'
    /usr/local/bundle/gems/httpx-1.3.3/lib/httpx/chainable.rb:10:in `post'
    test/jobs/foo_job_test.rb:14:in `block (2 levels) in <class:FooJobTest>'
    /usr/local/bundle/gems/activestorage-7.2.1/lib/active_storage/downloader.rb:15:in `block in open'
    /usr/local/bundle/gems/activestorage-7.2.1/lib/active_storage/downloader.rb:24:in `open_tempfile'
    /usr/local/bundle/gems/activestorage-7.2.1/lib/active_storage/downloader.rb:12:in `open'
    /usr/local/bundle/gems/activestorage-7.2.1/lib/active_storage/service.rb:92:in `open'
    /usr/local/bundle/gems/activestorage-7.2.1models/active_storage/blob.rb:306:in `open'
    /usr/local/bundle/gems/activesupport-7.2.1/lib/active_support/delegation.rb:192:in `public_send'
    /usr/local/bundle/gems/activesupport-7.2.1/lib/active_support/delegation.rb:192:in `method_missing'
    /usr/local/bundle/gems/activesupport-7.2.1/lib/active_support/delegation.rb:171:in `public_send'
    /usr/local/bundle/gems/activesupport-7.2.1/lib/active_support/delegation.rb:171:in `method_missing'
    test/jobs/foo_job_test.rb:12:in `block in <class:FooJobTest>'
    /usr/local/bundle/gems/minitest-5.25.1/lib/minitest/test.rb:94:in `block (2 levels) in run'
    /usr/local/bundle/gems/minitest-5.25.1/lib/minitest/test.rb:190:in `capture_exceptions'
    /usr/local/bundle/gems/minitest-5.25.1/lib/minitest/test.rb:89:in `block in run'
    /usr/local/bundle/gems/minitest-5.25.1/lib/minitest.rb:367:in `time_it'
    /usr/local/bundle/gems/minitest-5.25.1/lib/minitest/test.rb:88:in `run'
    /usr/local/bundle/gems/activesupport-7.2.1/lib/active_support/executor/test_helper.rb:5:in `block in run'
    /usr/local/bundle/gems/activesupport-7.2.1/lib/active_support/execution_wrapper.rb:104:in `perform'
    /usr/local/bundle/gems/activesupport-7.2.1/lib/active_support/executor/test_helper.rb:5:in `run'
    /usr/local/bundle/gems/minitest-5.25.1/lib/minitest.rb:1207:in `run_one_method'
    /usr/local/bundle/gems/minitest-5.25.1/lib/minitest.rb:446:in `run_one_method'
    /usr/local/bundle/gems/minitest-5.25.1/lib/minitest.rb:433:in `block (2 levels) in run'
    /usr/local/bundle/gems/minitest-5.25.1/lib/minitest.rb:429:in `each'
    /usr/local/bundle/gems/minitest-5.25.1/lib/minitest.rb:429:in `block in run'
    /usr/local/bundle/gems/minitest-5.25.1/lib/minitest.rb:471:in `on_signal'
    /usr/local/bundle/gems/minitest-5.25.1/lib/minitest.rb:458:in `with_info_handler'
    /usr/local/bundle/gems/minitest-5.25.1/lib/minitest.rb:428:in `run'
    /usr/local/bundle/gems/railties-7.2.1/lib/rails/test_unit/line_filtering.rb:10:in `run'
    /usr/local/bundle/gems/minitest-5.25.1/lib/minitest.rb:331:in `block in __run'
    /usr/local/bundle/gems/minitest-5.25.1/lib/minitest.rb:331:in `map'
    /usr/local/bundle/gems/minitest-5.25.1/lib/minitest.rb:331:in `__run'
    /usr/local/bundle/gems/minitest-5.25.1/lib/minitest.rb:287:in `run'
    /usr/local/bundle/gems/minitest-5.25.1/lib/minitest.rb:85:in `block in autorun'
```

</p>
</details> 

Showing the full, unaltered backtrace like this is much more useful in starting to figure out what is going on. This initially regressed with https://github.com/rails/rails/pull/50563 and carried over in changes from https://github.com/rails/rails/pull/51670

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
