### PR TITLE
Fix `String#mb_chars` to never mutate the original String

### DIFF
--- a/activesupport/lib/active_support/multibyte/chars.rb
+++ b/activesupport/lib/active_support/multibyte/chars.rb
@@ -55,7 +55,10 @@ module ActiveSupport # :nodoc:
       # Creates a new Chars instance by wrapping _string_.
       def initialize(string)
         @wrapped_string = string
-        @wrapped_string.force_encoding(Encoding::UTF_8) unless @wrapped_string.frozen?
+        if string.encoding != Encoding::UTF_8
+          @wrapped_string = @wrapped_string.dup
+          @wrapped_string.force_encoding(Encoding::UTF_8)
+        end
       end
 
       # Forward all undefined methods to the wrapped string.

--- a/activesupport/test/multibyte_test_helpers.rb
+++ b/activesupport/test/multibyte_test_helpers.rb
@@ -1,9 +1,10 @@
 # frozen_string_literal: true
 
 module MultibyteTestHelpers
-  UNICODE_STRING = "こにちわ"
-  ASCII_STRING = "ohayo"
-  BYTE_STRING = (+"\270\236\010\210\245").force_encoding("ASCII-8BIT").freeze
+  # We use Symbol#to_s to create these strings so warnings are emitted if they are mutated
+  UNICODE_STRING = :"こにちわ".to_s
+  ASCII_STRING = :"ohayo".to_s
+  BYTE_STRING = "\270\236\010\210\245".b.freeze
 
   def chars(str)
     ActiveSupport::Multibyte::Chars.new(str)


### PR DESCRIPTION
Fix: https://github.com/rails/rails/issues/54076

If we have to call `force_encoding`, we should dup the argument regardless of wheter it is frozen or not as not not mutate our arguments.
