### PR TITLE
Convert `[]` in heading to `-squarebrackets` in DOM id

### DIFF
--- a/guides/rails_guides/markdown.rb
+++ b/guides/rails_guides/markdown.rb
@@ -55,6 +55,7 @@ module RailsGuides
 
         text.downcase.gsub(/\?/, "-questionmark")
                      .gsub(/!/, "-bang")
+                     .gsub(/\[\]/, "-squarebrackets")
                      .gsub(/[#{escaped_chars}]+/, " ").strip
                      .gsub(/\s+/, "-")
       end


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because I noticed this warning when I run `rake guides:lint`:

```
*** DUPLICATE ID: 'working-with-validation-errors-errors', please make sure that there are no headings with the same name at the same level.
```

This is due to us having headings with `errors` and `errors[]` in Active Record Validations guide:

https://github.com/rails/rails/blob/096fb3be5a6b92993a0dcffc455c7e32f6f92373/guides/source/active_record_validations.md#L1646

https://github.com/rails/rails/blob/096fb3be5a6b92993a0dcffc455c7e32f6f92373/guides/source/active_record_validations.md#L1683

### Detail

This Pull Request changes the code that generates DOM id to considered `[]` as special cases and converts them to `-squarebrackets`

Example:

```md
# Working with validation errors

## `errors`

## `errors[]`
```

Before:

    #working-with-validation-errors

    #working-with-validation-errors-errors

    #working-with-validation-errors-errors <= duplicate

After:

    #working-with-validation-errors

    #working-with-validation-errors-errors

    #working-with-validation-errors-errors-squarebrackets

### Additional information

This change also makes the index on the right side works as well, as currently both `errors` and `errors[]` would link to `errors` (due to id collision).

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
