### PR TITLE
Maintain AR connection pools in the background

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Introduce new database configuration options `keepalive`, `max_age`, and
+    `min_connections` -- and rename `pool` to `max_connections` to match.
+
+    There are no changes to default behavior, but these allow for more specific
+    control over pool behavior.
+
+    *Matthew Draper*, *Chris AtLee*, *Rachael Wright-Munn*
+
 *   Move `LIMIT` validation from query generation to when `limit()` is called.
 
     *Hartley McGuire*, *Shuyang*

--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_handler.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_handler.rb
@@ -158,9 +158,7 @@ module ActiveRecord
         each_connection_pool(role).any?(&:active_connection?)
       end
 
-      # Returns any connections in use by the current thread back to the pool,
-      # and also returns connections to the pool cached by threads that are no
-      # longer alive.
+      # Returns any connections in use by the current thread back to the pool.
       def clear_active_connections!(role = nil)
         each_connection_pool(role).each do |pool|
           pool.release_connection

--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -751,6 +751,20 @@ module ActiveRecord
         end
       end
 
+      # Preconnect all connections in the pool. This saves pool users from
+      # having to wait for a connection to be established when first using it
+      # after checkout.
+      def preconnect
+        sequential_maintenance -> c { (!c.connected? || !c.verified?) && c.allow_preconnect } do |conn|
+          conn.connect!
+        rescue
+          # Wholesale rescue: there's nothing we can do but move on. The
+          # connection will go back to the pool, and the next consumer will
+          # presumably try to connect again -- which will either work, or
+          # fail and they'll be able to report the exception.
+        end
+      end
+
       def num_waiting_in_queue # :nodoc:
         @available.num_waiting
       end

--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -225,7 +225,8 @@ module ActiveRecord
       include ConnectionAdapters::AbstractPool
 
       attr_accessor :automatic_reconnect, :checkout_timeout
-      attr_reader :db_config, :size, :reaper, :pool_config, :async_executor, :role, :shard
+      attr_reader :db_config, :max_size, :min_size, :reaper, :pool_config, :async_executor, :role, :shard
+      alias :size :max_size
 
       delegate :schema_reflection, :server_version, to: :pool_config
 
@@ -245,7 +246,8 @@ module ActiveRecord
 
         @checkout_timeout = db_config.checkout_timeout
         @idle_timeout = db_config.idle_timeout
-        @size = db_config.pool
+        @max_size = db_config.pool
+        @min_size = db_config.min_size
 
         # This variable tracks the cache of threads mapped to reserved connections, with the
         # sole purpose of speeding up the +connection+ method. It is not the authoritative
@@ -630,7 +632,7 @@ module ActiveRecord
           @available.delete conn
 
           # @available.any_waiting? => true means that prior to removing this
-          # conn, the pool was at its max size (@connections.size == @size).
+          # conn, the pool was at its max size (@connections.size == @max_size).
           # This would mean that any threads stuck waiting in the queue wouldn't
           # know they could checkout_new_connection, so let's do it for them.
           # Because condition-wait loop is encapsulated in the Queue class
@@ -645,7 +647,7 @@ module ActiveRecord
         # would like not to hold the main mutex while checking out new connections.
         # Thus there is some chance that needs_new_connection information is now
         # stale, we can live with that (bulk_make_new_connections will make
-        # sure not to exceed the pool's @size limit).
+        # sure not to exceed the pool's @max_size limit).
         bulk_make_new_connections(1) if needs_new_connection
       end
 
@@ -678,11 +680,27 @@ module ActiveRecord
       def flush(minimum_idle = @idle_timeout)
         return if minimum_idle.nil?
 
-        idle_connections = synchronize do
+        removed_connections = synchronize do
           return if self.discarded?
-          @connections.select do |conn|
+
+          idle_connections = @connections.select do |conn|
             !conn.in_use? && conn.seconds_idle >= minimum_idle
-          end.each do |conn|
+          end.sort_by { |conn| -conn.seconds_idle } # sort longest idle first
+
+          # Don't go below our configured pool minimum unless we're flushing
+          # everything
+          idles_to_retain =
+            if minimum_idle > 0
+              @min_size - (@connections.size - idle_connections.size)
+            else
+              0
+            end
+
+          if idles_to_retain > 0
+            idle_connections.pop idles_to_retain
+          end
+
+          idle_connections.each do |conn|
             conn.lease
 
             @available.delete conn
@@ -690,7 +708,7 @@ module ActiveRecord
           end
         end
 
-        idle_connections.each do |conn|
+        removed_connections.each do |conn|
           conn.disconnect!
         end
       end
@@ -875,7 +893,7 @@ module ActiveRecord
         # this is unfortunately not concurrent
         def bulk_make_new_connections(num_new_conns_needed)
           num_new_conns_needed.times do
-            # try_to_checkout_new_connection will not exceed pool's @size limit
+            # try_to_checkout_new_connection will not exceed pool's @max_size limit
             if new_conn = try_to_checkout_new_connection
               # make the new_conn available to the starving threads stuck @available Queue
               checkin(new_conn)
@@ -1060,17 +1078,17 @@ module ActiveRecord
         end
         alias_method :release, :remove_connection_from_thread_cache
 
-        # If the pool is not at a <tt>@size</tt> limit, establish new connection. Connecting
+        # If the pool is not at a <tt>@max_size</tt> limit, establish new connection. Connecting
         # to the DB is done outside main synchronized section.
         #--
         # Implementation constraint: a newly established connection returned by this
         # method must be in the +.leased+ state.
         def try_to_checkout_new_connection
           # first in synchronized section check if establishing new conns is allowed
-          # and increment @now_connecting, to prevent overstepping this pool's @size
+          # and increment @now_connecting, to prevent overstepping this pool's @max_size
           # constraint
           do_checkout = synchronize do
-            if @threads_blocking_new_connections.zero? && (@connections.size + @now_connecting) < @size
+            if @threads_blocking_new_connections.zero? && (@connections.size + @now_connecting) < @max_size
               @now_connecting += 1
             end
           end

--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -225,7 +225,7 @@ module ActiveRecord
       include ConnectionAdapters::AbstractPool
 
       attr_accessor :automatic_reconnect, :checkout_timeout
-      attr_reader :db_config, :max_size, :min_size, :keepalive, :reaper, :pool_config, :async_executor, :role, :shard
+      attr_reader :db_config, :max_size, :min_size, :max_age, :keepalive, :reaper, :pool_config, :async_executor, :role, :shard
       alias :size :max_size
 
       delegate :schema_reflection, :server_version, to: :pool_config
@@ -248,6 +248,7 @@ module ActiveRecord
         @idle_timeout = db_config.idle_timeout
         @max_size = db_config.pool
         @min_size = db_config.min_size
+        @max_age = db_config.max_age
         @keepalive = db_config.keepalive
 
         # This variable tracks the cache of threads mapped to reserved connections, with the
@@ -749,6 +750,16 @@ module ActiveRecord
           while new_conn = try_to_checkout_new_connection { @connections.size < @min_size }
             checkin(new_conn)
           end
+        end
+      end
+
+      def retire_old_connections(max_age = @max_age)
+        max_age ||= Float::INFINITY
+
+        sequential_maintenance -> c { c.connection_age&.>= max_age } do |conn|
+          # Disconnect, then return the adapter to the pool. Preconnect will
+          # handle the rest.
+          conn.disconnect!
         end
       end
 

--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -547,6 +547,12 @@ module ActiveRecord
         @connections.nil?
       end
 
+      def maintainable? # :nodoc:
+        synchronize do
+          @connections&.size&.> 0 || (activated? && @min_connections > 0)
+        end
+      end
+
       # Clears reloadable connections from the pool and re-connects connections that
       # require reloading.
       #

--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -521,6 +521,9 @@ module ActiveRecord
               @connections = []
               @leases.clear
               @available.clear
+
+              # Stop maintaining the minimum size until reactivated
+              @activated = false
             end
           end
         end

--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -706,6 +706,10 @@ module ActiveRecord
         @available.num_waiting
       end
 
+      def num_available_in_queue # :nodoc:
+        @available.size
+      end
+
       # Returns the connection pool's usage statistic.
       #
       #    ActiveRecord::Base.connection_pool.stat # => { size: 15, connections: 1, busy: 1, dead: 0, idle: 0, waiting: 0, checkout_timeout: 5 }
@@ -766,6 +770,65 @@ module ActiveRecord
             end
           when :global_thread_pool
             ActiveRecord.global_thread_pool_async_query_executor
+          end
+        end
+
+        # Perform maintenance work on pool connections. This method will
+        # select a connection to work on by calling the +candidate_selector+
+        # proc while holding the pool lock. If a connection is selected, it
+        # will be checked out for maintenance and passed to the
+        # +maintenance_work+ proc. The connection will always be returned to
+        # the pool after the proc completes.
+        #
+        # If the pool has async threads, all work will be scheduled there.
+        # Otherwise, this method will block until all work is complete.
+        #
+        # Each connection will only be processed once per call to this method,
+        # but (particularly in the async case) there is no protection against
+        # a second call to this method starting to work through the list
+        # before the first call has completed. (Though regular pool behaviour
+        # will prevent two instances from working on the same specific
+        # connection at the same time.)
+        def sequential_maintenance(candidate_selector, &maintenance_work)
+          # This hash doesn't need to be synchronized, because it's only
+          # used by one thread at a time: the +perform_work+ block gives
+          # up its right to +connections_visited+ when it schedules the
+          # next iteration.
+          connections_visited = Hash.new(false)
+          connections_visited.compare_by_identity
+
+          perform_work = lambda do
+            connection_to_maintain = nil
+
+            synchronize do
+              unless self.discarded?
+                if connection_to_maintain = @connections.select { |conn| !conn.in_use? }.select(&candidate_selector).sort_by(&:seconds_idle).find { |conn| !connections_visited[conn] }
+                  checkout_for_maintenance connection_to_maintain
+                end
+              end
+            end
+
+            if connection_to_maintain
+              connections_visited[connection_to_maintain] = true
+
+              # If we're running async, we can schedule the next round of work
+              # as soon as we've grabbed a connection to work on.
+              @async_executor&.post(&perform_work)
+
+              begin
+                maintenance_work.call connection_to_maintain
+              ensure
+                return_from_maintenance connection_to_maintain
+              end
+
+              true
+            end
+          end
+
+          if @async_executor
+            @async_executor.post(&perform_work)
+          else
+            nil while perform_work.call
           end
         end
 

--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -794,6 +794,21 @@ module ActiveRecord
         end
       end
 
+      # Immediately mark all current connections as due for replacement,
+      # equivalent to them having reached +max_age+ -- even if there is
+      # no +max_age+ configured.
+      def recycle!
+        synchronize do
+          return if self.discarded?
+
+          @connections.each do |conn|
+            conn.force_retirement
+          end
+        end
+
+        retire_old_connections
+      end
+
       def num_waiting_in_queue # :nodoc:
         @available.num_waiting
       end

--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -225,7 +225,7 @@ module ActiveRecord
       include ConnectionAdapters::AbstractPool
 
       attr_accessor :automatic_reconnect, :checkout_timeout
-      attr_reader :db_config, :max_size, :min_size, :reaper, :pool_config, :async_executor, :role, :shard
+      attr_reader :db_config, :max_size, :min_size, :keepalive, :reaper, :pool_config, :async_executor, :role, :shard
       alias :size :max_size
 
       delegate :schema_reflection, :server_version, to: :pool_config
@@ -248,6 +248,7 @@ module ActiveRecord
         @idle_timeout = db_config.idle_timeout
         @max_size = db_config.pool
         @min_size = db_config.min_size
+        @keepalive = db_config.keepalive
 
         # This variable tracks the cache of threads mapped to reserved connections, with the
         # sole purpose of speeding up the +connection+ method. It is not the authoritative
@@ -762,6 +763,23 @@ module ActiveRecord
           # connection will go back to the pool, and the next consumer will
           # presumably try to connect again -- which will either work, or
           # fail and they'll be able to report the exception.
+        end
+      end
+
+      # Prod any connections that have been idle for longer than the configured
+      # keepalive time. This will incidentally verify the connection is still
+      # alive, but the main purpose is to show the server (and any intermediate
+      # network hops) that we're still here and using the connection.
+      def keep_alive(threshold = @keepalive)
+        return if threshold.nil?
+
+        sequential_maintenance -> c { (c.seconds_since_last_activity || 0) > threshold } do |conn|
+          # conn.active? will cause some amount of network activity, which is all
+          # we need to provide a keepalive signal.
+          #
+          # If it returns false, the connection is already broken; disconnect,
+          # so it can be found and repaired.
+          conn.disconnect! unless conn.active?
         end
       end
 

--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool/queue.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool/queue.rb
@@ -62,6 +62,13 @@ module ActiveRecord
           end
         end
 
+        # Number of elements in the queue.
+        def size
+          synchronize do
+            @queue.size
+          end
+        end
+
         # Remove the head of the queue.
         #
         # If +timeout+ is not given, remove and return the head of the

--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool/queue.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool/queue.rb
@@ -40,6 +40,14 @@ module ActiveRecord
           end
         end
 
+        # Add +element+ to the back of the queue.  Never blocks.
+        def add_back(element)
+          synchronize do
+            @queue.unshift element
+            @cond.signal
+          end
+        end
+
         # If +element+ is in the queue, remove and return it, or +nil+.
         def delete(element)
           synchronize do

--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool/reaper.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool/reaper.rb
@@ -55,6 +55,7 @@ module ActiveRecord
                       p.reap
                       p.flush
                       p.prepopulate
+                      p.preconnect
                     rescue WeakRef::RefError
                     end
 

--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool/reaper.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool/reaper.rb
@@ -54,6 +54,7 @@ module ActiveRecord
                     @pools[frequency].each do |p|
                       p.reap
                       p.flush
+                      p.prepopulate
                     rescue WeakRef::RefError
                     end
 

--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool/reaper.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool/reaper.rb
@@ -55,6 +55,7 @@ module ActiveRecord
                       p.reap
                       p.flush
                       p.prepopulate
+                      p.keep_alive
                       p.preconnect
                     rescue WeakRef::RefError
                     end

--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool/reaper.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool/reaper.rb
@@ -51,7 +51,9 @@ module ActiveRecord
                       pool.weakref_alive? && !pool.discarded?
                     end
 
-                    @pools[frequency].each do |p|
+                    @pools[frequency].each do |ref|
+                      p = ref.__getobj__
+
                       p.reap
                       p.flush
                       p.prepopulate

--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool/reaper.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool/reaper.rb
@@ -55,6 +55,7 @@ module ActiveRecord
                       p.reap
                       p.flush
                       p.prepopulate
+                      p.retire_old_connections
                       p.keep_alive
                       p.preconnect
                     rescue WeakRef::RefError

--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool/reaper.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool/reaper.rb
@@ -72,12 +72,14 @@ module ActiveRecord
                       p = ref.__getobj__
                       next unless p.maintainable?
 
-                      p.reap
-                      p.flush
-                      p.prepopulate
-                      p.retire_old_connections
-                      p.keep_alive
-                      p.preconnect
+                      pool.reaper_lock do
+                        p.reap
+                        p.flush
+                        p.prepopulate
+                        p.retire_old_connections
+                        p.keep_alive
+                        p.preconnect
+                      end
                     rescue WeakRef::RefError
                     end
 

--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool/reaper.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool/reaper.rb
@@ -70,6 +70,7 @@ module ActiveRecord
 
                     @pools[frequency].each do |ref|
                       p = ref.__getobj__
+                      next unless p.maintainable?
 
                       p.reap
                       p.flush

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -42,6 +42,7 @@ module ActiveRecord
 
       attr_reader :pool
       attr_reader :visitor, :owner, :logger, :lock
+      attr_accessor :allow_preconnect
       alias :in_use? :owner
 
       def pool=(value)
@@ -152,6 +153,7 @@ module ActiveRecord
         @owner = nil
         @pool = ActiveRecord::ConnectionAdapters::NullPool.new
         @idle_since = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+        @allow_preconnect = true
         @visitor = arel_visitor
         @statements = build_statement_pool
         self.lock_thread = nil
@@ -672,12 +674,15 @@ module ActiveRecord
         deadline = retry_deadline && Process.clock_gettime(Process::CLOCK_MONOTONIC) + retry_deadline
 
         @lock.synchronize do
+          @allow_preconnect = false
+
           reconnect
 
           enable_lazy_transactions!
           @raw_connection_dirty = false
           @last_activity = Process.clock_gettime(Process::CLOCK_MONOTONIC)
           @verified = true
+          @allow_preconnect = true
 
           reset_transaction(restore: restore_transactions) do
             clear_cache!(new_connection: true)
@@ -773,6 +778,7 @@ module ActiveRecord
               attempt_configure_connection
               @last_activity = Process.clock_gettime(Process::CLOCK_MONOTONIC)
               @verified = true
+              @allow_preconnect = true
               return
             end
 
@@ -791,6 +797,10 @@ module ActiveRecord
       def clean! # :nodoc:
         @raw_connection_dirty = false
         @verified = nil
+      end
+
+      def verified? # :nodoc:
+        @verified
       end
 
       # Provides access to the underlying database driver for this adapter. For

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -304,7 +304,7 @@ module ActiveRecord
       end
 
       # this method must only be called while holding connection pool's mutex
-      def expire
+      def expire(update_idle = true) # :nodoc:
         if in_use?
           if @owner != ActiveSupport::IsolatedExecutionState.context
             raise ActiveRecordError, "Cannot expire connection, " \
@@ -312,7 +312,7 @@ module ActiveRecord
               "Current thread: #{ActiveSupport::IsolatedExecutionState.context}."
           end
 
-          @idle_since = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+          @idle_since = Process.clock_gettime(Process::CLOCK_MONOTONIC) if update_idle
           @owner = nil
         else
           raise ActiveRecordError, "Cannot expire connection, it is not currently leased."

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -173,6 +173,8 @@ module ActiveRecord
         @raw_connection_dirty = false
         @last_activity = nil
         @verified = false
+
+        @pool_jitter = rand * max_jitter
       end
 
       def inspect # :nodoc:
@@ -198,6 +200,11 @@ module ActiveRecord
         if preventing_writes? && write_query?(sql)
           raise ActiveRecord::ReadOnlyError, "Write query attempted while in readonly mode: #{sql}"
         end
+      end
+
+      MAX_JITTER = 0.0..1.0 # :nodoc:
+      def max_jitter
+        (@config[:pool_jitter] || 0.2).to_f.clamp(MAX_JITTER)
       end
 
       def replica?
@@ -305,6 +312,10 @@ module ActiveRecord
 
       def schema_cache
         @pool.schema_cache || (@schema_cache ||= BoundSchemaReflection.for_lone_connection(@pool.schema_reflection, self))
+      end
+
+      def pool_jitter(duration)
+        duration * (1.0 - @pool_jitter)
       end
 
       # this method must only be called while holding connection pool's mutex

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -358,6 +358,12 @@ module ActiveRecord
         end
       end
 
+      # Mark the connection as needing to be retired, as if the age has
+      # exceeded the maximum allowed.
+      def force_retirement # :nodoc:
+        @connected_since &&= -Float::INFINITY
+      end
+
       def unprepared_statement
         cache = prepared_statements_disabled_cache.add?(object_id) if @prepared_statements
         yield

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -786,6 +786,7 @@ module ActiveRecord
           end
         end
 
+        @last_activity = Process.clock_gettime(Process::CLOCK_MONOTONIC)
         @verified = true
       end
 

--- a/activerecord/lib/active_record/database_configurations/database_config.rb
+++ b/activerecord/lib/active_record/database_configurations/database_config.rb
@@ -48,7 +48,11 @@ module ActiveRecord
         raise NotImplementedError
       end
 
-      def pool
+      def min_connections
+        raise NotImplementedError
+      end
+
+      def max_connections
         raise NotImplementedError
       end
 

--- a/activerecord/lib/active_record/database_configurations/hash_config.rb
+++ b/activerecord/lib/active_record/database_configurations/hash_config.rb
@@ -73,6 +73,10 @@ module ActiveRecord
         (configuration_hash[:pool] || 5).to_i
       end
 
+      def min_size
+        (configuration_hash[:min_size] || 0).to_i
+      end
+
       def min_threads
         (configuration_hash[:min_threads] || 0).to_i
       end

--- a/activerecord/lib/active_record/database_configurations/hash_config.rb
+++ b/activerecord/lib/active_record/database_configurations/hash_config.rb
@@ -108,6 +108,11 @@ module ActiveRecord
         timeout if timeout > 0
       end
 
+      def keepalive
+        keepalive = (configuration_hash[:keepalive] || 600).to_f
+        keepalive if keepalive > 0
+      end
+
       def adapter
         configuration_hash[:adapter]&.to_s
       end

--- a/activerecord/lib/active_record/database_configurations/hash_config.rb
+++ b/activerecord/lib/active_record/database_configurations/hash_config.rb
@@ -85,6 +85,15 @@ module ActiveRecord
         (configuration_hash[:max_threads] || pool).to_i
       end
 
+      def max_age
+        v = configuration_hash[:max_age]&.to_i
+        if v && v > 0
+          v
+        else
+          Float::INFINITY
+        end
+      end
+
       def query_cache
         configuration_hash[:query_cache]
       end

--- a/activerecord/lib/active_record/database_configurations/hash_config.rb
+++ b/activerecord/lib/active_record/database_configurations/hash_config.rb
@@ -112,10 +112,8 @@ module ActiveRecord
         (configuration_hash[:checkout_timeout] || 5).to_f
       end
 
-      # `reaping_frequency` is configurable mostly for historical reasons, but it
-      # could also be useful if someone wants a very low `idle_timeout`.
-      def reaping_frequency
-        configuration_hash.fetch(:reaping_frequency, 60)&.to_f
+      def reaping_frequency # :nodoc:
+        configuration_hash.fetch(:reaping_frequency, default_reaping_frequency)&.to_f
       end
 
       def idle_timeout
@@ -204,6 +202,12 @@ module ActiveRecord
           when :sql
             "structure.sql"
           end
+        end
+
+        def default_reaping_frequency
+          # Reap every 20 seconds by default, but run more often as necessary to
+          # meet other configured timeouts.
+          [20, idle_timeout, max_age, keepalive].compact.min
         end
     end
   end

--- a/activerecord/test/cases/attribute_methods_test.rb
+++ b/activerecord/test/cases/attribute_methods_test.rb
@@ -1157,8 +1157,6 @@ class AttributeMethodsTest < ActiveRecord::TestCase
       assert_no_queries(include_schema: true) do
         @target.define_attribute_methods
       end
-    ensure
-      ActiveRecord::Base.connection_pool.disconnect!
     end
   end
 
@@ -1630,12 +1628,5 @@ class AttributeMethodsTest < ActiveRecord::TestCase
           "I'm private"
         end
       private_method
-    end
-
-    def with_temporary_connection_pool(&block)
-      pool_config = ActiveRecord::Base.lease_connection.pool.pool_config
-      new_pool = ActiveRecord::ConnectionAdapters::ConnectionPool.new(pool_config)
-
-      pool_config.stub(:pool, new_pool, &block)
     end
 end

--- a/activerecord/test/cases/connection_adapters/adapter_leasing_test.rb
+++ b/activerecord/test/cases/connection_adapters/adapter_leasing_test.rb
@@ -54,6 +54,8 @@ module ActiveRecord
         assert_not_predicate @adapter, :in_use?
 
         assert_equal @adapter, pool.lease_connection
+      ensure
+        pool&.disconnect!
       end
     end
   end

--- a/activerecord/test/cases/connection_adapters/merge_and_resolve_default_url_config_test.rb
+++ b/activerecord/test/cases/connection_adapters/merge_and_resolve_default_url_config_test.rb
@@ -323,13 +323,13 @@ module ActiveRecord
       def test_merge_no_conflicts_with_database_url
         ENV["DATABASE_URL"] = "postgres://localhost/foo"
 
-        config   = { "default_env" => { "adapter" => "abstract", "pool" => "5" } }
+        config   = { "default_env" => { "adapter" => "abstract", "max_connections" => "5" } }
         actual   = resolve_config(config)
         expected = {
           adapter: "postgresql",
           database: "foo",
           host: "localhost",
-          pool: "5"
+          max_connections: "5"
         }
 
         assert_equal expected, actual
@@ -338,13 +338,13 @@ module ActiveRecord
       def test_merge_conflicts_with_database_url
         ENV["DATABASE_URL"] = "postgres://localhost/foo"
 
-        config   = { "default_env" => { "adapter" => "abstract", "database" => "NOT-FOO", "pool" => "5" } }
+        config   = { "default_env" => { "adapter" => "abstract", "database" => "NOT-FOO", "max_connections" => "5" } }
         actual   = resolve_config(config)
         expected = {
           adapter: "postgresql",
           database: "foo",
           host: "localhost",
-          pool: "5"
+          max_connections: "5"
         }
 
         assert_equal expected, actual
@@ -353,28 +353,28 @@ module ActiveRecord
       def test_merge_no_conflicts_with_database_url_and_adapter
         ENV["DATABASE_URL"] = "postgres://localhost/foo"
 
-        config   = { "default_env" => { "adapter" => "postgresql", "pool" => "5" } }
+        config   = { "default_env" => { "adapter" => "postgresql", "max_connections" => "5" } }
         actual   = resolve_config(config)
         expected = {
           adapter: "postgresql",
           database: "foo",
           host: "localhost",
-          pool: "5"
+          max_connections: "5"
         }
 
         assert_equal expected, actual
       end
 
-      def test_merge_no_conflicts_with_database_url_and_numeric_pool
+      def test_merge_no_conflicts_with_database_url_and_numeric_max_connections
         ENV["DATABASE_URL"] = "postgres://localhost/foo"
 
-        config   = { "default_env" => { "adapter" => "abstract", "pool" => 5 } }
+        config   = { "default_env" => { "adapter" => "abstract", "max_connections" => 5 } }
         actual   = resolve_config(config)
         expected = {
           adapter: "postgresql",
           database: "foo",
           host: "localhost",
-          pool: 5
+          max_connections: 5
         }
 
         assert_equal expected, actual
@@ -385,25 +385,25 @@ module ActiveRecord
 
         config = {
           "default_env" => {
-            "primary" => { "adapter" => "abstract", "pool" => 5 },
-            "animals" => { "adapter" => "abstract", "pool" => 5 }
+            "primary" => { "adapter" => "abstract", "max_connections" => 5 },
+            "animals" => { "adapter" => "abstract", "max_connections" => 5 }
           }
         }
 
         configs = ActiveRecord::DatabaseConfigurations.new(config)
         actual = configs.configs_for(env_name: "default_env", name: "primary").configuration_hash
         expected = {
-          adapter:  "postgresql",
+          adapter: "postgresql",
           database: "foo",
-          host:     "localhost",
-          pool:     5
+          host: "localhost",
+          max_connections: 5
         }
 
         assert_equal expected, actual
 
         configs = ActiveRecord::DatabaseConfigurations.new(config)
         actual = configs.configs_for(env_name: "default_env", name: "animals").configuration_hash
-        expected = { adapter: "abstract", pool: 5 }
+        expected = { adapter: "abstract", max_connections: 5 }
 
         assert_equal expected, actual
       end
@@ -415,8 +415,8 @@ module ActiveRecord
 
         config = {
           "default_env" => {
-            "primary" => { "adapter" => "abstract", "pool" => 5 },
-            "animals" => { "adapter" => "abstract", "pool" => 5 }
+            "primary" => { "adapter" => "abstract", "max_connections" => 5 },
+            "animals" => { "adapter" => "abstract", "max_connections" => 5 }
           }
         }
 

--- a/activerecord/test/cases/connection_pool_test.rb
+++ b/activerecord/test/cases/connection_pool_test.rb
@@ -14,8 +14,6 @@ module ActiveRecord
       attr_reader :pool
 
       def setup
-        @previous_isolation_level = ActiveSupport::IsolatedExecutionState.isolation_level
-
         # Keep a duplicate pool so we do not bother others
         config = ActiveRecord::Base.connection_pool.db_config
         @db_config = ActiveRecord::DatabaseConfigurations::HashConfig.new(
@@ -43,7 +41,6 @@ module ActiveRecord
       def teardown
         super
         @pool.disconnect!
-        ActiveSupport::IsolatedExecutionState.isolation_level = @previous_isolation_level
       end
 
       def test_checkout_after_close
@@ -1019,9 +1016,17 @@ module ActiveRecord
       end
 
       def setup
-        super
+        @previous_isolation_level = ActiveSupport::IsolatedExecutionState.isolation_level
+
         ActiveSupport::IsolatedExecutionState.isolation_level = :thread
         @connection_test_model_class = ThreadConnectionTestModel
+
+        super
+      end
+
+      def teardown
+        super
+        ActiveSupport::IsolatedExecutionState.isolation_level = @previous_isolation_level
       end
 
       def test_lock_thread_allow_fiber_reentrency
@@ -1077,9 +1082,17 @@ module ActiveRecord
       end
 
       def setup
-        super
+        @previous_isolation_level = ActiveSupport::IsolatedExecutionState.isolation_level
+
         ActiveSupport::IsolatedExecutionState.isolation_level = :fiber
         @connection_test_model_class = FiberConnectionTestModel
+
+        super
+      end
+
+      def teardown
+        super
+        ActiveSupport::IsolatedExecutionState.isolation_level = @previous_isolation_level
       end
 
       private

--- a/activerecord/test/cases/connection_pool_test.rb
+++ b/activerecord/test/cases/connection_pool_test.rb
@@ -436,6 +436,24 @@ module ActiveRecord
         assert_equal 3, pool.connections.length
       end
 
+      def test_preconnect
+        pool = new_pool_with_options(min_size: 3, max_size: 3, async: false)
+        pool.activate
+        pool.prepopulate
+
+        assert_equal 3, pool.connections.length
+        pool.connections.each do |conn|
+          assert_not_predicate conn, :connected?
+        end
+
+        pool.preconnect
+
+        assert_equal 3, pool.connections.length
+        pool.connections.each do |conn|
+          assert_predicate conn, :connected?
+        end
+      end
+
       def test_remove_connection
         conn = @pool.checkout
         assert_predicate conn, :in_use?

--- a/activerecord/test/cases/connection_pool_test.rb
+++ b/activerecord/test/cases/connection_pool_test.rb
@@ -282,6 +282,16 @@ module ActiveRecord
         assert_equal 0, @pool.connections.length
       end
 
+      def test_min_size_configuration
+        @pool.disconnect!
+
+        @pool = new_pool_with_options(min_size: 1)
+
+        @pool.activate
+        @pool.prepopulate
+        assert_equal 1, @pool.connections.length
+      end
+
       def test_idle_timeout_configuration_with_min_size
         @pool.disconnect!
 

--- a/activerecord/test/cases/connection_pool_test.rb
+++ b/activerecord/test/cases/connection_pool_test.rb
@@ -149,7 +149,7 @@ module ActiveRecord
 
       def test_full_pool_blocking_shares_load_interlock
         skip_fiber_testing
-        @pool.instance_variable_set(:@max_size, 1)
+        @pool.instance_variable_set(:@max_connections, 1)
 
         load_interlock_latch = Concurrent::CountDownLatch.new
         connection_latch = Concurrent::CountDownLatch.new
@@ -236,7 +236,7 @@ module ActiveRecord
 
       def test_inactive_are_returned_from_dead_thread
         ready = Concurrent::CountDownLatch.new
-        @pool.instance_variable_set(:@max_size, 1)
+        @pool.instance_variable_set(:@max_connections, 1)
 
         child = new_thread do
           @pool.checkout
@@ -282,20 +282,20 @@ module ActiveRecord
         assert_equal 0, @pool.connections.length
       end
 
-      def test_min_size_configuration
+      def test_min_connections_configuration
         @pool.disconnect!
 
-        @pool = new_pool_with_options(min_size: 1)
+        @pool = new_pool_with_options(min_connections: 1)
 
         @pool.activate
         @pool.prepopulate
         assert_equal 1, @pool.connections.length
       end
 
-      def test_idle_timeout_configuration_with_min_size
+      def test_idle_timeout_configuration_with_min_connections
         @pool.disconnect!
 
-        @pool = new_pool_with_options(idle_timeout: "0.02", min_size: 1)
+        @pool = new_pool_with_options(idle_timeout: "0.02", min_connections: 1)
         connections = 2.times.map { @pool.checkout }
         connections.each { |conn| @pool.checkin(conn) }
 
@@ -419,7 +419,7 @@ module ActiveRecord
       end
 
       def test_prepopulate
-        pool = new_pool_with_options(min_size: 3, max_size: 3, async: false)
+        pool = new_pool_with_options(min_connections: 3, max_connections: 3, async: false)
 
         assert_equal 0, pool.connections.length
         assert_not_predicate pool, :activated?
@@ -437,7 +437,7 @@ module ActiveRecord
       end
 
       def test_preconnect
-        pool = new_pool_with_options(min_size: 3, max_size: 3, async: false)
+        pool = new_pool_with_options(min_connections: 3, max_connections: 3, async: false)
         pool.activate
         pool.prepopulate
 
@@ -686,7 +686,7 @@ module ActiveRecord
       def test_checkout_fairness
         skip_fiber_testing
 
-        @pool.instance_variable_set(:@max_size, 10)
+        @pool.instance_variable_set(:@max_connections, 10)
         expected = (1..@pool.size).to_a.freeze
         # check out all connections so our threads start out waiting
         conns = expected.map { @pool.checkout }
@@ -733,7 +733,7 @@ module ActiveRecord
       def test_checkout_fairness_by_group
         skip_fiber_testing
 
-        @pool.instance_variable_set(:@max_size, 10)
+        @pool.instance_variable_set(:@max_connections, 10)
         # take all the connections
         conns = (1..10).map { @pool.checkout }
         mutex = Mutex.new
@@ -834,7 +834,7 @@ module ActiveRecord
         completion_list = []
         selection_list = []
 
-        @pool.instance_variable_set(:@max_size, 3)
+        @pool.instance_variable_set(:@max_connections, 3)
         @pool.instance_variable_set(:@async_executor, work_collector)
 
         3.times.map { @pool.checkout }.each do |conn|
@@ -872,7 +872,7 @@ module ActiveRecord
         completion_list = []
         selection_list = []
 
-        @pool.instance_variable_set(:@max_size, 3)
+        @pool.instance_variable_set(:@max_connections, 3)
         @pool.instance_variable_set(:@async_executor, nil)
 
         3.times.map { @pool.checkout }.each do |conn|
@@ -1406,7 +1406,7 @@ module ActiveRecord
         end
 
         def with_single_connection_pool(**options)
-          config = @db_config.configuration_hash.merge(pool: 1, **options)
+          config = @db_config.configuration_hash.merge(max_connections: 1, **options)
           db_config = ActiveRecord::DatabaseConfigurations::HashConfig.new("arunit", "primary", config)
           pool_config = ActiveRecord::ConnectionAdapters::PoolConfig.new(ActiveRecord::Base, db_config, :writing, :default)
 

--- a/activerecord/test/cases/connection_pool_test.rb
+++ b/activerecord/test/cases/connection_pool_test.rb
@@ -644,7 +644,7 @@ module ActiveRecord
       end
 
       def test_idle_through_keepalive
-        pool = new_pool_with_options(keepalive: 0.1, pool_jitter: 0, idle_timeout: 0.5, async: false)
+        pool = new_pool_with_options(keepalive: 0.1, pool_jitter: 0, idle_timeout: 0.5, async: false, reaping_frequency: 30)
         conn = pool.checkout
         conn.connect!
         pool.checkin conn

--- a/activerecord/test/cases/connection_pool_test.rb
+++ b/activerecord/test/cases/connection_pool_test.rb
@@ -27,6 +27,8 @@ module ActiveRecord
         @pool_config = ActiveRecord::ConnectionAdapters::PoolConfig.new(ActiveRecord::Base, @db_config, :writing, :default)
         @pool = ConnectionPool.new(@pool_config)
 
+        @pools = [@pool]
+
         if in_memory_db?
           # Separate connections to an in-memory database create an entirely new database,
           # with an empty schema etc, so we just stub out this schema on the fly.
@@ -40,7 +42,7 @@ module ActiveRecord
 
       def teardown
         super
-        @pool.disconnect!
+        @pools&.each(&:disconnect!)
       end
 
       def test_checkout_after_close
@@ -259,11 +261,7 @@ module ActiveRecord
       def test_idle_timeout_configuration
         @pool.disconnect!
 
-        config = @db_config.configuration_hash.merge(idle_timeout: "0.02")
-        db_config = ActiveRecord::DatabaseConfigurations::HashConfig.new(@db_config.env_name, @db_config.name, config)
-
-        pool_config = ActiveRecord::ConnectionAdapters::PoolConfig.new(ActiveRecord::Base, db_config, :writing, :default)
-        @pool = ConnectionPool.new(pool_config)
+        @pool = new_pool_with_options(idle_timeout: "0.02")
         idle_conn = @pool.checkout
         @pool.checkin(idle_conn)
 
@@ -287,10 +285,7 @@ module ActiveRecord
       def test_disable_flush
         @pool.disconnect!
 
-        config = @db_config.configuration_hash.merge(idle_timeout: -5)
-        db_config = ActiveRecord::DatabaseConfigurations::HashConfig.new(@db_config.env_name, @db_config.name, config)
-        pool_config = ActiveRecord::ConnectionAdapters::PoolConfig.new(ActiveRecord::Base, db_config, :writing, :default)
-        @pool = ConnectionPool.new(pool_config)
+        @pool = new_pool_with_options(idle_timeout: -5)
         idle_conn = @pool.checkout
         @pool.checkin(idle_conn)
 
@@ -398,6 +393,8 @@ module ActiveRecord
           assert pool.lease_connection
           pool.lease_connection.close
         end.join
+      ensure
+        pool&.disconnect!
       end
 
       def test_checkout_order_is_lifo
@@ -534,6 +531,8 @@ module ActiveRecord
 
         pool.disconnect!
         assert pool.lease_connection
+      ensure
+        pool&.disconnect!
       end
 
       def test_automatic_reconnect_can_be_disabled
@@ -548,6 +547,8 @@ module ActiveRecord
         assert_raises(ConnectionNotEstablished) do
           pool.with_connection
         end
+      ensure
+        pool&.disconnect!
       end
 
       def test_pool_sets_connection_visitor
@@ -1005,6 +1006,16 @@ module ActiveRecord
           yield(pool = ConnectionPool.new(pool_config))
         ensure
           pool.disconnect! if pool
+        end
+
+        def new_pool_with_options(async: true, **options)
+          config = @db_config.configuration_hash.merge(options)
+          db_config = ActiveRecord::DatabaseConfigurations::HashConfig.new(@db_config.env_name, @db_config.name, config)
+          pool_config = ActiveRecord::ConnectionAdapters::PoolConfig.new(ActiveRecord::Base, db_config, :writing, :default)
+          pool = ConnectionPool.new(pool_config)
+          pool.instance_variable_set(:@async_executor, nil) unless async
+          @pools << pool
+          pool
         end
     end
 

--- a/activerecord/test/cases/connection_pool_test.rb
+++ b/activerecord/test/cases/connection_pool_test.rb
@@ -1348,6 +1348,8 @@ module ActiveRecord
         assert_equal :shard_one, pool_config.shard
         assert_equal :shard_one, pool.shard
         assert_equal :shard_one, pool.lease_connection.shard
+      ensure
+        pool&.disconnect!
       end
 
       def test_pin_connection_always_returns_the_same_connection
@@ -1471,6 +1473,8 @@ module ActiveRecord
         pool = ConnectionPool.new(pool_config)
 
         assert_match(/#<ActiveRecord::ConnectionAdapters::ConnectionPool env_name="\w+" role=:reading shard=:shard_one>/, pool.inspect)
+      ensure
+        pool&.disconnect!
       end
 
       private

--- a/activerecord/test/cases/connection_pool_test.rb
+++ b/activerecord/test/cases/connection_pool_test.rb
@@ -261,13 +261,13 @@ module ActiveRecord
       def test_idle_timeout_configuration
         @pool.disconnect!
 
-        @pool = new_pool_with_options(idle_timeout: "0.02")
+        @pool = new_pool_with_options(idle_timeout: "200")
         idle_conn = @pool.checkout
         @pool.checkin(idle_conn)
 
         idle_conn.instance_variable_set(
           :@idle_since,
-          Process.clock_gettime(Process::CLOCK_MONOTONIC) - 0.01
+          Process.clock_gettime(Process::CLOCK_MONOTONIC) - 199
         )
 
         @pool.flush
@@ -275,7 +275,7 @@ module ActiveRecord
 
         idle_conn.instance_variable_set(
           :@idle_since,
-          Process.clock_gettime(Process::CLOCK_MONOTONIC) - 0.03
+          Process.clock_gettime(Process::CLOCK_MONOTONIC) - 201
         )
 
         @pool.flush
@@ -295,14 +295,14 @@ module ActiveRecord
       def test_idle_timeout_configuration_with_min_connections
         @pool.disconnect!
 
-        @pool = new_pool_with_options(idle_timeout: "0.02", min_connections: 1)
+        @pool = new_pool_with_options(idle_timeout: "200", min_connections: 1)
         connections = 2.times.map { @pool.checkout }
         connections.each { |conn| @pool.checkin(conn) }
 
         connections.each do |conn|
           conn.instance_variable_set(
             :@idle_since,
-            Process.clock_gettime(Process::CLOCK_MONOTONIC) - 0.01
+            Process.clock_gettime(Process::CLOCK_MONOTONIC) - 199
           )
         end
 
@@ -312,7 +312,7 @@ module ActiveRecord
         connections.each do |conn|
           conn.instance_variable_set(
             :@idle_since,
-            Process.clock_gettime(Process::CLOCK_MONOTONIC) - 0.03
+            Process.clock_gettime(Process::CLOCK_MONOTONIC) - 201
           )
         end
 

--- a/activerecord/test/cases/database_configurations/hash_config_test.rb
+++ b/activerecord/test/cases/database_configurations/hash_config_test.rb
@@ -5,19 +5,79 @@ require "cases/helper"
 module ActiveRecord
   class DatabaseConfigurations
     class HashConfigTest < ActiveRecord::TestCase
-      def test_pool_default_when_nil
-        config = HashConfig.new("default_env", "primary", pool: nil, adapter: "abstract")
-        assert_equal 5, config.pool
+      def test_pool_config_raises_deprecation
+        config = nil
+        assert_deprecated ActiveRecord.deprecator do
+          config = HashConfig.new("default_env", "primary", pool: 6, adapter: "abstract")
+        end
+        assert_equal 6, config.max_connections
       end
 
-      def test_pool_overrides_with_value
-        config = HashConfig.new("default_env", "primary", pool: "0", adapter: "abstract")
-        assert_equal 0, config.pool
-      end
-
-      def test_when_no_pool_uses_default
+      def test_pool_is_deprecated
         config = HashConfig.new("default_env", "primary", adapter: "abstract")
-        assert_equal 5, config.pool
+        assert_deprecated ActiveRecord.deprecator do
+          assert_equal 5, config.pool
+        end
+      end
+
+      def test_max_age_default_when_nil
+        config = HashConfig.new("default_env", "primary", max_age: nil, adapter: "abstract")
+        assert_equal Float::INFINITY, config.max_age
+      end
+
+      def test_max_age_overrides_with_value
+        config = HashConfig.new("default_env", "primary", max_age: "500", adapter: "abstract")
+        assert_equal 500, config.max_age
+      end
+
+      def test_when_no_max_age_uses_default
+        config = HashConfig.new("default_env", "primary", adapter: "abstract")
+        assert_equal Float::INFINITY, config.max_age
+      end
+
+      def test_keepalive_default_when_nil
+        config = HashConfig.new("default_env", "primary", keepalive: nil, adapter: "abstract")
+        assert_equal 600, config.keepalive
+      end
+
+      def test_keepalive_overrides_with_value
+        config = HashConfig.new("default_env", "primary", keepalive: "500", adapter: "abstract")
+        assert_equal 500, config.keepalive
+      end
+
+      def test_when_no_keepalive_uses_default
+        config = HashConfig.new("default_env", "primary", adapter: "abstract")
+        assert_equal 600, config.keepalive
+      end
+
+      def test_max_connections_default_when_nil
+        config = HashConfig.new("default_env", "primary", max_connections: nil, adapter: "abstract")
+        assert_equal 5, config.max_connections
+      end
+
+      def test_max_connections_overrides_with_value
+        config = HashConfig.new("default_env", "primary", max_connections: "0", adapter: "abstract")
+        assert_equal 0, config.max_connections
+      end
+
+      def test_when_no_max_connections_uses_default
+        config = HashConfig.new("default_env", "primary", adapter: "abstract")
+        assert_equal 5, config.max_connections
+      end
+
+      def test_min_connections_default_when_nil
+        config = HashConfig.new("default_env", "primary", min_connections: nil, adapter: "abstract")
+        assert_equal 0, config.min_connections
+      end
+
+      def test_min_connections_overrides_with_value
+        config = HashConfig.new("default_env", "primary", min_connections: "5", adapter: "abstract")
+        assert_equal 5, config.min_connections
+      end
+
+      def test_when_no_min_connections_uses_default
+        config = HashConfig.new("default_env", "primary", adapter: "abstract")
+        assert_equal 0, config.min_connections
       end
 
       def test_min_threads_with_value
@@ -35,19 +95,19 @@ module ActiveRecord
         assert_equal 10, config.max_threads
       end
 
-      def test_max_threads_default_uses_pool_default
+      def test_max_threads_default_uses_max_connections_default
         config = HashConfig.new("default_env", "primary", adapter: "abstract")
-        assert_equal 5, config.pool
+        assert_equal 5, config.max_connections
         assert_equal 5, config.max_threads
       end
 
-      def test_max_threads_uses_pool_when_set
-        config = HashConfig.new("default_env", "primary", pool: 1, adapter: "abstract")
-        assert_equal 1, config.pool
+      def test_max_threads_uses_max_connections_when_set
+        config = HashConfig.new("default_env", "primary", max_connections: 1, adapter: "abstract")
+        assert_equal 1, config.max_connections
         assert_equal 1, config.max_threads
       end
 
-      def test_max_queue_is_pool_multiplied_by_4
+      def test_max_queue_is_max_threads_multiplied_by_4
         config = HashConfig.new("default_env", "primary", adapter: "abstract")
         assert_equal 5, config.max_threads
         assert_equal config.max_threads * 4, config.max_queue

--- a/activerecord/test/cases/database_configurations/hash_config_test.rb
+++ b/activerecord/test/cases/database_configurations/hash_config_test.rb
@@ -140,7 +140,12 @@ module ActiveRecord
 
       def test_when_no_reaping_frequency_uses_default
         config = HashConfig.new("default_env", "primary", adapter: "abstract")
-        assert_equal 60.0, config.reaping_frequency
+        assert_equal 20.0, config.reaping_frequency
+      end
+
+      def test_reaping_frequency_is_reduced_for_low_keepalive
+        config = HashConfig.new("default_env", "primary", keepalive: "15", adapter: "abstract")
+        assert_equal 15.0, config.reaping_frequency
       end
 
       def test_idle_timeout_default_when_nil

--- a/activerecord/test/cases/database_configurations/resolver_test.rb
+++ b/activerecord/test/cases/database_configurations/resolver_test.rb
@@ -43,14 +43,14 @@ module ActiveRecord
         end
 
         def test_url_sub_key_merges_correctly
-          hash = { "url" => "abstract://foo?encoding=utf8&", "adapter" => "sqlite3", "host" => "bar", "pool" => "3" }
+          hash = { "url" => "abstract://foo?encoding=utf8&", "adapter" => "sqlite3", "host" => "bar", "max_connections" => "3" }
           pool_config = resolve_db_config :production, "production" => hash
 
           assert_equal({
-            adapter:  "abstract",
-            host:     "foo",
-            encoding: "utf8",
-            pool:     "3"
+            adapter:         "abstract",
+            host:            "foo",
+            encoding:        "utf8",
+            max_connections: "3"
           }, pool_config.configuration_hash)
         end
 

--- a/activerecord/test/cases/pooled_connections_test.rb
+++ b/activerecord/test/cases/pooled_connections_test.rb
@@ -32,7 +32,7 @@ class PooledConnectionsTest < ActiveRecord::TestCase
     end
 
     def test_pooled_connection_remove
-      ActiveRecord::Base.establish_connection(@connection.merge(pool: 2, checkout_timeout: 0.5))
+      ActiveRecord::Base.establish_connection(@connection.merge(max_connections: 2, checkout_timeout: 0.5))
       old_connection = ActiveRecord::Base.lease_connection
       extra_connection = ActiveRecord::Base.connection_pool.checkout
       ActiveRecord::Base.connection_pool.remove(extra_connection)
@@ -41,8 +41,8 @@ class PooledConnectionsTest < ActiveRecord::TestCase
 
     private
       # Will deadlock due to lack of Monitor timeouts in 1.9
-      def checkout_checkin_connections(pool_size, threads)
-        ActiveRecord::Base.establish_connection(@connection.merge(pool: pool_size, checkout_timeout: 0.5))
+      def checkout_checkin_connections(max_connections, threads)
+        ActiveRecord::Base.establish_connection(@connection.merge(max_connections: max_connections, checkout_timeout: 0.5))
         @connection_count = 0
         @timed_out = 0
         threads.times do
@@ -57,8 +57,8 @@ class PooledConnectionsTest < ActiveRecord::TestCase
         end
       end
 
-      def checkout_checkin_connections_loop(pool_size, loops)
-        ActiveRecord::Base.establish_connection(@connection.merge(pool: pool_size, checkout_timeout: 0.5))
+      def checkout_checkin_connections_loop(max_connections, loops)
+        ActiveRecord::Base.establish_connection(@connection.merge(max_connections: max_connections, checkout_timeout: 0.5))
         @connection_count = 0
         @timed_out = 0
         loops.times do

--- a/activerecord/test/cases/query_cache_test.rb
+++ b/activerecord/test/cases/query_cache_test.rb
@@ -339,8 +339,6 @@ class QueryCacheTest < ActiveRecord::TestCase
       ActiveRecord::Base.connection_pool.connections.each do |conn|
         assert_cache :off, conn
       end
-    ensure
-      ActiveRecord::Base.connection_pool.disconnect!
     end
   end
 
@@ -830,13 +828,6 @@ class QueryCacheTest < ActiveRecord::TestCase
   end
 
   private
-    def with_temporary_connection_pool(&block)
-      pool_config = ActiveRecord::Base.lease_connection.pool.pool_config
-      new_pool = ActiveRecord::ConnectionAdapters::ConnectionPool.new(pool_config)
-
-      pool_config.stub(:pool, new_pool, &block)
-    end
-
     def middleware(&app)
       executor = Class.new(ActiveSupport::Executor)
       ActiveRecord::QueryCache.install_executor_hooks executor

--- a/activerecord/test/cases/reaper_test.rb
+++ b/activerecord/test/cases/reaper_test.rb
@@ -35,6 +35,9 @@ module ActiveRecord
 
         def preconnect
         end
+
+        def keep_alive
+        end
       end
 
       # A reaper with nil time should never reap connections

--- a/activerecord/test/cases/reaper_test.rb
+++ b/activerecord/test/cases/reaper_test.rb
@@ -38,6 +38,9 @@ module ActiveRecord
 
         def keep_alive
         end
+
+        def retire_old_connections
+        end
       end
 
       # A reaper with nil time should never reap connections

--- a/activerecord/test/cases/reaper_test.rb
+++ b/activerecord/test/cases/reaper_test.rb
@@ -29,6 +29,9 @@ module ActiveRecord
         def discarded?
           @discarded
         end
+
+        def prepopulate
+        end
       end
 
       # A reaper with nil time should never reap connections

--- a/activerecord/test/cases/reaper_test.rb
+++ b/activerecord/test/cases/reaper_test.rb
@@ -32,6 +32,9 @@ module ActiveRecord
 
         def prepopulate
         end
+
+        def preconnect
+        end
       end
 
       # A reaper with nil time should never reap connections

--- a/activerecord/test/cases/reaper_test.rb
+++ b/activerecord/test/cases/reaper_test.rb
@@ -41,6 +41,10 @@ module ActiveRecord
 
         def retire_old_connections
         end
+
+        def maintainable?
+          !discarded? && !flushed && !reaped
+        end
       end
 
       # A reaper with nil time should never reap connections

--- a/activerecord/test/cases/reaper_test.rb
+++ b/activerecord/test/cases/reaper_test.rb
@@ -45,6 +45,10 @@ module ActiveRecord
         def maintainable?
           !discarded? && !flushed && !reaped
         end
+
+        def reaper_lock
+          yield
+        end
       end
 
       # A reaper with nil time should never reap connections

--- a/activerecord/test/cases/schema_loading_test.rb
+++ b/activerecord/test/cases/schema_loading_test.rb
@@ -69,8 +69,6 @@ class SchemaLoadingTest < ActiveRecord::TestCase
         klass.load_schema
       end
       assert_equal 1, klass.load_schema_calls
-    ensure
-      ActiveRecord::Base.connection_pool.disconnect!
     end
   end
 
@@ -81,12 +79,5 @@ class SchemaLoadingTest < ActiveRecord::TestCase
         self.table_name = :lock_without_defaults
         yield self if block_given?
       end
-    end
-
-    def with_temporary_connection_pool(&block)
-      pool_config = ActiveRecord::Base.lease_connection.pool.pool_config
-      new_pool = ActiveRecord::ConnectionAdapters::ConnectionPool.new(pool_config)
-
-      pool_config.stub(:pool, new_pool, &block)
     end
 end

--- a/activerecord/test/cases/test_case.rb
+++ b/activerecord/test/cases/test_case.rb
@@ -190,6 +190,15 @@ module ActiveRecord
       end
     end
 
+    def with_temporary_connection_pool(&block)
+      pool_config = ActiveRecord::Base.connection_pool.pool_config
+      new_pool = ActiveRecord::ConnectionAdapters::ConnectionPool.new(pool_config)
+
+      pool_config.stub(:pool, new_pool, &block)
+    ensure
+      new_pool&.disconnect!
+    end
+
     def with_postgresql_datetime_type(type)
       adapter = ActiveRecord::ConnectionAdapters::PostgreSQLAdapter
       adapter.remove_instance_variable(:@native_database_types) if adapter.instance_variable_defined?(:@native_database_types)

--- a/activerecord/test/support/adapter_helper.rb
+++ b/activerecord/test/support/adapter_helper.rb
@@ -4,7 +4,7 @@ module AdapterHelper
   def current_adapter?(*types)
     types.any? do |type|
       ActiveRecord::ConnectionAdapters.const_defined?(type) &&
-        ActiveRecord::Base.lease_connection.is_a?(ActiveRecord::ConnectionAdapters.const_get(type))
+        ActiveRecord::Base.connection_pool.db_config.adapter_class <= ActiveRecord::ConnectionAdapters.const_get(type)
     end
   end
 

--- a/activerecord/test/support/adapter_helper.rb
+++ b/activerecord/test/support/adapter_helper.rb
@@ -101,4 +101,80 @@ module AdapterHelper
     connection.disable_extension(extension, force: :cascade)
     connection.reconnect!
   end
+
+  # Detects whether the server side of the connection physically has a
+  # transaction open, independently of the adapter's opinion. Skips if we don't
+  # know how to detect this.
+  def raw_transaction_open?(connection)
+    if current_adapter?(:PostgreSQLAdapter)
+      connection.instance_variable_get(:@raw_connection).transaction_status == ::PG::PQTRANS_INTRANS
+    elsif current_adapter?(:Mysql2Adapter, :TrilogyAdapter)
+      begin
+        connection.instance_variable_get(:@raw_connection).query("SAVEPOINT transaction_test")
+        connection.instance_variable_get(:@raw_connection).query("RELEASE SAVEPOINT transaction_test")
+
+        true
+      rescue
+        false
+      end
+    elsif current_adapter?(:SQLite3Adapter)
+      begin
+        connection.instance_variable_get(:@raw_connection).transaction { nil }
+        false
+      rescue
+        true
+      end
+    else
+      skip("raw_transaction_open? unsupported")
+    end
+  end
+
+  # Arrange for the server to disconnect the connection, leaving it broken (by
+  # setting, and then sleeping to exceed, a very short timeout). Skips if we
+  # can't do so.
+  def remote_disconnect(connection)
+    if current_adapter?(:PostgreSQLAdapter)
+      # Connection was left in a bad state, need to reconnect to simulate fresh disconnect
+      connection.verify! if connection.instance_variable_get(:@raw_connection).status == ::PG::CONNECTION_BAD
+      unless connection.instance_variable_get(:@raw_connection).transaction_status == ::PG::PQTRANS_INTRANS
+        connection.instance_variable_get(:@raw_connection).async_exec("begin")
+      end
+      connection.instance_variable_get(:@raw_connection).async_exec("set idle_in_transaction_session_timeout = '10ms'")
+      sleep 0.05
+    elsif current_adapter?(:Mysql2Adapter, :TrilogyAdapter)
+      connection.send(:internal_execute, "set @@wait_timeout=1", materialize_transactions: false)
+      sleep 1.2
+    else
+      skip("remote_disconnect unsupported")
+    end
+  end
+
+  def connection_id_from_server(connection)
+    case connection.adapter_name
+    when "Mysql2", "Trilogy"
+      connection.execute("SELECT CONNECTION_ID()").to_a[0][0]
+    when "PostgreSQL"
+      connection.execute("SELECT pg_backend_pid()").to_a[0]["pg_backend_pid"]
+    else
+      skip("connection_id_from_server unsupported")
+    end
+  end
+
+  # Uses a separate connection to admin-kill the connection with the given ID
+  # from the server side. Skips if we can't do so.
+  def kill_connection_from_server(connection_id, pool = ActiveRecord::Base.connection_pool)
+    actor_connection = pool.checkout
+    pool.remove(actor_connection)
+
+    case actor_connection.adapter_name
+    when "Mysql2", "Trilogy"
+      actor_connection.execute("KILL #{connection_id}")
+    when "PostgreSQL"
+      actor_connection.execute("SELECT pg_terminate_backend(#{connection_id})")
+    else
+      skip("kill_connection_from_server unsupported")
+    end
+
+    actor_connection.close
+  end
 end

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/mysql.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/mysql.yml.tt
@@ -12,7 +12,7 @@
 default: &default
   adapter: mysql2
   encoding: utf8mb4
-  pool: <%%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+  max_connections: <%%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
   username: root
   password:
 <% if database.socket -%>

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/postgresql.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/postgresql.yml.tt
@@ -17,7 +17,7 @@ default: &default
   encoding: unicode
   # For details on connection pooling, see Rails configuration guide
   # https://guides.rubyonrails.org/configuring.html#database-pooling
-  pool: <%%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+  max_connections: <%%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
 <% if devcontainer? -%>
   <%% if ENV["DB_HOST"] %>
   host: <%%= ENV["DB_HOST"] %>

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/sqlite3.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/sqlite3.yml.tt
@@ -6,7 +6,7 @@
 #
 default: &default
   adapter: sqlite3
-  pool: <%%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+  max_connections: <%%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
   timeout: 5000
 
 development:

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/trilogy.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/trilogy.yml.tt
@@ -12,7 +12,7 @@
 default: &default
   adapter: trilogy
   encoding: utf8mb4
-  pool: <%%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+  max_connections: <%%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
   username: root
   password:
   host: <%%= ENV.fetch("DB_HOST") { "<%= database.host %>" } %>

--- a/railties/test/application/dbconsole_test.rb
+++ b/railties/test/application/dbconsole_test.rb
@@ -23,7 +23,7 @@ module ApplicationTests
         development:
            database: <%= Rails.application.config.database %>
            adapter: sqlite3
-           pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+           max_connections: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
            timeout: 5000
       YAML
 
@@ -44,7 +44,7 @@ module ApplicationTests
       app_file "config/database.yml", <<-YAML
         default: &default
           adapter: sqlite3
-          pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+          max_connections: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
           timeout: 5000
 
         development:

--- a/railties/test/application/multi_db_rake_test.rb
+++ b/railties/test/application/multi_db_rake_test.rb
@@ -36,7 +36,7 @@ module ApplicationTests
       app_file "config/database.yml", <<-YAML
         default: &default
           adapter: sqlite3
-          pool: 5
+          max_connections: 5
           timeout: 5000
           variables:
             statement_timeout: 1000

--- a/railties/test/application/rake/dbs_test.rb
+++ b/railties/test/application/rake/dbs_test.rb
@@ -486,7 +486,7 @@ module ApplicationTests
             f.puts <<-YAML
             default: &default
               adapter: sqlite3
-              pool: 5
+              max_connections: 5
               timeout: 5000
               variables:
                 statement_timeout: 1000
@@ -508,7 +508,7 @@ module ApplicationTests
             f.puts <<-YAML
             default: &default
               adapter: sqlite3
-              pool: 5
+              max_connections: 5
               timeout: 5000
               variables:
                 statement_timeout: 1000

--- a/railties/test/commands/dbconsole_test.rb
+++ b/railties/test/commands/dbconsole_test.rb
@@ -29,7 +29,7 @@ class Rails::DBConsoleTest < ActiveSupport::TestCase
         "database" => "foo_test",
         "user" => "foo",
         "password" => "bar",
-        "pool" => "5",
+        "max_connections" => "5",
         "timeout" => "3000"
       }
     }
@@ -47,16 +47,16 @@ class Rails::DBConsoleTest < ActiveSupport::TestCase
   end
 
   def test_config_with_database_url_only
-    ENV["DATABASE_URL"] = "postgresql://foo:bar@localhost:9000/foo_test?pool=5&timeout=3000"
+    ENV["DATABASE_URL"] = "postgresql://foo:bar@localhost:9000/foo_test?max_connections=5&timeout=3000"
     expected = {
-      adapter:  "postgresql",
-      host:     "localhost",
-      port:     9000,
-      database: "foo_test",
-      username: "foo",
-      password: "bar",
-      pool:     "5",
-      timeout:  "3000"
+      adapter:         "postgresql",
+      host:            "localhost",
+      port:            9000,
+      database:        "foo_test",
+      username:        "foo",
+      password:        "bar",
+      max_connections: "5",
+      timeout:         "3000"
     }.sort
 
     app_db_config(nil) do
@@ -66,17 +66,17 @@ class Rails::DBConsoleTest < ActiveSupport::TestCase
 
   def test_config_choose_database_url_if_exists
     host = "database-url-host.com"
-    ENV["DATABASE_URL"] = "postgresql://foo:bar@#{host}:9000/foo_test?pool=5&timeout=3000"
+    ENV["DATABASE_URL"] = "postgresql://foo:bar@#{host}:9000/foo_test?max_connections=5&timeout=3000"
     sample_config = {
       "test" => {
-        "adapter"  => "postgresql",
-        "host"     => "not-the-#{host}",
-        "port"     => 9000,
-        "database" => "foo_test",
-        "username" => "foo",
-        "password" => "bar",
-        "pool"     => "5",
-        "timeout"  => "3000"
+        "adapter"         => "postgresql",
+        "host"            => "not-the-#{host}",
+        "port"            => 9000,
+        "database"        => "foo_test",
+        "username"        => "foo",
+        "password"        => "bar",
+        "max_connections" => "5",
+        "timeout"         => "3000"
       }
     }
     app_db_config(sample_config) do

--- a/railties/test/isolation/abstract_unit.rb
+++ b/railties/test/isolation/abstract_unit.rb
@@ -155,7 +155,7 @@ module TestHelpers
       <<-YAML
         default: &default
           adapter: sqlite3
-          pool: 5
+          max_connections: 5
           timeout: 5000
         development:
           <<: *default
@@ -173,7 +173,7 @@ module TestHelpers
       <<-YAML
         default: &default
           adapter: sqlite3
-          pool: 5
+          max_connections: 5
           timeout: 5000
           variables:
             statement_timeout: 1000
@@ -501,7 +501,7 @@ module TestHelpers
           f.puts <<-YAML
           default: &default
             adapter: postgresql
-            pool: 5
+            max_connections: 5
           development:
             primary:
               <<: *default
@@ -517,7 +517,7 @@ module TestHelpers
           f.puts <<-YAML
           default: &default
             adapter: postgresql
-            pool: 5
+            max_connections: 5
           development:
             <<: *default
             database: #{database_name}_development
@@ -537,7 +537,7 @@ module TestHelpers
           f.puts <<-YAML
           default: &default
             adapter: mysql2
-            pool: 5
+            max_connections: 5
             username: root
           <% if ENV['MYSQL_CODESPACES'] %>
             password: 'root'
@@ -563,7 +563,7 @@ module TestHelpers
           f.puts <<-YAML
           default: &default
             adapter: mysql2
-            pool: 5
+            max_connections: 5
             username: root
           <% if ENV['MYSQL_CODESPACES'] %>
             password: 'root'


### PR DESCRIPTION
Recruit the Reaper to do more work in keeping the connection pool healthy:

* retiring connections that have been idle[^1] for too long, or that have been open beyond a configured total maximum age
* creating occasional activity on inactive[^1] connections
* keeping the pool prepopulated up to its minimum size
* proactively connecting to the target database from any pooled connections that had lazily deferred that step
* resetting or replacing connections that are known to be broken


For most applications this is going to make no difference. For large applications with multiple active connection pools, though, it will allow more maintenance work to be done in the background and/or in parallel. 


Maximum total connection lifetime is helpful, for example, to facilitate smooth database server failover: as long as the old server remains available for (max lifetime) seconds after a load balancer switches to a new server, no in-flight activity will be interrupted.


Subsumes and thus closes #50990; fixes #50989


[^1]: "idle" and "inactive" here distinguish between connections that have not been requested by the application in a while (idle) and those that have not spoken to their remote server in a while (inactive). The former is a desirable opportunity to reduce our connection count (`idle_timeout`); the latter is a risk that the server or a firewall may drop a connection we still anticipate using (avoided by `keepalive`).