### PR TITLE
Enable comments formatting on bash examples in guides

### DIFF
--- a/guides/rails_guides/markdown/renderer.rb
+++ b/guides/rails_guides/markdown/renderer.rb
@@ -32,7 +32,7 @@ module RailsGuides
       def block_code(code, language)
         language, lines = split_language_highlights(language)
         formatter = Rouge::Formatters::HTMLLineHighlighter.new(Rouge::Formatters::HTML.new, highlight_lines: lines)
-        lexer = ::Rouge::Lexer.find_fancy(lexer_language(language))
+        lexer = ::Rouge::Lexer.find_fancy(lexer_language_with_options(language))
         formatted_code = formatter.format(lexer.lex(code))
         <<~HTML
           <div class="interstitial code">
@@ -94,6 +94,16 @@ module RailsGuides
             "plaintext"
           else
             ::Rouge::Lexer.find(code_type) ? code_type : "plaintext"
+          end
+        end
+
+        def lexer_language_with_options(code_type)
+          language = lexer_language(code_type)
+          case language
+          when "console"
+            "#{language}?comments=true"
+          else
+            language
           end
         end
 


### PR DESCRIPTION
The Rouge [ConsoleLexer](https://www.rubydoc.info/gems/rouge/Rouge/Lexers/ConsoleLexer) allows marking lines starting with `#` as comments instead of a prompt (which is the default).
This improves the formatting of bash examples.


## Before

<img width="839" alt="image" src="https://github.com/user-attachments/assets/38a71428-15a5-49ef-bad8-d7bcf6112f7b" />

## After

<img width="836" alt="image" src="https://github.com/user-attachments/assets/e7a91895-cb9f-468e-b347-5338a40cc772" />

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
