### PR TITLE
docs: rails controller overview guide - small typo [ci skip]

### DIFF
--- a/guides/source/action_controller_overview.md
+++ b/guides/source/action_controller_overview.md
@@ -825,7 +825,7 @@ it will do with what the previous action put in the flash.
 
 #### Displaying flash messages
 
-If a previous action _has_ set a flash message, it's a good idea of display that
+If a previous action _has_ set a flash message, it's a good idea to display that
 to the user. We can accomplish this consistently by adding the HTML for
 displaying any flash messages in the application's default layout. Here's an
 example from `app/views/layouts/application.html.erb`:


### PR DESCRIPTION
# **Fix typo in flash message documentation**

---

## **Description**
This PR fixes a small typo in the Rails documentation for flash messages. Specifically:
- The word "of" is corrected to "to" in the sentence:
  > _"If a previous action **has** set a flash message, it's a good idea of display that."_
  Updated to:
  > _"If a previous action **has** set a flash message, it's a good idea to display that."_

---

## **Changes Made**
- Corrected a grammatical error in the documentation file.

---

## **Why This is Needed**
Improving the accuracy and readability of the documentation ensures that developers can better understand the Rails framework without confusion.

---

## **Checklist**
- [x] Typo corrected.
- [x] No function

