### PR TITLE
Fold `AM::Type::BigInteger#serialize` implementation into `Integer`

### DIFF
--- a/activemodel/lib/active_model/type/big_integer.rb
+++ b/activemodel/lib/active_model/type/big_integer.rb
@@ -23,32 +23,15 @@ module ActiveModel
     # All casting and serialization are performed in the same way as the
     # standard ActiveModel::Type::Integer type.
     class BigInteger < Integer
-      def serialize(value) # :nodoc:
-        case value
-        when ::Integer
-          # noop
-        when ::String
-          int = value.to_i
-          if int.zero? && value != "0"
-            return if non_numeric_string?(value)
-          end
-          value = int
-        else
-          value = super
-        end
-
-        value
-      end
-
-      def serialize_cast_value(value) # :nodoc:
-        value
-      end
-
       def serializable?(value, &_)
         true
       end
 
       private
+        def ensure_within_range!(_value)
+          # noop
+        end
+
         def max_value
           ::Float::INFINITY
         end

--- a/activemodel/lib/active_model/type/integer.rb
+++ b/activemodel/lib/active_model/type/integer.rb
@@ -77,18 +77,13 @@ module ActiveModel
           value = super
         end
 
-        if out_of_range?(value)
-          raise ActiveModel::RangeError, "#{value} is out of range for #{self.class} with limit #{_limit} bytes"
-        end
+        ensure_within_range!(value)
 
         value
       end
 
       def serialize_cast_value(value) # :nodoc:
-        if out_of_range?(value)
-          raise ActiveModel::RangeError, "#{value} is out of range for #{self.class} with limit #{_limit} bytes"
-        end
-
+        ensure_within_range!(value)
         value
       end
 
@@ -100,6 +95,13 @@ module ActiveModel
       end
 
       private
+
+        def ensure_within_range!(value)
+          return unless out_of_range?(value)
+
+          raise ActiveModel::RangeError, "#{value} is out of range for #{self.class} with limit #{_limit} bytes"
+        end
+
         def out_of_range?(value)
           value && (@max <= value || @min > value)
         end


### PR DESCRIPTION
I'm bothered by exactly the same implementation of `#serialize` in `BigInteger` and `Integer` types, except for the `out_of_range?` check. Plus for non-Integer and non-String values `BigInteger` calls into `super` which goes to Integer's implementation and performs the same check until finally reaching `Numeric`'s implementation which bounces back to `Integer#cast_value` 

So I propose we use Integer's implementation and separate `ensure_within_range` check to be no-oped in `BigInteger`
It's a cosmetic change and the only justification I have that it performs better on this micro benchmark even though application unlikely to experience any visible gains

<details>
  <summary>Benchmark</summary>
    
  ```ruby
  # frozen_string_literal: true

  require "bundler/inline"

  gemfile(true) do
    source "https://rubygems.org"

    gem "rails", path: "."
    gem "benchmark-ips"
  end

  require "active_model/railtie"
  require "benchmark/ips"

  class UserId
    def initialize(value)
      @value = value
    end

    def to_i
      @value
    end
  end

  Benchmark.ips do |x|
    value = UserId.new(9223372036854775807)
    raise "smth is wrong in the setup" if ActiveModel::Type::BigInteger.new.serialize(value) != 9223372036854775807

    big_int = ActiveModel::Type::BigInteger.new
    current_branch = `git rev-parse --abbrev-ref HEAD`.strip


    x.report("big_integer_#{current_branch}") { big_int.serialize(value)}
    x.save! 'tmp/bigint_conversion_benchmark'
    x.compare!
  end
  ```
  
</details>

Results:
```
ruby 3.3.1 (2024-04-23 revision c56cd86388) [x86_64-linux]
Warming up --------------------------------------
big_integer_fold-big-int-serialization-logic-into-integer
                       201.722k i/100ms
Calculating -------------------------------------
big_integer_fold-big-int-serialization-logic-into-integer
                          2.057M (± 1.9%) i/s  (486.19 ns/i) -     10.288M in   5.003621s

Comparison:
big_integer_fold-big-int-serialization-logic-into-integer:  2056813.2 i/s
    big_integer_main:  1575427.5 i/s - 1.31x  slower
```