### PR TITLE
ErrorSubscriber: also marks the error causes as reported

### DIFF
--- a/activesupport/lib/active_support/error_reporter.rb
+++ b/activesupport/lib/active_support/error_reporter.rb
@@ -232,8 +232,11 @@ module ActiveSupport
         end
       end
 
-      unless error.frozen?
-        error.instance_variable_set(:@__rails_error_reported, true)
+      while error
+        unless error.frozen?
+          error.instance_variable_set(:@__rails_error_reported, true)
+        end
+        error = error.cause
       end
 
       nil


### PR DESCRIPTION
Fix: https://github.com/rails/rails/issues/53938

In some cases like `Template::Error`, the error may be unwrapped up the stack and end up being reported twice.
