### PR TITLE
No dump of the entire template when a syntax error is encountered:

### DIFF
--- a/actionview/lib/action_view/template/error.rb
+++ b/actionview/lib/action_view/template/error.rb
@@ -260,9 +260,13 @@ module ActionView
     end
 
     def message
-      <<~MESSAGE
-        Encountered a syntax error while rendering template: check #{@offending_code_string}
-      MESSAGE
+      if template.is_a?(Template::Inline)
+        <<~MESSAGE
+          Encountered a syntax error while rendering template: check #{@offending_code_string}
+        MESSAGE
+      else
+        "Encountered a syntax error while rendering template located at: #{template.short_identifier}"
+      end
     end
 
     def annotated_source_code

--- a/railties/test/application/rendering_test.rb
+++ b/railties/test/application/rendering_test.rb
@@ -86,5 +86,69 @@ module ApplicationTests
       assert_equal 200, last_response.status
       assert_equal({ format: :awesome, handler: RubbyHandler }.inspect, last_response.body)
     end
+
+    test "template content is dumped if rendered inline and a syntax error is encountered" do
+      app_file "config/routes.rb", <<-RUBY
+        Rails.application.routes.draw do
+          root to: 'pages#show'
+        end
+      RUBY
+
+      app_file "app/controllers/pages_controller.rb", <<-RUBY
+        class PagesController < ApplicationController
+          layout false
+
+          def show
+            render(inline: "<% [ %>")
+          end
+        end
+      RUBY
+
+      app("development")
+
+      get("/", {}, { "HTTPS" => "on" })
+
+      assert_equal 500, last_response.status
+      document = Nokogiri::HTML5.parse(last_response.body)
+      nodes = document.css("div.exception-message>div.message")
+
+      assert_not_empty(nodes)
+      assert_equal("Encountered a syntax error while rendering template: check <% [ %>\n", nodes.first.text)
+    end
+
+    test "template content is not dumped when rendered from file and a syntax error is encountered" do
+      app_file "config/routes.rb", <<-RUBY
+        Rails.application.routes.draw do
+          root to: 'pages#show'
+        end
+      RUBY
+
+      app_file "app/controllers/pages_controller.rb", <<-RUBY
+        class PagesController < ApplicationController
+          layout false
+
+          def show
+          end
+        end
+      RUBY
+
+      app_file "app/views/pages/show.html.erb", <<-RUBY
+        <% [ %>
+      RUBY
+
+      app("development")
+
+      get("/", {}, { "HTTPS" => "on" })
+
+      assert_equal 500, last_response.status
+      document = Nokogiri::HTML5.parse(last_response.body)
+      nodes = document.css("div.exception-message>div.message")
+
+      assert_not_empty(nodes)
+      assert_equal(
+        "Encountered a syntax error while rendering template located at: app/views/pages/show.html.erb",
+        nodes.first.text,
+      )
+    end
   end
 end


### PR DESCRIPTION

### Motivation / Background

No dump of the entire template when a syntax error is encountered:

- When rendering a erb template with a syntax error, we were previously dumping the entire content of the template file into the debug view, un-itended, un-highlighted and all in red. It really doesn't help and distract a user from seeing the actually useful stack trace.

  The only time where this could be useful is when we render a inline template (that could be dynamicallt generated), and therefore it kinda make sense to dump it's content.

  This commit prevents dumping the content of the template if rendered from a file, and will keep dumping inline content.

### Before

<img width="800" alt="image" src="https://github.com/user-attachments/assets/ec788403-99f3-4116-93a6-37e1322845f2" />


### After

<img width="1067" alt="image" src="https://github.com/user-attachments/assets/7e010249-f266-4d2e-8866-a2f709ef97ac" />



### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
