### PR TITLE
Fix example should use class method instead of DatabaseStatements#transaction [ci skip]

### DIFF
--- a/activerecord/lib/active_record/transactions.rb
+++ b/activerecord/lib/active_record/transactions.rb
@@ -219,12 +219,11 @@ module ActiveRecord
     # database error will occur because the savepoint has already been
     # automatically released. The following example demonstrates the problem:
     #
-    #   Model.lease_connection.transaction do                           # BEGIN
-    #     Model.lease_connection.transaction(requires_new: true) do     # CREATE SAVEPOINT active_record_1
-    #       Model.lease_connection.create_table(...)                    # active_record_1 now automatically released
-    #     end                                                     # RELEASE SAVEPOINT active_record_1
-    #                                                             # ^^^^ BOOM! database error!
-    #   end
+    #   Model.transaction do                           # BEGIN
+    #     Model.transaction(requires_new: true) do     # CREATE SAVEPOINT active_record_1
+    #       Model.lease_connection.create_table(...)   # active_record_1 now automatically released
+    #     end                                          # RELEASE SAVEPOINT active_record_1
+    #   end                                            # ^^^^ BOOM! database error!
     #
     # Note that "TRUNCATE" is also a MySQL DDL statement!
     module ClassMethods


### PR DESCRIPTION
:green_circle: https://zzak-transaction-class-metho.rails-docs-preview.pages.dev/api/classes/ActiveRecord/Transactions/ClassMethods.html#module-ActiveRecord::Transactions::ClassMethods-label-Caveats

Also fixes the alignment of the comments.

![Screenshot from 2024-12-22 09-25-53](https://github.com/user-attachments/assets/4abe51e1-e91b-4b10-beb8-efaed0a25e61)


See: https://edgeapi.rubyonrails.org/classes/ActiveRecord/Transactions/ClassMethods.html#module-ActiveRecord::Transactions::ClassMethods-label-Caveats

/cc @skipkayhil 