### PR TITLE
Add db-agnostic enum column definition support

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,20 @@
+*   Introduce enum column type to MySQL and SQLite
+
+    All database adapters now support the `enum` column type to allow database
+    agnostic operations. To specify values for an enum column in MySQL adapters,
+    use the `values` option. Using the `values` option in PostgreSQL would allow
+    implicit creation of enum types. Enums in SQLite are represented as strings.
+
+    ```ruby
+    def up
+      create_table :cats do |t|
+        t.enum :current_mood, enum_type: "mood", values: ["happy", "sad"], default: "happy", null: false
+      end
+    end
+    ```
+
+    *Jenny Shen*
+
 *   Introduce a before-fork hook in `ActiveSupport::Testing::Parallelization` to clear existing
     connections, to avoid fork-safety issues with the mysql2 adapter.
 

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_creation.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_creation.rb
@@ -32,7 +32,7 @@ module ActiveRecord
         end
 
         def visit_ColumnDefinition(o)
-          o.sql_type = type_to_sql(o.type, **o.options)
+          o.sql_type = type_to_sql(o.type, column_name: o.name, **o.options)
           column_sql = +"#{quote_column_name(o.name)} #{o.sql_type}"
           add_column_options!(column_sql, column_options(o)) unless o.type == :primary_key
           column_sql

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
@@ -86,7 +86,9 @@ module ActiveRecord
         :comment,
         :primary_key,
         :if_exists,
-        :if_not_exists
+        :if_not_exists,
+        :values,
+        :enum_type
       ]
 
       def primary_key?
@@ -339,7 +341,7 @@ module ActiveRecord
       #
       # See TableDefinition#column
 
-      define_column_methods :bigint, :binary, :boolean, :date, :datetime, :decimal,
+      define_column_methods :bigint, :binary, :boolean, :date, :datetime, :decimal, :enum,
         :float, :integer, :json, :string, :text, :time, :timestamp, :virtual
 
       alias :blob :binary

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -44,6 +44,7 @@ module ActiveRecord
         blob:        { name: "blob" },
         boolean:     { name: "boolean" },
         json:        { name: "json" },
+        enum:        {}, # set dynamically based on values spec
       }
 
       class StatementPool < ConnectionAdapters::StatementPool # :nodoc:

--- a/activerecord/lib/active_record/connection_adapters/mysql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/schema_statements.rb
@@ -109,7 +109,7 @@ module ActiveRecord
         end
 
         # Maps logical Rails types to MySQL-specific data types.
-        def type_to_sql(type, limit: nil, precision: nil, scale: nil, size: limit_to_size(limit, type), unsigned: nil, **)
+        def type_to_sql(type, limit: nil, precision: nil, scale: nil, size: limit_to_size(limit, type), unsigned: nil, values: nil, **)
           sql =
             case type.to_s
             when "integer"
@@ -124,6 +124,10 @@ module ActiveRecord
               else
                 type_with_size_to_sql("blob", size)
               end
+            when "enum"
+              raise ArgumentError, "values are required for enums" if values.nil?
+
+              "ENUM(#{values.map { |value| "'#{value}'" }.join(",")})"
             else
               super
             end

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_definitions.rb
@@ -185,7 +185,7 @@ module ActiveRecord
         define_column_methods :bigserial, :bit, :bit_varying, :cidr, :citext, :daterange,
           :hstore, :inet, :interval, :int4range, :int8range, :jsonb, :ltree, :macaddr,
           :money, :numrange, :oid, :point, :line, :lseg, :box, :path, :polygon, :circle,
-          :serial, :tsrange, :tstzrange, :tsvector, :uuid, :xml, :timestamptz, :enum
+          :serial, :tsrange, :tstzrange, :tsvector, :uuid, :xml, :timestamptz
       end
 
       ExclusionConstraintDefinition = Struct.new(:table_name, :expression, :options) do
@@ -282,7 +282,7 @@ module ActiveRecord
 
         private
           def valid_column_definition_options
-            super + [:array, :using, :cast_as, :as, :type, :enum_type, :stored]
+            super + [:array, :using, :cast_as, :as, :type, :stored]
           end
 
           def aliased_types(name, fallback)

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_dumper.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_dumper.rb
@@ -80,7 +80,11 @@ module ActiveRecord
               spec = { type: schema_type(column).inspect }.merge!(spec)
             end
 
-            spec[:enum_type] = column.sql_type.inspect if column.enum?
+            if column.enum?
+              spec[:enum_type] = column.sql_type.inspect unless column.name == column.sql_type
+              _name, values = @connection.enum_types.find { |name, _values| name == column.sql_type }
+              spec[:values] = values.inspect
+            end
 
             spec
           end

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -848,7 +848,7 @@ module ActiveRecord
         end
 
         # Maps logical Rails types to PostgreSQL-specific data types.
-        def type_to_sql(type, limit: nil, precision: nil, scale: nil, array: nil, enum_type: nil, **) # :nodoc:
+        def type_to_sql(type, column_name: nil, limit: nil, precision: nil, scale: nil, array: nil, enum_type: nil, values: nil, **) # :nodoc:
           sql = \
             case type.to_s
             when "binary"
@@ -873,9 +873,9 @@ module ActiveRecord
               else raise ArgumentError, "No integer type has byte size #{limit}. Use a numeric with scale 0 instead."
               end
             when "enum"
-              raise ArgumentError, "enum_type is required for enums" if enum_type.nil?
+              raise ArgumentError, "enum_type or values is required for enums" if enum_type.nil? && values.nil?
 
-              enum_type
+              enum_type || column_name
             else
               super
             end

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -550,6 +550,11 @@ module ActiveRecord
                 JOIN pg_namespace n ON t.typnamespace = n.oid
                 WHERE t.typname = #{scope[:name]}
                   AND n.nspname = #{scope[:schema]}
+                  AND (
+                    SELECT array_agg(e.enumlabel ORDER BY e.enumsortorder)
+                    FROM pg_enum e
+                    WHERE e.enumtypid = t.oid
+                  ) = ARRAY[#{sql_values}]::name[]
               ) THEN
                   CREATE TYPE #{quote_table_name(name)} AS ENUM (#{sql_values});
               END IF;

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -102,6 +102,7 @@ module ActiveRecord
         binary:       { name: "blob" },
         boolean:      { name: "boolean" },
         json:         { name: "json" },
+        enum:         { name: "varchar" },
       }
 
       DEFAULT_PRAGMAS = {

--- a/activerecord/test/cases/adapters/abstract_mysql_adapter/mysql_enum_test.rb
+++ b/activerecord/test/cases/adapters/abstract_mysql_adapter/mysql_enum_test.rb
@@ -1,47 +1,66 @@
 # frozen_string_literal: true
 
 require "cases/helper"
-require "support/schema_dumping_helper"
+require "cases/enum_shared_test_cases"
 
-class MySQLEnumTest < ActiveRecord::AbstractMysqlTestCase
-  self.use_transactional_tests = false
-
-  include SchemaDumpingHelper
-
-  class EnumTest < ActiveRecord::Base
-    attribute :state, :integer
-
-    enum :state, {
-      start: 0,
-      middle: 1,
-      finish: 2
-    }
-  end
-
-  def setup
-    EnumTest.lease_connection.create_table :enum_tests, id: false, force: true do |t|
-      t.column :enum_column, "enum('text','blob','tiny','medium','long','unsigned','bigint')"
-      t.column :state, "TINYINT(1)"
-    end
-  end
+module MySQLSharedEnumTestCases
+  include SharedEnumTestCases
 
   def test_should_not_be_unsigned
-    column = EnumTest.columns_hash["enum_column"]
+    column = EnumTest.columns_hash["current_mood"]
     assert_not_predicate column, :unsigned?
   end
 
   def test_should_not_be_bigint
-    column = EnumTest.columns_hash["enum_column"]
+    column = EnumTest.columns_hash["current_mood"]
     assert_not_predicate column, :bigint?
   end
 
   def test_schema_dumping
     schema = dump_table_schema "enum_tests"
-    assert_match %r{t\.column "enum_column", "enum\('text','blob','tiny','medium','long','unsigned','bigint'\)"$}, schema
+    assert_match %r{t\.enum "current_mood", default: "sad", values: \["sad", "ok", "happy"\]}, schema
+  end
+end
+
+class MySQLEnumTest < ActiveRecord::AbstractMysqlTestCase
+  include MySQLSharedEnumTestCases
+
+  self.use_transactional_tests = false
+
+  def setup
+    @connection = ActiveRecord::Base.lease_connection
+    @connection.create_table :enum_tests, force: true do |t|
+      t.column :current_mood, 'enum("sad","ok","happy")', default: "sad"
+    end
   end
 
-  def test_enum_with_attribute
-    enum_test = EnumTest.create!(state: :middle)
-    assert_equal "middle", enum_test.state
+  def test_schema_load
+    original, $stdout = $stdout, StringIO.new
+
+    ActiveRecord::Schema.define do
+      create_enum :color, ["blue", "green"]
+
+      change_table :enum_tests do |t|
+        t.enum :best_color, enum_type: "color", values: ["blue", "green"], default: "blue", null: false
+      end
+    end
+
+    assert @connection.column_exists?(:enum_tests, :best_color, "string", values: ["blue", "green"], default: "blue", null: false)
+  ensure
+    $stdout = original
   end
+
+  def test_enum_column_without_values_raises_error
+    error = assert_raises(ArgumentError) do
+      @connection.add_column :enum_tests, :best_color, :enum, null: false
+    end
+
+    assert_equal "values are required for enums", error.message
+  end
+end
+
+class MySQLEnumWithValuesTest < ActiveRecord::AbstractMysqlTestCase
+  include MySQLSharedEnumTestCases
+
+  self.use_transactional_tests = false
 end

--- a/activerecord/test/cases/adapters/postgresql/enum_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/enum_test.rb
@@ -6,6 +6,11 @@ require "cases/enum_shared_test_cases"
 module PostgresqlEnumSharedTestCases
   include SharedEnumTestCases
 
+  def teardown
+    reset_connection
+    super
+  end
+
   def test_column
     EnumTest.reset_column_information
     column = EnumTest.columns_hash["current_mood"]

--- a/activerecord/test/cases/adapters/postgresql/enum_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/enum_test.rb
@@ -1,161 +1,124 @@
 # frozen_string_literal: true
 
 require "cases/helper"
-require "support/connection_helper"
-require "support/schema_dumping_helper"
+require "cases/enum_shared_test_cases"
 
-class PostgresqlEnumTest < ActiveRecord::PostgreSQLTestCase
-  include ConnectionHelper
-  include SchemaDumpingHelper
-
-  class PostgresqlEnum < ActiveRecord::Base
-    self.table_name = "postgresql_enums"
-
-    enum :current_mood, {
-      sad: "sad",
-      okay: "ok", # different spelling
-      happy: "happy",
-      aliased_field: "happy"
-    }, prefix: true
-  end
-
-  def setup
-    @connection = ActiveRecord::Base.lease_connection
-    @connection.transaction do
-      @connection.create_enum("mood", ["sad", "ok", "happy"])
-      @connection.create_table("postgresql_enums") do |t|
-        t.column :current_mood, :mood
-      end
-    end
-  end
-
-  teardown do
-    reset_connection
-    @connection.drop_table "postgresql_enums", if_exists: true
-    @connection.drop_enum "mood", if_exists: true
-    reset_connection
-  end
+module PostgresqlEnumSharedTestCases
+  include SharedEnumTestCases
 
   def test_column
-    column = PostgresqlEnum.columns_hash["current_mood"]
+    EnumTest.reset_column_information
+    column = EnumTest.columns_hash["current_mood"]
     assert_equal :enum, column.type
-    assert_equal "mood", column.sql_type
+    assert_equal enum_type, column.sql_type
     assert_not_predicate column, :array?
 
-    type = PostgresqlEnum.type_for_attribute("current_mood")
+    type = EnumTest.type_for_attribute("current_mood")
     assert_not_predicate type, :binary?
   end
 
-  def test_enum_defaults
-    @connection.add_column "postgresql_enums", "good_mood", :mood, default: "happy"
-    PostgresqlEnum.reset_column_information
-
-    assert_equal "happy", PostgresqlEnum.column_defaults["good_mood"]
-    assert_equal "happy", PostgresqlEnum.new.good_mood
-  ensure
-    PostgresqlEnum.reset_column_information
-  end
-
-  def test_enum_mapping
-    @connection.execute "INSERT INTO postgresql_enums VALUES (1, 'sad');"
-    enum = PostgresqlEnum.first
-    assert_equal "sad", enum.current_mood
-
-    enum.current_mood = "happy"
-    enum.save!
-
-    assert_equal "happy", enum.reload.current_mood
-  end
-
-  def test_invalid_enum_update
-    @connection.execute "INSERT INTO postgresql_enums VALUES (1, 'sad');"
-    enum = PostgresqlEnum.first
-
-    assert_raise ArgumentError do
-      enum.current_mood = "angry"
-    end
-  end
-
   def test_no_oid_warning
-    @connection.execute "INSERT INTO postgresql_enums VALUES (1, 'sad');"
-    stderr_output = capture(:stderr) { PostgresqlEnum.first }
+    @connection.execute "INSERT INTO enum_tests VALUES (1, 'sad');"
+    stderr_output = capture(:stderr) { EnumTest.first }
 
     assert_predicate stderr_output, :blank?
   end
 
-  def test_enum_type_cast
-    enum = PostgresqlEnum.new
-    enum.current_mood = :happy
-
-    assert_equal "happy", enum.current_mood
-  end
-
-  def test_assigning_enum_to_nil
-    model = PostgresqlEnum.new(current_mood: nil)
-
-    assert_nil model.current_mood
-    assert model.save
-    assert_nil model.reload.current_mood
-  end
-
-  def test_schema_dump
-    @connection.add_column "postgresql_enums", "good_mood", :mood, default: "happy", null: false
-
-    output = dump_table_schema("postgresql_enums")
-
-    assert_includes output, "# Note that some types may not work with other database engines. Be careful if changing database."
-
-    assert_includes output, 'create_enum "mood", ["sad", "ok", "happy"]'
-
-    assert_includes output, 't.enum "current_mood", enum_type: "mood"'
-    assert_includes output, 't.enum "good_mood", default: "happy", null: false, enum_type: "mood"'
-  end
-
   def test_schema_dump_renamed_enum
-    @connection.rename_enum :mood, :feeling
+    @connection.rename_enum enum_type, :feeling
 
-    output = dump_table_schema("postgresql_enums")
+    output = dump_table_schema("enum_tests")
 
     assert_includes output, 'create_enum "feeling", ["sad", "ok", "happy"]'
-
-    assert_includes output, 't.enum "current_mood", enum_type: "feeling"'
+    assert_includes output, 't.enum "current_mood", default: "sad", enum_type: "feeling", values: ["sad", "ok", "happy"]'
   end
 
   def test_schema_dump_renamed_enum_with_to_option
-    @connection.rename_enum :mood, to: :feeling
+    @connection.rename_enum enum_type, to: :feeling
 
-    output = dump_table_schema("postgresql_enums")
+    output = dump_table_schema("enum_tests")
 
     assert_includes output, 'create_enum "feeling", ["sad", "ok", "happy"]'
-
-    assert_includes output, 't.enum "current_mood", enum_type: "feeling"'
+    assert_includes output, 't.enum "current_mood", default: "sad", enum_type: "feeling", values: ["sad", "ok", "happy"]'
   end
 
   def test_schema_dump_added_enum_value
     skip("Adding enum values can not be run in a transaction") if @connection.database_version < 10_00_00
 
-    @connection.add_enum_value :mood, :angry, before: :ok
-    @connection.add_enum_value :mood, :nervous, after: :ok
-    @connection.add_enum_value :mood, :glad
+    @connection.add_enum_value enum_type, :angry, before: :ok
+    @connection.add_enum_value enum_type, :nervous, after: :ok
+    @connection.add_enum_value enum_type, :glad
 
     assert_nothing_raised do
-      @connection.add_enum_value :mood, :glad, if_not_exists: true
-      @connection.add_enum_value :mood, :curious, if_not_exists: true
+      @connection.add_enum_value enum_type, :glad, if_not_exists: true
+      @connection.add_enum_value enum_type, :curious, if_not_exists: true
     end
 
-    output = dump_table_schema("postgresql_enums")
+    output = dump_table_schema("enum_tests")
 
-    assert_includes output, 'create_enum "mood", ["sad", "angry", "ok", "nervous", "happy", "glad", "curious"]'
+    assert_includes output, "create_enum \"#{enum_type}\", [\"sad\", \"angry\", \"ok\", \"nervous\", \"happy\", \"glad\", \"curious\"]"
   end
 
   def test_schema_dump_renamed_enum_value
     skip("Renaming enum values is only supported in PostgreSQL 10 or later") if @connection.database_version < 10_00_00
 
-    @connection.rename_enum_value :mood, from: :ok, to: :okay
+    @connection.rename_enum_value enum_type, from: :ok, to: :okay
 
-    output = dump_table_schema("postgresql_enums")
+    output = dump_table_schema("enum_tests")
 
-    assert_includes output, 'create_enum "mood", ["sad", "okay", "happy"]'
+    assert_includes output, "create_enum \"#{enum_type}\", [\"sad\", \"okay\", \"happy\"]"
+  end
+
+  def test_create_enum_type_with_different_values
+    assert_raises ActiveRecord::StatementInvalid do
+      @connection.create_enum enum_type, ["mad", "glad"]
+    end
+  end
+
+  def test_works_with_activerecord_enum
+    model = EnumTest.create!
+    model.current_mood_okay!
+
+    model = EnumTest.find(model.id)
+    assert_equal "okay", model.current_mood
+
+    model.current_mood = "happy"
+    model.save!
+
+    model = EnumTest.find(model.id)
+    assert_predicate model, :current_mood_happy?
+  end
+end
+
+class PostgresqlEnumTest < ActiveRecord::PostgreSQLTestCase
+  include PostgresqlEnumSharedTestCases
+
+  def setup
+    @connection = ActiveRecord::Base.lease_connection
+    @connection.transaction do
+      @connection.create_enum("mood", ["sad", "ok", "happy"])
+      @connection.create_table("enum_tests") do |t|
+        t.column :current_mood, :mood, default: "sad"
+      end
+    end
+  end
+
+  def test_schema_dump
+    @connection.add_column "enum_tests", "good_mood", enum_type, default: "happy", null: false
+    @connection.add_column "enum_tests", "bad_mood", :enum, values: ["angry", "mad", "sad"], default: "sad", null: false
+    @connection.add_column "enum_tests", "party_mood", :enum, values: ["excited", "happy"], default: "happy", enum_type: "fun_mood", null: false
+
+    output = dump_table_schema("enum_tests")
+
+    assert_includes output, "# Note that some types may not work with other database engines. Be careful if changing database."
+
+    assert_includes output, "create_enum \"#{enum_type}\", [\"sad\", \"ok\", \"happy\"]"
+    assert_includes output, 'create_enum "bad_mood", ["angry", "mad", "sad"]'
+    assert_includes output, 'create_enum "fun_mood", ["excited", "happy"]'
+
+    assert_includes output, "t.enum \"good_mood\", default: \"happy\", null: false, enum_type: \"#{enum_type}\", values: [\"sad\", \"ok\", \"happy\"]"
+    assert_includes output, 't.enum "bad_mood", default: "sad", null: false, values: ["angry", "mad", "sad"]'
+    assert_includes output, 't.enum "party_mood", default: "happy", null: false, enum_type: "fun_mood", values: ["excited", "happy"]'
   end
 
   def test_schema_load
@@ -164,14 +127,22 @@ class PostgresqlEnumTest < ActiveRecord::PostgreSQLTestCase
     ActiveRecord::Schema.define do
       create_enum :color, ["blue", "green"]
 
-      change_table :postgresql_enums do |t|
-        t.enum :best_color, enum_type: "color", default: "blue", null: false
+      change_table :enum_tests do |t|
+        t.enum :best_color, enum_type: "color", values: ["blue", "green"], default: "blue", null: false
       end
     end
 
-    assert @connection.column_exists?(:postgresql_enums, :best_color, sql_type: "color", default: "blue", null: false)
+    assert @connection.column_exists?(:enum_tests, :best_color, "enum", values: ["blue", "green"], default: "blue", null: false)
   ensure
     $stdout = original
+  end
+
+  def test_enum_column_without_values_or_enum_type_raises_error
+    error = assert_raises(ArgumentError) do
+      @connection.add_column :enum_tests, :best_color, :enum, null: false
+    end
+
+    assert_equal "enum_type or values is required for enums", error.message
   end
 
   def test_drop_enum
@@ -190,31 +161,17 @@ class PostgresqlEnumTest < ActiveRecord::PostgreSQLTestCase
     end
   end
 
-  def test_works_with_activerecord_enum
-    model = PostgresqlEnum.create!
-    model.current_mood_okay!
-
-    model = PostgresqlEnum.find(model.id)
-    assert_equal "okay", model.current_mood
-
-    model.current_mood = "happy"
-    model.save!
-
-    model = PostgresqlEnum.find(model.id)
-    assert_predicate model, :current_mood_happy?
-  end
-
   def test_enum_type_scoped_to_schemas
     with_test_schema("test_schema") do
       @connection.create_enum("mood_in_other_schema", ["sad", "ok", "happy"])
 
       assert_nothing_raised do
-        @connection.create_table("postgresql_enums_in_other_schema") do |t|
+        @connection.create_table("enum_tests_in_other_schema") do |t|
           t.column :current_mood, :mood_in_other_schema, default: "happy", null: false
         end
       end
 
-      assert @connection.table_exists?("postgresql_enums_in_other_schema")
+      assert @connection.table_exists?("enum_tests_in_other_schema")
     end
   end
 
@@ -222,14 +179,14 @@ class PostgresqlEnumTest < ActiveRecord::PostgreSQLTestCase
     @connection.create_schema("test_schema")
     @connection.create_enum("test_schema.mood_in_other_schema", ["sad", "ok", "happy"])
 
-    @connection.create_table("test_schema.postgresql_enums_in_other_schema") do |t|
+    @connection.create_table("test_schema.enum_tests_in_other_schema") do |t|
       t.column :current_mood, "test_schema.mood_in_other_schema"
     end
 
-    assert @connection.table_exists?("test_schema.postgresql_enums_in_other_schema")
+    assert @connection.table_exists?("test_schema.enum_tests_in_other_schema")
 
     assert_nothing_raised do
-      @connection.drop_table("test_schema.postgresql_enums_in_other_schema")
+      @connection.drop_table("test_schema.enum_tests_in_other_schema")
       @connection.drop_enum("test_schema.mood_in_other_schema")
     end
   ensure
@@ -242,13 +199,13 @@ class PostgresqlEnumTest < ActiveRecord::PostgreSQLTestCase
 
     with_test_schema("test_schema") do
       @connection.create_enum("mood_in_test_schema", ["sad", "ok", "happy"])
-      @connection.create_table("postgresql_enums_in_test_schema") do |t|
+      @connection.create_table("enum_tests_in_test_schema") do |t|
         t.column :current_mood, :mood_in_test_schema
       end
 
-      output = dump_table_schema("postgresql_enums_in_test_schema")
+      output = dump_table_schema("enum_tests_in_test_schema")
 
-      assert_includes output, 'create_enum "public.mood", ["sad", "ok", "happy"]'
+      assert_includes output, "create_enum \"public.#{enum_type}\", [\"sad\", \"ok\", \"happy\"]"
       assert_includes output, 'create_enum "mood_in_test_schema", ["sad", "ok", "happy"]'
       assert_includes output, 't.enum "current_mood", enum_type: "mood_in_test_schema"'
       assert_not_includes output, 'create_enum "other_schema.mood_in_other_schema"'
@@ -264,22 +221,26 @@ class PostgresqlEnumTest < ActiveRecord::PostgreSQLTestCase
           create_enum "mood_in_test_schema", ["sad", "ok", "happy"]
           create_enum "public.mood", ["sad", "ok", "happy"]
 
-          create_table "postgresql_enums_in_test_schema", force: :cascade do |t|
+          create_table "enum_tests_in_test_schema", force: :cascade do |t|
             t.enum "current_mood", enum_type: "mood_in_test_schema"
           end
         end
 
-        assert @connection.column_exists?(:postgresql_enums_in_test_schema, :current_mood, sql_type: "mood_in_test_schema")
+        assert @connection.column_exists?(:enum_tests_in_test_schema, :current_mood, sql_type: "mood_in_test_schema")
       end
 
       # This is outside `with_test_schema`, so we need to explicitly specify which schema we query
-      assert @connection.column_exists?("test_schema.postgresql_enums_in_test_schema", :current_mood, sql_type: "test_schema.mood_in_test_schema")
+      assert @connection.column_exists?("test_schema.enum_tests_in_test_schema", :current_mood, sql_type: "test_schema.mood_in_test_schema")
     end
   ensure
     @connection.drop_schema("test_schema")
   end
 
   private
+    def enum_type
+      "mood"
+    end
+
     def with_test_schema(name, drop: true)
       old_search_path = @connection.schema_search_path
       @connection.create_schema(name)
@@ -289,5 +250,32 @@ class PostgresqlEnumTest < ActiveRecord::PostgreSQLTestCase
       @connection.drop_schema(name) if drop
       @connection.schema_search_path = old_search_path
       @connection.schema_cache.clear!
+    end
+end
+
+class PostgresqlEnumWithValuesAndEnumTypeTest < ActiveRecord::PostgreSQLTestCase
+  include PostgresqlEnumSharedTestCases
+
+  private
+    def enum_type
+      "mood"
+    end
+end
+
+class PostgresqlEnumWithValuesTest < ActiveRecord::PostgreSQLTestCase
+  include PostgresqlEnumSharedTestCases
+
+  def setup
+    @connection = ActiveRecord::Base.lease_connection
+    @connection.transaction do
+      @connection.create_table("enum_tests") do |t|
+        t.enum :current_mood, values: ["sad", "ok", "happy"], default: "sad"
+      end
+    end
+  end
+
+  private
+    def enum_type
+      "current_mood"
     end
 end

--- a/activerecord/test/cases/adapters/sqlite3/enum_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/enum_test.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+require "cases/enum_shared_test_cases"
+
+class EnumTest < ActiveRecord::SQLite3TestCase
+  include SharedEnumTestCases
+
+  def test_schema_dump
+    schema = dump_table_schema "enum_tests"
+    assert_match %r{t\.string "current_mood", default: "sad"}, schema
+  end
+
+  def test_schema_load
+    original, $stdout = $stdout, StringIO.new
+
+    ActiveRecord::Schema.define do
+      create_enum :color, ["blue", "green"]
+
+      change_table :enum_tests do |t|
+        t.enum :best_color, enum_type: "color", values: ["blue", "green"], default: "blue", null: false
+      end
+    end
+
+    assert @connection.column_exists?(:enum_tests, :best_color, "string", default: "blue", null: false)
+  ensure
+    $stdout = original
+  end
+end

--- a/activerecord/test/cases/enum_attribute_test.rb
+++ b/activerecord/test/cases/enum_attribute_test.rb
@@ -5,7 +5,7 @@ require "models/author"
 require "models/book"
 require "active_support/log_subscriber/test_helper"
 
-class EnumTest < ActiveRecord::TestCase
+class EnumAttributeTest < ActiveRecord::TestCase
   fixtures :books, :authors, :author_addresses
 
   setup do

--- a/activerecord/test/cases/enum_shared_test_cases.rb
+++ b/activerecord/test/cases/enum_shared_test_cases.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+require "support/connection_helper"
+require "support/schema_dumping_helper"
+
+module SharedEnumTestCases
+  include ConnectionHelper
+  include SchemaDumpingHelper
+
+  class EnumTest < ActiveRecord::Base
+    self.table_name = "enum_tests"
+
+    enum :current_mood, {
+      sad: "sad",
+      okay: "ok", # different spelling
+      happy: "happy",
+      aliased_field: "happy"
+    }, prefix: true
+  end
+
+  def setup
+    super
+    @connection = ActiveRecord::Base.lease_connection
+    @connection.create_table("enum_tests") do |t|
+      t.enum :current_mood, enum_type: "mood", values: ["sad", "ok", "happy"], default: "sad"
+    end
+  end
+
+  def teardown
+    reset_connection
+    @connection.drop_table "enum_tests", if_exists: true
+    if current_adapter?(:PostgreSQLAdapter)
+      @connection.enum_types.each do |enum_type, values|
+        @connection.drop_enum enum_type
+      end
+    end
+    reset_connection
+
+    super
+  end
+
+  def test_enum_defaults
+    assert_equal "sad", EnumTest.column_defaults["current_mood"]
+    assert_equal "sad", EnumTest.new.current_mood
+  end
+
+  def test_enum_mapping
+    @connection.execute "INSERT INTO enum_tests VALUES (1, 'sad');"
+    enum = EnumTest.first
+    assert_equal "sad", enum.current_mood
+
+    enum.current_mood = "happy"
+    enum.save!
+
+    assert_equal "happy", enum.reload.current_mood
+  end
+
+  def test_invalid_enum_update
+    @connection.execute "INSERT INTO enum_tests VALUES (1, 'sad');"
+    enum = EnumTest.first
+
+    assert_raise ArgumentError do
+      enum.current_mood = "angry"
+    end
+  end
+
+  def test_enum_type_cast
+    enum = EnumTest.new
+    enum.current_mood = :happy
+
+    assert_equal "happy", enum.current_mood
+  end
+
+  def test_assigning_enum_to_nil
+    model = EnumTest.new(current_mood: nil)
+
+    assert_nil model.current_mood
+    assert model.save
+    assert_nil model.reload.current_mood
+  end
+end

--- a/activerecord/test/cases/enum_shared_test_cases.rb
+++ b/activerecord/test/cases/enum_shared_test_cases.rb
@@ -28,14 +28,12 @@ module SharedEnumTestCases
   end
 
   def teardown
-    reset_connection
     @connection.drop_table "enum_tests", if_exists: true
     if current_adapter?(:PostgreSQLAdapter)
       @connection.enum_types.each do |enum_type, values|
         @connection.drop_enum enum_type
       end
     end
-    reset_connection
 
     super
   end

--- a/activerecord/test/cases/migration/invalid_options_test.rb
+++ b/activerecord/test/cases/migration/invalid_options_test.rb
@@ -8,12 +8,12 @@ module ActiveRecord
       include ActiveRecord::Migration::TestHelper
 
       def invalid_add_column_option_exception_message(key)
-        default_keys = [":limit", ":precision", ":scale", ":default", ":null", ":collation", ":comment", ":primary_key", ":if_exists", ":if_not_exists"]
+        default_keys = [":limit", ":precision", ":scale", ":default", ":null", ":collation", ":comment", ":primary_key", ":if_exists", ":if_not_exists", ":values", ":enum_type"]
 
         if current_adapter?(:Mysql2Adapter, :TrilogyAdapter)
           default_keys.concat([":auto_increment", ":charset", ":as", ":size", ":unsigned", ":first", ":after", ":type", ":stored"])
         elsif current_adapter?(:PostgreSQLAdapter)
-          default_keys.concat([":array", ":using", ":cast_as", ":as", ":type", ":enum_type", ":stored"])
+          default_keys.concat([":array", ":using", ":cast_as", ":as", ":type", ":stored"])
         elsif current_adapter?(:SQLite3Adapter)
           default_keys.concat([":as", ":type", ":stored"])
         end


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background
Currently, there is no unified approach to define enums in the schema. Different schemas need to be created for each DBMS if there are enums defined, because each adapter defines them differently. At Shopify, we are investigating supporting different DBMSs for our monolith and we would like to centralize on one schema instead of one per adapter. This PR would help achieve that by unifying enum definitions.

Postgresql allows one to create enums by 1. Create enum type through `create_enum` and 2. Defining the `enum_type` that would like to be used in a column.

```ruby
  def up
    create_enum "value", ["value1", "value2", "value3"]
    create_table "enum_table" do |t|
      t.column :enum_column, :value
    end
  end
```

MySQL allows enums by specifying the column type as the `sql_type`. 

```ruby
  def up
    create_table "enum_table" do |t|
      t.column :enum_column, "enum('value1', 'value2', 'value3')"
    end
  end
```
and SQLite doesn't have a native enum type.

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

### Detail

This PR adds a new option, `values`, to be used by the enum column. This is required to create MySQL's enum SQL type.

For Postgres, if an enum column is defined with a values option, we will now try to create the enum with the values given (unless the enum is created already with the same values). The `enum_type` will default to the column name.

For SQLite, an enum will be mapped as a string. This was the simplest for setting a default for the enum as opposed to using an integer since the default is represented as string.

#### Example migration
```ruby
  def up
    create_table "enum_table" do |t|
      t.enum :enum_column, values: ["value1", "value2", "value3"], enum_type: "status"
    end
  end
```

#### Resulting PostgreSQL schema
```ruby
ActiveRecord::Schema[8.1].define(version: 2025_01_29_154347) do
  # Custom types defined in this database.
  # Note that some types may not work with other database engines. Be careful if changing database.
  create_enum "status", ["value1", "value2", "value3"]

  create_table "enum_table", force: :cascade do |t|
     t.enum "enum_column", enum_type: "status", values: ["value1", "value2", "value3"]
  end
end
```

#### Resulting MySQL schema
```ruby
ActiveRecord::Schema[8.1].define(version: 2025_01_29_154347) do
  create_table "enum_table", force: :cascade do |t|
     t.enum "enum_column", values: ["value1", "value2", "value3"]
  end
end
```

#### Resulting SQLite schema
```ruby
ActiveRecord::Schema[8.1].define(version: 2025_01_29_154347) do
  create_table "enum_table", force: :cascade do |t|
     t.string "enum_column"
  end
end
```

The resulting schemas can be loaded by any DB adapter.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
