### PR TITLE
Add a config for automatically including `nonce` in `javascript_tag`, `javascript_include_tag` and `stylesheet_link_tag`

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -47,4 +47,8 @@
 
     *brendon*
 
+*   Add a new configuration `content_security_policy_nonce_auto` for automatically adding a nonce to the tags affected by the directives specified by the `content_security_policy_nonce_directives` configuration option.
+
+    *francktrouillez*
+
 Please check [8-0-stable](https://github.com/rails/rails/blob/8-0-stable/actionview/CHANGELOG.md) for previous changes.

--- a/actionview/lib/action_view/helpers/asset_tag_helper.rb
+++ b/actionview/lib/action_view/helpers/asset_tag_helper.rb
@@ -26,6 +26,8 @@ module ActionView
       mattr_accessor :image_decoding
       mattr_accessor :preload_links_header
       mattr_accessor :apply_stylesheet_media_default
+      mattr_accessor :auto_include_nonce_for_scripts
+      mattr_accessor :auto_include_nonce_for_styles
 
       # Returns an HTML script tag for each of the +sources+ provided.
       #
@@ -135,7 +137,7 @@ module ActionView
             "src" => href,
             "crossorigin" => crossorigin
           }.merge!(options)
-          if tag_options["nonce"] == true
+          if tag_options["nonce"] == true || (!tag_options.key?("nonce") && auto_include_nonce_for_scripts)
             tag_options["nonce"] = content_security_policy_nonce
           end
           content_tag("script", "", tag_options)
@@ -225,7 +227,7 @@ module ActionView
             "crossorigin" => crossorigin,
             "href" => href
           }.merge!(options)
-          if tag_options["nonce"] == true
+          if tag_options["nonce"] == true || (!tag_options.key?("nonce") && auto_include_nonce_for_styles)
             tag_options["nonce"] = content_security_policy_nonce
           end
 

--- a/actionview/lib/action_view/helpers/javascript_helper.rb
+++ b/actionview/lib/action_view/helpers/javascript_helper.rb
@@ -4,6 +4,8 @@ module ActionView
   module Helpers # :nodoc:
     # = Action View JavaScript \Helpers
     module JavaScriptHelper
+      mattr_accessor :auto_include_nonce
+
       JS_ESCAPE_MAP = {
         "\\"    => "\\\\",
         "</"    => '<\/',
@@ -81,7 +83,7 @@ module ActionView
             content_or_options_with_block
           end
 
-        if html_options[:nonce] == true
+        if html_options[:nonce] == true || (!html_options.key?(:nonce) && auto_include_nonce)
           html_options[:nonce] = content_security_policy_nonce
         end
 

--- a/actionview/lib/action_view/railtie.rb
+++ b/actionview/lib/action_view/railtie.rb
@@ -72,6 +72,12 @@ module ActionView
     end
 
     config.after_initialize do |app|
+      ActionView::Helpers::AssetTagHelper.auto_include_nonce_for_scripts = app.config.content_security_policy_nonce_auto && app.config.content_security_policy_nonce_directives.intersect?(["script-src", "script-src-elem", "script-src-attr"]) && app.config.content_security_policy_nonce_generator.present?
+      ActionView::Helpers::AssetTagHelper.auto_include_nonce_for_styles = app.config.content_security_policy_nonce_auto && app.config.content_security_policy_nonce_directives.intersect?(["style-src", "style-src-elem", "style-src-attr"]) && app.config.content_security_policy_nonce_generator.present?
+      ActionView::Helpers::JavaScriptHelper.auto_include_nonce = app.config.content_security_policy_nonce_auto && app.config.content_security_policy_nonce_directives.intersect?(["script-src", "script-src-elem", "script-src-attr"]) && app.config.content_security_policy_nonce_generator.present?
+    end
+
+    config.after_initialize do |app|
       ActiveSupport.on_load(:action_view) do
         app.config.action_view.each do |k, v|
           send "#{k}=", v

--- a/actionview/test/template/asset_tag_helper_test.rb
+++ b/actionview/test/template/asset_tag_helper_test.rb
@@ -15,6 +15,24 @@ module AssetTagHelperTestHelpers
   ensure
     ActionView::Helpers::AssetTagHelper.preload_links_header = original_preload_links_header
   end
+
+  def with_auto_include_nonce_for_scripts(new_auto_include_nonce_for_scripts = true)
+    original_auto_include_nonce_for_scripts = ActionView::Helpers::AssetTagHelper.auto_include_nonce_for_scripts
+    ActionView::Helpers::AssetTagHelper.auto_include_nonce_for_scripts = new_auto_include_nonce_for_scripts
+
+    yield
+  ensure
+    ActionView::Helpers::AssetTagHelper.auto_include_nonce_for_scripts = original_auto_include_nonce_for_scripts
+  end
+
+  def with_auto_include_nonce_for_styles(new_auto_include_nonce_for_styles = true)
+    original_auto_include_nonce_for_styles = ActionView::Helpers::AssetTagHelper.auto_include_nonce_for_styles
+    ActionView::Helpers::AssetTagHelper.auto_include_nonce_for_styles = new_auto_include_nonce_for_styles
+
+    yield
+  ensure
+    ActionView::Helpers::AssetTagHelper.auto_include_nonce_for_styles = original_auto_include_nonce_for_styles
+  end
 end
 
 class AssetTagHelperTest < ActionView::TestCase
@@ -540,6 +558,12 @@ class AssetTagHelperTest < ActionView::TestCase
     assert_dom_equal %(<script src="/javascripts/bank.js" nonce="iyhD0Yc0W+c="></script>), javascript_include_tag("bank", nonce: true)
   end
 
+  def test_javascript_include_tag_nonce_with_auto_nonce
+    with_auto_include_nonce_for_scripts do
+      assert_dom_equal %(<script src="/javascripts/bank.js" nonce="iyhD0Yc0W+c="></script>), javascript_include_tag("bank")
+    end
+  end
+
   def test_stylesheet_path
     StylePathToTag.each { |method, tag| assert_dom_equal(tag, eval(method)) }
   end
@@ -562,6 +586,12 @@ class AssetTagHelperTest < ActionView::TestCase
 
   def test_stylesheet_link_tag_nonce
     assert_dom_equal %(<link rel="stylesheet" href="/stylesheets/foo.css" nonce="iyhD0Yc0W+c="></link>), stylesheet_link_tag("foo.css", nonce: true)
+  end
+
+  def test_stylesheet_link_tag_nonce_with_auto_nonce
+    with_auto_include_nonce_for_styles do
+      assert_dom_equal %(<link rel="stylesheet" href="/stylesheets/foo.css" nonce="iyhD0Yc0W+c="></link>), stylesheet_link_tag("foo.css")
+    end
   end
 
   def test_stylesheet_link_tag_with_missing_source

--- a/actionview/test/template/javascript_helper_test.rb
+++ b/actionview/test/template/javascript_helper_test.rb
@@ -10,6 +10,7 @@ class JavaScriptHelperTest < ActionView::TestCase
 
   setup do
     @old_escape_html_entities_in_json = ActiveSupport.escape_html_entities_in_json
+    @old_auto_include_nonce = ActionView::Helpers::JavaScriptHelper.auto_include_nonce
     ActiveSupport.escape_html_entities_in_json = true
     @template = self
     @request = Class.new do
@@ -19,6 +20,7 @@ class JavaScriptHelperTest < ActionView::TestCase
 
   def teardown
     ActiveSupport.escape_html_entities_in_json = @old_escape_html_entities_in_json
+    ActionView::Helpers::JavaScriptHelper.auto_include_nonce = @old_auto_include_nonce
   end
 
   def test_escape_javascript
@@ -76,5 +78,13 @@ class JavaScriptHelperTest < ActionView::TestCase
 
   def test_javascript_cdata_section
     assert_dom_equal "\n//<![CDATA[\nalert('hello')\n//]]>\n", javascript_cdata_section("alert('hello')")
+  end
+
+  def test_javascript_tag_with_auto_nonce_for_content_security_policy
+    instance_eval { def content_security_policy_nonce = "iyhD0Yc0W+c=" }
+    ActionView::Helpers::JavaScriptHelper.auto_include_nonce = true
+
+    assert_dom_equal "<script nonce=\"iyhD0Yc0W+c=\">\n//<![CDATA[\nalert('hello')\n//]]>\n</script>",
+      javascript_tag("alert('hello')")
   end
 end

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -284,6 +284,10 @@ console do
 end
 ```
 
+#### `config.content_security_policy_nonce_auto`
+
+See [Adding a Nonce](security.html#adding-a-nonce) in the Security Guide
+
 #### `config.content_security_policy_nonce_directives`
 
 See [Adding a Nonce](security.html#adding-a-nonce) in the Security Guide

--- a/guides/source/security.md
+++ b/guides/source/security.md
@@ -1503,6 +1503,21 @@ The same works with `javascript_include_tag` and the `stylesheet_link_tag`:
 <%= stylesheet_link_tag "style.css", nonce: true %>
 ```
 
+To automatically attach a nonce to `javascript_tag`, `javascript_include_tag`, and
+`stylesheet_link_tag` if the corresponding directives are specified in `config.content_security_policy_nonce_directives`,
+you can set `config.content_security_policy_nonce_auto` to `true`:
+
+```ruby
+Rails.application.config.content_security_policy_nonce_auto = true
+```
+
+This is especially useful for 3rd-party views when using nonce-based source expressions
+in your Content Security Policy.
+
+NOTE: Be mindful of caching. Since the nonce is typically generated per request,
+enabling this may lead to cache fragmentation or stale content if your caching strategy
+doesn't account for dynamic nonces.
+
 Use [`csp_meta_tag`](https://api.rubyonrails.org/classes/ActionView/Helpers/CspHelper.html#method-i-csp_meta_tag)
 helper to create a meta tag "csp-nonce" with the per-session nonce value
 for allowing inline `<script>` tags.

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -21,6 +21,7 @@ module Rails
                     :beginning_of_week, :filter_redirect, :x,
                     :content_security_policy_report_only,
                     :content_security_policy_nonce_generator, :content_security_policy_nonce_directives,
+                    :content_security_policy_nonce_auto,
                     :require_master_key, :credentials, :disable_sandbox, :sandbox_by_default,
                     :add_autoload_paths_to_load_path, :rake_eager_load, :server_timing, :log_file_size,
                     :dom_testing_default_html_version, :yjit
@@ -72,6 +73,7 @@ module Rails
         @content_security_policy_report_only     = false
         @content_security_policy_nonce_generator = nil
         @content_security_policy_nonce_directives = nil
+        @content_security_policy_nonce_auto      = false
         @require_master_key                      = false
         @loaded_config_version                   = nil
         @credentials                             = ActiveSupport::InheritableOptions.new(credentials_defaults)

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/content_security_policy.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/content_security_policy.rb.tt
@@ -20,6 +20,10 @@
 #   config.content_security_policy_nonce_generator = ->(request) { request.session.id.to_s }
 #   config.content_security_policy_nonce_directives = %w(script-src style-src)
 #
+#   # Automatically add `nonce` to `javascript_tag`, `javascript_include_tag`, and `stylesheet_link_tag`
+#   # if the corresponding directives are specified in `content_security_policy_nonce_directives`.
+#   # config.content_security_policy_nonce_auto = true
+#
 #   # Report violations without enforcing the policy.
 #   # config.content_security_policy_report_only = true
 # end


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

When using `nonce` in context of [Content Security Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP), the `nonce` attribute can currently not be added automatically to the tags used in the views.

This means that the `nonce` attribute must be added manually to each tag (`javascript_tag`, `javascript_include_tag` and `stylesheet_link_tag`) that requires it.

From my understanding, there's currently no way to automatically add those nonces to the tags.

The current solutions to this I could identify are:
- Overriding the `javascript_include_tag` and `stylesheet_link_tag` helpers to explicitly add the `nonce` attribute.
- Adding manually `nonce: true` to each tag, even though this means tags in views coming straight from third-parties will not benefit from it, and might be blocked by the CSP, even though my application should trust them.

Ideally, I would like to have access to a configuration option to automatically enable the `nonce` attribute on the tags that require it.

I don't know if there's a better way to handle this, or if there's a specific reason why we wouldn't want to.

### Detail

This pull request main change is the addition of a new configuration option `content_security_policy_nonce_auto` that allows to automatically include a `nonce` to tags affected by the directives specified in the config option `content_security_policy_nonce_directives`. In order to keep the current behavior, the new configuration option is set to `false` by default.

### Additional information

This would allow developers to easily enable the `nonce` attribute for the tags that require it, without having to manually add it to each tag. This also means that gems that are trusted and used by the application would automatically benefit from the `nonce` attribute, even if the views are internal to the third-party.

Once again, I don't know if there's a better way to handle this, or if there's a specific reason why we wouldn't want to allow such behavior.

I'm open to any feedback or suggestions on how to improve this pull request.

Thank you for your time and consideration!

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
