### PR TITLE
Fix inserts on MySQL with no `RETURNING` support for a table with multiple auto populated columns

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -174,6 +174,10 @@ module ActiveRecord
         mariadb? && database_version >= "10.5.0"
       end
 
+      def return_value_after_insert?(column) # :nodoc:
+        supports_insert_returning? ? column.auto_populated? : column.auto_increment?
+      end
+
       def get_advisory_lock(lock_name, timeout = 0) # :nodoc:
         query_value("SELECT GET_LOCK(#{quote(lock_name.to_s)}, #{timeout})") == 1
       end

--- a/activerecord/test/cases/persistence_test.rb
+++ b/activerecord/test/cases/persistence_test.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "cases/helper"
+require "models/auto_id"
 require "models/aircraft"
 require "models/dashboard"
 require "models/clothing_item"
@@ -36,6 +37,22 @@ class PersistenceTest < ActiveRecord::TestCase
     topic = TitlePrimaryKeyTopic.create!(title: "title pk topic")
 
     assert_not_nil topic.attributes["id"]
+  end
+
+  def test_populates_autoincremented_id_pk_regardless_of_its_position_in_columns_list
+    auto_populated_column_names = AutoId.columns.select(&:auto_populated?).map(&:name)
+
+    # It's important we test a scenario where tables has more than one auto populated column
+    # and the first column is not the primary key. Otherwise it will be a regular test not asserting this special case.
+    assert auto_populated_column_names.size > 1
+    assert_not_equal AutoId.primary_key, auto_populated_column_names.first
+
+    record = AutoId.create!
+    last_id = AutoId.last.id
+
+    assert_not_nil last_id
+    assert last_id > 0
+    assert_equal last_id, record.id
   end
 
   def test_populates_non_primary_key_autoincremented_column_for_a_cpk_model

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -105,8 +105,9 @@ ActiveRecord::Schema.define do
   end
 
   create_table :auto_id_tests, force: true, id: false do |t|
-    t.primary_key :auto_id
     t.integer     :value
+    t.timestamp   :published_at, default: -> { "CURRENT_TIMESTAMP" }
+    t.primary_key :auto_id
   end
 
   create_table :binaries, force: true do |t|


### PR DESCRIPTION
This bug existed from `7.2` so we may need to consider backporting the fix

Fixes https://github.com/rails/rails/issues/54136
Additional fix for https://github.com/rails/rails/issues/50001

c2c861f98ae25d0daa177898db48f12de1065cf6 wasn't a sufficient fix for tables that have more than just one auto populated column but the database doesn't support `RETURNING` statement.

This commit ensures that mysql adapters will only consider `auto_increment` columns to be returned after insert which also implies that only one column can be returned after insert.

Essentially what I'm trying to achieve is to ensure that `Model._returning_columns_for_insert` never returns more than one column for databases where we know `RETURNING` is not a thing and only one auto-incremented column can be returned.
Though I'm not making any explicit assertion for that as `_returning_columns_for_insert` is just an internal concept and can change behind the scenes.