### PR TITLE
[ci skip] Add a mention to `db:create` in the getting started guide:

### DIFF
--- a/guides/source/getting_started.md
+++ b/guides/source/getting_started.md
@@ -168,9 +168,15 @@ Rails.
 Hello, Rails!
 -------------
 
-Let's start easy and boot up our Rails server for the first time.
+Let's start easy by creating our application's database and boot up our Rails server for the first time.
 
-In your terminal, run the following command in the `store` directory:
+In your terminal, run the following commands in the `store` directory:
+
+```bash
+$ bin/rails db:create
+```
+
+This will initially create the application's database.
 
 ```bash
 $ bin/rails server


### PR DESCRIPTION
I found it strange that there is no mention of creating a database in the getting started guide and it relies on the fact that sqlite (which is the DB used by default) will create it automatically.

Although it's not required thanks to sqlite's magic, I think this should be mentioned for educational purposes and to avoid users encoutering their first problem with Rails after reading 2 paragraphs in the event that they created their application with a different DB.

I don't think this is a cognitive overload to add it in the first few sentences of the getting started guide.

This used to be explained a while ago but got removed without explanation in https://github.com/rails/rails/commit/dcfb990e1bd56df44595782bd0fe356e6c8f2c76#diff-2d11e0db459fb264a714f77651a2da83c53bc35155b1cf7440a11901544dee22L421-L429

