### PR TITLE
Fix code render in `ActionController::Caching` docs [ci skip]

### DIFF
--- a/actionpack/lib/action_controller/caching.rb
+++ b/actionpack/lib/action_controller/caching.rb
@@ -9,9 +9,8 @@ module ActionController
   # of calculations, renderings, and database calls around for subsequent
   # requests.
   #
-  # You can read more about each approach by clicking the modules below.
-  #
   # Note: To turn off all caching provided by Action Controller, set
+  #
   #     config.action_controller.perform_caching = false
   #
   # ## Caching stores


### PR DESCRIPTION
Changes:

- The configuration code example was not being highlighted correcly
- There is not a module list below
