### PR TITLE
[RF-DOCS] Remove stray closing tag in Rails 8 Authentication generator code snippet [ci-skip]

### DIFF
--- a/guides/source/security.md
+++ b/guides/source/security.md
@@ -220,7 +220,7 @@ For example:
 
 ```html+erb
 <% if authenticated? %>
-  <%= button_to "Sign Out", session_path, method: :delete  %></li>
+  <%= button_to "Sign Out", session_path, method: :delete  %>
 <% else %>
   <%= link_to "Sign In", new_session_path %>
 <% end %>


### PR DESCRIPTION
### Motivation / Background

I noticed a small typo when reading about the new Rails 8 Authentication generator.

This Pull Request removes a stray closing tag in a sample code snippet.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
