### PR TITLE
Add `active_support/core_ext/symbol/inflections`

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,18 @@
+*   Add `Symbol` class support for inflections
+
+    New inflections include:
+
+    * `camelize` (and its `camelcase` alias)
+    * `dasherize`
+    * `underscore`
+
+    ```ruby
+    :firstName.underscore           # => :first_name
+    :first_name.camelcase(:lower)   # => :firstName
+    ```
+
+    *Sean Doyle*
+
 ## Rails 8.1.0.beta1 (September 04, 2025) ##
 
 *   Add `ActiveSupport::Cache::Store#namespace=` and `#namespace`.

--- a/activesupport/lib/active_support/core_ext/symbol.rb
+++ b/activesupport/lib/active_support/core_ext/symbol.rb
@@ -1,3 +1,4 @@
 # frozen_string_literal: true
 
+require "active_support/core_ext/symbol/inflections"
 require "active_support/core_ext/symbol/starts_ends_with"

--- a/activesupport/lib/active_support/core_ext/symbol/inflections.rb
+++ b/activesupport/lib/active_support/core_ext/symbol/inflections.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "active_support/core_ext/string/inflections"
+
+# Symbol inflections define new methods on the Symbol class to transform names for different purposes.
+# For instance, you can figure out the name of a table from the name of a class.
+#
+#   :ScaleScore.tableize # => :scale_scores
+#
+class Symbol
+  ##
+  # :call-seq: camelize(first_letter = :upper)
+  #
+  # See String#camelize.
+  def camelize(...)
+    name.camelize(...).to_sym
+  end
+  alias_method :camelcase, :camelize
+
+  # See String#dasherize.
+  def dasherize
+    name.dasherize.to_sym
+  end
+
+  # See String#underscore.
+  def underscore
+    name.underscore.to_sym
+  end
+end

--- a/activesupport/test/core_ext/symbol_ext_test.rb
+++ b/activesupport/test/core_ext/symbol_ext_test.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative "../abstract_unit"
+require_relative "../inflector_test_cases"
 require "active_support/core_ext/symbol"
 
 class SymbolStartsEndsWithTest < ActiveSupport::TestCase
@@ -17,5 +18,47 @@ class SymbolStartsEndsWithTest < ActiveSupport::TestCase
     assert_not s.ends_with?("el")
     assert s.ends_with?("he", "lo")
     assert_not s.ends_with?("he", "ll")
+  end
+end
+
+class SymbolInflectionsTest < ActiveSupport::TestCase
+  include InflectorTestCases
+
+  def test_camelize
+    CamelToUnderscore.each do |camel, underscore|
+      assert_equal(camel.to_sym, underscore.to_sym.camelize)
+      assert_equal(camel.to_sym, underscore.to_sym.camelcase)
+    end
+  end
+
+  def test_camelize_lower
+    assert_equal(:capital, :Capital.camelize(:lower))
+    assert_equal(:capital, :Capital.camelcase(:lower))
+  end
+
+  def test_camelize_upper
+    assert_equal(:Capital, :Capital.camelize(:upper))
+    assert_equal(:Capital, :Capital.camelcase(:upper))
+  end
+
+  def test_dasherize
+    UnderscoresToDashes.each do |underscored, dasherized|
+      assert_equal(dasherized.to_sym, underscored.to_sym.dasherize)
+    end
+  end
+
+  def test_underscore
+    CamelToUnderscore.each do |camel, underscore|
+      assert_equal(underscore.to_sym, camel.to_sym.underscore)
+    end
+
+    assert_equal :html_tidy, :HTMLTidy.underscore
+    assert_equal :html_tidy_generator, :HTMLTidyGenerator.underscore
+  end
+
+  def test_underscore_to_lower_camel
+    UnderscoreToLowerCamel.each do |underscored, lower_camel|
+      assert_equal(lower_camel.to_sym, underscored.to_sym.camelize(:lower))
+    end
   end
 end


### PR DESCRIPTION
Problem
---

When iterating a Hash with unknown key types, it can be tedious to
select, reject, or transform keys can be either String or Symbol:

```ruby
hash = { :firstName => "Ruby", "lastName" => "on Rails" }

# Before
underscored_hash = hash.transform_keys(&:underscore) # raises NoMethodError
underscored_hash = hash.transform_keys { |key|
  transformed = key.to_s.underscore
  key.is_a?(Symbol) ? transformed.to_sym : transformed
}
underscored_hash # => { :first_name => "Ruby", "last_name" => "on Rails" }
```

Proposal
---

Introduce the `active_support/core_ext/symbol/inflections` module to
delegate Symbol [inflection][] support to the frozen `String` returned
from [Symbol#name][] method. Once delegated, transform the value back to
a Symbol by calling `#to_sym`.

```ruby
hash = { :firstName => "Ruby", "lastName" => "on Rails" }

# After
underscored_hash = hash.transform_keys(&:underscore)
underscored_hash # => { :first_name => "Ruby", "last_name" => "on Rails" }
```

New inflections include:

* `camelize` (and its `camelcase` alias)
* `dasherize`
* `underscore`

Since the implementation relies on `Symbol#name` being a frozen String,
there are only String allocations the first time the value is
transformed.

[inflection]: https://guides.rubyonrails.org/active_support_core_extensions.html#inflections
[Symbol#name]: https://ruby-doc.org/core-3.0.0/Symbol.html#method-i-name

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
