### PR TITLE
Support for additional file integrity checksum algorithms for cloud services

### DIFF
--- a/actiontext/test/unit/attachable_test.rb
+++ b/actiontext/test/unit/attachable_test.rb
@@ -14,7 +14,7 @@ class ActionText::AttachableTest < ActiveSupport::TestCase
         metadata: { identified: true },
         service_name: "test",
         byte_size: 4,
-        checksum: "CY9rzUYh03PK3k6DJie09g==",
+        checksum: ActiveStorage::Checksum.new("CY9rzUYh03PK3k6DJie09g==", :MD5).as_json,
         created_at: Time.zone.now.as_json,
         attachable_sgid: attachable.attachable_sgid
       }.deep_stringify_keys
@@ -33,7 +33,7 @@ class ActionText::AttachableTest < ActiveSupport::TestCase
       metadata: { identified: true },
       service_name: "test",
       byte_size: 4,
-      checksum: "CY9rzUYh03PK3k6DJie09g==",
+      checksum: ActiveStorage::Checksum.new("CY9rzUYh03PK3k6DJie09g==", :MD5).as_json,
       created_at: nil,
       attachable_sgid: nil
     }.deep_stringify_keys

--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Support additional file checksum algorithms in Azure Adapter
+
+    Add support for CRC64 to S3 service for
+    file integrity checking.
+    Add default_digest_algorithm configuration allowing selection of default
+    checksum algorithm for service. Keep default value as MD5
+
+    *Matt Pasquini*
+
 *   Support additional file checksum algorithms in GCS Adapter
 
     Add support for CRC32c to S3 service for

--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Support additional file checksum algorithms in S3 Adapter
+
+    Add support for CRC32, CRC32c, SHA1, SHA256, and CRC64NVMe to S3 service for
+    file integrity checking.
+    Add default_digest_algorithm configuration allowing selection of default
+    checksum algorithm for service. Keep default value as MD5
+
+    *Matt Pasquini*
+
 *   Introduce ActiveSupport::Checksum
 
     Refactor to support file additional integrity check algorithm in services

--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -11,9 +11,9 @@
 
     *Sean Doyle*
 
-*   Add support for alternative MD5 implementation through `config.active_storage.checksum_implementation`.
+*   Add support for fallback MD5 implementation
 
-    Also automatically degrade to using the slower `Digest::MD5` implementation if `OpenSSL::Digest::MD5`
+    Automatically degrade to using the slower `Digest::MD5` implementation if `OpenSSL::Digest::MD5`
     is found to be disabled because of OpenSSL FIPS mode.
 
     *Matt Pasquini*, *Jean Boussier*

--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Introduce ActiveSupport::Checksum
+
+    Refactor to support file additional integrity check algorithm in services
+
+    *Matt Pasquini*
+
 *   Delegate `ActiveStorage::Filename#to_str` to `#to_s`
 
     Supports checking String equality:

--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Support additional file checksum algorithms in GCS Adapter
+
+    Add support for CRC32c to S3 service for
+    file integrity checking.
+    Add default_digest_algorithm configuration allowing selection of default
+    checksum algorithm for service. Keep default value as MD5
+
+    *Matt Pasquini*
+
 *   Support additional file checksum algorithms in S3 Adapter
 
     Add support for CRC32, CRC32c, SHA1, SHA256, and CRC64NVMe to S3 service for

--- a/activestorage/app/controllers/active_storage/disk_controller.rb
+++ b/activestorage/app/controllers/active_storage/disk_controller.rb
@@ -22,7 +22,8 @@ class ActiveStorage::DiskController < ActiveStorage::BaseController
   def update
     if token = decode_verified_token
       if acceptable_content?(token)
-        named_disk_service(token[:service_name]).upload token[:key], request.body, checksum: token[:checksum]
+        checksum = ActiveStorage::Checksum.new(token[:checksum][:digest], token[:checksum][:algorithm])
+        named_disk_service(token[:service_name]).upload token[:key], request.body, checksum: checksum
         head :no_content
       else
         head :unprocessable_entity

--- a/activestorage/app/jobs/active_storage/mirror_job.rb
+++ b/activestorage/app/jobs/active_storage/mirror_job.rb
@@ -10,6 +10,6 @@ class ActiveStorage::MirrorJob < ActiveStorage::BaseJob
   retry_on ActiveStorage::IntegrityError, attempts: 10, wait: :polynomially_longer
 
   def perform(key, checksum:)
-    ActiveStorage::Blob.service.try(:mirror, key, checksum: checksum)
+    ActiveStorage::Blob.service.try(:mirror, key, checksum: ActiveStorage::Checksum.load(checksum))
   end
 end

--- a/activestorage/app/models/active_storage/blob.rb
+++ b/activestorage/app/models/active_storage/blob.rb
@@ -220,7 +220,6 @@ class ActiveStorage::Blob < ActiveStorage::Record
   # Returns a URL that can be used to directly upload a file for this blob on the service. This URL is intended to be
   # short-lived for security and only generated on-demand by the client-side JavaScript responsible for doing the uploading.
   def service_url_for_direct_upload(expires_in: ActiveStorage.service_urls_expire_in)
-    checksum = ActiveStorage::Checksum.load(self.checksum.to_s)
     service.url_for_direct_upload key, expires_in: expires_in, content_type: content_type, content_length: byte_size, checksum: checksum, custom_metadata: custom_metadata
   end
 
@@ -299,7 +298,7 @@ class ActiveStorage::Blob < ActiveStorage::Record
   end
 
   def mirror_later # :nodoc:
-    service.mirror_later key, checksum: checksum.to_s if service.respond_to?(:mirror_later)
+    service.mirror_later key, checksum: checksum if service.respond_to?(:mirror_later)
   end
 
   # Deletes the files on the service associated with the blob. This should only be done if the blob is going to be

--- a/activestorage/app/models/active_storage/blob.rb
+++ b/activestorage/app/models/active_storage/blob.rb
@@ -331,8 +331,9 @@ class ActiveStorage::Blob < ActiveStorage::Record
   private
     def compute_checksum_in_chunks(io)
       raise ArgumentError, "io must be rewindable" unless io.respond_to?(:rewind)
+      return unless service_name
 
-      ActiveStorage.checksum_implementation.new.tap do |checksum|
+      service.checksum_implementation.new.tap do |checksum|
         read_buffer = "".b
         while io.read(5.megabytes, read_buffer)
           checksum << read_buffer

--- a/activestorage/app/models/active_storage/checksum.rb
+++ b/activestorage/app/models/active_storage/checksum.rb
@@ -2,11 +2,9 @@
 
 class ActiveStorage::Checksum # :nodoc:
   attr_reader :digest, :algorithm
-  SUPPORTED_CHECKSUMS = [:MD5]
-  @md5_class    = nil
 
-  def initialize(digest, algorithm = nil)
-    @digest, @algorithm = digest, algorithm || :MD5
+  def initialize(digest, algorithm = :MD5)
+    @digest, @algorithm = digest, algorithm&.to_sym
   end
 
   def ==(other)
@@ -20,8 +18,7 @@ class ActiveStorage::Checksum # :nodoc:
 
   class << self
     def load(checksum)
-      # checksum is string in format of "<algorithm>:<digest>" like "SHA256:<SHA256Hash>"
-      # or legacy case "<MD5hash>"
+      # checksum is string in format "<MD5hash>" or "<algorithm>:<digest>" like "SHA256:<SHA256Hash>"
 
       unless checksum.blank?
         algorithm, digest = checksum.split(":", 2)
@@ -31,7 +28,7 @@ class ActiveStorage::Checksum # :nodoc:
           algorithm = :MD5
         end
 
-        new(digest, algorithm.to_sym)
+        new(digest, algorithm)
       end
     end
 

--- a/activestorage/app/models/active_storage/checksum.rb
+++ b/activestorage/app/models/active_storage/checksum.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+class ActiveStorage::Checksum # :nodoc:
+  attr_reader :digest, :algorithm
+  SUPPORTED_CHECKSUMS = [:MD5]
+  @md5_class    = nil
+
+  def initialize(digest, algorithm = nil)
+    @digest, @algorithm = digest, algorithm || :MD5
+  end
+
+  def ==(other)
+    return super unless other.is_a?(ActiveStorage::Checksum)
+    digest == other.digest && algorithm == other.algorithm
+  end
+
+  def to_s
+    self.class.dump(self)
+  end
+
+  class << self
+    def load(checksum)
+      # checksum is string in format of "<algorithm>:<digest>" like "SHA256:<SHA256Hash>"
+      # or legacy case "<MD5hash>"
+
+      unless checksum.blank?
+        algorithm, digest = checksum.split(":", 2)
+        unless digest
+          # if no ":" to split on, checksum is MD5 digest
+          digest = algorithm
+          algorithm = :MD5
+        end
+
+        new(digest, algorithm.to_sym)
+      end
+    end
+
+    def dump(checksum)
+      return unless checksum
+
+      # preserve legacy data format for MD5
+      if checksum.algorithm == :MD5
+        checksum.digest
+      else
+        "#{checksum.algorithm}:#{checksum.digest}"
+      end
+    end
+  end
+end

--- a/activestorage/lib/active_storage.rb
+++ b/activestorage/lib/active_storage.rb
@@ -365,15 +365,6 @@ module ActiveStorage
 
   mattr_accessor :track_variants, default: false
 
-  singleton_class.attr_accessor :checksum_implementation
-  @checksum_implementation = OpenSSL::Digest::MD5
-  begin
-    @checksum_implementation.hexdigest("test")
-  rescue # OpenSSL may have MD5 disabled
-    require "digest/md5"
-    @checksum_implementation = Digest::MD5
-  end
-
   mattr_accessor :video_preview_arguments, default: "-y -vframes 1 -f image2"
 
   module Transformers

--- a/activestorage/lib/active_storage/downloader.rb
+++ b/activestorage/lib/active_storage/downloader.rb
@@ -35,7 +35,7 @@ module ActiveStorage
       end
 
       def verify_integrity_of(file, checksum:)
-        unless ActiveStorage.checksum_implementation.file(file).base64digest == checksum
+        unless service.file(file) == checksum
           raise ActiveStorage::IntegrityError
         end
       end

--- a/activestorage/lib/active_storage/downloader.rb
+++ b/activestorage/lib/active_storage/downloader.rb
@@ -35,7 +35,9 @@ module ActiveStorage
       end
 
       def verify_integrity_of(file, checksum:)
-        unless service.file(file) == checksum
+        file_checksum = service.file(file)
+        checksum = checksum.digest if file_checksum.is_a?(String)
+        unless file_checksum == checksum
           raise ActiveStorage::IntegrityError
         end
       end

--- a/activestorage/lib/active_storage/engine.rb
+++ b/activestorage/lib/active_storage/engine.rb
@@ -151,9 +151,6 @@ module ActiveStorage
         ActiveStorage.binary_content_type = app.config.active_storage.binary_content_type || "application/octet-stream"
         ActiveStorage.video_preview_arguments = app.config.active_storage.video_preview_arguments || "-y -vframes 1 -f image2"
         ActiveStorage.track_variants = app.config.active_storage.track_variants || false
-        if app.config.active_storage.checksum_implementation
-          ActiveStorage.checksum_implementation = app.config.active_storage.checksum_implementation
-        end
       end
     end
 

--- a/activestorage/lib/active_storage/errors.rb
+++ b/activestorage/lib/active_storage/errors.rb
@@ -26,4 +26,7 @@ module ActiveStorage
 
   # Raised when a Previewer is unable to generate a preview image.
   class PreviewError < Error; end
+
+  # Raised when a checksum is not supported by a service
+  class UnsupportedChecksumError < Error; end
 end

--- a/activestorage/lib/active_storage/fixture_set.rb
+++ b/activestorage/lib/active_storage/fixture_set.rb
@@ -73,7 +73,15 @@ module ActiveStorage
       instance.assign_attributes(attributes)
       instance.upload_without_unfurling(io)
 
-      instance.attributes.transform_values { |value| value.is_a?(Hash) ? value.to_json : value }.compact.to_json
+      instance.attributes.transform_values do |value|
+        if value.is_a?(Hash)
+          value.to_json
+        elsif value.is_a?(ActiveStorage::Checksum)
+          ActiveStorage::Checksum.dump(value)
+        else
+          value
+        end
+      end.compact.to_json
     end
   end
 end

--- a/activestorage/lib/active_storage/service.rb
+++ b/activestorage/lib/active_storage/service.rb
@@ -156,8 +156,18 @@ module ActiveStorage
       checksum_implementation.file(file).base64digest
     end
 
+    @@checksum_implementation = nil
     def checksum_implementation
-      ActiveStorage.checksum_implementation
+      return @@checksum_implementation if @@checksum_implementation
+
+      @@checksum_implementation = OpenSSL::Digest::MD5
+      begin
+        @@checksum_implementation.hexdigest("test")
+        @@checksum_implementation
+      rescue # OpenSSL may have MD5 disabled
+        require "digest/md5"
+        @@checksum_implementation = Digest::MD5
+      end
     end
 
     private

--- a/activestorage/lib/active_storage/service.rb
+++ b/activestorage/lib/active_storage/service.rb
@@ -149,24 +149,24 @@ module ActiveStorage
     end
 
     def base64digest(io, algorithm: :MD5)
-      ActiveStorage::Checksum.new(checksum_implementation(algorithm:).base64digest(io), algorithm).digest
+      ActiveStorage::Checksum.new(checksum_implementation(algorithm:).base64digest(io), algorithm)
     end
 
     def file(file, algorithm: :MD5)
-      ActiveStorage::Checksum.new(checksum_implementation(algorithm:).file(file).base64digest, algorithm).digest
+      ActiveStorage::Checksum.new(checksum_implementation(algorithm:).file(file).base64digest, algorithm)
     end
 
     def compute_checksum_in_chunks(io, algorithm: :MD5)
       raise ArgumentError, "io must be rewindable" unless io.respond_to?(:rewind)
 
-      checksum_implementation(algorithm:).new.tap do |checksum|
+      ActiveStorage::Checksum.new(checksum_implementation(algorithm:).new.tap do |checksum|
         read_buffer = "".b
         while io.read(5.megabytes, read_buffer)
           checksum << read_buffer
         end
 
         io.rewind
-      end.base64digest
+      end.base64digest, algorithm)
     end
 
     def checksum_implementation(algorithm: :MD5)

--- a/activestorage/lib/active_storage/service.rb
+++ b/activestorage/lib/active_storage/service.rb
@@ -148,15 +148,15 @@ module ActiveStorage
       @public
     end
 
-    def base64digest(io, algorithm: :MD5)
+    def base64digest(io, algorithm: default_digest_algorithm)
       ActiveStorage::Checksum.new(checksum_implementation(algorithm:).base64digest(io), algorithm)
     end
 
-    def file(file, algorithm: :MD5)
+    def file(file, algorithm: default_digest_algorithm)
       ActiveStorage::Checksum.new(checksum_implementation(algorithm:).file(file).base64digest, algorithm)
     end
 
-    def compute_checksum_in_chunks(io, algorithm: :MD5)
+    def compute_checksum_in_chunks(io, algorithm: default_digest_algorithm)
       raise ArgumentError, "io must be rewindable" unless io.respond_to?(:rewind)
 
       ActiveStorage::Checksum.new(checksum_implementation(algorithm:).new.tap do |checksum|
@@ -169,12 +169,16 @@ module ActiveStorage
       end.base64digest, algorithm)
     end
 
-    def checksum_implementation(algorithm: :MD5)
+    def checksum_implementation(algorithm: default_digest_algorithm)
       self.send(algorithm.downcase)
     end
 
-    private
+    def default_digest_algorithm
+      return @default_digest_algorithm if @default_digest_algorithm
+      :MD5
+    end
 
+    private
       def md5
         return @md5_class if @md5_class
         @md5_class = OpenSSL::Digest::MD5

--- a/activestorage/lib/active_storage/service.rb
+++ b/activestorage/lib/active_storage/service.rb
@@ -148,6 +148,18 @@ module ActiveStorage
       @public
     end
 
+    def base64digest(io)
+      checksum_implementation.base64digest(io)
+    end
+
+    def file(file)
+      checksum_implementation.file(file).base64digest
+    end
+
+    def checksum_implementation
+      ActiveStorage.checksum_implementation
+    end
+
     private
       def private_url(key, expires_in:, filename:, disposition:, content_type:, **)
         raise NotImplementedError

--- a/activestorage/lib/active_storage/service/azure_storage_service.rb
+++ b/activestorage/lib/active_storage/service/azure_storage_service.rb
@@ -33,7 +33,7 @@ module ActiveStorage
         handle_errors do
           content_disposition = content_disposition_with(filename: filename, type: disposition) if disposition && filename
 
-          client.create_block_blob(container, key, IO.try_convert(io) || io, content_md5: checksum, content_type: content_type, content_disposition: content_disposition, metadata: custom_metadata)
+          client.create_block_blob(container, key, IO.try_convert(io) || io, content_md5: checksum&.digest, content_type: content_type, content_disposition: content_disposition, metadata: custom_metadata)
         end
       end
     end
@@ -110,10 +110,10 @@ module ActiveStorage
       end
     end
 
-    def headers_for_direct_upload(key, content_type:, checksum:, filename: nil, disposition: nil, custom_metadata: {}, **)
+    def headers_for_direct_upload(key, content_type:, config:, filename: nil, disposition: nil, custom_metadata: {}, **)
       content_disposition = content_disposition_with(type: disposition, filename: filename) if filename
 
-      { "Content-Type" => content_type, "Content-MD5" => checksum, "x-ms-blob-content-disposition" => content_disposition, "x-ms-blob-type" => "BlockBlob", **custom_metadata_headers(custom_metadata) }
+      { "Content-Type" => content_type, "Content-MD5" => checksum&.digest, "x-ms-blob-content-disposition" => content_disposition, "x-ms-blob-type" => "BlockBlob", **custom_metadata_headers(custom_metadata) }
     end
 
     def compose(source_keys, destination_key, filename: nil, content_type: nil, disposition: nil, custom_metadata: {})

--- a/activestorage/lib/active_storage/service/disk_service.rb
+++ b/activestorage/lib/active_storage/service/disk_service.rb
@@ -161,7 +161,7 @@ module ActiveStorage
       end
 
       def ensure_integrity_of(key, checksum)
-        unless ActiveStorage.checksum_implementation.file(path_for(key)).base64digest == checksum
+        unless file(path_for(key)) == checksum
           delete key
           raise ActiveStorage::IntegrityError
         end

--- a/activestorage/lib/active_storage/service/gcs_service.rb
+++ b/activestorage/lib/active_storage/service/gcs_service.rb
@@ -25,7 +25,7 @@ module ActiveStorage
         # binary and attachment when the file's content type requires it. The only way to force them is to
         # store them as object's metadata.
         content_disposition = content_disposition_with(type: disposition, filename: filename) if disposition && filename
-        bucket.create_file(io, key, md5: checksum, cache_control: @config[:cache_control], content_type: content_type, content_disposition: content_disposition, metadata: custom_metadata)
+        bucket.create_file(io, key, md5: checksum&.digest, cache_control: @config[:cache_control], content_type: content_type, content_disposition: content_disposition, metadata: custom_metadata)
       rescue Google::Cloud::InvalidArgumentError
         raise ActiveStorage::IntegrityError
       end
@@ -105,7 +105,7 @@ module ActiveStorage
         headers.merge!(custom_metadata_headers(custom_metadata))
 
         args = {
-          content_md5: checksum,
+          content_md5: checksum&.digest,
           expires: expires_in,
           headers: headers,
           method: "PUT",
@@ -128,7 +128,7 @@ module ActiveStorage
     def headers_for_direct_upload(key, checksum:, filename: nil, disposition: nil, custom_metadata: {}, **)
       content_disposition = content_disposition_with(type: disposition, filename: filename) if filename
 
-      headers = { "Content-MD5" => checksum, "Content-Disposition" => content_disposition, **custom_metadata_headers(custom_metadata) }
+      headers = { "Content-MD5" => checksum&.digest, "Content-Disposition" => content_disposition, **custom_metadata_headers(custom_metadata) }
       if @config[:cache_control].present?
         headers["Cache-Control"] = @config[:cache_control]
       end

--- a/activestorage/lib/active_storage/service/mirror_service.rb
+++ b/activestorage/lib/active_storage/service/mirror_service.rb
@@ -59,7 +59,7 @@ module ActiveStorage
     end
 
     def mirror_later(key, checksum:) # :nodoc:
-      ActiveStorage::MirrorJob.perform_later key, checksum: checksum.to_s
+      ActiveStorage::MirrorJob.perform_later key, checksum: ActiveStorage::Checksum.dump(checksum)
     end
 
     # Copy the file at the +key+ from the primary service to each of the mirrors where it doesn't already exist.

--- a/activestorage/lib/active_storage/service/mirror_service.rb
+++ b/activestorage/lib/active_storage/service/mirror_service.rb
@@ -59,7 +59,7 @@ module ActiveStorage
     end
 
     def mirror_later(key, checksum:) # :nodoc:
-      ActiveStorage::MirrorJob.perform_later key, checksum: checksum
+      ActiveStorage::MirrorJob.perform_later key, checksum: checksum.to_s
     end
 
     # Copy the file at the +key+ from the primary service to each of the mirrors where it doesn't already exist.

--- a/activestorage/lib/active_storage/service/s3_service.rb
+++ b/activestorage/lib/active_storage/service/s3_service.rb
@@ -82,7 +82,7 @@ module ActiveStorage
     def url_for_direct_upload(key, expires_in:, content_type:, content_length:, checksum:, custom_metadata: {})
       instrument :url, key: key do |payload|
         generated_url = object_for(key).presigned_url :put, expires_in: expires_in.to_i,
-          content_type: content_type, content_length: content_length, content_md5: checksum,
+          content_type: content_type, content_length: content_length, content_md5: checksum&.digest,
           metadata: custom_metadata, whitelist_headers: ["content-length"], **upload_options
 
         payload[:url] = generated_url
@@ -94,7 +94,7 @@ module ActiveStorage
     def headers_for_direct_upload(key, content_type:, checksum:, filename: nil, disposition: nil, custom_metadata: {}, **)
       content_disposition = content_disposition_with(type: disposition, filename: filename) if filename
 
-      { "Content-Type" => content_type, "Content-MD5" => checksum, "Content-Disposition" => content_disposition, **custom_metadata_headers(custom_metadata) }
+      { "Content-Type" => content_type, "Content-MD5" => checksum&.digest, "Content-Disposition" => content_disposition, **custom_metadata_headers(custom_metadata) }
     end
 
     def compose(source_keys, destination_key, filename: nil, content_type: nil, disposition: nil, custom_metadata: {})
@@ -131,7 +131,7 @@ module ActiveStorage
       MINIMUM_UPLOAD_PART_SIZE   = 5.megabytes
 
       def upload_with_single_part(key, io, checksum: nil, content_type: nil, content_disposition: nil, custom_metadata: {})
-        object_for(key).put(body: io, content_md5: checksum, content_type: content_type, content_disposition: content_disposition, metadata: custom_metadata, **upload_options)
+        object_for(key).put(body: io, content_md5: checksum&.digest, content_type: content_type, content_disposition: content_disposition, metadata: custom_metadata, **upload_options)
       rescue Aws::S3::Errors::BadDigest
         raise ActiveStorage::IntegrityError
       end

--- a/activestorage/test/controllers/direct_uploads_controller_test.rb
+++ b/activestorage/test/controllers/direct_uploads_controller_test.rb
@@ -15,7 +15,7 @@ if SERVICE_CONFIGURATIONS[:s3] && SERVICE_CONFIGURATIONS[:s3][:access_key_id].pr
     end
 
     test "creating new direct upload" do
-      checksum = ActiveStorage.checksum_implementation.base64digest("Hello")
+      checksum = ActiveStorage::Blob.service.base64digest("Hello")
       metadata = {
         "foo" => "bar",
         "my_key_1" => "my_value_1",
@@ -61,7 +61,7 @@ if SERVICE_CONFIGURATIONS[:gcs]
     end
 
     test "creating new direct upload" do
-      checksum = ActiveStorage.checksum_implementation.base64digest("Hello")
+      checksum = ActiveStorage::Blob.service.base64digest("Hello")
       metadata = {
         "foo" => "bar",
         "my_key_1" => "my_value_1",
@@ -106,7 +106,7 @@ if SERVICE_CONFIGURATIONS[:azure]
     end
 
     test "creating new direct upload" do
-      checksum = ActiveStorage.checksum_implementation.base64digest("Hello")
+      checksum = ActiveStorage::Blob.service.base64digest("Hello")
       metadata = {
         "foo" => "bar",
         "my_key_1" => "my_value_1",
@@ -136,7 +136,7 @@ end
 
 class ActiveStorage::DiskDirectUploadsControllerTest < ActionDispatch::IntegrationTest
   test "creating new direct upload" do
-    checksum = ActiveStorage.checksum_implementation.base64digest("Hello")
+    checksum = ActiveStorage::Blob.service.base64digest("Hello")
     metadata = {
       "foo" => "bar",
       "my_key_1" => "my_value_1",
@@ -161,7 +161,7 @@ class ActiveStorage::DiskDirectUploadsControllerTest < ActionDispatch::Integrati
   end
 
   test "creating new direct upload does not include root in json" do
-    checksum = ActiveStorage.checksum_implementation.base64digest("Hello")
+    checksum = ActiveStorage::Blob.service.base64digest("Hello")
     metadata = {
       "foo" => "bar",
       "my_key_1" => "my_value_1",

--- a/activestorage/test/controllers/direct_uploads_controller_test.rb
+++ b/activestorage/test/controllers/direct_uploads_controller_test.rb
@@ -15,7 +15,7 @@ if SERVICE_CONFIGURATIONS[:s3] && SERVICE_CONFIGURATIONS[:s3][:access_key_id].pr
     end
 
     test "creating new direct upload" do
-      checksum = ActiveStorage::Checksum.load(ActiveStorage::Blob.service.base64digest("Hello").to_s)
+      checksum = ActiveStorage::Blob.service.base64digest("Hello")
       metadata = {
         "foo" => "bar",
         "my_key_1" => "my_value_1",
@@ -61,7 +61,7 @@ if SERVICE_CONFIGURATIONS[:gcs]
     end
 
     test "creating new direct upload" do
-      checksum = ActiveStorage::Checksum.load(ActiveStorage::Blob.service.base64digest("Hello").to_s)
+      checksum = ActiveStorage::Blob.service.base64digest("Hello")
       metadata = {
         "foo" => "bar",
         "my_key_1" => "my_value_1",
@@ -106,7 +106,7 @@ if SERVICE_CONFIGURATIONS[:azure]
     end
 
     test "creating new direct upload" do
-      checksum = ActiveStorage::Checksum.load(ActiveStorage::Blob.service.base64digest("Hello").to_s)
+      checksum = ActiveStorage::Blob.service.base64digest("Hello")
       metadata = {
         "foo" => "bar",
         "my_key_1" => "my_value_1",
@@ -161,7 +161,7 @@ class ActiveStorage::DiskDirectUploadsControllerTest < ActionDispatch::Integrati
   end
 
   test "creating new direct upload (checksum non-MD5 string, not matching default_digest_algorithm)" do
-    checksum = OpenSSL::Digest::SHA256.base64digest("Hello")
+    checksum = ActiveStorage::Checksum.new(OpenSSL::Digest::SHA256.base64digest("Hello"), :SHA256)
     metadata = {
       "foo" => "bar",
       "my_key_1" => "my_value_1",
@@ -186,7 +186,7 @@ class ActiveStorage::DiskDirectUploadsControllerTest < ActionDispatch::Integrati
   end
 
   test "creating new direct upload (checksum as hash)" do
-    checksum = ActiveStorage::Blob.base64digest("Hello")
+    checksum = ActiveStorage::Blob.service.base64digest("Hello")
     metadata = {
       "foo" => "bar",
       "my_key_1" => "my_value_1",

--- a/activestorage/test/controllers/direct_uploads_controller_test.rb
+++ b/activestorage/test/controllers/direct_uploads_controller_test.rb
@@ -15,7 +15,7 @@ if SERVICE_CONFIGURATIONS[:s3] && SERVICE_CONFIGURATIONS[:s3][:access_key_id].pr
     end
 
     test "creating new direct upload" do
-      checksum = ActiveStorage::Blob.service.base64digest("Hello")
+      checksum = ActiveStorage::Checksum.load(ActiveStorage::Blob.service.base64digest("Hello").to_s)
       metadata = {
         "foo" => "bar",
         "my_key_1" => "my_value_1",
@@ -34,7 +34,7 @@ if SERVICE_CONFIGURATIONS[:s3] && SERVICE_CONFIGURATIONS[:s3][:access_key_id].pr
         assert_equal ActiveStorage::Blob.find(details["id"]), ActiveStorage::Blob.find_signed!(details["signed_id"])
         assert_equal "hello.txt", details["filename"]
         assert_equal 6, details["byte_size"]
-        assert_equal checksum, details["checksum"]
+        assert_equal checksum.as_json, details["checksum"]
         assert_equal metadata, details["metadata"]
         assert_equal "text/plain", details["content_type"]
         assert_match SERVICE_CONFIGURATIONS[:s3][:bucket], details["direct_upload"]["url"]
@@ -61,7 +61,7 @@ if SERVICE_CONFIGURATIONS[:gcs]
     end
 
     test "creating new direct upload" do
-      checksum = ActiveStorage::Blob.service.base64digest("Hello")
+      checksum = ActiveStorage::Checksum.load(ActiveStorage::Blob.service.base64digest("Hello").to_s)
       metadata = {
         "foo" => "bar",
         "my_key_1" => "my_value_1",
@@ -80,7 +80,7 @@ if SERVICE_CONFIGURATIONS[:gcs]
         assert_equal ActiveStorage::Blob.find(details["id"]), ActiveStorage::Blob.find_signed!(details["signed_id"])
         assert_equal "hello.txt", details["filename"]
         assert_equal 6, details["byte_size"]
-        assert_equal checksum, details["checksum"]
+        assert_equal checksum.as_json, details["checksum"]
         assert_equal metadata, details["metadata"]
         assert_equal "text/plain", details["content_type"]
         assert_match %r{storage\.googleapis\.com/#{@config[:bucket]}}, details["direct_upload"]["url"]
@@ -106,7 +106,7 @@ if SERVICE_CONFIGURATIONS[:azure]
     end
 
     test "creating new direct upload" do
-      checksum = ActiveStorage::Blob.service.base64digest("Hello")
+      checksum = ActiveStorage::Checksum.load(ActiveStorage::Blob.service.base64digest("Hello").to_s)
       metadata = {
         "foo" => "bar",
         "my_key_1" => "my_value_1",
@@ -122,7 +122,7 @@ if SERVICE_CONFIGURATIONS[:azure]
         assert_equal ActiveStorage::Blob.find(details["id"]), ActiveStorage::Blob.find_signed!(details["signed_id"])
         assert_equal "hello.txt", details["filename"]
         assert_equal 6, details["byte_size"]
-        assert_equal checksum, details["checksum"]
+        assert_equal checksum.as_json, details["checksum"]
         assert_equal metadata, details["metadata"]
         assert_equal "text/plain", details["content_type"]
         assert_match %r{#{@config[:storage_account_name]}\.blob\.core\.windows\.net/#{@config[:container]}}, details["direct_upload"]["url"]
@@ -146,13 +146,13 @@ class ActiveStorage::DiskDirectUploadsControllerTest < ActionDispatch::Integrati
     }
 
     post rails_direct_uploads_url, params: { blob: {
-      filename: "hello.txt", byte_size: 6, checksum: checksum, content_type: "text/plain", metadata: metadata } }
+      filename: "hello.txt", byte_size: 6, checksum: checksum.to_s, content_type: "text/plain", metadata: metadata } }
 
     response.parsed_body.tap do |details|
       assert_equal ActiveStorage::Blob.find(details["id"]), ActiveStorage::Blob.find_signed!(details["signed_id"])
       assert_equal "hello.txt", details["filename"]
       assert_equal 6, details["byte_size"]
-      assert_equal checksum, details["checksum"]
+      assert_equal checksum.as_json, details["checksum"]
       assert_equal metadata, details["metadata"]
       assert_equal "text/plain", details["content_type"]
       assert_match(/rails\/active_storage\/disk/, details["direct_upload"]["url"])
@@ -172,7 +172,7 @@ class ActiveStorage::DiskDirectUploadsControllerTest < ActionDispatch::Integrati
 
     set_include_root_in_json(true) do
       post rails_direct_uploads_url, params: { blob: {
-        filename: "hello.txt", byte_size: 6, checksum: checksum, content_type: "text/plain", metadata: metadata } }
+        filename: "hello.txt", byte_size: 6, checksum: checksum.to_s, content_type: "text/plain", metadata: metadata } }
     end
 
     response.parsed_body.tap do |details|

--- a/activestorage/test/controllers/disk_controller_test.rb
+++ b/activestorage/test/controllers/disk_controller_test.rb
@@ -74,7 +74,7 @@ class ActiveStorage::DiskControllerTest < ActionDispatch::IntegrationTest
 
   test "directly uploading blob with integrity" do
     data = "Something else entirely!"
-    blob = create_blob_before_direct_upload byte_size: data.size, checksum: ActiveStorage.checksum_implementation.base64digest(data)
+    blob = create_blob_before_direct_upload byte_size: data.size, checksum: ActiveStorage::Blob.service.base64digest(data)
 
     put blob.service_url_for_direct_upload, params: data, headers: { "Content-Type" => "text/plain" }
     assert_response :no_content
@@ -83,7 +83,7 @@ class ActiveStorage::DiskControllerTest < ActionDispatch::IntegrationTest
 
   test "directly uploading blob without integrity" do
     data = "Something else entirely!"
-    blob = create_blob_before_direct_upload byte_size: data.size, checksum: ActiveStorage.checksum_implementation.base64digest("bad data")
+    blob = create_blob_before_direct_upload byte_size: data.size, checksum: ActiveStorage::Blob.service.base64digest("bad data")
 
     put blob.service_url_for_direct_upload, params: data
     assert_response :unprocessable_entity
@@ -92,7 +92,7 @@ class ActiveStorage::DiskControllerTest < ActionDispatch::IntegrationTest
 
   test "directly uploading blob with mismatched content type" do
     data = "Something else entirely!"
-    blob = create_blob_before_direct_upload byte_size: data.size, checksum: ActiveStorage.checksum_implementation.base64digest(data)
+    blob = create_blob_before_direct_upload byte_size: data.size, checksum: ActiveStorage::Blob.service.base64digest(data)
 
     put blob.service_url_for_direct_upload, params: data, headers: { "Content-Type" => "application/octet-stream" }
     assert_response :unprocessable_entity
@@ -102,7 +102,7 @@ class ActiveStorage::DiskControllerTest < ActionDispatch::IntegrationTest
   test "directly uploading blob with different but equivalent content type" do
     data = "Something else entirely!"
     blob = create_blob_before_direct_upload(
-      byte_size: data.size, checksum: ActiveStorage.checksum_implementation.base64digest(data), content_type: "application/x-gzip")
+      byte_size: data.size, checksum: ActiveStorage::Blob.service.base64digest(data), content_type: "application/x-gzip")
 
     put blob.service_url_for_direct_upload, params: data, headers: { "Content-Type" => "application/x-gzip" }
     assert_response :no_content
@@ -111,7 +111,7 @@ class ActiveStorage::DiskControllerTest < ActionDispatch::IntegrationTest
 
   test "directly uploading blob with mismatched content length" do
     data = "Something else entirely!"
-    blob = create_blob_before_direct_upload byte_size: data.size - 1, checksum: ActiveStorage.checksum_implementation.base64digest(data)
+    blob = create_blob_before_direct_upload byte_size: data.size - 1, checksum: ActiveStorage::Blob.service.base64digest(data)
 
     put blob.service_url_for_direct_upload, params: data, headers: { "Content-Type" => "text/plain" }
     assert_response :unprocessable_entity

--- a/activestorage/test/models/attachment_test.rb
+++ b/activestorage/test/models/attachment_test.rb
@@ -41,7 +41,9 @@ class ActiveStorage::AttachmentTest < ActiveSupport::TestCase
   test "attaching a blob doesn't touch the record" do
     data = "Something else entirely!"
     io = StringIO.new(data)
-    blob = create_blob_before_direct_upload byte_size: data.size, checksum: ActiveStorage::Blob.service.base64digest(data)
+    checksum = ActiveStorage::Blob.service.base64digest(data)
+
+    blob = create_blob_before_direct_upload byte_size: data.size, checksum: checksum
     blob.upload(io)
 
     user = User.create!(

--- a/activestorage/test/models/attachment_test.rb
+++ b/activestorage/test/models/attachment_test.rb
@@ -41,7 +41,7 @@ class ActiveStorage::AttachmentTest < ActiveSupport::TestCase
   test "attaching a blob doesn't touch the record" do
     data = "Something else entirely!"
     io = StringIO.new(data)
-    blob = create_blob_before_direct_upload byte_size: data.size, checksum: ActiveStorage.checksum_implementation.base64digest(data)
+    blob = create_blob_before_direct_upload byte_size: data.size, checksum: ActiveStorage::Blob.service.base64digest(data)
     blob.upload(io)
 
     user = User.create!(

--- a/activestorage/test/models/blob_test.rb
+++ b/activestorage/test/models/blob_test.rb
@@ -38,7 +38,7 @@ class ActiveStorage::BlobTest < ActiveSupport::TestCase
 
     assert_equal data, blob.download
     assert_equal data.length, blob.byte_size
-    assert_equal ActiveStorage.checksum_implementation.base64digest(data), blob.checksum
+    assert_equal blob.service.base64digest(data), blob.checksum
   end
 
   test "create_and_upload extracts content type from data" do
@@ -188,7 +188,7 @@ class ActiveStorage::BlobTest < ActiveSupport::TestCase
 
   test "open without integrity" do
     create_blob(data: "Hello, world!").tap do |blob|
-      blob.update! checksum: ActiveStorage.checksum_implementation.base64digest("Goodbye, world!")
+      blob.update! checksum: blob.service.base64digest("Goodbye, world!")
 
       assert_raises ActiveStorage::IntegrityError do
         blob.open { |file| flunk "Expected integrity check to fail" }

--- a/activestorage/test/models/checksum_test.rb
+++ b/activestorage/test/models/checksum_test.rb
@@ -111,5 +111,4 @@ class ActiveStorage::ChecksumTest < ActiveSupport::TestCase
   test "load returns nil when nil" do
     assert_nil ActiveStorage::Checksum.load(nil)
   end
-
 end

--- a/activestorage/test/models/checksum_test.rb
+++ b/activestorage/test/models/checksum_test.rb
@@ -1,0 +1,115 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "database/setup"
+require "active_support/testing/method_call_assertions"
+
+class ActiveStorage::ChecksumTest < ActiveSupport::TestCase
+  include ActiveSupport::Testing::MethodCallAssertions
+  include ActiveJob::TestHelper
+
+  test "new ActiveStorage::Checksum" do
+    algorithm = :SHA256
+    digest = "GF+NsyJx/iX1Yab8k4suJkMG7DBO2lGAB9F2SCY4GWk="
+    cksum = ActiveStorage::Checksum.new(digest, algorithm)
+
+    assert_equal cksum.algorithm, algorithm
+    assert_equal cksum.digest, digest
+  end
+
+  test "new ActiveStorage::Checksum without algorithm assumes MD5" do
+    digest = "ixqZU8RhEpaoJ6v4xHgE1w=="
+    cksum = ActiveStorage::Checksum.new(digest)
+
+    assert_equal :MD5, cksum.algorithm
+    assert_equal digest, cksum.digest
+  end
+
+  test "equality when digest and algorithm are equal" do
+    algorithm = :MD5
+    digest_expected = "ixqZU8RhEpaoJ6v4xHgE1w=="
+    cksum_expected = ActiveStorage::Checksum.new(digest_expected, algorithm)
+
+    cksum = ActiveStorage::Checksum.new(digest_expected, algorithm)
+
+    assert_equal cksum_expected.algorithm, cksum.algorithm
+    assert_equal cksum_expected.digest, cksum.digest
+    assert_equal cksum_expected, cksum
+  end
+
+  test "not equality when digests are not equal" do
+    algorithm = :MD5
+    digest_expected = "ixqZU8RhEpaoJ6v4xHgE1w=="
+    cksum_expected = ActiveStorage::Checksum.new(digest_expected, algorithm)
+
+    digest_different = "b8QiIzpAp1ofAo4Rw80RQA=="
+    cksum = ActiveStorage::Checksum.new(digest_different, algorithm)
+
+    assert_not_equal cksum_expected.digest, cksum.digest
+    assert_not_equal cksum_expected, cksum
+  end
+
+  test "dump returns nil for nil" do
+    assert_nil ActiveStorage::Checksum.dump(nil)
+  end
+
+  test "dump returns MD5 digest for MD5 algorithm" do
+    algorithm = :MD5
+    digest = "ixqZU8RhEpaoJ6v4xHgE1w=="
+    cksum = ActiveStorage::Checksum.new(digest, algorithm)
+
+    assert_equal ActiveStorage::Checksum.dump(cksum), cksum.digest
+  end
+
+  test "dump returns concatenated format" do
+    algorithm = :SHA256
+    digest = "GF+NsyJx/iX1Yab8k4suJkMG7DBO2lGAB9F2SCY4GWk="
+
+    cksum = ActiveStorage::Checksum.new(digest, algorithm)
+
+    assert_equal ActiveStorage::Checksum.dump(cksum), "#{algorithm}:#{digest}"
+  end
+
+  test "to_s returns nil when no digest" do
+    cksum = ActiveStorage::Checksum.new(nil)
+
+    assert_nil cksum.to_s
+  end
+
+  test "to_s returns MD5 digest for MD5 algorithm" do
+    algorithm = :MD5
+    digest = "ixqZU8RhEpaoJ6v4xHgE1w=="
+    cksum = ActiveStorage::Checksum.new(digest, algorithm)
+
+    assert_equal cksum.to_s, cksum.digest
+  end
+
+  test "to_s returns concatenated format" do
+    algorithm = :SHA256
+    digest = "GF+NsyJx/iX1Yab8k4suJkMG7DBO2lGAB9F2SCY4GWk="
+    cksum = ActiveStorage::Checksum.new(digest, algorithm)
+
+    assert_equal cksum.to_s, "#{algorithm}:#{digest}"
+  end
+
+  test "load returns instance when legacy MD5 format" do
+    algorithm = :MD5
+    digest = "ixqZU8RhEpaoJ6v4xHgE1w=="
+    cksum = ActiveStorage::Checksum.new(digest, algorithm)
+
+    assert_equal ActiveStorage::Checksum.load(digest), cksum
+  end
+
+  test "load returns instance when concatenated format" do
+    algorithm = :SHA256
+    digest = "GF+NsyJx/iX1Yab8k4suJkMG7DBO2lGAB9F2SCY4GWk="
+    cksum = ActiveStorage::Checksum.new(digest, algorithm)
+
+    assert_equal ActiveStorage::Checksum.load("#{algorithm}:#{digest}"), cksum
+  end
+
+  test "load returns nil when nil" do
+    assert_nil ActiveStorage::Checksum.load(nil)
+  end
+
+end

--- a/activestorage/test/service/azure_storage_public_service_test.rb
+++ b/activestorage/test/service/azure_storage_public_service_test.rb
@@ -21,7 +21,7 @@ if SERVICE_CONFIGURATIONS[:azure_public]
     test "direct upload" do
       key          = SecureRandom.base58(24)
       data         = "Something else entirely!"
-      checksum     = ActiveStorage.checksum_implementation.base64digest(data)
+      checksum     = @service.base64digest(data)
       content_type = "text/xml"
       url          = @service.url_for_direct_upload(key, expires_in: 5.minutes, content_type: content_type, content_length: data.size, checksum: checksum)
 

--- a/activestorage/test/service/azure_storage_service_test.rb
+++ b/activestorage/test/service/azure_storage_service_test.rb
@@ -12,7 +12,7 @@ if SERVICE_CONFIGURATIONS[:azure]
     test "direct upload with content type" do
       key          = SecureRandom.base58(24)
       data         = "Something else entirely!"
-      checksum     = ActiveStorage.checksum_implementation.base64digest(data)
+      checksum     = @service.base64digest(data)
       content_type = "text/xml"
       url          = @service.url_for_direct_upload(key, expires_in: 5.minutes, content_type: content_type, content_length: data.size, checksum: checksum)
 
@@ -34,7 +34,7 @@ if SERVICE_CONFIGURATIONS[:azure]
     test "direct upload with content disposition" do
       key      = SecureRandom.base58(24)
       data     = "Something else entirely!"
-      checksum = ActiveStorage.checksum_implementation.base64digest(data)
+      checksum = @service.base64digest(data)
       url      = @service.url_for_direct_upload(key, expires_in: 5.minutes, content_type: "text/plain", content_length: data.size, checksum: checksum)
 
       uri = URI.parse url
@@ -56,7 +56,7 @@ if SERVICE_CONFIGURATIONS[:azure]
       key      = SecureRandom.base58(24)
       data     = "Foobar"
 
-      @service.upload(key, StringIO.new(data), checksum: ActiveStorage.checksum_implementation.base64digest(data), filename: ActiveStorage::Filename.new("test.txt"), content_type: "text/plain")
+      @service.upload(key, StringIO.new(data), checksum: @service.base64digest(data), filename: ActiveStorage::Filename.new("test.txt"), content_type: "text/plain")
 
       url = @service.url(key, expires_in: 2.minutes, disposition: :attachment, content_type: nil, filename: ActiveStorage::Filename.new("test.html"))
       response = Net::HTTP.get_response(URI(url))
@@ -70,7 +70,7 @@ if SERVICE_CONFIGURATIONS[:azure]
       key  = SecureRandom.base58(24)
       data = "Foobar"
 
-      @service.upload(key, StringIO.new(data), checksum: ActiveStorage.checksum_implementation.base64digest(data), filename: ActiveStorage::Filename.new("test.txt"), disposition: :inline)
+      @service.upload(key, StringIO.new(data), checksum: @service.base64digest(data), filename: ActiveStorage::Filename.new("test.txt"), disposition: :inline)
 
       assert_equal("inline; filename=\"test.txt\"; filename*=UTF-8''test.txt", @service.client.get_blob_properties(@service.container, key).properties[:content_disposition])
 
@@ -85,7 +85,7 @@ if SERVICE_CONFIGURATIONS[:azure]
       key  = SecureRandom.base58(24)
       data = "Foobar"
 
-      @service.upload(key, StringIO.new(data), checksum: ActiveStorage.checksum_implementation.base64digest(data), filename: ActiveStorage::Filename.new("test.txt"), custom_metadata: { "foo" => "baz" })
+      @service.upload(key, StringIO.new(data), checksum: @service.base64digest(data), filename: ActiveStorage::Filename.new("test.txt"), custom_metadata: { "foo" => "baz" })
       url = @service.url(key, expires_in: 2.minutes, disposition: :inline, content_type: "text/html", filename: ActiveStorage::Filename.new("test.html"))
 
       response = Net::HTTP.get_response(URI(url))

--- a/activestorage/test/service/disk_service_test.rb
+++ b/activestorage/test/service/disk_service_test.rb
@@ -18,7 +18,7 @@ class ActiveStorage::Service::DiskServiceTest < ActiveSupport::TestCase
 
     key      = SecureRandom.base58(24)
     data     = "Something else entirely!"
-    checksum = Digest::MD5.base64digest(data)
+    checksum = @service.base64digest(data)
 
     begin
       assert_match(/^https:\/\/example.com\/rails\/active_storage\/disk\/.*$/,

--- a/activestorage/test/service/gcs_public_service_test.rb
+++ b/activestorage/test/service/gcs_public_service_test.rb
@@ -21,7 +21,7 @@ if SERVICE_CONFIGURATIONS[:gcs_public]
     test "direct upload" do
       key      = SecureRandom.base58(24)
       data     = "Something else entirely!"
-      checksum = ActiveStorage.checksum_implementation.base64digest(data)
+      checksum = @service.base64digest(data)
       url      = @service.url_for_direct_upload(key, expires_in: 5.minutes, content_type: "text/plain", content_length: data.size, checksum: checksum)
 
       uri = URI.parse url

--- a/activestorage/test/service/gcs_public_service_test.rb
+++ b/activestorage/test/service/gcs_public_service_test.rb
@@ -28,7 +28,11 @@ if SERVICE_CONFIGURATIONS[:gcs_public]
       request = Net::HTTP::Put.new uri.request_uri
       request.body = data
       request.add_field "Content-Type", ""
-      request.add_field "Content-MD5", checksum.digest
+      if checksum.algorithm == :MD5
+        request.add_field "Content-MD5", checksum.digest
+      else
+        request.add_field "x-goog-hash", "#{checksum.algorithm}=#{checksum.digest}"
+      end
       Net::HTTP.start(uri.host, uri.port, use_ssl: true) do |http|
         http.request request
       end

--- a/activestorage/test/service/gcs_public_service_test.rb
+++ b/activestorage/test/service/gcs_public_service_test.rb
@@ -28,7 +28,7 @@ if SERVICE_CONFIGURATIONS[:gcs_public]
       request = Net::HTTP::Put.new uri.request_uri
       request.body = data
       request.add_field "Content-Type", ""
-      request.add_field "Content-MD5", checksum
+      request.add_field "Content-MD5", checksum.digest
       Net::HTTP.start(uri.host, uri.port, use_ssl: true) do |http|
         http.request request
       end

--- a/activestorage/test/service/gcs_service_test.rb
+++ b/activestorage/test/service/gcs_service_test.rb
@@ -23,7 +23,7 @@ if SERVICE_CONFIGURATIONS[:gcs]
       request = Net::HTTP::Put.new uri.request_uri
       request.body = data
       request.add_field "Content-Type", ""
-      request.add_field "Content-MD5", checksum
+      request.add_field "Content-MD5", checksum.digest
       Net::HTTP.start(uri.host, uri.port, use_ssl: true) do |http|
         http.request request
       end
@@ -63,7 +63,7 @@ if SERVICE_CONFIGURATIONS[:gcs]
 
       key      = SecureRandom.base58(24)
       data     = "Some text"
-      checksum = Digest::MD5.base64digest(data)
+      checksum = service.base64digest(data)
       url      = service.url_for_direct_upload(key, expires_in: 5.minutes, content_type: "text/plain", content_length: data.size, checksum: checksum)
 
       uri = URI.parse url
@@ -122,7 +122,7 @@ if SERVICE_CONFIGURATIONS[:gcs]
       config_with_cache_control = { gcs: SERVICE_CONFIGURATIONS[:gcs].merge({ cache_control: "public, max-age=1800" }) }
       service = ActiveStorage::Service.configure(:gcs, config_with_cache_control)
 
-      service.upload(key, StringIO.new(data), checksum: Digest::MD5.base64digest(data), content_type: "text/plain")
+      service.upload(key, StringIO.new(data), checksum: service.base64digest(data), content_type: "text/plain")
 
       url = service.url(key, expires_in: 2.minutes, disposition: :inline, content_type: "text/html", filename: ActiveStorage::Filename.new("test.html"))
 
@@ -135,7 +135,7 @@ if SERVICE_CONFIGURATIONS[:gcs]
     test "upload with custom_metadata" do
       key      = SecureRandom.base58(24)
       data     = "Something else entirely!"
-      @service.upload(key, StringIO.new(data), checksum: Digest::MD5.base64digest(data), content_type: "text/plain", custom_metadata: { "foo" => "baz" })
+      @service.upload(key, StringIO.new(data), checksum: @service.base64digest(data), content_type: "text/plain", custom_metadata: { "foo" => "baz" })
 
       url = @service.url(key, expires_in: 2.minutes, disposition: :inline, content_type: "text/html", filename: ActiveStorage::Filename.new("test.html"))
 
@@ -173,14 +173,14 @@ if SERVICE_CONFIGURATIONS[:gcs]
 
         key      = SecureRandom.base58(24)
         data     = "Some text"
-        checksum = Digest::MD5.base64digest(data)
+        checksum = service.base64digest(data)
         url      = service.url_for_direct_upload(key, expires_in: 5.minutes, content_type: "text/plain", content_length: data.size, checksum: checksum)
 
         uri = URI.parse(url)
         request = Net::HTTP::Put.new(uri.request_uri)
         request.body = data
         request.add_field("Content-Type", "")
-        request.add_field("Content-MD5", checksum)
+        request.add_field("Content-MD5", checksum.digest)
         Net::HTTP.start(uri.host, uri.port, use_ssl: true) do |http|
           http.request request
         end

--- a/activestorage/test/service/gcs_service_test.rb
+++ b/activestorage/test/service/gcs_service_test.rb
@@ -16,7 +16,7 @@ if SERVICE_CONFIGURATIONS[:gcs]
     test "direct upload" do
       key      = SecureRandom.base58(24)
       data     = "Something else entirely!"
-      checksum = ActiveStorage.checksum_implementation.base64digest(data)
+      checksum = @service.base64digest(data)
       url      = @service.url_for_direct_upload(key, expires_in: 5.minutes, content_type: "text/plain", content_length: data.size, checksum: checksum)
 
       uri = URI.parse url
@@ -36,7 +36,7 @@ if SERVICE_CONFIGURATIONS[:gcs]
     test "direct upload with content disposition" do
       key      = SecureRandom.base58(24)
       data     = "Something else entirely!"
-      checksum = ActiveStorage.checksum_implementation.base64digest(data)
+      checksum = @service.base64digest(data)
       url      = @service.url_for_direct_upload(key, expires_in: 5.minutes, content_type: "text/plain", content_length: data.size, checksum: checksum)
 
       uri = URI.parse url
@@ -91,7 +91,7 @@ if SERVICE_CONFIGURATIONS[:gcs]
       key      = SecureRandom.base58(24)
       data     = "Something else entirely!"
 
-      @service.upload(key, StringIO.new(data), checksum: ActiveStorage.checksum_implementation.base64digest(data), disposition: :attachment, filename: ActiveStorage::Filename.new("test.txt"), content_type: "text/plain")
+      @service.upload(key, StringIO.new(data), checksum: @service.base64digest(data), disposition: :attachment, filename: ActiveStorage::Filename.new("test.txt"), content_type: "text/plain")
 
       url = @service.url(key, expires_in: 2.minutes, disposition: :inline, content_type: "text/html", filename: ActiveStorage::Filename.new("test.html"))
       response = Net::HTTP.get_response(URI(url))
@@ -105,7 +105,7 @@ if SERVICE_CONFIGURATIONS[:gcs]
       key      = SecureRandom.base58(24)
       data     = "Something else entirely!"
 
-      @service.upload(key, StringIO.new(data), checksum: ActiveStorage.checksum_implementation.base64digest(data), content_type: "text/plain")
+      @service.upload(key, StringIO.new(data), checksum: @service.base64digest(data), content_type: "text/plain")
 
       url = @service.url(key, expires_in: 2.minutes, disposition: :inline, content_type: "text/html", filename: ActiveStorage::Filename.new("test.html"))
       response = Net::HTTP.get_response(URI(url))
@@ -148,7 +148,7 @@ if SERVICE_CONFIGURATIONS[:gcs]
     test "update custom_metadata" do
       key      = SecureRandom.base58(24)
       data     = "Something else entirely!"
-      @service.upload(key, StringIO.new(data), checksum: ActiveStorage.checksum_implementation.base64digest(data), disposition: :attachment, filename: ActiveStorage::Filename.new("test.html"), content_type: "text/html", custom_metadata: { "foo" => "baz" })
+      @service.upload(key, StringIO.new(data), checksum: @service.base64digest(data), disposition: :attachment, filename: ActiveStorage::Filename.new("test.html"), content_type: "text/html", custom_metadata: { "foo" => "baz" })
 
       @service.update_metadata(key, disposition: :inline, filename: ActiveStorage::Filename.new("test.txt"), content_type: "text/plain", custom_metadata: { "foo" => "bar" })
       url = @service.url(key, expires_in: 2.minutes, disposition: :attachment, content_type: "text/html", filename: ActiveStorage::Filename.new("test.html"))

--- a/activestorage/test/service/mirror_service_test.rb
+++ b/activestorage/test/service/mirror_service_test.rb
@@ -29,7 +29,7 @@ class ActiveStorage::Service::MirrorServiceTest < ActiveSupport::TestCase
     key      = SecureRandom.base58(24)
     data     = "Something else entirely!"
     io       = StringIO.new(data)
-    checksum = ActiveStorage.checksum_implementation.base64digest(data)
+    checksum = @service.base64digest(data)
 
     assert_performed_jobs 1, only: ActiveStorage::MirrorJob do
       @service.upload key, io.tap(&:read), checksum: checksum
@@ -49,7 +49,7 @@ class ActiveStorage::Service::MirrorServiceTest < ActiveSupport::TestCase
   test "downloading from primary service" do
     key      = SecureRandom.base58(24)
     data     = "Something else entirely!"
-    checksum = ActiveStorage.checksum_implementation.base64digest(data)
+    checksum = @service.base64digest(data)
 
     @service.primary.upload key, StringIO.new(data), checksum: checksum
 
@@ -68,7 +68,7 @@ class ActiveStorage::Service::MirrorServiceTest < ActiveSupport::TestCase
   test "mirroring a file from the primary service to secondary services where it doesn't exist" do
     key      = SecureRandom.base58(24)
     data     = "Something else entirely!"
-    checksum = ActiveStorage.checksum_implementation.base64digest(data)
+    checksum = @service.base64digest(data)
 
     @service.primary.upload key, StringIO.new(data), checksum: checksum
     @service.mirrors.third.upload key, StringIO.new("Surprise!")

--- a/activestorage/test/service/s3_public_service_test.rb
+++ b/activestorage/test/service/s3_public_service_test.rb
@@ -42,7 +42,7 @@ if SERVICE_CONFIGURATIONS[:s3_public]
       request = Net::HTTP::Put.new uri.request_uri
       request.body = data
       request.add_field "Content-Type", "text/plain"
-      request.add_field "Content-MD5", checksum
+      request.add_field "Content-MD5", checksum.digest
       Net::HTTP.start(uri.host, uri.port, use_ssl: true) do |http|
         http.request request
       end

--- a/activestorage/test/service/s3_public_service_test.rb
+++ b/activestorage/test/service/s3_public_service_test.rb
@@ -35,7 +35,7 @@ if SERVICE_CONFIGURATIONS[:s3_public]
     test "direct upload" do
       key      = SecureRandom.base58(24)
       data     = "Something else entirely!"
-      checksum = ActiveStorage.checksum_implementation.base64digest(data)
+      checksum = @service.base64digest(data)
       url      = @service.url_for_direct_upload(key, expires_in: 5.minutes, content_type: "text/plain", content_length: data.size, checksum: checksum)
 
       uri = URI.parse url

--- a/activestorage/test/service/s3_public_service_test.rb
+++ b/activestorage/test/service/s3_public_service_test.rb
@@ -42,7 +42,12 @@ if SERVICE_CONFIGURATIONS[:s3_public]
       request = Net::HTTP::Put.new uri.request_uri
       request.body = data
       request.add_field "Content-Type", "text/plain"
-      request.add_field "Content-MD5", checksum.digest
+      if checksum.digest == :MD5
+        request.add_field "Content-MD5", checksum.digest
+      else
+        request.add_field "x-amz-checksum-#{checksum.algorithm.downcase}", checksum.digest
+      end
+
       Net::HTTP.start(uri.host, uri.port, use_ssl: true) do |http|
         http.request request
       end

--- a/activestorage/test/service/s3_service_test.rb
+++ b/activestorage/test/service/s3_service_test.rb
@@ -17,7 +17,7 @@ if SERVICE_CONFIGURATIONS[:s3]
     test "direct upload" do
       key      = SecureRandom.base58(24)
       data     = "Something else entirely!"
-      checksum = ActiveStorage.checksum_implementation.base64digest(data)
+      checksum = @service.base64digest(data)
       url      = @service.url_for_direct_upload(key, expires_in: 5.minutes, content_type: "text/plain", content_length: data.size, checksum: checksum)
 
       uri = URI.parse url
@@ -37,7 +37,7 @@ if SERVICE_CONFIGURATIONS[:s3]
     test "direct upload with content disposition" do
       key      = SecureRandom.base58(24)
       data     = "Something else entirely!"
-      checksum = ActiveStorage.checksum_implementation.base64digest(data)
+      checksum = @service.base64digest(data)
       url      = @service.url_for_direct_upload(key, expires_in: 5.minutes, content_type: "text/plain", content_length: data.size, checksum: checksum)
 
       uri = URI.parse url
@@ -58,7 +58,7 @@ if SERVICE_CONFIGURATIONS[:s3]
     test "directly uploading file larger than the provided content-length does not work" do
       key      = SecureRandom.base58(24)
       data     = "Some text that is longer than the specified content length"
-      checksum = ActiveStorage.checksum_implementation.base64digest(data)
+      checksum = @service.base64digest(data)
       url      = @service.url_for_direct_upload(key, expires_in: 5.minutes, content_type: "text/plain", content_length: data.size - 1, checksum: checksum)
 
       uri = URI.parse url
@@ -99,7 +99,7 @@ if SERVICE_CONFIGURATIONS[:s3]
       begin
         key  = SecureRandom.base58(24)
         data = "Something else entirely!"
-        service.upload key, StringIO.new(data), checksum: ActiveStorage.checksum_implementation.base64digest(data)
+        service.upload key, StringIO.new(data), checksum: service.base64digest(data)
 
         assert_equal "AES256", service.bucket.object(key).server_side_encryption
       ensure
@@ -115,7 +115,7 @@ if SERVICE_CONFIGURATIONS[:s3]
       @service.upload(
         key,
         StringIO.new(data),
-        checksum: ActiveStorage.checksum_implementation.base64digest(data),
+        checksum: @service.base64digest(data),
         filename: "cool_data.txt",
         content_type: content_type
       )
@@ -131,7 +131,7 @@ if SERVICE_CONFIGURATIONS[:s3]
       @service.upload(
         key,
         StringIO.new(data),
-        checksum: Digest::MD5.base64digest(data),
+        checksum: @service.base64digest(data),
         content_type: "text/plain",
         custom_metadata: { "foo" => "baz" },
         filename: "custom_metadata.txt"
@@ -152,7 +152,7 @@ if SERVICE_CONFIGURATIONS[:s3]
       @service.upload(
         key,
         StringIO.new(data),
-        checksum: ActiveStorage.checksum_implementation.base64digest(data),
+        checksum: @service.base64digest(data),
         filename: ActiveStorage::Filename.new("cool_data.txt"),
         disposition: :attachment
       )
@@ -169,7 +169,7 @@ if SERVICE_CONFIGURATIONS[:s3]
         key  = SecureRandom.base58(24)
         data = SecureRandom.bytes(8.megabytes)
 
-        service.upload key, StringIO.new(data), checksum: ActiveStorage.checksum_implementation.base64digest(data)
+        service.upload key, StringIO.new(data), checksum: service.base64digest(data)
         assert data == service.download(key)
       ensure
         service.delete key
@@ -183,7 +183,7 @@ if SERVICE_CONFIGURATIONS[:s3]
         key  = SecureRandom.base58(24)
         data = SecureRandom.bytes(3.megabytes)
 
-        service.upload key, StringIO.new(data), checksum: ActiveStorage.checksum_implementation.base64digest(data)
+        service.upload key, StringIO.new(data), checksum: service.base64digest(data)
         assert data == service.download(key)
       ensure
         service.delete key

--- a/activestorage/test/service/shared_service_tests.rb
+++ b/activestorage/test/service/shared_service_tests.rb
@@ -23,7 +23,7 @@ module ActiveStorage::Service::SharedServiceTests
     test "uploading with integrity" do
       key  = SecureRandom.base58(24)
       data = "Something else entirely!"
-      @service.upload(key, StringIO.new(data), checksum: ActiveStorage::Checksum.load(@service.base64digest(data).to_s))
+      @service.upload(key, StringIO.new(data), checksum: @service.base64digest(data))
 
       assert_equal data, @service.download(key)
     ensure
@@ -35,7 +35,7 @@ module ActiveStorage::Service::SharedServiceTests
       data = "Something else entirely!"
 
       assert_raises(ActiveStorage::IntegrityError) do
-        @service.upload(key, StringIO.new(data), checksum: ActiveStorage::Checksum.load(@service.base64digest("bad data").to_s))
+        @service.upload(key, StringIO.new(data), checksum: @service.base64digest("bad data"))
       end
 
       assert_not @service.exist?(key)
@@ -49,7 +49,7 @@ module ActiveStorage::Service::SharedServiceTests
       @service.upload(
         key,
         StringIO.new(data),
-        checksum: ActiveStorage::Checksum.load(@service.base64digest(data).to_s),
+        checksum: @service.base64digest(data),
         filename: "racecar.jpg",
         content_type: "image/jpeg"
       )
@@ -147,7 +147,7 @@ module ActiveStorage::Service::SharedServiceTests
         @service.upload(
           key,
           StringIO.new(data),
-          checksum: ActiveStorage::Checksum.load(@service.base64digest(data).to_s),
+          checksum: @service.base64digest(data),
           disposition: :attachment,
           filename: ActiveStorage::Filename.new("test.html"),
           content_type: "text/html",

--- a/activestorage/test/service/shared_service_tests.rb
+++ b/activestorage/test/service/shared_service_tests.rb
@@ -22,7 +22,7 @@ module ActiveStorage::Service::SharedServiceTests
     test "uploading with integrity" do
       key  = SecureRandom.base58(24)
       data = "Something else entirely!"
-      @service.upload(key, StringIO.new(data), checksum: ActiveStorage.checksum_implementation.base64digest(data))
+      @service.upload(key, StringIO.new(data), checksum: @service.base64digest(data))
 
       assert_equal data, @service.download(key)
     ensure
@@ -34,7 +34,7 @@ module ActiveStorage::Service::SharedServiceTests
       data = "Something else entirely!"
 
       assert_raises(ActiveStorage::IntegrityError) do
-        @service.upload(key, StringIO.new(data), checksum: ActiveStorage.checksum_implementation.base64digest("bad data"))
+        @service.upload(key, StringIO.new(data), checksum: @service.base64digest("bad data"))
       end
 
       assert_not @service.exist?(key)
@@ -48,7 +48,7 @@ module ActiveStorage::Service::SharedServiceTests
       @service.upload(
         key,
         StringIO.new(data),
-        checksum: ActiveStorage.checksum_implementation.base64digest(data),
+        checksum: @service.base64digest(data),
         filename: "racecar.jpg",
         content_type: "image/jpeg"
       )
@@ -146,7 +146,7 @@ module ActiveStorage::Service::SharedServiceTests
         @service.upload(
           key,
           StringIO.new(data),
-          checksum: Digest::MD5.base64digest(data),
+          checksum: @service.base64digest(data),
           disposition: :attachment,
           filename: ActiveStorage::Filename.new("test.html"),
           content_type: "text/html",

--- a/activestorage/test/service/shared_service_tests.rb
+++ b/activestorage/test/service/shared_service_tests.rb
@@ -2,6 +2,7 @@
 
 require "test_helper"
 require "active_support/core_ext/securerandom"
+require "active_support/testing/method_call_assertions"
 
 module ActiveStorage::Service::SharedServiceTests
   extend ActiveSupport::Concern
@@ -22,7 +23,7 @@ module ActiveStorage::Service::SharedServiceTests
     test "uploading with integrity" do
       key  = SecureRandom.base58(24)
       data = "Something else entirely!"
-      @service.upload(key, StringIO.new(data), checksum: @service.base64digest(data))
+      @service.upload(key, StringIO.new(data), checksum: ActiveStorage::Checksum.load(@service.base64digest(data).to_s))
 
       assert_equal data, @service.download(key)
     ensure
@@ -34,7 +35,7 @@ module ActiveStorage::Service::SharedServiceTests
       data = "Something else entirely!"
 
       assert_raises(ActiveStorage::IntegrityError) do
-        @service.upload(key, StringIO.new(data), checksum: @service.base64digest("bad data"))
+        @service.upload(key, StringIO.new(data), checksum: ActiveStorage::Checksum.load(@service.base64digest("bad data").to_s))
       end
 
       assert_not @service.exist?(key)
@@ -48,7 +49,7 @@ module ActiveStorage::Service::SharedServiceTests
       @service.upload(
         key,
         StringIO.new(data),
-        checksum: @service.base64digest(data),
+        checksum: ActiveStorage::Checksum.load(@service.base64digest(data).to_s),
         filename: "racecar.jpg",
         content_type: "image/jpeg"
       )
@@ -146,7 +147,7 @@ module ActiveStorage::Service::SharedServiceTests
         @service.upload(
           key,
           StringIO.new(data),
-          checksum: @service.base64digest(data),
+          checksum: ActiveStorage::Checksum.load(@service.base64digest(data).to_s),
           disposition: :attachment,
           filename: ActiveStorage::Filename.new("test.html"),
           content_type: "text/html",

--- a/activestorage/test/service/shared_service_tests.rb
+++ b/activestorage/test/service/shared_service_tests.rb
@@ -157,5 +157,25 @@ module ActiveStorage::Service::SharedServiceTests
 
       assert_equal "Together", @service.download(destination_key)
     end
+
+    test "md5 returns OpenSSL::Digest::MD5 class" do
+      old_class = @service.instance_variable_get(:@md5_class)
+      @service.instance_variable_set(:@md5_class, nil)
+
+      assert_equal OpenSSL::Digest::MD5, @service.send(:md5)
+
+      @service.instance_variable_set(:@md5_class, old_class)
+    end
+
+    test "md5 returns Digest::MD5 class when OpenSSL unavailable" do
+      old_class = @service.instance_variable_get(:@md5_class)
+      @service.instance_variable_set(:@md5_class, nil)
+
+      OpenSSL::Digest::MD5.stub :hexdigest, proc { |input| raise StandardError } do
+        assert_equal Digest::MD5, @service.send(:md5)
+      end
+
+      @service.instance_variable_set(:@md5_class, old_class)
+    end
   end
 end

--- a/activestorage/test/test_helper.rb
+++ b/activestorage/test/test_helper.rb
@@ -58,10 +58,10 @@ class ActiveSupport::TestCase
     def directly_upload_file_blob(filename: "racecar.jpg", content_type: "image/jpeg", record: nil)
       file = file_fixture(filename)
       byte_size = file.size
-      checksum = ActiveStorage.checksum_implementation.file(file).base64digest
+      service = ActiveStorage::Blob.service.try(:primary) || ActiveStorage::Blob.service
+      checksum = service.file(file)
 
       create_blob_before_direct_upload(filename: filename, byte_size: byte_size, checksum: checksum, content_type: content_type, record: record).tap do |blob|
-        service = ActiveStorage::Blob.service.try(:primary) || ActiveStorage::Blob.service
         service.upload(blob.key, file.open)
       end
     end

--- a/activestorage/test/test_helper.rb
+++ b/activestorage/test/test_helper.rb
@@ -48,6 +48,7 @@ class ActiveSupport::TestCase
     end
 
     def create_blob_before_direct_upload(key: nil, filename: "hello.txt", byte_size:, checksum:, content_type: "text/plain", record: nil)
+      checksum = ActiveStorage::Checksum.load(checksum.to_s) if checksum
       ActiveStorage::Blob.create_before_direct_upload! key: key, filename: filename, byte_size: byte_size, checksum: checksum, content_type: content_type, record: record
     end
 

--- a/activestorage/test/test_helper.rb
+++ b/activestorage/test/test_helper.rb
@@ -48,7 +48,6 @@ class ActiveSupport::TestCase
     end
 
     def create_blob_before_direct_upload(key: nil, filename: "hello.txt", byte_size:, checksum:, content_type: "text/plain", record: nil)
-      checksum = ActiveStorage::Checksum.load(checksum.to_s) if checksum
       ActiveStorage::Blob.create_before_direct_upload! key: key, filename: filename, byte_size: byte_size, checksum: checksum, content_type: content_type, record: record
     end
 

--- a/guides/source/active_storage_overview.md
+++ b/guides/source/active_storage_overview.md
@@ -153,6 +153,7 @@ Declare a Disk service in `config/storage.yml`:
 local:
   service: Disk
   root: <%= Rails.root.join("storage") %>
+  default_digest_algorithm: "SHA256"
 ```
 
 ### S3 Service (Amazon S3 and S3-compatible APIs)

--- a/guides/source/active_storage_overview.md
+++ b/guides/source/active_storage_overview.md
@@ -246,6 +246,7 @@ google:
   credentials: <%= Rails.root.join("path/to/keyfile.json") %>
   project: ""
   bucket: your_own_bucket-<%= Rails.env %>
+  default_digest_algorithm: "CRC32c"
 ```
 
 Optionally provide a Hash of credentials instead of a keyfile path:

--- a/guides/source/active_storage_overview.md
+++ b/guides/source/active_storage_overview.md
@@ -228,6 +228,7 @@ azure:
   storage_account_name: your_account_name
   storage_access_key: <%= Rails.application.credentials.dig(:azure_storage, :storage_access_key) %>
   container: your_container_name-<%= Rails.env %>
+  default_digest_algorithm: "CRC64"
 ```
 
 Add the [`azure-storage-blob`](https://github.com/Azure/azure-storage-ruby) gem to your `Gemfile`:

--- a/guides/source/active_storage_overview.md
+++ b/guides/source/active_storage_overview.md
@@ -182,6 +182,7 @@ amazon:
   http_open_timeout: 0
   http_read_timeout: 0
   retry_limit: 0
+  default_digest_algorithm: "SHA256"
   upload:
     server_side_encryption: "" # 'aws:kms' or 'AES256'
     cache_control: "private, max-age=<%= 1.day.to_i %>"

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -2961,15 +2961,6 @@ The default value is `/https?:\/\/localhost:\d+/` in the `development` environme
 
 `config.active_storage` provides the following configuration options:
 
-#### `config.active_storage.checksum_implementation`
-
-Specify which digest implementation to use for internal checksums.
-The value must respond to Ruby's `Digest` interface.
-
-| Starting with version | The default value is                    |
-| --------------------- | --------------------------------------- |
-| (original)            | `OpenSSL::Digest::MD5` or `Digest::MD5` |
-
 #### `config.active_storage.variant_processor`
 
 Accepts a symbol `:mini_magick` or `:vips`, specifying whether variant transformations and blob analysis will be performed with MiniMagick or ruby-vips.


### PR DESCRIPTION
### Motivation / Background

S3, GCS, and Azure all support file integrity checksums other than MD5. The intent of this PR is to support these to ActiveStorage service classes and centralize hashing functionality.

### Detail

- Goal was to improve FIPS support #34443 by adding additional methods of file integrity hashing and remove #54040
- Make ActiveStorage service adapters responsible for checksums and implementation of hashing
- Add ActiveStorage::Checksum class to keep digest/algorithm coupled
- Replace ActiveStorage::Blob checksum with backwards compatible encoded ActiveStorage::Checksum
- Expand direct upload interface to allow passing of algorithm + digest as either ActiveStorage::Checksum compatible string format `MD5:vckNNU4TN7zbzl+o3tjXPQ==` or hash `checksum: { algorithm: "MD5", digest: "vckNNU4TN7zbzl+o3tjXPQ=="}`. Keep backwards compatibility of existing string format as MD5 digest

### Additional information

- Supports all algorithms for Azure, GCS, & S3 ~except for CRC64-NVMe for S3. [PR merged](https://github.com/postmodern/digest-crc/pull/45) to Digest::CRC 7.0~

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
