### PR TITLE
Remove reload! command due to conflict with helper

### DIFF
--- a/railties/lib/rails/commands/console/irb_console.rb
+++ b/railties/lib/rails/commands/console/irb_console.rb
@@ -59,22 +59,11 @@ module Rails
       end
     end
 
-    class ReloadCommand < IRB::Command::Base
-      category "Rails console"
-      description "Reloads the Rails application."
-
-      def execute(*)
-        puts "Reloading..."
-        Rails.application.reloader.reload!
-      end
-    end
-
     IRB::HelperMethod.register(:helper, ControllerHelper)
     IRB::HelperMethod.register(:controller, ControllerInstance)
     IRB::HelperMethod.register(:new_session, NewSession)
     IRB::HelperMethod.register(:app, AppInstance)
     IRB::HelperMethod.register(:reload!, ReloadHelper)
-    IRB::Command.register(:reload!, ReloadCommand)
 
     class IRBConsole
       def initialize(app)


### PR DESCRIPTION
The helper enables both of the following:

```
$ rails c
Loading development environment (Rails 8.1.0.alpha)
min(dev)> reload!; puts "test"
Reloading...
test
=> nil
min(dev)> reload! ; puts "test"
Reloading...
test
min(dev)>
```

whereas the command prevents the second case from working (the first is interpreted as the helper):

```
$ rails c
Loading development environment (Rails 8.1.0.alpha)
min(dev)> reload!; puts "test"
Reloading...
test
=> nil
min(dev)> reload! ; puts "test"
Reloading...
min(dev)>
```

(please backport to `7-2-stable` as well)

---

From https://github.com/rails/rails/pull/52996#issuecomment-2386326225:

> That said, I don't think it makes sense to have it both a command and a helper method. I think the command should be removed since this PR has been merged.
