### PR TITLE
Support preloading of sti child association

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Allow preloading of STI children model associations. Same behaviour as polymorphic one
+
+    *Gauthier Monserand*
+
 *   Add support for enabling or disabling transactional tests per database.
 
     A test class can now override the default `use_transactional_tests` setting

--- a/activerecord/lib/active_record/associations/preloader/branch.rb
+++ b/activerecord/lib/active_record/associations/preloader/branch.rb
@@ -82,7 +82,7 @@ module ActiveRecord
           polymorphic_parent = !root? && parent.polymorphic?
           source_records.each do |record|
             reflection = record.class._reflect_on_association(association)
-            next if polymorphic_parent && !reflection || !record.association(association).klass
+            next if !reflection && (polymorphic_parent || association_found_in_sti?) || !record.association(association).klass
             (h[reflection] ||= []) << record
           end
           h
@@ -146,6 +146,14 @@ module ActiveRecord
             else
               Association
             end
+          end
+
+          def association_found_in_sti?
+            return @association_found_in_sti if defined?(@association_found_in_sti)
+
+            @association_found_in_sti =
+              source_records.first &&
+              source_records.first.class.base_class.subclasses.any? { |subclass| subclass._reflect_on_association(association) }
           end
       end
     end


### PR DESCRIPTION
Don't raise on association not found if any sti class in the hierarchy implement association while preparing records to be preloaded.

if DeadParrot and LiveParrot inherits from Parrot and DeadParrot belongs_to :killer

We enable preload of killer while loading Parrots

    Parrot.preload(:killer)

### Motivation / Background

Polymorphism already has this behaviour. Today we need to use ActiveRecord::Associations::Preloader manually to load dead parrots's killer, or the records of our rails application.

This is a lot easier to write and more coherent for the framework.

### Detail

This Pull Request changes grouped_records fonction to detect if any subclass implement the relation to allow loading without error. This keep the existing errors, no other test had to be changed.

Polymorphism is detected on parent, but sti can't.

If there is no records, there was no error raised previously

If we have at least a record we parse sti class hierarchy to see if any implement the association

The subclasses parsing is done only once in the process and only at a time where an exception would have been previously raised (in fact, previously if only DeadParrot records where returned there was no error, but it was dangerous to predict)

We can't use the records as they may not have the association and the behaviour must be predictible and coherent

### Additional information

N/A

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [X] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
