### PR TITLE
Fix `ActionDispatch::Executor` to unwrap exceptions like other middlewares

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/executor.rb
+++ b/actionpack/lib/action_dispatch/middleware/executor.rb
@@ -22,7 +22,10 @@ module ActionDispatch
 
         returned = response << ::Rack::BodyProxy.new(response.pop) { state.complete! }
       rescue => error
-        @executor.error_reporter.report(error, handled: false, source: "application.action_dispatch")
+        request = ActionDispatch::Request.new env
+        backtrace_cleaner = request.get_header("action_dispatch.backtrace_cleaner")
+        wrapper = ExceptionWrapper.new(backtrace_cleaner, error)
+        @executor.error_reporter.report(wrapper.unwrapped_exception, handled: false, source: "application.action_dispatch")
         raise
       ensure
         state.complete! unless returned


### PR DESCRIPTION
Fix: https://github.com/rails/rails/issues/53938

`ShowExceptions` and `DebugExceptions` know about some specific error classes that aren't meant to be displayed but simply wrap the real underlying error.

`ActionDispatch::Executor` should use the same logic.
