### PR TITLE
SQLite3: Use default function as default insert value

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/sqlite3/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3/database_statements.rb
@@ -138,7 +138,11 @@ module ActiveRecord
           end
 
           def default_insert_value(column)
-            column.default
+            if column.default_function
+              Arel.sql(column.default_function)
+            else
+              column.default
+            end
           end
       end
     end

--- a/activerecord/test/cases/fixtures_test.rb
+++ b/activerecord/test/cases/fixtures_test.rb
@@ -6,6 +6,7 @@ require "models/admin"
 require "models/admin/account"
 require "models/admin/randomly_named_c1"
 require "models/admin/user"
+require "models/aircraft"
 require "models/author"
 require "models/binary"
 require "models/book"
@@ -112,8 +113,6 @@ class FixturesTest < ActiveRecord::TestCase
     end
 
     def test_bulk_insert_with_a_multi_statement_query_raises_an_exception_when_any_insert_fails
-      require "models/aircraft"
-
       assert_equal false, Aircraft.columns_hash["wheels_count"].null
       fixtures = {
         "aircraft" => [
@@ -476,6 +475,20 @@ class FixturesTest < ActiveRecord::TestCase
     create_fixtures("tasks")
     first = Task.find(1)
     assert first
+  end
+
+  def test_insert_with_default_function
+    create_fixtures("aircrafts")
+
+    aircraft = Aircraft.find_by(name: "boeing-with-no-manufactured-at")
+    assert_equal Time.now.utc.strftime("%Y-%m-%d %H:%M:%S"), aircraft.manufactured_at.strftime("%Y-%m-%d %H:%M:%S")
+  end
+
+  def test_insert_with_default_value
+    create_fixtures("aircrafts")
+
+    aircraft = Aircraft.find_by(name: "boeing-with-no-wheels")
+    assert_equal 0, aircraft.wheels_count
   end
 
   def test_logger_level_invariant

--- a/activerecord/test/fixtures/aircrafts.yml
+++ b/activerecord/test/fixtures/aircrafts.yml
@@ -1,0 +1,7 @@
+no_wheels:
+  name: boeing-with-no-wheels
+  manufactured_at: 2024-01-01
+
+no_manufactured_at:
+  name: boeing-with-no-manufactured-at
+  wheels_count: 2


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

Follow up to: https://github.com/rails/rails/pull/52562

When creating fixtures, I noticed that columns with defaults set as a function like `CURRENT_TIMESTAMP` and `datetime('now')` still insert nil values. This is because `default_insert_value` for SQLite only returns the default value.

### Detail
Changed `SQLite3::DatabaseStatements#default_insert_value` to return the default function if it is present.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
