### PR TITLE
Explicitly call I18n.exception_handler on missing translation

### DIFF
--- a/actionview/lib/action_view/helpers/translation_helper.rb
+++ b/actionview/lib/action_view/helpers/translation_helper.rb
@@ -140,7 +140,12 @@ module ActionView
         end
 
         def missing_translation(key, options)
-          keys = I18n.normalize_keys(options[:locale] || I18n.locale, key, options[:scope])
+          locale = options[:locale] || I18n.locale
+
+          i18n_exception = I18n::MissingTranslation.new(locale, key, options)
+          I18n.exception_handler.call(i18n_exception, locale, key, options)
+
+          keys = I18n.normalize_keys(locale, key, options[:scope])
 
           title = +"translation missing: #{keys.join(".")}"
 


### PR DESCRIPTION
Fix: https://github.com/rails/rails/issues/54419

Since `TranslationHelper#translate` always sets a `default`, missing translation is never considered like an error by `I18n` and the error handler is never called.

This makes I18n's exception handler pretty much unusable.

The solution is to explicitly call it ourselves, but the downside is we need to allocate that exception, which isn't free, but supposedly it's not expected to happen often.

Not sure if it is something we want to backport, though. Probably not.