### PR TITLE
[ci skip] Update guide docs for updated environment files

### DIFF
--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -1471,7 +1471,7 @@ The default value depends on the `config.load_defaults` target version:
 #### `config.active_record.query_log_tags_enabled`
 
 Specifies whether or not to enable adapter-level query comments. Defaults to
-`false`.
+`false`, but is set to `true` in the default generated `config/environments/development.rb` file.
 
 NOTE: When this is set to `true` database prepared statements will be automatically disabled.
 
@@ -2717,8 +2717,7 @@ Configures the behavior of disallowed deprecation warnings. See
 [`Deprecation::Behavior`][deprecation_behavior] for a description of the
 available options.
 
-In the default generated `config/environments` files, this is set to `:raise`
-for both development and test, and it is omitted for production in favor of
+This option is intended for development and test. For production, favor
 [`config.active_support.report_deprecations`](#config-active-support-report-deprecations).
 
 #### `config.active_support.disallowed_deprecation_warnings`


### PR DESCRIPTION
* https://github.com/rails/rails/pull/51831
* https://github.com/rails/rails/pull/51342
* ~~https://github.com/rails/rails/pull/52887~~ Not true anymore since https://github.com/rails/rails/pull/53627

Probably more, these are the ones I noticed.