### PR TITLE
Don't dup query values if they're frozen

### DIFF
--- a/activerecord/lib/active_record/relation/query_attribute.rb
+++ b/activerecord/lib/active_record/relation/query_attribute.rb
@@ -15,7 +15,9 @@ module ActiveRecord
         elsif @type.serialized?
           value_for_database
         elsif @type.mutable? # If the type is simply mutable, we deep_dup it.
-          @value_before_type_cast = @value_before_type_cast.deep_dup
+          unless @value_before_type_cast.frozen?
+            @value_before_type_cast = @value_before_type_cast.deep_dup
+          end
         end
       end
 


### PR DESCRIPTION
We shouldn't dup query values if those values are frozen.  For example if you have a script like:

```ruby
class Post < ActiveRecord::Base
  default_scope { where(author: "foo", title: "bar") }
end
```

The "foo" and "bar" strings would get dup'd even if you have frozen_string_literals set.  I think this impacts all `where` calls, not just default_scope, and I think frozen string literals are more common so this should help more than just default_scope