### PR TITLE
Add database reset suggestion [ci-skip]

### DIFF
--- a/guides/source/active_record_migrations.md
+++ b/guides/source/active_record_migrations.md
@@ -1303,6 +1303,15 @@ contents of the current `db/schema.rb` or `db/structure.sql` file. If a
 migration can't be rolled back, `bin/rails db:reset` may not help you. To find
 out more about dumping the schema see [Schema Dumping and You][] section.
 
+If you need an alternative to `db:reset` that explicitly runs all migrations,
+consider using the `bin/rails db:migrate:reset` command. You can follow that
+command with `bin/rails db:seed` if needed.
+
+NOTE: `bin/rails db:reset` rebuilds the database using the current schema. On
+the other hand, `bin/rails db:migrate:reset` replays all migrations from the
+beginning, which can lead to schema drift if, for example, migrations have been
+altered, reordered, or removed.
+
 [Schema Dumping and You]: #schema-dumping-and-you
 
 ### Running Specific Migrations


### PR DESCRIPTION
Documents `db:migrate:reset` as an alternative to `db:reset` that does run migrations.

### Motivation / Background

The Resetting the Database section has a note stating that resetting the database won't run migrations. This Pull Request adds a short comment stating what that command would look like in case you do need (or want) to run them. 

### Detail

This Pull Request changes the Resetting the Database section in the Active Record Migrations guide.