### PR TITLE
Remove note about nested locale folders configuration

### DIFF
--- a/guides/source/i18n.md
+++ b/guides/source/i18n.md
@@ -589,13 +589,6 @@ For example, your `config/locales` directory could look like this:
 
 This way, you can separate model and model attribute names from text inside views, and all of this from the "defaults" (e.g. date and time formats). Other stores for the i18n library could provide different means of such separation.
 
-NOTE: The default locale loading mechanism in Rails does not load locale files in nested dictionaries, like we have here. So, for this to work, we must explicitly tell Rails to look further:
-
-```ruby
-# config/application.rb
-config.i18n.load_path += Dir[Rails.root.join("config", "locales", "**", "*.{rb,yml}")]
-```
-
 Overview of the I18n API Features
 ---------------------------------
 


### PR DESCRIPTION
This was added in #41872 and released in Rails 7.0

Fixes #53912.
