### PR TITLE
Add enum values option to PostgreSQL enum columns

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,20 @@
+*   Add enum values option to PostgreSQL enum columns.
+
+    It is now possible to specify the values of an enum type column when
+    defining a column. If an `enum_type` is not specified, the enum type
+    name will default to the column name. Schemas will include the values
+    of the enum type in each column definition.
+
+    ```ruby
+    def up
+      create_table :cats do |t|
+        t.enum :current_mood, enum_type: "mood", values: ["happy", "sad"], default: "happy", null: false
+      end
+    end
+    ```
+
+    *Jenny Shen*
+
 *   Introduce a before-fork hook in `ActiveSupport::Testing::Parallelization` to clear existing
     connections, to avoid fork-safety issues with the mysql2 adapter.
 

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_creation.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_creation.rb
@@ -32,7 +32,7 @@ module ActiveRecord
         end
 
         def visit_ColumnDefinition(o)
-          o.sql_type = type_to_sql(o.type, **o.options)
+          o.sql_type = type_to_sql(o.type, column_name: o.name, **o.options)
           column_sql = +"#{quote_column_name(o.name)} #{o.sql_type}"
           add_column_options!(column_sql, column_options(o)) unless o.type == :primary_key
           column_sql

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_definitions.rb
@@ -282,7 +282,7 @@ module ActiveRecord
 
         private
           def valid_column_definition_options
-            super + [:array, :using, :cast_as, :as, :type, :enum_type, :stored]
+            super + [:array, :using, :cast_as, :as, :type, :enum_type, :stored, :values]
           end
 
           def aliased_types(name, fallback)

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_dumper.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_dumper.rb
@@ -80,7 +80,11 @@ module ActiveRecord
               spec = { type: schema_type(column).inspect }.merge!(spec)
             end
 
-            spec[:enum_type] = column.sql_type.inspect if column.enum?
+            if column.enum?
+              spec[:enum_type] = column.sql_type.inspect unless column.name == column.sql_type
+              _name, values = @connection.enum_types.find { |name, _values| name == column.sql_type }
+              spec[:values] = values.inspect
+            end
 
             spec
           end

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -848,7 +848,7 @@ module ActiveRecord
         end
 
         # Maps logical Rails types to PostgreSQL-specific data types.
-        def type_to_sql(type, limit: nil, precision: nil, scale: nil, array: nil, enum_type: nil, **) # :nodoc:
+        def type_to_sql(type, column_name: nil, limit: nil, precision: nil, scale: nil, array: nil, enum_type: nil, values: nil, **) # :nodoc:
           sql = \
             case type.to_s
             when "binary"
@@ -873,9 +873,9 @@ module ActiveRecord
               else raise ArgumentError, "No integer type has byte size #{limit}. Use a numeric with scale 0 instead."
               end
             when "enum"
-              raise ArgumentError, "enum_type is required for enums" if enum_type.nil?
+              raise ArgumentError, "enum_type or values is required for enums" if enum_type.nil? && values.nil?
 
-              enum_type
+              enum_type || column_name
             else
               super
             end

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -550,6 +550,11 @@ module ActiveRecord
                 JOIN pg_namespace n ON t.typnamespace = n.oid
                 WHERE t.typname = #{scope[:name]}
                   AND n.nspname = #{scope[:schema]}
+                  AND (
+                    SELECT array_agg(e.enumlabel ORDER BY e.enumsortorder)
+                    FROM pg_enum e
+                    WHERE e.enumtypid = t.oid
+                  ) = ARRAY[#{sql_values}]::name[]
               ) THEN
                   CREATE TYPE #{quote_table_name(name)} AS ENUM (#{sql_values});
               END IF;

--- a/activerecord/test/cases/migration/invalid_options_test.rb
+++ b/activerecord/test/cases/migration/invalid_options_test.rb
@@ -13,7 +13,7 @@ module ActiveRecord
         if current_adapter?(:Mysql2Adapter, :TrilogyAdapter)
           default_keys.concat([":auto_increment", ":charset", ":as", ":size", ":unsigned", ":first", ":after", ":type", ":stored"])
         elsif current_adapter?(:PostgreSQLAdapter)
-          default_keys.concat([":array", ":using", ":cast_as", ":as", ":type", ":enum_type", ":stored"])
+          default_keys.concat([":array", ":using", ":cast_as", ":as", ":type", ":enum_type", ":stored", ":values"])
         elsif current_adapter?(:SQLite3Adapter)
           default_keys.concat([":as", ":type", ":stored"])
         end


### PR DESCRIPTION
### Motivation / Background
Currently, Postgresql allows one to create enums by 1. Create enum type through `create_enum` and 2. Defining the enum type that would like to be used in a column.

```ruby
  def up
    create_enum "value", ["value1", "value2", "value3"]
    create_table "enum_table" do |t|
      t.column :enum_column, :value
    end
  end
```

However, I would like to implement something similar for MySQL enums. This can be done by introducing a `values` option.

#### MySQL current
```ruby
  def up
    create_table "enum_table" do |t|
      t.column :enum_column, "enum('value1', 'value2', 'value3')"
    end
  end
```

#### MySQL proposed
```ruby
  def up
    create_table "enum_table" do |t|
      t.enum :enum_column, values: ["value1", "value2", "value3"]
    end
  end
```

It would be preferable for the enum syntax to be db-agnostic between adapters. This would be possible if Postgres enum columns also have some sort of `values` option.

### Detail

This PR adds the values option to the enum column which shows in the db schema. If an enum column is defined with a values option, we will now try to create the enum with the values given (unless the enum is created already with the same values).

#### Example migration
```ruby
  def up
    create_table "enum_table" do |t|
      t.enum :enum_column, values: ["value1", "value2", "value3"], enum_type: "status"
    end
  end
```

#### Example schema
```ruby
ActiveRecord::Schema[8.1].define(version: 2025_01_29_154347) do
  # Custom types defined in this database.
  # Note that some types may not work with other database engines. Be careful if changing database.
  create_enum "status", ["value1", "value2", "value3"]

  create_table "enum_table", force: :cascade do |t|
     t.enum "enum_column", enum_type: "status", values: ["value1", "value2", "value3"]
  end
end
```
I decided to leave the `create_enum` statements as I wasn't sure how to deal with dropping enum types with enum columns and they would be a no-op for other DB adapters.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.

