### PR TITLE
Fix ActionDispatch::Request::HTTP_METHOD_LOOKUP being impacted by inflections from gems

### DIFF
--- a/actionpack/lib/action_dispatch/http/request.rb
+++ b/actionpack/lib/action_dispatch/http/request.rb
@@ -138,7 +138,7 @@ module ActionDispatch
 
     # Populate the HTTP method lookup cache.
     HTTP_METHODS.each { |method|
-      HTTP_METHOD_LOOKUP[method] = method.underscore.to_sym
+      HTTP_METHOD_LOOKUP[method] = method.downcase.underscore.to_sym
     }
 
     alias raw_request_method request_method # :nodoc:


### PR DESCRIPTION
If a gem adds inflections before `action_dispatch/http/request` is loaded into the runtime, then it's possible that calls to `method#underscore` cause invalid values to be generated when defining `ActionDispatch::Request::HTTP_METHOD_LOOKUP`.

For example, if a gem adds `"OS"` as an acronym, then this will cause `"POST"` to be converted to `:p_os_t`.

### Motivation / Background

In my application, I have Rails engines that add inflection acronyms.  Specifically, I have one that's adding "OS" as an acronym.  This causes the `underscore` call for `"POST"` to be interpreted like so:

```
testapp(dev)> ActionDispatch::Request::HTTP_METHOD_LOOKUP['POST']
=> :p_os_t
```

The reason is that, depending on the order in which initializers are run, the inflections initializer for my Rails engine adds the `"OS"` acronym *before* `action_dispatch/http/request` is loaded.

This PR prevents that from happening by lower-casing the http verbs *first* before calling `underscore`, avoiding the interpretation of any part of an http method as an acronym.

### Detail

This Pull Request changes the `HTTP_METHOD_LOOKUP` definition to avoid the possibility of interpreting any http method strings as acronyms, regardless of whether the application or its gems define acronyms before or after the definition of that constant.

### Additional information

To reproduce the issue:

* Create a new application
* Create a Rails engine in the application (e.g. `engines/testengine`) and add it to the Gemfile
* Remove `web-console` from the Gemfile to avoid `action_dispatch` from getting loaded before initializers run
* Add an initializer to the engine which adds an inflection acronym for `"OS"`
* Run the rails console
* Observe the value of `ActionDispatch::Request::HTTP_METHOD_LOOKUP["POST"]`

Related PRs:
* https://github.com/rails/rails/pull/8632

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.

It's unclear how to best define tests for this since it's dependent on acronyms being defined before the code for `action_dispatch/http/request` is evaluated.