### PR TITLE
Change the internal transaction state to be closed when the transaction is finalized

### DIFF
--- a/activerecord/lib/active_record.rb
+++ b/activerecord/lib/active_record.rb
@@ -550,7 +550,7 @@ module ActiveRecord
       if active_connection = pool.active_connection
         current_transaction = active_connection.current_transaction
 
-        if current_transaction.open? && current_transaction.joinable? && !current_transaction.state.invalidated?
+        if current_transaction.open? && current_transaction.joinable?
           open_transactions << current_transaction
         end
       end

--- a/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
@@ -175,11 +175,11 @@ module ActiveRecord
       end
 
       def open?
-        true
+        !closed?
       end
 
       def closed?
-        false
+        @state.finalized?
       end
 
       def add_record(record, ensure_finalize = true)

--- a/activerecord/lib/active_record/transaction.rb
+++ b/activerecord/lib/active_record/transaction.rb
@@ -112,7 +112,7 @@ module ActiveRecord
 
     # Returns true if the transaction doesn't exist or is finalized.
     def closed?
-      @internal_transaction.nil? || @internal_transaction.state.finalized?
+      @internal_transaction.nil? || @internal_transaction.closed?
     end
 
     alias_method :blank?, :closed?


### PR DESCRIPTION
Before we were using the null pattern to calculate if the transaction is open or not, but there are cases like when the transaction is invalidated that we keep the transaction object around, and just change the state.

The previous behavior made us miss cases where the transaction aren't not really open in our code. See 2f571a5258278f66cb8ef05e667fd7ff1d3d0fe5.

The public facing transaction object already had the behavior we are implementing here, so we are just aligning the internal transaction object to have the same behavior.