### PR TITLE
Fix rails new with --devcontainer --pretend

### DIFF
--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -272,9 +272,9 @@ module Rails
         dev: options[:dev],
         node: using_node?,
         app_name: app_name,
-        skip_solid: options[:skip_solid]
+        skip_solid: options[:skip_solid],
+        pretend: options[:pretend]
       }
-
       Rails::Generators::DevcontainerGenerator.new([], devcontainer_options).invoke_all
     end
   end

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -1296,6 +1296,12 @@ class AppGeneratorTest < Rails::Generators::TestCase
     assert_file "config/application.rb", /^module MyApp$/
   end
 
+  def test_devcontainer_supports_pretend
+    run_generator [ destination_root, "--devcontainer", "--pretend" ]
+
+    assert_no_file(".devcontainer/devcontainer.json")
+  end
+
   def test_devcontainer
     run_generator [destination_root, "--devcontainer", "--name=my-app"]
 


### PR DESCRIPTION
### Motivation / Background

$ rails new foo --devcontainer --pretend
currently fails as the `DevcontainerGenerator` doesn't receive the pretend-option.
This currently results in a .devcontainer folder being created in CWD, followed by a templating error that halts the process.

Fix #53441

### Detail

This PR passes the pretend-option to the `DevcontainerGenerator` so it won't generate anything (and then blow up), and instead just show the files it would create:
```
...
      create  tmp/storage/.keep
      create  .devcontainer
      create  .devcontainer/devcontainer.json
      create  .devcontainer/Dockerfile
      create  .devcontainer/compose.yaml
      create  config/database.yml
...
```

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* ~~[ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.~~
