### PR TITLE
Avoid crashing when highlighting ERB templates with multi-line methods

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Fix a crash in ERB template error highlighting when the error occurs on a
+    line in the compiled template that is past the end of the source template.
+
+    *Martin Emde*
+
 *   Improve reliability of ERB template error highlighting.
     Fix infinite loops and crashes in highlighting and
     improve tolerance for alternate ERB handlers.

--- a/actionview/lib/action_view/template/handlers/erb.rb
+++ b/actionview/lib/action_view/template/handlers/erb.rb
@@ -42,7 +42,9 @@ module ActionView
         # source location inside the template.
         def translate_location(spot, backtrace_location, source)
           # Tokenize the source line
-          tokens = ::ERB::Util.tokenize(source.lines[backtrace_location.lineno - 1])
+          source_lines = source.lines
+          return nil if source_lines.size < backtrace_location.lineno
+          tokens = ::ERB::Util.tokenize(source_lines[backtrace_location.lineno - 1])
           new_first_column = find_offset(spot[:snippet], tokens, spot[:first_column])
           lineno_delta = spot[:first_lineno] - backtrace_location.lineno
           spot[:first_lineno] -= lineno_delta
@@ -51,7 +53,7 @@ module ActionView
           column_delta = spot[:first_column] - new_first_column
           spot[:first_column] -= column_delta
           spot[:last_column] -= column_delta
-          spot[:script_lines] = source.lines
+          spot[:script_lines] = source_lines
 
           spot
         rescue NotImplementedError, LocationParsingError

--- a/actionview/test/template/template_test.rb
+++ b/actionview/test/template/template_test.rb
@@ -339,16 +339,32 @@ class TestERBTemplate < ActiveSupport::TestCase
     assert_equal expected, new_template(source).translate_location(backtrace_location, spot)
   end
 
+  # merely tests for the case where the backtrace and spot disagree about lineno
   def test_template_translate_location_lineno_offset
     highlight = "nomethoderror"
     source = "<%= nomethoderror %>"
-    compiled = "\n'.freeze; @output_buffer.append=  nomethoderror ; @output_buffer.safe_append='\n"
+    compiled = "'.freeze; @output_buffer.append=  nomethoderror ; @output_buffer.safe_append='"
 
     backtrace_location = Data.define(:lineno).new(lineno: 1)
     spot = spot_highlight(compiled, highlight, first_lineno: 2, last_lineno: 2)
     expected = spot_highlight(source, highlight, snippet: compiled)
 
     assert_equal expected, new_template(source).translate_location(backtrace_location, spot)
+  end
+
+  # We are testing the failure case here. `find_offset` doesn't correctly handle the case
+  # where the line number is not the same in the backtrace and template.
+  def test_template_translate_location_with_multiline_code_source
+    highlight = "nomethoderror"
+    source = "<%=\ngood(\n nomethoderror\n) %>"
+    extracted_line = " nomethoderror\n"
+    compiled = "ValidatedOutputBuffer.wrap(@output_buffer, ({}), ' \ngood(\n nomethoderror\n" \
+               ") '.freeze, true).safe_none_append=( \ngood(\n nomethoderror\n) );\n@output_buffer"
+
+    backtrace_location = Data.define(:lineno).new(lineno: 6)
+    spot = spot_highlight(compiled, highlight, first_column: 1, first_lineno: 6, last_lineno: 6, snippet: extracted_line)
+
+    assert_equal spot, new_template(source).translate_location(backtrace_location, spot)
   end
 
   def test_template_translate_location_with_multibye_string_before_highlight


### PR DESCRIPTION
### Motivation / Background

Follow up on #53657. I found a discussion on related fix PR #48184 where @jpcody summarized a problem with multi-line ERB highlighting caused by errors on templates with multiple lines in an ERB tag.

### Detail

Unfortunately, I had to abandon my previous fix for now. This fixes the narrower problem of avoiding crashing when the compiled template error line number is past the end of the source template.

### Additional information

This seems to happen when a template contains a tag like this:

```erb
<%=
  link_to(
    name,
    url,
    class: "..."
  )
%>
```

The problem is actually quite complicated to fix, which is why I abandoned my original approach. When you have blocks like this, a failure on one of the middle lines immediately fails. I wrote a fix for that originally. However, that fix is somewhat useless if we can't even identify which line we're supposed to be looking at.

The real problem here is that the line identified in a backtrace could be a totally different line in the template. The current code _only_ searches 1 line. I'm looking at how bad a full template search would be, but I don't expect it to be quick.

I'd love to be able to highlight these correctly. Finding errors in templates can be painful.

I think to do it "right" we're going to need help from the ERB compiler to provide a source map or AST that we can use to correlate failures to template locations. I don't think tokenizing and scanning the entire file is the best solution.

cc @byroot since you looked at the last PR. I've had to narrow the scope of this, so it's much smaller now.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
