### PR TITLE
Don't wrap redis in `ConnectionPool` if already given one for `ActiveSupport::Cache::RedisCacheStore`

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Avoid wrapping redis in a `ConnectionPool` when using `ActiveSupport::Cache::RedisCacheStore` if the `:redis`
+    option is already a `ConnectionPool`.
+
+    *Joshua Young*
+
 *   Alter `ERB::Util.tokenize` to return :PLAIN token with full input string when string doesn't contain ERB tags.
 
     *Martin Emde*

--- a/activesupport/lib/active_support/cache.rb
+++ b/activesupport/lib/active_support/cache.rb
@@ -186,6 +186,9 @@ module ActiveSupport
     #   @last_mod_time = Time.now  # Invalidate the entire cache by changing namespace
     #
     class Store
+      # Default +ConnectionPool+ options
+      DEFAULT_POOL_OPTIONS = { size: 5, timeout: 5 }.freeze
+
       cattr_accessor :logger, instance_writer: true
       cattr_accessor :raise_on_invalid_cache_expiration_time, default: false
 
@@ -194,9 +197,6 @@ module ActiveSupport
 
       class << self
         private
-          DEFAULT_POOL_OPTIONS = { size: 5, timeout: 5 }.freeze
-          private_constant :DEFAULT_POOL_OPTIONS
-
           def retrieve_pool_options(options)
             if options.key?(:pool)
               pool_options = options.delete(:pool)

--- a/activesupport/lib/active_support/cache/redis_cache_store.rb
+++ b/activesupport/lib/active_support/cache/redis_cache_store.rb
@@ -111,15 +111,25 @@ module ActiveSupport
 
       # Creates a new Redis cache store.
       #
-      # There are four ways to provide the Redis client used by the cache: the
-      # +:redis+ param can be a Redis instance or a block that returns a Redis
-      # instance, or the +:url+ param can be a string or an array of strings
-      # which will be used to create a Redis instance or a +Redis::Distributed+
-      # instance.
+      # There are a few ways to provide the Redis client used by the cache:
+      #
+      # 1. The +:redis+ param can be:
+      #    - A Redis instance.
+      #    - A +ConnectionPool+ instance wrapping a Redis instance.
+      #    - A block that returns a Redis instance.
+      #
+      # 2. The +:url+ param can be:
+      #    - A string used to create a Redis instance.
+      #    - An array of strings used to create a +Redis::Distributed+ instance.
+      #
+      # If the final Redis instance is not already a +ConnectionPool+, it will
+      # be wrapped in one using +ActiveSupport::Cache::Store::DEFAULT_POOL_OPTIONS+.
+      # These options can be overridden with the +:pool+ param, or the pool can be
+      # disabled with +:pool: false+.
       #
       #   Option  Class       Result
-      #   :redis  Proc    ->  options[:redis].call
       #   :redis  Object  ->  options[:redis]
+      #   :redis  Proc    ->  options[:redis].call
       #   :url    String  ->  Redis.new(url: …)
       #   :url    Array   ->  Redis::Distributed.new([{ url: … }, { url: … }, …])
       #
@@ -149,7 +159,8 @@ module ActiveSupport
       def initialize(error_handler: DEFAULT_ERROR_HANDLER, **redis_options)
         universal_options = redis_options.extract!(*UNIVERSAL_OPTIONS)
 
-        if pool_options = self.class.send(:retrieve_pool_options, redis_options)
+        already_pool = redis_options[:redis].instance_of?(::ConnectionPool)
+        if !already_pool && pool_options = self.class.send(:retrieve_pool_options, redis_options)
           @redis = ::ConnectionPool.new(pool_options) { self.class.build_redis(**redis_options) }
         else
           @redis = self.class.build_redis(**redis_options)

--- a/activesupport/test/cache/stores/redis_cache_store_test.rb
+++ b/activesupport/test/cache/stores/redis_cache_store_test.rb
@@ -328,6 +328,16 @@ module ActiveSupport::Cache::RedisCacheStoreTests
       assert_equal 5, pool.instance_variable_get(:@timeout)
     end
 
+    def test_no_connection_pooling_by_default_when_already_pool
+      redis = ::ConnectionPool.new(size: 10, timeout: 2.5) { Redis.new }
+      cache = ActiveSupport::Cache.lookup_store(:redis_cache_store, redis: redis)
+      pool = cache.redis
+      assert_kind_of ::ConnectionPool, pool
+      assert_same redis, pool
+      assert_equal 10, pool.size
+      assert_equal 2.5, pool.instance_variable_get(:@timeout)
+    end
+
     private
       def store
         [:redis_cache_store]


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

At @buildkite we use many instances of redis and redis cluster directly, already wrapped in a connection pool. Sometimes we opt to utilise `ActiveSupport::Cache::RedisCacheStore` when we need local/in-memory scoped caching. In these cases, to get around the default behaviour of wrapping redis in a `ConnectionPool` on 7.1+ we pass in `pool: false`, which works just fine. I thought that maybe our setup is not that uncommon(?) and it would be good to take into account if a `ConnectionPool` has already been passed in via `redis:` and not wrap it if so.

I did consider whether the `pool` option should take precedence if also given in this case, however I can't think of a reason anyone would want a double wrapped pool and opted to discard those options i.e. let this guard take precedence. This also means we don't have to pollute `.retrieve_pool_options` or override it in just the redis cache store.

Just noting that this does not (and cannot) apply to `MemCacheStore` as it only expects addresses to be passed in.

Also, I wonder if it would be worth documenting that a `ConnectionPool` object is supported as an argument for `redis:`. It works currently cause [this case](https://github.com/rails/rails/blob/44673c80bde08f17659a709279972827ffa0ae64/activesupport/lib/active_support/cache/redis_cache_store.rb#L86-L87) doesn't explicitly check if it is an instance of redis/cluster.
 
### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
