### PR TITLE
Fix incorrect expiration time in ActiveSupport::Cache::Store#fetch

### DIFF
--- a/activesupport/lib/active_support/cache.rb
+++ b/activesupport/lib/active_support/cache.rb
@@ -1037,8 +1037,7 @@ module ActiveSupport
               # When an entry has a positive :race_condition_ttl defined, put the stale entry back into the cache
               # for a brief period while the entry is being recalculated.
               entry.expires_at = Time.now.to_f + race_ttl
-              options[:expires_in] = race_ttl * 2
-              write_entry(key, entry, **options)
+              write_entry(key, entry, **options, expires_in: race_ttl * 2)
             else
               delete_entry(key, **options)
             end

--- a/activesupport/test/cache/behaviors/cache_store_behavior.rb
+++ b/activesupport/test/cache/behaviors/cache_store_behavior.rb
@@ -647,6 +647,26 @@ module CacheStoreBehavior
     end
   end
 
+  def test_fetch_race_condition_protection
+    time = Time.now
+    key = SecureRandom.uuid
+    value = SecureRandom.uuid
+    expires_in = 60
+
+    @cache.write(key, value, expires_in:)
+    Time.stub(:now, time + expires_in + 1) do
+      fetched_value = @cache.fetch(key, expires_in:, race_condition_ttl: 10) do
+        SecureRandom.uuid
+      end
+      assert_not_equal fetched_value, value
+      assert_not_nil fetched_value
+    end
+
+    Time.stub(:now, time + 2 * expires_in) do
+      assert_not_nil @cache.read(key)
+    end
+  end
+
   def test_fetch_multi_race_condition_protection
     time = Time.now
     key = SecureRandom.uuid


### PR DESCRIPTION
### Motivation / Background
Fixes #54229
ActiveSupport::Cache::Store#fetch

### Detail
ActiveSupport::Cache::Store#fetch write a the stale value during
race_condition_ttl time window so the current process have time to
process the block, and cache serve the stale value for other callers
The stale value is written for expires_in =  2*race_condition_ttl, but
the expires_in is leaked through options hash.
When the process set the value at the end instead of using the
expires_at/expires_in supplied in fetch, it uses 2*race_condition_ttl
that was set previously
The commit fix this behavior and ensure we use the correct expiration
for the newly computed value

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [X] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
