### PR TITLE
Do not create `scan_js` workflow on `--skip-js`

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/github/ci.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/github/ci.yml.tt
@@ -24,7 +24,7 @@ jobs:
         run: bin/brakeman --no-pager
 
 <% end -%>
-<%- if options[:javascript] == "importmap"  && !options[:api] && !options[:skip_javascript] -%>
+<%- if options[:javascript] == "importmap" && !options[:api] && !options[:skip_javascript] -%>
   scan_js:
     runs-on: ubuntu-latest
 

--- a/railties/lib/rails/generators/rails/app/templates/github/ci.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/github/ci.yml.tt
@@ -24,7 +24,7 @@ jobs:
         run: bin/brakeman --no-pager
 
 <% end -%>
-<%- if options[:javascript] == "importmap"  && !options[:api] -%>
+<%- if options[:javascript] == "importmap"  && !options[:api] && !options[:skip_javascript] -%>
   scan_js:
     runs-on: ubuntu-latest
 

--- a/railties/test/generators/api_app_generator_test.rb
+++ b/railties/test/generators/api_app_generator_test.rb
@@ -61,6 +61,7 @@ class ApiAppGeneratorTest < Rails::Generators::TestCase
     assert_file ".github/workflows/ci.yml" do |content|
       assert_no_match(/test:system/, content)
       assert_no_match(/screenshots/, content)
+      assert_no_match(/scan_js/, content)
     end
   end
 

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -548,6 +548,10 @@ class AppGeneratorTest < Rails::Generators::TestCase
     assert_file "app/views/layouts/application.html.erb" do |contents|
       assert_match(/stylesheet_link_tag\s+:app %>/, contents)
     end
+
+    assert_file ".github/workflows/ci.yml" do |file|
+      assert_no_match("scan_js", file)
+    end
   end
 
   def test_inclusion_of_jbuilder


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because it fixes `rails new -J foo` creates `scan_js` workflow which depends on `importmaps`.

### Detail

This Pull Request adds additional check to support https://github.com/rails/rails/pull/52927. Rails generator now only generate the `scan_js` CI workflow for the full-stack rails app using javascript and `importmaps` as javascript bundling.

Previously the `scan_js` workflow was generated even when `--skip-js` is used, resulting in the `bin/importmap: No such file or directory` error when pushing the code to the GitHub repo.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
