### PR TITLE
Preserve duplicate columns in `ActiveRecord::Base#select`

### DIFF
--- a/activerecord/lib/active_record/relation/merger.rb
+++ b/activerecord/lib/active_record/relation/merger.rb
@@ -85,9 +85,9 @@ module ActiveRecord
           return if other.select_values.empty?
 
           if other.model == relation.model
-            relation.select_values |= other.select_values
+            relation.select_values += other.select_values
           else
-            relation.select_values |= other.instance_eval do
+            relation.select_values += other.instance_eval do
               arel_columns(select_values)
             end
           end

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -426,7 +426,7 @@ module ActiveRecord
     end
 
     def _select!(*fields) # :nodoc:
-      self.select_values |= fields
+      self.select_values += fields
       self
     end
 

--- a/activerecord/test/cases/relation/select_test.rb
+++ b/activerecord/test/cases/relation/select_test.rb
@@ -115,6 +115,14 @@ module ActiveRecord
       assert_not_nil post.post_title
     end
 
+    def test_select_preserves_duplicate_columns
+      quoted_posts_id = Regexp.escape(quote_table_name("posts.id"))
+      quoted_posts = Regexp.escape(quote_table_name("posts"))
+      assert_queries_match(/SELECT #{quoted_posts_id}, #{quoted_posts_id} FROM #{quoted_posts}/i) do
+        Post.select(:id, :id).to_a
+      end
+    end
+
     def test_reselect
       expected = Post.select(:title).to_sql
       assert_equal expected, Post.select(:title, :body).reselect(:title).to_sql

--- a/activerecord/test/cases/relation_test.rb
+++ b/activerecord/test/cases/relation_test.rb
@@ -50,7 +50,7 @@ module ActiveRecord
       }
       expected.default = [ Object.new ]
 
-      Relation::MULTI_VALUE_METHODS.each do |method|
+      (Relation::MULTI_VALUE_METHODS - [:select]).each do |method|
         getter, setter = "#{method}_values", "#{method}_values="
         values = expected[method]
         relation = Relation.new(FakeKlass)
@@ -291,6 +291,15 @@ module ActiveRecord
       relation = Post.joins(:comments).merge Comment.joins(:ratings)
 
       assert_equal 3, relation.where(id: post.id).pluck(:id).size
+    end
+
+    def test_merge_preserves_duplicate_columns
+      quoted_posts_id = Regexp.escape(quote_table_name("posts.id"))
+      quoted_posts = Regexp.escape(quote_table_name("posts"))
+      posts = Post.select(:id)
+      assert_queries_match(/SELECT #{quoted_posts_id}, #{quoted_posts_id} FROM #{quoted_posts}/i) do
+        posts.merge(posts).to_a
+      end
     end
 
     def test_merge_raises_with_invalid_argument


### PR DESCRIPTION
Fixes #53715 (see there for the problem description).