### PR TITLE
Fix with_connection not pinning when permanent

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -313,6 +313,10 @@ module ActiveRecord
       end
 
       def permanent_lease? # :nodoc:
+        connection_lease.sticky
+      end
+
+      def sticky_unset? # :nodoc:
         connection_lease.sticky.nil?
       end
 
@@ -399,7 +403,12 @@ module ActiveRecord
       def with_connection(prevent_permanent_checkout: false)
         lease = connection_lease
         sticky_was = lease.sticky
-        lease.sticky = false if prevent_permanent_checkout
+
+        if ActiveRecord.permanent_connection_checkout == true
+          lease.sticky = true
+        elsif prevent_permanent_checkout
+          lease.sticky = false
+        end
 
         if lease.connection
           begin

--- a/activerecord/lib/active_record/connection_handling.rb
+++ b/activerecord/lib/active_record/connection_handling.rb
@@ -273,7 +273,7 @@ module ActiveRecord
     # Soft deprecated. Use +#with_connection+ or +#lease_connection+ instead.
     def connection
       pool = connection_pool
-      if pool.permanent_lease?
+      if pool.sticky_unset?
         case ActiveRecord.permanent_connection_checkout
         when :deprecated
           ActiveRecord.deprecator.warn <<~MESSAGE


### PR DESCRIPTION
### Motivation / Background

`ActiveRecord.permanent_connection_checkout` was [introduced][1] along with `with_connection` to enable granular connection checkouts for application that do not want connections pinned to a Thread/Fiber for the duration of a request. The configuration was intended to be opt-in, however when applications exclusively use `with_connection` (not `{lease_,}connection`), connections will not be pinned regardless of `permanent_connection_checkout`'s value.

### Detail

This commit fixes the issue by ensuring connection checked out by `with_connection` will be pinned when `permanent_connection_checkout` is `true`.

Additionally, the private/nodoc `permanent_lease?` was renamed to `sticky_unset?` because that more accurately reflects the method's behavior and allows us to make assertions that the connection was "permanently leased" by checking the sticky bit for truthiness.

[1]: https://github.com/rails/rails/commit/dd8fd52c072b8f6777ad6d8acf86054fa1923dd9

cc @byroot 

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
