### PR TITLE
Introduce versions formatter for the schema dumper

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,14 @@
+*   Introduce versions formatter for the schema dumper.
+
+    It is now possible to override how schema dumper formats versions information inside the
+    `structure.sql` file. Currently, the versions are simply sorted in the decreasing order.
+    Within large teams, this can potentially cause many merge conflicts near the top of the list.
+
+    Now, the custom formatter can be provided with a custom sorting logic (e.g. by hash values
+    of the versions), which can greatly reduce the number of conflicts.
+
+    *fatkodima*
+
 *   Serialized attributes can now be marked as comparable.
 
     A not rare issue when working with serialized attributes is that the serialized representation of an object

--- a/activerecord/lib/active_record.rb
+++ b/activerecord/lib/active_record.rb
@@ -404,6 +404,12 @@ module ActiveRecord
   self.migration_strategy = Migration::DefaultStrategy
 
   ##
+  # :singleton-method: schema_versions_formatter
+  # Specify the formatter used by schema dumper to format versions information.
+  singleton_class.attr_accessor :schema_versions_formatter
+  self.schema_versions_formatter = Migration::DefaultSchemaVersionsFormatter
+
+  ##
   # :singleton-method: dump_schema_after_migration
   # Specify whether schema dump should happen at the end of the
   # bin/rails db:migrate command. This is true by default, which is useful for the

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -1353,7 +1353,7 @@ module ActiveRecord
         execute schema_creation.accept(at)
       end
 
-      def dump_schema_information # :nodoc:
+      def dump_schema_versions # :nodoc:
         versions = pool.schema_migration.versions
         insert_versions_sql(versions) if versions.any?
       end
@@ -1876,16 +1876,8 @@ module ActiveRecord
         end
 
         def insert_versions_sql(versions)
-          sm_table = quote_table_name(pool.schema_migration.table_name)
-
-          if versions.is_a?(Array)
-            sql = +"INSERT INTO #{sm_table} (version) VALUES\n"
-            sql << versions.reverse.map { |v| "(#{quote(v)})" }.join(",\n")
-            sql << ";"
-            sql
-          else
-            "INSERT INTO #{sm_table} (version) VALUES (#{quote(versions)});"
-          end
+          versions_formatter = ActiveRecord.schema_versions_formatter.new(self)
+          versions_formatter.format(versions)
         end
 
         def data_source_sql(name = nil, type: nil)

--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -571,6 +571,7 @@ module ActiveRecord
   class Migration
     autoload :CommandRecorder, "active_record/migration/command_recorder"
     autoload :Compatibility, "active_record/migration/compatibility"
+    autoload :DefaultSchemaVersionsFormatter, "active_record/migration/default_schema_versions_formatter"
     autoload :JoinTable, "active_record/migration/join_table"
     autoload :ExecutionStrategy, "active_record/migration/execution_strategy"
     autoload :DefaultStrategy, "active_record/migration/default_strategy"

--- a/activerecord/lib/active_record/migration/default_schema_versions_formatter.rb
+++ b/activerecord/lib/active_record/migration/default_schema_versions_formatter.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module ActiveRecord
+  class Migration
+    # This class is used by the schema dumper to format versions information.
+    #
+    # The class receives the current +connection+ when initialized.
+    class DefaultSchemaVersionsFormatter # :nodoc:
+      def initialize(connection)
+        @connection = connection
+      end
+
+      def format(versions)
+        sm_table = connection.quote_table_name(connection.pool.schema_migration.table_name)
+
+        if versions.is_a?(Array)
+          sql = +"INSERT INTO #{sm_table} (version) VALUES\n"
+          sql << versions.reverse.map { |v| "(#{connection.quote(v)})" }.join(",\n")
+          sql << ";"
+          sql
+        else
+          "INSERT INTO #{sm_table} (version) VALUES (#{connection.quote(versions)});"
+        end
+      end
+
+      private
+        attr_reader :connection
+    end
+  end
+end

--- a/activerecord/lib/active_record/tasks/database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/database_tasks.rb
@@ -445,7 +445,7 @@ module ActiveRecord
           structure_dump(db_config, filename)
           if migration_connection_pool.schema_migration.table_exists?
             File.open(filename, "a") do |f|
-              f.puts migration_connection.dump_schema_information
+              f.puts migration_connection.dump_schema_versions
               f.print "\n"
             end
           end

--- a/activerecord/test/cases/schema_dumper_test.rb
+++ b/activerecord/test/cases/schema_dumper_test.rb
@@ -18,19 +18,19 @@ class SchemaDumperTest < ActiveRecord::TestCase
     @@standard_dump ||= dump_all_table_schema
   end
 
-  def test_dump_schema_information_with_empty_versions
+  def test_dump_schema_versions_with_empty_versions
     @schema_migration.delete_all_versions
-    schema_info = ActiveRecord::Base.lease_connection.dump_schema_information
+    schema_info = ActiveRecord::Base.lease_connection.dump_schema_versions
     assert_no_match(/INSERT INTO/, schema_info)
   end
 
-  def test_dump_schema_information_outputs_lexically_reverse_ordered_versions_regardless_of_database_order
+  def test_dump_schema_versions_outputs_lexically_reverse_ordered_versions_regardless_of_database_order
     versions = %w{ 20100101010101 20100201010101 20100301010101 }
     versions.shuffle.each do |v|
       @schema_migration.create_version(v)
     end
 
-    schema_info = ActiveRecord::Base.lease_connection.dump_schema_information
+    schema_info = ActiveRecord::Base.lease_connection.dump_schema_versions
     expected = <<~STR
     INSERT INTO #{quote_table_name("schema_migrations")} (version) VALUES
     ('20100301010101'),

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -1205,6 +1205,27 @@ end
 config.active_record.migration_strategy = CustomMigrationStrategy
 ```
 
+#### `config.active_record.schema_versions_formatter`
+
+Controls the formatter class used by schema dumper to format versions information. Custom class can be provided
+to change the default behavior:
+
+```ruby
+class CustomSchemaVersionsFormatter
+  def format(versions)
+    # Special sorting of versions to reduce the likelihood of conflicts.
+    sorted_versions = versions.sort { |a, b| b.to_s.reverse <=> a.to_s.reverse }
+
+    sql = +"INSERT INTO schema_migrations (version) VALUES\n"
+    sql << sorted_versions.map { |v| "(#{connection.quote(v)})" }.join(",\n")
+    sql << ";"
+    sql
+  end
+end
+
+config.active_record.schema_versions_formatter = CustomSchemaVersionsFormatter
+```
+
 #### `config.active_record.lock_optimistically`
 
 Controls whether Active Record will use optimistic locking and is `true` by default.


### PR DESCRIPTION
Follow up to #44363 (cc @ghiculescu).

Previously, the versions were sorted in decreasing order and new added to the top of the list. Within large-enough teams, this can cause many merge conflicts near the top of this list. Within my company, we have lots of developers pushing lots of schema changes and half of the time someone merges a PR, lots of existing PRs now have conflicts with the master.

Now, the versions are sorted by their reverse representations (`20241201183002` -> `20038110214202`), in decreasing (can be increasing, does not matter, but to be consistent with the previous implementation) order. This will greatly reduce the likelihood of merge conflicts as now new versions can be inserted at any place in the existing list. I did a simple calculation and while before we had a likelihood of conflict within a list of, say 5 top elements (20%), now - within a whole list of 600+ items (0.1%).

I also added a comment with reversed version representation for each version within dumped `structure.sql` file for people to more easily solve the merge conflicts. But we can remove this and add a comment at the top of the `INSERT` describing the algorithm.

For existing apps, there will be a large diff the next time `structure.sql` is generated.