### PR TITLE
Enum negative scopes should match nil values

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,16 @@
+*   Enum negative scopes should match nil values.
+
+    ```ruby
+    enum :nullable_status, [:single, :married]
+
+    # Before:
+    scope :not_single, -> { where.not(nullable_status: 0) }
+    # Later:
+    scope :not_single, -> { where.not(nullable_status: 0).or(where(nullable_status: nil)) }
+    ```
+
+    *Lázaro Nixon*
+
 *   Fix SQL notifications sometimes not sent when using async queries.
 
     ```ruby

--- a/activerecord/lib/active_record/enum.rb
+++ b/activerecord/lib/active_record/enum.rb
@@ -315,9 +315,9 @@ module ActiveRecord
               klass.send(:detect_enum_conflict!, name, value_method_name, true)
               klass.scope value_method_name, -> { where(name => value) }
 
-              # scope :not_active, -> { where.not(status: 0) }
+              # scope :not_active, -> { where.not(status: 0).or(where(status: nil)) }
               klass.send(:detect_enum_conflict!, name, "not_#{value_method_name}", true)
-              klass.scope "not_#{value_method_name}", -> { where.not(name => value) }
+              klass.scope "not_#{value_method_name}", -> { where.not(name => value).or(where(name => nil)) }
             end
           end
       end

--- a/activerecord/test/cases/enum_test.rb
+++ b/activerecord/test/cases/enum_test.rb
@@ -87,6 +87,7 @@ class EnumTest < ActiveRecord::TestCase
   test "find via negative scope" do
     assert Book.not_published.exclude?(@book)
     assert Book.not_proposed.include?(@book)
+    assert Book.not_single.include?(@book)
   end
 
   test "find via where with values" do


### PR DESCRIPTION
### Motivation / Background

Enum negative scopes don't match nil values. 
We usually expect nil values, even though the database implements the match differently.

### Detail

Given:

```ruby
enum :nullable_status, [:single, :married]
```

Before:

```ruby
scope :not_single, -> { where.not(nullable_status: 0) }
 ```

Later:

```ruby
scope :not_single, -> { where.not(nullable_status: 0).or(where(nullable_status: nil)) }
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
