### PR TITLE
Tag helper buffer for nested elements with multiple children

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -18,4 +18,9 @@
 
     *brendon*
 
+*   Add a buffer to tag helpers to allow simpler generation of nested
+    HTML elements with multiple children.
+
+    *Naofumi Kagami*
+
 Please check [8-0-stable](https://github.com/rails/rails/blob/8-0-stable/actionview/CHANGELOG.md) for previous changes.

--- a/actionview/lib/action_view/helpers/tag_helper.rb
+++ b/actionview/lib/action_view/helpers/tag_helper.rb
@@ -227,7 +227,11 @@ module ActionView
         end
 
         def tag_string(name, content = nil, options, escape: true, &block)
-          content = @view_context.capture(self, &block) if block
+          if block
+            buffer = []
+            content = @view_context.capture(buffer, &block)
+            content = safe_join(buffer.compact_blank) if buffer.present?
+          end
 
           content_tag_string(name, content, options, escape)
         end
@@ -347,6 +351,16 @@ module ActionView
       #   tag.h1 'All titles fit to print' # => <h1>All titles fit to print</h1>
       #
       #   tag.div tag.p('Hello world!')  # => <div><p>Hello world!</p></div>
+      #
+      # To embed multiple children, push them into the buffer provided as a block argument:
+      #
+      #   tag.div { |b|
+      #     b << tag.p('Hello world!')
+      #     b << false && tag.p('This will be ignored')
+      #     b << tag.p('This will be ignored too') if false
+      #     b << tag.p('Konnichiwa Sekai!')
+      #   }
+      #   # => <div><p>Hello world!</p><p>Konnichiwa Sekai!</p></div>
       #
       # Content can also be captured with a block, which is useful in templates:
       #

--- a/actionview/test/template/tag_helper_test.rb
+++ b/actionview/test/template/tag_helper_test.rb
@@ -243,9 +243,19 @@ class TagHelperTest < ActionView::TestCase
     assert_equal "<div>content</div>",
                  tag.div { "content" }
     assert_equal "<div id=\"header\"><span>hello</span></div>",
-                 tag.div(id: "header") { |tag| tag.span "hello" }
+                 tag.div(id: "header") { tag.span "hello" }
     assert_equal "<div id=\"header\"><div class=\"world\"><span>hello</span></div></div>",
-                 tag.div(id: "header") { |tag| tag.div(class: "world") { tag.span "hello" } }
+                 tag.div(id: "header") { tag.div(class: "world") { tag.span "hello" } }
+  end
+
+  def test_tag_builder_nested_with_multiple_children_including_false
+    assert_equal "<div id=\"header\"><span>hello</span><span>world</span></div>",
+                 tag.div(id: "header") { |b|
+                   b << tag.span("hello")
+                   b << false && tag.span("This will be ignored")
+                   b << tag.span("This will be ignored too") if false
+                   b << tag.span("world")
+                 }
   end
 
   def test_content_tag_with_block_in_erb


### PR DESCRIPTION
### Motivation / Background

This Pull Request adds a buffer to the content block in ActionView::Helpers::TagHelper#tag. This allows us to easily generate HTML for nested elements with multiple children.

Current Tag helpers can render HTML by just writing pure Ruby inside a helper function. This allows us to create very lightweight components, without the need for ERB or external libraries. However, Tag helpers currently lack a mechanism for handling nested elements with multiple children. The proposed solution addresses this limitation.

**HTML: The HTML that we want to generate**
```html
<figure>
  <img src="/path/to/image.jpg" alt="Alternate Text" />
  <figcaption>Figure Caption</figcaption>
</figure>
```

**View helper: The helper function to generate the above HTML using this pull request**

```ruby
def figure(src, alt:, figcaption: nil)
  tag.figure do |b|
    b << tag.img(src:, alt:)
    b << tag.figcaption(figcaption) if figcaption.present?
  end
end
```

#### Without this Pull Request 

Without this buffer, we typically have to use either of the two following workarounds that are cumbersome, or fallback to ERB.

**Workaround: With concatenation**

```ruby
def figure(src, alt:, figcaption: nil)
  figure_content = tag.img(src:, alt:)
  figure_content += tag.figcaption(figcaption) if figcaption.present?
  tag.figure do
    figure_content
  end
end
```

**Workaround: With `safe_join`**

```ruby
def figure(src, alt:, figcaption: nil)
  tag.figure do
    safe_join([
      tag.img(src:, alt:),
      tag.figcaption(figcaption) if figcaption.present?
    ])
  end
end
```

Additional details on the motivation can be found in this blog post ["Rails View Helpers for Components"](https://dev.to/naofumik/rails-view-helpers-for-components-481c)


### Details

This Pull Request introduces a buffer (implemented as an Array) inside `ActionView::Helpers::TagHelper#tag_string` that is passed to `CaptureHelper#capture`. This buffer can be used to capture multiple child HTML elements which are `#safe_join`-ed, and then passed to `#content_tag_string`.

By also applying `#compact_blank` to the buffer, we additionally ignore falsey expressions, similar to how JSX ignores `false && <SomeComponent />` and doesn't render "false" as a string.

#### Potential impact on pre-existing code

The previous code inside `ActionView::Helpers::TagHelper#tag_string` passes `self` to `CaptureHelper#capture`. I have removed this because it would require the helper to be written with an unused block variable (`_tag` in the example below). The `self` passed into `CaptureHelper#capture` is undocumented and only used in one test case, and removing it still allows the test to pass (this is removed in this PR). I am unable to imagine a good use case for `self`, and I am assuming that usage in the wild is extremely rare.

The code that passes in `self` was introduced in https://github.com/rails/rails/pull/25543

**Example if we preserve the `self` block variable**
```ruby
def figure(src, alt:, figcaption: nil)
  tag.figure do |_tag, b|
    b << tag.img(src:, alt:)
    b << tag.figcaption(figcaption) if figcaption.present?
  end
end
```

This is the only situation I am aware of where the current change may impact pre-existing code.

### Note

This Pull Request only applies to the newer `#tag.<tag name>(...)` syntax. It has no impact on the legacy `#content_tag` method.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
