### PR TITLE
Pad a space after screenshot image path or html url for clickability

### DIFF
--- a/actionpack/lib/action_dispatch/system_testing/test_helpers/screenshot_helper.rb
+++ b/actionpack/lib/action_dispatch/system_testing/test_helpers/screenshot_helper.rb
@@ -132,8 +132,8 @@ module ActionDispatch
           end
 
           def display_image(html:, screenshot_output:)
-            message = +"[Screenshot Image]: #{image_path}\n"
-            message << +"[Screenshot HTML]: #{html_path}\n" if html
+            message = +"[Screenshot Image]: #{image_path} \n"
+            message << +"[Screenshot HTML]: #{html_path} \n" if html
 
             case screenshot_output || output_type
             when "artifact"

--- a/actionpack/test/dispatch/system_testing/screenshot_helper_test.rb
+++ b/actionpack/test/dispatch/system_testing/screenshot_helper_test.rb
@@ -80,6 +80,19 @@ class ScreenshotHelperTest < ActiveSupport::TestCase
     assert_equal "simple", @new_test.send(:output_type)
   end
 
+  test "take_screenshot saves image and shows link to it" do
+    display_image_actual = nil
+
+    Rails.stub :root, Pathname.getwd do
+      @new_test.stub :save_image, nil do
+        @new_test.stub :show, -> (img) { display_image_actual = img } do
+          @new_test.take_screenshot
+        end
+      end
+    end
+    assert_match %r|\[Screenshot Image\].+?tmp/screenshots/1_x\.png |, display_image_actual
+  end
+
   test "take_screenshot saves HTML and shows link to it when using RAILS_SYSTEM_TESTING_SCREENSHOT_HTML env" do
     original_html_setting = ENV["RAILS_SYSTEM_TESTING_SCREENSHOT_HTML"]
     ENV["RAILS_SYSTEM_TESTING_SCREENSHOT_HTML"] = "1"
@@ -97,7 +110,7 @@ class ScreenshotHelperTest < ActiveSupport::TestCase
       end
     end
     assert called_save_html
-    assert_match %r|\[Screenshot HTML\].+?tmp/screenshots/1_x\.html|, display_image_actual
+    assert_match %r|\[Screenshot HTML\].+?tmp/screenshots/1_x\.html |, display_image_actual
   ensure
     ENV["RAILS_SYSTEM_TESTING_SCREENSHOT_HTML"] = original_html_setting
   end
@@ -116,7 +129,7 @@ class ScreenshotHelperTest < ActiveSupport::TestCase
       end
     end
     assert called_save_html
-    assert_match %r|\[Screenshot HTML\].+?tmp/screenshots/1_x\.html|, display_image_actual
+    assert_match %r|\[Screenshot HTML\].+?tmp/screenshots/1_x\.html |, display_image_actual
   end
 
   test "take_screenshot allows changing screenshot display format via RAILS_SYSTEM_TESTING_SCREENSHOT env" do


### PR DESCRIPTION
Fixes #54347