### PR TITLE
Avoid crash to validate circular autosave association

### DIFF
--- a/activerecord/lib/active_record/autosave_association.rb
+++ b/activerecord/lib/active_record/autosave_association.rb
@@ -383,6 +383,8 @@ module ActiveRecord
         end
 
         if association.options[:autosave]
+          return if equal?(record)
+
           associated_errors.each { |error|
             errors.objects.append(
               Associations::NestedError.new(association, error)


### PR DESCRIPTION
Fixes #53544

Repro:

```ruby
require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"

  gem "rails", ">= 7.2.0"
  gem "sqlite3"
end

require "active_record/railtie"
require "minitest/autorun"

ENV["DATABASE_URL"] = "sqlite3::memory:"

class TestApp < Rails::Application
  config.load_defaults Rails::VERSION::STRING.to_f
  config.eager_load = false
  config.logger = Logger.new($stdout)
  config.secret_key_base = "secret_key_base"
end
Rails.application.initialize!

ActiveRecord::Schema.define do
  create_table :comments, force: true do |t|
    t.integer :parent_comment_id
    t.text :text
  end
end

class Comment < ActiveRecord::Base
  has_many :child_comments, class_name: "Comment", foreign_key: "parent_comment_id", inverse_of: :parent_comment, dependent: :nullify
  belongs_to :parent_comment, class_name: "Comment", foreign_key: "parent_comment_id", inverse_of: :child_comments, optional: true
  accepts_nested_attributes_for :child_comments

  validates_presence_of :text
end

class BugTest < ActiveSupport::TestCase
  def test_association_stuff
    child = Comment.new
    child.child_comments << child
    child.save
    assert_equal 0, child.child_comments.count
  end
end
```