### PR TITLE
Don't enable YJIT in development and test environments

### DIFF
--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -60,6 +60,8 @@ Below are the default values associated with each target version. In cases of co
 
 #### Default Values for Target Version 8.1
 
+- [`config.yjit`](#config-yjit): `!Rails.env.local?`
+
 #### Default Values for Target Version 8.0
 
 - [`Regexp.timeout`](#regexp-timeout): `1`
@@ -644,6 +646,7 @@ deploying to a memory constrained environment you may want to set this to `false
 | --------------------- | -------------------- |
 | (original)            | `false`              |
 | 7.2                   | `true`               |
+| 8.1                   | `!Rails.env.local?`  |
 
 ### Configuring Assets
 

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Don't enable YJIT in development and test environments
+
+    Development and test environment tend to reload code and redefine methods (e.g. mocking),
+    hence YJIT isn't generally faster in these environments.
+
+    *Ali Ismayilov*, *Jean Boussier*
+
 *   Only include PermissionsPolicy::Middleware if policy is configured.
 
     *Petrik de Heus*

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -348,6 +348,11 @@ module Rails
           Regexp.timeout ||= 1 if Regexp.respond_to?(:timeout=)
         when "8.1"
           load_defaults "8.0"
+
+          # Development and test environment tend to reload code and
+          # redefine methods (e.g. mocking), hence YJIT isn't generally
+          # faster in these environments.
+          self.yjit = !Rails.env.local?
         else
           raise "Unknown version #{target_version.to_s.inspect}"
         end

--- a/tools/rail_inspector/lib/rail_inspector/configuring/check/framework_defaults.rb
+++ b/tools/rail_inspector/lib/rail_inspector/configuring/check/framework_defaults.rb
@@ -21,6 +21,8 @@ module RailInspector
 
               next if defaults_file_content.include? app_config
 
+              next if config == "self.yjit"
+
               add_error(config)
             end
           end


### PR DESCRIPTION
### Motivation / Background

We've measured consistent ~30% improvement in our total test suite run when YJIT is disabled.

### Detail

This Pull Request has been created to suggest a better default for newly created Rails apps.

### Additional information

I'm not an expert on this topic, but my understanding is that YJIT incurs a penalty on the first run of a code path, with subsequent runs being faster. This makes it a great default for most production environments, where certain parts of the code are executed more frequently. However, in test suite runs, most code paths are usually executed only once, so the initial penalty is not offset, and the benefits of YJIT are never fully realized.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
