### PR TITLE
Add dot suffix to headings in guides

### DIFF
--- a/guides/rails_guides/markdown.rb
+++ b/guides/rails_guides/markdown.rb
@@ -185,15 +185,15 @@ module RailsGuides
         case hierarchy.size
         when 1
           @index_counter[2] = @index_counter[3] = @index_counter[4] = 0
-          "#{@index_counter[1] += 1}"
+          "#{@index_counter[1] += 1}."
         when 2
           @index_counter[3] = @index_counter[4] = 0
-          "#{@index_counter[1]}.#{@index_counter[2] += 1}"
+          "#{@index_counter[1]}.#{@index_counter[2] += 1}."
         when 3
           @index_counter[4] = 0
-          "#{@index_counter[1]}.#{@index_counter[2]}.#{@index_counter[3] += 1}"
+          "#{@index_counter[1]}.#{@index_counter[2]}.#{@index_counter[3] += 1}."
         when 4
-          "#{@index_counter[1]}.#{@index_counter[2]}.#{@index_counter[3]}.#{@index_counter[4] += 1}"
+          "#{@index_counter[1]}.#{@index_counter[2]}.#{@index_counter[3]}.#{@index_counter[4] += 1}."
         end
       end
 


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because I noticed that the headings for the Rails Guides main topics look something like this:

<img width="1433" alt="image" src="https://github.com/user-attachments/assets/b794de9d-5d91-4b31-845b-768581b17532" />

Noticed "2 Rails Philosophy" and "3 Creating a New Rails App", there's nothing separate the numbering from the heading itself.

### Detail

This Pull Request changes the headings for the first level (`<h2>`) to have a dot suffix after the numbering:

<img width="1448" alt="image" src="https://github.com/user-attachments/assets/a66b1806-2e31-48cb-a9b9-7caf8182e6b0" />

### Additional information

I understand that this might fall into aesthetic change of the guide. However, I believe this increase the readability of the guide as this dot suffix clearly separate the numbering from the heading.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
