### PR TITLE
Add `ActiveSupport::Configurable.config=` writer

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,18 @@
+*   Add `ActiveSupport::Configurable.config=` writer
+
+    ```ruby
+    class User
+      include ActiveSupport::Configurable
+    end
+
+    User.config = { allowed_access: true, level: 1 }
+
+    User.config.allowed_access # => true
+    User.config.level          # => 1
+    ```
+
+    *Sean Doyle*
+
 *   Alter `ERB::Util.tokenize` to return :PLAIN token with full input string when string doesn't contain ERB tags.
 
     *Martin Emde*

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -4031,6 +4031,34 @@ development:
 Rails.application.config_for(:example)[:foo][:bar] #=> { baz: 1, qux: 2 }
 ```
 
+Classes can include [ActiveSupport::Configurable](https://api.rubyonrails.org/classes/ActiveSupport/Configurable.html) to add class-level and instance-level access to a configuration object.
+
+```ruby
+class Payment
+  include ActiveSupport::Configurable
+end
+
+Payment.config.environment = "development"
+
+Payment.config.environment # => "development"
+
+payment = Payment.new
+
+payment.config.environment # => "development"
+```
+
+Classes that include `ActiveSupport::Configurable` also support writing
+configurations loaded from `Rails::Application.config_for`:
+
+```ruby
+Payment.config = Rails::Application.config_for(:payment)
+
+Payment.config.environment  # => "development"
+Payment.config.merchant_id  # => "development_merchant_id"
+Payment.config.public_key   # => "development_public_key"
+Payment.config.private_key  # => "development_private_key"
+```
+
 Search Engines Indexing
 -----------------------
 


### PR DESCRIPTION
### Motivation / Background

The absence of direct `#config=` assignment methods as class and instance methods can be surprising.

In order to extend or override class- and instance-level configurations made available through the [ActiveSupport::Configurable](https://edgeapi.rubyonrails.org/classes/ActiveSupport/Configurable.html), applications can iterate over the new values and assign them directly:

```ruby
new_configurations.each do |name, value|
  User.config[name] = value
end
```

Alternatively, applications can call `ActiveSupport::OrderedOptions#merge!` or combine both `ActiveSupport::OrderedOptions#clear!` and `#merge!`:

```ruby
# to combine configurations
User.config.merge!(new_configurations)

# to reset and override configurations
User.config.clear!
User.config.merge!(new_configurations)
```

### Detail

This commit introduces class- and instance-level `#config=` writer methods to create entirely new configurations from the provided values. The methods are designed to load values from instances of InheritableOptions, OrderedOptions, or Hash into the configuration.

```ruby
require "active_support/configurable"

class User
  include ActiveSupport::Configurable
end

User.config = { allowed_access: true, level: 1 }

user = User.new

user.config.allowed_access # => true
user.config.level          # => 1
```

Supports assigning configurations read via
[Rails::Application#config_for](https://edgeapi.rubyonrails.org/classes/Rails/Application.html#method-i-config_for). For example, consider the following YAML file:

```yaml
 # config/users.yml
shared:
  allowed_access: true
  level: 1
```

Configuration values read via the [Rails::Application#config_for](https://edgeapi.rubyonrails.org/classes/Rails/Application.html#method-i-config_for) can be assigned directly:

```ruby
User.config = Rails.application.config_for(:users)

User.config.allowed_access # => true
User.config.level # => 1
```

This commit also includes additional guidance in the [Custom Configuration](https://guides.rubyonrails.org/configuring.html#custom-configuration) heading of the _Configuring Rails Applications_ Guides Page to mention [ActiveSupport::Configurable](https://edgeapi.rubyonrails.org/classes/ActiveSupport/Configurable.html#method-i-config).

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
