### PR TITLE
Fix two unused block warnings in arel

### DIFF
--- a/actionpack/test/controller/filters_test.rb
+++ b/actionpack/test/controller/filters_test.rb
@@ -514,7 +514,7 @@ class FilterTest < ActionController::TestCase
         @filters << "action_two"
       end
 
-      def non_yielding_action(&_)
+      def non_yielding_action(&)
         @filters << "it didn't yield"
       end
 

--- a/activejob/lib/active_job/enqueuing.rb
+++ b/activejob/lib/active_job/enqueuing.rb
@@ -88,7 +88,7 @@ module ActiveJob
       end
 
       private
-        def job_or_instantiate(*args, &_) # :doc:
+        def job_or_instantiate(*args, &) # :doc:
           args.first.is_a?(self) ? args.first : new(*args)
         end
         ruby2_keywords(:job_or_instantiate)

--- a/activemodel/lib/active_model/attribute.rb
+++ b/activemodel/lib/active_model/attribute.rb
@@ -38,7 +38,7 @@ module ActiveModel
       @value = value unless value.nil?
     end
 
-    def value(&_)
+    def value(&)
       # `defined?` is cheaper than `||=` when we get back falsy values
       @value = type_cast(value_before_type_cast) unless defined?(@value)
       @value

--- a/activemodel/lib/active_model/type/big_integer.rb
+++ b/activemodel/lib/active_model/type/big_integer.rb
@@ -44,7 +44,7 @@ module ActiveModel
         value
       end
 
-      def serializable?(value, &_)
+      def serializable?(value, &)
         true
       end
 

--- a/activemodel/lib/active_model/type/value.rb
+++ b/activemodel/lib/active_model/type/value.rb
@@ -25,7 +25,7 @@ module ActiveModel
       # by the database.  For example a boolean type can return +true+ if the
       # value parameter is a Ruby boolean, but may return +false+ if the value
       # parameter is some other object.
-      def serializable?(value, &_)
+      def serializable?(value, &)
         true
       end
 

--- a/activerecord/lib/active_record/statement_cache.rb
+++ b/activerecord/lib/active_record/statement_cache.rb
@@ -74,13 +74,13 @@ module ActiveRecord
         self
       end
 
-      def add_bind(obj, &_)
+      def add_bind(obj, &)
         @binds << obj
         @parts << Substitute.new
         self
       end
 
-      def add_binds(binds, proc_for_binds = nil, &_)
+      def add_binds(binds, proc_for_binds = nil, &)
         @binds.concat proc_for_binds ? binds.map(&proc_for_binds) : binds
         binds.size.times do |i|
           @parts << ", " unless i == 0

--- a/activerecord/lib/active_record/statement_cache.rb
+++ b/activerecord/lib/active_record/statement_cache.rb
@@ -74,13 +74,13 @@ module ActiveRecord
         self
       end
 
-      def add_bind(obj)
+      def add_bind(obj, &_)
         @binds << obj
         @parts << Substitute.new
         self
       end
 
-      def add_binds(binds, proc_for_binds = nil)
+      def add_binds(binds, proc_for_binds = nil, &_)
         @binds.concat proc_for_binds ? binds.map(&proc_for_binds) : binds
         binds.size.times do |i|
           @parts << ", " unless i == 0

--- a/activerecord/lib/arel/collectors/bind.rb
+++ b/activerecord/lib/arel/collectors/bind.rb
@@ -18,7 +18,7 @@ module Arel # :nodoc: all
         self
       end
 
-      def add_binds(binds, proc_for_binds = nil, &_)
+      def add_binds(binds, proc_for_binds = nil, &)
         @binds.concat proc_for_binds ? binds.map(&proc_for_binds) : binds
         self
       end

--- a/activerecord/lib/arel/collectors/bind.rb
+++ b/activerecord/lib/arel/collectors/bind.rb
@@ -18,7 +18,7 @@ module Arel # :nodoc: all
         self
       end
 
-      def add_binds(binds, proc_for_binds = nil)
+      def add_binds(binds, proc_for_binds = nil, &_)
         @binds.concat proc_for_binds ? binds.map(&proc_for_binds) : binds
         self
       end

--- a/activerecord/lib/arel/collectors/sql_string.rb
+++ b/activerecord/lib/arel/collectors/sql_string.rb
@@ -12,7 +12,7 @@ module Arel # :nodoc: all
         @bind_index = 1
       end
 
-      def add_bind(bind)
+      def add_bind(bind, &_)
         self << yield(@bind_index)
         @bind_index += 1
         self

--- a/activerecord/lib/arel/collectors/sql_string.rb
+++ b/activerecord/lib/arel/collectors/sql_string.rb
@@ -12,7 +12,7 @@ module Arel # :nodoc: all
         @bind_index = 1
       end
 
-      def add_bind(bind, &_)
+      def add_bind(bind, &)
         self << yield(@bind_index)
         @bind_index += 1
         self

--- a/activerecord/lib/arel/collectors/substitute_binds.rb
+++ b/activerecord/lib/arel/collectors/substitute_binds.rb
@@ -15,12 +15,12 @@ module Arel # :nodoc: all
         self
       end
 
-      def add_bind(bind, &_)
+      def add_bind(bind, &)
         bind = bind.value_for_database if bind.respond_to?(:value_for_database)
         self << quoter.quote(bind)
       end
 
-      def add_binds(binds, proc_for_binds = nil, &_)
+      def add_binds(binds, proc_for_binds = nil, &)
         self << binds.map { |bind| quoter.quote(bind) }.join(", ")
       end
 

--- a/activerecord/lib/arel/collectors/substitute_binds.rb
+++ b/activerecord/lib/arel/collectors/substitute_binds.rb
@@ -15,12 +15,12 @@ module Arel # :nodoc: all
         self
       end
 
-      def add_bind(bind)
+      def add_bind(bind, &_)
         bind = bind.value_for_database if bind.respond_to?(:value_for_database)
         self << quoter.quote(bind)
       end
 
-      def add_binds(binds, proc_for_binds = nil)
+      def add_binds(binds, proc_for_binds = nil, &_)
         self << binds.map { |bind| quoter.quote(bind) }.join(", ")
       end
 

--- a/activerecord/lib/arel/nodes/binary.rb
+++ b/activerecord/lib/arel/nodes/binary.rb
@@ -30,7 +30,7 @@ module Arel # :nodoc: all
     end
 
     module FetchAttribute
-      def fetch_attribute
+      def fetch_attribute(&)
         if left.is_a?(Arel::Attributes::Attribute)
           yield left
         elsif right.is_a?(Arel::Attributes::Attribute)

--- a/activerecord/lib/arel/nodes/node.rb
+++ b/activerecord/lib/arel/nodes/node.rb
@@ -152,7 +152,7 @@ module Arel # :nodoc: all
         end
       end
 
-      def fetch_attribute(&_)
+      def fetch_attribute(&)
       end
 
       def equality?; false; end

--- a/activerecord/lib/arel/nodes/node.rb
+++ b/activerecord/lib/arel/nodes/node.rb
@@ -152,7 +152,7 @@ module Arel # :nodoc: all
         end
       end
 
-      def fetch_attribute
+      def fetch_attribute(&_)
       end
 
       def equality?; false; end

--- a/activerecord/lib/arel/nodes/sql_literal.rb
+++ b/activerecord/lib/arel/nodes/sql_literal.rb
@@ -19,7 +19,7 @@ module Arel # :nodoc: all
         coder.scalar = self.to_s
       end
 
-      def fetch_attribute
+      def fetch_attribute(&_)
       end
 
       def +(other)

--- a/activerecord/lib/arel/nodes/sql_literal.rb
+++ b/activerecord/lib/arel/nodes/sql_literal.rb
@@ -19,7 +19,7 @@ module Arel # :nodoc: all
         coder.scalar = self.to_s
       end
 
-      def fetch_attribute(&_)
+      def fetch_attribute(&)
       end
 
       def +(other)


### PR DESCRIPTION
This will always forward the block: https://github.com/rails/rails/blob/f1e610ec20532a1fdce6d3ce94d8d610bca48d89/activerecord/lib/arel.rb#L68-L72
but these two ignore it

Same with `add_bind`/`add_binds`, they may also be passed a block:
https://github.com/rails/rails/blob/f1e610ec20532a1fdce6d3ce94d8d610bca48d89/activerecord/lib/arel/visitors/to_sql.rb#L756-L762
https://github.com/rails/rails/blob/f1e610ec20532a1fdce6d3ce94d8d610bca48d89/activerecord/lib/arel/visitors/to_sql.rb#L352