### PR TITLE
Stop clearing thread locals in test environment when controller includes ActionController::Live

### DIFF
--- a/actionpack/lib/action_controller/metal/live.rb
+++ b/actionpack/lib/action_controller/metal/live.rb
@@ -301,9 +301,8 @@ module ActionController
               error = e
             end
           ensure
-            # Ensure we clean up any thread locals we copied so that the thread can reused.
             ActiveSupport::IsolatedExecutionState.clear
-            locals.each { |k, _| t2[k] = nil }
+            clean_up_thread_locals(locals, t2)
 
             @_response.commit!
           end
@@ -375,6 +374,11 @@ module ActionController
           t2.abort_on_exception = true
           yield
         end
+      end
+
+      # Ensure we clean up any thread locals we copied so that the thread can reused.
+      def clean_up_thread_locals(locals, thread) # :nodoc:
+        locals.each { |k, _| thread[k] = nil }
       end
 
       def self.live_thread_pool_executor

--- a/actionpack/lib/action_controller/test_case.rb
+++ b/actionpack/lib/action_controller/test_case.rb
@@ -29,6 +29,14 @@ module ActionController
       yield
     end
 
+    # Because of the above, we need to prevent the clearing of thread locals, since
+    # no new thread is actually spawned in the test environment.
+    alias_method :original_clean_up_thread_locals, :clean_up_thread_locals
+
+    silence_redefinition_of_method :clean_up_thread_locals
+    def clean_up_thread_locals(*args) # :nodoc:
+    end
+
     # Avoid a deadlock from the queue filling up
     Buffer.queue_size = nil
   end

--- a/actionpack/test/controller/live_stream_test.rb
+++ b/actionpack/test/controller/live_stream_test.rb
@@ -360,6 +360,10 @@ module ActionController
       def @controller.new_controller_thread(&block)
         original_new_controller_thread(&block)
       end
+
+      def @controller.clean_up_thread_locals(*args)
+        original_clean_up_thread_locals(*args)
+      end
     end
 
     def test_set_cookie
@@ -674,7 +678,7 @@ module ActionController
     tests TestController
 
     def test_thread_locals_do_not_get_reset_in_test_environment
-      Thread.current[:setting]            = "aaron"
+      Thread.current[:setting] = "aaron"
 
       get :greet
 

--- a/actionpack/test/controller/live_stream_test.rb
+++ b/actionpack/test/controller/live_stream_test.rb
@@ -658,6 +658,30 @@ module ActionController
     end
   end
 
+  class LiveControllerThreadTest < ActionController::TestCase
+    class TestController < ActionController::Base
+      include ActionController::Live
+
+      def greet
+        response.headers["Content-Type"] = "text/event-stream"
+        %w{ hello world }.each do |word|
+          response.stream.write word
+        end
+        response.stream.close
+      end
+    end
+
+    tests TestController
+
+    def test_thread_locals_do_not_get_reset_in_test_environment
+      Thread.current[:setting]            = "aaron"
+
+      get :greet
+
+      assert_equal "aaron", Thread.current[:setting]
+    end
+  end
+
   class BufferTest < ActionController::TestCase
     def test_nil_callback
       buf = ActionController::Live::Buffer.new nil


### PR DESCRIPTION
### Motivation / Background

In https://github.com/rails/rails/pull/52731 a thread pool was added to ActionController::Live, which required clearing thread locals to support thread reuse.

However, in https://github.com/rails/rails/commit/a640da454fdb9cd8806a1b6bd98c2da93f1b53b9#diff-830266b353d76aacab4b00ae785f171b94dc1f9370202aa173ba386b502b6991R15, the thread used to process these requests was monkey patched in the test environment so as not to actually spawn a new thread. (See reasons for that in commit link)


<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

### Detail

This PR adds an additional monkey patch for the thread local clearing behavior to make this a no-op in tests. This is needed to prevent incorrectly clearing thread local variables of the main thread.

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

Some additional motivation - a test utility our app is using relies on storing testing state in thread local variables. Without this fix, that utility has its state wiped resulting in incorrect test failures.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.

cc @tenderlove 
