### PR TITLE
Remove N+1 due to column name resolution in PG adapter methods

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -620,15 +620,13 @@ module ActiveRecord
           fk_info.map do |row|
             to_table = Utils.unquote_identifier(row["to_table"])
 
-            first_if_only_one = ->(arr) { arr.size == 1 ? arr.first : arr }
-
-            column = first_if_only_one.call(decode_string_array(row["conkey_names"]))
-            primary_key = first_if_only_one.call(decode_string_array(row["confkey_names"]))
+            column = decode_string_array(row["conkey_names"])
+            primary_key = decode_string_array(row["confkey_names"])
 
             options = {
-              column: column,
+              column: column.size == 1 ? column.first : column,
               name: row["name"],
-              primary_key: primary_key
+              primary_key: primary_key.size == 1 ? primary_key.first : primary_key
             }
 
             options[:on_delete] = extract_foreign_key_action(row["on_delete"])
@@ -1173,11 +1171,7 @@ module ActiveRecord
           end
 
           def decode_string_array(value)
-            array_decoder.decode(value)
-          end
-
-          def array_decoder
-            @array_decoder ||= PG::TextDecoder::Array.new
+            PG::TextDecoder::Array.new.decode(value)
           end
       end
     end

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -112,7 +112,7 @@ module ActiveRecord
             inddef = row[3]
             comment = row[4]
             valid = row[5]
-            columns = row[6]
+            columns = decode_string_array(row[6])
 
             using, expressions, include, nulls_not_distinct, where = inddef.scan(/ USING (\w+?) \((.+?)\)(?: INCLUDE \((.+?)\))?( NULLS NOT DISTINCT)?(?: WHERE (.+))?\z/m).flatten
 
@@ -123,9 +123,6 @@ module ActiveRecord
             if indkey.include?(0)
               columns = expressions
             else
-              decoder = PG::TextDecoder::Array.new
-              columns = decoder.decode(columns)
-
               # prevent INCLUDE columns from being matched
               columns.reject! { |c| include_columns.include?(c) }
 
@@ -591,31 +588,42 @@ module ActiveRecord
         def foreign_keys(table_name)
           scope = quoted_scope(table_name)
           fk_info = internal_exec_query(<<~SQL, "SCHEMA", allow_retry: true, materialize_transactions: false)
-            SELECT t2.oid::regclass::text AS to_table, a1.attname AS column, a2.attname AS primary_key, c.conname AS name, c.confupdtype AS on_update, c.confdeltype AS on_delete, c.convalidated AS valid, c.condeferrable AS deferrable, c.condeferred AS deferred, c.conkey, c.confkey, c.conrelid, c.confrelid
+            SELECT t2.oid::regclass::text AS to_table, c.conname AS name, c.confupdtype AS on_update, c.confdeltype AS on_delete, c.convalidated AS valid, c.condeferrable AS deferrable, c.condeferred AS deferred, c.conrelid, c.confrelid,
+              (
+                SELECT array_agg(a.attname ORDER BY idx)
+                FROM (
+                  SELECT idx, c.conkey[idx] AS conkey_elem
+                  FROM generate_subscripts(c.conkey, 1) AS idx
+                ) indexed_conkeys
+                JOIN pg_attribute a ON a.attrelid = t1.oid
+                AND a.attnum = indexed_conkeys.conkey_elem
+              ) AS conkey_names,
+              (
+                SELECT array_agg(a.attname ORDER BY idx)
+                FROM (
+                  SELECT idx, c.confkey[idx] AS confkey_elem
+                  FROM generate_subscripts(c.confkey, 1) AS idx
+                ) indexed_confkeys
+                JOIN pg_attribute a ON a.attrelid = t2.oid
+                AND a.attnum = indexed_confkeys.confkey_elem
+              ) AS confkey_names
             FROM pg_constraint c
             JOIN pg_class t1 ON c.conrelid = t1.oid
             JOIN pg_class t2 ON c.confrelid = t2.oid
-            JOIN pg_attribute a1 ON a1.attnum = c.conkey[1] AND a1.attrelid = t1.oid
-            JOIN pg_attribute a2 ON a2.attnum = c.confkey[1] AND a2.attrelid = t2.oid
-            JOIN pg_namespace t3 ON c.connamespace = t3.oid
+            JOIN pg_namespace n ON c.connamespace = n.oid
             WHERE c.contype = 'f'
               AND t1.relname = #{scope[:name]}
-              AND t3.nspname = #{scope[:schema]}
+              AND n.nspname = #{scope[:schema]}
             ORDER BY c.conname
           SQL
 
           fk_info.map do |row|
             to_table = Utils.unquote_identifier(row["to_table"])
-            conkey = row["conkey"].scan(/\d+/).map(&:to_i)
-            confkey = row["confkey"].scan(/\d+/).map(&:to_i)
 
-            if conkey.size > 1
-              column = column_names_from_column_numbers(row["conrelid"], conkey)
-              primary_key = column_names_from_column_numbers(row["confrelid"], confkey)
-            else
-              column = Utils.unquote_identifier(row["column"])
-              primary_key = row["primary_key"]
-            end
+            first_if_only_one = ->(arr) { arr.size == 1 ? arr.first : arr }
+
+            column = first_if_only_one.call(decode_string_array(row["conkey_names"]))
+            primary_key = first_if_only_one.call(decode_string_array(row["confkey_names"]))
 
             options = {
               column: column,
@@ -705,7 +713,16 @@ module ActiveRecord
           scope = quoted_scope(table_name)
 
           unique_info = internal_exec_query(<<~SQL, "SCHEMA", allow_retry: true, materialize_transactions: false)
-            SELECT c.conname, c.conrelid, c.conkey, c.condeferrable, c.condeferred, pg_get_constraintdef(c.oid) AS constraintdef
+            SELECT c.conname, c.conrelid, c.condeferrable, c.condeferred, pg_get_constraintdef(c.oid) AS constraintdef,
+            (
+              SELECT array_agg(a.attname ORDER BY idx)
+              FROM (
+                SELECT idx, c.conkey[idx] AS conkey_elem
+                FROM generate_subscripts(c.conkey, 1) AS idx
+              ) indexed_conkeys
+              JOIN pg_attribute a ON a.attrelid = t.oid
+              AND a.attnum = indexed_conkeys.conkey_elem
+            ) AS conkey_names
             FROM pg_constraint c
             JOIN pg_class t ON c.conrelid = t.oid
             JOIN pg_namespace n ON n.oid = c.connamespace
@@ -715,8 +732,7 @@ module ActiveRecord
           SQL
 
           unique_info.map do |row|
-            conkey = row["conkey"].delete("{}").split(",").map(&:to_i)
-            columns = column_names_from_column_numbers(row["conrelid"], conkey)
+            columns = decode_string_array(row["conkey_names"])
 
             nulls_not_distinct = row["constraintdef"].start_with?("UNIQUE NULLS NOT DISTINCT")
             deferrable = extract_constraint_deferrable(row["condeferrable"], row["condeferred"])
@@ -1156,13 +1172,12 @@ module ActiveRecord
             [name.schema, name.identifier]
           end
 
-          def column_names_from_column_numbers(table_oid, column_numbers)
-            Hash[query(<<~SQL, "SCHEMA")].values_at(*column_numbers).compact
-              SELECT a.attnum, a.attname
-              FROM pg_attribute a
-              WHERE a.attrelid = #{table_oid}
-              AND a.attnum IN (#{column_numbers.join(", ")})
-            SQL
+          def decode_string_array(value)
+            array_decoder.decode(value)
+          end
+
+          def array_decoder
+            @array_decoder ||= PG::TextDecoder::Array.new
           end
       end
     end


### PR DESCRIPTION
### Motivation / Background

I spotted in a test (that uses issued-DB-query tracking) that calling `indices` makes N+1 queries based on the number of indexes on a table. After investigation, it seems that there are a couple of other methods that can be simplified to avoid multiple trips to the DB when resolving column ids to names.

### Detail

For a table with N indices, rather than issuing one query to retrieve the indices, and then N queries to resolve the indexed column ids to their names, we can instead issue one query that retrieves the indices along with their column names.

Similarly, we can avoid an N+1 when retrieving column names for multi-column `foreign_keys` and `unique_constraints`.

N.b. the sub-queries are quite verbose due to maintaining PG 9.3 compatability. If using >= 9.4 then `unnest(...) WITH ORDINALITY` would remove the inner sub-queries that generate the array indices used for ordering, saving ~12 lines. 9.4 was [first released](https://www.postgresql.org/support/versioning/) nearly 10 years ago, and has been unsupported for nearly 5, so perhaps it [is time](https://github.com/rails/rails/pull/41526) to [raise the minimum version](https://github.com/rails/rails/pull/49598#issuecomment-1774517546) of PG required by Rails?

### Additional information

With the following test in a file in this repo, we can see the change in behaviour before and after this PR.

```ruby
# frozen_string_literal: true

require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"

  gem "pry-byebug"

  # gem "rails", path: "."
  gem "rails"

  gem "pg"
end

require "active_record/railtie"
require "minitest/autorun"

class TestApp < Rails::Application
  config.load_defaults Rails::VERSION::STRING.to_f
  config.eager_load = false
  config.logger = Logger.new($stdout)
end
Rails.application.initialize!

ActiveRecord::Schema.define do
  create_table :things, force: :cascade do |t|
    t.integer :a
    t.integer :b
    t.integer :c, index: :unique
    t.integer :d, index: :unique
    t.integer :e
    t.integer :f
    t.integer :g

    t.index '(a*2), b', name: "index_things_on_double_a_and_b"

    t.index %i[a b], unique: true
  end

  execute("ALTER TABLE things ADD CONSTRAINT unique_ef UNIQUE (e, f);")
  execute("ALTER TABLE things ADD CONSTRAINT unique_g UNIQUE (g);")

  create_table :other_things, force: :cascade do |t|
    t.references :things, foreign_key: true
  end

  create_table :products, primary_key: [:store_id, :sku], force: :cascade do |t|
    t.integer :store_id
    t.string :sku
    t.text :description
  end

  create_table :product_orders, force: true do |t|
    t.integer :product_store_id
    t.string :product_sku
  end

  add_foreign_key :product_orders, :products, primary_key: [:store_id, :sku]
end

class Thing < ActiveRecord::Base
end

class Product < ActiveRecord::Base
end

class ProductOrder < ActiveRecord::Base
end

module LogQuery
  def raw_execute(sql, ...)
    puts ">>>>>> raw_execute:\n#{sql}"
    super
  end
end

ActiveRecord::ConnectionAdapters::DatabaseStatements.prepend(LogQuery)


class BugTest < ActiveSupport::TestCase
  def test_association_stuff
    conn = ActiveRecord::Base.connection
    assert_equal(
      [["a", "b"], ["c"], ["d"], "((a * 2)), b", ["e", "f"], ["g"]],
      conn.indexes(Thing.table_name).map(&:columns)
    )
    assert_equal(
      [["e", "f"], ["g"]],
      conn.unique_constraints(Thing.table_name).map(&:column)
    )
    assert_equal(
      [["product_store_id", "product_sku"]],
      conn.foreign_keys(ProductOrder.table_name).map { _1.options[:column] }
    )
  end
end
```

If the above is saved in a file called `test.rb` then execute it with `DATABASE_URL=postgresql://... ruby test.rb`. 

Before this PR the logged queries are:
```
>>>>>> raw_execute:
SELECT distinct i.relname, d.indisunique, d.indkey, pg_get_indexdef(d.indexrelid), t.oid,
                pg_catalog.obj_description(i.oid, 'pg_class') AS comment, d.indisvalid
FROM pg_class t
INNER JOIN pg_index d ON t.oid = d.indrelid
INNER JOIN pg_class i ON d.indexrelid = i.oid
LEFT JOIN pg_namespace n ON n.oid = t.relnamespace
WHERE i.relkind IN ('i', 'I')
  AND d.indisprimary = 'f'
  AND t.relname = 'things'
  AND n.nspname = ANY (current_schemas(false))
ORDER BY i.relname
>>>>>> raw_execute:
SELECT a.attnum, a.attname
FROM pg_attribute a
WHERE a.attrelid = 226032
AND a.attnum IN (2, 3)
>>>>>> raw_execute:
SELECT a.attnum, a.attname
FROM pg_attribute a
WHERE a.attrelid = 226032
AND a.attnum IN (4)
>>>>>> raw_execute:
SELECT a.attnum, a.attname
FROM pg_attribute a
WHERE a.attrelid = 226032
AND a.attnum IN (5)
>>>>>> raw_execute:
SELECT a.attnum, a.attname
FROM pg_attribute a
WHERE a.attrelid = 226032
AND a.attnum IN (6, 7)
>>>>>> raw_execute:
SELECT a.attnum, a.attname
FROM pg_attribute a
WHERE a.attrelid = 226032
AND a.attnum IN (8)
>>>>>> raw_execute:
SELECT c.conname, c.conrelid, c.conkey, c.condeferrable, c.condeferred, pg_get_constraintdef(c.oid) AS constraintdef
FROM pg_constraint c
JOIN pg_class t ON c.conrelid = t.oid
JOIN pg_namespace n ON n.oid = c.connamespace
WHERE c.contype = 'u'
  AND t.relname = 'things'
  AND n.nspname = ANY (current_schemas(false))
>>>>>> raw_execute:
SELECT a.attnum, a.attname
FROM pg_attribute a
WHERE a.attrelid = 226032
AND a.attnum IN (6, 7)
>>>>>> raw_execute:
SELECT a.attnum, a.attname
FROM pg_attribute a
WHERE a.attrelid = 226032
AND a.attnum IN (8)
>>>>>> raw_execute:
SELECT t2.oid::regclass::text AS to_table, a1.attname AS column, a2.attname AS primary_key, c.conname AS name, c.confupdtype AS on_update, c.confdeltype AS on_delete, c.convalidated AS valid, c.condeferrable AS deferrable, c.condeferred AS deferred, c.conkey, c.confkey, c.conrelid, c.confrelid
FROM pg_constraint c
JOIN pg_class t1 ON c.conrelid = t1.oid
JOIN pg_class t2 ON c.confrelid = t2.oid
JOIN pg_attribute a1 ON a1.attnum = c.conkey[1] AND a1.attrelid = t1.oid
JOIN pg_attribute a2 ON a2.attnum = c.confkey[1] AND a2.attrelid = t2.oid
JOIN pg_namespace t3 ON c.connamespace = t3.oid
WHERE c.contype = 'f'
  AND t1.relname = 'product_orders'
  AND t3.nspname = ANY (current_schemas(false))
ORDER BY c.conname
>>>>>> raw_execute:
SELECT a.attnum, a.attname
FROM pg_attribute a
WHERE a.attrelid = 226067
AND a.attnum IN (2, 3)
>>>>>> raw_execute:
SELECT a.attnum, a.attname
FROM pg_attribute a
WHERE a.attrelid = 226059
AND a.attnum IN (1, 2)
```
and after this PR (after swapping the `gem "rails"` when in the Rails repo with this PR's branch checked out):
```
>>>>>> raw_execute:
SELECT distinct i.relname, d.indisunique,
                (
                  SELECT array_agg(a.attname ORDER BY idx)
                  FROM (
                    SELECT idx, d.indkey[idx] AS indkey_elem
                    FROM generate_subscripts(d.indkey, 1) AS idx
                  ) indexed_indkeys
                  LEFT JOIN pg_attribute a ON a.attrelid = t.oid
                  AND a.attnum = NULLIF(indexed_indkeys.indkey_elem, 0)
                ) AS indkey_names,
                pg_get_indexdef(d.indexrelid), t.oid,
                pg_catalog.obj_description(i.oid, 'pg_class') AS comment, d.indisvalid
FROM pg_class t
INNER JOIN pg_index d ON t.oid = d.indrelid
INNER JOIN pg_class i ON d.indexrelid = i.oid
LEFT JOIN pg_namespace n ON n.oid = t.relnamespace
WHERE i.relkind IN ('i', 'I')
  AND d.indisprimary = 'f'
  AND t.relname = 'things'
  AND n.nspname = ANY (current_schemas(false))
ORDER BY i.relname
>>>>>> raw_execute:
SELECT c.conname, c.conrelid, c.condeferrable, c.condeferred, pg_get_constraintdef(c.oid) AS constraintdef,
(
  SELECT array_agg(a.attname ORDER BY idx)
  FROM (
    SELECT idx, c.conkey[idx] AS conkey_elem
    FROM generate_subscripts(c.conkey, 1) AS idx
  ) indexed_conkeys
  JOIN pg_attribute a ON a.attrelid = t.oid
  AND a.attnum = indexed_conkeys.conkey_elem
) AS conkey_names
FROM pg_constraint c
JOIN pg_class t ON c.conrelid = t.oid
JOIN pg_namespace n ON n.oid = c.connamespace
WHERE c.contype = 'u'
  AND t.relname = 'things'
  AND n.nspname = ANY (current_schemas(false))
>>>>>> raw_execute:
SELECT t2.oid::regclass::text AS to_table, c.conname AS name, c.confupdtype AS on_update, c.confdeltype AS on_delete, c.convalidated AS valid, c.condeferrable AS deferrable, c.condeferred AS deferred, c.conrelid, c.confrelid,
  (
    SELECT array_agg(a.attname ORDER BY idx)
    FROM (
      SELECT idx, c.conkey[idx] AS conkey_elem
      FROM generate_subscripts(c.conkey, 1) AS idx
    ) indexed_conkeys
    JOIN pg_attribute a ON a.attrelid = t1.oid
    AND a.attnum = indexed_conkeys.conkey_elem
  ) AS conkey_names,
  (
    SELECT array_agg(a.attname ORDER BY idx)
    FROM (
      SELECT idx, c.confkey[idx] AS confkey_elem
      FROM generate_subscripts(c.confkey, 1) AS idx
    ) indexed_confkeys
    JOIN pg_attribute a ON a.attrelid = t2.oid
    AND a.attnum = indexed_confkeys.confkey_elem
  ) AS confkey_names
FROM pg_constraint c
JOIN pg_class t1 ON c.conrelid = t1.oid
JOIN pg_class t2 ON c.confrelid = t2.oid
JOIN pg_namespace n ON c.connamespace = n.oid
WHERE c.contype = 'f'
  AND t1.relname = 'product_orders'
  AND n.nspname = ANY (current_schemas(false))
ORDER BY c.conname
```

we can see only 3 top-level SELECTs instead of 1+5 + 1+2 + 1+2 = 12

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
