### PR TITLE
fix: `ArgumentError`s raised during template rendering

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,21 @@
+*   Argument errors related to strict locals in templates now raise an
+    `ActionView::StrictLocalsError`, and all other argument errors are reraised as-is.
+
+    Previously, any `ArgumentError` raised during template rendering was swallowed during strict
+    local error handling, so that an `ArgumentError` unrelated to strict locals (e.g., a helper
+    method invoked with incorrect arguments) would be replaced by a similar `ArgumentError` with an
+    unrelated backtrace, making it difficult to debug templates.
+
+    Now, any `ArgumentError` unrelated to strict locals is reraised, preserving the original
+    backtrace for developers.
+
+    Also note that `ActionView::StrictLocalsError` is a subclass of `ArgumentError`, so any existing
+    code that rescues `ArgumentError` will continue to work.
+
+    Fixes #52227.
+
+    *Mike Dalessio*
+
 *   Improve error highlighting of multi-line methods in ERB templates or
     templates where the error occurs within a do-end block.
 

--- a/actionview/lib/action_view/base.rb
+++ b/actionview/lib/action_view/base.rb
@@ -267,15 +267,12 @@ module ActionView # :nodoc:
         begin
           public_send(method, locals, buffer, **locals, &block)
         rescue ArgumentError => argument_error
-          raise(
-            ArgumentError,
-            argument_error.
-              message.
-                gsub("unknown keyword:", "unknown local:").
-                gsub("missing keyword:", "missing local:").
-                gsub("no keywords accepted", "no locals accepted").
-                concat(" for #{@current_template.short_identifier}")
-          )
+          public_send_line = __LINE__ - 2
+          frame = argument_error.backtrace_locations[1]
+          if frame.path == __FILE__ && frame.lineno == public_send_line
+            raise StrictLocalsError.new(argument_error, @current_template)
+          end
+          raise
         end
       else
         public_send(method, locals, buffer, &block)

--- a/actionview/lib/action_view/template/error.rb
+++ b/actionview/lib/action_view/template/error.rb
@@ -27,6 +27,17 @@ module ActionView
     end
   end
 
+  class StrictLocalsError < ArgumentError # :nodoc:
+    def initialize(argument_error, template)
+      message = argument_error.message.
+                  gsub("unknown keyword:", "unknown local:").
+                  gsub("missing keyword:", "missing local:").
+                  gsub("no keywords accepted", "no locals accepted").
+                  concat(" for #{template.short_identifier}")
+      super(message)
+    end
+  end
+
   class MissingTemplate < ActionViewError # :nodoc:
     attr_reader :path, :paths, :prefixes, :partial
 


### PR DESCRIPTION
### Motivation / Background

Issue #52227 pointed out that any argument error in a template with strict locals would be swallowed and replaced by an exception with unrelated backtrace, which made debugging templates difficult.

Fixes #52227


### Detail

Argument errors related to strict locals in templates now raise an `ActionView::StrictLocalsError`, and all other `ArgumentError` exceptions are reraised as-is.

Previously, any `ArgumentError` raised during template rendering was swallowed during strict local error handling, so that an `ArgumentError` unrelated to strict locals (e.g., a helper method invoked with incorrect arguments) would be replaced by a similar `ArgumentError` with an unrelated backtrace, making it difficult to debug templates.

Now, any `ArgumentError` unrelated to strict locals is reraised, preserving the original backtrace for developers.

Also note that `ActionView::StrictLocalsError` is a subclass of `ArgumentError`, so any existing code that rescues `ArgumentError` will continue to work.


### Additional information

It's not necessary to introduce a new exception type to solve this problem, but doing so encapsulates the "strict locals" error message construction nicely, making `ActionView::Base#_run` a bit more readable.


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
