### PR TITLE
scaffold: generate valid html when the model has_many_attached

### DIFF
--- a/railties/lib/rails/generators/erb/scaffold/templates/partial.html.erb.tt
+++ b/railties/lib/rails/generators/erb/scaffold/templates/partial.html.erb.tt
@@ -1,6 +1,6 @@
 <div id="<%%= dom_id <%= singular_name %> %>">
 <% attributes.reject(&:password_digest?).each do |attribute| -%>
-  <p>
+  <div>
     <strong><%= attribute.human_name %>:</strong>
 <% if attribute.attachment? -%>
     <%%= link_to <%= singular_name %>.<%= attribute.column_name %>.filename, <%= singular_name %>.<%= attribute.column_name %> if <%= singular_name %>.<%= attribute.column_name %>.attached? %>
@@ -11,7 +11,7 @@
 <% else -%>
     <%%= <%= singular_name %>.<%= attribute.column_name %> %>
 <% end -%>
-  </p>
+  </div>
 
 <% end -%>
 </div>


### PR DESCRIPTION
### Motivation / Background

The scaffold generator generates invalid html when the model has_many_attached. The affected view is the partial that, in the case of having many attached , generates something like this:

```
  <p>
    <strong>Gallery:</strong>
      <div><a href="/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsiZGF0YSI6MiwicHVyIjoiYmxvYl9pZCJ9fQ==--942bb66748e4b8f95bf3e96d9f9a63ec06c694a3/5d1lghe68rh4ce8bj42tulnkj6.png">5d1lghe68rh4ce8bj42tulnkj6.png</a></div>
  </p>
```

The problem is that the `p` tag cannot contain block-level elements (https://www.w3.org/TR/html401/struct/text.html#h-9.3.1). The browser interprets it this way:

![image](https://github.com/user-attachments/assets/8dee40d6-6494-42d7-b4e5-ffb3d15c0abc)

and the html validator complains about this too:

![image](https://github.com/user-attachments/assets/b895c894-3675-409b-b282-674e597b3dc0)

### Detail

This PR fix this by replacing the `p` tag with `div`, generating valid html:

![image](https://github.com/user-attachments/assets/f9bad46a-a803-4bf2-9c14-ed17b2b4a82b)

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
