### PR TITLE
`PoolConfig` should not keep a reference to the connection class.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   The Pool Config no longer keeps a reference to the connection class.
+
+    Keeping a reference to the class caused subtle issues when combined with reloading in
+    development. Fixes #54343.
+
+    *Mike Dalessio*
+
 *   Fix SQL notifications sometimes not sent when using async queries.
 
     ```ruby

--- a/activerecord/test/cases/connection_adapters/connection_handler_test.rb
+++ b/activerecord/test/cases/connection_adapters/connection_handler_test.rb
@@ -279,18 +279,19 @@ module ActiveRecord
         assert_equal([@pool], @handler.connection_pools)
       end
 
+      class MyClass2 < Base
+      end
+
       def test_a_class_using_custom_pool_and_switching_back_to_primary
-        klass2 = Class.new(Base) { def self.name; "klass2"; end }
+        assert_same MyClass2.lease_connection, ActiveRecord::Base.lease_connection
 
-        assert_same klass2.lease_connection, ActiveRecord::Base.lease_connection
+        pool = MyClass2.establish_connection(ActiveRecord::Base.connection_pool.db_config.configuration_hash)
+        assert_same MyClass2.lease_connection, pool.lease_connection
+        assert_not_same MyClass2.lease_connection, ActiveRecord::Base.lease_connection
 
-        pool = klass2.establish_connection(ActiveRecord::Base.connection_pool.db_config.configuration_hash)
-        assert_same klass2.lease_connection, pool.lease_connection
-        assert_not_same klass2.lease_connection, ActiveRecord::Base.lease_connection
+        MyClass2.remove_connection
 
-        klass2.remove_connection
-
-        assert_same klass2.lease_connection, ActiveRecord::Base.lease_connection
+        assert_same MyClass2.lease_connection, ActiveRecord::Base.lease_connection
       end
 
       class ApplicationRecord < ActiveRecord::Base


### PR DESCRIPTION
### Motivation / Background

Issue #54343 describes a problem wherein the Active Record `PoolConfig` class keeps a reference to a connection class that has been reloaded in development, leading to issues like https://github.com/rails/solid_cache/issues/238


### Detail

This PR modifies `PoolConfig` to store in instance variables:

- the connection class name
- whether the connection class is the primary abstract connection class

and drops the reference to the class itself.

It also implements accessors for `connection_class` which will set the two values mentioned above, but also retrieve the class by name using `constantize`.


### Additional information

I don't feel great about there not being unit tests for `PoolConfig#connection_class` and `#connection_class=`. My optimistic assumption is that these accessors are being exercised indirectly through other parts of the test suite, and that may be adequate, but let me know if you want me to add some tests.


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
