### PR TITLE
Reduce the frequency of Dependabot updates in new projects.

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/github/dependabot.yml
+++ b/railties/lib/rails/generators/rails/app/templates/github/dependabot.yml
@@ -3,10 +3,10 @@ updates:
 - package-ecosystem: bundler
   directory: "/"
   schedule:
-    interval: daily
+    interval: weekly
   open-pull-requests-limit: 10
 - package-ecosystem: github-actions
   directory: "/"
   schedule:
-    interval: daily
+    interval: weekly
   open-pull-requests-limit: 10

--- a/railties/lib/rails/generators/rails/plugin/templates/github/dependabot.yml
+++ b/railties/lib/rails/generators/rails/plugin/templates/github/dependabot.yml
@@ -3,10 +3,10 @@ updates:
 - package-ecosystem: bundler
   directory: "/"
   schedule:
-    interval: daily
+    interval: weekly
   open-pull-requests-limit: 10
 - package-ecosystem: github-actions
   directory: "/"
   schedule:
-    interval: daily
+    interval: weekly
   open-pull-requests-limit: 10


### PR DESCRIPTION
### Motivation / Background

This Pull Request reduces the default frequency of Dependabot updates from `daily` to `weekly`. While daily updates help ensure projects stay up to date, they can overwhelm users with too many pull requests, leading some to disable or delete `dependabot.yml` altogether.

A weekly schedule strikes a better balance, keeping dependencies current while reducing noise. This change could encourage users to retain Dependabot as part of their projects instead of removing it due to update fatigue.

### Detail

This Pull Request modifies the `dependabot.yml` template to set the update interval to `weekly` for both Bundler and GitHub Actions ecosystems.

### Additional Information

This change [aligns with feedback suggesting that reducing the frequency of updates](https://github.com/rails/rails/issues/53148#issuecomment-2594942959) can make Dependabot more user-friendly and less intrusive. Weekly updates still allow projects to stay current without overwhelming developers.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why.
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.