### PR TITLE
Add ActiveRecord database method simple_query to simplify the knowledge required to run raw SQL queries

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,20 @@
+*   Add database method `simple_query`
+
+    ```ruby
+      sql = <<~SQL
+        SELECT
+          orders.category,
+          COUNT(*)
+        FROM orders
+        WHERE orders.company_id = :company_id AND orders.updated_by_user_id = :user_id
+        GROUP BY 1
+      SQL
+
+      ActiveRecord::Base.connection.simple_query(sql, company_id: company.id, user_id: user.id)
+    ```
+
+    *westonganger*
+
 *   Allow to reset cache counters for multiple records.
 
     ```

--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -148,6 +148,26 @@ module ActiveRecord
         internal_exec_query(sql, name, binds, prepare: prepare)
       end
 
+      # Executes +sql+ statement in the context of this connection using
+      # Returns an array of record hashes with the column names as keys and column values
+      # as values.
+      # Example usage:
+      #
+      #   ActiveRecord::Base.connection.simple_query("SELECT * FROM posts WHERE company_id = :company_id AND user_id = :user_id", company_id: company.id, user_id: user_id)
+      def simple_query(sql, binds = nil, **splat_binds)
+        if binds.nil? && splat_binds
+          binds = splat_binds
+        end
+
+        if binds.is_a?(Array)
+          sanitized_sql = ActiveRecord::Base.sanitize_sql_array([sql, *binds])
+        else
+          sanitized_sql = ActiveRecord::Base.sanitize_sql_array([sql, binds])
+        end
+
+        select_all(sanitized_sql).to_a
+      end
+
       # Executes insert +sql+ statement in the context of this connection using
       # +binds+ as the bind substitutes. +name+ is logged along with
       # the executed +sql+ statement.

--- a/activerecord/test/cases/adapter_test.rb
+++ b/activerecord/test/cases/adapter_test.rb
@@ -333,6 +333,55 @@ module ActiveRecord
       assert_equal "special_db_type", @connection.type_to_sql(:special_db_type)
     end
 
+    def test_simple_query_with_splat
+      result = @connection.simple_query("SELECT id FROM posts WHERE id IN (:id, :id_2)", id: 1, id_2: 2)
+
+      first, second = result
+
+      assert result.is_a?(Array)
+
+      assert_equal 2, result.size
+
+      assert_equal({ "id" => 1 }, first)
+      assert_equal({ "id" => 2 }, second)
+    end
+
+    def test_simple_query_with_hash
+      result = @connection.simple_query("SELECT id FROM posts WHERE id IN (:id, :id_2)", { id: 1, id_2: 2 })
+
+      first, second = result
+
+      assert result.is_a?(Array)
+
+      assert_equal 2, result.size
+
+      assert_equal({ "id" => 1 }, first)
+      assert_equal({ "id" => 2 }, second)
+    end
+
+    def test_simple_query_with_array
+      result = @connection.simple_query("SELECT id FROM posts WHERE id IN (?, ?)", [1, 2])
+
+      first, second = result
+
+      assert result.is_a?(Array)
+
+      assert_equal 2, result.size
+
+      assert_equal({ "id" => 1 }, first)
+      assert_equal({ "id" => 2 }, second)
+    end
+
+    def test_simple_query_with_single_argument
+      result = @connection.simple_query("SELECT id FROM posts WHERE id = ?", 1)
+
+      assert result.is_a?(Array)
+
+      assert_equal 1, result.size
+
+      assert_equal({ "id" => 1 }, result.first)
+    end
+
     test "inspect does not show secrets" do
       output = @connection.inspect
 


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created because I would appreciate if ActiveRecord core provided a method which easily provides a way to query SQL with the following caveats:
- Performs sql sanitization automatically (`sanitize_sql_array` or similar)
- Accepts query arguments in the same format as other AR methods such as `where` etc.
- Uses the most performant/safest approach (ex. `select_all` instead of `execute`) 

Some reasons for adding a new method:

1. Many tutorials would suggest to use `execute` which is not the method most people need. They likely want `exec_query`. But then even the user is likely better by `select_all` instead. Would be nice if we could provide a default method which helps re-enforce this knowledge.
2. Once people figure out how to use `execute` then they may start using it without SQL sanitization. Would be nice to steer them otherwise.
3. Once people figure out that they want SQL sanitization then the go looking for how to do this. So far the method I have come across is `sanitize_sql_array` which feels like it has some discoverability issues on the naming and also the syntax to use it feels quite "obtuse"/hard-to-use because of the array style argument Ex. `sanitize_sql_array([sql_str, {foo: "a", bar: "b"}])`
4. If one has much deeper knowledge then you might know of `MyModel.connection.select_all("select title from posts where id=?", nil, [1000])` but I have to put a weird nil as the 2nd argument to the method, I also need to know to wrap the binds in an extra array? (also how do I use non positional binds its not obvious)

### Detail

This Pull Request changes ActiveRecord to add a new database method called `simple_query`

Usage: (Note: The actual query here is extremely simple and is only being used for usage example)

```ruby
sql = <<~SQL
  SELECT
    orders.category,
    COUNT(IF(orders.company_id = :company_id)) as num_for_company,
    COUNT(*) as num
  FROM orders
  WHERE orders.updated_by_user_id = :user_id
  GROUP BY 1
SQL

ActiveRecord::Base.connection.simple_query(sql, company_id: company.id, user_id: user.id)
```

### Additional information

**I am well aware that regular ActiveRecord is the better pattern and should be used most of the time.** I've found that just sometimes there just are scenarios where I just need to reach for raw SQL (often with multiple aggregations and group by), it happens. I just really wish Rails was there to hold my hand on that 95% of use cases where we need nothing other than to perform a crazy `SELECT` query, instead I am having to find all sorts of different flawed abstraction methods in each different Rails app I work on.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
