### PR TITLE
[Fix #52530] Ensure all Nary children are evaluated when extracting attributes for WhereClause#merge

### DIFF
--- a/activerecord/lib/active_record/relation/where_clause.rb
+++ b/activerecord/lib/active_record/relation/where_clause.rb
@@ -135,10 +135,14 @@ module ActiveRecord
 
         def extract_attribute(node)
           attr_node = nil
-          Arel.fetch_attribute(node) do |attr|
-            return if attr_node&.!= attr # all attr nodes should be the same
+
+          valid_attrs = Arel.fetch_attribute(node) do |attr|
+            !attr_node || attr_node == attr # all attr nodes should be the same
+          ensure
             attr_node = attr
           end
+          return unless valid_attrs # all nested nodes should yield an attribute
+
           attr_node
         end
 


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

Fixes https://github.com/rails/rails/issues/52530

### Detail

Currently, when extracting attributes from `Nary` (`And` or `Or`) children for a merge, if the first child yields a valid attribute and the second one doesn't yield anything ([like in the case of an `SqlLiteral`](https://github.com/rails/rails/blob/79df80b45873590f827fdd67b485fda4ad2f58b7/activerecord/lib/arel/nodes/sql_literal.rb#L22-L23)), [we stop iterating through the remaining nodes (`#all?`)](https://github.com/rails/rails/blob/79df80b45873590f827fdd67b485fda4ad2f58b7/activerecord/lib/arel/nodes/nary.rb#L22), and [return the attribute for the first child as the attribute for the entire node](https://github.com/rails/rails/blob/79df80b45873590f827fdd67b485fda4ad2f58b7/activerecord/lib/active_record/relation/where_clause.rb#L142).

In the case of the linked issue, this resulted in such attributes being excluded from the current where clause as it was considered to be conflicting with the where clause being merged in, resulting in an incorrect query.

This patch ensures that in such cases we also ensure that all nodes have yielded an attribute i.e. the return of `Arel.fetch_attribute` is truthy, similar to [how this is handled when excluding predicates](https://github.com/rails/rails/blob/79df80b45873590f827fdd67b485fda4ad2f58b7/activerecord/lib/active_record/relation/where_clause.rb#L181-L183).

Seeing as this is the only node type where children are evaluated and that we already return early if the body of `Arel.fetch_attribute` is falsey, I used this as an opportunity to refactor that block so we don't need to explicitly return early when the attribute nodes are different.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.