### PR TITLE
Freeze controller_name

### DIFF
--- a/actionpack/lib/action_controller/metal.rb
+++ b/actionpack/lib/action_controller/metal.rb
@@ -128,7 +128,7 @@ module ActionController
     # #### Returns
     # *   `string`
     def self.controller_name
-      @controller_name ||= (name.demodulize.delete_suffix("Controller").underscore unless anonymous?)
+      @controller_name ||= (name.demodulize.delete_suffix("Controller").underscore unless anonymous?).freeze
     end
 
     def self.make_response!(request)


### PR DESCRIPTION
I recently added an annoying bug to an application by passing controller_name into a method and then calling delete_suffix! within. This was obviously my fault, but I can’t think of a valid reason you should be able to do that, so to prevent others wasting as much time as me debugging the issue, it seems like freezing it would be a good idea.


### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
