### PR TITLE
Delegate `ActiveStorage::Filename#to_str` to `#to_s`

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,16 @@
+*   Delegate `ActiveStorage::Filename#to_str` to `#to_s`
+
+    Supports checking String equality:
+
+    ```ruby
+    filename = ActiveStorage::Filename.new("file.txt")
+    filename == "file.txt" # => true
+    filename in "file.txt" # => true
+    "file.txt" == filename # => true
+    ```
+
+    *Sean Doyle*
+
 *   Add support for alternative MD5 implementation through `config.active_storage.checksum_implementation`.
 
     Also automatically degrade to using the slower `Digest::MD5` implementation if `OpenSSL::Digest::MD5`

--- a/activestorage/app/models/active_storage/filename.rb
+++ b/activestorage/app/models/active_storage/filename.rb
@@ -64,6 +64,7 @@ class ActiveStorage::Filename
   def to_s
     sanitized.to_s
   end
+  alias_method :to_str, :to_s
 
   def as_json(*)
     to_s

--- a/activestorage/test/models/filename_test.rb
+++ b/activestorage/test/models/filename_test.rb
@@ -54,6 +54,12 @@ class ActiveStorage::FilenameTest < ActiveSupport::TestCase
     assert_operator ActiveStorage::Filename.new("foo-bar.pdf"), :==, ActiveStorage::Filename.new("foo\tbar.pdf")
   end
 
+  test "String equality" do
+    assert_operator "foo-bar.pdf", :===, ActiveStorage::Filename.new("foo-bar.pdf")
+    assert_equal "foo-bar.pdf", ActiveStorage::Filename.new("foo-bar.pdf")
+    assert_pattern { ActiveStorage::Filename.new("foo-bar.pdf") => "foo-bar.pdf" }
+  end
+
   test "encoding to json" do
     assert_equal '"foo.pdf"', ActiveStorage::Filename.new("foo.pdf").to_json
     assert_equal '{"filename":"foo.pdf"}', { filename: ActiveStorage::Filename.new("foo.pdf") }.to_json


### PR DESCRIPTION
### Motivation / Background

Supports checking String equality:

```ruby
filename = ActiveStorage::Filename.new("file.txt")
filename == "file.txt" # => true
filename in "file.txt" # => true
"file.txt" == filename # => true
```

Prior to this change, tests asserting equality would need to coerce the `ActiveStorage::Filename` instance to a string:

```ruby
blob = # create ActiveStorage::Blob

assert_equal "file.txt", blob.filename.to_s
```

After this change, the equality check will automatically coerce:

```ruby
blob = # create ActiveStorage::Blob

assert_equal "file.txt", blob.filename
```

### Additional information

As an added benefit, the filename will match in `case` and `if ... in` statements:

```ruby
blob = # create ActiveStorage::Blob
filename = blob.filename

case filename
when "file.txt" then ...
end

if filename in "file.txt"
  # ...
end
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
