### PR TITLE
Add test coverage for generators help output

### DIFF
--- a/railties/test/application/generators_test.rb
+++ b/railties/test/application/generators_test.rb
@@ -193,14 +193,12 @@ module ApplicationTests
     end
 
     test "help does not show hidden namespaces and hidden commands" do
-      FileUtils.cd(rails_root) do
-        output = rails("generate", "--help")
-        assert_no_match "active_record:migration", output
-        assert_no_match "credentials", output
+      output = rails("generate", "--help")
+      assert_no_match "active_record:migration", output
+      assert_no_match "credentials", output
 
-        output = rails("destroy", "--help")
-        assert_no_match "active_record:migration", output
-      end
+      output = rails("destroy", "--help")
+      assert_no_match "active_record:migration", output
     end
 
     test "skip collision check" do

--- a/railties/test/generators_test.rb
+++ b/railties/test/generators_test.rb
@@ -144,6 +144,33 @@ class GeneratorsTest < Rails::Generators::TestCase
     assert_no_match(/^  app$/, output)
   end
 
+  def test_rails_generators_help_lists_all_generators
+    output = capture(:stdout) { Rails::Generators.help }
+
+    generator_list = output.split("Please choose a generator below.\n", 2).last
+
+    sections = {
+      "Rails" => %w[application_record model scaffold_controller],
+      "ActiveRecord" => %w[active_record:application_record active_record:multi_db],
+      "Erb" => %w[erb:authentication],
+      "TestUnit" => %w[test_unit:install test_unit:mailbox],
+    }
+
+    ignored_namespaces = %w[Fixjour Foobar QueueClassic Sidekiq Stimulus SuckerPunch Tailwindcss UsageTemplate]
+
+    sections.each do |section, generators|
+      assert_match(/^#{section}/, generator_list, "Expected section #{section} to be in the output")
+      generators.each do |generator|
+        assert_match(/^\s{2}#{generator}$/, generator_list, "Expected generator #{generator} in section #{section}")
+      end
+    end
+
+    output_sections = generator_list.scan(/^(.*):$/).flatten
+    actual_sections = output_sections - ignored_namespaces
+
+    assert_equal sections.keys.sort, actual_sections.sort
+  end
+
   def test_rails_generators_help_does_not_include_app_nor_plugin_new
     output = capture(:stdout) { Rails::Generators.help }
     assert_no_match(/app\W/, output)


### PR DESCRIPTION
We want to make changes to this command, for example removing "erb:authentication" or "test_unit" (especially if you're using rspec or another test_framework)... but we realized that how we got here is there are no tests to ensure that any additions to Railties and aren't explicitly filtered (via hidden_namespaces) will cause this test to fail.

cc @skipkayhil 