### PR TITLE
Use `secret_key_base` from ENV or credentials when present locally

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Use `secret_key_base` from ENV or credentials when present locally.
+
+    When ENV["SECRET_KEY_BASE"] or
+    `Rails.application.credentials.secret_key_base` is set for test or
+    development, it is used for the `Rails.config.secret_key_base`,
+    instead of generating a `tmp/local_secret.txt` file.
+
+    *Petrik de Heus*
+
 *   The authentication generator's `SessionsController` sets the `Clear-Site-Data` header on logout.
 
     By default the header will be set to `"cache","storage"` to help prevent data leakage after

--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -457,18 +457,21 @@ module Rails
     # is used to create all ActiveSupport::MessageVerifier and ActiveSupport::MessageEncryptor instances,
     # including the ones that sign and encrypt cookies.
     #
-    # In development and test, this is randomly generated and stored in a
-    # temporary file in <tt>tmp/local_secret.txt</tt>.
+    # We look for it first in <tt>ENV["SECRET_KEY_BASE"]</tt>, then in
+    # +credentials.secret_key_base+. For most applications, the correct place
+    # to store it is in the encrypted credentials file.
     #
-    # You can also set <tt>ENV["SECRET_KEY_BASE_DUMMY"]</tt> to trigger the use of a randomly generated
-    # secret_key_base that's stored in a temporary file. This is useful when precompiling assets for
-    # production as part of a build step that otherwise does not need access to the production secrets.
+    # In development and test, if the secret_key_base is still empty, it is
+    # randomly generated and stored in a temporary file in
+    # <tt>tmp/local_secret.txt</tt>.
+    #
+    # Generating a random secret_key_base and storing it in
+    # <tt>tmp/local_secret.txt</tt> can also be triggered by setting
+    # <tt>ENV["SECRET_KEY_BASE_DUMMY"]</tt>. This is useful when precompiling
+    # assets for production as part of a build step that otherwise does not
+    # need access to the production secrets.
     #
     # Dockerfile example: <tt>RUN SECRET_KEY_BASE_DUMMY=1 bundle exec rails assets:precompile</tt>.
-    #
-    # In all other environments, we look for it first in <tt>ENV["SECRET_KEY_BASE"]</tt>,
-    # then +credentials.secret_key_base+. For most applications, the correct place to store it is in the
-    # encrypted credentials file.
     def secret_key_base
       config.secret_key_base
     end

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -510,16 +510,18 @@ module Rails
 
       def secret_key_base
         @secret_key_base || begin
-          self.secret_key_base = if generate_local_secret?
+          self.secret_key_base = if ENV["SECRET_KEY_BASE_DUMMY"]
             generate_local_secret
           else
-            ENV["SECRET_KEY_BASE"] || Rails.application.credentials.secret_key_base
+            ENV["SECRET_KEY_BASE"] ||
+              Rails.application.credentials.secret_key_base ||
+              (Rails.env.local? && generate_local_secret)
           end
         end
       end
 
       def secret_key_base=(new_secret_key_base)
-        if new_secret_key_base.nil? && generate_local_secret?
+        if new_secret_key_base.nil? && Rails.env.local?
           @secret_key_base = generate_local_secret
         elsif new_secret_key_base.is_a?(String) && new_secret_key_base.present?
           @secret_key_base = new_secret_key_base
@@ -646,10 +648,6 @@ module Rails
           end
 
           File.binread(key_file)
-        end
-
-        def generate_local_secret?
-          Rails.env.local? || ENV["SECRET_KEY_BASE_DUMMY"]
         end
     end
   end


### PR DESCRIPTION
### Motivation / Background

Since 0c76f17f2dbf0d7ad90c890e6f334743cacce41f  a `tmp/local_secret.txt` is always used for `Rails.config.secret_key_base` in the test and development environments. Previously, `ENV["SECRET_KEY_BASE"]` or `Rails.application.credentials.secret_key_base` were used if present.

As the `secret_key_base` is used to generate signed IDs, it breaks Action Text attachments in development if they previously used the `secret_key_base` from ENV var or credentials. Accidentally deleting `tmp/local_secret.txt` will also break all local Action Text attachments.

The race condition in generating the local secret file, as reported in https://github.com/rails/rails/issues/53661, should be avoidable by setting `ENV["SECRET_KEY_BASE"]` or `Rails.application.credentials.secret_key_base`, but this currently doesn't work.

Fixes #53661 
Fixes #54277

### Details

When `ENV["SECRET_KEY_BASE"]` or `Rails.application.credentials.secret_key_base` is set for test or development, it should be used for the `Rails.config.secret_key_base`, instead of generating a `tmp/local_secret.txt`.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
