### PR TITLE
Avoid object allocation in reverse_merge! using merge! and block

### DIFF
--- a/activesupport/lib/active_support/core_ext/hash/reverse_merge.rb
+++ b/activesupport/lib/active_support/core_ext/hash/reverse_merge.rb
@@ -18,7 +18,7 @@ class Hash
 
   # Destructive +reverse_merge+.
   def reverse_merge!(other_hash)
-    replace(reverse_merge(other_hash))
+    merge!(other_hash) { |key, old, new| old }
   end
   alias_method :reverse_update, :reverse_merge!
   alias_method :with_defaults!, :reverse_merge!


### PR DESCRIPTION
The current implementation of reverse_merge! creates another Hash object before replacing the receiver's state. This is a bit of shames, since in using destructive methods we often want to avoid extra allocations.

Hash#merge! with a block that returns the existing value on a key collision does the same job and avoids the allocation. It also turns out to be a bit faster which is nice.

Here's my code to test the allocations and speed.

```ruby
require 'active_support/core_ext/hash'
require 'memory_profiler'

a = { a: 1, b: 2 }
b = { a: 2 }

MemoryProfiler.report do
  a.reverse_merge!(b)
end.pretty_print
```

Outputs

Total allocated: 168 bytes (1 objects)
Total retained:  0 bytes (0 objects)

```ruby
require 'active_support/core_ext/hash'
require 'memory_profiler'

a = { a: 1, b: 2 }
b = { a: 2 }
MemoryProfiler.report do
  a.merge!(b) { |key, old_value, new_value| old_value }
end.pretty_print
```

Outputs

Total allocated: 0 bytes (0 objects)
Total retained:  0 bytes (0 objects)

```ruby
require 'active_support/core_ext/hash'
require 'benchmark'

n = 10_000
Benchmark.bm do |x|
  x.report('current reverse_merge!') {
    n.times do
      a.dup.reverse_merge!(b)
    end
  }
  x.report('merge! with block') {
    n.times do
      a.dup.merge!(b) { |key, old_value, new_value| old_value }
    end
  }
end
```

Outputs

user     system      total        real
current reverse_merge!  0.010278   0.000739   0.011017 (  0.011029)
merge! with block       0.007167   0.000077   0.007244 (  0.007306)

<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created because [REPLACE ME]

### Detail

This Pull Request changes [REPLACE ME]

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
