### PR TITLE
Accept `on_rotation` argument in `find_signed`

### DIFF
--- a/activerecord/lib/active_record/signed_id.rb
+++ b/activerecord/lib/active_record/signed_id.rb
@@ -49,10 +49,10 @@ module ActiveRecord
       #
       #   travel_back
       #   User.find_signed signed_id, purpose: :password_reset # => User.first
-      def find_signed(signed_id, purpose: nil)
+      def find_signed(signed_id, purpose: nil, on_rotation: nil)
         raise UnknownPrimaryKey.new(self) if primary_key.nil?
 
-        if id = signed_id_verifier.verified(signed_id, purpose: combine_signed_id_purposes(purpose))
+        if id = signed_id_verifier.verified(signed_id, purpose: combine_signed_id_purposes(purpose), on_rotation: on_rotation)
           find_by primary_key => id
         end
       end
@@ -69,8 +69,8 @@ module ActiveRecord
       #   signed_id = User.first.signed_id
       #   User.first.destroy
       #   User.find_signed! signed_id # => ActiveRecord::RecordNotFound
-      def find_signed!(signed_id, purpose: nil)
-        if id = signed_id_verifier.verify(signed_id, purpose: combine_signed_id_purposes(purpose))
+      def find_signed!(signed_id, purpose: nil, on_rotation: nil)
+        if id = signed_id_verifier.verify(signed_id, purpose: combine_signed_id_purposes(purpose), on_rotation: on_rotation)
           find(id)
         end
       end

--- a/activerecord/test/cases/signed_id_test.rb
+++ b/activerecord/test/cases/signed_id_test.rb
@@ -192,6 +192,23 @@ class SignedIdTest < ActiveRecord::TestCase
     Account.signed_id_verifier = old_verifier
   end
 
+  test "on_rotation callback using find_signed & find_signed!" do
+    old_verifier = Account.signed_id_verifier
+
+    Account.signed_id_verifier = ActiveSupport::MessageVerifier.new("old secret")
+    old_account_signed_id = @account.signed_id
+    Account.signed_id_verifier = ActiveSupport::MessageVerifier.new("new secret")
+    Account.signed_id_verifier.rotate("old secret")
+    on_rotation_is_called = false
+    assert Account.find_signed(old_account_signed_id, on_rotation: -> { on_rotation_is_called = true })
+    assert on_rotation_is_called
+    on_rotation_is_called = false
+    assert Account.find_signed!(old_account_signed_id, on_rotation: -> { on_rotation_is_called = true })
+    assert on_rotation_is_called
+  ensure
+    Account.signed_id_verifier = old_verifier
+  end
+
   test "cannot get a signed ID for a new record" do
     assert_raises ArgumentError, match: /Cannot get a signed_id for a new record/ do
       Account.new.signed_id


### PR DESCRIPTION
Ref: #54357 

The `on_rotation` callback can be useful for the `find_signed` and `find_signed!` methods, which are used to locate records by signed IDs. This callback is triggered whenever the `signed_id_verifier` uses rotated secret keys, making it valuable for monitoring and tracking purposes.