### PR TITLE
Fix default docker build.

### DIFF
--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -598,7 +598,7 @@ module Rails
 
       def dockerfile_build_packages
         # start with the essentials
-        packages = %w(build-essential git pkg-config)
+        packages = %w(build-essential git pkg-config libyaml-dev)
 
         # add database support
         packages << database.build_package unless skip_active_record?


### PR DESCRIPTION
In recent Ruby images libyaml-dev was removed.
This package is required to install/build psych gem.

refs https://github.com/docker-library/ruby/pull/493
