### PR TITLE
Do not validate associated records that haven't changed

### DIFF
--- a/activerecord/test/cases/autosave_association_test.rb
+++ b/activerecord/test/cases/autosave_association_test.rb
@@ -1490,6 +1490,17 @@ class TestDestroyAsPartOfAutosaveAssociation < ActiveRecord::TestCase
     assert_predicate @pirate, :valid?
   end
 
+  def test_should_skip_validation_on_habtm_if_persisted_and_unchanged
+    parrot = @pirate.parrots.create!(name: "parrots_1")
+    parrot.update_column(:name, "")
+    parrot.reload
+    assert_not_predicate parrot, :valid?
+
+    new_pirate = Pirate.new(catchphrase: "Arr")
+    new_pirate.parrots = @pirate.parrots
+    new_pirate.save!
+  end
+
   def test_a_child_marked_for_destruction_should_not_be_destroyed_twice_while_saving_habtm
     @pirate.parrots.create!(name: "parrots_1")
 


### PR DESCRIPTION
Fix: https://github.com/rails/rails/issues/17621
Redo of: https://github.com/rails/rails/pull/18612

You should be able to create a reference to an invalid record as long as you don't modify it.

This was initially fixed in https://github.com/rails/rails/pull/18612 but was reverted in https://github.com/rails/rails/commit/2c02bc0a47777ad8cf98e1465c08b1a68151803e because it was causing other bugs.

Some tests were added as part of the revert to avoid future regressions.
