### PR TITLE
Use Rack's SERVER_PROTOCOL instead of HTTP_VERSION header

### DIFF
--- a/actionpack/lib/action_controller/metal/live.rb
+++ b/actionpack/lib/action_controller/metal/live.rb
@@ -58,7 +58,7 @@ module ActionController
 
     module ClassMethods
       def make_response!(request)
-        if request.get_header("HTTP_VERSION") == "HTTP/1.0"
+        if (request.get_header("SERVER_PROTOCOL") || request.get_header("HTTP_VERSION")) == "HTTP/1.0"
           super
         else
           Live::Response.new.tap do |res|


### PR DESCRIPTION
Fix: https://github.com/rails/rails/issues/53925
Ref: https://github.com/rack/rack/pull/1883

This will prevent issues with future version of rack and/or servers.
