### PR TITLE
Fix race condition in ConnectionPool#checkout on @pinned_connection

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -545,20 +545,25 @@ module ActiveRecord
       # Raises:
       # - ActiveRecord::ConnectionTimeoutError no connection can be obtained from the pool.
       def checkout(checkout_timeout = @checkout_timeout)
-        if @pinned_connection
-          @pinned_connection.lock.synchronize do
-            synchronize do
+        return checkout_and_verify(acquire_connection(checkout_timeout)) unless @pinned_connection
+
+        @pinned_connection.lock.synchronize do
+          synchronize do
+            # The pinned connection may have been cleaned up before we synchronized, so check if it is still present
+            if @pinned_connection
               @pinned_connection.verify!
+
               # Any leased connection must be in @connections otherwise
               # some methods like #connected? won't behave correctly
               unless @connections.include?(@pinned_connection)
                 @connections << @pinned_connection
               end
+
+              @pinned_connection
+            else
+              checkout_and_verify(acquire_connection(checkout_timeout))
             end
           end
-          @pinned_connection
-        else
-          checkout_and_verify(acquire_connection(checkout_timeout))
         end
       end
 


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because it fixes a race condition in `ConnectionPool#checkout`. 

Fixes #53980.

### Detail

This Pull Request changes the way we checkout a pinned connection, by double checking that the pinned connection is not cleaned up. In `ConnectionPool#checkout`, the `@pinned_connection` can be cleaned up if another thread executes the `unpin_connection!` method, while we don't have a lock acquired on the connection pool yet. 

### Additional information

The lock on pinned connection was introduced recently in #52235. It solved another deadlock problem. I am not able to reproduce that deadlock after making this change.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
