### PR TITLE
Fix rdoc code render in `Rails::CodeStatistics` docs [ci skip]

### DIFF
--- a/railties/lib/rails/code_statistics.rb
+++ b/railties/lib/rails/code_statistics.rb
@@ -45,11 +45,11 @@ module Rails
     class_attribute :directories, default: DIRECTORIES
     class_attribute :test_types, default: TEST_TYPES
 
-    # Add directories to the output of the `bin/rails stats` command.
+    # Add directories to the output of the <tt>bin/rails stats</tt> command.
     #
     #   Rails::CodeStatistics.register_directory("My Directory", "path/to/dir")
     #
-    # For directories that contain test code, set the `test_directory` argument to true.
+    # For directories that contain test code, set the <tt>test_directory</tt> argument to true.
     #
     #   Rails::CodeStatistics.register_directory("Model specs", "spec/models", test_directory: true)
     def self.register_directory(label, path, test_directory: false)


### PR DESCRIPTION
Noticed that the `bin/rails stats` and `test_directory` were probably meant to be rendered (?), but were not.

Before:

<img width="1062" alt="Screenshot 2024-12-19 at 11 51 15" src="https://github.com/user-attachments/assets/bff7d867-f9d8-4be2-b138-d24991ecdc77" />

After:

<img width="1062" alt="Screenshot 2024-12-19 at 11 49 58" src="https://github.com/user-attachments/assets/f42b8e22-1385-4c13-b241-c7bc8c3a9203" />

