### PR TITLE
Mark generate_alias_attribute_methods, alias_attribute_method_definiton as private API

### DIFF
--- a/activemodel/lib/active_model/attribute_methods.rb
+++ b/activemodel/lib/active_model/attribute_methods.rb
@@ -214,7 +214,7 @@ module ActiveModel
         end
       end
 
-      def generate_alias_attribute_methods(code_generator, new_name, old_name)
+      def generate_alias_attribute_methods(code_generator, new_name, old_name) # :nodoc:
         ActiveSupport::CodeGenerator.batch(code_generator, __FILE__, __LINE__) do |owner|
           attribute_method_patterns.each do |pattern|
             alias_attribute_method_definition(code_generator, pattern, new_name, old_name)

--- a/activerecord/lib/active_record/attribute_methods.rb
+++ b/activerecord/lib/active_record/attribute_methods.rb
@@ -84,7 +84,7 @@ module ActiveRecord
         attribute_method_patterns_cache.clear
       end
 
-      def alias_attribute_method_definition(code_generator, pattern, new_name, old_name)
+      def alias_attribute_method_definition(code_generator, pattern, new_name, old_name) # :nodoc:
         old_name = old_name.to_s
 
         if !abstract_class? && !has_attribute?(old_name)


### PR DESCRIPTION
When looking at #50154, I noticed these methods were accidentally set to public.

This probably also should be backported.

/cc @byroot 