### PR TITLE
Revert has-many-through association changes + add regression test

### DIFF
--- a/activerecord/lib/active_record/associations/association.rb
+++ b/activerecord/lib/active_record/associations/association.rb
@@ -189,14 +189,7 @@ module ActiveRecord
       def load_target
         @target = find_target(async: false) if (@stale_state && stale_target?) || find_target?
         if !@target && set_through_target_for_new_record?
-          reflections = reflection.chain
-          reflections.pop
-          reflections.reverse!
-
-          @target = reflections.reduce(through_association.target) do |middle_target, reflection|
-            break unless middle_target
-            middle_target.association(reflection.source_reflection_name).target
-          end
+          @target = through_association.target.association(reflection.source_reflection_name).target
         end
 
         loaded! unless loaded?

--- a/activerecord/lib/active_record/associations/association.rb
+++ b/activerecord/lib/active_record/associations/association.rb
@@ -193,9 +193,9 @@ module ActiveRecord
           reflections.pop
           reflections.reverse!
 
-          @target = reflections.reduce(through_association.target) do |middle_target, through_reflection|
+          @target = reflections.reduce(through_association.target) do |middle_target, reflection|
             break unless middle_target
-            middle_target.association(through_reflection.source_reflection_name).load_target
+            middle_target.association(reflection.source_reflection_name).target
           end
         end
 

--- a/activerecord/lib/active_record/associations/association.rb
+++ b/activerecord/lib/active_record/associations/association.rb
@@ -188,9 +188,6 @@ module ActiveRecord
       # not reraised. The proxy is \reset and +nil+ is the return value.
       def load_target
         @target = find_target(async: false) if (@stale_state && stale_target?) || find_target?
-        if !@target && set_through_target_for_new_record?
-          @target = through_association.target.association(reflection.source_reflection_name).target
-        end
 
         loaded! unless loaded?
         target
@@ -322,10 +319,6 @@ module ActiveRecord
 
         def find_target?
           !loaded? && (!owner.new_record? || foreign_key_present?) && klass
-        end
-
-        def set_through_target_for_new_record?
-          owner.new_record? && reflection.through_reflection? && through_association.target
         end
 
         # Returns true if there is a foreign key present on the owner which

--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -272,14 +272,6 @@ module ActiveRecord
       def load_target
         if find_target?
           @target = merge_target_lists(find_target, target)
-        elsif target.empty? && set_through_target_for_new_record?
-          @target = if through_reflection.collection?
-            through_association.target.flat_map do |record|
-              record.association(reflection.source_reflection_name).target
-            end
-          else
-            through_association.target.association(reflection.source_reflection_name).target
-          end
         end
 
         loaded!

--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -273,18 +273,12 @@ module ActiveRecord
         if find_target?
           @target = merge_target_lists(find_target, target)
         elsif target.empty? && set_through_target_for_new_record?
-          reflections = reflection.chain
-          reflections.pop
-          reflections.reverse!
-
-          @target = reflections.reduce(through_association.target) do |middle_target, reflection|
-            if middle_target.empty?
-              break []
-            elsif reflection.collection?
-              middle_target.flat_map { |record| record.association(reflection.source_reflection_name).target }
-            else
-              middle_target.association(reflection.source_reflection_name).target
+          @target = if through_reflection.collection?
+            through_association.target.flat_map do |record|
+              record.association(reflection.source_reflection_name).target
             end
+          else
+            through_association.target.association(reflection.source_reflection_name).target
           end
         end
 

--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -279,7 +279,7 @@ module ActiveRecord
             if middle_target.nil? || (middle_reflection.collection? && middle_target.empty?)
               break []
             elsif middle_reflection.collection?
-              middle_target.flat_map { |record| record.association(through_reflection.source_reflection_name).load_target }.compact
+              middle_target.flat_map { |record| record.association(through_reflection.source_reflection_name).load_target }
             else
               middle_target.association(through_reflection.source_reflection_name).load_target
             end

--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -273,15 +273,17 @@ module ActiveRecord
         if find_target?
           @target = merge_target_lists(find_target, target)
         elsif target.empty? && set_through_target_for_new_record?
-          reflections = reflection.chain.reverse!
+          reflections = reflection.chain
+          reflections.pop
+          reflections.reverse!
 
-          @target = reflections.each_cons(2).reduce(through_association.target) do |middle_target, (middle_reflection, through_reflection)|
-            if middle_target.nil? || (middle_reflection.collection? && middle_target.empty?)
+          @target = reflections.reduce(through_association.target) do |middle_target, reflection|
+            if middle_target.empty?
               break []
-            elsif middle_reflection.collection?
-              middle_target.flat_map { |record| record.association(through_reflection.source_reflection_name).load_target }
+            elsif reflection.collection?
+              middle_target.flat_map { |record| record.association(reflection.source_reflection_name).target }
             else
-              middle_target.association(through_reflection.source_reflection_name).load_target
+              middle_target.association(reflection.source_reflection_name).target
             end
           end
         end

--- a/activerecord/lib/active_record/autosave_association.rb
+++ b/activerecord/lib/active_record/autosave_association.rb
@@ -297,15 +297,7 @@ module ActiveRecord
       # unless the parent is/was a new record itself.
       def associated_records_to_validate_or_save(association, new_record, autosave)
         if new_record || custom_validation_context?
-          target = association && association.target
-          if target && association.reflection.through_reflection
-            # We expect new through records to be autosaved by their direct parent.
-            # This prevents already persisted through records from being validated or saved
-            # more than once.
-            target.find_all(&:changed_for_autosave?)
-          else
-            target
-          end
+          association && association.target
         elsif autosave
           association.target.find_all(&:changed_for_autosave?)
         else

--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -655,10 +655,6 @@ module ActiveRecord
         self
       end
 
-      def source_reflection_name
-        source_reflection.name
-      end
-
       # A chain of reflections from this one back to the owner. For more see the explanation in
       # ThroughReflection.
       def collect_join_chain

--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -1235,7 +1235,7 @@ module ActiveRecord
 
     class PolymorphicReflection < AbstractReflection # :nodoc:
       delegate :klass, :scope, :plural_name, :type, :join_primary_key, :join_foreign_key,
-               :name, :scope_for, :collection?, to: :@reflection
+               :name, :scope_for, to: :@reflection
 
       def initialize(reflection, previous_reflection)
         super()

--- a/activerecord/test/cases/associations/has_many_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_through_associations_test.rb
@@ -41,7 +41,6 @@ require "models/cpk"
 require "models/zine"
 require "models/interest"
 require "models/human"
-require "models/account"
 
 class HasManyThroughAssociationsTest < ActiveRecord::TestCase
   fixtures :posts, :readers, :people, :comments, :authors, :categories, :taggings, :tags,
@@ -68,24 +67,7 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
     assert_predicate subscriber_2, :persisted?
     assert_predicate book, :new_record?
     book.subscriptions.each { |subscription| assert_predicate subscription, :new_record? }
-    assert_equal [subscriber_1, subscriber_2].sort, book.subscribers.sort
-  end
-
-  def test_setting_association_on_new_record_sets_nested_through_records
-    account_1 = Account.create!(firm_name: "account 1", credit_limit: 100)
-    subscriber_1 = Subscriber.create!(nick: "nick 1", account: account_1)
-    account_2 = Account.create!(firm_name: "account 2", credit_limit: 100)
-    subscriber_2 = Subscriber.create!(nick: "nick 2", account: account_2)
-    subscription_1 = Subscription.new(subscriber: subscriber_1)
-    subscription_2 = Subscription.new(subscriber: subscriber_2)
-    book = Book.new
-    book.subscriptions = [subscription_1, subscription_2]
-
-    assert_predicate subscriber_1, :persisted?
-    assert_predicate subscriber_2, :persisted?
-    assert_predicate book, :new_record?
-    book.subscriptions.each { |subscription| assert_predicate subscription, :new_record? }
-    assert_equal [account_1, account_2].sort, book.subscriber_accounts.sort
+    assert_equal book.subscribers.sort, [subscriber_1, subscriber_2].sort
   end
 
   def test_has_many_through_create_record

--- a/activerecord/test/cases/associations/has_many_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_through_associations_test.rb
@@ -56,20 +56,6 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
     Reader.create person_id: 0, post_id: 0
   end
 
-  def test_setting_association_on_new_record_sets_through_records
-    subscriber_1, subscriber_2 = Subscriber.create!(nick: "nick 1"), Subscriber.create!(nick: "nick 2")
-    subscription_1 = Subscription.new(subscriber: subscriber_1)
-    subscription_2 = Subscription.new(subscriber: subscriber_2)
-    book = Book.new
-    book.subscriptions = [subscription_1, subscription_2]
-
-    assert_predicate subscriber_1, :persisted?
-    assert_predicate subscriber_2, :persisted?
-    assert_predicate book, :new_record?
-    book.subscriptions.each { |subscription| assert_predicate subscription, :new_record? }
-    assert_equal book.subscribers.sort, [subscriber_1, subscriber_2].sort
-  end
-
   def test_has_many_through_create_record
     assert books(:awdr).subscribers.create!(nick: "bob")
   end

--- a/activerecord/test/cases/associations/has_many_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_through_associations_test.rb
@@ -57,20 +57,7 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
     Reader.create person_id: 0, post_id: 0
   end
 
-  def test_setting_has_many_through_one_association_on_new_record_sets_through_records
-    account_1, account_2 = Account.create!(credit_limit: 100), Account.create!(credit_limit: 100)
-    firm = Firm.new(accounts: [account_1, account_2])
-    client = Client.new
-    client.firm = firm
-
-    assert_predicate account_1, :persisted?
-    assert_predicate account_2, :persisted?
-    assert_predicate client, :new_record?
-    assert_predicate client.firm, :new_record?
-    assert_no_queries { assert_equal [account_1, account_2].sort, client.accounts.sort }
-  end
-
-  def test_setting_has_many_through_many_association_on_new_record_sets_through_records
+  def test_setting_association_on_new_record_sets_through_records
     subscriber_1, subscriber_2 = Subscriber.create!(nick: "nick 1"), Subscriber.create!(nick: "nick 2")
     subscription_1 = Subscription.new(subscriber: subscriber_1)
     subscription_2 = Subscription.new(subscriber: subscriber_2)
@@ -81,42 +68,10 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
     assert_predicate subscriber_2, :persisted?
     assert_predicate book, :new_record?
     book.subscriptions.each { |subscription| assert_predicate subscription, :new_record? }
-    assert_no_queries { assert_equal [subscriber_1, subscriber_2].sort, book.subscribers.sort }
+    assert_equal [subscriber_1, subscriber_2].sort, book.subscribers.sort
   end
 
-  def test_setting_nested_has_many_through_one_association_on_new_record_sets_nested_through_records
-    post_tagging_1, post_tagging_2 = Tagging.create!, Tagging.create!
-    post = Post.create!(title: "Tagged", body: "Post", taggings: [post_tagging_1, post_tagging_2])
-    author = Author.new(name: "Josh")
-    author.posts = [post]
-    categorization = Categorization.new
-    categorization.author = author
-
-    assert_predicate post_tagging_1, :persisted?
-    assert_predicate post_tagging_2, :persisted?
-    assert_predicate post, :persisted?
-    assert_predicate categorization, :new_record?
-    assert_predicate categorization.author, :new_record?
-    assert_no_queries { assert_equal [post_tagging_1, post_tagging_2].sort, categorization.post_taggings.sort }
-  end
-
-  def test_setting_nested_has_many_through_one_association_on_new_record_sets_targetless_nested_through_records
-    post = Post.create!(title: "Tagged", body: "Post")
-    post_tagging_1, post_tagging_2 = Tagging.create!(taggable: post), Tagging.create!(taggable: post)
-    author = Author.new(name: "Josh")
-    author.posts = [post]
-    categorization = Categorization.new
-    categorization.author = author
-
-    assert_predicate post_tagging_1, :persisted?
-    assert_predicate post_tagging_2, :persisted?
-    assert_predicate post, :persisted?
-    assert_predicate categorization, :new_record?
-    assert_predicate categorization.author, :new_record?
-    assert_queries_count(1) { assert_equal [post_tagging_1, post_tagging_2].sort, categorization.post_taggings.sort }
-  end
-
-  def test_setting_nested_has_many_through_many_association_on_new_record_sets_nested_through_records
+  def test_setting_association_on_new_record_sets_nested_through_records
     account_1 = Account.create!(firm_name: "account 1", credit_limit: 100)
     subscriber_1 = Subscriber.create!(nick: "nick 1", account: account_1)
     account_2 = Account.create!(firm_name: "account 2", credit_limit: 100)
@@ -128,11 +83,9 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
 
     assert_predicate subscriber_1, :persisted?
     assert_predicate subscriber_2, :persisted?
-    assert_predicate account_1, :persisted?
-    assert_predicate account_2, :persisted?
     assert_predicate book, :new_record?
     book.subscriptions.each { |subscription| assert_predicate subscription, :new_record? }
-    assert_no_queries { assert_equal [account_1, account_2].sort, book.subscriber_accounts.sort }
+    assert_equal [account_1, account_2].sort, book.subscriber_accounts.sort
   end
 
   def test_has_many_through_create_record

--- a/activerecord/test/cases/associations/has_many_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_through_associations_test.rb
@@ -29,6 +29,9 @@ require "models/categorization"
 require "models/member"
 require "models/membership"
 require "models/club"
+require "models/program"
+require "models/program_offering"
+require "models/enrollment"
 require "models/organization"
 require "models/user"
 require "models/family"
@@ -1546,6 +1549,21 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
 
     assert_equal [category.id], author.special_categories_with_condition_ids
     assert_equal [], author.nonspecial_categories_with_condition_ids
+  end
+
+  def test_has_many_through_from_same_parent_to_same_child_creates_join_models
+    club = Club.new(name: "Awesome Rails Club")
+    member = club.simple_members.build(name: "Jane Doe")
+
+    program = Program.new(name: "Learn Ruby on Rails")
+    program.members << member
+
+    club.programs << program
+
+    club.save!
+
+    assert_equal(1, program.enrollments.size)
+    assert_equal(1, club.simple_memberships.size)
   end
 
   def test_single_has_many_through_association_with_unpersisted_parent_instance

--- a/activerecord/test/cases/associations/has_many_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_through_associations_test.rb
@@ -84,44 +84,6 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
     assert_no_queries { assert_equal [subscriber_1, subscriber_2].sort, book.subscribers.sort }
   end
 
-  def test_setting_has_many_through_many_association_with_missing_targets_on_new_record_sets_empty_through_records
-    subscription_1 = Subscription.new
-    subscription_2 = Subscription.new
-    book = Book.new
-    book.subscriptions = [subscription_1, subscription_2]
-
-    assert_predicate book, :new_record?
-    book.subscriptions.each { |subscription| assert_predicate subscription, :new_record? }
-    assert_no_queries { assert_equal [], book.subscribers }
-  end
-
-  def test_setting_has_many_through_many_association_with_partial_missing_targets_on_new_record_sets_partial_through_records
-    subscriber_1 = Subscriber.create!(nick: "nick 1")
-    subscription_1 = Subscription.new(subscriber: subscriber_1)
-    subscription_2 = Subscription.new
-    book = Book.new
-    book.subscriptions = [subscription_1, subscription_2]
-
-    assert_predicate subscriber_1, :persisted?
-    assert_predicate book, :new_record?
-    book.subscriptions.each { |subscription| assert_predicate subscription, :new_record? }
-    assert_no_queries { assert_equal [subscriber_1], book.subscribers }
-  end
-
-  def test_setting_polymorphic_has_many_through_many_association_on_new_record_sets_through_records
-    human_1, human_2 = Human.create!, Human.create!
-    interest_1 = Interest.new(polymorphic_human: human_1)
-    interest_2 = Interest.new(polymorphic_human: human_2)
-    zine = Zine.new
-    zine.interests = [interest_1, interest_2]
-
-    assert_predicate human_1, :persisted?
-    assert_predicate human_2, :persisted?
-    assert_predicate zine, :new_record?
-    zine.interests.each { |interest| assert_predicate interest, :new_record? }
-    assert_no_queries { assert_equal [human_1, human_2].sort, zine.polymorphic_humans.sort }
-  end
-
   def test_setting_nested_has_many_through_one_association_on_new_record_sets_nested_through_records
     post_tagging_1, post_tagging_2 = Tagging.create!, Tagging.create!
     post = Post.create!(title: "Tagged", body: "Post", taggings: [post_tagging_1, post_tagging_2])

--- a/activerecord/test/cases/associations/has_one_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_one_through_associations_test.rb
@@ -55,20 +55,6 @@ class HasOneThroughAssociationsTest < ActiveRecord::TestCase
     assert_equal club, member.club
   end
 
-  def test_setting_association_on_new_record_sets_nested_through_record
-    category = Category.create!(name: "General")
-    club = Club.create!(category: category)
-    membership = CurrentMembership.new(club: club)
-    member = Member.new
-    member.current_membership = membership
-
-    assert_predicate category, :persisted?
-    assert_predicate club, :persisted?
-    assert_predicate member, :new_record?
-    assert_predicate member.current_membership, :new_record?
-    assert_equal club.category, member.club_category
-  end
-
   def test_creating_association_creates_through_record
     new_member = Member.create(name: "Chris")
     new_member.club = Club.create(name: "LRUG")

--- a/activerecord/test/cases/associations/has_one_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_one_through_associations_test.rb
@@ -43,18 +43,6 @@ class HasOneThroughAssociationsTest < ActiveRecord::TestCase
     end
   end
 
-  def test_setting_association_on_new_record_sets_through_record
-    club = Club.create!
-    membership = CurrentMembership.new(club: club)
-    member = Member.new
-    member.current_membership = membership
-
-    assert_predicate club, :persisted?
-    assert_predicate member, :new_record?
-    assert_predicate member.current_membership, :new_record?
-    assert_equal club, member.club
-  end
-
   def test_creating_association_creates_through_record
     new_member = Member.create(name: "Chris")
     new_member.club = Club.create(name: "LRUG")

--- a/activerecord/test/cases/associations/has_one_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_one_through_associations_test.rb
@@ -23,7 +23,6 @@ require "models/carrier"
 require "models/shop_account"
 require "models/customer_carrier"
 require "models/cpk"
-require "models/rating"
 
 class HasOneThroughAssociationsTest < ActiveRecord::TestCase
   fixtures :member_types, :members, :clubs, :memberships, :sponsors, :organizations, :minivans,
@@ -53,7 +52,7 @@ class HasOneThroughAssociationsTest < ActiveRecord::TestCase
     assert_predicate club, :persisted?
     assert_predicate member, :new_record?
     assert_predicate member.current_membership, :new_record?
-    assert_no_queries { assert_equal club, member.club }
+    assert_equal club, member.club
   end
 
   def test_setting_association_on_new_record_sets_nested_through_record
@@ -67,38 +66,7 @@ class HasOneThroughAssociationsTest < ActiveRecord::TestCase
     assert_predicate club, :persisted?
     assert_predicate member, :new_record?
     assert_predicate member.current_membership, :new_record?
-    assert_no_queries { assert_equal club.category, member.club_category }
-  end
-
-  def test_setting_association_on_new_record_sets_not_loaded_nested_through_record
-    category = Category.create!(name: "General")
-    club = Club.create!(category: category)
-    club.reload
-    membership = CurrentMembership.new(club: club)
-    member = Member.new
-    member.current_membership = membership
-
-    assert_predicate category, :persisted?
-    assert_predicate club, :persisted?
-    assert_predicate member, :new_record?
-    assert_predicate member.current_membership, :new_record?
-    assert_queries_count(1) { assert_equal club.category, member.club_category }
-  end
-
-  def test_setting_association_on_new_record_sets_nested_through_record_with_belongs_to
-    essay = Essay.create!
-    author = Author.create!(name: "Josh", owned_essay: essay)
-    post = Post.create!(title: "Foo", body: "Bar", author: author)
-    comment = Comment.new(post: post)
-    rating = Rating.new
-    rating.comment = comment
-
-    assert_predicate essay, :persisted?
-    assert_predicate author, :persisted?
-    assert_predicate post, :persisted?
-    assert_predicate rating, :new_record?
-    assert_predicate rating.comment, :new_record?
-    assert_no_queries { assert_equal essay, rating.owned_essay }
+    assert_equal club.category, member.club_category
   end
 
   def test_creating_association_creates_through_record

--- a/activerecord/test/cases/autosave_association_test.rb
+++ b/activerecord/test/cases/autosave_association_test.rb
@@ -40,9 +40,6 @@ require "models/chef"
 require "models/cake_designer"
 require "models/drink_designer"
 require "models/cpk"
-require "models/family"
-require "models/family_tree"
-require "models/user"
 
 class TestAutosaveAssociationsInGeneral < ActiveRecord::TestCase
   def test_autosave_works_even_when_other_callbacks_update_the_parent_model
@@ -1149,34 +1146,6 @@ class TestDefaultAutosaveAssociationOnNewRecord < ActiveRecord::TestCase
     post.save!
 
     assert_equal 1, post.categories.reload.length
-  end
-
-  FamilyLoadingMiddleAndThroughRecordsBeforeSave = Class.new(Family) do
-    before_save do
-      family_trees.map(&:member) + members
-    end
-  end
-
-  def test_autosave_new_record_with_hmt_and_middle_record_built_by_parent
-    family = FamilyLoadingMiddleAndThroughRecordsBeforeSave.new
-    family_tree = family.family_trees.build
-    family_tree.build_member
-    family.save!
-    family.reload
-
-    assert_equal 1, family.family_trees.size
-    assert_equal 1, family.members.size
-  end
-
-  def test_autosave_new_record_with_hmt_and_middle_record_built_by_through_record
-    family = FamilyLoadingMiddleAndThroughRecordsBeforeSave.new
-    member = family.members.build
-    family.family_trees.build(member: member)
-    family.save!
-    family.reload
-
-    assert_equal 1, family.family_trees.size
-    assert_equal 1, family.members.size
   end
 end
 

--- a/activerecord/test/models/book.rb
+++ b/activerecord/test/models/book.rb
@@ -9,7 +9,6 @@ class Book < ActiveRecord::Base
 
   has_many :subscriptions
   has_many :subscribers, through: :subscriptions
-  has_many :subscriber_accounts, through: :subscribers, source: :account
 
   has_one :essay
 

--- a/activerecord/test/models/club.rb
+++ b/activerecord/test/models/club.rb
@@ -15,6 +15,12 @@ class Club < ActiveRecord::Base
 
   scope :general, -> { left_joins(:category).where(categories: { name: "General" }).unscope(:limit) }
 
+  has_many :program_offerings
+  has_many :programs, through: :program_offerings
+
+  has_many :simple_memberships, class_name: "Membership"
+  has_many :simple_members, through: :simple_memberships, foreign_key: "member_id"
+
   accepts_nested_attributes_for :membership
 
   private

--- a/activerecord/test/models/enrollment.rb
+++ b/activerecord/test/models/enrollment.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class Enrollment < ActiveRecord::Base
+  belongs_to :program
+  belongs_to :member, class_name: "SimpleMember"
+end

--- a/activerecord/test/models/family_tree.rb
+++ b/activerecord/test/models/family_tree.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class FamilyTree < ActiveRecord::Base
-  belongs_to :user
-
   belongs_to :member, class_name: "User", foreign_key: "member_id"
   belongs_to :family
 end

--- a/activerecord/test/models/member.rb
+++ b/activerecord/test/models/member.rb
@@ -44,6 +44,13 @@ class Member < ActiveRecord::Base
   scope :with_member_type_id, -> (id) { where(member_type_id: id) }
 end
 
+class SimpleMember < ActiveRecord::Base
+  self.table_name = "members"
+
+  has_many :memberships
+  has_many :clubs, through: :memberships
+end
+
 class SelfMember < ActiveRecord::Base
   self.table_name = "members"
   has_and_belongs_to_many :friends, class_name: "SelfMember", join_table: "member_friends"

--- a/activerecord/test/models/member_detail.rb
+++ b/activerecord/test/models/member_detail.rb
@@ -5,7 +5,6 @@ class MemberDetail < ActiveRecord::Base
   belongs_to :organization
   has_one :member_type, through: :member
   has_one :membership, through: :member
-  has_one :sponsor, through: :membership
   has_one :admittable, through: :member, source_type: "Member"
 
   has_many :organization_member_details, through: :organization, source: :member_details

--- a/activerecord/test/models/membership.rb
+++ b/activerecord/test/models/membership.rb
@@ -4,6 +4,9 @@ class Membership < ActiveRecord::Base
   enum :type, %i(Membership CurrentMembership SuperMembership SelectedMembership TenantMembership)
   belongs_to :member
   belongs_to :club
+  has_one :sponsor, through: :club
+
+  belongs_to :simple_member, foreign_key: "member_id"
 end
 
 class CurrentMembership < Membership

--- a/activerecord/test/models/membership.rb
+++ b/activerecord/test/models/membership.rb
@@ -4,7 +4,6 @@ class Membership < ActiveRecord::Base
   enum :type, %i(Membership CurrentMembership SuperMembership SelectedMembership TenantMembership)
   belongs_to :member
   belongs_to :club
-  has_one :sponsor, through: :club
 end
 
 class CurrentMembership < Membership

--- a/activerecord/test/models/post.rb
+++ b/activerecord/test/models/post.rb
@@ -46,7 +46,6 @@ class Post < ActiveRecord::Base
   }
 
   belongs_to :author
-  has_one :owned_essay, through: :author
   belongs_to :readonly_author, -> { readonly }, class_name: "Author", foreign_key: :author_id
 
   belongs_to :author_with_posts, -> { includes(:posts) }, class_name: "Author", foreign_key: :author_id

--- a/activerecord/test/models/program.rb
+++ b/activerecord/test/models/program.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class Program < ActiveRecord::Base
+  has_many :enrollments
+  has_many :members, through: :enrollments, class_name: "SimpleMember"
+end

--- a/activerecord/test/models/program_offering.rb
+++ b/activerecord/test/models/program_offering.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class ProgramOffering < ActiveRecord::Base
+  belongs_to :club
+  belongs_to :program
+end

--- a/activerecord/test/models/rating.rb
+++ b/activerecord/test/models/rating.rb
@@ -2,8 +2,6 @@
 
 class Rating < ActiveRecord::Base
   belongs_to :comment
-  has_one :post, through: :comment
-  has_one :owned_essay, through: :post
   has_many :taggings, as: :taggable
   has_many :taggings_without_tag, -> { left_joins(:tag).where("tags.id": [nil, 0]) }, as: :taggable, class_name: "Tagging"
   has_many :taggings_with_no_tag, -> { joins("LEFT OUTER JOIN tags ON tags.id = taggings.tag_id").where("tags.id": nil) }, as: :taggable, class_name: "Tagging"

--- a/activerecord/test/models/subscriber.rb
+++ b/activerecord/test/models/subscriber.rb
@@ -3,8 +3,6 @@
 class Subscriber < ActiveRecord::Base
   self.primary_key = "nick"
 
-  belongs_to :account
-
   has_many :subscriptions
   has_many :books, through: :subscriptions
 end

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -1174,7 +1174,6 @@ ActiveRecord::Schema.define do
     t.integer :books_count, null: false, default: 0
     t.integer :update_count, null: false, default: 0
     t.index :nick, unique: true
-    t.references :account
   end
 
   create_table :subscriptions, force: true do |t|

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -588,6 +588,11 @@ ActiveRecord::Schema.define do
     t.references :car, index: false
   end
 
+  create_table :enrollments, force: true do |t|
+    t.integer  :program_id
+    t.integer  :member_id
+  end
+
   create_table :entrants, force: true do |t|
     t.string  :name, null: false
     t.integer :course_id, null: false
@@ -1016,6 +1021,16 @@ ActiveRecord::Schema.define do
     t.string :name
     t.decimal :price
     t.decimal :discounted_price
+  end
+
+  create_table :program_offerings, force: true do |t|
+    t.integer  :club_id
+    t.integer  :program_id
+    t.datetime :start_date
+  end
+
+  create_table :programs, force: true do |t|
+    t.string   :name
   end
 
   add_check_constraint :products, "price > discounted_price", name: "products_price_check"


### PR DESCRIPTION
### Motivation / Background

This PR reverts commits related to has-many-through association behaviour changing. These changes are still causing issues with Shopify's Rails monolith 😞 (I've added a regression test to demonstrate the issue we're seeing).  We've decided it's simplest to roll the changes back for now, since it seems like there are still uncaught corner cases / other potential regressions to these changes. If we attempt these changes again, Shopify can probably help test this a bit more thoroughly on our CI.

More context around some of the original issues: https://github.com/rails/rails/issues/54176 
This was addressed by https://github.com/rails/rails/pull/54238, but that is leading to other failures on our end.

### Detail

Reverts the following PRs: 
- https://github.com/rails/rails/pull/54238
- https://github.com/rails/rails/pull/54046
- https://github.com/rails/rails/pull/53957
- https://github.com/rails/rails/pull/53869
- https://github.com/rails/rails/pull/51114

Adds a regression test that fails without the changes above reverted. 

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.

cc @eileencodes @joshuay03 
