### PR TITLE
Fix `#to_query` to not include `=` for nil values

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   `nil.to_query("key")` now returns `key`.
+
+    Previously it would return `key=`, preventing round tripping with `Rack::Utils.parse_nested_query`.
+
+    *Erol Fornoles*
+
 *   Avoid wrapping redis in a `ConnectionPool` when using `ActiveSupport::Cache::RedisCacheStore` if the `:redis`
     option is already a `ConnectionPool`.
 

--- a/activesupport/lib/active_support/core_ext/object/to_query.rb
+++ b/activesupport/lib/active_support/core_ext/object/to_query.rb
@@ -16,6 +16,11 @@ class Object
 end
 
 class NilClass
+  # Returns a CGI-escaped +key+.
+  def to_query(key)
+    CGI.escape(key.to_param)
+  end
+
   # Returns +self+.
   def to_param
     self

--- a/activesupport/test/core_ext/object/to_query_test.rb
+++ b/activesupport/test/core_ext/object/to_query_test.rb
@@ -49,7 +49,7 @@ class ToQueryTest < ActiveSupport::TestCase
   end
 
   def test_empty_array
-    assert_equal "person%5B%5D=", [].to_query("person")
+    assert_equal "person%5B%5D", [].to_query("person")
   end
 
   def test_nested_empty_hash
@@ -59,7 +59,7 @@ class ToQueryTest < ActiveSupport::TestCase
       a: 1, b: { c: 3, d: {} }
     assert_query_equal "",
       a: { b: { c: {} } }
-    assert_query_equal "b%5Bc%5D=false&b%5Be%5D=&b%5Bf%5D=&p=12",
+    assert_query_equal "b%5Bc%5D=false&b%5Be%5D&b%5Bf%5D=&p=12",
       p: 12, b: { c: false, e: nil, f: "" }
     assert_query_equal "b%5Bc%5D=3&b%5Bf%5D=",
       b: { c: 3, k: {}, f: "" }


### PR DESCRIPTION
Fix: https://github.com/rails/rails/issues/28322

This is more consistent with the behavior of `Rack::Utils.parse_nested_query`.
