### PR TITLE
Handle missing attributes for AM::Translation#human_attribute_name

### DIFF
--- a/activemodel/test/cases/translation_test.rb
+++ b/activemodel/test/cases/translation_test.rb
@@ -104,6 +104,16 @@ class ActiveModelI18nTests < ActiveModel::TestCase
     assert_equal "person model", Child.model_name.human
   end
 
+  def test_translated_attributes_when_nil
+    I18n.backend.store_translations "en", activemodel: { attributes: { "person/addresses": { street: "Person Address Street" } } }
+    assert_equal("Addresses", Person.human_attribute_name("addresses.#{nil}"))
+  end
+
+  def test_translated_deeply_nested_attributes_when_nil
+    I18n.backend.store_translations "en", activemodel: { attributes: { "person/contacts/addresses": { street: "Deeply Nested Address Street" } } }
+    assert_equal("Addresses/contacts", Person.human_attribute_name("addresses.contacts.#{nil}"))
+  end
+
   def test_translated_subclass_model_when_missing_translation
     assert_equal "Child", Child.model_name.human
   end


### PR DESCRIPTION
Fixes #54250

```ruby
require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"

  #gem "rails", "~>7.0.0"
  gem "rails", "~>7.2.0"

  gem "sqlite3"
  # Rails 7.0 deps:
  #gem "sqlite3", "~>1.4"
  #gem "timeout", "~>0.1"
  #gem "securerandom"
  #gem "concurrent-ruby", "1.3.4"
end

require "active_record"
require "minitest/autorun"
require "logger"

ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")
ActiveRecord::Base.logger = ActiveSupport::Logger.new(STDOUT)

I18n.backend.store_translations(
  :ja,
  {
    activerecord: {
      attributes: {
        "post/status": {
            draft: 'draft in Japanese',
            published: 'published in Japanese',
        },
        "post/author": {
          name: "Name in Japanese"
        }
      }
    }
  }
)

ActiveRecord::Schema.define do
  create_table :posts, force: true do |t|
    t.integer :status
  end

  create_table :authors, force: true do |t|
    t.string :name
  end
end

class Post < ActiveRecord::Base
  enum :status, draft: 0, published: 1
  belongs_to :author
end

class BugTest < ActiveSupport::TestCase
  def test_association_stuff
    value = nil
    assert_nothing_raised { Post.human_attribute_name("status.#{value}", {locale: :ja}) }
    attr = Post.human_attribute_name("status.#{value}", {locale: :ja})
    assert_equal "Status", attr

    assert_nothing_raised { Post.human_attribute_name("author.name", {locale: :ja}) }
    attr = Post.human_attribute_name("author.name", {locale: :ja})
    assert_equal "Name in Japanese", attr
  end
end
```

Raises `I18n::InvalidPluralizationData`:

```
  1) Error:
BugTest#test_association_stuff:
I18n::InvalidPluralizationData: translation data {:draft=>"draft in Japanese", :published=>"published in Japanese"} can not be used with :count => 1. key 'one' is missing.
    /home/zzak/.rbenv/versions/3.3.6/lib/ruby/gems/3.3.0/gems/i18n-1.14.6/lib/i18n/backend/base.rb:187:in `pluralize'
    /home/zzak/.rbenv/versions/3.3.6/lib/ruby/gems/3.3.0/gems/i18n-1.14.6/lib/i18n/backend/base.rb:50:in `translate'
    /home/zzak/.rbenv/versions/3.3.6/lib/ruby/gems/3.3.0/gems/i18n-1.14.6/lib/i18n.rb:394:in `block in translate_key'
    /home/zzak/.rbenv/versions/3.3.6/lib/ruby/gems/3.3.0/gems/i18n-1.14.6/lib/i18n.rb:393:in `catch'
    /home/zzak/.rbenv/versions/3.3.6/lib/ruby/gems/3.3.0/gems/i18n-1.14.6/lib/i18n.rb:393:in `translate_key'
    /home/zzak/.rbenv/versions/3.3.6/lib/ruby/gems/3.3.0/gems/i18n-1.14.6/lib/i18n.rb:223:in `translate'
    bug.rb:87:in `translate'
    /home/zzak/.rbenv/versions/3.3.6/lib/ruby/gems/3.3.0/gems/activemodel-7.2.2.1/lib/active_model/translation.rb:67:in `human_attribute_name'
    bug.rb:98:in `block in test_association_stuff'
    /home/zzak/.rbenv/versions/3.3.6/lib/ruby/gems/3.3.0/gems/activesupport-7.2.2.1/lib/active_support/testing/assertions.rb:49:in `assert_nothing_raised'
    bug.rb:98:in `test_association_stuff'

1 runs, 0 assertions, 0 failures, 1 errors, 0 skips
```

/cc @r7kamura @sakai-mf
