### PR TITLE
Fix NoMethodError when a non-string CSRF token is passed through header

### DIFF
--- a/actionpack/lib/action_controller/metal/request_forgery_protection.rb
+++ b/actionpack/lib/action_controller/metal/request_forgery_protection.rb
@@ -507,7 +507,7 @@ module ActionController # :nodoc:
       # Checks the client's masked token to see if it matches the session token.
       # Essentially the inverse of `masked_authenticity_token`.
       def valid_authenticity_token?(session, encoded_masked_token) # :doc:
-        if encoded_masked_token.nil? || encoded_masked_token.empty? || !encoded_masked_token.is_a?(String)
+        if !encoded_masked_token.is_a?(String) || encoded_masked_token.empty?
           return false
         end
 

--- a/actionpack/test/controller/request_forgery_protection_test.rb
+++ b/actionpack/test/controller/request_forgery_protection_test.rb
@@ -675,7 +675,7 @@ module RequestForgeryProtectionTests
 
   def test_should_not_raise_error_if_token_is_not_a_string
     assert_blocked do
-      patch :index, params: { custom_authenticity_token: { foo: "bar" } }
+      patch :index, params: { custom_authenticity_token: 1 }, as: :json
     end
   end
 


### PR DESCRIPTION
### Motivation / Background

In some cases a CSRF token may be passed through the header that is not a string. This doesn't typically happen in normal requests but may occur during penetration testing or malicious requests. This change fixes that error so that a `ActionController::InvalidAuthenticityToken` is raised instead.

### Steps to reproduce
<!-- (Guidelines for creating a bug report are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#creating-a-bug-report)) -->

1. Send a POST request to a CSRF-protected resource with HTTP headers containing a non-string value (like an integer).


```ruby
  # actionpack/test/controller/request_forgery_protection_test.rb
  def test_should_raise_for_post_with_non_string_token_in_header
    @request.env["HTTP_X_CSRF_TOKEN"] = 123
    assert_blocked { post :index }
  end
```

### Expected behavior
<!-- Tell us what should happen -->

`ActionController::InvalidAuthenticityToken` should be raised.

### Actual behavior
<!-- Tell us what happens instead -->

`NoMethodError` is raised instead.

```
Failure:
RequestForgeryProtectionControllerUsingCustomStrategyTest#test_should_raise_for_post_with_non_string_token_in_header [test/controller/request_forgery_protection_test.rb:503]:
[RequestForgeryProtectionControllerUsingCustomStrategy::FakeException] exception expected, not
Class: <NoMethodError>
Message: <"undefined method `empty?' for an instance of Integer">
---Backtrace---
/home/ryenski/Projects/rails/actionpack/lib/action_controller/metal/request_forgery_protection.rb:510:in `valid_authenticity_token?'
/home/ryenski/Projects/rails/actionpack/lib/action_controller/metal/request_forgery_protection.rb:478:in `block in any_authenticity_token_valid?'
/home/ryenski/Projects/rails/actionpack/lib/action_controller/metal/request_forgery_protection.rb:477:in `any?'
/home/ryenski/Projects/rails/actionpack/lib/action_controller/metal/request_forgery_protection.rb:477:in `any_authenticity_token_valid?'
/home/ryenski/Projects/rails/actionpack/lib/action_controller/metal/request_forgery_protection.rb:472:in `verified_request?'
/home/ryenski/Projects/rails/actionpack/lib/action_controller/metal/request_forgery_protection.rb:401:in `verify_authenticity_token'
/home/ryenski/Projects/rails/activesupport/lib/active_support/callbacks.rb:361:in `block in make_lambda'
/home/ryenski/Projects/rails/activesupport/lib/active_support/callbacks.rb:178:in `block in call'
/home/ryenski/Projects/rails/actionpack/lib/abstract_controller/callbacks.rb:34:in `block (2 levels) in <module:Callbacks>'
/home/ryenski/Projects/rails/activesupport/lib/active_support/callbacks.rb:179:in `call'
/home/ryenski/Projects/rails/activesupport/lib/active_support/callbacks.rb:559:in `block in invoke_before'
/home/ryenski/Projects/rails/activesupport/lib/active_support/callbacks.rb:559:in `each'
/home/ryenski/Projects/rails/activesupport/lib/active_support/callbacks.rb:559:in `invoke_before'
/home/ryenski/Projects/rails/activesupport/lib/active_support/callbacks.rb:108:in `run_callbacks'
/home/ryenski/Projects/rails/actionpack/lib/abstract_controller/callbacks.rb:260:in `process_action'
/home/ryenski/Projects/rails/actionpack/lib/action_controller/metal/rescue.rb:27:in `process_action'
/home/ryenski/Projects/rails/actionpack/lib/action_controller/metal/instrumentation.rb:76:in `block in process_action'
/home/ryenski/Projects/rails/activesupport/lib/active_support/notifications.rb:210:in `block in instrument'
/home/ryenski/Projects/rails/activesupport/lib/active_support/notifications/instrumenter.rb:58:in `instrument'
/home/ryenski/Projects/rails/activesupport/lib/active_support/notifications.rb:210:in `instrument'
/home/ryenski/Projects/rails/actionpack/lib/action_controller/metal/instrumentation.rb:75:in `process_action'
/home/ryenski/Projects/rails/actionpack/lib/action_controller/metal/params_wrapper.rb:259:in `process_action'
/home/ryenski/Projects/rails/actionpack/lib/abstract_controller/base.rb:167:in `process'
/home/ryenski/Projects/rails/actionview/lib/action_view/rendering.rb:40:in `process'
/home/ryenski/Projects/rails/actionpack/lib/action_controller/metal.rb:252:in `dispatch'
/home/ryenski/Projects/rails/actionpack/lib/action_controller/test_case.rb:639:in `block in process_controller_response'
/home/ryenski/Projects/rails/actionpack/lib/action_controller/test_case.rb:631:in `wrap_execution'
/home/ryenski/Projects/rails/actionpack/lib/action_controller/test_case.rb:639:in `process_controller_response'
/home/ryenski/Projects/rails/actionpack/lib/action_controller/test_case.rb:549:in `process'
/home/ryenski/Projects/rails/actionpack/lib/action_controller/test_case.rb:446:in `post'
/home/ryenski/Projects/rails/actionpack/test/controller/request_forgery_protection_test.rb:503:in `block in test_should_raise_for_post_with_non_string_token_in_header'
---------------
```

<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
