### PR TITLE
Add missing period to generated Puma config [ci skip]

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/puma.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/puma.rb.tt
@@ -34,7 +34,7 @@ port ENV.fetch("PORT", 3000)
 plugin :tmp_restart
 
 <% unless skip_solid? -%>
-# Run the Solid Queue supervisor inside of Puma for single-server deployments
+# Run the Solid Queue supervisor inside of Puma for single-server deployments.
 plugin :solid_queue if ENV["SOLID_QUEUE_IN_PUMA"]
 
 <% end -%>


### PR DESCRIPTION
# Description
Just adds a missing period in the automatically generated `config/puma.rb` 😃.
