### PR TITLE
Fix multibyte character tokenization bug in ERB::Util

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Fix a bug in `ERB::Util.tokenize` that causes incorrect tokenization when ERB tags are preceeded by multibyte characters.
+
+    *Martin Emde*
+
 *   Add `ActiveSupport::Testing::NotificationAssertions` module to help with testing `ActiveSupport::Notifications`.
 
     *Nicholas La Roux*, *Yishu See*, *Sean Doyle*

--- a/activesupport/lib/active_support/core_ext/erb/util.rb
+++ b/activesupport/lib/active_support/core_ext/erb/util.rb
@@ -174,7 +174,7 @@ class ERB
 
         case source.matched
         when start_re
-          tokens << [:TEXT, source.string[pos, len]] if len > 0
+          tokens << [:TEXT, source.string.byteslice(pos, len)] if len > 0
           tokens << [:OPEN, source.matched]
           if source.scan(/(.*?)(?=#{finish_re}|\z)/m)
             tokens << [:CODE, source.matched] unless source.matched.empty?
@@ -183,7 +183,7 @@ class ERB
             raise NotImplementedError
           end
         when finish_re
-          tokens << [:CODE, source.string[pos, len]] if len > 0
+          tokens << [:CODE, source.string.byteslice(pos, len)] if len > 0
           tokens << [:CLOSE, source.matched]
         else
           raise NotImplementedError, source.matched

--- a/activesupport/test/core_ext/erb_util_test.rb
+++ b/activesupport/test/core_ext/erb_util_test.rb
@@ -135,6 +135,24 @@ module ActiveSupport
       ], actual_tokens
     end
 
+    def test_multibyte_characters_start
+      source = "こんにちは<%= name %>"
+      actual_tokens = tokenize source
+      assert_equal [[:TEXT, "こんにちは"],
+                    [:OPEN, "<%="],
+                    [:CODE, " name "],
+                    [:CLOSE, "%>"],
+      ], actual_tokens
+    end
+
+    def test_multibyte_characters_end
+      source = " 'こんにちは' %>"
+      actual_tokens = tokenize source
+      assert_equal [[:CODE, " 'こんにちは' "],
+                    [:CLOSE, "%>"],
+      ], actual_tokens
+    end
+
     def tokenize(source)
       ERB::Util.tokenize source
     end


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because there are problems parsing certain ERB templates that cause error highlighting to be wrong.

### Detail

StringScanner uses bytes, so use byteslice so that all length calculations are done in bytes.

### Additional information

The tests I added fail as follows when multibyte characters exist before the tag:

```diff
Failure:
ActiveSupport::ERBUtilTest#test_multibyte_characters_start [test/core_ext/erb_util_test.rb:141]:
--- expected
+++ actual
@@ -1 +1 @@
-[[:TEXT, "こんにちは"], [:OPEN, "<%="], [:CODE, " name "], [:CLOSE, "%>"]]
+[[:TEXT, "こんにちは<%= name %"], [:OPEN, "<%="], [:CODE, " name "], [:CLOSE, "%>"]]

Failure:
ActiveSupport::ERBUtilTest#test_multibyte_characters_end [test/core_ext/erb_util_test.rb:151]:
--- expected
+++ actual
@@ -1 +1 @@
-[[:CODE, " 'こんにちは' "], [:CLOSE, "%>"]]
+[[:CODE, " 'こんにちは' %>"], [:CLOSE, "%>"]]
```

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [X] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
