### PR TITLE
[ci skip] Remove guide docs for `rackup`

### DIFF
--- a/guides/source/rails_on_rack.md
+++ b/guides/source/rails_on_rack.md
@@ -58,28 +58,6 @@ class Server < ::Rack::Server
 end
 ```
 
-### `rackup`
-
-To use `rackup` instead of Rails' `bin/rails server`, you can put the following inside `config.ru` of your Rails application's root directory:
-
-```ruby
-# Rails.root/config.ru
-require_relative "config/environment"
-run Rails.application
-```
-
-And start the server:
-
-```bash
-$ rackup config.ru
-```
-
-To find out more about different `rackup` options, you can run:
-
-```bash
-$ rackup --help
-```
-
 ### Development and Auto-reloading
 
 Middlewares are loaded once and are not monitored for changes. You will have to restart the server for changes to be reflected in the running application.


### PR DESCRIPTION
Rackup now recommends to not use it: https://github.com/rack/rackup?tab=readme-ov-file#soft-deprecation

I'd wager a guess and say that most apps (in a rails context) are already using either `bin/rails server` or just invoke their chosen server directly anyways.

Additionally, this info outdated. `config.ru` is already generated in such a way that users don't have to change anything: https://github.com/rails/rails/blob/32dcdcaef666e0043b0df844aa167201d50f8c9c/railties/lib/rails/generators/rails/app/templates/config.ru.tt