### PR TITLE
Fix invalid response when rescuing `ActionController::Redirecting::UnsafeRedirectError` in a controller

### DIFF
--- a/actionpack/lib/action_controller/metal/redirecting.rb
+++ b/actionpack/lib/action_controller/metal/redirecting.rb
@@ -106,13 +106,14 @@ module ActionController
 
       allow_other_host = response_options.delete(:allow_other_host) { _allow_other_host }
 
-      self.status = _extract_redirect_to_status(options, response_options)
+      proposed_status = _extract_redirect_to_status(options, response_options)
 
       redirect_to_location = _compute_redirect_to_location(request, options)
       _ensure_url_is_http_header_safe(redirect_to_location)
 
       self.location      = _enforce_open_redirect_protection(redirect_to_location, allow_other_host: allow_other_host)
       self.response_body = ""
+      self.status        = proposed_status
     end
 
     # Soft deprecated alias for #redirect_back_or_to where the `fallback_location`

--- a/actionpack/test/controller/redirect_test.rb
+++ b/actionpack/test/controller/redirect_test.rb
@@ -203,6 +203,14 @@ class RedirectController < ActionController::Base
     redirect_to "\000/lol\r\nwat"
   end
 
+  def redirect_to_external_with_rescue
+    begin
+      redirect_to "http://www.rubyonrails.org/", allow_other_host: false
+    rescue ActionController::Redirecting::UnsafeRedirectError
+      render plain: "caught error"
+    end
+  end
+
   def rescue_errors(e) raise e end
 
   private
@@ -615,6 +623,11 @@ class RedirectTest < ActionController::TestCase
     assert_equal request, payload[:request]
     assert_equal 302, payload[:status]
     assert_equal "http://test.host/redirect/hello_world", payload[:location]
+  end
+
+  def test_redirect_to_external_with_rescue
+    get :redirect_to_external_with_rescue
+    assert_response :ok
   end
 
   private


### PR DESCRIPTION
Consider a controller that does this:

```ruby
    begin
      redirect_to "http://www.rubyonrails.org/", allow_other_host: false
    rescue ActionController::Redirecting::UnsafeRedirectError
      render plain: "caught error"
    end
```

The `redirect_to` will raise and the `rescue` will execute. But currently, the response status will still be changed (to 302). So even if you render something, we will return to the browser a 302 response code, with no response location.

I don't think this is a valid response, and it's definitely surprising: if `redirect_to` raises, you don't expect it to still tell the browser to redirect.

This PR fixes this, by only setting the status once the location has been verified.

Note: I came across this issue while trying to work around https://github.com/rails/rails/issues/53464, but it's not dependent on that issue.
