### PR TITLE
[WIP] Pass original file with ImageAnalyzer yield call

### DIFF
--- a/activestorage/lib/active_storage/analyzer/image_analyzer/image_magick.rb
+++ b/activestorage/lib/active_storage/analyzer/image_analyzer/image_magick.rb
@@ -23,7 +23,7 @@ module ActiveStorage
           end
 
           if image.valid?
-            yield image
+            yield image, file
           else
             logger.info "Skipping image analysis because ImageMagick doesn't support the file"
             {}

--- a/activestorage/lib/active_storage/analyzer/image_analyzer/vips.rb
+++ b/activestorage/lib/active_storage/analyzer/image_analyzer/vips.rb
@@ -27,7 +27,7 @@ module ActiveStorage
           end
 
           if image
-            yield image
+            yield image, file
           else
             {}
           end


### PR DESCRIPTION
### Motivation / Background

I recently had to implement a dominant color extraction logic for one of the rails app i maintain. This app uses ActiveStorage for attachments handling and after doing a short research, it turned out i can accomplish that using custom analyzers. Extracting the color from image is as simple as `ColorExtractor.new(vips_image_instance)` however, it turned out it was not trivial to add that logic simply by decorating `ImageAnalyzer` and adding this call there + saving the result with blob metadata. Heres what i initially did:

```ruby
module ActiveStorage::Analyzer::ImageAnalyzerDecorator
  def metadata
    read_image do |image|
      dominant_color = DominantColorFinder.new(image).call

      if rotated_image?(image)
        { width: image.height, height: image.width, dominant_color: dominant_color }
      else
        { width: image.width, height: image.height, dominant_color: dominant_color }
      end
    end
  end
end

ActiveStorage::Analyzer::ImageAnalyzer.prepend(ActiveStorage::Analyzer::ImageAnalyzerDecorator)
```

However, for some reason, they way how vips handles images breaks them in some way and the dominant color extraction logic is not able to be run anymore (`VipsJpeg: out of order read at line xxx` errors when trying to do anything on the loaded `image`). It's not clear to me what is causing that but after playing around, i found out i was able to call the `DominantColorFinder` on a fresh `::Vips::Image.new_from_file` instance that has no other operations performed on it. However, as only modified `VipsImage` instance is being passed to the `yield` block of `Analyzers::Vips`, i don't have access to the original file from the `ImageAnalyzer#metadata`. 

The only way to overcome that would be to call `download_blob_to_tempfile` before the `read_image` in `ImageAnalyzer#metadata` which would make it look like that:

```ruby
module ActiveStorage::Analyzer::ImageAnalyzerDecorator
  def metadata
    download_blob_to_tempfile do |file|
      image = ::Vips::Image.new_from_file(file.path, access: :sequential)
      @dominant_color = DominantColorFinder.new(image).call
    end

    read_image do |image|
      if rotated_image?(image)
        { width: image.height, height: image.width, dominant_color: @dominant_color }
      else
        { width: image.width, height: image.height, dominant_color: @dominant_color }
      end
    end
  end
end

ActiveStorage::Analyzer::ImageAnalyzer.prepend(ActiveStorage::Analyzer::ImageAnalyzerDecorator)
```

But that's far from ideal as, in total, `download_blob_to_tempfile` is being called twice which translates to file being downloaded twice during this entire operation as the tempfile is not being memoized between the calls (please correct me if I'm wrong though).

So, the most elegant way of doing that i was able to find was to pass the original tempfile downloaded by `Vips` and `ImageMagic` in order to make it able to access it on blob metadata preparation. How my decorated ImageAnalyzer could finally look is as follows:

```ruby
module ActiveStorage::Analyzer::ImageAnalyzerDecorator
  def metadata
    read_image do |image, file|
      img = ::Vips::Image.new_from_file(file.path, access: :sequential)
      dominant_color = DominantColorFinder.new(img).call

      if rotated_image?(image)
        { width: image.height, height: image.width, dominant_color: dominant_color }
      else
        { width: image.width, height: image.height, dominant_color: dominant_color }
      end
    end
  end
end

ActiveStorage::Analyzer::ImageAnalyzer.prepend(ActiveStorage::Analyzer::ImageAnalyzerDecorator)
```

PS. I went for module appending instead of custom analyzer for simplicity's sake. The custom analyzer would inherit from `ImageAnalyzer` anyway.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
