### PR TITLE
Fix wrongly formatted Markdown in `FixtureFile` docs [ci-skip]

### DIFF
--- a/actionpack/lib/action_dispatch/testing/test_process.rb
+++ b/actionpack/lib/action_dispatch/testing/test_process.rb
@@ -9,8 +9,7 @@ module ActionDispatch
   module TestProcess
     module FixtureFile
       # Shortcut for
-      # `Rack::Test::UploadedFile.new(File.join(ActionDispatch::IntegrationTest.file_f
-      # ixture_path, path), type)`:
+      # `Rack::Test::UploadedFile.new(File.join(ActionDispatch::IntegrationTest.file_fixture_path, path), type)`:
       #
       #     post :change_avatar, params: { avatar: file_fixture_upload('david.png', 'image/png') }
       #


### PR DESCRIPTION
# Description
Fixes a wrongly formatted piece of code in the Markdown documentation

![Screenshot 2024-12-05 at 11 16 16](https://github.com/user-attachments/assets/d4254e91-c64d-46c9-b376-34c46eab29c9)
