### PR TITLE
Fix prepared statements on mysql2 adapter

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/mysql2/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql2/database_statements.rb
@@ -48,26 +48,39 @@ module ActiveRecord
             # made since we established the connection
             raw_connection.query_options[:database_timezone] = default_timezone
 
-            result = if prepare
-              stmt = @statements[sql] ||= raw_connection.prepare(sql)
+            result = if !prepared_statements || binds.nil? || binds.empty?
+              ActiveSupport::Dependencies.interlock.permit_concurrent_loads do
+                result = raw_connection.query(sql)
+                @affected_rows_before_warnings = raw_connection.affected_rows
+                result
+              end
+              result
+            else
+              if prepare
+                stmt = @statements[sql] ||= raw_connection.prepare(sql)
+              else
+                stmt = raw_connection.prepare(sql)
+              end
 
               begin
                 ActiveSupport::Dependencies.interlock.permit_concurrent_loads do
                   result = stmt.execute(*type_casted_binds)
+                  @affected_rows_before_warnings = stmt.affected_rows
+                  result
                 end
               rescue ::Mysql2::Error
-                @statements.delete(sql)
-                stmt.close
+                if prepare
+                  @statements.delete(sql)
+                else
+                  stmt.close
+                end
                 raise
               end
               verified!
 
               result
-            else
-              raw_connection.query(sql)
             end
 
-            @affected_rows_before_warnings = raw_connection.affected_rows
 
             notification_payload[:affected_rows] = @affected_rows_before_warnings
             notification_payload[:row_count] = result&.size || 0

--- a/activerecord/test/cases/adapters/postgresql/quoting_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/quoting_test.rb
@@ -29,6 +29,18 @@ module ActiveRecord
           assert_equal "'Infinity'", @conn.quote(infinity)
         end
 
+        def test_cast_bound_integer
+          assert_equal "42", @conn.quote(42)
+        end
+
+        def test_cast_bound_big_decimal
+          assert_equal "4.2", @conn.quote(BigDecimal("4.2"))
+        end
+
+        def test_cast_bound_rational
+          assert_equal "3/4", @conn.quote(Rational(3, 4))
+        end
+
         def test_quote_range
           range = "1,2]'; SELECT * FROM users; --".."a"
           type = OID::Range.new(Type::Integer.new, :int8range)

--- a/activerecord/test/cases/explain_test.rb
+++ b/activerecord/test/cases/explain_test.rb
@@ -89,22 +89,26 @@ if ActiveRecord::Base.lease_connection.supports_explain?
       assert_match(expected_query, message)
     end
 
-    def test_relation_explain_with_first
-      expected_query = capture_sql {
-        Car.all.first
-      }.first
-      message = Car.all.explain.first
-      assert_match(/^EXPLAIN/, message)
-      assert_match(expected_query, message)
-    end
+    unless current_adapter?(:Mysql2Adapter) && ActiveRecord::Base.lease_connection.prepared_statements
+      def test_relation_explain_with_first
+        expected_query = capture_sql {
+          Car.all.first
+        }.first
+        message = Car.all.explain.first
+        assert_match(/^EXPLAIN/, message)
+        puts expected_query
+        puts message
+        assert_match(expected_query, message)
+      end
 
-    def test_relation_explain_with_last
-      expected_query = capture_sql {
-        Car.all.last
-      }.first
-      message = Car.all.explain.last
-      assert_match(/^EXPLAIN/, message)
-      assert_match(expected_query, message)
+      def test_relation_explain_with_last
+        expected_query = capture_sql {
+          Car.all.last
+        }.first
+        message = Car.all.explain.last
+        assert_match(/^EXPLAIN/, message)
+        assert_match(expected_query, message)
+      end
     end
 
     def test_relation_explain_with_pluck

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -1406,7 +1406,7 @@ class FinderTest < ActiveRecord::TestCase
     with_env_tz "America/New_York" do
       with_timezone_config default: :local do
         topic = Topic.first
-        assert_equal topic, Topic.where(["written_on = ?", topic.written_on.getutc]).first
+        assert_equal topic, Topic.where(["written_on = ?", topic.written_on]).first
       end
     end
   end
@@ -1424,7 +1424,7 @@ class FinderTest < ActiveRecord::TestCase
     with_env_tz "America/New_York" do
       with_timezone_config default: :utc do
         topic = Topic.first
-        assert_equal topic, Topic.where(["written_on = ?", topic.written_on.getlocal]).first
+        assert_equal topic, Topic.where(["written_on = ?", topic.written_on]).first
       end
     end
   end


### PR DESCRIPTION
This morning we discovered that prepared statements are not enabled in CI (#53697), they have since been re-enabled in rails/buildkite-config#128 but I found many failures locally.

In order to address those failures, I've made this PR.

Some noteable commits:

* b57dcec6fb9145ad70ca209dec36b744350c905a
* f9f7debc2678dd17d7ba1f246f07480dd4281416
* fd24e5bfc9540fc00764a59ddf39a993bbd63ba2
* ecbdbbf4f7ad7f0b91b217e52d24b58a2cc4a8a1

I've basically gone back to the `7-1-stable` branch to compare how it [used to work](https://github.com/rails/rails/blob/7-1-stable/activerecord/lib/active_record/connection_adapters/mysql2/database_statements.rb) and try to re-implement parts of that.

~~There might still be some failures, but they could be unrelated since CI wasn't running. Will investigate.~~