### PR TITLE
Remove redundant "Filtering" comment [ci skip]

### DIFF
--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -1287,9 +1287,6 @@ module ActionController
         keys - params.keys - always_permitted_parameters
       end
 
-      #
-      # --- Filtering ----------------------------------------------------------
-      #
       # This is a list of permitted scalar types that includes the ones supported in
       # XML and JSON requests.
       #


### PR DESCRIPTION
The comment in question was not rendered in the previous style of API docs:

![old](https://github.com/user-attachments/assets/e0e404f7-ed50-45bc-a44e-5c07e7380dea)

---
However it renders in a weird way in the new style of API docs:

![new](https://github.com/user-attachments/assets/24a768cc-215e-4c82-8a84-9ae8a6589518)

---

I believe we can remove that comment. I also checked and there is no other place in the code with a comment of that type, `# ---`.

---

After the commit, the API docs look like this:

![after](https://github.com/user-attachments/assets/313b0e27-df51-466e-a264-cf8dd322d5b6)

[ci skip] [ci-skip]