### PR TITLE
Fix `ActiveModel::AttributeAssignment#assign_attributes` to accept objects without `each`

### DIFF
--- a/activemodel/lib/active_model/attribute_assignment.rb
+++ b/activemodel/lib/active_model/attribute_assignment.rb
@@ -59,7 +59,7 @@ module ActiveModel
 
     private
       def _assign_attributes(attributes)
-        attributes.each do |k, v|
+        attributes.each_pair do |k, v|
           _assign_attribute(k, v)
         end
       end

--- a/activemodel/test/cases/attribute_assignment_test.rb
+++ b/activemodel/test/cases/attribute_assignment_test.rb
@@ -148,4 +148,14 @@ class AttributeAssignmentTest < ActiveModel::TestCase
     model = Model.new
     assert_nil model.assign_attributes(ProtectedParams.new({}))
   end
+
+  test "passing an object with each_pair but without each" do
+    model = Model.new
+    h = { name: "hello", description: "world" }
+    h.instance_eval { undef :each }
+    model.assign_attributes(h)
+
+    assert_equal "hello", model.name
+    assert_equal "world", model.description
+  end
 end


### PR DESCRIPTION
### Motivation / Background

`ActiveModel::AttributeAssignment#assign_attributes` checks if the argument responds to `each_pair`, and raises an exception if it does not.

However, in `_assign_attributes`, the argument is enumerated using `each`. As a result, if the argument has `each_pair` but not `each`, this error check results in a false negative. (An example of such an object is `OpenStruct`.)

```ruby
require 'active_model'
require 'ostruct'

class C
  include ActiveModel::AttributeAssignment
  attr_accessor :name
end

o = OpenStruct.new
o.name = 'foo'

c = C.new
c.assign_attributes(o)
p c.name #=> nil
```

### Detail

The argument is only required to respond to `each_pair`.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
