### PR TITLE
Make ActiveRecord::Association API public

### DIFF
--- a/activerecord/lib/active_record/associations/collection_proxy.rb
+++ b/activerecord/lib/active_record/associations/collection_proxy.rb
@@ -37,6 +37,7 @@ module ActiveRecord
         extend(*extensions) if extensions.any?
       end
 
+      # Returns the associated target collection.
       def target
         @association.target
       end


### PR DESCRIPTION
Follow up to #51925

/cc @p8

:link: Preview: https://zzak-public-association-api.rails-docs-preview.pages.dev/api/classes/ActiveRecord/Associations/Association