### PR TITLE
Migrate applicable `railties` tests to use `NotificationAssertions`

### DIFF
--- a/railties/test/application/initializers/notifications_test.rb
+++ b/railties/test/application/initializers/notifications_test.rb
@@ -45,14 +45,10 @@ module ApplicationTests
     test "rails load_config_initializer event is instrumented" do
       app_file "config/initializers/foo.rb", ""
 
-      events = []
-      callback = ->(*_) { events << _ }
-      ActiveSupport::Notifications.subscribed(callback, "load_config_initializer.railties") do
-        app
-      end
+      event = capture_notifications("load_config_initializer.railties") { app }.first
 
-      assert_equal %w[load_config_initializer.railties], events.map(&:first)
-      assert_includes events.first.last[:initializer], "config/initializers/foo.rb"
+      assert_equal "load_config_initializer.railties", event.name
+      assert_match "config/initializers/foo.rb", event.payload[:initializer]
     end
   end
 end


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because I believe we can greatly simplify many `ActiveSupport::Notifications` centric tests using the recently merged `ActiveSupport::Testing::NotificationAssertions` test helper module. While it does not accommodate for all tests, it does work in a majority of cases.

This specific PR is for `railties`.

Follow up to
- https://github.com/rails/rails/pull/53065

Extracted from
- https://github.com/rails/rails/pull/53700

### Detail

This Pull Request changes `railties` test(s) to use the new `NotificationAssertions` helper module, which thus allows us to cleanup various now redundant local notification capturing helper methods.

Note, if any such cleanup appears incorrect or subpar, please let me know. I'll gladly revert the change. This is the first time I've looked at more or less all of these tests so it is possible I've overlooked something.

### Additional information

This is a first pass at cleaning up Rails using this module. The module itself is only v1 at this point. I have some ideas for how we can further enhance the module to be more applicable in more cases and allow for even cleaner testing: https://github.com/rails/rails/pull/53065#issuecomment-2452017030. Have WIP implementations of `payload_subset` for `assert_notification` and `filter` for all methods.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.

I don't believe this qualifies as a change that needs to be reflected in the changelog as it is non-user-facing and does not change the public API of Rails.