### PR TITLE
Custom headers for ActionCable WebSocket [Fix #54127]

### DIFF
--- a/actioncable/app/assets/javascripts/action_cable.js
+++ b/actioncable/app/assets/javascripts/action_cable.js
@@ -155,7 +155,7 @@
         if (this.webSocket) {
           this.uninstallEventHandlers();
         }
-        this.webSocket = new adapters.WebSocket(this.consumer.url, socketProtocols);
+        this.webSocket = new adapters.WebSocket(this.consumer.url, socketProtocols, {headers:this.consumer.headers});
         this.installEventHandlers();
         this.monitor.start();
         return true;
@@ -440,8 +440,9 @@
     }
   }
   class Consumer {
-    constructor(url) {
+    constructor(url, headers = {}) {
       this._url = url;
+      this.headers = headers;
       this.subscriptions = new Subscriptions(this);
       this.connection = new Connection(this);
       this.subprotocols = [];
@@ -483,8 +484,8 @@
       return url;
     }
   }
-  function createConsumer(url = getConfig("url") || INTERNAL.default_mount_path) {
-    return new Consumer(url);
+  function createConsumer(url = getConfig("url") || INTERNAL.default_mount_path, headers) {
+    return new Consumer(url, headers);
   }
   function getConfig(name) {
     const element = document.head.querySelector(`meta[name='action-cable-${name}']`);

--- a/actioncable/app/assets/javascripts/actioncable.esm.js
+++ b/actioncable/app/assets/javascripts/actioncable.esm.js
@@ -161,7 +161,7 @@ class Connection {
       if (this.webSocket) {
         this.uninstallEventHandlers();
       }
-      this.webSocket = new adapters.WebSocket(this.consumer.url, socketProtocols);
+      this.webSocket = new adapters.WebSocket(this.consumer.url, socketProtocols, {headers:this.consumer.headers});
       this.installEventHandlers();
       this.monitor.start();
       return true;
@@ -453,8 +453,9 @@ class Subscriptions {
 }
 
 class Consumer {
-  constructor(url) {
+  constructor(url, headers = {}) {
     this._url = url;
+    this.headers = headers;
     this.subscriptions = new Subscriptions(this);
     this.connection = new Connection(this);
     this.subprotocols = [];
@@ -498,8 +499,8 @@ function createWebSocketURL(url) {
   }
 }
 
-function createConsumer(url = getConfig("url") || INTERNAL.default_mount_path) {
-  return new Consumer(url);
+function createConsumer(url = getConfig("url") || INTERNAL.default_mount_path, headers) {
+  return new Consumer(url, headers);
 }
 
 function getConfig(name) {

--- a/actioncable/app/assets/javascripts/actioncable.js
+++ b/actioncable/app/assets/javascripts/actioncable.js
@@ -155,7 +155,7 @@
         if (this.webSocket) {
           this.uninstallEventHandlers();
         }
-        this.webSocket = new adapters.WebSocket(this.consumer.url, socketProtocols);
+        this.webSocket = new adapters.WebSocket(this.consumer.url, socketProtocols, {headers:this.consumer.headers});
         this.installEventHandlers();
         this.monitor.start();
         return true;
@@ -440,8 +440,9 @@
     }
   }
   class Consumer {
-    constructor(url) {
+    constructor(url, headers = {}) {
       this._url = url;
+      this.headers = headers;
       this.subscriptions = new Subscriptions(this);
       this.connection = new Connection(this);
       this.subprotocols = [];
@@ -483,8 +484,8 @@
       return url;
     }
   }
-  function createConsumer(url = getConfig("url") || INTERNAL.default_mount_path) {
-    return new Consumer(url);
+  function createConsumer(url = getConfig("url") || INTERNAL.default_mount_path, headers) {
+    return new Consumer(url, headers);
   }
   function getConfig(name) {
     const element = document.head.querySelector(`meta[name='action-cable-${name}']`);

--- a/actioncable/app/javascript/action_cable/connection.js
+++ b/actioncable/app/javascript/action_cable/connection.js
@@ -36,7 +36,7 @@ class Connection {
       const socketProtocols = [...protocols, ...this.consumer.subprotocols || []]
       logger.log(`Opening WebSocket, current state is ${this.getState()}, subprotocols: ${socketProtocols}`)
       if (this.webSocket) { this.uninstallEventHandlers() }
-      this.webSocket = new adapters.WebSocket(this.consumer.url, socketProtocols)
+      this.webSocket = new adapters.WebSocket(this.consumer.url, socketProtocols,{headers:this.consumer.headers})
       this.installEventHandlers()
       this.monitor.start()
       return true

--- a/actioncable/app/javascript/action_cable/consumer.js
+++ b/actioncable/app/javascript/action_cable/consumer.js
@@ -28,8 +28,9 @@ import Subscriptions from "./subscriptions"
 // automatically resubscribe.
 
 export default class Consumer {
-  constructor(url) {
+  constructor(url, headers = {}) {
     this._url = url
+    this.headers = headers
     this.subscriptions = new Subscriptions(this)
     this.connection = new Connection(this)
     this.subprotocols = []

--- a/actioncable/app/javascript/action_cable/index.js
+++ b/actioncable/app/javascript/action_cable/index.js
@@ -21,8 +21,8 @@ export {
   logger,
 }
 
-export function createConsumer(url = getConfig("url") || INTERNAL.default_mount_path) {
-  return new Consumer(url)
+export function createConsumer(url = getConfig("url") || INTERNAL.default_mount_path, headers) {
+  return new Consumer(url, headers)
 }
 
 export function getConfig(name) {

--- a/guides/source/action_cable_overview.md
+++ b/guides/source/action_cable_overview.md
@@ -307,6 +307,19 @@ function getWebSocketURL() {
 }
 ```
 
+#### Headers
+
+You can pass custom headers to the WebSocket connection by providing them as the second argument to `createConsumer`:
+
+```js
+const headers = { 
+  'X-API-KEY': 'secret-key',
+  'Content-Type': 'application/json'
+}
+
+createConsumer(url, headers)
+```
+
 #### Subscriber
 
 A consumer becomes a subscriber by creating a subscription to a given channel:


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because I need to be able to pass along custom Headers to the WebSocket used by the ActionCable.

As stated in this [issue](https://github.com/rails/rails/issues/54127)

### Detail

This Pull Request changes the JS code that is used to communicate with the ActionCable.

### Additional information

N/A

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
