### PR TITLE
Update prompt_regexp for console code examples in guides

### DIFF
--- a/guides/rails_guides/markdown/renderer.rb
+++ b/guides/rails_guides/markdown/renderer.rb
@@ -88,7 +88,7 @@ module RailsGuides
             when "bash"
               /^\$ /
             when "irb"
-              /^irb.*?> /
+              /^(irb.*?|\w+\(\w+\))> /
             end
 
           if prompt_regexp


### PR DESCRIPTION
For code examples in irb we remove the prompt (`irb>`) from the results for the copy button. For the following example the result would be `puts "hello!"`:
```irb
irb> puts "hello!"
```

With the updated console prompt the regexp needs to change to support:
```irb
blog(test)> puts "hello!"
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
