### PR TITLE
Handle polymorphic collection associations when setting through records

### DIFF
--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -279,7 +279,7 @@ module ActiveRecord
             if middle_target.nil? || (middle_reflection.collection? && middle_target.empty?)
               break []
             elsif middle_reflection.collection?
-              middle_target.flat_map { |record| record.association(through_reflection.source_reflection_name).load_target }
+              middle_target.flat_map { |record| record.association(through_reflection.source_reflection_name).load_target }.compact
             else
               middle_target.association(through_reflection.source_reflection_name).load_target
             end

--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -1235,7 +1235,7 @@ module ActiveRecord
 
     class PolymorphicReflection < AbstractReflection # :nodoc:
       delegate :klass, :scope, :plural_name, :type, :join_primary_key, :join_foreign_key,
-               :name, :scope_for, to: :@reflection
+               :name, :scope_for, :collection?, to: :@reflection
 
       def initialize(reflection, previous_reflection)
         super()

--- a/activerecord/test/cases/associations/has_many_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_through_associations_test.rb
@@ -84,6 +84,44 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
     assert_no_queries { assert_equal [subscriber_1, subscriber_2].sort, book.subscribers.sort }
   end
 
+  def test_setting_has_many_through_many_association_with_missing_targets_on_new_record_sets_empty_through_records
+    subscription_1 = Subscription.new
+    subscription_2 = Subscription.new
+    book = Book.new
+    book.subscriptions = [subscription_1, subscription_2]
+
+    assert_predicate book, :new_record?
+    book.subscriptions.each { |subscription| assert_predicate subscription, :new_record? }
+    assert_no_queries { assert_equal [], book.subscribers }
+  end
+
+  def test_setting_has_many_through_many_association_with_partial_missing_targets_on_new_record_sets_partial_through_records
+    subscriber_1 = Subscriber.create!(nick: "nick 1")
+    subscription_1 = Subscription.new(subscriber: subscriber_1)
+    subscription_2 = Subscription.new
+    book = Book.new
+    book.subscriptions = [subscription_1, subscription_2]
+
+    assert_predicate subscriber_1, :persisted?
+    assert_predicate book, :new_record?
+    book.subscriptions.each { |subscription| assert_predicate subscription, :new_record? }
+    assert_no_queries { assert_equal [subscriber_1], book.subscribers }
+  end
+
+  def test_setting_polymorphic_has_many_through_many_association_on_new_record_sets_through_records
+    human_1, human_2 = Human.create!, Human.create!
+    interest_1 = Interest.new(polymorphic_human: human_1)
+    interest_2 = Interest.new(polymorphic_human: human_2)
+    zine = Zine.new
+    zine.interests = [interest_1, interest_2]
+
+    assert_predicate human_1, :persisted?
+    assert_predicate human_2, :persisted?
+    assert_predicate zine, :new_record?
+    zine.interests.each { |interest| assert_predicate interest, :new_record? }
+    assert_no_queries { assert_equal [human_1, human_2].sort, zine.polymorphic_humans.sort }
+  end
+
   def test_setting_nested_has_many_through_one_association_on_new_record_sets_nested_through_records
     post_tagging_1, post_tagging_2 = Tagging.create!, Tagging.create!
     post = Post.create!(title: "Tagged", body: "Post", taggings: [post_tagging_1, post_tagging_2])


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

Context:
- https://github.com/rails/rails/pull/51114
- https://github.com/rails/rails/pull/53869
- https://github.com/rails/rails/pull/53957

Resolves https://github.com/rails/rails/pull/53957#discussion_r1897415637

### Detail

1. Fixes the error reported in the comment linked above by delegating `PolymorphicReflection#collection?` to the underlying reflection. An alternative way to do this, and ensure a similar issue doesn't catch someone off guard again, is to delegate these methods the way `ThroughReflection#collection?` [does it](https://github.com/rails/rails/blob/6df15e25c875e9c1ee39acb0bc161b6c47531331/activerecord/lib/active_record/reflection.rb#L1230-L1233). Let me know if that would be preferred.
2. Once I fixed the issue above I realised that in cases where a singular through target has not been set on the middle target, the through collection could could contain `nil` targets, which is not ideal. I patched this to ensure that only valid targets are set.

Both these cases only affect collection associations, and I've added tests to cover them.

cc/ @byroot

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.