### PR TITLE
Make column name optional for `index_exists?`

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Make column name optional for `index_exists?`.
+
+    This aligns well with `remove_index` signature as well, where
+    index name doesn't need to be derived from the column names.
+
+    *Ali Ismayiliov*
+
 *   Change the payload name of `sql.active_record` notification for eager
     loading from "SQL" to "#{model.name} Eager Load".
 

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
@@ -764,7 +764,7 @@ module ActiveRecord
       #  end
       #
       # See {connection.index_exists?}[rdoc-ref:SchemaStatements#index_exists?]
-      def index_exists?(column_name, **options)
+      def index_exists?(column_name = nil, **options)
         @base.index_exists?(name, column_name, **options)
       end
 

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -99,7 +99,7 @@ module ActiveRecord
       #   # Check a valid index exists (PostgreSQL only)
       #   index_exists?(:suppliers, :company_id, valid: true)
       #
-      def index_exists?(table_name, column_name, **options)
+      def index_exists?(table_name, column_name = nil, **options)
         indexes(table_name).any? { |i| i.defined_for?(column_name, **options) }
       end
 

--- a/activerecord/lib/active_record/migration/compatibility.rb
+++ b/activerecord/lib/active_record/migration/compatibility.rb
@@ -445,7 +445,7 @@ module ActiveRecord
           super
         end
 
-        def index_exists?(table_name, column_name, **options)
+        def index_exists?(table_name, column_name = nil, **options)
           column_names = Array(column_name).map(&:to_s)
           options[:name] =
             if options[:name].present?

--- a/activerecord/test/cases/migration/index_test.rb
+++ b/activerecord/test/cases/migration/index_test.rb
@@ -178,6 +178,7 @@ module ActiveRecord
         connection.add_index :testings, [:foo, :bar], name: "my_index"
         assert connection.index_exists?(:testings, [:foo, :bar], name: "my_index")
         assert connection.index_exists?(:testings, [], name: "my_index")
+        assert connection.index_exists?(:testings, name: "my_index")
         assert_not connection.index_exists?(:testings, [:foo], name: "my_index")
       end
 


### PR DESCRIPTION
### Motivation / Background

Currently, when using `index_exists?` the index name is derived from the column names if supplied. And if the column names aren't supplied `options[:name]` is used. This means that the column argument in the `index_exists?` method can be optional. Similar behavior already exists on `remove_index`.

### Detail

This Pull Request changes allows the following invocation:
```ruby
table.index_exists?(name: "index_name")
index_exists?(:table, name: "index_name")
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
