### PR TITLE
Fix forward compatibility issue of URL safe signed Id

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Fix forward compatibility issue of URL safe signed Id
+
+    If a URL-safe signed ID verification fails, a secondary verifier is used as a fallback to ensure forward compatibility during rollout.
+
+    After a successful rollout of this version, `Rails.application.config.active_record.url_safe_signed_id` can be set to `true` to disable the fallback.
+
+    *Ali Sepehri*
+
 *   Fix support for PostgreSQL enum types with commas in their name.
 
     *Arthur Hess*


### PR DESCRIPTION
Fixes #53710 

This Pull Request has been created because making signed Id URL safe is not forward compatible and it causes issue during rollout. Old instances of the application which haven't been updated yet cannot verify newly created URL safe signed Ids.

### Detail

This Pull Request uses a secondary signed Id verifier as a fallback to ensure forward compatibility during rollout.

After a successful rollout of these changes, `Rails.application.config.active_record.url_safe_signed_id` can be set to `true` to disable the fallback.

### Todo
For the latest version `url_safe_signed_id` variable can be removed and make the signed Id URL safe by default.
