### PR TITLE
Don't add `bin/thrust` if `thruster` is not in Gemfile

### DIFF
--- a/railties/lib/rails/commands/app/update_command.rb
+++ b/railties/lib/rails/commands/app/update_command.rb
@@ -71,6 +71,7 @@ module Rails
               skip_action_cable:   !defined?(ActionCable::Engine),
               skip_brakeman:       skip_gem?("brakeman"),
               skip_rubocop:        skip_gem?("rubocop"),
+              skip_thruster:       skip_gem?("thruster"),
               skip_test:           !defined?(Rails::TestUnitRailtie),
               skip_system_test:    Rails.application.config.generators.system_tests.nil?,
               skip_asset_pipeline: asset_pipeline.nil?,

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -304,6 +304,16 @@ class AppGeneratorTest < Rails::Generators::TestCase
     end
   end
 
+  def test_app_update_preserves_skip_thruster
+    run_generator [ destination_root, "--skip-thruster" ]
+
+    FileUtils.cd(destination_root) do
+      assert_no_changes -> { File.exist?("bin/thrust") } do
+        run_app_update
+      end
+    end
+  end
+
   def test_app_update_preserves_skip_test
     run_generator [ destination_root, "--skip-test" ]
 


### PR DESCRIPTION
Similar to https://github.com/rails/rails/pull/52578
I mentioned it in https://github.com/rails/rails/issues/52576#issuecomment-2283857478 but then forgot, sorry 😬 

Running `app:update` after upgrading to Rails 8.0.0 results in `bin/thrust` being added even though `thruster` is not in the Gemfile.

This fixes it by checking if `thruster` is in the Gemfile to set the `--skip-thruster` option when running the generator in the `app:update` command.
