### PR TITLE
Do not mark routes as loaded during `RoutesReloader#reload!` call.

### DIFF
--- a/railties/lib/rails/application/routes_reloader.rb
+++ b/railties/lib/rails/application/routes_reloader.rb
@@ -10,7 +10,7 @@ module Rails
       attr_reader :route_sets, :paths, :external_routes, :loaded
       attr_accessor :eager_load
       attr_writer :run_after_load_paths # :nodoc:
-      delegate :execute_if_updated, :execute, :updated?, to: :updater
+      delegate :execute_if_updated, :updated?, to: :updater
 
       def initialize
         @paths      = []
@@ -21,13 +21,17 @@ module Rails
       end
 
       def reload!
-        @loaded = true
         clear!
         load_paths
         finalize!
         route_sets.each(&:eager_load!) if eager_load
       ensure
         revert
+      end
+
+      def execute
+        @loaded = true
+        updater.execute
       end
 
       def execute_unless_loaded

--- a/railties/test/application/routing_test.rb
+++ b/railties/test/application/routing_test.rb
@@ -314,6 +314,31 @@ module ApplicationTests
       assert_equal "WIN", last_response.body
     end
 
+    test "routes appending blocks after reload" do
+      app_file "config/routes.rb", <<-RUBY
+        Rails.application.routes.draw do
+          get ':controller/:action'
+        end
+      RUBY
+
+      add_to_config <<-R
+        config.before_eager_load do |app|
+          app.reload_routes!
+        end
+
+        config.after_initialize do |app|
+          app.routes.append do
+            get '/win' => lambda { |e| [200, {'Content-Type'=>'text/plain'}, ['WIN']] }
+          end
+        end
+      R
+
+      app "production"
+
+      get "/win"
+      assert_equal "WIN", last_response.body
+    end
+
     test "routes drawing from config/routes" do
       app_file "config/routes.rb", <<-RUBY
         AppTemplate::Application.routes.draw do


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because when https://github.com/rails/rails/pull/52353 was merged it introduced a bug that Devise users encountered (https://github.com/heartcombo/devise/issues/5720, https://github.com/heartcombo/devise/issues/5716)

Devise stores mapping information during routes initialization (https://github.com/heartcombo/devise/blob/12c796e4994c9fbdc12eb0d6b70450cf82fcec62/lib/devise/rails/routes.rb#L243) so if some of your code depends on this mapping you might want to use Devise's configuration called `reload_routes` (https://github.com/heartcombo/devise/blob/12c796e4994c9fbdc12eb0d6b70450cf82fcec62/lib/devise/rails.rb#L17) that makes sure that during eager loading we draw routes before we do eager loading itself so you could use `Devise.mapping` anywhere in your code. 

But when https://github.com/rails/rails/pull/52353 was introduced it made it impossible to reload routes during `before_eager_load` callback because if we do it it won't be possible to add more routes at later stage of application initialization (e.g `ActiveCable` prepends route during `after_initialize` callback)

### Detail

This Pull Request changes the way we mark routes as loaded by moving it to `RoutesReloader#execute` instead of doing it inside of `RoutesReloader#reload!`

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.

/cc @gmcgibbon 