### PR TITLE
Fix benchmark_generator_test

### DIFF
--- a/railties/test/generators/benchmark_generator_test.rb
+++ b/railties/test/generators/benchmark_generator_test.rb
@@ -27,8 +27,6 @@ module Rails
 
             # Any benchmarking setup goes here...
 
-
-
             Benchmark.ips do |x|
               x.report("before") { }
               x.report("after") { }
@@ -59,8 +57,6 @@ module Rails
             require_relative "../../config/environment"
 
             # Any benchmarking setup goes here...
-
-
 
             Benchmark.ips do |x|
               x.report("with_patch") { }


### PR DESCRIPTION
```
$ bin/test test/generators/benchmark_generator_test.rb

Run options: --seed 39734

F

Failure:
Rails::Generators::BenchmarkGeneratorTest#test_generate_benchmark [test/generators/benchmark_generator_test.rb:22]:
--- expected
+++ actual
@@ -4,8 +4,6 @@

 # Any benchmarking setup goes here...

-
-
 Benchmark.ips do |x|
   x.report(\"before\") { }
   x.report(\"after\") { }

bin/test test/generators/benchmark_generator_test.rb:15

..F

Failure:
Rails::Generators::BenchmarkGeneratorTest#test_generate_benchmark_with_reports [test/generators/benchmark_generator_test.rb:55]:
--- expected
+++ actual
@@ -4,8 +4,6 @@

 # Any benchmarking setup goes here...

-
-
 Benchmark.ips do |x|
   x.report(\"with_patch\") { }
   x.report(\"without_patch\") { }

bin/test test/generators/benchmark_generator_test.rb:52
```

Caused by #54173
Examble build: 
https://buildkite.com/rails/rails/builds/115520#01944f5c-edce-4758-8871-3a2c48a11743/1251-1260