### PR TITLE
Replace Forwardable with ActiveSupport::Delegation

### DIFF
--- a/activemodel/lib/active_model/errors.rb
+++ b/activemodel/lib/active_model/errors.rb
@@ -5,7 +5,6 @@ require "active_support/core_ext/string/inflections"
 require "active_support/core_ext/object/deep_dup"
 require "active_model/error"
 require "active_model/nested_error"
-require "forwardable"
 
 module ActiveModel
   # = Active \Model \Errors
@@ -61,8 +60,6 @@ module ActiveModel
   class Errors
     include Enumerable
 
-    extend Forwardable
-
     ##
     # :method: each
     #
@@ -100,7 +97,7 @@ module ActiveModel
     #
     # Returns number of errors.
 
-    def_delegators :@errors, :each, :clear, :empty?, :size, :uniq!
+    delegate :each, :clear, :empty?, :size, :uniq!, to: :@errors
 
     # The actual array of +Error+ objects
     # This method is aliased to <tt>objects</tt>.

--- a/activemodel/lib/active_model/nested_error.rb
+++ b/activemodel/lib/active_model/nested_error.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "active_model/error"
-require "forwardable"
 
 module ActiveModel
   class NestedError < Error
@@ -16,7 +15,6 @@ module ActiveModel
 
     attr_reader :inner_error
 
-    extend Forwardable
-    def_delegators :@inner_error, :message
+    delegate :message, to: :@inner_error
   end
 end


### PR DESCRIPTION
ActiveSupport::Delegation accomplishes the same thing as Forwardable and is already required in all frameworks through `active_support/rails`.