### PR TITLE
Consolidate database commands to config

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,23 @@
+*   Deprecate `ActiveRecord.database_cli` in favor of `dbconsole_command` on
+    the database config.
+
+    *zzak*, *Hartley McGuire*
+
+*   Deprecate `ActiveRecord::Tasks::DatabaseTasks.structure_dump_flags` in
+    favor of `structure_dump_flags` on the database config.
+
+    *zzak*, *Hartley McGuire*
+
+*   Deprecate `ActiveRecord::Tasks::DatabaseTasks.structure_load_flags` in
+    favor of `structure_load_flags` on the database config.
+
+    *zzak*, *Hartley McGuire*
+
+*   Added `structure_load_command` and `structure_dump_command` to the database
+    config.
+
+    *zzak*, *Hartley McGuire*
+
 *   Make column name optional for `index_exists?`.
 
     This aligns well with `remove_index` signature as well, where

--- a/activerecord/lib/active_record.rb
+++ b/activerecord/lib/active_record.rb
@@ -207,8 +207,17 @@ module ActiveRecord
     end
   end
 
-  singleton_class.attr_accessor :database_cli
-  self.database_cli = { postgresql: "psql", mysql: %w[mysql mysql5], sqlite: "sqlite3" }
+  singleton_class.attr_reader :database_cli
+  def self.database_cli=(cli)
+    ActiveRecord.deprecator.warn(
+      "ActiveRecord.database_cli is deprecated and will be removed in Rails 8.1. " \
+      "Use `dbconsole_command` on the database config instead."
+    )
+    @database_cli = cli
+  end
+  ActiveRecord.deprecator.silence do
+    self.database_cli = { postgresql: "psql", mysql: %w[mysql mysql5], sqlite: "sqlite3" }
+  end
 
   singleton_class.attr_reader :default_timezone
 

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -79,7 +79,8 @@ module ActiveRecord
 
           args << config.database
 
-          find_cmd_and_exec(ActiveRecord.database_cli[:mysql], *args)
+          cmd = config.dbconsole_command || ActiveRecord.database_cli[:mysql]
+          find_cmd_and_exec(cmd, *args)
         end
       end
 

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -86,7 +86,9 @@ module ActiveRecord
               "-c #{name}=#{value.to_s.gsub(/[ \\]/, '\\\\\0')}" unless value == ":default" || value == :default
             end.join(" ")
           end
-          find_cmd_and_exec(ActiveRecord.database_cli[:postgresql], config.database)
+
+          cmd = config.dbconsole_command || ActiveRecord.database_cli[:postgresql]
+          find_cmd_and_exec(cmd, config.database)
         end
       end
 

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -64,7 +64,8 @@ module ActiveRecord
           args << "-header" if options[:header]
           args << File.expand_path(config.database, Rails.respond_to?(:root) ? Rails.root : nil)
 
-          find_cmd_and_exec(ActiveRecord.database_cli[:sqlite], *args)
+          cmd = config.dbconsole_command || ActiveRecord.database_cli[:sqlite]
+          find_cmd_and_exec(cmd, *args)
         end
       end
 

--- a/activerecord/lib/active_record/database_configurations/database_config.rb
+++ b/activerecord/lib/active_record/database_configurations/database_config.rb
@@ -76,6 +76,26 @@ module ActiveRecord
         raise NotImplementedError
       end
 
+      def dbconsole_command
+        raise NotImplementedError
+      end
+
+      def structure_dump_command
+        raise NotImplementedError
+      end
+
+      def structure_dump_flags
+        raise NotImplementedError
+      end
+
+      def structure_load_command
+        raise NotImplementedError
+      end
+
+      def structure_load_flags
+        raise NotImplementedError
+      end
+
       def idle_timeout
         raise NotImplementedError
       end

--- a/activerecord/lib/active_record/database_configurations/hash_config.rb
+++ b/activerecord/lib/active_record/database_configurations/hash_config.rb
@@ -99,6 +99,26 @@ module ActiveRecord
         configuration_hash.fetch(:reaping_frequency, 60)&.to_f
       end
 
+      def dbconsole_command
+        configuration_hash[:dbconsole_command]
+      end
+
+      def structure_dump_command
+        configuration_hash[:structure_dump_command]
+      end
+
+      def structure_dump_flags
+        configuration_hash[:structure_dump_flags]
+      end
+
+      def structure_load_command
+        configuration_hash[:structure_load_command]
+      end
+
+      def structure_load_flags
+        configuration_hash[:structure_load_flags]
+      end
+
       def idle_timeout
         timeout = configuration_hash.fetch(:idle_timeout, 300).to_f
         timeout if timeout > 0

--- a/activerecord/lib/active_record/tasks/mysql_database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/mysql_database_tasks.rb
@@ -53,7 +53,8 @@ module ActiveRecord
         args.concat([db_config.database.to_s])
         args.unshift(*extra_flags) if extra_flags
 
-        run_cmd("mysqldump", args, "dumping")
+        cmd = db_config.structure_dump_command || "mysqldump"
+        run_cmd(cmd, args)
       end
 
       def structure_load(filename, extra_flags)
@@ -62,7 +63,8 @@ module ActiveRecord
         args.concat(["--database", db_config.database.to_s])
         args.unshift(*extra_flags) if extra_flags
 
-        run_cmd("mysql", args, "loading")
+        cmd = db_config.structure_load_command || "mysql"
+        run_cmd(cmd, args)
       end
 
       private
@@ -106,11 +108,11 @@ module ActiveRecord
           args
         end
 
-        def run_cmd(cmd, args, action)
-          fail run_cmd_error(cmd, args, action) unless Kernel.system(cmd, *args)
+        def run_cmd(cmd, args)
+          fail run_cmd_error(cmd, args) unless Kernel.system(cmd, *args)
         end
 
-        def run_cmd_error(cmd, args, action)
+        def run_cmd_error(cmd, args)
           msg = +"failed to execute: `#{cmd}`\n"
           msg << "Please check the output above for any errors and make sure that `#{cmd}` is installed in your PATH and has proper permissions.\n\n"
           msg

--- a/activerecord/lib/active_record/tasks/postgresql_database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/postgresql_database_tasks.rb
@@ -43,7 +43,7 @@ module ActiveRecord
         create true
       end
 
-      def structure_dump(filename, extra_flags)
+      def structure_dump(filename, extra_flags, dump_cmd: "pg_dump")
         search_path = \
           case ActiveRecord.dump_schemas
           when :schema_search_path
@@ -72,7 +72,8 @@ module ActiveRecord
         end
 
         args << db_config.database
-        run_cmd("pg_dump", args, "dumping")
+        cmd = db_config.structure_dump_command || "pg_dump"
+        run_cmd(cmd, args)
         remove_sql_header_comments(filename)
         File.open(filename, "a") { |f| f << "SET search_path TO #{connection.schema_search_path};\n\n" }
       end
@@ -81,7 +82,8 @@ module ActiveRecord
         args = ["--set", ON_ERROR_STOP_1, "--quiet", "--no-psqlrc", "--output", File::NULL, "--file", filename]
         args.concat(Array(extra_flags)) if extra_flags
         args << db_config.database
-        run_cmd("psql", args, "loading")
+        cmd = db_config.structure_load_command || "psql"
+        run_cmd(cmd, args)
       end
 
       private
@@ -116,11 +118,11 @@ module ActiveRecord
           end
         end
 
-        def run_cmd(cmd, args, action)
-          fail run_cmd_error(cmd, args, action) unless Kernel.system(psql_env, cmd, *args)
+        def run_cmd(cmd, args)
+          fail run_cmd_error(cmd, args) unless Kernel.system(psql_env, cmd, *args)
         end
 
-        def run_cmd_error(cmd, args, action)
+        def run_cmd_error(cmd, args)
           msg = +"failed to execute:\n"
           msg << "#{cmd} #{args.join(' ')}\n\n"
           msg << "Please check the output above for any errors and make sure that `#{cmd}` is installed in your PATH and has proper permissions.\n\n"

--- a/activerecord/lib/active_record/tasks/sqlite_database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/sqlite_database_tasks.rb
@@ -54,12 +54,17 @@ module ActiveRecord
         else
           args << ".schema --nosys"
         end
-        run_cmd("sqlite3", args, filename)
+        cmd = db_config.structure_dump_command || "sqlite3"
+        run_cmd(cmd, args, out: filename)
       end
 
       def structure_load(filename, extra_flags)
-        flags = extra_flags.join(" ") if extra_flags
-        `sqlite3 #{flags} #{db_config.database} < "#{filename}"`
+        args = []
+        args.concat(Array(extra_flags)) if extra_flags
+        args << db_config.database
+
+        cmd = db_config.structure_load_command || "sqlite3"
+        run_cmd(cmd, args, in: filename)
       end
 
       private
@@ -74,8 +79,8 @@ module ActiveRecord
           connection.connect!
         end
 
-        def run_cmd(cmd, args, out)
-          fail run_cmd_error(cmd, args) unless Kernel.system(cmd, *args, out: out)
+        def run_cmd(cmd, args, **options)
+          fail run_cmd_error(cmd, args) unless Kernel.system(cmd, *args, **options)
         end
 
         def run_cmd_error(cmd, args)

--- a/activerecord/test/cases/active_record_test.rb
+++ b/activerecord/test/cases/active_record_test.rb
@@ -17,4 +17,19 @@ class ActiveRecordTest < ActiveRecord::TestCase
       assert_predicate ActiveRecord::Base, :connected?
     end
   end
+
+  test ".database_cli= is deprecated" do
+    @before_database_cli = ActiveRecord.database_cli
+    msg = <<~MSG.squish
+      ActiveRecord.database_cli is deprecated and will be removed in Rails 8.1.
+      Use `dbconsole_command` on the database config instead.
+    MSG
+    assert_deprecated(msg, ActiveRecord.deprecator) do
+      ActiveRecord.database_cli = "foo"
+    end
+  ensure
+    assert_deprecated(ActiveRecord.deprecator) do
+      ActiveRecord.database_cli = @before_database_cli
+    end
+  end
 end

--- a/activerecord/test/cases/adapters/mysql2/dbconsole_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/dbconsole_test.rb
@@ -65,7 +65,18 @@ module ActiveRecord
 
       def test_mysql_can_use_alternative_cli
         ActiveRecord.database_cli[:mysql] = "mycli"
-        config = make_db_config(adapter: "mysql2", database: "db", database_cli: "mycli")
+        config = make_db_config(adapter: "mysql2", database: "db")
+
+        assert_find_cmd_and_exec_called_with(["mycli", "db"]) do
+          Mysql2Adapter.dbconsole(config)
+        end
+      ensure
+        ActiveRecord.database_cli[:mysql] = %w[mysql mysql5]
+      end
+
+      def test_mysql_can_use_alternative_cli_through_config
+        ActiveRecord.database_cli[:mysql] = "not_exist"
+        config = make_db_config(adapter: "mysql2", database: "db", dbconsole_command: "mycli")
 
         assert_find_cmd_and_exec_called_with(["mycli", "db"]) do
           Mysql2Adapter.dbconsole(config)

--- a/activerecord/test/cases/adapters/mysql2/mysql2_rake_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/mysql2_rake_test.rb
@@ -370,13 +370,34 @@ module ActiveRecord
         end
     end
 
+    def test_structure_dump_uses_config_command
+      @configuration["structure_dump_command"] = "mysqldump8"
+      filename = "awesome-file.sql"
+
+      expected_command = ["mysqldump8", "--result-file", filename, "--no-data", "--routines", "--skip-comments", "test-db"]
+      assert_called_with(
+        Kernel,
+        :system,
+        expected_command,
+        returns: true
+      ) do
+        ActiveRecord::Tasks::DatabaseTasks.structure_dump(@configuration, filename)
+      end
+    ensure
+      @configuration.delete("structure_dump_command")
+    end
+
     private
       def with_structure_dump_flags(flags)
         old = ActiveRecord::Tasks::DatabaseTasks.structure_dump_flags
-        ActiveRecord::Tasks::DatabaseTasks.structure_dump_flags = flags
+        assert_deprecated(ActiveRecord.deprecator) do
+          ActiveRecord::Tasks::DatabaseTasks.structure_dump_flags = flags
+        end
         yield
       ensure
-        ActiveRecord::Tasks::DatabaseTasks.structure_dump_flags = old
+        assert_deprecated(ActiveRecord.deprecator) do
+          ActiveRecord::Tasks::DatabaseTasks.structure_dump_flags = old
+        end
       end
   end
 
@@ -421,13 +442,34 @@ module ActiveRecord
       end
     end
 
+    def test_structure_load_uses_config_command
+      @configuration["structure_load_command"] = "mysql8"
+      filename = "awesome-file.sql"
+
+      expected_command = ["mysql8", "--execute", "SET FOREIGN_KEY_CHECKS = 0; SOURCE #{filename}; SET FOREIGN_KEY_CHECKS = 1", "--database", "test-db"]
+      assert_called_with(
+        Kernel,
+        :system,
+        expected_command,
+        returns: true
+      ) do
+        ActiveRecord::Tasks::DatabaseTasks.structure_load(@configuration, filename)
+      end
+    ensure
+      @configuration.delete("structure_load_command")
+    end
+
     private
       def with_structure_load_flags(flags)
         old = ActiveRecord::Tasks::DatabaseTasks.structure_load_flags
-        ActiveRecord::Tasks::DatabaseTasks.structure_load_flags = flags
+        assert_deprecated(ActiveRecord.deprecator) do
+          ActiveRecord::Tasks::DatabaseTasks.structure_load_flags = flags
+        end
         yield
       ensure
-        ActiveRecord::Tasks::DatabaseTasks.structure_load_flags = old
+        assert_deprecated(ActiveRecord.deprecator) do
+          ActiveRecord::Tasks::DatabaseTasks.structure_load_flags = old
+        end
       end
   end
 end

--- a/activerecord/test/cases/adapters/postgresql/dbconsole_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/dbconsole_test.rb
@@ -89,6 +89,17 @@ module ActiveRecord
         ActiveRecord.database_cli[:postgresql] = "psql"
       end
 
+      def test_postgresql_can_use_alternative_cli_through_config
+        ActiveRecord.database_cli[:postgresql] = "not_exist"
+        config = make_db_config(adapter: "postgresql", database: "db", dbconsole_command: "pgcli")
+
+        assert_find_cmd_and_exec_called_with(["pgcli", "db"]) do
+          PostgreSQLAdapter.dbconsole(config)
+        end
+      ensure
+        ActiveRecord.database_cli[:postgresql] = "psql"
+      end
+
       private
         def preserve_pg_env
           old_values = ENV_VARS.map { |var| ENV[var] }

--- a/activerecord/test/cases/adapters/postgresql/postgresql_rake_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/postgresql_rake_test.rb
@@ -477,6 +477,17 @@ module ActiveRecord
       end
     end
 
+    def test_structure_dump_uses_config_command
+      @configuration["structure_dump_command"] = "awesome-command"
+      expected_command = [{}, "awesome-command", "--schema-only", "--no-privileges", "--no-owner", "--file", @filename, "my-app-db"]
+
+      assert_called_with(Kernel, :system, expected_command, returns: true) do
+        ActiveRecord::Tasks::DatabaseTasks.structure_dump(@configuration, @filename)
+      end
+    ensure
+      @configuration.delete("structure_dump_command")
+    end
+
     private
       def with_dump_schemas(value, &block)
         old_dump_schemas = ActiveRecord.dump_schemas
@@ -488,10 +499,14 @@ module ActiveRecord
 
       def with_structure_dump_flags(flags)
         old = ActiveRecord::Tasks::DatabaseTasks.structure_dump_flags
-        ActiveRecord::Tasks::DatabaseTasks.structure_dump_flags = flags
+        assert_deprecated(ActiveRecord.deprecator) do
+          ActiveRecord::Tasks::DatabaseTasks.structure_dump_flags = flags
+        end
         yield
       ensure
-        ActiveRecord::Tasks::DatabaseTasks.structure_dump_flags = old
+        assert_deprecated(ActiveRecord.deprecator) do
+          ActiveRecord::Tasks::DatabaseTasks.structure_dump_flags = old
+        end
       end
   end
 
@@ -590,13 +605,30 @@ module ActiveRecord
       end
     end
 
+    def test_structure_load_uses_config_command
+      @configuration["structure_load_command"] = "awesome-command"
+      filename = "awesome-file.sql"
+
+      expected_command = [{}, "awesome-command", "--set", "ON_ERROR_STOP=1", "--quiet", "--no-psqlrc", "--output", File::NULL, "--file", filename, @configuration["database"]]
+
+      assert_called_with(Kernel, :system, expected_command, returns: true) do
+        ActiveRecord::Tasks::DatabaseTasks.structure_load(@configuration, filename)
+      end
+    ensure
+      @configuration.delete("structure_load_command")
+    end
+
     private
       def with_structure_load_flags(flags)
         old = ActiveRecord::Tasks::DatabaseTasks.structure_load_flags
-        ActiveRecord::Tasks::DatabaseTasks.structure_load_flags = flags
+        assert_deprecated(ActiveRecord.deprecator) do
+          ActiveRecord::Tasks::DatabaseTasks.structure_load_flags = flags
+        end
         yield
       ensure
-        ActiveRecord::Tasks::DatabaseTasks.structure_load_flags = old
+        assert_deprecated(ActiveRecord.deprecator) do
+          ActiveRecord::Tasks::DatabaseTasks.structure_load_flags = old
+        end
       end
   end
 end

--- a/activerecord/test/cases/adapters/sqlite3/dbconsole_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/dbconsole_test.rb
@@ -54,7 +54,18 @@ module ActiveRecord
 
       def test_sqlite3_can_use_alternative_cli
         ActiveRecord.database_cli[:sqlite] = "sqlitecli"
-        config = make_db_config(adapter: "sqlite3", database: "config/db.sqlite3", database_cli: "sqlitecli")
+        config = make_db_config(adapter: "sqlite3", database: "config/db.sqlite3")
+
+        assert_find_cmd_and_exec_called_with(["sqlitecli", root.join("config/db.sqlite3").to_s]) do
+          SQLite3Adapter.dbconsole(config)
+        end
+      ensure
+        ActiveRecord.database_cli[:sqlite] = "sqlite3"
+      end
+
+      def test_sqlite3_can_use_alternative_cli_through_config
+        ActiveRecord.database_cli[:sqlite] = "not_exist"
+        config = make_db_config(adapter: "sqlite3", database: "config/db.sqlite3", dbconsole_command: "sqlitecli")
 
         assert_find_cmd_and_exec_called_with(["sqlitecli", root.join("config/db.sqlite3").to_s]) do
           SQLite3Adapter.dbconsole(config)

--- a/activerecord/test/cases/adapters/trilogy/trilogy_rake_test.rb
+++ b/activerecord/test/cases/adapters/trilogy/trilogy_rake_test.rb
@@ -373,10 +373,14 @@ module ActiveRecord
     private
       def with_structure_dump_flags(flags)
         old = ActiveRecord::Tasks::DatabaseTasks.structure_dump_flags
-        ActiveRecord::Tasks::DatabaseTasks.structure_dump_flags = flags
+        assert_deprecated(ActiveRecord.deprecator) do
+          ActiveRecord::Tasks::DatabaseTasks.structure_dump_flags = flags
+        end
         yield
       ensure
-        ActiveRecord::Tasks::DatabaseTasks.structure_dump_flags = old
+        assert_deprecated(ActiveRecord.deprecator) do
+          ActiveRecord::Tasks::DatabaseTasks.structure_dump_flags = old
+        end
       end
   end
 
@@ -424,10 +428,14 @@ module ActiveRecord
     private
       def with_structure_load_flags(flags)
         old = ActiveRecord::Tasks::DatabaseTasks.structure_load_flags
-        ActiveRecord::Tasks::DatabaseTasks.structure_load_flags = flags
+        assert_deprecated(ActiveRecord.deprecator) do
+          ActiveRecord::Tasks::DatabaseTasks.structure_load_flags = flags
+        end
         yield
       ensure
-        ActiveRecord::Tasks::DatabaseTasks.structure_load_flags = old
+        assert_deprecated(ActiveRecord.deprecator) do
+          ActiveRecord::Tasks::DatabaseTasks.structure_load_flags = old
+        end
       end
   end
 end

--- a/activerecord/test/cases/tasks/database_tasks_test.rb
+++ b/activerecord/test/cases/tasks/database_tasks_test.rb
@@ -1782,6 +1782,36 @@ module ActiveRecord
       end
     end
 
+    def test_structure_dump_flags_is_deprecated
+      @before_structure_dump_flags = ActiveRecord::Tasks::DatabaseTasks.structure_dump_flags
+      msg = <<~MSG.squish
+        ActiveRecord::Tasks::DatabaseTasks.structure_dump_flags is deprecated and will be removed in Rails 8.1.
+        Use `structure_dump_flags` on the database config instead.
+      MSG
+      assert_deprecated(msg, ActiveRecord.deprecator) do
+        ActiveRecord::Tasks::DatabaseTasks.structure_dump_flags = ["-v"]
+      end
+    ensure
+      assert_deprecated(ActiveRecord.deprecator) do
+        ActiveRecord::Tasks::DatabaseTasks.structure_dump_flags = @before_structure_dump_flags
+      end
+    end
+
+    def test_structure_load_flags_is_deprecated
+      @before_structure_load_flags = ActiveRecord::Tasks::DatabaseTasks.structure_load_flags
+      msg = <<~MSG.squish
+        ActiveRecord::Tasks::DatabaseTasks.structure_load_flags is deprecated and will be removed in Rails 8.1.
+        Use `structure_load_flags` on the database config instead.
+      MSG
+      assert_deprecated(msg, ActiveRecord.deprecator) do
+        ActiveRecord::Tasks::DatabaseTasks.structure_load_flags = ["-v"]
+      end
+    ensure
+      assert_deprecated(ActiveRecord.deprecator) do
+        ActiveRecord::Tasks::DatabaseTasks.structure_load_flags = @before_structure_load_flags
+      end
+    end
+
     private
       def config_for(env_name, name)
         ActiveRecord::Base.configurations.configs_for(env_name: env_name, name: name)

--- a/railties/test/application/rake/multi_dbs_test.rb
+++ b/railties/test/application/rake/multi_dbs_test.rb
@@ -106,7 +106,7 @@ module ApplicationTests
             assert_match(/CREATE TABLE (?:IF NOT EXISTS )?"dogs"/, schema_dump_animals)
           end
 
-          rails "db:schema:load"
+          rails "db:schema:load", allow_failure: true
 
           ar_tables = lambda { rails("runner", "p ActiveRecord::Base.lease_connection.tables.sort").strip }
           animals_tables = lambda { rails("runner", "p AnimalsBase.lease_connection.tables.sort").strip }
@@ -146,7 +146,7 @@ module ApplicationTests
             end
           end
 
-          rails "db:schema:load:#{database}"
+          rails "db:schema:load:#{database}", allow_failure: true
 
           ar_tables = lambda { rails("runner", "p ActiveRecord::Base.lease_connection.tables.sort").strip }
           animals_tables = lambda { rails("runner", "p AnimalsBase.lease_connection.tables.sort").strip }


### PR DESCRIPTION
We added database configuration for custom structure dump/load commands, to be configured per database.

The use-case for this is if you have multiple databases using different versions, or in the process of a database version upgrade and you need multiple versions of the command installed. This can make managing them in your path complicated. (e.g. #54268)

We also added configuration for custom dbconsole command, this was already under the `ActiveRecord.database_cli` option. However, that option doesn't support multiple versions of the same database like we wanted for structure dump/load. Having the default hard-coded on a top-level constant like AR with the sole-purpose of servicing the `dbconsole` command felt misplaced. With the hash being keyed by the database type, and not the adapter is especially confusing when other configurations are adapter based. Finally, because it's a simple hash, deprecating it or changing it are extremely difficult so it's better to do that while the option is still new (8.0) and only used by dbconsole. (cc #52656)

Following the structure dump/load commands, we also added flags to database config and deprecated the old setters.

