### PR TITLE
[Guides] Update error reporting docs to include `test` env in description of .unexpected

### DIFF
--- a/guides/source/error_reporting.md
+++ b/guides/source/error_reporting.md
@@ -182,7 +182,7 @@ You can report any unexpected error by calling
 When called in production, this method will return nil after the error is
 reported and the execution of your code will continue.
 
-When called in development, the error will be wrapped in a new error class (to
+When called in development or test, the error will be wrapped in a new error class (to
 ensure it's not being rescued higher in the stack) and surfaced to the developer
 for debugging.
 


### PR DESCRIPTION
This is a small update to the error reporting rails guide:
https://guides.rubyonrails.org/error_reporting.html#reporting-unexpected-errors

It specifies the behaviour of `Rails.error.unexpected` and describes `production` and `development` but does not mention `test`. I had to go look it up.

Turns out the behaviour is tied to `debug_mode` which is set to `consider_all_requests_local`, so for normal cases dev and test are the same. This PR just adds "or test" to clarify behaviour in all envs.
https://github.com/rails/rails/blob/cf6ff17e9a3c6c1139040b519a341f55f0be16cf/activesupport/lib/active_support/error_reporter.rb#L148
https://github.com/rails/rails/blob/9af3004fbb3bbbd35ac5eb2004ebeb74c2d6ff2d/railties/lib/rails/application/bootstrap.rb#L70


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
