### PR TITLE
Use `limit` in `#sole`, not `first`.

### DIFF
--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -141,7 +141,7 @@ module ActiveRecord
     #
     #   Product.where(["price = %?", price]).sole
     def sole
-      found, undesired = first(2)
+      found, undesired = limit(2)
 
       if found.nil?
         raise_record_not_found_exception!


### PR DESCRIPTION
`first` forces an ordering even if we've deliberately removed any orderings on the underlying scope. Given the nature of `#sole`, this change doesn't affect the results, but does allow the user to omit orderings where it would pessimise the query (as we've discovered on a large site).