### PR TITLE
Rewrite confusing code for getting association class

### DIFF
--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -425,10 +425,14 @@ module ActiveRecord
 
       def _klass(class_name) # :nodoc:
         if active_record.name.demodulize == class_name
-          return compute_class("::#{class_name}") rescue NameError
+          begin
+            compute_class("::#{class_name}")
+          rescue NameError
+            compute_class(class_name)
+          end
+        else
+          compute_class(class_name)
         end
-
-        compute_class(class_name)
       end
 
       def compute_class(name)


### PR DESCRIPTION
Follow up to #51948.

I had a hard time understanding how the code in the 
`return compute_class("::#{class_name}") rescue NameError` works.

Whether it works like
```ruby
return (compute_class("::#{class_name}") rescue NameError)
```

or like
```ruby
return begin
  compute_class("::#{class_name}") 
rescue NameError
  nil
end
```

or like 
```ruby
return begin
  compute_class("::#{class_name}") 
rescue 
  NameError
end
```
because `return Foo rescue NameError` returns `NameError` 😱

Only after looking at the AST, turns our it works like
```ruby
begin
  return compute_class("::#{class_name}") 
rescue NameError
end
```