### PR TITLE
Parallel tests with :number_of_processors uses cgroups-aware usable processor count

### DIFF
--- a/activesupport/lib/active_support/test_case.rb
+++ b/activesupport/lib/active_support/test_case.rb
@@ -79,8 +79,12 @@ module ActiveSupport
       # number of tests to run is above the +threshold+ param. The default value is
       # 50, and it's configurable via +config.active_support.test_parallelization_threshold+.
       def parallelize(workers: :number_of_processors, with: :processes, threshold: ActiveSupport.test_parallelization_threshold)
-        workers = Concurrent.processor_count if workers == :number_of_processors
-        workers = ENV["PARALLEL_WORKERS"].to_i if ENV["PARALLEL_WORKERS"]
+        case
+        when ENV["PARALLEL_WORKERS"]
+          workers = ENV["PARALLEL_WORKERS"].to_i
+        when workers == :number_of_processors
+          workers = (Concurrent.available_processor_count || Concurrent.processor_count).floor
+        end
 
         Minitest.parallel_executor = ActiveSupport::Testing::ParallelizeExecutor.new(size: workers, with: with, threshold: threshold)
       end


### PR DESCRIPTION
(We already require concurrent-ruby 1.3.1+ with support for this.)

References:
* https://github.com/rails/rails/pull/51924/commits/f719787c582839fd2fcd886d70b43da3ddad2ceb
* https://github.com/ruby-concurrency/concurrent-ruby/pull/1038