### PR TITLE
Fix DATABASE_URL variable in the ci template

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/github/ci.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/github/ci.yml.tt
@@ -120,8 +120,10 @@ jobs:
       - name: Run tests
         env:
           RAILS_ENV: test
-          <%- if options[:database] == "mysql" || options[:database] == "trilogy" -%>
+          <%- if options[:database] == "mysql" -%>
           DATABASE_URL: mysql2://127.0.0.1:3306
+          <%- elsif options[:database] == "trilogy" -%>
+          DATABASE_URL: trilogy://127.0.0.1:3306
           <%- elsif options[:database] == "postgresql" -%>
           DATABASE_URL: postgres://postgres:postgres@localhost:5432
           <%- end -%>

--- a/railties/lib/rails/generators/rails/plugin/templates/github/ci.yml.tt
+++ b/railties/lib/rails/generators/rails/plugin/templates/github/ci.yml.tt
@@ -84,8 +84,10 @@ jobs:
       - name: Run tests
         env:
           RAILS_ENV: test
-          <%- if options[:database] == "mysql" || options[:database] == "trilogy" -%>
+          <%- if options[:database] == "mysql" -%>
           DATABASE_URL: mysql2://127.0.0.1:3306
+          <%- elsif options[:database] == "trilogy" -%>
+          DATABASE_URL: trilogy://127.0.0.1:3306
           <%- elsif options[:database] == "postgresql" -%>
           DATABASE_URL: postgres://postgres:postgres@localhost:5432
           <%- end -%>
@@ -100,4 +102,3 @@ jobs:
           path: ${{ github.workspace }}/tmp/screenshots
           if-no-files-found: ignore
 <% end -%>
-


### PR DESCRIPTION
### Motivation / Background

![image](https://github.com/user-attachments/assets/e8ee8638-fc32-42af-b9b5-1c72b668b599)
Using `rails new xxx --database=trilogy` will create a default `.github/workflows/ci.yml` file, but the `DATABASE_URL` environment variable in this file does not match the database option, which cause to CI errors.

### Detail

This Pull Request changes:
- The `DATABASE_URL` environment variable in the default generated `.github/workflows/ci.yml` file should follow the database option.

### Checklist

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
