### PR TITLE
Remove incorrect transaction enqueuing documentation for perform_later

### DIFF
--- a/activejob/lib/active_job/enqueuing.rb
+++ b/activejob/lib/active_job/enqueuing.rb
@@ -66,18 +66,6 @@ module ActiveJob
       # Job#arguments or +false+ if the enqueue did not succeed.
       #
       # After the attempted enqueue, the job will be yielded to an optional block.
-      #
-      # If Active Job is used conjointly with Active Record, and #perform_later is called
-      # inside an Active Record transaction, then the enqueue is implicitly deferred to after
-      # the transaction is committed, or dropped if it's rolled back. In such case #perform_later
-      # will return the job instance like if it was successfully enqueued, but will still return
-      # +false+ if a callback prevented the job from being enqueued.
-      #
-      # This behavior can be changed on a per job basis:
-      #
-      #  class NotificationJob < ApplicationJob
-      #    self.enqueue_after_transaction_commit = false
-      #  end
       def perform_later(...)
         job = job_or_instantiate(...)
         enqueue_result = job.enqueue


### PR DESCRIPTION
### Motivation / Background
In https://github.com/rails/rails/pull/53375/ the default for enqueuing jobs after transactions was set to false, however it seems like the PR forgot to remove the relevant documentation for `perform_later` and it now states the exact opposite of the actual behavior. 

In the previous PR it is discussed if the default should be changed back to `true`, but as long as it is it not, I believe the documentation should reflect the actual behavior. 

### Detail

This pull request removes the incorrect information.

### Additional information

Even if Rails intends to change the default and don't want to merge this into main, it would make sense to merge it into 8.0, since the default will exist there.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
