### PR TITLE
Ensure `connection.exec_query` and `connection.execute` allows `Arel.sql` as input

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Ensure `connection.exec_query` and `connection.execute` allows `Arel.sql` as input. Previously would raise exception `TypeError: no implicit conversion of Arel::Nodes::BoundSqlLiteral into String`
+
+    *westonganger*
+
 *   Allow to reset cache counters for multiple records.
 
     ```

--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -133,7 +133,8 @@ module ActiveRecord
       # Note: depending on your database connector, the result returned by this
       # method may be manually memory managed. Consider using #exec_query
       # wrapper instead.
-      def execute(sql, name = nil, allow_retry: false)
+      def execute(arel_or_sql_string, name = nil, allow_retry: false)
+        sql, _binds, _preparable, _allow_retry = to_sql_and_binds(arel_or_sql_string)
         internal_execute(sql, name, allow_retry: allow_retry)
       end
 
@@ -144,7 +145,8 @@ module ActiveRecord
       # Note: the query is assumed to have side effects and the query cache
       # will be cleared. If the query is read-only, consider using #select_all
       # instead.
-      def exec_query(sql, name = "SQL", binds = [], prepare: false)
+      def exec_query(arel_or_sql_string, name = "SQL", binds = [], prepare: false)
+        sql, binds, _preparable, _allow_retry = to_sql_and_binds(arel_or_sql_string)
         internal_exec_query(sql, name, binds, prepare: prepare)
       end
 

--- a/activerecord/test/cases/adapter_test.rb
+++ b/activerecord/test/cases/adapter_test.rb
@@ -140,6 +140,21 @@ module ActiveRecord
       assert_not_empty result.columns
     end
 
+    test "#exec_query is compatible with Arel.sql with bindings" do
+      sanitized_sql = Arel.sql("SELECT * FROM subscribers WHERE id = :var", var: 1")
+      result = @connection.exec_query(sanitized_sql)
+      assert_instance_of(ActiveRecord::Result, result)
+      assert_empty result.rows
+      assert_not_empty result.columns
+    end
+
+    test "#execute is compatible with Arel.sql with bindings" do
+      sanitized_sql = Arel.sql("SELECT * FROM subscribers WHERE id = :var", var: 1")
+      assert_nothing_raised do
+        @connection.execute(sanitized_sql)
+      end
+    end
+
     if current_adapter?(:Mysql2Adapter, :TrilogyAdapter)
       def test_charset
         assert_not_nil @connection.charset


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

This Pull Request has been created because `Arel.sql` is incompatible with `exec_query` and `execute` (its only compatible with `select_all`, etc), seems that `exec_query` is expecting a string.

### Detail

This Pull Request fixes the issue where `exec_query` and `execute` are not compatible with `Arel.sql` (with bindings)

```ruby
sanitized_sql = Arel.sql("SELECT * FROM :table", table: table)
ApplicationRecord.connection.exec_query(sanitized_sql)
```

```
TypeError: no implicit conversion of Arel::Nodes::BoundSqlLiteral into String
    activerecord (8.0.0) lib/active_record/connection_adapters/sqlite3/database_statements.rb:13:in `match?'
    activerecord (8.0.0) lib/active_record/connection_adapters/sqlite3/database_statements.rb:13:in `write_query?'
    activerecord (8.0.0) lib/active_record/connection_adapters/abstract/database_statements.rb:375:in `mark_transaction_written_if_write'
    activerecord (8.0.0) lib/active_record/connection_adapters/abstract/database_statements.rb:576:in `preprocess_query'
    activerecord (8.0.0) lib/active_record/connection_adapters/abstract/database_statements.rb:590:in `internal_execute'
    activerecord (8.0.0) lib/active_record/connection_adapters/abstract/database_statements.rb:547:in `internal_exec_query'
    activerecord (8.0.0) lib/active_record/connection_adapters/abstract/database_statements.rb:148:in `exec_query'
    activerecord (8.0.0) lib/active_record/connection_adapters/abstract/query_cache.rb:27:in `exec_query'
```

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
