### PR TITLE
Fix column overwriting issue when using `select("*")` with joins in ActiveRecord 

### DIFF
--- a/activerecord/lib/active_record/result.rb
+++ b/activerecord/lib/active_record/result.rb
@@ -206,7 +206,7 @@ module ActiveRecord
         hash = {}
         length  = columns.length
         while index < length
-          hash[columns[index]] = index
+          hash[columns[index]] ||= index
           index += 1
         end
         hash.freeze

--- a/activerecord/test/cases/result_test.rb
+++ b/activerecord/test/cases/result_test.rb
@@ -126,7 +126,7 @@ module ActiveRecord
       assert_equal 2, result.columns.size
       result.each do |row|
         assert_equal 1, row.size
-        assert_equal "col 2", row["foo"]
+        assert_equal "col 1", row["foo"]
       end
     end
   end


### PR DESCRIPTION
### Motivation / Background
Fixes #53998 (see there for the detailed description).

### Detail

Now, model attributes are not overwritten by columns with the same name from joined tables.
