### PR TITLE
[Fixes #53758] Raise `ActiveRecord::ReadOnlyError` on lock query while preventing writes

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Raise `ActiveRecord::ReadOnlyError` when attempting a locking query in readonly mode.
+
+    *Joshua Young*
+
 *   Serialized attributes can now be marked as comparable.
 
     A not rare issue when working with serialized attributes is that the serialized representation of an object

--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -119,6 +119,12 @@ module ActiveRecord
         raise NotImplementedError
       end
 
+      # Determines whether the SQL statement is a lock query, specifically one that
+      # cannot be executed inside a read-only transaction.
+      def lock_query?(sql)
+        raise NotImplementedError
+      end
+
       # Executes the SQL statement in the context of this connection and returns
       # the raw result from the connection adapter.
       #
@@ -580,6 +586,7 @@ module ActiveRecord
 
         def preprocess_query(sql)
           check_if_write_query(sql)
+          check_if_lock_query(sql)
           mark_transaction_written_if_write(sql)
 
           # We call tranformers after the write checks so we don't add extra parsing work.

--- a/activerecord/lib/active_record/connection_adapters/mysql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/database_statements.rb
@@ -20,6 +20,22 @@ module ActiveRecord
           !READ_QUERY.match?(sql.b)
         end
 
+        LOCK_QUERY = ActiveRecord::ConnectionAdapters::AbstractAdapter.build_lock_query_regexp(
+          # table-level locks
+          :lock_table, :lock_tables, :unlock_table, :unlock_tables,
+          # row-level locks
+          :for_update, :for_share,
+          # read lock for table flushing
+          :read_lock
+        ) # :nodoc:
+        private_constant :LOCK_QUERY
+
+        def lock_query?(sql) # :nodoc:
+          LOCK_QUERY.match?(sql)
+        rescue ArgumentError # Invalid encoding
+          LOCK_QUERY.match?(sql.b)
+        end
+
         def high_precision_current_timestamp
           HIGH_PRECISION_CURRENT_TIMESTAMP
         end

--- a/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
@@ -27,6 +27,21 @@ module ActiveRecord
           !READ_QUERY.match?(sql.b)
         end
 
+        LOCK_QUERY = ActiveRecord::ConnectionAdapters::AbstractAdapter.build_lock_query_regexp(
+          # table-level locks
+          :in_access_share_mode, :in_row_share_mode, :in_row_exclusive_mode, :in_share_update_exclusive_mode,
+          :in_share_mode, :in_share_row_exclusive_mode, :in_exclusive_mode, :in_access_exclusive_mode,
+          # row-level locks
+          :for_update, :for_no_key_update, :for_share, :for_key_share
+        ) # :nodoc:
+        private_constant :LOCK_QUERY
+
+        def lock_query?(sql) # :nodoc:
+          LOCK_QUERY.match?(sql)
+        rescue ArgumentError # Invalid encoding
+          LOCK_QUERY.match?(sql.b)
+        end
+
         # Executes an SQL statement, returning a PG::Result object on success
         # or raising a PG::Error exception otherwise.
         #

--- a/activerecord/lib/active_record/connection_adapters/sqlite3/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3/database_statements.rb
@@ -15,6 +15,18 @@ module ActiveRecord
           !READ_QUERY.match?(sql.b)
         end
 
+        LOCK_QUERY = ActiveRecord::ConnectionAdapters::AbstractAdapter.build_lock_query_regexp(
+          # transaction locks
+          :immediate_transaction, :exclusive_transaction,
+        ) # :nodoc:
+        private_constant :LOCK_QUERY
+
+        def lock_query?(sql) # :nodoc:
+          LOCK_QUERY.match?(sql)
+        rescue ArgumentError # Invalid encoding
+          LOCK_QUERY.match?(sql.b)
+        end
+
         def explain(arel, binds = [], _options = [])
           sql    = "EXPLAIN QUERY PLAN " + to_sql(arel, binds)
           result = internal_exec_query(sql, "EXPLAIN", [])

--- a/activerecord/test/cases/adapters/abstract_mysql_adapter/adapter_prevent_writes_test.rb
+++ b/activerecord/test/cases/adapters/abstract_mysql_adapter/adapter_prevent_writes_test.rb
@@ -109,3 +109,86 @@ class AdapterPreventWritesTest < ActiveRecord::AbstractMysqlTestCase
       super(@conn, "ex", definition, &block)
     end
 end
+
+class AdapterPreventWritesLocksTest < ActiveRecord::AbstractMysqlTestCase
+  include DdlHelper
+
+  def setup
+    @conn = ActiveRecord::Base.lease_connection
+  end
+
+  def test_lock_table_raises_error_while_preventing_writes
+    with_example_table do
+      ActiveRecord::Base.while_preventing_writes do
+        assert_raises(ActiveRecord::ReadOnlyError) do
+          @conn.execute("LOCK TABLE `ex` WRITE")
+        end
+      end
+    end
+  end
+
+  def test_lock_tables_raises_error_while_preventing_writes
+    with_example_table do
+      ActiveRecord::Base.while_preventing_writes do
+        assert_raises(ActiveRecord::ReadOnlyError) do
+          @conn.execute("LOCK TABLES `ex` WRITE")
+        end
+      end
+    end
+  end
+
+  def test_unlock_table_raises_error_while_preventing_writes
+    with_example_table do
+      ActiveRecord::Base.while_preventing_writes do
+        assert_raises(ActiveRecord::ReadOnlyError) do
+          @conn.execute("UNLOCK TABLE")
+        end
+      end
+    end
+  end
+
+  def test_unlock_tables_raises_error_while_preventing_writes
+    with_example_table do
+      ActiveRecord::Base.while_preventing_writes do
+        assert_raises(ActiveRecord::ReadOnlyError) do
+          @conn.execute("UNLOCK TABLES")
+        end
+      end
+    end
+  end
+
+  def test_for_update_raises_error_while_preventing_writes
+    with_example_table do
+      ActiveRecord::Base.while_preventing_writes do
+        assert_raises(ActiveRecord::ReadOnlyError) do
+          @conn.execute("SELECT * FROM `ex` FOR UPDATE")
+        end
+      end
+    end
+  end
+
+  def test_for_share_raises_error_while_preventing_writes
+    with_example_table do
+      ActiveRecord::Base.while_preventing_writes do
+        assert_raises(ActiveRecord::ReadOnlyError) do
+          @conn.execute("SELECT * FROM `ex` FOR SHARE")
+        end
+      end
+    end
+  end
+
+  def test_read_lock_raises_error_while_preventing_writes
+    with_example_table do
+      ActiveRecord::Base.while_preventing_writes do
+        assert_raises(ActiveRecord::ReadOnlyError) do
+          @conn.execute("FLUSH TABLES WITH READ LOCK")
+        end
+      end
+    end
+  end
+
+  private
+    def with_example_table(definition = "id int auto_increment primary key, number int, data varchar(255)", &block)
+      super(@conn, "ex", definition, &block)
+    end
+end

--- a/activerecord/test/cases/adapters/postgresql/postgresql_adapter_prevent_writes_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/postgresql_adapter_prevent_writes_test.rb
@@ -98,5 +98,139 @@ module ActiveRecord
           super(@connection, "ex", definition, &block)
         end
     end
+
+    class PostgreSQLAdapterPreventWritesLocksTest < ActiveRecord::PostgreSQLTestCase
+      include DdlHelper
+      include ConnectionHelper
+
+      def setup
+        @connection = ActiveRecord::Base.lease_connection
+      end
+
+      def test_for_update_raises_error_while_preventing_writes
+        with_example_table do
+          ActiveRecord::Base.while_preventing_writes do
+            assert_raises(ActiveRecord::ReadOnlyError) do
+              @connection.execute("SELECT * FROM ex FOR UPDATE")
+            end
+          end
+        end
+      end
+
+      def test_for_no_key_update_raises_error_while_preventing_writes
+        with_example_table do
+          ActiveRecord::Base.while_preventing_writes do
+            assert_raises(ActiveRecord::ReadOnlyError) do
+              @connection.execute("SELECT * FROM ex FOR NO KEY UPDATE")
+            end
+          end
+        end
+      end
+
+      def test_for_share_raises_error_while_preventing_writes
+        with_example_table do
+          ActiveRecord::Base.while_preventing_writes do
+            assert_raises(ActiveRecord::ReadOnlyError) do
+              @connection.execute("SELECT * FROM ex FOR SHARE")
+            end
+          end
+        end
+      end
+
+      def test_for_key_share_raises_error_while_preventing_writes
+        with_example_table do
+          ActiveRecord::Base.while_preventing_writes do
+            assert_raises(ActiveRecord::ReadOnlyError) do
+              @connection.execute("SELECT * FROM ex FOR KEY SHARE")
+            end
+          end
+        end
+      end
+
+      def test_access_share_raises_error_while_preventing_writes
+        with_example_table do
+          ActiveRecord::Base.while_preventing_writes do
+            assert_raises(ActiveRecord::ReadOnlyError) do
+              @connection.execute("LOCK TABLE ex IN ACCESS SHARE MODE")
+            end
+          end
+        end
+      end
+
+      def test_row_share_raises_error_while_preventing_writes
+        with_example_table do
+          ActiveRecord::Base.while_preventing_writes do
+            assert_raises(ActiveRecord::ReadOnlyError) do
+              @connection.execute("LOCK TABLE ex IN ROW SHARE MODE")
+            end
+          end
+        end
+      end
+
+      def test_row_exclusive_raises_error_while_preventing_writes
+        with_example_table do
+          ActiveRecord::Base.while_preventing_writes do
+            assert_raises(ActiveRecord::ReadOnlyError) do
+              @connection.execute("LOCK TABLE ex IN ROW EXCLUSIVE MODE")
+            end
+          end
+        end
+      end
+
+      def test_share_update_exclusive_raises_error_while_preventing_writes
+        with_example_table do
+          ActiveRecord::Base.while_preventing_writes do
+            assert_raises(ActiveRecord::ReadOnlyError) do
+              @connection.execute("LOCK TABLE ex IN SHARE UPDATE EXCLUSIVE MODE")
+            end
+          end
+        end
+      end
+
+      def test_share_raises_error_while_preventing_writes
+        with_example_table do
+          ActiveRecord::Base.while_preventing_writes do
+            assert_raises(ActiveRecord::ReadOnlyError) do
+              @connection.execute("LOCK TABLE ex IN SHARE MODE")
+            end
+          end
+        end
+      end
+
+      def test_share_row_exclusive_raises_error_while_preventing_writes
+        with_example_table do
+          ActiveRecord::Base.while_preventing_writes do
+            assert_raises(ActiveRecord::ReadOnlyError) do
+              @connection.execute("LOCK TABLE ex IN SHARE ROW EXCLUSIVE MODE")
+            end
+          end
+        end
+      end
+
+      def test_exclusive_raises_error_while_preventing_writes
+        with_example_table do
+          ActiveRecord::Base.while_preventing_writes do
+            assert_raises(ActiveRecord::ReadOnlyError) do
+              @connection.execute("LOCK TABLE ex IN EXCLUSIVE MODE")
+            end
+          end
+        end
+      end
+
+      def test_access_exclusive_raises_error_while_preventing_writes
+        with_example_table do
+          ActiveRecord::Base.while_preventing_writes do
+            assert_raises(ActiveRecord::ReadOnlyError) do
+              @connection.execute("LOCK TABLE ex IN ACCESS EXCLUSIVE MODE")
+            end
+          end
+        end
+      end
+
+      private
+        def with_example_table(definition = "id serial primary key, number integer, data character varying(255)", &block)
+          super(@connection, "ex", definition, &block)
+        end
+    end
   end
 end


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

Raise `ActiveRecord::ReadOnlyError` when attempting a locking query in readonly mode i.e. `prevent_writes: true`. The locks covered by this logic are database/adapter-specific and ideally include only those that the database itself would raise an error for if attempted in a readonly session, such as on a replica.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.