### PR TITLE
ActiveStorage: implement attach!

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Implement `attach!` as a bang counterpart to `attach`.
+
+    This method raises an exception if the attachment was not saved, similar
+    to how `save!` raises an exception if an Active Record object is found to
+    be invalid prior to be persisted.
+
+    *Quentin de Metz*
+
 *   Correct unexpected behavior resulting from dependent: :purge when using
     has_one_attached or has_many_attached. Fixes #36423.
 

--- a/activestorage/lib/active_storage/attached/many.rb
+++ b/activestorage/lib/active_storage/attached/many.rb
@@ -56,6 +56,16 @@ module ActiveStorage
       record.public_send("#{name}")
     end
 
+    # Calls attach, and raises an exception if the record was meant to be saved but at least one of the validations failed.
+    #
+    #   document.images.attach!(params[:images]) # Array of ActionDispatch::Http::UploadedFile objects
+    #   document.images.attach!(params[:signed_blob_id]) # Signed reference to blob from direct upload
+    #   document.images.attach!(io: File.open("/path/to/racecar.jpg"), filename: "racecar.jpg", content_type: "image/jpeg")
+    #   document.images.attach!([ first_blob, second_blob ])
+    def attach!(*attachables)
+      attach(*attachables) || raise(ActiveRecord::RecordNotSaved.new("Failed to save the record", record))
+    end
+
     # Returns true if any attachments have been made.
     #
     #   class Gallery < ApplicationRecord

--- a/activestorage/lib/active_storage/attached/one.rb
+++ b/activestorage/lib/active_storage/attached/one.rb
@@ -69,6 +69,16 @@ module ActiveStorage
       record.public_send("#{name}")
     end
 
+    # Calls attach, and raises an exception if the record was meant to be saved but at least one of the validations failed.
+    #
+    #   person.avatar.attach!(params[:avatar]) # ActionDispatch::Http::UploadedFile object
+    #   person.avatar.attach!(params[:signed_blob_id]) # Signed reference to blob from direct upload
+    #   person.avatar.attach!(io: File.open("/path/to/face.jpg"), filename: "face.jpg", content_type: "image/jpeg")
+    #   person.avatar.attach!(avatar_blob) # ActiveStorage::Blob object
+    def attach!(attachable)
+      attach(attachable) || raise(ActiveRecord::RecordNotSaved.new("Failed to save the record", record))
+    end
+
     # Returns +true+ if an attachment has been made.
     #
     #   class User < ApplicationRecord

--- a/activestorage/test/models/attached/many_test.rb
+++ b/activestorage/test/models/attached/many_test.rb
@@ -817,6 +817,15 @@ class ActiveStorage::ManyAttachedTest < ActiveSupport::TestCase
     assert_nil return_value
   end
 
+  test "raises error when calling attach! to attach blobs to a persisted, unchanged, and invalid record" do
+    @user.update_attribute(:name, nil)
+    assert_not @user.valid?
+
+    assert_raises(ActiveRecord::RecordNotSaved) do
+      @user.highlights.attach! create_blob(filename: "racecar.jpg"), create_blob(filename: "funky.jpg"), create_blob(filename: "town.jpg")
+    end
+  end
+
   test "attaching blobs to a changed record, returns the attachments" do
     @user.name = "Tina"
     @user.highlights.attach create_blob(filename: "racecar.jpg")

--- a/activestorage/test/models/attached/one_test.rb
+++ b/activestorage/test/models/attached/one_test.rb
@@ -128,6 +128,15 @@ class ActiveStorage::OneAttachedTest < ActiveSupport::TestCase
     assert_nil return_value
   end
 
+  test "raises error when calling attach! to attach a blob to a persisted, unchanged, and invalid record" do
+    @user.update_attribute(:name, nil)
+    assert_not @user.valid?
+
+    assert_raises(ActiveRecord::RecordNotSaved) do
+      @user.avatar.attach! create_blob(filename: "funky.jpg")
+    end
+  end
+
   test "attaching a blob to a changed record, returns the attachment" do
     @user.name = "Tina"
     return_value = @user.avatar.attach create_blob(filename: "funky.jpg")


### PR DESCRIPTION
### Motivation / Background

All persistence-related ActiveRecord methods - except the ones designed to bypass validations - have a "bang" counterpart (e.g. `save` and `save!`).

ActiveStorage implements `attach` which calls `save` under the hood. However, `attach!` is not implemented.
If the caller forgets to check the return value of `attach`, the attachment may be silently lost.

This PR is an implementation of `attach!` as the "bang" counterpart of `attach`

### Detail

I took inspiration from how `ActiveRecord::Persistence#save!` is implemented.

### Additional information

(from https://guides.rubyonrails.org/active_record_basics.html#validations)

> Methods like save, create and update validate a model before persisting it to the database. If the model is invalid, no database operations are performed. In this case the save and update methods return false. The create method still returns the object, which can be checked for errors. All of these methods have a bang counterpart (that is, save!, create! and update!), which are stricter in that they raise an ActiveRecord::RecordInvalid exception when validation fails.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
