### PR TITLE
Remove example from validation_context

### DIFF
--- a/activemodel/lib/active_model/validations.rb
+++ b/activemodel/lib/active_model/validations.rb
@@ -437,20 +437,6 @@ module ActiveModel
     alias :read_attribute_for_validation :send
 
     # Returns the context when running validations.
-    #
-    # This is useful when running validations except a certain context (opposite to the +on+ option).
-    #
-    #   class Person
-    #     include ActiveModel::Validations
-    #
-    #     attr_accessor :name
-    #     validates :name, presence: true, if: -> { validation_context != :custom }
-    #   end
-    #
-    #   person = Person.new
-    #   person.valid?          #=> false
-    #   person.valid?(:new)    #=> false
-    #   person.valid?(:custom) #=> true
     def validation_context
       context_for_validation.context
     end


### PR DESCRIPTION
Since the [`except_on` option] was added we have a better way to skip validations on certain contexts, so this example is no longer fitting.

[`except_on` option]: https://github.com/rails/rails/pull/43495/files

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
