### PR TITLE
Add turbo meta tags to the application template

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/app/views/layouts/application.html.erb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/app/views/layouts/application.html.erb.tt
@@ -5,6 +5,11 @@
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="mobile-web-app-capable" content="yes">
+    <%- unless options[:skip_hotwire] || options[:skip_javascript] -%>
+    <meta name="view-transition" content="same-origin">
+    <meta name="turbo-refresh-method" content="morph">
+    <meta name="turbo-refresh-scroll" content="preserve">
+    <%- end -%>
     <%%= csrf_meta_tags %>
     <%%= csp_meta_tag %>
 

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -921,6 +921,9 @@ class AppGeneratorTest < Rails::Generators::TestCase
     assert_gem "stimulus-rails"
     assert_file "app/views/layouts/application.html.erb" do |content|
       assert_match(/data-turbo-track/, content)
+      assert_match(/view-transition/, content)
+      assert_match(/turbo-refresh-method/, content)
+      assert_match(/turbo-refresh-scroll/, content)
     end
   end
 
@@ -931,6 +934,9 @@ class AppGeneratorTest < Rails::Generators::TestCase
     assert_no_gem "turbo-rails"
     assert_file "app/views/layouts/application.html.erb" do |content|
       assert_no_match(/data-turbo-track/, content)
+      assert_no_match(/view-transition/, content)
+      assert_no_match(/turbo-refresh-method/, content)
+      assert_no_match(/turbo-refresh-scroll/, content)
     end
     assert_no_file "app/javascript/application.js"
   end


### PR DESCRIPTION
### Motivation / Background

Turbo morph was introduced as the happiest navigation path for Rails. It usually replaces turbo streams and offers more modern navigation. Is there any reason not to recommend this pattern when creating a new Rails app?

I'm also proposing view transitions to be enabled by default. The fading effect is subtle, and I see no reason not to recommend enabling it.

### Additional information

https://dev.37signals.com/a-happier-happy-path-in-turbo-with-morphing/

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
