### PR TITLE
Action Cable pg adapter: avoid using a pinned connection

### DIFF
--- a/actioncable/lib/action_cable/subscription_adapter/postgresql.rb
+++ b/actioncable/lib/action_cable/subscription_adapter/postgresql.rb
@@ -35,18 +35,17 @@ module ActionCable
       end
 
       def with_subscriptions_connection(&block) # :nodoc:
-        ar_conn = ActiveRecord::Base.connection_pool.checkout.tap do |conn|
-          # Action Cable is taking ownership over this database connection, and will
-          # perform the necessary cleanup tasks
-          ActiveRecord::Base.connection_pool.remove(conn)
-        end
+        # Action Cable is taking ownership over this database connection, and will
+        # perform the necessary cleanup tasks.
+        # We purposedly avoid #checkout to not end up with a pinned connection
+        ar_conn = ActiveRecord::Base.connection_pool.new_connection
         pg_conn = ar_conn.raw_connection
 
         verify!(pg_conn)
         pg_conn.exec("SET application_name = #{pg_conn.escape_identifier(identifier)}")
         yield pg_conn
       ensure
-        ar_conn.disconnect!
+        ar_conn&.disconnect!
       end
 
       def with_broadcast_connection(&block) # :nodoc:

--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -693,6 +693,14 @@ module ActiveRecord
         Thread.pass
       end
 
+      def new_connection # :nodoc:
+        connection = db_config.new_connection
+        connection.pool = self
+        connection
+      rescue ConnectionNotEstablished => ex
+        raise ex.set_pool(self)
+      end
+
       private
         def connection_lease
           @leases[ActiveSupport::IsolatedExecutionState.context]
@@ -877,14 +885,6 @@ module ActiveRecord
           end
         end
         alias_method :release, :remove_connection_from_thread_cache
-
-        def new_connection
-          connection = db_config.new_connection
-          connection.pool = self
-          connection
-        rescue ConnectionNotEstablished => ex
-          raise ex.set_pool(self)
-        end
 
         # If the pool is not at a <tt>@size</tt> limit, establish new connection. Connecting
         # to the DB is done outside main synchronized section.


### PR DESCRIPTION
Fix: https://github.com/rails/rails/issues/53883

Action Cable must avoid using a pinned connection to subscribe to notifications as it can't be done in a thread safe way.

So it must ensure it has a dedicated connection for that.
