### PR TITLE
refactor(test): do not dump when not necessary

### DIFF
--- a/activerecord/test/cases/adapters/postgresql/enum_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/enum_test.rb
@@ -246,7 +246,7 @@ class PostgresqlEnumTest < ActiveRecord::PostgreSQLTestCase
         t.column :current_mood, :mood_in_test_schema
       end
 
-      output = dump_all_table_schema
+      output = dump_table_schema("postgresql_enums_in_test_schema")
 
       assert_includes output, 'create_enum "public.mood", ["sad", "ok", "happy"]'
       assert_includes output, 'create_enum "mood_in_test_schema", ["sad", "ok", "happy"]'

--- a/activerecord/test/cases/tasks/database_tasks_test.rb
+++ b/activerecord/test/cases/tasks/database_tasks_test.rb
@@ -370,7 +370,9 @@ module ActiveRecord
           FileUtils.rm_rf(dir)
           assert_not File.file?(path)
 
-          ActiveRecord::Tasks::DatabaseTasks.dump_schema(db_config)
+          ActiveRecord::SchemaDumper.stub(:dump, "") do # Do not actually dump for test performances
+            ActiveRecord::Tasks::DatabaseTasks.dump_schema(db_config)
+          end
 
           assert File.file?(path)
         end
@@ -389,7 +391,9 @@ module ActiveRecord
           FileUtils.rm_rf(dir)
           assert_not File.file?(path)
 
-          ActiveRecord::Tasks::DatabaseTasks.dump_schema(db_config)
+          ActiveRecord::SchemaDumper.stub(:dump, "") do # Do not actually dump for test performances
+            ActiveRecord::Tasks::DatabaseTasks.dump_schema(db_config)
+          end
 
           assert File.file?(path)
         end


### PR DESCRIPTION
I maintain https://github.com/cockroachdb/activerecord-cockroachdb-adapter and I'm improving the test suite timing. I know that work has already been done in rails to reduce the number of schema dump done (https://github.com/rails/rails/pull/47499). I believe there are a few more we can avoid.
