### PR TITLE
Add support for `ActiveSupport::Duration` param to `Range#step`

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,21 @@
+*   Add support for `ActiveSupport::Duration` step for ranges.
+
+    Previously:
+
+    ```ruby
+    (Date.new(2005, 1, 31)..).step(1.month).first(3).map(&:to_s)
+    # => ["2005-01-31", "9205-01-31", "16405-01-31"]
+    ```
+
+    After this change:
+
+    ```ruby
+    (Date.new(2005, 1, 31)..).step(1.month).first(3).map(&:to_s)
+    # => ["2005-01-31", "2005-02-28", "2005-03-31"]
+    ```
+
+    *Lovro Bikić*
+
 *   Fix a bug in `ERB::Util.tokenize` that causes incorrect tokenization when ERB tags are preceeded by multibyte characters.
 
     *Martin Emde*

--- a/activesupport/lib/active_support/core_ext/range/each.rb
+++ b/activesupport/lib/active_support/core_ext/range/each.rb
@@ -11,12 +11,44 @@ module ActiveSupport
 
     def step(n = 1, &block)
       ensure_iteration_allowed
-      super
+
+      case n
+      when ActiveSupport::Duration
+        duration_step(n, &block)
+      else
+        super
+      end
     end
 
     private
       def ensure_iteration_allowed
+        raise TypeError, "can't iterate beginless range" unless self.begin
         raise TypeError, "can't iterate from #{first.class}" if first.is_a?(TimeWithZone)
+      end
+
+      def duration_step(step, &block)
+        if block_given?
+          iterate(step, &block)
+
+          self
+        else
+          Enumerator.new do |yielder|
+            iterate(step) do |value|
+              yielder << value
+            end
+          end
+        end
+      end
+
+      def iterate(step, &block)
+        value, i = self.begin, 0
+
+        while cover?(value)
+          yield value
+
+          i += 1
+          value = self.begin + (step * i)
+        end
       end
   end
 end

--- a/activesupport/test/core_ext/range_ext_test.rb
+++ b/activesupport/test/core_ext/range_ext_test.rb
@@ -279,4 +279,83 @@ class RangeTest < ActiveSupport::TestCase
     datetime = DateTime.now
     assert(((datetime - 1.hour)..datetime).step(1) { })
   end
+
+  def test_date_range_with_numeric_step
+    enum = (Date.new(2005, 12, 10)..Date.new(2005, 12, 15)).step(2)
+
+    assert_equal [Date.new(2005, 12, 10), Date.new(2005, 12, 12), Date.new(2005, 12, 14)], enum.to_a
+  end
+
+  def test_date_range_with_day_step
+    enum = (Date.new(2005, 12, 10)..Date.new(2005, 12, 15)).step(2.days)
+
+    assert_equal [Date.new(2005, 12, 10), Date.new(2005, 12, 12), Date.new(2005, 12, 14)], enum.to_a
+    assert_kind_of Enumerator, enum
+  end
+
+  def test_date_range_with_month_step
+    enum = (Date.new(2005, 01, 01)..Date.new(2005, 03, 01)).step(1.month)
+
+    assert_equal [Date.new(2005, 01, 01), Date.new(2005, 02, 01), Date.new(2005, 03, 01)], enum.to_a
+  end
+
+  def test_end_of_month_date_range_with_month_step
+    enum = (Date.new(2005, 01, 31)..Date.new(2005, 03, 31)).step(1.month)
+
+    assert_equal [Date.new(2005, 01, 31), Date.new(2005, 02, 28), Date.new(2005, 03, 31)], enum.to_a
+  end
+
+  def test_date_range_with_year_step
+    enum = (Date.new(2005, 01, 01)...Date.new(2008, 01, 01)).step(1.year)
+
+    assert_equal [Date.new(2005, 01, 01), Date.new(2006, 01, 01), Date.new(2007, 01, 01)], enum.to_a
+  end
+
+  def test_beginless_date_range_step
+    assert_raise TypeError do
+      (..Date.new(2008, 02, 01)).step(1.day)
+    end
+  end
+
+  def test_endless_date_range_step
+    enum = (Date.new(2005, 01, 01)..).step(1.year)
+
+    assert_equal [Date.new(2005, 01, 01), Date.new(2006, 01, 01), Date.new(2007, 01, 01)], enum.first(3)
+  end
+
+  def test_date_range_with_step_and_block
+    range = (Date.new(2005, 01, 01)..Date.new(2005, 03, 01))
+
+    result = []
+    step_range = range.step(1.month) { |element| result << (element + 1.day) }
+
+    assert_equal [Date.new(2005, 01, 02), Date.new(2005, 02, 02), Date.new(2005, 03, 02)], result
+    assert_equal step_range, range
+  end
+
+  def test_date_range_with_end_greater_than_begin_and_step
+    enum = (Date.new(2005, 01, 01)..Date.new(2000, 01, 01)).step(1.year)
+
+    assert_equal [], enum.to_a
+  end
+
+  def test_time_range_with_duration_step
+    enum = (Time.utc(2005, 01, 01, 17, 0, 0)..).step(1.hour)
+
+    assert_equal [
+      Time.utc(2005, 01, 01, 17, 0, 0),
+      Time.utc(2005, 01, 01, 18, 0, 0),
+      Time.utc(2005, 01, 01, 19, 0, 0),
+    ], enum.first(3)
+  end
+
+  def test_date_time_range_with_duration_step
+    enum = (DateTime.new(2005, 01, 01, 17, 0, 0)..).step(1.hour)
+
+    assert_equal [
+      DateTime.new(2005, 01, 01, 17, 0, 0),
+      DateTime.new(2005, 01, 01, 18, 0, 0),
+      DateTime.new(2005, 01, 01, 19, 0, 0),
+    ], enum.first(3)
+  end
 end


### PR DESCRIPTION
### Motivation / Background

Currently, stepping over a date/time `Range` with an `ActiveSupport::Duration` object produces an unintuitive result:
```ruby
(Date.current..).step(1.month).first(3)
# => [Wed, 27 Nov 2024, Wed, 27 Nov 9224, Wed, 27 Nov 16424]
```
and the result is basically equivalent to:
```ruby
[Date.current, Date.current + 1.month.to_i, Date.current + 2.months.to_i]
```
since `ActiveSupport::Duration` step is effectively used as an integer.

That is unfortunate because it would be useful to iterate over date and time ranges with steps of various durations:
```ruby
(Time.current.beginning_of_hour..).step(30.minutes).first(5)
# first 5 half-hours starting from the current hour

Date.current.all_year.step(1.week)
# first day of each week in the current year

(Date.current.beginning_of_year..).step(3.months).first(4)
# beginning of each quarter in the current year

(Date.current..).step(1.month).lazy.map(&:end_of_month)
# last day in each month starting from the current month

# and so on and so on
```

The possibilities here are endless, and I think this would be a valuable tool to support many use-cases.

### Detail

This PR adds special handling for `ActiveSupport::Duration` step param inside `Range#step` to produce the desired result. Except for different iteration result, original [`Range#step`](https://docs.ruby-lang.org/en/master/Range.html#method-i-step) behavior is preserved (block-handling and return values).

With this functionality, the original example now returns:
```ruby
(Date.current..).step(1.month).first(3)
# => [Wed, 27 Nov 2024, Fri, 27 Dec 2024, Mon, 27 Jan 2025]
```

### Additional information

Currently, some of the desired results can be achieved with the help of `beginning_of_*` and `end_of_*` methods, e.g. (when evaluated in this branch):
```ruby
Date.current.all_year.step(1.week).to_a == Date.current.all_year.map(&:beginning_of_week).uniq
# => true
```
however this is also not intuitive and is wasteful (in this case, `Date#beginning_of_week` is called for every day in a year). There are probably some other, less wasteful ways to achieve the same result, but I don't think any is as intuitive as using `Range#step`.

Another alternative is to use the DB when possible. Postgres has a [`generate_series`](https://www.postgresql.org/docs/17/functions-srf.html#FUNCTIONS-SRF-SERIES) function, so the above example can also be achieved with:
```ruby
ApplicationRecord.connection.select_values(<<~SQL)
  SELECT generate_series('2024-01-01'::date, '2024-12-31'::date, '1 week'::interval)::date
SQL
```
However, this functionality is not available on all DBMSs.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [ ] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.

I'll update commit description (and possibly documentation?) if this proposal gets accepted, didn't want to bother with it for now in case it gets rejected.
