### PR TITLE
Improve argument validation in `ActiveSupport::ErrorReporter#handle`

### DIFF
--- a/activesupport/lib/active_support/error_reporter.rb
+++ b/activesupport/lib/active_support/error_reporter.rb
@@ -217,7 +217,7 @@ module ActiveSupport
         raise ArgumentError, "severity must be one of #{SEVERITIES.map(&:inspect).join(", ")}, got: #{severity.inspect}"
       end
 
-      full_context = ActiveSupport::ExecutionContext.to_h.merge(context)
+      full_context = ActiveSupport::ExecutionContext.to_h.merge(context || {})
       disabled_subscribers = ActiveSupport::IsolatedExecutionState[self]
       @subscribers.each do |subscriber|
         unless disabled_subscribers&.any? { |s| s === subscriber }

--- a/activesupport/lib/active_support/error_reporter.rb
+++ b/activesupport/lib/active_support/error_reporter.rb
@@ -209,6 +209,8 @@ module ActiveSupport
     #
     def report(error, handled: true, severity: handled ? :warning : :error, context: {}, source: DEFAULT_SOURCE)
       return if error.instance_variable_defined?(:@__rails_error_reported)
+      raise ArgumentError, "Reported error must be an Exception, got: #{error.inspect}" unless error.is_a?(Exception)
+
       ensure_backtrace(error)
 
       unless SEVERITIES.include?(severity)

--- a/activesupport/test/error_reporter_test.rb
+++ b/activesupport/test/error_reporter_test.rb
@@ -284,6 +284,11 @@ class ErrorReporterTest < ActiveSupport::TestCase
     assert_includes error.message, "Reported error must be an Exception"
   end
 
+  test "report accepts context as nil" do
+    @reporter.report(@error, context: nil)
+    assert_equal({}, @subscriber.events.last[4])
+  end
+
   test "report errors only once" do
     assert_difference -> { @subscriber.events.size }, +1 do
       @reporter.report(@error, handled: false)

--- a/activesupport/test/error_reporter_test.rb
+++ b/activesupport/test/error_reporter_test.rb
@@ -270,6 +270,20 @@ class ErrorReporterTest < ActiveSupport::TestCase
     end
   end
 
+  test "report raises if passed an argument that is not an Exception" do
+    error = assert_raises ArgumentError do
+      @reporter.report(Object.new)
+    end
+    assert_includes error.message, "Reported error must be an Exception"
+  end
+
+  test "report raises if passed a String" do
+    error = assert_raises ArgumentError do
+      @reporter.report("An error message")
+    end
+    assert_includes error.message, "Reported error must be an Exception"
+  end
+
   test "report errors only once" do
     assert_difference -> { @subscriber.events.size }, +1 do
       @reporter.report(@error, handled: false)

--- a/activesupport/test/error_reporter_test.rb
+++ b/activesupport/test/error_reporter_test.rb
@@ -257,6 +257,19 @@ class ErrorReporterTest < ActiveSupport::TestCase
     assert_equal :error, @subscriber.events.dig(0, 2)
   end
 
+  test "errors be reported with valid severity" do
+    ActiveSupport::ErrorReporter::SEVERITIES.each do |severity|
+      @reporter.report(StandardError.new, severity: severity)
+      assert_equal severity, @subscriber.events.last[2]
+    end
+  end
+
+  test "errors with invalid severity raise" do
+    assert_raises ArgumentError do
+      @reporter.report(@error, severity: :invalid)
+    end
+  end
+
   test "report errors only once" do
     assert_difference -> { @subscriber.events.size }, +1 do
       @reporter.report(@error, handled: false)


### PR DESCRIPTION
## Motivation / Background

These are a few quality of life improvements from using `Rails.error.report` and friends through our large application.

First, it raises an `ArgumentError` when passed something that isn't a subclass of `Exception`. Previously it would not validate this and the backtrace parsing would be the first thing to trip up over the unexpected value. Now it will raise a descriptive error. We encountered this most commonly when someone would attempt to report a String like they can currently raise a string:

```
> Rails.error.report("got some bad data")
undefined method 'backtrace' for an instance of String (NoMethodError)
        return unless error.backtrace.nil?
```

Second, the `context:` param defaults to an empty hash. It can accept an empty hash. But in some cases when passed in a context hash from another source that turns out to be `nil` it would raise internally. We can make this better by defaulting to the desired `{}` behaviour and save the error reporter from itself raising:

```
> Rails.error.report(StandardError.new, context: nil)
no implicit conversion of nil into Hash (TypeError)
      full_context = ActiveSupport::ExecutionContext.to_h.merge(context)
                                                                ^^^^^^^
```

Third, I improved some test coverage while I was in there. I found `severity` argument validation was not tested.

I didn't update the CHANGELOG, but I can if this is worth it. IMO it's too small.


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
