### PR TITLE
Remove redundant codes in section 16.4 of  getting_started.md [ci skip]

### DIFF
--- a/guides/source/getting_started.md
+++ b/guides/source/getting_started.md
@@ -2335,7 +2335,6 @@ Notifications module.
 class Product < ApplicationRecord
   include Notifications
 
-  has_many :subscribers, dependent: :destroy
   has_one_attached :featured_image
   has_rich_text :description
 


### PR DESCRIPTION
### Motivation / Background

When I was studying [Rails Guides - Getting Started with Rails](https://guides.rubyonrails.org/getting_started.html#extracting-a-concern) today, I founded in section 16.4  the concern module already include the `has_many` association as follows:

```ruby
module Product::Notifications
  extend ActiveSupport::Concern

  included do
    has_many :subscribers, dependent: :destroy
    after_update_commit :notify_subscribers, if: :back_in_stock?
  end
 
  # ...
end
```

But below it the `Product` model still include this association, I think it should be removed:

```ruby
class Product < ApplicationRecord
  include Notifications

  has_many :subscribers, dependent: :destroy
  # ...
end
```


