### PR TITLE
Fix retrieving PostgreSQL indexes with keyword-named columns

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -112,7 +112,7 @@ module ActiveRecord
             inddef = row[3]
             comment = row[4]
             valid = row[5]
-            columns = decode_string_array(row[6])
+            columns = decode_string_array(row[6]).map { |c| Utils.unquote_identifier(c.strip.gsub('""', '"')) }
 
             using, expressions, include, nulls_not_distinct, where = inddef.scan(/ USING (\w+?) \((.+?)\)(?: INCLUDE \((.+?)\))?( NULLS NOT DISTINCT)?(?: WHERE (.+))?\z/m).flatten
 

--- a/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
@@ -414,6 +414,22 @@ module ActiveRecord
         end
       end
 
+      def test_index_keyword_column_name
+        with_example_table("timestamp integer") do
+          @connection.add_index "ex", :timestamp, name: "keyword"
+          index = @connection.indexes("ex").find { |idx| idx.name == "keyword" }
+          assert_equal ["timestamp"], index.columns
+        end
+      end
+
+      def test_index_escaped_quotes_column_name
+        with_example_table(%{"I""like""quotes" integer}) do
+          @connection.add_index "ex", :"I\"like\"quotes", name: "quotes"
+          index = @connection.indexes("ex").find { |idx| idx.name == "quotes" }
+          assert_equal ["I\"like\"quotes"], index.columns
+        end
+      end
+
       def test_columns_for_distinct_zero_orders
         assert_equal "posts.id",
           @connection.columns_for_distinct("posts.id", [])


### PR DESCRIPTION
Fixes #54057.
Closes #54058.