### PR TITLE
Fix task `abort_if_pending_migrations` to not use the return value from `Array#flatten!`

### DIFF
--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -333,7 +333,7 @@ db_namespace = namespace :db do
       pending_migrations << pool.migration_context.open.pending_migrations
     end
 
-    pending_migrations = pending_migrations.flatten!
+    pending_migrations.flatten!
 
     if pending_migrations.any?
       puts "You have #{pending_migrations.size} pending #{pending_migrations.size > 1 ? 'migrations:' : 'migration:'}"


### PR DESCRIPTION
### Motivation / Background

The code currently reads

```ruby
pending_migrations = pending_migrations.flatten!
```

which is fine almost all of the time. However, `Array#flatten!` returns `nil` if the array is unchanged, leading to a `NoMethodError` exception later in the task.


### Detail

I think this is self-evidently a small, safe change:

```ruby
pending_migrations.flatten!
```

though of course we could also go with the slightly more verbose:

```ruby
pending_migrations = pending_migrations.flatten
```

but I prefer the first form.


### Additional information

I ran across this while working on a gem to make horizontal sharding more dynamic. When bootstrapping a Rails app (`db:prepare` et al), there are temporarily no connection pools, meaning `DatabaseTasks.with_temporary_pool_for_each` iterates zero times. In this case, the `pending_migrations` array is unchanged by `Array#flatten!` so it returns `nil` leading to the `NoMethodError` exception when calling `#any?` in the next line.

This scenario is not yet a real-world use case, but hopefully you'll agree that the fixed code is more correct in any case.


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [-] Tests are added or updated if you fix a bug or add a feature.
* [-] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
