### PR TITLE
Add an option to ensure uniqueness of newly generated session IDs in `Session::CacheStore`

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   Add `check_collisions` option to `ActionDispatch::Session::CacheStore`.
+
+    Newly generated session ids use 128 bits of randomness, which is more than
+    enough to ensure collisions can't happen, but if you need to harden sessions
+    even more, you can enable this option to check in the session store that the id
+    is indeed free you can enable that option. This however incurs an extra write
+    on session creation.
+
+    *Shia*
+
 *   In ExceptionWrapper, match backtrace lines with built templates more often,
     allowing improved highlighting of errors within do-end blocks in templates.
     Fix for Ruby 3.4 to match new method labels in backtrace.


### PR DESCRIPTION
## Background

`Session::CacheStore`, which uses `ActiveSupport::Cache::Store` as session storage, relies on `SecureRandom.hex(16)` to ensure session ID uniqueness. ([ref](https://github.com/rails/rails/blob/6d638f9f30c976d3e8899714459e776b3acb0cf2/actionpack/lib/action_dispatch/middleware/session/abstract_store.rb#L28-L32)) While this provides 2^128 possible values and is practically sufficient in most cases (Ref: [Birthday attack - Wikipedia](https://en.wikipedia.org/wiki/Birthday_attack)), there are certain systems where additional measures are preferred to guarantee uniqueness, even at the cost of some extra overhead (e.g., a single `set` command for `RedisCacheStore`).

## Proposal

I propose adding an option to `Session::CacheStore` to guarantee session ID uniqueness by checking whether the generated session ID is already in use. This option could be named something like `ensure_sid_uniqueness` or something better.

## Reference implementations

- `Session::MemCacheStore` with Dalli includes logic to regenerate session IDs if the generated ID already exists.
    - Ref: https://github.com/petergoldstein/dalli/blob/67942b8db6ba8ae9c39e30d9c0c63fb1525586b3/lib/rack/session/dalli.rb#L126-L133
- The session store implementation in `redis-store` uses a similar approach.
    - Ref: https://github.com/redis-store/redis-rack/blob/d2cb7cb512687d81e817a44f8498b1e39f727261/lib/rack/session/redis.rb#L22-L31
