### PR TITLE
Use assert_raises(match:) for lock_version: nil tests

### DIFF
--- a/activerecord/lib/active_record/locking/optimistic.rb
+++ b/activerecord/lib/active_record/locking/optimistic.rb
@@ -103,7 +103,7 @@ module ActiveRecord
 
             if self[locking_column].nil?
               raise(<<-MSG.squish)
-                For optimistic locking, '#{locking_column}' should not be set to `nil`/`NULL`.
+                For optimistic locking, locking_column ('#{locking_column}') can't be nil.
                 Are you missing a default value or validation on '#{locking_column}'?
               MSG
             end

--- a/activerecord/test/cases/locking_test.rb
+++ b/activerecord/test/cases/locking_test.rb
@@ -307,24 +307,14 @@ class OptimisticLockingTest < ActiveRecord::TestCase
 
   def test_update_lock_version_to_nil_without_validation_or_constraint_raises_error
     t1 = LockWithoutDefault.create!(title: "title1")
-    error = assert_raises(RuntimeError) { t1.update(lock_version: nil) }
-
-    assert_match(locking_column_nil_error_message, error.message)
-
-    error = assert_raises(RuntimeError) { t1.update!(lock_version: nil) }
-
-    assert_match(locking_column_nil_error_message, error.message)
+    assert_raises(RuntimeError, match: locking_column_nil_error_message) { t1.update(lock_version: nil) }
+    assert_raises(RuntimeError, match: locking_column_nil_error_message) { t1.update!(lock_version: nil) }
   end
 
   def test_update_lock_version_to_nil_without_validation_raises
     person = Person.find(1)
-    error = assert_raises(RuntimeError) { person.update(lock_version: nil) }
-
-    assert_match(locking_column_nil_error_message, error.message)
-
-    error = assert_raises(RuntimeError) { person.update!(lock_version: nil) }
-
-    assert_match(locking_column_nil_error_message, error.message)
+    assert_raises(RuntimeError, match: locking_column_nil_error_message) { person.update(lock_version: nil) }
+    assert_raises(RuntimeError, match: locking_column_nil_error_message) { person.update!(lock_version: nil) }
   end
 
   def test_update_lock_version_to_nil_with_validation_does_not_raise_runtime_lock_version_error
@@ -597,7 +587,10 @@ class OptimisticLockingTest < ActiveRecord::TestCase
 
   private
     def locking_column_nil_error_message
-      /'lock_version' should not be set to `nil`/
+      <<-MSG.squish
+        For optimistic locking, locking_column ('lock_version') can't be nil.
+        Are you missing a default value or validation on 'lock_version'?
+      MSG
     end
 end
 


### PR DESCRIPTION
Follow up to #53364

We typically don't refer to `nil` as NULL and there isn't a need to use backticks for fixed-width in an error message here, imo.