### PR TITLE
Migrate applicable `actionpack` tests to use `NotificationAssertions`

### DIFF
--- a/actionpack/test/controller/allow_browser_test.rb
+++ b/actionpack/test/controller/allow_browser_test.rb
@@ -84,7 +84,7 @@ class AllowBrowserTest < ActionController::TestCase
   end
 
   test "a blocked request instruments a browser_block.action_controller event" do
-    event, *rest = capture_instrumentation_events "browser_block.action_controller" do
+    event, *rest = capture_notifications "browser_block.action_controller" do
       get_with_agent :modern, CHROME_118
     end
 
@@ -97,11 +97,5 @@ class AllowBrowserTest < ActionController::TestCase
     def get_with_agent(action, agent)
       @request.headers["User-Agent"] = agent
       get action
-    end
-
-    def capture_instrumentation_events(pattern, &block)
-      events = []
-      ActiveSupport::Notifications.subscribed(->(e) { events << e }, pattern, &block)
-      events
     end
 end

--- a/actionpack/test/controller/caching_test.rb
+++ b/actionpack/test/controller/caching_test.rb
@@ -255,15 +255,9 @@ Ciao
   end
 
   def test_fragment_cache_instrumentation
-    payload = nil
-
-    subscriber = proc do |event|
-      payload = event.payload
-    end
-
-    ActiveSupport::Notifications.subscribed(subscriber, "read_fragment.action_controller") do
+    payload = capture_notifications("read_fragment.action_controller") do
       get :inline_fragment_cached
-    end
+    end.first.payload
 
     assert_equal "functional_caching", payload[:controller]
     assert_equal "inline_fragment_cached", payload[:action]

--- a/actionpack/test/controller/live_stream_test.rb
+++ b/actionpack/test/controller/live_stream_test.rb
@@ -388,16 +388,15 @@ module ActionController
     end
 
     def test_send_stream_instrumentation
-      payload = nil
-      subscriber = proc { |event| payload = event.payload }
+      expected_payload = {
+        filename: "sample.csv",
+        disposition: "attachment",
+        type: "text/csv"
+      }
 
-      ActiveSupport::Notifications.subscribed(subscriber, "send_stream.action_controller") do
+      assert_notification("send_stream.action_controller", expected_payload) do
         get :send_stream_with_explicit_content_type
       end
-
-      assert_equal "sample.csv", payload[:filename]
-      assert_equal "attachment", payload[:disposition]
-      assert_equal "text/csv", payload[:type]
     end
 
     def test_send_stream_with_options

--- a/actionpack/test/controller/redirect_test.rb
+++ b/actionpack/test/controller/redirect_test.rb
@@ -608,15 +608,9 @@ class RedirectTest < ActionController::TestCase
   end
 
   def test_redirect_to_instrumentation
-    payload = nil
-
-    subscriber = proc do |event|
-      payload = event.payload
-    end
-
-    ActiveSupport::Notifications.subscribed(subscriber, "redirect_to.action_controller") do
+    payload = capture_notifications("redirect_to.action_controller") do
       get :simple_redirect
-    end
+    end.first.payload
 
     assert_equal request, payload[:request]
     assert_equal 302, payload[:status]

--- a/actionpack/test/controller/send_file_test.rb
+++ b/actionpack/test/controller/send_file_test.rb
@@ -209,33 +209,18 @@ class SendFileTest < ActionController::TestCase
 
   def test_send_file_instrumentation
     @controller.options = { disposition: :inline }
-    payload = nil
 
-    subscriber = proc do |event|
-      payload = event.payload
-    end
-
-    ActiveSupport::Notifications.subscribed(subscriber, "send_file.action_controller") do
+    assert_notification("send_file.action_controller", path: __FILE__, disposition: :inline) do
       process("file")
     end
-
-    assert_equal __FILE__, payload[:path]
-    assert_equal :inline, payload[:disposition]
   end
 
   def test_send_data_instrumentation
     @controller.options = { content_type: "application/x-ruby" }
-    payload = nil
 
-    subscriber = proc do |event|
-      payload = event.payload
-    end
-
-    ActiveSupport::Notifications.subscribed(subscriber, "send_data.action_controller") do
+    assert_notification("send_data.action_controller", content_type: "application/x-ruby") do
       process("data")
     end
-
-    assert_equal("application/x-ruby", payload[:content_type])
   end
 
   %w(file data).each do |method|

--- a/actionpack/test/dispatch/routing/instrumentation_test.rb
+++ b/actionpack/test/dispatch/routing/instrumentation_test.rb
@@ -8,7 +8,11 @@ class RoutingInstrumentationTest < ActionDispatch::IntegrationTest
       get "redirect", to: redirect("/login")
     end
 
-    event = subscribed("redirect.action_dispatch") { get "/redirect" }
+    event = capture_notifications("redirect.action_dispatch") do
+      assert_notifications_count("redirect.action_dispatch", 1) do
+        get "/redirect"
+      end
+    end.first
 
     assert_equal 301, event.payload[:status]
     assert_equal "http://www.example.com/login", event.payload[:location]
@@ -22,12 +26,5 @@ class RoutingInstrumentationTest < ActionDispatch::IntegrationTest
         routes.draw(&block)
         @app = RoutedRackApp.new routes
       end
-    end
-
-    def subscribed(event_pattern, &block)
-      event = nil
-      subscriber = -> (_event) { event = _event }
-      ActiveSupport::Notifications.subscribed(subscriber, event_pattern, &block)
-      event
     end
 end


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because I believe we can greatly simplify many `ActiveSupport::Notifications` centric tests using the recently merged `ActiveSupport::Testing::NotificationAssertions` test helper module. While it does not accommodate for all tests, it does work in a majority of cases.

This specific PR is for `actionpack`.

Follow up to
- https://github.com/rails/rails/pull/53065

Extracted from
- https://github.com/rails/rails/pull/53700

### Detail

This Pull Request changes `actionpack` test(s) to use the new `NotificationAssertions` helper module, which thus allows us to cleanup various now redundant local notification capturing helper methods.

Note, if any such cleanup appears incorrect or subpar, please let me know. I'll gladly revert the change. This is the first time I've looked at more or less all of these tests so it is possible I've overlooked something.

### Additional information

This is a first pass at cleaning up Rails using this module. The module itself is only v1 at this point. I have some ideas for how we can further enhance the module to be more applicable in more cases and allow for even cleaner testing: https://github.com/rails/rails/pull/53065#issuecomment-2452017030. Have WIP implementations of `payload_subset` for `assert_notification` and `filter` for all methods.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.

I don't believe this qualifies as a change that needs to be reflected in the changelog as it is non-user-facing and does not change the public API of Rails.