### PR TITLE
Call out pitfalls with Encryption when upgrading

### DIFF
--- a/guides/source/7_1_release_notes.md
+++ b/guides/source/7_1_release_notes.md
@@ -729,6 +729,8 @@ Please refer to the [Changelog][active-record] for detailed changes.
 
 *   Add validation option for `enum`.
 
+*   The default hash digest for `ActiveRecord::Encryption`, used for attributes defined with `encrypts`, is now `SHA256`, changed from `SHA1` in the default configuration. These defaults also include `support_sha1_for_non_deterministic_encryption = false` which can lead to apps being unable to decrypt data encrypted with the old default hash digest if data is not re-encrypted.
+
 Active Storage
 --------------
 

--- a/guides/source/upgrading_ruby_on_rails.md
+++ b/guides/source/upgrading_ruby_on_rails.md
@@ -365,6 +365,12 @@ versions, there are two scenarios to consider:
     config.active_record.encryption.hash_digest_class = OpenSSL::Digest::SHA1
     ```
 
+    If all of your data was encrypted non-deterministicly (the default unless `encrypts` is passed `deterministic: true`, you can instead configure SHA-256 for Active Record Encryption as in scenario 2 below and also allow columns previously encrypted with SHA-1 to be decrypted by setting:
+
+    ```ruby
+    config.active_record.encryption.support_sha1_for_non_deterministic_encryption = true
+    ```
+
 2. If you have `config.active_support.key_generator_hash_digest_class` configured as SHA-256 (the new default
    in 7.0), then you need to configure SHA-256 for Active Record Encryption:
 
@@ -387,7 +393,7 @@ by the aforementioned bug, this configuration should be enabled:
 config.active_record.encryption.support_sha1_for_non_deterministic_encryption = true
 ```
 
-If you are working with encrypted data, please carefully review the above.
+**If you are working with encrypted data, please carefully review the above.**
 
 ### New ways to handle exceptions in Controller Tests, Integration Tests, and System Tests
 


### PR DESCRIPTION
As has been noted in a few issues, upgrading from Rails to 7.1 config defaults can lead to data loss or confusion as the hash_digest_class changed from SHA1 to SHA256 but we don't by default class changed from SHA1 to SHA256 but we don't by default class changed from SHA1 to SHA256 but we don't by default class changed from SHA1 to SHA256 but we don't by default set
`support_sha1_for_non_deterministic_encryption = true`.

This adds the change to the 7.0->7.1 upgrade notes and to the 7.1 release notes.

https://github.com/rails/rails/issues/48204
https://github.com/rails/rails/issues/50212
https://github.com/rails/rails/issues/50226
Further writeup: https://calebhearth.com/rails-7-1-encryption-errors 

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
