### PR TITLE
Faster initializer tsort

### DIFF
--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -609,7 +609,7 @@ module Rails
     end
 
     def railties_initializers(current) # :nodoc:
-      initializers = []
+      initializers = Initializable::Collection.new
       ordered_railties.reverse.flatten.each do |r|
         if r == self
           initializers += current

--- a/railties/lib/rails/initializable.rb
+++ b/railties/lib/rails/initializable.rb
@@ -9,23 +9,15 @@ module Rails
     end
 
     class Initializer
-      attr_reader :name, :block
+      attr_reader :name, :block, :before, :after
 
-      def initialize(name, context, options, &block)
-        options[:group] ||= :default
-        @name, @context, @options, @block = name, context, options, block
-      end
-
-      def before
-        @options[:before]
-      end
-
-      def after
-        @options[:after]
+      def initialize(name, context, before:, after:, group: nil, &block)
+        @group = group || :default
+        @name, @before, @after, @context, @block = name, before, after, context, block
       end
 
       def belongs_to?(group)
-        @options[:group] == group || @options[:group] == :all
+        @group == group || @group == :all
       end
 
       def run(*args)
@@ -34,7 +26,7 @@ module Rails
 
       def bind(context)
         return self if @context
-        Initializer.new(@name, context, @options, &block)
+        Initializer.new(@name, context, before:, after:, group: @group, &block)
       end
 
       def context_class
@@ -42,16 +34,54 @@ module Rails
       end
     end
 
-    class Collection < Array
+    class Collection
+      include Enumerable
       include TSort
+
+      def initialize(initializers = nil)
+        @order = Hash.new { |hash, key| hash[key] = Set.new }
+        @resolve = Hash.new { |hash, key| hash[key] = Set.new }
+        @collection = []
+        concat(initializers) if initializers
+      end
+
+      def to_a
+        @collection
+      end
+
+      def last
+        @collection.last
+      end
+
+      def each(&block)
+        @collection.each(&block)
+      end
 
       alias :tsort_each_node :each
       def tsort_each_child(initializer, &block)
-        select { |i| i.before == initializer.name || i.name == initializer.after }.each(&block)
+        @order[initializer.name].each do |name|
+          @resolve[name].each(&block)
+        end
       end
 
       def +(other)
-        Collection.new(to_a + other.to_a)
+        dup.concat(other.to_a)
+      end
+
+      def <<(initializer)
+        @collection << initializer
+        @order[initializer.before] << initializer.name if initializer.before
+        @order[initializer.name] << initializer.after if initializer.after
+        @resolve[initializer.name] << initializer
+      end
+
+      def concat(initializers)
+        initializers.each(&method(:<<))
+        self
+      end
+
+      def has?(name)
+        @resolve.key?(name)
       end
     end
 
@@ -87,8 +117,10 @@ module Rails
 
       def initializer(name, opts = {}, &blk)
         raise ArgumentError, "A block must be passed when defining an initializer" unless blk
-        opts[:after] ||= initializers.last.name unless initializers.empty? || initializers.find { |i| i.name == opts[:before] }
-        initializers << Initializer.new(name, nil, opts, &blk)
+        opts[:after] ||= initializers.last&.name unless initializers.has?(opts[:before])
+        initializers << Initializer.new(
+          name, nil, before: opts[:before], after: opts[:after], group: opts[:group], &blk
+        )
       end
     end
   end


### PR DESCRIPTION
### Motivation / Background

I noticed while profiling my app that initializer sorting is a bit slow. The app is very large, and has many initializers, so this makes sense. However, I think it could be better:

<img width="417" alt="Screenshot 2024-11-12 at 6 36 23 PM" src="https://github.com/user-attachments/assets/d965f035-179a-4c08-84d5-d9dee57a9c5e">

This Pull Request has been created because iterating initializers for each node child is expensive. Instead, we can use a hash to speed up tsorting children to iterate less often. This can save a lot of time on larger apps:

Before:
```
Warming up --------------------------------------
  tsort initializers    24.000 i/100ms
Calculating -------------------------------------
  tsort initializers    244.212 (± 2.5%) i/s    (4.09 ms/i) -      1.224k in   5.015190s
```

After:
```
Warming up --------------------------------------
  tsort initializers   179.000 i/100ms
Calculating -------------------------------------
  tsort initializers      1.791k (± 1.1%) i/s  (558.27 μs/i) -      9.129k in   5.097031s
```

### Detail

Benchmark:
```rb
# frozen_string_literal: true

require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"

  gem "rails", path: "..."
  gem "benchmark-ips"
end

require "rails/all"

class MyApp < Rails::Application
  config.eager_load = false
end


Benchmark.ips do |x|
  x.report("tsort initializers") do
    Rails.application.initializers.tsort_each { }
  end
end
```

This Pull Request changes `Rails::Initializable::Collection` to sort when an initializer is added, so each node child can be found quicker. This patch saves ~400ms on my app.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.

cc @kmcphillips 
