### PR TITLE
Move to GitHubs new issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,3 +1,8 @@
+---
+name: Bug report
+about: Report an issue with Rails you've discovered
+---
+
 ### Steps to reproduce
 <!-- (Guidelines for creating a bug report are [available
 here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#creating-a-bug-report)) -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false


### PR DESCRIPTION
Currently, creating a new issue does not populate the text area anymore. Viewing the template file [via the GitHub UI](https://github.com/rails/rails/blob/f132ba641a2720376f00071556fc85cbb2a6965f/.github/issue_template.md) shows the following:

![image](https://github.com/user-attachments/assets/fe1b9d17-b0b0-46dd-85fd-51a4131152b2)


Could do a bunch more with these, this just makes it work again mostly how it used to work. It will look like this (or try it out at https://github.com/Earlopain/rails/issues):

![image](https://github.com/user-attachments/assets/f09d3e4e-3ec8-4de3-98cb-96ed28af8d58)

Clicking on the bug report option opens the issue textbox 