### PR TITLE
[Fix #54326] Respect the association primary key when setting inverse records for association relations

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Fix associations not respecting the `:primary_key` option when the association is a `has_one` or any
+    association with a custom scope.
+
+    *Joshua Young*
+
 *   Attributes filtered by `filter_attributes` will now also be filtered by `filter_parameters`
     so sensitive information is not leaked.
 
@@ -489,6 +494,7 @@
     ```ruby
     serialize :config, coder: ActiveRecord::Coder::JSON.new(symbolize_names: true)
     ```
+
     *matthaigh27*
 
 *   Deprecate using `insert_all`/`upsert_all` with unpersisted records in associations.

--- a/activerecord/lib/active_record/associations/association.rb
+++ b/activerecord/lib/active_record/associations/association.rb
@@ -409,11 +409,14 @@ module ActiveRecord
         end
 
         def matches_foreign_key?(record)
+          foreign_key = reflection.foreign_key
+          primary_key = reflection.association_primary_key(klass)
+
           if foreign_key_for?(record)
-            record.read_attribute(reflection.foreign_key) == owner.id ||
-              (foreign_key_for?(owner) && owner.read_attribute(reflection.foreign_key) == record.id)
+            record.read_attribute(foreign_key) == owner.read_attribute(primary_key) ||
+              (foreign_key_for?(owner) && owner.read_attribute(foreign_key) == record.read_attribute(primary_key))
           else
-            owner.read_attribute(reflection.foreign_key) == record.id
+            owner.read_attribute(foreign_key) == record.read_attribute(primary_key)
           end
         end
     end

--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -923,6 +923,14 @@ module ActiveRecord
           Associations::HasOneAssociation
         end
       end
+
+      def association_primary_key(klass = nil)
+        if primary_key = options[:primary_key]
+          @association_primary_key ||= -primary_key.to_s
+        else
+          primary_key(klass || self.klass)
+        end
+      end
     end
 
     class BelongsToReflection < AssociationReflection # :nodoc:

--- a/activerecord/test/cases/associations/inverse_associations_test.rb
+++ b/activerecord/test/cases/associations/inverse_associations_test.rb
@@ -20,6 +20,7 @@ require "models/developer"
 require "models/company"
 require "models/project"
 require "models/author"
+require "models/essay"
 require "models/user"
 require "models/room"
 require "models/contract"
@@ -421,6 +422,22 @@ class InverseHasOneTests < ActiveRecord::TestCase
     assert_match "Did you mean?", error.detailed_message
     assert_equal "confused_human", error.corrections.first
   end
+
+  def test_inverse_record_should_be_set_with_custom_association_primary_key
+    author = Author.create!(name: "Josh")
+    author.create_essay_2_with_belongs_to_inverse_of!
+    author.reload
+
+    assert_same author, author.essay_2_with_belongs_to_inverse_of.author
+  end
+
+  def test_inverse_record_should_be_set_with_custom_association_primary_key_and_custom_scope
+    author = Author.create!(name: "Josh")
+    author.create_essay_2_with_belongs_to_scoped_inverse_of!
+    author.reload
+
+    assert_same author, author.essay_2_with_belongs_to_scoped_inverse_of.author
+  end
 end
 
 class InverseHasManyTests < ActiveRecord::TestCase
@@ -714,6 +731,22 @@ class InverseHasManyTests < ActiveRecord::TestCase
 
     assert_equal post2, comment.post
   end
+
+  def test_inverse_record_should_be_set_with_custom_association_primary_key
+    author = Author.create!(name: "Josh")
+    author.essays_2_with_belongs_to_inverse_of.create!
+    author.reload
+
+    assert_same author, author.essays_2_with_belongs_to_inverse_of.first.author
+  end
+
+  def test_inverse_record_should_be_set_with_custom_association_primary_key_and_custom_scope
+    author = Author.create!(name: "Josh")
+    author.essays_2_with_belongs_to_scoped_inverse_of.create!
+    author.reload
+
+    assert_same author, author.essays_2_with_belongs_to_scoped_inverse_of.first.author
+  end
 end
 
 class InverseBelongsToTests < ActiveRecord::TestCase
@@ -921,6 +954,22 @@ class InverseBelongsToTests < ActiveRecord::TestCase
       assert_equal 1, interest.human.interests.size
     end
   end
+
+  def test_inverse_record_should_be_set_with_custom_association_primary_key
+    author = Author.create!(name: "Josh")
+    essay = author.create_essay_2_with_belongs_to_inverse_of!
+    essay.reload
+
+    assert_same essay, essay.author.essay_2_with_belongs_to_inverse_of
+  end
+
+  def test_inverse_record_should_be_set_with_custom_association_primary_key_and_custom_scope
+    author = Author.create!(name: "Josh")
+    essay = author.create_essay_2_with_belongs_to_scoped_inverse_of!
+    essay.reload
+
+    assert_same essay, essay.author.essay_2_with_belongs_to_scoped_inverse_of
+  end
 end
 
 class InversePolymorphicBelongsToTests < ActiveRecord::TestCase
@@ -1051,6 +1100,22 @@ class InversePolymorphicBelongsToTests < ActiveRecord::TestCase
     assert_nothing_raised { Face.first.polymorphic_human = Human.first }
     # fails because Interest does have the correct inverse_of
     assert_raise(ActiveRecord::InverseOfAssociationNotFoundError) { Face.first.polymorphic_human = Interest.first }
+  end
+
+  def test_inverse_record_should_be_set_with_custom_association_primary_key
+    author = Author.create!(name: "Josh")
+    essay = author.create_essay_with_belongs_to_inverse_of!
+    essay.reload
+
+    assert_same essay, essay.writer.essay_with_belongs_to_inverse_of
+  end
+
+  def test_inverse_record_should_be_set_with_custom_association_primary_key_and_custom_scope
+    author = Author.create!(name: "Josh")
+    essay = author.create_essay_with_belongs_to_scoped_inverse_of!
+    essay.reload
+
+    assert_same essay, essay.writer.essay_with_belongs_to_scoped_inverse_of
   end
 end
 

--- a/activerecord/test/cases/reflection_test.rb
+++ b/activerecord/test/cases/reflection_test.rb
@@ -426,7 +426,7 @@ class ReflectionTest < ActiveRecord::TestCase
   def test_association_primary_key
     # Normal association
     assert_equal "id",   Author.reflect_on_association(:posts).association_primary_key.to_s
-    assert_equal "id",   Author.reflect_on_association(:essay).association_primary_key.to_s
+    assert_equal "name", Author.reflect_on_association(:essay).association_primary_key.to_s
     assert_equal "name", Essay.reflect_on_association(:writer).association_primary_key.to_s
 
     # Through association (uses the :primary_key option from the source reflection)

--- a/activerecord/test/models/author.rb
+++ b/activerecord/test/models/author.rb
@@ -181,16 +181,24 @@ class Author < ActiveRecord::Base
   has_one :essay, primary_key: :name, as: :writer
   has_one :essay_category, through: :essay, source: :category
   has_one :essay_owner, through: :essay, source: :owner
+  has_one :essay_with_belongs_to_inverse_of, as: :writer, class_name: "EssayWithBelongsToInverseOf", foreign_key: :author_id, primary_key: :name, inverse_of: :writer
+  has_one :essay_with_belongs_to_scoped_inverse_of, -> { where("1=1") }, as: :writer, class_name: "EssayWithBelongsToScopedInverseOf", foreign_key: :author_id, primary_key: :name, inverse_of: :writer
 
   has_one :essay_2, primary_key: :name, class_name: "Essay", foreign_key: :author_id
   has_one :essay_category_2, through: :essay_2, source: :category
+  has_one :essay_2_with_belongs_to_inverse_of, class_name: "EssayWithBelongsToInverseOf", foreign_key: :author_id, primary_key: :name, inverse_of: :author
+  has_one :essay_2_with_belongs_to_scoped_inverse_of, -> { where("1=1") }, class_name: "EssayWithBelongsToScopedInverseOf", foreign_key: :author_id, primary_key: :name, inverse_of: :author
 
   has_many :essays, primary_key: :name, as: :writer
   has_many :essay_categories, through: :essays, source: :category
   has_many :essay_owners, through: :essays, source: :owner
+  has_many :essays_with_belongs_to_inverse_of, as: :writer, class_name: "EssayWithBelongsToInverseOf", foreign_key: :author_id, primary_key: :name, inverse_of: :writer
+  has_many :essays_with_belongs_to_scoped_inverse_of, -> { where("1=1") }, as: :writer, class_name: "EssayWithBelongsToScopedInverseOf", foreign_key: :author_id, primary_key: :name, inverse_of: :writer
 
   has_many :essays_2, primary_key: :name, class_name: "Essay", foreign_key: :author_id
   has_many :essay_categories_2, through: :essays_2, source: :category
+  has_many :essays_2_with_belongs_to_inverse_of, class_name: "EssayWithBelongsToInverseOf", foreign_key: :author_id, primary_key: :name, inverse_of: :author
+  has_many :essays_2_with_belongs_to_scoped_inverse_of, -> { where("1=1") }, class_name: "EssayWithBelongsToScopedInverseOf", foreign_key: :author_id, primary_key: :name, inverse_of: :author
 
   belongs_to :owned_essay, primary_key: :name, class_name: "Essay"
   has_one :owned_essay_category, through: :owned_essay, source: :category

--- a/activerecord/test/models/essay.rb
+++ b/activerecord/test/models/essay.rb
@@ -9,5 +9,16 @@ end
 
 class EssaySpecial < Essay
 end
+
 class TypedEssay < Essay
+end
+
+class EssayWithBelongsToInverseOf < Essay
+  belongs_to :author, primary_key: :name, inverse_of: :essay_2_with_belongs_to_inverse_of
+  belongs_to :writer, primary_key: :name, polymorphic: true, inverse_of: :essay_with_belongs_to_inverse_of
+end
+
+class EssayWithBelongsToScopedInverseOf < Essay
+  belongs_to :author, -> { where("1=1") }, primary_key: :name, inverse_of: :essay_2_with_belongs_to_scoped_inverse_of
+  belongs_to :writer, -> { where("1=1") }, primary_key: :name, polymorphic: true, inverse_of: :essay_with_belongs_to_scoped_inverse_of
 end


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

Fixes https://github.com/rails/rails/issues/54326

### Detail

Updates `#matches_foreign_key?` which is used to check if inverse records can be set on associations whose queries are executed with a custom scope to first use the association's primary key if set, and if not fall back to the model's primary key.

When working on this I found that even without a custom scope, `:primary_key` isn't respected on `has_one` associations, so I've also included a fix for this which ensures that the `:primary_key` option is first checked when fetching the association's primary key for `has_one`.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.