### PR TITLE
Fix MiniMagic::Image.mime_type deprecation in ASto test

### DIFF
--- a/activestorage/test/previewer/video_previewer_test.rb
+++ b/activestorage/test/previewer/video_previewer_test.rb
@@ -16,7 +16,7 @@ class ActiveStorage::Previewer::VideoPreviewerTest < ActiveSupport::TestCase
       image = MiniMagick::Image.read(attachable[:io])
       assert_equal 640, image.width
       assert_equal 480, image.height
-      assert_equal "image/jpeg", image.mime_type
+      assert_equal "image/jpeg", Marcel::Magic.by_extension(image.type).type
     end
   end
 


### PR DESCRIPTION
```
[MiniMagick] MiniMagick::Image#mime_type has been deprecated, because it wasn't returning correct result for all formats ImageMagick supports. Unfortunately, returning the correct MIME type would be very slow, because it would require ImageMagick to read the whole file. It's better to use Marcel and MimeMagic gems, which are able to determine the MIME type just from the image header.
```

[[eg](https://buildkite.com/rails/rails/builds/115455#0194455d-a2d1-4dee-be65-1f557422a6fe/1152-3839)]

This method is removed in v5 of `mini_magick` gem:

> Removed deprecated Image#mime_type, as it wasn't accurate.
> MIME type from file content should be determined either using Marcel
> or MimeMagic, or mime-types or MiniMime using Image#type.

Since we depend on it through `image_processing` gem (`mini_magick (>= 4.9.5, < 5)`), while work is being done in janko/image_processing#132 so sooner or later this test will fail.