### PR TITLE
Use already-loaded relation contents in #sole

### DIFF
--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -141,7 +141,7 @@ module ActiveRecord
     #
     #   Product.where(["price = %?", price]).sole
     def sole
-      found, undesired = limit(2)
+      found, undesired = take(2)
 
       if found.nil?
         raise_record_not_found_exception!

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -794,6 +794,15 @@ class FinderTest < ActiveRecord::TestCase
     end
   end
 
+  def test_sole_on_loaded_relation
+    relation = Topic.where("title = 'The First Topic'").load
+    expected_topic = topics(:first)
+
+    assert_no_queries do
+      assert_equal expected_topic, relation.sole
+    end
+  end
+
   def test_first
     assert_equal topics(:second).title, Topic.where("title = 'The Second Topic of the day'").first.title
   end


### PR DESCRIPTION
Fixes a regression in #53982, which could result in additional queries being run.

`take` is the closer unordered parallel of `first`, because (unlike `limit`, which must construct a new relation) it still knows to consider already-loaded relation contents.

