### PR TITLE
Add support for materialized CTEs

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,18 @@
+*   Add support for materialized CTE by introducing a `.as_cte` query method
+
+    ```ruby
+    Post.with(
+      Post.where("comments_count > ?", 0).as_cte(:posts_with_comments, materialized: true)
+    )
+    # => ActiveRecord::Relation
+    # WITH "posts_with_comments" AS MATERIALIZED (
+    #   SELECT "posts".* FROM "posts" WHERE (comments_count > 0)
+    # )
+    # SELECT "posts".* FROM "posts"
+    ```
+
+    *Jean-Louis Giordano*
+
 *   `ActiveRecord::Coder::JSON` can be instantiated
 
     Options can now be passed to `ActiveRecord::Coder::JSON` when instantiating the coder. This allows:

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -1917,7 +1917,7 @@ module ActiveRecord
 
       def build_with_value_from_hash(hash)
         hash.map do |name, value|
-          Arel::Nodes::TableAlias.new(build_with_expression_from_value(value), name)
+          Arel::Nodes::Cte.new(name, build_with_expression_from_value(value))
         end
       end
 

--- a/activerecord/test/cases/relation/delegation_test.rb
+++ b/activerecord/test/cases/relation/delegation_test.rb
@@ -62,7 +62,7 @@ module ActiveRecord
       ActiveRecord::SpawnMethods.public_instance_methods(false) - [:spawn, :merge!] +
       ActiveRecord::QueryMethods.public_instance_methods(false).reject { |method|
         method.end_with?("=", "!", "?", "value", "values", "clause")
-      } - [:all, :reverse_order, :arel, :extensions, :construct_join_dependency] + [
+      } - [:all, :reverse_order, :arel, :as_cte, :extensions, :construct_join_dependency] + [
         :any?, :many?, :none?, :one?,
         :first_or_create, :first_or_create!, :first_or_initialize,
         :find_or_create_by, :find_or_create_by!, :find_or_initialize_by,

--- a/activerecord/test/cases/relation/with_test.rb
+++ b/activerecord/test/cases/relation/with_test.rb
@@ -25,6 +25,14 @@ module ActiveRecord
         assert_equal POSTS_WITH_COMMENTS, relation.order(:id).pluck(:id)
       end
 
+      def test_with_when_arel_cte_is_passed_as_an_argument
+        relation = Post
+          .with(Arel::Nodes::Cte.new(:posts_with_comments, Post.where("legacy_comments_count > 0")))
+          .from("posts_with_comments AS posts")
+
+        assert_equal POSTS_WITH_COMMENTS, relation.order(:id).pluck(:id)
+      end
+
       def test_with_when_hash_with_multiple_elements_of_different_type_is_passed_as_an_argument
         cte_options = {
           posts_with_tags: Post.arel_table.project(Arel.star).where(Post.arel_table[:tags_count].gt(0)),


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because I had the needed to add a MATERIALIZED hint to a Common Table Expression (CTE) in one of my rails applications, and that is not currently supported by the current implementation of `ActiveRecord::QueryMethods#with`.

### Detail

The proposed change is split into 3 steps (I made a separate commit for each)

1. Use `Arel::Nodes::Cte` instead of `Arel::Nodes::TableAlias` when building a CTE query
2. Allow passing in an instance of `Arel::Nodes::TableAlias` to `.with`
3. Add a `.as_cte` query method for convenience

This change allows for CTEs to be written like this:

```ruby
Post.with(Post.where("comments_count > ?", 0).as_cte(:post_with_comment))
Post.with(Post.where("comments_count > ?", 0).as_cte(:post_with_comment, materialized: true))
Post.with(Post.where("comments_count > ?", 0).as_cte(:post_with_comment, materialized: false))
Post.with_recursive(Post.where("comments_count > ?", 0).as_cte(:post_with_comment))
Post.with_recursive(Post.where("comments_count > ?", 0).as_cte(:post_with_comment, materialized: true))
Post.with_recursive(Post.where("comments_count > ?", 0).as_cte(:post_with_comment, materialized: false))
```

### Additional information

I was prompted to make a pull request with this proposal in on this thread: https://github.com/rails/rails/pull/48305#issuecomment-2605521114

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
