### PR TITLE
allow path regexp in SilenceRequest middleware

### DIFF
--- a/railties/lib/rails/rack/silence_request.rb
+++ b/railties/lib/rails/rack/silence_request.rb
@@ -10,10 +10,13 @@ module Rails
     # This is useful for preventing recurring requests like health checks from clogging the logging.
     # This middleware is used to do just that against the path /up in production by default.
     #
-    # Example:
+    # Examples:
     #
     #   config.middleware.insert_before \
     #     Rails::Rack::Logger, Rails::Rack::SilenceRequest, path: "/up"
+    #
+    #   config.middleware.insert_before \
+    #     Rails::Rack::Logger, Rails::Rack::SilenceRequest, path: /test$/
     #
     # This middleware can also be configured using `config.silence_healthcheck_path = "/up"` in Rails.
     class SilenceRequest
@@ -22,7 +25,7 @@ module Rails
       end
 
       def call(env)
-        if env["PATH_INFO"] == @path
+        if @path === env["PATH_INFO"]
           Rails.logger.silence { @app.call(env) }
         else
           @app.call(env)

--- a/railties/test/rack_silence_request_test.rb
+++ b/railties/test/rack_silence_request_test.rb
@@ -18,4 +18,18 @@ class RackSilenceRequestTest < ActiveSupport::TestCase
 
     assert mock_logger.verify
   end
+
+  test "silence request using a Regexp" do
+    mock_logger = Minitest::Mock.new
+    mock_logger.expect :silence, nil
+
+    app = Rails::Rack::SilenceRequest.new(lambda { |env| [200, env, "app"] }, path: /up/)
+
+    Rails.stub(:logger, mock_logger) do
+      app.call(Rack::MockRequest.env_for("http://example.com/up"))
+      app.call(Rack::MockRequest.env_for("http://example.com/down"))
+    end
+
+    assert mock_logger.verify
+  end
 end


### PR DESCRIPTION
One line change that allows more than a single route to be silenced using a regexp pattern. 