### PR TITLE
Fix rdoc code render in `ActionCable::Connection::TestCase` docs [ci skip]

### DIFF
--- a/actioncable/lib/action_cable/connection/test_case.rb
+++ b/actioncable/lib/action_cable/connection/test_case.rb
@@ -75,11 +75,8 @@ module ActionCable
     #
     # ## Basic example
     #
-    # Unit tests are written as follows:
-    #
-    # 1.  Simulate a connection attempt by calling `connect`.
-    # 2.  Assert state, e.g. identifiers, has been assigned.
-    #
+    # Unit tests are written by first simulating a connection attempt by calling
+    # `connect` and then asserting state, e.g. identifiers, have been assigned.
     #
     #     class ApplicationCable::ConnectionTest < ActionCable::Connection::TestCase
     #       def test_connects_with_proper_cookie


### PR DESCRIPTION
Before:

<img width="807" alt="Screenshot 2024-12-13 at 15 11 55" src="https://github.com/user-attachments/assets/8d5257b8-bd03-4e46-b0af-29debb1e8425" />

After:

<img width="830" alt="Screenshot 2024-12-13 at 15 47 40" src="https://github.com/user-attachments/assets/6960a717-97ab-4c3b-a917-001558cae3f7" />

I assume the first portion of the code example was being seen as the end of the list.
