### PR TITLE
Skip minitest v5.25.3 to workaround CI failures

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@
 source "https://rubygems.org"
 gemspec
 
-gem "minitest"
+gem "minitest", "!= 5.25.3"
 
 # We need a newish Rake since Active Job sets its test tasks' descriptions.
 gem "rake", ">= 13"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -367,7 +367,7 @@ GEM
     mini_magick (4.13.2)
     mini_mime (1.1.5)
     mini_portile2 (2.8.7)
-    minitest (5.25.1)
+    minitest (5.25.2)
     minitest-bisect (1.7.0)
       minitest-server (~> 1.0)
       path_expander (~> 1.1)
@@ -698,7 +698,7 @@ DEPENDENCIES
   libxml-ruby
   listen (~> 3.3)
   mdl (!= 0.13.0)
-  minitest
+  minitest (!= 5.25.3)
   minitest-bisect
   minitest-ci
   minitest-retry


### PR DESCRIPTION
### Motivation / Background

This commit skips minitest v5.25.3 to workaround CI failures as per reported https://github.com/rails/rails/issues/53813

Fix #53813

### Detail
It workarounds this error.

```ruby
$ bundle update minitest --conservative
Fetching gem metadata from https://rubygems.org/.........
Resolving dependencies...
Resolving dependencies...
Using minitest 5.25.3 (was 5.25.1)
Bundle updated!
$ bin/test
/home/yahonda/.rbenv/versions/3.3.6/lib/ruby/gems/3.3.0/gems/minitest-5.25.3/lib/minitest/mock.rb:269:in `<module:Expectations>': undefined method `infect_an_assertion' for module Minitest::Expectations (NoMethodError)

  infect_an_assertion :assert_mock, :must_verify, :unary
  ^^^^^^^^^^^^^^^^^^^
	from /home/yahonda/.rbenv/versions/3.3.6/lib/ruby/gems/3.3.0/gems/minitest-5.25.3/lib/minitest/mock.rb:261:in `<top (required)>'
	from /home/yahonda/.rbenv/versions/3.3.6/lib/ruby/3.3.0/bundled_gems.rb:69:in `require'
	from /home/yahonda/.rbenv/versions/3.3.6/lib/ruby/3.3.0/bundled_gems.rb:69:in `block (2 levels) in replace_require'
	from /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/testing/method_call_assertions.rb:3:in `<top (required)>'
	from /home/yahonda/.rbenv/versions/3.3.6/lib/ruby/3.3.0/bundled_gems.rb:69:in `require'
	from /home/yahonda/.rbenv/versions/3.3.6/lib/ruby/3.3.0/bundled_gems.rb:69:in `block (2 levels) in replace_require'
	from /home/yahonda/src/github.com/rails/rails/activesupport/test/abstract_unit.rb:16:in `<top (required)>'
	from /home/yahonda/src/github.com/rails/rails/activesupport/test/actionable_error_test.rb:3:in `require_relative'
	from /home/yahonda/src/github.com/rails/rails/activesupport/test/actionable_error_test.rb:3:in `<top (required)>'
	from /home/yahonda/.rbenv/versions/3.3.6/lib/ruby/3.3.0/bundled_gems.rb:69:in `require'
	from /home/yahonda/.rbenv/versions/3.3.6/lib/ruby/3.3.0/bundled_gems.rb:69:in `block (2 levels) in replace_require'
	from /home/yahonda/src/github.com/rails/rails/railties/lib/rails/test_unit/runner.rb:62:in `block in load_tests'
	from /home/yahonda/src/github.com/rails/rails/railties/lib/rails/test_unit/runner.rb:60:in `each'
	from /home/yahonda/src/github.com/rails/rails/railties/lib/rails/test_unit/runner.rb:60:in `load_tests'
	from /home/yahonda/src/github.com/rails/rails/railties/lib/rails/test_unit/runner.rb:52:in `run'
	from /home/yahonda/src/github.com/rails/rails/tools/test.rb:18:in `<top (required)>'
	from bin/test:5:in `require_relative'
	from bin/test:5:in `<main>'
$ git diff
diff --git a/Gemfile.lock b/Gemfile.lock
index 263b7c4029..28cec71a21 100644
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -367,7 +367,7 @@ GEM
     mini_magick (4.13.2)
     mini_mime (1.1.5)
     mini_portile2 (2.8.7)
-    minitest (5.25.1)
+    minitest (5.25.3)
     minitest-bisect (1.7.0)
       minitest-server (~> 1.0)
       path_expander (~> 1.1)
$
```

### Additional information

Refer to https://github.com/minitest/minitest/issues/1022


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
