### PR TITLE
Fix `if_exists`/`if_not_exists` for foreign keys addition and removal

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -1172,9 +1172,10 @@ module ActiveRecord
       #   +:deferred+ or +:immediate+ to specify the default behavior. Defaults to +false+.
       def add_foreign_key(from_table, to_table, **options)
         return unless use_foreign_keys?
-        return if options[:if_not_exists] == true && foreign_key_exists?(from_table, to_table, **options.slice(:column))
 
         options = foreign_key_options(from_table, to_table, options)
+        return if options[:if_not_exists] == true && foreign_key_exists?(from_table, to_table, **options.slice(:column, :primary_key))
+
         at = create_alter_table from_table
         at.add_foreign_key to_table, options
 
@@ -1213,7 +1214,7 @@ module ActiveRecord
       #   The name of the table that contains the referenced primary key.
       def remove_foreign_key(from_table, to_table = nil, **options)
         return unless use_foreign_keys?
-        return if options.delete(:if_exists) == true && !foreign_key_exists?(from_table, to_table)
+        return if options.delete(:if_exists) == true && !foreign_key_exists?(from_table, to_table, **options.slice(:column))
 
         fk_name_to_delete = foreign_key_for!(from_table, to_table: to_table, **options).name
 

--- a/activerecord/lib/active_record/connection_adapters/sqlite3/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3/schema_statements.rb
@@ -63,7 +63,7 @@ module ActiveRecord
         end
 
         def remove_foreign_key(from_table, to_table = nil, **options)
-          return if options.delete(:if_exists) == true && !foreign_key_exists?(from_table, to_table)
+          return if options.delete(:if_exists) == true && !foreign_key_exists?(from_table, to_table, **options.slice(:column))
 
           to_table ||= options[:to_table]
           options = options.except(:name, :to_table, :validate)

--- a/activerecord/test/cases/migration/foreign_key_test.rb
+++ b/activerecord/test/cases/migration/foreign_key_test.rb
@@ -235,13 +235,29 @@ if ActiveRecord::Base.lease_connection.supports_foreign_keys?
         end
 
         def test_add_foreign_key_with_if_not_exists_to_already_referenced_table
-          @connection.add_foreign_key :astronauts, :rockets
-          @connection.add_foreign_key :astronauts, :rockets, column: "favorite_rocket_id", if_not_exists: true
+          @connection.add_foreign_key :astronauts, :rockets, column: "favorite_rocket_id"
+          @connection.add_foreign_key :astronauts, :rockets, if_not_exists: true
 
           foreign_keys = @connection.foreign_keys("astronauts")
           assert_equal 2, foreign_keys.size
           assert foreign_keys.all? { |fk| fk.to_table == "rockets" }
           assert_equal ["favorite_rocket_id", "rocket_id"], foreign_keys.map(&:column).sort
+        end
+
+        def test_add_foreign_key_with_if_not_exists_considers_primary_key_option
+          @connection.add_column :rockets, :id_for_type_change, :bigint
+
+          # Is needed to be able to reference by foreign key
+          @connection.add_index :rockets, :id_for_type_change, unique: true
+
+          @connection.add_foreign_key :astronauts, :rockets
+          @connection.add_foreign_key(:astronauts, :rockets, primary_key: :id_for_type_change,
+            name: "custom_pk",  if_not_exists: true)
+
+          foreign_keys = @connection.foreign_keys("astronauts")
+          assert_equal 2, foreign_keys.size
+          assert foreign_keys.all? { |fk| fk.to_table == "rockets" }
+          assert_equal ["id", "id_for_type_change"], foreign_keys.map(&:primary_key).sort
         end
 
         def test_add_foreign_key_with_non_standard_primary_key
@@ -422,6 +438,15 @@ if ActiveRecord::Base.lease_connection.supports_foreign_keys?
           assert_equal 1, @connection.foreign_keys("astronauts").size
           @connection.remove_foreign_key :astronauts, name: "fancy_named_fk"
           assert_equal [], @connection.foreign_keys("astronauts")
+        end
+
+        def test_remove_foreign_key_if_exists_and_custom_column
+          @connection.add_column :astronauts, :myrocket_id, :bigint
+          @connection.add_foreign_key :astronauts, :rockets
+          assert_equal 1, @connection.foreign_keys("astronauts").size
+
+          @connection.remove_foreign_key :astronauts, :rockets, column: :myrocket_id, if_exists: true
+          assert_equal 1, @connection.foreign_keys("astronauts").size
         end
 
         def test_remove_foreign_non_existing_foreign_key_raises


### PR DESCRIPTION
Currently, there are a few problems with foreign keys additions/removals and if_exists/if_not_exists (all these cases are reflected in the added test cases).

1. if there is a foreign key on a custom column and `add_foreign_key` on a default column with `if_not_exists` is used, the error is raised, because `foreign_key_exists?` returns true (custom column was not passed and it just checks if there is any foreign key to the target table)
2. when adding a foreign key with `if_not_exists`, `:primary_key` is not considered. In postgres, it is a popular practice when changing the type of a primary key to create a duplicate column (say named `id_for_type_change`) and before switching to it copy all the database objects from primary key to it too (indexes, foreign keys etc).
3. When removing a foreign key with `if_exists`, custom column is not considered. So if there is a standard foreign key (on a default column) and we use `remove_foreign_key ..., column: :my_custom_column, if_exists: true`, `foreign_key_exists?` just returns true because there is any foreign key and then raises afterwards. 