### PR TITLE
Load the routes in the console when calling the `app` IRB helper

### DIFF
--- a/railties/lib/rails/commands/console/irb_console.rb
+++ b/railties/lib/rails/commands/console/irb_console.rb
@@ -31,6 +31,7 @@ module Rails
 
       def execute(*)
         app = Rails.application
+        app.reload_routes_unless_loaded
         session = ActionDispatch::Integration::Session.new(app)
 
         # This makes app.url_for and app.foo_path available in the console

--- a/railties/test/application/console_test.rb
+++ b/railties/test/application/console_test.rb
@@ -186,6 +186,18 @@ class FullStackConsoleTest < ActiveSupport::TestCase
     write_prompt "app.foo_path", "/foo"
   end
 
+  def test_app_routes_are_loaded
+    app_file "config/routes.rb", <<-RUBY
+      Rails.application.routes.draw do
+        get 'foo', to: 'foo#index'
+      end
+    RUBY
+
+    spawn_console("-e development")
+
+    write_prompt "app.methods.grep(/foo_path/)", "[:foo_path]"
+  end
+
   def test_reload_command_fires_preparation_and_cleanup_callbacks
     options = "-e development"
     spawn_console(options)


### PR DESCRIPTION
### Motivation / Background

Load the routes in the console when calling  the `app` IRB helper:

- When running a console, the routes are not loaded, which results in not being able to see what route helpers are available.

```shell
$ bin/rails c
$ catana(dev)> app.methods.grep(/_(path|url)/) # []
$ catana(dev)> app.foo_path # Works. The routes are now loaded.
$ catana(dev)> app.methods.grep(/_(path|url)/) # [:foo_path]
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
