### PR TITLE
Fix returning docs for upsert_all [ci skip]

### DIFF
--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -820,7 +820,7 @@ module ActiveRecord
     #
     # [:returning]
     #   (PostgreSQL, SQLite3, and MariaDB only) An array of attributes to return for all successfully
-    #   inserted records, which by default is the primary key.
+    #   upserted records, which by default is the primary key.
     #   Pass <tt>returning: %w[ id name ]</tt> for both id and name
     #   or <tt>returning: false</tt> to omit the underlying <tt>RETURNING</tt> SQL
     #   clause entirely.


### PR DESCRIPTION
`upsert_all` is used to try to INSERT rows in a table, falling back to an UPDATE operation for the rows that would be duplicate.

The result of `upsert_all` (driven by `returning_by`) includes both the rows that were inserted and the rows that were updated, but the documentation was not super clear about this:

> An array of attributes to return for all successfully inserted records

[ci-skip]