### PR TITLE
Deprecate the `validate: false` option for `foreign_key` and `check_constraint`

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Deprecate the `validate: false` option for `foreign_key` and `check_constraint`.
+
+    PostgreSQL ignores the `NOT VALID` option for foreign keys and check constraints in a `CREATE TABLE` statement.
+    To enable the `NOT VALID` option, use `add_foreign_key` or `add_check_constraint`, which generate `ALTER TABLE` statements.
+
+    *Yasuo Honda*
+
 *   Fix using the `SQLite3Adapter`'s `dbconsole` method outside of a Rails application.
 
     *Hartley McGuire*

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_definitions.rb
@@ -261,6 +261,30 @@ module ActiveRecord
           unique_constraints << new_unique_constraint_definition(column_name, options)
         end
 
+        def foreign_key(*args, **options)
+          if options[:validate] == false
+            ActiveRecord.deprecator.warn(<<~MSG)
+              Providing validate: false for foreign_key is deprecated because PostgreSQL ignores it.
+              This option will cause an `ArgumentError` in Rails 8.2.
+              Use add_foreign_key with validate: false to create a NOT VALID foreign key instead.
+            MSG
+          end
+
+          super
+        end
+
+        def check_constraint(expression, **options)
+          if options[:validate] == false
+            ActiveRecord.deprecator.warn(<<~MSG)
+              Providing validate: false for check_constraint is deprecated because PostgreSQL ignores it.
+              This option will raise an ArgumentError in Rails 8.2.
+              Use add_check_constraint with validate: false to create a NOT VALID check constraint instead.
+            MSG
+          end
+
+          super
+        end
+
         def new_exclusion_constraint_definition(expression, options) # :nodoc:
           options = @conn.exclusion_constraint_options(name, expression, options)
           ExclusionConstraintDefinition.new(name, expression, options)

--- a/activerecord/lib/active_record/migration/compatibility.rb
+++ b/activerecord/lib/active_record/migration/compatibility.rb
@@ -32,6 +32,29 @@ module ActiveRecord
       V8_1 = Current
 
       class V8_0 < V8_1
+        if connection.adapter_name == "PostgreSQL"
+          module TableDefinition
+            def foreign_key(*args, **options)
+              options.delete(:validate)
+              super
+            end
+
+            def check_constraint(expression, **options)
+              options.delete(:validate)
+              super
+            end
+          end
+        end
+
+        private
+          def compatible_table_definition(t)
+            if connection.adapter_name == "PostgreSQL"
+              class << t
+                prepend TableDefinition
+              end
+            end
+            super
+          end
       end
 
       class V7_2 < V8_0

--- a/activerecord/test/cases/migration/check_constraint_test.rb
+++ b/activerecord/test/cases/migration/check_constraint_test.rb
@@ -206,6 +206,18 @@ if ActiveRecord::Base.lease_connection.supports_check_constraints?
 
             assert_match %r{\s+t.check_constraint "quantity > 0", name: "quantity_check"$}, output
           end
+
+          def test_not_valid_check_constraint_in_create_table_is_deprecated
+            assert_deprecated(ActiveRecord.deprecator) do
+              @connection.create_table :nonvalid_constraints, id: false, force: true do |t|
+                t.string :name
+                t.check_constraint "char_length(name) >= 5", name: "name_const", validate: false
+              end
+            ensure
+              @connection.drop_table(:nonvalid_constraints, if_exists: true)
+              ActiveRecord::Base.clear_cache!
+            end
+          end
         else
           # Check constraint should still be created, but should not be invalid
           def test_add_invalid_check_constraint

--- a/activerecord/test/cases/migration/foreign_key_test.rb
+++ b/activerecord/test/cases/migration/foreign_key_test.rb
@@ -546,6 +546,23 @@ if ActiveRecord::Base.lease_connection.supports_foreign_keys?
 
             assert_match %r{\s+add_foreign_key "astronauts", "rockets"$}, output
           end
+
+          def test_not_valid_forein_key_in_create_table_is_deprecated
+            assert_deprecated(ActiveRecord.deprecator) do
+              @connection.create_table :nonvalid_rockets, force: true do |t|
+                t.string :name
+              end
+              @connection.create_table :nonvalid_astronauts, force: true do |t|
+                t.string :name
+                t.references :rocket
+                t.foreign_key :nonvalid_rockets, column: "rocket_id", validate: false
+              end
+            end
+          ensure
+            @connection.drop_table(:nonvalid_astronauts, if_exists: true)
+            @connection.drop_table(:nonvalid_rockets, if_exists: true)
+            ActiveRecord::Base.clear_cache!
+          end
         else
           # Foreign key should still be created, but should not be invalid
           def test_add_invalid_foreign_key


### PR DESCRIPTION
This pull request Deprecate the `validate: false` option for `foreign_key` and `check_constraint`.

### Motivation / Background

The `foreign_key` and `check_constraint` with `validate: false` option actually create valid constraints
because PostgreSQL ignores `NOT VALID` option in `CREATE TABLE` statements.
    
To enable the `NOT VALID` option, use `add_foreign_key` or `add_check_constraint`, which generate `ALTER TABLE` statements.
    
### Detail
Here are the example of check constraints.

- `check_constraint` with `validate: false` option creates a valid check constraint

```ruby
create_table :posts, force: true do |t|
  t.check_constraint "id > 0", name: "foo", validate: false
end
```

```sql
CREATE TABLE "posts" ("id" bigserial primary key, CONSTRAINT foo CHECK (id > 0) NOT VALID);
SELECT conname, convalidated FROM pg_constraint WHERE contype = 'c' AND conname = 'foo';

/*
 conname | convalidated
---------+--------------
 foo     | t
(1 row)
*/
```

- `add_check_constraint` with `validate: false` option creates a invalid check constraint

```ruby
create_table :posts, force: true do |t|
end
add_check_constraint :posts, "id > 0", name: "foo", validate: false
```

```sql
CREATE TABLE "posts" ("id" bigserial primary key);
ALTER TABLE "posts" ADD CONSTRAINT foo CHECK (id > 0) NOT VALID;
SELECT conname, convalidated FROM pg_constraint WHERE contype = 'c' AND conname = 'foo';
/*
 conname | convalidated
---------+--------------
 foo     | f
(1 row)
*/
```



### Additional information
Related to #53732

Refer to the following discussion at pgsql-hackers mailing list. https://www.postgresql.org/message-id/202412050936.bse4z5tbmze6%40alvherre.pgsql

> Maybe it would have been wise to forbid NOT VALID when used with CREATE
> TABLE.  But we didn't.  Should we do that now?  Maybe we can just
> document that you can specify it but it doesn't do anything.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
