### PR TITLE
Avoid running `bundle install` in plugin generator tests when possible

### DIFF
--- a/railties/test/plugin_helpers.rb
+++ b/railties/test/plugin_helpers.rb
@@ -21,9 +21,6 @@ module PluginHelpers
       gem "rails", path: #{File.expand_path("../..", __dir__).inspect}
     RUBY
     File.write(gemfile_path, gemfile)
-
-    # Make sure the plugin's dependencies are installed.
-    in_plugin_context(plugin_path) { system(*%w[bundle install], out: File::NULL, exception: true) }
   end
 
   def in_plugin_context(plugin_path, &block)


### PR DESCRIPTION
These tests fail when not connected to the internet:

```
$ bin/test test/generators/scaffold_generator_test.rb

Run options: --seed 45913

.......Could not reach host index.rubygems.org. Check your network connection and try again.
E

Error:
ScaffoldGeneratorTest#test_scaffold_tests_pass_by_default_inside_api_full_engine:
RuntimeError: Command failed with exit 17: bundle
    test/plugin_helpers.rb:26:in `system'
    test/plugin_helpers.rb:26:in `block in prepare_plugin'
    test/plugin_helpers.rb:34:in `block in in_plugin_context'
    /home/zzak/.rbenv/versions/3.3.6/lib/ruby/gems/3.3.0/gems/bundler-2.5.16/lib/bundler.rb:429:in `block in with_unbundled_env'
    /home/zzak/.rbenv/versions/3.3.6/lib/ruby/gems/3.3.0/gems/bundler-2.5.16/lib/bundler.rb:684:in `with_env'
    /home/zzak/.rbenv/versions/3.3.6/lib/ruby/gems/3.3.0/gems/bundler-2.5.16/lib/bundler.rb:429:in `with_unbundled_env'
    test/plugin_helpers.rb:36:in `block in in_plugin_context'
    test/plugin_helpers.rb:36:in `chdir'
    test/plugin_helpers.rb:36:in `in_plugin_context'
    test/plugin_helpers.rb:26:in `prepare_plugin'
    test/plugin_helpers.rb:6:in `generate_plugin'
    test/plugin_helpers.rb:40:in `with_new_plugin'
    test/generators/scaffold_generator_test.rb:628:in `test_scaffold_tests_pass_by_default_inside_api_full_engine'

bin/test test/generators/scaffold_generator_test.rb:625

.Could not reach host index.rubygems.org. Check your network connection and try again.
E

Error:
ScaffoldGeneratorTest#test_scaffold_tests_pass_by_default_inside_full_engine:
RuntimeError: Command failed with exit 17: bundle
    test/plugin_helpers.rb:26:in `system'
    test/plugin_helpers.rb:26:in `block in prepare_plugin'
    test/plugin_helpers.rb:34:in `block in in_plugin_context'
    /home/zzak/.rbenv/versions/3.3.6/lib/ruby/gems/3.3.0/gems/bundler-2.5.16/lib/bundler.rb:429:in `block in with_unbundled_env'
    /home/zzak/.rbenv/versions/3.3.6/lib/ruby/gems/3.3.0/gems/bundler-2.5.16/lib/bundler.rb:684:in `with_env'
    /home/zzak/.rbenv/versions/3.3.6/lib/ruby/gems/3.3.0/gems/bundler-2.5.16/lib/bundler.rb:429:in `with_unbundled_env'
    test/plugin_helpers.rb:36:in `block in in_plugin_context'
    test/plugin_helpers.rb:36:in `chdir'
    test/plugin_helpers.rb:36:in `in_plugin_context'
    test/plugin_helpers.rb:26:in `prepare_plugin'
    test/plugin_helpers.rb:6:in `generate_plugin'
    test/plugin_helpers.rb:40:in `with_new_plugin'
    test/generators/scaffold_generator_test.rb:604:in `test_scaffold_tests_pass_by_default_inside_full_engine'

bin/test test/generators/scaffold_generator_test.rb:601

...Could not reach host index.rubygems.org. Check your network connection and try again.
E

Error:
ScaffoldGeneratorTest#test_scaffold_tests_pass_by_default_inside_namespaced_mountable_engine:
RuntimeError: Command failed with exit 17: bundle
    test/plugin_helpers.rb:26:in `system'
    test/plugin_helpers.rb:26:in `block in prepare_plugin'
    test/plugin_helpers.rb:34:in `block in in_plugin_context'
    /home/zzak/.rbenv/versions/3.3.6/lib/ruby/gems/3.3.0/gems/bundler-2.5.16/lib/bundler.rb:429:in `block in with_unbundled_env'
    /home/zzak/.rbenv/versions/3.3.6/lib/ruby/gems/3.3.0/gems/bundler-2.5.16/lib/bundler.rb:684:in `with_env'
    /home/zzak/.rbenv/versions/3.3.6/lib/ruby/gems/3.3.0/gems/bundler-2.5.16/lib/bundler.rb:429:in `with_unbundled_env'
    test/plugin_helpers.rb:36:in `block in in_plugin_context'
    test/plugin_helpers.rb:36:in `chdir'
    test/plugin_helpers.rb:36:in `in_plugin_context'
    test/plugin_helpers.rb:26:in `prepare_plugin'
    test/plugin_helpers.rb:6:in `generate_plugin'
    test/plugin_helpers.rb:40:in `with_new_plugin'
    test/generators/scaffold_generator_test.rb:586:in `test_scaffold_tests_pass_by_default_inside_namespaced_mountable_engine'

bin/test test/generators/scaffold_generator_test.rb:583

.Could not reach host index.rubygems.org. Check your network connection and try again.
E

Error:
ScaffoldGeneratorTest#test_scaffold_tests_pass_by_default_inside_api_mountable_engine:
RuntimeError: Command failed with exit 17: bundle
    test/plugin_helpers.rb:26:in `system'
    test/plugin_helpers.rb:26:in `block in prepare_plugin'
    test/plugin_helpers.rb:34:in `block in in_plugin_context'
    /home/zzak/.rbenv/versions/3.3.6/lib/ruby/gems/3.3.0/gems/bundler-2.5.16/lib/bundler.rb:429:in `block in with_unbundled_env'
    /home/zzak/.rbenv/versions/3.3.6/lib/ruby/gems/3.3.0/gems/bundler-2.5.16/lib/bundler.rb:684:in `with_env'
    /home/zzak/.rbenv/versions/3.3.6/lib/ruby/gems/3.3.0/gems/bundler-2.5.16/lib/bundler.rb:429:in `with_unbundled_env'
    test/plugin_helpers.rb:36:in `block in in_plugin_context'
    test/plugin_helpers.rb:36:in `chdir'
    test/plugin_helpers.rb:36:in `in_plugin_context'
    test/plugin_helpers.rb:26:in `prepare_plugin'
    test/plugin_helpers.rb:6:in `generate_plugin'
    test/plugin_helpers.rb:40:in `with_new_plugin'
    test/generators/scaffold_generator_test.rb:616:in `test_scaffold_tests_pass_by_default_inside_api_mountable_engine'

bin/test test/generators/scaffold_generator_test.rb:613

.........Could not reach host index.rubygems.org. Check your network connection and try again.
E

Error:
ScaffoldGeneratorTest#test_scaffold_tests_pass_by_default_inside_mountable_engine:
RuntimeError: Command failed with exit 17: bundle
    test/plugin_helpers.rb:26:in `system'
    test/plugin_helpers.rb:26:in `block in prepare_plugin'
    test/plugin_helpers.rb:34:in `block in in_plugin_context'
    /home/zzak/.rbenv/versions/3.3.6/lib/ruby/gems/3.3.0/gems/bundler-2.5.16/lib/bundler.rb:429:in `block in with_unbundled_env'
    /home/zzak/.rbenv/versions/3.3.6/lib/ruby/gems/3.3.0/gems/bundler-2.5.16/lib/bundler.rb:684:in `with_env'
    /home/zzak/.rbenv/versions/3.3.6/lib/ruby/gems/3.3.0/gems/bundler-2.5.16/lib/bundler.rb:429:in `with_unbundled_env'
    test/plugin_helpers.rb:36:in `block in in_plugin_context'
    test/plugin_helpers.rb:36:in `chdir'
    test/plugin_helpers.rb:36:in `in_plugin_context'
    test/plugin_helpers.rb:26:in `prepare_plugin'
    test/plugin_helpers.rb:6:in `generate_plugin'
    test/plugin_helpers.rb:40:in `with_new_plugin'
    test/generators/scaffold_generator_test.rb:574:in `test_scaffold_tests_pass_by_default_inside_mountable_engine'

bin/test test/generators/scaffold_generator_test.rb:571

.

Finished in 7.257972s, 3.7200 runs/s, 71.2320 assertions/s.
27 runs, 517 assertions, 0 failures, 5 errors, 0 skips
```

Actually, I found these because I was looking at the railties CI logs and saw this message periodically:

```
Don't run Bundler as root. Installing your bundle as root will break this
application for all non-root users on this machine.
```

This tells me that we are running `bundle install` in our tests, which we should avoid because its slow.