### PR TITLE
perf FileUpdateChecker, ignore gems paths

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   FileUpdateChecker and EventedFileUpdateChecker ignore changes in Gem.path now.
+
+    *Ermolaev Andrey*, *zzak*
+
 *   The new method `ActiveSupport::BacktraceCleaner#first_clean_frame` returns
     the first clean frame of the caller's backtrace, or `nil`. Useful when you
     want to report the application-level location where something happened.

--- a/activesupport/lib/active_support/evented_file_update_checker.rb
+++ b/activesupport/lib/active_support/evented_file_update_checker.rb
@@ -73,9 +73,13 @@ module ActiveSupport
       attr_reader :updated, :files
 
       def initialize(files, dirs)
-        @files = files.map { |file| Pathname(file).expand_path }.to_set
+        gem_paths = Gem.path
+        files = files.map { |f| Pathname(f).expand_path }
+        files.reject! { |f| f.to_s.start_with?(*gem_paths) }
+        @files = files.to_set
 
         @dirs = dirs.each_with_object({}) do |(dir, exts), hash|
+          next if dir.start_with?(*gem_paths)
           hash[Pathname(dir).expand_path] = Array(exts).map { |ext| ext.to_s.sub(/\A\.?/, ".") }.to_set
         end
 

--- a/activesupport/lib/active_support/file_update_checker.rb
+++ b/activesupport/lib/active_support/file_update_checker.rb
@@ -46,8 +46,11 @@ module ActiveSupport
         raise ArgumentError, "A block is required to initialize a FileUpdateChecker"
       end
 
-      @files = files.freeze
-      @globs = compile_glob(dirs)
+      gem_paths = Gem.path
+      @files = files.reject { |file| File.expand_path(file).start_with?(*gem_paths) }.freeze
+
+      @globs = compile_glob(dirs)&.reject { |dir| dir.start_with?(*gem_paths) }
+
       @block = block
 
       @watched    = nil

--- a/activesupport/lib/active_support/i18n_railtie.rb
+++ b/activesupport/lib/active_support/i18n_railtie.rb
@@ -66,8 +66,7 @@ module I18n
 
       if app.config.reloading_enabled?
         directories = watched_dirs_with_extensions(reloadable_paths)
-        root_load_paths = I18n.load_path.select { |path| path.to_s.start_with?(Rails.root.to_s) }
-        reloader = app.config.file_watcher.new(root_load_paths, directories) do
+        reloader = app.config.file_watcher.new(I18n.load_path, directories) do
           I18n.load_path.delete_if { |path| path.to_s.start_with?(Rails.root.to_s) && !File.exist?(path) }
           I18n.load_path |= reloadable_paths.flat_map(&:existent)
         end


### PR DESCRIPTION
Improve performance change file in development (when reload page), on app with many gems

### Detail

Some gems add paths to `ActiveSupport::Dependencies.autoload_paths`:

```
 "/Users/ermolaev/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/good_job-4.4.2/app/charts",
 "/Users/ermolaev/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/good_job-4.4.2/app/controllers",
 "/Users/ermolaev/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/good_job-4.4.2/app/filters",
 "/Users/ermolaev/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/good_job-4.4.2/app/frontend",
 "/Users/ermolaev/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/good_job-4.4.2/app/helpers",
 "/Users/ermolaev/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/good_job-4.4.2/app/models",
 "/Users/ermolaev/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/good_job-4.4.2/app/models/concerns",
 "/Users/ermolaev/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/devise-4.9.4/app/controllers",
 "/Users/ermolaev/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/devise-4.9.4/app/helpers",
 "/Users/ermolaev/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/devise-4.9.4/app/mailers",
 "/Users/ermolaev/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/view_component-3.8.0/app/controllers",
 "/Users/ermolaev/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/view_component-3.8.0/app/controllers/concerns",
 "/Users/ermolaev/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/view_component-3.8.0/app/helpers",
 "/Users/ermolaev/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/view_component-contrib-0.2.3/app/views"
```


to `I18n.load_path`:

```
["/Users/ermolaev/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/dotiw-5.3.3/lib/dotiw/locale/ar.yml",
 "/Users/ermolaev/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/dotiw-5.3.3/lib/dotiw/locale/da.yml",
 "/Users/ermolaev/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/dotiw-5.3.3/lib/dotiw/locale/de.yml",
 "/Users/ermolaev/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/dotiw-5.3.3/lib/dotiw/locale/en.yml",
 "/Users/ermolaev/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/dotiw-5.3.3/lib/dotiw/locale/es.yml",
 "/Users/ermolaev/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/dotiw-5.3.3/lib/dotiw/locale/fr.yml",
 "/Users/ermolaev/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/dotiw-5.3.3/lib/dotiw/locale/id.yml",
 "/Users/ermolaev/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/dotiw-5.3.3/lib/dotiw/locale/it.yml",
 "/Users/ermolaev/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/dotiw-5.3.3/lib/dotiw/locale/ja.yml",
 "/Users/ermolaev/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/dotiw-5.3.3/lib/dotiw/locale/ko.yml",
 "/Users/ermolaev/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/dotiw-5.3.3/lib/dotiw/locale/nb.yml",
 "/Users/ermolaev/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/dotiw-5.3.3/lib/dotiw/locale/nl.yml",
 "/Users/ermolaev/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/dotiw-5.3.3/lib/dotiw/locale/pl.yml",
 "/Users/ermolaev/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/dotiw-5.3.3/lib/dotiw/locale/pt-BR.yml",
 "/Users/ermolaev/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/dotiw-5.3.3/lib/dotiw/locale/ru.yml",
 "/Users/ermolaev/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/dotiw-5.3.3/lib/dotiw/locale/sv.yml",
 "/Users/ermolaev/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/dotiw-5.3.3/lib/dotiw/locale/vi.yml",
 "/Users/ermolaev/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/dotiw-5.3.3/lib/dotiw/locale/zh-CN.yml",
 "/Users/ermolaev/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/dotiw-5.3.3/lib/dotiw/locale/zh-TW.yml",
 "/Users/ermolaev/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/activesupport-7.1.5/lib/active_support/locale/en.yml",
 "/Users/ermolaev/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/activesupport-7.1.5/lib/active_support/locale/en.rb",
 "/Users/ermolaev/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/activemodel-7.1.5/lib/active_model/locale/en.yml",
 "/Users/ermolaev/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/activerecord-7.1.5/lib/active_record/locale/en.yml",
 "/Users/ermolaev/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/actionview-7.1.5/lib/action_view/locale/en.yml",
 "/Users/ermolaev/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/responders-3.1.1/lib/responders/locales/en.yml",
 "/Users/ermolaev/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/ancestry-4.3.3/lib/ancestry/locales/en.yml",
 "/Users/ermolaev/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/numbers_and_words-1.0.0/lib/numbers_and_words/i18n/locales/numbers.cs.yml",
 "/Users/ermolaev/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/numbers_and_words-1.0.0/lib/numbers_and_words/i18n/locales/numbers.da.yml",
 "/Users/ermolaev/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/numbers_and_words-1.0.0/lib/numbers_and_words/i18n/locales/numbers.de.yml",
 "/Users/ermolaev/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/numbers_and_words-1.0.0/lib/numbers_and_words/i18n/locales/numbers.en-GB.yml",
 "/Users/ermolaev/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/numbers_and_words-1.0.0/lib/numbers_and_words/i18n/locales/numbers.en.yml",
 "/Users/ermolaev/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/numbers_and_words-1.0.0/lib/numbers_and_words/i18n/locales/numbers.es.yml",
 "/Users/ermolaev/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/numbers_and_words-1.0.0/lib/numbers_and_words/i18n/locales/numbers.et.yml",
 "/Users/ermolaev/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/numbers_and_words-1.0.0/lib/numbers_and_words/i18n/locales/numbers.fr.yml",
 "/Users/ermolaev/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/numbers_and_words-1.0.0/lib/numbers_and_words/i18n/locales/numbers.hu.yml",
 "/Users/ermolaev/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/numbers_and_words-1.0.0/lib/numbers_and_words/i18n/locales/numbers.hy.yml",
 "/Users/ermolaev/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/numbers_and_words-1.0.0/lib/numbers_and_words/i18n/locales/numbers.it.yml",
 "/Users/ermolaev/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/numbers_and_words-1.0.0/lib/numbers_and_words/i18n/locales/numbers.ka.yml",
 "/Users/ermolaev/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/numbers_and_words-1.0.0/lib/numbers_and_words/i18n/locales/numbers.kz.yml",
 "/Users/ermolaev/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/numbers_and_words-1.0.0/lib/numbers_and_words/i18n/locales/numbers.lt.yml",
 "/Users/ermolaev/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/numbers_and_words-1.0.0/lib/numbers_and_words/i18n/locales/numbers.lv.yml",
 "/Users/ermolaev/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/numbers_and_words-1.0.0/lib/numbers_and_words/i18n/locales/numbers.nl.yml",
 "/Users/ermolaev/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/numbers_and_words-1.0.0/lib/numbers_and_words/i18n/locales/numbers.pt-BR.yml",
 "/Users/ermolaev/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/numbers_and_words-1.0.0/lib/numbers_and_words/i18n/locales/numbers.pt.yml",
 "/Users/ermolaev/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/numbers_and_words-1.0.0/lib/numbers_and_words/i18n/locales/numbers.ru.yml",
 "/Users/ermolaev/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/numbers_and_words-1.0.0/lib/numbers_and_words/i18n/locales/numbers.se.yml",
 "/Users/ermolaev/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/numbers_and_words-1.0.0/lib/numbers_and_words/i18n/locales/numbers.tr.yml",
 "/Users/ermolaev/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/numbers_and_words-1.0.0/lib/numbers_and_words/i18n/locales/numbers.ua.yml",
 "/Users/ermolaev/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/numbers_and_words-1.0.0/lib/numbers_and_words/i18n/locales/numbers.vi.yml",
 "/Users/ermolaev/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/numbers_and_words-1.0.0/lib/numbers_and_words/i18n/plurals/plurals.rb",
 "/Users/ermolaev/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/recaptcha-5.17.0/lib/recaptcha/../../rails/locales/en.yml",
 "/Users/ermolaev/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/rails-i18n-7.0.10/lib/rails_i18n/../../rails/locale/ru.yml",
 "/Users/ermolaev/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/rails-i18n-7.0.10/lib/rails_i18n/../../rails/locale/en.yml",
 "/Users/ermolaev/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/rails-i18n-7.0.10/lib/rails_i18n/../../rails/pluralization/ru.rb",
 "/Users/ermolaev/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/rails-i18n-7.0.10/lib/rails_i18n/../../rails/pluralization/en.rb",
 "/Users/ermolaev/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/rails-i18n-7.0.10/lib/rails_i18n/../../rails/transliteration/ru.rb",
 "/Users/ermolaev/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/devise-4.9.4/config/locales/en.yml",
 "/Users/ermolaev/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/good_job-4.4.2/config/locales/de.yml",
 "/Users/ermolaev/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/good_job-4.4.2/config/locales/en.yml",
 "/Users/ermolaev/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/good_job-4.4.2/config/locales/es.yml",
 "/Users/ermolaev/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/good_job-4.4.2/config/locales/fr.yml",
 "/Users/ermolaev/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/good_job-4.4.2/config/locales/it.yml",
 "/Users/ermolaev/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/good_job-4.4.2/config/locales/ja.yml",
 "/Users/ermolaev/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/good_job-4.4.2/config/locales/ko.yml",
 "/Users/ermolaev/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/good_job-4.4.2/config/locales/nl.yml",
 "/Users/ermolaev/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/good_job-4.4.2/config/locales/pt-BR.yml",
 "/Users/ermolaev/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/good_job-4.4.2/config/locales/ru.yml",
 "/Users/ermolaev/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/good_job-4.4.2/config/locales/tr.yml",
 "/Users/ermolaev/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/good_job-4.4.2/config/locales/uk.yml"
```

to `ActionView::PathRegistry.all_file_system_resolvers.map(&:path)`

```
"/Users/ermolaev/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/turbo-rails-2.0.11/app/views",
"/Users/ermolaev/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/view_component-3.8.0/app/views",
"/Users/ermolaev/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/devise-4.9.4/app/views",
"/Users/ermolaev/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/good_job-4.4.2/app/views",
```

### Additional information

check files into gems affect performance, need chek files only in app

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
