### PR TITLE
Don’t use parentheses in ERB scaffolded `form_with`

### DIFF
--- a/railties/lib/rails/generators/erb/scaffold/templates/_form.html.erb.tt
+++ b/railties/lib/rails/generators/erb/scaffold/templates/_form.html.erb.tt
@@ -1,4 +1,4 @@
-<%%= form_with(model: <%= model_resource_name %>) do |form| %>
+<%%= form_with model: <%= model_resource_name %> do |form| %>
   <%% if <%= singular_table_name %>.errors.any? %>
     <div style="color: red">
       <h2><%%= pluralize(<%= singular_table_name %>.errors.count, "error") %> prohibited this <%= singular_table_name %> from being saved:</h2>


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because `form_with` in the generated/scaffolded `_form.html.erb` partial uses parentheses.

This is inconsistent with the authentication generator generated forms that do not use parentheses:

https://github.com/rails/rails/blob/a8709e6ea26eca73a652af4fdd0a9f7db5352af4/railties/lib/rails/generators/erb/authentication/templates/app/views/sessions/new.html.erb#L4

https://github.com/rails/rails/blob/a8709e6ea26eca73a652af4fdd0a9f7db5352af4/railties/lib/rails/generators/erb/authentication/templates/app/views/passwords/new.html.erb#L5

https://github.com/rails/rails/blob/a8709e6ea26eca73a652af4fdd0a9f7db5352af4/railties/lib/rails/generators/erb/authentication/templates/app/views/passwords/edit.html.erb#L5

It is also inconsistent with most code examples in the [`form_with`](https://api.rubyonrails.org/classes/ActionView/Helpers/FormHelper.html#method-i-form_with) API docs which mostly do not use parentheses.

### Detail

This Pull Request removes parentheses from `_form.html.erb.tt`'s `form_with`.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
