### PR TITLE
Add missing whitespace to Generating Child Models section [ci skip]

### DIFF
--- a/guides/source/association_basics.md
+++ b/guides/source/association_basics.md
@@ -1768,7 +1768,7 @@ Next, we generate the `Car`, `Motorcycle`, and `Bicycle` models that inherit
 from Vehicle. These models won't have their own tables; instead, they will use
 the `vehicles` table.
 
-To generate the`Car` model:
+To generate the `Car` model:
 
 ```bash
 $ bin/rails generate model car --parent=Vehicle


### PR DESCRIPTION
Fixing a small typo by adding a missing whitespace to [Generating Child Models](https://guides.rubyonrails.org/association_basics.html#generating-child-models) section.