### PR TITLE
Fix missing hyperlink on new Getting Started tutorial [ci-skip]

### DIFF
--- a/guides/source/getting_started.md
+++ b/guides/source/getting_started.md
@@ -2932,7 +2932,7 @@ Here are some ideas:
 We also recommend learning more by reading other Ruby on Rails Guides:
 
 * [Active Record Basics](active_record_basics.html)
-* [Layouts and Rendering in Rails]()
+* [Layouts and Rendering in Rails](layouts_and_rendering.html)
 * [Testing Rails Applications](testing.html)
 * [Debugging Rails Applications](debugging_rails_applications.html)
 * [Securing Rails Applications](security.html)


### PR DESCRIPTION
There's a missing hyperlink at the bottom of the new Getting Started tutorial