### PR TITLE
Keep the attribute's name translation as is:

### DIFF
--- a/activemodel/lib/active_model/translation.rb
+++ b/activemodel/lib/active_model/translation.rb
@@ -77,10 +77,12 @@ module ActiveModel
       defaults << options[:default] if options[:default]
       defaults << MISSING_TRANSLATION unless raise_on_missing
 
+      capitalize_missing_translation = options.delete(:_capitalize) { true }
       translation = I18n.translate(defaults.shift, count: 1, raise: raise_on_missing, **options, default: defaults)
       if translation == MISSING_TRANSLATION
-        translation = attribute.present? ? attribute.humanize : namespace.humanize
+        translation = (attribute.presence || namespace).humanize(capitalize: capitalize_missing_translation)
       end
+
       translation
     end
   end

--- a/activerecord/lib/active_record/associations/has_many_association.rb
+++ b/activerecord/lib/active_record/associations/has_many_association.rb
@@ -18,7 +18,7 @@ module ActiveRecord
 
         when :restrict_with_error
           unless empty?
-            record = owner.class.human_attribute_name(reflection.name).downcase
+            record = owner.class.human_attribute_name(reflection.name, _capitalize: false)
             owner.errors.add(:base, :'restrict_dependent_destroy.has_many', record: record)
             throw(:abort)
           end

--- a/activerecord/lib/active_record/associations/has_one_association.rb
+++ b/activerecord/lib/active_record/associations/has_one_association.rb
@@ -13,7 +13,7 @@ module ActiveRecord
 
         when :restrict_with_error
           if load_target
-            record = owner.class.human_attribute_name(reflection.name).downcase
+            record = owner.class.human_attribute_name(reflection.name, _capitalize: false)
             owner.errors.add(:base, :'restrict_dependent_destroy.has_one', record: record)
             throw(:abort)
           end

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -2006,7 +2006,7 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
 
   def test_restrict_with_error_with_locale
     I18n.backend = I18n::Backend::Simple.new
-    I18n.backend.store_translations "en", activerecord: { attributes: { restricted_with_error_firm: { companies: "client companies" } } }
+    I18n.backend.store_translations "en", activerecord: { attributes: { restricted_with_error_firm: { companies: "LLC companies" } } }
     firm = RestrictedWithErrorFirm.create!(name: "restrict")
     firm.companies.create(name: "child")
 
@@ -2016,7 +2016,7 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
 
     assert_not_empty firm.errors
 
-    assert_equal "Cannot delete record because dependent client companies exist", firm.errors[:base].first
+    assert_equal "Cannot delete record because dependent LLC companies exist", firm.errors[:base].first
     assert RestrictedWithErrorFirm.exists?(name: "restrict")
     assert firm.companies.exists?(name: "child")
   ensure

--- a/activerecord/test/cases/associations/has_one_associations_test.rb
+++ b/activerecord/test/cases/associations/has_one_associations_test.rb
@@ -243,7 +243,7 @@ class HasOneAssociationsTest < ActiveRecord::TestCase
 
   def test_restrict_with_error_with_locale
     I18n.backend = I18n::Backend::Simple.new
-    I18n.backend.store_translations "en", activerecord: { attributes: { restricted_with_error_firm: { account: "firm account" } } }
+    I18n.backend.store_translations "en", activerecord: { attributes: { restricted_with_error_firm: { account: "LLC account" } } }
     firm = RestrictedWithErrorFirm.create!(name: "restrict")
     firm.create_account(credit_limit: 10)
 
@@ -252,7 +252,7 @@ class HasOneAssociationsTest < ActiveRecord::TestCase
     firm.destroy
 
     assert_not_empty firm.errors
-    assert_equal "Cannot delete record because a dependent firm account exists", firm.errors[:base].first
+    assert_equal "Cannot delete record because a dependent LLC account exists", firm.errors[:base].first
     assert RestrictedWithErrorFirm.exists?(name: "restrict")
     assert_predicate firm.account, :present?
   ensure


### PR DESCRIPTION
### Motivation / Background

- When an error is added to a record due to `restrict_dependent_destroy` error, we were always downcasing its attribute name even when an application had specified a translation.

  Now, the attribute's name will be downcased only when no translation exists.

  Fix #53448

### Detail

There is an existing test when no translation exists: https://github.com/rails/rails/blob/8c7e39497f069e354d67ed14c63fa31383871e5d/activerecord/test/cases/associations/has_many_associations_test.rb#L2002

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
