### PR TITLE
Add support for index visibility for MySQL v8.0.0+ and MariaDB v10.6.0+

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,41 @@
+*   Support disabling indexes for MySQL v8.0.0+ and MariaDB v10.6.0+
+
+    MySQL 8.0.0 added an option to disable indexes from being used by the query
+    optimizer by making them "invisible". This allows the index to still be maintained
+    and updated but no queries will be permitted to use it. This can be useful for adding
+    new invisible indexes or making existing indexes invisible before dropping them
+    to ensure queries are not negatively affected.
+    See https://dev.mysql.com/blog-archive/mysql-8-0-invisible-indexes/ for more details.
+
+    MariaDB 10.6.0 also added support for this feature by allowing indexes to be "ignored"
+    in queries. See https://mariadb.com/kb/en/ignored-indexes/ for more details.
+
+    Active Record now supports this option for MySQL 8.0.0+ and MariaDB 10.6.0+ for
+    index creation and alteration where the new index option `enabled: true/false` can be
+    passed to column and index methods as below:
+
+    ```ruby
+    add_index :users, :email, enabled: false
+    enable_index :users, :email
+    add_column :users, :dob, :string, index: { enabled: false }
+
+    change_table :users do |t|
+      t.index :name, enabled: false
+      t.index :dob
+      t.disable_index :dob
+      t.column :username, :string, index: { enabled: false }
+      t.references :account, index: { enabled: false }
+    end
+
+    create_table :users do |t|
+      t.string :name, index: { enabled: false }
+      t.string :email
+      t.index :email, enabled: false
+    end
+    ```
+
+    *Merve Taner*
+
 *   Respect `implicit_order_column` in `ActiveRecord::Relation#reverse_order`.
 
     *Joshua Young*

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -555,6 +555,10 @@ module ActiveRecord
         false
       end
 
+      def supports_disabling_indexes?
+        false
+      end
+
       def return_value_after_insert?(column) # :nodoc:
         column.auto_populated?
       end

--- a/activerecord/lib/active_record/connection_adapters/mysql/schema_creation.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/schema_creation.rb
@@ -49,6 +49,8 @@ module ActiveRecord
             sql << "USING #{o.using}" if o.using
             sql << "ON #{quote_table_name(o.table)}" if create
             sql << "(#{quoted_columns(o)})"
+            sql << "INVISIBLE" if o.disabled? && !mariadb?
+            sql << "IGNORED" if o.disabled? && mariadb?
 
             add_sql_comment!(sql.join(" "), o.comment)
           end

--- a/activerecord/lib/active_record/migration/command_recorder.rb
+++ b/activerecord/lib/active_record/migration/command_recorder.rb
@@ -44,6 +44,8 @@ module ActiveRecord
     # * rename_enum_value (must supply a +:from+ and +:to+ option)
     # * rename_index
     # * rename_table
+    # * enable_index
+    # * disable_index
     class CommandRecorder
       ReversibleAndIrreversibleMethods = [
         :create_table, :create_join_table, :rename_table, :add_column, :remove_column,
@@ -58,7 +60,8 @@ module ActiveRecord
         :add_unique_constraint, :remove_unique_constraint,
         :create_enum, :drop_enum, :rename_enum, :add_enum_value, :rename_enum_value,
         :create_schema, :drop_schema,
-        :create_virtual_table, :drop_virtual_table
+        :create_virtual_table, :drop_virtual_table,
+        :enable_index, :disable_index
       ]
       include JoinTable
 
@@ -182,6 +185,16 @@ module ActiveRecord
         end
 
         include StraightReversions
+
+        def invert_enable_index(args)
+          table_name, index_name = args
+          [:disable_index, [table_name, index_name]]
+        end
+
+        def invert_disable_index(args)
+          table_name, index_name = args
+          [:enable_index, [table_name, index_name]]
+        end
 
         def invert_transaction(args, &block)
           sub_recorder = CommandRecorder.new(delegate)

--- a/activerecord/lib/active_record/schema_dumper.rb
+++ b/activerecord/lib/active_record/schema_dumper.rb
@@ -277,6 +277,7 @@ module ActiveRecord
         index_parts << "nulls_not_distinct: #{index.nulls_not_distinct.inspect}" if index.nulls_not_distinct
         index_parts << "type: #{index.type.inspect}" if index.type
         index_parts << "comment: #{index.comment.inspect}" if index.comment
+        index_parts << "enabled: #{index.enabled.inspect}" if @connection.supports_disabling_indexes? && index.disabled?
         index_parts
       end
 

--- a/activerecord/test/cases/migration/change_table_test.rb
+++ b/activerecord/test/cases/migration/change_table_test.rb
@@ -214,6 +214,37 @@ module ActiveRecord
         end
       end
 
+      if ActiveRecord::Base.lease_connection.supports_disabling_indexes?
+        def test_column_creates_column_with_disabled_index
+          with_change_table do |t|
+            expect :add_column, nil, [:delete_me, :bar, :integer]
+            expect :add_index, nil, [:delete_me, :bar], enabled: false
+            t.column :bar, :integer, index: { enabled: false }
+          end
+        end
+
+        def test_index_creates_disabled_index
+          with_change_table do |t|
+            expect :add_index, nil, [:delete_me, :bar], enabled: false
+            t.index :bar, enabled: false
+          end
+        end
+
+        def test_disable_index_disables_index
+          with_change_table do |t|
+            expect :disable_index, nil, [:delete_me, :bar]
+            t.disable_index :bar
+          end
+        end
+
+        def test_enable_index_enables_index
+          with_change_table do |t|
+            expect :enable_index, nil, [:delete_me, :bar]
+            t.enable_index :bar
+          end
+        end
+      end
+
       def test_index_creates_index
         with_change_table do |t|
           expect :add_index, nil, [:delete_me, :bar]

--- a/activerecord/test/cases/migration/columns_test.rb
+++ b/activerecord/test/cases/migration/columns_test.rb
@@ -388,6 +388,19 @@ module ActiveRecord
         connection.drop_table(:my_table) rescue nil
       end
 
+      if ActiveRecord::Base.lease_connection.supports_disabling_indexes?
+        def test_column_with_disabled_index
+          connection.create_table "my_table", force: true do |t|
+            t.column "col_one", :bigint
+            t.column "col_two", :bigint, index: { enabled: false }
+          end
+
+          assert connection.index_exists?("my_table", :col_two, enabled: false)
+        ensure
+          connection.drop_table(:my_table) rescue nil
+        end
+      end
+
       def test_add_column_without_column_name
         e = assert_raise ArgumentError do
           connection.create_table "my_table", force: true do |t|

--- a/activerecord/test/cases/migration/command_recorder_test.rb
+++ b/activerecord/test/cases/migration/command_recorder_test.rb
@@ -315,6 +315,28 @@ module ActiveRecord
         assert_equal [:remove_index, [:table, :one, algorithm: :concurrently], nil], remove
       end
 
+      if ActiveRecord::Base.lease_connection.supports_disabling_indexes?
+        def test_invert_add_index_with_disabled_option
+          remove = @recorder.inverse_of :add_index, [:table, :one, enabled: false]
+          assert_equal [:remove_index, [:table, :one, enabled: false], nil], remove
+        end
+
+        def test_invert_remove_index_with_disabled_option
+          add = @recorder.inverse_of :remove_index, [:table, :one, enabled: false]
+          assert_equal [:add_index, [:table, :one, enabled: false]], add
+        end
+
+        def test_invert_disable_index
+          enable = @recorder.inverse_of :disable_index, [:table, :disabled_index]
+          assert_equal [:enable_index, [:table, :disabled_index]], enable
+        end
+
+        def test_invert_enable_index
+          disable = @recorder.inverse_of :enable_index, [:table, :enabled_index]
+          assert_equal [:disable_index, [:table, :enabled_index]], disable
+        end
+      end
+
       def test_invert_remove_index
         add = @recorder.inverse_of :remove_index, [:table, :one]
         assert_equal [:add_index, [:table, :one]], add

--- a/activerecord/test/cases/migration/index_test.rb
+++ b/activerecord/test/cases/migration/index_test.rb
@@ -321,6 +321,21 @@ module ActiveRecord
         assert_not connection.index_exists?("testings", "last_name", nulls_not_distinct: true)
       end
 
+      if ActiveRecord::Base.lease_connection.supports_disabling_indexes?
+        def test_index_visibility_through_add_index
+          connection.add_index(:testings, :foo, enabled: false)
+
+          assert connection.index_exists?(:testings, :foo, enabled: false)
+        end
+
+        def test_index_disabling_through_disable_index
+          connection.add_index(:testings, :foo)
+          connection.disable_index(:testings, "index_testings_on_foo")
+
+          assert connection.index_exists?(:testings, :foo, enabled: false)
+        end
+      end
+
       private
         def good_index_name
           "x" * connection.index_name_length

--- a/activerecord/test/cases/migration/invalid_options_test.rb
+++ b/activerecord/test/cases/migration/invalid_options_test.rb
@@ -22,7 +22,13 @@ module ActiveRecord
       end
 
       def invalid_add_index_option_exception_message(key)
-        "Unknown key: :#{key}. Valid keys are: :unique, :length, :order, :opclass, :where, :type, :using, :comment, :algorithm, :include, :nulls_not_distinct"
+        default_keys = [":unique", ":length", ":order", ":opclass", ":where", ":type", ":using", ":comment", ":algorithm", ":include", ":nulls_not_distinct"]
+
+        if connection.supports_disabling_indexes?
+          default_keys.concat([":enabled"])
+        end
+
+        "Unknown key: :#{key}. Valid keys are: #{default_keys.join(", ")}"
       end
 
       def invalid_create_table_option_exception_message(key)

--- a/activerecord/test/cases/migration/references_index_test.rb
+++ b/activerecord/test/cases/migration/references_index_test.rb
@@ -25,6 +25,16 @@ module ActiveRecord
         assert connection.index_exists?(table_name, :foo_id, name: :index_testings_on_foo_id)
       end
 
+      if ActiveRecord::Base.lease_connection.supports_disabling_indexes?
+        def test_creates_invisible_index
+          connection.create_table table_name do |t|
+            t.references :foo, index: { enabled: false }
+          end
+
+          assert connection.index_exists?(table_name, :foo_id, name: :index_testings_on_foo_id, enabled: false)
+        end
+      end
+
       def test_creates_index_by_default_even_if_index_option_is_not_passed
         connection.create_table table_name do |t|
           t.references :foo

--- a/activerecord/test/cases/schema_dumper_test.rb
+++ b/activerecord/test/cases/schema_dumper_test.rb
@@ -226,6 +226,13 @@ class SchemaDumperTest < ActiveRecord::TestCase
     end
   end
 
+  if ActiveRecord::Base.lease_connection.supports_disabling_indexes?
+    def test_schema_dumps_index_visibility
+      index_definition = dump_table_schema("companies").split(/\n/).grep(/t\.index.*company_disabled_index/).first.strip
+      assert_equal 't.index ["firm_id", "client_of"], name: "company_disabled_index", enabled: false', index_definition
+    end
+  end
+
   if ActiveRecord::Base.lease_connection.supports_check_constraints?
     def test_schema_dumps_check_constraints
       constraint_definition = dump_table_schema("products").split(/\n/).grep(/t.check_constraint.*products_price_check/).first.strip

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -427,6 +427,10 @@ ActiveRecord::Schema.define do
         t.index "(CONCAT_WS(`firm_name`, `name`, _utf8mb4' '))", name: "full_name_index"
       end
     end
+
+    if supports_disabling_indexes?
+      t.index [:firm_id, :client_of], name: "company_disabled_index", enabled: false
+    end
   end
 
   create_table :content, force: true do |t|


### PR DESCRIPTION
### Motivation / Background

This pull request aims to integrate support for the MySQL v8.0.0+ `(ALTER/CREATE) INDEX ... INVISIBLE` and MariaDB v 10.6.0+ `(ALTER/CREATE) INDEX .... IGNORED` functionality into Rails to enhance our index management capabilities within the Rails environment. 

Making an index invisible allows the index to be maintained and updated but it is not permitted to be used by the query optimizer. This feature enables a more gradual rollout of index changes, allowing developers to monitor the impact on performance before fully committing to using/dropping an index. More details can be found here: https://dev.mysql.com/blog-archive/mysql-8-0-invisible-indexes/ for MySQL and https://mariadb.com/kb/en/ignored-indexes/ for MariaDB

Currently, this migration is executable as a SQL statement. However, this limitation results in the lack of reflection in the `schema.rb` file, which means that the visibility state of indexes is not accurately captured during the schema:load process.

By adding the ability to modify index visibility through existing column and index methods, we will ensure that the index visibility state is properly represented in `schema.rb`. This enhancement not only provides clarity regarding the visibility of indexes but also improves the convenience of managing these options, making it easier to implement and revert index visibility changes when necessary.

### Detail

This Pull Request adds support to active record migrations to allow an index to be created "invisible/ignored" as enabled or disabled:

```ruby
        add_index :users, :email, enabled: false
        enable_index :users, :email
        add_column :users, :dob, :string, index: { enabled: false }

        change_table :users do |t|
          t.index :name, enabled: false
          t.index :dob
          t.disable_index :dob
          t.column :username, :string, index: { enabled: false }
          t.references :account, index: { enabled: false }
        end

        create_table :users do |t|
          t.string :name, index: { enabled: false }
          t.string :email
          t.index :email, enabled: false
        end
 ```

Index options are extended to recognise `enabled: true/false` option, which allows an index to be created as invisible through existing column or index methods. 

Two new methods has also been added, `enable_index` and `disable_index`, to manage the visibility of an existing index, which are also both reversible migrations. 

This feature is only supported by MySQL v8.0.0+ and MariaDB v10.6.0+ and Argument/Not Implemented errors are raised accordingly. 

Sqlite does not have a corresponding feature. PostgreSQL has a flag `indisvalid` that when `true` prevents the index to be not used by the query planner but still maintained (similar to the "invisible/ignored" indexes). However this flag can also be updated automatically by PostgreSQL if the index is deemed corrupt and requires super user permissions to update it if needed. As this is not very similar to a user managed index usability in query planner, I have decided not to extend this feature to PostgreSQL in this PR. There is a [discussion]((https://postgrespro.com/list/thread-id/2712171) on adding this feature to PostgreSQL in the near feature with `enable/disable` index. 

Naming of the option `enabled: true/false` is to have more clarity on an index being used by queries or not. Other options were `visible: true/false` and `ignored: true/false`

In both MySQL and MariaDB, `ALTER INDEX` is used to change the state of the "visibility/ignoring" of the index, however as `ALTER INDEX` is used also by PostgreSQL for other index operations, we did not want to have the `alter_index` method to be couple to index usage in queries, and created specific methods that deal with "enabling/disabling" of index usage in queries instead.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [ ] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
