### PR TITLE
Support horizontal rules in options_for_select

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Support horizontal rules in `options_for_select` by rendering `---` values as `<hr>`.
+
+    *Lázaro Nixon*
+
 *   Respect `html_options[:form]` when `collection_checkboxes` generates the
     hidden `<input>`.
 

--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,4 +1,4 @@
-*   Support horizontal rules in `options_for_select` by rendering `---` values as `<hr>`.
+*   Support horizontal rules in `options_for_select` by rendering `:horizontal_rule` values as `<hr>`.
 
     *Lázaro Nixon*
 

--- a/actionview/lib/action_view/helpers/form_options_helper.rb
+++ b/actionview/lib/action_view/helpers/form_options_helper.rb
@@ -305,17 +305,17 @@ module ActionView
       # become lasts. If +selected+ is specified, the matching "last" or element will get the selected option-tag. +selected+
       # may also be an array of values to be selected when using a multiple select.
       #
-      #   options_for_select([["Dollar", "$"], ["Kroner", "DKK"], "---"])
+      #   options_for_select([["Dollar", "$"], ["Kroner", "DKK"], :horizontal_rule])
       #   # => <option value="$">Dollar</option>
       #   # => <option value="DKK">Kroner</option>
       #   # => <hr>
       #
-      #   options_for_select([ "VISA", "MasterCard", "---" ], "MasterCard")
+      #   options_for_select([ "VISA", "MasterCard", :horizontal_rule ], "MasterCard")
       #   # => <option value="VISA">VISA</option>
       #   # => <option selected="selected" value="MasterCard">MasterCard</option>
       #   # => <hr>
       #
-      #   options_for_select({ "Basic" => "$20", "Plus" => "$40", "Section 1" => "---" }, "$40")
+      #   options_for_select({ "Basic" => "$20", "Plus" => "$40", "Section 1" => :horizontal_rule }, "$40")
       #   # => <option value="$20">Basic</option>
       #   # => <option value="$40" selected="selected">Plus</option>
       #   # => <hr>
@@ -367,16 +367,16 @@ module ActionView
 
         container.map do |element|
           html_attributes = option_html_attributes(element)
-          text, value = option_text_and_value(element).map(&:to_s)
+          text, value = option_text_and_value(element)
 
-          html_attributes[:selected] ||= option_value_selected?(value, selected)
-          html_attributes[:disabled] ||= disabled && option_value_selected?(value, disabled)
-          html_attributes[:value] = value
+          html_attributes[:selected] ||= option_value_selected?(value.to_s, selected)
+          html_attributes[:disabled] ||= disabled && option_value_selected?(value.to_s, disabled)
+          html_attributes[:value] = value.to_s
 
-          if [text, value].include?("---")
+          if value == :horizontal_rule
             tag_builder.hr
           else
-            tag_builder.content_tag_string(:option, text, html_attributes)
+            tag_builder.content_tag_string(:option, text.to_s, html_attributes)
           end
         end.join("\n").html_safe
       end

--- a/actionview/lib/action_view/helpers/form_options_helper.rb
+++ b/actionview/lib/action_view/helpers/form_options_helper.rb
@@ -305,17 +305,20 @@ module ActionView
       # become lasts. If +selected+ is specified, the matching "last" or element will get the selected option-tag. +selected+
       # may also be an array of values to be selected when using a multiple select.
       #
-      #   options_for_select([["Dollar", "$"], ["Kroner", "DKK"]])
+      #   options_for_select([["Dollar", "$"], ["Kroner", "DKK"], "---"])
       #   # => <option value="$">Dollar</option>
       #   # => <option value="DKK">Kroner</option>
+      #   # => <hr>
       #
-      #   options_for_select([ "VISA", "MasterCard" ], "MasterCard")
+      #   options_for_select([ "VISA", "MasterCard", "---" ], "MasterCard")
       #   # => <option value="VISA">VISA</option>
       #   # => <option selected="selected" value="MasterCard">MasterCard</option>
+      #   # => <hr>
       #
-      #   options_for_select({ "Basic" => "$20", "Plus" => "$40" }, "$40")
+      #   options_for_select({ "Basic" => "$20", "Plus" => "$40", "Section 1" => "---" }, "$40")
       #   # => <option value="$20">Basic</option>
       #   # => <option value="$40" selected="selected">Plus</option>
+      #   # => <hr>
       #
       #   options_for_select([ "VISA", "MasterCard", "Discover" ], ["VISA", "Discover"])
       #   # => <option selected="selected" value="VISA">VISA</option>
@@ -370,7 +373,11 @@ module ActionView
           html_attributes[:disabled] ||= disabled && option_value_selected?(value, disabled)
           html_attributes[:value] = value
 
-          tag_builder.content_tag_string(:option, text, html_attributes)
+          if [text, value].include?("---")
+            tag_builder.hr
+          else
+            tag_builder.content_tag_string(:option, text, html_attributes)
+          end
         end.join("\n").html_safe
       end
 

--- a/actionview/test/template/form_options_helper_test.rb
+++ b/actionview/test/template/form_options_helper_test.rb
@@ -186,6 +186,13 @@ class FormOptionsHelperTest < ActionView::TestCase
     )
   end
 
+  def test_array_options_for_select_with_horizontal_rules
+    assert_dom_equal(
+      "<option value=\"&lt;Denmark&gt;\">&lt;Denmark&gt;</option>\n<option value=\"USA\">USA</option>\n<option value=\"Sweden\">Sweden</option>\n<hr>",
+      options_for_select([ "<Denmark>", "USA", "Sweden", "---" ])
+    )
+  end
+
   def test_array_options_for_select_with_custom_defined_selected
     assert_dom_equal(
       "<option selected=\"selected\" type=\"Coach\" value=\"1\">Richard Bandler</option>\n<option type=\"Coachee\" value=\"1\">Richard Bandler</option>",
@@ -274,6 +281,10 @@ class FormOptionsHelperTest < ActionView::TestCase
     assert_dom_equal(
       "<option value=\"Dollar\">$</option>\n<option value=\"&lt;Kroner&gt;\">&lt;DKR&gt;</option>",
       options_for_select("$" => "Dollar", "<DKR>" => "<Kroner>").split("\n").join("\n")
+    )
+    assert_dom_equal(
+      "<option value=\"Dollar\">$</option>\n<hr>\n<option value=\"&lt;Kroner&gt;\">&lt;DKR&gt;</option>\n<hr>",
+      options_for_select("$" => "Dollar", "Section 1" => "---", "<DKR>" => "<Kroner>", "Section 2" => "---").split("\n").join("\n")
     )
     assert_dom_equal(
       "<option value=\"Dollar\" selected=\"selected\">$</option>\n<option value=\"&lt;Kroner&gt;\">&lt;DKR&gt;</option>",

--- a/actionview/test/template/form_options_helper_test.rb
+++ b/actionview/test/template/form_options_helper_test.rb
@@ -189,7 +189,7 @@ class FormOptionsHelperTest < ActionView::TestCase
   def test_array_options_for_select_with_horizontal_rules
     assert_dom_equal(
       "<option value=\"&lt;Denmark&gt;\">&lt;Denmark&gt;</option>\n<option value=\"USA\">USA</option>\n<option value=\"Sweden\">Sweden</option>\n<hr>",
-      options_for_select([ "<Denmark>", "USA", "Sweden", "---" ])
+      options_for_select([ "<Denmark>", "USA", "Sweden", :horizontal_rule ])
     )
   end
 
@@ -284,7 +284,7 @@ class FormOptionsHelperTest < ActionView::TestCase
     )
     assert_dom_equal(
       "<option value=\"Dollar\">$</option>\n<hr>\n<option value=\"&lt;Kroner&gt;\">&lt;DKR&gt;</option>\n<hr>",
-      options_for_select("$" => "Dollar", "Section 1" => "---", "<DKR>" => "<Kroner>", "Section 2" => "---").split("\n").join("\n")
+      options_for_select("$" => "Dollar", "Section 1" => :horizontal_rule, "<DKR>" => "<Kroner>", "Section 2" => :horizontal_rule).split("\n").join("\n")
     )
     assert_dom_equal(
       "<option value=\"Dollar\" selected=\"selected\">$</option>\n<option value=\"&lt;Kroner&gt;\">&lt;DKR&gt;</option>",


### PR DESCRIPTION
### Motivation / Background

Nowadays, you can add `<hr>` (horizontal rule)  into the list of select options, but `options_for_select` doesn't support it.

https://developer.chrome.com/blog/hr-in-select

![image](https://github.com/user-attachments/assets/736081a7-b0c8-4779-962e-9c5bb05820ad)


### Detail

This PR changes `options_for_select` to interpret `:horizontal_rule` as  `<hr>`.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
