### PR TITLE
Do not set the `Clear-Site-Data` header for Chrome users

### DIFF
--- a/railties/lib/rails/generators/rails/authentication/templates/app/controllers/sessions_controller.rb.tt
+++ b/railties/lib/rails/generators/rails/authentication/templates/app/controllers/sessions_controller.rb.tt
@@ -16,7 +16,18 @@ class SessionsController < ApplicationController
 
   def destroy
     terminate_session
-    clear_site_data
+
+    # Prompt the browser to clear storage and cache data, except on Chrome where it can
+    # take 20+ seconds (see https://issues.chromium.org/issues/41343050)
+    clear_site_data unless parsed_user_agent.browser == "Chrome"
+
     redirect_to new_session_path
   end
+
+  private
+
+    def parsed_user_agent
+      require "useragent"
+      UserAgent.parse(request.user_agent)
+    end
 end


### PR DESCRIPTION
### Motivation / Background

Since #54230, the session controller generated by the authentication generator sets the `Clear-Site-Data` header on logout so that the browser clears the storage and cache data associated to the site. Unfortunately, this takes [20+ seconds][1] on Chrome which degrades user experience.

[1]: https://issues.chromium.org/issues/41343050

### Detail

Clearing the storage and cache data isn't critical so let's not set the header for Chrome users.

### Additional information

Folks at GitHub apparently started setting that header in 2021 and ended up disabling it for Chrome-based user agents (see this [comment](https://issues.chromium.org/issues/41343050#comment49)).

I considered opting out all Chromium-based browsers, but from my testing, Edge on macOS is not affected (despite being Chromium-based). So I assumed that only Chrome was affected.

Separately, I'm wondering whether it wouldn't make more sense to revert #54230 to keep the generated code simple.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
