### PR TITLE
Improve comment in default RuboCop binstub [ci skip]

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/bin/rubocop.tt
+++ b/railties/lib/rails/generators/rails/app/templates/bin/rubocop.tt
@@ -1,7 +1,7 @@
 require "rubygems"
 require "bundler/setup"
 
-# explicit rubocop config increases performance slightly while avoiding config confusion.
+# Explicit RuboCop config increases performance slightly while avoiding config confusion.
 ARGV.unshift("--config", File.expand_path("../.rubocop.yml", __dir__))
 
 load Gem.bin_path("rubocop", "rubocop")


### PR DESCRIPTION
# Description
This PR just improves a comment in the default generated `bin/rubocop` binstub. 😃