### PR TITLE
Ensure ActiveJob `enqueued_count` is an Integer

### DIFF
--- a/activejob/lib/active_job/log_subscriber.rb
+++ b/activejob/lib/active_job/log_subscriber.rb
@@ -50,7 +50,7 @@ module ActiveJob
       info do
         jobs = event.payload[:jobs]
         adapter = event.payload[:adapter]
-        enqueued_count = event.payload[:enqueued_count]
+        enqueued_count = event.payload[:enqueued_count].to_i
 
         if enqueued_count == jobs.size
           enqueued_jobs_message(adapter, jobs)

--- a/activejob/test/cases/logging_test.rb
+++ b/activejob/test/cases/logging_test.rb
@@ -369,6 +369,25 @@ class LoggingTest < ActiveSupport::TestCase
     assert_match(/Enqueued 3 jobs to .+ \(2 HelloJob, 1 LoggingJob\)/, @logger.messages)
   end
 
+  def test_enqueue_all_graceful_failure_when_enqueued_count_is_nil
+    original_adapter = ActiveJob::Base.queue_adapter
+
+    stubbed_inline_adapter = ActiveJob::QueueAdapters::InlineAdapter.new
+    def stubbed_inline_adapter.respond_to?(method_name, include_private = false)
+      method_name == :enqueue_all || super
+    end
+    def stubbed_inline_adapter.enqueue_all(*)
+      nil
+    end
+
+    ActiveJob::Base.queue_adapter = stubbed_inline_adapter
+
+    ActiveJob.perform_all_later(LoggingJob.new("Dummy"), HelloJob.new("Jamie"), HelloJob.new("John"))
+    assert_match(/Failed enqueuing 3 jobs to .+/, @logger.messages)
+  ensure
+    ActiveJob::Base.queue_adapter = original_adapter
+  end
+
   def test_enqueue_log_level
     @logger.level = WARN
     HelloJob.perform_later "Dummy"


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because of a bug whereby an ActiveJob adapter may return `nil` via [`enqueue_all`](https://github.com/rails/rails/blob/main/activejob/lib/active_job/enqueuing.rb#L19) which gets passed as the [`enqueued_count`](https://github.com/rails/rails/blob/main/activejob/lib/active_job/instrumentation.rb#L10) and causes a Ruby error in the [`LogSubscriber` class](https://github.com/rails/rails/blob/main/activejob/lib/active_job/log_subscriber.rb#L60).

### Detail

This Pull Request changes the `ActiveJob::LogSubscriber` to handle cases where `nil` is passed, by converting it to `0`.

### Additional information

N/A

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
