### PR TITLE
Add `Rails.env.remote?`

### DIFF
--- a/activesupport/lib/active_support/environment_inquirer.rb
+++ b/activesupport/lib/active_support/environment_inquirer.rb
@@ -36,5 +36,10 @@ module ActiveSupport
     def local?
       @local
     end
+
+    # Returns true if we're not in development or test environment.
+    def remote?
+      !local?
+    end
   end
 end

--- a/activesupport/test/environment_inquirer_test.rb
+++ b/activesupport/test/environment_inquirer_test.rb
@@ -9,6 +9,12 @@ class EnvironmentInquirerTest < ActiveSupport::TestCase
     assert_not ActiveSupport::EnvironmentInquirer.new("production").local?
   end
 
+  test "remote predicate" do
+    assert_not ActiveSupport::EnvironmentInquirer.new("development").remote?
+    assert_not ActiveSupport::EnvironmentInquirer.new("test").remote?
+    assert_predicate ActiveSupport::EnvironmentInquirer.new("production"), :remote?
+  end
+
   test "prevent local from being used as an actual environment name" do
     assert_raises(ArgumentError) do
       ActiveSupport::EnvironmentInquirer.new("local")


### PR DESCRIPTION
I have a silly little method I copy around:

```ruby
def productionish?
  Rails.env.production? || Rails.env.staging?
end
```

Today I decided, enough is enough! 

This PR is a compliment to https://github.com/rails/rails/pull/46786; rather than having to do inverted checks like `!Rails.env.local?` or `unless Rails.env.local?`, I propose a new `Rails.env.remote?`, which is simply `!@local`. 