### PR TITLE
Support joins in `update_all` for Postgresql and SQlite

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,18 @@
+*   Better support UPDATE with JOIN for Postgresql and SQLite3
+
+    Previously when generating update queries with one or more JOIN clauses,
+    Active Record would use a sub query which would prevent to reference the joined
+    tables in the `SET` clause, for instance:
+
+    ```ruby
+    Comment.joins(:post).update_all("title = posts.title")
+    ```
+
+    This is now supported as long as the relation doesn't also use a `LIMIT`, `ORDER` or
+    `GROUP BY` clause. This was supported by the MySQL adapter for a long time.
+
+    *Jean Boussier*
+
 *   Introduce a before-fork hook in `ActiveSupport::Testing::Parallelization` to clear existing
     connections, to avoid fork-safety issues with the mysql2 adapter.
 

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -1407,7 +1407,7 @@ module ActiveRecord
 
       def _increment_attribute(attribute, value = 1)
         bind = predicate_builder.build_bind_attribute(attribute.name, value.abs)
-        expr = table.coalesce(Arel::Nodes::UnqualifiedColumn.new(attribute), 0)
+        expr = table.coalesce(attribute, 0)
         expr = value < 0 ? expr - bind : expr + bind
         expr.expr
       end

--- a/activerecord/lib/arel/visitors/postgresql.rb
+++ b/activerecord/lib/arel/visitors/postgresql.rb
@@ -4,6 +4,62 @@ module Arel # :nodoc: all
   module Visitors
     class PostgreSQL < Arel::Visitors::ToSql
       private
+        def visit_Arel_Nodes_UpdateStatement(o, collector)
+          collector.retryable = false
+          o = prepare_update_statement(o)
+
+          collector << "UPDATE "
+
+          # UPDATE with JOIN is in the form of:
+          #
+          #   UPDATE t1
+          #   SET ..
+          #   FROM t2
+          #   WHERE t1.join_id = t2.join_id
+          #
+          # Or if more than one join is present:
+          #
+          #   UPDATE t1
+          #   SET ..
+          #   FROM t2
+          #   JOIN t3 ON t2.join_id = t3.join_id
+          #   WHERE t1.join_id = t2.join_id
+          if has_join_sources?(o)
+            visit o.relation.left, collector
+            collect_nodes_for o.values, collector, " SET "
+            collector << " FROM "
+            first_join, *remaining_joins = o.relation.right
+            visit first_join.left, collector
+
+            if remaining_joins && !remaining_joins.empty?
+              collector << " "
+              remaining_joins.each do |join|
+                visit join, collector
+              end
+            end
+
+            collect_nodes_for [first_join.right.expr] + o.wheres, collector, " WHERE ", " AND "
+          else
+            collector = visit o.relation, collector
+            collect_nodes_for o.values, collector, " SET "
+            collect_nodes_for o.wheres, collector, " WHERE ", " AND "
+          end
+
+          collect_nodes_for o.orders, collector, " ORDER BY "
+          maybe_visit o.limit, collector
+        end
+
+        # In the simple case, PostgreSQL allows us to place FROM or JOINs directly into the UPDATE
+        # query. However, this does not allow for LIMIT, OFFSET and ORDER. To support
+        # these, we must use a subquery.
+        def prepare_update_statement(o)
+          if has_join_sources?(o) && !has_limit_or_offset_or_orders?(o) && !has_group_by_and_having?(o)
+            o
+          else
+            super
+          end
+        end
+
         def visit_Arel_Nodes_Matches(o, collector)
           op = o.case_sensitive ? " LIKE " : " ILIKE "
           collector = infix_value o, collector, op

--- a/activerecord/lib/arel/visitors/sqlite.rb
+++ b/activerecord/lib/arel/visitors/sqlite.rb
@@ -4,6 +4,62 @@ module Arel # :nodoc: all
   module Visitors
     class SQLite < Arel::Visitors::ToSql
       private
+        def visit_Arel_Nodes_UpdateStatement(o, collector)
+          collector.retryable = false
+          o = prepare_update_statement(o)
+
+          collector << "UPDATE "
+
+          # UPDATE with JOIN is in the form of:
+          #
+          #   UPDATE t1
+          #   SET ..
+          #   FROM t2
+          #   WHERE t1.join_id = t2.join_id
+          #
+          # Or if more than one join is present:
+          #
+          #   UPDATE t1
+          #   SET ..
+          #   FROM t2
+          #   JOIN t3 ON t2.join_id = t3.join_id
+          #   WHERE t1.join_id = t2.join_id
+          if has_join_sources?(o)
+            visit o.relation.left, collector
+            collect_nodes_for o.values, collector, " SET "
+
+            collector << " FROM "
+            first_join, *remaining_joins = o.relation.right
+            visit first_join.left, collector
+
+            if remaining_joins && !remaining_joins.empty?
+              collector << " "
+              remaining_joins.each do |join|
+                visit join, collector
+              end
+            end
+
+            collect_nodes_for [first_join.right.expr] + o.wheres, collector, " WHERE ", " AND "
+          else
+            collector = visit o.relation, collector
+            collect_nodes_for o.values, collector, " SET "
+            collect_nodes_for o.wheres, collector, " WHERE ", " AND "
+          end
+
+          collect_nodes_for o.orders, collector, " ORDER BY "
+          maybe_visit o.limit, collector
+        end
+
+        def prepare_update_statement(o)
+          # Sqlite need to be built with the SQLITE_ENABLE_UPDATE_DELETE_LIMIT compile-time option
+          # to support LIMIT/OFFSET/ORDER in UPDATE and DELETE statements.
+          if has_join_sources?(o) && !has_limit_or_offset_or_orders?(o) && !has_group_by_and_having?(o)
+            o
+          else
+            super
+          end
+        end
+
         # Locks are not supported in SQLite
         def visit_Arel_Nodes_Lock(o, collector)
           collector


### PR DESCRIPTION
Fix: https://github.com/rails/rails/issues/13496

Both support UPDATE with JOIN but in a weird way. The first join has to be turned into a `FROM + WHERE`.

Also they doesn't support UPDATE with LIMIT/OFFSET nor with GROUP BY, so in such case there's really nothing we can do.
