### PR TITLE
Ensure image_processing is installed for new apps

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
@@ -42,7 +42,7 @@ gem "thruster", require: false
 <% unless skip_active_storage? -%>
 
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
-# gem "image_processing", "~> 1.2"
+gem "image_processing", "~> 1.2"
 <% end -%>
 <%- if options.api? -%>
 

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -3917,12 +3917,12 @@ module ApplicationTests
         ActiveStorage.video_preview_arguments
     end
 
-    test "ActiveStorage.variant_processor uses mini_magick without Rails 7 defaults" do
+    test "ActiveStorage.variant_processor is nil without Rails 7 defaults" do
       remove_from_config '.*config\.load_defaults.*\n'
 
       app "development"
 
-      assert_equal nil, ActiveStorage.variant_processor
+      assert_nil ActiveStorage.variant_processor
     end
 
     test "ActiveStorage.variant_processor uses vips by default" do

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -1621,7 +1621,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
     end
 
     def assert_gem_for_active_storage
-      assert_file "Gemfile", /^# gem "image_processing"/
+      assert_file "Gemfile", /^gem "image_processing"/
     end
 
     def assert_frameworks_are_not_required_when_active_storage_is_skipped


### PR DESCRIPTION
Fixes #54152

When we decided to load the variant processor early, during boot, as opposed to when processing variants we ended up making a lazy dependency non-lazy.

In other words, we set the default variant processor as `:vips` but don't require the gem as a hard dependency making an unfortunate gap where booting a Rails app will generate this warning. Not good.

However, making it a gemspec dependency on Active Storage seems a bit much, and we can opt-in new applications to avoid the warning. I assume that existing apps which are using Active Storage likely already have added the dependency.

This is an alternative to #54155 which just adds an extra line to the warning about unsetting the variant_processor flag.

/cc @skipkayhil @Earlopain 

There is also a bit of historical context in #32471 for reference.