### PR TITLE
Fix load_active_support initializer doc [ci skip]

### DIFF
--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -3869,7 +3869,7 @@ Below is a comprehensive list of all the initializers found in Rails in the orde
 
 * `load_environment_hook`: Serves as a placeholder so that `:load_environment_config` can be defined to run before it.
 
-* `load_active_support`: Requires `active_support/dependencies` which sets up the basis for Active Support. Optionally requires `active_support/all` if `config.active_support.bare` is un-truthful, which is the default.
+* `load_active_support`: Optionally requires `active_support/all` if `config.active_support.bare` is un-truthful, which is the default.
 
 * `initialize_logger`: Initializes the logger (an `ActiveSupport::BroadcastLogger` object) for the application and makes it accessible at `Rails.logger`, provided that no initializer inserted before this point has defined `Rails.logger`.
 


### PR DESCRIPTION
I went through git history and can't find a time where it ever loaded Dependencies, it seems like it's always dealt with `active_support/all` and for at least one commit it applied some `config.active_support` values.