### PR TITLE
Change `ActionText::RichText#embeds` assignment to `before_validation`

### DIFF
--- a/actiontext/CHANGELOG.md
+++ b/actiontext/CHANGELOG.md
@@ -1,2 +1,5 @@
+*   Change `ActionText::RichText#embeds` assignment from `before_save` to `before_validation`
+
+    *Sean Doyle*
 
 Please check [8-0-stable](https://github.com/rails/rails/blob/8-0-stable/actiontext/CHANGELOG.md) for previous changes.

--- a/actiontext/app/models/action_text/rich_text.rb
+++ b/actiontext/app/models/action_text/rich_text.rb
@@ -48,10 +48,13 @@ module ActionText
     ##
     # :method: embeds
     #
-    # Returns the `ActiveStorage::Blob`s of the embedded files.
+    # Returns the `ActiveStorage::Attachment` records from the embedded files.
+    #
+    # Attached `ActiveStorage::Blob` records are extracted from the `body`
+    # in a # [before_validation](/classes/ActiveModel/Validations/Callbacks/ClassMethods.html#method-i-before_validation) callback.
     has_many_attached :embeds
 
-    before_save do
+    before_validation do
       self.embeds = body.attachables.grep(ActiveStorage::Blob).uniq if body.present?
     end
 


### PR DESCRIPTION
### Motivation / Background

Prior to this commit, assignment to the `embeds` association happens _after_ validation callbacks, so it isn't possible to incorporate Rich Text-related file validation.

### Detail

For example, consider rejecting `text/plain` files when creating `Message` records:

```ruby
class Message < ApplicationRecord
  has_rich_text :content

  validate do
    if content.embeds.any? { |attachment| attachment.blob.content_type == "text/plain" }
      errors.add(:content, "Cannot attach text/plain files")
    end
  end
end
```

Without this change, the `content.embeds` association is empty at the time the `validate` block is evaluated, since that assignment occurs in a `before_save` callback on the `ActionText::Content` class.

Alongside this change, the commit corrects the documentation on the `has_many_attached :embeds` line. The returned collection is of `ActiveStorage::Attachment` records and **not** `ActiveStorage::Blob` records as documented.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
