### PR TITLE
Remove `TrilogyAdapterTest`'s custom notification assertion helpers

### DIFF
--- a/activerecord/test/cases/adapters/trilogy/trilogy_adapter_test.rb
+++ b/activerecord/test/cases/adapters/trilogy/trilogy_adapter_test.rb
@@ -432,42 +432,4 @@ class TrilogyAdapterTest < ActiveRecord::TrilogyTestCase
       ActiveRecord::ConnectionAdapters::TrilogyAdapter.new(prepared_statements: true).connect!
     end
   end
-
-  # Create a temporary subscription to verify notification is sent.
-  # Optionally verify the notification payload includes expected types.
-  def assert_notification(notification, expected_payload = {}, &block)
-    notification_sent = false
-
-    subscription = lambda do |_, _, _, _, payload|
-      notification_sent = true
-
-      expected_payload.each do |key, value|
-        assert(
-          value === payload[key],
-          "Expected notification payload[:#{key}] to match #{value.inspect}, but got #{payload[key].inspect}."
-        )
-      end
-    end
-
-    ActiveSupport::Notifications.subscribed(subscription, notification) do
-      block.call if block_given?
-    end
-
-    assert notification_sent, "#{notification} notification was not sent"
-  end
-
-  # Create a temporary subscription to verify notification was not sent.
-  def assert_no_notification(notification, &block)
-    notification_sent = false
-
-    subscription = lambda do |*args|
-      notification_sent = true
-    end
-
-    ActiveSupport::Notifications.subscribed(subscription, notification) do
-      block.call if block_given?
-    end
-
-    assert_not notification_sent, "#{notification} notification was sent"
-  end
 end


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because we no longer need these custom notification assertion helpers since we have `ActiveSupport::Testing::NotificationAssertions` which has its own equivalent methods.

Follow up to
- https://github.com/rails/rails/pull/53065

### Detail

This Pull Request changes `TrilogyAdapterTest`. Simple cleanup.

### Additional information

n/a

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
  * No need for changelog entry.