### PR TITLE
Refine a step in the Sprockets to Propshaft migration guide

### DIFF
--- a/guides/source/asset_pipeline.md
+++ b/guides/source/asset_pipeline.md
@@ -920,9 +920,10 @@ Some key steps in the migration include:
 4. Remove the `config.assets.paths << Rails.root.join('app', 'assets')` line
    from your `application.rb` file.
 
-5. Migrate asset helpers by replacing all instances of asset helpers (e.g.,
-   `image_url`) with standard URLs because Propshaft utilizes relative paths.
-   For example, `image_url("logo.png")` will become `url("/logo.png")`.
+5. Migrate asset helpers by replacing all instances of asset helpers in your CSS
+   files (e.g., `image_url`) with standard `url()` functions, keeping in mind
+   that Propshaft utilizes relative paths.
+   For example, `image_url("logo.png")` may become `url("/logo.png")`.
 
 6. If you're relying on Sprockets for transpiling, you'll need to switch to a
    Node-based transpiler like Webpack, esbuild, or Vite. You can use the


### PR DESCRIPTION
While migrating from Sprockets to Propshaft, I found [one of the migration steps](https://github.com/rails/rails/blob/main/guides/source/asset_pipeline.md?plain=1#L923) mentioned in the [Asset Pipeline Guide](https://guides.rubyonrails.org/asset_pipeline.html#migration-steps) quite confusing. The step says:

> 5. Migrate asset helpers by replacing all instances of asset helpers (e.g., `image_url`) with standard URLs because Propshaft utilizes relative paths. For example, `image_url("logo.png")` will become `url("/logo.png")`.

I got stuck a bit, wondering what asset helpers does this talk about. _Is it about [Action View Asset helpers](https://api.rubyonrails.org/classes/ActionView/Helpers/AssetUrlHelper.html) that we use overall the templates? Quite surely no. Is this CSS/JS-specific? Probably…_

Later I found that this is most probably a summary of [this step](https://github.com/rails/propshaft/blob/main/UPGRADING.md#asset-helpers) from the Upgrading guide in the Propshaft gem. From there it seems clearer that this is all about migrating Sprockets asset helpers _in the CSS files_ to [standard `url()` CSS functions](https://developer.mozilla.org/en-US/docs/Web/CSS/url_function). Therefore, I tried to reword the paragraph a bit to make it clearer for me.