### PR TITLE
Don't include `script` and `style` content to node plaintext conversion

### DIFF
--- a/actiontext/lib/action_text/content.rb
+++ b/actiontext/lib/action_text/content.rb
@@ -123,10 +123,11 @@ module ActionText
     #     content.to_plain_text # => "safeunsafe"
     #
     # NOTE: that the returned string is not HTML safe and should not be rendered in
-    # browsers.
+    # browsers without additional sanitization.
     #
     #     content = ActionText::Content.new("&lt;script&gt;alert()&lt;/script&gt;")
     #     content.to_plain_text # => "<script>alert()</script>"
+    #     ActionText::ContentHelper.sanitizer.sanitize(content.to_plain_text) # => ""
     def to_plain_text
       render_attachments(with_full_attributes: false, &:to_plain_text).fragment.to_plain_text
     end

--- a/actiontext/lib/action_text/plain_text_conversion.rb
+++ b/actiontext/lib/action_text/plain_text_conversion.rb
@@ -22,9 +22,15 @@ module ActionText
       def plain_text_for_node_children(node)
         texts = []
         node.children.each_with_index do |child, index|
+          next if skippable?(child)
+
           texts << plain_text_for_node(child, index)
         end
         texts.join
+      end
+
+      def skippable?(node)
+        node.name == "script" || node.name == "style"
       end
 
       def plain_text_method_for_node(node)

--- a/actiontext/test/unit/plain_text_conversion_test.rb
+++ b/actiontext/test/unit/plain_text_conversion_test.rb
@@ -144,6 +144,30 @@ class ActionText::PlainTextConversionTest < ActiveSupport::TestCase
     )
   end
 
+  test "script tags are ignored" do
+    assert_converted_to(
+      "Hello world!",
+      <<~HTML
+        <script type="javascript">
+          console.log("message");
+        </script>
+        <div><strong>Hello </strong>world!</div>
+      HTML
+    )
+  end
+
+  test "style tags are ignored" do
+    assert_converted_to(
+      "Hello world!",
+      <<~HTML
+        <style type="text/css">
+          body { color: red; }
+        </style>
+        <div><strong>Hello </strong>world!</div>
+      HTML
+    )
+  end
+
   private
     def assert_converted_to(plain_text, html)
       assert_equal plain_text, ActionText::Content.new(html).to_plain_text

--- a/guides/source/action_text_overview.md
+++ b/guides/source/action_text_overview.md
@@ -181,8 +181,8 @@ content as follows:
 
 `ActionText::RichText#to_s` safely transforms RichText into an HTML String. On
 the other hand `ActionText::RichText#to_plain_text` returns a string that is not
-HTML safe and should not be rendered in browsers. You can learn more about
-Action Text's sanitization process in the [`ActionText::RichText`
+HTML safe and should not be rendered in browsers without additional sanitization.
+You can learn more about Action Text's sanitization process in the [`ActionText::RichText`
 documentation](https://api.rubyonrails.org/classes/ActionText/RichText.html).
 
 NOTE: If there's an attached resource within `content` field, it might not show


### PR DESCRIPTION
### Motivation / Background

The content of a `script` or `style` tag shouldn't be included in the plaintext conversion of a node.

### Detail

Given this HTML

```html
<script type="javascript">
  console.log("message");
</script>
<div><strong>Hello </strong>world!</div>
```

The plaintext conversion previously returned:

```txt
 console.log(\"message\");Hello world!
```

Now returns:

```txt
Hello world!
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
