### PR TITLE
Getting Started Unsubscribe Link Section - Add param to the unsubscribe route

### DIFF
--- a/guides/source/getting_started.md
+++ b/guides/source/getting_started.md
@@ -2353,10 +2353,11 @@ module could be used in multiple models to provide the same functionality.
 A subscriber may want to unsubscribe at some point, so let's build that next.
 
 First, we need a route for unsubscribing that will be the URL we include in
-emails.
+emails, explicitly setting the identifying param to `token` (instead of the
+standard `id`).
 
 ```ruby
-  resource :unsubscribe, only: [ :show ]
+  resource :unsubscribe, param: :token, only: [ :show ]
 ```
 
 Active Record has a feature called `generates_token_for` that can generate


### PR DESCRIPTION
### Motivation / Background

The Getting Started guide's Unsubscribe Link Section adds the unsubscribe route without specifying the param as token, but the rest of the code assumes that the param is token and not the default id. Hence, running the code as specified in the current version of the guide results in an error when calling the unsubscribe_url helper. 

This pull request adds the missing param argument to the unsubscribe route declaration, which fixes the above issue.

### Detail

ibid

### Additional information

N/A

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
