### PR TITLE
Make the devcontainer script work with podman

### DIFF
--- a/tools/devcontainer
+++ b/tools/devcontainer
@@ -4,6 +4,30 @@
 require "json"
 require "open3"
 
+# To use podman on macOS:
+#
+#   $ brew install podman
+#   $ brew install podman-compose
+#   $ podman machine init
+#   $ podman machine start
+#   $ tools/devcontainer up
+#
+# Then in another terminal
+#
+#   $ tools/devcontainer run-user-commands
+#   $ tools/devcontainer sh
+def exe?(program)
+  ENV["PATH"].split(File::PATH_SEPARATOR).each do |path|
+    File.join(path, program).tap { |p|
+      return p if File.executable? p
+      next
+    }
+  end
+  nil
+end
+
+DOCKER = ENV["DOCKER"] || exe?("podman") || exe?("docker")
+
 VARS = {
   "localWorkspaceFolderBasename" => Dir.pwd.split(File::SEPARATOR).last
 }
@@ -20,11 +44,12 @@ env = info["containerEnv"].map { |k, v| "-e #{k}=#{v}" }.join " "
 
 case ARGV[0]
 when "up"
-  system "docker", "compose", "-f", ".devcontainer/#{info["dockerComposeFile"]}", "up"
+  compose_file = File.expand_path(".devcontainer/#{info["dockerComposeFile"]}")
+  system DOCKER, "compose", "-f", compose_file, "up"
 when "run-user-commands"
-  service_id, _, _ = Open3.capture3("docker ps -q -f name=#{info["service"]}")
-  system "docker exec #{env} -w #{working_dir} -it #{service_id.chomp} /bin/bash -i #{info["postCreateCommand"]}"
+  service_id, _, _ = Open3.capture3("#{DOCKER} ps -q -f name=#{info["service"]}")
+  system "#{DOCKER} exec #{env} -w #{working_dir} -it #{service_id.chomp} /bin/bash -i #{info["postCreateCommand"]}"
 when "sh"
-  service_id, _, _ = Open3.capture3("docker ps -q -f name=#{info["service"]}")
-  system "docker exec #{env} -w #{working_dir} -it #{service_id.chomp} /bin/bash"
+  service_id, _, _ = Open3.capture3("#{DOCKER} ps -q -f name=#{info["service"]}")
+  system "#{DOCKER} exec #{env} -w #{working_dir} -it #{service_id.chomp} /bin/bash"
 end


### PR DESCRIPTION
This just makes the devcontainer script optionally work with podman.  It will try to detect if you have podman installed, then use it, otherwise it tries to use docker.