### PR TITLE
Migrate applicable `activejob` tests to use `NotificationAssertions`

### DIFF
--- a/activejob/test/cases/instrumentation_test.rb
+++ b/activejob/test/cases/instrumentation_test.rb
@@ -12,43 +12,28 @@ class InstrumentationTest < ActiveSupport::TestCase
   end
 
   test "perform_now emits perform events" do
-    events = subscribed(/perform.*\.active_job/) { HelloJob.perform_now("World!") }
+    events = capture_notifications(/perform.*\.active_job/) { HelloJob.perform_now("World!") }
+
     assert_equal 2, events.size
-    assert_equal "perform_start.active_job", events[0].first
-    assert_equal "perform.active_job", events[1].first
+    assert_equal "perform_start.active_job", events[0].name
+    assert_equal "perform.active_job", events[1].name
   end
 
   test "perform_later emits an enqueue event" do
-    events = subscribed("enqueue.active_job") { HelloJob.perform_later("World!") }
-    assert_equal 1, events.size
+    assert_notifications_count("enqueue.active_job", 1) { HelloJob.perform_later("World!") }
   end
 
   unless adapter_is?(:inline, :sneakers)
     test "retry emits an enqueue retry event" do
-      events = subscribed("enqueue_retry.active_job") do
-        perform_enqueued_jobs { RetryJob.perform_later("DefaultsError", 2) }
-      end
-      assert_equal 1, events.size
+      assert_notifications_count("enqueue_retry.active_job", 1) { RetryJob.perform_later("DefaultsError", 2) }
     end
 
     test "retry exhaustion emits a retry_stopped event" do
-      events = subscribed("retry_stopped.active_job") do
-        perform_enqueued_jobs { RetryJob.perform_later("CustomCatchError", 6) }
-      end
-      assert_equal 1, events.size
+      assert_notifications_count("retry_stopped.active_job", 1) { RetryJob.perform_later("CustomCatchError", 6) }
     end
   end
 
   test "discard emits a discard event" do
-    events = subscribed("discard.active_job") do
-      perform_enqueued_jobs { RetryJob.perform_later("DiscardableError", 2) }
-    end
-    assert_equal 1, events.size
-  end
-
-  def subscribed(name, &block)
-    [].tap do |events|
-      ActiveSupport::Notifications.subscribed(-> (*args) { events << args }, name, &block)
-    end
+    assert_notifications_count("discard.active_job", 1) { RetryJob.perform_later("DiscardableError", 6) }
   end
 end

--- a/activejob/test/cases/logging_test.rb
+++ b/activejob/test/cases/logging_test.rb
@@ -50,12 +50,6 @@ class LoggingTest < ActiveSupport::TestCase
     ActiveJob::Base.logger = logger
   end
 
-  def subscribed(&block)
-    [].tap do |events|
-      ActiveSupport::Notifications.subscribed(-> (*args) { events << args }, /enqueue.*\.active_job/, &block)
-    end
-  end
-
   def test_uses_active_job_as_tag
     HelloJob.perform_later "Cristian"
     assert_match(/\[ActiveJob\]/, @logger.messages)
@@ -105,32 +99,35 @@ class LoggingTest < ActiveSupport::TestCase
   end
 
   def test_enqueue_job_logging
-    events = subscribed { HelloJob.perform_later "Cristian" }
+    assert_notifications_count(/enqueue.*\.active_job/, 1) do
+      assert_notifications_count("enqueue.active_job", 1) do
+        HelloJob.perform_later "Cristian"
+      end
+    end
+
     assert_match(/Enqueued HelloJob \(Job ID: .*?\) to .*?:.*Cristian/, @logger.messages)
-    assert_equal(1, events.count)
-    key, * = events.first
-    assert_equal("enqueue.active_job", key)
   end
 
   def test_enqueue_job_log_error_when_callback_chain_is_halted
-    events = subscribed { AbortBeforeEnqueueJob.perform_later }
+    assert_notifications_count(/enqueue.*\.active_job/, 1) do
+      assert_notification("enqueue.active_job") do
+        AbortBeforeEnqueueJob.perform_later
+      end
+    end
+
     assert_match(/Failed enqueuing AbortBeforeEnqueueJob.* a before_enqueue callback halted/, @logger.messages)
-    assert_equal(1, events.count)
-    key, * = events.first
-    assert_equal("enqueue.active_job", key)
   end
 
   def test_enqueue_job_log_error_when_error_is_raised_during_callback_chain
-    events = subscribed do
-      assert_raises(AbortBeforeEnqueueJob::MyError) do
-        AbortBeforeEnqueueJob.perform_later(:raise)
+    assert_notifications_count(/enqueue.*\.active_job/, 1) do
+      assert_notification("enqueue.active_job") do
+        assert_raises(AbortBeforeEnqueueJob::MyError) do
+          AbortBeforeEnqueueJob.perform_later(:raise)
+        end
       end
     end
 
     assert_match(/Failed enqueuing AbortBeforeEnqueueJob/, @logger.messages)
-    assert_equal(1, events.count)
-    key, * = events.first
-    assert_equal("enqueue.active_job", key)
   end
 
   def test_perform_job_logging
@@ -154,7 +151,7 @@ class LoggingTest < ActiveSupport::TestCase
   end
 
   def test_perform_job_log_error_when_callback_chain_is_halted
-    subscribed { AbortBeforeEnqueueJob.perform_now }
+    AbortBeforeEnqueueJob.perform_now
     assert_match(/Error performing AbortBeforeEnqueueJob.* a before_perform callback halted/, @logger.messages)
   end
 
@@ -165,7 +162,7 @@ class LoggingTest < ActiveSupport::TestCase
       end
     end
 
-    subscribed { job.perform_now }
+    job.perform_now
     assert_no_match(/Error performing AbortBeforeEnqueueJob.* a before_perform callback halted/, @logger.messages)
   end
 
@@ -179,10 +176,8 @@ class LoggingTest < ActiveSupport::TestCase
       end
     end.new([:dont_abort, :abort])
 
-    subscribed do
-      job.perform_now
-      job.perform_now
-    end
+    job.perform_now
+    job.perform_now
 
     assert_equal(1, @logger.messages.scan(/a before_perform callback halted the job execution/).size)
   end
@@ -215,42 +210,47 @@ class LoggingTest < ActiveSupport::TestCase
 
   unless adapter_is?(:inline, :sneakers)
     def test_enqueue_at_job_logging
-      events = subscribed { HelloJob.set(wait_until: 24.hours.from_now).perform_later "Cristian" }
+      assert_notifications_count(/enqueue.*\.active_job/, 1) do
+        assert_notification("enqueue_at.active_job") do
+          HelloJob.set(wait_until: 24.hours.from_now).perform_later "Cristian"
+        end
+      end
+
       assert_match(/Enqueued HelloJob \(Job ID: .*\) to .*? at.*Cristian/, @logger.messages)
-      assert_equal(1, events.count)
-      key, * = events.first
-      assert_equal("enqueue_at.active_job", key)
     end
   end
 
   def test_enqueue_at_job_log_error_when_callback_chain_is_halted
-    events = subscribed { AbortBeforeEnqueueJob.set(wait: 1.second).perform_later }
+    assert_notifications_count(/enqueue.*\.active_job/, 1) do
+      assert_notification("enqueue_at.active_job") do
+        AbortBeforeEnqueueJob.set(wait: 1.second).perform_later
+      end
+    end
+
     assert_match(/Failed enqueuing AbortBeforeEnqueueJob.* a before_enqueue callback halted/, @logger.messages)
-    assert_equal(1, events.count)
-    key, * = events.first
-    assert_equal("enqueue_at.active_job", key)
   end
 
   def test_enqueue_at_job_log_error_when_error_is_raised_during_callback_chain
-    events = subscribed do
-      assert_raises(AbortBeforeEnqueueJob::MyError) do
-        AbortBeforeEnqueueJob.set(wait: 1.second).perform_later(:raise)
+    assert_notifications_count(/enqueue.*\.active_job/, 1) do
+      assert_notification("enqueue_at.active_job") do
+        assert_raises(AbortBeforeEnqueueJob::MyError) do
+          AbortBeforeEnqueueJob.set(wait: 1.second).perform_later(:raise)
+        end
       end
     end
 
     assert_match(/Failed enqueuing AbortBeforeEnqueueJob/, @logger.messages)
-    assert_equal(1, events.count)
-    key, * = events.first
-    assert_equal("enqueue_at.active_job", key)
   end
 
   unless adapter_is?(:inline, :sneakers)
     def test_enqueue_in_job_logging
-      events = subscribed { HelloJob.set(wait: 2.seconds).perform_later "Cristian" }
+      assert_notifications_count(/enqueue.*\.active_job/, 1) do
+        assert_notification("enqueue_at.active_job") do
+          HelloJob.set(wait: 2.seconds).perform_later "Cristian"
+        end
+      end
+
       assert_match(/Enqueued HelloJob \(Job ID: .*\) to .*? at.*Cristian/, @logger.messages)
-      assert_equal(1, events.count)
-      key, * = events.first
-      assert_equal("enqueue_at.active_job", key)
     end
   end
 

--- a/activejob/test/cases/queuing_test.rb
+++ b/activejob/test/cases/queuing_test.rb
@@ -87,19 +87,13 @@ class QueuingTest < ActiveSupport::TestCase
 
   test "perform_all_later instrumentation" do
     jobs = HelloJob.new("Jamie"), HelloJob.new("John")
-    called = false
 
-    subscriber = proc do |_, _, _, _, payload|
-      called = true
-      assert payload[:adapter]
-      assert_equal jobs, payload[:jobs]
-      assert_equal 2, payload[:enqueued_count]
-    end
-
-    ActiveSupport::Notifications.subscribed(subscriber, "enqueue_all.active_job") do
+    payload = capture_notifications("enqueue_all.active_job") do
       ActiveJob.perform_all_later(jobs)
-    end
+    end.first.payload
 
-    assert called
+    assert payload[:adapter]
+    assert_equal jobs, payload[:jobs]
+    assert_equal 2, payload[:enqueued_count]
   end
 end


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because I believe we can greatly simplify many `ActiveSupport::Notifications` centric tests using the recently merged `ActiveSupport::Testing::NotificationAssertions` test helper module. While it does not accommodate for all tests, it does work in a majority of cases.

This specific PR is for `activejob`.

Follow up to
- https://github.com/rails/rails/pull/53065

Extracted from
- https://github.com/rails/rails/pull/53700

### Detail

This Pull Request changes `activejob` test(s) to use the new `NotificationAssertions` helper module, which thus allows us to cleanup various now redundant local notification capturing helper methods.

Note, if any such cleanup appears incorrect or subpar, please let me know. I'll gladly revert the change. This is the first time I've looked at more or less all of these tests so it is possible I've overlooked something.

### Additional information

This is a first pass at cleaning up Rails using this module. The module itself is only v1 at this point. I have some ideas for how we can further enhance the module to be more applicable in more cases and allow for even cleaner testing: https://github.com/rails/rails/pull/53065#issuecomment-2452017030. Have WIP implementations of `payload_subset` for `assert_notification` and `filter` for all methods.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.

I don't believe this qualifies as a change that needs to be reflected in the changelog as it is non-user-facing and does not change the public API of Rails.