### PR TITLE
Fix inconsistency between `delete_all` & `update_all` allowed methods:

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,14 @@
+*   Deprecate usage of unsupported methods in conjunction with `update_all`:
+
+    `update_all` will now print a deprecation message if a query includes either `WITH`,
+    `WITH RECURSIVE` or `DISTINCT` statements. Those were never supported and were ignored
+    when generating the SQL query.
+
+    An error will be raised in a future Rails release. This behaviour will be consistent
+    with `delete_all` which currently raises an error for unsupported statements.
+
+    *Edouard Chin*
+
 *   The table columns inside `schema.rb` are now sorted alphabetically.
 
     Previously they'd be sorted by creation order, which can cause merge conflicts when two

--- a/activerecord/test/cases/relation/update_all_test.rb
+++ b/activerecord/test/cases/relation/update_all_test.rb
@@ -75,6 +75,16 @@ class UpdateAllTest < ActiveRecord::TestCase
     end
   end
 
+  def test_update_all_with_unpermitted_relation_raises_error
+    assert_deprecated("`distinct` is not supported by `update_all`", ActiveRecord.deprecator) do
+      Author.distinct.update_all(name: "Bob")
+    end
+
+    assert_deprecated("`with` is not supported by `update_all`", ActiveRecord.deprecator) do
+      Author.with(limited: Author.where(name: "")).update_all(name: "Bob")
+    end
+  end
+
   def test_update_all_with_left_joins
     pets = Pet.left_joins(:toys).where(toys: { name: "Bone" })
 


### PR DESCRIPTION
### Motivation / Background

At the moment, `update_all` and `delete_all` doesn't support `WITH`, `WITH RECURSIVE` and `DISTINCT` statements.

Calling `Post.with(ex: Post.where(title: "")).delete_all` raises an error.

However calling `Post.with(ex: Post.where(title: "")).update_all` executes the following SQL `UPDATE "posts" SET "title" = blabla`, which can be surprising for users.

This commit adds a deprecation message to warn users that those statements have no effect, with the intention of raising the same error as when using `delete_all` in a future Rails release.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
