### PR TITLE
Improve the use of Ruby terms [ci skip]

### DIFF
--- a/guides/source/action_text_overview.md
+++ b/guides/source/action_text_overview.md
@@ -342,8 +342,9 @@ user.to_global_id.to_s #=> gid://MyRailsApp/User/1
 user.to_signed_global_id.to_s #=> BAh7CEkiCG…
 ```
 
-NOTE: We can mix `GlobalID::Identification` into any model with a `.find(id)`
-class method. Support is automatically included in Active Record.
+NOTE: We can mix-in `GlobalID::Identification` into any model that has a
+`.find(id)` class method. Naturally, this mix-in support is part of
+Active Record.
 
 The above code will return our identifier to uniquely identify a model instance.
 


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created to suggest using Ruby-specific technical terms when referring directly to Ruby functions, methods, etc. Additionally, it recommends avoiding these terms when they do not refer to Ruby-related functionality.

### Detail

- Change "mix" to "mix-in" because it directly refers to Ruby's mix-in functionality.
- Change "include" to "is part of" because it does not directly refer to the `Module#include` method in this context.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
