### PR TITLE
Add `railspect requires` for auditing `require`s

### DIFF
--- a/actiontext/lib/action_text/rendering.rb
+++ b/actiontext/lib/action_text/rendering.rb
@@ -2,7 +2,6 @@
 
 # :markup: markdown
 
-require "active_support/concern"
 require "active_support/core_ext/module/attribute_accessors_per_thread"
 
 module ActionText

--- a/activemodel/lib/active_model/error.rb
+++ b/activemodel/lib/active_model/error.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "active_support/core_ext/class/attribute"
 
 module ActiveModel
   # = Active \Model \Error

--- a/activemodel/lib/active_model/naming.rb
+++ b/activemodel/lib/active_model/naming.rb
@@ -3,7 +3,6 @@
 require "active_support/core_ext/hash/except"
 require "active_support/core_ext/module/introspection"
 require "active_support/core_ext/module/redefine_method"
-require "active_support/core_ext/module/delegation"
 
 module ActiveModel
   class Name

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "active_support/core_ext/enumerable"
-require "active_support/core_ext/module/delegation"
 require "active_support/parameter_filter"
 require "concurrent/map"
 

--- a/activerecord/lib/active_record/errors.rb
+++ b/activerecord/lib/active_record/errors.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "active_support/deprecation"
 
 module ActiveRecord
   include ActiveSupport::Deprecation::DeprecatedConstantAccessor

--- a/activerecord/lib/active_record/explain_registry.rb
+++ b/activerecord/lib/active_record/explain_registry.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "active_support/core_ext/module/delegation"
 
 module ActiveRecord
   # This is a thread locals registry for EXPLAIN. For example

--- a/activerecord/lib/active_record/relation/delegation.rb
+++ b/activerecord/lib/active_record/relation/delegation.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "active_support/core_ext/module/delegation"
 
 module ActiveRecord
   module Delegation # :nodoc:

--- a/activerecord/lib/active_record/scoping.rb
+++ b/activerecord/lib/active_record/scoping.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "active_support/core_ext/module/delegation"
 
 module ActiveRecord
   module Scoping

--- a/activestorage/lib/active_storage/attached.rb
+++ b/activestorage/lib/active_storage/attached.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "active_support/core_ext/module/delegation"
 
 module ActiveStorage
   # = Active Storage \Attached

--- a/activestorage/lib/active_storage/service/mirror_service.rb
+++ b/activestorage/lib/active_storage/service/mirror_service.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "active_support/core_ext/module/delegation"
 
 module ActiveStorage
   # = Active Storage Mirror \Service

--- a/railties/lib/rails.rb
+++ b/railties/lib/rails.rb
@@ -3,10 +3,9 @@
 require "pathname"
 
 require "active_support"
+require "active_support/rails"
 require "active_support/core_ext/kernel/reporting"
-require "active_support/core_ext/module/delegation"
 require "active_support/core_ext/array/extract_options"
-require "active_support/core_ext/object/blank"
 
 require "rails/version"
 require "rails/deprecator"

--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -2,10 +2,8 @@
 
 require "yaml"
 require "active_support/core_ext/hash/keys"
-require "active_support/core_ext/object/blank"
 require "active_support/key_generator"
 require "active_support/message_verifiers"
-require "active_support/deprecation"
 require "active_support/encrypted_configuration"
 require "active_support/hash_with_indifferent_access"
 require "active_support/configuration_file"

--- a/railties/lib/rails/application/routes_reloader.rb
+++ b/railties/lib/rails/application/routes_reloader.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "active_support/core_ext/module/delegation"
 
 module Rails
   class Application

--- a/railties/lib/rails/command.rb
+++ b/railties/lib/rails/command.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 require "active_support"
+require "active_support/rails"
 require "active_support/core_ext/enumerable"
-require "active_support/core_ext/object/blank"
 require "rails/deprecator"
 
 require "thor"

--- a/railties/lib/rails/command/base.rb
+++ b/railties/lib/rails/command/base.rb
@@ -3,8 +3,6 @@
 require "thor"
 require "erb"
 
-require "active_support/core_ext/class/attribute"
-require "active_support/core_ext/module/delegation"
 require "active_support/core_ext/string/inflections"
 
 require "rails/command/actions"

--- a/railties/lib/rails/command/environment_argument.rb
+++ b/railties/lib/rails/command/environment_argument.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "active_support"
-require "active_support/core_ext/class/attribute"
 
 module Rails
   module Command

--- a/railties/lib/rails/engine.rb
+++ b/railties/lib/rails/engine.rb
@@ -3,7 +3,6 @@
 require "rails/railtie"
 require "rails/engine/railties"
 require "active_support/callbacks"
-require "active_support/core_ext/module/delegation"
 require "active_support/core_ext/object/try"
 require "pathname"
 

--- a/railties/lib/rails/generators/migration.rb
+++ b/railties/lib/rails/generators/migration.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "active_support/concern"
 require "rails/generators/actions/create_migration"
 
 module Rails

--- a/railties/lib/rails/generators/testing/behavior.rb
+++ b/railties/lib/rails/generators/testing/behavior.rb
@@ -1,11 +1,8 @@
 # frozen_string_literal: true
 
-require "active_support/core_ext/class/attribute"
-require "active_support/core_ext/module/delegation"
 require "active_support/core_ext/hash/reverse_merge"
 require "active_support/core_ext/kernel/reporting"
 require "active_support/testing/stream"
-require "active_support/concern"
 require "rails/generators"
 
 module Rails

--- a/railties/lib/rails/initializable.rb
+++ b/railties/lib/rails/initializable.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "tsort"
-require "active_support/core_ext/module/delegation"
 
 module Rails
   module Initializable

--- a/railties/lib/rails/railtie.rb
+++ b/railties/lib/rails/railtie.rb
@@ -4,7 +4,6 @@ require "rails/initializable"
 require "active_support/descendants_tracker"
 require "active_support/inflector"
 require "active_support/core_ext/module/introspection"
-require "active_support/core_ext/module/delegation"
 
 module Rails
   # +Rails::Railtie+ is the core of the \Rails framework and provides

--- a/railties/lib/rails/railtie/configurable.rb
+++ b/railties/lib/rails/railtie/configurable.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "active_support/concern"
 
 module Rails
   class Railtie

--- a/railties/lib/rails/test_unit/reporter.rb
+++ b/railties/lib/rails/test_unit/reporter.rb
@@ -1,12 +1,13 @@
 # frozen_string_literal: true
 
-require "active_support/core_ext/class/attribute"
 require "minitest"
 
 module Rails
   class TestUnitReporter < Minitest::StatisticsReporter
-    class_attribute :app_root
-    class_attribute :executable, default: "bin/rails test"
+    singleton_class.attr_accessor :app_root
+
+    @executable = "bin/rails test"
+    singleton_class.attr_accessor :executable
 
     def prerecord(test_class, test_name)
       super
@@ -86,7 +87,7 @@ module Rails
           result.method(result.name).source_location
         end
 
-        "#{executable} #{relative_path_for(location)}:#{line}"
+        "#{self.class.executable} #{relative_path_for(location)}:#{line}"
       end
 
       def app_root

--- a/tools/rail_inspector/lib/rail_inspector.rb
+++ b/tools/rail_inspector/lib/rail_inspector.rb
@@ -25,4 +25,14 @@ require_relative "rail_inspector/version"
 # SOFTWARE.
 
 module RailInspector
+  class << self
+    def frameworks(rails_path)
+      @frameworks ||= begin
+        spec = Gem::Specification.load(rails_path.join("rails.gemspec").to_s)
+        names = spec.dependencies.map(&:name)
+        names.delete("bundler")
+        names
+      end
+    end
+  end
 end

--- a/tools/rail_inspector/lib/rail_inspector/cli.rb
+++ b/tools/rail_inspector/lib/rail_inspector/cli.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "thor"
+require_relative "../rail_inspector"
 
 module RailInspector
   class Cli < Thor
@@ -29,6 +30,14 @@ module RailInspector
       exit checker.errors.empty? unless options[:autocorrect]
 
       checker.write!
+    end
+
+    desc "requires RAILS_PATH", "Check for autoloads being required"
+    option :autocorrect, type: :boolean, aliases: :a
+    def requires(rails_path)
+      require_relative "./requires"
+
+      exit Requires.new(rails_path, options[:autocorrect]).call
     end
   end
 end

--- a/tools/rail_inspector/lib/rail_inspector/requires.rb
+++ b/tools/rail_inspector/lib/rail_inspector/requires.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+require "active_support"
+require "active_support/core_ext/string"
+require "prism"
+
+require_relative "./visitor/load"
+
+module RailInspector
+  class Requires
+    def initialize(rails_path, autocorrect)
+      @loads = {}
+      @rails_path = Pathname.new(rails_path)
+      @exit = true
+      @autocorrect = autocorrect
+    end
+
+    def call
+      populate_loads
+
+      prevent_active_support_rails_requires
+
+      @exit
+    end
+
+    private
+      def populate_loads
+        current_file = nil
+        v = Visitor::Load.new { @loads[current_file] }
+
+        @rails_path.glob("{#{frameworks.join(",")}}/lib/**/*.rb") do |file_pathname|
+          current_file = file_pathname.to_s
+
+          @loads[current_file] = { requires: [], autoloads: [] }
+
+          Prism.parse_file(current_file).value.accept(v)
+        end
+      end
+
+      def prevent_active_support_rails_requires
+        frameworks.each do |framework|
+          next if framework == "activesupport"
+
+          @rails_path.glob("#{framework}/lib/*.rb").each do |root_path|
+            root_requires = @loads[root_path.to_s][:requires]
+            next if root_requires.include?("active_support/rails")
+
+            # required transitively
+            next if root_requires.include?("action_dispatch")
+            # action_pack namespace doesn't include any code
+            # arel does not depend on active_support at all
+            next if ["action_pack.rb", "arel.rb"].include?(root_path.basename.to_s)
+
+            @exit = false
+            puts root_path
+            puts "  + \"active_support/rails\" (framework root)"
+          end
+        end
+
+        active_support_rails_requires = @loads["activesupport/lib/active_support/rails.rb"][:requires]
+
+        duplicated_requires = {}
+
+        @loads.each do |path, file_loads|
+          next if path.start_with? "activesupport"
+
+          if active_support_rails_requires.intersect?(file_loads[:requires])
+            duplicated_requires[path] = active_support_rails_requires.intersection(file_loads[:requires])
+          end
+        end
+
+        duplicated_requires.each do |path, offenses|
+          @exit = false
+          puts path
+          offenses.each do |duplicate_require|
+            puts "  - #{duplicate_require} (active_support/rails)"
+
+            next unless @autocorrect
+
+            file = File.read(path)
+            file.gsub!("require \"#{duplicate_require}\"\n", "")
+
+            File.write(path, file)
+          end
+        end
+      end
+
+      def frameworks
+        RailInspector.frameworks(@rails_path)
+      end
+  end
+end

--- a/tools/rail_inspector/lib/rail_inspector/visitor/load.rb
+++ b/tools/rail_inspector/lib/rail_inspector/visitor/load.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require "prism"
+
+module RailInspector
+  module Visitor
+    class Load < Prism::Visitor
+      def initialize(&block)
+        @current_loads = block
+        @namespace_stack = []
+      end
+
+      def visit_module_node(node)
+        case node.constant_path
+        in Prism::ConstantReadNode[name:]
+          @namespace_stack << name
+        in Prism::ConstantPathNode
+          @namespace_stack << node.constant_path.full_name
+        end
+
+        super
+
+        @namespace_stack.pop
+      end
+      alias visit_class_node visit_module_node
+
+      def visit_call_node(node)
+        case node.name
+        when :require
+          case node.arguments.arguments[0]
+          in Prism::StringNode[unescaped:]
+            @current_loads.call[:requires] << unescaped
+          else
+            # dynamic require, like "active_support/cache/#{store}"
+          end
+        when :autoload
+          case node.arguments.arguments
+          in [Prism::SymbolNode[unescaped:]]
+            namespaced_const = @namespace_stack.join("::")
+            namespaced_const << "::" << unescaped
+
+            @current_loads.call[:autoloads] << namespaced_const.underscore
+          in [Prism::SymbolNode, Prism::StringNode[unescaped:]]
+            @current_loads.call[:autoloads] << unescaped
+          end
+        end
+      end
+    end
+  end
+end

--- a/tools/rail_inspector/test/rail_inspector/visitor/load_test.rb
+++ b/tools/rail_inspector/test/rail_inspector/visitor/load_test.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "rail_inspector/visitor/load"
+
+class LoadTest < Minitest::Test
+  def test_finds_requires_and_autoloads
+    source = <<~FILE
+    require "a"
+    require "b"
+
+    module D
+      require "k"
+
+      autoload :L
+      autoload :M, "n/o"
+
+      class E::F
+        require "p/q"
+
+        autoload :G
+        autoload :H, "i/j"
+      end
+    end
+    FILE
+
+    loads = { requires: [], autoloads: [] }
+
+    visitor = RailInspector::Visitor::Load.new { loads }
+    Prism.parse(source).value.accept(visitor)
+
+    assert_equal ["a", "b", "k", "p/q"], loads[:requires]
+    assert_equal ["d/l", "n/o", "d/e/f/g", "i/j"], loads[:autoloads]
+  end
+end


### PR DESCRIPTION
This first commit sets up the command, a visitor to gather data, and a simple lint to demonstrate its use.

This first lint ensures that "active_support/rails" is required in all frameworks (one was missing this require but this was addressed in a [previous commit][1]), and then checks that none of the requires in "active_support/rails" are called again (except in Active Support since it does not require "active_support/rails").

[1]: https://github.com/skipkayhil/rails/commit/2e920b0097dab768738ea20849dec8029f31e14e

---

`./tools/railspect requires . -a` + manual fixes

Manually add require to lib/rails.rb because it's a framework entrypoint, lib/rails/command.rb because its the entrypoint for the
CLI.

Additionally migrated Rails::TestUnitReporter off of `class_attribute` since the class is internal and doesn't need the additional features (It gets required very early when running Rails' test suite).
