### PR TITLE
Deprecate `ActiveSupport::Configurable`

### DIFF
--- a/actionmailer/lib/action_mailer/railtie.rb
+++ b/actionmailer/lib/action_mailer/railtie.rb
@@ -73,12 +73,6 @@ module ActionMailer
       app.config.paths["test/mailers/previews"].concat(options.preview_paths)
     end
 
-    initializer "action_mailer.compile_config_methods" do
-      ActiveSupport.on_load(:action_mailer) do
-        config.compile_methods! if config.respond_to?(:compile_methods!)
-      end
-    end
-
     config.after_initialize do |app|
       options = app.config.action_mailer
 

--- a/actionpack/lib/abstract_controller/asset_paths.rb
+++ b/actionpack/lib/abstract_controller/asset_paths.rb
@@ -7,8 +7,10 @@ module AbstractController
     extend ActiveSupport::Concern
 
     included do
-      config_accessor :asset_host, :assets_dir, :javascripts_dir,
-        :stylesheets_dir, :default_asset_host_protocol, :relative_url_root
+      singleton_class.delegate :asset_host, :asset_host=, :assets_dir, :assets_dir=, :javascripts_dir, :javascripts_dir=,
+        :stylesheets_dir, :stylesheets_dir=, :default_asset_host_protocol, :default_asset_host_protocol=, :relative_url_root, :relative_url_root=, to: :config
+      delegate :asset_host, :asset_host=, :assets_dir, :assets_dir=, :javascripts_dir, :javascripts_dir=,
+        :stylesheets_dir, :stylesheets_dir=, :default_asset_host_protocol, :default_asset_host_protocol=, :relative_url_root, :relative_url_root=, to: :config
     end
   end
 end

--- a/actionpack/lib/abstract_controller/caching.rb
+++ b/actionpack/lib/abstract_controller/caching.rb
@@ -32,13 +32,16 @@ module AbstractController
     included do
       extend ConfigMethods
 
-      config_accessor :default_static_extension
+      singleton_class.delegate :default_static_extension, :default_static_extension=, to: :config
+      delegate :default_static_extension, :default_static_extension=, to: :config
       self.default_static_extension ||= ".html"
 
-      config_accessor :perform_caching
+      singleton_class.delegate :perform_caching, :perform_caching=, to: :config
+      delegate :perform_caching, :perform_caching=, to: :config
       self.perform_caching = true if perform_caching.nil?
 
-      config_accessor :enable_fragment_cache_logging
+      singleton_class.delegate :enable_fragment_cache_logging, :enable_fragment_cache_logging=, to: :config
+      delegate :enable_fragment_cache_logging, :enable_fragment_cache_logging=, to: :config
       self.enable_fragment_cache_logging = false
 
       class_attribute :_view_cache_dependencies, default: []

--- a/actionpack/lib/abstract_controller/logger.rb
+++ b/actionpack/lib/abstract_controller/logger.rb
@@ -9,7 +9,8 @@ module AbstractController
     extend ActiveSupport::Concern
 
     included do
-      config_accessor :logger
+      singleton_class.delegate :logger, :logger=, to: :config
+      delegate :logger, :logger=, to: :config
       include ActiveSupport::Benchmarkable
     end
   end

--- a/actionpack/lib/action_controller/metal/request_forgery_protection.rb
+++ b/actionpack/lib/action_controller/metal/request_forgery_protection.rb
@@ -71,32 +71,39 @@ module ActionController # :nodoc:
     included do
       # Sets the token parameter name for RequestForgery. Calling
       # `protect_from_forgery` sets it to `:authenticity_token` by default.
-      config_accessor :request_forgery_protection_token
+      singleton_class.delegate :request_forgery_protection_token, :request_forgery_protection_token=, to: :config
+      delegate :request_forgery_protection_token, :request_forgery_protection_token=, to: :config
       self.request_forgery_protection_token ||= :authenticity_token
 
       # Holds the class which implements the request forgery protection.
-      config_accessor :forgery_protection_strategy
+      singleton_class.delegate :forgery_protection_strategy, :forgery_protection_strategy=, to: :config
+      delegate :forgery_protection_strategy, :forgery_protection_strategy=, to: :config
       self.forgery_protection_strategy = nil
 
       # Controls whether request forgery protection is turned on or not. Turned off by
       # default only in test mode.
-      config_accessor :allow_forgery_protection
+      singleton_class.delegate :allow_forgery_protection, :allow_forgery_protection=, to: :config
+      delegate :allow_forgery_protection, :allow_forgery_protection=, to: :config
       self.allow_forgery_protection = true if allow_forgery_protection.nil?
 
       # Controls whether a CSRF failure logs a warning. On by default.
-      config_accessor :log_warning_on_csrf_failure
+      singleton_class.delegate :log_warning_on_csrf_failure, :log_warning_on_csrf_failure=, to: :config
+      delegate :log_warning_on_csrf_failure, :log_warning_on_csrf_failure=, to: :config
       self.log_warning_on_csrf_failure = true
 
       # Controls whether the Origin header is checked in addition to the CSRF token.
-      config_accessor :forgery_protection_origin_check
+      singleton_class.delegate :forgery_protection_origin_check, :forgery_protection_origin_check=, to: :config
+      delegate :forgery_protection_origin_check, :forgery_protection_origin_check=, to: :config
       self.forgery_protection_origin_check = false
 
       # Controls whether form-action/method specific CSRF tokens are used.
-      config_accessor :per_form_csrf_tokens
+      singleton_class.delegate :per_form_csrf_tokens, :per_form_csrf_tokens=, to: :config
+      delegate :per_form_csrf_tokens, :per_form_csrf_tokens=, to: :config
       self.per_form_csrf_tokens = false
 
       # The strategy to use for storing and retrieving CSRF tokens.
-      config_accessor :csrf_token_storage_strategy
+      singleton_class.delegate :csrf_token_storage_strategy, :csrf_token_storage_strategy=, to: :config
+      delegate :csrf_token_storage_strategy, :csrf_token_storage_strategy=, to: :config
       self.csrf_token_storage_strategy = SessionStore.new
 
       helper_method :form_authenticity_token

--- a/actionpack/lib/action_controller/railtie.rb
+++ b/actionpack/lib/action_controller/railtie.rb
@@ -93,12 +93,6 @@ module ActionController
       end
     end
 
-    initializer "action_controller.compile_config_methods" do
-      ActiveSupport.on_load(:action_controller) do
-        config.compile_methods! if config.respond_to?(:compile_methods!)
-      end
-    end
-
     initializer "action_controller.request_forgery_protection" do |app|
       ActiveSupport.on_load(:action_controller_base) do
         if app.config.action_controller.default_protect_from_forgery

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Deprecate `ActiveSupport::Configurable`
+
+    *Sean Doyle*
+
 *   `nil.to_query("key")` now returns `key`.
 
     Previously it would return `key=`, preventing round tripping with `Rack::Utils.parse_nested_query`.

--- a/activesupport/lib/active_support.rb
+++ b/activesupport/lib/active_support.rb
@@ -91,6 +91,10 @@ module ActiveSupport
   autoload :SafeBuffer, "active_support/core_ext/string/output_safety"
   autoload :TestCase
 
+  include Deprecation::DeprecatedConstantAccessor
+
+  deprecate_constant :Configurable, "class_attribute :config, default: {}", deprecator: ActiveSupport.deprecator
+
   def self.eager_load!
     super
 


### PR DESCRIPTION
### Motivation / Background

This proposal is based on a [code review comment][]:

> I think we should deprecate and remove this module. It is only used
> once inside the framework, in a place that perhaps don't even need it
> anymore and I don't think it adds much for our users. They would be
> better served with their own config object that is just a hash.

### Detail

To achieve this outcome, replace the only internal occurrence of `ActiveSupport::Configurable` with a [class_attribute][]. Similarly, replace [config_accessor][] calls with class- and instance-level calls to [delegate][] for the readers and writers.

[code review comment]: https://github.com/rails/rails/pull/53796#issuecomment-2512417545
[class_attribute]: https://edgeapi.rubyonrails.org/classes/Class.html#method-i-class_attribute
[config_accessor]: https://edgeapi.rubyonrails.org/classes/ActiveSupport/Configurable/ClassMethods.html#method-i-config_accessor
[delegate]: https://edgeapi.rubyonrails.org/classes/Module.html#method-i-delegate

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
