### PR TITLE
Better error message for `Enumerable#sole`

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,22 @@
+*   Better error message for `Enumerable#sole`.
+
+    Include the number of items in the message if there are more than one.
+
+    Before:
+
+    ```ruby
+    [1, 2].sole
+    # => raises Enumerable::SoleItemExpectedError: multiple items found
+    ```
+
+    After:
+
+    ```ruby
+    [1, 2].sole
+    # => raises Enumerable::SoleItemExpectedError: 2 items found
+    ```
+
+    *Dani Acherkan*
 *   `ActiveSupport::CurrentAttributes#attributes` now will return a new hash object on each call.
 
     Previously, the same hash object was returned each time that method was called.

--- a/activesupport/lib/active_support/core_ext/enumerable.rb
+++ b/activesupport/lib/active_support/core_ext/enumerable.rb
@@ -207,12 +207,12 @@ module Enumerable
   #
   #   ["x"].sole          # => "x"
   #   Set.new.sole        # => Enumerable::SoleItemExpectedError: no item found
-  #   { a: 1, b: 2 }.sole # => Enumerable::SoleItemExpectedError: multiple items found
+  #   { a: 1, b: 2 }.sole # => Enumerable::SoleItemExpectedError: 2 items found
   def sole
     case count
     when 1   then return first # rubocop:disable Style/RedundantReturn
     when 0   then raise ActiveSupport::EnumerableCoreExt::SoleItemExpectedError, "no item found"
-    when 2.. then raise ActiveSupport::EnumerableCoreExt::SoleItemExpectedError, "multiple items found"
+    when 2.. then raise ActiveSupport::EnumerableCoreExt::SoleItemExpectedError, "#{count} items found"
     end
   end
 end

--- a/activesupport/lib/active_support/core_ext/enumerable.rb
+++ b/activesupport/lib/active_support/core_ext/enumerable.rb
@@ -209,10 +209,10 @@ module Enumerable
   #   Set.new.sole        # => Enumerable::SoleItemExpectedError: no item found
   #   { a: 1, b: 2 }.sole # => Enumerable::SoleItemExpectedError: 2 items found
   def sole
-    case count
+    case (c = count)
     when 1   then return first # rubocop:disable Style/RedundantReturn
     when 0   then raise ActiveSupport::EnumerableCoreExt::SoleItemExpectedError, "no item found"
-    when 2.. then raise ActiveSupport::EnumerableCoreExt::SoleItemExpectedError, "#{count} items found"
+    when 2.. then raise ActiveSupport::EnumerableCoreExt::SoleItemExpectedError, "#{c} items found"
     end
   end
 end

--- a/activesupport/test/core_ext/enumerable_test.rb
+++ b/activesupport/test/core_ext/enumerable_test.rb
@@ -394,10 +394,10 @@ class EnumerableTests < ActiveSupport::TestCase
   def test_sole
     expected_raise = Enumerable::SoleItemExpectedError
 
-    assert_raise(expected_raise) { GenericEnumerable.new([]).sole }
+    assert_raise(expected_raise, match: "no item found") { GenericEnumerable.new([]).sole }
     assert_equal 1, GenericEnumerable.new([1]).sole
-    assert_raise(expected_raise) { GenericEnumerable.new([1, 2]).sole }
-    assert_raise(expected_raise) { GenericEnumerable.new([1, nil]).sole }
+    assert_raise(expected_raise, match: "2 items found") { GenericEnumerable.new([1, 2]).sole }
+    assert_raise(expected_raise, match: "2 items found") { GenericEnumerable.new([1, nil]).sole }
   end
 
   def test_doesnt_bust_constant_cache


### PR DESCRIPTION
Include the number of items in the message if there are more than one.

### Motivation / Background

The error message raised when calling `Enumerable#sole` can be made slightly more helpful by including the (offending) number of items in the enumerable. 

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
