### PR TITLE
Add missing `supports_insert_on_duplicate_update?` checks to some tests

### DIFF
--- a/activerecord/test/cases/insert_all_test.rb
+++ b/activerecord/test/cases/insert_all_test.rb
@@ -770,6 +770,8 @@ class InsertAllTest < ActiveRecord::TestCase
   end
 
   def test_upsert_all_resets_relation
+    skip unless supports_insert_on_duplicate_update?
+
     audit_logs = Developer.create!(name: "Alice").audit_logs.load
 
     assert_changes "audit_logs.loaded?", from: true, to: false do
@@ -786,6 +788,8 @@ class InsertAllTest < ActiveRecord::TestCase
   end
 
   def test_upsert_all_has_many_through
+    skip unless supports_insert_on_duplicate_update?
+
     book = Book.first
     assert_raise(ArgumentError) { book.subscribers.upsert_all([ { nick: "Jimmy" } ]) }
   end


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

Some tests in `activerecord/test/cases/insert_all_test.rb` are missing the `supports_insert_on_duplicate_update?` check before trying to call `upsert_all`. 

The `upsert_all` method should only be called on database adapters that support UPSERT. The core adapters (MySQL/SQLite/Postgresql) support UPSERT, however SQL Server does not support UPSERT and so the missing checks are causing tests to fail.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
