### PR TITLE
Ensure that `ActiveStorage.analyzers` doesn't contain nil

### DIFF
--- a/activestorage/lib/active_storage/engine.rb
+++ b/activestorage/lib/active_storage/engine.rb
@@ -102,7 +102,7 @@ module ActiveStorage
               ]
             end
 
-          ActiveStorage.analyzers = [analyzer].concat(app.config.active_storage.analyzers || [])
+          ActiveStorage.analyzers = [analyzer].compact.concat(app.config.active_storage.analyzers || [])
           ActiveStorage.variant_transformer = transformer
         rescue LoadError => error
           case error.message

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -3931,6 +3931,14 @@ module ApplicationTests
       assert_equal :vips, ActiveStorage.variant_processor
     end
 
+    test "ActiveStorage.analyzers doesn't contain nil when variant_processor = nil" do
+      add_to_config "config.active_storage.variant_processor = nil"
+
+      app "development"
+
+      assert_not_includes ActiveStorage.analyzers, nil
+    end
+
     test "ActiveStorage.supported_image_processing_methods can be configured via config.active_storage.supported_image_processing_methods" do
       remove_from_config '.*config\.load_defaults.*\n'
 


### PR DESCRIPTION
### Motivation / Background

When setting `config.active_storage.variant_processor = nil`, there will be neither vips nor mini_magick. Not error will be raised as nothing is autoloaded, so `analysers` will be nil. This later blows up when trying to analyse a blob.

### Detail

https://github.com/rails/rails/pull/54166 puts `image_processing` into the gemfile by default, but when it is removed or not present and you opt out of variants through config, analysing blobs will fail because of the nil value.

cc @zzak

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
