### PR TITLE
Only link back to referer if referer is a `GET` request

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Only link back to referer if referer is a `GET` request when passing `:back`
+    to `link_to`.
+
+    *Steve Polito*
+
 *   Fix a crash in ERB template error highlighting when the error occurs on a
     line in the compiled template that is past the end of the source template.
 

--- a/actionview/lib/action_view/helpers/url_helper.rb
+++ b/actionview/lib/action_view/helpers/url_helper.rb
@@ -55,7 +55,9 @@ module ActionView
       def _filtered_referrer # :nodoc:
         if controller.respond_to?(:request)
           referrer = controller.request.env["HTTP_REFERER"]
-          if referrer && URI(referrer).scheme != "javascript"
+          request_method = controller.request.env["REQUEST_METHOD"]
+
+          if referrer && request_method == "GET" && URI(referrer).scheme != "javascript"
             referrer
           end
         end

--- a/actionview/test/template/url_helper_test.rb
+++ b/actionview/test/template/url_helper_test.rb
@@ -72,7 +72,7 @@ class UrlHelperTest < ActiveSupport::TestCase
 
   def test_url_for_with_back
     referer = "http://www.example.com/referer"
-    @controller = Struct.new(:request).new(Struct.new(:env).new({ "HTTP_REFERER" => referer }))
+    @controller = Struct.new(:request).new(Struct.new(:env).new({ "HTTP_REFERER" => referer, "REQUEST_METHOD" => "GET" }))
 
     assert_equal "http://www.example.com/referer", url_for(:back)
   end
@@ -481,9 +481,16 @@ class UrlHelperTest < ActiveSupport::TestCase
   end
 
   def test_link_tag_with_back
-    env = { "HTTP_REFERER" => "http://www.example.com/referer" }
+    env = { "HTTP_REFERER" => "http://www.example.com/referer", "REQUEST_METHOD" => "GET" }
     @controller = Struct.new(:request).new(Struct.new(:env).new(env))
     expected = %{<a href="#{env["HTTP_REFERER"]}">go back</a>}
+    assert_dom_equal expected, link_to("go back", :back)
+  end
+
+  def test_link_tag_with_back_non_get
+    env = { "HTTP_REFERER" => "http://www.example.com/referer", "REQUEST_METHOD" => "POST" }
+    @controller = Struct.new(:request).new(Struct.new(:env).new(env))
+    expected = %{<a href="javascript:history.back()">go back</a>}
     assert_dom_equal expected, link_to("go back", :back)
   end
 


### PR DESCRIPTION
### Motivation / Background

Currently, passing `:back` to `link_to` will link to the `referer` if it exists, regardless of its request method. This means there are cases where we will link to a `referer` for a `POST` request, which results in unexpected behavior. Take the following as an example.

```ruby
def create
  @product = Product.new(product_params)

  if @product.save
    redirect_to products_path, notice: "Product was successfully created."
  else
    render :new, status: :unprocessable_entity
  end
end
```

```erb
<% # app/views/products/new.html.erb %>

<%= link_to "Go back", :back %>
```

If a user were to navigate to `Products#new` from a page, and enter invalid data, the server would respond with `Products#new`, making the _that_ the `referer`.

### Detail

This commit checks to see if the `"REQUEST_METHOD"` was `"GET"` before setting the `referer`.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
