### PR TITLE
Use `_N` as a parallel tests databases suffixes

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Use `_N` as a parallel tests databases suffixes
+
+    Peviously, `-N` was used as a suffix. This can cause problems for RDBMSes
+    which do not support dashes in database names.
+
+    *fatkodima*
+
 *   Remember when a database connection has recently been verified (for
     two seconds, by default), to avoid repeated reverifications during a
     single request.

--- a/activerecord/lib/active_record/test_databases.rb
+++ b/activerecord/lib/active_record/test_databases.rb
@@ -12,7 +12,7 @@ module ActiveRecord
       old, ENV["VERBOSE"] = ENV["VERBOSE"], "false"
 
       ActiveRecord::Base.configurations.configs_for(env_name: env_name).each do |db_config|
-        db_config._database = "#{db_config.database}-#{i}"
+        db_config._database = "#{db_config.database}_#{i}"
 
         ActiveRecord::Tasks::DatabaseTasks.reconstruct_from_schema(db_config, ActiveRecord.schema_format, nil)
       end

--- a/activerecord/test/cases/test_databases_test.rb
+++ b/activerecord/test/cases/test_databases_test.rb
@@ -14,7 +14,7 @@ class TestDatabasesTest < ActiveRecord::TestCase
       }
 
       base_db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", name: "primary")
-      expected_database = "#{base_db_config.database}-2"
+      expected_database = "#{base_db_config.database}_2"
 
       ActiveRecord::Tasks::DatabaseTasks.stub(:reconstruct_from_schema, ->(db_config, _, _) {
         assert_equal expected_database, db_config.database
@@ -37,7 +37,7 @@ class TestDatabasesTest < ActiveRecord::TestCase
 
       idx = 42
       base_db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", name: "primary")
-      expected_database = "#{base_db_config.database}-#{idx}"
+      expected_database = "#{base_db_config.database}_#{idx}"
 
       ActiveRecord::Tasks::DatabaseTasks.stub(:reconstruct_from_schema, ->(db_config, _, _) {
         assert_equal expected_database, db_config.database

--- a/activesupport/lib/active_support/test_case.rb
+++ b/activesupport/lib/active_support/test_case.rb
@@ -52,8 +52,8 @@ module ActiveSupport
       # is forked. For each process a new database will be created suffixed
       # with the worker number.
       #
-      #   test-database-0
-      #   test-database-1
+      #   test-database_0
+      #   test-database_1
       #
       # If <tt>ENV["PARALLEL_WORKERS"]</tt> is set the workers argument will be ignored
       # and the environment variable will be used instead. This is useful for CI

--- a/guides/source/testing.md
+++ b/guides/source/testing.md
@@ -589,7 +589,7 @@ $ PARALLEL_WORKERS=15 bin/rails test
 
 When parallelizing tests, Active Record automatically handles creating a database and loading the schema into the database for each
 process. The databases will be suffixed with the number corresponding to the worker. For example, if you
-have 2 workers the tests will create `test-database-0` and `test-database-1` respectively.
+have 2 workers the tests will create `test-database_0` and `test-database_1` respectively.
 
 If the number of workers passed is 1 or fewer the processes will not be forked and the tests will not
 be parallelized and they will use the original `test-database` database.


### PR DESCRIPTION
Fixes #53780 (see there for a discussion).

We can even skip using `-` or `_` and just use a `db_name0`, `db_name1` naming pattern etc (like in https://github.com/grosser/parallel_tests).