### PR TITLE
Skip persisted through targets when autosaving collection associations

### DIFF
--- a/activerecord/lib/active_record/autosave_association.rb
+++ b/activerecord/lib/active_record/autosave_association.rb
@@ -297,7 +297,15 @@ module ActiveRecord
       # unless the parent is/was a new record itself.
       def associated_records_to_validate_or_save(association, new_record, autosave)
         if new_record || custom_validation_context?
-          association && association.target
+          target = association && association.target
+          if target && association.reflection.through_reflection
+            # We expect new through records to be autosaved by their direct parent.
+            # This prevents already persisted through records from being validated or saved
+            # more than once.
+            target.find_all(&:changed_for_autosave?)
+          else
+            target
+          end
         elsif autosave
           association.target.find_all(&:changed_for_autosave?)
         else

--- a/activerecord/test/cases/autosave_association_test.rb
+++ b/activerecord/test/cases/autosave_association_test.rb
@@ -40,6 +40,9 @@ require "models/chef"
 require "models/cake_designer"
 require "models/drink_designer"
 require "models/cpk"
+require "models/family"
+require "models/family_tree"
+require "models/user"
 
 class TestAutosaveAssociationsInGeneral < ActiveRecord::TestCase
   def test_autosave_works_even_when_other_callbacks_update_the_parent_model
@@ -1146,6 +1149,34 @@ class TestDefaultAutosaveAssociationOnNewRecord < ActiveRecord::TestCase
     post.save!
 
     assert_equal 1, post.categories.reload.length
+  end
+
+  FamilyLoadingMiddleAndThroughRecordsBeforeSave = Class.new(Family) do
+    before_save do
+      family_trees.map(&:member) + members
+    end
+  end
+
+  def test_autosave_new_record_with_hmt_and_middle_record_built_by_parent
+    family = FamilyLoadingMiddleAndThroughRecordsBeforeSave.new
+    family_tree = family.family_trees.build
+    family_tree.build_member
+    family.save!
+    family.reload
+
+    assert_equal 1, family.family_trees.size
+    assert_equal 1, family.members.size
+  end
+
+  def test_autosave_new_record_with_hmt_and_middle_record_built_by_through_record
+    family = FamilyLoadingMiddleAndThroughRecordsBeforeSave.new
+    member = family.members.build
+    family.family_trees.build(member: member)
+    family.save!
+    family.reload
+
+    assert_equal 1, family.family_trees.size
+    assert_equal 1, family.members.size
   end
 end
 


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

Fixes https://github.com/rails/rails/issues/54176

### Detail

I recommend reading through the issue linked above, as well as the comments, which provide all the context behind this change.

To summarize all that, I recently merged a bunch of patches (linked below) that ensure that new through records built by the middle record are also set on the through parent when the through association reader is called. That has resulted in duplicate autosaving of collection through records, first by the through parent, then by the direct parent i.e. the middle record. The former is new behaviour as that collection would previously be empty.

This fix ensures that we only autosave new/changed through records when saving the through parent, as the through record would already have been autosaved by the direct parent, and we don't want to autosave the persisted (i.e. not new/changed) through record again. This was pretty much the behavior before my patches, its just that now we need to specifically exclude previously unset records, while also ensuring we continue to autosave other manually built/updated (`changed_for_autosave?`) through records.

- https://github.com/rails/rails/pull/51114
- https://github.com/rails/rails/pull/53869
- https://github.com/rails/rails/pull/53957
- https://github.com/rails/rails/pull/54046

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.