### PR TITLE
[ci-skip][docs] Fix result of sample code in strong parameter API doc

### DIFF
--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -621,7 +621,7 @@ module ActionController
     #     })
     #
     #     params.permit(person: :contact).require(:person)
-    #     # => #<ActionController::Parameters {} permitted: true>
+    #     # => ActionController::ParameterMissing: param is missing or the value is empty or invalid: person
     #
     #     params.permit(person: { contact: :phone }).require(:person)
     #     # => #<ActionController::Parameters {"contact"=>#<ActionController::Parameters {"phone"=>"555-1234"} permitted: true>} permitted: true>


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because I found that the following result in strong parameters' API doc does not match the actual behaviors and the description above. 

```ruby
# https://github.com/rails/rails/blob/main/actionpack/lib/action_controller/metal/strong_parameters.rb#L623
params.permit(person: :contact).require(:person)
# => #<ActionController::Parameters {} permitted: true>
```

The actual behavior in rails console is as follows:

```irb
# actual behavior in Rails 8 and 7.2:
rails8app(dev)> params.permit(person: :contact).require(:person)
(rails8app):9:in `<main>': param is missing or the value is empty or invalid: person (ActionController::ParameterMissing)
```

In addition, the description for the sample codes says as follows, so I guess the sample codes should've shown that one of the three the cases will not be allowed.

> Note that if you use permit in a key that points to a hash, it won’t allow all the hash. You also need to specify which attributes inside the hash should be permitted.

@martinemde I'd be glad if you'd kindly check this PR is valid or not 🙏

### Detail

This Pull Request just changes the result of `params.permit(person: :contact).require(:person)` as follows:

```diff
-    #     # => #<ActionController::Parameters {} permitted: true>
+    #     # => ActionController::ParameterMissing: param is missing or the value is empty or invalid: person
```

### Additional information

FYI: Omitting the trailing `require` results the following, but I guess this might not be intended and recommended.

```irb
rails8app(dev)> params.permit(person: :contact)
=> #<ActionController::Parameters {"person"=>#<ActionController::Parameters {} permitted: true>} permitted: true>
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
