### PR TITLE
Add CSP nonce to preload links

### DIFF
--- a/actionview/lib/action_view/helpers/asset_tag_helper.rb
+++ b/actionview/lib/action_view/helpers/asset_tag_helper.rb
@@ -127,6 +127,7 @@ module ActionView
             preload_link = "<#{href}>; rel=#{rel}; as=script"
             preload_link += "; crossorigin=#{crossorigin}" unless crossorigin.nil?
             preload_link += "; integrity=#{integrity}" unless integrity.nil?
+            preload_link += "; nonce=#{content_security_policy_nonce}" if options["nonce"] == true
             preload_link += "; nopush" if nopush
             preload_links << preload_link
           end
@@ -215,6 +216,7 @@ module ActionView
             preload_link = "<#{href}>; rel=preload; as=style"
             preload_link += "; crossorigin=#{crossorigin}" unless crossorigin.nil?
             preload_link += "; integrity=#{integrity}" unless integrity.nil?
+            preload_link += "; nonce=#{content_security_policy_nonce}" if options["nonce"] == true
             preload_link += "; nopush" if nopush
             preload_links << preload_link
           end
@@ -362,6 +364,13 @@ module ActionView
         integrity = options[:integrity]
         nopush = options.delete(:nopush) || false
         rel = mime_type == "module" ? "modulepreload" : "preload"
+        add_nonce = content_security_policy_nonce &&
+          respond_to?(:request) &&
+          request.content_security_policy_nonce_directives&.include?("#{as_type}-src")
+
+        if add_nonce
+          options[:nonce] = content_security_policy_nonce
+        end
 
         link_tag = tag.link(
           rel: rel,
@@ -375,6 +384,7 @@ module ActionView
         preload_link += "; type=#{mime_type}" if mime_type
         preload_link += "; crossorigin=#{crossorigin}" if crossorigin
         preload_link += "; integrity=#{integrity}" if integrity
+        preload_link += "; nonce=#{content_security_policy_nonce}" if add_nonce
         preload_link += "; nopush" if nopush
 
         send_preload_links_header([preload_link])


### PR DESCRIPTION
Preload link tags need the CSP nonce added if the policy is configured with a nonce, otherwise browsers won't load these resources. At least Chrome also requires the nonce attribute in the HTTP Link header.

### Motivation / Background

This change fixes fixes CSP resource loading issues related to preload links (in the document via `<link>` tags or in the HTTP `Link` header field).
When scripts or styles require a nonce to be included, browsers will refuse to preload these resources unless the `nonce` attribute is set correctly.

### Additional information

See e.g. https://issues.chromium.org/issues/41308002 - Chrome at some point didn't handle the `nonce` attribute in link elements/headers, which led to CSP violations.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why.
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
