### PR TITLE
Fix: ensure PostgreSQL enum types can contain commas

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_dumper.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_dumper.rb
@@ -22,7 +22,7 @@ module ActiveRecord
               stream.puts "  # Custom types defined in this database."
               stream.puts "  # Note that some types may not work with other database engines. Be careful if changing database."
               types.sort.each do |name, values|
-                stream.puts "  create_enum #{name.inspect}, #{values.split(",").inspect}"
+                stream.puts "  create_enum #{name.inspect}, #{values.inspect}"
               end
               stream.puts
             end

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -521,7 +521,7 @@ module ActiveRecord
             type.typname AS name,
             type.OID AS oid,
             n.nspname AS schema,
-            string_agg(enum.enumlabel, ',' ORDER BY enum.enumsortorder) AS value
+            array_agg(enum.enumlabel ORDER BY enum.enumsortorder) AS value
           FROM pg_enum AS enum
           JOIN pg_type AS type ON (type.oid = enum.enumtypid)
           JOIN pg_namespace n ON type.typnamespace = n.oid

--- a/activerecord/test/cases/adapters/postgresql/invertible_migration_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/invertible_migration_test.rb
@@ -79,7 +79,7 @@ class PostgresqlInvertibleMigrationTest < ActiveRecord::PostgreSQLTestCase
     CreateEnumMigration.new.migrate(:up)
 
     assert @connection.column_exists?(:enums, :best_color, sql_type: "color", default: "blue", null: false)
-    assert_equal [["color", "blue,green"]], @connection.enum_types
+    assert_equal [["color", ["blue", "green"]]], @connection.enum_types
 
     CreateEnumMigration.new.migrate(:down)
 
@@ -94,7 +94,7 @@ class PostgresqlInvertibleMigrationTest < ActiveRecord::PostgreSQLTestCase
     assert_equal [], @connection.enum_types
 
     DropEnumMigration.new.migrate(:down)
-    assert_equal [["color", "blue,green"]], @connection.enum_types
+    assert_equal [["color", ["blue", "green"]]], @connection.enum_types
   end
 
   def test_migrate_revert_add_and_validate_check_constraint


### PR DESCRIPTION
### Motivation / Background

PostgreSQL enums can have commas in their values, but this is not supported by the current implementation in ActiveRecord::ConnectionAdapters::PostgreSQL::SchemaDumper

This PR fixes this by updating `PostgreSQLAdapter.enum_types` to use PG `array_agg` instead of `string_agg`, effectively passing an array to the SchemaDumper and removing the need for splitting on commas.

### Detail

Fixes #54140

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [X] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.