### PR TITLE
Raise a more specific error when the job class can't be instantiated

### DIFF
--- a/activejob/CHANGELOG.md
+++ b/activejob/CHANGELOG.md
@@ -1,2 +1,9 @@
+*   Raise a more specific error during deserialization when a previously serialized job class is now unknown.
+
+    `ActiveJob::UnknownJobClassError` will be raised instead of a more generic
+    `NameError` to make it easily possible for adapters to tell if the `NameError`
+    was raised during job execution or deserialization.
+
+    *Earlopain*
 
 Please check [8-0-stable](https://github.com/rails/rails/blob/8-0-stable/activejob/CHANGELOG.md) for previous changes.

--- a/activejob/lib/active_job.rb
+++ b/activejob/lib/active_job.rb
@@ -39,6 +39,7 @@ module ActiveJob
   autoload :Arguments
   autoload :DeserializationError, "active_job/arguments"
   autoload :SerializationError, "active_job/arguments"
+  autoload :UnknownJobClassError, "active_job/core"
   autoload :EnqueueAfterTransactionCommit
 
   eager_autoload do

--- a/activejob/test/cases/job_serialization_test.rb
+++ b/activejob/test/cases/job_serialization_test.rb
@@ -38,6 +38,17 @@ class JobSerializationTest < ActiveSupport::TestCase
     assert_equal h2.serialize, h3.serialize
   end
 
+  test "deserialize raises a specific exception on unknown `job_class`" do
+    payload = HelloJob.new.serialize
+
+    # Simulate the job class being missing, for example during rolling deploys when
+    # the server enqueues a new job but the job processor hasn't been restarted yet.
+    payload["job_class"] = "IDontExist"
+    assert_raises(ActiveJob::UnknownJobClassError) do
+      HelloJob.deserialize(payload)
+    end
+  end
+
   test "deserialize sets locale" do
     job = HelloJob.new
     job.deserialize "locale" => "es"


### PR DESCRIPTION
### Motivation / Background

During a rolling deploy, jobs maybe be enqueued that the job processor doesn't know about yet. Currently it's not easily possible for an adapter to know if the exception originated from user code or not.

The same can happen in the other direction of course (job got enqueued and new codebase doesn't contain it anymore), this just allows adapters to decide on what happens.

### Detail

Add a new exception to raise that inherits from `NameError` for compatibility.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
