### PR TITLE
AS::MessageVerifier#verify always accept both safe and unsafe encoding

### DIFF
--- a/activesupport/lib/active_support/message_verifier.rb
+++ b/activesupport/lib/active_support/message_verifier.rb
@@ -154,6 +154,8 @@ module ActiveSupport
     #   not URL-safe. In other words, they can contain "+" and "/". If you want to
     #   generate URL-safe strings (in compliance with "Base 64 Encoding with URL
     #   and Filename Safe Alphabet" in RFC 4648), you can pass +true+.
+    #   Note that MessageVerifier will always accept both URL-safe and URL-unsafe
+    #   encoded messages, to allow a smooth transition between the two settings.
     #
     # [+:force_legacy_metadata_serializer+]
     #   Whether to use the legacy metadata serializer, which serializes the
@@ -318,6 +320,13 @@ module ActiveSupport
     end
 
     private
+      def decode(encoded, url_safe: @url_safe)
+        catch :invalid_message_format do
+          return super
+        end
+        super(encoded, url_safe: !url_safe)
+      end
+
       def sign_encoded(encoded)
         digest = generate_digest(encoded)
         encoded << SEPARATOR << digest


### PR DESCRIPTION
Fix: https://github.com/rails/rails/issues/53710
Fix: https://github.com/rails/rails/pull/54290

The Rails 7.1 to 7.2 upgrade can be very complicated if you use Active Record's `find_signed` feature, as its MessageVerifier switched from regular Base64 encoding to URL-safe Base64 encoding, making all previously generated ids invalid.

To ease the transition, MessageVerifier's `url_safe` option now only control which encoding method is used to generate messages, for decoding them both are always valid.

cc @beauraF @AliSepehri 
Also cc @matthewd for sanity checks.

~~The idea here is to backport this change all the way back to 7.1, to ease the upgrade process. (I know it's out of policy, but that seem the sensible thing to do).~~

I don't see the need for an option that would disable the fallback behavior, but @matthewd if you feel strongly about it, I can add it.
