### PR TITLE
Make Rails::Initializable::Collection more array-like

### DIFF
--- a/railties/lib/rails/initializable.rb
+++ b/railties/lib/rails/initializable.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "tsort"
+require "active_support/core_ext/module/delegation"
 
 module Rails
   module Initializable
@@ -38,6 +39,8 @@ module Rails
       include Enumerable
       include TSort
 
+      delegate_missing_to :@collection
+
       def initialize(initializers = nil)
         @order = Hash.new { |hash, key| hash[key] = Set.new }
         @resolve = Hash.new { |hash, key| hash[key] = Set.new }
@@ -73,10 +76,20 @@ module Rails
         @order[initializer.before] << initializer.name if initializer.before
         @order[initializer.name] << initializer.after if initializer.after
         @resolve[initializer.name] << initializer
+        self
       end
 
-      def concat(initializers)
+      def push(*initializers)
         initializers.each(&method(:<<))
+        self
+      end
+
+      alias_method(:append, :push)
+
+      def concat(*initializer_collections)
+        initializer_collections.each do |initializers|
+          initializers.each(&method(:<<))
+        end
         self
       end
 


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because https://github.com/rails/rails/pull/53615 made the API for initiailizable collections not respond to as many methods (and subsequently not be able to be treated as an array anymore). Since this is [public API](https://api.rubyonrails.org/classes/Rails/Initializable/Collection.html), we should restore this behaviour to not break applications.

### Detail

This Pull Request changes Rails::Initializable::Collection to respond to more array methods, as it previously did.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
