### PR TITLE
Redesign ActionView::Template::Handlers::ERB.find_offset to handle edge cases

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Improve reliability of ERB template error highlighting.
+    Fix infinite loops and crashes in highlighting and
+    improve tolerance for alternate ERB handlers.
+
+    *Martin Emde*
+
 *   Allow `hidden_field` and `hidden_field_tag` to accept a custom autocomplete value.
 
     *brendon*

--- a/actionview/test/template/template_test.rb
+++ b/actionview/test/template/template_test.rb
@@ -65,6 +65,18 @@ class TestERBTemplate < ActiveSupport::TestCase
     @template.render(@context, locals, implicit_locals: implicit_locals)
   end
 
+  def spot_highlight(compiled, highlight, first_column: nil, **options)
+    # rindex by default since our tests usually put the highlight last
+    first_column ||= compiled.rindex(highlight) || 999
+    last_column = first_column + highlight.size
+    spot = {
+      first_column:, last_column:, snippet: compiled,
+      first_lineno: 1, last_lineno: 1, script_lines: compiled.lines,
+    }
+    spot.merge!(options)
+    spot
+  end
+
   def setup
     @context = Context.with_empty_template_cache.empty
     super
@@ -313,5 +325,112 @@ class TestERBTemplate < ActiveSupport::TestCase
   def test_template_inspect
     @template = new_template("hello")
     assert_equal "#<ActionView::Template hello template locals=[]>", @template.inspect
+  end
+
+  def test_template_translate_location
+    highlight = "nomethoderror"
+    source = "<%= nomethoderror %>"
+    compiled = "'.freeze; @output_buffer.append=  nomethoderror ; @output_buffer.safe_append='\n"
+
+    backtrace_location = Data.define(:lineno).new(lineno: 1)
+    spot = spot_highlight(compiled, highlight)
+    expected = spot_highlight(source, highlight, snippet: compiled)
+
+    assert_equal expected, new_template(source).translate_location(backtrace_location, spot)
+  end
+
+  def test_template_translate_location_lineno_offset
+    highlight = "nomethoderror"
+    source = "<%= nomethoderror %>"
+    compiled = "\n'.freeze; @output_buffer.append=  nomethoderror ; @output_buffer.safe_append='\n"
+
+    backtrace_location = Data.define(:lineno).new(lineno: 1)
+    spot = spot_highlight(compiled, highlight, first_lineno: 2, last_lineno: 2)
+    expected = spot_highlight(source, highlight, snippet: compiled)
+
+    assert_equal expected, new_template(source).translate_location(backtrace_location, spot)
+  end
+
+  def test_template_translate_location_with_multibye_string_before_highlight
+    highlight = "nomethoderror"
+    source = String.new("\u{a5}<%= nomethoderror %>", encoding: Encoding::UTF_8) # yen symbol
+    compiled = String.new("\u{a5}'.freeze; @output_buffer.append=  nomethoderror ; @output_buffer.safe_append='\n", encoding: Encoding::UTF_8)
+
+    backtrace_location = Data.define(:lineno).new(lineno: 1)
+    spot = spot_highlight(compiled, highlight)
+    expected = spot_highlight(source, highlight, snippet: compiled)
+
+    assert_equal expected, new_template(source).translate_location(backtrace_location, spot)
+  end
+
+  def test_template_translate_location_no_match_in_compiled
+    highlight = "nomatch"
+    source = "<%= nomatch %>"
+    compiled = "this source does not contain the highlight, so the original spot is returned"
+
+    backtrace_location = Data.define(:lineno).new(lineno: 1)
+    spot = spot_highlight(compiled, highlight, first_column: 50)
+
+    assert_equal spot, new_template(source).translate_location(backtrace_location, spot)
+  end
+
+  def test_template_translate_location_text_includes_highlight
+    highlight = "nomethoderror"
+    source = " nomethoderror <%= nomethoderror %>"
+    compiled = " nomethoderror '.freeze; @output_buffer.append=  nomethoderror ; @output_buffer.safe_append='\n"
+
+    backtrace_location = Data.define(:lineno).new(lineno: 1)
+    spot = spot_highlight(compiled, highlight)
+    expected = spot_highlight(source, highlight, snippet: compiled)
+
+    assert_equal expected, new_template(source).translate_location(backtrace_location, spot)
+  end
+
+  def test_template_translate_location_space_separated_erb_tags
+    highlight = "nomethoderror"
+    source = "<%= goodcode %> <%= nomethoderror %>"
+    compiled = "'.freeze; @output_buffer.append=  goodcode ; @output_buffer.safe_append=' '.freeze; @output_buffer.append=  nomethoderror ; @output_buffer.safe_append='\n"
+
+    backtrace_location = Data.define(:lineno).new(lineno: 1)
+    spot = spot_highlight(compiled, highlight)
+    expected = spot_highlight(source, highlight, snippet: compiled)
+
+    assert_equal expected, new_template(source).translate_location(backtrace_location, spot)
+  end
+
+  def test_template_translate_location_consecutive_erb_tags
+    highlight = "nomethoderror"
+    source = "<%= goodcode %><%= nomethoderror %>"
+    compiled = "'.freeze; @output_buffer.append=  goodcode ; @output_buffer.append=  nomethoderror ; @output_buffer.safe_append='\n"
+
+    backtrace_location = Data.define(:lineno).new(lineno: 1)
+    spot = spot_highlight(compiled, highlight)
+    expected = spot_highlight(source, highlight, snippet: compiled)
+
+    assert_equal expected, new_template(source).translate_location(backtrace_location, spot)
+  end
+
+  def test_template_translate_location_repeated_highlight_in_compiled_template
+    highlight = "nomethoderror"
+    source = "<%= nomethoderror %>"
+    compiled = "ValidatedOutputBuffer.wrap(@output_buffer, ({}), ' nomethoderror '.freeze, true).safe_none_append=  nomethoderror ; @output_buffer.safe_append='\n"
+
+    backtrace_location = Data.define(:lineno).new(lineno: 1)
+    spot = spot_highlight(compiled, highlight)
+    expected = spot_highlight(source, highlight, snippet: compiled)
+
+    assert_equal expected, new_template(source).translate_location(backtrace_location, spot)
+  end
+
+  def test_template_translate_location_flaky_pathological_template
+    highlight = "flakymethod"
+    source = "<%= flakymethod %> flakymethod <%= flakymethod " # fails on second call, no tailing %>
+    compiled = "ValidatedOutputBuffer.wrap(@output_buffer, ({}), ' flakymethod '.freeze, true).safe_none_append=( flakymethod );@output_buffer.safe_append=' flakymethod '.freeze;ValidatedOutputBuffer.wrap(@output_buffer, ({}), ' flakymethod '.freeze, true).safe_none_append=( flakymethod "
+
+    backtrace_location = Data.define(:lineno).new(lineno: 1)
+    spot = spot_highlight(compiled, highlight)
+    expected = spot_highlight(source, highlight, snippet: compiled)
+
+    assert_equal expected, new_template(source).translate_location(backtrace_location, spot)
   end
 end


### PR DESCRIPTION
### Motivation / Background

The code for finding offsets in the ERB templates outright fails in some cases, causing 500s in the error template. In other cases it will bail out early when it's possible to find and highlight correctly.

### Detail

This PR fixes many of the issues that regularly occur and correctly highlights more often. Also adds test coverage of the translate_location method on ActionView::Template, many of which failed before this fix.


### Additional information

Problems in `better-html` gem originally prompted me to dig into this, but this solves many rails-only highlight failures or crashes depending on the template. For example, the following template will cause the request to loop forever in current rails:

```erb
<%= goodcode %><%= nomethoderror %>
```

Any template where the compiled code doesn't contain the template code will also loop forever (for example a bug in the template compiler or something changing spacing).

`better-html` also reliably causes the error page to 500 because it has duplicate copies of the template code in the compiled template. The only way to fix this in better-html would be to fully patch this method to make it correct, which causes its own problems. The solution I suggest here supports better-html without doing anything explicit to do so. It merely supports the case where a string could occur multiple times in the compiled output which happens in vanilla rails, but less often than in `better-html`

Fixes: https://github.com/Shopify/better-html/issues/121
Probably Fixes: https://github.com/rails/rails/issues/53388 (I found the same infinite loop and have added test coverage for most of these cases)

CC: @byroot and @jhawthorn because you have both been looking at related issues. FYI @tenderlove, it looks like you wrote the previous implementation. 

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [X] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
