### PR TITLE
Fix routes being cleared when using `reload_routes!`:

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Fix `Rails.application.reload_routes!` from clearing almost all routes.
+
+    When calling `Rails.application.reload_routes!` inside a middleware of
+    a Rake task, it was possible under certain conditions that all routes would be cleared.
+    If ran inside a middleware, this would result in getting a 404 on most page you visit.
+    This issue was only happening in development.
+
+    *Edouard Chin*
+
 *   Add resource name to the `ArgumentError` that's raised when invalid `:only` or `:except` options are given to `#resource` or `#resources`
 
     This makes it easier to locate the source of the problem, especially for routes drawn by gems.

--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -156,7 +156,11 @@ module Rails
 
     # Reload application routes regardless if they changed or not.
     def reload_routes!
-      routes_reloader.reload!
+      if routes_reloader.execute_unless_loaded
+        routes_reloader.loaded = false
+      else
+        routes_reloader.reload!
+      end
     end
 
     def reload_routes_unless_loaded # :nodoc:

--- a/railties/lib/rails/application/routes_reloader.rb
+++ b/railties/lib/rails/application/routes_reloader.rb
@@ -8,7 +8,7 @@ module Rails
 
       attr_reader :route_sets, :paths, :external_routes, :loaded
       attr_accessor :eager_load
-      attr_writer :run_after_load_paths # :nodoc:
+      attr_writer :run_after_load_paths, :loaded # :nodoc:
       delegate :execute_if_updated, :updated?, to: :updater
 
       def initialize

--- a/railties/test/application/rake_test.rb
+++ b/railties/test/application/rake_test.rb
@@ -185,6 +185,26 @@ module ApplicationTests
       assert_match(/Code LOC: \d+\s+Test LOC: \d+\s+ Code to Test Ratio: 1:\w+/, rails("stats"))
     end
 
+    def test_reload_routes
+      add_to_config <<-RUBY
+        rake_tasks do
+          task do_something: :environment do
+            Rails.application.reload_routes!
+            puts Rails.application.routes.named_routes.to_h.keys.join(" ")
+          end
+        end
+      RUBY
+
+      app_file "config/routes.rb", <<-RUBY
+        Rails.application.routes.draw do
+          get "foo", to: "foo#bar", as: :my_great_route
+        end
+      RUBY
+
+      output = Dir.chdir(app_path) { `bin/rails do_something` }
+      assert_includes(output.lines.first, "my_great_route")
+    end
+
     def test_loading_specific_fixtures
       rails "generate", "model", "user", "username:string", "password:string"
       rails "generate", "model", "product", "name:string"


### PR DESCRIPTION
## Fix routes being cleared when using `reload_routes!`:

### Motivation / Background

Pretty sure it fixes #54297 and #53205, but both issues didn't provide enough information.
Though it fixes a legitimate issue on a public API method.

### Detail

When using `Rails.application.reload_routes!` (which is public API), in certain conditions, it is possible that this will clear almost all routes in the routeset.

The line of code making this happen is this one. https://github.com/rails/rails/blob/38e9a72db45842d1d2f05fb2272df3a10225f981/actionpack/lib/action_dispatch/routing/route_set.rb#L460

That flag is supposed to be `true` for the entire duration of evaluating multiple route files. This was the case before https://github.com/rails/rails/pull/53522, which introduced the issue. It indirectly resets that flag to false because of a recursion. This is a summary of the code order execution when calling `Rails.application.reload_routes`:

1) The RouteSet sets the `disable_clear_and_finalize` flag to false, so that no routes gets cleared in between multiple call to `Rails.application.routes.draw`. [here](https://github.com/rails/rails/blob/38e9a72db45842d1d2f05fb2272df3a10225f981/railties/lib/rails/application/routes_reloader.rb#L57)
2) All route files get evaluated, and any call to `Rails.application.routes.draw` gets picked up.
3) We enter a recursion because the RouteSet in development is a LazyRouteSet which when calling `draw` reloads the route. [here](https://github.com/rails/rails/blob/38e9a72db45842d1d2f05fb2272df3a10225f981/railties/lib/rails/engine/lazy_route_set.rb#L72) and [here](https://github.com/rails/rails/blob/38e9a72db45842d1d2f05fb2272df3a10225f981/railties/lib/rails/application.rb#L163)
4) All route files get evaluated again, the `disable_clear_and_finalize` is reset to false, we exit the recursion and continue where we were.
5) The `disable_clear_and_finalize` is now false, any call to `Rails.application.draw` now resets all routes before it gets evaluated. Which basically means the very last one would have effect.

------------------------

I can only think of two way where `reload_routes` may cause a issue:

- Inside a Rake task
- Inside a middleware

This is because the application needs to be initialized and the routeset never evaluated in order to trigger the bug. https://github.com/railsware/js-routes/pull/320 and https://github.com/amatsuda/traceroute/issues/49 confirms it.

## Solution

When calling `reload_routes!`, if the routes were never loaded, load them and set the `loaded` flag. Otherwise, also load them but with the difference that with the `loaded` flag set, we won't reset all routes.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
