### PR TITLE
Fix removing foreign keys with `:restrict` action for MySQL

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/mysql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/schema_statements.rb
@@ -85,6 +85,13 @@ module ActiveRecord
           super
         end
 
+        def remove_foreign_key(from_table, to_table = nil, **options)
+          # RESTRICT is by default in MySQL.
+          options.delete(:on_update) if options[:on_update] == :restrict
+          options.delete(:on_delete) if options[:on_delete] == :restrict
+          super
+        end
+
         def internal_string_options_for_primary_key
           super.tap do |options|
             if !row_format_dynamic_by_default? && CHARSETS_OF_4BYTES_MAXLEN.include?(charset)

--- a/activerecord/test/cases/migration/foreign_key_test.rb
+++ b/activerecord/test/cases/migration/foreign_key_test.rb
@@ -468,6 +468,13 @@ if ActiveRecord::Base.lease_connection.supports_foreign_keys?
             @connection.foreign_keys("astronauts").map { |fk| [fk.from_table, fk.to_table, fk.column] }
         end
 
+        def test_remove_foreign_key_with_restrict_action
+          @connection.add_foreign_key :astronauts, :rockets, on_delete: :restrict
+          assert_equal 1, @connection.foreign_keys("astronauts").size
+          @connection.remove_foreign_key :astronauts, :rockets, on_delete: :restrict
+          assert_empty @connection.foreign_keys("astronauts")
+        end
+
         if ActiveRecord::Base.lease_connection.supports_validate_constraints?
           def test_add_invalid_foreign_key
             @connection.add_foreign_key :astronauts, :rockets, column: "rocket_id", validate: false


### PR DESCRIPTION
Fixes #53935.

When created foreign keys in MySQL with `:restrict` action are dumped, they skip this setting and set it to `nil` because "RESTRICT" is by default in MySQL - https://github.com/rails/rails/blob/c22f7f9a4f523e69899d567acc19a0e6eaac3d36/activerecord/lib/active_record/connection_adapters/mysql/schema_statements.rb#L218-L220

We need to also ignore the `:restrict` value when removing a foreign key.