### PR TITLE
Add note about Arel.sql in documentation for sanitize_sql_array

### DIFF
--- a/activerecord/lib/active_record/sanitization.rb
+++ b/activerecord/lib/active_record/sanitization.rb
@@ -155,6 +155,8 @@ module ActiveRecord
       #
       #   sanitize_sql_array(["role = ?", 0])
       #   # => "role = '0'"
+      #
+      #   Before using this method, please consider if Arel.sql would be better for your use-case
       def sanitize_sql_array(ary)
         statement, *values = ary
         if values.first.is_a?(Hash) && /:\w+/.match?(statement)


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because of a discussion we had in https://github.com/rails/rails/pull/53695

`Arel.sql` seems to be far more intuitive to use than `sanitize_sql_array`

### Detail

This Pull Request changes the documentation for `sanitize_sql_array` so that it suggests to use `Arel.sql` as an alternative.

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
