### PR TITLE
Update default homebrew path in `database.yml` comments

### DIFF
--- a/guides/source/command_line.md
+++ b/guides/source/command_line.md
@@ -99,7 +99,7 @@ Let's see what it put in our `config/database.yml`:
 # Install the pg driver:
 #   gem install pg
 # On macOS with Homebrew:
-#   gem install pg -- --with-pg-config=/usr/local/bin/pg_config
+#   gem install pg -- --with-pg-config=/opt/homebrew/bin/pg_config
 # On Windows:
 #   gem install pg
 #       Choose the win32 build.

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/postgresql.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/postgresql.yml.tt
@@ -3,7 +3,7 @@
 # Install the pg driver:
 #   gem install pg
 # On macOS with Homebrew:
-#   gem install pg -- --with-pg-config=/usr/local/bin/pg_config
+#   gem install pg -- --with-pg-config=/opt/homebrew/bin/pg_config
 # On Windows:
 #   gem install pg
 #       Choose the win32 build.


### PR DESCRIPTION
Since Apple Silicon (2020), the default path for homebrew is `/opt/homebrew` (https://github.com/Homebrew/brew/releases/tag/2.5.10)