### PR TITLE
Deprecate `String#mb_chars` and `AS::Multibyte::Chars`.

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Deprecate `String#mb_chars` and `ActiveSupport::Multibyte::Chars`.
+
+    These APIs are a relic of the Ruby 1.8 days when Ruby strings weren't encoding
+    aware. There is no legitimate reasons to need these APIs today.
+
+    *Jean Boussier*
+
 *   Deprecate `ActiveSupport::Configurable`
 
     *Sean Doyle*

--- a/activesupport/lib/active_support/multibyte.rb
+++ b/activesupport/lib/active_support/multibyte.rb
@@ -12,6 +12,10 @@ module ActiveSupport # :nodoc:
     #
     #   ActiveSupport::Multibyte.proxy_class = CharsForUTF32
     def self.proxy_class=(klass)
+      ActiveSupport.deprecator.warn(
+        "ActiveSupport::Multibyte.proxy_class= is deprecated and will be removed in Rails 8.2. " \
+        "Use normal string methods instead."
+      )
       @proxy_class = klass
     end
 

--- a/activesupport/lib/active_support/multibyte/chars.rb
+++ b/activesupport/lib/active_support/multibyte/chars.rb
@@ -5,6 +5,11 @@ require "active_support/core_ext/string/access"
 require "active_support/core_ext/string/behavior"
 require "active_support/core_ext/module/delegation"
 
+ActiveSupport.deprecator.warn(
+  "ActiveSupport::Multibyte::Chars and String#mb_chars are deprecated and will be removed in Rails 8.2. " \
+  "Use normal string methods instead."
+)
+
 module ActiveSupport # :nodoc:
   module Multibyte # :nodoc:
     # = Active Support \Multibyte \Chars

--- a/activesupport/test/abstract_unit.rb
+++ b/activesupport/test/abstract_unit.rb
@@ -34,6 +34,10 @@ ActiveSupport::Cache.format_version = 7.1
 # Disable available locale checks to avoid warnings running the test suite.
 I18n.enforce_available_locales = false
 
+ActiveSupport.deprecator.silence do
+  ActiveSupport::Multibyte.const_get(:Chars)
+end
+
 class ActiveSupport::TestCase
   if Process.respond_to?(:fork) && !Gem.win_platform?
     parallelize


### PR DESCRIPTION
This is a relic of pre Ruby 1.9 times when Ruby strings weren't encoding aware. Using this API in 2025 is a huge smell.
