### PR TITLE
Remove stale documentation about `assets.debug` [ci skip]

### DIFF
--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -695,7 +695,7 @@ Enables the use of SHA256 fingerprints in asset names. Set to `true` by default.
 
 #### `config.assets.debug`
 
-Disables the concatenation and compression of assets. Set to `true` by default in `development.rb`.
+Disables the concatenation and compression of assets.
 
 #### `config.assets.version`
 


### PR DESCRIPTION
### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created because when I was upgrading a Rails application and comparing my `development.rb` with the newly generated one via `rails app:update`, I noticed that the incoming version had `config.assets.debug = true` removed. But when I checked the latest documentation it said that it was enabled by default in `development.rb` which no longer seems to be correct.

### Detail

This Pull Request changes stale documentation about `assets.debug` since the default was removed from the `development.rb` template: https://github.com/rails/rails/commit/adec7e7ba87e3d268149d0020d54dc211eb02ada

### Additional information

If desired, this comment that used to accompany the setting in `development.rb` could be added to the documentation if it is still relevant:
```
This option may cause significant delays in view rendering with a large number of complex assets.
```

If documentation changes are backported, this change might be worthy of backporting since it seems this impacted Rails 7.0+.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
