### PR TITLE
[docs] Add `active_record_encryption.rb` bug report template

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,6 +16,13 @@
 
 * If possible, use the relevant bug report templates to create the issue. Simply copy the content of the appropriate template into a .rb file, make the necessary changes to demonstrate the issue, and **paste the content into the issue description**:
   * [**Active Record** (models, database) issues](https://github.com/rails/rails/blob/main/guides/bug_report_templates/active_record.rb)
+  * [**Active Record Migrations** issues](https://github.com/rails/rails/blob/main/guides/bug_report_templates/active_record_migrations.rb)
+  * [**Active Record Encryption** issues](https://github.com/rails/rails/blob/main/guides/bug_report_templates/active_record_encryption.rb)
+  * [**Action View** (views, helpers) issues](https://github.com/rails/rails/blob/main/guides/bug_report_templates/action_view.rb)
+  * [**Active Job** issues](https://github.com/rails/rails/blob/main/guides/bug_report_templates/active_job.rb)
+  * [**Active Storage** issues](https://github.com/rails/rails/blob/main/guides/bug_report_templates/active_storage.rb)
+  * [**Action Mailer** issues](https://github.com/rails/rails/blob/main/guides/bug_report_templates/action_mailer.rb)
+  * [**Action Mailbox** issues](https://github.com/rails/rails/blob/main/guides/bug_report_templates/action_mailbox.rb)
   * [**Action Pack** (controllers, routing) issues](https://github.com/rails/rails/blob/main/guides/bug_report_templates/action_controller.rb)
   * [**Generic template** for other issues](https://github.com/rails/rails/blob/main/guides/bug_report_templates/generic.rb)
 

--- a/guides/bug_report_templates/active_record_encryption.rb
+++ b/guides/bug_report_templates/active_record_encryption.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require "bundler/inline"
+
+gemfile(true) do
+  source "https://rubygems.org"
+
+  gem "rails"
+  # If you want to test against edge Rails replace the previous line with this:
+  # gem "rails", github: "rails/rails", branch: "main"
+
+  gem "sqlite3"
+end
+
+require "active_record/railtie"
+require "minitest/autorun"
+
+# This connection will do for database-independent bug reports.
+ENV["DATABASE_URL"] = "sqlite3::memory:"
+
+class TestApp < Rails::Application
+  config.load_defaults Rails::VERSION::STRING.to_f
+  config.eager_load = false
+  config.logger = Logger.new($stdout)
+  config.secret_key_base = "secret_key_base"
+
+  config.active_record.encryption.primary_key = "primary_key"
+  config.active_record.encryption.deterministic_key = "deterministic_key"
+  config.active_record.encryption.key_derivation_salt = "key_derivation_salt"
+end
+Rails.application.initialize!
+
+ActiveRecord::Schema.define do
+  create_table :users, force: true do |t|
+    t.string :email
+  end
+end
+
+class User < ActiveRecord::Base
+  encrypts :email
+end
+
+class BugTest < ActiveSupport::TestCase
+  def test_encryption_stuff
+    post = User.create!(email: "test@example.com")
+
+    encrypted_email = post.read_attribute_before_type_cast(:email)
+
+    assert_not_equal "test@example.com", encrypted_email
+    assert_not_equal post.read_attribute(:email), encrypted_email
+
+    assert_equal "test@example.com", post.email
+  end
+end

--- a/guides/source/contributing_to_ruby_on_rails.md
+++ b/guides/source/contributing_to_ruby_on_rails.md
@@ -41,6 +41,7 @@ Having a way to reproduce your issue will help people confirm, investigate, and 
 
 * Template for Active Record (models, database) issues: [link](https://github.com/rails/rails/blob/main/guides/bug_report_templates/active_record.rb)
 * Template for testing Active Record (migration) issues: [link](https://github.com/rails/rails/blob/main/guides/bug_report_templates/active_record_migrations.rb)
+* Template for Active Record Encryption issues: [link](https://github.com/rails/rails/blob/main/guides/bug_report_templates/active_record_encryption.rb)
 * Template for Action Pack (controllers, routing) issues: [link](https://github.com/rails/rails/blob/main/guides/bug_report_templates/action_controller.rb)
 * Template for Action View (views, helpers) issues: [link](https://github.com/rails/rails/blob/main/guides/bug_report_templates/action_view.rb)
 * Template for Active Job issues: [link](https://github.com/rails/rails/blob/main/guides/bug_report_templates/active_job.rb)


### PR DESCRIPTION
I often find myself spending some time trying to figure out a reproduction script for [encryption issues](https://github.com/rails/rails/issues?q=is%3Aissue+label%3Aencryption)
The setup ends up being simple, copy of the main active record template plus a few configuration lines:
https://github.com/rails/rails/blob/2914eb1220dd8f1829d56b839ca293084c72b757/guides/bug_report_templates/active_record_encryption.rb#L26-L28

So I'd like to propose we either add a separate bug report template or at least fold these changes into main `active_record.rb` template to make it "encryption-ready"

https://github.com/rails/rails/blob/cfc6c5656f10452f354cd5bd28dd4ae020834a40/guides/bug_report_templates/active_record.rb#L1

Assertions for this template were taken from the `assert_encrypted_attribute` assertion

https://github.com/rails/rails/blob/cfc6c5656f10452f354cd5bd28dd4ae020834a40/activerecord/test/cases/encryption/helper.rb#L18

I'm not 100% sure we want to maintain one more template but I'm positive we want to make it simpler to report encryption bugs and we should either modify existing template or add a new one 