### PR TITLE
Fix count with group by qualified name on loaded relation

### DIFF
--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -522,7 +522,9 @@ module ActiveRecord
           associated   = association && association.belongs_to? # only count belongs_to associations
           group_fields = Array(association.foreign_key) if associated
         end
-        group_fields = arel_columns(group_fields)
+
+        relation = except(:group).distinct!(false)
+        group_fields = relation.arel_columns(group_fields)
 
         model.with_connection do |connection|
           column_alias_tracker = ColumnAliasTracker.new(connection)
@@ -532,8 +534,6 @@ module ActiveRecord
             column_alias_tracker.alias_for(field.to_s.downcase)
           }
           group_columns = group_aliases.zip(group_fields)
-
-          relation = except(:group).distinct!(false)
 
           column = relation.aggregate_column(column_name)
           column_alias = column_alias_tracker.alias_for("#{operation} #{column_name.to_s.downcase}")

--- a/activerecord/test/cases/calculations_test.rb
+++ b/activerecord/test/cases/calculations_test.rb
@@ -53,6 +53,20 @@ class CalculationsTest < ActiveRecord::TestCase
     assert_equal 318, accounts.sum("accounts.credit_limit")
   end
 
+  def test_should_count_with_group_by_qualified_name_on_loaded
+    accounts = Account.group("accounts.id")
+
+    expected = { 1 => 1, 2 => 1, 3 => 1, 4 => 1, 5 => 1, 6 => 1 }
+
+    assert_not_predicate accounts, :loaded?
+    assert_equal expected, accounts.count
+
+    accounts.load
+
+    assert_predicate accounts, :loaded?
+    assert_equal expected, accounts.count
+  end
+
   def test_should_average_field
     assert_equal 53.0, Account.average(:credit_limit)
     assert_async_equal 53.0, Account.async_average(:credit_limit)


### PR DESCRIPTION
Run `arel_columns` on the spawned relation because `arel_columns` is no longer a side-effect free helper method since #53064.

Fixes #53934.
