### PR TITLE
Active Storage: control downloaded filename

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,16 @@
+*   Control downloaded filename encoded into `Content-Disposition` header
+    through `:filename` query parameter nested within `:disposition`
+
+    ```ruby
+    # before - might not download file to `avatar.png` depending on browser
+    link_to "Download", rails_blob_path(user.avatar, disposition: "attachment"), download: "avatar.png")
+
+    # after
+    link_to "Download", rails_blob_path(user.avatar, disposition: { disposition: "attachment", filename: "avatar.png" })
+    ```
+
+    *Sean Doyle*
+
 *   Fix `MirrorService#mirror` losing blob metadata when copying to mirrors.
 
     Mirrored copies on S3, Azure, and GCS were served as `application/octet-stream`

--- a/activestorage/app/controllers/active_storage/blobs/proxy_controller.rb
+++ b/activestorage/app/controllers/active_storage/blobs/proxy_controller.rb
@@ -33,7 +33,11 @@ class ActiveStorage::Blobs::ProxyController < ActiveStorage::BaseController
         response.headers["Accept-Ranges"] = "bytes"
         response.headers["Content-Length"] = @blob.byte_size.to_s
 
-        send_blob_stream @blob, disposition: params[:disposition]
+        if (disposition = params[:disposition]).is_a?(ActionController::Parameters)
+          disposition, filename = disposition[:disposition], disposition[:filename]
+        end
+
+        send_blob_stream @blob, disposition: disposition, filename: filename
       end
     end
   end

--- a/activestorage/app/controllers/active_storage/representations/proxy_controller.rb
+++ b/activestorage/app/controllers/active_storage/representations/proxy_controller.rb
@@ -26,7 +26,11 @@ class ActiveStorage::Representations::ProxyController < ActiveStorage::Represent
 
   def show
     http_cache_forever public: true do
-      send_blob_stream @representation, disposition: params[:disposition]
+      if (disposition = params[:disposition]).is_a?(ActionController::Parameters)
+        disposition, filename = disposition[:disposition], disposition[:filename]
+      end
+
+      send_blob_stream @representation, disposition: disposition, filename: filename
     end
   end
 end

--- a/activestorage/app/controllers/concerns/active_storage/streaming.rb
+++ b/activestorage/app/controllers/concerns/active_storage/streaming.rb
@@ -60,9 +60,9 @@ module ActiveStorage::Streaming
 
     # Stream the blob from storage directly to the response. The disposition can be controlled by setting +disposition+.
     # The content type and filename is set directly from the +blob+.
-    def send_blob_stream(blob, disposition: nil) # :doc:
+    def send_blob_stream(blob, disposition: nil, filename: nil) # :doc:
       send_stream(
-          filename: blob.filename.sanitized,
+          filename: filename || blob.filename.sanitized,
           disposition: blob.forced_disposition_for_serving || disposition || DEFAULT_BLOB_STREAMING_DISPOSITION,
           type: blob.content_type_for_serving) do |stream|
         blob.download do |chunk|

--- a/activestorage/test/controllers/blobs/proxy_controller_test.rb
+++ b/activestorage/test/controllers/blobs/proxy_controller_test.rb
@@ -58,6 +58,13 @@ class ActiveStorage::Blobs::ProxyControllerTest < ActionDispatch::IntegrationTes
     assert_match(/^attachment; /, response.headers["Content-Disposition"])
   end
 
+  test "caller can change filename" do
+    blob = create_blob(content_type: "image/jpeg", filename: "from_blob.jpg")
+    url = rails_storage_proxy_url(blob, disposition: { disposition: "attachment", filename: "from_parameter.jpg" })
+    get url
+    assert_match(/^attachment; filename="from_parameter.jpg";/, response.headers["Content-Disposition"])
+  end
+
   test "signed ID within expiration duration" do
     get rails_storage_proxy_url(create_file_blob(filename: "racecar.jpg"), expires_in: 1.minute)
     assert_response :success

--- a/activestorage/test/controllers/representations/proxy_controller_test.rb
+++ b/activestorage/test/controllers/representations/proxy_controller_test.rb
@@ -22,6 +22,18 @@ class ActiveStorage::Representations::ProxyControllerWithVariantsTest < ActionDi
     assert_equal @blob.variant(@transformations).download, response.body
   end
 
+  test "showing variant attachment with filename" do
+    get rails_blob_representation_proxy_url(
+      disposition: { disposition: :attachment, filename: "file.jpg" },
+      filename: @blob.filename,
+      signed_blob_id: @blob.signed_id,
+      variation_key: ActiveStorage::Variation.encode(@transformations))
+
+    assert_response :ok
+    assert_match(/^attachment; filename="file.jpg";/, response.headers["Content-Disposition"])
+    assert_equal @blob.variant(@transformations).download, response.body
+  end
+
   test "showing variant inline" do
     get rails_blob_representation_proxy_url(
       filename: @blob.filename,

--- a/guides/source/active_storage_overview.md
+++ b/guides/source/active_storage_overview.md
@@ -530,7 +530,11 @@ helpers generate the same permanent Rails URL but allow you to specify the file
 [Content-Disposition Header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Content-Disposition).
 
 ```ruby
+# Derive the filename
 rails_blob_path(user.profile_photo, disposition: "attachment")
+
+# Specify the filename
+rails_blob_path(user.profile_photo, disposition: { disposition: "attachment", filename: "profile_photo.png" })
 ```
 
 WARNING: To prevent XSS attacks, Active Storage forces the Content-Disposition


### PR DESCRIPTION
### Motivation / Background

While browsers support reading a filename for a downloaded file from an `<a>` element's `[download]` attribute, that attribute's value has a lower precedence than a filename specified in the response's [Content-Disposition][] header:

> If the Content-Disposition header has different information from the download attribute, resulting behavior may differ:
> * If the header specifies a filename, it takes priority over a filename specified in the download attribute.
> * If the header specifies a disposition of inline, Chrome and Firefox prioritize the attribute and treat it as a download. Old Firefox versions (before 82) prioritize the header and will display the content inline.

### Detail

When files are served with an `inline;`-prefixed `Content-Disposition` header, the absence of a filename allows the browser to read the filename from the `[download]` attribute on the `<a>` element.

However, files served with `attachment;`-prefixed `Content-Disposition` headers (either explicitly through requests to to `rails_blob_url(..., disposition: "attachment")` URLs or implicitly for files with types listed in [config.active_storage.content_types_to_serve_as_binary][]) cannot control the name of the downloaded file. For most services, this means that applications cannot override storage-service generated files (for example:
`-var-folders-4q-q308vb3s12x2rzrgppdsz0540000gn-T-20241114-56163-dfyqb1.pdf`).

This commit adds support for overriding that filename with a `:filename` query parameter (through the same mechanism as the [`disposition` query parameter][redirect-mode]).

### Additional Notes

The [Active Storage routes](https://github.com/rails/rails/blob/4df235f7c0149ac7be86580d41a74a7785cb9bb9/activestorage/config/routes.rb#L5-L11) utilize the `*filename` dynamic segment. At the controller level, the value of the `params[:filename]` path pattern collides with any `?filename=` query parameter. 

To work around this constraint, the existing `disposition` query parameter could be re-purposed to support both String and Hash values: When nested, the filename is derived from the `:filename` query parameter nested under the `:disposition` key.

```ruby
# before - might not download file to `avatar.png` depending on browser
link_to "Download", rails_blob_path(user.avatar, disposition: "attachment"), download: "avatar.png")

# after
link_to "Download", rails_blob_path(user.avatar, disposition: { disposition: "attachment", filename: "avatar.png" })
```

The structure of the keyword arguments nested underneath the `:disposition` key was chosen to match the expected arguments for [ActionDispatch::Http::ContentDisposition][].

[download]: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#download
[Content-Disposition]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Disposition
[config.active_storage.content_types_to_serve_as_binary]: https://guides.rubyonrails.org/configuring.html#config-active-storage-content-types-to-serve-as-binary
[redirect-mode]: https://guides.rubyonrails.org/v8.0.0/active_storage_overview.html#redirect-mode
[ActionDispatch::Http::ContentDisposition]: https://github.com/rails/rails/blob/v8.0.3/actionpack/lib/action_dispatch/http/content_disposition.rb#L8

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
