### PR TITLE
Prevent persisting invalid record:

### DIFF
--- a/activerecord/lib/active_record/autosave_association.rb
+++ b/activerecord/lib/active_record/autosave_association.rb
@@ -370,27 +370,29 @@ module ActiveRecord
       # enabled records if they're marked_for_destruction? or destroyed.
       def association_valid?(association, record)
         return true if record.destroyed? || (association.options[:autosave] && record.marked_for_destruction?)
-        if custom_validation_context?
-          context = validation_context
+
+        context = validation_context if custom_validation_context?
+        return true if record.valid?(context)
+
+        if record.changed? || record.new_record? || context
+          associated_errors = record.errors.objects
         else
-          # If the associated record is unchanged we shouldn't auto validate it.
-          # Even if a record is invalid you should still be able to create new references
-          # to it.
-          return true if !record.new_record? && !record.changed?
+          # If there are existing invalid records in the DB, we should still be able to reference them.
+          # Unless a record (no matter where in the association chain) is invalid and is being changed.
+          associated_errors = record.errors.objects.select { |error| error.is_a?(Associations::NestedError) }
         end
 
-        unless valid = record.valid?(context)
-          if association.options[:autosave]
-            record.errors.each { |error|
-              self.errors.objects.append(
-                Associations::NestedError.new(association, error)
-              )
-            }
-          else
-            errors.add(association.reflection.name)
-          end
+        if association.options[:autosave]
+          associated_errors.each { |error|
+            errors.objects.append(
+              Associations::NestedError.new(association, error)
+            )
+          }
+        elsif associated_errors.any?
+          errors.add(association.reflection.name)
         end
-        valid
+
+        errors.any?
       end
 
       # Is used as an around_save callback to check while saving a collection

--- a/activerecord/test/cases/nested_attributes_test.rb
+++ b/activerecord/test/cases/nested_attributes_test.rb
@@ -1206,12 +1206,19 @@ class TestIndexErrorsWithNestedAttributesOnlyMode < ActiveRecord::TestCase
 end
 
 class TestNestedAttributesWithExtend < ActiveRecord::TestCase
-  setup do
-    Pirate.accepts_nested_attributes_for :treasures
-  end
-
   def test_extend_affects_nested_attributes
-    pirate = Pirate.create!(catchphrase: "Don' botharrr talkin' like one, savvy?")
+    super_pirate = Class.new(ActiveRecord::Base) do
+      self.table_name = "pirates"
+
+      has_many :treasures, as: :looter, extend: Pirate::PostTreasuresExtension
+      self.accepts_nested_attributes_for :treasures
+
+      def self.name
+        "SuperPirate"
+      end
+    end
+
+    pirate = super_pirate.create!(catchphrase: "Don' botharrr talkin' like one, savvy?")
     pirate.treasures_attributes = [{ id: nil }]
     assert_equal "from extension", pirate.treasures[0].name
   end

--- a/activerecord/test/models/treasure.rb
+++ b/activerecord/test/models/treasure.rb
@@ -6,7 +6,7 @@ class Treasure < ActiveRecord::Base
   # No counter_cache option given
   belongs_to :ship
 
-  has_many :price_estimates, as: :estimate_of
+  has_many :price_estimates, as: :estimate_of, autosave: true
   has_and_belongs_to_many :rich_people, join_table: "peoples_treasures", validate: false
 
   accepts_nested_attributes_for :looter


### PR DESCRIPTION
Prevent persisting invalid record:

- Fix #54267

### Motivation / Background

- In #53951, the goal was to allow saving a record and its association even if the association had existing invalid records in the DB. We would not validate the association in that case.

  The problem of not validating, is that it stops the validation chain and it's possible that other records in subsequent relations are being modified and are invalid. e.g. `Company -has_many-> Developers -has_many-> Computers`, if a computer is changed with invalid value and the company get saved, this would bypass the computer validation and persist it.

  This commit fixes that by ensuring there are no validation errors from *changed* records in the whole association chain.

This Pull Request has been created because [REPLACE ME]

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
