### PR TITLE
Improve error highlighting of multiline methods in ERB templates

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   In ExceptionWrapper, match backtrace lines with built templates more often,
+    allowing improved highlighting of errors within do-end blocks in templates.
+    Fix for Ruby 3.4 to match new method labels in backtrace.
+
+    *Martin Emde*
+
 *   Allow setting content type with a symbol of the Mime type.
 
     ```ruby

--- a/actionpack/lib/action_dispatch/middleware/exception_wrapper.rb
+++ b/actionpack/lib/action_dispatch/middleware/exception_wrapper.rb
@@ -261,13 +261,13 @@ module ActionDispatch
         end
 
         (@exception.backtrace_locations || []).map do |loc|
-          if built_methods.key?(loc.label.to_s)
+          if built_methods.key?(loc.base_label)
             thread_backtrace_location = if loc.respond_to?(:__getobj__)
               loc.__getobj__
             else
               loc
             end
-            SourceMapLocation.new(thread_backtrace_location, built_methods[loc.label.to_s])
+            SourceMapLocation.new(thread_backtrace_location, built_methods[loc.base_label])
           else
             loc
           end

--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Improve error highlighting of multi-line methods in ERB templates or
+    templates where the error occurs within a do-end block.
+
+    *Martin Emde*
+
 *   Fix a crash in ERB template error highlighting when the error occurs on a
     line in the compiled template that is past the end of the source template.
 

--- a/actionview/lib/action_view/template/handlers/erb.rb
+++ b/actionview/lib/action_view/template/handlers/erb.rb
@@ -152,8 +152,9 @@ module ActionView
 
         def offset_source_tokens(source_tokens)
           source_offset = 0
-          with_offset = source_tokens.filter_map do |(name, str)|
-            result = [name, str, source_offset] if name == :CODE || name == :TEXT
+          with_offset = source_tokens.filter_map do |name, str|
+            result = [:CODE, str, source_offset] if name == :CODE || name == :PLAIN
+            result = [:TEXT, str, source_offset] if name == :TEXT
             source_offset += str.bytesize
             result
           end

--- a/actionview/lib/action_view/template/handlers/erb.rb
+++ b/actionview/lib/action_view/template/handlers/erb.rb
@@ -40,17 +40,19 @@ module ActionView
 
         # Translate an error location returned by ErrorHighlight to the correct
         # source location inside the template.
-        def translate_location(spot, backtrace_location, source)
-          # Tokenize the source line
+        def translate_location(spot, _backtrace_location, source)
+          compiled = spot[:script_lines]
+          highlight = compiled[spot[:first_lineno] - 1]&.byteslice((spot[:first_column] - 1)...spot[:last_column])
+          return nil if highlight.blank?
+
           source_lines = source.lines
-          return nil if source_lines.size < backtrace_location.lineno
-          tokens = ::ERB::Util.tokenize(source_lines[backtrace_location.lineno - 1])
-          new_first_column = find_offset(spot[:snippet], tokens, spot[:first_column])
-          lineno_delta = spot[:first_lineno] - backtrace_location.lineno
+          lineno_delta = find_lineno_offset(compiled, source_lines, highlight, spot[:first_lineno])
+
+          tokens = ::ERB::Util.tokenize(source_lines[spot[:first_lineno] - lineno_delta - 1])
+          column_delta = find_offset(spot[:snippet], tokens, spot[:first_column])
+
           spot[:first_lineno] -= lineno_delta
           spot[:last_lineno] -= lineno_delta
-
-          column_delta = spot[:first_column] - new_first_column
           spot[:first_column] -= column_delta
           spot[:last_column] -= column_delta
           spot[:script_lines] = source_lines
@@ -107,6 +109,28 @@ module ActionView
           raise WrongEncodingError.new(string, string.encoding)
         end
 
+        # Return the offset between the error lineno and the source lineno.
+        # Searches in reverse from the backtrace lineno so we have a better
+        # chance of finding the correct line
+        #
+        # The compiled template is likely to be longer than the source.
+        # Use the difference between the compiled and source sizes to
+        # determine the earliest line that could contain the highlight.
+        def find_lineno_offset(compiled, source_lines, highlight, error_lineno)
+          first_index = error_lineno - 1 - compiled.size + source_lines.size
+          first_index = 0 if first_index < 0
+
+          last_index = error_lineno - 1
+          last_index = source_lines.size - 1 if last_index >= source_lines.size
+
+          last_index.downto(first_index) do |line_index|
+            next unless source_lines[line_index].include?(highlight)
+            return error_lineno - 1 - line_index
+          end
+
+          raise LocationParsingError, "Couldn't find code snippet"
+        end
+
         # Find which token in the source template spans the byte range that
         # contains the error_column, then return the offset compared to the
         # original source template.
@@ -137,7 +161,7 @@ module ActionView
                 matched_str = true
 
                 if name == :CODE && compiled.pos <= error_column && compiled.pos + str.bytesize >= error_column
-                  return error_column - compiled.pos + offset
+                  return compiled.pos - offset
                 end
 
                 compiled.pos += str.bytesize

--- a/actionview/test/template/template_test.rb
+++ b/actionview/test/template/template_test.rb
@@ -67,8 +67,8 @@ class TestERBTemplate < ActiveSupport::TestCase
 
   def spot_highlight(compiled, highlight, first_column: nil, **options)
     # rindex by default since our tests usually put the highlight last
-    first_column ||= compiled.rindex(highlight) || 999
-    last_column = first_column + highlight.size
+    first_column ||= compiled.byterindex(highlight) || 999
+    last_column = first_column + highlight.bytesize
     spot = {
       first_column:, last_column:, snippet: compiled,
       first_lineno: 1, last_lineno: 1, script_lines: compiled.lines,
@@ -332,51 +332,35 @@ class TestERBTemplate < ActiveSupport::TestCase
     source = "<%= nomethoderror %>"
     compiled = "'.freeze; @output_buffer.append=  nomethoderror ; @output_buffer.safe_append='\n"
 
-    backtrace_location = Data.define(:lineno).new(lineno: 1)
     spot = spot_highlight(compiled, highlight)
     expected = spot_highlight(source, highlight, snippet: compiled)
 
-    assert_equal expected, new_template(source).translate_location(backtrace_location, spot)
+    assert_equal expected, new_template(source).translate_location(nil, spot)
   end
 
-  # merely tests for the case where the backtrace and spot disagree about lineno
-  def test_template_translate_location_lineno_offset
-    highlight = "nomethoderror"
-    source = "<%= nomethoderror %>"
-    compiled = "'.freeze; @output_buffer.append=  nomethoderror ; @output_buffer.safe_append='"
-
-    backtrace_location = Data.define(:lineno).new(lineno: 1)
-    spot = spot_highlight(compiled, highlight, first_lineno: 2, last_lineno: 2)
-    expected = spot_highlight(source, highlight, snippet: compiled)
-
-    assert_equal expected, new_template(source).translate_location(backtrace_location, spot)
-  end
-
-  # We are testing the failure case here. `find_offset` doesn't correctly handle the case
-  # where the line number is not the same in the backtrace and template.
   def test_template_translate_location_with_multiline_code_source
     highlight = "nomethoderror"
     source = "<%=\ngood(\n nomethoderror\n) %>"
     extracted_line = " nomethoderror\n"
-    compiled = "ValidatedOutputBuffer.wrap(@output_buffer, ({}), ' \ngood(\n nomethoderror\n" \
-               ") '.freeze, true).safe_none_append=( \ngood(\n nomethoderror\n) );\n@output_buffer"
+    compiled = "ValidatedOutputBuffer.wrap(@output_buffer, ({}), '\ngood(\n nomethoderror\n) '.freeze, true).safe_none_append=(\ngood(\n nomethoderror\n) );\n@output_buffer"
 
-    backtrace_location = Data.define(:lineno).new(lineno: 6)
     spot = spot_highlight(compiled, highlight, first_column: 1, first_lineno: 6, last_lineno: 6, snippet: extracted_line)
+    expected = spot_highlight(source, highlight, first_column: 1, first_lineno: 3, last_lineno: 3, snippet: extracted_line)
 
-    assert_equal spot, new_template(source).translate_location(backtrace_location, spot)
+    assert_equal expected, new_template(source).translate_location(nil, spot)
   end
 
   def test_template_translate_location_with_multibye_string_before_highlight
-    highlight = "nomethoderror"
-    source = String.new("\u{a5}<%= nomethoderror %>", encoding: Encoding::UTF_8) # yen symbol
-    compiled = String.new("\u{a5}'.freeze; @output_buffer.append=  nomethoderror ; @output_buffer.safe_append='\n", encoding: Encoding::UTF_8)
+    highlight = "nope"
+    # ensure the byte offset is enough to make us miss the highlight if wrong
+    multibyte = String.new("\u{a5}\u{a5}\u{a5}\u{a5}\u{a5}\u{a5}\u{a5}", encoding: Encoding::UTF_8) # yen symbol
+    source = "#{multibyte}<%= nope %>"
+    compiled = "#{multibyte}'.freeze; @output_buffer.append=  nope ; @output_buffer.safe_append='\n"
 
-    backtrace_location = Data.define(:lineno).new(lineno: 1)
     spot = spot_highlight(compiled, highlight)
     expected = spot_highlight(source, highlight, snippet: compiled)
 
-    assert_equal expected, new_template(source).translate_location(backtrace_location, spot)
+    assert_equal expected, new_template(source).translate_location(nil, spot)
   end
 
   def test_template_translate_location_no_match_in_compiled
@@ -384,10 +368,9 @@ class TestERBTemplate < ActiveSupport::TestCase
     source = "<%= nomatch %>"
     compiled = "this source does not contain the highlight, so the original spot is returned"
 
-    backtrace_location = Data.define(:lineno).new(lineno: 1)
     spot = spot_highlight(compiled, highlight, first_column: 50)
 
-    assert_equal spot, new_template(source).translate_location(backtrace_location, spot)
+    assert_equal spot, new_template(source).translate_location(nil, spot)
   end
 
   def test_template_translate_location_text_includes_highlight
@@ -395,11 +378,10 @@ class TestERBTemplate < ActiveSupport::TestCase
     source = " nomethoderror <%= nomethoderror %>"
     compiled = " nomethoderror '.freeze; @output_buffer.append=  nomethoderror ; @output_buffer.safe_append='\n"
 
-    backtrace_location = Data.define(:lineno).new(lineno: 1)
     spot = spot_highlight(compiled, highlight)
     expected = spot_highlight(source, highlight, snippet: compiled)
 
-    assert_equal expected, new_template(source).translate_location(backtrace_location, spot)
+    assert_equal expected, new_template(source).translate_location(nil, spot)
   end
 
   def test_template_translate_location_space_separated_erb_tags
@@ -407,11 +389,10 @@ class TestERBTemplate < ActiveSupport::TestCase
     source = "<%= goodcode %> <%= nomethoderror %>"
     compiled = "'.freeze; @output_buffer.append=  goodcode ; @output_buffer.safe_append=' '.freeze; @output_buffer.append=  nomethoderror ; @output_buffer.safe_append='\n"
 
-    backtrace_location = Data.define(:lineno).new(lineno: 1)
     spot = spot_highlight(compiled, highlight)
     expected = spot_highlight(source, highlight, snippet: compiled)
 
-    assert_equal expected, new_template(source).translate_location(backtrace_location, spot)
+    assert_equal expected, new_template(source).translate_location(nil, spot)
   end
 
   def test_template_translate_location_consecutive_erb_tags
@@ -419,11 +400,10 @@ class TestERBTemplate < ActiveSupport::TestCase
     source = "<%= goodcode %><%= nomethoderror %>"
     compiled = "'.freeze; @output_buffer.append=  goodcode ; @output_buffer.append=  nomethoderror ; @output_buffer.safe_append='\n"
 
-    backtrace_location = Data.define(:lineno).new(lineno: 1)
     spot = spot_highlight(compiled, highlight)
     expected = spot_highlight(source, highlight, snippet: compiled)
 
-    assert_equal expected, new_template(source).translate_location(backtrace_location, spot)
+    assert_equal expected, new_template(source).translate_location(nil, spot)
   end
 
   def test_template_translate_location_repeated_highlight_in_compiled_template
@@ -431,11 +411,10 @@ class TestERBTemplate < ActiveSupport::TestCase
     source = "<%= nomethoderror %>"
     compiled = "ValidatedOutputBuffer.wrap(@output_buffer, ({}), ' nomethoderror '.freeze, true).safe_none_append=  nomethoderror ; @output_buffer.safe_append='\n"
 
-    backtrace_location = Data.define(:lineno).new(lineno: 1)
     spot = spot_highlight(compiled, highlight)
     expected = spot_highlight(source, highlight, snippet: compiled)
 
-    assert_equal expected, new_template(source).translate_location(backtrace_location, spot)
+    assert_equal expected, new_template(source).translate_location(nil, spot)
   end
 
   def test_template_translate_location_flaky_pathological_template
@@ -443,10 +422,9 @@ class TestERBTemplate < ActiveSupport::TestCase
     source = "<%= flakymethod %> flakymethod <%= flakymethod " # fails on second call, no tailing %>
     compiled = "ValidatedOutputBuffer.wrap(@output_buffer, ({}), ' flakymethod '.freeze, true).safe_none_append=( flakymethod );@output_buffer.safe_append=' flakymethod '.freeze;ValidatedOutputBuffer.wrap(@output_buffer, ({}), ' flakymethod '.freeze, true).safe_none_append=( flakymethod "
 
-    backtrace_location = Data.define(:lineno).new(lineno: 1)
     spot = spot_highlight(compiled, highlight)
     expected = spot_highlight(source, highlight, snippet: compiled)
 
-    assert_equal expected, new_template(source).translate_location(backtrace_location, spot)
+    assert_equal expected, new_template(source).translate_location(nil, spot)
   end
 end

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Alter `ERB::Util.tokenize` to return :PLAIN token with full input string when string doesn't contain ERB tags.
+
+    *Martin Emde*
+
 *   Fix a bug in `ERB::Util.tokenize` that causes incorrect tokenization when ERB tags are preceeded by multibyte characters.
 
     *Martin Emde*

--- a/activesupport/lib/active_support/core_ext/erb/util.rb
+++ b/activesupport/lib/active_support/core_ext/erb/util.rb
@@ -169,7 +169,7 @@ class ERB
       while !source.eos?
         pos = source.pos
         source.scan_until(/(?:#{start_re}|#{finish_re})/)
-        raise NotImplementedError if source.matched.nil?
+        return [[:PLAIN, source.string]] unless source.matched?
         len = source.pos - source.matched.bytesize - pos
 
         case source.matched

--- a/activesupport/lib/active_support/syntax_error_proxy.rb
+++ b/activesupport/lib/active_support/syntax_error_proxy.rb
@@ -18,6 +18,9 @@ module ActiveSupport
 
       def label
       end
+
+      def base_label
+      end
     end
 
     class BacktraceLocationProxy < DelegateClass(Thread::Backtrace::Location) # :nodoc:

--- a/activesupport/test/core_ext/erb_util_test.rb
+++ b/activesupport/test/core_ext/erb_util_test.rb
@@ -135,6 +135,14 @@ module ActiveSupport
       ], actual_tokens
     end
 
+    # This happens when a template is multiline and no
+    # ERB tags are used on the current line.
+    def test_plain_without_tags
+      source = " @post.title\n"
+      actual_tokens = tokenize source
+      assert_equal [[:PLAIN, " @post.title"]], actual_tokens
+    end
+
     def test_multibyte_characters_start
       source = "こんにちは<%= name %>"
       actual_tokens = tokenize source


### PR DESCRIPTION
### Motivation / Background

Multi-line ERB tags can cause a shift in the line number of the compiled code vs the source template. Improve by finding the highlight to look for, then searching backwards from the error lineno until we find the code or exceed a reasonably likely position (further back than the difference between the compiled and source template size).

Additionally, improves highlighting when code is in a block in a template. Previously this prevented associating the error with the template, causing the backtrace builder to show the compiled source at best. Fixed by using `loc.base_label` instead of `loc.label` to associate backtrace with template, which is also apparently necessary to fix template highlighting in Ruby 3.4.

### Detail

This improves highlighting for templates like the following. Previously the highlighted couldn't find the line in the source because the backtrace line was wrong due to the multi-line tag:

```erb
<% link_to(
  name,
  not_a_method_path
) %>
```

More complex ones like this, where previously the presence of the block nesting, would cause the template to be unable to highlight failures within any block.

```erb
<% @members.each do |member| %>
  <% member.teams.each do |team| %>
    <%= oops_not_a_method %>
  <% end %>
<% end %>
```

I made this as 3 separate commits. Each of them work independently to improve error highlight, but since they all together make multi-line highlighting work better, I've included them all here.

Here it is actually highlighting like never before in dev:

<img width="667" alt="Screenshot 2024-11-27 at 11 31 56 AM" src="https://github.com/user-attachments/assets/4caa8a97-8ab8-48bb-8d05-80dfee71883e">

### Additional information

Includes an additional fix for #53655 (Multibyte character tokenization)
Related to #53657 (ActionView::Template::Handlers::ERB.find_offset improvements)
Actually fixes #53696 (Avoid crashing on multi-line templates) - now we highlight when we used to just avoid crashing.

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [X] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.