### PR TITLE
Show db:migrate:reset in `rake --tasks`

### DIFF
--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -160,7 +160,7 @@ db_namespace = namespace :db do
       end
     end
 
-    # desc 'Resets your database using your migrations for the current environment'
+    desc "Resets your database using your migrations for the current environment"
     task reset: ["db:drop", "db:create", "db:schema:dump", "db:migrate"]
 
     desc 'Run the "up" for a given migration VERSION.'


### PR DESCRIPTION
### Motivation / Background

This was [previously][1] hidden, but is now more relevant because `db:migrate` loads the schema before migrating and developers are interested in the previous behavior.

[1]: https://github.com/rails/rails/commit/983815632cc1d316c7c803a47be28f1abe6698fb

### Detail

Ref #53649
Ref #53899
Fixes #53989
Ref #54106

### Additional information

This should be backported to `8-0-stable`. ~I'll see if there's a good place to document the `db:migrate` change in the CHANGELOG/upgrading guide.~

Edit: it's already in the CHANGELOG 🤔 

https://github.com/rails/rails/blob/f91d09425c51520a601359f5dc215f104df20712/activerecord/CHANGELOG.md?plain=1#L228

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
