### PR TITLE
Doc: Format CSRF argument lists [ci skip]

### DIFF
--- a/actionpack/lib/action_controller/metal/request_forgery_protection.rb
+++ b/actionpack/lib/action_controller/metal/request_forgery_protection.rb
@@ -149,6 +149,7 @@ module ActionController # :nodoc:
       #
       #
       # Built-in unverified request handling methods are:
+      #
       # *   `:exception` - Raises ActionController::InvalidAuthenticityToken
       #     exception.
       # *   `:reset_session` - Resets the session.
@@ -177,6 +178,7 @@ module ActionController # :nodoc:
       #
       #
       # Built-in session token strategies are:
+      #
       # *   `:session` - Store the CSRF token in the session.  Used as default if
       #     `:store` option is not specified.
       # *   `:cookie` - Store the CSRF token in an encrypted cookie.


### PR DESCRIPTION
Add newlines to the `ActionController::RequestForgeryProtection` method documention to treat `*`-prefixed lines as `<li>` elements.

Before
---

<img width="1021" alt="Screenshot 2025-01-18 at 9 11 04 AM" src="https://github.com/user-attachments/assets/725080c8-eda2-4bfd-a36a-9a255c8efd41" />
<img width="1015" alt="Screenshot 2025-01-18 at 9 11 18 AM" src="https://github.com/user-attachments/assets/67f2cd8c-a5a2-4d5a-ac23-fbb2ae8e8e24" />

After
---

<img width="816" alt="Screenshot 2025-01-18 at 9 11 36 AM" src="https://github.com/user-attachments/assets/5a5abf06-0118-4e3f-8602-0023d388b5a0" />
<img width="810" alt="Screenshot 2025-01-18 at 9 11 42 AM" src="https://github.com/user-attachments/assets/8124b314-0ccb-47a4-8051-dd72d209a2a4" />
