### PR TITLE
Added current_namespace? for ActionView URL helpers

### DIFF
--- a/actionview/lib/action_view/helpers/url_helper.rb
+++ b/actionview/lib/action_view/helpers/url_helper.rb
@@ -575,6 +575,34 @@ module ActionView
         url_string == request_uri
       end
 
+      # True if the current request URI was generated within the given +namespace+.
+      #
+      # ==== Examples
+      # Let's say we're in the <tt>http://www.example.com/admin/users</tt> action.
+      #
+      #   current_namespace?('admin')
+      #   # => true
+      #
+      #   current_namespace?('users')
+      #   # => false
+      #
+      #   current_namespace?('admin/users')
+      #   # => true
+      #
+      #   current_namespace?('admin/users/1')
+      #   # => true
+      def current_namespace?(namespace)
+        unless request
+          raise "You cannot use helpers that need to determine the current " \
+                "namespace unless your view context provides a Request object " \
+                "in a #request method"
+        end
+
+        return false unless request.get? || request.head?
+
+        request.path.match?(%r{/#{namespace}/})
+      end
+
       # Creates an SMS anchor link tag to the specified +phone_number+. When the
       # link is clicked, the default SMS messaging app is opened ready to send a
       # message to the linked phone number. If the +body+ option is specified,

--- a/actionview/test/template/url_helper_test.rb
+++ b/actionview/test/template/url_helper_test.rb
@@ -903,7 +903,7 @@ class UrlHelperTest < ActiveSupport::TestCase
     assert_equal({ class: "special" }, options)
   end
 
-  def test_sms_to
+  def test_current_page?
     assert_dom_equal %{<a href="sms:15155555785;">15155555785</a>}, sms_to("15155555785")
     assert_dom_equal %{<a href="sms:15155555785;">Jim Jones</a>}, sms_to("15155555785", "Jim Jones")
     assert_dom_equal(
@@ -912,6 +912,22 @@ class UrlHelperTest < ActiveSupport::TestCase
     )
     assert_equal sms_to("15155555785", "Jim Jones", "class" => "admin"),
                  sms_to("15155555785", "Jim Jones", class: "admin")
+  end
+
+  def test_current_namespace?
+    assert_raises(RuntimeError) { current_namespace?("admin") }
+
+    @request = request_for_url("/admin/posts", method: :post)
+    assert_not current_namespace?("admin")
+
+    @request = request_for_url("/admin/users")
+
+    assert current_namespace?("admin")
+    assert_not current_namespace?("admin/users")
+    assert_not current_namespace?("users")
+
+    @request = request_for_url("/admin/users/1")
+    assert current_namespace?("admin/users")
   end
 
   def test_sms_to_with_options

--- a/actionview/test/template/url_helper_test.rb
+++ b/actionview/test/template/url_helper_test.rb
@@ -903,7 +903,7 @@ class UrlHelperTest < ActiveSupport::TestCase
     assert_equal({ class: "special" }, options)
   end
 
-  def test_current_page?
+  def test_sms_to
     assert_dom_equal %{<a href="sms:15155555785;">15155555785</a>}, sms_to("15155555785")
     assert_dom_equal %{<a href="sms:15155555785;">Jim Jones</a>}, sms_to("15155555785", "Jim Jones")
     assert_dom_equal(


### PR DESCRIPTION
### Motivation / Background

Imagine that you need to add custom styles/logic for specific route namespaces. 
For example, I have links to the admin panel in my shared navbar, and when I work the nested resources, I want to see the styled link.
```
%= link_to "Books", admin_books_path,
  class: "#{current_namespace?('admin') ? 'border-indigo-500 text-gray-900' : 'border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700'}" %>

```
It could be helpful for developers with a short logic based on current namespaces.


This Pull Request has been created because I need a method to check my current namespace.

### Detail

This Pull Request changes:
- Add a new helper method `current_namespace?(namespace)`

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
