### PR TITLE
Fix typo in 'Getting Started' guide - Replace 'textarea' with 'text_a…

### DIFF
--- a/guides/source/getting_started.md
+++ b/guides/source/getting_started.md
@@ -840,7 +840,7 @@ Let's create `app/views/articles/new.html.erb` with the following contents:
 
   <div>
     <%= form.label :body %><br>
-    <%= form.textarea :body %>
+    <%= form.text_area :body %>
   </div>
 
   <div>
@@ -1493,7 +1493,7 @@ So first, we'll wire up the Article show template
   </p>
   <p>
     <%= form.label :body %><br>
-    <%= form.textarea :body %>
+    <%= form.text_area :body %>
   </p>
   <p>
     <%= form.submit %>


### PR DESCRIPTION
This PR corrects a minor typo in the “Getting Started” guide, where textarea is used instead of text_area. This typo appears in two locations within the documentation and may lead to errors when following along with the guide.

Files Changed:
•	guides/source/getting_started.md 


Why is this Change Needed?
When users follow the guide, the incorrect use of textarea results in an error: undefined method 'textarea' for an instance of ActionView::Helpers::FormBuilder. Correcting this typo to text_area will be a fix.




