### PR TITLE
[ci-skip][doc] Fix typo in edge Validation Guides

### DIFF
--- a/guides/source/active_record_validations.md
+++ b/guides/source/active_record_validations.md
@@ -361,7 +361,7 @@ In modern Rails applications, the more concise validate syntax is commonly used,
 for example:
 
 ```ruby
-validate :name, presence: true
+validates :name, presence: true
 ```
 
 However, older versions of Rails used "helper" methods, such as:


### PR DESCRIPTION
### Motivation / Background

Just to fix a typo in validation guide:

```diff
-validate :name, presence: true
+validates :name, presence: true
```

The context is not for custom validations:

https://edgeguides.rubyonrails.org/active_record_validations.html#validations

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
