### PR TITLE
[8-0-stable] Backport "Fix two unused block warnings in arel"

### DIFF
--- a/activerecord/lib/active_record/statement_cache.rb
+++ b/activerecord/lib/active_record/statement_cache.rb
@@ -74,13 +74,13 @@ module ActiveRecord
         self
       end
 
-      def add_bind(obj)
+      def add_bind(obj, &)
         @binds << obj
         @parts << Substitute.new
         self
       end
 
-      def add_binds(binds, proc_for_binds = nil)
+      def add_binds(binds, proc_for_binds = nil, &)
         @binds.concat proc_for_binds ? binds.map(&proc_for_binds) : binds
         binds.size.times do |i|
           @parts << ", " unless i == 0

--- a/activerecord/lib/arel/collectors/bind.rb
+++ b/activerecord/lib/arel/collectors/bind.rb
@@ -18,7 +18,7 @@ module Arel # :nodoc: all
         self
       end
 
-      def add_binds(binds, proc_for_binds = nil)
+      def add_binds(binds, proc_for_binds = nil, &)
         @binds.concat proc_for_binds ? binds.map(&proc_for_binds) : binds
         self
       end

--- a/activerecord/lib/arel/collectors/sql_string.rb
+++ b/activerecord/lib/arel/collectors/sql_string.rb
@@ -12,7 +12,7 @@ module Arel # :nodoc: all
         @bind_index = 1
       end
 
-      def add_bind(bind)
+      def add_bind(bind, &)
         self << yield(@bind_index)
         @bind_index += 1
         self

--- a/activerecord/lib/arel/collectors/substitute_binds.rb
+++ b/activerecord/lib/arel/collectors/substitute_binds.rb
@@ -15,12 +15,12 @@ module Arel # :nodoc: all
         self
       end
 
-      def add_bind(bind)
+      def add_bind(bind, &)
         bind = bind.value_for_database if bind.respond_to?(:value_for_database)
         self << quoter.quote(bind)
       end
 
-      def add_binds(binds, proc_for_binds = nil)
+      def add_binds(binds, proc_for_binds = nil, &)
         self << binds.map { |bind| quoter.quote(bind) }.join(", ")
       end
 

--- a/activerecord/lib/arel/nodes/binary.rb
+++ b/activerecord/lib/arel/nodes/binary.rb
@@ -30,7 +30,7 @@ module Arel # :nodoc: all
     end
 
     module FetchAttribute
-      def fetch_attribute
+      def fetch_attribute(&)
         if left.is_a?(Arel::Attributes::Attribute)
           yield left
         elsif right.is_a?(Arel::Attributes::Attribute)

--- a/activerecord/lib/arel/nodes/node.rb
+++ b/activerecord/lib/arel/nodes/node.rb
@@ -152,7 +152,7 @@ module Arel # :nodoc: all
         end
       end
 
-      def fetch_attribute
+      def fetch_attribute(&)
       end
 
       def equality?; false; end

--- a/activerecord/lib/arel/nodes/sql_literal.rb
+++ b/activerecord/lib/arel/nodes/sql_literal.rb
@@ -19,7 +19,7 @@ module Arel # :nodoc: all
         coder.scalar = self.to_s
       end
 
-      def fetch_attribute
+      def fetch_attribute(&)
       end
 
       def +(other)


### PR DESCRIPTION
Backports #54361, Fix two unused block warnings in arel

I dropped the cosmetic changes that were part of that PR. One didn't apply cleanly and they are not relevant.