### PR TITLE
Fix minor issues with bug report templates

### DIFF
--- a/guides/CHANGELOG.md
+++ b/guides/CHANGELOG.md
@@ -1,2 +1,6 @@
+*   Ensure all bug report templates set `config.secret_key_base` to avoid
+    generation of `tmp/local_secret.txt` files when running the report template.
+
+    *Andrew White*
 
 Please check [8-0-stable](https://github.com/rails/rails/blob/8-0-stable/guides/CHANGELOG.md) for previous changes.

--- a/guides/CHANGELOG.md
+++ b/guides/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   In the Active Job bug report template set the queue adapter to the
+    test adapter so that `assert_enqueued_with` can pass.
+
+    *Andrew White*
+
 *   Ensure all bug report templates set `config.secret_key_base` to avoid
     generation of `tmp/local_secret.txt` files when running the report template.
 

--- a/guides/bug_report_templates/action_view.rb
+++ b/guides/bug_report_templates/action_view.rb
@@ -18,6 +18,7 @@ class TestApp < Rails::Application
   config.load_defaults Rails::VERSION::STRING.to_f
   config.eager_load = false
   config.logger = Logger.new($stdout)
+  config.secret_key_base = "secret_key_base"
 end
 Rails.application.initialize!
 

--- a/guides/bug_report_templates/active_job.rb
+++ b/guides/bug_report_templates/active_job.rb
@@ -17,6 +17,7 @@ class TestApp < Rails::Application
   config.load_defaults Rails::VERSION::STRING.to_f
   config.eager_load = false
   config.secret_key_base = "secret_key_base"
+  config.active_job.queue_adapter = :test
 
   config.logger = Logger.new($stdout)
 end

--- a/guides/bug_report_templates/active_record.rb
+++ b/guides/bug_report_templates/active_record.rb
@@ -22,6 +22,7 @@ class TestApp < Rails::Application
   config.load_defaults Rails::VERSION::STRING.to_f
   config.eager_load = false
   config.logger = Logger.new($stdout)
+  config.secret_key_base = "secret_key_base"
 end
 Rails.application.initialize!
 

--- a/guides/bug_report_templates/active_record_migrations.rb
+++ b/guides/bug_report_templates/active_record_migrations.rb
@@ -22,6 +22,7 @@ class TestApp < Rails::Application
   config.load_defaults Rails::VERSION::STRING.to_f
   config.eager_load = false
   config.logger = Logger.new($stdout)
+  config.secret_key_base = "secret_key_base"
 end
 Rails.application.initialize!
 


### PR DESCRIPTION
Whilst investigating some bugs recently I noticed the report templates were generating `local_secret.txt` files in my working directory. Upon investigation I could see that after #53642 the Rails application in the templates for Active Job, Active Record and Active Record Migrations was being initialized. Previously these were treated as standalone gems that didn't require an application to be initialized so the `config.secret_key_base` was never set like other templates.

On checking my changes I also discovered the template for Active Job was failing by default as the queue adapter was not set to `:test` which the `assert_enqueued_with` method relies on.