### PR TITLE
Support symbol proc on callback conditional

### DIFF
--- a/activesupport/lib/active_support/callbacks.rb
+++ b/activesupport/lib/active_support/callbacks.rb
@@ -498,9 +498,10 @@ module ActiveSupport
           when Conditionals::Value
             ProcCall.new(filter)
           when ::Proc
-            if filter.arity > 1
+            case filter.arity
+            when 2
               InstanceExec2.new(filter)
-            elsif filter.arity > 0
+            when 1, -2
               InstanceExec1.new(filter)
             else
               InstanceExec0.new(filter)

--- a/activesupport/test/callbacks_test.rb
+++ b/activesupport/test/callbacks_test.rb
@@ -189,6 +189,8 @@ module CallbacksTest
     before_save Proc.new { |r| r.history << "b00m" }, if: Proc.new { |r| false }
     before_save Proc.new { |r| r.history << [:before_save, :proc] }, unless: Proc.new { |r| false }
     before_save Proc.new { |r| r.history << "b00m" }, unless: Proc.new { |r| true }
+    before_save Proc.new { |r| r.history << "b00m" }, unless: proc(&:history)
+    before_save Proc.new { |r| r.history << "b00m" }, unless: lambda(&:history)
     # symbol
     before_save Proc.new { |r| r.history << [:before_save, :symbol] }, if: :yes
     before_save Proc.new { |r| r.history << "b00m" }, if: :no


### PR DESCRIPTION
### Motivation / Background  
ActiveSupport::Callbacks supports both symbol method names and lambda functions, but it does not support SymbolProc, which can occasionally be used. Of course, a SymbolProc can be replaced with a simple symbol method name. However, due to meta-programming, errors may surface far from the callback definition and without a meaningful stack trace.   
![image](https://github.com/user-attachments/assets/5b3ed540-5bc5-408a-a68e-65745a6a9e39)

Even printing the stack trace from Rails itself does not help much in such cases. Here is the image after adding some debug statements inside Rails, I identified the output and discovered what `callback_name` refers to:  
![image](https://github.com/user-attachments/assets/9f629522-db84-4126-89bb-c1b038c5b68a)

My suggestion here is to either add support for SymbolProc or raise a clearer, this PR is to support SymbolProc  

Fixes #54056  

### Detail  
This PR modifies the `CallTemplate` inside ActiveSupport::Callbacks to handle cases where the method arity is less than 0. In such cases, the proc is assumed to be a SymbolProc, and it is treated as having a single argument.  

### Additional Information  
This error is indirectly caused by auto-linting files in a `before_commit` hook since RuboCop enables the following cop by default:  https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/SymbolProc 

### Checklist  
* [x] This Pull Request addresses a single change. Unrelated changes should be opened in separate PRs.  
* [x] The commit message includes a detailed description of what was changed and why. If this PR fixes a related issue, it is referenced in the commit message (e.g., `[Fix #issue-number]`).  
* [x] Tests have been added or updated for bug fixes or new features.  
* [x] CHANGELOG files have been updated for libraries with behavioral changes or new features. Documentation-only changes and minor bug fixes are excluded.