### PR TITLE
Deprecate `insert_all` with unpersisted associations

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Deprecate using `insert_all`/`upsert_all` with unpersisted records in associations.
+
+    Using these methods on associations containing unpersisted records will now
+    show a deprecation warning, as the unpersisted records will be lost after
+    the operation. This will become an error in Rails 8.2.
+
+    *Nick Schwaderer*
+
 *   Make column name optional for `index_exists?`.
 
     This aligns well with `remove_index` signature as well, where

--- a/activerecord/lib/active_record/associations/collection_proxy.rb
+++ b/activerecord/lib/active_record/associations/collection_proxy.rb
@@ -1128,7 +1128,18 @@ module ActiveRecord
       %w(insert insert_all insert! insert_all! upsert upsert_all).each do |method|
         class_eval <<~RUBY, __FILE__, __LINE__ + 1
           def #{method}(...)
-            scope.#{method}(...).tap { reset }
+            if @association&.target&.any? { |r| r.new_record? }
+              association_name = @association.reflection.name
+              ActiveRecord.deprecator.warn(<<~MSG)
+                Using #{method} on association \#{association_name} with unpersisted records
+                is deprecated. The unpersisted records will be lost after this operation.
+                Please either persist your records first or store them separately before
+                calling #{method}.
+              MSG
+              scope.#{method}(...)
+            else
+              scope.#{method}(...).tap { reset }
+            end
           end
         RUBY
       end

--- a/activerecord/test/cases/insert_all_test.rb
+++ b/activerecord/test/cases/insert_all_test.rb
@@ -863,6 +863,106 @@ class InsertAllTest < ActiveRecord::TestCase
     end
   end
 
+  def test_insert_all_with_unpersisted_records_triggers_deprecation
+    author = Author.create!(name: "Rafael")
+    author.books.build(title: "Unpersisted Book")
+
+    assert_deprecated(ActiveRecord.deprecator) do
+      author.books.insert({ title: "New Book" })
+    end
+
+    author.books.load
+    assert_includes author.books.pluck(:title), "Unpersisted Book"
+  end
+
+  def test_insert_all_without_unpersisted_records_has_no_deprecation
+    author = Author.create!(name: "Rafael")
+
+    assert_not_deprecated(ActiveRecord.deprecator) do
+      author.books.insert_all([{ title: "New Book" }])
+    end
+  end
+
+  def test_insert_with_unpersisted_records_triggers_deprecation
+    author = Author.create!(name: "Rafael")
+    author.books.build(title: "Unpersisted Book")
+
+    assert_deprecated(ActiveRecord.deprecator) do
+      author.books.insert({ title: "New Book" })
+    end
+
+    author.books.load
+    assert_includes author.books.pluck(:title), "Unpersisted Book"
+  end
+
+  def test_insert_without_unpersisted_records_has_no_deprecation
+    author = Author.create!(name: "Rafael")
+
+    assert_not_deprecated(ActiveRecord.deprecator) do
+      author.books.insert({ title: "New Book" })
+    end
+  end
+
+  def test_insert_all_bang_with_unpersisted_record_triggers_deprecation
+    author = Author.create!(name: "Rafael")
+    author.books.build(title: "Unpersisted Book")
+
+    assert_deprecated(ActiveRecord.deprecator) do
+      author.books.insert_all!([{ title: "New Book" }])
+    end
+
+    author.books.load
+    assert_includes author.books.pluck(:title), "Unpersisted Book"
+  end
+
+  def test_insert_all_bang_without_unpersisted_records_has_no_deprecation
+    author = Author.create!(name: "Rafael")
+
+    assert_not_deprecated(ActiveRecord.deprecator) do
+      author.books.insert_all!([{ title: "New Book" }])
+    end
+  end
+
+  def test_upsert_all_with_unpersisted_record_triggers_deprecation
+    author = Author.create!(name: "Rafael")
+    author.books.build(title: "Unpersisted Book")
+
+    assert_deprecated(ActiveRecord.deprecator) do
+      author.books.upsert_all([{ title: "New Book" }])
+    end
+
+    author.books.load
+    assert_includes author.books.pluck(:title), "Unpersisted Book"
+  end
+
+  def test_upsert_all_without_unpersisted_records_has_no_deprecation
+    author = Author.create!(name: "Rafael")
+
+    assert_not_deprecated(ActiveRecord.deprecator) do
+      author.books.upsert_all([{ title: "New Book" }])
+    end
+  end
+
+  def test_upsert_with_unpersisted_record_triggers_deprecation
+    author = Author.create!(name: "Rafael")
+    author.books.build(title: "Unpersisted Book")
+
+    assert_deprecated(ActiveRecord.deprecator) do
+      author.books.upsert({ title: "New Book" })
+    end
+
+    author.books.load
+    assert_includes author.books.pluck(:title), "Unpersisted Book"
+  end
+
+  def test_upsert_without_unpersisted_records_has_no_deprecation
+    author = Author.create!(name: "Rafael")
+
+    assert_not_deprecated(ActiveRecord.deprecator) do
+      author.books.upsert({ title: "New Book" })
+    end
+  end
+
   private
     def capture_log_output
       output = StringIO.new


### PR DESCRIPTION
Ref: https://github.com/rails/rails/pull/45943

The above changes cause an unexpected regression. Using `insert_all` now wipes out prior unpersisted built associations. I think this is probably correct behavior. But let's emit a deprecation in the meantime to let users know that this behavior will change in the future and make it a hard change in Rails 8.1.

This will apply as normal where there isn't a breaking change.

### Repro

Breaks on main, passes on Rails 8.0.

```ruby
require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"
  gem "rails", github: "rails/rails", branch: "main"
  gem "sqlite3"
end

require "active_record"
require "minitest/autorun"
require "logger"

ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")
ActiveRecord::Base.logger = Logger.new(STDOUT)

ActiveRecord::Schema.define do
  create_table :authors, force: true do |t|
    t.string(:name)
  end

  create_table :books, force: true do |t|
    t.belongs_to(:author)
    t.string(:title)
  end
end

class Author < ActiveRecord::Base
  has_many :books
end

class Book < ActiveRecord::Base
  belongs_to :author
end

class BugTest < Minitest::Test
  def test_insert_all_wipes_unpersisted_records
    author = Author.create!(name: "DHH")

    author.books.build(title: "Unpersisted Book 1")
    author.books.build(title: "Unpersisted Book 2")

    author.books.load

    assert_equal(2, author.books.to_a.size)
    assert(author.books.to_a.all?(&:new_record?))

    author.books.insert_all([{ title: "Agile Web Development with Rails" }])

    assert_equal(2, author.books.target.size, "Unpersisted records should still be in memory")
    assert_equal(
      ["Unpersisted Book 1", "Unpersisted Book 2"],
      author.books.target.map(&:title),
      "Unpersisted records should be preserved",
    )
  end
end
```

### For Reviewers

I would like to tell the user where this call is happening. The best I could come up with is `{to_a.reject(&:persisted?).map(&:class).uniq.join(', ')}` in the message. Any ideas on improvements? 

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
