### PR TITLE
Fix usable values for openssl_verify_mode in Action Mailer configuration guide [ci skip]

### DIFF
--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -2445,7 +2445,7 @@ Allows detailed configuration for the `:smtp` delivery method. It accepts a hash
 * `:authentication` - If your mail server requires authentication, you need to specify the authentication type here. This is a symbol and one of `:plain`, `:login`, `:cram_md5`.
 * `:enable_starttls` - Use STARTTLS when connecting to your SMTP server and fail if unsupported. It defaults to `false`.
 * `:enable_starttls_auto` - Detects if STARTTLS is enabled in your SMTP server and starts to use it. It defaults to `true`.
-* `:openssl_verify_mode` - When using TLS, you can set how OpenSSL checks the certificate. This is useful if you need to validate a self-signed and/or a wildcard certificate. This can be one of the OpenSSL verify constants, `:none` or `:peer` -- or the constant directly `OpenSSL::SSL::VERIFY_NONE` or `OpenSSL::SSL::VERIFY_PEER`, respectively.
+* `:openssl_verify_mode` - When using TLS, you can set how OpenSSL checks the certificate. This is useful if you need to validate a self-signed and/or a wildcard certificate. This can be the name of one of the OpenSSL verify constants, `'none'` or `'peer'` - or the constant directly `OpenSSL::SSL::VERIFY_NONE` or `OpenSSL::SSL::VERIFY_PEER`, respectively.
 * `:ssl/:tls` - Enables the SMTP connection to use SMTP/TLS (SMTPS: SMTP over direct TLS connection).
 * `:open_timeout` - Number of seconds to wait while attempting to open a connection.
 * `:read_timeout` - Number of seconds to wait until timing-out a read(2) call.


### PR DESCRIPTION
### Motivation / Background

I followed the [Configuration Guide](https://edgeguides.rubyonrails.org/configuring.html#config-action-mailer-smtp-settings) for setting the `openssl_verify_mode` SMTP settings in Action Mailer. I specifically used a Symbol `:none` as mentioned in the guide. However this leads to the following error on Rails 8 when trying to send an email:

```
TypeError: no implicit conversion of Symbol into Integer
  
/usr/local/bundle/ruby/3.3.0/gems/net-smtp-0.5.0/lib/net/smtp.rb:698:in `initialize'
/usr/local/bundle/ruby/3.3.0/gems/net-smtp-0.5.0/lib/net/smtp.rb:698:in `new'
/usr/local/bundle/ruby/3.3.0/gems/net-smtp-0.5.0/lib/net/smtp.rb:698:in `ssl_socket'
/usr/local/bundle/ruby/3.3.0/gems/net-smtp-0.5.0/lib/net/smtp.rb:703:in `tlsconnect'
/usr/local/bundle/ruby/3.3.0/gems/net-smtp-0.5.0/lib/net/smtp.rb:683:in `do_start'
/usr/local/bundle/ruby/3.3.0/gems/net-smtp-0.5.0/lib/net/smtp.rb:642:in `start'
/usr/local/bundle/ruby/3.3.0/gems/mail-2.8.1/lib/mail/network/delivery_methods/smtp.rb:109:in `start_smtp_session'
/usr/local/bundle/ruby/3.3.0/gems/mail-2.8.1/lib/mail/network/delivery_methods/smtp.rb:100:in `deliver!'
/usr/local/bundle/ruby/3.3.0/gems/mail-2.8.1/lib/mail/message.rb:269:in `deliver!'
```

It turns out that the Mail gem [supports only String values](https://github.com/mikel/mail/blob/73db11a6463ec330a36d68cfb77ef99511126cb0/lib/mail/network/delivery_methods/smtp.rb#L189) in the `openssl_verify_mode` configuration, not Symbols.

This is also supported by the documentation of the Mail gem which specifically [speaks](https://github.com/mikel/mail/blob/73db11a6463ec330a36d68cfb77ef99511126cb0/lib/mail/network/delivery_methods/smtp.rb#L57) about _"a string containing the name of an OpenSSL verify mode"_ as a possible value for the `openssl_verify_mode` setting.

I confirmed that the same setting works for me when a String is used instead.

Therefore, I propose to change the suggested values to Strings in the Guide.
