### PR TITLE
Fix `rotate(on_on_rotation:)` and `#on_rotation`

### DIFF
--- a/activesupport/lib/active_support/messages/rotator.rb
+++ b/activesupport/lib/active_support/messages/rotator.rb
@@ -11,8 +11,14 @@ module ActiveSupport
         @on_rotation = on_rotation
       end
 
-      def rotate(*args, **options)
+      def rotate(*args, on_rotation: nil, **options)
+        @on_rotation = on_rotation if on_rotation
         fall_back_to build_rotation(*args, **options)
+      end
+
+      def on_rotation(&on_rotation)
+        @on_rotation = on_rotation
+        self
       end
 
       def fall_back_to(fallback)

--- a/activesupport/test/messages/message_rotator_tests.rb
+++ b/activesupport/test/messages/message_rotator_tests.rb
@@ -45,6 +45,26 @@ module MessageRotatorTests
       assert called
     end
 
+    test "rotate(on_rotation:) is called on successful rotation" do
+      called = nil
+      codec = make_codec(secret("new")).rotate(secret("old"), on_rotation: proc { called = true })
+      old_codec = make_codec(secret("old"))
+      old_message = encode(DATA, old_codec)
+      assert_equal DATA, decode(old_message, codec)
+      assert called
+    end
+
+    test "rotate().on_rotation is called on successful rotation" do
+      called = nil
+      codec = make_codec(secret("new")).rotate(secret("old")).on_rotation do
+        called = true
+      end
+      old_codec = make_codec(secret("old"))
+      old_message = encode(DATA, old_codec)
+      assert_equal DATA, decode(old_message, codec)
+      assert called
+    end
+
     test "on_rotation is not called when no rotation is necessary" do
       called = nil
       assert_rotate [secret("same"), on_rotation: proc { called = true }], [secret("same")]


### PR DESCRIPTION
Ref: https://github.com/rails/rails/pull/44179
Fix: https://github.com/rails/rails/issues/54357

`MessageVerifier` and `MessageEncryptor` were intended to accept an `on_rotation` callback from the `#rotate` method or from the `#on_rotation` method.

This is particularly useful for codecs that aren't created by the user, but by the framework, like `ActiveRecord::Base.signed_id_verifier`

cc @AliSepehri, @jonathanhefner 

We should backport this to 8.0 and 7.2 (potentially 7.1?), because it was a documented feature, but never worked.
