### PR TITLE
`PoolConfig` double-checks its connection class reference for reloading

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   PoolConfig is careful to handle class reloading.
+
+    Keeping a reference to the class caused subtle issues when combined with reloading in
+    development. Fixes #54343.
+
+    *Mike Dalessio*
+
 *   Fix SQL notifications sometimes not sent when using async queries.
 
     ```ruby


### PR DESCRIPTION
### Motivation / Background

Issue #54343 describes a problem wherein the Active Record `PoolConfig` class keeps a reference to a connection class that has been reloaded in development, leading to issues like https://github.com/rails/solid_cache/issues/238

### Detail

This is attempt number 2 to address this problem, see #54349 for comparison.

This pull request simply does a lookup of the constant when `#connection_class` is called, in case the class has been reloaded.

That lookup may fail in scenarios where classes are given names but are not assigned to a constant. In that case, the class can't/won't be reloaded, so we're not worried about it.

### Additional information


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [-] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
