### PR TITLE
[ci skip] Add instructions for setting up the testing database in plugin docs

### DIFF
--- a/guides/source/plugins.md
+++ b/guides/source/plugins.md
@@ -68,6 +68,15 @@ spec.metadata["changelog_uri"] = "http://example.com"
 
 Then run the `bundle install` command.
 
+After that, set up your testing database by navigating to the `test/dummy` directory and running the following command:
+
+```bash
+$ cd test/dummy
+$ bin/rails db:create
+```
+
+Once the database is created, return to the plugin's root directory (`cd ../..`).
+
 Now you can run the tests using the `bin/test` command, and you should see:
 
 ```bash


### PR DESCRIPTION
### Motivation / Background

While following [the documentation to create a plugin](https://guides.rubyonrails.org/plugins.html), I encountered the following error when running [bin/test](https://github.com/rails/rails/blob/main/guides/source/plugins.md?plain=1#L74):

```
% bin/test
~/.rbenv/versions/3.4.1/lib/ruby/gems/3.4.0/gems/activerecord-8.0.1/lib/active_record/connection_adapters/postgresql_adapter.rb:63:in 'ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.new_client': We could not find your database: dummy_test. Available database configurations can be found in config/database.yml. (ActiveRecord::NoDatabaseError)

To resolve this error:

- Did you not create the database, or did you delete it? To create the database, run:

    bin/rails db:create
```

Before running the tests, the dummy_test database needs to be created. I added instructions to the documentation for setting up the database.