### PR TITLE
Update PostgreSQL UUID documentation [ci-skip]

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_definitions.rb
@@ -16,22 +16,10 @@ module ActiveRecord
         #     t.timestamps
         #   end
         #
-        # By default, this will use the <tt>gen_random_uuid()</tt> function from the
-        # +pgcrypto+ extension. As that extension is only available in
-        # PostgreSQL 9.4+, for earlier versions an explicit default can be set
-        # to use <tt>uuid_generate_v4()</tt> from the +uuid-ossp+ extension instead:
+        # By default, this will use the <tt>gen_random_uuid()</tt> function.
         #
-        #   create_table :stuffs, id: false do |t|
-        #     t.primary_key :id, :uuid, default: "uuid_generate_v4()"
-        #     t.uuid :foo_id
-        #     t.timestamps
-        #   end
-        #
-        # To enable the appropriate extension, which is a requirement, use
-        # the +enable_extension+ method in your migrations.
-        #
-        # To use a UUID primary key without any of the extensions, set the
-        # +:default+ option to +nil+:
+        # To use a UUID primary key without any defaults, set the +:default+
+        # option to +nil+:
         #
         #   create_table :stuffs, id: false do |t|
         #     t.primary_key :id, :uuid, default: nil


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because the function has been moved to core since version 13.

### Detail

This Pull Request changes the documentation to not mislead people into installing unnecessary extension when using newer (supported) PostgreSQL.

### Additional information

The documentation seems a bit too complex now (three different conditions, and one partially overlaps the other) and I'd suggest dropping them to bare minimum of version requirement (13+) and mention the extension and different function in passing (or not at all).

Or maybe even drop the whole mention and relevant checks (`supports_pgcrypto_uuid?` etc) as version 12 and lower are no longer supported.

Alternatively, suggest `uuid-ossp`/`uuid_generate_v4` for version up to 12 and ignore `pgcrypto`.

The documentation than can be something like  this instead:

```
        # By default, this will use the <tt>gen_random_uuid()</tt> function.
        # As that function is only available in PostgreSQL 13+, for earlier
        # versions an explicit default can be set to use 
        # <tt>uuid_generate_v4()</tt> from the +uuid-ossp+ extension instead:
```

And update `supports_pgcrypto_uuid?` to just `supports_uuid?` (and the version accordingly)

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
