### PR TITLE
Remove unused require from active_record/test/connection_management_test

### DIFF
--- a/activerecord/test/cases/connection_management_test.rb
+++ b/activerecord/test/cases/connection_management_test.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "cases/helper"
-require "rack"
 
 module ActiveRecord
   module ConnectionAdapters


### PR DESCRIPTION
Follow up to #54023, sorry I should have checked for more occurrences.

TIL: this was added in 2b812408c9 when the query cache was a rack middleware.