### PR TITLE
[ci skip] Clarify the doc for creating links:

### DIFF
--- a/guides/source/getting_started.md
+++ b/guides/source/getting_started.md
@@ -1100,7 +1100,7 @@ Let's refactor this to use these helpers:
 <div id="products">
   <% @products.each do |product| %>
     <div>
-      <%= link_to product.name, product %>
+      <%= link_to product.name, product_path(product.id) %>
     </div>
   <% end %>
 </div>
@@ -1147,7 +1147,7 @@ We can update `app/views/products/index.html.erb` to link to the new action.
 <div id="products">
   <% @products.each do |product| %>
     <div>
-      <%= link_to product.name, product %>
+      <%= link_to product.name, product_path(product.id) %>
     </div>
   <% end %>
 </div>


### PR DESCRIPTION
- We mention how `*_path` works with various examples and suddenly use a code snippet that don't use the `*_path` method.

  Modified the doc to use `product_path(product.id)`, to make it explicit. While it's longer, it's clearer, especially since we are in the "getting started guide"

  I don't think mentioning how `link_to(product)` works is a good idea in this guide, the `link_to` accepts a crazy amount of different values with many heuristics to determine the url to generate. This is documented in the action view guide and in the API. Let's keep it simple in the Getting Started guide.

  Fix #54162


