### PR TITLE
Backport #51351 into 7.1: Don't enqueue jobs to process a preview image if no variant requires it

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,7 @@
+* Don't enqueue jobs to process a preview image if no variant requires it.
+
+  Rosa Gutierrez
+
 ## Rails 7.1.5 (October 30, 2024) ##
 
 *   No changes.

--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,6 +1,6 @@
-* Don't enqueue jobs to process a preview image if no variant requires it.
+*   Don't enqueue jobs to process a preview image if no variant requires it.
 
-  Rosa Gutierrez
+    Rosa Gutierrez
 
 ## Rails 7.1.5 (October 30, 2024) ##
 

--- a/activestorage/app/models/active_storage/attachment.rb
+++ b/activestorage/app/models/active_storage/attachment.rb
@@ -138,7 +138,7 @@ class ActiveStorage::Attachment < ActiveStorage::Record
         end
       }
 
-      if blob.preview_image_needed_before_processing_variants?
+      if blob.preview_image_needed_before_processing_variants? && preprocessed_variations.any?
         blob.create_preview_image_later(preprocessed_variations)
       else
         preprocessed_variations.each do |transformations|

--- a/activestorage/test/jobs/preview_image_job_test.rb
+++ b/activestorage/test/jobs/preview_image_job_test.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "database/setup"
+
+class ActiveStorage::PreviewImageJobTest < ActiveJob::TestCase
+  setup do
+    @blob = create_file_blob(filename: "report.pdf", content_type: "application/pdf")
+    @transformation = { resize_to_limit: [ 100, 100 ] }
+  end
+
+  test "creates preview" do
+    assert_changes -> { @blob.preview_image.attached? }, from: false, to: true do
+      ActiveStorage::PreviewImageJob.perform_now @blob, [ @transformation ]
+    end
+  end
+
+  test "enqueues transform variant jobs" do
+    assert_enqueued_with job: ActiveStorage::TransformJob, args: [ @blob, @transformation ] do
+      ActiveStorage::PreviewImageJob.perform_now @blob, [ @transformation ]
+    end
+  end
+end

--- a/activestorage/test/models/attached/many_test.rb
+++ b/activestorage/test/models/attached/many_test.rb
@@ -894,7 +894,7 @@ class ActiveStorage::ManyAttachedTest < ActiveSupport::TestCase
   end
 
   test "transforms variants later conditionally via proc" do
-    assert_no_enqueued_jobs only: ActiveStorage::TransformJob do
+    assert_no_enqueued_jobs only: [ ActiveStorage::TransformJob, ActiveStorage::PreviewImageJob ] do
       @user.highlights_with_conditional_preprocessed.attach create_file_blob(filename: "racecar.jpg")
     end
 
@@ -907,7 +907,7 @@ class ActiveStorage::ManyAttachedTest < ActiveSupport::TestCase
   end
 
   test "transforms variants later conditionally via method" do
-    assert_no_enqueued_jobs only: ActiveStorage::TransformJob do
+    assert_no_enqueued_jobs only: [ ActiveStorage::TransformJob, ActiveStorage::PreviewImageJob ] do
       @user.highlights_with_conditional_preprocessed.attach create_file_blob(filename: "racecar.jpg")
     end
 
@@ -915,14 +915,16 @@ class ActiveStorage::ManyAttachedTest < ActiveSupport::TestCase
     @user.update(name: "transform via method")
 
     assert_enqueued_with job: ActiveStorage::TransformJob, args: [blob, resize_to_limit: [3, 3]] do
-      @user.highlights_with_conditional_preprocessed.attach blob
+      assert_no_enqueued_jobs only: ActiveStorage::PreviewImageJob do
+        @user.highlights_with_conditional_preprocessed.attach blob
+      end
     end
   end
 
-  test "avoids enqueuing transform later job when blob is not representable" do
+  test "avoids enqueuing transform later and create preview job job when blob is not representable" do
     unrepresentable_blob = create_blob(filename: "hello.txt")
 
-    assert_no_enqueued_jobs only: ActiveStorage::TransformJob do
+    assert_no_enqueued_jobs only: [ ActiveStorage::TransformJob, ActiveStorage::PreviewImageJob ] do
       @user.highlights_with_preprocessed.attach unrepresentable_blob
     end
   end

--- a/activestorage/test/models/attached/one_test.rb
+++ b/activestorage/test/models/attached/one_test.rb
@@ -836,7 +836,7 @@ class ActiveStorage::OneAttachedTest < ActiveSupport::TestCase
   end
 
   test "transforms variants later conditionally via proc" do
-    assert_no_enqueued_jobs only: ActiveStorage::TransformJob do
+    assert_no_enqueued_jobs only: [ ActiveStorage::TransformJob, ActiveStorage::PreviewImageJob ] do
       @user.avatar_with_conditional_preprocessed.attach create_file_blob(filename: "racecar.jpg")
     end
 
@@ -849,7 +849,7 @@ class ActiveStorage::OneAttachedTest < ActiveSupport::TestCase
   end
 
   test "transforms variants later conditionally via method" do
-    assert_no_enqueued_jobs only: ActiveStorage::TransformJob do
+    assert_no_enqueued_jobs only: [ ActiveStorage::TransformJob, ActiveStorage::PreviewImageJob ] do
       @user.avatar_with_conditional_preprocessed.attach create_file_blob(filename: "racecar.jpg")
     end
 
@@ -861,11 +861,29 @@ class ActiveStorage::OneAttachedTest < ActiveSupport::TestCase
     end
   end
 
-  test "avoids enqueuing transform later job when blob is not representable" do
+  test "avoids enqueuing transform later job or preview image job when blob is not representable" do
     unrepresentable_blob = create_blob(filename: "hello.txt")
 
-    assert_no_enqueued_jobs only: ActiveStorage::TransformJob do
+    assert_no_enqueued_jobs only: [ ActiveStorage::TransformJob, ActiveStorage::PreviewImageJob ]  do
       @user.avatar_with_preprocessed.attach unrepresentable_blob
+    end
+  end
+
+  test "avoids enqueuing transform later job or preview later job if there aren't any variants to preprocess" do
+    blob = create_file_blob(filename: "report.pdf")
+
+    assert_no_enqueued_jobs only: [ ActiveStorage::TransformJob, ActiveStorage::PreviewImageJob ] do
+      @user.resume.attach blob
+    end
+  end
+
+  test "creates preview later without transforming variants if required and there are variants to preprocess" do
+    blob = create_file_blob(filename: "report.pdf")
+
+    assert_enqueued_with job: ActiveStorage::PreviewImageJob, args: [blob, [resize_to_fill: [400, 400]]] do
+      assert_no_enqueued_jobs only: ActiveStorage::TransformJob do
+        @user.resume_with_preprocessing.attach blob
+      end
     end
   end
 end

--- a/activestorage/test/models/reflection_test.rb
+++ b/activestorage/test/models/reflection_test.rb
@@ -39,8 +39,8 @@ class ActiveStorage::ReflectionTest < ActiveSupport::TestCase
   test "reflecting on all attachments" do
     reflections = User.reflect_on_all_attachments.sort_by(&:name)
     assert_equal [ User ], reflections.collect(&:active_record).uniq
-    assert_equal %i[ avatar avatar_with_conditional_preprocessed avatar_with_preprocessed avatar_with_variants cover_photo highlights highlights_with_conditional_preprocessed highlights_with_preprocessed highlights_with_variants intro_video name_pronunciation_audio vlogs ], reflections.collect(&:name)
-    assert_equal %i[ has_one_attached has_one_attached has_one_attached has_one_attached has_one_attached has_many_attached has_many_attached has_many_attached has_many_attached has_one_attached has_one_attached has_many_attached ], reflections.collect(&:macro)
-    assert_equal [ :purge_later, :purge_later, :purge_later, :purge_later, false, :purge_later, :purge_later, :purge_later, :purge_later, :purge_later, :purge_later, false ], reflections.collect { |reflection| reflection.options[:dependent] }
+    assert_equal %i[ avatar avatar_with_conditional_preprocessed avatar_with_preprocessed avatar_with_variants cover_photo highlights highlights_with_conditional_preprocessed highlights_with_preprocessed highlights_with_variants intro_video name_pronunciation_audio resume resume_with_preprocessing vlogs ], reflections.collect(&:name)
+    assert_equal %i[ has_one_attached has_one_attached has_one_attached has_one_attached has_one_attached has_many_attached has_many_attached has_many_attached has_many_attached has_one_attached has_one_attached has_one_attached has_one_attached has_many_attached ], reflections.collect(&:macro)
+    assert_equal [ :purge_later, :purge_later, :purge_later, :purge_later, false, :purge_later, :purge_later, :purge_later, :purge_later, :purge_later, :purge_later, :purge_later, :purge_later, false ], reflections.collect { |reflection| reflection.options[:dependent] }
   end
 end

--- a/activestorage/test/test_helper.rb
+++ b/activestorage/test/test_helper.rb
@@ -176,6 +176,12 @@ class User < ActiveRecord::Base
     attachable.variant :method, resize_to_limit: [3, 3],
       preprocessed: :should_preprocessed?
   end
+  has_one_attached :resume do |attachable|
+    attachable.variant :preview, resize_to_fill: [400, 400]
+  end
+  has_one_attached :resume_with_preprocessing do |attachable|
+    attachable.variant :preview, resize_to_fill: [400, 400], preprocessed: true
+  end
 
   accepts_nested_attributes_for :highlights_attachments, allow_destroy: true
 


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created because I would like to backport the changes made on https://github.com/rails/rails/pull/51351, which were included in Rails 7.2, into the next 7.1 release.

### Detail

This Pull Request will stop the unnecesarry enqueueing of jobs to process a preview image when there are no variants that requires it.

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

See https://github.com/rails/rails/pull/51351/files

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
