### PR TITLE
Handle new records in `#increment!`

### DIFF
--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -641,8 +641,15 @@ module ActiveRecord
     # This means that any other modified attributes will still be dirty.
     # Validations and callbacks are skipped. Supports the +touch+ option from
     # +update_counters+, see that for more.
+    #
+    # This method raises an ActiveRecord::ActiveRecordError when called on new
+    # objects, or when at least one of the attributes is marked as readonly.
+    #
     # Returns +self+.
     def increment!(attribute, by = 1, touch: nil)
+      raise ActiveRecordError, "cannot update a new record" if new_record?
+      raise ActiveRecordError, "cannot update a destroyed record" if destroyed?
+
       increment(attribute, by)
       change = public_send(attribute) - (public_send(:"#{attribute}_in_database") || 0)
       self.class.update_counters(id, attribute => change, touch: touch)

--- a/activerecord/test/cases/persistence_test.rb
+++ b/activerecord/test/cases/persistence_test.rb
@@ -344,6 +344,27 @@ class PersistenceTest < ActiveRecord::TestCase
     assert_raises(ArgumentError) { topic.increment! }
   end
 
+  def test_increment_new_record
+    topic = Topic.new
+
+    assert_no_queries do
+      assert_raises ActiveRecord::ActiveRecordError do
+        topic.increment!(:replies_count)
+      end
+    end
+  end
+
+  def test_increment_destroyed_record
+    topic = topics(:first)
+    topic.destroy
+
+    assert_no_queries do
+      assert_raises ActiveRecord::ActiveRecordError do
+        topic.increment!(:replies_count)
+      end
+    end
+  end
+
   def test_destroy_many
     clients = Client.find([2, 3])
 


### PR DESCRIPTION
Fix: https://github.com/rails/rails/issues/26420

Back in Rails 4, calling `#increment!` on a new record would save it, but I don't think it's a good behavior, and it no longer has done so for many years now.

It's better to raise like `#update_columns`.
