### PR TITLE
Simplify SecureRandom extension implementation

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -97,7 +97,7 @@ PATH
       i18n (>= 1.6, < 2)
       logger (>= 1.4.2)
       minitest (>= 5.1)
-      securerandom (>= 0.3)
+      securerandom (>= 0.4)
       tzinfo (~> 2.0, >= 2.0.5)
       uri (>= 0.13.1)
     rails (8.1.0.alpha)

--- a/activesupport/activesupport.gemspec
+++ b/activesupport/activesupport.gemspec
@@ -43,7 +43,7 @@ Gem::Specification.new do |s|
   s.add_dependency "drb"
   s.add_dependency "bigdecimal"
   s.add_dependency "logger", ">= 1.4.2"
-  s.add_dependency "securerandom", ">= 0.3"
+  s.add_dependency "securerandom", ">= 0.4"
   s.add_dependency "uri", ">= 0.13.1"
   s.add_dependency "benchmark", ">= 0.3"
 end

--- a/activesupport/lib/active_support/core_ext/securerandom.rb
+++ b/activesupport/lib/active_support/core_ext/securerandom.rb
@@ -16,18 +16,8 @@ module SecureRandom
   #
   #   p SecureRandom.base58 # => "4kUgL2pdQMSCQtjE"
   #   p SecureRandom.base58(24) # => "77TMHrHJFvFDwodq8w7Ev2m7"
-  if SecureRandom.method(:alphanumeric).parameters.size == 2 # Remove check when Ruby 3.3 is the minimum supported version
-    def self.base58(n = 16)
-      alphanumeric(n, chars: BASE58_ALPHABET)
-    end
-  else
-    def self.base58(n = 16)
-      SecureRandom.random_bytes(n).unpack("C*").map do |byte|
-        idx = byte % 64
-        idx = SecureRandom.random_number(58) if idx >= 58
-        BASE58_ALPHABET[idx]
-      end.join
-    end
+  def self.base58(n = 16)
+    alphanumeric(n, chars: BASE58_ALPHABET)
   end
 
   # SecureRandom.base36 generates a random base36 string in lowercase.
@@ -41,17 +31,7 @@ module SecureRandom
   #
   #   p SecureRandom.base36 # => "4kugl2pdqmscqtje"
   #   p SecureRandom.base36(24) # => "77tmhrhjfvfdwodq8w7ev2m7"
-  if SecureRandom.method(:alphanumeric).parameters.size == 2 # Remove check when Ruby 3.3 is the minimum supported version
-    def self.base36(n = 16)
-      alphanumeric(n, chars: BASE36_ALPHABET)
-    end
-  else
-    def self.base36(n = 16)
-      SecureRandom.random_bytes(n).unpack("C*").map do |byte|
-        idx = byte % 64
-        idx = SecureRandom.random_number(36) if idx >= 36
-        BASE36_ALPHABET[idx]
-      end.join
-    end
+  def self.base36(n = 16)
+    alphanumeric(n, chars: BASE36_ALPHABET)
   end
 end


### PR DESCRIPTION
If we require `securerandom >= 0.4` we can get rid of the fallback code.
