### PR TITLE
[Fix #47849] Correctly strip newlines from check constraints for MySQL 8.0.16+

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -746,9 +746,7 @@ module ActiveRecord
 
       private
         def strip_whitespace_characters(expression)
-          expression = expression.gsub(/\\n|\\\\/, "")
-          expression = expression.gsub(/\s{2,}/, " ")
-          expression
+          expression.gsub('\\\n', "").gsub("x0A", "").squish
         end
 
         def extended_type_map_key


### PR DESCRIPTION
### Motivation / Background

The regular expression used to strip whitespace characters from check constraints that I added in #47851 was incorrectly specified, and resulted in `n` characters being left in the output.

### Detail

This PR changes the `strip_whitespace_characters` method I previously introduced to ensure that check constraints are output in a format that allows them to be restored.

Given the DDL for our table (edited to remove private details about our app):

```sql
CREATE TABLE `sample_table` (
  `id` int NOT NULL AUTO_INCREMENT,
  `approver_ids` json DEFAULT NULL,
  PRIMARY KEY (`id`),
  CONSTRAINT `non_empty_approver_ids_array` CHECK (json_schema_valid(_utf8mb4'\n        {\n          "oneOf": [\n            {\n              "type": "null"\n            },\n            {\n              "type": "array",\n              "minItems": 1,\n              "items": {\n                "type": "integer",\n                "minimum": 0\n              }\n            }\n          ]\n        }',`approver_ids`))
) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
```

On the `7-2-stable` branch (our app isn't yet compatible with Rails 8, but the underlying code here hasn't changed), the constraint `non_empty_approver_ids_array` here results in the output:

```sql
json_schema_valid(_utf8mb4'n {n "oneOf": [n {n "type": "null"n },n {n "type": "array",n "minItems": 1,n "items": {n "type": "integer",n "minimum": 0n }n }n ]n }',`approver_ids`)
```

This is invalid when we restore the schema dump.

With the fix from this PR in place, the output becomes:

```sql
json_schema_valid(_utf8mb4' { "oneOf": [ { "type": "null" }, { "type": "array", "minItems": 1, "items": { "type": "integer", "minimum": 0 } } ] }',`approver_ids`)
```

This is valid and allows the schema dump to be restored correctly.

As a bonus, the revised code no longer uses regular expressions to avoid the same mistake occurring in the future.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
