### PR TITLE
Cleanup some private constants from API doc

### DIFF
--- a/actionpack/lib/action_controller/metal/request_forgery_protection.rb
+++ b/actionpack/lib/action_controller/metal/request_forgery_protection.rb
@@ -626,6 +626,7 @@ module ActionController # :nodoc:
         If you cannot change the referrer policy, you can disable origin checking with the
         Rails.application.config.action_controller.forgery_protection_origin_check setting.
       MSG
+      private_constant :NULL_ORIGIN_MESSAGE
 
       # Checks if the request originated from the same origin by looking at the Origin
       # header.

--- a/actionpack/lib/action_dispatch/http/filter_parameters.rb
+++ b/actionpack/lib/action_dispatch/http/filter_parameters.rb
@@ -17,9 +17,11 @@ module ActionDispatch
     # For more information about filter behavior, see
     # ActiveSupport::ParameterFilter.
     module FilterParameters
-      ENV_MATCH = [/RAW_POST_DATA/, "rack.request.form_vars"] # :nodoc:
-      NULL_PARAM_FILTER = ActiveSupport::ParameterFilter.new # :nodoc:
-      NULL_ENV_FILTER   = ActiveSupport::ParameterFilter.new ENV_MATCH # :nodoc:
+      # :stopdoc:
+      ENV_MATCH = [/RAW_POST_DATA/, "rack.request.form_vars"]
+      NULL_PARAM_FILTER = ActiveSupport::ParameterFilter.new
+      NULL_ENV_FILTER   = ActiveSupport::ParameterFilter.new ENV_MATCH
+      # :startdoc:
 
       def initialize
         super


### PR DESCRIPTION
* Make RequestForgeryProtection::NULL_ORIGIN_MESSAGE private
  * https://edgeapi.rubyonrails.org/classes/ActionController/RequestForgeryProtection.html#constant-NULL_ORIGIN_MESSAGE

* Make FilterParameters#ENV_MATCH, NULL_ENV_FILTER, NULL_PARAM_FILTER nodoc
  * https://edgeapi.rubyonrails.org/classes/ActionDispatch/Http/FilterParameters.html#constant-ENV_MATCH