### PR TITLE
Fix an incorrect example in the doc of the Strong Parameters [ci skip]

### DIFF
--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -765,7 +765,7 @@ module ActionController
     #
     #     params = ActionController::Parameters.new(tags: ["rails", "parameters"])
     #     permitted = params.expect(tags: [])
-    #     permitted.permitted?      # => true
+    #     permitted                 # => ["rails", "parameters"]
     #     permitted.is_a?(Array)    # => true
     #     permitted.size            # => 2
     #


### PR DESCRIPTION
### Motivation / Background

This PR fixes an incorrect example in the doc of the Strong Parameters.

### Detail

Calling `permitted?` on an array object will raise a `NoMethodError`:

```ruby
params = ActionController::Parameters.new(tags: ["rails", "parameters"])
# => #<ActionController::Parameters {"tags"=>["rails", "parameters"]} permitted: false>

permitted = params.expect(tags: [])
# => ["rails", "parameters"]

permitted.permitted?
# => undefined method `permitted?' for an instance of Array (NoMethodError)
```

In the documentation example, the value of the `permitted` variable is explicitly shown instead.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
