### PR TITLE
Add a script for using dev containers outside VSCode

### DIFF
--- a/.devcontainer/boot.sh
+++ b/.devcontainer/boot.sh
@@ -1,7 +1,9 @@
 bundle install
 
-. ${NVM_DIR}/nvm.sh && nvm install --lts
-yarn install
+if [[ ! -z "${NVM_DIR}" ]]; then
+  . ${NVM_DIR}/nvm.sh && nvm install --lts
+  yarn install
+fi
 
 cd activerecord
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -39,7 +39,7 @@
 				"Shopify.ruby-lsp"
 			]
 		}
-	},
+	}
 
 	// Uncomment to connect as root instead. More info: https://containers.dev/implementors/json_reference/#remoteUser.
 	// "remoteUser": "root"

--- a/tools/devcontainer
+++ b/tools/devcontainer
@@ -1,0 +1,30 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "json"
+require "open3"
+
+VARS = {
+  "localWorkspaceFolderBasename" => Dir.pwd.split(File::SEPARATOR).last
+}
+
+data = File.binread ".devcontainer/devcontainer.json"
+data.gsub!(/^\s*\/\/.*$/, "") # strip comments
+info = JSON.load data
+
+working_dir = info["workspaceFolder"].gsub(/\${([^}]*)}/) { |x|
+  VARS.fetch($1)
+}
+
+env = info["containerEnv"].map { |k, v| "-e #{k}=#{v}" }.join " "
+
+case ARGV[0]
+when "up"
+  system "docker compose -f .devcontainer/#{info["dockerComposeFile"]} up"
+when "run-user-commands"
+  service_id, _, _ = Open3.capture3("docker ps -q -f name=#{info["service"]}")
+  system "docker exec #{env} -w #{working_dir} -it #{service_id.chomp} /bin/bash -i #{info["postCreateCommand"]}"
+when "sh"
+  service_id, _, _ = Open3.capture3("docker ps -q -f name=#{info["service"]}")
+  system "docker exec #{env} -w #{working_dir} -it #{service_id.chomp} /bin/bash"
+end

--- a/tools/devcontainer
+++ b/tools/devcontainer
@@ -20,7 +20,7 @@ env = info["containerEnv"].map { |k, v| "-e #{k}=#{v}" }.join " "
 
 case ARGV[0]
 when "up"
-  system "docker compose -f .devcontainer/#{info["dockerComposeFile"]} up"
+  system "docker", "compose", "-f", ".devcontainer/#{info["dockerComposeFile"]}", "up"
 when "run-user-commands"
   service_id, _, _ = Open3.capture3("docker ps -q -f name=#{info["service"]}")
   system "docker exec #{env} -w #{working_dir} -it #{service_id.chomp} /bin/bash -i #{info["postCreateCommand"]}"


### PR DESCRIPTION
I want to use the devcontainer info, but I don't want to use VSCode. This commit adds a small script that reads the devcontainer JSON file and runs docker commands based on the information in the JSON file.

Usage is like this:

In terminal 1, run `tool/devcontainer up`

After that thing is running do `tool/devcontainer run-user-commands` to make sure gems are bundled and database is set up.

Finally run `tool/devcontainer sh` to get a shell inside the container.

I had to change the JSON file because it had a trailing comma.  I also had to change `.devcontainer/boot.sh` because I don't seem to have `NVM_DIR` set up and I'm not sure where that environment variables comes from.

Here is a screenshot with the terminal running `tool/devcontainer up`:


<img width="1411" alt="Screenshot 2025-01-17 at 3 47 50 PM" src="https://github.com/user-attachments/assets/7bb4635f-3395-431b-b7f6-91a0179b009a" />

Here is a screenshot inside the dev container:

<img width="1411" alt="Screenshot 2025-01-17 at 3 48 13 PM" src="https://github.com/user-attachments/assets/4199099f-746b-4e9c-83f4-f75c11492425" />
