### PR TITLE
Only include PermissionsPolicy::Middleware if global policy is configured

### DIFF
--- a/actionpack/lib/action_controller/metal/permissions_policy.rb
+++ b/actionpack/lib/action_controller/metal/permissions_policy.rb
@@ -24,8 +24,17 @@ module ActionController # :nodoc:
       #       end
       #     end
       #
+      # Requires a global policy defined in an initializer, which can be
+      # empty:
+      #
+      #     Rails.application.config.permissions_policy do |policy|
+      #       # policy.gyroscope :none
+      #     end
       def permissions_policy(**options, &block)
         before_action(options) do
+          unless request.respond_to?(:permissions_policy)
+            raise "Cannot override permissions_policy if no global permissions_policy configured."
+          end
           if block_given?
             policy = request.permissions_policy.clone
             instance_exec(policy, &block)

--- a/actionpack/lib/action_dispatch/http/permissions_policy.rb
+++ b/actionpack/lib/action_dispatch/http/permissions_policy.rb
@@ -186,4 +186,8 @@ module ActionDispatch # :nodoc:
         end
       end
   end
+
+  ActiveSupport.on_load(:action_dispatch_request) do
+    include ActionDispatch::PermissionsPolicy::Request
+  end
 end

--- a/actionpack/lib/action_dispatch/http/request.rb
+++ b/actionpack/lib/action_dispatch/http/request.rb
@@ -25,7 +25,6 @@ module ActionDispatch
     include ActionDispatch::Http::FilterParameters
     include ActionDispatch::Http::URL
     include ActionDispatch::ContentSecurityPolicy::Request
-    include ActionDispatch::PermissionsPolicy::Request
     include Rack::Request::Env
 
     autoload :Session, "action_dispatch/request/session"

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,2 +1,5 @@
+*   Only include PermissionsPolicy::Middleware if policy is configured.
+
+    *Petrik de Heus*
 
 Please check [8-0-stable](https://github.com/rails/rails/blob/8-0-stable/railties/CHANGELOG.md) for previous changes.

--- a/railties/lib/rails/application/default_middleware_stack.rb
+++ b/railties/lib/rails/application/default_middleware_stack.rb
@@ -83,7 +83,7 @@ module Rails
           unless config.api_only
             middleware.use ::ActionDispatch::Flash
             middleware.use ::ActionDispatch::ContentSecurityPolicy::Middleware
-            middleware.use ::ActionDispatch::PermissionsPolicy::Middleware
+            middleware.use ::ActionDispatch::PermissionsPolicy::Middleware if config.permissions_policy
           end
 
           middleware.use ::Rack::Head

--- a/railties/test/application/middleware/permission_policy_test.rb
+++ b/railties/test/application/middleware/permission_policy_test.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require "isolation/abstract_unit"
+
+module ApplicationTests
+  class PermissionPolicyTest < ActiveSupport::TestCase
+    include ActiveSupport::Testing::Isolation
+
+    def setup
+      build_app
+    end
+
+    def teardown
+      teardown_app
+    end
+
+    test "overriding permissions_policy raises if no global policy configured" do
+      make_basic_app
+      app.config.action_dispatch.show_exceptions = :none
+
+      class ::OmgController < ActionController::Base
+        permissions_policy do |f|
+          f.gyroscope :none
+        end
+
+        def index
+          head :ok
+        end
+      end
+
+      assert_raises RuntimeError, match: /Cannot override permissions_policy/ do
+        get "/"
+      end
+    end
+  end
+end

--- a/railties/test/commands/middleware_test.rb
+++ b/railties/test/commands/middleware_test.rb
@@ -46,7 +46,6 @@ class Rails::Command::MiddlewareTest < ActiveSupport::TestCase
       "ActionDispatch::Session::CookieStore",
       "ActionDispatch::Flash",
       "ActionDispatch::ContentSecurityPolicy::Middleware",
-      "ActionDispatch::PermissionsPolicy::Middleware",
       "Rack::Head",
       "Rack::ConditionalGet",
       "Rack::ETag",
@@ -83,7 +82,6 @@ class Rails::Command::MiddlewareTest < ActiveSupport::TestCase
       "ActionDispatch::Session::CookieStore",
       "ActionDispatch::Flash",
       "ActionDispatch::ContentSecurityPolicy::Middleware",
-      "ActionDispatch::PermissionsPolicy::Middleware",
       "Rack::Head",
       "Rack::ConditionalGet",
       "Rack::ETag",
@@ -214,6 +212,13 @@ class Rails::Command::MiddlewareTest < ActiveSupport::TestCase
     boot!
 
     assert_equal [{ redirect: { host: "example.com" }, ssl_default_redirect_status: 308 }], Rails.application.middleware[1].args
+  end
+
+  test "ActionDispatch::PermissionsPolicy::MiddlewareStack is included if permissions_policy set" do
+    add_to_config "config.permissions_policy { ActionDispatch::PermissionsPolicy.new }"
+    boot!
+
+    assert_includes middleware, "ActionDispatch::PermissionsPolicy::Middleware"
   end
 
   test "removing Active Record omits its middleware" do


### PR DESCRIPTION
### Motivation / Background

Commit f973075aa447dc77b0c4515aa3f6ff62dab49a4e dropped the default PermissionsPolicy initializer, but the middleware is still included in every application.

If the no policy is configured the middleware can be ignored as it doesn't do anything.

Overriding the permissions_policy in controllers will fail now if no global policy defined.

This is a breaking change that would require a deprecation warning.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
