### PR TITLE
Disconnect existing SQLite connection before dropping database

### DIFF
--- a/activerecord/lib/active_record/tasks/sqlite_database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/sqlite_database_tasks.rb
@@ -20,6 +20,8 @@ module ActiveRecord
       end
 
       def drop
+        connection.disconnect!
+
         db_path = db_config.database
         file = File.absolute_path?(db_path) ? db_path : File.join(root, db_path)
         FileUtils.rm(file)


### PR DESCRIPTION
### Motivation / Background

This prevents leaving the connection in a bad state after removing the DB files, and then using the connection for something else that might not work. This happens if you have only `development` configured and you run the tasks `db:reset` or `db:drop` followed by other tasks like `db:create db:schema_load`, etc. The same connection is reused for tasks after `db:drop`, and that won't work. It doesn't happen when both `development` and `test` environments are configured, as DB tasks for those are run together, and switching between dev and test ensures we disconnect from the connection between tasks.


Fixes #53832, which includes more details about the problem.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature: ⚠️ there aren't any tests that exercise this path, as `drop` and `create` for DB tasks are always stubbed. 
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
