### PR TITLE
Update environment name to development in active jobs basics guide [ci skip]

### DIFF
--- a/guides/source/active_job_basics.md
+++ b/guides/source/active_job_basics.md
@@ -145,7 +145,7 @@ outstanding jobs are lost with the default async backend. This can be fine for
 smaller apps or non-critical jobs in development.
 
 However, if you use Solid Queue instead, you can configure it in the same way as
-in the production environment:
+in the development environment:
 
 ```ruby
 # config/environments/development.rb
@@ -154,7 +154,7 @@ config.solid_queue.connects_to = { database: { writing: :queue } }
 ```
 
 which sets the `:solid_queue` adapter as the default for Active Job in the
-production environment, and connects to the `queue` database for writing.
+development environment, and connects to the `queue` database for writing.
 
 Thereafter, you'd add `queue` to the development database configuration:
 


### PR DESCRIPTION
Update environment from `production` to `development` in the [Development](https://guides.rubyonrails.org/active_job_basics.html#development) section of the Active Job Basics guide
