### PR TITLE
Handle cyclic template dependencies

### DIFF
--- a/actionview/lib/action_view/digestor.rb
+++ b/actionview/lib/action_view/digestor.rb
@@ -107,8 +107,12 @@ module ActionView
         end.join("-")
       end
 
-      def to_dep_map
-        children.any? ? { name => children.map(&:to_dep_map) } : name
+      def to_dep_map(seen = Set.new.compare_by_identity)
+        if seen.add?(self)
+          children.any? ? { name => children.map { |c| c.to_dep_map(seen) } } : name
+        else # the tree has a cycle
+          name
+        end
       end
     end
 

--- a/actionview/test/fixtures/digestor/comments/_cycle_a.html.erb
+++ b/actionview/test/fixtures/digestor/comments/_cycle_a.html.erb
@@ -1,0 +1,3 @@
+<% if some_condition %>
+  <%= render partial: "cycle_b" %>
+<% end %>

--- a/actionview/test/fixtures/digestor/comments/_cycle_b.html.erb
+++ b/actionview/test/fixtures/digestor/comments/_cycle_b.html.erb
@@ -1,0 +1,3 @@
+<% if some_other_condition %>
+  <%= render partial: "cycle_a" %>
+<% end %>

--- a/actionview/test/fixtures/digestor/comments/cycle.html.erb
+++ b/actionview/test/fixtures/digestor/comments/cycle.html.erb
@@ -1,0 +1,1 @@
+<%= render partial: "cycle_a" %>

--- a/actionview/test/template/digestor_test.rb
+++ b/actionview/test/template/digestor_test.rb
@@ -296,6 +296,21 @@ class TemplateDigestorTest < ActionView::TestCase
     assert_equal first_digest, second_digest
   end
 
+  def test_digest_cache_with_cycle
+    expected_deps = [
+      {
+        "comments/cycle_a" => [
+          {
+            "comments/cycle_b" => [
+              "comments/cycle_a",
+            ],
+          },
+        ],
+      },
+    ]
+    assert_equal expected_deps, nested_dependencies("comments/cycle")
+  end
+
   def test_digest_cache_cleanup_with_recursion_and_template_caching_off
     disable_resolver_caching do
       first_digest = digest("level/_recursion")


### PR DESCRIPTION
Fix: https://github.com/rails/rails/issues/18667

Pretty straightforward, we keep track of nodes when walking the tree and stop the cycle there.