### PR TITLE
Do not accept invalid values for `where` with polymorphic associations

### DIFF
--- a/activerecord/lib/active_record/relation/predicate_builder/polymorphic_array_value.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder/polymorphic_array_value.rb
@@ -38,6 +38,10 @@ module ActiveRecord
             value.class
           elsif value.is_a?(Relation)
             value.model
+          elsif value.nil?
+            nil
+          else
+            raise ArgumentError, "#{value.inspect} is not a valid #{associated_table.association_name}"
           end
         end
 

--- a/activerecord/lib/active_record/table_metadata.rb
+++ b/activerecord/lib/active_record/table_metadata.rb
@@ -62,6 +62,10 @@ module ActiveRecord
       reflection&.through_reflection?
     end
 
+    def association_name
+      reflection&.name
+    end
+
     def reflect_on_aggregation(aggregation_name)
       klass&.reflect_on_aggregation(aggregation_name)
     end

--- a/activerecord/test/cases/associations/belongs_to_associations_test.rb
+++ b/activerecord/test/cases/associations/belongs_to_associations_test.rb
@@ -59,6 +59,12 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
     assert_equal comments(:greetings), Comment.where(author: [nil]).first
   end
 
+  def test_where_on_polymorphic_association_with_invalid_value
+    assert_raises(ArgumentError, match: /"invalid" is not a valid author/) do
+      Comment.where(author: "invalid")
+    end
+  end
+
   def test_where_on_polymorphic_association_with_empty_array
     assert_empty Comment.where(author: [])
   end

--- a/activerecord/test/cases/relation/where_test.rb
+++ b/activerecord/test/cases/relation/where_test.rb
@@ -441,7 +441,8 @@ module ActiveRecord
     end
 
     def test_where_on_association_with_custom_primary_key_with_array_of_ids
-      essay = Essay.where(writer: ["David"]).first
+      author = authors(:david)
+      essay = Essay.where(author: [author.name]).first
 
       assert_equal essays(:david_modest_proposal), essay
     end


### PR DESCRIPTION
Fixes #53590 (see there for the description).

When an invalid value is passed for `.where` with a polymorphic association, that value is passed as `id` to the query, but the `type` is silently ignored, which can lead to invalid records being fetched. 