### PR TITLE
Add canonical link tag to guides head

### DIFF
--- a/guides/rails_guides/generator.rb
+++ b/guides/rails_guides/generator.rb
@@ -186,13 +186,14 @@ module RailsGuides
 
         view = ActionView::Base.with_empty_template_cache.with_view_paths(
           [@source_dir],
-          edge:         @edge,
-          version:      @version,
-          epub:         "epub/#{epub_filename}",
-          language:     @language,
-          direction:    @direction,
-          uuid:         SecureRandom.uuid,
-          digest_paths: @digest_paths
+          edge:          @edge,
+          version:       @version,
+          epub:          "epub/#{epub_filename}",
+          language:      @language,
+          direction:     @direction,
+          uuid:          SecureRandom.uuid,
+          digest_paths:  @digest_paths,
+          canonical_url: canonical_url(output_file)
         )
         view.extend(Helpers)
 
@@ -221,6 +222,12 @@ module RailsGuides
         File.open(output_path, "w") do |f|
           f.write(result)
         end if !dry_run?
+      end
+
+      def canonical_url(path)
+        url = "https://guides.rubyonrails.org/"
+        url += path unless path == "index.html"
+        url
       end
 
       def warn_about_broken_links(html)

--- a/guides/source/layout.html.erb
+++ b/guides/source/layout.html.erb
@@ -13,6 +13,8 @@
 
   <link rel="apple-touch-icon" href="images/icon.png">
 
+  <link rel="canonical" href="<%= @canonical %>">
+
   <script src="<%= digest_path('javascripts/@hotwired--turbo.js') %>" data-turbo-track="reload"></script>
   <script src="<%= digest_path('javascripts/clipboard.js') %>" data-turbo-track="reload"></script>
   <script src="<%= digest_path('javascripts/guides.js') %>" data-turbo-track="reload"></script>


### PR DESCRIPTION
### Motivation / Background

The [canonical link](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/rel#canonical) tells search engines what URL is preferred for the current document. By pointing to the latest released version, it makes sure search engines prefer the latest versions in search results.

For example searching for "active storage guide" will show results for the edge guides and the v5.2 guides, but not the latest release:
https://duckduckgo.com/?q=rails+active+storage+guide&t=ffab&ia=web

<img width="696" alt="image" src="https://github.com/user-attachments/assets/85ef768d-bbb2-4f17-980a-1854d6065a31">

Having a canonical link will show the latest release instead "https://guides.rubyonrails.org".

Guides that have been removed will have a canonical URL that will result in a 404. These will mostly be ignored by search engines, but we can also not show the canonical url for guides that will be deleted in the next version.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
