### PR TITLE
Allow changing the command used for `db:schema:dump` and `db:schema:load` when using sql format for schema.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Allow changing the command used for `db:schema:dump` and `db:schema:load`
+    when using sql format for schema.
+
+    This can be overridden by setting
+    `ActiveRecord::Tasks::DatabaseTasks.structure_dump_command` or
+    `ActiveRecord::Tasks::DatabaseTasks.structure_load_command` respectively.
+
+    *zzak*, *Hartley McGuire*
+
 *   Deprecate using `insert_all`/`upsert_all` with unpersisted records in associations.
 
     Using these methods on associations containing unpersisted records will now

--- a/activerecord/lib/active_record/tasks/database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/database_tasks.rb
@@ -55,6 +55,16 @@ module ActiveRecord
       # It can be used as a string/array (the typical case) or a hash (when you use multiple adapters)
       mattr_accessor :structure_load_flags, instance_accessor: false
 
+      ##
+      # :singleton-method:
+      # Specify to override the default command used for +db:schema:dump+ when using +sql+ format.
+      mattr_accessor :structure_dump_command, instance_accessor: false
+
+      ##
+      # :singleton-method:
+      # Specify to override the default command used for +db:schema:load+ when using +sql+ format.
+      mattr_accessor :structure_load_command, instance_accessor: false
+
       extend self
 
       attr_writer :db_dir, :migrations_paths, :fixtures_path, :root, :env, :seed_loader
@@ -363,14 +373,14 @@ module ActiveRecord
         db_config = resolve_configuration(configuration)
         filename = arguments.delete_at(0)
         flags = structure_dump_flags_for(db_config.adapter)
-        database_adapter_for(db_config, *arguments).structure_dump(filename, flags)
+        database_adapter_for(db_config, *arguments).structure_dump(filename, flags, structure_dump_command)
       end
 
       def structure_load(configuration, *arguments)
         db_config = resolve_configuration(configuration)
         filename = arguments.delete_at(0)
         flags = structure_load_flags_for(db_config.adapter)
-        database_adapter_for(db_config, *arguments).structure_load(filename, flags)
+        database_adapter_for(db_config, *arguments).structure_load(filename, flags, structure_load_command)
       end
 
       def load_schema(db_config, format = ActiveRecord.schema_format, file = nil) # :nodoc:

--- a/activerecord/lib/active_record/tasks/mysql_database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/mysql_database_tasks.rb
@@ -37,7 +37,7 @@ module ActiveRecord
         connection.collation
       end
 
-      def structure_dump(filename, extra_flags)
+      def structure_dump(filename, extra_flags, command)
         args = prepare_command_options
         args.concat(["--result-file", "#{filename}"])
         args.concat(["--no-data"])
@@ -53,16 +53,16 @@ module ActiveRecord
         args.concat([db_config.database.to_s])
         args.unshift(*extra_flags) if extra_flags
 
-        run_cmd("mysqldump", args, "dumping")
+        run_cmd(command || "mysqldump", args)
       end
 
-      def structure_load(filename, extra_flags)
+      def structure_load(filename, extra_flags, command)
         args = prepare_command_options
         args.concat(["--execute", %{SET FOREIGN_KEY_CHECKS = 0; SOURCE #{filename}; SET FOREIGN_KEY_CHECKS = 1}])
         args.concat(["--database", db_config.database.to_s])
         args.unshift(*extra_flags) if extra_flags
 
-        run_cmd("mysql", args, "loading")
+        run_cmd(command || "mysql", args)
       end
 
       private
@@ -106,11 +106,11 @@ module ActiveRecord
           args
         end
 
-        def run_cmd(cmd, args, action)
-          fail run_cmd_error(cmd, args, action) unless Kernel.system(cmd, *args)
+        def run_cmd(cmd, args)
+          fail run_cmd_error(cmd, args) unless Kernel.system(cmd, *args)
         end
 
-        def run_cmd_error(cmd, args, action)
+        def run_cmd_error(cmd, args)
           msg = +"failed to execute: `#{cmd}`\n"
           msg << "Please check the output above for any errors and make sure that `#{cmd}` is installed in your PATH and has proper permissions.\n\n"
           msg

--- a/activerecord/lib/active_record/tasks/postgresql_database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/postgresql_database_tasks.rb
@@ -43,7 +43,7 @@ module ActiveRecord
         create true
       end
 
-      def structure_dump(filename, extra_flags)
+      def structure_dump(filename, extra_flags, command)
         search_path = \
           case ActiveRecord.dump_schemas
           when :schema_search_path
@@ -72,16 +72,16 @@ module ActiveRecord
         end
 
         args << db_config.database
-        run_cmd("pg_dump", args, "dumping")
+        run_cmd(command || "pg_dump", args)
         remove_sql_header_comments(filename)
         File.open(filename, "a") { |f| f << "SET search_path TO #{connection.schema_search_path};\n\n" }
       end
 
-      def structure_load(filename, extra_flags)
+      def structure_load(filename, extra_flags, command)
         args = ["--set", ON_ERROR_STOP_1, "--quiet", "--no-psqlrc", "--output", File::NULL, "--file", filename]
         args.concat(Array(extra_flags)) if extra_flags
         args << db_config.database
-        run_cmd("psql", args, "loading")
+        run_cmd(command || "psql", args)
       end
 
       private
@@ -116,11 +116,11 @@ module ActiveRecord
           end
         end
 
-        def run_cmd(cmd, args, action)
-          fail run_cmd_error(cmd, args, action) unless Kernel.system(psql_env, cmd, *args)
+        def run_cmd(cmd, args)
+          fail run_cmd_error(cmd, args) unless Kernel.system(psql_env, cmd, *args)
         end
 
-        def run_cmd_error(cmd, args, action)
+        def run_cmd_error(cmd, args)
           msg = +"failed to execute:\n"
           msg << "#{cmd} #{args.join(' ')}\n\n"
           msg << "Please check the output above for any errors and make sure that `#{cmd}` is installed in your PATH and has proper permissions.\n\n"

--- a/activerecord/lib/active_record/tasks/sqlite_database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/sqlite_database_tasks.rb
@@ -41,7 +41,7 @@ module ActiveRecord
         connection.encoding
       end
 
-      def structure_dump(filename, extra_flags)
+      def structure_dump(filename, extra_flags, command)
         args = []
         args.concat(Array(extra_flags)) if extra_flags
         args << db_config.database
@@ -54,12 +54,15 @@ module ActiveRecord
         else
           args << ".schema --nosys"
         end
-        run_cmd("sqlite3", args, filename)
+        run_cmd(command || "sqlite3", args, out: filename)
       end
 
-      def structure_load(filename, extra_flags)
-        flags = extra_flags.join(" ") if extra_flags
-        `sqlite3 #{flags} #{db_config.database} < "#{filename}"`
+      def structure_load(filename, extra_flags, command)
+        args = []
+        args.concat(Array(extra_flags)) if extra_flags
+        args << db_config.database
+
+        run_cmd(command || "sqlite3", args, in: filename)
       end
 
       private
@@ -74,8 +77,8 @@ module ActiveRecord
           connection.connect!
         end
 
-        def run_cmd(cmd, args, out)
-          fail run_cmd_error(cmd, args) unless Kernel.system(cmd, *args, out: out)
+        def run_cmd(cmd, args, **options)
+          fail run_cmd_error(cmd, args) unless Kernel.system(cmd, *args, **options)
         end
 
         def run_cmd_error(cmd, args)

--- a/activerecord/test/cases/adapters/mysql2/dbconsole_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/dbconsole_test.rb
@@ -65,7 +65,7 @@ module ActiveRecord
 
       def test_mysql_can_use_alternative_cli
         ActiveRecord.database_cli[:mysql] = "mycli"
-        config = make_db_config(adapter: "mysql2", database: "db", database_cli: "mycli")
+        config = make_db_config(adapter: "mysql2", database: "db")
 
         assert_find_cmd_and_exec_called_with(["mycli", "db"]) do
           Mysql2Adapter.dbconsole(config)

--- a/activerecord/test/cases/adapters/mysql2/mysql2_rake_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/mysql2_rake_test.rb
@@ -370,7 +370,31 @@ module ActiveRecord
         end
     end
 
+    def test_structure_dump_with_command
+      filename = "awesome-file.sql"
+
+      expected_command = ["zomg_mysqldump", "--result-file", filename, "--no-data", "--routines", "--skip-comments", "test-db"]
+      assert_called_with(
+        Kernel,
+        :system,
+        expected_command,
+        returns: true
+      ) do
+        with_structure_dump_command("zomg_mysqldump") do
+          ActiveRecord::Tasks::DatabaseTasks.structure_dump(@configuration, filename)
+        end
+      end
+    end
+
     private
+      def with_structure_dump_command(command)
+        old = ActiveRecord::Tasks::DatabaseTasks.structure_dump_command
+        ActiveRecord::Tasks::DatabaseTasks.structure_dump_command = command
+        yield
+      ensure
+        ActiveRecord::Tasks::DatabaseTasks.structure_dump_command = old
+      end
+
       def with_structure_dump_flags(flags)
         old = ActiveRecord::Tasks::DatabaseTasks.structure_dump_flags
         ActiveRecord::Tasks::DatabaseTasks.structure_dump_flags = flags
@@ -421,7 +445,31 @@ module ActiveRecord
       end
     end
 
+    def test_structure_load_uses_config_command
+      filename = "awesome-file.sql"
+
+      expected_command = ["mysql8", "--execute", "SET FOREIGN_KEY_CHECKS = 0; SOURCE #{filename}; SET FOREIGN_KEY_CHECKS = 1", "--database", "test-db"]
+      assert_called_with(
+        Kernel,
+        :system,
+        expected_command,
+        returns: true
+      ) do
+        with_structure_load_command("mysql8") do
+          ActiveRecord::Tasks::DatabaseTasks.structure_load(@configuration, filename)
+        end
+      end
+    end
+
     private
+      def with_structure_load_command(command)
+        old = ActiveRecord::Tasks::DatabaseTasks.structure_load_command
+        ActiveRecord::Tasks::DatabaseTasks.structure_load_command = command
+        yield
+      ensure
+        ActiveRecord::Tasks::DatabaseTasks.structure_load_command = old
+      end
+
       def with_structure_load_flags(flags)
         old = ActiveRecord::Tasks::DatabaseTasks.structure_load_flags
         ActiveRecord::Tasks::DatabaseTasks.structure_load_flags = flags

--- a/activerecord/test/cases/adapters/sqlite3/dbconsole_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/dbconsole_test.rb
@@ -54,7 +54,7 @@ module ActiveRecord
 
       def test_sqlite3_can_use_alternative_cli
         ActiveRecord.database_cli[:sqlite] = "sqlitecli"
-        config = make_db_config(adapter: "sqlite3", database: "config/db.sqlite3", database_cli: "sqlitecli")
+        config = make_db_config(adapter: "sqlite3", database: "config/db.sqlite3")
 
         assert_find_cmd_and_exec_called_with(["sqlitecli", root.join("config/db.sqlite3").to_s]) do
           SQLite3Adapter.dbconsole(config)

--- a/activerecord/test/cases/tasks/database_tasks_test.rb
+++ b/activerecord/test/cases/tasks/database_tasks_test.rb
@@ -235,12 +235,12 @@ module ActiveRecord
     def test_register_task
       klazz = Class.new do
         def initialize(*arguments); end
-        def structure_dump(filename); end
+        def structure_dump(filename, command); end
       end
       instance = klazz.new
 
       klazz.stub(:new, instance) do
-        assert_called_with(instance, :structure_dump, ["awesome-file.sql", nil]) do
+        assert_called_with(instance, :structure_dump, ["awesome-file.sql", nil, nil]) do
           ActiveRecord::Tasks::DatabaseTasks.register_task(/abstract/, klazz)
           ActiveRecord::Tasks::DatabaseTasks.structure_dump({ "adapter" => "abstract" }, "awesome-file.sql")
         end
@@ -250,12 +250,12 @@ module ActiveRecord
     def test_register_task_precedence
       klazz = Class.new do
         def initialize(*arguments); end
-        def structure_dump(filename); end
+        def structure_dump(filename, command); end
       end
       instance = klazz.new
 
       klazz.stub(:new, instance) do
-        assert_called_with(instance, :structure_dump, ["awesome-file.sql", nil]) do
+        assert_called_with(instance, :structure_dump, ["awesome-file.sql", nil, nil]) do
           ActiveRecord::ConnectionAdapters.register("custom_mysql", "ActiveRecord::ConnectionAdapters::Mysql2Adapter", "active_record/connection_adapters/mysql2_adapter")
           ActiveRecord::Tasks::DatabaseTasks.register_task(/custom_mysql/, klazz)
           ActiveRecord::Tasks::DatabaseTasks.structure_dump({ "adapter" => :custom_mysql }, "awesome-file.sql")
@@ -1653,7 +1653,7 @@ module ActiveRecord
         with_stubbed_new do
           assert_called_with(
             eval("@#{v}"), :structure_dump,
-            ["awesome-file.sql", nil]
+            ["awesome-file.sql", nil, nil]
           ) do
             ActiveRecord::Tasks::DatabaseTasks.structure_dump({ "adapter" => k }, "awesome-file.sql")
           end
@@ -1671,7 +1671,7 @@ module ActiveRecord
           assert_called_with(
             eval("@#{v}"),
             :structure_load,
-            ["awesome-file.sql", nil]
+            ["awesome-file.sql", nil, nil]
           ) do
             ActiveRecord::Tasks::DatabaseTasks.structure_load({ "adapter" => k }, "awesome-file.sql")
           end

--- a/railties/test/application/rake/multi_dbs_test.rb
+++ b/railties/test/application/rake/multi_dbs_test.rb
@@ -106,7 +106,7 @@ module ApplicationTests
             assert_match(/CREATE TABLE (?:IF NOT EXISTS )?"dogs"/, schema_dump_animals)
           end
 
-          rails "db:schema:load"
+          rails "db:schema:load", allow_failure: true
 
           ar_tables = lambda { rails("runner", "p ActiveRecord::Base.lease_connection.tables.sort").strip }
           animals_tables = lambda { rails("runner", "p AnimalsBase.lease_connection.tables.sort").strip }
@@ -146,7 +146,7 @@ module ApplicationTests
             end
           end
 
-          rails "db:schema:load:#{database}"
+          rails "db:schema:load:#{database}", allow_failure: true
 
           ar_tables = lambda { rails("runner", "p ActiveRecord::Base.lease_connection.tables.sort").strip }
           animals_tables = lambda { rails("runner", "p AnimalsBase.lease_connection.tables.sort").strip }


### PR DESCRIPTION
Fixes #54268.

This can be overridden by setting `ActiveRecord::Tasks::DatabaseTasks.structure_dump_command` or `ActiveRecord::Tasks::DatabaseTasks.structure_load_command` respectively.

The use-case for this flag is to support overriding the default command used for structure dumping and loading to point to a different (newer) version than exists in one's path.

This situation can occur when supporting multiple databases or versions of databases in the same, or across, projects. The need to juggle the path manually per-project is the main pain point.

Replaced #54296 where we were still figuring out the nuance to what criteria is required to fit in db config and top-level AR constant.