### PR TITLE
Fix `merge` with `unscope` relations of different classes

### DIFF
--- a/activerecord/lib/active_record/relation/merger.rb
+++ b/activerecord/lib/active_record/relation/merger.rb
@@ -52,10 +52,12 @@ module ActiveRecord
       NORMAL_VALUES = Relation::VALUE_METHODS - Relation::CLAUSE_METHODS -
                       [
                         :select, :includes, :preload, :joins, :left_outer_joins,
-                        :order, :reverse_order, :lock, :create_with, :reordering
+                        :order, :reverse_order, :lock, :create_with, :reordering, :unscope
                       ]
 
       def merge
+        merge_unscope_values
+
         NORMAL_VALUES.each do |name|
           value = values[name]
           # The unless clause is here mostly for performance reasons (since the `send` call might be moderately
@@ -81,6 +83,14 @@ module ActiveRecord
       end
 
       private
+        def merge_unscope_values
+          return if other.unscope_values.empty?
+
+          if other.table == relation.table
+            relation.unscope!(*other.unscope_values)
+          end
+        end
+
         def merge_select_values
           return if other.select_values.empty?
 

--- a/activerecord/test/cases/relation_test.rb
+++ b/activerecord/test/cases/relation_test.rb
@@ -294,6 +294,16 @@ module ActiveRecord
       assert_equal 3, relation.where(id: post.id).pluck(:id).size
     end
 
+    def test_relation_merging_with_joins_and_unscope_on_merged_relation
+      post1 = Post.create!(title: "foo", body: "foo body")
+      post1.comments.create!(body: "foo comment 1")
+      post2 = Post.create!(title: "bar", body: "bar body")
+      post2.comments.create!(body: "bar comment 1")
+
+      relation = Post.where(body: "foo body").joins(:comments).merge(Comment.where("1=0").unscope(:where))
+      assert_equal 1, relation.count
+    end
+
     def test_merge_raises_with_invalid_argument
       assert_raises ArgumentError do
         relation = Relation.new(FakeKlass)


### PR DESCRIPTION
Fixes #53888 (see there for the detailed description).

Currently, when merging 2 relations for different models, the `unscope` from the inner relation is incorrectly merged into the outer relation.

We also need to apply `unscope` *before* all the other conditions (`NORMAL_VALUES.each do |name|` line) to unscope all the current conditions (skipping all future in the call chain ones).