### PR TITLE
Remove `# typed: true` sigil

### DIFF
--- a/activesupport/lib/active_support/testing/notification_assertions.rb
+++ b/activesupport/lib/active_support/testing/notification_assertions.rb
@@ -1,5 +1,3 @@
-
-# typed: true
 # frozen_string_literal: true
 
 module ActiveSupport


### PR DESCRIPTION
This is the only place in our codebase where sigil was added (#53065), so it was probably added accidentally.

cc @larouxn @eileencodes 