### PR TITLE
Correct typo in active storage analyzer

### DIFF
--- a/activestorage/lib/active_storage/analyzer/image_analyzer/vips.rb
+++ b/activestorage/lib/active_storage/analyzer/image_analyzer/vips.rb
@@ -32,7 +32,7 @@ module ActiveStorage
             {}
           end
         rescue ::Vips::Error => error
-          logger.error "Skipping image analysis due to an Vips error: #{error.message}"
+          logger.error "Skipping image analysis due to a Vips error: #{error.message}"
           {}
         end
       end


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because I have spotted a typo inside the Vips ActiveStorage analyzer file.

### Detail

### Additional information

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
