### PR TITLE
Let Rails decide when lazy load hooks are executed

### DIFF
--- a/activejob/test/support/integration/dummy_app_template.rb
+++ b/activejob/test/support/integration/dummy_app_template.rb
@@ -4,11 +4,6 @@ if ENV["AJ_ADAPTER"] == "delayed_job"
   generate "delayed_job:active_record", "--quiet"
 end
 
-initializer "activejob.rb", <<-CODE
-require "#{File.expand_path("jobs_manager.rb",  __dir__)}"
-JobsManager.current_manager.setup
-CODE
-
 initializer "i18n.rb", <<-CODE
 I18n.available_locales = [:en, :de]
 CODE

--- a/activejob/test/support/integration/helper.rb
+++ b/activejob/test/support/integration/helper.rb
@@ -24,6 +24,8 @@ Rails.backtrace_cleaner.remove_silencers!
 require_relative "test_case_helpers"
 ActiveSupport::TestCase.include(TestCaseHelpers)
 
+require_relative "jobs_manager"
+JobsManager.current_manager.setup
 JobsManager.current_manager.start_workers
 
 Minitest.after_run do

--- a/activesupport/test/lazy_load_hooks_test.rb
+++ b/activesupport/test/lazy_load_hooks_test.rb
@@ -174,6 +174,18 @@ class LazyLoadHooksTest < ActiveSupport::TestCase
     assert_equal "Hulk Hogan", context.second_wrestler
   end
 
+  def test_pausing_hooks
+    i = 0
+    ActiveSupport.load_hooks.pause
+    ActiveSupport.on_load(:paused_hook) { i += 1 }
+    ActiveSupport.run_load_hooks(:paused_hook)
+    assert_equal 0, i
+    ActiveSupport.load_hooks.start
+    assert_equal 1, i
+  ensure
+    ActiveSupport.load_hooks.start
+  end
+
 private
   def incr_amt
     5

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Let Rails decide when lazy load hooks are executed.
+
+    *Petrik de Heus*
+
 *   Don't enable YJIT in development and test environments
 
     Development and test environment tend to reload code and redefine methods (e.g. mocking),

--- a/railties/lib/rails/application/bootstrap.rb
+++ b/railties/lib/rails/application/bootstrap.rb
@@ -10,6 +10,11 @@ module Rails
     module Bootstrap
       include Initializable
 
+      # Don't run load hooks too early.
+      initializer :pause_load_hooks do |app|
+        ActiveSupport.load_hooks.pause
+      end
+
       initializer :load_environment_hook, group: :all do end
 
       initializer :load_active_support, group: :all do

--- a/railties/lib/rails/application/finisher.rb
+++ b/railties/lib/rails/application/finisher.rb
@@ -67,6 +67,10 @@ module Rails
         end
       end
 
+      initializer :start_load_hooks do |app|
+        ActiveSupport.load_hooks.start
+      end
+
       # This needs to happen before eager load so it happens
       # in exactly the same point regardless of config.eager_load
       initializer :run_prepare_callbacks do |app|

--- a/railties/test/application/initializers/frameworks_test.rb
+++ b/railties/test/application/initializers/frameworks_test.rb
@@ -374,7 +374,9 @@ module ApplicationTests
 
     test "connections checked out during initialization are returned to the pool" do
       app_file "config/initializers/active_record.rb", <<-RUBY
-        ActiveRecord::Base.lease_connection
+        Rails.application.config.to_prepare do
+          ActiveRecord::Base.lease_connection
+        end
       RUBY
       app("development")
       assert_not_predicate ActiveRecord::Base.connection_pool, :active_connection?

--- a/railties/test/application/query_logs_test.rb
+++ b/railties/test/application/query_logs_test.rb
@@ -89,8 +89,10 @@ module ApplicationTests
     test "controller and job tags are defined by default" do
       add_to_config "config.active_record.query_log_tags_enabled = true"
       app_file "config/initializers/active_record.rb", <<-RUBY
-        raise "Expected prepared_statements to be enabled" unless ActiveRecord::Base.lease_connection.prepared_statements
-        ActiveRecord::Base.lease_connection.execute("SELECT 1")
+        Rails.application.config.to_prepare do
+          raise "Expected prepared_statements to be enabled" unless ActiveRecord::Base.lease_connection.prepared_statements
+          ActiveRecord::Base.lease_connection.execute("SELECT 1")
+        end
       RUBY
 
       boot_app


### PR DESCRIPTION
LazyLoadHooks can load frameworks to early when accessing frameworks prematurely in initializers. By delaying execution until Rails decides it's safe, we can prevent premature loading of frameworks.

This adds the ability to LazyLoadHooks to pause executing load hooks. An
initializer is added that pauses the load hooks when bootstrapping.
Another initializer starts the load hooks just before the
`:run_prepare_callbacks` initializer, so `to_prepare` blocks still work
as expected.

This also wraps the logic into a seperate class to reduce polluting of ActiveSupport with instance variables.

Fixes: #50133

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
