### PR TITLE
Cleanup ActiveSupport::JSON

### DIFF
--- a/activesupport/lib/active_support/json/decoding.rb
+++ b/activesupport/lib/active_support/json/decoding.rb
@@ -20,7 +20,7 @@ module ActiveSupport
       #   ActiveSupport::JSON.decode("{\"team\":\"rails\",\"players\":\"36\"}")
       #   => {"team" => "rails", "players" => "36"}
       def decode(json)
-        data = ::JSON.parse(json, quirks_mode: true)
+        data = ::JSON.parse(json)
 
         if ActiveSupport.parse_json_times
           convert_dates_from(data)

--- a/activesupport/lib/active_support/json/encoding.rb
+++ b/activesupport/lib/active_support/json/encoding.rb
@@ -89,7 +89,7 @@ module ActiveSupport
 
           # Encode a "jsonified" Ruby data structure using the JSON gem
           def stringify(jsonified)
-            ::JSON.generate(jsonified, quirks_mode: true, max_nesting: false)
+            ::JSON.generate(jsonified)
           end
       end
 

--- a/guides/source/upgrading_ruby_on_rails.md
+++ b/guides/source/upgrading_ruby_on_rails.md
@@ -2177,7 +2177,7 @@ end
 ```irb
 irb> FooBar.new.to_json
 => "{\"foo\":\"bar\"}"
-irb> JSON.generate(FooBar.new, quirks_mode: true)
+irb> JSON.generate(FooBar.new)
 => "\"#<FooBar:0x007fa80a481610>\""
 ```
 


### PR DESCRIPTION
The `quirks_mode` options hasn't been a thing since 9 years ago. As for `max_nesting: false`, it's not a good idea, the default nesting of 100 is plenty and allow to better handle circular dependencies.

FYI: @matthaigh27