### PR TITLE
Add `application-name` metadata to application layout

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   Add `application-name` metadata to application layout
+
+    The following metatag will be added to `app/views/layouts/application.html.erb`
+
+    ```html
+    <meta name="application-name" content="Name of Rails Application">
+    ```
+
+    *Steve Polito*
+
 *   Use `secret_key_base` from ENV or credentials when present locally.
 
     When ENV["SECRET_KEY_BASE"] or

--- a/railties/lib/rails/generators/rails/app/templates/app/views/layouts/application.html.erb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/app/views/layouts/application.html.erb.tt
@@ -4,6 +4,7 @@
     <title><%%= content_for(:title) || "<%= app_name.titleize %>" %></title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta name="application-name" content="<%= app_name.titleize %>">
     <meta name="mobile-web-app-capable" content="yes">
     <%%= csrf_meta_tags %>
     <%%= csp_meta_tag %>

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -443,6 +443,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
   def test_application_name_is_normalized_in_config
     run_generator [File.join(destination_root, "MyWebSite"), "-d", "postgresql"]
     assert_file "MyWebSite/app/views/layouts/application.html.erb", /content_for\(:title\) \|\| "My Web Site"/
+    assert_file "MyWebSite/app/views/layouts/application.html.erb", /meta\sname="application-name"\scontent="My Web Site/
     assert_file "MyWebSite/config/database.yml", /my_web_site_production/
   end
 


### PR DESCRIPTION
 ### Motivation / Background
  
Supports efforts such as #50528.
  
### Detail
  
  The following metatag will be added to `app/views/layouts/application.html.erb`
  
  ```html
  <meta name="application-name" content="Name of Rails Application">
  ```
  
  The `application-name` is a [standard metadata name][smn], and compliments existing app-related metatags.
  
  [smn]:  https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta/name
  
  ### Checklist
  
  Before submitting the PR make sure the following are checked:
  
  * [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
  * [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
  * [x] Tests are added or updated if you fix a bug or add a feature.
  * [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
