### PR TITLE
Document additional skip options for rails new [ci skip]

### DIFF
--- a/guides/source/command_line.md
+++ b/guides/source/command_line.md
@@ -66,7 +66,12 @@ If you wish to skip some files from being generated or skip some libraries, you 
 | `--skip-system-test`    | Skip system test files                                   |
 | `--skip-bootsnap`       | Skip bootsnap gem                                        |
 | `--skip-dev-gems`       | Skip adding development gems                             |
+| `--skip-thruster`       | Skip Thruster setup                                      |
 | `--skip-rubocop`        | Skip RuboCop setup                                       |
+| `--skip-brakeman`       | Skip brakeman setup                                      |
+| `--skip-ci`             | Skip GitHub CI files                                     |
+| `--skip-kamal`          | Skip Kamal setup                                         |
+| `--skip-solid`          | Skip Solid Cache, Queue, and Cable setup                 |
 
 These are just some of the options that `rails new` accepts. For a full list of options, type `rails new --help`.
 


### PR DESCRIPTION
Adds some of the newer available skip options to the guides in the same order and format they appear in the CLI.

Apologies in advance if there is anything wrong with this PR, or if it's not needed. I've read the contributing guidelines, but this is my first PR for Rails.

### Motivation / Background

This Pull Request has been created because I was giving Rails 8 a run and noticed a few options for `rails new` within `rails new --help` that I didn't see in the docs and thought it may be useful to add them.

### Detail

This Pull Request adds to the documentation for the Rails Guides, specifically the [The Rails Command Line](https://guides.rubyonrails.org/command_line.html#rails-new) page and the list of available skip options.


