### PR TITLE
[Fix #54134] Add resource name to the `ArgumentError` that's raised when invalid `:only` or `:except` options are given to `#resource` or `#resources`

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,19 @@
+*   Add resource name to the `ArgumentError` that's raised when invalid `:only` or `:except` options are given to `#resource` or `#resources`
+
+    This makes it easier to locate the source of the problem, especially for routes drawn by gems.
+
+    Before:
+    ```
+    :only and :except must include only [:index, :create, :new, :show, :update, :destroy, :edit], but also included [:foo, :bar]
+    ```
+
+    After:
+    ```
+    Route `resources :products` - :only and :except must include only [:index, :create, :new, :show, :update, :destroy, :edit], but also included [:foo, :bar]
+    ```
+
+    *Jeremy Green*
+
 *   Add `check_collisions` option to `ActionDispatch::Session::CacheStore`.
 
     Newly generated session ids use 128 bits of randomness, which is more than

--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -1328,7 +1328,8 @@ module ActionDispatch
 
             valid_actions = self.class.default_actions(false) # ignore api_only for this validation
             if (invalid_actions = invalid_only_except_options(valid_actions, only:, except:).presence)
-              raise ArgumentError, ":only and :except must include only #{valid_actions}, but also included #{invalid_actions}"
+              error_prefix = "Route `resource#{"s" unless singleton?} :#{entities}`"
+              raise ArgumentError, "#{error_prefix} - :only and :except must include only #{valid_actions}, but also included #{invalid_actions}"
             end
 
             @name       = entities.to_s

--- a/actionpack/test/controller/resources_test.rb
+++ b/actionpack/test/controller/resources_test.rb
@@ -1131,7 +1131,7 @@ class ResourcesTest < ActionController::TestCase
   end
 
   def test_invalid_only_option_for_resources
-    expected_message = ":only and :except must include only [:index, :create, :new, :show, :update, :destroy, :edit], but also included [:foo, :bar]"
+    expected_message = "Route `resources :products` - :only and :except must include only [:index, :create, :new, :show, :update, :destroy, :edit], but also included [:foo, :bar]"
     assert_raise(ArgumentError, match: expected_message) do
       with_routing do |set|
         set.draw do
@@ -1142,7 +1142,7 @@ class ResourcesTest < ActionController::TestCase
   end
 
   def test_invalid_only_option_for_singleton_resource
-    expected_message = ":only and :except must include only [:show, :create, :update, :destroy, :new, :edit], but also included [:foo, :bar]"
+    expected_message = "Route `resource :products` - :only and :except must include only [:show, :create, :update, :destroy, :new, :edit], but also included [:foo, :bar]"
     assert_raise(ArgumentError, match: expected_message) do
       with_routing do |set|
         set.draw do
@@ -1153,7 +1153,7 @@ class ResourcesTest < ActionController::TestCase
   end
 
   def test_invalid_except_option_for_resources
-    expected_message = ":only and :except must include only [:index, :create, :new, :show, :update, :destroy, :edit], but also included [:foo]"
+    expected_message = "Route `resources :products` - :only and :except must include only [:index, :create, :new, :show, :update, :destroy, :edit], but also included [:foo]"
 
     assert_raise(ArgumentError, match: expected_message) do
       with_routing do |set|
@@ -1165,7 +1165,7 @@ class ResourcesTest < ActionController::TestCase
   end
 
   def test_invalid_except_option_for_singleton_resource
-    expected_message = ":only and :except must include only [:show, :create, :update, :destroy, :new, :edit], but also included [:foo]"
+    expected_message = "Route `resource :products` - :only and :except must include only [:show, :create, :update, :destroy, :new, :edit], but also included [:foo]"
     assert_raise(ArgumentError, match: expected_message) do
       with_routing do |set|
         set.draw do


### PR DESCRIPTION
### Motivation / Background

Fixes https://github.com/rails/rails/issues/54134

### Detail

This makes it easier to locate the source of the problem, especially for routes drawn by gems.

Before:

    :only and :except must include only [:index, :create, :new, :show, :update, :destroy, :edit], but also included [:foo, :bar]

After:

    Route `resources :products` - :only and :except must include only [:index, :create, :new, :show, :update, :destroy, :edit], but also included [:foo, :bar]

### Additional information

N/A

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
