### PR TITLE
 ActiveModel::Attribute: elide dup for immutable types

### DIFF
--- a/activemodel/lib/active_model/attribute.rb
+++ b/activemodel/lib/active_model/attribute.rb
@@ -96,6 +96,14 @@ module ActiveModel
       end
     end
 
+    def dup_or_share # :nodoc:
+      if @type.mutable?
+        dup
+      else
+        self # If the underlying type is immutable we can get away with not duping
+      end
+    end
+
     def type_cast(*)
       raise NotImplementedError
     end

--- a/activemodel/lib/active_model/attribute/user_provided_default.rb
+++ b/activemodel/lib/active_model/attribute/user_provided_default.rb
@@ -26,6 +26,16 @@ module ActiveModel
         self.class.new(name, user_provided_value, type, original_attribute)
       end
 
+      def dup_or_share # :nodoc:
+        # Can't elide dup when the default is a Proc
+        # See Attribute#dup_or_share
+        if @user_provided_value.is_a?(Proc)
+          dup
+        else
+          super
+        end
+      end
+
       def marshal_dump
         result = [
           name,

--- a/activemodel/lib/active_model/attribute_set.rb
+++ b/activemodel/lib/active_model/attribute_set.rb
@@ -71,7 +71,7 @@ module ActiveModel
     end
 
     def deep_dup
-      AttributeSet.new(attributes.transform_values(&:deep_dup))
+      AttributeSet.new(attributes.transform_values(&:dup_or_share))
     end
 
     def initialize_dup(_)

--- a/activemodel/lib/active_model/type/date_time.rb
+++ b/activemodel/lib/active_model/type/date_time.rb
@@ -50,6 +50,14 @@ module ActiveModel
         :datetime
       end
 
+      def mutable? # :nodoc:
+        # Time#zone can be mutated by #utc or #localtime
+        # However when serializing the time zone will always
+        # be coerced and even if the zone was mutated Time instances
+        # remain equal, so we don't need to implement `#changed_in_place?`
+        true
+      end
+
       private
         def cast_value(value)
           return apply_seconds_precision(value) unless value.is_a?(::String)

--- a/activemodel/lib/active_model/type/string.rb
+++ b/activemodel/lib/active_model/type/string.rb
@@ -19,6 +19,10 @@ module ActiveModel
         end
       end
 
+      def mutable? # :nodoc:
+        true
+      end
+
       def to_immutable_string
         ImmutableString.new(
           true: @true,

--- a/activemodel/lib/active_model/type/time.rb
+++ b/activemodel/lib/active_model/type/time.rb
@@ -46,6 +46,14 @@ module ActiveModel
         :time
       end
 
+      def mutable? # :nodoc:
+        # Time#zone can be mutated by #utc or #localtime
+        # However when serializing the time zone will always
+        # be coerced and even if the zone was mutated Time instances
+        # remain equal, so we don't need to implement `#changed_in_place?`
+        true
+      end
+
       def user_input_in_time_zone(value)
         return unless value.present?
 


### PR DESCRIPTION
This is a redo of https://github.com/rails/rails/pull/53337
Which was reverted in https://github.com/rails/rails/pull/53347

`Attribute` is mostly immutable, but the deserialized value is memoized, and that value can potentially be mutable, and mutated.

When the value is immutable however, we can share instances.

Benchmark: https://gist.github.com/casperisfine/ae56bec1e7eecbff3a696b367e2bafa2

Before:

```
ruby 3.4.0dev (2024-12-12T09:30:43Z master 197a3efc75) +YJIT +PRISM [arm64-darwin23]
Warming up --------------------------------------
        ActiveRecord     4.664k i/100ms
Calculating -------------------------------------
        ActiveRecord     46.983k (± 1.0%) i/s   (21.28 μs/i) -    237.864k in   5.063292s
```

After:

```
ruby 3.4.0dev (2024-12-12T09:30:43Z master 197a3efc75) +YJIT +PRISM [arm64-darwin23]
Warming up --------------------------------------
        ActiveRecord     5.404k i/100ms
Calculating -------------------------------------
        ActiveRecord     53.502k (± 1.4%) i/s   (18.69 μs/i) -    270.200k in   5.051328s
```
