### PR TITLE
Forward `fill_in_rich_text_area` options to Capybara

### DIFF
--- a/actiontext/CHANGELOG.md
+++ b/actiontext/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Forward `fill_in_rich_text_area` options to Capybara
+
+    ```ruby
+    fill_in_rich_textarea "Rich text editor", id: "trix_editor_1", with: "Hello world!"
+    ```
+
+    *Sean Doyle*
+
 *   Attachment upload progress accounts for server processing time.
 
     *Jeremy Daer*

--- a/actiontext/lib/action_text/system_test_helper.rb
+++ b/actiontext/lib/action_text/system_test_helper.rb
@@ -14,6 +14,7 @@ module ActionText
     # *   its `aria-label`
     # *   the `name` of its input
     #
+    # Additional options are forwarded to Capybara as filters
     #
     # Examples:
     #
@@ -33,8 +34,8 @@ module ActionText
     #     # <input id="trix_input_1" name="message[content]" type="hidden">
     #     # <trix-editor input="trix_input_1"></trix-editor>
     #     fill_in_rich_textarea "message[content]", with: "Hello <em>world!</em>"
-    def fill_in_rich_textarea(locator = nil, with:)
-      find(:rich_textarea, locator).execute_script("this.editor.loadHTML(arguments[0])", with.to_s)
+    def fill_in_rich_textarea(locator = nil, with:, **)
+      find(:rich_textarea, locator, **).execute_script("this.editor.loadHTML(arguments[0])", with.to_s)
     end
     alias_method :fill_in_rich_text_area, :fill_in_rich_textarea
   end

--- a/actiontext/test/system/system_test_helper_test.rb
+++ b/actiontext/test/system/system_test_helper_test.rb
@@ -27,7 +27,7 @@ class ActionText::SystemTestHelperTest < ApplicationSystemTestCase
 
   test "filling in a rich-text area by label" do
     assert_selector :label, "Message content label", for: "message_content"
-    fill_in_rich_textarea "Message content label", with: "Hello world!"
+    fill_in_rich_textarea "Message content label", id: "message_content", with: "Hello world!"
     assert_selector :field, "message[content]", with: /Hello world!/, type: "hidden"
   end
 


### PR DESCRIPTION
### Motivation / Background

Capybara supports a range of global [selectors][]:

> All Selectors below support the listed selector specific filters in
> addition to the following system-wide filters

> * `:id` (String, Regexp, XPath::Expression) - Matches the id attribute
> * `:class` (String, Array, Regexp, XPath::Expression) - Matches the class(es) provided
> * `:style` (String, Regexp, Hash) - Match on elements style
> * `:above` (Element) - Match elements above the passed element on the page
> * `:below` (Element) - Match elements below the passed element on the page
> * `:left_of` (Element) - Match elements left of the passed element on the page
> * `:right_of` (Element) - Match elements right of the passed element on the page
> * `:near` (Element) - Match elements near (within 50px) the passed element on the page
> * `:focused` (Boolean) - Match elements with focus (requires driver support)

While the Action Text-provided `#fill_in_rich_text_area` System Test helper is capable of resolving `<trix-editor>` elements (through the `:rich_textarea` custom Capybara selector), it doesn't support additional options (except for `:with`).

### Detail

This commit forwards any available options to the underlying call to [find][] as filters.

This enables combining `<label>`-based locator text alongside global filters like `:focused` or `:id`:

```ruby
fill_in_rich_text_area "Label text with [id]", id: "trix_editor_1", with: "Hello"
fill_in_rich_text_area "Label text matching :focus", focused: true, with: "Hello"
fill_in_rich_text_area "Label text not matching :focus", focused: false, with: "Hello"
```

[selectors]: https://rubydoc.info/github/teamcapybara/capybara/master/Capybara/Selector
[find]: https://rubydoc.info/github/teamcapybara/capybara/master/Capybara/Node/Finders:find

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
