### PR TITLE
[ci-skip][docs] Fix sample code for `:allow_blank`

### DIFF
--- a/guides/source/active_record_validations.md
+++ b/guides/source/active_record_validations.md
@@ -1156,7 +1156,7 @@ empty string for example.
 
 ```ruby
 class Topic < ApplicationRecord
-  validates :title, length: { is: 5 }, allow_blank: true
+  validates :title, length: { is: 6 }, allow_blank: true
 end
 ```
 
@@ -1166,7 +1166,7 @@ irb> Topic.create(title: "").valid?
 irb> Topic.create(title: nil).valid?
 => true
 irb> Topic.create(title: "short").valid?
-=> false # 'short' is not of length 5, so validation fails even though it's not blank
+=> false # 'short' is not of length 6, so validation fails even though it's not blank
 ```
 
 ### `:message`


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because the comment "'short' is not of length **5**, so validation fails even though it's not blank" added by https://github.com/rails/rails/pull/52951 does not make sense:

```ruby
class Topic < ApplicationRecord
  validates :title, length: { is: 5 }, allow_blank: true
end
```

```irb
irb> Topic.create(title: "").valid?
=> true
irb> Topic.create(title: nil).valid?
=> true
irb> Topic.create(title: "short").valid?
=> false # 'short' is not of length 5, so validation fails even though it's not blank
```

I guess the length of "short" is 5: `"short".length  #=> 5`

### Detail

This Pull Request changes `length: { is: 5 }` to `length: { is: 6 }`, as well as updating `'short' is not of length 5` to `'short' is not of length 6` for consistency.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
