### PR TITLE
 Maintain connection verification for 2 seconds after use

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   Remember when a database connection has recently been verified (for
+    two seconds, by default), to avoid repeated reverifications during a
+    single request.
+
+    This should recreate a similar rate of verification as in Rails 7.1,
+    where connections are leased for the duration of a request, and thus
+    only verified once.
+
+    *Matthew Draper*
+
 *   Allow to reset cache counters for multiple records.
 
     ```

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -218,6 +218,10 @@ module ActiveRecord
         (@config[:connection_retries] || 1).to_i
       end
 
+      def verify_timeout
+        (@config[:verify_timeout] || 2).to_i
+      end
+
       def retry_deadline
         if @config[:retry_deadline]
           @config[:retry_deadline].to_f
@@ -1003,6 +1007,9 @@ module ActiveRecord
             if @verified
               # Cool, we're confident the connection's ready to use. (Note this might have
               # become true during the above #materialize_transactions.)
+            elsif (last_activity = seconds_since_last_activity) && last_activity < verify_timeout
+              # We haven't actually verified the connection since we acquired it, but it
+              # has been used very recently. We're going to assume it's still okay.
             elsif reconnectable
               if allow_retry
                 # Not sure about the connection yet, but if anything goes wrong we can

--- a/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
@@ -106,7 +106,14 @@ module ActiveRecord
       end
 
       def active?
-        connected? && @lock.synchronize { @raw_connection&.ping } || false
+        if connected?
+          @lock.synchronize do
+            if @raw_connection&.ping
+              verified!
+              true
+            end
+          end
+        end || false
       end
 
       alias :reset! :reconnect!

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -349,6 +349,7 @@ module ActiveRecord
         @lock.synchronize do
           return false unless @raw_connection
           @raw_connection.query ";"
+          verified!
         end
         true
       rescue PG::Error

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -207,7 +207,12 @@ module ActiveRecord
         !(@raw_connection.nil? || @raw_connection.closed?)
       end
 
-      alias_method :active?, :connected?
+      def active?
+        if connected?
+          verified!
+          true
+        end
+      end
 
       alias :reset! :reconnect!
 

--- a/activerecord/lib/active_record/connection_adapters/trilogy_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/trilogy_adapter.rb
@@ -121,7 +121,7 @@ module ActiveRecord
       end
 
       def active?
-        connected? && @lock.synchronize { @raw_connection&.ping } || false
+        connected? && @lock.synchronize { @raw_connection&.ping; verified! } || false
       rescue ::Trilogy::Error
         false
       end


### PR DESCRIPTION
This means that a database connection that fails in between two requests that are less than ~5~ **2** seconds apart may cause the failure-following request to die (if its first query is not retryable).

That's not a big concern in practice: per-request verification is intended to protect against the case that the database connection failed some large time before the request arrives. A request beginning within seconds of the failure is morally equivalent to a request that was already in flight.

Between automatically retryable select queries and BEGINs, the first query of a request will very commonly be retryable anyway. This change's value is in our new use of short-term leasing via `with_connection`, where we can otherwise end up re-verifying for every non-retryable query.

Previously discussed:
* https://github.com/rails/rails/pull/53425
* https://github.com/rails/rails/pull/53662

---

The new `@last_activity` overlaps very closely with the existing `@verified`. We're planning to backport this change, so I wanted to minimize even-internal changes for now. We can probably follow up with a main-only change to drop `@verified` entirely.


