### PR TITLE
Make the schema cache forward compatible with the changes in Column

### DIFF
--- a/activerecord/lib/active_record/attributes.rb
+++ b/activerecord/lib/active_record/attributes.rb
@@ -241,8 +241,11 @@ module ActiveRecord
 
       def _default_attributes # :nodoc:
         @default_attributes ||= begin
-          attributes_hash = columns_hash.transform_values do |column|
-            ActiveModel::Attribute.from_database(column.name, column.default, type_for_column(column))
+          # TODO: Remove the need for a connection after we release 8.1.
+          attributes_hash = with_connection do |connection|
+            columns_hash.transform_values do |column|
+              ActiveModel::Attribute.from_database(column.name, column.default, type_for_column(connection, column))
+            end
           end
 
           attribute_set = ActiveModel::AttributeSet.new(attributes_hash)
@@ -297,7 +300,8 @@ module ActiveRecord
           Type.lookup(name, **options, adapter: Type.adapter_name_from(self))
         end
 
-        def type_for_column(column)
+        def type_for_column(connection, column)
+          # TODO: Remove the need for a connection after we release 8.1.
           hook_attribute_type(column.name, super)
         end
     end

--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -624,7 +624,8 @@ module ActiveRecord
 
             columns.map do |name, column|
               if fixture.key?(name)
-                with_yaml_fallback(column.cast_type.serialize(fixture[name]))
+                # TODO: Remove fetch_cast_type and the need for connection after we release 8.1.
+                with_yaml_fallback(column.fetch_cast_type(self).serialize(fixture[name]))
               else
                 default_insert_value(column)
               end

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_dumper.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_dumper.rb
@@ -85,7 +85,8 @@ module ActiveRecord
 
         def schema_default(column)
           return unless column.has_default?
-          type = column.cast_type
+          # TODO: Remove fetch_cast_type and the need for connection after we release 8.1.
+          type = column.fetch_cast_type(@connection)
           default = type.deserialize(column.default)
           if default.nil?
             schema_expression(column)

--- a/activerecord/lib/active_record/connection_adapters/column.rb
+++ b/activerecord/lib/active_record/connection_adapters/column.rb
@@ -7,7 +7,7 @@ module ActiveRecord
     class Column
       include Deduplicable
 
-      attr_reader :name, :cast_type, :default, :sql_type_metadata, :null, :default_function, :collation, :comment
+      attr_reader :name, :default, :sql_type_metadata, :null, :default_function, :collation, :comment
 
       delegate :precision, :scale, :limit, :type, :sql_type, to: :sql_type_metadata, allow_nil: true
 
@@ -26,6 +26,11 @@ module ActiveRecord
         @default_function = default_function
         @collation = collation
         @comment = comment
+      end
+
+      def fetch_cast_type(connection) # :nodoc:
+        # TODO: Remove fetch_cast_type and the need for connection after we release 8.1.
+        @cast_type || connection.lookup_cast_type(sql_type)
       end
 
       def has_default?
@@ -104,6 +109,9 @@ module ActiveRecord
       def virtual?
         false
       end
+
+      protected
+        attr_reader :cast_type
 
       private
         def deduplicated

--- a/activerecord/lib/active_record/connection_adapters/postgresql/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/quoting.rb
@@ -160,7 +160,8 @@ module ActiveRecord
           elsif column.type == :uuid && value.is_a?(String) && value.include?("()")
             value # Does not quote function default values for UUID columns
           elsif column.respond_to?(:array?)
-            quote(column.cast_type.serialize(value))
+            # TODO: Remove fetch_cast_type and the need for connection after we release 8.1.
+            quote(column.fetch_cast_type(self).serialize(value))
           else
             super
           end
@@ -186,11 +187,12 @@ module ActiveRecord
           end
         end
 
-        private
-          def lookup_cast_type(sql_type)
-            super(query_value("SELECT #{quote(sql_type)}::regtype::oid", "SCHEMA").to_i)
-          end
+        # TODO: Make this method private after we release 8.1.
+        def lookup_cast_type(sql_type) # :nodoc:
+          super(query_value("SELECT #{quote(sql_type)}::regtype::oid", "SCHEMA").to_i)
+        end
 
+        private
           def encode_array(array_data)
             encoder = array_data.encoder
             values = type_cast_array(array_data.values)

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -654,7 +654,8 @@ module ActiveRecord
                 column_options[:stored] = column.virtual_stored?
                 column_options[:type] = column.type
               elsif column.has_default?
-                default = column.cast_type.deserialize(column.default)
+                # TODO: Remove fetch_cast_type and the need for connection after we release 8.1.
+                default = column.fetch_cast_type(self).deserialize(column.default)
                 default = -> { column.default_function } if default.nil?
 
                 unless column.auto_increment?

--- a/activerecord/lib/active_record/model_schema.rb
+++ b/activerecord/lib/active_record/model_schema.rb
@@ -619,8 +619,9 @@ module ActiveRecord
           end
         end
 
-        def type_for_column(column)
-          type = column.cast_type
+        def type_for_column(connection, column)
+          # TODO: Remove the need for a connection after we release 8.1.
+          type = column.fetch_cast_type(connection)
 
           if immutable_strings_by_default && type.respond_to?(:to_immutable_string)
             type = type.to_immutable_string

--- a/activerecord/lib/active_record/type_caster/connection.rb
+++ b/activerecord/lib/active_record/type_caster/connection.rb
@@ -19,7 +19,8 @@ module ActiveRecord
         if schema_cache.data_source_exists?(table_name)
           column = schema_cache.columns_hash(table_name)[attr_name.to_s]
           if column
-            type = column.cast_type
+            # TODO: Remove fetch_cast_type and the need for connection after we release 8.1.
+            type = column.fetch_cast_type(@klass.lease_connection)
           end
         end
 

--- a/activerecord/test/assets/schema_dump_8_0.yml
+++ b/activerecord/test/assets/schema_dump_8_0.yml
@@ -1,0 +1,134 @@
+--- !ruby/object:ActiveRecord::ConnectionAdapters::SchemaCache
+columns:
+  colleges:
+  - &1 !ruby/object:ActiveRecord::ConnectionAdapters::Column
+    auto_increment: true
+    name: id
+    sql_type_metadata: &4 !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
+      sql_type: INTEGER
+      type: :integer
+      limit:
+      precision:
+      scale:
+    'null': false
+    default:
+    default_function:
+    collation:
+    comment:
+  - &2 !ruby/object:ActiveRecord::ConnectionAdapters::Column
+    auto_increment:
+    name: name
+    sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
+      sql_type: varchar
+      type: :string
+      limit:
+      precision:
+      scale:
+    'null': false
+    default:
+    default_function:
+    collation:
+    comment:
+  courses:
+  - *1
+  - *2
+  - !ruby/object:ActiveRecord::ConnectionAdapters::Column
+    auto_increment:
+    name: college_id
+    sql_type_metadata: *4
+    'null': true
+    default:
+    default_function:
+    collation:
+    comment:
+  courses_professors:
+  - !ruby/object:ActiveRecord::ConnectionAdapters::Column
+    auto_increment:
+    name: course_id
+    sql_type_metadata: *4
+    'null': true
+    default:
+    default_function:
+    collation:
+    comment:
+  - !ruby/object:ActiveRecord::ConnectionAdapters::Column
+    auto_increment:
+    name: professor_id
+    sql_type_metadata: *4
+    'null': true
+    default:
+    default_function:
+    collation:
+    comment:
+  dogs:
+  - *1
+  professors:
+  - *1
+  - *2
+primary_keys:
+  colleges: id
+  courses: id
+  courses_professors:
+  dogs: id
+  professors: id
+data_sources:
+  colleges: true
+  courses: true
+  courses_professors: true
+  dogs: true
+  professors: true
+indexes:
+  colleges: []
+  courses:
+  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+    table: courses
+    name: index_courses_on_college_id
+    unique: false
+    columns:
+    - college_id
+    lengths: {}
+    orders: {}
+    opclasses: {}
+    where:
+    type:
+    using:
+    include:
+    nulls_not_distinct:
+    comment:
+    valid: true
+  courses_professors:
+  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+    table: courses_professors
+    name: index_courses_professors_on_professor_id
+    unique: false
+    columns:
+    - professor_id
+    lengths: {}
+    orders: {}
+    opclasses: {}
+    where:
+    type:
+    using:
+    include:
+    nulls_not_distinct:
+    comment:
+    valid: true
+  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+    table: courses_professors
+    name: index_courses_professors_on_course_id
+    unique: false
+    columns:
+    - course_id
+    lengths: {}
+    orders: {}
+    opclasses: {}
+    where:
+    type:
+    using:
+    include:
+    nulls_not_distinct:
+    comment:
+    valid: true
+  dogs: []
+  professors: []
+version: 0

--- a/activerecord/test/cases/migration/change_schema_test.rb
+++ b/activerecord/test/cases/migration/change_schema_test.rb
@@ -70,8 +70,8 @@ module ActiveRecord
         five = columns.detect { |c| c.name == "five" } unless mysql
 
         assert_equal "hello", one.default
-        assert_equal true, two.cast_type.deserialize(two.default)
-        assert_equal false, three.cast_type.deserialize(three.default)
+        assert_equal true, two.fetch_cast_type(connection).deserialize(two.default)
+        assert_equal false, three.fetch_cast_type(connection).deserialize(three.default)
         assert_equal "1", four.default
         assert_equal "hello", five.default unless mysql
       end

--- a/activerecord/test/cases/migration/columns_test.rb
+++ b/activerecord/test/cases/migration/columns_test.rb
@@ -195,7 +195,7 @@ module ActiveRecord
 
         old_columns = connection.columns(TestModel.table_name)
         assert old_columns.find { |c|
-          default = c.cast_type.deserialize(c.default)
+          default = c.fetch_cast_type(connection).deserialize(c.default)
           c.name == "approved" && c.type == :boolean && default == true
         }
 
@@ -203,11 +203,11 @@ module ActiveRecord
         new_columns = connection.columns(TestModel.table_name)
 
         assert_not new_columns.find { |c|
-          default = c.cast_type.deserialize(c.default)
+          default = c.fetch_cast_type(connection).deserialize(c.default)
           c.name == "approved" && c.type == :boolean && default == true
         }
         assert new_columns.find { |c|
-          default = c.cast_type.deserialize(c.default)
+          default = c.fetch_cast_type(connection).deserialize(c.default)
           c.name == "approved" && c.type == :boolean && default == false
         }
         change_column :test_models, :approved, :boolean, default: true


### PR DESCRIPTION
Since #54333 The Column class added a new attribute `cast_type` that might not be in the schema cache dump made by a Rails 8.0 application.

In that case, we should fallback to the previous behavior and fetch the type from the connection.

Of course this is not ideal since it will still require a connection to get the cast type, but for schema cache dumps made by Rails 8.1 we will not need to connect to the database anymore.

This code can be removed after we release Rails 8.1.