### PR TITLE
Fix RuboCop offense in benchmark generator template [ci skip]

### DIFF
--- a/railties/lib/rails/generators/rails/benchmark/templates/benchmark.rb.tt
+++ b/railties/lib/rails/generators/rails/benchmark/templates/benchmark.rb.tt
@@ -4,8 +4,6 @@ require_relative "../../config/environment"
 
 # Any benchmarking setup goes here...
 
-
-
 Benchmark.ips do |x|
 <%- reports.each do |report| -%>
   x.report("<%= report %>") { }


### PR DESCRIPTION
If you try to generate a new benchmark for your Rails app with:
```sh
bin/rails g benchmark my_cool_benchmark
```

You will end up with a new file at `script/benchmarks/my_cool_benchmark.rb` which contains this:

```rb
# frozen_string_literal: true

require_relative "../../config/environment"

# Any benchmarking setup goes here...



Benchmark.ips do |x|
  x.report("before") { }
  x.report("after") { }

  x.compare!
end
```

However, the 2 new lines after the 
```rb
# Any benchmarking setup goes here...
```

comment are RuboCop offenses that can easily be avoided here :)