### PR TITLE
Fix running individual app:update commands

### DIFF
--- a/railties/lib/rails/commands/app/update_command.rb
+++ b/railties/lib/rails/commands/app/update_command.rb
@@ -24,22 +24,26 @@ module Rails
 
         desc "configs", "Update config files in the application config/ directory", hide: true
         def configs
+          require_application!
           app_generator.create_boot_file
           app_generator.update_config_files
         end
 
         desc "bin", "Add or update executables in the application bin/ directory", hide: true
         def bin
+          require_application!
           app_generator.update_bin_files
         end
 
         desc "public_directory", "Add or update files in the application public/ directory", hide: true
         def public_directory
+          require_application!
           app_generator.create_public_files
         end
 
         desc "active_storage", "Run the active_storage:update command", hide: true
         def active_storage
+          require_application!
           app_generator.update_active_storage
         end
 


### PR DESCRIPTION
### Motivation / Background

This fixes a regression introduced in https://github.com/rails/rails/pull/53647, where the individual `app:update` commands (like `app:update:configs` or `app:update:bin`) can no longer be ran on their own, as they require the app to be loaded and it no longer is.

### Detail

Right now if you run one of the `app:update:...` commands (the main command works fine) you'll get an error:

```
❯ rails app:update:configs

/Users/dennis/.local/share/mise/installs/ruby/3.4.1/lib/ruby/gems/3.4.0/gems/railties-8.0.1/lib/rails/commands/app/update_command.rb:61:in 'Rails::Command::App::UpdateCommand#generator_options': undefined method 'application' for module Rails (NoMethodError)

              api:                 !!Rails.application.config.api_only,
                                          ^^^^^^^^^^^^
        from /Users/dennis/.local/share/mise/installs/ruby/3.4.1/lib/ruby/gems/3.4.0/gems/railties-8.0.1/lib/rails/commands/app/update_command.rb:53:in 'Rails::Command::App::UpdateCommand#app_generator'
        from /Users/dennis/.local/share/mise/installs/ruby/3.4.1/lib/ruby/gems/3.4.0/gems/railties-8.0.1/lib/rails/commands/app/update_command.rb:26:in 'Rails::Command::App::UpdateCommand#configs'
        from /Users/dennis/.local/share/mise/installs/ruby/3.4.1/lib/ruby/gems/3.4.0/gems/thor-1.3.2/lib/thor/command.rb:28:in 'Thor::Command#run'
        from /Users/dennis/.local/share/mise/installs/ruby/3.4.1/lib/ruby/gems/3.4.0/gems/thor-1.3.2/lib/thor/invocation.rb:127:in 'Thor::Invocation#invoke_command'
        from /Users/dennis/.local/share/mise/installs/ruby/3.4.1/lib/ruby/gems/3.4.0/gems/railties-8.0.1/lib/rails/command/base.rb:178:in 'Rails::Command::Base#invoke_command'
        from /Users/dennis/.local/share/mise/installs/ruby/3.4.1/lib/ruby/gems/3.4.0/gems/thor-1.3.2/lib/thor.rb:538:in 'Thor.dispatch'
        from /Users/dennis/.local/share/mise/installs/ruby/3.4.1/lib/ruby/gems/3.4.0/gems/railties-8.0.1/lib/rails/command/base.rb:73:in 'Rails::Command::Base.perform'
        from /Users/dennis/.local/share/mise/installs/ruby/3.4.1/lib/ruby/gems/3.4.0/gems/railties-8.0.1/lib/rails/command.rb:65:in 'block in Rails::Command.invoke'
        from /Users/dennis/.local/share/mise/installs/ruby/3.4.1/lib/ruby/gems/3.4.0/gems/railties-8.0.1/lib/rails/command.rb:143:in 'Rails::Command.with_argv'
        from /Users/dennis/.local/share/mise/installs/ruby/3.4.1/lib/ruby/gems/3.4.0/gems/railties-8.0.1/lib/rails/command.rb:63:in 'Rails::Command.invoke'
        from /Users/dennis/.local/share/mise/installs/ruby/3.4.1/lib/ruby/gems/3.4.0/gems/railties-8.0.1/lib/rails/commands.rb:18:in '<main>'
        from /Users/dennis/.local/share/mise/installs/ruby/3.4.1/lib/ruby/3.4.0/bundled_gems.rb:82:in 'Kernel.require'
        from /Users/dennis/.local/share/mise/installs/ruby/3.4.1/lib/ruby/3.4.0/bundled_gems.rb:82:in 'block (2 levels) in Kernel#replace_require'
        from /Users/dennis/.local/share/mise/installs/ruby/3.4.1/lib/ruby/gems/3.4.0/gems/bootsnap-1.18.4/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30:in 'Kernel#require'
        from /Users/dennis/.local/share/mise/installs/ruby/3.4.1/lib/ruby/gems/3.4.0/gems/railties-8.0.1/lib/rails/app_loader.rb:59:in 'block in Rails::AppLoader#exec_app'
        from <internal:kernel>:168:in 'Kernel#loop'
        from /Users/dennis/.local/share/mise/installs/ruby/3.4.1/lib/ruby/gems/3.4.0/gems/railties-8.0.1/lib/rails/app_loader.rb:48:in 'Rails::AppLoader#exec_app'
        from /Users/dennis/.local/share/mise/installs/ruby/3.4.1/lib/ruby/gems/3.4.0/gems/railties-8.0.1/lib/rails/cli.rb:7:in '<top (required)>'
        from /Users/dennis/.local/share/mise/installs/ruby/3.4.1/lib/ruby/3.4.0/bundled_gems.rb:82:in 'Kernel.require'
        from /Users/dennis/.local/share/mise/installs/ruby/3.4.1/lib/ruby/3.4.0/bundled_gems.rb:82:in 'block (2 levels) in Kernel#replace_require'
        from /Users/dennis/.local/share/mise/installs/ruby/3.4.1/lib/ruby/gems/3.4.0/gems/railties-8.0.1/exe/rails:10:in '<top (required)>'
        from bin/rails:27:in 'Kernel#load'
        from bin/rails:27:in '<main>'
```

This is because in this commit (https://github.com/rails/rails/pull/53647/commits/dd56d70f190b95241a4992813f88bbfbcd9d1a81) the `require_application` call was moved to the `perform` method, making only the general command work.

Calling these individually seems to be supported, from these comments:

https://github.com/rails/rails/blob/be9aa73dd72f1097be5d45a58d7912447a266bd1/railties/lib/rails/commands/app/update_command.rb#L13

https://github.com/rails/rails/blob/be9aa73dd72f1097be5d45a58d7912447a266bd1/railties/lib/rails/app_loader.rb#L19-L23


### Questions

* Does this warrant additional tests? Maybe the test can be rewritten to test the individual commands for the specific parts they do, not having to introduce new tests as I guess they are not that fast as they do some IO. Before I do I'd like some guidance on what's best.
* The commit that broke this adds `Rails.application.deprecators.silenced = true` to the `perform` method, do we want to call that on all commands?
* Does this warrant a CHANGELOG entry?

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
