### PR TITLE
Fix flaky test for async destroying of a polymorphic `belongs_to` association

### DIFF
--- a/activerecord/test/models/essay_destroy_async.rb
+++ b/activerecord/test/models/essay_destroy_async.rb
@@ -3,7 +3,7 @@
 class EssayDestroyAsync < ActiveRecord::Base
   self.table_name = "essays"
   belongs_to :book, dependent: :destroy_async, class_name: "BookDestroyAsync"
-  belongs_to :writer, primary_key: :name, polymorphic: true, dependent: :destroy_async
+  belongs_to :writer, polymorphic: true, dependent: :destroy_async
 end
 
 class LongEssayDestroyAsync < EssayDestroyAsync


### PR DESCRIPTION
Fixes https://github.com/rails/rails/pull/53769#discussion_r1866700050 (cc @zzak)

To reproduce
```
$ cd activerecord
$ bin/test --seed 16437

F

Failure:
DestroyAssociationAsyncTest#test_polymorphic_belongs_to [test/activejob/destroy_association_async_test.rb:221]:
`Author.count` didn't change by -1, but by -2.
Expected: 3
  Actual: 2


bin/test test/activejob/destroy_association_async_test.rb:213
```

The problem was that the association was defined with a `:name` as a primary key and then inside `ActiveRecord::DestroyAssociationAsyncJob` when the associated record was destroyed, there were 2 authors with the same name.