### PR TITLE
Fix reloader deadlock in ActionController Live by adding timeout loop to ActionDispatch Response#await_commit

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,2 +1,5 @@
+*   Fix reloader deadlock in ActionController Live by adding timeout loop to ActionDispatch Response#await_commit
+
+    *Nate Matykiewicz, Ben Sheldon*
 
 Please check [8-0-stable](https://github.com/rails/rails/blob/8-0-stable/actionpack/CHANGELOG.md) for previous changes.

--- a/actionpack/lib/action_controller/metal/live.rb
+++ b/actionpack/lib/action_controller/metal/live.rb
@@ -310,8 +310,11 @@ module ActionController
         end
       }
 
-      ActiveSupport::Dependencies.interlock.permit_concurrent_loads do
-        @_response.await_commit
+      committed = nil
+      until committed do
+        ActiveSupport::Dependencies.interlock.permit_concurrent_loads do
+          committed = @_response.await_commit(0.5)
+        end
       end
 
       raise error if error

--- a/actionpack/lib/action_dispatch/http/response.rb
+++ b/actionpack/lib/action_dispatch/http/response.rb
@@ -206,9 +206,14 @@ module ActionDispatch # :nodoc:
     def set_header(key, v); @headers[key] = v;   end
     def delete_header(key); @headers.delete key; end
 
-    def await_commit
+    def await_commit(timeout = nil)
       synchronize do
-        @cv.wait_until { @committed }
+        if timeout
+          @cv.wait(timeout) unless @committed
+          @committed
+        else
+          @cv.wait_until { @committed }
+        end
       end
     end
 

--- a/actionpack/test/dispatch/response_test.rb
+++ b/actionpack/test/dispatch/response_test.rb
@@ -19,6 +19,17 @@ class ResponseTest < ActiveSupport::TestCase
     assert t.join(0.5)
   end
 
+  def test_can_wait_until_commit_with_timeout
+    latch = Concurrent::CountDownLatch.new
+    t = Thread.new {
+      @response.await_commit(0.1)
+      latch.count_down
+    }
+    latch.wait(0.2)
+    refute_predicate @response, :committed?
+    assert(t.join(0.5))
+  end
+
   def test_stream_close
     @response.stream.close
     assert_predicate @response.stream, :closed?


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

This PR fixes a code reloader deadlock within `ActionController::Metal::Live` that was observed while using Active Storage proxying. Here is the deadlock telemetry reported by [ActionDispatch::DebugLocks](https://api.rubyonrails.org/classes/ActionDispatch/DebugLocks.html):

https://gist.github.com/bensheldon/7be66e66527d60d36210d40c075d4df0

As I understand it, there is a deadlock that occurs between these points:

1. A shared lock is taken by the parent thread and waits for the response to commit
    https://github.com/rails/rails/blob/7c303b9ddf1c133cfe6d147998c0b01d82261444/actionpack/lib/action_controller/metal/live.rb#L312-L314
3. The reloader initiates a unload and waits for the previous shared lock to be released
4. The child thread waits for the unload to complete before it can take a shared lock to commit the response. Which will never happen.
   https://github.com/rails/rails/blob/7c303b9ddf1c133cfe6d147998c0b01d82261444/actionpack/lib/action_controller/metal/live.rb#L281-L282

(Found by @natematykiewicz)
<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

### Detail

This Pull Request adds a loop around the `permit_concurrent_loads` block, along with a timeout to `await_commit`. This allows the shared lock to be periodically released and thus break the deadlock.

I made the `wait_commit` timeout optional and preserved the old behavior. But this is the only usage of that method within Rails, so that might be unnecessary.

### Additional information

<!-- Provide additional information such as benchmarks, reference to other repositories or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
