### PR TITLE
`AR::Middleware::ShardSelector` support for granular database connection switching

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,19 @@
+*   `ActiveRecord::Middleware::ShardSelector` supports granular database connection switching.
+
+    A new configuration option, `class_name:`, is introduced to
+    `config.active_record.shard_selector` to allow an application to specify the abstract connection
+    class to be switched by the shard selection middleware. The default class is
+    `ActiveRecord::Base`.
+
+    For example, this configuration tells `ShardSelector` to switch shards using
+    `AnimalsRecord.connected_to`:
+
+    ```
+    config.active_record.shard_selector = { class_name: "AnimalsRecord" }
+    ```
+
+    *Mike Dalessio*
+
 *   Reset relations after `insert_all`/`upsert_all`.
 
     Bulk insert/upsert methods will now call `reset` if used on a relation, matching the behavior of `update_all`.

--- a/activerecord/test/cases/shard_selector_test.rb
+++ b/activerecord/test/cases/shard_selector_test.rb
@@ -41,5 +41,38 @@ module ActiveRecord
 
       assert_equal [200, {}, ["body"]], middleware.call("REQUEST_METHOD" => "GET")
     end
+
+    def test_middleware_can_do_granular_database_connection_switching
+      klass = Class.new(ActiveRecord::Base) do |k|
+        class << self
+          attr_reader :connected_to_shard
+
+          def connected_to(shard:)
+            @connected_to_shard = shard
+            yield
+          end
+
+          def prohibit_shard_swapping(...)
+            yield
+          end
+
+          def connected_to?(role: nil, shard:)
+            @connected_to_shard.to_sym == shard.to_sym
+          end
+        end
+      end
+      Object.const_set :ShardSelectorTestModel, klass
+
+      middleware = ActiveRecord::Middleware::ShardSelector.new(lambda { |env|
+        assert_not ActiveRecord::Base.connected_to?(role: :writing, shard: :shard_one)
+        assert klass.connected_to?(role: :writing, shard: :shard_one)
+        [200, {}, ["body"]]
+      }, ->(*) { :shard_one }, { class_name: "ShardSelectorTestModel" })
+
+      assert_equal [200, {}, ["body"]], middleware.call("REQUEST_METHOD" => "GET")
+      assert_equal(:shard_one, klass.connected_to_shard)
+    ensure
+      Object.send(:remove_const, :ShardSelectorTestModel)
+    end
   end
 end


### PR DESCRIPTION
### Motivation / Background

Rails's horizontal sharding is supported on non-primary databases. However, the `ShardSelector` middleware only supports global shard switching using `ActiveRecord::Base.connected_to`.

This PR introduces a configuration option `class_name:` that allows `ShardSelector` to be used for granular switching on a specific abstract connection class.

Also this PR updates the "Multiple Databases" guide and generally improves the `ShardSelector` documentation.

### Detail

Adds a `class_name:` configuration option to `ShardSelector` to override the abstract connection class used for switching.

It takes a class _name_ instead of a class because the shard selector must be configured in the application configuration which is likely to be run before model classes have been loaded.

### Additional information

I could have added some logic to cache the class once constantized, but figured that could be a separate PR (since the `lock:` option could also be cached) and kept this change as slim as possible.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
