### PR TITLE
Fix boolean columns triggering MySQL deprecation

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -42,7 +42,7 @@ module ActiveRecord
         date:        { name: "date" },
         binary:      { name: "blob" },
         blob:        { name: "blob" },
-        boolean:     { name: "tinyint", limit: 1 },
+        boolean:     { name: "boolean" },
         json:        { name: "json" },
       }
 


### PR DESCRIPTION
### Motivation / Background

Previously, when creating a boolean column for a MySQL database

```ruby
class AddSoldToProduct < ActiveRecord::Migration[8.0]
  def change
    add_column :products, :sold, :boolean
  end
end
```

Active Record would create a query like

```SQL
ALTER TABLE `products` ADD `sold` tinyint(1)
```

which would trigger a deprecation warning in MySQL 8.0.17+

```
1681: Integer display width is deprecated and will be removed in a future release.
```

Additionally, starting in MySQL 8.0.19, integer display widths are no longer included in the output of `SHOW CREATE TABLES` with the exception of `tinyint(1)` because

> MySQL Connectors make the assumption that TINYINT(1) columns
> originated as BOOLEAN columns; this exception enables them to continue
> to make that assumption.

### Detail

This commit changes Active Record to use the `boolean` alias for MySQL (which still results in `tinyint(1)` columns) but does not emit the deprecation warning for using an integer display width.

```SQL
ALTER TABLE `products` ADD `sold` boolean
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
