### PR TITLE
Changing column nullability does not change default function

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Fix MySQL default functions getting dropped when changing a column's nullability.
+
+    *Bastian Bartmann*
+
 *   SQLite extensions can be configured in `config/database.yml`.
 
     The database configuration option `extensions:` allows an application to load SQLite extensions

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -403,7 +403,11 @@ module ActiveRecord
         type ||= column.sql_type
 
         unless options.key?(:default)
-          options[:default] = column.default
+          options[:default] = if column.default_function
+            -> { column.default_function }
+          else
+            column.default
+          end
         end
 
         unless options.key?(:null)


### PR DESCRIPTION
### Motivation / Background

I noticed that changing a columns nullability on MySQL drops the columns default function. This shouldn't happen. I verified this doesn't happen with "normal" default values. Say we have the following table:

```ruby
create_table "tests", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
  t.datetime "created_at", default: -> { "(now())" }
  t.datetime "updated_at", default: "2024-12-04 10:41:01"
end
```

And the following migration:

```ruby
class TestMigration < ActiveRecord::Migration[8.0]
  def change
    change_column_null(:books, :created_at, false)
    change_column_null(:books, :updated_at, false)
  end
end
```

Running the migration will result in the following schema:

```ruby
create_table "tests", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
  t.datetime "created_at", null: false
  t.datetime "updated_at", default: "2024-12-04 10:41:01", null: false
end
```

### Detail

This happens because we have to build a `MODIFY` statement with the entire column definition (e.g., `ALTER TABLE x MODIFY x VARCHAR(255) DFEAULT 'default' NOT NULL`) and we will attempt to use the previous default value if no new one was specified. However, `MySQL::Column` has separate attributes for default values and functions, and the code to build the column definition did not account for that.

### Additional information

This bug only affects the MySQL adapter due to how it builds the `MODIFY` statement. The other adapters seem to update the nullability in separation (e.g., `ALTER TABLE x ALTER COLUMN x SET NOT NULL` for PostgreSQL).

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.