### PR TITLE
Allow configuring Active Storage base controller parent class

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Allow configuring Active Storage base controller parent class
+
+    This enables users to change the parent class for
+    `ActiveStorage::BaseController`, including the option to inherit from
+    `ActionController::API` for api-only apps.
+
+    *Andrew White*, *Santiago Bartesaghi*, *zzak*
+
 *   Fix image analyzer reporting wrong dimensions for EXIF orientations involving a mirror.
 
     `rotated_image?` was swapping width/height for orientations 2 and 4 (flip-only, no 90°

--- a/activestorage/app/controllers/active_storage/base_controller.rb
+++ b/activestorage/app/controllers/active_storage/base_controller.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
 # The base class for all Active Storage controllers.
-class ActiveStorage::BaseController < ActionController::Base
+class ActiveStorage::BaseController < ActiveStorage.base_controller_parent.constantize
   include ActiveStorage::SetCurrent
 
-  protect_from_forgery with: :exception
+  protect_from_forgery with: :exception if respond_to?(:protect_against_forgery?)
 
-  self.etag_with_template_digest = false
+  self.etag_with_template_digest = false if respond_to?(:etag_with_template_digest)
 end

--- a/activestorage/app/controllers/active_storage/disk_controller.rb
+++ b/activestorage/app/controllers/active_storage/disk_controller.rb
@@ -7,7 +7,9 @@
 class ActiveStorage::DiskController < ActiveStorage::BaseController
   include ActiveStorage::FileServer
 
-  skip_forgery_protection
+  if respond_to?(:skip_forgery_protection)
+    skip_forgery_protection
+  end
 
   def show
     if key = decode_verified_key

--- a/activestorage/lib/active_storage.rb
+++ b/activestorage/lib/active_storage.rb
@@ -367,6 +367,8 @@ module ActiveStorage
   mattr_accessor :draw_routes, default: true
   mattr_accessor :resolve_model_to_route, default: :rails_storage_redirect
 
+  mattr_accessor :base_controller_parent, default: "::ActionController::Base"
+
   mattr_accessor :track_variants, default: false
 
   singleton_class.attr_accessor :checksum_implementation

--- a/activestorage/lib/active_storage/engine.rb
+++ b/activestorage/lib/active_storage/engine.rb
@@ -127,6 +127,13 @@ module ActiveStorage
         ActiveStorage.draw_routes       = app.config.active_storage.draw_routes != false
         ActiveStorage.resolve_model_to_route = app.config.active_storage.resolve_model_to_route || :rails_storage_redirect
 
+        ActiveStorage.base_controller_parent = app.config.active_storage.base_controller_parent ||
+          if app.config.api_only
+            "::ActionController::API"
+          else
+            "::ActionController::Base"
+          end
+
         ActiveStorage.supported_image_processing_methods += app.config.active_storage.supported_image_processing_methods || []
         ActiveStorage.unsupported_image_processing_arguments = app.config.active_storage.unsupported_image_processing_arguments || %w(
           -debug

--- a/railties/test/application/active_storage/direct_uploads_integration_test.rb
+++ b/railties/test/application/active_storage/direct_uploads_integration_test.rb
@@ -1,0 +1,192 @@
+# frozen_string_literal: true
+
+require "isolation/abstract_unit"
+require "rack/test"
+require "rails-dom-testing"
+
+module ApplicationTests
+  class DirectUploadsIntegrationTest < ActiveSupport::TestCase
+    include ActiveSupport::Testing::Isolation
+    include Rack::Test::Methods
+    include Rails::Dom::Testing::Assertions
+
+    self.file_fixture_path = "#{RAILS_FRAMEWORK_ROOT}/activestorage/test/fixtures/files"
+
+    def setup
+      build_app
+    end
+
+    def teardown
+      teardown_app
+    end
+
+    def test_creating_new_upload
+      rails "active_storage:install"
+      rails "db:migrate"
+
+      app("development")
+
+      file = file_fixture("racecar.jpg")
+      checksum = OpenSSL::Digest::MD5.new(file.read).base64digest
+      key = SecureRandom.base58(24)
+
+      file_data = {
+        key: key,
+        filename: file.basename.to_s,
+        content_type: "image/jpeg",
+        byte_size: file.size,
+        checksum: checksum
+      }
+
+      post(
+        "/rails/active_storage/direct_uploads",
+        { blob: file_data }.to_json,
+        { "CONTENT_TYPE" => "application/json" }
+      )
+      assert_equal 200, last_response.status
+
+      response_data = JSON.parse(last_response.body)
+
+      assert_equal "image/jpeg", response_data["content_type"]
+      assert_equal checksum, response_data["checksum"]
+      assert_equal file.size, response_data["byte_size"]
+      assert_equal file.basename.to_s, response_data["filename"]
+      assert_equal "local", response_data["service_name"]
+    end
+
+    def test_creating_new_upload_with_forgery_protection_enabled
+      add_to_config "config.action_controller.allow_forgery_protection = true"
+      rails "active_storage:install"
+      rails "db:migrate"
+
+      app("development")
+
+      file = file_fixture("racecar.jpg")
+      checksum = OpenSSL::Digest::MD5.new(file.read).base64digest
+      key = SecureRandom.base58(24)
+
+      file_data = {
+        key: key,
+        filename: file.basename.to_s,
+        content_type: "image/jpeg",
+        byte_size: file.size,
+        checksum: checksum
+      }
+
+      post(
+        "/rails/active_storage/direct_uploads",
+        { blob: file_data }.to_json,
+        { "CONTENT_TYPE" => "application/json", "HTTP_SEC_FETCH_SITE" => "cross-site" }
+      )
+      assert_equal 422, last_response.status
+    end
+
+    def test_api_only
+      add_to_config "config.api_only = true"
+      rails "active_storage:install"
+      rails "db:migrate"
+
+      app("development")
+
+      file = file_fixture("racecar.jpg")
+      checksum = OpenSSL::Digest::MD5.new(file.read).base64digest
+      key = SecureRandom.base58(24)
+
+      file_data = {
+        key: key,
+        filename: file.basename.to_s,
+        content_type: "image/jpeg",
+        byte_size: file.size,
+        checksum: checksum
+      }
+
+      post(
+        "/rails/active_storage/direct_uploads",
+        { blob: file_data }.to_json,
+        { "CONTENT_TYPE" => "application/json" }
+      )
+      assert_equal 200, last_response.status
+      response_data = JSON.parse(last_response.body)
+
+      assert_equal "image/jpeg", response_data["content_type"]
+      assert_equal checksum, response_data["checksum"]
+      assert_equal file.size, response_data["byte_size"]
+      assert_equal file.basename.to_s, response_data["filename"]
+      assert_equal "local", response_data["service_name"]
+    end
+
+    def test_etag_with_template_digest
+      rails "active_storage:install"
+      rails "db:migrate"
+
+      app("development")
+
+      file = file_fixture("racecar.jpg")
+      checksum = OpenSSL::Digest::MD5.new(file.read).base64digest
+      key = SecureRandom.base58(24)
+
+      file_data = {
+        key: key,
+        filename: file.basename.to_s,
+        content_type: "image/jpeg",
+        byte_size: file.size,
+        checksum: checksum
+      }
+
+      post(
+        "/rails/active_storage/direct_uploads",
+        { blob: file_data }.to_json,
+        { "CONTENT_TYPE" => "application/json" }
+      )
+      assert_equal 200, last_response.status
+
+      response_data = JSON.parse(last_response.body)
+
+      assert_equal "image/jpeg", response_data["content_type"]
+      assert_equal checksum, response_data["checksum"]
+      assert_equal file.size, response_data["byte_size"]
+      assert_equal file.basename.to_s, response_data["filename"]
+      assert_equal "local", response_data["service_name"]
+
+      expected_etag = generate_etag(last_response.body)
+      assert_equal expected_etag, last_response.headers["ETag"]
+    end
+
+    def test_api_only_with_custom_session
+      remove_from_config "config.action_controller.allow_forgery_protection = false"
+      add_to_config "config.api_only = true"
+      add_to_config "config.active_storage.base_controller_parent = \"::ActionController::Base\""
+      add_to_config "config.session_store :cookie_store, key: '_myapp_session'"
+      add_to_config "config.middleware.use config.session_store, config.session_options"
+
+      rails "active_storage:install"
+      rails "db:migrate"
+
+      app("development")
+
+      file = file_fixture("racecar.jpg")
+      checksum = OpenSSL::Digest::MD5.new(file.read).base64digest
+      key = SecureRandom.base58(24)
+
+      file_data = {
+        key: key,
+        filename: file.basename.to_s,
+        content_type: "image/jpeg",
+        byte_size: file.size,
+        checksum: checksum
+      }
+
+      post(
+        "/rails/active_storage/direct_uploads",
+        { blob: file_data }.to_json,
+        { "CONTENT_TYPE" => "application/json", "HTTP_SEC_FETCH_SITE" => "cross-site" }
+      )
+      assert_equal 422, last_response.status
+    end
+
+    private
+      def generate_etag(body)
+        "W/\"#{ActiveSupport::Digest.hexdigest(body)}\""
+      end
+  end
+end


### PR DESCRIPTION
This enables users to change the parent class for ActiveStorage::BaseController, including the option to inherit from ActionController::API for api-only apps.

Fixes #32208
Rebase of #32238 with tests and using the approach to configure the parent with a flag as suggested here:
https://github.com/rails/rails/pull/32238#issuecomment-1141969885