### PR TITLE
Fix assert_no_file with unused block warning

### DIFF
--- a/railties/test/generators/api_app_generator_test.rb
+++ b/railties/test/generators/api_app_generator_test.rb
@@ -107,9 +107,7 @@ class ApiAppGeneratorTest < Rails::Generators::TestCase
       assert_no_match(%r/gem "tailwindcss-rails"/, content)
     end
 
-    assert_no_file "app/views/layouts/application.html.erb" do |content|
-      assert_no_match(/tailwind/, content)
-    end
+    assert_no_file "app/views/layouts/application.html.erb"
   end
 
   def test_app_update_does_not_generate_unnecessary_config_files


### PR DESCRIPTION
```
$ bin/test test/generators/api_app_generator_test.rb

test/generators/api_app_generator_test.rb:110: warning: the block passed to 'assert_no_file' defined at /home/zzak/code/rails/railties/lib/rails/generators/testing/assertions.rb:47 may be ignored
```

`assert_no_file` does not use the block, so it's unnecessary to keep this assertion about the contents.

https://github.com/rails/rails/blob/79df80b45873590f827fdd67b485fda4ad2f58b7/railties/lib/rails/generators/testing/assertions.rb#L47

Actually this was pointed out by @skipkayhil in https://github.com/rails/rails/pull/50907#discussion_r1469083605 but we just missed it.