### PR TITLE
Workaround for `cannot load such file -- net/smtp (LoadError)`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -129,6 +129,7 @@ end
 gem "aws-sdk-sns", require: false
 gem "webmock"
 gem "httpclient", github: "nahi/httpclient", branch: "master", require: false
+gem "net-smtp", github: "ruby/net-smtp", ref: "d496a829f9b99adb44ecc1768c4d005e5f7b779e", require: false
 
 # Add your own local bundler stuff.
 local_gemfile = File.expand_path(".Gemfile", __dir__)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,6 +17,14 @@ GIT
       rdoc (>= 5.0)
       rouge
 
+GIT
+  remote: https://github.com/ruby/net-smtp.git
+  revision: d496a829f9b99adb44ecc1768c4d005e5f7b779e
+  ref: d496a829f9b99adb44ecc1768c4d005e5f7b779e
+  specs:
+    net-smtp (0.5.0)
+      net-protocol
+
 PATH
   remote: .
   specs:
@@ -396,8 +404,6 @@ GEM
       net-ssh (>= 2.6.5, < 8.0.0)
     net-sftp (4.0.0)
       net-ssh (>= 5.0.0, < 8.0.0)
-    net-smtp (0.5.0)
-      net-protocol
     net-ssh (7.3.0)
     nio4r (2.7.4)
     nokogiri (1.18.1)
@@ -703,6 +709,7 @@ DEPENDENCIES
   minitest-retry
   msgpack (>= 1.7.0)
   mysql2 (~> 0.5)
+  net-smtp!
   nokogiri (>= 1.8.1, != 1.11.0)
   pg (~> 1.3)
   prism

--- a/guides/bug_report_templates/action_mailbox.rb
+++ b/guides/bug_report_templates/action_mailbox.rb
@@ -10,6 +10,7 @@ gemfile(true) do
   # gem "rails", github: "rails/rails", branch: "main"
 
   gem "sqlite3"
+  gem "net-smtp", github: "ruby/net-smtp", ref: "d496a829f9b99adb44ecc1768c4d005e5f7b779e", require: false
 end
 
 require "active_record/railtie"

--- a/guides/bug_report_templates/action_mailer.rb
+++ b/guides/bug_report_templates/action_mailer.rb
@@ -8,6 +8,7 @@ gemfile(true) do
   gem "rails"
   # If you want to test against edge Rails replace the previous line with this:
   # gem "rails", github: "rails/rails", branch: "main"
+  gem "net-smtp", github: "ruby/net-smtp", ref: "d496a829f9b99adb44ecc1768c4d005e5f7b779e", require: false
 end
 
 require "action_mailer/railtie"


### PR DESCRIPTION
### Motivation / Background

This commit addresses the Rails Nightly CI failure since: https://buildkite.com/rails/rails-nightly/builds/1694#0194b3e0-213e-441d-b977-8c32f4ed1524

### Detail

This workaround can be reverted when the newer version of `net-smtp` is released that includes https://github.com/ruby/net-smtp/pull/90

- Steps to reproduce

```ruby
cd rails
git clone https://github.com/rails/buildkite-config .buildkite/
RUBY_IMAGE=rubylang/ruby:master docker compose -f .buildkite/docker-compose.yml build base && CI=1 docker compose -f .buildkite/docker-compose.yml run default runner actiontext 'rake test'
```

- Actual result without this commit
```ruby
+++ actiontext: rake test
/usr/local/bin/ruby -w -I"lib:test" /usr/local/lib/ruby/gems/3.5.0+0/gems/rake-13.2.1/lib/rake/rake_test_loader.rb "test/integration/controller_render_test.rb" "test/integration/job_render_test.rb" "test/integration/mailer_render_test.rb" "test/javascript_package_test.rb" "test/models/table_name_test.rb" "test/template/form_helper_test.rb" "test/unit/attachable_test.rb" "test/unit/attachment_test.rb" "test/unit/content_test.rb" "test/unit/fixture_set_test.rb" "test/unit/model_encryption_test.rb" "test/unit/model_test.rb" "test/unit/plain_text_conversion_test.rb" "test/unit/strict_loading_test.rb" "test/unit/trix_attachment_test.rb"
/usr/local/lib/ruby/gems/3.5.0+0/gems/capybara-3.40.0/lib/capybara/session/config.rb:95: warning: URI::RFC3986_PARSER.make_regexp is obsolete. Use URI::RFC2396_PARSER.make_regexp explicitly.
/usr/local/lib/ruby/gems/3.5.0+0/bundler/gems/httpclient-d57cc6d5ffee/lib/httpclient/util.rb:71: warning: literal string will be frozen in the future (run with --debug-frozen-string-literal for more information)
/usr/local/lib/ruby/3.5.0+0/bundled_gems.rb:76:in 'Kernel.require': cannot load such file -- net/smtp (LoadError)
Did you mean?  net/sftp
	from /usr/local/lib/ruby/3.5.0+0/bundled_gems.rb:76:in 'block (2 levels) in Kernel#replace_require'
```

### Additional information

Refer to https://github.com/ruby/net-smtp/pull/90
https://github.com/ruby/ruby/pull/12659

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
