### PR TITLE
Use global Std stream instead of constant in default `bin/setup`

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/bin/setup.tt
+++ b/railties/lib/rails/generators/rails/app/templates/bin/setup.tt
@@ -38,7 +38,7 @@ FileUtils.chdir APP_ROOT do
 
   unless ARGV.include?("--skip-server")
     puts "\n== Starting development server =="
-    STDOUT.flush # flush the output before exec(2) so that it displays
+    $stdout.flush # flush the output before exec(2) so that it displays
     exec "bin/dev"
   end
 end


### PR DESCRIPTION
# Description
Both the [Ruby style guide](https://github.com/rubocop/ruby-style-guide?tab=readme-ov-file#global-inputoutput-streams) and [RuboCop](https://docs.rubocop.org/rubocop/cops_style.html#styleglobalstdstream) suggest that it's better to use the global Std streams instead of their constant counterparts.
