### PR TITLE
Fixes columns with double quotes

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -90,7 +90,7 @@ module ActiveRecord
             SELECT distinct i.relname, d.indisunique, d.indkey, pg_get_indexdef(d.indexrelid),
                             pg_catalog.obj_description(i.oid, 'pg_class') AS comment, d.indisvalid,
                             ARRAY(
-                              SELECT pg_get_indexdef(d.indexrelid, k + 1, true)
+                              SELECT REPLACE(pg_get_indexdef(d.indexrelid, k + 1, true), '"', '')
                               FROM generate_subscripts(d.indkey, 1) AS k
                               ORDER BY k
                             ) AS columns


### PR DESCRIPTION
Fixes #54057



cc @fatkodima 

<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

Some column identifiers are stored with double quotes in postgresql. in order to retrieve the index columns we replace the double quotes with an empty string

Here is a spec from the `pg` gem regarding this case
https://github.com/ged/ruby-pg/blob/c6d1047b419e87e57aaec076d9338e80f9bd269a/spec/pg/type_spec.rb#L679

the issue is that Pg decoder escapes those double quotes resulting in a wrong column name ( unless we sanitize it )


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
