### PR TITLE
Backport `#[]` and `#[]=` to Active Model

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,3 +1,30 @@
+*   Migrate methods from `ActiveRecord::AttributeMethods`, `ActiveRecord::Attributes::Read` and `ActiveRecord::Attributes::Write` to Active Model
+
+    ```ruby
+    class Topic
+      include ActiveModel::AttributeMethods
+
+      attr_accessor :title
+
+      alias_attribute :heading, :title
+    end
+
+    topic = Topic.new
+    topic[:title] = "Hello Title"
+    topic[:title] # => "Hello Title"
+
+    topic.write_attribute(:title, "Hello Title Method")
+    topic.read_attribute(:title) # => "Hello Title Method"
+
+    topic[:heading] = "Hello Heading"
+    topic[:heading] # => "Hello Heading"
+
+    topic.write_attribute(:heading, "Hello Heading Method")
+    topic.read_attribute(:heading) # => "Hello Heading Method"
+    ```
+
+    *Sean Doyle*
+
 *   Fix `normalizes` re-applying normalizations on every validation of an
     unpersisted record, and speed up validation of normalized attributes.
 

--- a/activemodel/lib/active_model/attribute_methods.rb
+++ b/activemodel/lib/active_model/attribute_methods.rb
@@ -54,11 +54,11 @@ module ActiveModel
   #       end
   #
   #       def clear_attribute(attr)
-  #         send("#{attr}=", nil)
+  #         self[attr] = nil
   #       end
   #
   #       def reset_attribute_to_default!(attr)
-  #         send("#{attr}=", 'Default Name')
+  #         self[attr] = 'Default Name'
   #       end
   #   end
   module AttributeMethods
@@ -99,7 +99,7 @@ module ActiveModel
       #
       #     private
       #       def clear_attribute(attr)
-      #         send("#{attr}=", nil)
+      #         self[attr] = nil
       #       end
       #   end
       #
@@ -135,7 +135,7 @@ module ActiveModel
       #
       #     private
       #       def attribute_short?(attr)
-      #         send(attr).length < 5
+      #         self[attr].length < 5
       #       end
       #   end
       #
@@ -171,7 +171,7 @@ module ActiveModel
       #
       #     private
       #       def reset_attribute_to_default!(attr)
-      #         send("#{attr}=", 'Default Name')
+      #         self[attr] = 'Default Name'
       #       end
       #   end
       #
@@ -198,7 +198,7 @@ module ActiveModel
       #
       #     private
       #       def attribute_short?(attr)
-      #         send(attr).length < 5
+      #         self[attr].length < 5
       #       end
       #   end
       #
@@ -274,7 +274,7 @@ module ActiveModel
       #
       #     private
       #       def clear_attribute(attr)
-      #         send("#{attr}=", nil)
+      #         self[attr] = nil
       #       end
       #   end
       def define_attribute_methods(*attr_names)
@@ -308,7 +308,7 @@ module ActiveModel
       #
       #     private
       #       def attribute_short?(attr)
-      #         send(attr).length < 5
+      #         self[attr].length < 5
       #       end
       #   end
       #
@@ -367,7 +367,7 @@ module ActiveModel
       #
       #     private
       #       def attribute_short?(attr)
-      #         send(attr).length < 5
+      #         self[attr].length < 5
       #       end
       #   end
       #
@@ -492,6 +492,64 @@ module ActiveModel
         end
     end
 
+    # Returns the value of the attribute identified by +attr_name+ after it has
+    # been type cast. (For information about specific type casting behavior, see
+    # the types under ActiveModel::Type.)
+    #
+    #   class Person
+    #     include ActiveModel::AttributeMethods
+    #
+    #     attr_accessor :name
+    #   end
+    #
+    #   person = Person.new
+    #   person.name = "Francesco"
+    #   person[:name] # => "Francesco"
+    #
+    # Raises ActiveModel::MissingAttributeError if the attribute is missing.
+    #
+    #   person = Person.new
+    #   person[:date_of_birth]   # => ActiveModel::MissingAttributeError: missing attribute 'date_of_birth' for Person
+    def [](attr_name)
+      read_attribute(attr_name) { |n| missing_attribute(n, caller) }
+    end
+
+    # Returns the value of the attribute identified by +attr_name+ after it
+    # has been type cast. For example, a date attribute will cast "2004-12-12"
+    # to <tt>Date.new(2004, 12, 12)</tt>. (For information about specific type
+    # casting behavior, see the types under ActiveModel::Type.)
+    def read_attribute(attr_name, &block)
+      name = attr_name.to_s
+      name = self.class.attribute_aliases[name] || name
+
+      _read_attribute(name, &block)
+    end
+
+    # Updates the attribute identified by +attr_name+ using the specified
+    # +value+. The attribute value will be type cast upon being read.
+    #
+    #   class Person
+    #     include ActiveModel::AttributeMethods
+    #
+    #     attr_accessor :name
+    #   end
+    #
+    #   person = Person.new
+    #   person[:name] = "Francesco"
+    #   person.name # => "Francesco"
+    def []=(attr_name, value)
+      write_attribute(attr_name, value)
+    end
+
+    # Updates the attribute identified by +attr_name+ using the specified
+    # +value+. The attribute value will be type cast upon being read.
+    def write_attribute(attr_name, value)
+      name = attr_name.to_s
+      name = self.class.attribute_aliases[name] || name
+
+      _write_attribute(name, value)
+    end
+
     # Allows access to the object attributes, which are held in the hash
     # returned by <tt>attributes</tt>, as though they were first-class
     # methods. So a +Person+ class with a +name+ attribute can for example use
@@ -553,6 +611,14 @@ module ActiveModel
 
       def _read_attribute(attr)
         __send__(attr)
+      rescue NoMethodError
+        block_given? ? yield(attr) : missing_attribute(attr, caller)
+      end
+
+      def _write_attribute(attr, value)
+        __send__(:"#{attr}=", value)
+      rescue NoMethodError
+        missing_attribute(attr, caller)
       end
 
       module AttrNames # :nodoc:

--- a/activemodel/lib/active_model/attributes.rb
+++ b/activemodel/lib/active_model/attributes.rb
@@ -162,8 +162,9 @@ module ActiveModel
       end
       alias :attribute= :_write_attribute
 
-      def attribute(attr_name)
-        @attributes.fetch_value(attr_name)
+      def _read_attribute(attr_name, &block)
+        @attributes.fetch_value(attr_name, &block)
       end
+      alias :attribute :_read_attribute
   end
 end

--- a/activemodel/test/cases/attribute_methods_test.rb
+++ b/activemodel/test/cases/attribute_methods_test.rb
@@ -52,6 +52,21 @@ protected
   end
 end
 
+class ModelWithAttributes3
+  include ActiveModel::AttributeMethods
+
+  attr_accessor :value
+
+  attribute_method_suffix "?"
+
+  define_attribute_methods :value
+
+  private
+    def attribute?(name)
+      self[name].present?
+    end
+end
+
 class ModelWithAttributesWithSpaces
   include ActiveModel::AttributeMethods
 
@@ -103,6 +118,14 @@ end
 
 class AttributeMethodsTest < ActiveModel::TestCase
   include ActiveSupport::Testing::RactorsAssertions
+
+  class Topic
+    include ActiveModel::AttributeMethods
+
+    attr_accessor :title
+
+    alias_attribute :heading, :title
+  end
 
   test "method missing works correctly even if attributes method is not defined" do
     assert_raises(NoMethodError) { ModelWithoutAttributesMethod.new.foo }
@@ -293,6 +316,16 @@ class AttributeMethodsTest < ActiveModel::TestCase
     assert_equal "bar", attrs["foo"]
   end
 
+  test "accessing a suffixed attribute through #[]" do
+    m = ModelWithAttributes3.new
+
+    assert_not_predicate m, :value?
+
+    m.value = true
+
+    assert_predicate m, :value?
+  end
+
   test "defined attribute doesn't expand positional hash argument" do
     ModelWithAttributes2.define_attribute_methods(:foo)
 
@@ -451,5 +484,100 @@ class AttributeMethodsTest < ActiveModel::TestCase
     end
 
     assert_ractor_shareable model.attribute_method_patterns
+  end
+
+  test "write_attribute" do
+    topic = Topic.new
+    topic.write_attribute :title, "Still another topic"
+    assert_equal "Still another topic", topic.title
+
+    topic[:title] = "Still another topic: part 2"
+    assert_equal "Still another topic: part 2", topic.title
+
+    topic.write_attribute "title", "Still another topic: part 3"
+    assert_equal "Still another topic: part 3", topic.title
+
+    topic["title"] = "Still another topic: part 4"
+    assert_equal "Still another topic: part 4", topic.title
+  end
+
+  test "write_attribute can write aliased attributes as well" do
+    topic = Topic.new
+    topic.title = "Don't change the topic"
+    topic.write_attribute :heading, "New topic"
+
+    assert_equal "New topic", topic.title
+  end
+
+  test "write_attribute raises ActiveModel::MissingAttributeError when the attribute does not exist" do
+    topic = Topic.new
+    assert_raises(ActiveModel::MissingAttributeError) { topic[:no_column_exists] = "Hello!" }
+  end
+
+  test "read_attribute" do
+    topic = Topic.new
+    topic.title = "Don't change the topic"
+    assert_equal "Don't change the topic", topic.read_attribute("title")
+    assert_equal "Don't change the topic", topic["title"]
+
+    assert_equal "Don't change the topic", topic.read_attribute(:title)
+    assert_equal "Don't change the topic", topic[:title]
+  end
+
+  test "read_attribute can read aliased attributes as well" do
+    topic = Topic.new
+    topic.title = "Don't change the topic"
+
+    assert_equal "Don't change the topic", topic.read_attribute("heading")
+    assert_equal "Don't change the topic", topic["heading"]
+
+    assert_equal "Don't change the topic", topic.read_attribute(:heading)
+    assert_equal "Don't change the topic", topic[:heading]
+  end
+
+  test "read_attribute raises ActiveModel::MissingAttributeError when the attribute does not exist" do
+    topic = Topic.new
+    assert_raises(ActiveModel::MissingAttributeError) { topic[:no_column_exists] }
+    assert_raises(ActiveModel::MissingAttributeError) { topic.read_attribute(:no_column_exists) }
+  end
+
+  test "overridden write_attribute" do
+    topic = Topic.new
+    def topic.write_attribute(attr_name, value)
+      super(attr_name, value.downcase)
+    end
+
+    topic.write_attribute :title, "Yet another topic"
+    assert_equal "yet another topic", topic.title
+
+    topic[:title] = "Yet another topic: part 2"
+    assert_equal "yet another topic: part 2", topic.title
+
+    topic.write_attribute "title", "Yet another topic: part 3"
+    assert_equal "yet another topic: part 3", topic.title
+
+    topic["title"] = "Yet another topic: part 4"
+    assert_equal "yet another topic: part 4", topic.title
+  end
+
+  test "overridden read_attribute" do
+    topic = Topic.new
+    topic.title = "Stop changing the topic"
+    def topic.read_attribute(attr_name)
+      super(attr_name).upcase
+    end
+
+    assert_equal "STOP CHANGING THE TOPIC", topic.read_attribute("title")
+    assert_equal "STOP CHANGING THE TOPIC", topic["title"]
+
+    assert_equal "STOP CHANGING THE TOPIC", topic.read_attribute(:title)
+    assert_equal "STOP CHANGING THE TOPIC", topic[:title]
+  end
+
+  test "non-attribute read and write" do
+    topic = Topic.new
+    assert_not_respond_to topic, "mumbo"
+    assert_raise(NoMethodError) { topic.mumbo }
+    assert_raise(NoMethodError) { topic.mumbo = 5 }
   end
 end

--- a/activerecord/lib/active_record/attribute_methods.rb
+++ b/activerecord/lib/active_record/attribute_methods.rb
@@ -391,6 +391,10 @@ module ActiveRecord
       !value.nil? && !(value.respond_to?(:empty?) && value.empty?)
     end
 
+    ##
+    # :method: []
+    # :call-seq: [](attr_name)
+    #
     # Returns the value of the attribute identified by +attr_name+ after it has
     # been type cast. (For information about specific type casting behavior, see
     # the types under ActiveModel::Type.)
@@ -412,10 +416,11 @@ module ActiveRecord
     #   person[:date_of_birth]   # => ActiveModel::MissingAttributeError: missing attribute 'date_of_birth' for Person
     #   person[:organization_id] # => ActiveModel::MissingAttributeError: missing attribute 'organization_id' for Person
     #   person[:id]              # => nil
-    def [](attr_name)
-      read_attribute(attr_name) { |n| missing_attribute(n, caller) }
-    end
 
+    ##
+    # :method: []=
+    # :call-seq: []=(attr_name, value)
+    #
     # Updates the attribute identified by +attr_name+ using the specified
     # +value+. The attribute value will be type cast upon being read.
     #
@@ -425,9 +430,6 @@ module ActiveRecord
     #   person = Person.new
     #   person[:date_of_birth] = "2004-12-12"
     #   person[:date_of_birth] # => Date.new(2004, 12, 12)
-    def []=(attr_name, value)
-      write_attribute(attr_name, value)
-    end
 
     # Returns the name of all database fields which have been read from this
     # model. This can be useful in development mode to determine which fields

--- a/activerecord/lib/active_record/attribute_methods/read.rb
+++ b/activerecord/lib/active_record/attribute_methods/read.rb
@@ -22,16 +22,11 @@ module ActiveRecord
           end
       end
 
-      # Returns the value of the attribute identified by +attr_name+ after it
-      # has been type cast. For example, a date attribute will cast "2004-12-12"
-      # to <tt>Date.new(2004, 12, 12)</tt>. (For information about specific type
-      # casting behavior, see the types under ActiveModel::Type.)
-      def read_attribute(attr_name, &block)
-        name = attr_name.to_s
-        name = self.class.attribute_aliases[name] || name
-
-        @attributes.fetch_value(name, &block)
-      end
+      ##
+      # :method: read_attribute
+      # :call-seq: read_attribute(attr_name, &block)
+      #
+      # See ActiveModel::AttributeMethods#read_attribute.
 
       # This method exists to avoid the expensive primary_key check internally, without
       # breaking compatibility with the read_attribute API

--- a/activerecord/lib/active_record/attribute_methods/write.rb
+++ b/activerecord/lib/active_record/attribute_methods/write.rb
@@ -26,8 +26,11 @@ module ActiveRecord
           end
       end
 
-      # Updates the attribute identified by +attr_name+ using the specified
-      # +value+. The attribute value will be type cast upon being read.
+      ##
+      # :method: write_attribute
+      # :call-seq: write_attribute(attr_name, value)
+      #
+      # See ActiveModel::AttributeMethods#write_attribute.
       def write_attribute(attr_name, value)
         name = attr_name.to_s
         name = self.class.attribute_aliases[name] || name

--- a/activerecord/test/cases/attribute_methods_test.rb
+++ b/activerecord/test/cases/attribute_methods_test.rb
@@ -408,28 +408,6 @@ class AttributeMethodsTest < ActiveRecord::TestCase
     assert_equal(topic, topicReloaded)
   end
 
-  test "write_attribute" do
-    topic = Topic.new
-    topic.write_attribute :title, "Still another topic"
-    assert_equal "Still another topic", topic.title
-
-    topic[:title] = "Still another topic: part 2"
-    assert_equal "Still another topic: part 2", topic.title
-
-    topic.write_attribute "title", "Still another topic: part 3"
-    assert_equal "Still another topic: part 3", topic.title
-
-    topic["title"] = "Still another topic: part 4"
-    assert_equal "Still another topic: part 4", topic.title
-  end
-
-  test "write_attribute can write aliased attributes as well" do
-    topic = Topic.new(title: "Don't change the topic")
-    topic.write_attribute :heading, "New topic"
-
-    assert_equal "New topic", topic.title
-  end
-
   test "write_attribute raises ActiveModel::MissingAttributeError when the attribute does not exist" do
     topic = Topic.first
     assert_raises(ActiveModel::MissingAttributeError) { topic.update_columns(no_column_exists: "Hello!") }
@@ -446,26 +424,6 @@ class AttributeMethodsTest < ActiveRecord::TestCase
     topic = Topic.first
     assert_nothing_raised { topic.update_columns(heading: "Hello!") }
     assert_nothing_raised { topic.update(heading: "Hello!") }
-  end
-
-  test "read_attribute" do
-    topic = Topic.new
-    topic.title = "Don't change the topic"
-    assert_equal "Don't change the topic", topic.read_attribute("title")
-    assert_equal "Don't change the topic", topic["title"]
-
-    assert_equal "Don't change the topic", topic.read_attribute(:title)
-    assert_equal "Don't change the topic", topic[:title]
-  end
-
-  test "read_attribute can read aliased attributes as well" do
-    topic = Topic.new(title: "Don't change the topic")
-
-    assert_equal "Don't change the topic", topic.read_attribute("heading")
-    assert_equal "Don't change the topic", topic["heading"]
-
-    assert_equal "Don't change the topic", topic.read_attribute(:heading)
-    assert_equal "Don't change the topic", topic[:heading]
   end
 
   test "read_attribute raises ActiveModel::MissingAttributeError when the attribute isn't selected" do
@@ -506,39 +464,6 @@ class AttributeMethodsTest < ActiveRecord::TestCase
 
     topic.approved = "true"
     assert_predicate topic, :approved?, "approved should be true"
-  end
-
-  test "overridden write_attribute" do
-    topic = Topic.new
-    def topic.write_attribute(attr_name, value)
-      super(attr_name, value.downcase)
-    end
-
-    topic.write_attribute :title, "Yet another topic"
-    assert_equal "yet another topic", topic.title
-
-    topic[:title] = "Yet another topic: part 2"
-    assert_equal "yet another topic: part 2", topic.title
-
-    topic.write_attribute "title", "Yet another topic: part 3"
-    assert_equal "yet another topic: part 3", topic.title
-
-    topic["title"] = "Yet another topic: part 4"
-    assert_equal "yet another topic: part 4", topic.title
-  end
-
-  test "overridden read_attribute" do
-    topic = Topic.new
-    topic.title = "Stop changing the topic"
-    def topic.read_attribute(attr_name)
-      super(attr_name).upcase
-    end
-
-    assert_equal "STOP CHANGING THE TOPIC", topic.read_attribute("title")
-    assert_equal "STOP CHANGING THE TOPIC", topic["title"]
-
-    assert_equal "STOP CHANGING THE TOPIC", topic.read_attribute(:title)
-    assert_equal "STOP CHANGING THE TOPIC", topic[:title]
   end
 
   test "read overridden attribute" do
@@ -670,13 +595,6 @@ class AttributeMethodsTest < ActiveRecord::TestCase
 
     object.int_value = "0"
     assert_not_predicate object, :int_value?
-  end
-
-  test "non-attribute read and write" do
-    topic = Topic.new
-    assert_not_respond_to topic, "mumbo"
-    assert_raise(NoMethodError) { topic.mumbo }
-    assert_raise(NoMethodError) { topic.mumbo = 5 }
   end
 
   test "undeclared attribute method does not affect respond_to? and method_missing" do


### PR DESCRIPTION
### Motivation / Background

Migrate the `ActiveRecord::AttributeMethods#[]` [read][] method, the `ActiveRecord::AttributeMethods#[]=` [write][] method, as well as the underlying [ActiveRecord::AttributeMethods::Read#read_attribute][read_attribute] and [ActiveRecord::AttributeMethods::Write#write_attribute][write_attribute] methods from Active Record to Active Model.

```ruby
topic = Topic.new
topic[:title] = "Topic Title"
topic[:title] # => "Topic Title"
```

### Detail
This change preserves existing Active Record behavior, while introducing a new read and write syntax to classes that mix-in `ActiveModel::Attributes`. 

This supports dynamic read and write operations where the name of the attribute is sourced from an unknown String or Symbol key. For example, consider a model that includes [ActiveModel::AttributeMethods][]

```ruby
class Topic
  include ActiveModel::AttributeMethods

  attr_accessor :title

  attribute_method_prefix "reset_"
  attribute_method_suffix "?"
  
  define_attribute_methods :title

  def reset_attribute(attr_name)
    # ...
  end

  def attribute?(attr_name)
    # ...
  end
end

topic = Topic.new
topic.title = "Hello World"
topic.title? # => true
topic.reset_title
topic.title # => nil
topic.title? # => false
```

Before this change, `Topic#reset_attribute` and `Topic#attribute?` could require the use of dynamic method invocation through sending a message with a String interpolated name:

```rb
def reset_attribute(attr_name)
  send(:"#{attr_name}=", nil)
end

def attribute?(attr_name)
  send(:"#{attr_name}").present?
end
```

After this change, the methods could utilize the new `#[]` and `#[]=` methods to handle that dynamic message sending:

```diff
 def reset_attribute(attr_name)
-  send(:"#{attr_name}=", nil)
+  self[attr_name] = nil
 end

 def attribute?(attr_name)
-  send(:"#{attr_name}").present?
+  self[attr_name].present?
 end
```

In addition to mimicking Active Record, there are some other niceties like integration with [Enumerable#pluck][] and [Enumerable#pick][]:

```ruby
topics = [
  Topic.new(title: "First"),
  Topic.new(title: "Second")
]

topics.pluck(:title) # => ["First", "Second"]
topics.pick(:title) # => "First"
```

[read]: https://edgeapi.rubyonrails.org/classes/ActiveRecord/AttributeMethods.html#method-i-5B-5D
[write]: https://edgeapi.rubyonrails.org/classes/ActiveRecord/AttributeMethods.html#method-i-5B-5D-3D
[write_attribute]: https://edgeapi.rubyonrails.org/classes/ActiveRecord/AttributeMethods/Write.html#method-i-write_attribute
[read_attribute]: https://edgeapi.rubyonrails.org/classes/ActiveRecord/AttributeMethods/Read.html#method-i-read_attribute
[ActiveModel::AttributeMethods]: https://edgeapi.rubyonrails.org/classes/ActiveModel/AttributeMethods.html
[Enumerable#pluck]: https://edgeapi.rubyonrails.org/classes/Enumerable.html#method-i-pluck
[Enumerable#pick]: https://edgeapi.rubyonrails.org/classes/Enumerable.html#method-i-pick
[write]: https://github.com/rails/rails/blob/main/activerecord/lib/active_record/normalization.rb#L28

### Additional information

I did a cursory search of [closed and rejected Active Model pull requests](https://github.com/rails/rails/pulls?q=is%3Apr+is%3Aclosed+label%3Aactivemodel). If there is a prior attempt at proposing this change, I've missed it. If there are details or historical details, I'm happy to respond to them if they're shared.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
