### PR TITLE
Add has_complex_password method for out of the box password complexity validation

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,2 +1,5 @@
+*   Introduce `has_complex_password` method to allow for out of the box complex password validation
+
+    *Baden Ashford*
 
 Please check [8-0-stable](https://github.com/rails/rails/blob/8-0-stable/activemodel/CHANGELOG.md) for previous changes.

--- a/activemodel/lib/active_model.rb
+++ b/activemodel/lib/active_model.rb
@@ -41,6 +41,7 @@ module ActiveModel
   autoload :AttributeRegistration
   autoload :BlockValidator, "active_model/validator"
   autoload :Callbacks
+  autoload :ComplexPassword
   autoload :Conversion
   autoload :Dirty
   autoload :EachValidator, "active_model/validator"

--- a/activemodel/lib/active_model/complex_password.rb
+++ b/activemodel/lib/active_model/complex_password.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+module ActiveModel
+  module ComplexPassword
+    extend ActiveSupport::Concern
+
+    module ClassMethods
+      # Adds methods to allow for password complexity validation across
+      # presence of a number, special character, lowercase letter, and uppercase letter.
+      #
+      # ==== Examples
+      #
+      # ===== Using default password complexity requirements
+      #   class User
+      #     include ActiveModel::ComplexPassword
+      #     attr_accessor :password
+      #     has_complex_password
+      #   end
+      #
+      #   user = User.new
+      #   user
+      #   user.valid? # => false
+      #   user.errors[:password] # => ["can't be blank", "must contain at least one number", "must contain at least one special character", "must contain at least one lowercase letter", "must contain at least one uppercase letter"]
+      #
+      #   user = User.new(password = "Abc123!")
+      #   user.valid? # => true
+      #
+      # ===== Customizing password complexity requirements
+      #   class User
+      #     include ActiveModel::ComplexPassword
+      #     attr_accessor :secret
+      #     has_complex_password(:secret, must_contain_number: false)
+      #   end
+      #
+      #   user = User.new
+      #   user.valid? # => false
+      #   user.errors[:secret] # => ["can't be blank", "must contain at least one special character", "must contain at least one lowercase letter", "must contain at least one uppercase letter"]
+      #
+      #   user = User.new(password = "ABCabc!")
+      #   user.valid? # => true
+      def has_complex_password(
+        attribute = :password,
+        must_contain_number: true,
+        must_contain_special_character: true,
+        must_contain_lowercase: true,
+        must_contain_uppercase: true,
+        special_characters: "!?@#$%^&*()_+-=[]{}|:;<>,./")
+
+        validate do |record|
+          record.errors.add(attribute, :blank) unless record.public_send(attribute).present?
+        end
+
+        validate do |record|
+          if record.public_send(attribute).present?
+            password = record.public_send(attribute)
+
+            record.errors.add(attribute, :must_contain_number) if must_contain_number && !password.match(/\d/)
+            record.errors.add(attribute, :must_contain_special_character) if must_contain_special_character && !password.match(/[#{Regexp.escape(special_characters)}]/)
+            record.errors.add(attribute, :must_contain_lowercase) if must_contain_lowercase && !password.match(/\p{Lower}/)
+            record.errors.add(attribute, :must_contain_uppercase) if must_contain_uppercase && !password.match(/\p{Upper}/)
+          end
+        end
+      end
+    end
+  end
+end

--- a/activemodel/lib/active_model/locale/en.yml
+++ b/activemodel/lib/active_model/locale/en.yml
@@ -36,3 +36,7 @@ en:
       in: "must be in %{count}"
       odd: "must be odd"
       even: "must be even"
+      must_contain_lowercase: "must contain at least one lowercase letter"
+      must_contain_uppercase: "must contain at least one uppercase letter"
+      must_contain_number: "must contain at least one number"
+      must_contain_special_character: "must contain at least one special character"

--- a/activemodel/test/cases/complex_password_test.rb
+++ b/activemodel/test/cases/complex_password_test.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+
+class ComplexPasswordTest < ActiveModel::TestCase
+  class ComplexPasswordUser
+    include ActiveModel::Model
+    include ActiveModel::ComplexPassword
+
+    attr_accessor :password
+
+    has_complex_password
+  end
+
+  test "password must contain a number" do
+    user = ComplexPasswordUser.new(password: "Abcdef!")
+    user.valid?
+    assert_equal ["must contain at least one number"], user.errors[:password]
+  end
+
+  test "password must contain a special character" do
+    user = ComplexPasswordUser.new(password: "Abcdef1")
+    user.valid?
+    assert_equal ["must contain at least one special character"], user.errors[:password]
+  end
+
+  test "password must contain at least one lowercase letter" do
+    user = ComplexPasswordUser.new(password: "ABCDEF1!")
+    user.valid?
+    assert_equal ["must contain at least one lowercase letter"], user.errors[:password]
+  end
+
+  test "password must contain an uppercase letter" do
+    user = ComplexPasswordUser.new(password: "abcdef1!")
+    user.valid?
+    assert_equal ["must contain at least one uppercase letter"], user.errors[:password]
+  end
+
+  test "password must not be blank" do
+    user = ComplexPasswordUser.new(password: "")
+    user.valid?
+    assert_equal ["can't be blank"], user.errors[:password]
+  end
+
+  test "password is valid" do
+    user = ComplexPasswordUser.new(password: "Abc123!")
+    user.valid?
+    assert_empty user.errors[:password]
+  end
+end


### PR DESCRIPTION
### Motivation / Background
Inspired by my [PR on devise](https://github.com/heartcombo/devise/pull/5727), and the fact every rails repo I have been a part of has implemented this from first principles using active model validations 😄 

Password complexity is something all apps must have, this PR allows out of the box validation on all the usual password complexity stuff:
* presence of upper case
* presence of lower case
* presence of special character
* presence of number
 

### Detail

This PRt changes nothing out of the box, but surfaces the `has_strong_password` (name amendable of course). This method is configurable to allow the developer to more granularly validate the content of the attribute (usually `:password`) being validated on.

### Additional information
-

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
