### PR TITLE
Defer creating the Active Model attribute-method module

### DIFF
--- a/activemodel/lib/active_model/attribute_methods.rb
+++ b/activemodel/lib/active_model/attribute_methods.rb
@@ -373,7 +373,7 @@ module ActiveModel
       #   person.name_short? # => NoMethodError
       #   person.first_name  # => NoMethodError
       def undefine_attribute_methods
-        generated_attribute_methods.module_eval do
+        @generated_attribute_methods&.module_eval do
           undef_method(*instance_methods)
         end
         attribute_method_patterns_cache.clear
@@ -402,7 +402,7 @@ module ActiveModel
         end
 
         def instance_method_already_implemented?(method_name)
-          generated_attribute_methods.method_defined?(method_name)
+          @generated_attribute_methods&.method_defined?(method_name)
         end
 
         # The methods +method_missing+ and +respond_to?+ of this module are

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -116,6 +116,10 @@ class BasicsTest < ActiveRecord::TestCase
     assert_equal "Post::GeneratedRelationMethods", mod.inspect
   end
 
+  def test_no_anonymous_modules
+    assert_empty Photo.ancestors.select { |m| m.name.nil? }
+  end
+
   def test_arel_attribute_normalization
     assert_equal Post.arel_table["body"], Post.arel_table[:body]
     assert_equal Post.arel_table["body"], Post.arel_table[:text]


### PR DESCRIPTION
There's no need to create the module before we have something to put in it.

This started happening in Active Record models with #53955.

Ideally we should consider naming the Active Model `generated_attribute_methods` module, even when it _should_ exist, but for now I'm just going to address this case where we've started creating it needlessly.

(If we do want to name it in general, I think we'd need to consider whether it's reasonable to drop such a "private" constant into Active Model classes in the same way we already do from Active Record... plus potentially address the possible name conflict with AR's equivalent module, as a suitably-constructed set of code can surely still force them to co-exist.)