### PR TITLE
Correct generated ID values in fixture docs [ci skip]

### DIFF
--- a/activerecord/lib/active_record/fixtures.rb
+++ b/activerecord/lib/active_record/fixtures.rb
@@ -242,10 +242,10 @@ module ActiveRecord
   # and one for the humans. Why don't we generate the primary key instead?
   # Hashing each fixture's label yields a consistent ID:
   #
-  #   george: # generated id: 503576764
+  #   george: # generated id: 380982691
   #     name: George the Monkey
   #
-  #   reginald: # generated id: 324201669
+  #   reginald: # generated id: 41001176
   #     name: Reginald the Pirate
   #
   # Active Record looks at the fixture's model class, discovers the correct


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because the documentation for the "Stable, Autogenerated IDs" feature in fixtures has incorrect information about the IDs generated for two particular fixture names. I found it confusing when I was experimenting with the feature and trying to understand it.

### Detail

This Pull Request changes the IDs that the documentation says are associated with two fixture names. See the console output below.

```
3.3.6 :001 > ActiveRecord::FixtureSet.identify(:george)
 => 380982691 
3.3.6 :002 > ActiveRecord::FixtureSet.identify(:reginald)
 => 41001176 
```

### Additional information

The previous values for these IDs appear to have been added in https://github.com/rails/rails/commit/49eafd8c3620bf8e46d21d447fc634a12c8280ab, when the IDs would have been generated by the code `label.to_s.hash.abs`. I assume the values were correct at the time for someone's environment, but in https://github.com/rails/rails/commit/87adecfef59577be17a9731245cb201ecb1b477f the generation code was changed to use `Zlib.crc32`, which would have changed the IDs generated for the fixtures `:george` and `:reginald`. The IDs listed in the documentation were not updated, however.

It'd be easy for this to become out of date again if `ActiveRecord::FixtureSet.identify` changes. Possibly this section could be rewritten so that specific numbers don't need to be listed to get the point across.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
