### PR TITLE
Hide ActiveModel::Validations::AcceptanceValidator

### DIFF
--- a/activemodel/lib/active_model/validations/acceptance.rb
+++ b/activemodel/lib/active_model/validations/acceptance.rb
@@ -24,7 +24,7 @@ module ActiveModel
           Array(options[:accept]).include?(value)
         end
 
-        class LazilyDefineAttributes < Module
+        class LazilyDefineAttributes < Module # :nodoc:
           def initialize(attributes)
             @attributes = attributes.map(&:to_s)
           end


### PR DESCRIPTION
The `AcceptanceValidator` class appears even though it's using `:nodoc:` because it has a nested class.
See https://api.rubyonrails.org/v8.0.0/classes/ActiveModel/Validations/AcceptanceValidator.html and https://api.rubyonrails.org/v8.0.0/classes/ActiveModel/Validations/AcceptanceValidator/LazilyDefineAttributes.html.

I tried using `:nodoc: all` on `AcceptanceValidator` itself but for some reason, it doesn't work.

I try to debug a bit and when we hit this line: https://github.com/ruby/rdoc/blob/v6.7.0/lib/rdoc/rdoc.rb#L367, `done_documenting` is set to `false`, which sets `@document_self` back to `true` for `LazilyDefineAttributes`: https://github.com/ruby/rdoc/blob/v6.7.0/lib/rdoc/code_object.rb#L210
I'll try to figure out upstream if something is wrong, however in the meantime, this effectively hide AcceptanceValidator and the nested class.