### PR TITLE
Fix child record's validation clearing the parent's errors (has_one/belongs_to)

### DIFF
--- a/activerecord/lib/active_record/autosave_association.rb
+++ b/activerecord/lib/active_record/autosave_association.rb
@@ -332,8 +332,8 @@ module ActiveRecord
         return unless record && (record.changed_for_autosave? || custom_validation_context?)
 
         inverse_association = reflection.inverse_of && record.association(reflection.inverse_of.name)
-        return if inverse_association && (record.validating_belongs_to_for?(inverse_association) ||
-          record.autosaving_belongs_to_for?(inverse_association))
+
+        return if inverse_association && record.autosaving_belongs_to_for?(inverse_association)
 
         association_valid?(association, record)
       end

--- a/activerecord/test/cases/associations/nested_error_test.rb
+++ b/activerecord/test/cases/associations/nested_error_test.rb
@@ -3,6 +3,8 @@
 require "cases/helper"
 require "models/guitar"
 require "models/tuning_peg"
+require "models/ship"
+require "models/pirate"
 
 class AssociationsNestedErrorInAssociationOrderTest < ActiveRecord::TestCase
   test "index in association order" do
@@ -111,6 +113,21 @@ class AssociationsNestedErrorInNestedAttributesOrderTest < ActiveRecord::TestCas
       assert_equal owner, error.base
     ensure
       ActiveRecord.index_nested_attribute_errors = old_attribute_config
+    end
+
+    test "errors still present after nested model validated" do
+      pirate = Pirate.new catchphrase: "Barely an inconvenience!", ship_attributes: { name: nil }
+
+      assert_predicate pirate, :invalid?
+
+      error = pirate.errors.first.dup
+      assert_equal ActiveRecord::Associations::NestedError, error.class
+      assert_equal pirate.ship.errors.first, error.inner_error
+
+      # Should not affect pirate's errors
+      pirate.ship.valid?
+
+      assert_equal pirate.errors.objects, [error]
     end
   end
 end

--- a/activerecord/test/cases/autosave_association_test.rb
+++ b/activerecord/test/cases/autosave_association_test.rb
@@ -365,10 +365,10 @@ class TestDefaultAutosaveAssociationOnAHasOneAssociation < ActiveRecord::TestCas
 
   def test_callbacks_on_child_when_polymorphic_child_with_inverse_of_autosaves_parent
     chef = ChefWithPolymorphicInverseOf.create!(employable: DrinkDesigner.new)
-    assert_equal 1, chef.before_validation_callbacks_counter
+    assert_equal 2, chef.before_validation_callbacks_counter
     assert_equal 1, chef.before_create_callbacks_counter
     assert_equal 1, chef.before_save_callbacks_counter
-    assert_equal 1, chef.after_validation_callbacks_counter
+    assert_equal 2, chef.after_validation_callbacks_counter
     assert_equal 1, chef.after_create_callbacks_counter
     assert_equal 1, chef.after_save_callbacks_counter
   end


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created because I wanted to try fixing a bug, specifically FIXES #54367

I don't have a particular need for the bug to be fixed, I'm just trying to get more familiar with Rails.

### Detail

This Pull Request changes the validation logic on `has_one/belongs_to` associations to allow validation of `has_one`'s inverse while the `belongs_to` record is being validated.

Let `pirate` be the `has_one` side and `ship` be the `belongs_to` side. Ship's attributes have errors, pirate's do not.

Step 1:
- `pirate.valid?` -> pirate is validated -> pirate validates ship -> pirate now has ship's nested error

From my understanding, the way this worked before this PR was:
Step 2:
- `ship.valid?` 
  - -> ship is validated, sets a flag that belongs_to association is being validated
  - -> ship validates pirate
    - -> pirate sees that belongs_to association flag is up, does not validate ship
    - -> **pirate has no errors**

With this change:
Step 2:
- `ship.valid?` 
  - -> ship is validated, sets a flag that belongs_to association is being validated
  - -> ship validates pirate
    - -> pirate does not check flag
    - -> pirate validates ship
      - -> ship sees the belongs_to association flag is set, does not validate pirate
      - -> ship gets error on `:name`
    - -> pirate has a nested error on `ship.name`
  - -> **ship has a nested error on `pirate.ship.name`**

This seems to be consistent with 7.2.2. I confirmed manually by using the gist on the issue and changing the test:
```ruby
  def test_association_stuff
    dojo = Dojo.new({"master_attributes"=>{"name"=>""}})
    assert_equal false, dojo.valid?
    assert_equal 1, dojo.master.errors.count
    p dojo.master.errors
    assert_equal false, dojo.master.valid? # Call to dojo.master.valid? unexpectedly clears dojo.errors with Rails 8.0.1
    assert_equal 1, dojo.errors.count
    p dojo.master.errors
    assert_equal 2, dojo.master.errors.count
    assert_equal dojo.master.errors.objects.last.attribute, :"dojo.master.name"
  end

```

The outcome is the same on my branch and on 7.2.2. **If I should make an attempt to avoid the double validation of the `belongs_to` side, please let me know and I will try to make the change.**
  
### Additional information

Please see the gist posted on the issue.

This is my first time reading or modifying significant (and it was significant :weary:) amounts of Rails source code. It's also my first PR here, hopefully of many to come.

That said please don't feel the need to be pleasant, I'm willing to put in time to get this done right. I don't take offense at being told my code is bad or that I should make more changes, be as rude as you want.

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [X] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
