### PR TITLE
Clean up a few notification asserting tests

### DIFF
--- a/activerecord/test/cases/associations/eager_test.rb
+++ b/activerecord/test/cases/associations/eager_test.rb
@@ -1147,12 +1147,8 @@ class EagerAssociationTest < ActiveRecord::TestCase
   end
 
   def test_base_messages
-    payload = capture_notifications("instantiation.active_record") do
-      Developer.all.to_a
-    end.first.payload
-
-    assert_equal Developer.all.to_a.count, payload[:record_count]
-    assert_equal Developer.name, payload[:class_name]
+    expected_payload = { record_count: Developer.all.to_a.count, class_name: Developer.name }
+    assert_notification("instantiation.active_record", expected_payload) { Developer.all.to_a }
   end
 
   def test_load_with_sti_sharing_association

--- a/activestorage/test/analyzer/audio_analyzer_test.rb
+++ b/activestorage/test/analyzer/audio_analyzer_test.rb
@@ -18,13 +18,12 @@ class ActiveStorage::Analyzer::AudioAnalyzerTest < ActiveSupport::TestCase
   end
 
   test "instrumenting analysis" do
-    events = capture_notifications("analyze.active_storage") do
-      assert_notifications_count("analyze.active_storage", 1) do
-        blob = create_file_blob(filename: "audio.mp3", content_type: "audio/mp3")
+    blob = create_file_blob(filename: "audio.mp3", content_type: "audio/mp3")
+
+    assert_notifications_count("analyze.active_storage", 1) do
+      assert_notification("analyze.active_storage", analyzer: "ffprobe") do
         blob.analyze
       end
     end
-
-    assert_equal({ analyzer: "ffprobe" }, events.first.payload)
   end
 end

--- a/activestorage/test/analyzer/image_analyzer/image_magick_test.rb
+++ b/activestorage/test/analyzer/image_analyzer/image_magick_test.rb
@@ -47,14 +47,14 @@ class ActiveStorage::Analyzer::ImageAnalyzer::ImageMagickTest < ActiveSupport::T
   end
 
   test "instrumenting analysis" do
-    analyze_with_image_magick do
-      events = capture_notifications("analyze.active_storage") do
-        blob = create_file_blob(filename: "racecar.jpg", content_type: "image/jpeg")
-        blob.analyze
-      end
+    blob = create_file_blob(filename: "racecar.jpg", content_type: "image/jpeg")
 
-      assert_equal 1, events.size
-      assert_equal({ analyzer: "mini_magick" }, events.first.payload)
+    assert_notifications_count("analyze.active_storage", 1) do
+      assert_notification("analyze.active_storage", analyzer: "mini_magick") do
+        analyze_with_image_magick do
+          blob.analyze
+        end
+      end
     end
   end
 

--- a/activestorage/test/analyzer/video_analyzer_test.rb
+++ b/activestorage/test/analyzer/video_analyzer_test.rb
@@ -87,12 +87,12 @@ class ActiveStorage::Analyzer::VideoAnalyzerTest < ActiveSupport::TestCase
   end
 
   test "instrumenting analysis" do
-    events = capture_notifications("analyze.active_storage") do
-      blob = create_file_blob(filename: "video_without_audio_stream.mp4", content_type: "video/mp4")
-      blob.analyze
-    end
+    blob = create_file_blob(filename: "video.mp4", content_type: "video/mp4")
 
-    assert_equal 1, events.size
-    assert_equal({ analyzer: "ffprobe" }, events.first.payload)
+    assert_notifications_count("analyze.active_storage", 1) do
+      assert_notification("analyze.active_storage", analyzer: "ffprobe") do
+        blob.analyze
+      end
+    end
   end
 end

--- a/activesupport/test/cache/stores/memory_store_test.rb
+++ b/activesupport/test/cache/stores/memory_store_test.rb
@@ -44,13 +44,9 @@ class MemoryStoreTest < ActiveSupport::TestCase
     size = 3
     size.times { |i| @cache.write(i.to_s, i) }
 
-    events = capture_notifications("cache_cleanup.active_support") do
+    assert_notification("cache_cleanup.active_support", size: size, store: @cache.class.name) do
       @cache.cleanup
     end
-
-    assert_equal %w[cache_cleanup.active_support], events.map(&:name)
-    assert_equal size, events[0].payload[:size]
-    assert_equal @cache.class.name, events[0].payload[:store]
   end
 
   def test_nil_coder_bypasses_mutation_safeguard


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because there are some tests I updated to use the `NotificationAssertions` helpers that can be further improved by better utilizing said helpers for cleaner test implementations.

Follow up to
- https://github.com/rails/rails/pull/53822
- https://github.com/rails/rails/pull/53823
- https://github.com/rails/rails/pull/53824

### Detail

This Pull Request changes 1 `activerecord` test, 3 `activestorage` tests, and 1 `activesupport` test.

### Additional information

These changes don't require any changes to the underlying `NotificationAssertions` helpers and should be no-op.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
  * No CHANGELOG updates are required for this PR.