### PR TITLE
Polish delete_matched behavior

### DIFF
--- a/activesupport/lib/active_support/cache.rb
+++ b/activesupport/lib/active_support/cache.rb
@@ -777,6 +777,8 @@ module ActiveSupport
         # this method to translate a pattern that matches names into one that
         # matches namespaced keys.
         def key_matcher(pattern, options) # :doc:
+          return namespace_key(pattern, options) if pattern.is_a?(String)
+
           prefix = options[:namespace].is_a?(Proc) ? options[:namespace].call : options[:namespace]
           if prefix
             source = pattern.source

--- a/activesupport/lib/active_support/cache/redis_cache_store.rb
+++ b/activesupport/lib/active_support/cache/redis_cache_store.rb
@@ -216,7 +216,7 @@ module ActiveSupport
         unless String === matcher
           raise ArgumentError, "Only Redis glob strings are supported: #{matcher.inspect}"
         end
-        pattern = namespace_key(matcher, options)
+        pattern = key_matcher(matcher, options)
 
         instrument :delete_matched, pattern do
           redis.then do |c|

--- a/activesupport/test/cache/stores/memory_store_test.rb
+++ b/activesupport/test/cache/stores/memory_store_test.rb
@@ -83,6 +83,38 @@ class MemoryStoreTest < ActiveSupport::TestCase
     assert_equal true, @cache.write(1, "bbbb", expires_in: 1.second, unless_exist: true)
   end
 
+  def test_delete_matched
+    @cache.write("my_key", "my_value")
+    assert_equal "my_value", @cache.read("my_key")
+    @cache.delete_matched("my_key")
+    assert_nil @cache.read("my_key")
+  end
+
+  def test_delete_matched_with_regex
+    @cache.write("my_key", "my_value")
+    assert_equal "my_value", @cache.read("my_key")
+    @cache.delete_matched(/my_key/)
+    assert_nil @cache.read("my_key")
+  end
+
+  def test_namespaced_delete_matched
+    namespaced_cache = lookup_store(namespace: "foo")
+
+    namespaced_cache.write("my_key", "my_value")
+    assert_equal "my_value", namespaced_cache.read("my_key")
+    namespaced_cache.delete_matched("my_key")
+    assert_nil namespaced_cache.read("my_key")
+  end
+
+  def test_namespaced_delete_matched_with_regex
+    namespaced_cache = lookup_store(namespace: "foo")
+
+    namespaced_cache.write("my_key", "my_value")
+    assert_equal "my_value", namespaced_cache.read("my_key")
+    namespaced_cache.delete_matched(/my_key/)
+    assert_nil namespaced_cache.read("my_key")
+  end
+
   private
     def compression_always_disabled_by_default?
       true


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created because `ActiveSupport::Cache#delete_matched` has an inconsistent behavior depending on the actual Cache implementation, and because of this, it doesn't work in one specific case. That is when:
- Using `ActiveSupport::Cache::FileStore` or `ActiveSupport::Cache::MemoryStore`
- Configured with a `namespace`
- And calling it with a `String` pattern

Error is:
> NoMethodError: undefined method `source' for an instance of String
    lib/active_support/cache.rb:782:in `key_matcher'
    lib/active_support/cache/memory_store.rb:175:in `delete_matched'

The reason is that `ActiveSupport::Cache#key_matcher` is being called which in one branch of execution it assumes the pattern is a Regex.

Let's say we want to not support this case, then the inconsistency lays between the above mentioned cache stores and `ActiveSupport::Cache:RedisCacheStore` which only supports a String (Redis glob) as a param. Here the problem would be that we don't have a way to call `delete_matched` that would work for all of the cache implementations, which could be necessary for gems that want to use `delete_matched` without having to care about the underlaying cache store in use, or if you want to use different cache implementations in different environments (e.g. memory in development/test and redis in prod).

Note that the `key_matcher` method says
> \# Adds the namespace defined in the options to a pattern designed to
  \# match keys. Implementations that support delete_matched should call
  \# this method to translate a pattern that matches names into one that
  \# matches namespaced keys.

Which wasn't being respected by `ActiveSupport::Cache:RedisCacheStore`.

So with this PR we are now accepting both `String` and `Regex` for both `ActiveSupport::Cache::FileStore` or `ActiveSupport::Cache::MemoryStore`, by fixing the case when a the cache was namespaced.


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
