### PR TITLE
Skip generation system tests related code for CI when `--skip-system-test` is given

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/github/ci.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/github/ci.yml.tt
@@ -126,12 +126,12 @@ jobs:
           DATABASE_URL: postgres://postgres:postgres@localhost:5432
           <%- end -%>
           # REDIS_URL: redis://localhost:6379/0
-        <%- if options[:api] -%>
+        <%- if options[:api] || options[:skip_system_test] -%>
         run: bin/rails db:test:prepare test
         <%- else -%>
         run: bin/rails db:test:prepare test test:system
         <%- end -%>
-      <%- unless options[:api] -%>
+      <%- unless options[:api] || options[:skip_system_test] -%>
 
       - name: Keep screenshots from failed system tests
         uses: actions/upload-artifact@v4

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -544,7 +544,9 @@ class AppGeneratorTest < Rails::Generators::TestCase
     assert_no_directory("test/system")
 
     assert_file ".github/workflows/ci.yml" do |content|
-      assert_no_match(/google-chrome-stable/, content)
+      assert_match(/db:test:prepare test/, content)
+      assert_no_match(/test:system/, content)
+      assert_no_match(/screenshots/, content)
     end
   end
 


### PR DESCRIPTION
Fixes #53774.