### PR TITLE
[Fix #53581] Fix error when building devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -4,7 +4,7 @@
 ARG VARIANT="3.3.6"
 FROM ghcr.io/rails/devcontainer/images/ruby:${VARIANT}
 
-# [Optional] Uncomment this section to install additional OS packages.
+USER root
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && apt-get -y install --no-install-recommends \
         mariadb-client libmariadb-dev \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -4,9 +4,8 @@
 ARG VARIANT="3.3.6"
 FROM ghcr.io/rails/devcontainer/images/ruby:${VARIANT}
 
-USER root
-RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
-    && apt-get -y install --no-install-recommends \
+RUN sudo apt-get update && export DEBIAN_FRONTEND=noninteractive \
+    && sudo apt-get -y install --no-install-recommends \
         mariadb-client libmariadb-dev \
         postgresql-client postgresql-contrib libpq-dev \
         ffmpeg mupdf mupdf-tools libvips-dev poppler-utils \
@@ -32,7 +31,7 @@ COPY railties/railties.gemspec /tmp/rails/railties/
 COPY tools/releaser/releaser.gemspec /tmp/rails/tools/releaser/
 # Docker does not support COPY as users other than root. So we need to chown this dir so we
 # can bundle as vscode user and then remove the tmp dir
-RUN chown -R vscode:vscode /tmp/rails
+RUN sudo chown -R vscode:vscode /tmp/rails
 USER vscode
 RUN cd /tmp/rails \
     && /home/vscode/.rbenv/shims/bundle install \


### PR DESCRIPTION
### Motivation / Background

Fixes #53581 

### Detail

When building the Rails devcontainer the `apt-get` step of the Dockerfile was failing with a permissions error. Specifically:

```
> devcontainer build --workspace-folder .
...
=> ERROR [rails dev_container_auto_added_stage_label  2/19] RUN apt-get update && export DEBIAN_FRONTEND=noninteractive     && apt-get -y install --no-install-recommends         mariadb-client libmariadb-dev         postgr  0.1s
0.151 Reading package lists...
0.158 E: List directory /var/lib/apt/lists/partial is missing. - Acquire (13: Permission denied)
```

This PR fixes the permissions error by using `sudo` as appropriate.

The bug this PR fixes was introduced by #53554, but why this is so is not entirely clear.

### Additional information

N/A

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [N/A] Tests are added or updated if you fix a bug or add a feature.
* [N/A] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.