### PR TITLE
Run tests with --profile in CI

### DIFF
--- a/actioncable/Rakefile
+++ b/actioncable/Rakefile
@@ -15,6 +15,7 @@ Rake::TestTask.new do |t|
   t.test_files = FileList["#{__dir__}/test/**/*_test.rb"]
   t.warning = true
   t.verbose = true
+  t.options = "--profile" if ENV["CI"]
   t.ruby_opts = ["--dev"] if defined?(JRUBY_VERSION)
 end
 

--- a/actionmailbox/Rakefile
+++ b/actionmailbox/Rakefile
@@ -10,6 +10,7 @@ Rake::TestTask.new do |t|
   t.libs << "test"
   t.pattern = "test/**/*_test.rb"
   t.verbose = true
+  t.options = "--profile" if ENV["CI"]
 end
 
 namespace :test do

--- a/actionmailer/Rakefile
+++ b/actionmailer/Rakefile
@@ -13,6 +13,7 @@ Rake::TestTask.new { |t|
   t.pattern = "test/**/*_test.rb"
   t.warning = true
   t.verbose = true
+  t.options = "--profile" if ENV["CI"]
   t.ruby_opts = ["--dev"] if defined?(JRUBY_VERSION)
 }
 

--- a/actionpack/Rakefile
+++ b/actionpack/Rakefile
@@ -16,6 +16,7 @@ Rake::TestTask.new do |t|
 
   t.warning = true
   t.verbose = true
+  t.options = "--profile" if ENV["CI"]
   t.ruby_opts = ["--dev"] if defined?(JRUBY_VERSION)
 end
 

--- a/actiontext/Rakefile
+++ b/actiontext/Rakefile
@@ -10,12 +10,14 @@ Rake::TestTask.new do |t|
   t.libs << "test"
   t.test_files = FileList["test/**/*_test.rb"].exclude("test/system/**/*", "test/dummy/**/*")
   t.verbose = true
+  t.options = "--profile" if ENV["CI"]
 end
 
 Rake::TestTask.new "test:system" do |t|
   t.libs << "test"
   t.test_files = FileList["test/system/**/*_test.rb"]
   t.verbose = true
+  t.options = "--profile" if ENV["CI"]
 end
 
 namespace :test do

--- a/actionview/Rakefile
+++ b/actionview/Rakefile
@@ -27,6 +27,7 @@ namespace :test do
     t.test_files = FileList["test/template/**/*_test.rb"]
     t.warning = true
     t.verbose = true
+    t.options = "--profile" if ENV["CI"]
     t.ruby_opts = ["--dev"] if defined?(JRUBY_VERSION)
   end
 
@@ -37,6 +38,7 @@ namespace :test do
       t.test_files = FileList["test/activerecord/*_test.rb"]
       t.warning = true
       t.verbose = true
+      t.options = "--profile" if ENV["CI"]
       t.ruby_opts = ["--dev"] if defined?(JRUBY_VERSION)
     end
 
@@ -46,6 +48,7 @@ namespace :test do
       t.test_files = FileList["test/actionpack/**/*_test.rb"]
       t.warning = true
       t.verbose = true
+      t.options = "--profile" if ENV["CI"]
       t.ruby_opts = ["--dev"] if defined?(JRUBY_VERSION)
     end
   end

--- a/activejob/Rakefile
+++ b/activejob/Rakefile
@@ -41,6 +41,7 @@ namespace :test do
           (x.include?("async") && adapter != "async")
       }
       t.verbose = true
+      t.options = "--profile" if ENV["CI"]
       t.warning = true
       t.ruby_opts = ["--dev"] if defined?(JRUBY_VERSION)
     end
@@ -62,6 +63,7 @@ namespace :test do
         t.libs << "test"
         t.test_files = FileList["test/integration/**/*_test.rb"]
         t.verbose = true
+        t.options = "--profile" if ENV["CI"]
         t.warning = true
         t.ruby_opts = ["--dev"] if defined?(JRUBY_VERSION)
       end

--- a/activemodel/Rakefile
+++ b/activemodel/Rakefile
@@ -11,6 +11,7 @@ Rake::TestTask.new do |t|
   t.test_files = FileList["#{__dir__}/test/cases/**/*_test.rb"]
   t.warning = true
   t.verbose = true
+  t.options = "--profile" if ENV["CI"]
   t.ruby_opts = ["--dev"] if defined?(JRUBY_VERSION)
 end
 

--- a/activerecord/Rakefile
+++ b/activerecord/Rakefile
@@ -45,6 +45,7 @@ namespace :test do
 
     t.warning = true
     t.verbose = true
+    t.options = "--profile" if ENV["CI"]
   end
 end
 
@@ -69,6 +70,7 @@ end
       t.test_files = files
       t.warning = true
       t.verbose = true
+      t.options = "--profile" if ENV["CI"]
       t.ruby_opts = ["--dev"] if defined?(JRUBY_VERSION)
     end
 
@@ -80,6 +82,7 @@ end
           t.test_files = FileList["test/activejob/*_test.rb"]
           t.warning = true
           t.verbose = true
+          t.options = "--profile" if ENV["CI"]
           t.ruby_opts = ["--dev"] if defined?(JRUBY_VERSION)
         end
       end
@@ -186,6 +189,7 @@ end
 
           t.warning = true
           t.verbose = true
+          t.options = "--profile" if ENV["CI"]
           t.ruby_opts = ["--dev"] if defined?(JRUBY_VERSION)
         end
       end

--- a/activestorage/Rakefile
+++ b/activestorage/Rakefile
@@ -11,6 +11,7 @@ Rake::TestTask.new do |t|
   t.libs << "test"
   t.test_files = FileList["test/**/*_test.rb"]
   t.verbose = true
+  t.options = "--profile" if ENV["CI"]
   t.warning = true
 end
 

--- a/activesupport/Rakefile
+++ b/activesupport/Rakefile
@@ -10,6 +10,7 @@ Rake::TestTask.new do |t|
   t.pattern = "test/**/*_test.rb"
   t.warning = true
   t.verbose = true
+  t.options = "--profile" if ENV["CI"]
   t.ruby_opts = ["--dev"] if defined?(JRUBY_VERSION)
 end
 

--- a/railties/Rakefile
+++ b/railties/Rakefile
@@ -71,6 +71,7 @@ namespace :test do
 
     dirs = (ENV["TEST_DIR"] || ENV["TEST_DIRS"] || "**").split(",")
     test_options = ENV["TESTOPTS"].to_s.split(/[\s]+/)
+    test_options << "--profile" if ENV["CI"]
 
     test_patterns = dirs.map { |dir| "test/#{dir}/*_test.rb" }
     test_files = Dir[*test_patterns].select do |file|
@@ -143,5 +144,6 @@ Rake::TestTask.new("test:regular") do |t|
   t.pattern = "test/**/*_test.rb"
   t.warning = true
   t.verbose = true
+  t.options = "--profile" if ENV["CI"]
   t.ruby_opts = ["--dev"] if defined?(JRUBY_VERSION)
 end

--- a/railties/Rakefile
+++ b/railties/Rakefile
@@ -66,12 +66,13 @@ namespace :test do
 
     # Only generate the template app once.
     require_relative "test/isolation/abstract_unit"
+    require "minitest/rails_plugin"
 
     failing_files = []
 
     dirs = (ENV["TEST_DIR"] || ENV["TEST_DIRS"] || "**").split(",")
     test_options = ENV["TESTOPTS"].to_s.split(/[\s]+/)
-    test_options << "--profile" if ENV["CI"]
+    test_options << "--profile" if ENV["BUILDKITE"]
 
     test_patterns = dirs.map { |dir| "test/#{dir}/*_test.rb" }
     test_files = Dir[*test_patterns].select do |file|
@@ -95,6 +96,8 @@ namespace :test do
       test_files = buckets[n]
     end
 
+    output_file = Tempfile.new("railties_test_reporter")
+
     test_files.each do |file|
       puts "--- #{file}"
       fake_command = Shellwords.join([
@@ -109,6 +112,7 @@ namespace :test do
         # We could run these in parallel, but pretty much all of the
         # railties tests already run in parallel, so ¯\_(⊙︿⊙)_/¯
         Process.waitpid fork {
+          ENV["RAILTIES_OUTPUT_FILE"] = output_file.path
           ARGV.clear.concat test_options
           Rake.application = nil
 
@@ -124,9 +128,22 @@ namespace :test do
       end
     end
 
-    puts "--- All tests completed"
+    puts "+++ All tests completed"
+
+    if ENV["BUILDKITE"]
+      TestResult = Struct.new(:NAME, :failures, :assertions, :klass, :time, :source_location, :location)
+      profile = Minitest::ProfileReporter.new($stdout, profile: 10)
+      output_file.rewind
+      output_file.each_line do |result|
+        data = JSON.parse(result)
+        profile.results << TestResult.new(*data.values)
+      end
+
+      profile.summary
+    end
+
     unless failing_files.empty?
-      puts "^^^ +++"
+      puts "+++"
       puts
       puts "Failed in:"
       failing_files.each do |file|
@@ -136,6 +153,9 @@ namespace :test do
 
       exit 1
     end
+  ensure
+    output_file&.close
+    output_file&.unlink
   end
 end
 
@@ -144,6 +164,6 @@ Rake::TestTask.new("test:regular") do |t|
   t.pattern = "test/**/*_test.rb"
   t.warning = true
   t.verbose = true
-  t.options = "--profile" if ENV["CI"]
+  t.options = "--profile" if ENV["BUILDKITE"]
   t.ruby_opts = ["--dev"] if defined?(JRUBY_VERSION)
 end

--- a/railties/lib/minitest/rails_plugin.rb
+++ b/railties/lib/minitest/rails_plugin.rb
@@ -36,6 +36,10 @@ module Minitest
       @results << result
     end
 
+    def passed?
+      true
+    end
+
     def report
       total_time = @results.sum(&:time)
 

--- a/railties/lib/minitest/rails_plugin.rb
+++ b/railties/lib/minitest/rails_plugin.rb
@@ -26,6 +26,8 @@ module Minitest
   end
 
   class ProfileReporter < Reporter
+    attr_accessor :results
+
     def initialize(io = $stdout, options = {})
       super
       @results = []
@@ -33,7 +35,16 @@ module Minitest
     end
 
     def record(result)
-      @results << result
+      if output_file = ENV["RAILTIES_OUTPUT_FILE"]
+        File.open(output_file, "a") do |f|
+          # Round-trip for re-serialization
+          data = JSON.parse(result.to_json)
+          data[:location] = result.location
+          f.puts(data.to_json)
+        end
+      else
+        @results << result
+      end
     end
 
     def passed?
@@ -41,22 +52,32 @@ module Minitest
     end
 
     def report
-      total_time = @results.sum(&:time)
+      # Skip if we're outputting to a file
+      return if ENV["RAILTIES_OUTPUT_FILE"]
+      print_summary
+    end
 
-      @results.sort! { |a, b| b.time <=> a.time }
-      slow_results = @results.take(@count)
-      slow_tests_total_time = slow_results.sum(&:time)
-
-      ratio = (total_time == 0) ? 0.0 : (slow_tests_total_time / total_time) * 100
-
-      io.puts("\nTop %d slowest tests (%.2f seconds, %.1f%% of total time):\n" % [slow_results.size, slow_tests_total_time, ratio])
-      slow_results.each do |result|
-        io.puts("  %s\n    %.4f seconds %s\n" % [result.location, result.time, source_location(result)])
-      end
-      io.puts("\n")
+    def summary
+      print_summary
     end
 
     private
+      def print_summary
+        total_time = @results.sum(&:time)
+
+        @results.sort! { |a, b| b.time <=> a.time }
+        slow_results = @results.take(@count)
+        slow_tests_total_time = slow_results.sum(&:time)
+
+        ratio = (total_time == 0) ? 0.0 : (slow_tests_total_time / total_time) * 100
+
+        io.puts("\nTop %d slowest tests (%.2f seconds, %.1f%% of total time):\n" % [slow_results.size, slow_tests_total_time, ratio])
+        slow_results.each do |result|
+          io.puts("  %s\n    %.4f seconds %s\n" % [result.location, result.time, source_location(result)])
+        end
+        io.puts("\n")
+      end
+
       def source_location(result)
         filename, line = result.source_location
         return "" unless filename


### PR DESCRIPTION
This PR updates #51080 and changes the Railties tests to only output the profile data at the end of the run, not for each group.

/cc @byroot 