### PR TITLE
Don't cache `module_parent_name` on anonymous modules

### DIFF
--- a/activesupport/lib/active_support/core_ext/module/introspection.rb
+++ b/activesupport/lib/active_support/core_ext/module/introspection.rb
@@ -10,6 +10,9 @@ class Module
     if defined?(@parent_name)
       @parent_name
     else
+      name = self.name
+      return if name.nil?
+
       parent_name = name =~ /::[^:]+\z/ ? -$` : nil
       @parent_name = parent_name unless frozen?
       parent_name

--- a/activesupport/test/core_ext/module/introspection_test.rb
+++ b/activesupport/test/core_ext/module/introspection_test.rb
@@ -26,6 +26,15 @@ class IntrospectionTest < ActiveSupport::TestCase
     assert_equal "ParentA::B", ParentA::B::FrozenC.module_parent_name
   end
 
+  def test_module_parent_name_notice_changes
+    klass = Class.new
+    assert_nil klass.module_parent_name
+    ParentA.const_set(:NewClass, klass)
+    assert_equal "ParentA", klass.module_parent_name
+  ensure
+    ParentA.send(:remove_const, :NewClass) if ParentA.const_defined?(:NewClass)
+  end
+
   def test_module_parent
     assert_equal ParentA::B, ParentA::B::C.module_parent
     assert_equal ParentA, ParentA::B.module_parent
@@ -35,5 +44,14 @@ class IntrospectionTest < ActiveSupport::TestCase
   def test_module_parents
     assert_equal [ParentA::B, ParentA, Object], ParentA::B::C.module_parents
     assert_equal [ParentA, Object], ParentA::B.module_parents
+  end
+
+  def test_module_parent_notice_changes
+    klass = Class.new
+    assert_equal Object, klass.module_parent
+    ParentA.const_set(:NewClass, klass)
+    assert_equal ParentA, klass.module_parent
+  ensure
+    ParentA.send(:remove_const, :NewClass) if ParentA.const_defined?(:NewClass)
   end
 end


### PR DESCRIPTION
Fix: https://github.com/rails/rails/issues/53968

An anonymous module can become named if assigned later, hence it's incorrect to cache `module_parent_name` if the module is anonymous.
