### PR TITLE
Silence deprecate message during `app:udpate` command

### DIFF
--- a/railties/lib/rails/commands/app/update_command.rb
+++ b/railties/lib/rails/commands/app/update_command.rb
@@ -12,6 +12,9 @@ module Rails
 
         desc "update", "Update configs and some other initially generated files (or use just update:configs or update:bin)"
         def perform
+          require_application!
+          Rails.application.deprecators.silenced = true
+
           configs
           bin
           public_directory
@@ -21,26 +24,22 @@ module Rails
 
         desc "configs", "Update config files in the application config/ directory", hide: true
         def configs
-          require_application!
           app_generator.create_boot_file
           app_generator.update_config_files
         end
 
         desc "bin", "Add or update executables in the application bin/ directory", hide: true
         def bin
-          require_application!
           app_generator.update_bin_files
         end
 
         desc "public_directory", "Add or update files in the application public/ directory", hide: true
         def public_directory
-          require_application!
           app_generator.create_public_files
         end
 
         desc "active_storage", "Run the active_storage:update command", hide: true
         def active_storage
-          require_application!
           app_generator.update_active_storage
         end
 

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -376,6 +376,19 @@ class AppGeneratorTest < Rails::Generators::TestCase
     assert_no_file "config/storage.yml"
   end
 
+  def test_app_update_silence_deprecate_message
+    run_generator
+
+    FileUtils.cd(destination_root) do
+      File.open("config/initializers/deprecation.rb", "a") do |file|
+        file.puts "Rails.deprecator.warn('test deprecation message')"
+      end
+
+      stderr = capture(:stderr) { run_app_update }
+      assert_no_match(/test deprecation message/, stderr)
+    end
+  end
+
   def test_generator_skips_action_mailbox_when_skip_action_mailbox_is_given
     run_generator [destination_root, "--skip-action-mailbox"]
     assert_file "#{application_path}/config/application.rb", /#\s+require\s+["']action_mailbox\/engine["']/

--- a/railties/test/generators/generators_test_helper.rb
+++ b/railties/test/generators/generators_test_helper.rb
@@ -144,7 +144,7 @@ module GeneratorsTestHelper
       gemfile_contents.sub!(/^(gem "rails").*/, "\\1, path: #{File.expand_path("../../..", __dir__).inspect}")
       File.write("Gemfile", gemfile_contents)
 
-      quietly { system({ "BUNDLE_GEMFILE" => "Gemfile" }, "bin/rails app:update #{flags}", exception: true) }
+      silence_stream($stdout) { system({ "BUNDLE_GEMFILE" => "Gemfile" }, "bin/rails app:update #{flags}", exception: true) }
     end
   end
 


### PR DESCRIPTION
### Detail

When users run this command, they don't have a `new_framework_defaults` yet. So they may not know about new deprecations and messages would be just noise. I think it's better to silence those messages to avoid confusion.

Fixes #53558.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
