### PR TITLE
Suggest to use `bin/rails runner` in commands help [ci skip]

### DIFF
--- a/railties/lib/rails/generators/rails/benchmark/USAGE
+++ b/railties/lib/rails/generators/rails/benchmark/USAGE
@@ -13,7 +13,7 @@ Example:
         script/benchmarks/opt_compare.rb
 
     You can run the generated benchmark file using:
-        `ruby script/benchmarks/opt_compare.rb`
+        `bin/rails runner script/benchmarks/opt_compare.rb`
 
     You can specify different reports:
         `bin/rails generate benchmark opt_compare patch1 patch2 patch3`

--- a/railties/lib/rails/generators/rails/script/USAGE
+++ b/railties/lib/rails/generators/rails/script/USAGE
@@ -9,7 +9,7 @@ Example:
         script/my_script.rb
 
     You can run the script using:
-        `ruby script/my_script.rb`
+        `bin/rails runner script/my_script.rb`
 
     You can specify a folder:
         `bin/rails generate script cleanup/my_script`


### PR DESCRIPTION
If you try to display the output for the commands:
- `bin/rails g benchmark`
- `bin/rails g script`

You'll see that it suggest to run the scripts via `ruby script/...`.

I believe it makes more sense to use the Rails runner instead, because this way scripts are automatically wrapped with the Rails Executor (citing directly from the docs).
