### PR TITLE
Fix "Test is missing assertions" is caught by Strict Warnings

### DIFF
--- a/activesupport/lib/active_support/testing/tests_without_assertions.rb
+++ b/activesupport/lib/active_support/testing/tests_without_assertions.rb
@@ -11,7 +11,7 @@ module ActiveSupport
 
         if assertions.zero? && !skipped? && !error?
           file, line = method(name).source_location
-          warn "Test is missing assertions: `#{name}` #{file}:#{line}"
+          warn "Test is missing assertions: `#{name}` #{File.expand_path(file)}:#{line}"
         end
       end
     end

--- a/railties/test/application/generators_test.rb
+++ b/railties/test/application/generators_test.rb
@@ -188,7 +188,9 @@ module ApplicationTests
       end
 
       quietly do
-        Rails::Command.invoke(:generate, ["check_argv", "expected"]) # should not raise
+        assert_nothing_raised do
+          Rails::Command.invoke(:generate, ["check_argv", "expected"]) # should not raise
+        end
       end
     end
 

--- a/railties/test/application/initializers/frameworks_test.rb
+++ b/railties/test/application/initializers/frameworks_test.rb
@@ -220,7 +220,9 @@ module ApplicationTests
       rails %w(generate model post title:string)
 
       with_unhealthy_database do
-        app("development")
+        assert_nothing_raised do
+          app("development")
+        end
       end
     end
 

--- a/railties/test/application/loading_test.rb
+++ b/railties/test/application/loading_test.rb
@@ -89,7 +89,9 @@ class LoadingTest < ActiveSupport::TestCase
     require "#{rails_root}/config/environment"
     setup_ar!
 
-    User
+    assert_nothing_raised do
+      User
+    end
   end
 
   test "load config/environments/environment before Bootstrap initializers" do

--- a/railties/test/application/rake/tmp_test.rb
+++ b/railties/test/application/rake/tmp_test.rb
@@ -40,7 +40,9 @@ module ApplicationTests
 
       test "tmp:clear should work if folder missing" do
         FileUtils.remove_dir("#{app_path}/tmp")
-        rails "tmp:clear"
+        assert_nothing_raised do
+          rails "tmp:clear"
+        end
       end
     end
   end

--- a/railties/test/application/rake_test.rb
+++ b/railties/test/application/rake_test.rb
@@ -205,7 +205,9 @@ module ApplicationTests
       app_file "test/fixtures/products.csv", ""
 
       require "#{rails_root}/config/environment"
-      rails "db:fixtures:load"
+      assert_nothing_raised do
+        rails "db:fixtures:load"
+      end
     end
 
     def test_scaffold_tests_pass_by_default


### PR DESCRIPTION
```
$ RAILS_STRICT_WARNINGS=1 bin/test \
  test/application/generators_test.rb \
  test/application/initializers/frameworks_test.rb \
  test/application/loading_test.rb \
  test/application/rake/tmp_test.rb \
  test/application/rake_test.rb

Run options: --seed 7309

.............................Test is missing assertions: `test_tmp:clear_should_work_if_folder_missing` /home/zzak/code/rails/railties/test/application/rake/tmp_test.rb:41
E

Error:
ApplicationTests::RakeTests::TmpTest#test_tmp:clear_should_work_if_folder_missing:
ActiveSupport::RaiseWarnings::WarningError: Test is missing assertions: `test_tmp:clear_should_work_if_folder_missing` /home/zzak/code/rails/railties/test/application/rake/tmp_test.rb:41

    /home/zzak/code/rails/activesupport/lib/active_support/testing/strict_warnings.rb:38:in `warn'

bin/test test/application/rake/tmp_test.rb:41

Test is missing assertions: `test_ARGV_is_populated` /home/zzak/code/rails/railties/test/application/generators_test.rb:180
E

Error:
ApplicationTests::GeneratorsTest#test_ARGV_is_populated:
ActiveSupport::RaiseWarnings::WarningError: Test is missing assertions: `test_ARGV_is_populated` /home/zzak/code/rails/railties/test/application/generators_test.rb:180

    /home/zzak/code/rails/activesupport/lib/active_support/testing/strict_warnings.rb:38:in `warn'

bin/test test/application/generators_test.rb:180

......Test is missing assertions: `test_can_boot_with_an_unhealthy_database` /home/zzak/code/rails/railties/test/application/initializers/frameworks_test.rb:219
E

Error:
ApplicationTests::FrameworksTest#test_can_boot_with_an_unhealthy_database:
ActiveSupport::RaiseWarnings::WarningError: Test is missing assertions: `test_can_boot_with_an_unhealthy_database` /home/zzak/code/rails/railties/test/application/initializers/frameworks_test.rb:219

    /home/zzak/code/rails/activesupport/lib/active_support/testing/strict_warnings.rb:38:in `warn'

bin/test test/application/initializers/frameworks_test.rb:219

...............................Test is missing assertions: `test_loading_only_yml_fixtures` /home/zzak/code/rails/railties/test/application/rake_test.rb:202
E

Error:
ApplicationTests::RakeTest#test_loading_only_yml_fixtures:
ActiveSupport::RaiseWarnings::WarningError: Test is missing assertions: `test_loading_only_yml_fixtures` /home/zzak/code/rails/railties/test/application/rake_test.rb:202

    /home/zzak/code/rails/activesupport/lib/active_support/testing/strict_warnings.rb:38:in `warn'

bin/test test/application/rake_test.rb:202

...Test is missing assertions: `test_models_without_table_do_not_panic_on_scope_definitions_when_loaded` /home/zzak/code/rails/railties/test/application/loading_test.rb:82
E

Error:
LoadingTest#test_models_without_table_do_not_panic_on_scope_definitions_when_loaded:
ActiveSupport::RaiseWarnings::WarningError: Test is missing assertions: `test_models_without_table_do_not_panic_on_scope_definitions_when_loaded` /home/zzak/code/rails/railties/test/application/loading_test.rb:82

    /home/zzak/code/rails/activesupport/lib/active_support/testing/strict_warnings.rb:38:in `warn'

bin/test test/application/loading_test.rb:82
```

This doesn't fail in CI because the warning is using a relative path:

```
Test is missing assertions: `test_tmp:clear_should_work_if_folder_missing` test/application/rake/tmp_test.rb:41
```

Ref: https://buildkite.com/rails/rails/builds/113871#01933e25-4b3c-47f9-9b74-ea4ac84c6ae2/1292-1298

This can be reproduced locally like so:

```
RAILS_STRICT_WARNINGS=true ruby -w -Itest -Ilib -I../activesupport/lib -I../actionpack/lib -I../actionview/lib -I../activemodel/lib test/application/rake/tmp_test.rb

/home/zzak/.rbenv/versions/3.3.6/lib/ruby/gems/3.3.0/gems/bundler-2.5.16/lib/bundler/rubygems_ext.rb:250: warning: method redefined; discarding old encode_with
/home/zzak/.rbenv/versions/3.3.6/lib/ruby/3.3.0/rubygems/dependency.rb:341: warning: previous definition of encode_with was here
Run options: --seed 35733

Test is missing assertions: `test_tmp:clear_should_work_if_folder_missing` /home/zzak/code/rails/railties/test/application/rake/tmp_test.rb:41
E.

Finished in 0.118110s, 16.9334 runs/s, 33.8668 assertions/s.

  1) Error:
ApplicationTests::RakeTests::TmpTest#test_tmp:clear_should_work_if_folder_missing:
ActiveSupport::RaiseWarnings::WarningError: Test is missing assertions: `test_tmp:clear_should_work_if_folder_missing` /home/zzak/code/rails/railties/test/application/rake/tmp_test.rb:41

    /home/zzak/code/rails/activesupport/lib/active_support/testing/strict_warnings.rb:38:in `warn'

2 runs, 4 assertions, 0 failures, 1 errors, 0 skips
```

I went with pretty bland `assert_nothing_raised` but looking at the surrounding tests this might be sufficient. I'm also not sure if this will uncover other missing tests we missed, so I will fix those before merging.

/cc @fatkodima @byroot 