### PR TITLE
Fix the `rails new -A` CLI description

### DIFF
--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -71,7 +71,8 @@ module Rails
         class_option :skip_action_cable,   type: :boolean, aliases: "-C", default: nil,
                                            desc: "Skip Action Cable files"
 
-        class_option :skip_asset_pipeline, type: :boolean, aliases: "-A", default: nil
+        class_option :skip_asset_pipeline, type: :boolean, aliases: "-A", default: nil,
+                                           desc: "Skip the asset pipeline setup"
 
         class_option :skip_javascript,     type: :boolean, aliases: ["-J", "--skip-js"], default: (true if name == "plugin"),
                                            desc: "Skip JavaScript files"


### PR DESCRIPTION
The `-A` description in the CLI was `"Indicates when to generate skip asset pipeline"`. After this change it's `"Skip the asset pipeline"`, which mimics all existing "skip ..." descriptions.

```
# before
  -A,            [--skip-asset-pipeline]                                       # Indicates when to generate skip asset pipeline

# after
  -A,            [--skip-asset-pipeline]                                       # Skip the asset pipeline setup
```
