### PR TITLE
[RF-DOCS] Solid Queue updates in Active Job Basics [ci-skip]

### DIFF
--- a/guides/source/active_job_basics.md
+++ b/guides/source/active_job_basics.md
@@ -951,7 +951,7 @@ If you need help figuring out where jobs are coming from, you can enable [verbos
 Alternate Queuing Adapters
 --------------------------
 
-Active Job have other built-in adapters for multiple queuing backends (Sidekiq,
+Active Job has other built-in adapters for multiple queuing backends (Sidekiq,
 Resque, Delayed Job, and others). To get an up-to-date list of the adapters
 see the API Documentation for [`ActiveJob::QueueAdapters`][].
 

--- a/guides/source/active_job_basics.md
+++ b/guides/source/active_job_basics.md
@@ -382,6 +382,21 @@ Each task specifies a `class` or `command` and a `schedule` (parsed using [Fugit
 
 Read more about [Recurring Tasks in the Solid Queue documentation](https://github.com/rails/solid_queue?tab=readme-ov-file#recurring-tasks)
 
+### Job Tracking and Management
+
+To streamline job tracking and management, consider using a tool like
+[`mission_control-jobs`](https://github.com/rails/mission_control-jobs). This
+tool provides a centralized hub to monitor and manage your application's failed
+jobs, offering detailed insights into their statuses and retry behaviors.
+
+For example, if a job to process a large file fails due to a timeout,
+mission_control-jobs lets you inspect the failure reason, check job metadata
+(such as arguments and execution history), and decide whether to retry, requeue,
+or discard the job.
+
+Additionally, you can pair this tool with retry strategies to handle transient
+errors effectively.
+
 Queues
 ------
 

--- a/guides/source/active_job_basics.md
+++ b/guides/source/active_job_basics.md
@@ -403,8 +403,6 @@ class ApplicationMailer < ActionMailer::Base
 end
 ```
 
-Read more [Error Reporting on Jobs in the Solid Queue Documentation](https://github.com/rails/solid_queue?tab=readme-ov-file#error-reporting-on-jobs).
-
 ### Transactional Integrity on Jobs
 
 By default, Solid Queue uses a separate database from your main application. This avoids issues with transactional integrity, which ensures that jobs are only enqueued if the transaction commits.

--- a/guides/source/active_job_basics.md
+++ b/guides/source/active_job_basics.md
@@ -12,6 +12,7 @@ After reading this guide, you will know:
 * How to configure and use Solid Queue.
 * How to run jobs in the background.
 * How to send emails from your application asynchronously.
+
 --------------------------------------------------------------------------------
 
 What is Active Job?

--- a/guides/source/active_job_basics.md
+++ b/guides/source/active_job_basics.md
@@ -162,7 +162,7 @@ NOTE: The key `queue` from the database configuration needs to match the key use
 
 #### Development
 
-In development Rails provides an in-process queuing system, which keeps the
+In development Rails provides an asynchronous in-process queuing system, which keeps the
 jobs in RAM. If the process crashes or the machine is reset, then all
 outstanding jobs are lost with the default async backend. This can be fine for
 smaller apps or non-critical jobs in development.

--- a/guides/source/active_job_basics.md
+++ b/guides/source/active_job_basics.md
@@ -269,7 +269,7 @@ NOTE: The wildcard `*` (at the end of "production") is only allowed on its own o
 
 WARNING: Using wildcard queue names (e.g., `queues: active_storage*`) can slow down polling performance due to the need for a `DISTINCT` query to identify all matching queues, which can be slow on large tables. For better performance, it’s best to specify exact queue names instead of using wildcards.
 
-Active Job supports positive integer priorities when enqueuing jobs. You can read more about the [Priority section](#priority). This setup is helpful when you have jobs with different levels of importance or urgency in the same queue. Within a single queue, jobs are picked based on their priority (with lower values being higher priority). However, when you have multiple queues, the order of the queues themselves takes priority.
+Active Job supports positive integer priorities when enqueuing jobs (see [Priority section](#priority)). Within a single queue, jobs are picked based on their priority (with lower integers being higher priority). However, when you have multiple queues, the order of the queues themselves takes priority.
 
 For example, if you have two queues, `production` and `background`, jobs in the `production` queue will always be processed first, even if some jobs in the `background` queue have a higher priority.
 

--- a/guides/source/active_job_basics.md
+++ b/guides/source/active_job_basics.md
@@ -384,18 +384,17 @@ Read more about [Recurring Tasks in the Solid Queue documentation](https://githu
 
 ### Job Tracking and Management
 
-To streamline job tracking and management, consider using a tool like
-[`mission_control-jobs`](https://github.com/rails/mission_control-jobs). This
-tool provides a centralized hub to monitor and manage your application's failed
-jobs, offering detailed insights into their statuses and retry behaviors.
+A tool like [`mission_control-jobs`](https://github.com/rails/mission_control-jobs) can help centralize the monitoring and management of failed jobs. It provides insights into job statuses, failure reasons, and retry behaviors, enabling you to track and resolve issues more effectively.
 
-For example, if a job to process a large file fails due to a timeout,
-mission_control-jobs lets you inspect the failure reason, check job metadata
-(such as arguments and execution history), and decide whether to retry, requeue,
-or discard the job.
+For instance, if a job fails to process a large file due to a timeout, `mission_control-jobs` allows you to inspect the failure, review the job’s arguments and execution history, and decide whether to retry, requeue, or discard it.
 
-Additionally, you can pair this tool with retry strategies to handle transient
-errors effectively.
+Pairing this tool with retry strategies helps address transient errors. For example:
+
+```ruby
+retry_on ActiveRecord::Deadlocked, wait: 5.seconds, attempts: 3
+```
+
+This configuration retries the job up to three times with a 5-second delay between attempts in case of a database deadlock.
 
 Queues
 ------

--- a/guides/source/active_job_basics.md
+++ b/guides/source/active_job_basics.md
@@ -282,7 +282,7 @@ production:
       polling_interval: 5
 ```
 
-In the above example, will fetch jobs from queues starting with "production", then "background" when no `production*` jobs remain.
+In the above example, workers will fetch jobs from queues starting with "production", then "background" when no `production*` jobs remain.
 
 NOTE: The wildcard `*` (at the end of "production") is only allowed on its own or at the end of a queue name to match all queues with the same prefix. You can't specify queue names such as `*_some_queue`.
 

--- a/guides/source/active_job_basics.md
+++ b/guides/source/active_job_basics.md
@@ -117,7 +117,9 @@ That's it!
 
 ### Enqueue Jobs in Bulk
 
-You can enqueue multiple jobs at once using [`perform_all_later`](https://api.rubyonrails.org/classes/ActiveJob.html#method-c-perform_all_later). For more details see [Bulk Enqueuing](#bulk-enqueuing).
+You can enqueue multiple jobs at once using
+[`perform_all_later`](https://api.rubyonrails.org/classes/ActiveJob.html#method-c-perform_all_later).
+For more details see [Bulk Enqueuing](#bulk-enqueuing).
 
 Default Backend: Solid Queue
 ------------------------------
@@ -126,19 +128,21 @@ Solid Queue, which is enabled by default from Rails version 8.0 and onward, is a
 database-backed queuing system for Active Job, allowing you to queue large
 amounts of data without requiring additional dependencies such as Redis.
 
-Besides regular job enqueuing and processing, Solid Queue supports delayed jobs, concurrency controls, numeric priorities per job, priorities by queue order, and more.
+Besides regular job enqueuing and processing, Solid Queue supports delayed jobs,
+concurrency controls, numeric priorities per job, priorities by queue order, and
+more.
 
 ### Set Up
 
 #### Development
 
-In development, Rails provides an asynchronous in-process queuing system, which keeps the
-jobs in RAM. If the process crashes or the machine is reset, then all
+In development, Rails provides an asynchronous in-process queuing system, which
+keeps the jobs in RAM. If the process crashes or the machine is reset, then all
 outstanding jobs are lost with the default async backend. This can be fine for
 smaller apps or non-critical jobs in development.
 
-However, if you use Solid Queue instead, you
-can configure it in the same way as in the production environment:
+However, if you use Solid Queue instead, you can configure it in the same way as
+in the production environment:
 
 ```ruby
 # config/environments/development.rb
@@ -146,7 +150,8 @@ config.active_job.queue_adapter = :solid_queue
 config.solid_queue.connects_to = { database: { writing: :queue } }
 ```
 
-which sets the `:solid_queue` adapter as the default for Active Job in the production environment, and connects to the `queue` database for writing.
+which sets the `:solid_queue` adapter as the default for Active Job in the
+production environment, and connects to the `queue` database for writing.
 
 Thereafter, you'd add `queue` to the development database configuration:
 
@@ -162,9 +167,11 @@ development
     migrations_paths: db/queue_migrate
 ```
 
-NOTE: The key `queue` from the database configuration needs to match the key used in the configuration for `config.solid_queue.connects_to`.
+NOTE: The key `queue` from the database configuration needs to match the key
+used in the configuration for `config.solid_queue.connects_to`.
 
-You can run the migrations for the `queue` database to ensure all the tables in queue database are created:
+You can run the migrations for the `queue` database to ensure all the tables in
+queue database are created:
 
 ```bash
 $ bin/rails db:migrate:queue
@@ -182,7 +189,8 @@ bin/jobs start
 
 #### Production
 
-Solid Queue is already configured for the production environment. If you open `config/environments/production.rb`, you will see the following:
+Solid Queue is already configured for the production environment. If you open
+`config/environments/production.rb`, you will see the following:
 
 ```ruby
 # config/environments/production.rb
@@ -191,7 +199,8 @@ config.active_job.queue_adapter = :solid_queue
 config.solid_queue.connects_to = { database: { writing: :queue } }
 ```
 
-Additionally, the database connection for the `queue` database is configured in `config/database.yml`:
+Additionally, the database connection for the `queue` database is configured in
+`config/database.yml`:
 
 ```yaml
 # config/database.yml
@@ -209,7 +218,8 @@ production:
 
 ### Configuration
 
-The configuration options for Solid Queue are defined in `config/queue.yml`. Here is an example of the default configuration:
+The configuration options for Solid Queue are defined in `config/queue.yml`.
+Here is an example of the default configuration:
 
 ```yaml
 default: &default
@@ -223,16 +233,26 @@ default: &default
       polling_interval: 0.1
 ```
 
-In order to understand the configuration options for Solid Queue, you must understand the different types of roles:
+In order to understand the configuration options for Solid Queue, you must
+understand the different types of roles:
 
-- **Dispatchers**: They select jobs scheduled to run for the future. When it's time for these jobs to run, dispatchers move them from the `solid_queue_scheduled_executions` table to the `solid_queue_ready_executions` table so workers can pick them up. They also manage concurrency-related maintenance.
-- **Workers**: They pick up jobs that are ready to run. These jobs are taken from the `solid_queue_ready_executions` table.
-- **Scheduler**: This takes care of recurring tasks, adding jobs to the queue when they're due.
-- **Supervisor**: It oversees the whole system, managing workers and dispatchers. It starts and stops them as needed, monitors their health, and ensures everything runs smoothly.
+- **Dispatchers**: They select jobs scheduled to run for the future. When it's
+  time for these jobs to run, dispatchers move them from the
+  `solid_queue_scheduled_executions` table to the `solid_queue_ready_executions`
+  table so workers can pick them up. They also manage concurrency-related
+  maintenance.
+- **Workers**: They pick up jobs that are ready to run. These jobs are taken
+  from the `solid_queue_ready_executions` table.
+- **Scheduler**: This takes care of recurring tasks, adding jobs to the queue
+  when they're due.
+- **Supervisor**: It oversees the whole system, managing workers and
+  dispatchers. It starts and stops them as needed, monitors their health, and
+  ensures everything runs smoothly.
 
 Everything is optional in the `config/queue.yml`. If no configuration is
 provided, Solid Queue will run with one dispatcher and one worker with default
-settings. Below are some of the configuration options you can set in `config/queue.yml`:
+settings. Below are some of the configuration options you can set in
+`config/queue.yml`:
 
 | **Option**                           | **Description**                                                                                     | **Default Value**                             |
 | ------------------------------------ | --------------------------------------------------------------------------------------------------- | --------------------------------------------- |
@@ -244,7 +264,12 @@ settings. Below are some of the configuration options you can set in `config/que
 | **processes**                        | Number of worker processes forked by the supervisor. Each process can dedicate a CPU core.          | 1                                             |
 | **concurrency_maintenance**          | Whether the dispatcher performs concurrency maintenance work.                                       | true                                          |
 
-You can read more about these [configuration options in the Solid Queue documentation](https://github.com/rails/solid_queue?tab=readme-ov-file#configuration). There are also [additional configuration options](https://github.com/rails/solid_queue?tab=readme-ov-file#other-configuration-settings) that can be set in `config/<environment>.rb` to further configure Solid Queue in your Rails Application.
+You can read more about these [configuration options in the Solid Queue
+documentation](https://github.com/rails/solid_queue?tab=readme-ov-file#configuration).
+There are also [additional configuration
+options](https://github.com/rails/solid_queue?tab=readme-ov-file#other-configuration-settings)
+that can be set in `config/<environment>.rb` to further configure Solid Queue in
+your Rails Application.
 
 ### Queue Order
 
@@ -263,34 +288,66 @@ production:
       polling_interval: 5
 ```
 
-In the above example, workers will fetch jobs from queues starting with "active_storage", like  the `active_storage_analyse` queue and `active_storage_transform` queue. Only when no jobs remain in the `active_storage`-prefixed queues will workers move on to the `mailers` queue.
+In the above example, workers will fetch jobs from queues starting with
+"active_storage", like  the `active_storage_analyse` queue and
+`active_storage_transform` queue. Only when no jobs remain in the
+`active_storage`-prefixed queues will workers move on to the `mailers` queue.
 
-NOTE: The wildcard `*` (like at the end of "active_storage") is only allowed on its own or at the end of a queue name to match all queues with the same prefix. You can't specify queue names such as `*_some_queue`.
+NOTE: The wildcard `*` (like at the end of "active_storage") is only allowed on
+its own or at the end of a queue name to match all queues with the same prefix.
+You can't specify queue names such as `*_some_queue`.
 
-WARNING: Using wildcard queue names (e.g., `queues: active_storage*`) can slow down polling performance due to the need for a `DISTINCT` query to identify all matching queues, which can be slow on large tables. For better performance, it’s best to specify exact queue names instead of using wildcards.
+WARNING: Using wildcard queue names (e.g., `queues: active_storage*`) can slow
+down polling performance due to the need for a `DISTINCT` query to identify all
+matching queues, which can be slow on large tables. For better performance, it’s
+best to specify exact queue names instead of using wildcards.
 
-Active Job supports positive integer priorities when enqueuing jobs (see [Priority section](#priority)). Within a single queue, jobs are picked based on their priority (with lower integers being higher priority). However, when you have multiple queues, the order of the queues themselves takes priority.
+Active Job supports positive integer priorities when enqueuing jobs (see
+[Priority section](#priority)). Within a single queue, jobs are picked based on
+their priority (with lower integers being higher priority). However, when you
+have multiple queues, the order of the queues themselves takes priority.
 
-For example, if you have two queues, `production` and `background`, jobs in the `production` queue will always be processed first, even if some jobs in the `background` queue have a higher priority.
+For example, if you have two queues, `production` and `background`, jobs in the
+`production` queue will always be processed first, even if some jobs in the
+`background` queue have a higher priority.
 
 ### Threads, Processes, and Signals
 
-In Solid Queue, parallelism is achieved through threads (configurable via the [`threads` parameter](#configuration)), processes (via the [`processes` parameter](#configuration)), or horizontal scaling. The supervisor manages processes and responds to the following signals:
+In Solid Queue, parallelism is achieved through threads (configurable via the
+[`threads` parameter](#configuration)), processes (via the [`processes`
+parameter](#configuration)), or horizontal scaling. The supervisor manages
+processes and responds to the following signals:
 
-- **TERM, INT**: Starts graceful termination, sending a TERM signal and waiting up to `SolidQueue.shutdown_timeout`. If not finished, a QUIT signal forces processes to exit.
+- **TERM, INT**: Starts graceful termination, sending a TERM signal and waiting
+  up to `SolidQueue.shutdown_timeout`. If not finished, a QUIT signal forces
+  processes to exit.
 - **QUIT**: Forces immediate termination of processes.
 
-If a worker is killed unexpectedly (e.g., with a `KILL` signal), in-flight jobs are marked as failed, and errors like `SolidQueue::Processes::ProcessExitError` or `SolidQueue::Processes::ProcessPrunedError` are raised. Heartbeat settings help manage and detect expired processes. Read more about [Threads, Processes and Signals in the Solid Queue documentation](https://github.com/rails/solid_queue?tab=readme-ov-file#threads-processes-and-signals).
+If a worker is killed unexpectedly (e.g., with a `KILL` signal), in-flight jobs
+are marked as failed, and errors like `SolidQueue::Processes::ProcessExitError`
+or `SolidQueue::Processes::ProcessPrunedError` are raised. Heartbeat settings
+help manage and detect expired processes. Read more about [Threads, Processes
+and Signals in the Solid Queue
+documentation](https://github.com/rails/solid_queue?tab=readme-ov-file#threads-processes-and-signals).
 
 ### Errors When Enqueuing
 
-Solid Queue raises a `SolidQueue::Job::EnqueueError` when Active Record errors occur during job enqueuing. This is different from the `ActiveJob::EnqueueError` raised by Active Job, which handles the error and makes `perform_later` return false. This makes error handling trickier for jobs enqueued by Rails or third-party gems like `Turbo::Streams::BroadcastJob`.
+Solid Queue raises a `SolidQueue::Job::EnqueueError` when Active Record errors
+occur during job enqueuing. This is different from the `ActiveJob::EnqueueError`
+raised by Active Job, which handles the error and makes `perform_later` return
+false. This makes error handling trickier for jobs enqueued by Rails or
+third-party gems like `Turbo::Streams::BroadcastJob`.
 
-For recurring tasks, any errors encountered while enqueuing are logged, but they won’t be raised. Read more about [Errors When Enqueuing in the Solid Queue documentation](https://github.com/rails/solid_queue?tab=readme-ov-file#errors-when-enqueuing).
+For recurring tasks, any errors encountered while enqueuing are logged, but they
+won’t be raised. Read more about [Errors When Enqueuing in the Solid Queue
+documentation](https://github.com/rails/solid_queue?tab=readme-ov-file#errors-when-enqueuing).
 
 ### Concurrency Controls
 
-Solid Queue extends Active Job with concurrency controls, allowing you to limit how many jobs of a certain type or with specific arguments can run at the same time. If a job exceeds the limit, it will be blocked until another job finishes or the duration expires. For example:
+Solid Queue extends Active Job with concurrency controls, allowing you to limit
+how many jobs of a certain type or with specific arguments can run at the same
+time. If a job exceeds the limit, it will be blocked until another job finishes
+or the duration expires. For example:
 
 ```ruby
 class MyJob < ApplicationJob
@@ -302,9 +359,12 @@ class MyJob < ApplicationJob
 end
 ```
 
-In this example, only two `MyJob` instances for the same account will run concurrently. After that, other jobs will be blocked until one completes.
+In this example, only two `MyJob` instances for the same account will run
+concurrently. After that, other jobs will be blocked until one completes.
 
-The `group` parameter can be used to control concurrency across different job types. For instance, two different job classes that use the same group will have their concurrency limited together:
+The `group` parameter can be used to control concurrency across different job
+types. For instance, two different job classes that use the same group will have
+their concurrency limited together:
 
 ```ruby
 class Box::MovePostingsByContactToDesignatedBoxJob < ApplicationJob
@@ -316,13 +376,17 @@ class Bundle::RebundlePostingsJob < ApplicationJob
 end
 ```
 
-This ensures that only one job for a given contact can run at a time, regardless of the job class.
+This ensures that only one job for a given contact can run at a time, regardless
+of the job class.
 
-Read more about [Concurrency Controls in the Solid Queue documentation](https://github.com/rails/solid_queue?tab=readme-ov-file#concurrency-controls).
+Read more about [Concurrency Controls in the Solid Queue
+documentation](https://github.com/rails/solid_queue?tab=readme-ov-file#concurrency-controls).
 
 ### Error Reporting on Jobs
 
-If your error tracking service doesn’t automatically report job errors, you can manually hook into Active Job to report them. For example, you can add a `rescue_from` block in `ApplicationJob`:
+If your error tracking service doesn’t automatically report job errors, you can
+manually hook into Active Job to report them. For example, you can add a
+`rescue_from` block in `ApplicationJob`:
 
 ```ruby
 class ApplicationJob < ActiveJob::Base
@@ -333,7 +397,8 @@ class ApplicationJob < ActiveJob::Base
 end
 ```
 
-If you use ActionMailer, you’ll need to handle errors for `MailDeliveryJob` separately:
+If you use ActionMailer, you’ll need to handle errors for `MailDeliveryJob`
+separately:
 
 ```ruby
 class ApplicationMailer < ActionMailer::Base
@@ -346,9 +411,14 @@ end
 
 ### Transactional Integrity on Jobs
 
-By default, Solid Queue uses a separate database from your main application. This avoids issues with transactional integrity, which ensures that jobs are only enqueued if the transaction commits.
+By default, Solid Queue uses a separate database from your main application.
+This avoids issues with transactional integrity, which ensures that jobs are
+only enqueued if the transaction commits.
 
-However, if you use Solid Queue in the same database as your app, you can enable transactional integrity with Active Job’s `enqueue_after_transaction_commit` option which can be enabled for individual jobs or all jobs through `ApplicationJob`:
+However, if you use Solid Queue in the same database as your app, you can enable
+transactional integrity with Active Job’s `enqueue_after_transaction_commit`
+option which can be enabled for individual jobs or all jobs through
+`ApplicationJob`:
 
 ```ruby
 class ApplicationJob < ActiveJob::Base
@@ -356,11 +426,17 @@ class ApplicationJob < ActiveJob::Base
 end
 ```
 
-You can also configure Solid Queue to use the same database as your app while avoiding transactional integrity issues by setting up a separate database connection for Solid Queue jobs. Read more about [Transactional Integrity in the Solid Queue documentation](https://github.com/rails/solid_queue?tab=readme-ov-file#jobs-and-transactional-integrity)
+You can also configure Solid Queue to use the same database as your app while
+avoiding transactional integrity issues by setting up a separate database
+connection for Solid Queue jobs. Read more about [Transactional Integrity in the
+Solid Queue
+documentation](https://github.com/rails/solid_queue?tab=readme-ov-file#jobs-and-transactional-integrity)
 
 ### Recurring Tasks
 
-Solid Queue supports recurring tasks, similar to cron jobs. These tasks are defined in a configuration file (by default, `config/recurring.yml`) and can be scheduled at specific times. Here's an example of a task configuration:
+Solid Queue supports recurring tasks, similar to cron jobs. These tasks are
+defined in a configuration file (by default, `config/recurring.yml`) and can be
+scheduled at specific times. Here's an example of a task configuration:
 
 ```yaml
 production:
@@ -373,15 +449,28 @@ production:
     schedule: every day at 9am
 ```
 
-Each task specifies a `class` or `command` and a `schedule` (parsed using [Fugit](https://github.com/floraison/fugit)). You can also pass arguments to jobs, such as in the example for `MyJob` where `args` are passed. This can be passed as a single argument, a hash, or an array of arguments that can also include kwargs as the last element in the array. This allows jobs to run periodically or at specified times.
+Each task specifies a `class` or `command` and a `schedule` (parsed using
+[Fugit](https://github.com/floraison/fugit)). You can also pass arguments to
+jobs, such as in the example for `MyJob` where `args` are passed. This can be
+passed as a single argument, a hash, or an array of arguments that can also
+include kwargs as the last element in the array. This allows jobs to run
+periodically or at specified times.
 
-Read more about [Recurring Tasks in the Solid Queue documentation](https://github.com/rails/solid_queue?tab=readme-ov-file#recurring-tasks).
+Read more about [Recurring Tasks in the Solid Queue
+documentation](https://github.com/rails/solid_queue?tab=readme-ov-file#recurring-tasks).
 
 ### Job Tracking and Management
 
-A tool like [`mission_control-jobs`](https://github.com/rails/mission_control-jobs) can help centralize the monitoring and management of failed jobs. It provides insights into job statuses, failure reasons, and retry behaviors, enabling you to track and resolve issues more effectively.
+A tool like
+[`mission_control-jobs`](https://github.com/rails/mission_control-jobs) can help
+centralize the monitoring and management of failed jobs. It provides insights
+into job statuses, failure reasons, and retry behaviors, enabling you to track
+and resolve issues more effectively.
 
-For instance, if a job fails to process a large file due to a timeout, `mission_control-jobs` allows you to inspect the failure, review the job’s arguments and execution history, and decide whether to retry, requeue, or discard it.
+For instance, if a job fails to process a large file due to a timeout,
+`mission_control-jobs` allows you to inspect the failure, review the job’s
+arguments and execution history, and decide whether to retry, requeue, or
+discard it.
 
 Queues
 ------
@@ -500,7 +589,8 @@ NOTE: If you choose to use an [alternate queuing backend](#alternate-queuing-bac
 Priority
 --------
 
-You can schedule a job to run with a specific priority using `queue_with_priority`:
+You can schedule a job to run with a specific priority using
+`queue_with_priority`:
 
 ```ruby
 class GuestsCleanupJob < ApplicationJob
@@ -509,11 +599,18 @@ class GuestsCleanupJob < ApplicationJob
 end
 ```
 
-Solid Queue, the default queuing backend, prioritizes jobs based on the order of the queues.  You can read more about it in the [Order of Queues section](#queue-order). If you're using Solid Queue, and both the order of the queues and the priority option are used, the queue order will take precedence, and the priority option will only apply within each queue.
+Solid Queue, the default queuing backend, prioritizes jobs based on the order of
+the queues.  You can read more about it in the [Order of Queues
+section](#queue-order). If you're using Solid Queue, and both the order of the
+queues and the priority option are used, the queue order will take precedence,
+and the priority option will only apply within each queue.
 
-Other queuing backends may allow jobs to be prioritized relative to others within the same queue or across multiple queues. Refer to the documentation of your backend for more information.
+Other queuing backends may allow jobs to be prioritized relative to others
+within the same queue or across multiple queues. Refer to the documentation of
+your backend for more information.
 
-Similar to `queue_as`, you can also pass a block to `queue_with_priority` to be evaluated in the job context:
+Similar to `queue_as`, you can also pass a block to `queue_with_priority` to be
+evaluated in the job context:
 
 ```ruby
 class ProcessVideoJob < ApplicationJob
@@ -542,11 +639,13 @@ You can also pass a `:priority` option to `set`:
 MyJob.set(priority: 50).perform_later(record)
 ```
 
-NOTE: If a lower priority number performs before or after a higher priority number depends on the
-adapter implementation. Refer to documentation of your backend for more information.
-Adapter authors are encouraged to treat a lower number as more important.
+NOTE: If a lower priority number performs before or after a higher priority
+number depends on the adapter implementation. Refer to documentation of your
+backend for more information. Adapter authors are encouraged to treat a lower
+number as more important.
 
-[`queue_with_priority`]: https://api.rubyonrails.org/classes/ActiveJob/QueuePriority/ClassMethods.html#method-i-queue_with_priority
+[`queue_with_priority`]:
+    https://api.rubyonrails.org/classes/ActiveJob/QueuePriority/ClassMethods.html#method-i-queue_with_priority
 
 Callbacks
 ---------

--- a/guides/source/active_job_basics.md
+++ b/guides/source/active_job_basics.md
@@ -244,26 +244,7 @@ settings. Below are some of the configuration options you can set in `config/que
 | **processes**                        | Number of worker processes forked by the supervisor. Each process can dedicate a CPU core.          | 1                                             |
 | **concurrency_maintenance**          | Whether the dispatcher performs concurrency maintenance work.                                       | true                                          |
 
-You can read more about the [configuration options in the Solid Queue documentation](https://github.com/rails/solid_queue?tab=readme-ov-file#configuration).
-
-Additionally, you can further configure Solid Queue in your Rails Application by setting the following options in `config/<environment>.rb`:
-
-| **Setting**                            | **Description**                                                                              | **Default**                                                        |
-| -------------------------------------- | -------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
-| **logger**                             | Logger used by Solid Queue.                                                                  | App logger                                                         |
-| **app_executor**                       | Rails executor used to wrap asynchronous operations.                                         | App executor                                                       |
-| **on_thread_error**                    | Custom lambda/Proc to call on thread error.                                                  | `-> (exception) { Rails.error.report(exception, handled: false) }` |
-| **use_skip_locked**                    | Whether to use `FOR UPDATE SKIP LOCKED` for locking reads.                                   | Auto-detected, set to false if DB doesn't support it               |
-| **process_heartbeat_interval**         | Heartbeat interval for processes.                                                            | 60 seconds                                                         |
-| **process_alive_threshold**            | Time to wait before considering a process dead after its last heartbeat.                     | 5 minutes                                                          |
-| **shutdown_timeout**                   | Time the supervisor waits before forcing termination of processes after sending TERM signal. | 5 seconds                                                          |
-| **silence_polling**                    | Whether to silence Active Record logs when polling for jobs.                                 | true                                                               |
-| **supervisor_pidfile**                 | Path to the PID file created by the supervisor.                                              | nil                                                                |
-| **preserve_finished_jobs**             | Whether to keep finished jobs in the database.                                               | true                                                               |
-| **clear_finished_jobs_after**          | Period to keep finished jobs around if `preserve_finished_jobs` is true.                     | 1 day                                                              |
-| **default_concurrency_control_period** | Default duration for concurrency control in jobs.                                            | 3 minutes                                                          |
-
-You can read more about the [additional configuration options in the Solid Queue documentation](https://github.com/rails/solid_queue?tab=readme-ov-file#other-configuration-settings).
+You can read more about these [configuration options in the Solid Queue documentation](https://github.com/rails/solid_queue?tab=readme-ov-file#configuration). There are also [additional configuration options](https://github.com/rails/solid_queue?tab=readme-ov-file#other-configuration-settings) that can be set in `config/<environment>.rb` to further configure Solid Queue in your Rails Application.
 
 ### Queue Order
 
@@ -306,27 +287,6 @@ In Solid Queue, parallelism is achieved through threads (configurable via the [`
 
 If a worker is killed unexpectedly (e.g., with a `KILL` signal), in-flight jobs are marked as failed, and errors like `SolidQueue::Processes::ProcessExitError` or `SolidQueue::Processes::ProcessPrunedError` are raised. Heartbeat settings help manage and detect expired processes. Read more about [Threads, Processes and Signals in the Solid Queue documentation](https://github.com/rails/solid_queue?tab=readme-ov-file#threads-processes-and-signals).
 
-### Lifecycle Hooks
-
-Solid Queue provides lifecycle hooks that let you run code at specific points in the supervisor’s and worker’s lifecycles. The two supervisor lifecycle hooks are:
-
-- `start`: Runs after the supervisor boots but before it forks workers and dispatchers.
-- `stop`: Runs after receiving a shutdown signal (`TERM`, `INT`, or `QUIT`) but before graceful or immediate shutdown begins.
-
-Similarly, there are worker lifecycle hooks:
-
-- `worker_start`: Runs after a worker boots but before it starts polling.
-- `worker_stop`: Runs after receiving a shutdown signal but before the worker shuts down.
-
-You can use methods like `SolidQueue.on_start` and `SolidQueue.on_worker_start` to hook into these lifecycle points. For example:
-
-```ruby
-SolidQueue.on_start { start_metrics_server }
-SolidQueue.on_stop { stop_metrics_server }
-```
-
-Call these hooks before starting Solid Queue, usually in an initializer. Read more about [Lifecycle Hooks in the Solid Queue documentation](https://github.com/rails/solid_queue?tab=readme-ov-file#lifecycle-hooks).
-
 ### Errors When Enqueuing
 
 Solid Queue raises a `SolidQueue::Job::EnqueueError` when Active Record errors occur during job enqueuing. This is different from the `ActiveJob::EnqueueError` raised by Active Job, which handles the error and makes `perform_later` return false. This makes error handling trickier for jobs enqueued by Rails or third-party gems like `Turbo::Streams::BroadcastJob`.
@@ -364,20 +324,6 @@ end
 This ensures that only one job for a given contact can run at a time, regardless of the job class.
 
 Read more about [Concurrency Controls in the Solid Queue documentation](https://github.com/rails/solid_queue?tab=readme-ov-file#concurrency-controls).
-
-### Failed Jobs and Retries
-
-Failed jobs will be stored in the `solid_queue_failed_executions` table. You can inspect and retry them manually, for example:
-
-```ruby
-failed_execution = SolidQueue::FailedExecution.find(1)
-failed_execution.error # inspect the error
-
-failed_execution.retry  # Re-enqueues the job
-failed_execution.discard  # Deletes the failed job
-```
-
-For better tracking, you can use a tool like [`mission_control-jobs`](https://github.com/rails/mission_control-jobs) to manage failed jobs. Read more about [Failed Jobs and Retries in the Solid Queue Documentation](https://github.com/rails/solid_queue?tab=readme-ov-file#failed-jobs-and-retries).
 
 ### Error Reporting on Jobs
 

--- a/guides/source/active_job_basics.md
+++ b/guides/source/active_job_basics.md
@@ -543,7 +543,7 @@ option to `set`:
 MyJob.set(queue: :another_queue).perform_later(record)
 ```
 
-NOTE:If you choose to use an [alternate queueing adapter](#alternate-queuing-adapters) you may need to specify the queues to listen to.
+NOTE: If you choose to use an [alternate queueing adapter](#alternate-queuing-adapters) you may need to specify the queues to listen to.
 
 [`config.active_job.queue_name_delimiter`]: configuring.html#config-active-job-queue-name-delimiter
 [`config.active_job.queue_name_prefix`]: configuring.html#config-active-job-queue-name-prefix

--- a/guides/source/active_job_basics.md
+++ b/guides/source/active_job_basics.md
@@ -258,16 +258,16 @@ only then will it move onto the second, and so on.
 # config/queue.yml
 production:
   workers:
-    - queues:[production*, background]
+    - queues:[active_storage*, mailers]
       threads: 3
       polling_interval: 5
 ```
 
-In the above example, workers will fetch jobs from queues starting with "production", then "background" when no `production*` jobs remain.
+In the above example, workers will fetch jobs from queues starting with "active_storage", like  the `active_storage_analyse` queue and `active_storage_transform` queue. Only when no jobs remain in the `active_storage`-prefixed queues will workers move on to the `mailers` queue.
 
 NOTE: The wildcard `*` (at the end of "production") is only allowed on its own or at the end of a queue name to match all queues with the same prefix. You can't specify queue names such as `*_some_queue`.
 
-WARNING: Using wildcard queue names (e.g., `queues: production*`) can slow down polling performance due to the need for a `DISTINCT` query to identify all matching queues, which can be slow on large tables. For better performance, it’s best to specify exact queue names instead of using wildcards.
+WARNING: Using wildcard queue names (e.g., `queues: active_storage*`) can slow down polling performance due to the need for a `DISTINCT` query to identify all matching queues, which can be slow on large tables. For better performance, it’s best to specify exact queue names instead of using wildcards.
 
 Active Job supports positive integer priorities when enqueuing jobs. You can read more about the [Priority section](#priority). This setup is helpful when you have jobs with different levels of importance or urgency in the same queue. Within a single queue, jobs are picked based on their priority (with lower values being higher priority). However, when you have multiple queues, the order of the queues themselves takes priority.
 

--- a/guides/source/active_job_basics.md
+++ b/guides/source/active_job_basics.md
@@ -273,7 +273,6 @@ Active Job supports positive integer priorities when enqueuing jobs (see [Priori
 
 For example, if you have two queues, `production` and `background`, jobs in the `production` queue will always be processed first, even if some jobs in the `background` queue have a higher priority.
 
-
 ### Threads, Processes, and Signals
 
 In Solid Queue, parallelism is achieved through threads (configurable via the [`threads` parameter](#configuration)), processes (via the [`processes` parameter](#configuration)), or horizontal scaling. The supervisor manages processes and responds to the following signals:
@@ -287,7 +286,7 @@ If a worker is killed unexpectedly (e.g., with a `KILL` signal), in-flight jobs 
 
 Solid Queue raises a `SolidQueue::Job::EnqueueError` when Active Record errors occur during job enqueuing. This is different from the `ActiveJob::EnqueueError` raised by Active Job, which handles the error and makes `perform_later` return false. This makes error handling trickier for jobs enqueued by Rails or third-party gems like `Turbo::Streams::BroadcastJob`.
 
-For recurring tasks, any errors encountered while enqueuing are logged, but they won’t bubble up. Read more about [Errors When Enqueuing in the Solid Queue documentation](https://github.com/rails/solid_queue?tab=readme-ov-file#errors-when-enqueuing).
+For recurring tasks, any errors encountered while enqueuing are logged, but they won’t be raised. Read more about [Errors When Enqueuing in the Solid Queue documentation](https://github.com/rails/solid_queue?tab=readme-ov-file#errors-when-enqueuing).
 
 ### Concurrency Controls
 

--- a/guides/source/active_job_basics.md
+++ b/guides/source/active_job_basics.md
@@ -322,7 +322,7 @@ Read more about [Concurrency Controls in the Solid Queue documentation](https://
 
 ### Error Reporting on Jobs
 
-If your error tracking service doesn’t automatically report job errors, you can manually hook into Active Job to report exceptions. For example, you can add a `rescue_from` block in `ApplicationJob`:
+If your error tracking service doesn’t automatically report job errors, you can manually hook into Active Job to report them. For example, you can add a `rescue_from` block in `ApplicationJob`:
 
 ```ruby
 class ApplicationJob < ActiveJob::Base

--- a/guides/source/active_job_basics.md
+++ b/guides/source/active_job_basics.md
@@ -209,7 +209,7 @@ bin/jobs start
 
 ### Configuration
 
-The configuration options for Solid Queue are defined `config/queue.yml`. Here is an example of the default configuration:
+The configuration options for Solid Queue are defined  in `config/queue.yml`. Here is an example of the default configuration:
 
 ```yaml
 default: &default

--- a/guides/source/active_job_basics.md
+++ b/guides/source/active_job_basics.md
@@ -3,8 +3,8 @@
 Active Job Basics
 =================
 
-This guide provides you with all you need to get started in creating,
-enqueuing and executing background jobs.
+This guide provides you with all you need to get started in creating, enqueuing
+and executing background jobs.
 
 After reading this guide, you will know:
 
@@ -34,8 +34,8 @@ This section will provide a step-by-step guide to create a job and enqueue it.
 
 ### Create the Job
 
-Active Job provides a Rails generator to create jobs. The following will create a
-job in `app/jobs` (with an attached test case under `test/jobs`):
+Active Job provides a Rails generator to create jobs. The following will create
+a job in `app/jobs` (with an attached test case under `test/jobs`):
 
 ```bash
 $ bin/rails generate job guests_cleanup
@@ -67,8 +67,9 @@ end
 
 Note that you can define `perform` with as many arguments as you want.
 
-If you already have an abstract class and its name differs from `ApplicationJob`, you can pass
-the `--parent` option to indicate you want a different abstract class:
+If you already have an abstract class and its name differs from
+`ApplicationJob`, you can pass the `--parent` option to indicate you want a
+different abstract class:
 
 ```bash
 $ bin/rails generate job process_payment --parent=payment_job
@@ -112,8 +113,10 @@ GuestsCleanupJob.perform_later(guest1, guest2, filter: "some_filter")
 
 That's it!
 
-[`perform_later`]: https://api.rubyonrails.org/classes/ActiveJob/Enqueuing/ClassMethods.html#method-i-perform_later
-[`set`]: https://api.rubyonrails.org/classes/ActiveJob/Core/ClassMethods.html#method-i-set
+[`perform_later`]:
+    https://api.rubyonrails.org/classes/ActiveJob/Enqueuing/ClassMethods.html#method-i-perform_later
+[`set`]:
+    https://api.rubyonrails.org/classes/ActiveJob/Core/ClassMethods.html#method-i-set
 
 ### Enqueue Jobs in Bulk
 
@@ -579,11 +582,16 @@ option to `set`:
 MyJob.set(queue: :another_queue).perform_later(record)
 ```
 
-NOTE: If you choose to use an [alternate queuing backend](#alternate-queuing-backends) you may need to specify the queues to listen to.
+NOTE: If you choose to use an [alternate queuing
+backend](#alternate-queuing-backends) you may need to specify the queues to
+listen to.
 
-[`config.active_job.queue_name_delimiter`]: configuring.html#config-active-job-queue-name-delimiter
-[`config.active_job.queue_name_prefix`]: configuring.html#config-active-job-queue-name-prefix
-[`queue_as`]: https://api.rubyonrails.org/classes/ActiveJob/QueueName/ClassMethods.html#method-i-queue_as
+[`config.active_job.queue_name_delimiter`]:
+    configuring.html#config-active-job-queue-name-delimiter
+[`config.active_job.queue_name_prefix`]:
+    configuring.html#config-active-job-queue-name-prefix
+[`queue_as`]:
+    https://api.rubyonrails.org/classes/ActiveJob/QueueName/ClassMethods.html#method-i-queue_as
 
 
 Priority
@@ -692,12 +700,18 @@ end
 * [`around_perform`][]
 * [`after_perform`][]
 
-[`before_enqueue`]: https://api.rubyonrails.org/classes/ActiveJob/Callbacks/ClassMethods.html#method-i-before_enqueue
-[`around_enqueue`]: https://api.rubyonrails.org/classes/ActiveJob/Callbacks/ClassMethods.html#method-i-around_enqueue
-[`after_enqueue`]: https://api.rubyonrails.org/classes/ActiveJob/Callbacks/ClassMethods.html#method-i-after_enqueue
-[`before_perform`]: https://api.rubyonrails.org/classes/ActiveJob/Callbacks/ClassMethods.html#method-i-before_perform
-[`around_perform`]: https://api.rubyonrails.org/classes/ActiveJob/Callbacks/ClassMethods.html#method-i-around_perform
-[`after_perform`]: https://api.rubyonrails.org/classes/ActiveJob/Callbacks/ClassMethods.html#method-i-after_perform
+[`before_enqueue`]:
+    https://api.rubyonrails.org/classes/ActiveJob/Callbacks/ClassMethods.html#method-i-before_enqueue
+[`around_enqueue`]:
+    https://api.rubyonrails.org/classes/ActiveJob/Callbacks/ClassMethods.html#method-i-around_enqueue
+[`after_enqueue`]:
+    https://api.rubyonrails.org/classes/ActiveJob/Callbacks/ClassMethods.html#method-i-after_enqueue
+[`before_perform`]:
+    https://api.rubyonrails.org/classes/ActiveJob/Callbacks/ClassMethods.html#method-i-before_perform
+[`around_perform`]:
+    https://api.rubyonrails.org/classes/ActiveJob/Callbacks/ClassMethods.html#method-i-around_perform
+[`after_perform`]:
+    https://api.rubyonrails.org/classes/ActiveJob/Callbacks/ClassMethods.html#method-i-after_perform
 
 Please note that when enqueuing jobs in bulk using `perform_all_later`,
 callbacks such as `around_enqueue` will not be triggered on the individual jobs.
@@ -799,9 +813,10 @@ enqueue jobs one by one.
 Action Mailer
 ------------
 
-One of the most common jobs in a modern web application is sending emails outside
-of the request-response cycle, so the user doesn't have to wait on it. Active Job
-is integrated with Action Mailer so you can easily send emails asynchronously:
+One of the most common jobs in a modern web application is sending emails
+outside of the request-response cycle, so the user doesn't have to wait on it.
+Active Job is integrated with Action Mailer so you can easily send emails
+asynchronously:
 
 ```ruby
 # If you want to send the email now use #deliver_now
@@ -811,18 +826,18 @@ UserMailer.welcome(@user).deliver_now
 UserMailer.welcome(@user).deliver_later
 ```
 
-NOTE: Using the asynchronous queue from a Rake task (for example, to
-send an email using `.deliver_later`) will generally not work because Rake will
-likely end, causing the in-process thread pool to be deleted, before any/all
-of the `.deliver_later` emails are processed. To avoid this problem, use
-`.deliver_now` or run a persistent queue in development.
+NOTE: Using the asynchronous queue from a Rake task (for example, to send an
+email using `.deliver_later`) will generally not work because Rake will likely
+end, causing the in-process thread pool to be deleted, before any/all of the
+`.deliver_later` emails are processed. To avoid this problem, use `.deliver_now`
+or run a persistent queue in development.
 
 
 Internationalization
 --------------------
 
-Each job uses the `I18n.locale` set when the job was created. This is useful if you send
-emails asynchronously:
+Each job uses the `I18n.locale` set when the job was created. This is useful if
+you send emails asynchronously:
 
 ```ruby
 I18n.locale = :eo
@@ -836,7 +851,8 @@ Supported Types for Arguments
 
 ActiveJob supports the following types of arguments by default:
 
-  - Basic types (`NilClass`, `String`, `Integer`, `Float`, `BigDecimal`, `TrueClass`, `FalseClass`)
+  - Basic types (`NilClass`, `String`, `Integer`, `Float`, `BigDecimal`,
+    `TrueClass`, `FalseClass`)
   - `Symbol`
   - `Date`
   - `Time`
@@ -852,9 +868,11 @@ ActiveJob supports the following types of arguments by default:
 
 ### GlobalID
 
-Active Job supports [GlobalID](https://github.com/rails/globalid/blob/main/README.md) for parameters. This makes it possible to pass live
-Active Record objects to your job instead of class/id pairs, which you then have
-to manually deserialize. Before, jobs would look like this:
+Active Job supports
+[GlobalID](https://github.com/rails/globalid/blob/main/README.md) for
+parameters. This makes it possible to pass live Active Record objects to your
+job instead of class/id pairs, which you then have to manually deserialize.
+Before, jobs would look like this:
 
 ```ruby
 class TrashableCleanupJob < ApplicationJob
@@ -875,12 +893,13 @@ class TrashableCleanupJob < ApplicationJob
 end
 ```
 
-This works with any class that mixes in `GlobalID::Identification`, which
-by default has been mixed into Active Record classes.
+This works with any class that mixes in `GlobalID::Identification`, which by
+default has been mixed into Active Record classes.
 
 ### Serializers
 
-You can extend the list of supported argument types. You just need to define your own serializer:
+You can extend the list of supported argument types. You just need to define
+your own serializer:
 
 ```ruby
 # app/serializers/money_serializer.rb
@@ -915,8 +934,9 @@ and add this serializer to the list:
 Rails.application.config.active_job.custom_serializers << MoneySerializer
 ```
 
-Note that autoloading reloadable code during initialization is not supported. Thus it is recommended
-to set-up serializers to be loaded only once, e.g. by amending `config/application.rb` like this:
+Note that autoloading reloadable code during initialization is not supported.
+Thus it is recommended to set-up serializers to be loaded only once, e.g. by
+amending `config/application.rb` like this:
 
 ```ruby
 # config/application.rb
@@ -947,9 +967,11 @@ class GuestsCleanupJob < ApplicationJob
 end
 ```
 
-If an exception from a job is not rescued, then the job is referred to as "failed".
+If an exception from a job is not rescued, then the job is referred to as
+"failed".
 
-[`rescue_from`]: https://api.rubyonrails.org/classes/ActiveSupport/Rescuable/ClassMethods.html#method-i-rescue_from
+[`rescue_from`]:
+    https://api.rubyonrails.org/classes/ActiveSupport/Rescuable/ClassMethods.html#method-i-rescue_from
 
 ### Retrying or Discarding Failed Jobs
 
@@ -970,38 +992,43 @@ class RemoteServiceJob < ApplicationJob
 end
 ```
 
-[`discard_on`]: https://api.rubyonrails.org/classes/ActiveJob/Exceptions/ClassMethods.html#method-i-discard_on
-[`retry_on`]: https://api.rubyonrails.org/classes/ActiveJob/Exceptions/ClassMethods.html#method-i-retry_on
+[`discard_on`]:
+    https://api.rubyonrails.org/classes/ActiveJob/Exceptions/ClassMethods.html#method-i-discard_on
+[`retry_on`]:
+    https://api.rubyonrails.org/classes/ActiveJob/Exceptions/ClassMethods.html#method-i-retry_on
 
 ### Deserialization
 
 GlobalID allows serializing full Active Record objects passed to `#perform`.
 
-If a passed record is deleted after the job is enqueued but before the `#perform`
-method is called Active Job will raise an [`ActiveJob::DeserializationError`][]
-exception.
+If a passed record is deleted after the job is enqueued but before the
+`#perform` method is called Active Job will raise an
+[`ActiveJob::DeserializationError`][] exception.
 
-[`ActiveJob::DeserializationError`]: https://api.rubyonrails.org/classes/ActiveJob/DeserializationError.html
+[`ActiveJob::DeserializationError`]:
+    https://api.rubyonrails.org/classes/ActiveJob/DeserializationError.html
 
 Job Testing
 --------------
 
-You can find detailed instructions on how to test your jobs in the
-[testing guide](testing.html#testing-jobs).
+You can find detailed instructions on how to test your jobs in the [testing
+guide](testing.html#testing-jobs).
 
 Debugging
 ---------
 
-If you need help figuring out where jobs are coming from, you can enable [verbose logging](debugging_rails_applications.html#verbose-enqueue-logs).
+If you need help figuring out where jobs are coming from, you can enable
+[verbose logging](debugging_rails_applications.html#verbose-enqueue-logs).
 
 Alternate Queuing Backends
 --------------------------
 
 Active Job has other built-in adapters for multiple queuing backends (Sidekiq,
-Resque, Delayed Job, and others). To get an up-to-date list of the adapters
-see the API Documentation for [`ActiveJob::QueueAdapters`][].
+Resque, Delayed Job, and others). To get an up-to-date list of the adapters see
+the API Documentation for [`ActiveJob::QueueAdapters`][].
 
-[`ActiveJob::QueueAdapters`]: https://api.rubyonrails.org/classes/ActiveJob/QueueAdapters.html
+[`ActiveJob::QueueAdapters`]:
+    https://api.rubyonrails.org/classes/ActiveJob/QueueAdapters.html
 
 ### Configuring the Backend
 
@@ -1030,7 +1057,8 @@ end
 # Now your job will use `resque` as its backend queue adapter, overriding the default Solid Queue adapter.
 ```
 
-[`config.active_job.queue_adapter`]: configuring.html#config-active-job-queue-adapter
+[`config.active_job.queue_adapter`]:
+    configuring.html#config-active-job-queue-adapter
 
 ### Starting the Backend
 

--- a/guides/source/active_job_basics.md
+++ b/guides/source/active_job_basics.md
@@ -230,7 +230,7 @@ In order to understand the configuration options for Solid Queue, you must under
 - **Scheduler**: This takes care of recurring tasks, adding jobs to the queue when they're due.
 - **Supervisor**: It oversees the whole system, managing workers and dispatchers. It starts and stops them as needed, monitors their health, and ensures everything runs smoothly.
 
-Everything is optional in the `config/queue.yml`. If no configuration at all is
+Everything is optional in the `config/queue.yml`. If no configuration is
 provided, Solid Queue will run with one dispatcher and one worker with default
 settings. Below are some of the configuration options you can set in `config/queue.yml`:
 

--- a/guides/source/active_job_basics.md
+++ b/guides/source/active_job_basics.md
@@ -122,7 +122,7 @@ You can enqueue multiple jobs at once using [`perform_all_later`](https://api.ru
 Default Adapter: Solid Queue
 ------------------------------
 
-Solid Queue, which is enabled by default from Rails version 8.0 and onward is a
+Solid Queue, which is enabled by default from Rails version 8.0 and onward, is a
 database-backed queuing system for Active Job, allowing you to queue large
 amounts of data without requiring additional dependencies such as Redis.
 

--- a/guides/source/active_job_basics.md
+++ b/guides/source/active_job_basics.md
@@ -367,7 +367,7 @@ Read more about [Concurrency Controls in the Solid Queue documentation](https://
 
 ### Failed Jobs and Retries
 
-Solid Queue doesn’t provide automatic retries; it relies on Active Job for that. Failed jobs will be stored in the `solid_queue_failed_executions` table. You can inspect and retry them manually, for example:
+Failed jobs will be stored in the `solid_queue_failed_executions` table. You can inspect and retry them manually, for example:
 
 ```ruby
 failed_execution = SolidQueue::FailedExecution.find(1)

--- a/guides/source/active_job_basics.md
+++ b/guides/source/active_job_basics.md
@@ -1002,4 +1002,3 @@ Here is a noncomprehensive list of documentation:
 - [Delayed Job](https://github.com/collectiveidea/delayed_job#active-job)
 - [Que](https://github.com/que-rb/que#additional-rails-specific-setup)
 - [Good Job](https://github.com/bensheldon/good_job#readme)
-- [Solid Queue](https://github.com/rails/solid_queue?tab=readme-ov-file#solid-queue)

--- a/guides/source/active_job_basics.md
+++ b/guides/source/active_job_basics.md
@@ -209,7 +209,7 @@ production:
 
 ### Configuration
 
-The configuration options for Solid Queue are defined  in `config/queue.yml`. Here is an example of the default configuration:
+The configuration options for Solid Queue are defined in `config/queue.yml`. Here is an example of the default configuration:
 
 ```yaml
 default: &default

--- a/guides/source/active_job_basics.md
+++ b/guides/source/active_job_basics.md
@@ -119,7 +119,7 @@ That's it!
 
 You can enqueue multiple jobs at once using [`perform_all_later`](https://api.rubyonrails.org/classes/ActiveJob.html#method-c-perform_all_later). For more details see [Bulk Enqueuing](#bulk-enqueuing).
 
-Default Adapter: Solid Queue
+Default Backend: Solid Queue
 ------------------------------
 
 Solid Queue, which is enabled by default from Rails version 8.0 and onward, is a
@@ -489,7 +489,7 @@ option to `set`:
 MyJob.set(queue: :another_queue).perform_later(record)
 ```
 
-NOTE: If you choose to use an [alternate queueing adapter](#alternate-queuing-adapters) you may need to specify the queues to listen to.
+NOTE: If you choose to use an [alternate queuing backend](#alternate-queuing-backends) you may need to specify the queues to listen to.
 
 [`config.active_job.queue_name_delimiter`]: configuring.html#config-active-job-queue-name-delimiter
 [`config.active_job.queue_name_prefix`]: configuring.html#config-active-job-queue-name-prefix
@@ -508,9 +508,9 @@ class GuestsCleanupJob < ApplicationJob
 end
 ```
 
-Solid Queue, the default adapter, prioritizes jobs based on the order of the queues.  You can read more about it in the [Order of Queues section](#queue-order). If you're using Solid Queue, and both the order of the queues and the priority option are used, the queue order will take precedence, and the priority option will only apply within each queue.
+Solid Queue, the default queuing backend, prioritizes jobs based on the order of the queues.  You can read more about it in the [Order of Queues section](#queue-order). If you're using Solid Queue, and both the order of the queues and the priority option are used, the queue order will take precedence, and the priority option will only apply within each queue.
 
-Other adapters may allow jobs to be prioritized relative to others within the same queue or across multiple queues. Refer to the documentation of your backend for more information.
+Other queuing backends may allow jobs to be prioritized relative to others within the same queue or across multiple queues. Refer to the documentation of your backend for more information.
 
 Similar to `queue_as`, you can also pass a block to `queue_with_priority` to be evaluated in the job context:
 
@@ -688,7 +688,7 @@ For `perform_all_later`, bulk enqueuing needs to be backed by the queue backend.
 Solid Queue, the default queue backend, supports bulk enqueuing using
 `enqueue_all`.
 
-[Other backends](#alternate-queuing-adapters) like Sidekiq have a `push_bulk`
+[Other backends](#alternate-queuing-backends) like Sidekiq have a `push_bulk`
 method, which can push a large number of jobs to Redis and prevent the round
 trip network latency. GoodJob also supports bulk enqueuing with the
 `GoodJob::Bulk.enqueue` method.
@@ -894,7 +894,7 @@ Debugging
 
 If you need help figuring out where jobs are coming from, you can enable [verbose logging](debugging_rails_applications.html#verbose-enqueue-logs).
 
-Alternate Queuing Adapters
+Alternate Queuing Backends
 --------------------------
 
 Active Job has other built-in adapters for multiple queuing backends (Sidekiq,

--- a/guides/source/active_job_basics.md
+++ b/guides/source/active_job_basics.md
@@ -375,21 +375,13 @@ production:
 
 Each task specifies a `class` or `command` and a `schedule` (parsed using [Fugit](https://github.com/floraison/fugit)). You can also pass arguments to jobs, such as in the example for `MyJob` where `args` are passed. This can be passed as a single argument, a hash, or an array of arguments that can also include kwargs as the last element in the array. This allows jobs to run periodically or at specified times.
 
-Read more about [Recurring Tasks in the Solid Queue documentation](https://github.com/rails/solid_queue?tab=readme-ov-file#recurring-tasks)
+Read more about [Recurring Tasks in the Solid Queue documentation](https://github.com/rails/solid_queue?tab=readme-ov-file#recurring-tasks).
 
 ### Job Tracking and Management
 
 A tool like [`mission_control-jobs`](https://github.com/rails/mission_control-jobs) can help centralize the monitoring and management of failed jobs. It provides insights into job statuses, failure reasons, and retry behaviors, enabling you to track and resolve issues more effectively.
 
 For instance, if a job fails to process a large file due to a timeout, `mission_control-jobs` allows you to inspect the failure, review the job’s arguments and execution history, and decide whether to retry, requeue, or discard it.
-
-Pairing this tool with retry strategies helps address transient errors. For example:
-
-```ruby
-retry_on ActiveRecord::Deadlocked, wait: 5.seconds, attempts: 3
-```
-
-This configuration retries the job up to three times with a 5-second delay between attempts in case of a database deadlock.
 
 Queues
 ------

--- a/guides/source/active_job_basics.md
+++ b/guides/source/active_job_basics.md
@@ -126,7 +126,7 @@ Solid Queue, which is enabled by default from Rails version 8.0 and onward is a
 database-backed queuing system for Active Job, allowing you to queue large
 amounts of data without requiring additional dependencies such as Redis.
 
-Besides regular job enqueuing and processing, Solid Queue supports delayed jobs, concurrency controls, numeric priorities per job, priorities by queue order and more.
+Besides regular job enqueuing and processing, Solid Queue supports delayed jobs, concurrency controls, numeric priorities per job, priorities by queue order, and more.
 
 ### Set Up
 

--- a/guides/source/active_job_basics.md
+++ b/guides/source/active_job_basics.md
@@ -265,7 +265,7 @@ production:
 
 In the above example, workers will fetch jobs from queues starting with "active_storage", like  the `active_storage_analyse` queue and `active_storage_transform` queue. Only when no jobs remain in the `active_storage`-prefixed queues will workers move on to the `mailers` queue.
 
-NOTE: The wildcard `*` (at the end of "production") is only allowed on its own or at the end of a queue name to match all queues with the same prefix. You can't specify queue names such as `*_some_queue`.
+NOTE: The wildcard `*` (like at the end of "active_storage") is only allowed on its own or at the end of a queue name to match all queues with the same prefix. You can't specify queue names such as `*_some_queue`.
 
 WARNING: Using wildcard queue names (e.g., `queues: active_storage*`) can slow down polling performance due to the need for a `DISTINCT` query to identify all matching queues, which can be slow on large tables. For better performance, it’s best to specify exact queue names instead of using wildcards.
 
@@ -273,10 +273,6 @@ Active Job supports positive integer priorities when enqueuing jobs (see [Priori
 
 For example, if you have two queues, `production` and `background`, jobs in the `production` queue will always be processed first, even if some jobs in the `background` queue have a higher priority.
 
-WARNING: You should avoid using the `priority` option if you're relying on the
-order of the queues list. If both the order of the queues and the priority
-option are used, the queue order will take precedence, and the priority option
-will only apply within each queue.
 
 ### Threads, Processes, and Signals
 

--- a/guides/source/active_job_basics.md
+++ b/guides/source/active_job_basics.md
@@ -137,7 +137,7 @@ jobs in RAM. If the process crashes or the machine is reset, then all
 outstanding jobs are lost with the default async backend. This can be fine for
 smaller apps or non-critical jobs in development.
 
-However, if you want to use Solid Queue instead, you
+However, if you use Solid Queue instead, you
 can configure it in the same way as in the production environment:
 
 ```ruby

--- a/guides/source/active_job_basics.md
+++ b/guides/source/active_job_basics.md
@@ -356,7 +356,7 @@ class ApplicationJob < ActiveJob::Base
 end
 ```
 
-You can also configure Solid Queue to use the same database as your app while avoiding transactional integrity issues by setting up a separate database connection for Solid Queue jobs.Read more about [Transactional Integrity in the Solid Queue documentation](https://github.com/rails/solid_queue?tab=readme-ov-file#jobs-and-transactional-integrity)
+You can also configure Solid Queue to use the same database as your app while avoiding transactional integrity issues by setting up a separate database connection for Solid Queue jobs. Read more about [Transactional Integrity in the Solid Queue documentation](https://github.com/rails/solid_queue?tab=readme-ov-file#jobs-and-transactional-integrity)
 
 ### Recurring Tasks
 

--- a/guides/source/active_job_basics.md
+++ b/guides/source/active_job_basics.md
@@ -266,12 +266,11 @@ You can read more about the [additional configuration options in the Solid Queue
 
 ### Queue Order
 
-As per the configuration options in the [Configuration
-Options](#configuration-options), the `queues` configuration option will list
-the queues that workers will pick jobs from. In a list of queues, the order
-matters. Workers will pick jobs from the first queue in the list - once there
-are no more jobs in the first queue, only then will it move onto the second, and
-so on.
+As per the configuration options in the [Configuration section](#configuration),
+the `queues` configuration option will list the queues that workers will pick
+jobs from. In a list of queues, the order matters. Workers will pick jobs from
+the first queue in the list - once there are no more jobs in the first queue,
+only then will it move onto the second, and so on.
 
 ```yaml
 # config/queue.yml
@@ -564,7 +563,7 @@ class GuestsCleanupJob < ApplicationJob
 end
 ```
 
-Solid Queue, the default adapter, prioritizes jobs based on the order of the queues.  You can read more about it in the [Order of Queues section](#order-of-queues-in-solid-queue). If you're using Solid Queue, and both the order of the queues and the priority option are used, the queue order will take precedence, and the priority option will only apply within each queue.
+Solid Queue, the default adapter, prioritizes jobs based on the order of the queues.  You can read more about it in the [Order of Queues section](#queue-order). If you're using Solid Queue, and both the order of the queues and the priority option are used, the queue order will take precedence, and the priority option will only apply within each queue.
 
 Other adapters may allow jobs to be prioritized relative to others within the same queue or across multiple queues. Refer to the documentation of your backend for more information.
 
@@ -740,14 +739,14 @@ can be used to find out if a given job was successfully enqueued.
 
 ### Queue Backend Support
 
-For `perform_all_later`, bulk enqueuing needs to be backed by the [queue
-backend](#backends).
+For `perform_all_later`, bulk enqueuing needs to be backed by the queue backend.
+Solid Queue, the default queue backend, supports bulk enqueuing using
+`enqueue_all`.
 
-For example, Sidekiq has a `push_bulk` method, which can push a large number of
-jobs to Redis and prevent the round trip network latency. GoodJob also supports
-bulk enqueuing with the `GoodJob::Bulk.enqueue` method. The new queue backend
-[`Solid Queue`](https://github.com/rails/solid_queue/pull/93) has added
-support for bulk enqueuing as well.
+[Other backends](#alternate-queuing-adapters) like Sidekiq have a `push_bulk`
+method, which can push a large number of jobs to Redis and prevent the round
+trip network latency. GoodJob also supports bulk enqueuing with the
+`GoodJob::Bulk.enqueue` method.
 
 If the queue backend does *not* support bulk enqueuing, `perform_all_later` will
 enqueue jobs one by one.

--- a/guides/source/active_job_basics.md
+++ b/guides/source/active_job_basics.md
@@ -225,8 +225,8 @@ default: &default
 
 In order to understand the configuration options for Solid Queue, you must understand the different types of roles:
 
-- **Workers**: They pick up jobs that are ready to run. These jobs are taken from the `solid_queue_ready_executions` table.
 - **Dispatchers**: They select jobs scheduled to run for the future. When it's time for these jobs to run, dispatchers move them from the `solid_queue_scheduled_executions` table to the `solid_queue_ready_executions` table so workers can pick them up. They also manage concurrency-related maintenance.
+- **Workers**: They pick up jobs that are ready to run. These jobs are taken from the `solid_queue_ready_executions` table.
 - **Scheduler**: This takes care of recurring tasks, adding jobs to the queue when they're due.
 - **Supervisor**: It oversees the whole system, managing workers and dispatchers. It starts and stops them as needed, monitors their health, and ensures everything runs smoothly.
 


### PR DESCRIPTION
### Motivation / Background

In Rails 8, the Solid Trifacta has been added. This PR focuses on updating the Active Job guide to include information about Solid Queue.

### Detail

**This Pull Request:**

- [x] Update the Active Job Guide guide to include information about Solid Queue. 
- [x] Updates details about previous defaults and moves the Alternatives Adapters to the bottom. 
- [x] Move a few sections around to flow better.  

A significant amount of information that I have in this guide is specified in the [solid_queue gem README](https://github.com/rails/solid_queue?tab=readme-ov-file#recurring-tasks). In the Rails guides, I cover the basics and what's relevant, but then refer to the gem documentation for more information. I hope this pattern is fine, let me know if there is a different preference.

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [ ] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [ ] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
