### PR TITLE
Fix in_batches handling of limit when it's a string

### DIFF
--- a/activerecord/lib/active_record/relation/batches.rb
+++ b/activerecord/lib/active_record/relation/batches.rb
@@ -271,7 +271,7 @@ module ActiveRecord
       batch_limit = of
 
       if limit_value
-        remaining   = limit_value
+        remaining   = limit_value.to_i
         batch_limit = remaining if remaining < batch_limit
       end
 

--- a/activerecord/test/cases/batches_test.rb
+++ b/activerecord/test/cases/batches_test.rb
@@ -909,6 +909,18 @@ class EachTest < ActiveRecord::TestCase
       assert_equal limit, total
     end
 
+    test "in_batches should return limit records when limit is passed as string and load is #{load}" do
+      limit      = "5"
+      batch_size = 3
+      total      = 0
+
+      Post.limit(limit).in_batches(of: batch_size, load: load) do |batch|
+        total += batch.count
+      end
+
+      assert_equal limit.to_i, total
+    end
+
     test "in_batches should return limit records when limit is a multiple of the batch size and load is #{load}" do
       limit      = 6
       batch_size = 3


### PR DESCRIPTION
In batches limit string


### Motivation / Background

Other places of ActiveRecord work fine when `#limit` gets string argument -- be it from request params or commandline.
But `in_batches` just takes `limit_value` as it was in the scope and uses for number comparison, which of course throws exception if limit is a string.
This broke my raketask to-be-ran against a table with over 600M rows, so I need both `limit` (so the rake task can be executed in less-than-a-day runs) and `in_batches` to keep that memory under control.

### Detail

This tiny PR adds explicit `.to_i` on the `limit_value` within `in_batches`. With a test case of course, based on the test case above it.

### Additional information

Not sure if it's the proper way to do this casting, maybe it should be at the level of `limit_value` to ensure it always returns a number?

This is a minor bug fix so I'm not adding it to CHANGELOG.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
