### PR TITLE
Ensure binding is always `0.0.0.0`.

### DIFF
--- a/railties/lib/rails/generators/rails/devcontainer/templates/devcontainer/Dockerfile.tt
+++ b/railties/lib/rails/generators/rails/devcontainer/templates/devcontainer/Dockerfile.tt
@@ -1,3 +1,7 @@
 # Make sure RUBY_VERSION matches the Ruby version in .ruby-version
 ARG RUBY_VERSION=<%= Gem.ruby_version %>
 FROM ghcr.io/rails/devcontainer/images/ruby:$RUBY_VERSION
+
+# Ensure binding is always 0.0.0.0
+# Binds the server to all IP addresses of the container, so it can be accessed from outside the container.
+ENV BINDING="0.0.0.0"

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -1320,6 +1320,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
     end
     assert_file(".devcontainer/Dockerfile") do |content|
       assert_match(/ARG RUBY_VERSION=#{RUBY_VERSION}/, content)
+      assert_match(/ENV BINDING="0.0.0.0"/, content)
     end
     assert_file("test/application_system_test_case.rb") do |content|
       assert_match(/^    served_by host: "rails-app", port: ENV\["CAPYBARA_SERVER_PORT"\]/, content)

--- a/railties/test/generators/devcontainer_generator_test.rb
+++ b/railties/test/generators/devcontainer_generator_test.rb
@@ -346,6 +346,7 @@ module Rails
         def test_common_config
           assert_file(".devcontainer/Dockerfile") do |dockerfile|
             assert_match(/ARG RUBY_VERSION=#{RUBY_VERSION}/, dockerfile)
+            assert_match(/ENV BINDING="0.0.0.0"/, dockerfile)
           end
 
           assert_devcontainer_json_file do |devcontainer_json|


### PR DESCRIPTION
### Motivation / Background

This PR updates the Dockerfile to ensure the Rails server binds to all available IP addresses (`0.0.0.0`). This change allows the Rails app to be accessed externally from outside the container.

For a working example of this configuration in action, you can refer to [https://github.com/viktorianer/rails8-devcontainer-enhancements/pull/5](https://github.com/viktorianer/rails8-devcontainer-enhancements/pull/5). This showcases the same binding solution applied in a Rails app.

This Pull Request has been created because of discussion in https://github.com/rails/devcontainer/pull/52.

### Detail

While the default binding to `localhost` works with Docker in most cases, issues can arise when using alternative container runtimes like **Podman**. These runtimes may restrict access to services inside containers when they are bound only to `localhost`. By explicitly setting the binding to `0.0.0.0`, the Rails app becomes accessible externally on port 3000 across all runtimes, including Podman.

### Additional information

- **Fix for Podman and other alternative runtimes**: Resolves issues where the Rails app could not be accessed from outside the container.
- The Rails app will now be reachable on `http://localhost:3000` from external connections.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
