### PR TITLE
Update devcontainer to use new ruby 3.3.6 version

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,7 +1,7 @@
 # See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.191.1/containers/ruby/.devcontainer/base.Dockerfile
 
 # [Choice] Ruby version: 3, 3.3, 3.2, 3.1, 3.0, 2, 2.7, 2.6
-ARG VARIANT="3.3.5"
+ARG VARIANT="3.3.6"
 FROM ghcr.io/rails/devcontainer/images/ruby:${VARIANT}
 
 # [Optional] Uncomment this section to install additional OS packages.


### PR DESCRIPTION
This PR will update devcontainer ruby version to newly release 3.3.6 version 