### PR TITLE
Revert "Clear-Site-Data in generated authentication code"

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -24,13 +24,6 @@
 
     *Petrik de Heus*
 
-*   The authentication generator's `SessionsController` sets the `Clear-Site-Data` header on logout.
-
-    By default the header will be set to `"cache","storage"` to help prevent data leakage after
-    logout via the browser's "back/forward cache".
-
-    *Mike Dalessio*
-
 *   Introduce `RAILS_MASTER_KEY` placeholder in generated ci.yml files
 
     *Steve Polito*

--- a/railties/lib/rails/generators/rails/authentication/templates/app/controllers/concerns/authentication.rb.tt
+++ b/railties/lib/rails/generators/rails/authentication/templates/app/controllers/concerns/authentication.rb.tt
@@ -49,8 +49,4 @@ module Authentication
       Current.session.destroy
       cookies.delete(:session_id)
     end
-
-    def clear_site_data
-      response.headers["Clear-Site-Data"] = '"cache","storage"'
-    end
 end

--- a/railties/lib/rails/generators/rails/authentication/templates/app/controllers/sessions_controller.rb.tt
+++ b/railties/lib/rails/generators/rails/authentication/templates/app/controllers/sessions_controller.rb.tt
@@ -16,7 +16,6 @@ class SessionsController < ApplicationController
 
   def destroy
     terminate_session
-    clear_site_data
     redirect_to new_session_path
   end
 end


### PR DESCRIPTION
Revert: https://github.com/rails/rails/pull/54230
Fix: https://github.com/rails/rails/pull/54377

`Clear-Site-Data` can cause Google Chrome to lock up for upwards of 20 seconds. Ref: https://issues.chromium.org/issues/41343050

Given this issue doesn't seem likely to be fixed by Chrome soon, and given Chrome current market share, that seem like a big footgun for users.

cc @flavorjones @matthieuprat 