### PR TITLE
Specify schema for `plpgsql` extension in guides

### DIFF
--- a/guides/source/active_record_migrations.md
+++ b/guides/source/active_record_migrations.md
@@ -64,7 +64,7 @@ These special columns are automatically managed by Active Record if they exist.
 # db/schema.rb
 ActiveRecord::Schema[8.1].define(version: 2024_05_02_100843) do
   # These are extensions that must be enabled in order to support this database
-  enable_extension "plpgsql"
+  enable_extension "pg_catalog.plpgsql"
 
   create_table "products", force: :cascade do |t|
     t.string "name"


### PR DESCRIPTION
### Motivation / Background

I admit I am not quite certain where where this extension is even being enabled, seems to be some postgres default maybe.
Since https://github.com/rails/rails/pull/52313, extensions contain their schema here, and this one is not in `public`, but rather `pg_catalog`.

OTOH, when dumping these, maybe `pg_` schemas should be excluded? The dump doesn't contain postgres default schemas like this. https://github.com/rails/rails/blob/ff1c363ee54af4b8d4dbecbc58a9f6f43702b0d4/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb#L245-L253

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
