### PR TITLE
Check if Regexp.timeout = is supported in configuration.rb

### DIFF
--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -345,7 +345,7 @@ module Rails
             action_dispatch.strict_freshness = true
           end
 
-          Regexp.timeout ||= 1
+          Regexp.timeout ||= 1 if Regexp.respond_to?(:timeout=)
         when "8.1"
           load_defaults "8.0"
         else

--- a/tools/rail_inspector/lib/rail_inspector/visitor/framework_default.rb
+++ b/tools/rail_inspector/lib/rail_inspector/visitor/framework_default.rb
@@ -120,6 +120,7 @@ module RailInspector
 
             def respond_to_framework?(node)
               if node in SyntaxTree::CallNode[
+                   receiver: nil,
                    message: SyntaxTree::Ident[value: "respond_to?"],
                    arguments: SyntaxTree::ArgParen[
                      arguments: SyntaxTree::Args[


### PR DESCRIPTION
### Motivation / Background

See https://github.com/rails/rails/pull/53490#issuecomment-2465235043

TruffleRuby does not implement `Regexp.timeout/Regexp.timeout=` yet, and it might be quite tricky to implement (e.g. it might need changes in the Regexp engine, https://github.com/jruby/joni).
So it would be nice if it doesn't fail here when booting a Rails 8 app on TruffleRuby (latest release or head).
(we've had a couple reports of #53490 breaking Rails on TruffleRuby)

### Alternative

Wait that TruffleRuby implements `Regexp.timeout =`.
As mentioned above that might take some time, and of course that won't fix for the current TruffleRuby release, 24.1.0.
The next release, 24.2.0, is only in March 2025.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
