### PR TITLE
Update link in Rails documentation to use the main branch [ci skip]

### DIFF
--- a/guides/source/getting_started.md
+++ b/guides/source/getting_started.md
@@ -29,7 +29,7 @@ basics of Ruby so that you understand some of the basic terms and vocabulary you
 will see in this tutorial.
 
 - [Official Ruby Programming Language website](https://www.ruby-lang.org/en/documentation/)
-- [List of Free Programming Books](https://github.com/EbookFoundation/free-programming-books/blob/master/books/free-programming-books-langs.md#ruby)
+- [List of Free Programming Books](https://github.com/EbookFoundation/free-programming-books/blob/main/books/free-programming-books-langs.md#ruby)
 
 Rails Philosophy
 ----------------


### PR DESCRIPTION
**Motivation / Background:**

This Pull Request has been created because the current link in the documentation points to the master branch, which has been renamed to main. This change avoids unnecessary redirects and aligns with GitHub's updated branch naming conventions.

**Detail:**

This Pull Request updates the link in the Rails documentation:

From: https://github.com/EbookFoundation/free-programming-books/blob/master/books/free-programming-books-langs.md#ruby
To: https://github.com/EbookFoundation/free-programming-books/blob/main/books/free-programming-books-langs.md#ruby

**Additional Information:**

No additional tests or changelog updates are needed as this is a documentation-only change.

**Checklist:**

- [x] This Pull Request is related to one change.
- [x] Commit message has a detailed description of what changed and why.
- [x] No tests are required as this is a documentation update.
- [x] No CHANGELOG updates are needed.