### PR TITLE
Fix handle_warnings with mysql2 master

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -762,7 +762,6 @@ module ActiveRecord
         def handle_warnings(sql)
           return if ActiveRecord.db_warnings_action.nil? || @raw_connection.warning_count == 0
 
-          @affected_rows_before_warnings = @raw_connection.affected_rows
           warning_count = @raw_connection.warning_count
           result = @raw_connection.query("SHOW WARNINGS")
           result = [


### PR DESCRIPTION
```
$ bundle
Fetching https://github.com/brianmario/mysql2.git
Fetching gem metadata from https://rubygems.org/.........
Resolving dependencies...
Bundle complete! 85 Gemfile dependencies, 242 gems now installed.
Use `bundle info [gemname]` to see where a bundled gem is installed.

$ ARCONN=mysql2 bin/test test/cases/adapters/abstract_mysql_adapter/warnings_test.rb
Using mysql2
Run options: --seed 2498

E

Error:
WarningsTest#test_db_warnings_action_allows_a_list_of_warnings_to_ignore:
ActiveRecord::StatementInvalid: Mysql2::Error:
    lib/active_record/connection_adapters/abstract_mysql_adapter.rb:765:in `affected_rows'
    lib/active_record/connection_adapters/abstract_mysql_adapter.rb:765:in `handle_warnings'
    lib/active_record/connection_adapters/mysql2/database_statements.rb:103:in `perform_query'
    lib/active_record/connection_adapters/abstract/database_statements.rb:556:in `block (2 levels) in raw_execute'
    lib/active_record/connection_adapters/abstract_adapter.rb:1029:in `block in with_raw_connection'
    /home/zzak/code/rails/activesupport/lib/active_support/concurrency/load_interlock_aware_monitor.rb:23:in `handle_interrupt'
    /home/zzak/code/rails/activesupport/lib/active_support/concurrency/load_interlock_aware_monitor.rb:23:in `block in synchronize'
    /home/zzak/code/rails/activesupport/lib/active_support/concurrency/load_interlock_aware_monitor.rb:19:in `handle_interrupt'
    /home/zzak/code/rails/activesupport/lib/active_support/concurrency/load_interlock_aware_monitor.rb:19:in `synchronize'
    lib/active_record/connection_adapters/abstract_adapter.rb:998:in `with_raw_connection'
    lib/active_record/connection_adapters/abstract/database_statements.rb:555:in `block in raw_execute'
    /home/zzak/code/rails/activesupport/lib/active_support/notifications/instrumenter.rb:58:in `instrument'
    lib/active_record/connection_adapters/abstract_adapter.rb:1149:in `log'
    lib/active_record/connection_adapters/abstract/database_statements.rb:554:in `raw_execute'
    lib/active_record/connection_adapters/abstract/database_statements.rb:591:in `internal_execute'
    lib/active_record/connection_adapters/abstract/database_statements.rb:137:in `execute'
    lib/active_record/connection_adapters/abstract/query_cache.rb:27:in `execute'
    test/cases/adapters/abstract_mysql_adapter/warnings_test.rb:74:in `block (2 levels) in <class:WarningsTest>'
    test/cases/test_case.rb:172:in `with_db_warnings_action'
    test/cases/adapters/abstract_mysql_adapter/warnings_test.rb:73:in `block in <class:WarningsTest>'

bin/test test/cases/adapters/abstract_mysql_adapter/warnings_test.rb:72

F

Failure:
WarningsTest#test_db_warnings_action_:raise_on_warning [test/cases/adapters/abstract_mysql_adapter/warnings_test.rb:14]:
[ActiveRecord::SQLWarning] exception expected, not
Class: <ActiveRecord::StatementInvalid>
Message: <"Mysql2::Error: ">
---Backtrace---
/home/zzak/code/rails/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb:765:in `affected_rows'
/home/zzak/code/rails/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb:765:in `handle_warnings'
/home/zzak/code/rails/activerecord/lib/active_record/connection_adapters/mysql2/database_statements.rb:103:in `perform_query'
/home/zzak/code/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:556:in `block (2 levels) in raw_execute'
/home/zzak/code/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:1029:in `block in with_raw_connection'
/home/zzak/code/rails/activesupport/lib/active_support/concurrency/load_interlock_aware_monitor.rb:23:in `handle_interrupt'
/home/zzak/code/rails/activesupport/lib/active_support/concurrency/load_interlock_aware_monitor.rb:23:in `block in synchronize'
/home/zzak/code/rails/activesupport/lib/active_support/concurrency/load_interlock_aware_monitor.rb:19:in `handle_interrupt'
/home/zzak/code/rails/activesupport/lib/active_support/concurrency/load_interlock_aware_monitor.rb:19:in `synchronize'
/home/zzak/code/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:998:in `with_raw_connection'
/home/zzak/code/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:555:in `block in raw_execute'
/home/zzak/code/rails/activesupport/lib/active_support/notifications/instrumenter.rb:58:in `instrument'
/home/zzak/code/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:1149:in `log'
/home/zzak/code/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:554:in `raw_execute'
/home/zzak/code/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:591:in `internal_execute'
/home/zzak/code/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:137:in `execute'
/home/zzak/code/rails/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb:27:in `execute'
/home/zzak/code/rails/activerecord/test/cases/adapters/abstract_mysql_adapter/warnings_test.rb:15:in `block (3 levels) in <class:WarningsTest>'
---------------

bin/test test/cases/adapters/abstract_mysql_adapter/warnings_test.rb:12

E

Error:
WarningsTest#test_db_warnings_action_allows_a_list_of_codes_to_ignore:
ActiveRecord::StatementInvalid: Mysql2::Error:
    lib/active_record/connection_adapters/abstract_mysql_adapter.rb:765:in `affected_rows'
    lib/active_record/connection_adapters/abstract_mysql_adapter.rb:765:in `handle_warnings'
    lib/active_record/connection_adapters/mysql2/database_statements.rb:103:in `perform_query'
    lib/active_record/connection_adapters/abstract/database_statements.rb:556:in `block (2 levels) in raw_execute'
    lib/active_record/connection_adapters/abstract_adapter.rb:1029:in `block in with_raw_connection'
    /home/zzak/code/rails/activesupport/lib/active_support/concurrency/load_interlock_aware_monitor.rb:23:in `handle_interrupt'
    /home/zzak/code/rails/activesupport/lib/active_support/concurrency/load_interlock_aware_monitor.rb:23:in `block in synchronize'
    /home/zzak/code/rails/activesupport/lib/active_support/concurrency/load_interlock_aware_monitor.rb:19:in `handle_interrupt'
    /home/zzak/code/rails/activesupport/lib/active_support/concurrency/load_interlock_aware_monitor.rb:19:in `synchronize'
    lib/active_record/connection_adapters/abstract_adapter.rb:998:in `with_raw_connection'
    lib/active_record/connection_adapters/abstract/database_statements.rb:555:in `block in raw_execute'
    /home/zzak/code/rails/activesupport/lib/active_support/notifications/instrumenter.rb:58:in `instrument'
    lib/active_record/connection_adapters/abstract_adapter.rb:1149:in `log'
    lib/active_record/connection_adapters/abstract/database_statements.rb:554:in `raw_execute'
    lib/active_record/connection_adapters/abstract/database_statements.rb:591:in `internal_execute'
    lib/active_record/connection_adapters/abstract/database_statements.rb:137:in `execute'
    lib/active_record/connection_adapters/abstract/query_cache.rb:27:in `execute'
    test/cases/adapters/abstract_mysql_adapter/warnings_test.rb:82:in `block (2 levels) in <class:WarningsTest>'
    test/cases/test_case.rb:172:in `with_db_warnings_action'
    test/cases/adapters/abstract_mysql_adapter/warnings_test.rb:81:in `block in <class:WarningsTest>'

bin/test test/cases/adapters/abstract_mysql_adapter/warnings_test.rb:80

F

Failure:
WarningsTest#test_db_warnings_action_handles_when_warning_count_does_not_match_returned_warnings [test/cases/adapters/abstract_mysql_adapter/warnings_test.rb:100]:
[ActiveRecord::SQLWarning] exception expected, not
Class: <ActiveRecord::StatementInvalid>
Message: <"Mysql2::Error: ">
---Backtrace---
/home/zzak/code/rails/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb:765:in `affected_rows'
/home/zzak/code/rails/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb:765:in `handle_warnings'
/home/zzak/code/rails/activerecord/lib/active_record/connection_adapters/mysql2/database_statements.rb:103:in `perform_query'
/home/zzak/code/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:556:in `block (2 levels) in raw_execute'
/home/zzak/code/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:1029:in `block in with_raw_connection'
/home/zzak/code/rails/activesupport/lib/active_support/concurrency/load_interlock_aware_monitor.rb:23:in `handle_interrupt'
/home/zzak/code/rails/activesupport/lib/active_support/concurrency/load_interlock_aware_monitor.rb:23:in `block in synchronize'
/home/zzak/code/rails/activesupport/lib/active_support/concurrency/load_interlock_aware_monitor.rb:19:in `handle_interrupt'
/home/zzak/code/rails/activesupport/lib/active_support/concurrency/load_interlock_aware_monitor.rb:19:in `synchronize'
/home/zzak/code/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:998:in `with_raw_connection'
/home/zzak/code/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:555:in `block in raw_execute'
/home/zzak/code/rails/activesupport/lib/active_support/notifications/instrumenter.rb:58:in `instrument'
/home/zzak/code/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:1149:in `log'
/home/zzak/code/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:554:in `raw_execute'
/home/zzak/code/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:591:in `internal_execute'
/home/zzak/code/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:137:in `execute'
/home/zzak/code/rails/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb:27:in `execute'
/home/zzak/code/rails/activerecord/test/cases/adapters/abstract_mysql_adapter/warnings_test.rb:101:in `block (4 levels) in <class:WarningsTest>'
---------------

bin/test test/cases/adapters/abstract_mysql_adapter/warnings_test.rb:96

.E

Error:
WarningsTest#test_db_warnings_action_:log_on_warning:
ActiveRecord::StatementInvalid: Mysql2::Error:
    lib/active_record/connection_adapters/abstract_mysql_adapter.rb:765:in `affected_rows'
    lib/active_record/connection_adapters/abstract_mysql_adapter.rb:765:in `handle_warnings'
    lib/active_record/connection_adapters/mysql2/database_statements.rb:103:in `perform_query'
    lib/active_record/connection_adapters/abstract/database_statements.rb:556:in `block (2 levels) in raw_execute'
    lib/active_record/connection_adapters/abstract_adapter.rb:1029:in `block in with_raw_connection'
    /home/zzak/code/rails/activesupport/lib/active_support/concurrency/load_interlock_aware_monitor.rb:23:in `handle_interrupt'
    /home/zzak/code/rails/activesupport/lib/active_support/concurrency/load_interlock_aware_monitor.rb:23:in `block in synchronize'
    /home/zzak/code/rails/activesupport/lib/active_support/concurrency/load_interlock_aware_monitor.rb:19:in `handle_interrupt'
    /home/zzak/code/rails/activesupport/lib/active_support/concurrency/load_interlock_aware_monitor.rb:19:in `synchronize'
    lib/active_record/connection_adapters/abstract_adapter.rb:998:in `with_raw_connection'
    lib/active_record/connection_adapters/abstract/database_statements.rb:555:in `block in raw_execute'
    /home/zzak/code/rails/activesupport/lib/active_support/notifications/instrumenter.rb:58:in `instrument'
    lib/active_record/connection_adapters/abstract_adapter.rb:1149:in `log'
    lib/active_record/connection_adapters/abstract/database_statements.rb:554:in `raw_execute'
    lib/active_record/connection_adapters/abstract/database_statements.rb:591:in `internal_execute'
    lib/active_record/connection_adapters/abstract/database_statements.rb:137:in `execute'
    lib/active_record/connection_adapters/abstract/query_cache.rb:27:in `execute'
    test/cases/adapters/abstract_mysql_adapter/warnings_test.rb:34:in `block (3 levels) in <class:WarningsTest>'

bin/test test/cases/adapters/abstract_mysql_adapter/warnings_test.rb:29

E

Error:
WarningsTest#test_db_warnings_action_custom_proc_on_warning:
ActiveRecord::StatementInvalid: Mysql2::Error:
    lib/active_record/connection_adapters/abstract_mysql_adapter.rb:765:in `affected_rows'
    lib/active_record/connection_adapters/abstract_mysql_adapter.rb:765:in `handle_warnings'
    lib/active_record/connection_adapters/mysql2/database_statements.rb:103:in `perform_query'
    lib/active_record/connection_adapters/abstract/database_statements.rb:556:in `block (2 levels) in raw_execute'
    lib/active_record/connection_adapters/abstract_adapter.rb:1029:in `block in with_raw_connection'
    /home/zzak/code/rails/activesupport/lib/active_support/concurrency/load_interlock_aware_monitor.rb:23:in `handle_interrupt'
    /home/zzak/code/rails/activesupport/lib/active_support/concurrency/load_interlock_aware_monitor.rb:23:in `block in synchronize'
    /home/zzak/code/rails/activesupport/lib/active_support/concurrency/load_interlock_aware_monitor.rb:19:in `handle_interrupt'
    /home/zzak/code/rails/activesupport/lib/active_support/concurrency/load_interlock_aware_monitor.rb:19:in `synchronize'
    lib/active_record/connection_adapters/abstract_adapter.rb:998:in `with_raw_connection'
    lib/active_record/connection_adapters/abstract/database_statements.rb:555:in `block in raw_execute'
    /home/zzak/code/rails/activesupport/lib/active_support/notifications/instrumenter.rb:58:in `instrument'
    lib/active_record/connection_adapters/abstract_adapter.rb:1149:in `log'
    lib/active_record/connection_adapters/abstract/database_statements.rb:554:in `raw_execute'
    lib/active_record/connection_adapters/abstract/database_statements.rb:591:in `internal_execute'
    lib/active_record/connection_adapters/abstract/database_statements.rb:137:in `execute'
    lib/active_record/connection_adapters/abstract/query_cache.rb:27:in `execute'
    test/cases/adapters/abstract_mysql_adapter/warnings_test.rb:65:in `block (2 levels) in <class:WarningsTest>'
    test/cases/test_case.rb:172:in `with_db_warnings_action'
    test/cases/adapters/abstract_mysql_adapter/warnings_test.rb:64:in `block in <class:WarningsTest>'

bin/test test/cases/adapters/abstract_mysql_adapter/warnings_test.rb:56

E

Error:
WarningsTest#test_db_warnings_action_:report_on_warning:
ActiveRecord::StatementInvalid: Mysql2::Error:
    lib/active_record/connection_adapters/abstract_mysql_adapter.rb:765:in `affected_rows'
    lib/active_record/connection_adapters/abstract_mysql_adapter.rb:765:in `handle_warnings'
    lib/active_record/connection_adapters/mysql2/database_statements.rb:103:in `perform_query'
    lib/active_record/connection_adapters/abstract/database_statements.rb:556:in `block (2 levels) in raw_execute'
    lib/active_record/connection_adapters/abstract_adapter.rb:1029:in `block in with_raw_connection'
    /home/zzak/code/rails/activesupport/lib/active_support/concurrency/load_interlock_aware_monitor.rb:23:in `handle_interrupt'
    /home/zzak/code/rails/activesupport/lib/active_support/concurrency/load_interlock_aware_monitor.rb:23:in `block in synchronize'
    /home/zzak/code/rails/activesupport/lib/active_support/concurrency/load_interlock_aware_monitor.rb:19:in `handle_interrupt'
    /home/zzak/code/rails/activesupport/lib/active_support/concurrency/load_interlock_aware_monitor.rb:19:in `synchronize'
    lib/active_record/connection_adapters/abstract_adapter.rb:998:in `with_raw_connection'
    lib/active_record/connection_adapters/abstract/database_statements.rb:555:in `block in raw_execute'
    /home/zzak/code/rails/activesupport/lib/active_support/notifications/instrumenter.rb:58:in `instrument'
    lib/active_record/connection_adapters/abstract_adapter.rb:1149:in `log'
    lib/active_record/connection_adapters/abstract/database_statements.rb:554:in `raw_execute'
    lib/active_record/connection_adapters/abstract/database_statements.rb:591:in `internal_execute'
    lib/active_record/connection_adapters/abstract/database_statements.rb:137:in `execute'
    lib/active_record/connection_adapters/abstract/query_cache.rb:27:in `execute'
    test/cases/adapters/abstract_mysql_adapter/warnings_test.rb:47:in `block (2 levels) in <class:WarningsTest>'
    test/cases/test_case.rb:172:in `with_db_warnings_action'
    test/cases/adapters/abstract_mysql_adapter/warnings_test.rb:40:in `block in <class:WarningsTest>'

bin/test test/cases/adapters/abstract_mysql_adapter/warnings_test.rb:39
```

This was added in #46690, but I haven't dug into why this breaks yet, wanted to raise a PR first to make sure it doesn't break anything else.

/cc @byroot 