### PR TITLE
Make `raise_on_missing_translation` ignore `i18n.plural.rule`

### DIFF
--- a/activesupport/lib/active_support/i18n_railtie.rb
+++ b/activesupport/lib/active_support/i18n_railtie.rb
@@ -94,7 +94,13 @@ module I18n
           I18n.exception_handler.is_a?(I18n::ExceptionHandler) # Only override the i18n gem's default exception handler.
 
         I18n.exception_handler = ->(exception, *) {
-          exception = exception.to_exception if exception.is_a?(I18n::MissingTranslation)
+          if exception.is_a?(I18n::MissingTranslation)
+            # Do not raise if `i18n.plural.rule` is missing
+            # because the `i18n` gem has a fallback to handle it.
+            return if exception.key == :"i18n.plural.rule"
+
+            exception = exception.to_exception
+          end
           raise exception
         }
       end

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Make `raise_on_missing_translation` exception handler
+    ignore missing `i18n.plural.rule` translation.
+
+    *Grant Bourque*
+
 *   Add `application-name` metadata to application layout
 
     The following metatag will be added to `app/views/layouts/application.html.erb`

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -4500,6 +4500,21 @@ module ApplicationTests
       end
     end
 
+    test "raise_on_missing_translations = true and pluralization backend does not have plural rule for locale" do
+      add_to_config "config.i18n.raise_on_missing_translations = true"
+
+      app_file "config/initializers/i18n.rb", <<~RUBY
+        Rails.application.config.after_initialize do
+          I18n.backend.class.include(I18n::Backend::Pluralization)
+          I18n.backend.store_translations :en, apples: { one: "an apple", other: "some apples", zero: "no apples" }
+        end
+      RUBY
+
+      app "development"
+
+      assert_equal "no apples", I18n.t(:apples, count: 0)
+    end
+
     test "raise_on_missing_translations = false" do
       add_to_config "config.i18n.raise_on_missing_translations = false"
       app "development"


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because when upgrading an application to Rails 7.1 I noticed new missing translation exceptions in development that were originated from the code of the `i18n` gem.

A simple pluralization translation like `I18n.t(:apples, count: 0)` that worked in Rails 7.0 was suddenly raising:
```
I18n::MissingTranslationData: Translation missing: en.i18n.plural.rule
```

Here is my executable test case for it: https://gist.github.com/grantbdev/d980f0ca23fbc0a1f514a0c6a730cca2

I realized that the `i18n` gem was making the lookup that was failing: https://github.com/ruby-i18n/i18n/blob/v1.14.6/lib/i18n/backend/pluralization.rb#L82.
The `i18n` gem is expecting to handle when this lookup fails by checking the return value since this missing translation doesn't raise an exception by default in the gem. But the exception handler added by Rails 7.1's [`raise_on_missing_translation` setting makes all missing translations raise an exception](https://github.com/rails/rails/pull/47105), including this one inside the gem.

My first inclination was to create a change in the `i18n` gem and someone independently raised this issue there with a similar custom exception handler: https://github.com/ruby-i18n/i18n/issues/681.
However, everything works fine with `i18n` when using the defaults. A failing test case in their repo basically requires copying the custom exception handler from Rails. So while it would be nice for `i18n` to somehow perform this lookup without causing a missing translation in the first place, it seems like it is more the responsibility of the custom exception handler to handle this scenario.

As a workaround for the application I'm working on, when `config.i18n.raise_on_missing_translations` is true I'm setting `I18n.exception_handler` to the one I'm proposing in this pull request. My hope is that by having this merged into Rails I can remove this workaround and hopefully prevent this problem for someone else.

This is probably a rare scenario because it requires `Backend::Pluralization` to be included into `I18n::Backend::Simple` which is not done by default. It seems that the popular `rails-i18n` gem does this, but it also sets `i18n.plural.rule` so most users of that gem would presumably not experience a regression for Rails 7.1. The application I'm working on doesn't use `rails-i18n`, but it uses a different gem that only sets `i18n.plural.rule` for certain non-English locales.

### Detail

This Pull Request changes the `I18n.exception_handler` when `raise_on_missing_translation` is enabled to not raise an exception for missing translations with a key of `i18n.plural.rule`.

### Additional information

There might be different ways of handling this that could be considered better than filtering based on the exception key. If you have an idea, let me know!

Ideally I think this should be backported to 7.1+ since that is where the regression began and where late upgraders like me are most likely to encounter it.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
