### PR TITLE
Refactor ActiveRecord Signed ID to use global `Rails.application.message_verifiers`

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,83 @@
+*   Allow signed ID verifiers to be configurable via `Rails.application.message_verifiers`
+
+    Prior to this change, the primary way to configure signed ID verifiers was
+    to set `signed_id_verifier` on each model class:
+
+      ```ruby
+      Post.signed_id_verifier = ActiveSupport::MessageVerifier.new(...)
+      Comment.signed_id_verifier = ActiveSupport::MessageVerifier.new(...)
+      ```
+
+    And if the developer did not set `signed_id_verifier`, a verifier would be
+    instantiated with a secret derived from `secret_key_base` and the following
+    options:
+
+      ```ruby
+      { digest: "SHA256", serializer: JSON, url_safe: true }
+      ```
+
+    Thus it was cumbersome to rotate configuration for all verifiers.
+
+    This change defines a new Rails config: [`config.active_record.use_legacy_signed_id_verifier`][].
+    The default value is `:generate_and_verify`, which preserves the previous
+    behavior. However, when set to `:verify`, signed ID verifiers will use
+    configuration from `Rails.application.message_verifiers` (specifically,
+    `Rails.application.message_verifiers["active_record/signed_id"]`) to
+    generate and verify signed IDs, but will also verify signed IDs using the
+    older configuration.
+
+    To avoid complication, the new behavior only applies when `signed_id_verifier_secret`
+    is not set on a model class or any of its ancestors. Additionally,
+    `signed_id_verifier_secret` is now deprecated. If you are currently setting
+    `signed_id_verifier_secret` on a model class, you can set `signed_id_verifier`
+    instead:
+
+      ```ruby
+      # BEFORE
+      Post.signed_id_verifier_secret = "my secret"
+
+      # AFTER
+      Post.signed_id_verifier = ActiveSupport::MessageVerifier.new("my secret", digest: "SHA256", serializer: JSON, url_safe: true)
+      ```
+
+    To ease migration, `signed_id_verifier` has also been changed to behave as a
+    `class_attribute` (i.e. inheritable), but _only when `signed_id_verifier_secret`
+    is not set_:
+
+      ```ruby
+      # BEFORE
+      ActiveRecord::Base.signed_id_verifier = ActiveSupport::MessageVerifier.new(...)
+      Post.signed_id_verifier == ActiveRecord::Base.signed_id_verifier # => false
+
+      # AFTER
+      ActiveRecord::Base.signed_id_verifier = ActiveSupport::MessageVerifier.new(...)
+      Post.signed_id_verifier == ActiveRecord::Base.signed_id_verifier # => true
+
+      Post.signed_id_verifier_secret = "my secret" # => deprecation warning
+      Post.signed_id_verifier == ActiveRecord::Base.signed_id_verifier # => false
+      ```
+
+    Note, however, that it is recommended to eventually migrate from
+    model-specific verifiers to a unified configuration managed by
+    `Rails.application.message_verifiers`. `ActiveSupport::MessageVerifier#rotate`
+    can facilitate that transition. For example:
+
+      ```ruby
+      # BEFORE
+      # Generate and verify signed Post IDs using Post-specific configuration
+      Post.signed_id_verifier = ActiveSupport::MessageVerifier.new("post secret", ...)
+
+      # AFTER
+      # Generate and verify signed Post IDs using the unified configuration
+      Post.signed_id_verifier = Post.signed_id_verifier.dup
+      # Fall back to Post-specific configuration when verifying signed IDs
+      Post.signed_id_verifier.rotate("post secret", ...)
+      ```
+
+    [`config.active_record.use_legacy_signed_id_verifier`]: https://guides.rubyonrails.org/v8.1/configuring.html#config-active-record-use-legacy-signed-id-verifier
+
+    *Ali Sepehri*, *Jonathan Hefner*
+
 *   Prepend `extra_flags` in postgres' `structure_load`
 
     When specifying `structure_load_flags` with a postgres adapter, the flags

--- a/activerecord/lib/active_record.rb
+++ b/activerecord/lib/active_record.rb
@@ -506,6 +506,13 @@ module ActiveRecord
     }
   )
 
+  ##
+  # :singleton-method: message_verifiers
+  #
+  # ActiveSupport::MessageVerifiers instance for Active Record. If you are using
+  # Rails, this will be set to +Rails.application.message_verifiers+.
+  singleton_class.attr_accessor :message_verifiers
+
   def self.eager_load!
     super
     ActiveRecord::Locking.eager_load!

--- a/activerecord/lib/active_record/railtie.rb
+++ b/activerecord/lib/active_record/railtie.rb
@@ -38,6 +38,7 @@ module ActiveRecord
     config.active_record.raise_on_assign_to_attr_readonly = false
     config.active_record.belongs_to_required_validates_foreign_key = true
     config.active_record.generate_secure_token_on = :create
+    config.active_record.use_legacy_signed_id_verifier = :generate_and_verify
 
     config.active_record.queues = ActiveSupport::InheritableOptions.new
 
@@ -233,6 +234,7 @@ To keep using the current cache store, you can turn off cache versioning entirel
           :check_schema_cache_dump_version,
           :use_schema_cache_dump,
           :postgresql_adapter_decode_dates,
+          :use_legacy_signed_id_verifier,
         )
 
         configs_used_in_other_initializers.each do |k, v|
@@ -319,9 +321,18 @@ To keep using the current cache store, you can turn off cache versioning entirel
       end
     end
 
-    initializer "active_record.set_signed_id_verifier_secret" do
-      ActiveSupport.on_load(:active_record) do
-        self.signed_id_verifier_secret ||= -> { Rails.application.key_generator.generate_key("active_record/signed_id") }
+    initializer "active_record.configure_message_verifiers" do |app|
+      ActiveRecord.message_verifiers = app.message_verifiers
+
+      use_legacy_signed_id_verifier = app.config.active_record.use_legacy_signed_id_verifier
+      legacy_options = { digest: "SHA256", serializer: JSON, url_safe: true }
+
+      if use_legacy_signed_id_verifier == :generate_and_verify
+        app.message_verifiers.prepend { |salt| legacy_options if salt == "active_record/signed_id" }
+      elsif use_legacy_signed_id_verifier == :verify
+        app.message_verifiers.rotate { |salt| legacy_options if salt == "active_record/signed_id" }
+      elsif use_legacy_signed_id_verifier
+        raise ArgumentError, "Unrecognized value for config.active_record.use_legacy_signed_id_verifier: #{use_legacy_signed_id_verifier.inspect}"
       end
     end
 

--- a/activerecord/test/cases/signed_id_test.rb
+++ b/activerecord/test/cases/signed_id_test.rb
@@ -6,10 +6,6 @@ require "models/company"
 require "models/toy"
 require "models/matey"
 
-SIGNED_ID_VERIFIER_TEST_SECRET = -> { "This is normally set by the railtie initializer when used with Rails!" }
-
-ActiveRecord::Base.signed_id_verifier_secret = SIGNED_ID_VERIFIER_TEST_SECRET
-
 class SignedIdTest < ActiveRecord::TestCase
   class GetSignedIDInCallback < ActiveRecord::Base
     self.table_name = "accounts"
@@ -25,8 +21,15 @@ class SignedIdTest < ActiveRecord::TestCase
   fixtures :accounts, :toys, :companies
 
   setup do
+    @original_message_verifiers = ActiveRecord.message_verifiers
+    ActiveRecord.message_verifiers = ActiveSupport::MessageVerifiers.new { "secret" }.rotate_defaults
+
     @account = Account.first
     @toy = Toy.first
+  end
+
+  teardown do
+    ActiveRecord.message_verifiers = @original_message_verifiers
   end
 
   test "find signed record" do
@@ -156,71 +159,106 @@ class SignedIdTest < ActiveRecord::TestCase
     end
   end
 
-  test "fail to work without a signed_id_verifier_secret" do
-    ActiveRecord::Base.signed_id_verifier_secret = nil
-    Account.instance_variable_set :@signed_id_verifier, nil
-
-    assert_raises(ArgumentError) do
-      @account.signed_id
+  test "deprecation warning for setting signed_id_verifier_secret" do
+    assert_deprecated(ActiveRecord.deprecator) do
+      ActiveRecord::Base.signed_id_verifier_secret = "new secret"
     end
   ensure
-    ActiveRecord::Base.signed_id_verifier_secret = SIGNED_ID_VERIFIER_TEST_SECRET
+    ActiveRecord.deprecator.silence do
+      ActiveRecord::Base.signed_id_verifier_secret = nil
+    end
   end
 
-  test "fail to work without when signed_id_verifier_secret lambda is nil" do
-    ActiveRecord::Base.signed_id_verifier_secret = -> { nil }
-    Account.instance_variable_set :@signed_id_verifier, nil
+  test "fail to work when signed_id_verifier_secret lambda is nil" do
+    @original_secret = ActiveRecord::Base.signed_id_verifier_secret
+
+    ActiveRecord.deprecator.silence do
+      ActiveRecord::Base.signed_id_verifier_secret = -> { nil }
+    end
 
     assert_raises(ArgumentError) do
-      @account.signed_id
+      model.signed_id
     end
   ensure
-    ActiveRecord::Base.signed_id_verifier_secret = SIGNED_ID_VERIFIER_TEST_SECRET
+    ActiveRecord.deprecator.silence do
+      ActiveRecord::Base.signed_id_verifier_secret = @original_secret
+    end
   end
 
-  test "always output url_safe" do
-    signed_id = @account.signed_id(purpose: "~~~~~~~~~")
-    assert_not signed_id.include?("+")
+  test "signed_id_verifier is ActiveRecord.message_verifiers['active_record/signed_id'] by default" do
+    assert_same ActiveRecord.message_verifiers["active_record/signed_id"], model_class.signed_id_verifier
   end
 
-  test "use a custom verifier" do
-    old_verifier = Account.signed_id_verifier
-    Account.signed_id_verifier = ActiveSupport::MessageVerifier.new("sekret")
-    assert_not_equal ActiveRecord::Base.signed_id_verifier, Account.signed_id_verifier
-    assert_equal @account, Account.find_signed(@account.signed_id)
-  ensure
-    Account.signed_id_verifier = old_verifier
+  test "signed_id raises when ActiveRecord.message_verifiers has not been set" do
+    ActiveRecord.message_verifiers = nil
+
+    assert_raises(match: /to use signed IDs/) do
+      model.signed_id
+    end
+  end
+
+  test "using custom signed_id_verifier" do
+    model_class.signed_id_verifier = ActiveSupport::MessageVerifier.new("custom secret")
+    assert_equal model, model_class.find_signed(model.signed_id)
+  end
+
+  test "signed_id_verifier behaves as class_attribute" do
+    assert_same ActiveRecord::Base.signed_id_verifier, model_class.signed_id_verifier
+    assert_same model_class.signed_id_verifier, model_subclass.signed_id_verifier
+
+    model_class.signed_id_verifier = ActiveSupport::MessageVerifier.new("secret")
+
+    assert_not_same ActiveRecord::Base.signed_id_verifier, model_class.signed_id_verifier
+    assert_same model_class.signed_id_verifier, model_subclass.signed_id_verifier
+  end
+
+  test "when signed_id_verifier_secret is set, signed_id_verifier behaves as singleton instance variable" do
+    ActiveRecord.deprecator.silence do
+      model_class.signed_id_verifier_secret = "secret"
+    end
+
+    assert_no_changes -> { [ActiveRecord::Base.signed_id_verifier, model_subclass.signed_id_verifier] } do
+      model_class.signed_id_verifier = ActiveSupport::MessageVerifier.new("secret")
+    end
+  end
+
+  test "when signed_id_verifier_secret is set, signed_id_verifier uses legacy options by default" do
+    ActiveRecord.deprecator.silence do
+      model_class.signed_id_verifier_secret = "secret"
+    end
+
+    legacy_verifier = ActiveSupport::MessageVerifier.new("secret", digest: "SHA256", serializer: JSON, url_safe: true)
+
+    assert_equal "message", legacy_verifier.verify(model_class.signed_id_verifier.generate("message"))
+    assert_equal "message", model_class.signed_id_verifier.verify(legacy_verifier.generate("message"))
   end
 
   test "on_rotation callback using custom verifier" do
-    old_verifier = Account.signed_id_verifier
+    model_class.signed_id_verifier = ActiveSupport::MessageVerifier.new("old secret")
+    old_signed_id = model.signed_id
 
-    Account.signed_id_verifier = ActiveSupport::MessageVerifier.new("old secret")
-    old_account_signed_id = @account.signed_id
     on_rotation_is_called = false
-    Account.signed_id_verifier = ActiveSupport::MessageVerifier.new("new secret", on_rotation: -> { on_rotation_is_called = true })
-    Account.signed_id_verifier.rotate("old secret")
-    Account.find_signed(old_account_signed_id)
+    model_class.signed_id_verifier = ActiveSupport::MessageVerifier.new("new secret", on_rotation: -> { on_rotation_is_called = true })
+    model_class.signed_id_verifier.rotate("old secret")
+
+    model_class.find_signed(old_signed_id)
     assert on_rotation_is_called
-  ensure
-    Account.signed_id_verifier = old_verifier
   end
 
   test "on_rotation callback using find_signed & find_signed!" do
-    old_verifier = Account.signed_id_verifier
+    model_class.signed_id_verifier = ActiveSupport::MessageVerifier.new("old secret")
+    old_signed_id = model.signed_id
 
-    Account.signed_id_verifier = ActiveSupport::MessageVerifier.new("old secret")
-    old_account_signed_id = @account.signed_id
-    Account.signed_id_verifier = ActiveSupport::MessageVerifier.new("new secret")
-    Account.signed_id_verifier.rotate("old secret")
+    model_class.signed_id_verifier = ActiveSupport::MessageVerifier.new("new secret")
+    model_class.signed_id_verifier.rotate("old secret")
+
     on_rotation_is_called = false
-    assert Account.find_signed(old_account_signed_id, on_rotation: -> { on_rotation_is_called = true })
+    assert model_class.find_signed(old_signed_id, on_rotation: -> { on_rotation_is_called = true })
     assert on_rotation_is_called
+
     on_rotation_is_called = false
-    assert Account.find_signed!(old_account_signed_id, on_rotation: -> { on_rotation_is_called = true })
+    assert model_class.find_signed!(old_signed_id, on_rotation: -> { on_rotation_is_called = true })
     assert on_rotation_is_called
-  ensure
-    Account.signed_id_verifier = old_verifier
   end
 
   test "cannot get a signed ID for a new record" do
@@ -232,4 +270,17 @@ class SignedIdTest < ActiveRecord::TestCase
   test "can get a signed ID in an after_create" do
     assert_not_nil GetSignedIDInCallback.create.signed_id_from_callback
   end
+
+  private
+    def model_class
+      @model_class ||= Class.new(Account)
+    end
+
+    def model_subclass
+      @model_subclass ||= Class.new(model_class)
+    end
+
+    def model
+      @model ||= model_class.first
+    end
 end

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -1697,6 +1697,28 @@ required:
 config.active_record.database_cli = { postgresql: "pgcli", mysql: %w[ mycli mysql ] }
 ```
 
+#### `config.active_record.use_legacy_signed_id_verifier`
+
+Controls whether signed IDs are generated and verified using legacy options. Can be set to:
+
+* `:generate_and_verify` (default) - Generate and verify signed IDs using the following legacy options:
+
+    ```ruby
+    { digest: "SHA256", serializer: JSON, url_safe: true }
+    ```
+
+* `:verify` - Generate and verify signed IDs using options from [`Rails.application.message_verifiers`][], but fall back to verifying with the same options as `:generate_and_verify`.
+
+* false - Generate and verify signed IDs using options from [`Rails.application.message_verifiers`][] only.
+
+The purpose of this setting is to provide a smooth transition to a unified configuration for all message verifiers. Having a unified configuration makes it more straightforward to rotate secrets and upgrade signing algorithms.
+
+WARNING: Setting this to false may cause old signed IDs to become unreadable if `Rails.application.message_verifiers` is not properly configured. Use [`MessageVerifiers#rotate`][ActiveSupport::MessageVerifiers#rotate] or [`MessageVerifiers#prepend`][ActiveSupport::MessageVerifiers#prepend] to configure `Rails.application.message_verifiers` with the appropriate options, such as `:digest` and `:url_safe`.
+
+[`Rails.application.message_verifiers`]: https://api.rubyonrails.org/classes/Rails/Application.html#method-i-message_verifiers
+[ActiveSupport::MessageVerifiers#rotate]: https://api.rubyonrails.org/classes/ActiveSupport/MessageVerifiers.html#method-i-rotate
+[ActiveSupport::MessageVerifiers#prepend]: https://api.rubyonrails.org/classes/ActiveSupport/MessageVerifiers.html#method-i-prepend
+
 #### `ActiveRecord::ConnectionAdapters::Mysql2Adapter.emulate_booleans` and `ActiveRecord::ConnectionAdapters::TrilogyAdapter.emulate_booleans`
 
 Controls whether the Active Record MySQL adapter will consider all `tinyint(1)` columns as booleans. Defaults to `true`.

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -2929,6 +2929,85 @@ module ApplicationTests
       assert_equal false, ActiveRecord::Base.run_commit_callbacks_on_first_saved_instances_in_transaction
     end
 
+    test "config.active_record.use_legacy_signed_id_verifier is :generate_and_verify by default for new apps" do
+      app "development"
+
+      assert_equal :generate_and_verify, Rails.application.config.active_record.use_legacy_signed_id_verifier
+    end
+
+    test "Rails.application.message_verifiers['active_record/signed_id'] generates and verifies messages using legacy options when config.active_record.use_legacy_signed_id_verifier is :generate_and_verify" do
+      add_to_config <<-RUBY
+        config.active_record.use_legacy_signed_id_verifier = :generate_and_verify
+        config.secret_key_base = "secret"
+      RUBY
+
+      app "development"
+
+      signed_id_verifier = Rails.application.message_verifiers["active_record/signed_id"]
+
+      secret = app.key_generator.generate_key("active_record/signed_id")
+      legacy_verifier = ActiveSupport::MessageVerifier.new(secret, digest: "SHA256", serializer: JSON, url_safe: true)
+
+      assert_equal "message", legacy_verifier.verify(signed_id_verifier.generate("message"))
+      assert_equal "message", signed_id_verifier.verify(legacy_verifier.generate("message"))
+    end
+
+    test "Rails.application.message_verifiers['active_record/signed_id'] verifies messages using legacy options when config.active_record.use_legacy_signed_id_verifier is :verify" do
+      add_to_config <<-RUBY
+        config.active_record.use_legacy_signed_id_verifier = :verify
+        config.secret_key_base = "secret"
+      RUBY
+
+      app "development"
+
+      signed_id_verifier = Rails.application.message_verifiers["active_record/signed_id"]
+
+      secret = app.key_generator.generate_key("active_record/signed_id")
+      legacy_verifier = ActiveSupport::MessageVerifier.new(secret, digest: "SHA256", serializer: JSON, url_safe: true)
+
+      assert_equal "message", signed_id_verifier.verify(legacy_verifier.generate("message"))
+      assert_raises ActiveSupport::MessageVerifier::InvalidSignature do
+        legacy_verifier.verify(signed_id_verifier.generate("message"))
+      end
+    end
+
+    test "Rails.application.message_verifiers['active_record/signed_id'] does not use legacy options when config.active_record.use_legacy_signed_id_verifier is false" do
+      add_to_config <<-RUBY
+        config.active_record.use_legacy_signed_id_verifier = false
+        config.secret_key_base = "secret"
+      RUBY
+
+      app "development"
+
+      signed_id_verifier = Rails.application.message_verifiers["active_record/signed_id"]
+
+      secret = app.key_generator.generate_key("active_record/signed_id")
+      legacy_verifier = ActiveSupport::MessageVerifier.new(secret, digest: "SHA256", serializer: JSON, url_safe: true)
+
+      assert_raises ActiveSupport::MessageVerifier::InvalidSignature do
+        signed_id_verifier.verify(legacy_verifier.generate("message"))
+      end
+      assert_raises ActiveSupport::MessageVerifier::InvalidSignature do
+        legacy_verifier.verify(signed_id_verifier.generate("message"))
+      end
+    end
+
+    test "raises when config.active_record.use_legacy_signed_id_verifier has invalid value" do
+      add_to_config <<-RUBY
+        config.active_record.use_legacy_signed_id_verifier = :invalid_option
+      RUBY
+
+      assert_raise(match: /config.active_record.use_legacy_signed_id_verifier/) do
+        app "development"
+      end
+    end
+
+    test "ActiveRecord.message_verifiers is Rails.application.message_verifiers" do
+      app "development"
+
+      assert_same Rails.application.message_verifiers, ActiveRecord.message_verifiers
+    end
+
     test "PostgresqlAdapter.decode_dates is true by default for new apps" do
       app_file "config/initializers/active_record.rb", <<~RUBY
         ActiveRecord::Base.establish_connection(adapter: "postgresql")


### PR DESCRIPTION
### Ref: #54357 

This change ensures a unified configuration for all message verifiers, making it easier to rotate secrets and upgrade signing algorithms. See [message_verifiers](https://api.rubyonrails.org/classes/Rails/Application.html#method-i-message_verifiers) for more details.

### Details  
As suggested by @jonathanhefner [here](https://github.com/rails/rails/pull/54371/files#r1931046047), the best approach to resolve **issue #54357** is to use **MessageVerifiers**, similar to how `generated_token_verifier` was implemented previously.  

`config.active_record.use_legacy_signed_id_verifier` provides a smooth transition to this goal. It can be set to:

- `:generate_and_verify` (default) - Generate and verify signed IDs using the following legacy options:

```ruby
  { digest: "SHA256", serializer: JSON, url_safe: true }
```

- `:verify` - Generate and verify signed IDs using options from `Rails.application.message_verifiers`, but fall back to verifying with the same options as `:generate_and_verify`.

- `false` - Generate and verify signed IDs using options from `Rails.application.message_verifiers` only.

> **WARNING:** If `ActiveRecord::Base.signed_id_verifier_secret` is set in your application, Signed ID will not use global `message_verifiers`. 

---
These changes will enable proper usage of `rotate` and `on_rotation` as shown in the example below:  

```ruby
# Rotate verifier for Signed ID
Rails.application.message_verifiers.rotate do |salt|
  next nil if salt != 'active_record/signed_id'

  secret_generator = ->(_) { 'old_secret' }
  { secret_generator: secret_generator, digest: "SHA256", serializer: JSON, url_safe: true }
end

# Enable `transitional` mode for rolling deployment
Rails.application.message_verifiers.transitional = true

# `on_rotation` callback to log the usage of old verifiers
Rails.application.message_verifiers.on_rotation do
  puts "Old verifier used for verifying! Still in use!"
end
```

### Todos
- [x] Determine the Rails version in which the deprecated `signed_id_verifier_secret` will be removed.
- [x] Add tests for `railtie.rb` changes
- [x] Ensure CI passes
- [x] Update documentation
- [x] Update CHANGELOG.md file
