### PR TITLE
Add shortcut for ActiveRecord to log to STDOUT

### DIFF
--- a/activerecord/lib/active_record.rb
+++ b/activerecord/lib/active_record.rb
@@ -555,6 +555,33 @@ module ActiveRecord
     end
     open_transactions
   end
+
+  # Shortcut for switching logging to STDOUT.
+  #
+  # Calling it without block is identical to setting logger to +Logger.new(STDOUT)+
+  #
+  #   ActiveRecord.log_to_stdout
+  #   # Identical to ActiveRecord::Base.logger = Logger.new(STDOUT)
+  #
+  # Calling it with block will switch logging to STDOUT for the duration of block
+  # and restore it afterwards.
+  #
+  #   ActiveRecord.log_to_stdout do
+  #     # ...
+  #   end
+  def self.log_to_stdout
+    if block_given?
+      begin
+        original_logger = Base.logger
+        Base.logger = Logger.new(STDOUT)
+        yield
+      ensure
+        Base.logger = original_logger
+      end
+    else
+      Base.logger = Logger.new(STDOUT)
+    end
+  end
 end
 
 ActiveSupport.on_load(:active_record) do

--- a/activerecord/test/cases/active_record_test.rb
+++ b/activerecord/test/cases/active_record_test.rb
@@ -18,4 +18,26 @@ class ActiveRecordTest < ActiveRecord::TestCase
       assert_predicate ActiveRecord::Base, :connected?
     end
   end
+
+  test ".log_to_stdout switches logging to stdout" do
+    original_logger = ActiveRecord::Base.logger
+
+    assert_not ActiveSupport::Logger.logger_outputs_to?(ActiveRecord::Base.logger, STDOUT)
+
+    ActiveRecord.log_to_stdout
+
+    assert ActiveSupport::Logger.logger_outputs_to?(ActiveRecord::Base.logger, STDOUT)
+  ensure
+    ActiveRecord::Base.logger = original_logger
+  end
+
+  test ".log_to_stdout called with block switches logging to stdout for the duration of the block" do
+    assert_not ActiveSupport::Logger.logger_outputs_to?(ActiveRecord::Base.logger, STDOUT)
+
+    ActiveRecord.log_to_stdout do
+      assert ActiveSupport::Logger.logger_outputs_to?(ActiveRecord::Base.logger, STDOUT)
+    end
+
+    assert_not ActiveSupport::Logger.logger_outputs_to?(ActiveRecord::Base.logger, STDOUT)
+  end
 end


### PR DESCRIPTION
### Motivation / Background

This Pull Request adds shortcut to switch ActiveRecord logging to STDOUT.

I have this in `ApplicationRecord` or as monkey-patch in all my projects and I think it could be useful addition to the framework.

### Detail

During development or when debugging something I would like to see SQL queries that are executed and I usually do it like this:

```
class MyModelTest < ActiveSupport::TestCase
  test "does something on create" do
    ...
    original_logger = ActiveRecord::Base.logger
    ActiveRecord::Base.logger = Logger.new(STDOUT)
    # Code I want to debug
    MyModel.create(...)
    ...
    ActiveRecord::Base.logger = original_logger
    
    assert something_happend_during_create
  end
end
```

That way I get only SQL queries I'm interested in logged to STDOUT and displayed in test output.

Using `ActiveRecord.log_to_stdout` block method that can be simplified to:

```
class MyModelTest < ActiveSupport::TestCase
  test "does something on create" do
    ...
    ActiveRecord.log_to_stdout do
      # Code I want to debug
      MyModel.create(...)
    end
    
    assert something_happend_during_create
  end
end
```

It can also be called without block to "permanently" switch logs to STDOUT:

```
ActiveRecord.log_to_stdout
# is identical to
ActiveRecord::Base.logger = Logger.new(STDOUT)
```
This can be useful if you want to see logs in production console for example (although you can get that with `Rails.logger.level = :warn` also).

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
