### PR TITLE
Update `NotificationAssertions`'s  `assert_notifcation` to match against payload subsets and return matched notification

### DIFF
--- a/actionmailer/test/base_test.rb
+++ b/actionmailer/test/base_test.rb
@@ -973,14 +973,13 @@ class BaseTest < ActiveSupport::TestCase
   end
 
   test "notification for deliver" do
-    event = capture_notifications("deliver.action_mailer") do
-      assert_notifications_count("deliver.action_mailer", 1) do
+    assert_notifications_count("deliver.action_mailer", 1) do
+      notification = assert_notification("deliver.action_mailer") do
         BaseMailer.welcome(body: "Hello there").deliver_now
       end
-    end.first
 
-    assert_equal "deliver.action_mailer", event.name
-    assert_not_nil event.payload[:message_id]
+      assert_not_nil notification.payload[:message_id]
+    end
   end
 
   private

--- a/actionpack/test/controller/allow_browser_test.rb
+++ b/actionpack/test/controller/allow_browser_test.rb
@@ -84,13 +84,12 @@ class AllowBrowserTest < ActionController::TestCase
   end
 
   test "a blocked request instruments a browser_block.action_controller event" do
-    event, *rest = capture_notifications "browser_block.action_controller" do
+    notification = assert_notification("browser_block.action_controller") do
       get_with_agent :modern, CHROME_118
     end
 
-    assert_equal request, event.payload[:request]
-    assert_not_empty event.payload[:versions]
-    assert_empty rest
+    assert_equal request, notification.payload[:request]
+    assert_not_empty notification.payload[:versions]
   end
 
   private

--- a/actionpack/test/controller/caching_test.rb
+++ b/actionpack/test/controller/caching_test.rb
@@ -255,12 +255,9 @@ Ciao
   end
 
   def test_fragment_cache_instrumentation
-    payload = capture_notifications("read_fragment.action_controller") do
+    assert_notification("read_fragment.action_controller", controller: "functional_caching", action: "inline_fragment_cached") do
       get :inline_fragment_cached
-    end.first.payload
-
-    assert_equal "functional_caching", payload[:controller]
-    assert_equal "inline_fragment_cached", payload[:action]
+    end
   end
 
   def test_html_formatted_fragment_caching

--- a/actionpack/test/controller/redirect_test.rb
+++ b/actionpack/test/controller/redirect_test.rb
@@ -608,13 +608,11 @@ class RedirectTest < ActionController::TestCase
   end
 
   def test_redirect_to_instrumentation
-    payload = capture_notifications("redirect_to.action_controller") do
+    notification = assert_notification("redirect_to.action_controller", status: 302, location: "http://test.host/redirect/hello_world") do
       get :simple_redirect
-    end.first.payload
+    end
 
-    assert_equal request, payload[:request]
-    assert_equal 302, payload[:status]
-    assert_equal "http://test.host/redirect/hello_world", payload[:location]
+    assert_kind_of ActionDispatch::Request, notification.payload[:request]
   end
 
   def test_redirect_to_external_with_rescue

--- a/actionpack/test/dispatch/routing/instrumentation_test.rb
+++ b/actionpack/test/dispatch/routing/instrumentation_test.rb
@@ -8,15 +8,11 @@ class RoutingInstrumentationTest < ActionDispatch::IntegrationTest
       get "redirect", to: redirect("/login")
     end
 
-    event = capture_notifications("redirect.action_dispatch") do
-      assert_notifications_count("redirect.action_dispatch", 1) do
-        get "/redirect"
-      end
-    end.first
+    notification = assert_notification("redirect.action_dispatch", status: 301, location: "http://www.example.com/login") do
+      get "/redirect"
+    end
 
-    assert_equal 301, event.payload[:status]
-    assert_equal "http://www.example.com/login", event.payload[:location]
-    assert_kind_of ActionDispatch::Request, event.payload[:request]
+    assert_kind_of ActionDispatch::Request, notification.payload[:request]
   end
 
   private

--- a/actionview/test/activerecord/partial_rendering_query_test.rb
+++ b/actionview/test/activerecord/partial_rendering_query_test.rb
@@ -10,13 +10,10 @@ class PartialRenderingQueryTest < ActiveRecordTestCase
   end
 
   def test_render_with_relation_collection
-    notifications = capture_notifications("sql.active_record") do
-      @view.render partial: "topics/topic", collection: Topic.all
+    assert_notifications_count("sql.active_record", 1) do
+      assert_notification("sql.active_record", sql: 'SELECT "topics".* FROM "topics"') do
+        @view.render partial: "topics/topic", collection: Topic.all
+      end
     end
-
-    queries = notifications.filter_map { _1.payload[:sql] unless %w[ SCHEMA TRANSACTION ].include?(_1.payload[:name]) }
-
-    assert_equal 1, queries.size
-    assert_equal 'SELECT "topics".* FROM "topics"', queries[0]
   end
 end

--- a/activejob/test/cases/queuing_test.rb
+++ b/activejob/test/cases/queuing_test.rb
@@ -97,12 +97,10 @@ class QueuingTest < ActiveSupport::TestCase
   test "perform_all_later instrumentation" do
     jobs = HelloJob.new("Jamie"), HelloJob.new("John")
 
-    payload = capture_notifications("enqueue_all.active_job") do
+    notification = assert_notification("enqueue_all.active_job", jobs:, enqueued_count: 2) do
       ActiveJob.perform_all_later(jobs)
-    end.first.payload
+    end
 
-    assert payload[:adapter]
-    assert_equal jobs, payload[:jobs]
-    assert_equal 2, payload[:enqueued_count]
+    assert notification.payload[:adapter]
   end
 end

--- a/activerecord/test/activejob/job_runtime_test.rb
+++ b/activerecord/test/activejob/job_runtime_test.rb
@@ -15,17 +15,14 @@ class JobRuntimeTest < ActiveSupport::TestCase
   test "job notification payload includes db_runtime" do
     ActiveRecord::RuntimeRegistry.sql_runtime = 0.0
 
-    event = capture_notifications("perform.active_job") { TestJob.perform_now }.first
-
-    assert_equal 42, event.payload[:db_runtime]
+    assert_notification("perform.active_job", db_runtime: 42.0) { TestJob.perform_now }
   end
 
   test "db_runtime tracks database runtime for job only" do
     ActiveRecord::RuntimeRegistry.sql_runtime = 100.0
 
-    event = capture_notifications("perform.active_job") { TestJob.perform_now }.first
+    assert_notification("perform.active_job", db_runtime: 42.0) { TestJob.perform_now }
 
-    assert_equal 42.0, event.payload[:db_runtime]
     assert_equal 142.0, ActiveRecord::RuntimeRegistry.sql_runtime
   end
 end

--- a/activerecord/test/cases/associations/eager_test.rb
+++ b/activerecord/test/cases/associations/eager_test.rb
@@ -1136,14 +1136,14 @@ class EagerAssociationTest < ActiveRecord::TestCase
   end
 
   def test_association_loading_notification
-    payload = capture_notifications("instantiation.active_record") do
+    notification = assert_notification("instantiation.active_record", class_name: Developer.name) do
       Developer.all.merge!(includes: "projects", where: { "developers_projects.access_level" => 1 }, limit: 5).to_a.size
-    end.first.payload
+    end
+
     count = Developer.all.merge!(includes: "projects", where: { "developers_projects.access_level" => 1 }, limit: 5).to_a.size
 
     # eagerloaded row count should be greater than just developer count
-    assert_operator payload[:record_count], :>, count
-    assert_equal Developer.name, payload[:class_name]
+    assert_operator notification.payload[:record_count], :>, count
   end
 
   def test_base_messages

--- a/activerecord/test/cases/instrumentation_test.rb
+++ b/activerecord/test/cases/instrumentation_test.rb
@@ -128,11 +128,7 @@ module ActiveRecord
     end
 
     def test_payload_connection_with_query_cache_disabled
-      connection = ClothingItem.lease_connection
-
-      payload = capture_notifications("sql.active_record") { Book.first }.first.payload
-
-      assert_equal connection, payload[:connection]
+      assert_notification("sql.active_record", connection: ClothingItem.lease_connection) { Book.first }
     end
 
     def test_payload_connection_with_query_cache_enabled

--- a/activestorage/test/analyzer/image_analyzer/vips_test.rb
+++ b/activestorage/test/analyzer/image_analyzer/vips_test.rb
@@ -48,13 +48,13 @@ class ActiveStorage::Analyzer::ImageAnalyzer::VipsTest < ActiveSupport::TestCase
 
   test "instrumenting analysis" do
     analyze_with_vips do
-      events = capture_notifications("analyze.active_storage") do
-        blob = create_file_blob(filename: "racecar.jpg", content_type: "image/jpeg")
-        blob.analyze
-      end
+      blob = create_file_blob(filename: "racecar.jpg", content_type: "image/jpeg")
 
-      assert_equal 1, events.size
-      assert_equal({ analyzer: "vips" }, events.first.payload)
+      assert_notifications_count("analyze.active_storage", 1) do
+        assert_notification("analyze.active_storage", analyzer: "vips") do
+          blob.analyze
+        end
+      end
     end
   end
 

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,25 @@
+*   `ActiveSupport::Testing::NotificationAssertions`'s `assert_notification` now matches against payload subsets by default.
+
+    Previously the following assertion would fail due to excess key vals in the notification payload. Now with payload subset matching, it will pass.
+
+    ```ruby
+    assert_notification("post.submitted", title: "Cool Post") do
+      ActiveSupport::Notifications.instrument("post.submitted", title: "Cool Post", body: "Cool Body")
+    end
+    ```
+
+    Additionally, you can now persist a matched notification for more customized assertions.
+
+    ```ruby
+    notification = assert_notification("post.submitted", title: "Cool Post") do
+      ActiveSupport::Notifications.instrument("post.submitted", title: "Cool Post", body: Body.new("Cool Body"))
+    end
+
+    assert_instance_of(Body, notification.payload[:body])
+    ```
+
+    *Nicholas La Roux*
+
 *   Deprecate `String#mb_chars` and `ActiveSupport::Multibyte::Chars`.
 
     These APIs are a relic of the Ruby 1.8 days when Ruby strings weren't encoding

--- a/activesupport/test/testing/notification_assertions_test.rb
+++ b/activesupport/test/testing/notification_assertions_test.rb
@@ -13,6 +13,10 @@ module ActiveSupport
           ActiveSupport::Notifications.instrument("post.submitted", title: "Cool Post")
         end
 
+        assert_notification("post.submitted", title: "Cool Post") do # subset of payload
+          ActiveSupport::Notifications.instrument("post.submitted", title: "Cool Post", body: "Cool Body")
+        end
+
         assert_notification("post.submitted") do # payload omitted
           ActiveSupport::Notifications.instrument("post.submitted", title: "Cool Post")
         end
@@ -31,6 +35,16 @@ module ActiveSupport
             ActiveSupport::Notifications.instrument("post.submitted", title: "Cooler Post")
           end
         end
+
+        notification = assert_notification("post.submitted") do # returns notification, no payload specified
+          ActiveSupport::Notifications.instrument("post.submitted", title: "Cool Post")
+        end
+        assert_equal("post.submitted", notification.name)
+
+        notification = assert_notification("post.submitted", title: "Cool Post") do # returns notification
+          ActiveSupport::Notifications.instrument("post.submitted", title: "Cool Post")
+        end
+        assert_equal("post.submitted", notification.name)
       end
 
       def test_assert_notifications_count

--- a/railties/test/application/initializers/notifications_test.rb
+++ b/railties/test/application/initializers/notifications_test.rb
@@ -45,10 +45,9 @@ module ApplicationTests
     test "rails load_config_initializer event is instrumented" do
       app_file "config/initializers/foo.rb", ""
 
-      event = capture_notifications("load_config_initializer.railties") { app }.first
+      notification = assert_notification("load_config_initializer.railties") { app }
 
-      assert_equal "load_config_initializer.railties", event.name
-      assert_match "config/initializers/foo.rb", event.payload[:initializer]
+      assert_match "config/initializers/foo.rb", notification.payload[:initializer]
     end
   end
 end


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because:
1. One currently needs to exhaustively specify entire notification payloads (all key vals) in order to use `NotificationAssertions`'s `assert_notification`, which is not always practical or even possible. Thus, let's match against subsets by default. If one needs exhaustive matching they can do so manually via the following (point 2) or manual notification capture.
2. One currently needs to go lower level and `capture_notifications` even in cases where `assert_notification` would cover most of the desired assertions in the situation that one wants to do further, custom assertions against a matched notification. Thus, let's return the matched notification! Such is similar to how [Minitest's assert_raises](https://docs.seattlerb.org/minitest/Minitest/Assertions.html#method-i-assert_raises).

Regarding point 1. one example is we cannot currently use `assert_notification` in the following test because jobs' notifications' payloads contain various key vals, while we only want to assert against one.

https://github.com/rails/rails/blob/1b327ad4ed0fe5e8c2f1f795e2cf63f90a9833b5/activerecord/test/activejob/job_runtime_test.rb#L15-L21

Here's said assertion failing, exposing the list of payload key vals, only one of which we care about.

```ruby
vscode ➜ /workspaces/rails/activerecord (main) $ bin/test test/activejob/job_runtime_test.rb 
Using sqlite3_mem
Run options: --seed 23503

# Running:

.{:job=>#<JobRuntimeTest::TestJob:0x00007f80d3efa000 @arguments=[], @job_id="59c22946-0730-4db4-a63f-b71b72804a51", @queue_name=#<Proc:0x00007f80d40a4978 /workspaces/rails/activejob/lib/active_job/queue_name.rb:55 (lambda)>, @scheduled_at=nil, @priority=nil, @executions=1, @exception_executions={}, @timezone=nil, @_halted_callback_hook_called=nil>, :adapter=>#<ActiveJob::QueueAdapters::TestAdapter:0x00007f80d3e42388>, :db_runtime=>42.0, :aborted=>nil}
.

Finished in 0.002990s, 668.9259 runs/s, 1003.3888 assertions/s.
2 runs, 3 assertions, 0 failures, 0 errors, 0 skips
```

If we could assert against a subset of the said payload this test would be cleaner and simpler.

Follow up to
- https://github.com/rails/rails/pull/53065
- https://github.com/rails/rails/pull/53700 (merged as per gem PRs)
- https://github.com/rails/rails/pull/54084
- https://github.com/rails/rails/pull/54113 (specifically [this conversation](https://github.com/rails/rails/pull/54113#discussion_r1903083668), big thanks :pray: )

CC @seanpdoyle and @yishus as y'all may like to see this PR as well. :)

### Detail

This Pull Request changes `NotificationAssertions`'s `assert_notification` method to match against payload subsets by default and return the matched notification automatically so devs can do further assertions against it, should they wish.

Additionally it cleans up a large number of tests that were doing manual `capture_notifcations` based testing + assertions now that the main `assert_notification` method can support their testing use cases.

(also [updates one notification test unrelated to this change](https://github.com/rails/rails/commit/a146c7e8cb00d421d38d29a3ce082b4556b1d27a) I missed in https://github.com/rails/rails/pull/54084. can extract into its own PR if desired.)

### Additional information

I've been thinking about how to support payload subset matching with `assert_notification` for some time now. Was a feature I wanted to support within the scope of the original `NotificationAssertions` PR but I couldn't get it working as I wanted until now. Big thanks to @byroot for [this conversation](https://github.com/rails/rails/pull/54113#discussion_r1903083668), which inspired much of this revamped revamp.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
