### PR TITLE
Railties sprockets_assets_test use URI::RFC2396_PARSER instead of DEFAULT_PARSER

### DIFF
--- a/railties/test/application/sprockets_assets_test.rb
+++ b/railties/test/application/sprockets_assets_test.rb
@@ -348,7 +348,7 @@ module ApplicationTests
       # Load app env
       app "development"
 
-      get "/assets/#{URI::DEFAULT_PARSER.escape(asset_path)}"
+      get "/assets/#{URI::RFC2396_PARSER.escape(asset_path)}"
       assert_match "not an image really", last_response.body
       assert_file_exists("#{app_path}/public/assets/#{asset_path}")
     end


### PR DESCRIPTION
Same as #52779 but was added in #52887 before that PR was merged.

```
test/application/sprockets_assets_test.rb:351: warning: URI::RFC3986_PARSER.escape is obsolete. Use URI::RFC2396_PARSER.escape explicitly.
```

[[ref](https://buildkite.com/rails/rails/builds/115455#0194455d-a2e2-4f4c-add1-3eb69bdf0b6a/1282-1902)]

/cc @yahonda 
