### PR TITLE
Add instructive info when the rails generator fails

### DIFF
--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -621,7 +621,8 @@ module Rails
       end
 
       def prepare!
-        handle_version_request!(@argv.first)
+        return handle_version_request!(@argv.first) if ["--version", "-v"].include?(@argv.first)
+
         handle_invalid_command!(@argv.first, @argv) do
           handle_rails_rc!(@argv.drop(1))
         end
@@ -639,17 +640,16 @@ module Rails
 
       private
         def handle_version_request!(argument)
-          if ["--version", "-v"].include?(argument)
-            require "rails/version"
-            puts "Rails #{Rails::VERSION::STRING}"
-            exit(0)
-          end
+          require "rails/version"
+          puts "Rails #{Rails::VERSION::STRING}"
+          exit(0)
         end
 
         def handle_invalid_command!(argument, argv)
           if argument == "new"
             yield
           else
+            puts "command not found: #{argument}"
             ["--help"] + argv.drop(1)
           end
         end

--- a/railties/test/generators/argv_scrubber_test.rb
+++ b/railties/test/generators/argv_scrubber_test.rb
@@ -46,8 +46,13 @@ module Rails
       end
 
       def test_no_mutations
-        scrubber = ARGVScrubber.new ["hi mom"].freeze
+        scrubber = ARGVScrubber.new ["hi mom"]
+        output   = nil
+        scrubber.extend(Module.new {
+          define_method(:puts) { |string| output = string }
+        })
         args = scrubber.prepare!
+        assert_equal "command not found: hi mom", output
         assert_equal "--help", args.first
       end
 


### PR DESCRIPTION
Fixes #54358

### Detail

This Pull Request changes: 
Add info when running generators outside of the rails directory

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behaviour change or additional feature. Minor bug fixes and documentation changes should not be included.
