### PR TITLE
Fix `sum` with qualified name on loaded relation

### DIFF
--- a/activerecord/test/cases/calculations_test.rb
+++ b/activerecord/test/cases/calculations_test.rb
@@ -41,6 +41,18 @@ class CalculationsTest < ActiveRecord::TestCase
     assert_async_equal 318, Account.async_sum(Account.arel_table[:credit_limit])
   end
 
+  def test_should_sum_with_qualified_name_on_loaded
+    accounts = Account.all
+
+    assert_not_predicate accounts, :loaded?
+    assert_equal 318, accounts.sum("accounts.credit_limit")
+
+    accounts.load
+
+    assert_predicate accounts, :loaded?
+    assert_equal 318, accounts.sum("accounts.credit_limit")
+  end
+
   def test_should_average_field
     assert_equal 53.0, Account.average(:credit_limit)
     assert_async_equal 53.0, Account.async_average(:credit_limit)


### PR DESCRIPTION
Since #53064, calling `sum` with a qualified name on a loaded relation raised `ActiveRecord::UnmodifiableRelation`.

This appears to have been a regression between v7.2.1 and v7.2.2 due to 23284acc7eb79d1d3755fb1ad8525a04d3bc03d8. It's still broken on main as well.

It seems very similar to #53264, so I looked to that for guidance on the test and fix.

### Steps to Reproduce
```ruby
# frozen_string_literal: true

require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"

  gem "rails"
  # If you want to test against edge Rails replace the previous line with this:
  # gem "rails", github: "rails/rails", branch: "main"

  gem "sqlite3"
end

require "active_record/railtie"
require "minitest/autorun"

# This connection will do for database-independent bug reports.
ENV["DATABASE_URL"] = "sqlite3::memory:"

class TestApp < Rails::Application
  config.load_defaults Rails::VERSION::STRING.to_f
  config.eager_load = false
  config.logger = Logger.new($stdout)
  config.secret_key_base = "secret_key_base"
end
Rails.application.initialize!

ActiveRecord::Schema.define do
  create_table :posts, force: true do |t|
  end

  create_table :comments, force: true do |t|
    t.integer :post_id
  end
end

class Post < ActiveRecord::Base
  has_many :comments
end

class Comment < ActiveRecord::Base
  belongs_to :post
end

class BugTest < ActiveSupport::TestCase
  def test_calculation_with_qualified_name_on_loaded
    posts = Post.all

    assert_not_predicate posts, :loaded?
    assert_equal 0, posts.count("posts.id")

    posts.load

    assert_predicate posts, :loaded?
    assert_equal 0, posts.count("posts.id")
  end
end
```

### Backtrace
```
ActiveRecord::UnmodifiableRelation: ActiveRecord::UnmodifiableRelation
    /Users/chrisgunther/.gem/ruby/3.3.2/gems/activerecord-8.0.1/lib/active_record/relation/query_methods.rb:1747:in `assert_modifiable!'
    /Users/chrisgunther/.gem/ruby/3.3.2/gems/activerecord-8.0.1/lib/active_record/relation/query_methods.rb:179:in `references_values='
    /Users/chrisgunther/.gem/ruby/3.3.2/gems/activerecord-8.0.1/lib/active_record/relation/query_methods.rb:1979:in `arel_column_with_table'
    /Users/chrisgunther/.gem/ruby/3.3.2/gems/activerecord-8.0.1/lib/active_record/relation/query_methods.rb:1999:in `arel_column'
    /Users/chrisgunther/.gem/ruby/3.3.2/gems/activerecord-8.0.1/lib/active_record/relation/calculations.rb:460:in `aggregate_column'
    /Users/chrisgunther/.gem/ruby/3.3.2/gems/activerecord-8.0.1/lib/active_record/relation/calculations.rb:479:in `execute_simple_calculation'
    /Users/chrisgunther/.gem/ruby/3.3.2/gems/activerecord-8.0.1/lib/active_record/relation/calculations.rb:445:in `perform_calculation'
    /Users/chrisgunther/.gem/ruby/3.3.2/gems/activerecord-8.0.1/lib/active_record/relation/calculations.rb:245:in `calculate'
    /Users/chrisgunther/.gem/ruby/3.3.2/gems/activerecord-8.0.1/lib/active_record/relation/calculations.rb:102:in `count'
    bug.rb:56:in `test_calculation_with_qualified_name_on_loaded'
```