### PR TITLE
Fix belong_to typo in Active Record Associations guide [ci skip]

### DIFF
--- a/guides/source/association_basics.md
+++ b/guides/source/association_basics.md
@@ -1623,7 +1623,7 @@ In our example, `imageable_id` could be the ID of either an `Employee` or a
 either `Employee` or `Product`.
 
 While creating the polymorphic association manually is acceptable, it is instead
-recommended to use `t.references` or its alias `t.belong_to` and specify
+recommended to use `t.references` or its alias `t.belongs_to` and specify
 `polymorphic: true` so that Rails knows that the association is polymorphic, and
 it automatically adds both the foreign key and type columns to the table.
 


### PR DESCRIPTION
Fixing a minor typo in Active Record Associations / [Polymorphic Associations](https://guides.rubyonrails.org/association_basics.html#polymorphic-associations) chapter of Rails Guides.

The document refers to [belongs_to](https://api.rubyonrails.org/classes/ActiveRecord/ConnectionAdapters/TableDefinition.html#method-i-belongs_to) as `belong_to`, which is incorrect.