### PR TITLE
Update dev container links

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,4 +1,4 @@
-// For format details, see https://aka.ms/devcontainer.json.
+// For format details, see https://containers.dev/implementors/json_reference/.
 {
 	"name": "Rails project development",
 	"dockerComposeFile": "compose.yaml",
@@ -41,6 +41,6 @@
 		}
 	},
 
-	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// Uncomment to connect as root instead. More info: https://containers.dev/implementors/json_reference/#remoteUser.
 	// "remoteUser": "root"
 }

--- a/railties/lib/rails/generators/rails/devcontainer/templates/devcontainer/devcontainer.json.tt
+++ b/railties/lib/rails/generators/rails/devcontainer/templates/devcontainer/devcontainer.json.tt
@@ -1,5 +1,5 @@
-// For format details, see https://aka.ms/devcontainer.json. For config options, see the
-// README at: https://github.com/devcontainers/templates/tree/main/src/ruby
+// For format details, see https://containers.dev/implementors/json_reference/.
+// For config options, see the README at: https://github.com/devcontainers/templates/tree/main/src/ruby
 {
   "name": "<%= options[:app_name] %>",
   "dockerComposeFile": "compose.yaml",
@@ -23,7 +23,7 @@
   // Configure tool-specific properties.
   // "customizations": {},
 
-  // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+  // Uncomment to connect as root instead. More info: https://containers.dev/implementors/json_reference/#remoteUser.
   // "remoteUser": "root",
 
 <%- if !mounts.empty? -%>

--- a/railties/test/fixtures/.devcontainer/devcontainer.json
+++ b/railties/test/fixtures/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
-// For format details, see https://aka.ms/devcontainer.json. For config options, see the
-// README at: https://github.com/devcontainers/templates/tree/main/src/ruby
+// For format details, see https://containers.dev/implementors/json_reference/.
+// For config options, see the README at: https://github.com/devcontainers/templates/tree/main/src/ruby
 {
   "name": "tmp",
   "dockerComposeFile": "compose.yaml",
@@ -23,7 +23,7 @@
   // Configure tool-specific properties.
   // "customizations": {},
 
-  // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+  // Uncomment to connect as root instead. More info: https://containers.dev/implementors/json_reference/#remoteUser.
   // "remoteUser": "root",
 
   // Use 'postCreateCommand' to run commands after the container is created.


### PR DESCRIPTION
We already have some comments with links to the containers.dev website, which appears to be the official website for dev containers. This updates the remaining comments to stop using aka.ms links, which I believe is a Microsoft-run short URL service.