### PR TITLE
Warn to set config.as.variant_processor = nil

### DIFF
--- a/activestorage/lib/active_storage/engine.rb
+++ b/activestorage/lib/active_storage/engine.rb
@@ -110,11 +110,13 @@ module ActiveStorage
             ActiveStorage.logger.warn <<~WARNING.squish
               Using vips to process variants requires the libvips library.
               Please install libvips using the instructions on the libvips website.
+              Or use `config.active_storage.variant_processor = nil` if you are not processing variants.
             WARNING
           when /image_processing/
             ActiveStorage.logger.warn <<~WARNING.squish
               Generating image variants require the image_processing gem.
               Please add `gem 'image_processing', '~> 1.2'` to your Gemfile.
+              Or use `config.active_storage.variant_processor = nil` if you are not processing variants.
             WARNING
           else
             raise


### PR DESCRIPTION
Fixes #54152

In #45100 we decided that when the variant_processor is :vips or :mini_magick, we should try to eagerly load the library and throw a warning if the library was not available.

However, because `:vips` is the default, this will always show the warning unless the developer adds `image_processing` gem to their dependencies.

If they do not want to do this, they can opt-out by setting `config.active_storage.variant_processor = nil`.

See also #44991

/cc @skipkayhil 