### PR TITLE
Fix formatting of Actionpack options docs [ci-skip]

### DIFF
--- a/actionpack/lib/action_controller/metal/data_streaming.rb
+++ b/actionpack/lib/action_controller/metal/data_streaming.rb
@@ -28,7 +28,8 @@ module ActionController # :nodoc:
       # `send_file(params[:path])` allows a malicious user to download any file on
       # your server.
       #
-      # Options:
+      # #### Options:
+      #
       # *   `:filename` - suggests a filename for the browser to use. Defaults to
       #     `File.basename(path)`.
       # *   `:type` - specifies an HTTP content type. You can specify either a string
@@ -90,7 +91,8 @@ module ActionController # :nodoc:
       # inline data. You may also set the content type, the file name, and other
       # things.
       #
-      # Options:
+      # #### Options:
+      #
       # *   `:filename` - suggests a filename for the browser to use.
       # *   `:type` - specifies an HTTP content type. Defaults to
       #     `application/octet-stream`. You can specify either a string or a symbol

--- a/actionpack/lib/action_controller/metal/live.rb
+++ b/actionpack/lib/action_controller/metal/live.rb
@@ -326,7 +326,8 @@ module ActionController
     # or other running data where you don't want the entire file buffered in memory
     # first. Similar to send_data, but where the data is generated live.
     #
-    # Options:
+    # #### Options:
+    #
     # *   `:filename` - suggests a filename for the browser to use.
     # *   `:type` - specifies an HTTP content type. You can specify either a string
     #     or a symbol for a registered type with `Mime::Type.register`, for example


### PR DESCRIPTION
This was probably missed with the conversion to markdown.

### Before

<img width="1004" alt="image" src="https://github.com/user-attachments/assets/5ea39ad3-6e0d-4996-84a4-31bac69de792">

### After

<img width="989" alt="image" src="https://github.com/user-attachments/assets/e0637d67-b669-44be-9525-3334aac72c75">

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
