### PR TITLE
JSON serialized attributes can return symbolized keys

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   `ActiveRecord::Coder::JSON` can be instantiated
+
+    Options can now be passed to `ActiveRecord::Coder::JSON` when instantiating the coder. This allows:
+    ```ruby
+    serialize :config, coder: ActiveRecord::Coder::JSON.new(symbolize_names: true)
+    ```
+    *matthaigh27*
+
 *   Deprecate using `insert_all`/`upsert_all` with unpersisted records in associations.
 
     Using these methods on associations containing unpersisted records will now

--- a/activerecord/lib/active_record/attribute_methods/serialization.rb
+++ b/activerecord/lib/active_record/attribute_methods/serialization.rb
@@ -219,10 +219,11 @@ module ActiveRecord
             # When ::JSON is used, force it to go through the Active Support JSON encoder
             # to ensure special objects (e.g. Active Record models) are dumped correctly
             # using the #as_json hook.
-            coder = Coders::JSON if coder == ::JSON
 
             if coder == ::YAML || coder == Coders::YAMLColumn
               Coders::YAMLColumn.new(attr_name, type, **(yaml || {}))
+            elsif coder == ::JSON || coder == Coders::JSON
+              Coders::JSON.new
             elsif coder.respond_to?(:new) && !coder.respond_to?(:load)
               coder.new(attr_name, type)
             elsif type && type != Object

--- a/activerecord/lib/active_record/coders/json.rb
+++ b/activerecord/lib/active_record/coders/json.rb
@@ -2,13 +2,17 @@
 
 module ActiveRecord
   module Coders # :nodoc:
-    module JSON # :nodoc:
-      def self.dump(obj)
+    class JSON # :nodoc:
+      def initialize(options = {})
+        @options = options
+      end
+
+      def dump(obj)
         ActiveSupport::JSON.encode(obj)
       end
 
-      def self.load(json)
-        ActiveSupport::JSON.decode(json) unless json.blank?
+      def load(json)
+        ActiveSupport::JSON.decode(json, @options) unless json.blank?
       end
     end
   end

--- a/activerecord/test/cases/coders/json_test.rb
+++ b/activerecord/test/cases/coders/json_test.rb
@@ -6,11 +6,18 @@ module ActiveRecord
   module Coders
     class JSONTest < ActiveRecord::TestCase
       def test_returns_nil_if_empty_string_given
-        assert_nil JSON.load("")
+        coder = JSON.new
+        assert_nil coder.load("")
       end
 
       def test_returns_nil_if_nil_given
-        assert_nil JSON.load(nil)
+        coder = JSON.new
+        assert_nil coder.load(nil)
+      end
+
+      def test_coder_with_symbolize_names
+        coder = JSON.new(symbolize_names: true)
+        assert_equal({ foo: "bar" }, coder.load('{"foo":"bar"}'))
       end
     end
   end

--- a/activerecord/test/cases/serialized_attribute_test.rb
+++ b/activerecord/test/cases/serialized_attribute_test.rb
@@ -149,6 +149,17 @@ class SerializedAttributeTest < ActiveRecord::TestCase
     assert_nil t.content
   end
 
+  def test_json_symbolize_names_returns_symbolized_names
+    Topic.serialize :content, coder: ActiveRecord::Coders::JSON.new(symbolize_names: true)
+    my_post = posts(:welcome)
+
+    t = Topic.new(content: my_post)
+    t.save!
+    t.reload
+
+    assert_equal(t.content, t.content.deep_symbolize_keys)
+  end
+
   def test_serialized_attribute_declared_in_subclass
     hash = { "important1" => "value1", "important2" => "value2" }
     important_topic = ImportantTopic.create("important" => hash)

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   `ActiveSupport::JSON` now accepts options
+
+    It is now possible to pass options to `ActiveSupport::JSON`:
+    ```ruby
+    ActiveSupport::JSON.decode('{"key": "value"}', symbolize_names: true) # => { key: "value" }
+    ```
+
+    *matthaigh27*
+
 *   `ActiveSupport::Testing::NotificationAssertions`'s `assert_notification` now matches against payload subsets by default.
 
     Previously the following assertion would fail due to excess key vals in the notification payload. Now with payload subset matching, it will pass.

--- a/activesupport/lib/active_support/json/decoding.rb
+++ b/activesupport/lib/active_support/json/decoding.rb
@@ -19,8 +19,8 @@ module ActiveSupport
       #
       #   ActiveSupport::JSON.decode("{\"team\":\"rails\",\"players\":\"36\"}")
       #   => {"team" => "rails", "players" => "36"}
-      def decode(json)
-        data = ::JSON.parse(json)
+      def decode(json, options = {})
+        data = ::JSON.parse(json, options)
 
         if ActiveSupport.parse_json_times
           convert_dates_from(data)

--- a/activesupport/test/json/decoding_test.rb
+++ b/activesupport/test/json/decoding_test.rb
@@ -110,8 +110,11 @@ class TestJSONDecoding < ActiveSupport::TestCase
     assert_raise(ActiveSupport::JSON.parse_error) { ActiveSupport::JSON.decode(%()) }
   end
 
-  def test_cannot_pass_unsupported_options
-    assert_raise(ArgumentError) { ActiveSupport::JSON.decode("", create_additions: true) }
+  def test_symbolized_names_option
+    json = '{"foo":"bar"}'
+    assert_equal({ "foo" => "bar" }, ActiveSupport::JSON.decode(json))
+    assert_equal({ foo: "bar" }, ActiveSupport::JSON.decode(json, symbolize_names: true))
+    assert_equal({ foo: "bar" }, ActiveSupport::JSON.decode(json, { symbolize_names: true }))
   end
 
   private


### PR DESCRIPTION
- Allow `json: { symbolize_names: true }` to be passed to `serialize`
- Opted for `symbolize_names` for parity with `ruby/json`

<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created because I make heavy use of symbols and on JSON serialized attributes, I found myself always either using `.deep_symbolize_keys` or, when it wasn't causing problems, creating a `SymbolizedJSON` class just to pass `symbolize_names` into `JSON.parse`.

### Detail

This Pull Request changes the options available to the `serialize` attribute in active record. Similar to the `yaml:` option, you can now specify `json:` with the only option right now being `symbolize_names`

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
