### PR TITLE
[Fix #53564] Ensure normalized attribute queries are consistent for `nil` and normalized `nil`

### DIFF
--- a/activerecord/lib/active_record/relation/query_attribute.rb
+++ b/activerecord/lib/active_record/relation/query_attribute.rb
@@ -35,7 +35,7 @@ module ActiveRecord
       def nil?
         unless value_before_type_cast.is_a?(StatementCache::Substitute)
           value_before_type_cast.nil? ||
-            type.respond_to?(:subtype) && serializable? && value_for_database.nil?
+            (type.respond_to?(:subtype) || type.respond_to?(:normalizer)) && serializable? && value_for_database.nil?
         end
       end
 

--- a/activerecord/test/cases/normalized_attribute_test.rb
+++ b/activerecord/test/cases/normalized_attribute_test.rb
@@ -6,7 +6,7 @@ require "active_support/core_ext/string/inflections"
 
 class NormalizedAttributeTest < ActiveRecord::TestCase
   class NormalizedAircraft < Aircraft
-    normalizes :name, with: -> name { name.titlecase }
+    normalizes :name, with: -> name { name.presence&.titlecase }
     normalizes :manufactured_at, with: -> time { time.noon }
 
     attr_accessor :validated_name
@@ -81,6 +81,10 @@ class NormalizedAttributeTest < ActiveRecord::TestCase
   test "finds record by normalized value" do
     assert_equal @time.noon, @aircraft.manufactured_at
     assert_equal @aircraft, NormalizedAircraft.find_by(manufactured_at: @time.to_s)
+  end
+
+  test "uses the same query when finding record by nil and normalized nil values" do
+    assert_equal NormalizedAircraft.where(name: nil).to_sql, NormalizedAircraft.where(name: "").to_sql
   end
 
   test "can stack normalizations" do


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

Fixes https://github.com/rails/rails/issues/53564

### Detail

Updates `Arel::Visitors::ToSql#visit_Arel_Nodes_Equality` to look ahead at the database value and check if it's `nil`, and if so, uses `IS NULL` instead of `=` in the resulting query. The value is memoised [here](https://github.com/rails/rails/blob/852d0cd4123463cf215f4b024801b256857295c4/activerecord/lib/active_record/relation/query_attribute.rb#L26-L29), so I doubt this change has any major performance implications in the case where the condition is falsey and the `=` branch is executed.

**Edit:** Looks like `ActiveRecord::Relation::QueryAttribute#nil?` already does a similar check, so I went with [this approach](https://github.com/rails/rails/compare/0957be203f2d172ccdaa9a2a0023a56b551a4db4..a6e06e11fedc753bcc8018e4aed83f967c1f94a4) instead.

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

NA

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.