### PR TITLE
Fix deprecation warning caused by DST

### DIFF
--- a/activesupport/lib/active_support/core_ext/time/compatibility.rb
+++ b/activesupport/lib/active_support/core_ext/time/compatibility.rb
@@ -15,10 +15,18 @@ class Time
   end
 
   def preserve_timezone # :nodoc:
-    active_support_local_zone == zone || super
+    system_local_time? || super
   end
 
   private
+    def system_local_time?
+      if ::Time.equal?(self.class)
+        zone = self.zone
+        String === zone &&
+          (zone != "UTC" || active_support_local_zone == "UTC")
+      end
+    end
+
     @@active_support_local_tz = nil
 
     def active_support_local_zone


### PR DESCRIPTION
Clarify our logic for detecting whether the current Time value is in the system local timezone (i.e. that `getlocal` would be a no-op).

This fixes the fact that we would previously needlessly produce a deprecation warning when encountering a still-local value from the opposite DST state from the one we had cached in `active_support_local_zone`.

Fixes a current test failure in CI, which started failing when `US/Eastern` (the zone used in the test) swapped DST, and so currently no longer matched that of the fixed date in the existing tests (`2016-04-23`).

Instead of directly matching the string, we now rely on the fact that upstream `Time#zone` can only contain two categories of string value: literal `"UTC"`, or a system-provided abbreviation for the current local timezone. Thus, as long as we have a real `Time` object (and not a subclass, like TZInfo's, which _does_ return other strings), any non-`"UTC"` string indicates the value is a local time. (And then we need only special-case the [hopefully common] situation that the local zone _is_ UTC.)

Finally, we add new tests of the local-zone detection, and complement the existing [currently failing] tests with ones that would have failed prior to the recent DST change.

Extends the warning-avoidance from #52031; closes #53529.