### PR TITLE
Add payload subset matching support to `NotificationAssertions`'s `assert_notification`

### DIFF
--- a/actionpack/test/controller/caching_test.rb
+++ b/actionpack/test/controller/caching_test.rb
@@ -255,12 +255,10 @@ Ciao
   end
 
   def test_fragment_cache_instrumentation
-    payload = capture_notifications("read_fragment.action_controller") do
+    expected_payload = { controller: "functional_caching", action: "inline_fragment_cached" }
+    assert_notification("read_fragment.action_controller", expected_payload, payload_subset: true) do
       get :inline_fragment_cached
-    end.first.payload
-
-    assert_equal "functional_caching", payload[:controller]
-    assert_equal "inline_fragment_cached", payload[:action]
+    end
   end
 
   def test_html_formatted_fragment_caching

--- a/actionpack/test/controller/send_file_test.rb
+++ b/actionpack/test/controller/send_file_test.rb
@@ -210,7 +210,7 @@ class SendFileTest < ActionController::TestCase
   def test_send_file_instrumentation
     @controller.options = { disposition: :inline }
 
-    assert_notification("send_file.action_controller", path: __FILE__, disposition: :inline) do
+    assert_notification("send_file.action_controller", { path: __FILE__, disposition: :inline }) do
       process("file")
     end
   end
@@ -218,7 +218,7 @@ class SendFileTest < ActionController::TestCase
   def test_send_data_instrumentation
     @controller.options = { content_type: "application/x-ruby" }
 
-    assert_notification("send_data.action_controller", content_type: "application/x-ruby") do
+    assert_notification("send_data.action_controller", { content_type: "application/x-ruby" }) do
       process("data")
     end
   end

--- a/actionview/test/activerecord/partial_rendering_query_test.rb
+++ b/actionview/test/activerecord/partial_rendering_query_test.rb
@@ -10,13 +10,10 @@ class PartialRenderingQueryTest < ActiveRecordTestCase
   end
 
   def test_render_with_relation_collection
-    notifications = capture_notifications("sql.active_record") do
-      @view.render partial: "topics/topic", collection: Topic.all
+    assert_notifications_count("sql.active_record", 1) do
+      assert_notification("sql.active_record", { sql: 'SELECT "topics".* FROM "topics"' }, payload_subset: true) do
+        @view.render partial: "topics/topic", collection: Topic.all
+      end
     end
-
-    queries = notifications.filter_map { _1.payload[:sql] unless %w[ SCHEMA TRANSACTION ].include?(_1.payload[:name]) }
-
-    assert_equal 1, queries.size
-    assert_equal 'SELECT "topics".* FROM "topics"', queries[0]
   end
 end

--- a/activerecord/test/activejob/job_runtime_test.rb
+++ b/activerecord/test/activejob/job_runtime_test.rb
@@ -15,17 +15,14 @@ class JobRuntimeTest < ActiveSupport::TestCase
   test "job notification payload includes db_runtime" do
     ActiveRecord::RuntimeRegistry.sql_runtime = 0.0
 
-    event = capture_notifications("perform.active_job") { TestJob.perform_now }.first
-
-    assert_equal 42, event.payload[:db_runtime]
+    assert_notification("perform.active_job", { db_runtime: 42.0 }, payload_subset: true) { TestJob.perform_now }
   end
 
   test "db_runtime tracks database runtime for job only" do
     ActiveRecord::RuntimeRegistry.sql_runtime = 100.0
 
-    event = capture_notifications("perform.active_job") { TestJob.perform_now }.first
+    assert_notification("perform.active_job", { db_runtime: 42.0 }, payload_subset: true) { TestJob.perform_now }
 
-    assert_equal 42.0, event.payload[:db_runtime]
     assert_equal 142.0, ActiveRecord::RuntimeRegistry.sql_runtime
   end
 end

--- a/activerecord/test/cases/instrumentation_test.rb
+++ b/activerecord/test/cases/instrumentation_test.rb
@@ -128,11 +128,8 @@ module ActiveRecord
     end
 
     def test_payload_connection_with_query_cache_disabled
-      connection = ClothingItem.lease_connection
-
-      payload = capture_notifications("sql.active_record") { Book.first }.first.payload
-
-      assert_equal connection, payload[:connection]
+      expected_payload = { connection: ClothingItem.lease_connection }
+      assert_notification("sql.active_record", expected_payload, payload_subset: true) { Book.first }
     end
 
     def test_payload_connection_with_query_cache_enabled

--- a/activestorage/test/analyzer/audio_analyzer_test.rb
+++ b/activestorage/test/analyzer/audio_analyzer_test.rb
@@ -21,7 +21,7 @@ class ActiveStorage::Analyzer::AudioAnalyzerTest < ActiveSupport::TestCase
     blob = create_file_blob(filename: "audio.mp3", content_type: "audio/mp3")
 
     assert_notifications_count("analyze.active_storage", 1) do
-      assert_notification("analyze.active_storage", analyzer: "ffprobe") do
+      assert_notification("analyze.active_storage", { analyzer: "ffprobe" }) do
         blob.analyze
       end
     end

--- a/activestorage/test/analyzer/image_analyzer/image_magick_test.rb
+++ b/activestorage/test/analyzer/image_analyzer/image_magick_test.rb
@@ -50,7 +50,7 @@ class ActiveStorage::Analyzer::ImageAnalyzer::ImageMagickTest < ActiveSupport::T
     blob = create_file_blob(filename: "racecar.jpg", content_type: "image/jpeg")
 
     assert_notifications_count("analyze.active_storage", 1) do
-      assert_notification("analyze.active_storage", analyzer: "mini_magick") do
+      assert_notification("analyze.active_storage", { analyzer: "mini_magick" }) do
         analyze_with_image_magick do
           blob.analyze
         end

--- a/activestorage/test/analyzer/video_analyzer_test.rb
+++ b/activestorage/test/analyzer/video_analyzer_test.rb
@@ -90,7 +90,7 @@ class ActiveStorage::Analyzer::VideoAnalyzerTest < ActiveSupport::TestCase
     blob = create_file_blob(filename: "video.mp4", content_type: "video/mp4")
 
     assert_notifications_count("analyze.active_storage", 1) do
-      assert_notification("analyze.active_storage", analyzer: "ffprobe") do
+      assert_notification("analyze.active_storage", { analyzer: "ffprobe" }) do
         blob.analyze
       end
     end

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -47,4 +47,10 @@
 
     *Jonathan del Strother*
 
+*   `ActiveSupport::Testing::NotificationAssertions`'s `assert_notification` method now accepts a boolean `payload_subset` keyword argument which when set to `true` enables matching against a subset of a notification's `payload`. By default, it is set to `false`, matching payloads one to one.
+
+    Additionally, `assert_notification` now requires one to pass the optional `payload` argument as an explicit (`{}` wrapped) hash.
+
+    *Nicholas La Roux*
+
 Please check [8-0-stable](https://github.com/rails/rails/blob/8-0-stable/activesupport/CHANGELOG.md) for previous changes.

--- a/activesupport/test/cache/stores/memory_store_test.rb
+++ b/activesupport/test/cache/stores/memory_store_test.rb
@@ -44,7 +44,7 @@ class MemoryStoreTest < ActiveSupport::TestCase
     size = 3
     size.times { |i| @cache.write(i.to_s, i) }
 
-    assert_notification("cache_cleanup.active_support", size: size, store: @cache.class.name) do
+    assert_notification("cache_cleanup.active_support", { size: size, store: @cache.class.name }) do
       @cache.cleanup
     end
   end

--- a/activesupport/test/testing/notification_assertions_test.rb
+++ b/activesupport/test/testing/notification_assertions_test.rb
@@ -9,7 +9,7 @@ module ActiveSupport
       include NotificationAssertions
 
       def test_assert_notification
-        assert_notification("post.submitted", title: "Cool Post") do
+        assert_notification("post.submitted", { title: "Cool Post" }) do
           ActiveSupport::Notifications.instrument("post.submitted", title: "Cool Post")
         end
 
@@ -18,7 +18,7 @@ module ActiveSupport
         end
 
         assert_raises(Minitest::Assertion, match: /No post.submitted notifications were found/) do
-          assert_notification("post.submitted", title: "Cool Post") { nil } # no notifications
+          assert_notification("post.submitted", { title: "Cool Post" }) { nil } # no notifications
         end
 
         match = if RUBY_VERSION >= "3.4"
@@ -27,8 +27,23 @@ module ActiveSupport
           /No post.submitted notification with payload {:title=>"Cool Post"} was found/
         end
         assert_raises(Minitest::Assertion, match:) do
-          assert_notification("post.submitted", title: "Cool Post") do
+          assert_notification("post.submitted", { title: "Cool Post" }) do
             ActiveSupport::Notifications.instrument("post.submitted", title: "Cooler Post")
+          end
+        end
+
+        assert_notification("post.submitted", { title: "Cool Post" }, payload_subset: true) do
+          ActiveSupport::Notifications.instrument("post.submitted", title: "Cool Post", body: "Cool Body")
+        end
+
+        match = if RUBY_VERSION >= "3.4"
+          /No post.submitted notification with payload subset {title: "Cool Post"} was found/
+        else
+          /No post.submitted notification with payload subset {:title=>"Cool Post"} was found/
+        end
+        assert_raises(Minitest::Assertion, match:) do
+          assert_notification("post.submitted", { title: "Cool Post" }, payload_subset: true) do
+            ActiveSupport::Notifications.instrument("post.submitted", title: "Cooler Post", body: "Cool Body")
           end
         end
       end


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because one currently needs to exhaustively specify entire notification payloads (all key vals) in order to use `NotificationAssertions`'s `assert_notification`. While this is sometimes fine, i.e. payloads with only a few key vals, there are some cases in which payloads are rather large and one really only wants to assert a few of the key vals. This shortcoming forced one to manually capture notifications and assert against properties, which works, but I don't think should be necessary.

For example, we cannot currently use `assert_notification` in the following test because jobs' notifications' payloads contain various key vals, while we only want to assert against one.

https://github.com/rails/rails/blob/1b327ad4ed0fe5e8c2f1f795e2cf63f90a9833b5/activerecord/test/activejob/job_runtime_test.rb#L15-L21

Here's said assertion failing, exposing the list of payload key vals, only one of which we care about.

```ruby
vscode ➜ /workspaces/rails/activerecord (main) $ bin/test test/activejob/job_runtime_test.rb 
Using sqlite3_mem
Run options: --seed 23503

# Running:

.{:job=>#<JobRuntimeTest::TestJob:0x00007f80d3efa000 @arguments=[], @job_id="59c22946-0730-4db4-a63f-b71b72804a51", @queue_name=#<Proc:0x00007f80d40a4978 /workspaces/rails/activejob/lib/active_job/queue_name.rb:55 (lambda)>, @scheduled_at=nil, @priority=nil, @executions=1, @exception_executions={}, @timezone=nil, @_halted_callback_hook_called=nil>, :adapter=>#<ActiveJob::QueueAdapters::TestAdapter:0x00007f80d3e42388>, :db_runtime=>42.0, :aborted=>nil}
.

Finished in 0.002990s, 668.9259 runs/s, 1003.3888 assertions/s.
2 runs, 3 assertions, 0 failures, 0 errors, 0 skips
```

If we could assert against a subset of the said payload this test would be cleaner and simpler.

Follow up to
- https://github.com/rails/rails/pull/53065
- https://github.com/rails/rails/pull/53700 (merged as per gem PRs)
- https://github.com/rails/rails/pull/54084

### Detail

This Pull Request changes `NotificationAssertions`'s `assert_notification` method as well as some tests, both migrating a few to new `payload` argument shape and cleaning up some using the new `payload_subset` keyword argument.

Summary
- Makes `assert_notification` more useful in more cases for more people via new argument.
- Makes `assert_notification`'s `payload` argument clearer (now an explicit hash) _while_ said method is still not released in a stable Rails version. Thus, making this change now avoids a stable release breaking change. (still only in `main`, not in Rails 8, likely to be in 8.1)

### Additional information

I've been thinking about how to support payload subset matching with `assert_notification` for some time now. Was a feature I wanted to support within the scope of the original `NotificationAssertions` PR but I couldn't get it working as I wanted until now. That said, I am open to feedback on everything here including 1. whether we want this feature at all and 2. stylistically is `payload_subset` boolean kwarg the best implementation pattern.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
