### PR TITLE
Format `fill_in_rich_textarea` API docs correctly [ci skip]

### DIFF
--- a/actiontext/lib/action_text/system_test_helper.rb
+++ b/actiontext/lib/action_text/system_test_helper.rb
@@ -7,6 +7,7 @@ module ActionText
     # Locates a Trix editor and fills it in with the given HTML.
     #
     # The editor can be found by:
+    #
     # *   its `id`
     # *   its `placeholder`
     # *   the text from its `label` element


### PR DESCRIPTION
Add newline to [`ActionText::SystemTestHelper#fill_in_rich_textarea`](https://api.rubyonrails.org/classes/ActionText/SystemTestHelper.html#method-i-fill_in_rich_textarea) API docs, to format the list correctly.

## Before

![Screenshot 2025-01-18 at 12 54 39 PM](https://github.com/user-attachments/assets/2d0c4aae-c1dc-4b70-b939-07eccae34965)

## After

![Screenshot 2025-01-18 at 1 03 26 PM](https://github.com/user-attachments/assets/41f549e3-d3b2-49f4-a5e6-88e42f45c292)

## Additional information

After looking at @seanpdoyle's PR https://github.com/rails/rails/pull/54289 I decided to do a global search for other potential API docs list formatting issues by doing `ag ':\n.*\# \*'`. After a cursory glance at the search results, I only found 1 occurrence of bad formatting, which is why I have created this PR.

Interestingly, I noticed that some list items in the API docs are not preceded by newlines, yet they still format correctly as lists. 🤔 See https://github.com/rails/rails/pull/54289#issuecomment-2599867857 for such a case. Anyways, this PR is just a basic fix for the issue at hand.