### PR TITLE
Mysql2Adapter: stop calling `interlock.permit_concurrent_loads`

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/mysql2/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql2/database_statements.rb
@@ -50,22 +50,18 @@ module ActiveRecord
 
             result = nil
             if binds.nil? || binds.empty?
-              ActiveSupport::Dependencies.interlock.permit_concurrent_loads do
-                result = raw_connection.query(sql)
-                # Ref: https://github.com/brianmario/mysql2/pull/1383
-                # As of mysql2 0.5.6 `#affected_rows` might raise Mysql2::Error if a prepared statement
-                # from that same connection was GCed while `#query` released the GVL.
-                # By avoiding to call `#affected_rows` when we have a result, we reduce the likeliness
-                # of hitting the bug.
-                @affected_rows_before_warnings = result&.size || raw_connection.affected_rows
-              end
+              result = raw_connection.query(sql)
+              # Ref: https://github.com/brianmario/mysql2/pull/1383
+              # As of mysql2 0.5.6 `#affected_rows` might raise Mysql2::Error if a prepared statement
+              # from that same connection was GCed while `#query` released the GVL.
+              # By avoiding to call `#affected_rows` when we have a result, we reduce the likeliness
+              # of hitting the bug.
+              @affected_rows_before_warnings = result&.size || raw_connection.affected_rows
             elsif prepare
               stmt = @statements[sql] ||= raw_connection.prepare(sql)
               begin
-                ActiveSupport::Dependencies.interlock.permit_concurrent_loads do
-                  result = stmt.execute(*type_casted_binds)
-                  @affected_rows_before_warnings = stmt.affected_rows
-                end
+                result = stmt.execute(*type_casted_binds)
+                @affected_rows_before_warnings = stmt.affected_rows
               rescue ::Mysql2::Error
                 @statements.delete(sql)
                 raise
@@ -74,10 +70,8 @@ module ActiveRecord
               stmt = raw_connection.prepare(sql)
 
               begin
-                ActiveSupport::Dependencies.interlock.permit_concurrent_loads do
-                  result = stmt.execute(*type_casted_binds)
-                  @affected_rows_before_warnings = stmt.affected_rows
-                end
+                result = stmt.execute(*type_casted_binds)
+                @affected_rows_before_warnings = stmt.affected_rows
 
                 # Ref: https://github.com/brianmario/mysql2/pull/1383
                 # by eagerly closing uncached prepared statements, we also reduce the chances of


### PR DESCRIPTION
In `007e50d8e5a900547471b6c4ec79d9d217682c5d` all adapters started wrapping DB calls with the interlock release.

However in https://github.com/rails/rails/pull/44576, this was removed from all adapters but Mysql2.

This suggest it isn't really needed.
