### PR TITLE
Accept a block for `ActiveJob::ConfiguredJob#perform_later`

### DIFF
--- a/activejob/CHANGELOG.md
+++ b/activejob/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Accept a block for `ActiveJob::ConfiguredJob#perform_later`.
+
+    This was inconsistent with a regular `ActiveJob::Base#perform_later`.
+
+    *fatkodima*
+
 *   Raise a more specific error during deserialization when a previously serialized job class is now unknown.
 
     `ActiveJob::UnknownJobClassError` will be raised instead of a more generic

--- a/activejob/lib/active_job/configured_job.rb
+++ b/activejob/lib/active_job/configured_job.rb
@@ -12,7 +12,12 @@ module ActiveJob
     end
 
     def perform_later(...)
-      @job_class.new(...).enqueue @options
+      job = @job_class.new(...)
+      enqueue_result = job.enqueue(@options)
+
+      yield job if block_given?
+
+      enqueue_result
     end
 
     def perform_all_later(multi_args)

--- a/activejob/test/cases/queuing_test.rb
+++ b/activejob/test/cases/queuing_test.rb
@@ -50,6 +50,15 @@ class QueuingTest < ActiveSupport::TestCase
     end
   end
 
+  test "configured job is yielded to block after enqueue with successfully_enqueued property set" do
+    HelloJob.set(queue: :some_queue).perform_later "John" do |job|
+      assert_equal "John says hello", JobBuffer.last_value
+      assert_equal [ "John" ], job.arguments
+      assert_equal "some_queue", job.queue_name
+      assert_equal true, job.successfully_enqueued?
+    end
+  end
+
   test "when enqueuing raises an EnqueueError job is yielded to block with error set on job" do
     EnqueueErrorJob.perform_later do |job|
       assert_equal false, job.successfully_enqueued?


### PR DESCRIPTION
Fixes #53856.