### PR TITLE
Refactor `included` and `prepended` methods in ActiveSupport::Concern

### DIFF
--- a/activesupport/lib/active_support/concern.rb
+++ b/activesupport/lib/active_support/concern.rb
@@ -169,17 +169,13 @@ module ActiveSupport
     # so that you can write class macros here.
     # When you define more than one +prepended+ block, it raises an exception.
     def prepended(base = nil, &block)
-      if base.nil?
-        if instance_variable_defined?(:@_prepended_block)
-          if @_prepended_block.source_location != block.source_location
-            raise MultiplePrependBlocks
-          end
-        else
-          @_prepended_block = block
-        end
-      else
-        super
+      return super if base
+
+      if instance_variable_defined?(:@_prepended_block) && @_prepended_block.source_location != block.source_location
+        raise MultiplePrependBlocks
       end
+
+      @_prepended_block ||= block
     end
 
     # Define class methods from given block.

--- a/activesupport/lib/active_support/concern.rb
+++ b/activesupport/lib/active_support/concern.rb
@@ -156,17 +156,13 @@ module ActiveSupport
     # so that you can write class macros here.
     # When you define more than one +included+ block, it raises an exception.
     def included(base = nil, &block)
-      if base.nil?
-        if instance_variable_defined?(:@_included_block)
-          if @_included_block.source_location != block.source_location
-            raise MultipleIncludedBlocks
-          end
-        else
-          @_included_block = block
-        end
-      else
-        super
+      return super if base
+
+      if instance_variable_defined?(:@_included_block) && @_included_block.source_location != block.source_location
+        raise MultipleIncludedBlocks
       end
+
+      @_included_block ||= block
     end
 
     # Evaluate given block in context of base class,


### PR DESCRIPTION
### Motivation / Background
Code simplification and better readability.

### Detail

This pull request includes changes to the `included` and `prepended` methods in the `activesupport/lib/active_support/concern.rb` file to simplify the code and improve readability. 

* [`activesupport/lib/active_support/concern.rb`](diffhunk://#diff-1d38b892875ba41880d9158ed6b7316662a1db2431dc016ff1c30a13a728e686L159-R178): Simplified the `included` method by removing nested conditionals and using an early return if `base` is provided.
* [`activesupport/lib/active_support/concern.rb`](diffhunk://#diff-1d38b892875ba41880d9158ed6b7316662a1db2431dc016ff1c30a13a728e686L159-R178): Simplified the `prepended` method by removing nested conditionals and using an early return if `base` is provided.

