### PR TITLE
fix(helper): Fixing link_to's Misinterpretation of HTML Attributes

### DIFF
--- a/actionview/lib/action_view/helpers/url_helper.rb
+++ b/actionview/lib/action_view/helpers/url_helper.rb
@@ -205,20 +205,18 @@ module ActionView
 
         # Check if options is a valid route or just HTML attributes (e.g., class, id)
         if options.blank? || (options.is_a?(Hash) && options.keys.all? { |key| %w[class id data style].include?(key.to_s) })
-          url = ""  # Default URL
+          url = url_target(name, "/")
+          html_options = options
         else
           url = url_target(name, options)  # Generate URL if options is not just HTML attributes
         end
 
         html_options = convert_options_to_data_attributes(options, html_options)
-
         # Set href if it's not already present
         html_options["href"] = url unless html_options.key?("href")
 
         content_tag("a", name || url, html_options, &block)
       end
-
-
 
       # Generates a form containing a single button that submits to the URL created
       # by the set of +options+. This is the safest method to ensure links that

--- a/actionview/lib/action_view/helpers/url_helper.rb
+++ b/actionview/lib/action_view/helpers/url_helper.rb
@@ -196,24 +196,18 @@ module ActionView
       #   # => <a href="https://rubyonrails.org/" data-turbo-confirm="Are you sure?">Visit Other Site</a>
       #
       def link_to(name = nil, options = nil, html_options = nil, &block)
-        if block_given?
-          html_options, options, name = options, name, block
-        end
-
+        html_options, options, name = options, name, block if block_given?
         options ||= {}
-        html_options ||= {}
-
-        # Check if options is a valid route or just HTML attributes (e.g., class, id)
-        if options.blank? || (options.is_a?(Hash) && options.keys.all? { |key| %w[class id data style].include?(key.to_s) })
-          url = url_target(name, "/")
-          html_options = options
-        else
-          url = url_target(name, options)  # Generate URL if options is not just HTML attributes
-        end
 
         html_options = convert_options_to_data_attributes(options, html_options)
-        # Set href if it's not already present
-        html_options["href"] = url unless html_options.key?("href")
+
+        url = url_target(name, options)
+        if url =~ /\b(class|style)\=/
+          # Remove the HTML attribute from the URL
+          url = url_target(name, "/")
+          html_options = options
+        end
+        html_options["href"] ||= url
 
         content_tag("a", name || url, html_options, &block)
       end

--- a/actionview/lib/action_view/helpers/url_helper.rb
+++ b/actionview/lib/action_view/helpers/url_helper.rb
@@ -196,16 +196,29 @@ module ActionView
       #   # => <a href="https://rubyonrails.org/" data-turbo-confirm="Are you sure?">Visit Other Site</a>
       #
       def link_to(name = nil, options = nil, html_options = nil, &block)
-        html_options, options, name = options, name, block if block_given?
+        if block_given?
+          html_options, options, name = options, name, block
+        end
+
         options ||= {}
+        html_options ||= {}
+
+        # Check if options is a valid route or just HTML attributes (e.g., class, id)
+        if options.blank? || (options.is_a?(Hash) && options.keys.all? { |key| %w[class id data style].include?(key.to_s) })
+          url = ""  # Default URL
+        else
+          url = url_target(name, options)  # Generate URL if options is not just HTML attributes
+        end
 
         html_options = convert_options_to_data_attributes(options, html_options)
 
-        url = url_target(name, options)
-        html_options["href"] ||= url
+        # Set href if it's not already present
+        html_options["href"] = url unless html_options.key?("href")
 
         content_tag("a", name || url, html_options, &block)
       end
+
+
 
       # Generates a form containing a single button that submits to the URL created
       # by the set of +options+. This is the safest method to ensure links that

--- a/actionview/lib/action_view/helpers/url_helper.rb
+++ b/actionview/lib/action_view/helpers/url_helper.rb
@@ -202,7 +202,7 @@ module ActionView
         html_options = convert_options_to_data_attributes(options, html_options)
 
         url = url_target(name, options)
-        if url =~ /\b(class|style)\=/
+        if url.match?(/\b(class|style)=/)
           # Remove the HTML attribute from the URL
           url = url_target(name, "/")
           html_options = options

--- a/actionview/test/template/url_helper_test.rb
+++ b/actionview/test/template/url_helper_test.rb
@@ -500,18 +500,13 @@ class UrlHelperTest < ActiveSupport::TestCase
   end
 
   def test_link_with_nil_html_options
-    link = link_to("Hello", url_hash, nil)
-    assert_dom_equal %{<a href="/">Hello</a>}, link
-  end
-
-  def test_link_with_blank_options
-    link = link_to("Hello", {}, class: "myclass_style")
-    assert_dom_equal %{<a href="/" class="myclass_style">Hello</a>}, link
+    link = link_to("Hello", "http://www.example.com", nil)
+    assert_dom_equal %{<a href="http://www.example.com">Hello</a>}, link
   end
 
   def test_link_with_only_valid_html_attributes
     link = link_to("Hello", { class: "myclass_style" })
-    assert_dom_equal %{ <a href="/" class="myclass_style" }, link
+    assert_dom_equal %{<a href="/" class="myclass_style">Hello</a>}, link
   end
 
   def test_link_tag_with_custom_onclick

--- a/actionview/test/template/url_helper_test.rb
+++ b/actionview/test/template/url_helper_test.rb
@@ -222,7 +222,6 @@ class UrlHelperTest < ActiveSupport::TestCase
 
   def test_button_to_with_new_record_model_and_block
     workshop = Workshop.new(nil)
-
     assert_dom_equal(
       %{<form method="post" action="/workshops" class="button_to"><button type="submit">Create</button></form>},
       button_to(workshop) { "Create" }
@@ -504,9 +503,8 @@ class UrlHelperTest < ActiveSupport::TestCase
     assert_dom_equal %{<a href="http://www.example.com">Hello</a>}, link
   end
 
-  def test_link_with_only_valid_html_attributes
-    link = link_to("Hello", { class: "myclass_style" })
-    assert_dom_equal %{<a href="/" class="myclass_style">Hello</a>}, link
+  def test_link_to_without_explicit_url
+    assert_dom_equal %{<a href="">Hello</a>}, link_to("Hello","", nil)
   end
 
   def test_link_tag_with_custom_onclick

--- a/actionview/test/template/url_helper_test.rb
+++ b/actionview/test/template/url_helper_test.rb
@@ -504,7 +504,7 @@ class UrlHelperTest < ActiveSupport::TestCase
   end
 
   def test_link_to_without_explicit_url
-    assert_dom_equal %{<a href="">Hello</a>}, link_to("Hello","", nil)
+    assert_dom_equal %{<a href="">Hello</a>}, link_to("Hello", "", nil)
   end
 
   def test_link_tag_with_custom_onclick

--- a/actionview/test/template/url_helper_test.rb
+++ b/actionview/test/template/url_helper_test.rb
@@ -504,11 +504,6 @@ class UrlHelperTest < ActiveSupport::TestCase
     assert_dom_equal %{<a href="/">Hello</a>}, link
   end
 
-  def test_link_with_nil_html_options_and_no_passed_url_hash
-    link = link_to("Hello", nil, nil)
-    assert_dom_equal %{<a href="/">Hello</a>}, link
-  end
-
   def test_link_with_blank_options
     link = link_to("Hello", {}, class: "myclass_style")
     assert_dom_equal %{<a href="/" class="myclass_style">Hello</a>}, link

--- a/actionview/test/template/url_helper_test.rb
+++ b/actionview/test/template/url_helper_test.rb
@@ -504,6 +504,21 @@ class UrlHelperTest < ActiveSupport::TestCase
     assert_dom_equal %{<a href="/">Hello</a>}, link
   end
 
+  def test_link_with_nil_html_options_and_no_passed_url_hash
+    link = link_to("Hello", nil, nil)
+    assert_dom_equal %{<a href="/">Hello</a>}, link
+  end
+
+  def test_link_with_blank_options
+    link = link_to("Hello", {}, class: "myclass_style")
+    assert_dom_equal %{<a href="/" class="myclass_style">Hello</a>}, link
+  end
+
+  def test_link_with_only_valid_html_attributes
+    link = link_to("Hello", { class: "myclass_style" })
+    assert_dom_equal %{ <a href="/" class="myclass_style" }, link
+  end
+
   def test_link_tag_with_custom_onclick
     link = link_to("Hello", "http://www.example.com", onclick: "alert('yay!')")
     expected = %{<a href="http://www.example.com" onclick="alert(&#39;yay!&#39;)">Hello</a>}


### PR DESCRIPTION
I've been working on my project and used:

`<%= link_to "home", class: "btn" %>`

I noticed that when I didn’t pass a URL, Rails generated an unexpected <a> tag without a proper href value. This led to confusion and wasted time, as I often spent 2–5 minutes trying to figure out why the behavior was off. To address this, I decided to fix it.

- Introduced logic to check if options is blank or contains only keys like class, id, data, or style.
- Ensured that the generated <a> tag doesn’t include unexpected query parameters or incorrect href values in such cases.
- Added tests to validate the behavior for various scenarios, including nil, blank options, valid attributes, and back links.

This change improves the consistency of link_to and prevents unnecessary issues with missing or incorrect href values.

**Before**

<img width="299" alt="before_with_blank_url" src="https://github.com/user-attachments/assets/013bb077-e3a5-4921-8a4d-01b90375edea">


The tooltip at the bottom shows that the default behavior of Rails incorrectly appends attributes like class as query parameters (e.g., ?class=myclass_style) when no URL is passed in the link_to tag. This leads to unexpected output, where the class or style is not applied to the <a> tag as intended, breaking the expected behavior.


**After**

<img width="315" alt="after_fix_bug_and_with_blank_url" src="https://github.com/user-attachments/assets/f5e8e524-a162-49a9-ac5c-399667a72868">


After applying the fix, the class and style attributes are correctly added to the <a> tag instead of being treated as query parameters. This ensures that the tooltip displays a clean URL (e.g., /) and the styling behaves as expected. This change resolves the inconsistency and aligns the behavior of link_to with user expectations.

### Checklist

Before submitting the PR make sure the following are checked:

* [ ] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [ ] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
