### PR TITLE
Make ActiveJob tests runnable with `bin/test` again

### DIFF
--- a/activejob/test/cases/async_adapter_test.rb
+++ b/activejob/test/cases/async_adapter_test.rb
@@ -1,8 +1,9 @@
 # frozen_string_literal: true
 
 require "helper"
-require "active_job/queue_adapters/async_adapter"
 require "jobs/hello_job"
+
+return unless adapter_is?(:async)
 
 class AsyncAdapterTest < ActiveSupport::TestCase
   setup do

--- a/activejob/test/cases/delayed_job_adapter_test.rb
+++ b/activejob/test/cases/delayed_job_adapter_test.rb
@@ -1,9 +1,10 @@
 # frozen_string_literal: true
 
 require "helper"
-require "active_job/queue_adapters/delayed_job_adapter"
 require "jobs/disable_log_job"
 require "jobs/hello_job"
+
+return unless adapter_is?(:delayed_job)
 
 class DelayedJobAdapterTest < ActiveSupport::TestCase
   test "does not log arguments when log_arguments is set to false on a job" do

--- a/activejob/test/integration/queuing_test.rb
+++ b/activejob/test/integration/queuing_test.rb
@@ -6,6 +6,8 @@ require "jobs/hello_job"
 require "jobs/provider_jid_job"
 require "active_support/core_ext/numeric/time"
 
+return unless ENV["AJ_INTEGRATION_TESTS"] == "1"
+
 class QueuingTest < ActiveSupport::TestCase
   test "should run jobs enqueued on a listening queue" do
     TestJob.perform_later @id


### PR DESCRIPTION
A few things:
* Removal of `delayed_job` in the `Gemfile` causes a load error. CI is fine since this file is filtered out in the rake task
* The async adapter test assumes the async adapter to be present. Again not a problem on CI, but the default is the inline adapter
* Integration tests are run, they reference a job that is present only in the dummy app

`bin/test` is the documented mechanism for running tests of a single component: https://guides.rubyonrails.org/contributing_to_ruby_on_rails.html#for-a-particular-component