### PR TITLE
[ci skip] Fix docs for `default_form_builder`

### DIFF
--- a/actionmailer/lib/action_mailer/form_builder.rb
+++ b/actionmailer/lib/action_mailer/form_builder.rb
@@ -23,7 +23,7 @@ module ActionMailer
       # in the views rendered by this mailer and its subclasses.
       #
       # ==== Parameters
-      # * <tt>builder</tt> - Default form builder, an instance of ActionView::Helpers::FormBuilder
+      # * <tt>builder</tt> - Default form builder. Accepts a subclass of ActionView::Helpers::FormBuilder
       def default_form_builder(builder)
         self._default_form_builder = builder
       end

--- a/actionpack/lib/action_controller/form_builder.rb
+++ b/actionpack/lib/action_controller/form_builder.rb
@@ -40,7 +40,7 @@ module ActionController
       # rendered by this controller and its subclasses.
       #
       # #### Parameters
-      # *   `builder` - Default form builder, an instance of
+      # *   `builder` - Default form builder. Accepts a subclass of
       #     ActionView::Helpers::FormBuilder
       def default_form_builder(builder)
         self._default_form_builder = builder


### PR DESCRIPTION
Passing a instance is not what you're supposed to do here. The instance will instead be passed to you in `form_with` and similar.

The top-level documentation already explains it correctly: https://api.rubyonrails.org/classes/ActionController/FormBuilder.html