### PR TITLE
Ensure rdoc picks up Hash#deep_merge! [ci skip]

### DIFF
--- a/activesupport/lib/active_support/core_ext/hash/deep_merge.rb
+++ b/activesupport/lib/active_support/core_ext/hash/deep_merge.rb
@@ -36,6 +36,7 @@ class Hash
   #--
   # Implemented by ActiveSupport::DeepMergeable#deep_merge!.
 
+  ##
   def deep_merge?(other) # :nodoc:
     other.is_a?(Hash)
   end


### PR DESCRIPTION
Fixes #53754

Same thing we do in other cases:
https://github.com/rails/rails/blob/6dda150b5e4cd25c6af76b99fe9a5c5986691e05/activerecord/lib/active_record/core.rb#L528-L539

/cc @seanpdoyle 