### PR TITLE
Freeze database conversion types

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -728,12 +728,12 @@ module ActiveRecord
             m.alias_type %r(bit)i,  "binary"
           end
 
-          def register_integer_type(mapping, key, **options)
+          def register_integer_type(mapping, key, limit:)
             mapping.register_type(key) do |sql_type|
               if /\bunsigned\b/.match?(sql_type)
-                Type::UnsignedInteger.new(**options)
+                Type::UnsignedInteger.new(limit: limit)
               else
-                Type::Integer.new(**options)
+                Type::Integer.new(limit: limit)
               end
             end
           end

--- a/activerecord/lib/active_record/connection_adapters/postgresql/oid/array.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/oid/array.rb
@@ -16,8 +16,8 @@ module ActiveRecord
             @subtype = subtype
             @delimiter = delimiter
 
-            @pg_encoder = PG::TextEncoder::Array.new name: "#{type}[]", delimiter: delimiter
-            @pg_decoder = PG::TextDecoder::Array.new name: "#{type}[]", delimiter: delimiter
+            @pg_encoder = PG::TextEncoder::Array.new(name: "#{type}[]".freeze, delimiter: delimiter).freeze
+            @pg_decoder = PG::TextDecoder::Array.new(name: "#{type}[]".freeze, delimiter: delimiter).freeze
           end
 
           def deserialize(value)

--- a/activerecord/lib/active_record/connection_adapters/postgresql/oid/type_map_initializer.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/oid/type_map_initializer.rb
@@ -68,7 +68,7 @@ module ActiveRecord
 
             def register_array_type(row)
               register_with_subtype(row["oid"], row["typelem"].to_i) do |subtype|
-                OID::Array.new(subtype, row["typdelim"])
+                OID::Array.new(subtype, row["typdelim"].freeze)
               end
             end
 

--- a/activerecord/lib/active_record/type/hash_lookup_type_map.rb
+++ b/activerecord/lib/active_record/type/hash_lookup_type_map.rb
@@ -26,6 +26,7 @@ module ActiveRecord
         if block
           @mapping[key] = block
         else
+          value.freeze
           @mapping[key] = proc { value }
         end
         @cache.clear
@@ -50,7 +51,7 @@ module ActiveRecord
 
       private
         def perform_fetch(type, *args, &block)
-          @mapping.fetch(type, block).call(type, *args)
+          @mapping.fetch(type, block).call(type, *args).freeze
         end
     end
   end

--- a/activerecord/lib/active_record/type/type_map.rb
+++ b/activerecord/lib/active_record/type/type_map.rb
@@ -46,7 +46,7 @@ module ActiveRecord
           end
 
           if matching_pair
-            matching_pair.last.call(lookup_key)
+            matching_pair.last.call(lookup_key).freeze
           elsif @parent
             @parent.perform_fetch(lookup_key, &block)
           else

--- a/activerecord/test/cases/adapter_test.rb
+++ b/activerecord/test/cases/adapter_test.rb
@@ -14,6 +14,17 @@ module ActiveRecord
       @connection.materialize_transactions
     end
 
+    def test_type_map_is_ractor_shareable
+      # This is testing internals. Please feel free to remove this test
+      # or change it when internals change. The point is to make sure
+      # the type map is Ractor shareable.
+      @connection.tables.each do |table|
+        @connection.columns(table).each do |column|
+          assert_ractor_shareable @connection.lookup_cast_type_from_column(column)
+        end
+      end
+    end
+
     ##
     # PostgreSQL does not support null bytes in strings
     unless current_adapter?(:PostgreSQLAdapter) ||
@@ -338,6 +349,13 @@ module ActiveRecord
 
       assert_match(/ActiveRecord::ConnectionAdapters::\w+:0x[\da-f]+ env_name="\w+" role=:writing>/, output)
     end
+
+    private
+      def assert_ractor_shareable(obj)
+        # rubocop:disable Minitest/AssertWithExpectedArgument
+        assert(Ractor.shareable?(obj), -> { "Expected #{obj} to be shareable, but it wasn't" })
+        # rubocop:enable Minitest/AssertWithExpectedArgument
+      end
   end
 
   class AdapterForeignKeyTest < ActiveRecord::TestCase


### PR DESCRIPTION
I want to start moving Rails to be more Ractor friendly, and in support of that goal I want to start moving some of our long lived "global" objects to be frozen. `_default_attributes` keeps references to the database types, and it's my first target for Ractor shareability.