### PR TITLE
Deprecate remote form helpers

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,17 @@
+*   Deprecate `:remote` options for `form_for` and `:local` option for `form_with`.
+
+    Please use the `actionview-remote-form-helpers` gem to restore this functionality.
+
+    *zzak*, *Sean Doyle*
+
+*   Deprecate `ActionView::Base.automatically_disable_submit_tag=`,
+    `ActionView::Helpers::FormHelper.form_with_generates_remote_forms=`, and
+    `ActionView::Helpers::FormTagHelper.embed_authenticity_token_in_remote_forms=`.
+
+    Please use the `actionview-remote-form-helpers` gem to restore this functionality.
+
+    *zzak*, *Sean Doyle*
+
 *   Respect `html_options[:form]` when `collection_checkboxes` generates the
     hidden `<input>`.
 

--- a/actionview/lib/action_view/base.rb
+++ b/actionview/lib/action_view/base.rb
@@ -174,6 +174,23 @@ module ActionView # :nodoc:
 
     # Specify whether submit_tag should automatically disable on click
     cattr_accessor :automatically_disable_submit_tag, default: true
+    redefine_method :automatically_disable_submit_tag= do |value|
+      ActionView.deprecator.warn(<<~MSG.squish)
+        `ActionView::Base.automatically_disable_submit_tag=` is deprecated and will be removed in Rails 8.2.
+        Please use `actionview-remote-form-helpers` gem instead.
+      MSG
+      @@automatically_disable_submit_tag = value
+    end
+
+    class << self
+      redefine_method :automatically_disable_submit_tag= do |value|
+        ActionView.deprecator.warn(<<~MSG.squish)
+          `ActionView::Base.automatically_disable_submit_tag=` is deprecated and will be removed in Rails 8.2.
+          Please use `actionview-remote-form-helpers` gem instead.
+        MSG
+        @@automatically_disable_submit_tag = value
+      end
+    end
 
     # Annotate rendered view with file names
     cattr_accessor :annotate_rendered_view_with_filenames, default: false

--- a/actionview/lib/action_view/helpers/form_tag_helper.rb
+++ b/actionview/lib/action_view/helpers/form_tag_helper.rb
@@ -26,6 +26,24 @@ module ActionView
       mattr_accessor :embed_authenticity_token_in_remote_forms
       self.embed_authenticity_token_in_remote_forms = nil
 
+      redefine_method :embed_authenticity_token_in_remote_forms= do |value|
+        ActionView.deprecator.warn(<<~MSG.squish)
+          `ActionView::Helpers::FormTagHelper.embed_authenticity_token_in_remote_forms=` is deprecated and will be removed in Rails 8.2.
+          Please use `actionview-remote-form-helpers` gem instead.
+        MSG
+        @@embed_authenticity_token_in_remote_forms = value
+      end
+
+      class << self
+        redefine_method :embed_authenticity_token_in_remote_forms= do |value|
+          ActionView.deprecator.warn(<<~MSG.squish)
+            `ActionView::Helpers::FormTagHelper.embed_authenticity_token_in_remote_forms=` is deprecated and will be removed in Rails 8.2.
+            Please use `actionview-remote-form-helpers` gem instead.
+          MSG
+          @@embed_authenticity_token_in_remote_forms = value
+        end
+      end
+
       mattr_accessor :default_enforce_utf8, default: true
 
       # Starts a form tag that points the action to a URL configured with <tt>url_for_options</tt> just like
@@ -995,7 +1013,16 @@ module ActionView
             end
             html_options["accept-charset"] = "UTF-8"
 
-            html_options["data-remote"] = true if html_options.delete("remote")
+            if html_options.delete("remote")
+              ActionView.deprecator.warn(<<-MSG.squish)
+                Passing :local as an option is deprecated and will be removed in Rails 8.2.
+                To control the [data-remote] attribute, pass that option directly.
+                To control the generation of CSRF tokens, pass an :authenticity_token option directly.
+                Otherwise you can use the `actionview-remote-form-helpers` gem which provides the same behavior.
+              MSG
+
+              html_options["data-remote"] = true
+            end
 
             if html_options["data-remote"] &&
                embed_authenticity_token_in_remote_forms == false &&

--- a/actionview/test/template/form_helper_test.rb
+++ b/actionview/test/template/form_helper_test.rb
@@ -2372,10 +2372,12 @@ class FormHelperTest < ActionView::TestCase
   end
 
   def test_form_for_with_remote
-    form_for(@post, url: "/", remote: true, html: { id: "create-post", method: :patch }) do |f|
-      concat f.text_field(:title)
-      concat f.textarea(:body)
-      concat f.checkbox(:secret)
+    ActionView.deprecator.silence do
+      form_for(@post, url: "/", remote: true, html: { id: "create-post", method: :patch }) do |f|
+        concat f.text_field(:title)
+        concat f.textarea(:body)
+        concat f.checkbox(:secret)
+      end
     end
 
     expected = whole_form("/", "create-post", "edit_post", method: "patch", remote: true) do
@@ -2386,6 +2388,23 @@ class FormHelperTest < ActionView::TestCase
     end
 
     assert_dom_equal expected, @rendered
+  end
+
+  def test_form_for_with_remote_is_deprecated
+    msg = <<~MSG.squish
+      Passing :remote as an option is deprecated and will be removed in Rails 8.2.
+      To control the [data-remote] attribute, pass that option directly as `data: { remote: true }`.
+      To control the generation of CSRF tokens, pass `authenticity_token:` directly.
+      Otherwise you can use the `actionview-remote-form-helpers` gem which provides the same behavior.
+    MSG
+
+    assert_deprecated(msg, ActionView.deprecator) do
+      form_for(@post, url: "/", remote: true, html: { id: "create-post", method: :patch }) do |f|
+        concat f.text_field(:title)
+        concat f.textarea(:body)
+        concat f.checkbox(:secret)
+      end
+    end
   end
 
   def test_form_for_enforce_utf8_true
@@ -2441,10 +2460,12 @@ class FormHelperTest < ActionView::TestCase
   end
 
   def test_form_for_with_remote_in_html
-    form_for(@post, url: "/", html: { remote: true, id: "create-post", method: :patch }) do |f|
-      concat f.text_field(:title)
-      concat f.textarea(:body)
-      concat f.checkbox(:secret)
+    ActionView.deprecator.silence do
+      form_for(@post, url: "/", html: { remote: true, id: "create-post", method: :patch }) do |f|
+        concat f.text_field(:title)
+        concat f.textarea(:body)
+        concat f.checkbox(:secret)
+      end
     end
 
     expected = whole_form("/", "create-post", "edit_post", method: "patch", remote: true) do
@@ -2457,13 +2478,33 @@ class FormHelperTest < ActionView::TestCase
     assert_dom_equal expected, @rendered
   end
 
-  def test_form_for_with_remote_without_html
-    @post.persisted = false
-    @post.stub(:to_key, nil) do
-      form_for(@post, remote: true) do |f|
+  def test_form_for_with_remote_in_html_is_deprecated
+    msg = <<~MSG.squish
+      Passing :remote as an option nested inside :html is deprecated and will be removed in Rails 8.2.
+      To control the [data-remote] attribute, pass that option directly as `data: { remote: true }`.
+      To control the generation of CSRF tokens, pass `authenticity_token:` directly.
+      Otherwise you can use the `actionview-remote-form-helpers` gem which provides the same behavior.
+    MSG
+
+    assert_deprecated(msg, ActionView.deprecator) do
+      form_for(@post, url: "/", html: { remote: true, id: "create-post", method: :patch }) do |f|
         concat f.text_field(:title)
         concat f.textarea(:body)
         concat f.checkbox(:secret)
+      end
+    end
+  end
+
+
+  def test_form_for_with_remote_without_html
+    @post.persisted = false
+    @post.stub(:to_key, nil) do
+      ActionView.deprecator.silence do
+        form_for(@post, remote: true) do |f|
+          concat f.text_field(:title)
+          concat f.textarea(:body)
+          concat f.checkbox(:secret)
+        end
       end
 
       expected = whole_form("/posts", "new_post", "new_post", remote: true) do
@@ -4126,7 +4167,9 @@ class FormHelperTest < ActionView::TestCase
   end
 
   def test_form_for_with_data_attributes
-    form_for(@post, data: { behavior: "stuff" }, remote: true) { }
+    ActionView.deprecator.silence do
+      form_for(@post, data: { behavior: "stuff" }, remote: true) { }
+    end
     assert_match %r|data-behavior="stuff"|, @rendered
     assert_match %r|data-remote="true"|, @rendered
   end

--- a/actionview/test/template/form_tag_helper_test.rb
+++ b/actionview/test/template/form_tag_helper_test.rb
@@ -155,7 +155,9 @@ class FormTagHelperTest < ActionView::TestCase
   end
 
   def test_form_tag_with_remote
-    actual = form_tag({}, { remote: true })
+    actual = ActionView.deprecator.silence do
+      form_tag({}, { remote: true })
+    end
 
     expected = whole_form("http://www.example.com", remote: true)
     assert_dom_equal expected, actual
@@ -700,23 +702,63 @@ class FormTagHelperTest < ActionView::TestCase
   end
 
   def test_empty_submit_tag_with_opt_out
-    ActionView::Base.automatically_disable_submit_tag = false
+    ActionView.deprecator.silence do
+      ActionView::Base.automatically_disable_submit_tag = false
+    end
     assert_dom_equal(
       %(<input name='commit' type="submit" value="Save" />),
       submit_tag("Save")
     )
   ensure
-    ActionView::Base.automatically_disable_submit_tag = true
+    ActionView.deprecator.silence do
+      ActionView::Base.automatically_disable_submit_tag = true
+    end
   end
 
   def test_empty_submit_tag_with_opt_out_and_explicit_disabling
-    ActionView::Base.automatically_disable_submit_tag = false
+    ActionView.deprecator.silence do
+      ActionView::Base.automatically_disable_submit_tag = false
+    end
     assert_dom_equal(
       %(<input name='commit' type="submit" value="Save" />),
       submit_tag("Save", data: { disable_with: false })
     )
   ensure
-    ActionView::Base.automatically_disable_submit_tag = true
+    ActionView.deprecator.silence do
+      ActionView::Base.automatically_disable_submit_tag = true
+    end
+  end
+
+  def test_automatically_disable_submit_tag_is_deprecated
+    old_value = ActionView::Base.automatically_disable_submit_tag
+
+    msg = <<~MSG.squish
+      `ActionView::Base.automatically_disable_submit_tag=` is deprecated and will be removed in Rails 8.2.
+      Please use `actionview-remote-form-helpers` gem instead.
+    MSG
+    assert_deprecated(msg, ActionView.deprecator) do
+      ActionView::Base.automatically_disable_submit_tag = nil
+    end
+  ensure
+    ActionView.deprecator.silence do
+      ActionView::Base.automatically_disable_submit_tag = old_value
+    end
+  end
+
+  def test_embed_authenticity_token_in_remote_forms_is_deprecated
+    old_value = ActionView::Helpers::FormTagHelper.embed_authenticity_token_in_remote_forms
+
+    msg = <<~MSG.squish
+      `ActionView::Helpers::FormTagHelper.embed_authenticity_token_in_remote_forms=` is deprecated and will be removed in Rails 8.2.
+      Please use `actionview-remote-form-helpers` gem instead.
+    MSG
+    assert_deprecated(msg, ActionView.deprecator) do
+      ActionView::Helpers::FormTagHelper.embed_authenticity_token_in_remote_forms = nil
+    end
+  ensure
+    ActionView.deprecator.silence do
+      ActionView::Helpers::FormTagHelper.embed_authenticity_token_in_remote_forms = old_value
+    end
   end
 
   def test_submit_tag_having_data_disable_with_string


### PR DESCRIPTION
This builds off #43418, with a [gem](https://github.com/zzak/actionview-remote-form-helpers) to help those who can't easily remove the deprecations from their apps.

/cc @seanpdoyle @skipkayhil 