### PR TITLE
Handle DST in `to_time` deprecation causing failing test on `main`

### DIFF
--- a/activesupport/lib/active_support/core_ext/time/compatibility.rb
+++ b/activesupport/lib/active_support/core_ext/time/compatibility.rb
@@ -26,7 +26,7 @@ class Time
       @@active_support_local_zone ||=
         begin
           @@active_support_local_tz = ENV["TZ"]
-          Time.new.zone
+          Time.new(year, month, day).zone
         end
     end
 end


### PR DESCRIPTION
A test on `main` added in https://github.com/rails/rails/pull/52031 started failing over the weekend, because daylight savings just ended in North America.

![image](https://github.com/user-attachments/assets/6108514e-fb41-49c3-a3cd-f04900a02605)


Thus, calling `Time.new` inside `active_support_local_zone` might return a different `zone` to a `Time` constructed during DST.

This PR fixes that by calling `Time.new` with the the same year/month/day as the `Time` object we're comparing to. This should ensure we compare `zone` at the same time of the year.