### PR TITLE
Fix canonical_url in guides

### DIFF
--- a/guides/rails_guides/generator.rb
+++ b/guides/rails_guides/generator.rb
@@ -193,8 +193,7 @@ module RailsGuides
           language:      @language,
           direction:     @direction,
           uuid:          SecureRandom.uuid,
-          digest_paths:  @digest_paths,
-          canonical_url: canonical_url(output_file)
+          digest_paths:  @digest_paths
         )
         view.extend(Helpers)
 
@@ -223,12 +222,6 @@ module RailsGuides
         File.open(output_path, "w") do |f|
           f.write(result)
         end if !dry_run?
-      end
-
-      def canonical_url(path)
-        url = "https://guides.rubyonrails.org/"
-        url += path unless path == "index.html"
-        url
       end
 
       def warn_about_broken_links(html)

--- a/guides/rails_guides/helpers.rb
+++ b/guides/rails_guides/helpers.rb
@@ -47,6 +47,12 @@ module RailsGuides
       end
     end
 
+    def canonical_url(path)
+      url = "https://guides.rubyonrails.org/"
+      url += path unless path == "index.html"
+      url
+    end
+
     def code(&block)
       c = capture(&block)
       content_tag(:code, c)

--- a/guides/source/layout.html.erb
+++ b/guides/source/layout.html.erb
@@ -13,7 +13,7 @@
 
   <link rel="apple-touch-icon" href="images/icon.png">
 
-  <link rel="canonical" href="<%= @canonical %>">
+  <link rel="canonical" href="<%= canonical_url(@path) %>">
 
   <script src="<%= digest_path('javascripts/@hotwired--turbo.js') %>" data-turbo-track="reload"></script>
   <script src="<%= digest_path('javascripts/clipboard.js') %>" data-turbo-track="reload"></script>


### PR DESCRIPTION
The generator set `@canonical_url` while the template used `@canonical` (sorry 😞 ). As the `@path` is already set as well, we can move the logic to a helper and remove the instance var.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
