### PR TITLE
Extract --skip docs into section

### DIFF
--- a/guides/source/command_line.md
+++ b/guides/source/command_line.md
@@ -44,37 +44,6 @@ $ rails new my_app
 
 Rails will set up what seems like a huge amount of stuff for such a tiny command! We've got the entire Rails directory structure now with all the code we need to run our simple application right out of the box.
 
-If you wish to skip some files from being generated or skip some libraries, you can append any of the following arguments to your `rails new` command:
-
-| Argument                | Description                                              |
-|-------------------------|----------------------------------------------------------|
-| `--skip-git`            | Skip git init, .gitignore, and .gitattributes            |
-| `--skip-docker`         | Skip Dockerfile, .dockerignore and bin/docker-entrypoint |
-| `--skip-keeps`          | Skip source control .keep files                          |
-| `--skip-action-mailer`  | Skip Action Mailer files                                 |
-| `--skip-action-mailbox` | Skip Action Mailbox gem                                  |
-| `--skip-action-text`    | Skip Action Text gem                                     |
-| `--skip-active-record`  | Skip Active Record files                                 |
-| `--skip-active-job`     | Skip Active Job                                          |
-| `--skip-active-storage` | Skip Active Storage files                                |
-| `--skip-action-cable`   | Skip Action Cable files                                  |
-| `--skip-asset-pipeline` | Skip Asset Pipeline                                      |
-| `--skip-javascript`     | Skip JavaScript files                                    |
-| `--skip-hotwire`        | Skip Hotwire integration                                 |
-| `--skip-jbuilder`       | Skip jbuilder gem                                        |
-| `--skip-test`           | Skip test files                                          |
-| `--skip-system-test`    | Skip system test files                                   |
-| `--skip-bootsnap`       | Skip bootsnap gem                                        |
-| `--skip-dev-gems`       | Skip adding development gems                             |
-| `--skip-thruster`       | Skip Thruster setup                                      |
-| `--skip-rubocop`        | Skip RuboCop setup                                       |
-| `--skip-brakeman`       | Skip brakeman setup                                      |
-| `--skip-ci`             | Skip GitHub CI files                                     |
-| `--skip-kamal`          | Skip Kamal setup                                         |
-| `--skip-solid`          | Skip Solid Cache, Queue, and Cable setup                 |
-
-These are just some of the options that `rails new` accepts. For a full list of options, type `rails new --help`.
-
 ### Preconfigure a Different Database
 
 When creating a new Rails application, you have the option to specify what kind
@@ -123,6 +92,32 @@ development:
 ```
 
 It generated a database configuration corresponding to our choice of PostgreSQL.
+
+### Skipping Defaults
+
+If you wish to skip some files from being generated or skip some libraries
+entirely, you can pass one of the `--skip` arguments to the `rails new` command:
+
+```bash
+$ rails new sas --skip-active-storage
+Based on the specified options, the following options will also be activated:
+
+  --skip-action-mailbox [due to --skip-active-storage]
+  --skip-action-text [due to --skip-active-storage]
+
+      create
+      create  README.md
+      ...
+```
+
+In the above example, Action Mailbox and Action Text are skipped in addition to
+Active Storage because they depend on Active Storage functionality.
+
+For a full list of options (including what can be skipped), use `--help`:
+
+```bash
+$ rails new --help
+```
 
 Command Line Basics
 -------------------


### PR DESCRIPTION
### Motivation / Background

Previously, the CLI docs describing `--skip` options were a mostly-comprehensive list of options available that basically duplicates the output of `rails new --help`. A trickle of PRs have been opened to add missing options to the list, but it remains incomplete.

This isn't ideal because the list is toilsome to keep in sync with the actual list of options (and keeping them in sync isn't enforced/automatic). Additionally, the list isn't providing much independent value because the end of the section directs users to `rails new --help` for a full list of options anyways. 

### Detail

This commit aims to address these shortcomings by turning the content about `--skip` options into a dedicated section with an example. The example demonstrates using a `--skip` and how it can cause other things to be skipped as well. Additionally, the skip section is moved below "Preconfigure a Different Database" because that feels like a better introduction to CLI options than `--skip`.

### Additional information

cc @p8 @zzak 

How do we feel about this?

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
