### PR TITLE
Handle nested middle belongs_to, not-loaded target when setting through records

### DIFF
--- a/activerecord/lib/active_record/associations/association.rb
+++ b/activerecord/lib/active_record/associations/association.rb
@@ -193,9 +193,9 @@ module ActiveRecord
           reflections.pop
           reflections.reverse!
 
-          @target = reflections.reduce(through_association.target) do |middle_target, reflection|
+          @target = reflections.reduce(through_association.target) do |middle_target, through_reflection|
             break unless middle_target
-            middle_target.association(reflection.source_reflection_name).target
+            middle_target.association(through_reflection.source_reflection_name).load_target
           end
         end
 

--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -651,6 +651,10 @@ module ActiveRecord
         self
       end
 
+      def source_reflection_name
+        source_reflection.name
+      end
+
       # A chain of reflections from this one back to the owner. For more see the explanation in
       # ThroughReflection.
       def collect_join_chain

--- a/activerecord/test/cases/associations/has_many_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_through_associations_test.rb
@@ -57,7 +57,20 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
     Reader.create person_id: 0, post_id: 0
   end
 
-  def test_setting_association_on_new_record_sets_through_records
+  def test_setting_has_many_through_one_association_on_new_record_sets_through_records
+    account_1, account_2 = Account.create!(credit_limit: 100), Account.create!(credit_limit: 100)
+    firm = Firm.new(accounts: [account_1, account_2])
+    client = Client.new
+    client.firm = firm
+
+    assert_predicate account_1, :persisted?
+    assert_predicate account_2, :persisted?
+    assert_predicate client, :new_record?
+    assert_predicate client.firm, :new_record?
+    assert_no_queries { assert_equal [account_1, account_2].sort, client.accounts.sort }
+  end
+
+  def test_setting_has_many_through_many_association_on_new_record_sets_through_records
     subscriber_1, subscriber_2 = Subscriber.create!(nick: "nick 1"), Subscriber.create!(nick: "nick 2")
     subscription_1 = Subscription.new(subscriber: subscriber_1)
     subscription_2 = Subscription.new(subscriber: subscriber_2)
@@ -68,10 +81,42 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
     assert_predicate subscriber_2, :persisted?
     assert_predicate book, :new_record?
     book.subscriptions.each { |subscription| assert_predicate subscription, :new_record? }
-    assert_equal [subscriber_1, subscriber_2].sort, book.subscribers.sort
+    assert_no_queries { assert_equal [subscriber_1, subscriber_2].sort, book.subscribers.sort }
   end
 
-  def test_setting_association_on_new_record_sets_nested_through_records
+  def test_setting_nested_has_many_through_one_association_on_new_record_sets_nested_through_records
+    post_tagging_1, post_tagging_2 = Tagging.create!, Tagging.create!
+    post = Post.create!(title: "Tagged", body: "Post", taggings: [post_tagging_1, post_tagging_2])
+    author = Author.new(name: "Josh")
+    author.posts = [post]
+    categorization = Categorization.new
+    categorization.author = author
+
+    assert_predicate post_tagging_1, :persisted?
+    assert_predicate post_tagging_2, :persisted?
+    assert_predicate post, :persisted?
+    assert_predicate categorization, :new_record?
+    assert_predicate categorization.author, :new_record?
+    assert_no_queries { assert_equal [post_tagging_1, post_tagging_2].sort, categorization.post_taggings.sort }
+  end
+
+  def test_setting_nested_has_many_through_one_association_on_new_record_sets_targetless_nested_through_records
+    post = Post.create!(title: "Tagged", body: "Post")
+    post_tagging_1, post_tagging_2 = Tagging.create!(taggable: post), Tagging.create!(taggable: post)
+    author = Author.new(name: "Josh")
+    author.posts = [post]
+    categorization = Categorization.new
+    categorization.author = author
+
+    assert_predicate post_tagging_1, :persisted?
+    assert_predicate post_tagging_2, :persisted?
+    assert_predicate post, :persisted?
+    assert_predicate categorization, :new_record?
+    assert_predicate categorization.author, :new_record?
+    assert_queries_count(1) { assert_equal [post_tagging_1, post_tagging_2].sort, categorization.post_taggings.sort }
+  end
+
+  def test_setting_nested_has_many_through_many_association_on_new_record_sets_nested_through_records
     account_1 = Account.create!(firm_name: "account 1", credit_limit: 100)
     subscriber_1 = Subscriber.create!(nick: "nick 1", account: account_1)
     account_2 = Account.create!(firm_name: "account 2", credit_limit: 100)
@@ -83,9 +128,11 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
 
     assert_predicate subscriber_1, :persisted?
     assert_predicate subscriber_2, :persisted?
+    assert_predicate account_1, :persisted?
+    assert_predicate account_2, :persisted?
     assert_predicate book, :new_record?
     book.subscriptions.each { |subscription| assert_predicate subscription, :new_record? }
-    assert_equal [account_1, account_2].sort, book.subscriber_accounts.sort
+    assert_no_queries { assert_equal [account_1, account_2].sort, book.subscriber_accounts.sort }
   end
 
   def test_has_many_through_create_record

--- a/activerecord/test/cases/associations/has_one_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_one_through_associations_test.rb
@@ -23,6 +23,7 @@ require "models/carrier"
 require "models/shop_account"
 require "models/customer_carrier"
 require "models/cpk"
+require "models/rating"
 
 class HasOneThroughAssociationsTest < ActiveRecord::TestCase
   fixtures :member_types, :members, :clubs, :memberships, :sponsors, :organizations, :minivans,
@@ -52,7 +53,7 @@ class HasOneThroughAssociationsTest < ActiveRecord::TestCase
     assert_predicate club, :persisted?
     assert_predicate member, :new_record?
     assert_predicate member.current_membership, :new_record?
-    assert_equal club, member.club
+    assert_no_queries { assert_equal club, member.club }
   end
 
   def test_setting_association_on_new_record_sets_nested_through_record
@@ -66,7 +67,38 @@ class HasOneThroughAssociationsTest < ActiveRecord::TestCase
     assert_predicate club, :persisted?
     assert_predicate member, :new_record?
     assert_predicate member.current_membership, :new_record?
-    assert_equal club.category, member.club_category
+    assert_no_queries { assert_equal club.category, member.club_category }
+  end
+
+  def test_setting_association_on_new_record_sets_not_loaded_nested_through_record
+    category = Category.create!(name: "General")
+    club = Club.create!(category: category)
+    club.reload
+    membership = CurrentMembership.new(club: club)
+    member = Member.new
+    member.current_membership = membership
+
+    assert_predicate category, :persisted?
+    assert_predicate club, :persisted?
+    assert_predicate member, :new_record?
+    assert_predicate member.current_membership, :new_record?
+    assert_queries_count(1) { assert_equal club.category, member.club_category }
+  end
+
+  def test_setting_association_on_new_record_sets_nested_through_record_with_belongs_to
+    essay = Essay.create!
+    author = Author.create!(name: "Josh", owned_essay: essay)
+    post = Post.create!(title: "Foo", body: "Bar", author: author)
+    comment = Comment.new(post: post)
+    rating = Rating.new
+    rating.comment = comment
+
+    assert_predicate essay, :persisted?
+    assert_predicate author, :persisted?
+    assert_predicate post, :persisted?
+    assert_predicate rating, :new_record?
+    assert_predicate rating.comment, :new_record?
+    assert_no_queries { assert_equal essay, rating.owned_essay }
   end
 
   def test_creating_association_creates_through_record

--- a/activerecord/test/models/family_tree.rb
+++ b/activerecord/test/models/family_tree.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class FamilyTree < ActiveRecord::Base
+  belongs_to :user
+
   belongs_to :member, class_name: "User", foreign_key: "member_id"
   belongs_to :family
 end

--- a/activerecord/test/models/member_detail.rb
+++ b/activerecord/test/models/member_detail.rb
@@ -5,6 +5,7 @@ class MemberDetail < ActiveRecord::Base
   belongs_to :organization
   has_one :member_type, through: :member
   has_one :membership, through: :member
+  has_one :sponsor, through: :membership
   has_one :admittable, through: :member, source_type: "Member"
 
   has_many :organization_member_details, through: :organization, source: :member_details

--- a/activerecord/test/models/membership.rb
+++ b/activerecord/test/models/membership.rb
@@ -4,6 +4,7 @@ class Membership < ActiveRecord::Base
   enum :type, %i(Membership CurrentMembership SuperMembership SelectedMembership TenantMembership)
   belongs_to :member
   belongs_to :club
+  has_one :sponsor, through: :club
 end
 
 class CurrentMembership < Membership

--- a/activerecord/test/models/post.rb
+++ b/activerecord/test/models/post.rb
@@ -46,6 +46,7 @@ class Post < ActiveRecord::Base
   }
 
   belongs_to :author
+  has_one :owned_essay, through: :author
   belongs_to :readonly_author, -> { readonly }, class_name: "Author", foreign_key: :author_id
 
   belongs_to :author_with_posts, -> { includes(:posts) }, class_name: "Author", foreign_key: :author_id

--- a/activerecord/test/models/rating.rb
+++ b/activerecord/test/models/rating.rb
@@ -2,6 +2,8 @@
 
 class Rating < ActiveRecord::Base
   belongs_to :comment
+  has_one :post, through: :comment
+  has_one :owned_essay, through: :post
   has_many :taggings, as: :taggable
   has_many :taggings_without_tag, -> { left_joins(:tag).where("tags.id": [nil, 0]) }, as: :taggable, class_name: "Tagging"
   has_many :taggings_with_no_tag, -> { joins("LEFT OUTER JOIN tags ON tags.id = taggings.tag_id").where("tags.id": nil) }, as: :taggable, class_name: "Tagging"


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

Follow-up to:
- https://github.com/rails/rails/pull/51114
- https://github.com/rails/rails/pull/53869

Addresses the cases that don't work well with the current implementation starting from [this comment](https://github.com/rails/rails/pull/53869#issuecomment-2536888182).

1. In a nested through target case, If the middle reflection  is a `MacroReflection`, calling `#source_reflection_name` on it would raise cause that is only defined on `ThroughReflection`. I've now added it to `MacroReflection` as well. I think this is a better solution than updating the current logic to use `source_reflection.name` cause we don't need to go [look up the reflection itself unnecessarily](https://github.com/rails/rails/blob/bbd75854d78107a6db179557ba343d286baf46c5/activerecord/lib/active_record/reflection.rb#L1013) in the `ThroughReflection` case. Also it makes sense to have on both seeing as `#source_reflection` is defined on both. I've added a test that replicates the raise.
2. In some cases where either the middle target's associated records have been set in a way that's unreachable by the chain, or are no longer in-memory, I agree with @sromano that it makes sense to load the target, similar to how `Comment.new(post_id: 1).post` would load the association target even when it's a new record. I've added tests for these cases and updates other tests to ensure we're not executing queries unless the target actually needs to be queried.
3. Addresses some incorrect logic in the collection association case where the middle target in the iterations for the nested through target case could be singular, but we always check if it's `#empty?` which would eventually raise. I've added a test that replicates this raise as well.

cc/ @byroot Sorry it's a lot of context but hopefully this addresses all the remaining cases. Might be worth waiting for @sromano to test these changes as well, although the scripts provided in the previous PR all pass here.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.