### PR TITLE
Fix race condition in `ConnectionPool#checkout` on `@pinned_connection`

### DIFF
--- a/actionmailer/lib/action_mailer/inline_preview_interceptor.rb
+++ b/actionmailer/lib/action_mailer/inline_preview_interceptor.rb
@@ -6,7 +6,7 @@ module ActionMailer
   # = Action Mailer \InlinePreviewInterceptor
   #
   # Implements a mailer preview interceptor that converts image tag src attributes
-  # that use inline cid: style URLs to data: style URLs so that they are visible
+  # that use inline +cid:+ style URLs to +data:+ style URLs so that they are visible
   # when previewing an HTML email in a web browser.
   #
   # This interceptor is enabled by default. To disable it, delete it from the

--- a/actionpack/lib/action_dispatch/http/request.rb
+++ b/actionpack/lib/action_dispatch/http/request.rb
@@ -242,8 +242,9 @@ module ActionDispatch
     #
     #     send_early_hints("link" => "</style.css>; rel=preload; as=style,</script.js>; rel=preload")
     #
-    # If you are using `javascript_include_tag` or `stylesheet_link_tag` the Early
-    # Hints headers are included by default if supported.
+    # If you are using {javascript_include_tag}[rdoc-ref:ActionView::Helpers::AssetTagHelper#javascript_include_tag]
+    # or {stylesheet_link_tag}[rdoc-ref:ActionView::Helpers::AssetTagHelper#stylesheet_link_tag]
+    # the Early Hints headers are included by default if supported.
     def send_early_hints(links)
       env["rack.early_hints"]&.call(links)
     end

--- a/actionview/lib/action_view/helpers/output_safety_helper.rb
+++ b/actionview/lib/action_view/helpers/output_safety_helper.rb
@@ -38,8 +38,7 @@ module ActionView # :nodoc:
 
       # Converts the array to a comma-separated sentence where the last element is
       # joined by the connector word. This is the html_safe-aware version of
-      # ActiveSupport's {Array#to_sentence}[https://api.rubyonrails.org/classes/Array.html#method-i-to_sentence].
-      #
+      # ActiveSupport's Array#to_sentence.
       def to_sentence(array, options = {})
         options.assert_valid_keys(:words_connector, :two_words_connector, :last_word_connector, :locale)
 

--- a/activemodel/lib/active_model/type/float.rb
+++ b/activemodel/lib/active_model/type/float.rb
@@ -15,14 +15,6 @@ module ActiveModel
     #     attribute :weight, :float
     #   end
     #
-    # Values are cast using their +to_f+ method, except for the following
-    # strings:
-    #
-    # - Blank strings are cast to +nil+.
-    # - <tt>"Infinity"</tt> is cast to +Float::INFINITY+.
-    # - <tt>"-Infinity"</tt> is cast to <tt>-Float::INFINITY</tt>.
-    # - <tt>"NaN"</tt> is cast to +Float::NAN+.
-    #
     #   bag = BagOfCoffee.new
     #
     #   bag.weight = "0.25"
@@ -33,6 +25,14 @@ module ActiveModel
     #
     #   bag.weight = "NaN"
     #   bag.weight # => Float::NAN
+    #
+    # Values are cast using their +to_f+ method, except for the following
+    # strings:
+    #
+    # - Blank strings are cast to +nil+.
+    # - <tt>"Infinity"</tt> is cast to +Float::INFINITY+.
+    # - <tt>"-Infinity"</tt> is cast to <tt>-Float::INFINITY</tt>.
+    # - <tt>"NaN"</tt> is cast to +Float::NAN+.
     class Float < Value
       include Helpers::Numeric
 

--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -545,20 +545,25 @@ module ActiveRecord
       # Raises:
       # - ActiveRecord::ConnectionTimeoutError no connection can be obtained from the pool.
       def checkout(checkout_timeout = @checkout_timeout)
-        if @pinned_connection
+        return checkout_and_verify(acquire_connection(checkout_timeout)) unless @pinned_connection
+
+        @pinned_connection.lock.synchronize do
           synchronize do
-            @pinned_connection.lock.synchronize do
+            # The pinned connection may have been cleaned up before we synchronized, so check if it is still present
+            if @pinned_connection
               @pinned_connection.verify!
+
               # Any leased connection must be in @connections otherwise
               # some methods like #connected? won't behave correctly
               unless @connections.include?(@pinned_connection)
                 @connections << @pinned_connection
               end
+
+              @pinned_connection
+            else
+              checkout_and_verify(acquire_connection(checkout_timeout))
             end
           end
-          @pinned_connection
-        else
-          checkout_and_verify(acquire_connection(checkout_timeout))
         end
       end
 

--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -546,8 +546,8 @@ module ActiveRecord
       # - ActiveRecord::ConnectionTimeoutError no connection can be obtained from the pool.
       def checkout(checkout_timeout = @checkout_timeout)
         if @pinned_connection
-          @pinned_connection.lock.synchronize do
-            synchronize do
+          synchronize do
+            @pinned_connection.lock.synchronize do
               @pinned_connection.verify!
               # Any leased connection must be in @connections otherwise
               # some methods like #connected? won't behave correctly

--- a/activerecord/test/cases/active_record_test.rb
+++ b/activerecord/test/cases/active_record_test.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "cases/helper"
-require "rack"
 
 class ActiveRecordTest < ActiveRecord::TestCase
   self.use_transactional_tests = false

--- a/activerecord/test/cases/asynchronous_queries_test.rb
+++ b/activerecord/test/cases/asynchronous_queries_test.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "cases/helper"
-require "support/connection_helper"
 require "models/post"
 
 module AsynchronousQueriesSharedTests
@@ -127,6 +126,10 @@ class AsynchronousQueriesWithTransactionalTest < ActiveRecord::TestCase
 end
 
 class AsynchronousExecutorTypeTest < ActiveRecord::TestCase
+  def teardown
+    clean_up_connection_handler
+  end
+
   def test_null_configuration_uses_a_single_null_executor_by_default
     old_value = ActiveRecord.async_query_executor
     ActiveRecord.async_query_executor = nil
@@ -145,7 +148,6 @@ class AsynchronousExecutorTypeTest < ActiveRecord::TestCase
 
     assert_equal 2, handler.connection_pool_list(:all).count
   ensure
-    clean_up_connection_handler
     ActiveRecord.async_query_executor = old_value
   end
 
@@ -178,7 +180,6 @@ class AsynchronousExecutorTypeTest < ActiveRecord::TestCase
     assert_equal 2, handler.connection_pool_list(:all).count
     assert_equal async_pool1, async_pool2
   ensure
-    clean_up_connection_handler
     ActiveRecord.async_query_executor = old_value
   end
 
@@ -215,7 +216,6 @@ class AsynchronousExecutorTypeTest < ActiveRecord::TestCase
     assert_equal 2, handler.connection_pool_list(:all).count
     assert_equal async_pool1, async_pool2
   ensure
-    clean_up_connection_handler
     ActiveRecord.global_executor_concurrency = old_concurrency
     ActiveRecord.async_query_executor = old_value
     ActiveRecord.instance_variable_set(:@global_thread_pool_async_query_executor, old_global_thread_pool_async_query_executor)
@@ -269,7 +269,6 @@ class AsynchronousExecutorTypeTest < ActiveRecord::TestCase
     assert_equal 2, handler.connection_pool_list(:all).count
     assert_not_equal async_pool1, async_pool2
   ensure
-    clean_up_connection_handler
     ActiveRecord.async_query_executor = old_value
   end
 
@@ -304,7 +303,6 @@ class AsynchronousExecutorTypeTest < ActiveRecord::TestCase
     assert_equal 2, handler.connection_pool_list(:all).count
     assert_not_equal async_pool1, async_pool2
   ensure
-    clean_up_connection_handler
     ActiveRecord.async_query_executor = old_value
   end
 end

--- a/activerecord/test/cases/query_cache_test.rb
+++ b/activerecord/test/cases/query_cache_test.rb
@@ -5,7 +5,6 @@ require "models/topic"
 require "models/task"
 require "models/category"
 require "models/post"
-require "rack"
 
 class QueryCacheTest < ActiveRecord::TestCase
   self.use_transactional_tests = false

--- a/activesupport/lib/active_support/backtrace_cleaner.rb
+++ b/activesupport/lib/active_support/backtrace_cleaner.rb
@@ -79,7 +79,7 @@ module ActiveSupport
     #
     #   # Will turn "/my/rails/root/app/models/person.rb" into "app/models/person.rb"
     #   root = "#{Rails.root}/"
-    #   backtrace_cleaner.add_filter { |line| line.start_with?(root) ? line.from(root.size) : line }
+    #   backtrace_cleaner.add_filter { |line| line.delete_prefix(root) }
     def add_filter(&block)
       @filters << block
     end

--- a/activesupport/lib/active_support/broadcast_logger.rb
+++ b/activesupport/lib/active_support/broadcast_logger.rb
@@ -163,57 +163,57 @@ module ActiveSupport
       dispatch { |logger| logger.close }
     end
 
-    # +True+ if the log level allows entries with severity Logger::DEBUG to be written
-    # to at least one broadcast. +False+ otherwise.
+    # True if the log level allows entries with severity +Logger::DEBUG+ to be written
+    # to at least one broadcast. False otherwise.
     def debug?
       @broadcasts.any? { |logger| logger.debug? }
     end
 
-    # Sets the log level to Logger::DEBUG for the whole broadcast.
+    # Sets the log level to +Logger::DEBUG+ for the whole broadcast.
     def debug!
       dispatch { |logger| logger.debug! }
     end
 
-    # +True+ if the log level allows entries with severity Logger::INFO to be written
-    # to at least one broadcast. +False+ otherwise.
+    # True if the log level allows entries with severity +Logger::INFO+ to be written
+    # to at least one broadcast. False otherwise.
     def info?
       @broadcasts.any? { |logger| logger.info? }
     end
 
-    # Sets the log level to Logger::INFO for the whole broadcast.
+    # Sets the log level to +Logger::INFO+ for the whole broadcast.
     def info!
       dispatch { |logger| logger.info! }
     end
 
-    # +True+ if the log level allows entries with severity Logger::WARN to be written
-    # to at least one broadcast. +False+ otherwise.
+    # True if the log level allows entries with severity +Logger::WARN+ to be written
+    # to at least one broadcast. False otherwise.
     def warn?
       @broadcasts.any? { |logger| logger.warn? }
     end
 
-    # Sets the log level to Logger::WARN for the whole broadcast.
+    # Sets the log level to +Logger::WARN+ for the whole broadcast.
     def warn!
       dispatch { |logger| logger.warn! }
     end
 
-    # +True+ if the log level allows entries with severity Logger::ERROR to be written
-    # to at least one broadcast. +False+ otherwise.
+    # True if the log level allows entries with severity +Logger::ERROR+ to be written
+    # to at least one broadcast. False otherwise.
     def error?
       @broadcasts.any? { |logger| logger.error? }
     end
 
-    # Sets the log level to Logger::ERROR for the whole broadcast.
+    # Sets the log level to +Logger::ERROR+ for the whole broadcast.
     def error!
       dispatch { |logger| logger.error! }
     end
 
-    # +True+ if the log level allows entries with severity Logger::FATAL to be written
-    # to at least one broadcast. +False+ otherwise.
+    # True if the log level allows entries with severity +Logger::FATAL+ to be written
+    # to at least one broadcast. False otherwise.
     def fatal?
       @broadcasts.any? { |logger| logger.fatal? }
     end
 
-    # Sets the log level to Logger::FATAL for the whole broadcast.
+    # Sets the log level to +Logger::FATAL+ for the whole broadcast.
     def fatal!
       dispatch { |logger| logger.fatal! }
     end

--- a/activesupport/lib/active_support/core_ext/enumerable.rb
+++ b/activesupport/lib/active_support/core_ext/enumerable.rb
@@ -203,7 +203,7 @@ module Enumerable
   end
 
   # Returns the sole item in the enumerable. If there are no items, or more
-  # than one item, raises +Enumerable::SoleItemExpectedError+.
+  # than one item, raises Enumerable::SoleItemExpectedError.
   #
   #   ["x"].sole          # => "x"
   #   Set.new.sole        # => Enumerable::SoleItemExpectedError: no item found

--- a/guides/source/association_basics.md
+++ b/guides/source/association_basics.md
@@ -1623,7 +1623,7 @@ In our example, `imageable_id` could be the ID of either an `Employee` or a
 either `Employee` or `Product`.
 
 While creating the polymorphic association manually is acceptable, it is instead
-recommended to use `t.references` or its alias `t.belong_to` and specify
+recommended to use `t.references` or its alias `t.belongs_to` and specify
 `polymorphic: true` so that Rails knows that the association is polymorphic, and
 it automatically adds both the foreign key and type columns to the table.
 

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -1767,7 +1767,7 @@ Sets the host for the assets. Useful when CDNs are used for hosting assets rathe
 
 #### `config.action_controller.perform_caching`
 
-Configures whether the application should perform the caching features provided by the Action Controller component or not. Set to `false` in the development environment, `true` in production. If it's not specified, the default will be `true`.
+Configures whether the application should perform the caching features provided by the Action Controller component. Set to `false` in the development environment, `true` in production. If it's not specified, the default will be `true`.
 
 #### `config.action_controller.default_static_extension`
 

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -2773,7 +2773,7 @@ Specifies the logger to use within cache store operations.
 
 #### `ActiveSupport.utc_to_local_returns_utc_offset_times`
 
-Configures `ActiveSupport::TimeZone.utc_to_local` to return a time with a UTC
+Configures [`ActiveSupport::TimeZone.utc_to_local`][] to return a time with a UTC
 offset instead of a UTC time incorporating that offset.
 
 The default value depends on the `config.load_defaults` target version:
@@ -2782,6 +2782,8 @@ The default value depends on the `config.load_defaults` target version:
 | --------------------- | -------------------- |
 | (original)            | `false`              |
 | 6.1                   | `true`               |
+
+[`ActiveSupport::TimeZone.utc_to_local`]: https://api.rubyonrails.org/classes/ActiveSupport/TimeZone.html#method-i-utc_to_local
 
 #### `config.active_support.raise_on_invalid_cache_expiration_time`
 

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -2787,10 +2787,11 @@ The default value depends on the `config.load_defaults` target version:
 
 #### `config.active_support.raise_on_invalid_cache_expiration_time`
 
-Specifies if an `ArgumentError` should be raised if `Rails.cache` `fetch` or
-`write` are given an invalid `expires_at` or `expires_in` time.
+Specifies whether an `ArgumentError` should be raised if `Rails.cache`
+[`fetch`][ActiveSupport::Cache::Store#fetch] or [`write`][ActiveSupport::Cache::Store#write]
+are given an invalid `expires_at` or `expires_in` time.
 
-Options are `true`, and `false`. If `false`, the exception will be reported
+Options are `true` and `false`. If `false`, the exception will be reported
 as `handled` and logged instead.
 
 The default value depends on the `config.load_defaults` target version:
@@ -2799,6 +2800,9 @@ The default value depends on the `config.load_defaults` target version:
 | --------------------- | -------------------- |
 | (original)            | `false`              |
 | 7.1                   | `true`               |
+
+[ActiveSupport::Cache::Store#fetch]: https://api.rubyonrails.org/classes/ActiveSupport/Cache/Store.html#method-i-fetch
+[ActiveSupport::Cache::Store#write]: https://api.rubyonrails.org/classes/ActiveSupport/Cache/Store.html#method-i-write
 
 ### Configuring Active Job
 

--- a/guides/source/contributing_to_ruby_on_rails.md
+++ b/guides/source/contributing_to_ruby_on_rails.md
@@ -39,15 +39,15 @@ Once you open an issue, it may or may not see activity right away unless it is a
 
 Having a way to reproduce your issue will help people confirm, investigate, and ultimately fix your issue. You can do this by providing an executable test case. To make this process easier, we have prepared several bug report templates for you to use as a starting point:
 
-* Template for Active Record (models, database) issues: [link](https://github.com/rails/rails/blob/main/guides/bug_report_templates/active_record.rb)
-* Template for testing Active Record (migration) issues: [link](https://github.com/rails/rails/blob/main/guides/bug_report_templates/active_record_migrations.rb)
-* Template for Action Pack (controllers, routing) issues: [link](https://github.com/rails/rails/blob/main/guides/bug_report_templates/action_controller.rb)
-* Template for Action View (views, helpers) issues: [link](https://github.com/rails/rails/blob/main/guides/bug_report_templates/action_view.rb)
-* Template for Active Job issues: [link](https://github.com/rails/rails/blob/main/guides/bug_report_templates/active_job.rb)
-* Template for Active Storage issues: [link](https://github.com/rails/rails/blob/main/guides/bug_report_templates/active_storage.rb)
-* Template for Action Mailer issues: [link](https://github.com/rails/rails/blob/main/guides/bug_report_templates/action_mailer.rb)
-* Template for Action Mailbox issues: [link](https://github.com/rails/rails/blob/main/guides/bug_report_templates/action_mailbox.rb)
-* Generic template for other issues: [link](https://github.com/rails/rails/blob/main/guides/bug_report_templates/generic.rb)
+* [Template for Active Record (models, database) issues](https://github.com/rails/rails/blob/main/guides/bug_report_templates/active_record.rb)
+* [Template for testing Active Record (migration) issues](https://github.com/rails/rails/blob/main/guides/bug_report_templates/active_record_migrations.rb)
+* [Template for Action Pack (controllers, routing) issues](https://github.com/rails/rails/blob/main/guides/bug_report_templates/action_controller.rb)
+* [Template for Action View (views, helpers) issues](https://github.com/rails/rails/blob/main/guides/bug_report_templates/action_view.rb)
+* [Template for Active Job issues](https://github.com/rails/rails/blob/main/guides/bug_report_templates/active_job.rb)
+* [Template for Active Storage issues](https://github.com/rails/rails/blob/main/guides/bug_report_templates/active_storage.rb)
+* [Template for Action Mailer issues](https://github.com/rails/rails/blob/main/guides/bug_report_templates/action_mailer.rb)
+* [Template for Action Mailbox issues](https://github.com/rails/rails/blob/main/guides/bug_report_templates/action_mailbox.rb)
+* [Generic template for other issues](https://github.com/rails/rails/blob/main/guides/bug_report_templates/generic.rb)
 
 These templates include the boilerplate code to set up a test case. Copy the content of the appropriate template into a `.rb` file and make the necessary changes to demonstrate the issue. You can execute it by running `ruby the_file.rb` in your terminal. If all goes well, you should see your test case failing.
 

--- a/guides/source/getting_started.md
+++ b/guides/source/getting_started.md
@@ -2708,11 +2708,11 @@ full coverage of the application features.
 
 Learn more about [Testing Rails Applications](testing.html)
 
-Consistently Formatted Code with Rubocop
+Consistently Formatted Code with RuboCop
 ----------------------------------------
 
 When writing code we may sometimes use inconsistent formatting. Rails comes with
-a linter called Rubocop that helps keep our code formatted consistently.
+a linter called RuboCop that helps keep our code formatted consistently.
 
 We can check our code for consistency by running:
 
@@ -2729,7 +2729,7 @@ Inspecting 53 files
 53 files inspected, no offenses detected
 ```
 
-Rubocop can automatically fix offsenses using the `--autocorrect` flag (or its short version `-a`).
+RuboCop can automatically fix offenses using the `--autocorrect` flag (or its short version `-a`).
 
 ```
 $ bin/rubocop -a

--- a/guides/source/getting_started.md
+++ b/guides/source/getting_started.md
@@ -1457,7 +1457,7 @@ The last feature we need to implement is deleting products. We will add a
 `destroy` action to our `ProductsController` to handle `DELETE /products/:id`
 requests.
 
-Adding `destroy` to `before_action :set_product` let's us set the `@product`
+Adding `destroy` to `before_action :set_product` lets us set the `@product`
 instance variable in the same way we do for the other actions.
 
 ```ruby#2,35-38

--- a/guides/source/getting_started.md
+++ b/guides/source/getting_started.md
@@ -1862,7 +1862,7 @@ Rails makes it easy to translate your app into other languages.
 The `translate` or `t` helper in our views looks up a translation by name and
 returns the text for the current locale.
 
-In `app/products/index.html.erb`, let's update the header tag to use a
+In `app/views/products/index.html.erb`, let's update the header tag to use a
 translation.
 
 ```erb

--- a/guides/source/getting_started.md
+++ b/guides/source/getting_started.md
@@ -612,7 +612,7 @@ end
 
 You might remember that Rails automatically reloads changes during development.
 However, if the console is running when you make updates to the code, you'll
-need to manually refresh it. So let' do this now by running 'reload!'.
+need to manually refresh it. So let's do this now by running 'reload!'.
 
 ```irb
 store(dev)> reload!

--- a/guides/source/getting_started.md
+++ b/guides/source/getting_started.md
@@ -2932,7 +2932,7 @@ Here are some ideas:
 We also recommend learning more by reading other Ruby on Rails Guides:
 
 * [Active Record Basics](active_record_basics.html)
-* [Layouts and Rendering in Rails]()
+* [Layouts and Rendering in Rails](layouts_and_rendering.html)
 * [Testing Rails Applications](testing.html)
 * [Debugging Rails Applications](debugging_rails_applications.html)
 * [Securing Rails Applications](security.html)

--- a/guides/source/initialization.md
+++ b/guides/source/initialization.md
@@ -575,7 +575,7 @@ defines `bootstrap`, `railtie`, and `finisher` initializers. The `bootstrap` ini
 prepare the application (like initializing the logger) while the `finisher`
 initializers (like building the middleware stack) are run last. The `railtie`
 initializers are the initializers which have been defined on the `Rails::Application`
-itself and are run between the `bootstrap` and `finishers`.
+itself and are run between the `bootstrap` and `finisher`.
 
 NOTE: Do not confuse Railtie initializers overall with the [load_config_initializers](configuring.html#using-initializer-files)
 initializer instance or its associated config initializers in `config/initializers`.

--- a/railties/lib/rails/code_statistics.rb
+++ b/railties/lib/rails/code_statistics.rb
@@ -45,11 +45,11 @@ module Rails
     class_attribute :directories, default: DIRECTORIES
     class_attribute :test_types, default: TEST_TYPES
 
-    # Add directories to the output of the `bin/rails stats` command.
+    # Add directories to the output of the <tt>bin/rails stats</tt> command.
     #
     #   Rails::CodeStatistics.register_directory("My Directory", "path/to/dir")
     #
-    # For directories that contain test code, set the `test_directory` argument to true.
+    # For directories that contain test code, set the <tt>test_directory</tt> argument to true.
     #
     #   Rails::CodeStatistics.register_directory("Model specs", "spec/models", test_directory: true)
     def self.register_directory(label, path, test_directory: false)

--- a/railties/lib/rails/generators.rb
+++ b/railties/lib/rails/generators.rb
@@ -97,11 +97,11 @@ module Rails
       # generator group to fall back to another group in case of missing generators,
       # they can add a fallback.
       #
-      # For example, shoulda is considered a test_framework and is an extension
-      # of test_unit. However, most part of shoulda generators are similar to
-      # test_unit ones.
+      # For example, shoulda is considered a +test_framework+ and is an extension
+      # of +test_unit+. However, most part of shoulda generators are similar to
+      # +test_unit+ ones.
       #
-      # Shoulda then can tell generators to search for test_unit generators when
+      # Shoulda then can tell generators to search for +test_unit+ generators when
       # some of them are not available by adding a fallback:
       #
       #   Rails::Generators.fallbacks[:shoulda] = :test_unit

--- a/railties/lib/rails/generators/actions.rb
+++ b/railties/lib/rails/generators/actions.rb
@@ -489,12 +489,16 @@ module Rails
         end
         alias rebase_indentation optimize_indentation
 
-        # Indent the +Gemfile+ to the depth of @indentation
+        # Returns a string corresponding to the current indentation level
+        # (i.e. 2 * <code>@indentation</code> spaces). See also
+        # #with_indentation, which can be used to manage the indentation level.
         def indentation # :doc:
           "  " * @indentation
         end
 
-        # Manage +Gemfile+ indentation for a DSL action block
+        # Increases the current indentation indentation level for the duration
+        # of the given block, and decreases it after the block ends. Call
+        # #indentation to get an indentation string.
         def with_indentation(&block) # :doc:
           @indentation += 1
           instance_eval(&block)

--- a/railties/lib/rails/generators/actions.rb
+++ b/railties/lib/rails/generators/actions.rb
@@ -445,7 +445,7 @@ module Rails
 
       private
         # Define log for backwards compatibility. If just one argument is sent,
-        # invoke say, otherwise invoke say_status.
+        # invoke +say+, otherwise invoke +say_status+.
         def log(*args) # :doc:
           if args.size == 1
             say args.first.to_s
@@ -455,7 +455,7 @@ module Rails
           end
         end
 
-        # Runs the supplied command using either "rake ..." or "rails ..."
+        # Runs the supplied command using either +rake+ or +rails+
         # based on the executor parameter provided.
         def execute_command(executor, command, options = {}) # :doc:
           log executor, command

--- a/railties/lib/rails/generators/actions.rb
+++ b/railties/lib/rails/generators/actions.rb
@@ -445,11 +445,10 @@ module Rails
 
       private
         # Define log for backwards compatibility. If just one argument is sent,
-        # invoke say, otherwise invoke say_status. Differently from say and
-        # similarly to say_status, this method respects the quiet? option given.
+        # invoke say, otherwise invoke say_status.
         def log(*args) # :doc:
           if args.size == 1
-            say args.first.to_s unless options.quiet?
+            say args.first.to_s
           else
             args << (behavior == :invoke ? :green : :red)
             say_status(*args)

--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -71,7 +71,8 @@ module Rails
         class_option :skip_action_cable,   type: :boolean, aliases: "-C", default: nil,
                                            desc: "Skip Action Cable files"
 
-        class_option :skip_asset_pipeline, type: :boolean, aliases: "-A", default: nil
+        class_option :skip_asset_pipeline, type: :boolean, aliases: "-A", default: nil,
+                                           desc: "Skip the asset pipeline setup"
 
         class_option :skip_javascript,     type: :boolean, aliases: ["-J", "--skip-js"], default: (true if name == "plugin"),
                                            desc: "Skip JavaScript files"

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/mysql.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/mysql.yml.tt
@@ -1,4 +1,4 @@
-# MySQL. Versions 5.5.8 and up are supported.
+# MySQL. Versions 5.6.4 and up are supported.
 #
 # Install the MySQL driver
 #   gem install mysql2

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/trilogy.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/trilogy.yml.tt
@@ -15,14 +15,13 @@ default: &default
   pool: <%%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
   username: root
   password:
-<% if database.socket -%>
-  socket: <%= database.socket %>
-<% else -%>
   host: <%%= ENV.fetch("DB_HOST") { "<%= database.host %>" } %>
-<% end -%>
 
 development:
   <<: *default
+<% if database.socket -%>
+  socket: <%= database.socket %>
+<% end -%>
   database: <%= app_name %>_development
 
 # Warning: The database defined as "test" will be erased and
@@ -30,6 +29,9 @@ development:
 # Do not set this db to the same as development or production.
 test:
   <<: *default
+<% if database.socket -%>
+  socket: <%= database.socket %>
+<% end -%>
   database: <%= app_name %>_test
 
 # As with config/credentials.yml, you never want to store sensitive information,

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/trilogy.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/trilogy.yml.tt
@@ -1,4 +1,4 @@
-# MySQL. Versions 5.5.8 and up are supported.
+# MySQL. Versions 5.6.4 and up are supported.
 #
 # Install the MySQL driver
 #   gem install trilogy


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because it fixes a race condition in `ConnectionPool#checkout`. 

Fixes #53980.

### Detail

This Pull Request changes the order in which we acquire locks on the connection pool and the pinned connection. In `ConnectionPool#checkout`, the `@pinned_connection` can be cleaned up if another thread executes the `unpin_connection!` method, while we don't have a lock acquired on the connection pool yet. 

### Additional information

The lock on pinned connection was introduced recently in #52235. It solved another deadlock problem. I am not able to reproduce that deadlock after making this change.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
