### PR TITLE
Add path to version select in guides

### DIFF
--- a/guides/rails_guides/generator.rb
+++ b/guides/rails_guides/generator.rb
@@ -188,6 +188,7 @@ module RailsGuides
           [@source_dir],
           edge:          @edge,
           version:       @version,
+          path:          output_file,
           epub:          "epub/#{epub_filename}",
           language:      @language,
           direction:     @direction,

--- a/guides/source/layout.html.erb
+++ b/guides/source/layout.html.erb
@@ -70,7 +70,7 @@
             <select id="version-switcher-select" class="guides-version">
               <option value="https://edgeguides.rubyonrails.org/"<%= " selected" if @edge %>>Edge</option>
               <% %w[8.0 7.2 7.1 7.0 6.1 6.0 5.2 5.1 5.0 4.2 4.1 4.0 3.2 3.1 3.0 2.3].each do |version| %>
-                <option value="https://guides.rubyonrails.org/v<%= version %>/"<%= " selected" if @version&.start_with?("v#{version}") %>><%= version %></option>
+                <option value="https://guides.rubyonrails.org/v<%= version %>/<%= @path %>"<%= " selected" if @version&.start_with?("v#{version}") %>><%= version %></option>
               <% end %>
             </select>
           </span>


### PR DESCRIPTION
### Motivation / Background

When selecting another version of the guide we can append the path to the version URL. This makes sure someone stays on "Active Record Basics" guide when switching versions.

https://github.com/user-attachments/assets/05ef62a9-a08b-4ff1-9149-478c9dca5db3

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
