### PR TITLE
Log that prepared_statements enabled for mysql2

### DIFF
--- a/activerecord/test/support/connection.rb
+++ b/activerecord/test/support/connection.rb
@@ -20,7 +20,7 @@ module ARTest
 
   def self.connect
     ActiveRecord.async_query_executor = :global_thread_pool
-    puts "Using #{connection_name}"
+    puts "Using #{connection_name}#{ " with prepared statements" if ENV["MYSQL_PREPARED_STATEMENTS"]}"
 
     if ENV["BUILDKITE"]
       ActiveRecord::Base.logger = nil


### PR DESCRIPTION
Enabling this flag locally prevents the test schema from loading with mysql2, so this commit tests my theory that the ENV var is not making it to the CI job.