### PR TITLE
class_attribute: delegate to an internal namespaced method

### DIFF
--- a/activesupport/lib/active_support/callbacks.rb
+++ b/activesupport/lib/active_support/callbacks.rb
@@ -933,7 +933,10 @@ module ActiveSupport
           end
 
           def set_callbacks(name, callbacks) # :nodoc:
-            unless singleton_class.method_defined?(:__callbacks, false)
+            # HACK: We're making assumption on how `class_attribute` is implemented
+            # to save constantly duping the callback hash. If this desync with class_attribute
+            # we'll lose the optimization, but won't cause an actual behavior bug.
+            unless singleton_class.private_method_defined?(:__class_attr__callbacks, false)
               self.__callbacks = __callbacks.dup
             end
             self.__callbacks[name.to_sym] = callbacks

--- a/activesupport/lib/active_support/core_ext/class/attribute.rb
+++ b/activesupport/lib/active_support/core_ext/class/attribute.rb
@@ -93,12 +93,25 @@ class Class
       end
 
       name = name.to_sym
-      ::ActiveSupport::ClassAttribute.redefine(self, name, default)
+      namespaced_name = :"__class_attr_#{name}"
+      ::ActiveSupport::ClassAttribute.redefine(self, name, namespaced_name, default)
 
-      unless singleton_class?
+      delegators = [
+        "def #{name}; #{namespaced_name}; end",
+        "def #{name}=(value); self.#{namespaced_name} = value; end",
+      ]
+
+      class_methods.concat(delegators)
+      if singleton_class?
+        methods.concat(delegators)
+      else
         methods << <<~RUBY if instance_reader
           silence_redefinition_of_method def #{name}
-            defined?(@#{name}) ? @#{name} : self.class.#{name}
+            if defined?(@#{name})
+              @#{name}
+            else
+              self.class.#{name}
+            end
           end
         RUBY
       end

--- a/activesupport/test/callbacks_test.rb
+++ b/activesupport/test/callbacks_test.rb
@@ -256,7 +256,7 @@ module CallbacksTest
       end
     end
 
-    def respond_to_missing?(sym)
+    def respond_to_missing?(sym, include_private = false)
       sym.match?(/^(log|wrap)_/) || super
     end
   end

--- a/activesupport/test/core_ext/class/attribute_test.rb
+++ b/activesupport/test/core_ext/class/attribute_test.rb
@@ -103,6 +103,7 @@ class ClassAttributeTest < ActiveSupport::TestCase
     object = @klass.new
 
     object.singleton_class.setting = "foo"
+    assert_equal "foo", object.singleton_class.setting
     assert_equal "foo", object.setting
     assert_nil @klass.setting
 
@@ -156,5 +157,52 @@ class ClassAttributeTest < ActiveSupport::TestCase
     assert_predicate @klass.new, :system?
     instance.system = 2
     assert_equal 2, instance.system
+  end
+
+  module Prepending
+    @read = 0
+    @write = 0
+
+    singleton_class.attr_accessor :read, :write
+
+    def setting
+      Prepending.read += 1
+      super
+    end
+
+    def setting=(value)
+      Prepending.write += 1
+      super
+    end
+  end
+
+  test "allow to prepend accessors" do
+    @klass.singleton_class.prepend(Prepending)
+
+    @klass.setting
+    assert_equal 1, Prepending.read
+
+    @klass.setting = true
+    assert_equal 1, Prepending.write
+    assert_equal 1, Prepending.read
+
+    @klass.setting
+    assert_equal 2, Prepending.read
+
+    @sub.setting = false
+    assert_equal 2, Prepending.write
+    assert_equal 2, Prepending.read
+
+    @sub.setting = true
+    assert_equal 3, Prepending.write
+    assert_equal 2, Prepending.read
+  end
+
+  test "can check if value is set on a sub class" do
+    # Note: this isn't a public API test and it's OK to break it.
+    # However if it's broken make sure to update ActiveSupport::Callbacks::ClassMethods#set_callbacks
+    assert_equal false, @sub.singleton_class.private_method_defined?(:__class_attr_setting, false)
+    @sub.setting = true
+    assert_equal true, @sub.singleton_class.private_method_defined?(:__class_attr_setting, false)
   end
 end


### PR DESCRIPTION
Fix: https://github.com/rails/rails/issues/53606

`class_attribute` never composed well with `prepend` or `alias_method_chain`. Up to 7.2, whenever the value was re-assigned, the reder method was redefined.

Now, since 8.0, we no longer redefine the reader, or at least in less cases, but then the writer is sometimes redefined too, which restrict even more how much decoration can be done.

A solution to this is to define class attributes under a namespaces and then define a two simple delegator methods to allow decoration.

Of course it's one extra method call, but that's still miles better than what it used to be, and probably acceptable.

cc @zvkemp 