### PR TITLE
Also handle `ConnectionPool::Wrapper` objects in `RedisCacheStore`

### DIFF
--- a/activesupport/lib/active_support/cache/redis_cache_store.rb
+++ b/activesupport/lib/active_support/cache/redis_cache_store.rb
@@ -158,8 +158,11 @@ module ActiveSupport
       #   cache.exist?('bar') # => false
       def initialize(error_handler: DEFAULT_ERROR_HANDLER, **redis_options)
         universal_options = redis_options.extract!(*UNIVERSAL_OPTIONS)
+        redis = redis_options[:redis]
 
-        already_pool = redis_options[:redis].instance_of?(::ConnectionPool)
+        already_pool = redis.instance_of?(::ConnectionPool) ||
+                       (redis.respond_to?(:wrapped_pool) && redis.wrapped_pool.instance_of?(::ConnectionPool))
+
         if !already_pool && pool_options = self.class.send(:retrieve_pool_options, redis_options)
           @redis = ::ConnectionPool.new(pool_options) { self.class.build_redis(**redis_options) }
         else

--- a/activesupport/test/cache/stores/redis_cache_store_test.rb
+++ b/activesupport/test/cache/stores/redis_cache_store_test.rb
@@ -328,12 +328,24 @@ module ActiveSupport::Cache::RedisCacheStoreTests
       assert_equal 5, pool.instance_variable_get(:@timeout)
     end
 
-    def test_no_connection_pooling_by_default_when_already_pool
+    def test_no_connection_pooling_by_default_when_already_a_pool
       redis = ::ConnectionPool.new(size: 10, timeout: 2.5) { Redis.new }
       cache = ActiveSupport::Cache.lookup_store(:redis_cache_store, redis: redis)
       pool = cache.redis
       assert_kind_of ::ConnectionPool, pool
       assert_same redis, pool
+      assert_equal 10, pool.size
+      assert_equal 2.5, pool.instance_variable_get(:@timeout)
+    end
+
+    def test_no_connection_pooling_by_default_when_already_wrapped_in_a_pool
+      redis = ::ConnectionPool::Wrapper.new(size: 10, timeout: 2.5) { Redis.new }
+      cache = ActiveSupport::Cache.lookup_store(:redis_cache_store, redis: redis)
+      wrapped_redis = cache.redis
+      assert_kind_of ::Redis, wrapped_redis
+      assert_same redis, wrapped_redis
+      pool = wrapped_redis.wrapped_pool
+      assert_kind_of ::ConnectionPool, pool
       assert_equal 10, pool.size
       assert_equal 2.5, pool.instance_variable_get(:@timeout)
     end


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

Follow-up to https://github.com/rails/rails/pull/53845 which didn't consider `ConnectionPool::Wrapper` objects.

cc/ @byroot 

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.