### PR TITLE
Use `_path` instead of `_url` in auth session controller

### DIFF
--- a/railties/lib/rails/generators/rails/authentication/templates/app/controllers/sessions_controller.rb.tt
+++ b/railties/lib/rails/generators/rails/authentication/templates/app/controllers/sessions_controller.rb.tt
@@ -1,6 +1,6 @@
 class SessionsController < ApplicationController
   allow_unauthenticated_access only: %i[ new create ]
-  rate_limit to: 10, within: 3.minutes, only: :create, with: -> { redirect_to new_session_url, alert: "Try again later." }
+  rate_limit to: 10, within: 3.minutes, only: :create, with: -> { redirect_to new_session_path, alert: "Try again later." }
 
   def new
   end


### PR DESCRIPTION
Follow-up to https://github.com/rails/rails/pull/53445 and https://github.com/rails/rails/pull/53677#issuecomment-2493678906.

### Motivation / Background

This Pull Request has been created because in the authentication-generated `SessionsController`, there is a `redirect_to new_session_url` on line 3 and `redirect_to new_session_path` on line 13, which is inconsistent. It should be `_path` as mentioned by David in https://github.com/rails/rails/pull/53677#issuecomment-2493678906.

### Detail

This Pull Request changes the `SessionsController` to use `redirect_to new_session_path`.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
