### PR TITLE
Fix NoMethodError when type doesn't respond to mutable?

### DIFF
--- a/activemodel/lib/active_model/attribute.rb
+++ b/activemodel/lib/active_model/attribute.rb
@@ -97,7 +97,7 @@ module ActiveModel
     end
 
     def dup_or_share # :nodoc:
-      if @type.mutable?
+      if defined?(@type.mutable?) && @type.mutable?
         dup
       else
         self # If the underlying type is immutable we can get away with not duping


### PR DESCRIPTION
Follow up to https://github.com/rails/rails/pull/53921

When checking if a type is mutable in `Attribute#dup_or_share`, first verify the method exists using defined? before calling it. This fixes an issue where custom types that don't inherit from `ActiveModel::Type::Value` would raise `NoMethodError`, since `mutable?` is not defined on Object.

The first test fails without the `defined?(@type.mutable?)` guard (how it behaves right now in Rails main) as with the attribute API, you can pass any class as a type, not just subclasses of `ActiveModel::Type::Value`.

We noticed the problem as this would result in a `NoMethodError` when we saw some app code defined an attribute  in a class:

```ruby
attribute :baz, T::Array[Integer]  # as is the case with Sorbet
```
https://github.com/sorbet/sorbet/blob/master/gems/sorbet-runtime/lib/types/types/typed_array.rb

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [X] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
