### PR TITLE
Change the WEB_CONCURRENCY deploy comment default to `auto`

### DIFF
--- a/guides/source/tuning_performance_for_deployment.md
+++ b/guides/source/tuning_performance_for_deployment.md
@@ -122,7 +122,7 @@ or if the server is running multiple applications, to how many cores you want th
 If you only use one thread per worker, then you can increase it to above one per process to account for when workers are
 idle waiting for I/O operations.
 
-You can configure number of Puma workers by setting the `WEB_CONCURRENCY` environment variable.
+You can configure the number of Puma workers by setting the `WEB_CONCURRENCY` environment variable. Setting `WEB_CONCURRENCY=auto` will automatically adjust the Puma worker count to match the number of available CPUs. However, this setting might be inaccurate on cloud hosts with shared CPUs or platforms that report CPU counts incorrectly.
 
 ### YJIT
 

--- a/railties/lib/rails/generators/rails/app/templates/config/deploy.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/deploy.yml.tt
@@ -38,7 +38,7 @@ env:
 <% if skip_solid? -%>
   # clear:
   #   # Set number of cores available to the application on each server (default: 1).
-  #   WEB_CONCURRENCY: 2
+  #   WEB_CONCURRENCY: auto
 
   #   # Match this to any external database server to configure Active Record correctly
   #   DB_HOST: 192.168.0.2

--- a/railties/lib/rails/generators/rails/app/templates/config/puma.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/puma.rb.tt
@@ -7,7 +7,8 @@
 #
 # You can control the number of workers using ENV["WEB_CONCURRENCY"]. You
 # should only set this value when you want to run 2 or more workers. The
-# default is already 1.
+# default is already 1. You can set it to `auto` to automatically start a worker
+# for each available processor.
 #
 # The ideal number of threads per worker depends both on how much time the
 # application spends waiting for IO operations and on how much you wish to


### PR DESCRIPTION
https://github.com/puma/puma/pull/3439 introduced a new `WEB_CONCURRENCY=auto` setting for puma. The config sets puma's worker count to the count of available cpus.

This PR adds the new option to the explaining comments of a new project's default `puma.rb` config file.