### PR TITLE
Fix active record instrumentation not thread safe:

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,18 @@
+*   Fix SQL notifications sometimes not sent when using async queries.
+
+    ```ruby
+    Post.async_count
+    ActiveSupport::Notifications.subscribed(->(*) { "Will never reach here" }) do
+      Post.count
+    end
+    ```
+
+    In rare circumstances and under the right race condition, Active Support notifications
+    would no longer be dispatched after using an asynchronous query.
+    This is now fixed.
+
+    *Edouard Chin*
+
 *   Eliminate queries loading dumped schema cache on Postgres
 
     Improve resiliency by avoiding needing to open a database connection to load the

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -150,7 +150,6 @@ module ActiveRecord
         end
 
         @owner = nil
-        @instrumenter = ActiveSupport::Notifications.instrumenter
         @pool = ActiveRecord::ConnectionAdapters::NullPool.new
         @idle_since = Process.clock_gettime(Process::CLOCK_MONOTONIC)
         @visitor = arel_visitor
@@ -188,19 +187,6 @@ module ActiveRecord
           ActiveSupport::Concurrency::LoadInterlockAwareMonitor.new
         else
           ActiveSupport::Concurrency::NullLock
-        end
-      end
-
-      EXCEPTION_NEVER = { Exception => :never }.freeze # :nodoc:
-      EXCEPTION_IMMEDIATE = { Exception => :immediate }.freeze # :nodoc:
-      private_constant :EXCEPTION_NEVER, :EXCEPTION_IMMEDIATE
-      def with_instrumenter(instrumenter, &block) # :nodoc:
-        Thread.handle_interrupt(EXCEPTION_NEVER) do
-          previous_instrumenter = @instrumenter
-          @instrumenter = instrumenter
-          Thread.handle_interrupt(EXCEPTION_IMMEDIATE, &block)
-        ensure
-          @instrumenter = previous_instrumenter
         end
       end
 
@@ -1146,7 +1132,7 @@ module ActiveRecord
         end
 
         def log(sql, name = "SQL", binds = [], type_casted_binds = [], async: false, &block) # :doc:
-          @instrumenter.instrument(
+          instrumenter.instrument(
             "sql.active_record",
             sql:               sql,
             name:              name,
@@ -1161,6 +1147,10 @@ module ActiveRecord
           )
         rescue ActiveRecord::StatementInvalid => ex
           raise ex.set_query(sql, binds)
+        end
+
+        def instrumenter # :nodoc:
+          ActiveSupport::IsolatedExecutionState[:active_record_instrumenter] ||= ActiveSupport::Notifications.instrumenter
         end
 
         def translate_exception(exception, message:, sql:, binds:)

--- a/activerecord/lib/active_record/future_result.rb
+++ b/activerecord/lib/active_record/future_result.rb
@@ -108,9 +108,9 @@ module ActiveRecord
           begin
             if pending?
               @event_buffer = EventBuffer.new(self, @instrumenter)
-              connection.with_instrumenter(@event_buffer) do
-                execute_query(connection, async: true)
-              end
+              ActiveSupport::IsolatedExecutionState[:active_record_instrumenter] = @event_buffer
+
+              execute_query(connection, async: true)
             end
           ensure
             @mutex.unlock


### PR DESCRIPTION
Fix #54016

Fix active record instrumentation not thread safe:

### Motivation / Background

When using Active Record async feature, the instrumentation was not thread safe.

```ruby 
Post.count_async

ActiveSupport::Notifications.subscribed(->(*) { }, "active_record.sql") do
  Post.count
end
```

With the right race condition, the subscription would never fire up. This is due to temporarly overriding the instrumentation instance variable on the connection.


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
