### PR TITLE
Clear AR connections in tests before forking for parallelization

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Introduce a before-fork hook in `ActiveSupport::Testing::Parallelization` to clear existing
+    connections, to avoid fork-safety issues with the mysql2 adapter.
+
+    Fixes #41776
+
+    *Mike Dalessio*, *Donal McBreen*
+
 *   PoolConfig no longer keeps a reference to the connection class.
 
     Keeping a reference to the class caused subtle issues when combined with reloading in

--- a/activerecord/lib/active_record/test_databases.rb
+++ b/activerecord/lib/active_record/test_databases.rb
@@ -4,6 +4,10 @@ require "active_support/testing/parallelization"
 
 module ActiveRecord
   module TestDatabases # :nodoc:
+    ActiveSupport::Testing::Parallelization.before_fork_hook do
+      ActiveRecord::Base.connection_handler.clear_all_connections!
+    end
+
     ActiveSupport::Testing::Parallelization.after_fork_hook do |i|
       create_and_load_schema(i, env_name: ActiveRecord::ConnectionHandling::DEFAULT_ENV.call)
     end

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   `ActiveSupport::Testing::Parallelization.before_fork_hook` allows declaration of callbacks that
+    are invoked immediately before forking test workers.
+
+    *Mike Dalessio*
+
 *   Allow the `#freeze_time` testing helper to accept a date or time argument.
 
     ```ruby

--- a/activesupport/lib/active_support/testing/parallelization.rb
+++ b/activesupport/lib/active_support/testing/parallelization.rb
@@ -9,6 +9,14 @@ require "active_support/testing/parallelization/worker"
 module ActiveSupport
   module Testing
     class Parallelization # :nodoc:
+      @@before_fork_hooks = []
+
+      def self.before_fork_hook(&blk)
+        @@before_fork_hooks << blk
+      end
+
+      cattr_reader :before_fork_hooks
+
       @@after_fork_hooks = []
 
       def self.after_fork_hook(&blk)
@@ -32,7 +40,12 @@ module ActiveSupport
         @url = DRb.start_service("drbunix:", @queue_server).uri
       end
 
+      def before_fork
+        Parallelization.before_fork_hooks.each(&:cb)
+      end
+
       def start
+        before_fork
         @worker_pool = @worker_count.times.map do |worker|
           Worker.new(worker, @url).start
         end


### PR DESCRIPTION
### Motivation / Background

Works around #41176 which seems to affect the mysql2 adapter built with the mysql8 client library on MacOS.

### Detail

This PR introduces a before-fork hook into ActiveSupport::Testing::Parallelization, which is invoked immediately before spawning the worker processes.

This PR also implements a before-fork hook in ActiveRecord::TestDatabases to clear connections, to avoid the symptoms of poor fork-safety in the mysql2 8.0 client / mysql2 adapter.

We see this problem relatively often at 37s when running large test suites on MacOS development machines.

### Additional information

This PR does not directly address the fork-safety issue in the mysql8 client library, but closing connections in a test process before forking doesn't have any obvoius negative impacts that I know of, and so my hope is something like this would be an acceptable tradeoff.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [-] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
