### PR TITLE
Enable `#exists?` queries to be retryable

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Enable automatically retrying idempotent `#exists?` queries on connection
+    errors.
+
+    *Hartley McGuire*, *classidied*
+
 *   Deprecate usage of unsupported methods in conjunction with `update_all`:
 
     `update_all` will now print a deprecation message if a query includes either `WITH`,

--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -418,7 +418,7 @@ module ActiveRecord
         when :all
           Arel.star
         else
-          arel_column(column_name)
+          arel_column(column_name.to_s)
         end
       end
 

--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -441,7 +441,7 @@ module ActiveRecord
         if distinct_value && offset_value
           relation = except(:order).limit!(1)
         else
-          relation = except(:select, :distinct, :order)._select!(ONE_AS_ONE).limit!(1)
+          relation = except(:select, :distinct, :order)._select!(Arel.sql(ONE_AS_ONE, retryable: true)).limit!(1)
         end
 
         case conditions

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -1985,7 +1985,7 @@ module ActiveRecord
       def arel_column(field)
         field = field.name if is_symbol = field.is_a?(Symbol)
 
-        field = model.attribute_aliases[field] || field.to_s
+        field = model.attribute_aliases[field] || field
         from = from_clause.name || from_clause.value
 
         if model.columns_hash.key?(field) && (!from || table_name_matches?(from))

--- a/activerecord/test/cases/adapter_test.rb
+++ b/activerecord/test/cases/adapter_test.rb
@@ -710,6 +710,15 @@ module ActiveRecord
         assert_predicate @connection, :active?
       end
 
+      test "#exists? queries are retried and result in a reconnect" do
+        Post.first
+
+        remote_disconnect @connection
+
+        assert_predicate Post, :exists?
+        assert_predicate @connection, :active?
+      end
+
       test "queries containing SQL fragments are not retried" do
         Post.first
 


### PR DESCRIPTION
### Motivation / Background

Previously, `#exists?` queries could never be retryable because `"1 AS one"` was passed as a String (which would be wrapped as a non-retryable `SqlLiteral`).

### Detail

This commit addresses that issue by wrapping `"1 AS one"` in a `SqlLiteral` with `retryable: true`. While not guaranteeing that all `#exists?` queries can be retryable, this no longer prevents otherwise retryable `#exists?` queries from being retryable.

Additionally, a small change was needed to ensure the retryable `SqlLiteral` wasn't wrapped in a non-retryable `SqlLiteral`. A [previous commit][1] added a `to_s` in `arel_column` which caused all `SqlLiteral`s to be non-retryable (the `Arel.arel_node?` predicate would always be false since `field` was always a `String`). The `to_s` was moved to the specific case it was needed, which was inside `sum` calculations.

[1]: https://github.com/rails/rails/commit/aaad4932b26d731d9aa2b14f21207d6ddf83ea73

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
