### PR TITLE
Fix Mysql2Adapter support for prepared statements

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/mysql2/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql2/database_statements.rb
@@ -53,7 +53,7 @@ module ActiveRecord
 
               begin
                 ActiveSupport::Dependencies.interlock.permit_concurrent_loads do
-                  stmt.execute(*type_casted_binds)
+                  result = stmt.execute(*type_casted_binds)
                 end
               rescue ::Mysql2::Error
                 @statements.delete(sql)
@@ -61,6 +61,8 @@ module ActiveRecord
                 raise
               end
               verified!
+
+              result
             else
               raw_connection.query(sql)
             end

--- a/activerecord/test/cases/adapters/mysql2/mysql2_adapter_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/mysql2_adapter_test.rb
@@ -68,6 +68,11 @@ class Mysql2AdapterTest < ActiveRecord::Mysql2TestCase
     assert_equal false, adapter.prepared_statements
   end
 
+  def test_exec_query_with_prepared_statements
+    result = @conn.exec_query("SELECT 1", "SQL", [], prepare: true)
+    assert_equal [{ "1" => 1 }], result.to_a
+  end
+
   def test_exec_query_nothing_raises_with_no_result_queries
     assert_nothing_raised do
       with_example_table do


### PR DESCRIPTION
Fix: https://github.com/rails/rails/issues/53673

Performing a query with prepared statements using the Mysql2 adapter would result in `NoMethodError`.
