### PR TITLE
Provide first-class support for patches

### DIFF
--- a/railties/lib/rails/application/finisher.rb
+++ b/railties/lib/rails/application/finisher.rb
@@ -4,6 +4,7 @@ require "active_support/core_ext/string/inflections"
 require "active_support/core_ext/array/conversions"
 require "active_support/descendants_tracker"
 require "active_support/dependencies"
+require "rails/application/patch_loader"
 
 module Rails
   class Application
@@ -43,6 +44,12 @@ module Rails
         end
 
         autoloader.setup
+      end
+
+      initializer :add_patches do
+        config.patch_paths.each do |base_path|
+          PatchLoader.new(base_path).call
+        end
       end
 
       # Setup default session store if not already set in config/application.rb

--- a/railties/lib/rails/application/patch_loader.rb
+++ b/railties/lib/rails/application/patch_loader.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module Rails
+  class Application
+    class PatchLoader
+      DECORATED_CLASS_PATTERN = /(?<decorated_class>[A-Z][a-zA-Z:]+)(\.prepend[\s(])/
+
+      attr_reader :base_path, :autoloader
+
+      def initialize(base_path, autoloader: Rails.autoloaders.main)
+        @base_path = base_path
+        @autoloader = autoloader
+      end
+
+      def call
+        autoloader.dirs.grep(/#{base_path}/).each do |path|
+          Pathname.new(path).glob("**/*_patch.rb") do |patch_path|
+            # Match all the classes that are prepended in the file
+            matches = File.read(patch_path).scan(DECORATED_CLASS_PATTERN).flatten
+
+            # Don't do a thing if there's no prepending.
+            return unless matches.present?
+
+            # For each unique match, make sure we load the decorator when the base class is loaded
+            matches.uniq.each do |decorated_class|
+              # Zeitwerk tells us which constant it expects a file to provide.
+              decorator_constant = autoloader.cpath_expected_at(patch_path)
+              # Sprinkle some debugging.
+              Rails.logger.debug("Preparing to autoload #{decorated_class} with #{decorator_constant}")
+              # If the class has not been loaded, we can add a hook to load the decorator when it is.
+              # Multiple hooks are no problem, as long as all decorators are namespaced appropriately.
+              autoloader.on_load(decorated_class) do |base|
+                Rails.logger.debug("Loading #{decorator_constant} in order to modify #{base}")
+                decorator_constant.constantize
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/railties/lib/rails/engine/configuration.rb
+++ b/railties/lib/rails/engine/configuration.rb
@@ -83,6 +83,7 @@ module Rails
           paths.add "app/helpers",         eager_load: true
           paths.add "app/models",          eager_load: true
           paths.add "app/mailers",         eager_load: true
+          paths.add "app/patches",         eager_load: true
           paths.add "app/views"
 
           # If you add more lib subdirectories here that should not be managed
@@ -110,6 +111,10 @@ module Rails
 
           paths
         end
+      end
+
+      def patch_paths
+        paths["app/patches"]
       end
 
       def root=(value)


### PR DESCRIPTION
The changes in this commit allow developers to write patches to classes in other gems without breaking lazy loading. With the previous method of ignoring an `app/overrides` folder in the autoloader, and then `load`ing all of the files in that directory in a `config.to_prepare` hook, all the modified classes are implicitly eager loaded, which significantly slows down app startup on complex apps.

Instead, this makes use of the `on_load` callback that `zeitwerk` defines, and loads any modules that prepend themselves into loaded classes after they are loaded.

This is a rough implementation, and I expect it to need some iteration. 

### Motivation / Background

In the [Solidus](https://github.com/solidusio/solidus), [Spree](https://github.com/spree/spree) and [Alchemy](https://github.com/AlchemyCMS/alchemy_cms) ecosystems, apps created often make extensive use of patches. These are sometimes called `overrides` and sometimes `decorators`, and they are usually applied using the method that is currently recommended in the Rails guides for Engines: 

```ruby 
# config/application.rb
module MyApp
  class Application < Rails::Application
    # ...

    overrides = "#{Rails.root}/app/overrides"
    Rails.autoloaders.main.ignore(overrides)

    config.to_prepare do
      Dir.glob("#{overrides}/**/*_override.rb").sort.each do |override|
        load override
      end
    end
  end
end
```

This method has some drawbacks: 
1. The `config.to_prepare` constant is sometimes called twice on app startup. If there are any constants defined in the patching files, these get redefined, issueing a warning
2. Patches loaded this way are contagious: They load autoloadable code on app startup, slowing app startup down. 

The proposed method makes use of Zeitwerk's `on_load` callback, and only loads patches when the patched class itself is loaded. 
Here are the drawbacks though: 
1. If an autoloadable file has already been loaded by the time this code runs, the patches will not get applied automatically. 

Prior work has been done by [`solidus_support`](https://github.com/solidusio/solidus_support) by [@elia and @spaghetticode](https://github.com/solidusio/solidus_support/pull/60) and [myself](https://github.com/solidusio/solidus_support/pull/87) 

We're looking to create a robust, developer-friendly pattern for this unique feature of the Ruby/Rails ecosystem. The current implementation works, but modern Rails allows to make this a lot nicer.

Thanks to @tvdeyen for pairing on this, and to @jarednorman for providing feedback on the earlier iteration in `solidus_support`. 

### Additional information

I'll provide benchmarks soon.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
