### PR TITLE
Fix retrieving partial indexes with comments for SQLite

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/sqlite3/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3/schema_statements.rb
@@ -27,6 +27,7 @@ module ActiveRecord
               col["name"]
             end
 
+            where = where.sub(/\s*\/\*.*\*\/\z/, "") if where
             orders = {}
 
             if columns.any?(&:nil?) # index created with an expression

--- a/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
@@ -698,6 +698,15 @@ module ActiveRecord
         end
       end
 
+      def test_partial_index_with_comment
+        with_example_table do
+          @conn.add_index "ex", :id, name: "fun", where: "number > 0 /*tag:test*/"
+          index = @conn.indexes("ex").find { |idx| idx.name == "fun" }
+          assert_equal ["id"], index.columns
+          assert_equal "number > 0", index.where
+        end
+      end
+
       if ActiveRecord::Base.lease_connection.supports_expression_index?
         def test_expression_index
           with_example_table do


### PR DESCRIPTION
Fixes #53565.

This was probably unnoticed for so long, because sqlite get real traction only recently and people started to create partial indexes. The problem was that the existing regex https://github.com/rails/rails/blob/852d0cd4123463cf215f4b024801b256857295c4/activerecord/lib/active_record/connection_adapters/sqlite3/schema_statements.rb#L24 incorrectly greedily parses the comment under the `where` clause. Fixing it makes the regexp even more complex, so I think just striping it from the already parsed `where` is simpler.