### PR TITLE
[ci skip] Configure encryption in `active_record` bug report template

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,13 @@
 * If you're unable to find an open issue addressing the problem, [open a new one](https://github.com/rails/rails/issues/new). Be sure to include a **title and clear description**, as much relevant information as possible, and a **code sample** or an **executable test case** demonstrating the expected behavior that is not occurring.
 
 * If possible, use the relevant bug report templates to create the issue. Simply copy the content of the appropriate template into a .rb file, make the necessary changes to demonstrate the issue, and **paste the content into the issue description**:
-  * [**Active Record** (models, database) issues](https://github.com/rails/rails/blob/main/guides/bug_report_templates/active_record.rb)
+  * [**Active Record** (models, encryption, database) issues](https://github.com/rails/rails/blob/main/guides/bug_report_templates/active_record.rb)
+  * [**Active Record Migrations** issues](https://github.com/rails/rails/blob/main/guides/bug_report_templates/active_record_migrations.rb)
+  * [**Action View** (views, helpers) issues](https://github.com/rails/rails/blob/main/guides/bug_report_templates/action_view.rb)
+  * [**Active Job** issues](https://github.com/rails/rails/blob/main/guides/bug_report_templates/active_job.rb)
+  * [**Active Storage** issues](https://github.com/rails/rails/blob/main/guides/bug_report_templates/active_storage.rb)
+  * [**Action Mailer** issues](https://github.com/rails/rails/blob/main/guides/bug_report_templates/action_mailer.rb)
+  * [**Action Mailbox** issues](https://github.com/rails/rails/blob/main/guides/bug_report_templates/action_mailbox.rb)
   * [**Action Pack** (controllers, routing) issues](https://github.com/rails/rails/blob/main/guides/bug_report_templates/action_controller.rb)
   * [**Generic template** for other issues](https://github.com/rails/rails/blob/main/guides/bug_report_templates/generic.rb)
 

--- a/guides/bug_report_templates/active_record.rb
+++ b/guides/bug_report_templates/active_record.rb
@@ -23,6 +23,10 @@ class TestApp < Rails::Application
   config.eager_load = false
   config.logger = Logger.new($stdout)
   config.secret_key_base = "secret_key_base"
+
+  config.active_record.encryption.primary_key = "primary_key"
+  config.active_record.encryption.deterministic_key = "deterministic_key"
+  config.active_record.encryption.key_derivation_salt = "key_derivation_salt"
 end
 Rails.application.initialize!
 

--- a/guides/source/contributing_to_ruby_on_rails.md
+++ b/guides/source/contributing_to_ruby_on_rails.md
@@ -39,7 +39,7 @@ Once you open an issue, it may or may not see activity right away unless it is a
 
 Having a way to reproduce your issue will help people confirm, investigate, and ultimately fix your issue. You can do this by providing an executable test case. To make this process easier, we have prepared several bug report templates for you to use as a starting point:
 
-* [Template for Active Record (models, database) issues](https://github.com/rails/rails/blob/main/guides/bug_report_templates/active_record.rb)
+* [Template for Active Record (models, encryption,database) issues](https://github.com/rails/rails/blob/main/guides/bug_report_templates/active_record.rb)
 * [Template for testing Active Record (migration) issues](https://github.com/rails/rails/blob/main/guides/bug_report_templates/active_record_migrations.rb)
 * [Template for Action Pack (controllers, routing) issues](https://github.com/rails/rails/blob/main/guides/bug_report_templates/action_controller.rb)
 * [Template for Action View (views, helpers) issues](https://github.com/rails/rails/blob/main/guides/bug_report_templates/action_view.rb)


### PR DESCRIPTION
Substitutes https://github.com/rails/rails/pull/54006

I often find myself spending some time trying to figure out a reproduction script for [encryption issues](https://github.com/rails/rails/issues?q=is%3Aissue+label%3Aencryption), I assume many people have the same problem as encryption issues often come with no reproduction script

So I'd like to propose we fold these changes into main active_record.rb template to make it encryption-ready. The change is cheap, we only need to configure encryption keys.

