### PR TITLE
Fix prefixed headings in guide pages meta descriptions [ci-skip]

### DIFF
--- a/guides/rails_guides/markdown.rb
+++ b/guides/rails_guides/markdown.rb
@@ -23,8 +23,8 @@ module RailsGuides
       @raw_body = body
       extract_raw_header_and_body
       generate_header
-      generate_description
       generate_title
+      generate_description
       generate_body
       generate_structure
       generate_index
@@ -88,7 +88,7 @@ module RailsGuides
 
       def generate_description
         sanitizer = Rails::Html::FullSanitizer.new
-        @description = sanitizer.sanitize(@header).squish
+        @description = sanitizer.sanitize(@header).squish.delete_prefix(@heading)
       end
 
       def generate_structure
@@ -150,8 +150,8 @@ module RailsGuides
       end
 
       def generate_title
-        if heading = html_fragment(@header).at(:h1)
-          @title = "#{heading.text} — Ruby on Rails Guides"
+        if @heading = html_fragment(@header).at(:h1)
+          @title = "#{@heading.text} — Ruby on Rails Guides"
         else
           @title = "Ruby on Rails Guides"
         end


### PR DESCRIPTION
All descriptions and og:description meta tags currently are prefixed with the specific guide's h1. This happens when sanitizing the headers html fragment.