### PR TITLE
Generate session controller tests for auth generator

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Generate session controller tests when running the authentication generator.
+
+    *Jerome Dalbert*
+
 *   Add bin/bundler-audit and config/bundler-audit.yml for discovering and managing known security problems with app gems.
 
     *DHH*

--- a/railties/lib/rails/generators/test_unit/authentication/authentication_generator.rb
+++ b/railties/lib/rails/generators/test_unit/authentication/authentication_generator.rb
@@ -11,6 +11,7 @@ module TestUnit # :nodoc:
       end
 
       def create_controller_test_files
+        template "test/controllers/sessions_controller_test.rb"
         template "test/controllers/passwords_controller_test.rb"
       end
     end

--- a/railties/lib/rails/generators/test_unit/authentication/templates/test/controllers/sessions_controller_test.rb
+++ b/railties/lib/rails/generators/test_unit/authentication/templates/test/controllers/sessions_controller_test.rb
@@ -1,0 +1,33 @@
+require "test_helper"
+
+class SessionsControllerTest < ActionDispatch::IntegrationTest
+  setup { @user = User.take }
+
+  test "new" do
+    get new_session_url
+    assert_response :success
+  end
+
+  test "create with valid credentials" do
+    post session_url, params: { email_address: @user.email_address, password: "password" }
+
+    assert_redirected_to root_url
+    assert cookies[:session_id]
+  end
+
+  test "create with invalid credentials" do
+    post session_url, params: { email_address: @user.email_address, password: "wrong" }
+
+    assert_redirected_to new_session_url
+    assert_nil cookies[:session_id]
+  end
+
+  test "destroy" do
+    sign_in_as(User.take)
+
+    delete session_url
+
+    assert_redirected_to new_session_url
+    assert_empty cookies[:session_id]
+  end
+end

--- a/railties/lib/rails/generators/test_unit/authentication/templates/test/controllers/sessions_controller_test.rb
+++ b/railties/lib/rails/generators/test_unit/authentication/templates/test/controllers/sessions_controller_test.rb
@@ -4,30 +4,30 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
   setup { @user = User.take }
 
   test "new" do
-    get new_session_url
+    get new_session_path
     assert_response :success
   end
 
   test "create with valid credentials" do
-    post session_url, params: { email_address: @user.email_address, password: "password" }
+    post session_path, params: { email_address: @user.email_address, password: "password" }
 
-    assert_redirected_to root_url
+    assert_redirected_to root_path
     assert cookies[:session_id]
   end
 
   test "create with invalid credentials" do
-    post session_url, params: { email_address: @user.email_address, password: "wrong" }
+    post session_path, params: { email_address: @user.email_address, password: "wrong" }
 
-    assert_redirected_to new_session_url
+    assert_redirected_to new_session_path
     assert_nil cookies[:session_id]
   end
 
   test "destroy" do
     sign_in_as(User.take)
 
-    delete session_url
+    delete session_path
 
-    assert_redirected_to new_session_url
+    assert_redirected_to new_session_path
     assert_empty cookies[:session_id]
   end
 end

--- a/railties/test/generators/authentication_generator_test.rb
+++ b/railties/test/generators/authentication_generator_test.rb
@@ -60,6 +60,7 @@ class AuthenticationGeneratorTest < Rails::Generators::TestCase
 
     assert_file "test/models/user_test.rb"
     assert_file "test/fixtures/users.yml"
+    assert_file "test/controllers/sessions_controller_test.rb"
     assert_file "test/controllers/passwords_controller_test.rb"
 
     assert_file "test/test_helper.rb" do |content|


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because the `test_unit` authentication generator does not generate functional tests for controllers generated by the `rails` authentication generator.

The `test_unit` scaffold generator already [generates](https://github.com/rails/rails/blob/ce8a6f126beca56e3183b986e005cd7996b36813/railties/lib/rails/generators/test_unit/scaffold/templates/functional_test.rb.tt) functional tests when scaffolding controllers, so adding functional tests for authentication generated controllers seems natural and would increase consistency.

### Detail

This Pull Request changes the `test_unit` authentication generator to generate `SessionsController` functional tests.

The implementation strives to be Rails-idiomatic by drawing inspiration from Rails' [scaffold functional test](https://github.com/rails/rails/blob/ce8a6f126beca56e3183b986e005cd7996b36813/railties/lib/rails/generators/test_unit/scaffold/templates/functional_test.rb.tt) and 37signals' [Writebook](https://once.com/writebook) session controller tests and session test helpers.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
