### PR TITLE
Add `ActionDispatch::Request::Session#store` method to conform Rack spec

### DIFF
--- a/actionpack/lib/action_dispatch/request/session.rb
+++ b/actionpack/lib/action_dispatch/request/session.rb
@@ -155,6 +155,7 @@ module ActionDispatch
         load_for_write!
         @delegate[key.to_s] = value
       end
+      alias store []=
 
       # Clears the session.
       def clear


### PR DESCRIPTION
### Motivation / Background

[Rack specification](https://github.com/rack/rack/blob/main/SPEC.rdoc) states that a hash-like object stored in environment with `rack.session` key MUST implement `store/2` method with `[]=` semantics.

> rack.session
> A hash-like interface for storing request session data. The store must implement: store(key, value) (aliased as []=); fetch(key, default = nil) (aliased as []); delete(key); clear; to_hash (returning unfrozen Hash instance);

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
