### PR TITLE
Active Record Connection Pool: Don't try to clear unowned connections

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -872,7 +872,9 @@ module ActiveRecord
         #--
         # if owner_thread param is omitted, this must be called in synchronize block
         def remove_connection_from_thread_cache(conn, owner_thread = conn.owner)
-          @leases[owner_thread].clear(conn)
+          if owner_thread
+            @leases[owner_thread].clear(conn)
+          end
         end
         alias_method :release, :remove_connection_from_thread_cache
 


### PR DESCRIPTION
If `conn.owner` is `nil` there's no point trying to clear the lease, and worse, if we're on Ruby 3.3.5+, `WeakKeyMap#[]` will raise an error when trying to use `nil` as a key.

FYI: @zzak 