### PR TITLE
Flash.add_flash_types should define helpers as private

### DIFF
--- a/actionpack/lib/action_controller/metal/flash.rb
+++ b/actionpack/lib/action_controller/metal/flash.rb
@@ -38,14 +38,11 @@ module ActionController # :nodoc:
           define_method(type) do
             request.flash[type]
           end
+          private type
           helper_method(type) if respond_to?(:helper_method)
 
           self._flash_types += [type]
         end
-      end
-
-      def action_methods # :nodoc:
-        @action_methods ||= super - _flash_types.map(&:to_s).to_set
       end
     end
 

--- a/actionpack/test/controller/flash_test.rb
+++ b/actionpack/test/controller/flash_test.rb
@@ -274,7 +274,7 @@ class FlashIntegrationTest < ActionDispatch::IntegrationTest
 
     def set_bar
       flash[:bar] = "for great justice"
-      head :ok
+      render inline: "<%= bar %>"
     end
 
     def set_flash_optionally
@@ -330,7 +330,7 @@ class FlashIntegrationTest < ActionDispatch::IntegrationTest
     with_test_route_set do
       get "/set_bar"
       assert_response :success
-      assert_equal "for great justice", @controller.bar
+      assert_equal "for great justice", response.body
     end
   end
 
@@ -356,7 +356,7 @@ class FlashIntegrationTest < ActionDispatch::IntegrationTest
     end
   end
 
-  def test_flash_usable_in_metal_without_helper
+  def test_flash_unusable_in_metal_without_helper
     controller_class = nil
 
     assert_nothing_raised do
@@ -367,8 +367,11 @@ class FlashIntegrationTest < ActionDispatch::IntegrationTest
 
     controller = controller_class.new
 
-    assert_respond_to controller, :alert
-    assert_respond_to controller, :notice
+    assert_not_respond_to controller, :alert
+    assert_not_respond_to controller, :notice
+
+    assert_includes controller.private_methods, :alert
+    assert_includes controller.private_methods, :notice
   end
 
   private

--- a/actionpack/test/controller/helper_test.rb
+++ b/actionpack/test/controller/helper_test.rb
@@ -37,7 +37,7 @@ class JustMeController < ActionController::Base
   clear_helpers
 
   def flash
-    render inline: "<h1><%= notice %></h1>"
+    render inline: "<h1><%= request.flash[:notice] %></h1>"
   end
 
   def lib


### PR DESCRIPTION
Replaces #44868 to fix #44867.

Based on feedback from:
https://github.com/rails/rails/pull/44868#pullrequestreview-1618692109

/cc @r7kamura 

Repro:

```ruby
# frozen_string_literal: true

require 'bundler/inline'

gemfile do
  source 'https://rubygems.org'

  #gem 'rails'
  gem 'rails', path: '~/code/rails'
end

require 'rack/test'
require 'action_controller/railtie'

class TestApp < Rails::Application
  config.root = __dir__
  config.hosts << 'example.org'
  config.session_store :cookie_store, key: 'cookie_store_key'
  config.secret_key_base = 'secret_key_base'

  config.logger = ::Logger.new($stdout)
  ::Rails.logger  = config.logger

  routes.draw do
    get '/notice' => 'test#notice'
  end
end

class TestController < ActionController::Base
  include ::Rails.application.routes.url_helpers

  def notice
    head :ok
  end
end

require 'minitest/autorun'

class BugTest < Minitest::Test
  include ::Rack::Test::Methods

  def test_notice_action
    get '/notice'
    assert last_response.ok?
  end

  private

  def app
    ::Rails.application
  end
end

```