### PR TITLE
Consistently release the autoloading interlock from all adapters

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -553,7 +553,9 @@ module ActiveRecord
           type_casted_binds = type_casted_binds(binds)
           log(sql, name, binds, type_casted_binds, async: async) do |notification_payload|
             with_raw_connection(allow_retry: allow_retry, materialize_transactions: materialize_transactions) do |conn|
-              perform_query(conn, sql, binds, type_casted_binds, prepare: prepare, notification_payload: notification_payload, batch: batch)
+              ActiveSupport::Dependencies.interlock.permit_concurrent_loads do
+                perform_query(conn, sql, binds, type_casted_binds, prepare: prepare, notification_payload: notification_payload, batch: batch)
+              end
             end
           end
         end

--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -553,15 +553,20 @@ module ActiveRecord
           type_casted_binds = type_casted_binds(binds)
           log(sql, name, binds, type_casted_binds, async: async) do |notification_payload|
             with_raw_connection(allow_retry: allow_retry, materialize_transactions: materialize_transactions) do |conn|
-              ActiveSupport::Dependencies.interlock.permit_concurrent_loads do
+              result = ActiveSupport::Dependencies.interlock.permit_concurrent_loads do
                 perform_query(conn, sql, binds, type_casted_binds, prepare: prepare, notification_payload: notification_payload, batch: batch)
               end
+              handle_warnings(result, sql)
+              result
             end
           end
         end
 
         def perform_query(raw_connection, sql, binds, type_casted_binds, prepare:, notification_payload:, batch:)
           raise NotImplementedError
+        end
+
+        def handle_warnings(raw_result, sql)
         end
 
         # Receive a native adapter result object and returns an ActiveRecord::Result object.

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -759,7 +759,7 @@ module ActiveRecord
           end
         end
 
-        def handle_warnings(sql)
+        def handle_warnings(_initial_result, sql)
           return if ActiveRecord.db_warnings_action.nil? || @raw_connection.warning_count == 0
 
           warning_count = @raw_connection.warning_count

--- a/activerecord/lib/active_record/connection_adapters/mysql2/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql2/database_statements.rb
@@ -50,22 +50,18 @@ module ActiveRecord
 
             result = nil
             if binds.nil? || binds.empty?
-              ActiveSupport::Dependencies.interlock.permit_concurrent_loads do
-                result = raw_connection.query(sql)
-                # Ref: https://github.com/brianmario/mysql2/pull/1383
-                # As of mysql2 0.5.6 `#affected_rows` might raise Mysql2::Error if a prepared statement
-                # from that same connection was GCed while `#query` released the GVL.
-                # By avoiding to call `#affected_rows` when we have a result, we reduce the likeliness
-                # of hitting the bug.
-                @affected_rows_before_warnings = result&.size || raw_connection.affected_rows
-              end
+              result = raw_connection.query(sql)
+              # Ref: https://github.com/brianmario/mysql2/pull/1383
+              # As of mysql2 0.5.6 `#affected_rows` might raise Mysql2::Error if a prepared statement
+              # from that same connection was GCed while `#query` released the GVL.
+              # By avoiding to call `#affected_rows` when we have a result, we reduce the likeliness
+              # of hitting the bug.
+              @affected_rows_before_warnings = result&.size || raw_connection.affected_rows
             elsif prepare
               stmt = @statements[sql] ||= raw_connection.prepare(sql)
               begin
-                ActiveSupport::Dependencies.interlock.permit_concurrent_loads do
-                  result = stmt.execute(*type_casted_binds)
-                  @affected_rows_before_warnings = stmt.affected_rows
-                end
+                result = stmt.execute(*type_casted_binds)
+                @affected_rows_before_warnings = stmt.affected_rows
               rescue ::Mysql2::Error
                 @statements.delete(sql)
                 raise
@@ -74,10 +70,8 @@ module ActiveRecord
               stmt = raw_connection.prepare(sql)
 
               begin
-                ActiveSupport::Dependencies.interlock.permit_concurrent_loads do
-                  result = stmt.execute(*type_casted_binds)
-                  @affected_rows_before_warnings = stmt.affected_rows
-                end
+                result = stmt.execute(*type_casted_binds)
+                @affected_rows_before_warnings = stmt.affected_rows
 
                 # Ref: https://github.com/brianmario/mysql2/pull/1383
                 # by eagerly closing uncached prepared statements, we also reduce the chances of

--- a/activerecord/lib/active_record/connection_adapters/mysql2/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql2/database_statements.rb
@@ -94,7 +94,6 @@ module ActiveRecord
             raw_connection.abandon_results!
 
             verified!
-            handle_warnings(sql)
             result
           ensure
             if reset_multi_statement && active?

--- a/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
@@ -163,7 +163,6 @@ module ActiveRecord
             end
 
             verified!
-            handle_warnings(result)
 
             notification_payload[:affected_rows] = result.cmd_tuples
             notification_payload[:row_count] = result.count
@@ -215,7 +214,7 @@ module ActiveRecord
             pk unless pk.is_a?(Array)
           end
 
-          def handle_warnings(sql)
+          def handle_warnings(result, sql)
             @notice_receiver_sql_warnings.each do |warning|
               next if warning_ignored?(warning)
 

--- a/activerecord/lib/active_record/connection_adapters/trilogy/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/trilogy/database_statements.rb
@@ -29,7 +29,6 @@ module ActiveRecord
               raw_connection.next_result
             end
             verified!
-            handle_warnings(sql)
 
             notification_payload[:affected_rows] = result.affected_rows
             notification_payload[:row_count] = result.count


### PR DESCRIPTION
Fix: https://github.com/rails/rails/pull/53871

In `007e50d8e5a900547471b6c4ec79d9d217682c5d` all adapters started wrapping DB calls with the interlock release.

However in https://github.com/rails/rails/pull/44576, this was removed from all adapters but Mysql2.

This commit restore the proper release on all adapters.
