### PR TITLE
Rails Guides: PostgreSQL timestamp with time zone [ci skip]

### DIFF
--- a/guides/source/active_record_postgresql.md
+++ b/guides/source/active_record_postgresql.md
@@ -516,6 +516,34 @@ irb> event.duration
 => 2 days
 ```
 
+### Timestamps
+
+* [Date/Time Types](https://www.postgresql.org/docs/current/datatype-datetime.html)
+
+Rails migrations with timestamps store the time a model was created or updated. By default and for legacy reasons, the columns use the `timestamp without time zone` data type.
+
+```ruby
+# db/migrate/20241220144913_create_devices.rb
+create_table :post, id: :uuid do |t|
+  t.datetime :published_at
+  # By default, Active Record will set the data type of this column to `timestamp without time zone`.
+end
+```
+
+While this works ok, [PostgreSQL best practices](https://wiki.postgresql.org/wiki/Don't_Do_This#Don.27t_use_timestamp_.28without_time_zone.29) recommend that `timestamp with time zone` is used instead for timezone-aware timestamps.
+This must be configured before it can be used for new migrations.
+
+To configure `timestamp with time zone` as your new timestamp default data type, place the following configuration in the `config/application.rb` file.
+
+```ruby
+# config/application.rb
+ActiveSupport.on_load(:active_record_postgresqladapter) do
+  self.datetime_type = :timestamptz
+end
+```
+
+With that configuration in place, generate and apply new migrations, then verify their timestamps use the `timestamp with time zone` data type.
+
 UUID Primary Keys
 -----------------
 


### PR DESCRIPTION
This addition to the Active Record PostgreSQL Rails Guide documents how to use a configuration option to change the default timestamp data type from `timestamp without time zone` to `timestamp with time zone` (timezone-aware timestamps).

Support for this data type was added to Active Record earlier but is not used by default, requiring a configuration change to use. From the PR comments where it was added, there was a suggestion to document how to use this configuration option, prompting this PR.

I created a new Rails 8 application, generating migrations for scaffolds, and realized they weren't using this data type. I made this configuration change, destroyed and regenerated my scaffold migration, and verified the new data type was used.

I welcome your feedback on this guide content, placement within the guide, or anything else.

- Related PR: https://github.com/rails/rails/pull/41084
- Guide page: https://guides.rubyonrails.org/active_record_postgresql.html
- PostgreSQL best practices:
https://wiki.postgresql.org/wiki/Don't_Do_This#Don.27t_use_timestamp_.28without_time_zone.29

Thanks!

### Checklist

Before submitting the PR make sure the following are checked:

* [ ] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [ ] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
