### PR TITLE
Action Text: Dispatch Active Storage events with `id` and `file`

### DIFF
--- a/actiontext/CHANGELOG.md
+++ b/actiontext/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Dispatch all Active Storage `direct-upload:`-prefixed events
+
+    Add support for `direct-upload:before-blob-request` and `direct-upload:before-storage-request`.
+
+    Add `id` and `file` properties for parity with Active Storage.
+
+    *Sean Doyle*
+
 *   Support block children in editor elements alongside value.
 
     Blocks were introduced in #55827, but only as an alternative to the value

--- a/actiontext/app/assets/javascripts/actiontext.esm.js
+++ b/actiontext/app/assets/javascripts/actiontext.esm.js
@@ -887,6 +887,7 @@ class AttachmentUpload {
     this.element = element;
     this.directUpload = new DirectUpload(file, this.directUploadUrl, this);
     this.file = file;
+    this.dispatch("initialize");
   }
   start() {
     return new Promise(((resolve, reject) => {
@@ -894,7 +895,15 @@ class AttachmentUpload {
       this.dispatch("start");
     }));
   }
+  directUploadWillCreateBlobWithXHR(xhr) {
+    this.dispatch("before-blob-request", {
+      xhr: xhr
+    });
+  }
   directUploadWillStoreFileWithXHR(xhr) {
+    this.dispatch("before-storage-request", {
+      xhr: xhr
+    });
     xhr.upload.addEventListener("progress", (event => {
       const progress = event.loaded / event.total * 90;
       if (progress) {
@@ -956,6 +965,8 @@ class AttachmentUpload {
   }
   dispatch(name, detail = {}) {
     detail.attachment = this.attachment;
+    detail.file = this.directUpload.file;
+    detail.id = this.directUpload.id;
     return dispatchEvent(this.element, `direct-upload:${name}`, {
       detail: detail
     });

--- a/actiontext/app/assets/javascripts/actiontext.js
+++ b/actiontext/app/assets/javascripts/actiontext.js
@@ -861,6 +861,7 @@
       this.element = element;
       this.directUpload = new DirectUpload(file, this.directUploadUrl, this);
       this.file = file;
+      this.dispatch("initialize");
     }
     start() {
       return new Promise(((resolve, reject) => {
@@ -868,7 +869,15 @@
         this.dispatch("start");
       }));
     }
+    directUploadWillCreateBlobWithXHR(xhr) {
+      this.dispatch("before-blob-request", {
+        xhr: xhr
+      });
+    }
     directUploadWillStoreFileWithXHR(xhr) {
+      this.dispatch("before-storage-request", {
+        xhr: xhr
+      });
       xhr.upload.addEventListener("progress", (event => {
         const progress = event.loaded / event.total * 90;
         if (progress) {
@@ -930,6 +939,8 @@
     }
     dispatch(name, detail = {}) {
       detail.attachment = this.attachment;
+      detail.file = this.directUpload.file;
+      detail.id = this.directUpload.id;
       return dispatchEvent(this.element, `direct-upload:${name}`, {
         detail: detail
       });

--- a/actiontext/app/javascript/actiontext/attachment_upload.js
+++ b/actiontext/app/javascript/actiontext/attachment_upload.js
@@ -6,6 +6,7 @@ export class AttachmentUpload {
     this.element = element
     this.directUpload = new DirectUpload(file, this.directUploadUrl, this)
     this.file = file
+    this.dispatch("initialize")
   }
 
   start() {
@@ -15,7 +16,12 @@ export class AttachmentUpload {
     })
   }
 
+  directUploadWillCreateBlobWithXHR(xhr) {
+    this.dispatch("before-blob-request", { xhr })
+  }
+
   directUploadWillStoreFileWithXHR(xhr) {
+    this.dispatch("before-storage-request", { xhr })
     xhr.upload.addEventListener("progress", event => {
       // Scale upload progress to 0-90% range
       const progress = (event.loaded / event.total) * 90
@@ -91,6 +97,8 @@ export class AttachmentUpload {
 
   dispatch(name, detail = {}) {
     detail.attachment = this.attachment
+    detail.file = this.directUpload.file
+    detail.id = this.directUpload.id
     return dispatchEvent(this.element, `direct-upload:${name}`, { detail })
   }
 

--- a/actiontext/test/system/rich_text_editor_test.rb
+++ b/actiontext/test/system/rich_text_editor_test.rb
@@ -19,4 +19,88 @@ class ActionText::RichTextEditorTest < ApplicationSystemTestCase
       assert_selector :element, "img", src: %r{/rails/active_storage/representations/redirect/.*/#{image_file.basename}\Z}
     end
   end
+
+  test "dispatches direct-upload:-prefixed events when uploading a File" do
+    image_file = file_fixture("racecar.jpg")
+
+    visit new_message_url
+    events = capture_direct_upload_events do
+      attach_file image_file do
+        click_button "Attach Files"
+      end
+
+      assert_selector :element, "img", src: %r{/rails/active_storage/blobs/redirect/.*/#{image_file.basename}\Z}
+    end
+
+    assert_equal 1, ActiveStorage::Blob.where(filename: image_file.basename.to_s).count
+    assert_direct_upload_event events[0], "initialize"
+    assert_direct_upload_event events[1], "start"
+    assert_direct_upload_event events[2], "before-blob-request", xhr: "XMLHttpRequest"
+    assert_direct_upload_event events[3], "before-storage-request", xhr: "XMLHttpRequest"
+    assert_direct_upload_event events[4], "progress", progress: "Number"
+    assert_direct_upload_event events[5], "end"
+  end
+
+  test "dispatches direct-upload:error event when uploading fails" do
+    image_file = file_fixture("racecar.jpg")
+
+    visit new_message_url
+    events = capture_direct_upload_events offline: true do
+      accept_alert "Error creating Blob for \"#{image_file.basename}\". Status: 0" do
+        attach_file image_file do
+          click_button "Attach Files"
+        end
+      end
+
+      assert_no_selector :element, "img", src: /#{image_file.basename}\Z/
+    end
+
+    assert_empty ActiveStorage::Blob.where(filename: image_file.basename.to_s)
+    assert_direct_upload_event events.last, "error", error: "String"
+  end
+
+  def assert_direct_upload_event(event, name, target: find(:rich_text_area), **detail)
+    detail.with_defaults!(id: "Number", file: "File", attachment: "ManagedAttachment")
+
+    assert_equal({ type: "direct-upload:#{name}", target: target, detail: detail }, event)
+  end
+
+  def capture_direct_upload_events(offline: false, &block)
+    event_names = %w[
+      direct-upload:initialize
+      direct-upload:start
+      direct-upload:before-blob-request
+      direct-upload:before-storage-request
+      direct-upload:progress
+      direct-upload:error
+      direct-upload:end
+    ]
+    execute_script <<~JS, *event_names
+      window.capturedEvents = []
+
+      for (const eventName of arguments) {
+        addEventListener(eventName, ({ target, type, detail }) => {
+          const serialized = {}
+
+          for (const name in detail) {
+            serialized[name] = detail[name].constructor.name
+          }
+
+          window.capturedEvents.push({ target, type, detail: serialized })
+        }, { once: true })
+      }
+    JS
+
+    while_offline(offline, &block)
+
+    evaluate_script("window.capturedEvents").map(&:deep_symbolize_keys!)
+  end
+
+  def while_offline(value, &block)
+    # raises unknown error: network conditions must be set before it can be retrieved
+    # unless set to an initial value
+    page.driver.browser.network_conditions = { offline: !value }
+
+    page.driver.browser.with(network_conditions: { offline: value }, &block)
+  end
 end

--- a/guides/source/action_text_overview.md
+++ b/guides/source/action_text_overview.md
@@ -273,10 +273,13 @@ property.
 
 | Event name | Event target | Event data (`event.detail`) | Description |
 | --- | --- | --- | --- |
-| `direct-upload:start` | `<input>` | `{id, file}` | A direct upload is starting. |
-| `direct-upload:progress` | `<input>` | `{id, file, progress}` | As requests to store files progress. |
-| `direct-upload:error` | `<input>` | `{id, file, error}` | An error occurred. An `alert` will display unless this event is canceled. |
-| `direct-upload:end` | `<input>` | `{id, file}` | A direct upload has ended. |
+| `direct-upload:initialize` | `<trix-editor>` | `{id, file, attachment}` | Dispatched for every file after form submission. |
+| `direct-upload:start` | `<trix-editor>` | `{id, file, attachment}` | A direct upload is starting. |
+| `direct-upload:before-blob-request` | `<trix-editor>` | `{id, file, xhr, attachment}` | Before making a request to your application for direct upload metadata. |
+| `direct-upload:before-storage-request` | `<trix-editor>` | `{id, file, xhr, attachment}` | Before making a request to store a file. |
+| `direct-upload:progress` | `<trix-editor>` | `{id, file, progress, attachment}` | As requests to store files progress. |
+| `direct-upload:error` | `<trix-editor>` | `{id, file, error, attachment}` | An error occurred. An `alert` will display unless this event is canceled. |
+| `direct-upload:end` | `<trix-editor>` | `{id, file, attachment}` | A direct upload has ended. |
 
 NOTE: It is possible for files uploaded by Action Text through [Active Storage
 Direct Uploads](active_storage_overview.html#direct-uploads) to never be


### PR DESCRIPTION
### Motivation / Background

Follow-up to [#52680][]

Adjusts the Action Text-dispatched [Active Storage Direct Upload JavaScript Events][] to include both `id` and `file` properties as documented in the current [Action Text Attachment Direct Upload JavaScript Events][]. In addition to those properties, there were two events missing from the list:

* `direct-upload:before-blob-request`, `{id, file, xhr}`, Before making a request to your application for direct upload metadata.
* `direct-upload:before-storage-request`, `{id, file, xhr}`, Before making a request to store a file.

### Detail

The code change mimics the style of the Active Storage [DirectUploadController][] implementation.

Prior to this commit, the documentation mentioned that an `<input>` element would be the event target. In reality, the `AttachmentUpload` JavaScript class dispatches events treating the `<trix-editor>` element as its target.

This commit changes the documentation to account for that. 
Alongside the code change, this commit expands upon the existing guides documentation to also mention the `attachment` property that references a [Attachment][] instance.

To account for both _new events_ and _new properties_ in the `event.detail` object, this commit includes expanded system test coverage asserting that events are dispatched as described .

[#52680]: https://github.com/rails/rails/pull/52680
[Active Storage Direct Upload JavaScript Events]: https://guides.rubyonrails.org/v8.0.0/active_storage_overview.html#direct-upload-javascript-events
[Action Text Attachment Direct Upload JavaScript Events]: https://guides.rubyonrails.org/v8.0.0/action_text_overview.html#attachment-direct-upload-javascript-events
[DirectUploadController]: https://github.com/rails/rails/blob/v8.0.0/activestorage/app/javascript/activestorage/direct_upload_controller.js#L44-L48
[Attachment]: https://github.com/basecamp/trix/?tab=readme-ov-file#inserting-a-file

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
