### PR TITLE
Fix order of LEFT JOINS when using `eager_load`:

### DIFF
--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -458,7 +458,7 @@ module ActiveRecord
         join_dependency = construct_join_dependency(
           eager_load_values | includes_values, Arel::Nodes::OuterJoin
         )
-        relation = except(:includes, :eager_load, :preload).joins!(join_dependency)
+        relation = except(:includes, :eager_load, :preload).left_outer_joins!(join_dependency)
 
         if eager_loading && has_limit_or_offset? && !(
             using_limitable_reflections?(join_dependency.reflections) &&

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -294,6 +294,7 @@ module ActiveRecord
 
     def eager_load!(*args) # :nodoc:
       self.eager_load_values |= args
+      self.left_outer_joins_values |= args
       self
     end
 
@@ -819,6 +820,7 @@ module ActiveRecord
             raise ArgumentError, "Called unscope() with invalid unscoping argument ':#{scope}'. Valid arguments are :#{VALID_UNSCOPING_VALUES.to_a.join(", :")}."
           end
           assert_modifiable!
+          self.left_outer_joins_values -= eager_load_values if scope == :eager_load
           @values.delete(scope)
         when Hash
           scope.each do |key, target_value|

--- a/activerecord/test/cases/relation/merging_test.rb
+++ b/activerecord/test/cases/relation/merging_test.rb
@@ -208,6 +208,12 @@ class RelationMergingTest < ActiveRecord::TestCase
     end
   end
 
+  def test_relation_merging_with_eager_load_and_left_joins
+    result = Post.eager_load(:author).merge(Author.where.missing(:author_address_extra)).count
+
+    assert_equal(6, result)
+  end
+
   def test_relation_merging_with_locks
     devs = Developer.lock.where("salary >= 80000").order("id DESC").merge(Developer.limit(2))
     assert_predicate devs, :locked?

--- a/activerecord/test/cases/scoping/default_scoping_test.rb
+++ b/activerecord/test/cases/scoping/default_scoping_test.rb
@@ -418,6 +418,16 @@ class DefaultScopingTest < ActiveRecord::TestCase
     assert_equal false, received.first.projects.loaded?
   end
 
+  def test_unscope_eager_load_keeps_left_joins
+    Computer.destroy_all
+
+    expected = Developer.order(:id).collect(&:name)
+    received = Developer.eager_load(:projects).left_joins(:computers).unscope(:eager_load).group("developers.id")
+      .having("COUNT(computers.id) = 0").order(:id)
+
+    assert_equal expected, received.collect(&:name)
+  end
+
   def test_unscope_preloads
     expected = Developer.all.collect(&:name)
     received = Developer.preload(:projects).select(:id).unscope(:preload, :select)


### PR DESCRIPTION
> [!NOTE]
> As much as I dug on this, I'm not super familiar with this part of Active Record and don't know all the intrinsic this change can have. But all tests are passing without modifying any so I figured it would be worth a review.

### Motivation / Background

- Fix #54181
- When multiple stashed joins (eager load, left joins) were added, the join produced by eager loading always had the least precedence.

  This could result in producing invalid query in the following case:

  ```ruby
   Post.eager_load(:comments).merge(Comment.left_joins(:user)).count
   # SELECT COUNT(DISTINCT "posts"."id") FROM "posts" LEFT OUTER JOIN "users" ON "users"."id" = "comments"."user_id" LEFT OUTER JOIN "comments" ON "comments"."post_id" = "posts"."id"
  ```

  Now the order of LEFT JOIN produced by eager load will be respected.

### Detail

As mentioned by Kamipo in https://github.com/rails/rails/pull/35864, these are the orders of priority when producing join statements. But since an `eager_load` call always produce a LEFT OUTER JOIN, I couldn't find a good reason on why it had least precedence compare to other stashed joins who also produce LEFT OUTER JOIN.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
