### PR TITLE
Point to latest official Ruby documentation in Rails guides [ci skip]

### DIFF
--- a/guides/source/active_record_validations.md
+++ b/guides/source/active_record_validations.md
@@ -590,7 +590,7 @@ These options are all supported:
 
 NOTE: The validator requires a compare option be supplied. Each option accepts a
 value, proc, or symbol. Any class that includes
-[Comparable](https://ruby-doc.org/3.3.5/Comparable.html) can be compared.
+[Comparable](https://docs.ruby-lang.org/en/master/Comparable.html) can be compared.
 
 ### `format`
 

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -3182,7 +3182,7 @@ NOTE: `Rails::HTML5::Sanitizer` is not supported on JRuby, so on JRuby platforms
 #### `Regexp.timeout`
 
 
-See Ruby's documentation for [`Regexp.timeout=`](https://docs.ruby-lang.org/en/3.3/Regexp.html#method-c-timeout-3D).
+See Ruby's documentation for [`Regexp.timeout=`](https://docs.ruby-lang.org/en/master/Regexp.html#method-c-timeout-3D).
 
 ### Configuring a Database
 

--- a/guides/source/getting_started.md
+++ b/guides/source/getting_started.md
@@ -567,7 +567,7 @@ file, and replace its contents with:
 </ul>
 ```
 
-The above code is a mixture of HTML and *ERB*. ERB, short for [Embedded Ruby](https://docs.ruby-lang.org/en/3.2/ERB.html), is a templating system that
+The above code is a mixture of HTML and *ERB*. ERB, short for [Embedded Ruby](https://docs.ruby-lang.org/en/master/ERB.html), is a templating system that
 evaluates Ruby code embedded in a document. Here, we can see two types of ERB
 tags: `<% %>` and `<%= %>`. The `<% %>` tag means "evaluate the enclosed Ruby
 code." The `<%= %>` tag means "evaluate the enclosed Ruby code, and output the


### PR DESCRIPTION
# Description
Point to the latest official Ruby documentation (https://docs.ruby-lang.org/en/master/) across the Rails guides.

This way we don't have to modify the docs every time a new version of Ruby is released.