### PR TITLE
Fix typo in routing guide [ci skip]

### DIFF
--- a/guides/source/routing.md
+++ b/guides/source/routing.md
@@ -1292,7 +1292,7 @@ In this case, Rails will create all of the normal routes except the route for `d
 TIP: If your application has many RESTful routes, using `:only` and `:except` to
 generate only the routes that you actually need can cut down on memory use and
 speed up the routing process by eliminating [unused
-routed](#listing-unused-routes).
+routes](#listing-unused-routes).
 
 ### Translated Paths
 


### PR DESCRIPTION
Update the tip in section 4.8 of the routing guide (Restricting the Routes Created) to read "unused routes" instead of "unused routed" in the link text.
