### PR TITLE
Update link to Getting Started guide in Testing Rails guide [ci skip]

### DIFF
--- a/guides/source/testing.md
+++ b/guides/source/testing.md
@@ -91,7 +91,7 @@ NOTE: Your tests are run under `RAILS_ENV=test`. This is set by Rails automatica
 ### Writing Your First Test
 
 We introduced the `bin/rails generate model` command in the [Getting Started
-with Rails](getting_started.html#mvc-and-you-generating-a-model) guide.
+with Rails](getting_started.html#creating-a-database-model) guide.
 Alongside creating a model, this command also creates a test stub in the `test`
 directory:
 


### PR DESCRIPTION
Link was pointing to a section of Getting Started guide that was removed with #53846, this PR fixes the link location to appropriate new section.