### PR TITLE
Try to fix various flakes in AR tests

### DIFF
--- a/activerecord/test/cases/adapters/abstract_mysql_adapter/nested_deadlock_test.rb
+++ b/activerecord/test/cases/adapters/abstract_mysql_adapter/nested_deadlock_test.rb
@@ -48,7 +48,7 @@ module ActiveRecord
               Sample.transaction(requires_new: true) do
                 assert_current_transaction_is_savepoint_transaction
                 s1.lock!
-                barrier.wait
+                barrier.wait(30)
                 s2.update value: 1
               end
             end
@@ -60,7 +60,7 @@ module ActiveRecord
               Sample.transaction(requires_new: true) do
                 assert_current_transaction_is_savepoint_transaction
                 s2.lock!
-                barrier.wait
+                barrier.wait(30)
                 s1.update value: 2
               end
             end
@@ -91,7 +91,7 @@ module ActiveRecord
           Sample.transaction(requires_new: true) do
             assert_current_transaction_is_savepoint_transaction
             s1.lock!
-            barrier.wait
+            barrier.wait(30)
             s2.update value: 4
 
           rescue ActiveRecord::Deadlocked
@@ -113,7 +113,7 @@ module ActiveRecord
           Sample.transaction(requires_new: true) do
             assert_current_transaction_is_savepoint_transaction
             s2.lock!
-            barrier.wait
+            barrier.wait(30)
             s1.update value: 3
           rescue ActiveRecord::Deadlocked
             deadlocks += 1
@@ -143,7 +143,7 @@ module ActiveRecord
             Sample.transaction(requires_new: true) do
               assert_current_transaction_is_savepoint_transaction
               s1.lock!
-              barrier.wait
+              barrier.wait(30)
               s2.update value: 4
             end
           rescue ActiveRecord::Deadlocked
@@ -160,7 +160,7 @@ module ActiveRecord
             Sample.transaction(requires_new: true) do
               assert_current_transaction_is_savepoint_transaction
               s2.lock!
-              barrier.wait
+              barrier.wait(30)
               s1.update value: 3
             end
           rescue ActiveRecord::Deadlocked

--- a/activerecord/test/cases/encryption/concurrency_test.rb
+++ b/activerecord/test/cases/encryption/concurrency_test.rb
@@ -9,12 +9,12 @@ class ActiveRecord::Encryption::ConcurrencyTest < ActiveRecord::EncryptionTestCa
   end
 
   test "models can be encrypted and decrypted in different threads concurrently" do
-    4.times.collect { |index| thread_encrypting_and_decrypting("thread #{index}") }.each(&:join)
+    3.times.collect { |index| thread_encrypting_and_decrypting("thread #{index}") }.each(&:join)
   end
 
   def thread_encrypting_and_decrypting(thread_label)
-    EncryptedPost.insert_all 100.times.collect { |index| { title: "Article #{index} (#{thread_label})", body: "Body #{index} (#{thread_label})" } }
-    posts = EncryptedPost.last(100)
+    EncryptedPost.insert_all 10.times.collect { |index| { title: "Article #{index} (#{thread_label})", body: "Body #{index} (#{thread_label})" } }
+    posts = EncryptedPost.last(10)
 
     Thread.new do
       posts.each.with_index do |article, index|


### PR DESCRIPTION
These changes along with #53855 and I have been able to run without any failures on my machine.

```
for i in {1..50}; do ARCONN=mysql2 MYSQL_PREPARED_STATEMENTS=true bundle exec rake test:mysql2; done
```

This is after a few days of on-and-off running this at various lengths to try and identify problematic test cases or situations that could trigger flakes.

I'm not an expert here, but I do know the scientific method. :joy: Some of the stacktraces in the commit messages could be false positives, but the point is they are gone, and I thought it's a good point to ask. So would appreciate feedback and reviews. :bow:

/cc @byroot @matthewd 