### PR TITLE
Include DB accessory config in Kamal deploy template by default

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Include DB accessory config in Kamal deploy template by default
+
+    *Jatin Goyal*
+
 *   Don't enable YJIT in development and test environments
 
     Development and test environment tend to reload code and redefine methods (e.g. mocking),

--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -638,6 +638,14 @@ module Rails
         end
       end
 
+      def kamal_accessories_config_yaml
+        return if skip_kamal?
+
+        @kamal_accessories_config_yaml ||= if (db_config = database.kamal_db_config(app_name))
+          { "accessories" => db_config }.to_yaml(indentation: 2)[4..-2]
+        end
+      end
+
       def bundle_command(command, env = {})
         say_status :run, "bundle #{command}"
 
@@ -737,6 +745,7 @@ module Rails
 
         template "kamal-secrets.tt", ".kamal/secrets", force: true
         template "config/deploy.yml", force: true
+        template database.init_template, "db/init.sh" unless database.init_template.blank?
       end
 
       def run_solid

--- a/railties/lib/rails/generators/database.rb
+++ b/railties/lib/rails/generators/database.rb
@@ -44,6 +44,29 @@ module Rails
         def host
           "127.0.0.1"
         end
+
+        def init_template
+          "mysql-init.sh.tt"
+        end
+
+        def kamal_db_config(app_name)
+          {
+            "db" => {
+              "image" => "mysql:8.0",
+              "roles" => ["web"],
+              "port" => "127.0.0.1:3306:3306",
+              "env" => {
+                "clear" => {
+                  "MYSQL_ROOT_HOST" => "%",
+                  "MYSQL_USER" => app_name
+                },
+                "secret" => %w(MYSQL_ROOT_PASSWORD MYSQL_PASSWORD),
+              },
+              "directories" => ["data:/var/lib/mysql"],
+              "files" => ["db/init.sh:/docker-entrypoint-initdb.d/init.sh"]
+            }
+          }
+        end
       end
 
       module MariaDB
@@ -64,6 +87,29 @@ module Rails
             "environment" => {
               "MARIADB_ALLOW_EMPTY_ROOT_PASSWORD" => "true",
             },
+          }
+        end
+
+        def init_template
+          "mariadb-init.sh.tt"
+        end
+
+        def kamal_db_config(app_name)
+          {
+            "db" => {
+              "image" => "mariadb:10.5",
+              "roles" => ["web"],
+              "port" => "127.0.0.1:3306:3306",
+              "env" => {
+                "clear" => {
+                  "MARIADB_ROOT_HOST" => "%",
+                  "MARIADB_USER" => app_name
+                },
+                "secret" => %w(MARIADB_ROOT_PASSWORD MARIADB_PASSWORD),
+              },
+              "directories" => ["data:/var/lib/mysql"],
+              "files" => ["db/init.sh:/docker-entrypoint-initdb.d/init.sh"]
+            }
           }
         end
       end
@@ -139,6 +185,14 @@ module Rails
         "#{name}-data"
       end
 
+      def init_template
+        nil
+      end
+
+      def kamal_db_config(app_name)
+        raise NotImplementedError
+      end
+
       class MySQL2 < Database
         include MySQL
 
@@ -204,6 +258,23 @@ module Rails
         def feature_name
           "ghcr.io/rails/devcontainer/features/postgres-client"
         end
+
+        def kamal_db_config(app_name)
+          {
+            "db" => {
+              "image" => "postgres:15",
+              "roles" => ["web"],
+              "port" => "127.0.0.1:5432:5432",
+              "env" => {
+                "clear" => {
+                  "POSTGRES_USER" => app_name
+                },
+                "secret" => %w(POSTGRES_PASSWORD),
+              },
+              "directories" => ["data:/var/lib/postgresql/data"]
+            }
+          }
+        end
       end
 
       class Trilogy < Database
@@ -262,6 +333,10 @@ module Rails
         def feature_name
           "ghcr.io/rails/devcontainer/features/sqlite3"
         end
+
+        def kamal_db_config(app_name)
+          nil
+        end
       end
 
       class MariaDBMySQL2 < MySQL2
@@ -281,6 +356,8 @@ module Rails
         def base_package; end
         def build_package; end
         def feature_name; end
+        def init_template; end
+        def kamal_db_config(app_name); end
       end
     end
   end

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/mysql.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/mysql.yml.tt
@@ -55,6 +55,9 @@ test:
 <%- if options.skip_solid? -%>
 production:
   <<: *default
+<% if respond_to?(:kamal_accessories_config_yaml, true) && kamal_accessories_config_yaml -%>
+  host: <%= app_name %>-db
+<% end -%>
   database: <%= app_name %>_production
   username: <%= app_name %>
   password: <%%= ENV["<%= app_name.upcase %>_DATABASE_PASSWORD"] %>
@@ -62,6 +65,9 @@ production:
 production:
   primary: &primary_production
     <<: *default
+<% if respond_to?(:kamal_accessories_config_yaml, true) && kamal_accessories_config_yaml -%>
+    host: <%= app_name %>-db
+<% end -%>
     database: <%= app_name %>_production
     username: <%= app_name %>
     password: <%%= ENV["<%= app_name.upcase %>_DATABASE_PASSWORD"] %>

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/postgresql.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/postgresql.yml.tt
@@ -87,6 +87,9 @@ test:
 <%- if options.skip_solid? -%>
 production:
   <<: *default
+<% if respond_to?(:kamal_accessories_config_yaml, true) && kamal_accessories_config_yaml -%>
+  host: <%= app_name %>-db
+<% end -%>
   database: <%= app_name %>_production
   username: <%= app_name %>
   password: <%%= ENV["<%= app_name.upcase %>_DATABASE_PASSWORD"] %>
@@ -94,6 +97,9 @@ production:
 production:
   primary: &primary_production
     <<: *default
+<% if respond_to?(:kamal_accessories_config_yaml, true) && kamal_accessories_config_yaml -%>
+    host: <%= app_name %>-db
+<% end -%>
     database: <%= app_name %>_production
     username: <%= app_name %>
     password: <%%= ENV["<%= app_name.upcase %>_DATABASE_PASSWORD"] %>

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/trilogy.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/trilogy.yml.tt
@@ -57,6 +57,9 @@ test:
 <%- if options.skip_solid? -%>
 production:
   <<: *default
+<% if respond_to?(:kamal_accessories_config_yaml, true) && kamal_accessories_config_yaml -%>
+  host: <%= app_name %>-db
+<% end -%>
   database: <%= app_name %>_production
   username: <%= app_name %>
   password: <%%= ENV["<%= app_name.upcase %>_DATABASE_PASSWORD"] %>
@@ -64,6 +67,9 @@ production:
 production:
   primary: &primary_production
     <<: *default
+<% if respond_to?(:kamal_accessories_config_yaml, true) && kamal_accessories_config_yaml -%>
+    host: <%= app_name %>-db
+<% end -%>
     database: <%= app_name %>_production
     username: <%= app_name %>
     password: <%%= ENV["<%= app_name.upcase %>_DATABASE_PASSWORD"] %>

--- a/railties/lib/rails/generators/rails/app/templates/config/deploy.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/deploy.yml.tt
@@ -35,6 +35,9 @@ registry:
 env:
   secret:
     - RAILS_MASTER_KEY
+<% if kamal_accessories_config_yaml -%>
+    - <%= app_name.upcase %>_DATABASE_PASSWORD
+<% end -%>
 <% if skip_solid? -%>
   # clear:
   #   # Set number of cores available to the application on each server (default: 1).
@@ -104,22 +107,13 @@ builder:
 #   user: app
 
 # Use accessory services (secrets come from .kamal/secrets).
+<% if kamal_accessories_config_yaml -%>
+# Set value of <%= app_name.upcase %>_DATABASE_PASSWORD env in .kamal/secrets
+# and deploy with `bin/kamal setup`
+<%= kamal_accessories_config_yaml %>
+<% else -%>
 # accessories:
-#   db:
-#     image: mysql:8.0
-#     host: 192.168.0.2
-#     # Change to 3306 to expose port to the world instead of just local network.
-#     port: "127.0.0.1:3306:3306"
-#     env:
-#       clear:
-#         MYSQL_ROOT_HOST: '%'
-#       secret:
-#         - MYSQL_ROOT_PASSWORD
-#     files:
-#       - config/mysql/production.cnf:/etc/mysql/my.cnf
-#       - db/production.sql:/docker-entrypoint-initdb.d/setup.sql
-#     directories:
-#       - data:/var/lib/mysql
+<% end -%>
 #   redis:
 #     image: valkey/valkey:8
 #     host: 192.168.0.2

--- a/railties/lib/rails/generators/rails/app/templates/kamal-secrets.tt
+++ b/railties/lib/rails/generators/rails/app/templates/kamal-secrets.tt
@@ -15,3 +15,11 @@ KAMAL_REGISTRY_PASSWORD=$KAMAL_REGISTRY_PASSWORD
 
 # Improve security by using a password manager. Never check config/master.key into git!
 RAILS_MASTER_KEY=$(cat config/master.key)
+
+<% if secrets = database.kamal_db_config(app_name)&.dig("db", "env", "secret") -%>
+# DB Creds - just set <%= app_name.upcase %>_DATABASE_PASSWORD and you are ready to deploy
+<%= app_name.upcase %>_DATABASE_PASSWORD=$<%= app_name.upcase %>_DATABASE_PASSWORD
+<% secrets.each do |secret| -%>
+<%= secret %>=${<%= app_name.upcase %>_DATABASE_PASSWORD}
+<% end -%>
+<% end -%>

--- a/railties/lib/rails/generators/rails/app/templates/mariadb-init.sh.tt
+++ b/railties/lib/rails/generators/rails/app/templates/mariadb-init.sh.tt
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Use the MARIADB_PASSWORD environment variable to set the password
+MARIADB_PASSWORD=${MARIADB_PASSWORD}
+
+# Execute the SQL commands
+mysql -u root -p"${MARIADB_PASSWORD}" <<EOF
+<% if options[:database].in?(%w[trilogy mariadb-trilogy]) -%>
+# Switch to mysql_native_password for compatibility with trilogy
+# Trilogy does not support caching_sha2_password over non-TLS connections
+# Reference: https://github.com/trilogy-libraries/trilogy/pull/165
+ALTER USER '<%= app_name %>'@'%' IDENTIFIED VIA mysql_native_password USING PASSWORD('${MARIADB_PASSWORD}');
+<% end -%>
+# Grant non-admin privileges to application user
+GRANT SELECT, INSERT, UPDATE, DELETE, CREATE, DROP, REFERENCES, INDEX, ALTER, CREATE TEMPORARY TABLES, LOCK TABLES, EXECUTE, REPLICATION SLAVE, REPLICATION CLIENT, CREATE VIEW, SHOW VIEW, CREATE ROUTINE, ALTER ROUTINE, EVENT, TRIGGER ON *.* TO '<%= app_name %>'@'%';
+EOF

--- a/railties/lib/rails/generators/rails/app/templates/mysql-init.sh.tt
+++ b/railties/lib/rails/generators/rails/app/templates/mysql-init.sh.tt
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Use the MYSQL_PASSWORD environment variable to set the password
+MYSQL_PASSWORD=${MYSQL_PASSWORD}
+
+# Execute the SQL commands
+mysql -u root -p"${MYSQL_PASSWORD}" <<EOF
+<% if options[:database].in?(%w[trilogy mariadb-trilogy]) -%>
+# Switch to mysql_native_password for compatibility with trilogy
+# Trilogy does not support caching_sha2_password over non-TLS connections
+# Reference: https://github.com/trilogy-libraries/trilogy/pull/165
+ALTER USER '<%= app_name %>'@'%' IDENTIFIED WITH mysql_native_password BY '${MYSQL_PASSWORD}';
+<% end -%>
+# Grant non-admin privileges to application user
+GRANT SELECT, INSERT, UPDATE, DELETE, CREATE, DROP, REFERENCES, INDEX, ALTER, CREATE TEMPORARY TABLES, LOCK TABLES, EXECUTE, REPLICATION SLAVE, REPLICATION CLIENT, CREATE VIEW, SHOW VIEW, CREATE ROUTINE, ALTER ROUTINE, EVENT, TRIGGER ON *.* TO '<%= app_name %>'@'%';
+EOF


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

Since Rails 8 comes with Kamal out of the box, the production deployment path has been simpler than ever. But as of now `deploy.yml` does not contain config for DB accessory. So the developer still has to figure out the DB configuration to work with Kamal. 

I think Rails should offer the default DB configuration as well out of the box, to cater to a typical small Rails app with everything running on a single machine.

This PR adds the `db` accessory to `deploy.yml` based on user's chosen db.

### Detail

Configs for `sqlite3` and `postgresql` are straightforward.

For `mysql`, an init script needs to be run to provide app db user with access to create databases.

For `trilogy`, in addition to above, since `trilogy` adapter doesn't support the `caching_sha2_password` plugin on non-TLS connections, the password has to be configured with the `mysql_native_password` auth plugin.

Deployment tested for all 6 database adapters.

<!--
### Additional information

Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
