### PR TITLE
Document Action Text File Upload purging [ci skip]

### DIFF
--- a/guides/source/action_text_overview.md
+++ b/guides/source/action_text_overview.md
@@ -262,12 +262,26 @@ not being installed.
 
 #### Attachment Direct Upload JavaScript Events
 
+Action Text dispatches [Active Storage Direct Upload
+Events](active_storage_overview.html#direct-upload-javascript-events) during the
+File attachment lifecycle.
+
+In addition to the typical `event.detail` properties, Action Text also
+dispatches events with an
+[`event.detail.attachment`](https://github.com/basecamp/trix/?tab=readme-ov-file#inserting-a-file)
+property.
+
 | Event name | Event target | Event data (`event.detail`) | Description |
 | --- | --- | --- | --- |
 | `direct-upload:start` | `<input>` | `{id, file}` | A direct upload is starting. |
 | `direct-upload:progress` | `<input>` | `{id, file, progress}` | As requests to store files progress. |
 | `direct-upload:error` | `<input>` | `{id, file, error}` | An error occurred. An `alert` will display unless this event is canceled. |
 | `direct-upload:end` | `<input>` | `{id, file}` | A direct upload has ended. |
+
+NOTE: It is possible for files uploaded by Action Text through [Active Storage
+Direct Uploads](active_storage_overview.html#direct-uploads) to never be
+embedded within rich text content. Consider [purging unattached
+uploads](active_storage_overview.html#purging-unattached-uploads) regularly.
 
 ### Signed GlobalID
 


### PR DESCRIPTION
### Motivation / Background

File uploaded via Action Text's integration with Active Storage Direct Uploads may be saved to the server (and the backing storage service) without ever being associated to an `ActiveStorage::Attachment` or `ActionText::RichText` record.

This commit mirrors the [Active Storage Overview][] documentation's guidance to [Purge Unattached Uploads][] regularly.

[Active Storage Overview]: https://edgeguides.rubyonrails.org/active_storage_overview.html#integrating-with-libraries-or-frameworks
[Purge Unattached Uploads]: https://edgeguides.rubyonrails.org/active_storage_overview.html#purging-unattached-uploads