### PR TITLE
Return boolean for `authenticated?` helper

### DIFF
--- a/railties/lib/rails/generators/rails/authentication/templates/app/controllers/concerns/authentication.rb.tt
+++ b/railties/lib/rails/generators/rails/authentication/templates/app/controllers/concerns/authentication.rb.tt
@@ -14,7 +14,7 @@ module Authentication
 
   private
     def authenticated?
-      resume_session
+      resume_session.present?
     end
 
     def require_authentication


### PR DESCRIPTION
Very minor follow-up to https://github.com/rails/rails/pull/53175.

When you call the `authenticated?` helper in a debugging session it currently returns the session object, which doesn't look very clean IMO. This PR makes it return `true` or `false`.