### PR TITLE
Enable statement-cached queries to be retryable

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Enable automatically retrying idempotent association queries on connection
+    errors.
+
+    *Hartley McGuire*
+
 *   Add `allow_retry` to `sql.active_record` instrumentation.
 
     This enables identifying queries which are and are not automatically

--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -55,12 +55,15 @@ module ActiveRecord
       # can be used to query the database repeatedly.
       def cacheable_query(klass, arel) # :nodoc:
         if prepared_statements
+          collector = collector()
+          collector.retryable = true
           sql, binds = visitor.compile(arel.ast, collector)
-          query = klass.query(sql)
+          query = klass.query(sql, retryable: collector.retryable)
         else
           collector = klass.partial_query_collector
+          collector.retryable = true
           parts, binds = visitor.compile(arel.ast, collector)
-          query = klass.partial_query(parts)
+          query = klass.partial_query(parts, retryable: collector.retryable)
         end
         [query, binds]
       end

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -450,7 +450,7 @@ module ActiveRecord
               where(wheres).limit(1)
             }
 
-            statement.execute(values.flatten, connection, allow_retry: true).then do |r|
+            statement.execute(values.flatten, connection).then do |r|
               r.first
             rescue TypeError
               raise ActiveRecord::StatementInvalid

--- a/activerecord/test/cases/adapter_test.rb
+++ b/activerecord/test/cases/adapter_test.rb
@@ -702,14 +702,15 @@ module ActiveRecord
 
       test "idempotent SELECT queries allow retries" do
         notifications = capture_notifications("sql.active_record") do
-          assert Post.first
+          assert (a = Author.first)
           assert Post.where(id: [1, 2]).first
           assert Post.find(1)
           assert Post.find_by(title: "Welcome to the weblog")
           assert_predicate Post, :exists?
+          a.books.to_a
         end.select { |n| n.payload[:name] != "SCHEMA" }
 
-        assert_equal 5, notifications.length
+        assert_equal 6, notifications.length
 
         notifications.each do |n|
           assert n.payload[:allow_retry]


### PR DESCRIPTION
### Motivation / Background

The StatementCache uses a different code path for generating SQL and executing queries, so it doesn't currently benefit from the ability to mark queries as retryable. This mainly affects association SELECTs, because the other user of StatementCache is `find_by` and it explicitly passes `allow_retry: true` when executing a cached query.

### Detail

This commit enables queries that would be retryable without using the StatementCache to also be retryable when using it. Just like in `to_sql_and_binds`, `cacheable_query` now sets `retryable: true` on the `collector` that constructs the query and additionally copies the `collector`'s final `retryable` value to the query object. Then, instead of accepting an `allow_retry` parameter when executing the cached query, `execute` now uses the query object's `retryable` attribute.

### Additional Information

The test for this case uses Author/Books instead of Post/Comments because Comment has a `default_scope`, so `post.comments` does not use the statement cache.

It would be nice if we could assert that `author.books.to_a` uses the statement cache, but I'm not sure of an obvious way at the moment.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
