### PR TITLE
Update ActiveJob docs to show how to halt the callback chain

### DIFF
--- a/guides/source/active_job_basics.md
+++ b/guides/source/active_job_basics.md
@@ -12,7 +12,6 @@ After reading this guide, you will know:
 * How to configure and use Solid Queue.
 * How to run jobs in the background.
 * How to send emails from your application asynchronously.
-* How to halt a job's lifecycle callback execution.
 
 --------------------------------------------------------------------------------
 
@@ -748,23 +747,6 @@ class GuestsCleanupJob < ApplicationJob
 end
 ```
 
-A callback that `throws :abort` will [halt the callback chain](https://api.rubyonrails.org/classes/ActiveSupport/Callbacks.html)
-and skip the execution of any subsquent before, around and after callbacks:
-
-```ruby
-class GuestsCleanupJob < ApplicationJob
-  queue_as :default
-
-  before_enqueue do
-    throw :abort if ENV.fetch("DISABLE_GUESTS_CLEANUP_JOB", false)
-  end
-
-  def perform
-    # Do something later
-  end
-end
-```
-
 The macro-style class methods can also receive a block. Consider using this
 style if the code inside your block is so short that it fits in a single line.
 For example, you could send metrics for every job enqueued:
@@ -803,6 +785,25 @@ end
 Please note that when enqueuing jobs in bulk using `perform_all_later`,
 callbacks such as `around_enqueue` will not be triggered on the individual jobs.
 See [Bulk Enqueuing Callbacks](#bulk-enqueue-callbacks).
+
+### Halting Callbacks
+
+A callback that `throws :abort` will [halt the callback chain](https://api.rubyonrails.org/classes/ActiveSupport/Callbacks.html)
+and skip the execution of any subsequent before, around and after callbacks:
+
+```ruby
+class GuestsCleanupJob < ApplicationJob
+  queue_as :default
+
+  before_enqueue do
+    throw :abort if ENV.fetch("DISABLE_GUESTS_CLEANUP_JOB", false)
+  end
+
+  def perform
+    # Do something later
+  end
+end
+```
 
 Bulk Enqueuing
 --------------

--- a/guides/source/active_job_basics.md
+++ b/guides/source/active_job_basics.md
@@ -12,6 +12,7 @@ After reading this guide, you will know:
 * How to configure and use Solid Queue.
 * How to run jobs in the background.
 * How to send emails from your application asynchronously.
+* How to halt a job's lifecycle callback execution.
 
 --------------------------------------------------------------------------------
 
@@ -744,6 +745,23 @@ class GuestsCleanupJob < ApplicationJob
       yield
       # Do something after perform
     end
+end
+```
+
+A callback that `throws :abort` will [halt the callback chain](https://api.rubyonrails.org/classes/ActiveSupport/Callbacks.html)
+and skip the execution of any subsquent before, around and after callbacks:
+
+```ruby
+class GuestsCleanupJob < ApplicationJob
+  queue_as :default
+
+  before_enqueue do
+    throw :abort if ENV.fetch("DISABLE_GUESTS_CLEANUP_JOB", false)
+  end
+
+  def perform
+    # Do something later
+  end
 end
 ```
 


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because: I was reviewing a PR that used the callback chain halt technique but couldn't see any details in the ActiveJob docs on how these worked. I figure this change will be useful for someone else and avoid them having to read the source / other docs to find this info.

### Detail

This Pull Request changes the ActiveJob docs, to explain how job callback chain halting works. I coped the details from Active Record and provided a link to https://api.rubyonrails.org/classes/ActiveSupport/Callbacks.html for more details.

### Additional information

Seems the main place rails docs the [ActiveSupport callbacks](https://github.com/rails/rails/blob/a6dee8c5b1baffa0ac9e57016b90d8c88a8db1f6/activesupport/lib/active_support/callbacks.rb) are in https://guides.rubyonrails.org/active_record_callbacks.html. There is some information in the [ActiveSupport docs](https://api.rubyonrails.org/classes/ActiveSupport/Callbacks.html) 

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
