### PR TITLE
Skip tests if adapter does not support `insert_all`/`upsert_all`

### DIFF
--- a/activerecord/test/cases/collection_cache_key_test.rb
+++ b/activerecord/test/cases/collection_cache_key_test.rb
@@ -97,6 +97,8 @@ module ActiveRecord
     end
 
     test "insert_all will update cache_key" do
+      skip unless supports_insert_on_duplicate_skip?
+
       developers = Developer.all
       cache_key = developers.cache_key
 
@@ -106,6 +108,8 @@ module ActiveRecord
     end
 
     test "upsert_all will update cache_key" do
+      skip unless supports_insert_on_duplicate_update?
+
       developers = Developer.all
       cache_key = developers.cache_key
 


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

Similar to https://github.com/rails/rails/pull/53879, some tests are missing checks on whether the database adapter supports `upsert_all`/`insert_all` before calling them.

The `upsert_all`/`insert_all` methods should only be called on database adapters that support UPSERT. The core adapters (MySQL/SQLite/Postgresql) support UPSERT, however SQL Server does not support UPSERT and so the missing checks are causing tests to fail.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`