### PR TITLE
feat: Authentication generator's `SessionsController` clears browser cache at logout

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   The authentication generator's `SessionsController` sets the `Clear-Site-Data` header on logout.
+
+    By default the header will be set to `"cache","storage"` to help prevent data leakage after
+    logout via the browser's "back/forward cache".
+
+    *Mike Dalessio*
+
 *   Introduce `RAILS_MASTER_KEY` placeholder in generated ci.yml files
 
     *Steve Polito*

--- a/railties/lib/rails/generators/rails/authentication/templates/app/controllers/concerns/authentication.rb.tt
+++ b/railties/lib/rails/generators/rails/authentication/templates/app/controllers/concerns/authentication.rb.tt
@@ -49,4 +49,8 @@ module Authentication
       Current.session.destroy
       cookies.delete(:session_id)
     end
+
+    def clear_site_data
+      response.headers["Clear-Site-Data"] = '"cache","storage"'
+    end
 end

--- a/railties/lib/rails/generators/rails/authentication/templates/app/controllers/sessions_controller.rb.tt
+++ b/railties/lib/rails/generators/rails/authentication/templates/app/controllers/sessions_controller.rb.tt
@@ -16,6 +16,7 @@ class SessionsController < ApplicationController
 
   def destroy
     terminate_session
+    clear_site_data
     redirect_to new_session_path
   end
 end


### PR DESCRIPTION
### Motivation / Background

Over the last few years, modern browsers have implemented a "back/forward cache"[^1] feature which is how browsers render the page quickly when the user hits the back button (without making a request to the domain that served the page). Often this means that user data can still be accessed after logout, which can be hazardous particularly on a public computer.

One way to address this is to the `Cache-Control` header to prevent caching partly (on sensitive pages) or entirely, but that can be complex and potentially reduce the effectiveness of caching as a tool.

Instead, this PR updates the authentication generator to set the `Clear-Site-Data` header at signout/logout (when the session is destroyed).


### Detail

Destroying a session clears the browser cache for the site.

The "Clear-Site-Data" header[^2] is supported in most modern browsers, and sending it when a user signs out prevents the browser from displaying cached pages when a user hits the "back" button. By default the header will be set to `"cache","storage"` to help prevent data leakage after logout via the browser's "back/forward cache".

[^1]: https://developer.mozilla.org/en-US/docs/Glossary/bfcache
[^2]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Clear-Site-Data


### Additional information

This feature isn't critical to authentication, and some sites may want to clear more ("cookies") or less (not "storage", which also unregisters service workers), so totally fine if the core team decides not to accept. But I think the `clear_site_data` method is a good and useful reminder to consider a sharp security edge that many developers forget or aren't aware of.


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [-] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
