### PR TITLE
Migrate various tests to use `NotificationAssertions` helpers

### DIFF
--- a/actioncable/test/channel/base_test.rb
+++ b/actioncable/test/channel/base_test.rb
@@ -199,67 +199,49 @@ class ActionCable::Channel::BaseTest < ActionCable::TestCase
   end
 
   test "notification for perform_action" do
-    events = []
-    ActiveSupport::Notifications.subscribe("perform_action.action_cable") { |event| events << event }
-
     data = { "action" => :speak, "content" => "hello" }
-    @channel.perform_action data
+    expected_payload = { channel_class: "ActionCable::Channel::BaseTest::ChatChannel", action: :speak, data: }
 
-    assert_equal 1, events.length
-    assert_equal "perform_action.action_cable", events[0].name
-    assert_equal "ActionCable::Channel::BaseTest::ChatChannel", events[0].payload[:channel_class]
-    assert_equal :speak, events[0].payload[:action]
-    assert_equal data, events[0].payload[:data]
-  ensure
-    ActiveSupport::Notifications.unsubscribe "perform_action.action_cable"
+    assert_notifications_count("perform_action.action_cable", 1) do
+      assert_notification("perform_action.action_cable", expected_payload) do
+        @channel.perform_action data
+      end
+    end
   end
 
   test "notification for transmit" do
-    events = []
-    ActiveSupport::Notifications.subscribe("transmit.action_cable") { |event| events << event }
+    data = { data: "latest" }
+    expected_payload = { channel_class: "ActionCable::Channel::BaseTest::ChatChannel", data:, via: nil }
 
-    @channel.perform_action "action" => :get_latest
-    expected_data = { data: "latest" }
-
-    assert_equal 1, events.length
-    assert_equal "transmit.action_cable", events[0].name
-    assert_equal "ActionCable::Channel::BaseTest::ChatChannel", events[0].payload[:channel_class]
-    assert_equal expected_data, events[0].payload[:data]
-    assert_nil events[0].payload[:via]
-  ensure
-    ActiveSupport::Notifications.unsubscribe "transmit.action_cable"
+    assert_notifications_count("transmit.action_cable", 1) do
+      assert_notification("transmit.action_cable", expected_payload) do
+        @channel.perform_action "action" => :get_latest
+      end
+    end
   end
 
   test "notification for transmit_subscription_confirmation" do
+    expected_payload = { channel_class: "ActionCable::Channel::BaseTest::ChatChannel", identifier: "{id: 1}" }
+
     @channel.subscribe_to_channel
 
-    events = []
-    ActiveSupport::Notifications.subscribe("transmit_subscription_confirmation.action_cable") { |e| events << e }
-
-    @channel.stub(:subscription_confirmation_sent?, false) do
-      @channel.send(:transmit_subscription_confirmation)
-
-      assert_equal 1, events.length
-      assert_equal "transmit_subscription_confirmation.action_cable", events[0].name
-      assert_equal "ActionCable::Channel::BaseTest::ChatChannel", events[0].payload[:channel_class]
-      assert_equal "{id: 1}", events[0].payload[:identifier]
+    assert_notifications_count("transmit_subscription_confirmation.action_cable", 1) do
+      assert_notification("transmit_subscription_confirmation.action_cable", expected_payload) do
+        @channel.stub(:subscription_confirmation_sent?, false) do
+          @channel.send(:transmit_subscription_confirmation)
+        end
+      end
     end
-  ensure
-    ActiveSupport::Notifications.unsubscribe "transmit_subscription_confirmation.action_cable"
   end
 
   test "notification for transmit_subscription_rejection" do
-    events = []
-    ActiveSupport::Notifications.subscribe("transmit_subscription_rejection.action_cable") { |event| events << event }
+    expected_payload = { channel_class: "ActionCable::Channel::BaseTest::ChatChannel", identifier: "{id: 1}" }
 
-    @channel.send(:transmit_subscription_rejection)
-
-    assert_equal 1, events.length
-    assert_equal "transmit_subscription_rejection.action_cable", events[0].name
-    assert_equal "ActionCable::Channel::BaseTest::ChatChannel", events[0].payload[:channel_class]
-    assert_equal "{id: 1}", events[0].payload[:identifier]
-  ensure
-    ActiveSupport::Notifications.unsubscribe "transmit_subscription_rejection.action_cable"
+    assert_notifications_count("transmit_subscription_rejection.action_cable", 1) do
+      assert_notification("transmit_subscription_rejection.action_cable", expected_payload) do
+        @channel.send(:transmit_subscription_rejection)
+      end
+    end
   end
 
   test "behaves like rescuable" do

--- a/actionmailer/test/base_test.rb
+++ b/actionmailer/test/base_test.rb
@@ -963,31 +963,24 @@ class BaseTest < ActiveSupport::TestCase
   end
 
   test "notification for process" do
-    events = []
-    ActiveSupport::Notifications.subscribe("process.action_mailer") { |event| events << event }
+    expected_payload = { mailer: "BaseMailer", action: :welcome, args: [{ body: "Hello there" }] }
 
-    BaseMailer.welcome(body: "Hello there").deliver_now
-
-    assert_equal 1, events.length
-    assert_equal "process.action_mailer", events[0].name
-    assert_equal "BaseMailer", events[0].payload[:mailer]
-    assert_equal :welcome, events[0].payload[:action]
-    assert_equal [{ body: "Hello there" }], events[0].payload[:args]
-  ensure
-    ActiveSupport::Notifications.unsubscribe "process.action_mailer"
+    assert_notifications_count("process.action_mailer", 1) do
+      assert_notification("process.action_mailer", expected_payload) do
+        BaseMailer.welcome(body: "Hello there").deliver_now
+      end
+    end
   end
 
   test "notification for deliver" do
-    events = []
-    ActiveSupport::Notifications.subscribe("deliver.action_mailer") { |event| events << event }
+    event = capture_notifications("deliver.action_mailer") do
+      assert_notifications_count("deliver.action_mailer", 1) do
+        BaseMailer.welcome(body: "Hello there").deliver_now
+      end
+    end.first
 
-    BaseMailer.welcome(body: "Hello there").deliver_now
-
-    assert_equal 1, events.length
-    assert_equal "deliver.action_mailer", events[0].name
-    assert_not_nil events[0].payload[:message_id]
-  ensure
-    ActiveSupport::Notifications.unsubscribe "deliver.action_mailer"
+    assert_equal "deliver.action_mailer", event.name
+    assert_not_nil event.payload[:message_id]
   end
 
   private

--- a/actionmailer/test/caching_test.rb
+++ b/actionmailer/test/caching_test.rb
@@ -171,18 +171,15 @@ class FunctionalFragmentCachingTest < BaseCachingTest
 
   def test_fragment_cache_instrumentation
     @mailer.enable_fragment_cache_logging = true
-    payload = nil
 
-    subscriber = proc do |_, _, _, _, event_payload|
-      payload = event_payload
-    end
+    expected_payload = {
+      mailer: "caching_mailer",
+      key: [:views, "caching_mailer/fragment_cache:#{template_digest("caching_mailer/fragment_cache", "html")}", :caching]
+    }
 
-    ActiveSupport::Notifications.subscribed(subscriber, "read_fragment.action_mailer") do
+    assert_notification("read_fragment.action_mailer", expected_payload) do
       @mailer.fragment_cache
     end
-
-    assert_equal "caching_mailer", payload[:mailer]
-    assert_equal [ :views, "caching_mailer/fragment_cache:#{template_digest("caching_mailer/fragment_cache", "html")}", :caching ], payload[:key]
   ensure
     @mailer.enable_fragment_cache_logging = true
   end

--- a/actionpack/test/controller/allow_browser_test.rb
+++ b/actionpack/test/controller/allow_browser_test.rb
@@ -84,7 +84,7 @@ class AllowBrowserTest < ActionController::TestCase
   end
 
   test "a blocked request instruments a browser_block.action_controller event" do
-    event, *rest = capture_instrumentation_events "browser_block.action_controller" do
+    event, *rest = capture_notifications "browser_block.action_controller" do
       get_with_agent :modern, CHROME_118
     end
 
@@ -97,11 +97,5 @@ class AllowBrowserTest < ActionController::TestCase
     def get_with_agent(action, agent)
       @request.headers["User-Agent"] = agent
       get action
-    end
-
-    def capture_instrumentation_events(pattern, &block)
-      events = []
-      ActiveSupport::Notifications.subscribed(->(e) { events << e }, pattern, &block)
-      events
     end
 end

--- a/actionpack/test/controller/caching_test.rb
+++ b/actionpack/test/controller/caching_test.rb
@@ -255,15 +255,9 @@ Ciao
   end
 
   def test_fragment_cache_instrumentation
-    payload = nil
-
-    subscriber = proc do |event|
-      payload = event.payload
-    end
-
-    ActiveSupport::Notifications.subscribed(subscriber, "read_fragment.action_controller") do
+    payload = capture_notifications("read_fragment.action_controller") do
       get :inline_fragment_cached
-    end
+    end.first.payload
 
     assert_equal "functional_caching", payload[:controller]
     assert_equal "inline_fragment_cached", payload[:action]

--- a/actionpack/test/controller/live_stream_test.rb
+++ b/actionpack/test/controller/live_stream_test.rb
@@ -388,16 +388,15 @@ module ActionController
     end
 
     def test_send_stream_instrumentation
-      payload = nil
-      subscriber = proc { |event| payload = event.payload }
+      expected_payload = {
+        filename: "sample.csv",
+        disposition: "attachment",
+        type: "text/csv"
+      }
 
-      ActiveSupport::Notifications.subscribed(subscriber, "send_stream.action_controller") do
+      assert_notification("send_stream.action_controller", expected_payload) do
         get :send_stream_with_explicit_content_type
       end
-
-      assert_equal "sample.csv", payload[:filename]
-      assert_equal "attachment", payload[:disposition]
-      assert_equal "text/csv", payload[:type]
     end
 
     def test_send_stream_with_options

--- a/actionpack/test/controller/redirect_test.rb
+++ b/actionpack/test/controller/redirect_test.rb
@@ -608,15 +608,9 @@ class RedirectTest < ActionController::TestCase
   end
 
   def test_redirect_to_instrumentation
-    payload = nil
-
-    subscriber = proc do |event|
-      payload = event.payload
-    end
-
-    ActiveSupport::Notifications.subscribed(subscriber, "redirect_to.action_controller") do
+    payload = capture_notifications("redirect_to.action_controller") do
       get :simple_redirect
-    end
+    end.first.payload
 
     assert_equal request, payload[:request]
     assert_equal 302, payload[:status]

--- a/actionpack/test/controller/send_file_test.rb
+++ b/actionpack/test/controller/send_file_test.rb
@@ -209,33 +209,18 @@ class SendFileTest < ActionController::TestCase
 
   def test_send_file_instrumentation
     @controller.options = { disposition: :inline }
-    payload = nil
 
-    subscriber = proc do |event|
-      payload = event.payload
-    end
-
-    ActiveSupport::Notifications.subscribed(subscriber, "send_file.action_controller") do
+    assert_notification("send_file.action_controller", path: __FILE__, disposition: :inline) do
       process("file")
     end
-
-    assert_equal __FILE__, payload[:path]
-    assert_equal :inline, payload[:disposition]
   end
 
   def test_send_data_instrumentation
     @controller.options = { content_type: "application/x-ruby" }
-    payload = nil
 
-    subscriber = proc do |event|
-      payload = event.payload
-    end
-
-    ActiveSupport::Notifications.subscribed(subscriber, "send_data.action_controller") do
+    assert_notification("send_data.action_controller", content_type: "application/x-ruby") do
       process("data")
     end
-
-    assert_equal("application/x-ruby", payload[:content_type])
   end
 
   %w(file data).each do |method|

--- a/actionpack/test/dispatch/routing/instrumentation_test.rb
+++ b/actionpack/test/dispatch/routing/instrumentation_test.rb
@@ -8,7 +8,11 @@ class RoutingInstrumentationTest < ActionDispatch::IntegrationTest
       get "redirect", to: redirect("/login")
     end
 
-    event = subscribed("redirect.action_dispatch") { get "/redirect" }
+    event = capture_notifications("redirect.action_dispatch") do
+      assert_notifications_count("redirect.action_dispatch", 1) do
+        get "/redirect"
+      end
+    end.first
 
     assert_equal 301, event.payload[:status]
     assert_equal "http://www.example.com/login", event.payload[:location]
@@ -22,12 +26,5 @@ class RoutingInstrumentationTest < ActionDispatch::IntegrationTest
         routes.draw(&block)
         @app = RoutedRackApp.new routes
       end
-    end
-
-    def subscribed(event_pattern, &block)
-      event = nil
-      subscriber = -> (_event) { event = _event }
-      ActiveSupport::Notifications.subscribed(subscriber, event_pattern, &block)
-      event
     end
 end

--- a/activejob/test/cases/instrumentation_test.rb
+++ b/activejob/test/cases/instrumentation_test.rb
@@ -12,43 +12,28 @@ class InstrumentationTest < ActiveSupport::TestCase
   end
 
   test "perform_now emits perform events" do
-    events = subscribed(/perform.*\.active_job/) { HelloJob.perform_now("World!") }
+    events = capture_notifications(/perform.*\.active_job/) { HelloJob.perform_now("World!") }
+
     assert_equal 2, events.size
-    assert_equal "perform_start.active_job", events[0].first
-    assert_equal "perform.active_job", events[1].first
+    assert_equal "perform_start.active_job", events[0].name
+    assert_equal "perform.active_job", events[1].name
   end
 
   test "perform_later emits an enqueue event" do
-    events = subscribed("enqueue.active_job") { HelloJob.perform_later("World!") }
-    assert_equal 1, events.size
+    assert_notifications_count("enqueue.active_job", 1) { HelloJob.perform_later("World!") }
   end
 
   unless adapter_is?(:inline, :sneakers)
     test "retry emits an enqueue retry event" do
-      events = subscribed("enqueue_retry.active_job") do
-        perform_enqueued_jobs { RetryJob.perform_later("DefaultsError", 2) }
-      end
-      assert_equal 1, events.size
+      assert_notifications_count("enqueue_retry.active_job", 1) { RetryJob.perform_later("DefaultsError", 2) }
     end
 
     test "retry exhaustion emits a retry_stopped event" do
-      events = subscribed("retry_stopped.active_job") do
-        perform_enqueued_jobs { RetryJob.perform_later("CustomCatchError", 6) }
-      end
-      assert_equal 1, events.size
+      assert_notifications_count("retry_stopped.active_job", 1) { RetryJob.perform_later("CustomCatchError", 6) }
     end
   end
 
   test "discard emits a discard event" do
-    events = subscribed("discard.active_job") do
-      perform_enqueued_jobs { RetryJob.perform_later("DiscardableError", 2) }
-    end
-    assert_equal 1, events.size
-  end
-
-  def subscribed(name, &block)
-    [].tap do |events|
-      ActiveSupport::Notifications.subscribed(-> (*args) { events << args }, name, &block)
-    end
+    assert_notifications_count("discard.active_job", 1) { RetryJob.perform_later("DiscardableError", 6) }
   end
 end

--- a/activejob/test/cases/logging_test.rb
+++ b/activejob/test/cases/logging_test.rb
@@ -50,12 +50,6 @@ class LoggingTest < ActiveSupport::TestCase
     ActiveJob::Base.logger = logger
   end
 
-  def subscribed(&block)
-    [].tap do |events|
-      ActiveSupport::Notifications.subscribed(-> (*args) { events << args }, /enqueue.*\.active_job/, &block)
-    end
-  end
-
   def test_uses_active_job_as_tag
     HelloJob.perform_later "Cristian"
     assert_match(/\[ActiveJob\]/, @logger.messages)
@@ -105,32 +99,35 @@ class LoggingTest < ActiveSupport::TestCase
   end
 
   def test_enqueue_job_logging
-    events = subscribed { HelloJob.perform_later "Cristian" }
+    assert_notifications_count(/enqueue.*\.active_job/, 1) do
+      assert_notifications_count("enqueue.active_job", 1) do
+        HelloJob.perform_later "Cristian"
+      end
+    end
+
     assert_match(/Enqueued HelloJob \(Job ID: .*?\) to .*?:.*Cristian/, @logger.messages)
-    assert_equal(1, events.count)
-    key, * = events.first
-    assert_equal("enqueue.active_job", key)
   end
 
   def test_enqueue_job_log_error_when_callback_chain_is_halted
-    events = subscribed { AbortBeforeEnqueueJob.perform_later }
+    assert_notifications_count(/enqueue.*\.active_job/, 1) do
+      assert_notification("enqueue.active_job") do
+        AbortBeforeEnqueueJob.perform_later
+      end
+    end
+
     assert_match(/Failed enqueuing AbortBeforeEnqueueJob.* a before_enqueue callback halted/, @logger.messages)
-    assert_equal(1, events.count)
-    key, * = events.first
-    assert_equal("enqueue.active_job", key)
   end
 
   def test_enqueue_job_log_error_when_error_is_raised_during_callback_chain
-    events = subscribed do
-      assert_raises(AbortBeforeEnqueueJob::MyError) do
-        AbortBeforeEnqueueJob.perform_later(:raise)
+    assert_notifications_count(/enqueue.*\.active_job/, 1) do
+      assert_notification("enqueue.active_job") do
+        assert_raises(AbortBeforeEnqueueJob::MyError) do
+          AbortBeforeEnqueueJob.perform_later(:raise)
+        end
       end
     end
 
     assert_match(/Failed enqueuing AbortBeforeEnqueueJob/, @logger.messages)
-    assert_equal(1, events.count)
-    key, * = events.first
-    assert_equal("enqueue.active_job", key)
   end
 
   def test_perform_job_logging
@@ -154,7 +151,7 @@ class LoggingTest < ActiveSupport::TestCase
   end
 
   def test_perform_job_log_error_when_callback_chain_is_halted
-    subscribed { AbortBeforeEnqueueJob.perform_now }
+    AbortBeforeEnqueueJob.perform_now
     assert_match(/Error performing AbortBeforeEnqueueJob.* a before_perform callback halted/, @logger.messages)
   end
 
@@ -165,7 +162,7 @@ class LoggingTest < ActiveSupport::TestCase
       end
     end
 
-    subscribed { job.perform_now }
+    job.perform_now
     assert_no_match(/Error performing AbortBeforeEnqueueJob.* a before_perform callback halted/, @logger.messages)
   end
 
@@ -179,10 +176,8 @@ class LoggingTest < ActiveSupport::TestCase
       end
     end.new([:dont_abort, :abort])
 
-    subscribed do
-      job.perform_now
-      job.perform_now
-    end
+    job.perform_now
+    job.perform_now
 
     assert_equal(1, @logger.messages.scan(/a before_perform callback halted the job execution/).size)
   end
@@ -215,42 +210,47 @@ class LoggingTest < ActiveSupport::TestCase
 
   unless adapter_is?(:inline, :sneakers)
     def test_enqueue_at_job_logging
-      events = subscribed { HelloJob.set(wait_until: 24.hours.from_now).perform_later "Cristian" }
+      assert_notifications_count(/enqueue.*\.active_job/, 1) do
+        assert_notification("enqueue_at.active_job") do
+          HelloJob.set(wait_until: 24.hours.from_now).perform_later "Cristian"
+        end
+      end
+
       assert_match(/Enqueued HelloJob \(Job ID: .*\) to .*? at.*Cristian/, @logger.messages)
-      assert_equal(1, events.count)
-      key, * = events.first
-      assert_equal("enqueue_at.active_job", key)
     end
   end
 
   def test_enqueue_at_job_log_error_when_callback_chain_is_halted
-    events = subscribed { AbortBeforeEnqueueJob.set(wait: 1.second).perform_later }
+    assert_notifications_count(/enqueue.*\.active_job/, 1) do
+      assert_notification("enqueue_at.active_job") do
+        AbortBeforeEnqueueJob.set(wait: 1.second).perform_later
+      end
+    end
+
     assert_match(/Failed enqueuing AbortBeforeEnqueueJob.* a before_enqueue callback halted/, @logger.messages)
-    assert_equal(1, events.count)
-    key, * = events.first
-    assert_equal("enqueue_at.active_job", key)
   end
 
   def test_enqueue_at_job_log_error_when_error_is_raised_during_callback_chain
-    events = subscribed do
-      assert_raises(AbortBeforeEnqueueJob::MyError) do
-        AbortBeforeEnqueueJob.set(wait: 1.second).perform_later(:raise)
+    assert_notifications_count(/enqueue.*\.active_job/, 1) do
+      assert_notification("enqueue_at.active_job") do
+        assert_raises(AbortBeforeEnqueueJob::MyError) do
+          AbortBeforeEnqueueJob.set(wait: 1.second).perform_later(:raise)
+        end
       end
     end
 
     assert_match(/Failed enqueuing AbortBeforeEnqueueJob/, @logger.messages)
-    assert_equal(1, events.count)
-    key, * = events.first
-    assert_equal("enqueue_at.active_job", key)
   end
 
   unless adapter_is?(:inline, :sneakers)
     def test_enqueue_in_job_logging
-      events = subscribed { HelloJob.set(wait: 2.seconds).perform_later "Cristian" }
+      assert_notifications_count(/enqueue.*\.active_job/, 1) do
+        assert_notification("enqueue_at.active_job") do
+          HelloJob.set(wait: 2.seconds).perform_later "Cristian"
+        end
+      end
+
       assert_match(/Enqueued HelloJob \(Job ID: .*\) to .*? at.*Cristian/, @logger.messages)
-      assert_equal(1, events.count)
-      key, * = events.first
-      assert_equal("enqueue_at.active_job", key)
     end
   end
 

--- a/activejob/test/cases/queuing_test.rb
+++ b/activejob/test/cases/queuing_test.rb
@@ -87,19 +87,13 @@ class QueuingTest < ActiveSupport::TestCase
 
   test "perform_all_later instrumentation" do
     jobs = HelloJob.new("Jamie"), HelloJob.new("John")
-    called = false
 
-    subscriber = proc do |_, _, _, _, payload|
-      called = true
-      assert payload[:adapter]
-      assert_equal jobs, payload[:jobs]
-      assert_equal 2, payload[:enqueued_count]
-    end
-
-    ActiveSupport::Notifications.subscribed(subscriber, "enqueue_all.active_job") do
+    payload = capture_notifications("enqueue_all.active_job") do
       ActiveJob.perform_all_later(jobs)
-    end
+    end.first.payload
 
-    assert called
+    assert payload[:adapter]
+    assert_equal jobs, payload[:jobs]
+    assert_equal 2, payload[:enqueued_count]
   end
 end

--- a/activerecord/test/cases/instrumentation_test.rb
+++ b/activerecord/test/cases/instrumentation_test.rb
@@ -13,163 +13,142 @@ module ActiveRecord
 
     def test_payload_name_on_load
       Book.create(name: "test book")
-      subscriber = ActiveSupport::Notifications.subscribe("sql.active_record") do |_, _, _, _, payload|
-        if payload[:sql].match?("SELECT")
-          assert_equal "Book Load", payload[:name]
-        end
-      end
-      Book.first
-    ensure
-      ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
+
+      notification = capture_notifications("sql.active_record") { Book.first }
+        .find { _1.payload[:sql].match?("SELECT") }
+
+      assert_equal "Book Load", notification.payload[:name]
     end
 
     def test_payload_name_on_create
-      subscriber = ActiveSupport::Notifications.subscribe("sql.active_record") do |_, _, _, _, payload|
-        if payload[:sql].match?("INSERT")
-          assert_equal "Book Create", payload[:name]
-        end
-      end
-      Book.create(name: "test book")
-    ensure
-      ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
+      notification = capture_notifications("sql.active_record") { Book.create(name: "test book") }
+        .find { _1.payload[:sql].match?("INSERT") }
+
+      assert_equal "Book Create", notification.payload[:name]
     end
 
     def test_payload_name_on_update
-      subscriber = ActiveSupport::Notifications.subscribe("sql.active_record") do |_, _, _, _, payload|
-        if payload[:sql].match?("UPDATE")
-          assert_equal "Book Update", payload[:name]
-        end
-      end
       book = Book.create(name: "test book", format: "paperback")
-      book.update_attribute(:format, "ebook")
-    ensure
-      ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
+
+      notification = capture_notifications("sql.active_record") { book.update_attribute(:format, "ebook") }
+        .find { _1.payload[:sql].match?("UPDATE") }
+
+      assert_equal "Book Update", notification.payload[:name]
     end
 
     def test_payload_name_on_update_all
-      subscriber = ActiveSupport::Notifications.subscribe("sql.active_record") do |_, _, _, _, payload|
-        if payload[:sql].match?("UPDATE")
-          assert_equal "Book Update All", payload[:name]
-        end
-      end
-      Book.update_all(format: "ebook")
-    ensure
-      ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
+      notification = capture_notifications("sql.active_record") { Book.update_all(format: "ebook") }
+        .find { _1.payload[:sql].match?("UPDATE") }
+
+      assert_equal "Book Update All", notification.payload[:name]
     end
 
     def test_payload_name_on_destroy
-      subscriber = ActiveSupport::Notifications.subscribe("sql.active_record") do |_, _, _, _, payload|
-        if payload[:sql].match?("DELETE")
-          assert_equal "Book Destroy", payload[:name]
-        end
-      end
       book = Book.create(name: "test book")
-      book.destroy
-    ensure
-      ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
+
+      notification = capture_notifications("sql.active_record") { book.destroy }
+        .find { _1.payload[:sql].match?("DELETE") }
+
+      assert_equal "Book Destroy", notification.payload[:name]
     end
 
     def test_payload_name_on_delete_all
-      subscriber = ActiveSupport::Notifications.subscribe("sql.active_record") do |_, _, _, _, payload|
-        if payload[:sql].match?("DELETE")
-          assert_equal "Book Delete All", payload[:name]
-        end
-      end
-      Book.delete_all
-    ensure
-      ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
+      notification = capture_notifications("sql.active_record") { Book.delete_all }
+        .find { _1.payload[:sql].match?("DELETE") }
+
+      assert_equal "Book Delete All", notification.payload[:name]
     end
 
     def test_payload_name_on_pluck
-      subscriber = ActiveSupport::Notifications.subscribe("sql.active_record") do |_, _, _, _, payload|
-        if payload[:sql].match?("SELECT")
-          assert_equal "Book Pluck", payload[:name]
-        end
-      end
-      Book.pluck(:name)
-    ensure
-      ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
+      notification = capture_notifications("sql.active_record") { Book.pluck(:name) }
+        .find { _1.payload[:sql].match?("SELECT") }
+
+      assert_equal "Book Pluck", notification.payload[:name]
     end
 
     def test_payload_name_on_count
-      subscriber = ActiveSupport::Notifications.subscribe("sql.active_record") do |_, _, _, _, payload|
-        if payload[:sql].match?("SELECT")
-          assert_equal "Book Count", payload[:name]
-        end
-      end
-      Book.count
-    ensure
-      ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
+      notification = capture_notifications("sql.active_record") { Book.count }
+        .find { _1.payload[:sql].match?("SELECT") }
+
+      assert_equal "Book Count", notification.payload[:name]
     end
 
     def test_payload_name_on_grouped_count
-      subscriber = ActiveSupport::Notifications.subscribe("sql.active_record") do |_, _, _, _, payload|
-        if payload[:sql].match?("SELECT")
-          assert_equal "Book Count", payload[:name]
-        end
-      end
-      Book.group(:status).count
-    ensure
-      ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
+      notification = capture_notifications("sql.active_record") { Book.group(:status).count }
+        .find { _1.payload[:sql].match?("SELECT") }
+
+      assert_equal "Book Count", notification.payload[:name]
     end
 
     def test_payload_row_count_on_select_all
       10.times { Book.create(name: "row count book 1") }
-      subscriber = ActiveSupport::Notifications.subscribe("sql.active_record") do |_, _, _, _, payload|
-        if payload[:sql].match?("SELECT")
-          assert_equal 10, payload[:row_count]
-        end
-      end
-      Book.where(name: "row count book 1").to_a
-    ensure
-      ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
+
+      notification = capture_notifications("sql.active_record") { Book.where(name: "row count book 1").to_a }
+        .find { _1.payload[:sql].match?("SELECT") }
+
+      assert_equal 10, notification.payload[:row_count]
     end
 
     def test_payload_row_count_on_pluck
       10.times { Book.create(name: "row count book 2") }
-      subscriber = ActiveSupport::Notifications.subscribe("sql.active_record") do |_, _, _, _, payload|
-        if payload[:sql].match?("SELECT")
-          assert_equal 10, payload[:row_count]
-        end
-      end
-      Book.where(name: "row count book 2").pluck(:name)
-    ensure
-      ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
+
+      notification = capture_notifications("sql.active_record") { Book.where(name: "row count book 2").pluck(:name) }
+        .find { _1.payload[:sql].match?("SELECT") }
+
+      assert_equal 10, notification.payload[:row_count]
     end
 
     def test_payload_row_count_on_raw_sql
       10.times { Book.create(name: "row count book 3") }
-      subscriber = ActiveSupport::Notifications.subscribe("sql.active_record") do |_, _, _, _, payload|
-        if payload[:sql].match?("SELECT")
-          assert_equal 10, payload[:row_count]
-        end
-      end
-      ActiveRecord::Base.lease_connection.execute("SELECT * FROM books WHERE name='row count book 3';")
-    ensure
-      ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
+
+      notification = capture_notifications("sql.active_record") do
+        ActiveRecord::Base.lease_connection.execute("SELECT * FROM books WHERE name='row count book 3';")
+      end.find { _1.payload[:sql].match?("SELECT") }
+
+      assert_equal 10, notification.payload[:row_count]
     end
 
     def test_payload_row_count_on_cache
-      events = []
-      callback = -> (event) do
-        payload = event.payload
-        events << payload if payload[:sql].include?("SELECT")
-      end
-
       Book.create!(name: "row count book")
-      ActiveSupport::Notifications.subscribed(callback, "sql.active_record") do
+
+      notifications = capture_notifications("sql.active_record") do
         Book.cache do
           Book.first
           Book.first
         end
       end
 
-      assert_equal 2, events.size
-      assert_not events[0][:cached]
-      assert events[1][:cached]
+      payloads = notifications.select { _1.payload[:sql].match?("SELECT") }.map(&:payload)
 
-      assert_equal 1, events[0][:row_count]
-      assert_equal 1, events[1][:row_count]
+      assert_equal 2, payloads.size
+      assert_not payloads[0][:cached]
+      assert payloads[1][:cached]
+      assert_equal 1, payloads[0][:row_count]
+      assert_equal 1, payloads[1][:row_count]
+    end
+
+    def test_payload_connection_with_query_cache_disabled
+      connection = ClothingItem.lease_connection
+
+      payload = capture_notifications("sql.active_record") { Book.first }.first.payload
+
+      assert_equal connection, payload[:connection]
+    end
+
+    def test_payload_connection_with_query_cache_enabled
+      connection = ClothingItem.lease_connection
+
+      payloads = capture_notifications("sql.active_record") do
+        assert_notifications_count("sql.active_record", 2) do
+          Book.cache do
+            Book.first
+            Book.first
+          end
+        end
+      end.map(&:payload)
+
+      assert_equal connection, payloads.first[:connection]
+      assert_equal connection, payloads.second[:connection]
     end
 
     def test_payload_affected_rows
@@ -193,43 +172,13 @@ module ActiveRecord
       assert_equal [4, 3, 2, 0], affected_row_values
     end
 
-    def test_payload_connection_with_query_cache_disabled
-      connection = ClothingItem.lease_connection
-      subscriber = ActiveSupport::Notifications.subscribe("sql.active_record") do |_, _, _, _, payload|
-        assert_equal connection, payload[:connection]
-      end
-      Book.first
-    ensure
-      ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
-    end
-
-    def test_payload_connection_with_query_cache_enabled
-      connection = ClothingItem.lease_connection
-      subscriber = ActiveSupport::Notifications.subscribe("sql.active_record") do |_, _, _, _, payload|
-        assert_equal connection, payload[:connection]
-      end
-      Book.cache do
-        Book.first
-        Book.first
-      end
-    ensure
-      ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
-    end
-
     def test_no_instantiation_notification_when_no_records
       author = Author.create!(id: 100, name: "David")
 
-      called = false
-      subscriber = ActiveSupport::Notifications.subscribe("instantiation.active_record") do
-        called = true
+      assert_no_notifications("instantiation.active_record") do
+        Author.where(id: 0).to_a
+        author.books.to_a
       end
-
-      Author.where(id: 0).to_a
-      author.books.to_a
-
-      assert_equal false, called
-    ensure
-      ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
     end
   end
 

--- a/activestorage/test/analyzer/audio_analyzer_test.rb
+++ b/activestorage/test/analyzer/audio_analyzer_test.rb
@@ -18,12 +18,13 @@ class ActiveStorage::Analyzer::AudioAnalyzerTest < ActiveSupport::TestCase
   end
 
   test "instrumenting analysis" do
-    events = subscribe_events_from("analyze.active_storage")
+    events = capture_notifications("analyze.active_storage") do
+      assert_notifications_count("analyze.active_storage", 1) do
+        blob = create_file_blob(filename: "audio.mp3", content_type: "audio/mp3")
+        blob.analyze
+      end
+    end
 
-    blob = create_file_blob(filename: "audio.mp3", content_type: "audio/mp3")
-    blob.analyze
-
-    assert_equal 1, events.size
     assert_equal({ analyzer: "ffprobe" }, events.first.payload)
   end
 end

--- a/activestorage/test/analyzer/image_analyzer/image_magick_test.rb
+++ b/activestorage/test/analyzer/image_analyzer/image_magick_test.rb
@@ -48,10 +48,10 @@ class ActiveStorage::Analyzer::ImageAnalyzer::ImageMagickTest < ActiveSupport::T
 
   test "instrumenting analysis" do
     analyze_with_image_magick do
-      events = subscribe_events_from("analyze.active_storage")
-
-      blob = create_file_blob(filename: "racecar.jpg", content_type: "image/jpeg")
-      blob.analyze
+      events = capture_notifications("analyze.active_storage") do
+        blob = create_file_blob(filename: "racecar.jpg", content_type: "image/jpeg")
+        blob.analyze
+      end
 
       assert_equal 1, events.size
       assert_equal({ analyzer: "mini_magick" }, events.first.payload)

--- a/activestorage/test/analyzer/image_analyzer/vips_test.rb
+++ b/activestorage/test/analyzer/image_analyzer/vips_test.rb
@@ -48,10 +48,10 @@ class ActiveStorage::Analyzer::ImageAnalyzer::VipsTest < ActiveSupport::TestCase
 
   test "instrumenting analysis" do
     analyze_with_vips do
-      events = subscribe_events_from("analyze.active_storage")
-
-      blob = create_file_blob(filename: "racecar.jpg", content_type: "image/jpeg")
-      blob.analyze
+      events = capture_notifications("analyze.active_storage") do
+        blob = create_file_blob(filename: "racecar.jpg", content_type: "image/jpeg")
+        blob.analyze
+      end
 
       assert_equal 1, events.size
       assert_equal({ analyzer: "vips" }, events.first.payload)

--- a/activestorage/test/analyzer/video_analyzer_test.rb
+++ b/activestorage/test/analyzer/video_analyzer_test.rb
@@ -87,10 +87,10 @@ class ActiveStorage::Analyzer::VideoAnalyzerTest < ActiveSupport::TestCase
   end
 
   test "instrumenting analysis" do
-    events = subscribe_events_from("analyze.active_storage")
-
-    blob = create_file_blob(filename: "video_without_audio_stream.mp4", content_type: "video/mp4")
-    blob.analyze
+    events = capture_notifications("analyze.active_storage") do
+      blob = create_file_blob(filename: "video_without_audio_stream.mp4", content_type: "video/mp4")
+      blob.analyze
+    end
 
     assert_equal 1, events.size
     assert_equal({ analyzer: "ffprobe" }, events.first.payload)

--- a/activestorage/test/test_helper.rb
+++ b/activestorage/test/test_helper.rb
@@ -114,12 +114,6 @@ class ActiveSupport::TestCase
       ActionController::Base.raise_on_open_redirects = old_raise_on_open_redirects
       ActiveStorage::Blob.service = old_service
     end
-
-    def subscribe_events_from(name)
-      events = []
-      ActiveSupport::Notifications.subscribe(name) { |event| events << event }
-      events
-    end
 end
 
 require "global_id"

--- a/activesupport/test/cache/behaviors/local_cache_behavior.rb
+++ b/activesupport/test/cache/behaviors/local_cache_behavior.rb
@@ -3,13 +3,13 @@
 module LocalCacheBehavior
   def test_instrumentation_with_local_cache
     key = SecureRandom.uuid
-    events = with_instrumentation "write" do
+    events = capture_notifications("cache_write.active_support") do
       @cache.write(key, SecureRandom.uuid)
     end
     assert_equal @cache.class.name, events[0].payload[:store]
 
     @cache.with_local_cache do
-      events = with_instrumentation "read" do
+      events = capture_notifications("cache_read.active_support") do
         @cache.read(key)
         @cache.read(key)
       end

--- a/activesupport/test/cache/stores/memory_store_test.rb
+++ b/activesupport/test/cache/stores/memory_store_test.rb
@@ -44,7 +44,7 @@ class MemoryStoreTest < ActiveSupport::TestCase
     size = 3
     size.times { |i| @cache.write(i.to_s, i) }
 
-    events = with_instrumentation "cleanup" do
+    events = capture_notifications("cache_cleanup.active_support") do
       @cache.cleanup
     end
 

--- a/railties/test/application/initializers/notifications_test.rb
+++ b/railties/test/application/initializers/notifications_test.rb
@@ -45,14 +45,10 @@ module ApplicationTests
     test "rails load_config_initializer event is instrumented" do
       app_file "config/initializers/foo.rb", ""
 
-      events = []
-      callback = ->(*_) { events << _ }
-      ActiveSupport::Notifications.subscribed(callback, "load_config_initializer.railties") do
-        app
-      end
+      event = capture_notifications("load_config_initializer.railties") { app }.first
 
-      assert_equal %w[load_config_initializer.railties], events.map(&:first)
-      assert_includes events.first.last[:initializer], "config/initializers/foo.rb"
+      assert_equal "load_config_initializer.railties", event.name
+      assert_match "config/initializers/foo.rb", event.payload[:initializer]
     end
   end
 end


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because I believe we can greatly simplify many `ActiveSupport::Notifications` centric tests using the recently merged `ActiveSupport::Testing::NotificationAssertions` test helper module. While it does not accommodate for all tests, it does work in a majority of cases.

Follow up to
- https://github.com/rails/rails/pull/53065

### Detail

This Pull Request changes various tests across Rails to use the new `NotificationAssertions` helper module, which thus allows us to cleanup various now redundant local notification capturing helper methods.

Note, if any such cleanup appears incorrect or subpar, please let me know. I'll gladly revert the change. This is the first time I've looked at more or less all of these tests so it is possible I've overlooked something.

### Additional information

This is a first pass at cleaning up Rails using this module. The module itself is only v1 at this point. I have some ideas for how we can further enhance the module to be more applicable in more cases and allow for even cleaner testing: https://github.com/rails/rails/pull/53065#issuecomment-2452017030. Have WIP implementations of `payload_subset` for `assert_notification` and `filter` for all methods.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.

I don't believe this qualifies as a change that needs to be reflected in the changelog as it is non-user-facing and does not change the public API of Rails.