### PR TITLE
Workaround for mysql2 prepared statements flaky test

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/mysql2/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql2/database_statements.rb
@@ -71,6 +71,12 @@ module ActiveRecord
                 ActiveSupport::Dependencies.interlock.permit_concurrent_loads do
                   result = stmt.execute(*type_casted_binds)
                   @affected_rows_before_warnings = stmt.affected_rows
+
+                  # Ref: https://github.com/brianmario/mysql2/pull/1383
+                  # by eagerly closing uncached prepared statements, we also reduce the chances of
+                  # that bug happening. It can still happen if `#execute` is used as we have no callback
+                  # to eagerly close the statement.
+                  result.instance_variable_set(:@_ar_stmt_to_close, stmt) if result && !prepare
                   result
                 end
               rescue ::Mysql2::Error
@@ -102,16 +108,33 @@ module ActiveRecord
             end
           end
 
-          def cast_result(result)
-            if result.nil? || result.fields.empty?
+          def cast_result(raw_result)
+            return ActiveRecord::Result.empty if raw_result.nil?
+
+            fields = raw_result.fields
+
+            result = if fields.empty?
               ActiveRecord::Result.empty
             else
-              ActiveRecord::Result.new(result.fields, result.to_a)
+              ActiveRecord::Result.new(fields, raw_result.to_a)
             end
+
+            free_raw_result(raw_result)
+
+            result
           end
 
-          def affected_rows(result)
+          def affected_rows(raw_result)
+            free_raw_result(raw_result) if raw_result
+
             @affected_rows_before_warnings
+          end
+
+          def free_raw_result(raw_result)
+            raw_result.free
+            if stmt = raw_result.instance_variable_get(:@_ar_stmt_to_close)
+              stmt.close
+            end
           end
       end
     end


### PR DESCRIPTION
Ref: https://github.com/brianmario/mysql2/pull/1383

The proper fix can only be upstream, however we can reduce the likeliness of hitting the bug by only calling `#affected_rows` when strictly necessary, meaning when we performed a query that didn't return a result set.

cc @zzak @matthewd @tenderlove 

NB: Maybe we should just not allow prepared statements with MySQL2 given they're very clearly broken, and only allow them once `mysql2` `0.5.7` is released and is the version in use, thoughts?