### PR TITLE
Fix two unused block warnings on Ruby 3.4

### DIFF
--- a/activemodel/lib/active_model/attribute.rb
+++ b/activemodel/lib/active_model/attribute.rb
@@ -38,7 +38,7 @@ module ActiveModel
       @value = value unless value.nil?
     end
 
-    def value
+    def value(&_)
       # `defined?` is cheaper than `||=` when we get back falsy values
       @value = type_cast(value_before_type_cast) unless defined?(@value)
       @value

--- a/activemodel/lib/active_model/type/value.rb
+++ b/activemodel/lib/active_model/type/value.rb
@@ -25,7 +25,7 @@ module ActiveModel
       # by the database.  For example a boolean type can return +true+ if the
       # value parameter is a Ruby boolean, but may return +false+ if the value
       # parameter is some other object.
-      def serializable?(value)
+      def serializable?(value, &_)
         true
       end
 


### PR DESCRIPTION
```
/home/user/.rbenv/versions/3.4.1/lib/ruby/gems/3.4.0/gems/activemodel-8.0.1/lib/active_model/attribute.rb:63: warning: the block passed to 'ActiveModel::Type::Value#serializable?' defined at /home/user/.rbenv/versions/3.4.1/lib/ruby/gems/3.4.0/gems/activemodel-8.0.1/lib/active_model/type/value.rb:28 may be ignored
/home/user/.rbenv/versions/3.4.1/lib/ruby/gems/3.4.0/gems/activemodel-8.0.1/lib/active_model/attribute_set.rb:51: warning: the block passed to 'ActiveModel::Attribute#value' defined at /home/user/.rbenv/versions/3.4.1/lib/ruby/gems/3.4.0/gems/activemodel-8.0.1/lib/active_model/attribute.rb:41 may be ignored
```


One is similar to https://github.com/rails/rails/blob/c31cc0b2e451b9271bdfedc68884e8ae38a7c0fb/activemodel/lib/active_model/type/big_integer.rb#L47-L49

The other may be passed a block through `fetch_value`: https://github.com/rails/rails/blob/1d841b1e4c6e91d5e2df8cf42dda5496cbf36aeb/activemodel/lib/active_model/attribute_set.rb#L50-L52