### PR TITLE
Skip inflector when generating HTTP_METHOD_LOOKUP

### DIFF
--- a/actionpack/lib/action_dispatch/http/request.rb
+++ b/actionpack/lib/action_dispatch/http/request.rb
@@ -138,7 +138,7 @@ module ActionDispatch
 
     # Populate the HTTP method lookup cache.
     HTTP_METHODS.each { |method|
-      HTTP_METHOD_LOOKUP[method] = method.downcase.underscore.to_sym
+      HTTP_METHOD_LOOKUP[method] = method.downcase.tap { |m| m.tr!("-", "_") }.to_sym
     }
 
     alias raw_request_method request_method # :nodoc:


### PR DESCRIPTION
Ref #54227 

HTTP_METHOD_LOOKUP's creation was recently updated to explicitly use `downcase` since an application's custom inflections could previously affect it. However, `underscore` is still present even though the only transformation needed after `downcase` is substituting `-` for `_`.

Since `underscore` is overkill in this case, this commit replaces it with `tr!`.
