### PR TITLE
optionally use Dependabot for npm packages

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/github/dependabot.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/github/dependabot.yml.tt
@@ -10,3 +10,10 @@ updates:
   schedule:
     interval: daily
   open-pull-requests-limit: 10
+<%- if using_js_runtime? -%>
+- package-ecosystem: npm
+  directory: "/"
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 10
+<% end -%>


### PR DESCRIPTION
https://github.com/rails/rails/pull/50508 introduced the usage of Dependabot for keeping gems and Github actions up-to-date. This change adds just a little bit more functionality, and optionally includes `npm` packages as well. (This is something I've manually in the past.) 