### PR TITLE
Fix column_definition returning a wrong column:

### DIFF
--- a/activerecord/lib/active_record/type/internal/timezone.rb
+++ b/activerecord/lib/active_record/type/internal/timezone.rb
@@ -16,6 +16,13 @@ module ActiveRecord
         def default_timezone
           @timezone || ActiveRecord.default_timezone
         end
+
+        def ==(other)
+          super(other) && timezone == other.timezone
+        end
+
+        protected
+          attr_reader :timezone
       end
     end
   end

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -1982,4 +1982,12 @@ class BasicsTest < ActiveRecord::TestCase
       assert_not ActiveRecord::Base.current_preventing_writes
     end
   end
+
+  private
+    def with_timezone_config(cfg, &block)
+      super(cfg) do
+        Default.reset_column_information
+        block.call
+      end
+    end
 end


### PR DESCRIPTION
> [!NOTE]
> Mostly opening to starts the discussion. But I think this is a breaking change as this means applications defining custom types would now need to implement `==` or could face the same issue.

- The issue was introduced in 9ad36e067222478090b36a985090475bb03e398c.

 Now that a Column includes its cast type, the deduplicable feature that checks whether we have a colum in the cache would wrongly return an existing column that have the same type. https://github.com/rails/rails/blob/2ca006fb7fe881c225c000d9ab11e2a3554b70fa/activerecord/lib/active_record/connection_adapters/deduplicable.rb#L19 https://github.com/rails/rails/blob/2ca006fb7fe881c225c000d9ab11e2a3554b70fa/activerecord/lib/active_record/connection_adapters/column.rb#L81

  And because the Type::DateTime doesn't override `==`, 2 Type::DateTime objects would return true regardless of their timezone.