### PR TITLE
Migrate applicable `actionmailer` tests to use NotificationAssertions

### DIFF
--- a/actionmailer/test/base_test.rb
+++ b/actionmailer/test/base_test.rb
@@ -963,31 +963,24 @@ class BaseTest < ActiveSupport::TestCase
   end
 
   test "notification for process" do
-    events = []
-    ActiveSupport::Notifications.subscribe("process.action_mailer") { |event| events << event }
+    expected_payload = { mailer: "BaseMailer", action: :welcome, args: [{ body: "Hello there" }] }
 
-    BaseMailer.welcome(body: "Hello there").deliver_now
-
-    assert_equal 1, events.length
-    assert_equal "process.action_mailer", events[0].name
-    assert_equal "BaseMailer", events[0].payload[:mailer]
-    assert_equal :welcome, events[0].payload[:action]
-    assert_equal [{ body: "Hello there" }], events[0].payload[:args]
-  ensure
-    ActiveSupport::Notifications.unsubscribe "process.action_mailer"
+    assert_notifications_count("process.action_mailer", 1) do
+      assert_notification("process.action_mailer", expected_payload) do
+        BaseMailer.welcome(body: "Hello there").deliver_now
+      end
+    end
   end
 
   test "notification for deliver" do
-    events = []
-    ActiveSupport::Notifications.subscribe("deliver.action_mailer") { |event| events << event }
+    event = capture_notifications("deliver.action_mailer") do
+      assert_notifications_count("deliver.action_mailer", 1) do
+        BaseMailer.welcome(body: "Hello there").deliver_now
+      end
+    end.first
 
-    BaseMailer.welcome(body: "Hello there").deliver_now
-
-    assert_equal 1, events.length
-    assert_equal "deliver.action_mailer", events[0].name
-    assert_not_nil events[0].payload[:message_id]
-  ensure
-    ActiveSupport::Notifications.unsubscribe "deliver.action_mailer"
+    assert_equal "deliver.action_mailer", event.name
+    assert_not_nil event.payload[:message_id]
   end
 
   private

--- a/actionmailer/test/caching_test.rb
+++ b/actionmailer/test/caching_test.rb
@@ -171,18 +171,15 @@ class FunctionalFragmentCachingTest < BaseCachingTest
 
   def test_fragment_cache_instrumentation
     @mailer.enable_fragment_cache_logging = true
-    payload = nil
 
-    subscriber = proc do |_, _, _, _, event_payload|
-      payload = event_payload
-    end
+    expected_payload = {
+      mailer: "caching_mailer",
+      key: [:views, "caching_mailer/fragment_cache:#{template_digest("caching_mailer/fragment_cache", "html")}", :caching]
+    }
 
-    ActiveSupport::Notifications.subscribed(subscriber, "read_fragment.action_mailer") do
+    assert_notification("read_fragment.action_mailer", expected_payload) do
       @mailer.fragment_cache
     end
-
-    assert_equal "caching_mailer", payload[:mailer]
-    assert_equal [ :views, "caching_mailer/fragment_cache:#{template_digest("caching_mailer/fragment_cache", "html")}", :caching ], payload[:key]
   ensure
     @mailer.enable_fragment_cache_logging = true
   end


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because I believe we can greatly simplify many `ActiveSupport::Notifications` centric tests using the recently merged `ActiveSupport::Testing::NotificationAssertions` test helper module. While it does not accommodate for all tests, it does work in a majority of cases.

This specific PR is for `actionmailer`.

Follow up to
- https://github.com/rails/rails/pull/53065

Extracted from
- https://github.com/rails/rails/pull/53700

### Detail

This Pull Request changes `actionmailer` test(s) to use the new `NotificationAssertions` helper module, which thus allows us to cleanup various now redundant local notification capturing helper methods.

Note, if any such cleanup appears incorrect or subpar, please let me know. I'll gladly revert the change. This is the first time I've looked at more or less all of these tests so it is possible I've overlooked something.

### Additional information

This is a first pass at cleaning up Rails using this module. The module itself is only v1 at this point. I have some ideas for how we can further enhance the module to be more applicable in more cases and allow for even cleaner testing: https://github.com/rails/rails/pull/53065#issuecomment-2452017030. Have WIP implementations of `payload_subset` for `assert_notification` and `filter` for all methods.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.

I don't believe this qualifies as a change that needs to be reflected in the changelog as it is non-user-facing and does not change the public API of Rails.