### PR TITLE
Fixed a typo in the article "2.6.1.4 Building [ci skip]

### DIFF
--- a/guides/source/association_basics.md
+++ b/guides/source/association_basics.md
@@ -1395,8 +1395,8 @@ specified on the associated model, the associated object _will_ be saved.
 @assembly = @part.assemblies.create({ assembly_name: "Transmission housing" })
 ```
 
-Does the same as `collection.create`, but raises `ActiveRecord::RecordInvalid`
-if the record is invalid.
+`collection.create!` does the same as `collection.create`, but raises
+`ActiveRecord::RecordInvalid` if the record is invalid.
 
 The [`collection.reload`][] method returns a Relation of all of the associated
 objects, forcing a database read. If there are no associated objects, it returns


### PR DESCRIPTION
Fixed a  typo in the article "2.6.1.4 Building and Creating Associated Objects"

Was missed a mark "!"

I decided to fix this error because I trust your documentation 100% and I don't like mistakes, even if they are grammatical.

