### PR TITLE
Don't install a package for system test when applications don't use it

### DIFF
--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -609,6 +609,14 @@ module Rails
         packages.compact.sort
       end
 
+      def ci_packages
+        if depends_on_system_test?
+          dockerfile_build_packages << "google-chrome-stable"
+        else
+          dockerfile_build_packages
+        end
+      end
+
       def css_gemfile_entry
         return if options[:api]
         return unless options[:css]

--- a/railties/lib/rails/generators/rails/app/templates/github/ci.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/github/ci.yml.tt
@@ -100,7 +100,7 @@ jobs:
     <%- end -%>
     steps:
       - name: Install packages
-        run: sudo apt-get update && sudo apt-get install --no-install-recommends -y google-chrome-stable <%= dockerfile_base_packages.join(" ") %>
+        run: sudo apt-get update && sudo apt-get install --no-install-recommends -y <%= ci_packages.join(" ") %>
 
       - name: Checkout code
         uses: actions/checkout@v4

--- a/railties/lib/rails/generators/rails/plugin/templates/github/ci.yml.tt
+++ b/railties/lib/rails/generators/rails/plugin/templates/github/ci.yml.tt
@@ -64,7 +64,7 @@ jobs:
     <%- end -%>
     steps:
       - name: Install packages
-        run: sudo apt-get update && sudo apt-get install --no-install-recommends -y google-chrome-stable <%= dockerfile_base_packages.join(" ") %>
+        run: sudo apt-get update && sudo apt-get install --no-install-recommends -y <%= ci_packages.join(" ") %>
 
       - name: Checkout code
         uses: actions/checkout@v4

--- a/railties/test/generators/api_app_generator_test.rb
+++ b/railties/test/generators/api_app_generator_test.rb
@@ -62,6 +62,7 @@ class ApiAppGeneratorTest < Rails::Generators::TestCase
       assert_no_match(/test:system/, content)
       assert_no_match(/screenshots/, content)
       assert_no_match(/scan_js/, content)
+      assert_no_match(/google-chrome-stable/, content)
     end
   end
 

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -519,6 +519,10 @@ class AppGeneratorTest < Rails::Generators::TestCase
     assert_directory("test")
 
     assert_no_directory("test/system")
+
+    assert_file ".github/workflows/ci.yml" do |content|
+      assert_no_match(/google-chrome-stable/, content)
+    end
   end
 
   def test_does_not_generate_system_test_files_if_skip_system_test_is_given


### PR DESCRIPTION
### Detail

The `google-chrome-stable` is for system tests. So applications don't use it, the package is unneeded.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
