### PR TITLE
Correct documented order of `to_prepare` initialization event [ci skip]

### DIFF
--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -3762,7 +3762,7 @@ Rails has 5 initialization events which can be hooked into (listed in the order 
 
 * `before_initialize`: This is run directly before the initialization process of the application occurs with the `:bootstrap_hook` initializer near the beginning of the Rails initialization process.
 
-* `to_prepare`: Run after the initializers are run for all Railties (including the application itself), but before eager loading and the middleware stack is built. More importantly, will run upon every code reload in `development`, but only once (during boot-up) in `production` and `test`.
+* `to_prepare`: Run after the initializers are run for all Railties (including the application itself) and after the middleware stack is built, but before eager loading. More importantly, will run upon every code reload in `development`, but only once (during boot-up) in `production` and `test`.
 
 * `before_eager_load`: This is run directly before eager loading occurs, which is the default behavior for the `production` environment and not for the `development` environment.
 


### PR DESCRIPTION
[Fix #53682]

As described in the issue the documented order is incorrect. Since the order is that way since Rails 3.2 we just correct the documentation.