### PR TITLE
Migrate applicable `activestorage` tests to use `NotificationAssertions`

### DIFF
--- a/activestorage/test/analyzer/audio_analyzer_test.rb
+++ b/activestorage/test/analyzer/audio_analyzer_test.rb
@@ -18,12 +18,13 @@ class ActiveStorage::Analyzer::AudioAnalyzerTest < ActiveSupport::TestCase
   end
 
   test "instrumenting analysis" do
-    events = subscribe_events_from("analyze.active_storage")
+    events = capture_notifications("analyze.active_storage") do
+      assert_notifications_count("analyze.active_storage", 1) do
+        blob = create_file_blob(filename: "audio.mp3", content_type: "audio/mp3")
+        blob.analyze
+      end
+    end
 
-    blob = create_file_blob(filename: "audio.mp3", content_type: "audio/mp3")
-    blob.analyze
-
-    assert_equal 1, events.size
     assert_equal({ analyzer: "ffprobe" }, events.first.payload)
   end
 end

--- a/activestorage/test/analyzer/image_analyzer/image_magick_test.rb
+++ b/activestorage/test/analyzer/image_analyzer/image_magick_test.rb
@@ -48,10 +48,10 @@ class ActiveStorage::Analyzer::ImageAnalyzer::ImageMagickTest < ActiveSupport::T
 
   test "instrumenting analysis" do
     analyze_with_image_magick do
-      events = subscribe_events_from("analyze.active_storage")
-
-      blob = create_file_blob(filename: "racecar.jpg", content_type: "image/jpeg")
-      blob.analyze
+      events = capture_notifications("analyze.active_storage") do
+        blob = create_file_blob(filename: "racecar.jpg", content_type: "image/jpeg")
+        blob.analyze
+      end
 
       assert_equal 1, events.size
       assert_equal({ analyzer: "mini_magick" }, events.first.payload)

--- a/activestorage/test/analyzer/image_analyzer/vips_test.rb
+++ b/activestorage/test/analyzer/image_analyzer/vips_test.rb
@@ -48,10 +48,10 @@ class ActiveStorage::Analyzer::ImageAnalyzer::VipsTest < ActiveSupport::TestCase
 
   test "instrumenting analysis" do
     analyze_with_vips do
-      events = subscribe_events_from("analyze.active_storage")
-
-      blob = create_file_blob(filename: "racecar.jpg", content_type: "image/jpeg")
-      blob.analyze
+      events = capture_notifications("analyze.active_storage") do
+        blob = create_file_blob(filename: "racecar.jpg", content_type: "image/jpeg")
+        blob.analyze
+      end
 
       assert_equal 1, events.size
       assert_equal({ analyzer: "vips" }, events.first.payload)

--- a/activestorage/test/analyzer/video_analyzer_test.rb
+++ b/activestorage/test/analyzer/video_analyzer_test.rb
@@ -87,10 +87,10 @@ class ActiveStorage::Analyzer::VideoAnalyzerTest < ActiveSupport::TestCase
   end
 
   test "instrumenting analysis" do
-    events = subscribe_events_from("analyze.active_storage")
-
-    blob = create_file_blob(filename: "video_without_audio_stream.mp4", content_type: "video/mp4")
-    blob.analyze
+    events = capture_notifications("analyze.active_storage") do
+      blob = create_file_blob(filename: "video_without_audio_stream.mp4", content_type: "video/mp4")
+      blob.analyze
+    end
 
     assert_equal 1, events.size
     assert_equal({ analyzer: "ffprobe" }, events.first.payload)

--- a/activestorage/test/test_helper.rb
+++ b/activestorage/test/test_helper.rb
@@ -114,12 +114,6 @@ class ActiveSupport::TestCase
       ActionController::Base.raise_on_open_redirects = old_raise_on_open_redirects
       ActiveStorage::Blob.service = old_service
     end
-
-    def subscribe_events_from(name)
-      events = []
-      ActiveSupport::Notifications.subscribe(name) { |event| events << event }
-      events
-    end
 end
 
 require "global_id"


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because I believe we can greatly simplify many `ActiveSupport::Notifications` centric tests using the recently merged `ActiveSupport::Testing::NotificationAssertions` test helper module. While it does not accommodate for all tests, it does work in a majority of cases.

This specific PR is for `activestorage`.

Follow up to
- https://github.com/rails/rails/pull/53065

Extracted from
- https://github.com/rails/rails/pull/53700

### Detail

This Pull Request changes `activestorage` test(s) to use the new `NotificationAssertions` helper module, which thus allows us to cleanup various now redundant local notification capturing helper methods.

Note, if any such cleanup appears incorrect or subpar, please let me know. I'll gladly revert the change. This is the first time I've looked at more or less all of these tests so it is possible I've overlooked something.

### Additional information

This is a first pass at cleaning up Rails using this module. The module itself is only v1 at this point. I have some ideas for how we can further enhance the module to be more applicable in more cases and allow for even cleaner testing: https://github.com/rails/rails/pull/53065#issuecomment-2452017030. Have WIP implementations of `payload_subset` for `assert_notification` and `filter` for all methods.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.

I don't believe this qualifies as a change that needs to be reflected in the changelog as it is non-user-facing and does not change the public API of Rails.