### PR TITLE
Allow passing in a date or time to ActiveSupport::Testing::TimeHelpers#freeze_time

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,14 @@
+*   Allow the `#freeze_time` testing helper to accept a date or time argument.
+
+    ```ruby
+    Time.current # => Sun, 09 Jul 2024 15:34:49 EST -05:00
+    freeze_time Time.current + 1.day
+    sleep 1
+    Time.current # => Mon, 10 Jul 2024 15:34:49 EST -05:00
+    ```
+
+    *Joshua Young*
+
 *   `ActiveSupport::JSON` now accepts options
 
     It is now possible to pass options to `ActiveSupport::JSON`:

--- a/activesupport/lib/active_support/testing/time_helpers.rb
+++ b/activesupport/lib/active_support/testing/time_helpers.rb
@@ -238,12 +238,16 @@ module ActiveSupport
       end
       alias_method :unfreeze_time, :travel_back
 
-      # Calls +travel_to+ with +Time.now+. Forwards optional <tt>with_usec</tt> argument.
+      # Calls +travel_to+ with +date_or_time+, which defaults to +Time.now+.
+      # Forwards optional <tt>with_usec</tt> argument.
       #
       #   Time.current # => Sun, 09 Jul 2017 15:34:49 EST -05:00
       #   freeze_time
       #   sleep(1)
       #   Time.current # => Sun, 09 Jul 2017 15:34:49 EST -05:00
+      #   freeze_time Time.current + 1.day
+      #   sleep(1)
+      #   Time.current # => Mon, 10 Jul 2017 15:34:49 EST -05:00
       #
       # This method also accepts a block, which will return the current time back to its original
       # state at the end of the block:
@@ -254,8 +258,8 @@ module ActiveSupport
       #     User.create.created_at # => Sun, 09 Jul 2017 15:34:49 EST -05:00
       #   end
       #   Time.current # => Sun, 09 Jul 2017 15:34:50 EST -05:00
-      def freeze_time(with_usec: false, &block)
-        travel_to Time.now, with_usec: with_usec, &block
+      def freeze_time(date_or_time = Time.now, with_usec: false, &block)
+        travel_to date_or_time, with_usec: with_usec, &block
       end
 
       private

--- a/activesupport/test/time_travel_test.rb
+++ b/activesupport/test/time_travel_test.rb
@@ -487,6 +487,16 @@ class TimeTravelTest < ActiveSupport::TestCase
     travel_back
   end
 
+  def test_time_helper_freeze_time_with_time_arg
+    expected_time = Time.now + 1.day
+    freeze_time expected_time
+    sleep(1)
+
+    assert_equal expected_time.to_fs(:db), Time.now.to_fs(:db)
+  ensure
+    travel_back
+  end
+
   def test_time_helper_freeze_time_with_block
     expected_time = Time.now
 


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

We're in the process of migrating from [Timecop](https://github.com/travisjeffery/timecop) to the Rails testing time helpers. One major difference between the two is that Rails' `#travel_to` and `#freeze_time` both freeze time, whereas Timecop's `.travel` simply changes the current time without freezing it, and its `.freeze` freezes time. This means that the usual pattern when using Timecop in a specific frozen time scenario is:

```ruby
time = Date.new(2025, 1, 1).midnight
Timecop.freeze time
# ...
Timecop.travel time + 1.day
# ...
```

With Rails, this could just be:

```ruby
time = Date.new(2025, 1, 1).midnight
travel_to time
# ...
travel_to time time + 1.day # or travel 1.day
# ...
```

However, imo, it's not as clear semantically that this also freezes time. What this PR allows us to do is:

```ruby
time = Date.new(2025, 1, 1).midnight
freeze_time time
# ...
travel_to time + 1.day # or travel 1.day
# ...
```

which imo is a lot nicer to follow and will also make it easier to port Timecop utilising code like my example above.

### Detail

Adds a `date_or_time` positional arg to `ActiveSupport::Testing::TimeHelpers#freeze_time` which defaults to `Time.now` i.e. the current functionality. This simply calls `#travel_to` under the hood.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.