### PR TITLE
Update `has_one` example to use descending order [ci skip]

### DIFF
--- a/activerecord/lib/active_record/associations.rb
+++ b/activerecord/lib/active_record/associations.rb
@@ -1485,7 +1485,7 @@ module ActiveRecord
         #   has_one :credit_card, dependent: :destroy  # destroys the associated credit card
         #   has_one :credit_card, dependent: :nullify  # updates the associated records foreign
         #                                                 # key value to NULL rather than destroying it
-        #   has_one :last_comment, -> { order('posted_on') }, class_name: "Comment"
+        #   has_one :last_comment, -> { order('posted_on desc') }, class_name: "Comment"
         #   has_one :project_manager, -> { where(role: 'project_manager') }, class_name: "Person"
         #   has_one :attachment, as: :attachable
         #   has_one :boss, -> { readonly }


### PR DESCRIPTION
### Motivation / Background

Updated the `has_one :last_comment` example in the documentation to specify descending order ('posted_on desc'). This change ensures the ordering aligns with the name last_comment, making the example more intuitive and consistent with its intended purpose.
