### PR TITLE
Ensure the logger gem is loaded in Rails 7.0

### DIFF
--- a/activesupport/lib/active_support/logger_thread_safe_level.rb
+++ b/activesupport/lib/active_support/logger_thread_safe_level.rb
@@ -4,6 +4,7 @@ require "active_support/concern"
 require "active_support/core_ext/module/attribute_accessors"
 require "concurrent"
 require "fiber"
+require "logger"
 
 module ActiveSupport
   module LoggerThreadSafeLevel # :nodoc:


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because the `concurrent-ruby` gem's version 1.3.5 no longer loads the `logger` gem which breaks the internal logic of the `ActiveSupport::LoggerThreadSafeLevel` module.

This relates to the following commit in the `concurrent-ruby` gem included in version 1.3.5: https://github.com/ruby-concurrency/concurrent-ruby/commit/d7ce956dacd0b772273d39b8ed31a30cff7ecf38

### Detail

This Pull Request changes the assumption that `concurrent-ruby` loads the `logger` gem.

### Additional information

Fixes #54260 
Fixes #54263

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature. - Not sure how to test this as tests would need to be added for different versions of `concurrent-ruby`
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included. - I believe this is minor?
