### PR TITLE
railties/test_parser: Cache prism work done in definition_for 

### DIFF
--- a/railties/lib/rails/test_unit/test_parser.rb
+++ b/railties/lib/rails/test_unit/test_parser.rb
@@ -13,29 +13,32 @@ if defined?(Prism)
       # Parse a test file to extract the line ranges of all tests in both
       # method-style (def test_foo) and declarative-style (test "foo" do)
       module TestParser
+        @begins_to_ends = {}
         # Helper to translate a method object into the path and line range where
         # the method was defined.
         def self.definition_for(method)
           filepath, start_line = method.source_location
-          queue = [Prism.parse_file(filepath).value]
-
-          while (node = queue.shift)
-            case node.type
-            when :def_node
-              if node.location.start_line == start_line
-                return [filepath, start_line..node.location.end_line]
-              end
-            when :call_node
-              if node.location.start_line == start_line
-                return [filepath, start_line..node.location.end_line]
-              end
-            end
-
-            queue.concat(node.compact_child_nodes)
-          end
-
-          nil
+          @begins_to_ends[filepath] ||= ranges(filepath)
+          return unless end_line = @begins_to_ends[filepath][start_line]
+          [filepath, start_line..end_line]
         end
+
+        private
+          def self.ranges(filepath)
+            queue = [Prism.parse_file(filepath).value]
+            begins_to_ends = {}
+            while (node = queue.shift)
+              case node.type
+              when :def_node
+                begins_to_ends[node.location.start_line] = node.location.end_line
+              when :call_node
+                begins_to_ends[node.location.start_line] = node.location.end_line
+              end
+
+              queue.concat(node.compact_child_nodes)
+            end
+            begins_to_ends
+          end
       end
     end
   end


### PR DESCRIPTION
This PR applies to the Prism implementation of `definition_for`.

### Motivation

In files with lots of tests, `definition_for` is called repeatedly and performs a lot of work that really adds up. The work is reusable across many tests, so let's do it.

### Details
`definition_for` is used to extract the line numbers of a test, which is relevant when filtering tests to a line number or range, eg my_test.rb:1-2.

The filter itself operates by, for each test, comparing the lines the test spans against the filter. In the existing code, this will call `Prism.parse_file` and then walk the parse result until the matching definition/call is found.

For files with a large number of tests, this is fairly onerous and can dominate the test runtime. Fortunately, we can parse the file once and cache the starts and ends of every def/call node.
This brings the `definition_for` runtime down from seconds to low milliseconds.

We also see a reduction in gc time that is probably attributable to not repeatedly parsing the file.
For a test run in an 240 test file that went from 11s of `definition_for` to 20ms, gc went from 4.5 to 2.2 seconds.

Finally, for any user that has written a test reporter or otherwise hooked into the filters, this should provide speedup as well.

### Checklist

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x]  CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
