### PR TITLE
Remove deprecated call to mb_chars

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -1605,7 +1605,7 @@ module ActiveRecord
           name = "idx_on_#{Array(column) * '_'}"
 
           short_limit = max_index_name_size - hashed_identifier.bytesize
-          short_name = name.mb_chars.limit(short_limit).to_s
+          short_name = name.truncate_bytes(short_limit, omission: nil)
 
           "#{short_name}#{hashed_identifier}"
         end


### PR DESCRIPTION
Related to  #54081
cc @byroot 

When adding an index like the following : 
```ruby
add_reference :posts, :user, foreign_key: { on_delete: :nullify }, index: true, null: true
```

This triggers a deprecation warning. The fixi is simple and we just remove the call to `mb_chars`

<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

### Checklist

Before submitting the PR make sure the following are checked:

* [ ] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [ ] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
