### PR TITLE
Allow to tag serialized attributes as comparable

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,22 @@
+*   Serialized attributes can now be marked as comparable.
+
+    A not rare issue when working with serialized attributes is that the serialized representation of an object
+    can change over time. Either because you are migrating from one serializer to the other (e.g. YAML to JSON or to msgpack),
+    or because the serializer used subtly changed it's output.
+
+    One example is libyaml that used to have some extra trailing whitespaces, and recently fixed that.
+    When this sorts of thing happen, you end up with lots of records that report being changed even though
+    they aren't, which in the best case leads to a lot more writes to the database and in the worst case lead to nasty bugs.
+
+    The solution is to instead compare the deserialized representation of the object, however Active Record
+    can't assume the deserialized object has a working `==` method. Hence why this new functionality is opt-in.
+
+    ```ruby
+    serialized :config, type: Hash, coder: JSON, comparable: true
+    ```
+
+    *Jean Boussier*
+
 *   Fix MySQL default functions getting dropped when changing a column's nullability.
 
     *Bastian Bartmann*

--- a/activerecord/lib/active_record/type/serialized.rb
+++ b/activerecord/lib/active_record/type/serialized.rb
@@ -9,9 +9,10 @@ module ActiveRecord
 
       attr_reader :subtype, :coder
 
-      def initialize(subtype, coder)
+      def initialize(subtype, coder, comparable: false)
         @subtype = subtype
         @coder = coder
+        @comparable = comparable
         super(subtype)
       end
 
@@ -34,9 +35,15 @@ module ActiveRecord
 
       def changed_in_place?(raw_old_value, value)
         return false if value.nil?
-        raw_new_value = encoded(value)
-        raw_old_value.nil? != raw_new_value.nil? ||
-          subtype.changed_in_place?(raw_old_value, raw_new_value)
+
+        if @comparable
+          old_value = deserialize(raw_old_value)
+          old_value != value
+        else
+          raw_new_value = encoded(value)
+          raw_old_value.nil? != raw_new_value.nil? ||
+            subtype.changed_in_place?(raw_old_value, raw_new_value)
+        end
       end
 
       def accessor

--- a/activerecord/test/cases/serialized_attribute_test.rb
+++ b/activerecord/test/cases/serialized_attribute_test.rb
@@ -697,4 +697,29 @@ class SerializedAttributeTestWithYamlSafeLoad < SerializedAttributeTest
     topic = Topic.new(content: Time.now)
     assert topic.save
   end
+
+  def test_changed_in_place_compare_serialized_representation
+    Topic.serialize :content, type: Hash
+    topic = Topic.create!(content: { "a" => 1, "b" => 2 })
+
+    topic.content = { "a" => 1, "b" => 2 }
+    assert_not_predicate topic, :content_changed?
+
+    topic.content = { "b" => 2, "a" => 1 }
+    assert_predicate topic, :content_changed?
+  end
+
+  def test_changed_in_place_compare_deserialized_representation_when_comparable_is_set
+    Topic.serialize :content, type: Hash, comparable: true
+    topic = Topic.create!(content: { "a" => 1, "b" => 2 })
+
+    topic.content = { "a" => 1, "b" => 2 }
+    assert_not_predicate topic, :content_changed?
+
+    topic.content = { "b" => 2, "a" => 1 }
+    assert_not_predicate topic, :content_changed?
+
+    topic.content = {}
+    assert_predicate topic, :content_changed?
+  end
 end


### PR DESCRIPTION
Fix: https://github.com/rails/rails/pull/28416

A not rare issue when working with serialized attributes is that the serialized representation of an object can change over time. Either because you are migrating from one serializer to the other (e.g. YAML to JSON or to msgpack), or because the serializer used subtly changed it's output.

One example is `libyaml` that used to have some extra trailing whitespaces, and recently fixed that: https://github.com/yaml/libyaml/pull/186

When this sorts of thing happen, you end up with lots of records that report being changed even though they aren't, which in the best case leads to a lot more writes to the database and in the worst case lead to nasty bugs.

So ideally rather than to compare serialized representations, we'd compare the deserialized objects, however we can't assume the deserialized type has a proper working `==` method that deeply compare objects.

So the best thing we can do is to only do this if the type is declared as being comparable.
