### PR TITLE
fix referential_integrity for postgres partitioned tables

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/referential_integrity.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/referential_integrity.rb
@@ -45,7 +45,7 @@ Rails needs superuser privileges to disable referential integrity.
             BEGIN
             FOR r IN (
               SELECT FORMAT(
-                'UPDATE pg_catalog.pg_constraint SET convalidated=false WHERE conname = ''%1$I'' AND connamespace::regnamespace = ''%2$I''::regnamespace; ALTER TABLE %2$I.%3$I VALIDATE CONSTRAINT %1$I;',
+                'UPDATE pg_catalog.pg_constraint SET convalidated=false WHERE conname = ''%1$I'' AND connamespace::regnamespace = ''%2$I''::regnamespace AND conrelid::regclass = ''%3$I''::regclass; ALTER TABLE %2$I.%3$I VALIDATE CONSTRAINT %1$I;',
                 constraint_name,
                 table_schema,
                 table_name


### PR DESCRIPTION
Hello!

### Motivation / Background

We had an issue using `ActiveRecord::FixtureSet.create_fixtures` with partitioned tables in postgres. Each time we did a `rails db:migrate` after creating fixture resulted in an update of our `structure.sql` adding `NOT VALID` to mostly all our foreign key constraints on partitioned tables.

By digging into the code we discovered that it was linked to `ActiveRecord::ConnectionAdapters::PostgreSQL::ReferentialIntegrity#all_foreign_keys_valid!` that set constraints as `NOT VALID` before re-validating them. 

With partitioned tables, it leaves some partitions in NOT VALID state. This is because partitions can have foreign key constraints with the same name as the partitioned table. The `UDPATE` is not scoped to a specific table so it will mark all partitions as invalid, while only validating one table, leaving all the others invalid. By scoping the `UPDATE` to a specific table we ensure that we touch only the partition we are about to validate.

### Detail

This Pull Request scopes the `UPDATE pg_catalog.pg_constraint SET convalidated=false`  to the table we are about to validate. So it no longer put partition constraints in invalid states as side effects. Note that constraints on partition are still validated as they are also considered as their own table.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
