### PR TITLE
Restore back the ability to pass only database name for `DATABASE_URL`

### DIFF
--- a/activerecord/lib/active_record/database_configurations/connection_url_resolver.rb
+++ b/activerecord/lib/active_record/database_configurations/connection_url_resolver.rb
@@ -81,7 +81,9 @@ module ActiveRecord
 
         def resolved_adapter
           adapter = uri.scheme && @uri.scheme.tr("-", "_")
-          adapter = ActiveRecord.protocol_adapters[adapter] || adapter
+          if adapter && ActiveRecord.protocol_adapters[adapter]
+            adapter = ActiveRecord.protocol_adapters[adapter]
+          end
           adapter
         end
 

--- a/activerecord/test/cases/connection_adapters/merge_and_resolve_default_url_config_test.rb
+++ b/activerecord/test/cases/connection_adapters/merge_and_resolve_default_url_config_test.rb
@@ -124,6 +124,17 @@ module ActiveRecord
         assert_equal expected, actual.configuration_hash
       end
 
+      def test_resolver_with_database_uri_containing_only_database_name
+        ENV["DATABASE_URL"] = "foo"
+        ENV["RAILS_ENV"] = "test"
+
+        config = { "test" => { "adapter" => "postgres", "database" => "not_foo", "host" => "localhost" } }
+        actual = resolve_db_config(:test, config)
+        expected = { adapter: "postgres", database: "foo", host: "localhost" }
+
+        assert_equal expected, actual.configuration_hash
+      end
+
       def test_jdbc_url
         config   = { "production" => { "adapter" => "abstract", "url" => "jdbc:postgres://localhost/foo" } }
         actual   = resolve_config(config, "production")


### PR DESCRIPTION
Fixes #53624 (cc @byroot).