### PR TITLE
Set `framework_defaults` in Active Job and Action Mailer bug report t…

### DIFF
--- a/guides/bug_report_templates/action_mailer.rb
+++ b/guides/bug_report_templates/action_mailer.rb
@@ -13,6 +13,17 @@ end
 require "action_mailer/railtie"
 require "minitest/autorun"
 
+class TestApp < Rails::Application
+  config.load_defaults Rails::VERSION::STRING.to_f
+  config.root = __dir__
+  config.eager_load = false
+  config.hosts << "example.org"
+  config.secret_key_base = "secret_key_base"
+
+  config.logger = Logger.new($stdout)
+end
+Rails.application.initialize!
+
 class TestMailer < ActionMailer::Base
   def hello_world
     @message = "Hello, world"

--- a/guides/bug_report_templates/active_job.rb
+++ b/guides/bug_report_templates/active_job.rb
@@ -10,8 +10,17 @@ gemfile(true) do
   # gem "rails", github: "rails/rails", branch: "main"
 end
 
-require "active_job"
+require "active_job/railtie"
 require "minitest/autorun"
+
+class TestApp < Rails::Application
+  config.load_defaults Rails::VERSION::STRING.to_f
+  config.eager_load = false
+  config.secret_key_base = "secret_key_base"
+
+  config.logger = Logger.new($stdout)
+end
+Rails.application.initialize!
 
 class BuggyJob < ActiveJob::Base
   def perform


### PR DESCRIPTION
…emplates

Follow up to 0fedf12835442fa6204c8f39c1898fad / https://github.com/rails/rails/pull/53642 which missed the Active Job and Action Mailer templates.

When testing bugs using the bug report templates, it helps if the correct framework defaults are enabled for all templates. This makes sure the scripts behave more inline with a regular Rails application and allows easily testing older defaults.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
