### PR TITLE
Schneems/suggest tz data

### DIFF
--- a/actionpack/lib/action_dispatch/http/request.rb
+++ b/actionpack/lib/action_dispatch/http/request.rb
@@ -138,7 +138,7 @@ module ActionDispatch
 
     # Populate the HTTP method lookup cache.
     HTTP_METHODS.each { |method|
-      HTTP_METHOD_LOOKUP[method] = method.downcase.underscore.to_sym
+      HTTP_METHOD_LOOKUP[method] = method.downcase.tap { |m| m.tr!("-", "_") }.to_sym
     }
 
     alias raw_request_method request_method # :nodoc:

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Introduce a before-fork hook in `ActiveSupport::Testing::Parallelization` to clear existing
+    connections, to avoid fork-safety issues with the mysql2 adapter.
+
+    Fixes #41776
+
+    *Mike Dalessio*, *Donal McBreen*
+
 *   PoolConfig no longer keeps a reference to the connection class.
 
     Keeping a reference to the class caused subtle issues when combined with reloading in

--- a/activerecord/lib/active_record/migration/command_recorder.rb
+++ b/activerecord/lib/active_record/migration/command_recorder.rb
@@ -382,7 +382,8 @@ module ActiveRecord
             raise ActiveRecord::IrreversibleMigration, "rename_enum_value is only reversible if given a :from and :to option."
           end
 
-          [:rename_enum_value, [type_name, from: options[:to], to: options[:from]]]
+          options[:to], options[:from] = options[:from], options[:to]
+          [:rename_enum_value, [type_name, options]]
         end
 
         def invert_drop_virtual_table(args)

--- a/activerecord/lib/active_record/test_databases.rb
+++ b/activerecord/lib/active_record/test_databases.rb
@@ -4,6 +4,10 @@ require "active_support/testing/parallelization"
 
 module ActiveRecord
   module TestDatabases # :nodoc:
+    ActiveSupport::Testing::Parallelization.before_fork_hook do
+      ActiveRecord::Base.connection_handler.clear_all_connections!
+    end
+
     ActiveSupport::Testing::Parallelization.after_fork_hook do |i|
       create_and_load_schema(i, env_name: ActiveRecord::ConnectionHandling::DEFAULT_ENV.call)
     end

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   `ActiveSupport::Testing::Parallelization.before_fork_hook` allows declaration of callbacks that
+    are invoked immediately before forking test workers.
+
+    *Mike Dalessio*
+
 *   Allow the `#freeze_time` testing helper to accept a date or time argument.
 
     ```ruby

--- a/activesupport/lib/active_support/core_ext/time/zones.rb
+++ b/activesupport/lib/active_support/core_ext/time/zones.rb
@@ -90,6 +90,11 @@ class Time
     #
     #   Time.find_zone "America/New_York" # => #<ActiveSupport::TimeZone @name="America/New_York" ...>
     #   Time.find_zone "NOT-A-TIMEZONE"   # => nil
+    #
+    # Unlike `ActiveSupport::TimeZone[time_zone]`, this will not raise an error on an invalid input:
+    #
+    #   Time.find_zone(Object.new) => nil
+    #   ActiveSupport::TimeZone[Object.new] => ArgumentError
     def find_zone(time_zone)
       return time_zone unless time_zone
 

--- a/activesupport/lib/active_support/core_ext/time/zones.rb
+++ b/activesupport/lib/active_support/core_ext/time/zones.rb
@@ -81,7 +81,7 @@ class Time
     def find_zone!(time_zone)
       return time_zone unless time_zone
 
-      ActiveSupport::TimeZone[time_zone] || raise(ArgumentError, "Invalid Timezone: #{time_zone}")
+      ActiveSupport::TimeZone.find!(time_zone)
     end
 
     # Returns a TimeZone instance matching the time zone provided.
@@ -91,7 +91,9 @@ class Time
     #   Time.find_zone "America/New_York" # => #<ActiveSupport::TimeZone @name="America/New_York" ...>
     #   Time.find_zone "NOT-A-TIMEZONE"   # => nil
     def find_zone(time_zone)
-      find_zone!(time_zone) rescue nil
+      return time_zone unless time_zone
+
+      ActiveSupport::TimeZone.find!(time_zone, raise_error: false)
     end
   end
 end

--- a/activesupport/lib/active_support/core_ext/time/zones.rb
+++ b/activesupport/lib/active_support/core_ext/time/zones.rb
@@ -93,7 +93,7 @@ class Time
     def find_zone(time_zone)
       return time_zone unless time_zone
 
-      ActiveSupport::TimeZone.find!(time_zone, raise_error: false)
+      ActiveSupport::TimeZone.find!(time_zone, error_not_found: false, error_invalid_input: false)
     end
   end
 end

--- a/activesupport/lib/active_support/testing/parallelization.rb
+++ b/activesupport/lib/active_support/testing/parallelization.rb
@@ -9,6 +9,14 @@ require "active_support/testing/parallelization/worker"
 module ActiveSupport
   module Testing
     class Parallelization # :nodoc:
+      @@before_fork_hooks = []
+
+      def self.before_fork_hook(&blk)
+        @@before_fork_hooks << blk
+      end
+
+      cattr_reader :before_fork_hooks
+
       @@after_fork_hooks = []
 
       def self.after_fork_hook(&blk)
@@ -32,7 +40,12 @@ module ActiveSupport
         @url = DRb.start_service("drbunix:", @queue_server).uri
       end
 
+      def before_fork
+        Parallelization.before_fork_hooks.each(&:cb)
+      end
+
       def start
+        before_fork
         @worker_pool = @worker_count.times.map do |worker|
           Worker.new(worker, @url).start
         end

--- a/activesupport/lib/active_support/values/time_zone.rb
+++ b/activesupport/lib/active_support/values/time_zone.rb
@@ -230,7 +230,18 @@ module ActiveSupport
       # timezone to find. (The first one with that offset will be returned.)
       # Returns +nil+ if no such time zone is known to the system.
       def [](arg)
-        case arg
+        find!(arg, raise_error: false)
+      end
+
+
+      # Private API, do not use outside of ActiveSupport, it is unstable
+      #
+      # Finda timezone, if `raise_error` is truthy, an
+      # exception is raised.
+      #
+      # The error message can differ based on the class of `self`.
+      def find!(arg, raise_error: true) # :nodoc:
+        value = case arg
         when self
           arg
         when String
@@ -246,6 +257,12 @@ module ActiveSupport
           all.find { |z| z.utc_offset == arg.to_i }
         else
           raise ArgumentError, "invalid argument to TimeZone[]: #{arg.inspect}"
+        end
+
+        if !value && raise_error
+          raise(ArgumentError, "Invalid Timezone: #{time_zone}")
+        else
+          value
         end
       end
 

--- a/activesupport/lib/active_support/values/time_zone.rb
+++ b/activesupport/lib/active_support/values/time_zone.rb
@@ -260,7 +260,12 @@ module ActiveSupport
         end
 
         if !value && raise_error
-          raise(ArgumentError, "Invalid Timezone: #{time_zone}")
+          message = "Invalid Timezone: #{arg}"
+          if defined?(TZInfo::Data)
+            raise(ArgumentError, "#{message}.\nTimezones sourced from `tzinfo-data` gem")
+          else
+            raise(ArgumentError, "#{message}.\nTimezones sourced from the system zoneinfo file (`tzinfo-data` gem not loaded)")
+          end
         else
           value
         end

--- a/activesupport/lib/active_support/values/time_zone.rb
+++ b/activesupport/lib/active_support/values/time_zone.rb
@@ -230,17 +230,17 @@ module ActiveSupport
       # timezone to find. (The first one with that offset will be returned.)
       # Returns +nil+ if no such time zone is known to the system.
       def [](arg)
-        find!(arg, raise_error: false)
+        find!(arg, error_not_found: false)
       end
-
 
       # Private API, do not use outside of ActiveSupport, it is unstable
       #
       # Finda timezone, if `raise_error` is truthy, an
       # exception is raised.
+      # and `error_invalid_input` is truthy, an exception is raised.
       #
       # The error message can differ based on the class of `self`.
-      def find!(arg, raise_error: true) # :nodoc:
+      def find!(arg, error_not_found: true, error_invalid_input: true) # :nodoc:
         value = case arg
         when self
           arg
@@ -256,10 +256,10 @@ module ActiveSupport
           arg *= 3600 if arg.abs <= 13
           all.find { |z| z.utc_offset == arg.to_i }
         else
-          raise ArgumentError, "invalid argument to TimeZone[]: #{arg.inspect}"
+          raise ArgumentError, "invalid argument to TimeZone[]: #{arg.inspect}" if error_invalid_input
         end
 
-        if !value && raise_error
+        if !value && error_not_found
           message = "Invalid Timezone: #{arg}"
           if defined?(TZInfo::Data)
             raise(ArgumentError, "#{message}.\nTimezones sourced from `tzinfo-data` gem")

--- a/activesupport/lib/active_support/values/time_zone.rb
+++ b/activesupport/lib/active_support/values/time_zone.rb
@@ -224,10 +224,23 @@ module ActiveSupport
         @zones ||= zones_map.values.sort
       end
 
-      # Locate a specific time zone object. If the argument is a string, it
-      # is interpreted to mean the name of the timezone to locate. If it is a
-      # numeric value it is either the hour offset, or the second offset, of the
-      # timezone to find. (The first one with that offset will be returned.)
+      # Locate a specific time zone object.
+      #
+      # If the argument is a `String`, it is interpreted to mean the name of the
+      # timezone to locate e.g., "America/Chicago".
+      # If it is a `Numeric` or `Duration` value, it is either the hour offset or the second
+      # offset, of the timezone to find. (The first one with that offset will be returned.)
+      # If the input is an instance of `ActiveSupport::TimeZone` the input argument
+      # will be returned. If the input is an instance of `TZInfo::Timezone` it
+      # will return a lookup of the name, or add the timezone to the list of
+      # known timezones and then return the argument.
+      #
+      # An `ArgumentError`` will be raised for all other input classes. This behavior differs from
+      # `Time.find_zone` which will not error, but instead return nil:
+      #
+      #   ActiveSupport::TimeZone[Object.new] => ArgumentError
+      #   Time.find_zone(Object.new) => nil
+      #
       # Returns +nil+ if no such time zone is known to the system.
       def [](arg)
         find!(arg, error_not_found: false)
@@ -235,8 +248,8 @@ module ActiveSupport
 
       # Private API, do not use outside of ActiveSupport, it is unstable
       #
-      # Finda timezone, if `raise_error` is truthy, an
-      # exception is raised.
+      # Find a timezone, otherwise if `error_not_found` is truthy, an
+      # exception is raised. If the input argument's class is unknown
       # and `error_invalid_input` is truthy, an exception is raised.
       #
       # The error message can differ based on the class of `self`.

--- a/guides/source/active_record_querying.md
+++ b/guides/source/active_record_querying.md
@@ -1296,7 +1296,7 @@ class Book
   # Returns reviews if there are at least 5,
   # else consider this as non-reviewed book
   def highlighted_reviews
-    if reviews.count > 5
+    if reviews.count >= 5
       reviews
     else
       Review.none # Does not meet minimum threshold yet


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

Add location of Timezone data to error output

## Context

Timezones have evolved away from using a specific country to a geographic region. For example, `US/Central` has been moved to `America/Chicago`. Ubuntu 24.04 moved these "legacy" timezones out of the default installed system packages and placed them in `tzdata-legacy` https://packages.debian.org/sid/tzdata-legacy.

## Problem

By default, the `tzinfo` gem will attempt to source location information from the system, so if a user has an older timezone stored  in a database and tries to load it with ActiveSupport, it will fail on migration to Ubuntu 24.04 with the error:

```
/app/vendor/bundle/ruby/3.4.0/gems/activesupport-8.0.1/lib/active_support/core_ext/time/zones.rb:84:in 'Time.find_zone!': Invalid Timezone: US/Central (ArgumentError)

      ActiveSupport::TimeZone[time_zone] || raise(ArgumentError, "Invalid Timezone: #{time_zone}")
                                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
	from /app/vendor/bundle/ruby/3.4.0/gems/activesupport-8.0.1/lib/active_support/core_ext/date_and_time/zones.rb:21:in 'DateAndTime::Zones#in_time_zone'
```

Someone investigating the error might become confused if they believe that `US/Central` is a valid time zone. This confusion is compounded because it previously worked on Ubuntu 22.04. They might not know where to look to ensure that their timezone definitions are updated (or that `tzdata-legacy` has been `apt-get install`-d).

## Solution to the problem

A user can solve their problem by installing the `tzdata-legacy` package or switching to the `tzinfo-data` gem (which contains the legacy definitions).

## This PR

This PR provides a breadcrumb to the user on where to look next in the event of this confusing error. It provides truthy information that shouldn't go stale any time soon (the load order of data is documented by tzinfo and on the [`tzinfo-data` gem's README.md](https://github.com/tzinfo/tzinfo-data/blob/c3fd3b0fad2ac58927e83466aba46d566462524c/README.md)).

It stops short of encoding specific debugging information for this targeted problem as that information is less timeless and subject to change. Also, I'm mindful not to introduce too much logic in the exception case to reduce future maintenance burdens (and be mindful that exceptional code path performance is also important).

## Alternatives

We could add `tzinfo-data` as a required gem, or to the generated Gemfile. Even if we do that, it's still useful to know where the data was loaded from in the event of an error.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.


