### PR TITLE
Make Value type default to mutable

### DIFF
--- a/activemodel/lib/active_model/type/boolean.rb
+++ b/activemodel/lib/active_model/type/boolean.rb
@@ -12,6 +12,7 @@ module ActiveModel
     # - Empty strings are coerced to +nil+.
     # - All other values will be coerced to +true+.
     class Boolean < Value
+      include Helpers::Immutable
       FALSE_VALUES = [
         false, 0,
         "0", :"0",

--- a/activemodel/lib/active_model/type/date.rb
+++ b/activemodel/lib/active_model/type/date.rb
@@ -24,6 +24,7 @@ module ActiveModel
     # String values are parsed using the ISO 8601 date format. Any other values
     # are cast using their +to_date+ method, if it exists.
     class Date < Value
+      include Helpers::Immutable
       include Helpers::Timezone
       include Helpers::AcceptsMultiparameterTime.new
 

--- a/activemodel/lib/active_model/type/decimal.rb
+++ b/activemodel/lib/active_model/type/decimal.rb
@@ -43,6 +43,7 @@ module ActiveModel
     #     attribute :weight, :decimal, precision: 24
     #   end
     class Decimal < Value
+      include Helpers::Immutable
       include Helpers::Numeric
       BIGDECIMAL_PRECISION = 18
 

--- a/activemodel/lib/active_model/type/float.rb
+++ b/activemodel/lib/active_model/type/float.rb
@@ -34,6 +34,7 @@ module ActiveModel
     # - <tt>"-Infinity"</tt> is cast to <tt>-Float::INFINITY</tt>.
     # - <tt>"NaN"</tt> is cast to +Float::NAN+.
     class Float < Value
+      include Helpers::Immutable
       include Helpers::Numeric
 
       def type

--- a/activemodel/lib/active_model/type/helpers.rb
+++ b/activemodel/lib/active_model/type/helpers.rb
@@ -3,5 +3,6 @@
 require "active_model/type/helpers/accepts_multiparameter_time"
 require "active_model/type/helpers/numeric"
 require "active_model/type/helpers/mutable"
+require "active_model/type/helpers/immutable"
 require "active_model/type/helpers/time_value"
 require "active_model/type/helpers/timezone"

--- a/activemodel/lib/active_model/type/helpers/immutable.rb
+++ b/activemodel/lib/active_model/type/helpers/immutable.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module ActiveModel
+  module Type
+    module Helpers # :nodoc: all
+      module Immutable
+        def mutable? # :nodoc:
+          false
+        end
+      end
+    end
+  end
+end

--- a/activemodel/lib/active_model/type/immutable_string.rb
+++ b/activemodel/lib/active_model/type/immutable_string.rb
@@ -35,6 +35,8 @@ module ActiveModel
     #
     #   person.active # => "aye"
     class ImmutableString < Value
+      include Helpers::Immutable
+
       def initialize(**args)
         @true  = -(args.delete(:true)&.to_s  || "t")
         @false = -(args.delete(:false)&.to_s || "f")

--- a/activemodel/lib/active_model/type/integer.rb
+++ b/activemodel/lib/active_model/type/integer.rb
@@ -42,6 +42,7 @@ module ActiveModel
     #     attribute :age, :integer, limit: 6
     #   end
     class Integer < Value
+      include Helpers::Immutable
       include Helpers::Numeric
 
       # Column storage size in bytes.

--- a/activemodel/lib/active_model/type/time.rb
+++ b/activemodel/lib/active_model/type/time.rb
@@ -46,14 +46,6 @@ module ActiveModel
         :time
       end
 
-      def mutable? # :nodoc:
-        # Time#zone can be mutated by #utc or #localtime
-        # However when serializing the time zone will always
-        # be coerced and even if the zone was mutated Time instances
-        # remain equal, so we don't need to implement `#changed_in_place?`
-        true
-      end
-
       def user_input_in_time_zone(value)
         return unless value.present?
 

--- a/activemodel/lib/active_model/type/value.rb
+++ b/activemodel/lib/active_model/type/value.rb
@@ -138,7 +138,7 @@ module ActiveModel
       end
 
       def mutable? # :nodoc:
-        false
+        true
       end
 
       def as_json(*)

--- a/activemodel/test/cases/attribute_set_test.rb
+++ b/activemodel/test/cases/attribute_set_test.rb
@@ -2,6 +2,7 @@
 
 require "cases/helper"
 require "active_model/attribute_set"
+require "json"
 
 module ActiveModel
   class AttributeSetTest < ActiveModel::TestCase
@@ -288,6 +289,34 @@ module ActiveModel
       assert_equal false, attribute_set == nil
       assert_equal false, attribute_set == 1
       assert_equal true, attribute_set == attribute_set
+    end
+
+    class CustomMutableType < ::ActiveModel::Type::Value
+      def serialize(value)
+        return if value.nil?
+        JSON.dump(value)
+      end
+
+      def deserialize(value)
+        return if value.nil?
+        JSON.parse(value)
+      end
+
+      def changed_in_place?(old_value, new_value)
+        deserialize(old_value) != new_value
+      end
+    end
+
+    test "custom type is mutable" do
+      type = CustomMutableType.new()
+      attribute_set = AttributeSet::Builder.new(foo: type).build_from_database(foo: "[]")
+
+      # Ensure the type cast value is cached
+      attribute_set[:foo].value
+
+      dup = attribute_set.deep_dup
+      dup[:foo].value << "2"
+      assert_not_equal attribute_set[:foo].value, dup[:foo].value
     end
 
     private


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

After https://github.com/rails/rails/pull/53921 we noticed custom user types were immutable by default from ActiveModel::Type::Value (`mutable?` being nodoc). So we ran into unexpected scenarios where the custom types were not being properly duped due to being immutable in `dup_or_share`

### Detail

We change the default of `Value` type's `mutable?` to `true`. We made sure that all prior immutable types set `mutable?` to `false` via a new internal `Helpers::Immutable`