### PR TITLE
Fix for Google Lighthouse / PageSpeed Insight Tool being shown a 406 status code

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -644,7 +644,7 @@ GEM
     uber (0.1.0)
     unicode-display_width (2.6.0)
     uri (0.13.1)
-    useragent (0.16.10)
+    useragent (0.16.11)
     w3c_validators (1.3.7)
       json (>= 1.8)
       nokogiri (~> 1.6)

--- a/actionpack/test/controller/allow_browser_test.rb
+++ b/actionpack/test/controller/allow_browser_test.rb
@@ -34,6 +34,7 @@ class AllowBrowserTest < ActionController::TestCase
   IE_11         = "Mozilla/5.0 (Windows NT 10.0; WOW64; Trident/7.0; rv:11.0) like Gecko"
   OPERA_106     = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36 OPR/106.0.0.0"
   GOOGLE_BOT    = "Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5X Build/MMB29P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/W.X.Y.Z Mobile Safari/537.36 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)"
+  LIGHTHOUSE    = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/94.0.4590.2 Safari/537.36 Chrome-Lighthouse"
 
   test "blocked browser below version limit with callable" do
     get_with_agent :hello, FIREFOX_114
@@ -80,6 +81,12 @@ class AllowBrowserTest < ActionController::TestCase
     assert_response :ok
 
     get_with_agent :modern, GOOGLE_BOT
+    assert_response :ok
+
+    get_with_agent :hello, LIGHTHOUSE
+    assert_response :ok
+
+    get_with_agent :modern, LIGHTHOUSE
     assert_response :ok
   end
 


### PR DESCRIPTION
Fix for `allow_browser` throwing a 406 status code when request are made from Google Lighthouse / PageSpeed Insight Tool

### Motivation / Background

Google PageSpeed Insight is a tool that makes requests from a server to the website specificed. If it makes a request to newer Rails websites that use allow_browser feature then it returns a 406 status code as the browser is slightly older but we should treat this same as a bot like we do for crawling purpose and generate Page speed insights.

This Pull Request has been created to solve this issue where we want to support modern browser but also want bots to crawl without being thrown a 406 status code like in the case for Google's Lighthouse Tool.

![image](https://github.com/user-attachments/assets/77cb9fb8-8a44-49a0-8b74-006ba3343547)

### Detail

This PR bumps the useragent gem which has a fix for this where Lighthouse Tool is considered a bot and lets the request go through instead of terminating the request early with a 406 status code and new 406 page.

### Checklist

Before submitting the PR make sure the following are checked:

* [ ] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
