### PR TITLE
Set `framework_defaults` in all bug report templates

### DIFF
--- a/guides/bug_report_templates/action_controller.rb
+++ b/guides/bug_report_templates/action_controller.rb
@@ -11,18 +11,22 @@ gemfile(true) do
 end
 
 require "action_controller/railtie"
+require "minitest/autorun"
+require "rack/test"
 
 class TestApp < Rails::Application
+  config.load_defaults Rails::VERSION::STRING.to_f
   config.root = __dir__
+  config.eager_load = false
   config.hosts << "example.org"
   config.secret_key_base = "secret_key_base"
 
   config.logger = Logger.new($stdout)
-  Rails.logger  = config.logger
+end
+Rails.application.initialize!
 
-  routes.draw do
-    get "/" => "test#index"
-  end
+Rails.application.routes.draw do
+  get "/", to: "test#index"
 end
 
 class TestController < ActionController::Base
@@ -33,15 +37,13 @@ class TestController < ActionController::Base
   end
 end
 
-require "minitest/autorun"
-require "rack/test"
-
 class BugTest < ActiveSupport::TestCase
   include Rack::Test::Methods
 
   def test_returns_success
     get "/"
     assert last_response.ok?
+    assert_equal last_response.body, "Home"
   end
 
   private

--- a/guides/bug_report_templates/action_mailbox.rb
+++ b/guides/bug_report_templates/action_mailbox.rb
@@ -15,7 +15,8 @@ end
 require "active_record/railtie"
 require "active_storage/engine"
 require "action_mailbox/engine"
-require "tmpdir"
+
+ENV["DATABASE_URL"] = "sqlite3::memory:"
 
 class TestApp < Rails::Application
   config.load_defaults Rails::VERSION::STRING.to_f
@@ -27,7 +28,6 @@ class TestApp < Rails::Application
   config.secret_key_base = "secret_key_base"
 
   config.logger = Logger.new($stdout)
-  Rails.logger  = config.logger
 
   config.active_storage.service = :local
   config.active_storage.service_configurations = {
@@ -39,9 +39,6 @@ class TestApp < Rails::Application
 
   config.action_mailbox.ingress = :relay
 end
-
-ENV["DATABASE_URL"] = "sqlite3::memory:"
-
 Rails.application.initialize!
 
 require ActiveStorage::Engine.root.join("db/migrate/20170806125915_create_active_storage_tables.rb").to_s

--- a/guides/bug_report_templates/action_mailer.rb
+++ b/guides/bug_report_templates/action_mailer.rb
@@ -11,6 +11,7 @@ gemfile(true) do
 end
 
 require "action_mailer/railtie"
+require "minitest/autorun"
 
 class TestMailer < ActionMailer::Base
   def hello_world
@@ -22,8 +23,6 @@ class TestMailer < ActionMailer::Base
     end
   end
 end
-
-require "minitest/autorun"
 
 class BugTest < ActionMailer::TestCase
   test "renders HTML and Text body" do

--- a/guides/bug_report_templates/action_view.rb
+++ b/guides/bug_report_templates/action_view.rb
@@ -10,8 +10,16 @@ gemfile(true) do
   # gem "rails", github: "rails/rails", branch: "main"
 end
 
+require "action_controller/railtie"
+require "action_view/railtie"
 require "minitest/autorun"
-require "action_view"
+
+class TestApp < Rails::Application
+  config.load_defaults Rails::VERSION::STRING.to_f
+  config.eager_load = false
+  config.logger = Logger.new($stdout)
+end
+Rails.application.initialize!
 
 class BugTest < ActionView::TestCase
   helper do

--- a/guides/bug_report_templates/active_record.rb
+++ b/guides/bug_report_templates/active_record.rb
@@ -12,13 +12,18 @@ gemfile(true) do
   gem "sqlite3"
 end
 
-require "active_record"
+require "active_record/railtie"
 require "minitest/autorun"
-require "logger"
 
 # This connection will do for database-independent bug reports.
-ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")
-ActiveRecord::Base.logger = Logger.new(STDOUT)
+ENV["DATABASE_URL"] = "sqlite3::memory:"
+
+class TestApp < Rails::Application
+  config.load_defaults Rails::VERSION::STRING.to_f
+  config.eager_load = false
+  config.logger = Logger.new($stdout)
+end
+Rails.application.initialize!
 
 ActiveRecord::Schema.define do
   create_table :posts, force: true do |t|
@@ -40,7 +45,7 @@ end
 class BugTest < ActiveSupport::TestCase
   def test_association_stuff
     post = Post.create!
-    post.comments << Comment.create!
+    post.comments.create!
 
     assert_equal 1, post.comments.count
     assert_equal 1, Comment.count

--- a/guides/bug_report_templates/active_record_migrations.rb
+++ b/guides/bug_report_templates/active_record_migrations.rb
@@ -12,13 +12,18 @@ gemfile(true) do
   gem "sqlite3"
 end
 
-require "active_record"
+require "active_record/railtie"
 require "minitest/autorun"
-require "logger"
 
 # This connection will do for database-independent bug reports.
-ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")
-ActiveRecord::Base.logger = Logger.new(STDOUT)
+ENV["DATABASE_URL"] = "sqlite3::memory:"
+
+class TestApp < Rails::Application
+  config.load_defaults Rails::VERSION::STRING.to_f
+  config.eager_load = false
+  config.logger = Logger.new($stdout)
+end
+Rails.application.initialize!
 
 ActiveRecord::Schema.define do
   create_table :payments, force: true do |t|

--- a/guides/bug_report_templates/active_storage.rb
+++ b/guides/bug_report_templates/active_storage.rb
@@ -14,7 +14,9 @@ end
 
 require "active_record/railtie"
 require "active_storage/engine"
-require "tmpdir"
+require "minitest/autorun"
+
+ENV["DATABASE_URL"] = "sqlite3::memory:"
 
 class TestApp < Rails::Application
   config.load_defaults Rails::VERSION::STRING.to_f
@@ -36,9 +38,6 @@ class TestApp < Rails::Application
     }
   }
 end
-
-ENV["DATABASE_URL"] = "sqlite3::memory:"
-
 Rails.application.initialize!
 
 require ActiveStorage::Engine.root.join("db/migrate/20170806125915_create_active_storage_tables.rb").to_s
@@ -52,8 +51,6 @@ end
 class User < ActiveRecord::Base
   has_one_attached :profile
 end
-
-require "minitest/autorun"
 
 class BugTest < ActiveSupport::TestCase
   def test_upload_and_download


### PR DESCRIPTION
### Motivation

When testing bugs using the bug report templates, it helps if the correct framework defaults are enabled for all templates. This makes sure the scripts behave more inline with a regular Rails application and allows easily testing older defaults.

We already set the framework defaults for active_storage:
https://github.com/rails/rails/blob/869453f1a1c9cf840d71c5b9c950e04cec00f365/guides/bug_report_templates/active_storage.rb#L20

This also normalizes the templates somewhat and removes some unneeded code.
- Group requires
- Require Railties instead of gems
- Configure database connection with: `ENV["DATABASE_URL"]` (this is required when requiring "activerecord/railtie" and starting the application with `Rails.application.initialize!`
- Requiring `tmpdir` no longer seems required.
- Set `config.eager_load = false` to avoid warning about `eager_load` not being set.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
