### PR TITLE
Support hash-source in Content Security Policy

### DIFF
--- a/actionpack/lib/action_dispatch/http/content_security_policy.rb
+++ b/actionpack/lib/action_dispatch/http/content_security_policy.rb
@@ -171,6 +171,8 @@ module ActionDispatch # :nodoc:
       worker_src:                 "worker-src"
     }.freeze
 
+    HASH_SOURCE_ALGORITHM_PREFIXES = ["sha256-", "sha384-", "sha512-"].freeze
+
     DEFAULT_NONCE_DIRECTIVES = %w[script-src style-src].freeze
 
     private_constant :MAPPINGS, :DIRECTIVES, :DEFAULT_NONCE_DIRECTIVES
@@ -305,7 +307,13 @@ module ActionDispatch # :nodoc:
           case source
           when Symbol
             apply_mapping(source)
-          when String, Proc
+          when String
+            if hash_source?(source)
+              "'#{source}'"
+            else
+              source
+            end
+          when Proc
             source
           else
             raise ArgumentError, "Invalid content security policy source: #{source.inspect}"
@@ -373,6 +381,10 @@ module ActionDispatch # :nodoc:
 
       def nonce_directive?(directive, nonce_directives)
         nonce_directives.include?(directive)
+      end
+
+      def hash_source?(source)
+        source.start_with?(*HASH_SOURCE_ALGORITHM_PREFIXES)
       end
   end
 end

--- a/actionpack/test/dispatch/content_security_policy_test.rb
+++ b/actionpack/test/dispatch/content_security_policy_test.rb
@@ -269,6 +269,11 @@ class ContentSecurityPolicyTest < ActiveSupport::TestCase
     assert_no_match %r{upgrade-insecure-requests}, @policy.build
   end
 
+  def test_hash_sources
+    @policy.script_src "sha256-hash", "sha384-hash", "sha512-hash", "invalid-hash", "sha256hash"
+    assert_equal "script-src 'sha256-hash' 'sha384-hash' 'sha512-hash' invalid-hash sha256hash", @policy.build
+  end
+
   def test_multiple_sources
     @policy.script_src :self, :https
     assert_equal "script-src 'self' https:", @policy.build


### PR DESCRIPTION

<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

fixed https://github.com/rails/rails/issues/54200



### Detail

The CSP `hash-source` is not enclosed in `'` and is ignored by the browser.

According to the official W3C definition of a `hash-source,` it must be enclosed in `'`.

> hash-source = "'" hash-algorithm "-" base64-value "'"
> hash-algorithm = "sha256" / "sha384" / "sha512"
> https://www.w3.org/TR/CSP3/#grammardef-hash-source

### Additional information

CI is failing on `actioncable integration (3.3) rake test:integration`, but I have a feeling it is not related to this PR.

https://buildkite.com/rails/rails/builds/115605#01945d55-4ce1-4f4d-8f69-3cc3d409537e

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
