### PR TITLE
Document `ActiveSupport::Configurable` class methods [ci skip]

### DIFF
--- a/activesupport/lib/active_support/configurable.rb
+++ b/activesupport/lib/active_support/configurable.rb
@@ -27,6 +27,19 @@ module ActiveSupport
     end
 
     module ClassMethods
+      # Reads and writes attributes from a configuration OrderedOptions.
+      #
+      #   require "active_support/configurable"
+      #
+      #   class User
+      #     include ActiveSupport::Configurable
+      #   end
+      #
+      #   User.config.allowed_access = true
+      #   User.config.level = 1
+      #
+      #   User.config.allowed_access # => true
+      #   User.config.level          # => 1
       def config
         @_config ||= if respond_to?(:superclass) && superclass.respond_to?(:config)
           superclass.config.inheritable_copy
@@ -36,6 +49,21 @@ module ActiveSupport
         end
       end
 
+      # Configure values from within the passed block.
+      #
+      #   require "active_support/configurable"
+      #
+      #   class User
+      #     include ActiveSupport::Configurable
+      #   end
+      #
+      #   User.allowed_access # => nil
+      #
+      #   User.configure do |config|
+      #     config.allowed_access = true
+      #   end
+      #
+      #   User.allowed_access # => true
       def configure
         yield config
       end


### PR DESCRIPTION
### Detail

Add method-level documentation for the
`ActiveSupport::Configurable.configure` block method and `ActiveSupport::Configurable.config` attribute reader method.