### PR TITLE
Merge primary keys and column definition schema queries

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -143,9 +143,10 @@ module ActiveRecord
 
       # Returns just a table's primary key
       def primary_key(table_name)
-        pk = primary_keys(table_name)
-        pk = pk.first unless pk.size > 1
-        pk
+        columns(table_name)
+          .sort_by { |column| column.primary_idx || Float::INFINITY }
+          .filter_map { |column| column.name if column.primary? }
+          .then { |keys| keys.size > 1 ? keys : keys.first }
       end
 
       # Creates a new table with the name +table_name+. +table_name+ may either

--- a/activerecord/lib/active_record/connection_adapters/column.rb
+++ b/activerecord/lib/active_record/connection_adapters/column.rb
@@ -7,7 +7,7 @@ module ActiveRecord
     class Column
       include Deduplicable
 
-      attr_reader :name, :cast_type, :default, :sql_type_metadata, :null, :default_function, :collation, :comment
+      attr_reader :name, :cast_type, :default, :sql_type_metadata, :primary, :primary_idx, :null, :default_function, :collation, :comment
 
       delegate :precision, :scale, :limit, :type, :sql_type, to: :sql_type_metadata, allow_nil: true
 
@@ -17,15 +17,21 @@ module ActiveRecord
       # +default+ is the type-casted default value, such as +new+ in <tt>sales_stage varchar(20) default 'new'</tt>.
       # +sql_type_metadata+ is various information about the type of the column
       # +null+ determines if this column allows +NULL+ values.
-      def initialize(name, cast_type, default, sql_type_metadata = nil, null = true, default_function = nil, collation: nil, comment: nil, **)
+      def initialize(name, cast_type, default, sql_type_metadata = nil, primary = false, primary_idx = nil, null = true, default_function = nil, collation: nil, comment: nil, **)
         @name = name.freeze
         @cast_type = cast_type
         @sql_type_metadata = sql_type_metadata
+        @primary = primary
+        @primary_idx = primary_idx
         @null = null
         @default = default
         @default_function = default_function
         @collation = collation
         @comment = comment
+      end
+
+      def primary?
+        @primary
       end
 
       def has_default?
@@ -48,6 +54,8 @@ module ActiveRecord
         @name = coder["name"]
         @cast_type = coder["cast_type"]
         @sql_type_metadata = coder["sql_type_metadata"]
+        @primary = coder["primary"]
+        @primary_idx = coder["primary_idx"]
         @null = coder["null"]
         @default = coder["default"]
         @default_function = coder["default_function"]
@@ -59,6 +67,8 @@ module ActiveRecord
         coder["name"] = @name
         coder["cast_type"] = @cast_type
         coder["sql_type_metadata"] = @sql_type_metadata
+        coder["primary"] = @primary
+        coder["primary_idx"] = @primary_idx
         coder["null"] = @null
         coder["default"] = @default
         coder["default_function"] = @default_function
@@ -79,9 +89,11 @@ module ActiveRecord
         other.is_a?(Column) &&
           name == other.name &&
           cast_type == other.cast_type &&
-          default == other.default &&
           sql_type_metadata == other.sql_type_metadata &&
+          primary == other.primary &&
+          primary_idx == other.primary_idx &&
           null == other.null &&
+          default == other.default &&
           default_function == other.default_function &&
           collation == other.collation &&
           comment == other.comment
@@ -93,9 +105,11 @@ module ActiveRecord
           name.hash ^
           name.encoding.hash ^
           cast_type.hash ^
-          default.hash ^
           sql_type_metadata.hash ^
+          primary.hash ^
+          primary_idx.hash ^
           null.hash ^
+          default.hash ^
           default_function.hash ^
           collation.hash ^
           comment.hash

--- a/activerecord/lib/active_record/connection_adapters/mysql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/schema_statements.rb
@@ -212,6 +212,8 @@ module ActiveRecord
               lookup_cast_type(type_metadata.sql_type),
               default,
               type_metadata,
+              field["Key"] == "PRI" && field["SeqInIndex"],
+              field["SeqInIndex"],
               field["Null"] == "YES",
               default_function,
               collation: field["Collation"],

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -1029,15 +1029,30 @@ module ActiveRecord
         #  - ::regclass is a function that gives the id for a table name
         def column_definitions(table_name)
           query(<<~SQL, "SCHEMA")
-              SELECT a.attname, format_type(a.atttypid, a.atttypmod),
-                     pg_get_expr(d.adbin, d.adrelid), a.attnotnull, a.atttypid, a.atttypmod,
-                     c.collname, col_description(a.attrelid, a.attnum) AS comment,
+              WITH pk AS (
+                SELECT i.indrelid,
+                       u.indkey,
+                       u.ordinality AS idx
+                  FROM pg_index i, unnest(i.indkey) WITH ORDINALITY u(indkey, ordinality)
+                 WHERE i.indrelid = #{quote(quote_table_name(table_name))}::regclass AND i.indisprimary
+              )
+              SELECT a.attname,
+                     pg_get_expr(d.adbin, d.adrelid),
+                     format_type(a.atttypid, a.atttypmod),
+                     CASE WHEN pk.indrelid IS NOT NULL THEN true ELSE false END AS attisprimary,
+                     pk.idx AS attprimaryidx,
+                     a.attnotnull,
+                     a.atttypid,
+                     a.atttypmod,
+                     c.collname,
+                     col_description(a.attrelid, a.attnum) AS comment,
                      #{supports_identity_columns? ? 'attidentity' : quote('')} AS identity,
                      #{supports_virtual_columns? ? 'attgenerated' : quote('')} as attgenerated
                 FROM pg_attribute a
                 LEFT JOIN pg_attrdef d ON a.attrelid = d.adrelid AND a.attnum = d.adnum
                 LEFT JOIN pg_type t ON a.atttypid = t.oid
                 LEFT JOIN pg_collation c ON a.attcollation = c.oid AND a.attcollation <> t.typcollation
+                LEFT JOIN pk ON a.attrelid = pk.indrelid AND a.attnum = pk.indkey
                WHERE a.attrelid = #{quote(quote_table_name(table_name))}::regclass
                  AND a.attnum > 0 AND NOT a.attisdropped
                ORDER BY a.attnum

--- a/activerecord/lib/active_record/connection_adapters/schema_cache.rb
+++ b/activerecord/lib/active_record/connection_adapters/schema_cache.rb
@@ -299,7 +299,10 @@ module ActiveRecord
         @primary_keys.fetch(table_name) do
           pool.with_connection do |connection|
             if data_source_exists?(pool, table_name)
-              @primary_keys[deep_deduplicate(table_name)] = deep_deduplicate(connection.primary_key(table_name))
+              @primary_keys[deep_deduplicate(table_name)] = columns(pool, table_name)
+                .sort_by { |column| column.primary_idx || Float::INFINITY }
+                .filter_map { |column| column.name if column.primary? }
+                .then { |keys| keys.size > 1 ? keys : keys.first }
             end
           end
         end

--- a/activerecord/lib/active_record/connection_adapters/sqlite3/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3/schema_statements.rb
@@ -160,6 +160,8 @@ module ActiveRecord
               lookup_cast_type(field["type"]),
               default_value,
               type_metadata,
+              field["pk"] > 0,
+              (field["pk"] if field["pk"] > 0),
               field["notnull"].to_i == 0,
               default_function,
               collation: field["collation"],

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -307,11 +307,6 @@ module ActiveRecord
 
       # SCHEMA STATEMENTS ========================================
 
-      def primary_keys(table_name) # :nodoc:
-        pks = table_structure(table_name).select { |f| f["pk"] > 0 }
-        pks.sort_by { |f| f["pk"] }.map { |f| f["name"] }
-      end
-
       def remove_index(table_name, column_name = nil, **options) # :nodoc:
         return if options[:if_exists] && !index_exists?(table_name, column_name, **options)
 

--- a/activerecord/test/cases/adapters/postgresql/schema_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/schema_test.rb
@@ -537,7 +537,7 @@ class SchemaTest < ActiveRecord::PostgreSQLTestCase
 
   private
     def columns(table_name)
-      @connection.send(:column_definitions, table_name).map do |name, type, default|
+      @connection.send(:column_definitions, table_name).map do |name, default, type|
         "#{name} #{type}" + (default ? " default #{default}" : "")
       end
     end

--- a/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
@@ -811,7 +811,7 @@ module ActiveRecord
 
         connection.remove_column("barcode_cpks", "other_attr")
 
-        assert_equal ["region", "code"], connection.primary_keys("barcode_cpks")
+        assert_equal ["region", "code"], connection.primary_key("barcode_cpks")
 
         barcode = BarcodeCpk.first
         assert_equal region, barcode.region

--- a/activerecord/test/cases/primary_keys_test.rb
+++ b/activerecord/test/cases/primary_keys_test.rb
@@ -402,15 +402,15 @@ class CompositePrimaryKeyTest < ActiveRecord::TestCase
   end
 
   def test_composite_primary_key
-    assert_equal ["region", "code"], @connection.primary_keys("uber_barcodes")
+    assert_equal ["region", "code"], @connection.primary_key("uber_barcodes")
   end
 
   def test_composite_primary_key_with_reserved_words
-    assert_equal ["from", "to"], @connection.primary_keys("travels")
+    assert_equal ["from", "to"], @connection.primary_key("travels")
   end
 
   def test_composite_primary_key_out_of_order
-    assert_equal ["code", "region"], @connection.primary_keys("barcodes_reverse")
+    assert_equal ["code", "region"], @connection.primary_key("barcodes_reverse")
   end
 
   def test_assigning_a_composite_primary_key


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

<!--
### Motivation / Background
-->

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

Currently, the primary keys for a model's table are fetched in a separate query the first time they're needed. The exact way this happens varies by adapter:
- `sqlite3` - executes the [same query used to fetch column definitions](https://github.com/rails/rails/blob/c67d91b04d16072f902e86bd969946120449b1c5/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb#L310-L313) a second time, computes the keys and caches them in the schema cache
- `mysql2`/`trilogy` - executes a [separate query](https://github.com/rails/rails/blob/c67d91b04d16072f902e86bd969946120449b1c5/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb#L581-L594), computes the keys and caches them in the schema cache
- `postgresql` - executes a [separate query](https://github.com/rails/rails/blob/c67d91b04d16072f902e86bd969946120449b1c5/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb#L416-L430), computes the keys and caches them in the schema cache

My goal here was to explore merging the primary keys query into the column definitions query for `mysql2`, `trilogy` and `postgresql`, and utilising the (schema) cached column definitions to extract the primary keys for all adapters without having to perform another query. This saves a single round trip to the db per table during runtime at the cost of a possibly slightly more complex column definitions query. I initially began looking into thise for just `PostgreSQL`, for which I will share some explain analyze queries from a decent sized production database and table in the comments, but having dug into the code, realised it didn't make sense to implement for just a single adapter.

I was pleasantly surprised to find that the column definitions query for `sqlite3` already contained this information, which means that in that case we're now completely avoiding a duplicate query at no extra cost. Were this change to be accepted, I will however need some assistance in looking at the implications of this in `mysql2`/`trilogy` for which this merged query was not as straightforward to implement.

<!--
### Detail
-->

<!--
This Pull Request changes [REPLACE ME]
-->

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

<!--
### Checklist
-->

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.