### PR TITLE
Allow app to opt out of precompiling actiontext js assets

### DIFF
--- a/actiontext/lib/action_text/engine.rb
+++ b/actiontext/lib/action_text/engine.rb
@@ -15,6 +15,7 @@ module ActionText
     config.eager_load_namespaces << ActionText
 
     config.action_text = ActiveSupport::OrderedOptions.new
+    config.action_text.precompile_assets = true
     config.action_text.attachment_tag_name = "action-text-attachment"
     config.autoload_once_paths = %W(
       #{root}/app/helpers
@@ -33,8 +34,10 @@ module ActionText
     end
 
     initializer "action_text.asset" do
-      if Rails.application.config.respond_to?(:assets)
-        Rails.application.config.assets.precompile += %w( actiontext.js actiontext.esm.js trix.js trix.css )
+      config.after_initialize do |app|
+        if app.config.respond_to?(:assets) && app.config.action_text.precompile_assets
+          app.config.assets.precompile += %w( actiontext.js actiontext.esm.js trix.js trix.css )
+        end
       end
     end
 

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -3178,6 +3178,11 @@ Configures the HTML sanitizer used by Action Text by setting `ActionText::Conten
 
 NOTE: `Rails::HTML5::Sanitizer` is not supported on JRuby, so on JRuby platforms Rails will fall back to `Rails::HTML4::Sanitizer`.
 
+#### `config.action_text.precompile_assets`
+
+Determines whether the Action Text assets should be added to the asset pipeline precompilation. It
+has no effect if Sprockets is not used. The default value is `true`.
+
 #### `Regexp.timeout`
 
 


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created because it's impossible to opt-out precompilation of Action Text assets.

Action Cable and Active Storage have that option since https://github.com/rails/rails/pull/42856 and https://github.com/rails/rails/pull/43967.

I'm working on an app that doesn't need to precompile Action Text , Active Storage or Action Cable Js. The only way to achieve that right now is with the following configuration

```ruby
# config/application.rb

config.action_cable.precompile_assets = false
config.active_storage.precompile_assets = false
config.after_initialize do |app|
   app.config.assets.precompile -= %w( actiontext.js actiontext.esm.js trix.js trix.css )
end
```

It would be helpful if I could use an option for Action Text (`config.action_text.precompile_assets`)

### Detail

The PR follows the changes done in #43967:
- Introduce `action_text.precompile_assets` with `true` as the default value
- Modify `action_text.asset` initializer to add assets to `config.assets.precompile` based on the new option value
- Update docs

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->
I verified this locally. I found it hard to write a test for this. I searched and couldn't find tests for Action Cable or Active Storage.
