### PR TITLE
Fix lazy attribute method definitiont to be thread safe

### DIFF
--- a/activerecord/lib/active_record/attribute_methods.rb
+++ b/activerecord/lib/active_record/attribute_methods.rb
@@ -116,10 +116,11 @@ module ActiveRecord
             alias_attribute :id_value, :id if _has_attribute?("id")
           end
 
-          @attribute_methods_generated = true
-
           generate_alias_attributes
+
+          @attribute_methods_generated = true
         end
+
         true
       end
 
@@ -472,23 +473,27 @@ module ActiveRecord
       end
 
       def method_missing(name, ...)
-        unless self.class.attribute_methods_generated?
-          if self.class.method_defined?(name)
-            # The method is explicitly defined in the model, but calls a generated
-            # method with super. So we must resume the call chain at the right step.
-            last_method = method(name)
-            last_method = last_method.super_method while last_method.super_method
-            self.class.define_attribute_methods
-            if last_method.super_method
-              return last_method.super_method.call(...)
-            end
-          elsif self.class.define_attribute_methods
-            # Some attribute methods weren't generated yet, we retry the call
-            return public_send(name, ...)
-          end
+        # We can't know whether some method was defined or not because
+        # multiple thread might be concurrently be in this code path.
+        # So the first one would define the methods and the others would
+        # appear to already have them.
+        self.class.define_attribute_methods
+
+        # So in all cases we must behave as if the method was just defined.
+        method = begin
+          self.class.public_instance_method(name)
+        rescue NameError
+          nil
         end
 
-        super
+        # The method might be explicitly defined in the model, but call a generated
+        # method with super. So we must resume the call chain at the right step.
+        method = method.super_method while method && !method.owner.is_a?(GeneratedAttributeMethods)
+        if method
+          method.bind_call(self, ...)
+        else
+          super
+        end
       end
 
       def attribute_method?(attr_name)


### PR DESCRIPTION
Fix: https://github.com/rails/rails/issues/53667
Followup: https://github.com/rails/rails/pull/50594

We can't safely check if attribute methods were generated or not as we may be in a race with another thread. As such we must always consider that maybe the mehtod was just generated.
