### PR TITLE
Change testing `ProfileReporter`'s parent to `Reporter`

### DIFF
--- a/railties/lib/minitest/rails_plugin.rb
+++ b/railties/lib/minitest/rails_plugin.rb
@@ -25,7 +25,7 @@ module Minitest
     end
   end
 
-  class ProfileReporter < StatisticsReporter
+  class ProfileReporter < Reporter
     def initialize(io = $stdout, options = {})
       super
       @results = []


### PR DESCRIPTION
Fixes #53806.

Profile reporter was added in #49082.

The problem was that `StatisticsReporter` tracks only skipped or failed tests and determines if it succeeded via https://github.com/minitest/minitest/blob/2d542ffa8045d40fed7fae733c6ab674a2ffbf09/lib/minitest.rb#L858-L860, but `ProfileReporter` tracks all the tests and so that method always returns false. But the `ProfileReporter` should really inherit just from the `Reporter`.

@mattbrictson Can you confirm this fixes the issue?