### PR TITLE
Remove links to older guide versions from index page.

### DIFF
--- a/guides/source/_welcome.html.erb
+++ b/guides/source/_welcome.html.erb
@@ -14,20 +14,3 @@
   These guides are designed to make you immediately productive with Rails, and to help you understand how all of the pieces fit together.
 </p>
 <% end %>
-<p>
-The guides for earlier releases:
-<a href="https://guides.rubyonrails.org/v7.1/" data-turbo="false">Rails 7.1</a>,
-<a href="https://guides.rubyonrails.org/v7.0/" data-turbo="false">Rails 7.0</a>,
-<a href="https://guides.rubyonrails.org/v6.1/" data-turbo="false">Rails 6.1</a>,
-<a href="https://guides.rubyonrails.org/v6.0/" data-turbo="false">Rails 6.0</a>,
-<a href="https://guides.rubyonrails.org/v5.2/" data-turbo="false">Rails 5.2</a>,
-<a href="https://guides.rubyonrails.org/v5.1/" data-turbo="false">Rails 5.1</a>,
-<a href="https://guides.rubyonrails.org/v5.0/" data-turbo="false">Rails 5.0</a>,
-<a href="https://guides.rubyonrails.org/v4.2/" data-turbo="false">Rails 4.2</a>,
-<a href="https://guides.rubyonrails.org/v4.1/" data-turbo="false">Rails 4.1</a>,
-<a href="https://guides.rubyonrails.org/v4.0/" data-turbo="false">Rails 4.0</a>,
-<a href="https://guides.rubyonrails.org/v3.2/" data-turbo="false">Rails 3.2</a>,
-<a href="https://guides.rubyonrails.org/v3.1/" data-turbo="false">Rails 3.1</a>,
-<a href="https://guides.rubyonrails.org/v3.0/" data-turbo="false">Rails 3.0</a>, and
-<a href="https://guides.rubyonrails.org/v2.3/" data-turbo="false">Rails 2.3</a>.
-</p>


### PR DESCRIPTION
As older versions can now be selected with the dropdown version selector there is no need to link to unsupported versions on the guides homepage above the fold.