### PR TITLE
add support for json-serialized attributes in fixtures

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,36 @@
+*   Support serialized attributes (i.e. JSON) in fixtures.
+
+    Given a model with a serialized attribute
+
+    ```rb
+    # app/models/user.rb
+    class User
+      serialize :preferences, coder: JSON
+    end
+    ```
+
+    It's now possible to write fixtures as
+
+    ```yaml
+    # test/fixtures/users.yml
+    glaszig:
+      name: glaszig
+      preferences:
+        active: true
+        notifications: [ news, offers ]
+    ```
+
+    Instead of
+
+    ```yaml
+    # test/fixtures/users.yml
+    glaszig:
+      name: glaszig
+      preferences: <%= { active: true, notifications: [ news, offers ] }.to_json %>
+    ```
+
+    *glaszig*
+
 *   Allow bypassing primary key/constraint addition in `implicit_order_column`
 
     When specifying multiple columns in an array for `implicit_order_column`, adding

--- a/activerecord/lib/active_record/fixture_set/table_row.rb
+++ b/activerecord/lib/active_record/fixture_set/table_row.rb
@@ -90,6 +90,7 @@ module ActiveRecord
           model_class.composite_primary_key? ? generate_composite_primary_key : generate_primary_key
           resolve_enums
           resolve_sti_reflections
+          serialize_attributes
         end
 
         def reflection_class
@@ -202,6 +203,21 @@ module ActiveRecord
             end
             @table_rows.tables[table_name].concat(joins)
           end
+        end
+
+        def serialize_attributes
+          model_class.column_names.each do |column_name|
+            if coder = attribute_coder(column_name)
+              @row[column_name] = coder.dump(@row[column_name])
+            end
+          end
+        end
+
+        def attribute_coder(column_name)
+          return if @row[column_name].nil? || String === @row[column_name]
+
+          type = model_class.type_for_attribute(column_name)
+          type.coder if type.respond_to?(:coder)
         end
     end
   end

--- a/activerecord/test/cases/fixtures_test.rb
+++ b/activerecord/test/cases/fixtures_test.rb
@@ -1878,4 +1878,12 @@ class FixturesWithSerializedAttributesTest < ActiveRecord::TestCase
   def test_supports_json_attributes
     assert_equal ["Green", "Red", "Orange"], traffic_lights(:uk).state
   end
+
+  def test_raw_payload
+    assert_equal ["Grün", "Rot", "Gelb"], traffic_lights(:de).state
+  end
+
+  def test_nil
+    assert_nil traffic_lights(:none).state
+  end
 end

--- a/activerecord/test/cases/fixtures_test.rb
+++ b/activerecord/test/cases/fixtures_test.rb
@@ -1866,3 +1866,16 @@ class MultipleFixtureConnectionsTest < ActiveRecord::TestCase
     end
   end
 end
+
+class FixturesWithSerializedAttributesTest < ActiveRecord::TestCase
+  model = Class.new(TrafficLight) do
+    serialize :state, coder: JSON
+  end
+
+  set_fixture_class traffic_lights: model
+  fixtures :traffic_lights
+
+  def test_supports_json_attributes
+    assert_equal ["Green", "Red", "Orange"], traffic_lights(:uk).state
+  end
+end

--- a/activerecord/test/fixtures/traffic_lights.yml
+++ b/activerecord/test/fixtures/traffic_lights.yml
@@ -8,3 +8,16 @@ uk:
     - "Green, go ahead"
     - "Red, wait"
     - "Orange, caution light is about to switch"
+
+de:
+  location: DE
+  state: "[\"Grün\",\"Rot\",\"Gelb\"]"
+  long_state:
+    - "Grün, los!"
+    - "Rot, warte"
+    - "Gelb, Achtung."
+
+none:
+  location: NN
+  state:
+  long_state: ""


### PR DESCRIPTION
### Motivation / Background

i'm used to write the following fixtures

```rb
# app/models/user.rb
class User
  serialize :preferences, coder: JSON
end
```

```yaml
# test/fixtures/users.yml
glaszig:
  name: glaszig
  preferences: <%= { active: true, notifications: [ news, offers ] }.to_json %>
```

which becomes ugly when the json column gets more complex.

### Detail

this pr puts the yaml structure through the model attribute's coder and thus eliminates the need for `<%= { ... }.to_json %>` and allows to write the fixture like this:

```yaml
# test/fixtures/users.yml
glaszig:
  name: glaszig
  preferences:
    active: true
    notifications: [ news, offers ]
```

failing test before change:

```
Error:
FixturesWithSerializedAttributesTest#test_supports_json_attributes:
JSON::ParserError: unexpected token at '---
- Green
- Red
- Orange
'
    /usr/local/bundle/gems/json-2.9.0/lib/json/common.rb:221:in `parse'
    /usr/local/bundle/gems/json-2.9.0/lib/json/common.rb:221:in `parse'
    /rails/activesupport/lib/active_support/json/decoding.rb:23:in `decode'
    lib/active_record/coders/json.rb:11:in `load'
    lib/active_record/type/serialized.rb:22:in `deserialize'
    /rails/activemodel/lib/active_model/attribute_set/builder.rb:52:in `block in fetch_value'
    /rails/activemodel/lib/active_model/attribute_set/builder.rb:46:in `fetch'
    /rails/activemodel/lib/active_model/attribute_set/builder.rb:46:in `fetch_value'
    lib/active_record/attribute_methods/read.rb:51:in `_read_attribute'
    /rails/activemodel/lib/active_model/attribute_methods.rb:289:in `state'
    test/cases/fixtures_test.rb:1798:in `test_supports_json_attributes'
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
