### PR TITLE
Opt in to `to_time` preserving the receiver timezone to silence deprecation warnings in AV Tests

### DIFF
--- a/actionview/test/abstract_unit.rb
+++ b/actionview/test/abstract_unit.rb
@@ -44,6 +44,9 @@ ActionView.deprecator.debug = true
 # Disable available locale checks to avoid warnings running the test suite.
 I18n.enforce_available_locales = false
 
+# Opt in to `to_time` preserving the receiver timezone
+ActiveSupport.to_time_preserves_timezone = :zone
+
 ORIGINAL_LOCALES = I18n.available_locales.map(&:to_s).sort
 
 FIXTURE_LOAD_PATH = File.expand_path("fixtures", __dir__)

--- a/activesupport/lib/active_support/core_ext/date_and_time/compatibility.rb
+++ b/activesupport/lib/active_support/core_ext/date_and_time/compatibility.rb
@@ -26,7 +26,7 @@ module DateAndTime
         # Only warn once, the first time the value is used (which should
         # be the first time #to_time is called).
         ActiveSupport.deprecator.warn(
-          "`to_time` will always preserve the receiver timezone rather than system local time in Rails 8.1." \
+          "`to_time` will always preserve the receiver timezone rather than system local time in Rails 8.1. " \
           "To opt in to the new behavior, set `config.active_support.to_time_preserves_timezone = :zone`."
         )
 


### PR DESCRIPTION
```
DEPRECATION WARNING: `to_time` will always preserve the receiver timezone rather than system local time in Rails 8.1.To opt in to the new behavior, set `config.active_support.to_time_preserves_timezone = :zone`. (called from preserve_timezone at /home/zzak/code/rails/activesupport/lib/active_support/core_ext/date_and_time/compatibility.rb:40)
```

Also fixes the warning to add a space after "Rails 8.1.To opt in", like the other versions of the warning.