### PR TITLE
Migrate applicable `actioncable` tests to use `NotificationAssertions`

### DIFF
--- a/actioncable/test/channel/base_test.rb
+++ b/actioncable/test/channel/base_test.rb
@@ -199,67 +199,49 @@ class ActionCable::Channel::BaseTest < ActionCable::TestCase
   end
 
   test "notification for perform_action" do
-    events = []
-    ActiveSupport::Notifications.subscribe("perform_action.action_cable") { |event| events << event }
-
     data = { "action" => :speak, "content" => "hello" }
-    @channel.perform_action data
+    expected_payload = { channel_class: "ActionCable::Channel::BaseTest::ChatChannel", action: :speak, data: }
 
-    assert_equal 1, events.length
-    assert_equal "perform_action.action_cable", events[0].name
-    assert_equal "ActionCable::Channel::BaseTest::ChatChannel", events[0].payload[:channel_class]
-    assert_equal :speak, events[0].payload[:action]
-    assert_equal data, events[0].payload[:data]
-  ensure
-    ActiveSupport::Notifications.unsubscribe "perform_action.action_cable"
+    assert_notifications_count("perform_action.action_cable", 1) do
+      assert_notification("perform_action.action_cable", expected_payload) do
+        @channel.perform_action data
+      end
+    end
   end
 
   test "notification for transmit" do
-    events = []
-    ActiveSupport::Notifications.subscribe("transmit.action_cable") { |event| events << event }
+    data = { data: "latest" }
+    expected_payload = { channel_class: "ActionCable::Channel::BaseTest::ChatChannel", data:, via: nil }
 
-    @channel.perform_action "action" => :get_latest
-    expected_data = { data: "latest" }
-
-    assert_equal 1, events.length
-    assert_equal "transmit.action_cable", events[0].name
-    assert_equal "ActionCable::Channel::BaseTest::ChatChannel", events[0].payload[:channel_class]
-    assert_equal expected_data, events[0].payload[:data]
-    assert_nil events[0].payload[:via]
-  ensure
-    ActiveSupport::Notifications.unsubscribe "transmit.action_cable"
+    assert_notifications_count("transmit.action_cable", 1) do
+      assert_notification("transmit.action_cable", expected_payload) do
+        @channel.perform_action "action" => :get_latest
+      end
+    end
   end
 
   test "notification for transmit_subscription_confirmation" do
+    expected_payload = { channel_class: "ActionCable::Channel::BaseTest::ChatChannel", identifier: "{id: 1}" }
+
     @channel.subscribe_to_channel
 
-    events = []
-    ActiveSupport::Notifications.subscribe("transmit_subscription_confirmation.action_cable") { |e| events << e }
-
-    @channel.stub(:subscription_confirmation_sent?, false) do
-      @channel.send(:transmit_subscription_confirmation)
-
-      assert_equal 1, events.length
-      assert_equal "transmit_subscription_confirmation.action_cable", events[0].name
-      assert_equal "ActionCable::Channel::BaseTest::ChatChannel", events[0].payload[:channel_class]
-      assert_equal "{id: 1}", events[0].payload[:identifier]
+    assert_notifications_count("transmit_subscription_confirmation.action_cable", 1) do
+      assert_notification("transmit_subscription_confirmation.action_cable", expected_payload) do
+        @channel.stub(:subscription_confirmation_sent?, false) do
+          @channel.send(:transmit_subscription_confirmation)
+        end
+      end
     end
-  ensure
-    ActiveSupport::Notifications.unsubscribe "transmit_subscription_confirmation.action_cable"
   end
 
   test "notification for transmit_subscription_rejection" do
-    events = []
-    ActiveSupport::Notifications.subscribe("transmit_subscription_rejection.action_cable") { |event| events << event }
+    expected_payload = { channel_class: "ActionCable::Channel::BaseTest::ChatChannel", identifier: "{id: 1}" }
 
-    @channel.send(:transmit_subscription_rejection)
-
-    assert_equal 1, events.length
-    assert_equal "transmit_subscription_rejection.action_cable", events[0].name
-    assert_equal "ActionCable::Channel::BaseTest::ChatChannel", events[0].payload[:channel_class]
-    assert_equal "{id: 1}", events[0].payload[:identifier]
-  ensure
-    ActiveSupport::Notifications.unsubscribe "transmit_subscription_rejection.action_cable"
+    assert_notifications_count("transmit_subscription_rejection.action_cable", 1) do
+      assert_notification("transmit_subscription_rejection.action_cable", expected_payload) do
+        @channel.send(:transmit_subscription_rejection)
+      end
+    end
   end
 
   test "behaves like rescuable" do


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because I believe we can greatly simplify many `ActiveSupport::Notifications` centric tests using the recently merged `ActiveSupport::Testing::NotificationAssertions` test helper module. While it does not accommodate for all tests, it does work in a majority of cases.

This specific PR is for `actioncable`.

Follow up to
- https://github.com/rails/rails/pull/53065

Extracted from
- https://github.com/rails/rails/pull/53700

### Detail

This Pull Request changes `actioncable` test(s) to use the new `NotificationAssertions` helper module, which thus allows us to cleanup various now redundant local notification capturing helper methods.

Note, if any such cleanup appears incorrect or subpar, please let me know. I'll gladly revert the change. This is the first time I've looked at more or less all of these tests so it is possible I've overlooked something.

### Additional information

This is a first pass at cleaning up Rails using this module. The module itself is only v1 at this point. I have some ideas for how we can further enhance the module to be more applicable in more cases and allow for even cleaner testing: https://github.com/rails/rails/pull/53065#issuecomment-2452017030. Have WIP implementations of `payload_subset` for `assert_notification` and `filter` for all methods.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.

I don't believe this qualifies as a change that needs to be reflected in the changelog as it is non-user-facing and does not change the public API of Rails.