### PR TITLE
Further restrict which contradicted queries need to be run

### DIFF
--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -463,9 +463,12 @@ module ActiveRecord
       end
 
       def possible_aggregation?(column_names)
-        column_names.any? do |column_name|
-          Arel.arel_node?(column_name) ||
-            (column_name.is_a?(String) && column_name.include?("("))
+        column_names.all? do |column_name|
+          if column_name.is_a?(String)
+            column_name.include?("(")
+          else
+            Arel.arel_node?(column_name)
+          end
         end
       end
 

--- a/activerecord/test/cases/relation_test.rb
+++ b/activerecord/test/cases/relation_test.rb
@@ -445,7 +445,19 @@ module ActiveRecord
       end
     end
 
-    test "runs queries when using pick with expression column and empty IN" do
+    test "no queries when using pick with non-aggregate expression and empty IN" do
+      assert_queries_count(0) do
+        assert_nil Post.where(id: []).pick(Arel.sql("id"))
+      end
+    end
+
+    test "no queries when using pick with any non-aggregate expression and empty IN" do
+      assert_queries_count(0) do
+        assert_nil Post.where(id: []).pick(Arel.sql("id"), Arel.sql("LENGTH(title)"))
+      end
+    end
+
+    test "runs queries when using pick with aggregate expression despite empty IN" do
       assert_queries_count(1) do
         assert_equal 0, Post.where(id: []).pick(Arel.sql("COUNT(*)"))
       end


### PR DESCRIPTION
An `Arel.sql` value is an `Arel.arel_node?`, but we can ignore that while doing our string match.

We also only need to contemplate a whole-result aggregation if _every_ column matches: any plain column reference (or similar) disproves that possibility.


Narrows the number of queries affected by #53775 (cc @fatkodima), while retaining the fix for #53772.