### PR TITLE
Really make sure AS::Deprecation::Reporting constants are private

### DIFF
--- a/activesupport/lib/active_support/deprecation/reporting.rb
+++ b/activesupport/lib/active_support/deprecation/reporting.rb
@@ -149,8 +149,10 @@ module ActiveSupport
           [offending_line.path, offending_line.lineno, offending_line.label]
         end
 
-        RAILS_GEM_ROOT = File.expand_path("../../../..", __dir__) + "/" # :nodoc:
-        LIB_DIR = RbConfig::CONFIG["libdir"] # :nodoc:
+        RAILS_GEM_ROOT = File.expand_path("../../../..", __dir__) + "/"
+        private_constant :RAILS_GEM_ROOT
+        LIB_DIR = RbConfig::CONFIG["libdir"]
+        private_constant :LIB_DIR
 
         def ignored_callstack?(path)
           path.start_with?(RAILS_GEM_ROOT, LIB_DIR) || path.include?("<internal:")


### PR DESCRIPTION
When fixing #54190 I remembered this patch back in #52853, which actually did _not_ fix the issue:
https://edgeapi.rubyonrails.org/classes/ActiveSupport/Deprecation/Reporting.html#constant-LIB_DIR

This is because a constant declared after the `private` keyword is still public.
Alternatively we can `:stopdoc:` around these, but they probably should really be private constants.

I imagine this shouldn't be backported though.