### PR TITLE
Remove warning silence on Journey::Parser require

### DIFF
--- a/actionpack/lib/action_dispatch/journey/router.rb
+++ b/actionpack/lib/action_dispatch/journey/router.rb
@@ -5,12 +5,7 @@
 require "action_dispatch/journey/router/utils"
 require "action_dispatch/journey/routes"
 require "action_dispatch/journey/formatter"
-
-before = $-w
-$-w = false
 require "action_dispatch/journey/parser"
-$-w = before
-
 require "action_dispatch/journey/route"
 require "action_dispatch/journey/path/pattern"
 


### PR DESCRIPTION
I assume this was originally [added][1] because `Parser` was generated by `racc`, and parser generators have historically emitted many Ruby warnings.

However, now the parser is no longer generated by `racc` so the warning silencing is unnecessary (and could potentially cover up legitimate and fixable warnings in the hand written parser).

[1]: https://github.com/rails/journey/commit/53951dcdb39db93d2bf3f93391f8ecf16ca34dd0
