### PR TITLE
Allow ActiveStorage analyzers to be empty

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,23 @@
+*   Allow `ActiveStorage.analyzers` to be fully configurable
+
+    `ActiveStorage.analyzers` can be set to an empty array:
+
+    ```ruby
+    config.active_storage.analyzers = []
+    # => ActiveStorage.analyzers = []
+    ```
+
+    `ActiveStorage.analyzers` can be set to a custom analyzer:
+
+    ```ruby
+    config.active_storage.analyzers = [ CustomAnalyzer ]
+    # => ActiveStorage.analyzers = [ CustomAnalyzer ]
+    ```
+
+    If no configuration is provided, it will use the default analyzers.
+
+    *Alexandre Ruban*
+
 *   Delegate `ActiveStorage::Filename#to_str` to `#to_s`
 
     Supports checking String equality:

--- a/activestorage/lib/active_storage/engine.rb
+++ b/activestorage/lib/active_storage/engine.rb
@@ -25,7 +25,6 @@ module ActiveStorage
 
     config.active_storage = ActiveSupport::OrderedOptions.new
     config.active_storage.previewers = [ ActiveStorage::Previewer::PopplerPDFPreviewer, ActiveStorage::Previewer::MuPDFPreviewer, ActiveStorage::Previewer::VideoPreviewer ]
-    config.active_storage.analyzers = [ ActiveStorage::Analyzer::VideoAnalyzer, ActiveStorage::Analyzer::AudioAnalyzer ]
     config.active_storage.paths = ActiveSupport::OrderedOptions.new
     config.active_storage.queues = ActiveSupport::InheritableOptions.new
     config.active_storage.precompile_assets = true
@@ -102,7 +101,8 @@ module ActiveStorage
               ]
             end
 
-          ActiveStorage.analyzers = [analyzer].compact.concat(app.config.active_storage.analyzers || [])
+          ActiveStorage.analyzers = app.config.active_storage.analyzers ||
+            [ analyzer, ActiveStorage::Analyzer::VideoAnalyzer, ActiveStorage::Analyzer::AudioAnalyzer ].compact
           ActiveStorage.variant_transformer = transformer
         rescue LoadError => error
           case error.message

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -2986,8 +2986,28 @@ The default value depends on the `config.load_defaults` target version:
 Accepts an array of classes indicating the analyzers available for Active Storage blobs.
 By default, this is defined as:
 
+When the variant processor is set to `:vips`:
+
 ```ruby
-config.active_storage.analyzers = [ActiveStorage::Analyzer::ImageAnalyzer::Vips, ActiveStorage::Analyzer::ImageAnalyzer::ImageMagick, ActiveStorage::Analyzer::VideoAnalyzer, ActiveStorage::Analyzer::AudioAnalyzer]
+config.active_storage.analyzers = [ ActiveStorage::Analyzer::ImageAnalyzer::Vips, ActiveStorage::Analyzer::VideoAnalyzer, ActiveStorage::Analyzer::AudioAnalyzer ]
+```
+
+When the variant processor is set to `:mini_magick`:
+
+```ruby
+config.active_storage.analyzers = [ ActiveStorage::Analyzer::ImageAnalyzer::ImageMagick, ActiveStorage::Analyzer::VideoAnalyzer, ActiveStorage::Analyzer::AudioAnalyzer ]
+```
+
+It can also be configured to use custom analyzers:
+
+```ruby
+config.active_storage.analyzers = [ CustomAnalyzer ]
+```
+
+Finally, it can also be configured not to use any analyzers:
+
+```ruby
+config.active_storage.analyzers = []
 ```
 
 The image analyzers can extract width and height of an image blob; the video analyzer can extract width, height, duration, angle, aspect ratio, and presence/absence of video/audio channels of a video blob; the audio analyzer can extract duration and bit rate of an audio blob.

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -3930,6 +3930,26 @@ module ApplicationTests
       MESSAGE
     end
 
+    test "ActiveStorage.analyzers can be configured to be an empty array" do
+      add_to_config <<-RUBY
+        config.active_storage.analyzers = []
+      RUBY
+
+      app "development"
+
+      assert_equal [], ActiveStorage.analyzers
+    end
+
+    test "ActiveStorage.analyzers can be configured to custom analyzers" do
+      add_to_config <<-RUBY
+        config.active_storage.analyzers = [ ActiveStorage::Analyzer::ImageAnalyzer::ImageMagick ]
+      RUBY
+
+      app "development"
+
+      assert_equal [ ActiveStorage::Analyzer::ImageAnalyzer::ImageMagick ], ActiveStorage.analyzers
+    end
+
     test "ActiveStorage.draw_routes can be configured via config.active_storage.draw_routes" do
       app_file "config/environments/development.rb", <<-RUBY
         Rails.application.configure do


### PR DESCRIPTION
Previously, setting `config.active_storage.analyzers` to an empty array would still add a default analyzer to `ActiveStorage.analyzers`.

However, some applications do not require file to be analyzed and prefer to use ActiveStorage without any analyzers.

This commit resolves the issue by ensuring that no default analyzer is added when `config.active_storage.analyzers` is set to an empty value.

Fix #54391