### PR TITLE
`all_open_transactions` should not include invalidated transactions

### DIFF
--- a/activerecord/lib/active_record.rb
+++ b/activerecord/lib/active_record.rb
@@ -548,8 +548,10 @@ module ActiveRecord
     open_transactions = []
     Base.connection_handler.each_connection_pool do |pool|
       if active_connection = pool.active_connection
-        if active_connection.current_transaction.open? && active_connection.current_transaction.joinable?
-          open_transactions << active_connection.current_transaction
+        current_transaction = active_connection.current_transaction
+
+        if current_transaction.open? && current_transaction.joinable? && !current_transaction.state.invalidated?
+          open_transactions << current_transaction
         end
       end
     end

--- a/activerecord/test/cases/transactions_test.rb
+++ b/activerecord/test/cases/transactions_test.rb
@@ -67,6 +67,14 @@ module TransactionCallbacksTests
       raise ActiveRecord::Rollback
     end
     assert_equal 0, called
+
+    called = 0
+    Topic.transaction do |transaction|
+      transaction.instance_variable_get(:@internal_transaction).invalidate!
+      ActiveRecord.after_all_transactions_commit { called += 1 }
+      assert_equal 1, called
+    end
+    assert_equal 1, called
   end
 
   def test_after_current_transaction_commit_multidb_nested_transactions


### PR DESCRIPTION
invalidated transactions aren't really open. This can happen when a [transaction is retried][1], so the transaction is invalidated and when executing the block again, we would get an exception.

As there is no open transaction, the `after_all_transactions_commit` blocks should just execute as if there were no open transactions.

[1]: https://github.com/rails/rails/blob/d3e3eefeef20bfbec69a8358a7c39d3a7f20574c/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb#L1032