### PR TITLE
Fix add_unique_constraint/add_check_constraint/add_foreign_key to be revertible when given invalid options

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
@@ -159,6 +159,8 @@ module ActiveRecord
       end
 
       def defined_for?(to_table: nil, validate: nil, **options)
+        options = options.slice(*self.options.keys)
+
         (to_table.nil? || to_table.to_s == self.to_table) &&
           (validate.nil? || validate == self.options.fetch(:validate, validate)) &&
           options.all? { |k, v| Array(self.options[k]).map(&:to_s) == Array(v).map(&:to_s) }
@@ -185,6 +187,8 @@ module ActiveRecord
       end
 
       def defined_for?(name:, expression: nil, validate: nil, **options)
+        options = options.slice(*self.options.keys)
+
         self.name == name.to_s &&
           (validate.nil? || validate == self.options.fetch(:validate, validate)) &&
           options.all? { |k, v| self.options[k].to_s == v.to_s }

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_definitions.rb
@@ -232,6 +232,8 @@ module ActiveRecord
         end
 
         def defined_for?(name: nil, column: nil, **options)
+          options = options.slice(*self.options.keys)
+
           (name.nil? || self.name == name.to_s) &&
             (column.nil? || Array(self.column) == Array(column).map(&:to_s)) &&
             options.all? { |k, v| self.options[k].to_s == v.to_s }

--- a/activerecord/lib/active_record/connection_adapters/sqlite3/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3/schema_statements.rb
@@ -75,6 +75,7 @@ module ActiveRecord
               Base.pluralize_table_names ? table.pluralize : table
             end
             table = strip_table_name_prefix_and_suffix(table)
+            options = options.slice(*fk.options.keys)
             fk_to_table = strip_table_name_prefix_and_suffix(fk.to_table)
             fk_to_table == table && options.all? { |k, v| fk.options[k].to_s == v.to_s }
           end || raise(ArgumentError, "Table '#{from_table}' has no foreign key for #{to_table || options}")


### PR DESCRIPTION
Fixes #52419.
Closes #52903 (added author as coauthor).

Currently, `add_unique_constraint`/`add_check_constraint`/`add_foreign_key` methods ignore invalid options and successfully create the constraints. But it fails with "constraint not found" error when trying to revert migrations containing these. This is annoying. So this PR fixes that.