### PR TITLE
Make FileUpdateChecker faster with many extensions

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -28,4 +28,8 @@
 
     *Taketo Takashima*
 
+*   Make `ActiveSupport::FileUpdateChecker` faster when checking many file-extensions.
+
+    *Jonathan del Strother*
+
 Please check [8-0-stable](https://github.com/rails/rails/blob/8-0-stable/activesupport/CHANGELOG.md) for previous changes.

--- a/activesupport/lib/active_support/file_update_checker.rb
+++ b/activesupport/lib/active_support/file_update_checker.rb
@@ -47,7 +47,7 @@ module ActiveSupport
       end
 
       @files = files.freeze
-      @glob  = compile_glob(dirs)
+      @globs = compile_glob(dirs)
       @block = block
 
       @watched    = nil
@@ -103,7 +103,7 @@ module ActiveSupport
       def watched
         @watched || begin
           all = @files.select { |f| File.exist?(f) }
-          all.concat(Dir[@glob]) if @glob
+          all.concat(Dir[*@globs]) if @globs
           all.tap(&:uniq!)
         end
       end
@@ -145,10 +145,9 @@ module ActiveSupport
         hash.freeze # Freeze so changes aren't accidentally pushed
         return if hash.empty?
 
-        globs = hash.map do |key, value|
+        hash.map do |key, value|
           "#{escape(key)}/**/*#{compile_ext(value)}"
         end
-        "{#{globs.join(",")}}"
       end
 
       def escape(key)


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because FileUpdateChecker is surprisingly slow in importmap-rails projects


### Detail


Projects using propshaft/importmap-rails can end up constructing FileUpdateCheckers with globs looking like:

```
{/Users/jon/Developer/rails-importmaps/app/assets/images/**/*.{html,xhtml,text,txt,js,css,ics,csv,vcf,vtt,png,jpeg,jpg,jpe,pjpeg,gif,bmp,tiff,tif,svg,webp,mpeg,mpg,mpe,mp3,mp1,mp2,ogg,oga,spx,opus,m4a,mpg4,aac,webm,mp4,m4v,otf,ttf,woff,woff2,xml,rss,atom,yaml,yml,multipart_form,url_encoded_form,json,pdf,zip,gzip,gz,turbo_stream},
/Users/jon/Developer/rails-importmaps/app/assets/stylesheets/**/*.{html,xhtml,text,txt,js,css,ics,csv,vcf,vtt,png,jpeg,jpg,jpe,pjpeg,gif,bmp,tiff,tif,svg,webp,mpeg,mpg,mpe,mp3,mp1,mp2,ogg,oga,spx,opus,m4a,mpg4,aac,webm,mp4,m4v,otf,ttf,woff,woff2,xml,rss,atom,yaml,yml,multipart_form,url_encoded_form,json,pdf,zip,gzip,gz,turbo_stream},
/Users/jon/Developer/rails-importmaps/.devenv/bundle/ruby/3.3.0/gems/stimulus-rails-1.3.4/app/assets/javascripts/**/*.{html,xhtml,text,txt,js,css,ics,csv,vcf,vtt,png,jpeg,jpg,jpe,pjpeg,gif,bmp,tiff,tif,svg,webp,mpeg,mpg,mpe,mp3,mp1,mp2,ogg,oga,spx,opus,m4a,mpg4,aac,webm,mp4,m4v,otf,ttf,woff,woff2,xml,rss,atom,yaml,yml,multipart_form,url_encoded_form,json,pdf,zip,gzip,gz,turbo_stream},
/Users/jon/Developer/rails-importmaps/.devenv/bundle/ruby/3.3.0/gems/turbo-rails-2.0.11/app/assets/javascripts/**/*.{html,xhtml,text,txt,js,css,ics,csv,vcf,vtt,png,jpeg,jpg,jpe,pjpeg,gif,bmp,tiff,tif,svg,webp,mpeg,mpg,mpe,mp3,mp1,mp2,ogg,oga,spx,opus,m4a,mpg4,aac,webm,mp4,m4v,otf,ttf,woff,woff2,xml,rss,atom,yaml,yml,multipart_form,url_encoded_form,json,pdf,zip,gzip,gz,turbo_stream},
/Users/jon/Developer/rails-importmaps/.devenv/bundle/ruby/3.3.0/gems/actiontext-8.0.0/app/assets/javascripts/**/*.{html,xhtml,text,txt,js,css,ics,csv,vcf,vtt,png,jpeg,jpg,jpe,pjpeg,gif,bmp,tiff,tif,svg,webp,mpeg,mpg,mpe,mp3,mp1,mp2,ogg,oga,spx,opus,m4a,mpg4,aac,webm,mp4,m4v,otf,ttf,woff,woff2,xml,rss,atom,yaml,yml,multipart_form,url_encoded_form,json,pdf,zip,gzip,gz,turbo_stream},
/Users/jon/Developer/rails-importmaps/.devenv/bundle/ruby/3.3.0/gems/actiontext-8.0.0/app/assets/stylesheets/**/*.{html,xhtml,text,txt,js,css,ics,csv,vcf,vtt,png,jpeg,jpg,jpe,pjpeg,gif,bmp,tiff,tif,svg,webp,mpeg,mpg,mpe,mp3,mp1,mp2,ogg,oga,spx,opus,m4a,mpg4,aac,webm,mp4,m4v,otf,ttf,woff,woff2,xml,rss,atom,yaml,yml,multipart_form,url_encoded_form,json,pdf,zip,gzip,gz,turbo_stream},
/Users/jon/Developer/rails-importmaps/.devenv/bundle/ruby/3.3.0/gems/actioncable-8.0.0/app/assets/javascripts/**/*.{html,xhtml,text,txt,js,css,ics,csv,vcf,vtt,png,jpeg,jpg,jpe,pjpeg,gif,bmp,tiff,tif,svg,webp,mpeg,mpg,mpe,mp3,mp1,mp2,ogg,oga,spx,opus,m4a,mpg4,aac,webm,mp4,m4v,otf,ttf,woff,woff2,xml,rss,atom,yaml,yml,multipart_form,url_encoded_form,json,pdf,zip,gzip,gz,turbo_stream},
/Users/jon/Developer/rails-importmaps/.devenv/bundle/ruby/3.3.0/gems/activestorage-8.0.0/app/assets/javascripts/**/*.{html,xhtml,text,txt,js,css,ics,csv,vcf,vtt,png,jpeg,jpg,jpe,pjpeg,gif,bmp,tiff,tif,svg,webp,mpeg,mpg,mpe,mp3,mp1,mp2,ogg,oga,spx,opus,m4a,mpg4,aac,webm,mp4,m4v,otf,ttf,woff,woff2,xml,rss,atom,yaml,yml,multipart_form,url_encoded_form,json,pdf,zip,gzip,gz,turbo_stream},
/Users/jon/Developer/rails-importmaps/.devenv/bundle/ruby/3.3.0/gems/actionview-8.0.0/app/assets/javascripts/**/*.{html,xhtml,text,txt,js,css,ics,csv,vcf,vtt,png,jpeg,jpg,jpe,pjpeg,gif,bmp,tiff,tif,svg,webp,mpeg,mpg,mpe,mp3,mp1,mp2,ogg,oga,spx,opus,m4a,mpg4,aac,webm,mp4,m4v,otf,ttf,woff,woff2,xml,rss,atom,yaml,yml,multipart_form,url_encoded_form,json,pdf,zip,gzip,gz,turbo_stream},
/Users/jon/Developer/rails-importmaps/app/javascript/**/*.{html,xhtml,text,txt,js,css,ics,csv,vcf,vtt,png,jpeg,jpg,jpe,pjpeg,gif,bmp,tiff,tif,svg,webp,mpeg,mpg,mpe,mp3,mp1,mp2,ogg,oga,spx,opus,m4a,mpg4,aac,webm,mp4,m4v,otf,ttf,woff,woff2,xml,rss,atom,yaml,yml,multipart_form,url_encoded_form,json,pdf,zip,gzip,gz,turbo_stream},
/Users/jon/Developer/rails-importmaps/vendor/javascript/**/*.{html,xhtml,text,txt,js,css,ics,csv,vcf,vtt,png,jpeg,jpg,jpe,pjpeg,gif,bmp,tiff,tif,svg,webp,mpeg,mpg,mpe,mp3,mp1,mp2,ogg,oga,spx,opus,m4a,mpg4,aac,webm,mp4,m4v,otf,ttf,woff,woff2,xml,rss,atom,yaml,yml,multipart_form,url_encoded_form,json,pdf,zip,gzip,gz,turbo_stream}}
```

Generally speaking, globs with nested braces seem to perform very poorly.

If the glob looks like `app/assets/stylesheets/**/*.{css,scss,js}`, you just get one system call for each of app, app/assets, app/assets/stylesheets. This is the best-case scenario.

If the glob looks like `{app/assets/stylesheets/**/*.{css,scss,js}}` - which ought to be identical - you get three system calls for each of app, app/assets, app/assets/stylesheets. If you add more extensions to the inner glob, you multiply the number of system calls for every directory in the path.

 (I'm guessing ruby has an optimization somewhere for the single-brace scenario, but haven't been able to find it)

Fortunately, we can avoid this performance drop by just passing the directories as separate arguments to `Dir[]` - ie change

```ruby
Dir["{foo/**/*.{css,js},bar/**/*.{css,js}}"]
```

into

```ruby
Dir["foo/**/*.{css,js}", "bar/**/*.{css,js}"]
```

### Additional information

On a fresh importmap-rails project on macos 15.1 with ruby 3.3.5, `Rails.application.assets.load_path.cache_sweeper.execute_if_updated` takes around 15ms. After this optimization, it's around 0.5ms.


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
