### PR TITLE
Make importmap changes invalidate HTML etags by default

### DIFF
--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -510,9 +510,12 @@ module Rails
         [ turbo_rails_entry, stimulus_rails_entry ]
       end
 
+      def using_importmap?
+        options[:javascript] == "importmap"
+      end
+
       def using_js_runtime?
-        (options[:javascript] && !%w[importmap].include?(options[:javascript])) ||
-          (options[:css] && !%w[tailwind sass].include?(options[:css]))
+        (options[:javascript] && !using_importmap?) || (options[:css] && !%w[tailwind sass].include?(options[:css]))
       end
 
       def using_node?

--- a/railties/lib/rails/generators/rails/app/templates/app/controllers/application_controller.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/app/controllers/application_controller.rb.tt
@@ -2,5 +2,10 @@ class ApplicationController < ActionController::<%= options.api? ? "API" : "Base
 <%- unless options.api? -%>
   # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
   allow_browser versions: :modern
+<%- if options.using_importmap? -%>
+
+  # Changes to the importmap will invalidate the etag for HTML responses
+  stale_when_importmap_changes
+<% end -%>
 <% end -%>
 end


### PR DESCRIPTION
When using the importmap, you previously needed to manually add an etagger to the `ApplicationController` to ensure any changes would invalidate the HTML response etag. The [latest version of importmap-rails](https://github.com/rails/importmap-rails/releases/tag/v2.1.0) now has a macro to add this, so this PR adds a call to that in the default `ApplicationController`.