### PR TITLE
Add `active_support/core_ext/symbol/inquiry`

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   Add `active_support/core_ext/symbol/inquiry`
+
+    ```ruby
+    env = :test
+    env.inquiry.test? # => true
+    env.inquiry.production? # => false
+    ```
+
+    *Sean Doyle*
+
 *   Given an array of `Thread::Backtrace::Location` objects, the new method
     `ActiveSupport::BacktraceCleaner#clean_locations` returns an array with the
     clean ones:

--- a/activesupport/lib/active_support/core_ext/symbol.rb
+++ b/activesupport/lib/active_support/core_ext/symbol.rb
@@ -1,3 +1,4 @@
 # frozen_string_literal: true
 
+require "active_support/core_ext/symbol/inquiry"
 require "active_support/core_ext/symbol/starts_ends_with"

--- a/activesupport/lib/active_support/core_ext/symbol/inquiry.rb
+++ b/activesupport/lib/active_support/core_ext/symbol/inquiry.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+require "active_support/core_ext/string/inquiry"
+
+class Symbol
+  # See String#inquiry.
+  delegate :inquiry, to: :name
+end

--- a/activesupport/test/core_ext/symbol_ext_test.rb
+++ b/activesupport/test/core_ext/symbol_ext_test.rb
@@ -19,3 +19,10 @@ class SymbolStartsEndsWithTest < ActiveSupport::TestCase
     assert_not s.ends_with?("he", "ll")
   end
 end
+
+class SymbolInquiryTest < ActiveSupport::TestCase
+  def test_string_inquiry
+    assert_predicate :production.inquiry, :production?
+    assert_not_predicate :production.inquiry, :development?
+  end
+end


### PR DESCRIPTION
### Motivation / Background

Problem
---

When iterating over a Hash with unknown key types, it can be tedious to select, reject, or transform keys can be either String or Symbol:

```ruby
hash = { a: 1, "b": 2 }

 # Before
hash_with_inquiry_keys = hash.transform_keys(&:inquiry) # raises NoMethodError
hash_with_inquiry_keys = hash.transform_keys { |key| key.to_s.inquiry }

hash_with_inquiry_keys.any? { |key, value| key.a? } # => true
hash_with_inquiry_keys[:a]                          # => nil
hash_with_inquiry_keys["a"]                         # => 1
```

### Detail

Proposal
---

Introduce the `active_support/core_ext/symbol/inquiry` module to delegate Symbol [inquiry][] support to the frozen `String` returned from [Symbol#name][] method.

```ruby
hash = { a: 1, "b": 2 }

 # After
hash_with_inquiry_keys = hash.transform_keys(&:inquiry)

hash_with_inquiry_keys.any? { |key, value| key.a? } # => true
hash_with_inquiry_keys[:a]                          # => 1
hash_with_inquiry_keys["a"]                         # => nil
```

[inquiry]: https://edgeapi.rubyonrails.org/classes/String.html#method-i-inquiry
[Symbol#name]: https://ruby-doc.org/core-3.0.0/Symbol.html#method-i-name

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
