### PR TITLE
Don't generate the step for system tests when an application is API-only

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/github/ci.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/github/ci.yml.tt
@@ -131,6 +131,7 @@ jobs:
         <%- else -%>
         run: bin/rails db:test:prepare test test:system
         <%- end -%>
+      <%- unless options[:api] -%>
 
       - name: Keep screenshots from failed system tests
         uses: actions/upload-artifact@v4
@@ -139,4 +140,5 @@ jobs:
           name: screenshots
           path: ${{ github.workspace }}/tmp/screenshots
           if-no-files-found: ignore
+      <%- end -%>
 <% end -%>

--- a/railties/test/generators/api_app_generator_test.rb
+++ b/railties/test/generators/api_app_generator_test.rb
@@ -57,6 +57,11 @@ class ApiAppGeneratorTest < Rails::Generators::TestCase
     assert_file "config/environments/production.rb" do |content|
       assert_no_match(/action_controller\.perform_caching = true/, content)
     end
+
+    assert_file ".github/workflows/ci.yml" do |content|
+      assert_no_match(/test:system/, content)
+      assert_no_match(/screenshots/, content)
+    end
   end
 
   def test_dockerfile


### PR DESCRIPTION

### Motivation / Background

When an application is API-only, we don't run system tests. https://github.com/rails/rails/blob/ad4d2d2b5bdd4226b76d85c73500de0a9d48f7c2/railties/lib/rails/generators/rails/app/templates/github/ci.yml.tt#L129-L133

So keeping screenshots isn't needed too.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
