### PR TITLE
Inline `IsolatedExecutionState#state`

### DIFF
--- a/activesupport/lib/active_support/isolated_execution_state.rb
+++ b/activesupport/lib/active_support/isolated_execution_state.rb
@@ -33,23 +33,26 @@ module ActiveSupport
       end
 
       def [](key)
-        state[key]
+        if state = @scope.current.active_support_execution_state
+          state[key]
+        end
       end
 
       def []=(key, value)
+        state = (@scope.current.active_support_execution_state ||= {})
         state[key] = value
       end
 
       def key?(key)
-        state.key?(key)
+        @scope.current.active_support_execution_state&.key?(key)
       end
 
       def delete(key)
-        state.delete(key)
+        @scope.current.active_support_execution_state&.delete(key)
       end
 
       def clear
-        state.clear
+        @scope.current.active_support_execution_state&.clear
       end
 
       def context
@@ -62,11 +65,6 @@ module ActiveSupport
         # and streaming should be rethought.
         context.active_support_execution_state = other.active_support_execution_state.dup
       end
-
-      private
-        def state
-          context.active_support_execution_state ||= {}
-        end
     end
 
     self.isolation_level = :thread


### PR DESCRIPTION
Benchmark: https://gist.github.com/byroot/3d251c007c39f85b5e0c6cb268808887

The various IsolatedExecutionState methods are unsurprisingly the hottest spot in various Rails benchmarks, so it's worth micro-optimizing them a bit.

With yjit:

```
ruby 3.4.1 (2024-12-25 revision 48d4efcb85) +YJIT +PRISM [arm64-darwin23]
Warming up --------------------------------------
                orig   268.221k i/100ms
                 opt   331.076k i/100ms
Calculating -------------------------------------
                orig      2.719M (± 0.9%) i/s  (367.72 ns/i) -     13.679M in   5.030598s
                 opt      3.278M (± 1.4%) i/s  (305.08 ns/i) -     16.554M in   5.051307s

Comparison:
                orig:  2719444.1 i/s
                 opt:  3277778.4 i/s - 1.21x  faster
```

Without YJIT:

```
ruby 3.4.1 (2024-12-25 revision 48d4efcb85) +PRISM [arm64-darwin23]
Warming up --------------------------------------
                orig   133.735k i/100ms
                 opt   260.734k i/100ms
Calculating -------------------------------------
                orig      1.343M (± 0.2%) i/s  (744.37 ns/i) -      6.820M in   5.077015s
                 opt      2.602M (± 0.7%) i/s  (384.26 ns/i) -     13.037M in   5.009746s

Comparison:
                orig:  1343411.1 i/s
                 opt:  2602392.9 i/s - 1.94x  faster
```
