### PR TITLE
Allow to skip HashWithIndifferentAccess value conversion

### DIFF
--- a/activemodel/lib/active_model/attribute_mutation_tracker.rb
+++ b/activemodel/lib/active_model/attribute_mutation_tracker.rb
@@ -16,17 +16,17 @@ module ActiveModel
     end
 
     def changed_values
-      attr_names.each_with_object({}.with_indifferent_access) do |attr_name, result|
+      attr_names.each_with_object(ActiveSupport::HashWithIndifferentAccess.new) do |attr_name, result|
         if changed?(attr_name)
-          result[attr_name] = original_value(attr_name)
+          result.store(attr_name, original_value(attr_name), convert_value: false)
         end
       end
     end
 
     def changes
-      attr_names.each_with_object({}.with_indifferent_access) do |attr_name, result|
+      attr_names.each_with_object(ActiveSupport::HashWithIndifferentAccess.new) do |attr_name, result|
         if change = change_to_attribute(attr_name)
-          result[attr_name] = change
+          result.store(attr_name, change, convert_value: false)
         end
       end
     end

--- a/activerecord/test/cases/store_test.rb
+++ b/activerecord/test/cases/store_test.rb
@@ -31,6 +31,14 @@ class StoreTest < ActiveRecord::TestCase
     assert_equal "37signals.com", @john.homepage
   end
 
+  test "reading store attributes with indifferent access" do
+    @john.preferences = { "remember_login" => "yes" }
+    assert_equal "yes", @john.remember_login
+
+    @john.preferences = { remember_login: "no" }
+    assert_equal "no", @john.remember_login
+  end
+
   test "writing store attributes does not update unchanged value" do
     admin_user = Admin::User.new(homepage: nil)
     admin_user.homepage = nil

--- a/activerecord/test/models/admin/user.rb
+++ b/activerecord/test/models/admin/user.rb
@@ -16,18 +16,28 @@ class Admin::User < ActiveRecord::Base
   end
 
   belongs_to :account
+
   store :params, accessors: [ :token ], coder: YAML
+
   store :settings, accessors: [ :color, :homepage ]
   store_accessor :settings, :favorite_food
+
   store :parent, accessors: [:birthday, :name], prefix: true
+
   store :spouse, accessors: [:birthday], prefix: :partner
   store_accessor :spouse, :name, prefix: :partner
+
   store :configs, accessors: [ :secret_question ]
   store :configs, accessors: [ :two_factor_auth ], suffix: true
   store_accessor :configs, :login_retry, suffix: :config
-  store :preferences, accessors: [ :remember_login ]
+
+  serialize :preferences, type: Hash, coder: Coder.new
+  store_accessor :preferences, :remember_login
+
   store :json_data, accessors: [ :height, :weight ], coder: Coder.new
+
   store :json_data_empty, accessors: [ :is_a_good_guy ], coder: Coder.new
+
   store_accessor :json_options, :enable_friend_requests
 
   def phone_number

--- a/activesupport/lib/active_support/hash_with_indifferent_access.rb
+++ b/activesupport/lib/active_support/hash_with_indifferent_access.rb
@@ -95,11 +95,27 @@ module ActiveSupport
     #   hash[:key] = 'value'
     #
     # This value can be later fetched using either +:key+ or <tt>'key'</tt>.
+    #
+    # If the value is a Hash or contains one or multiple Hashes, they will be
+    # converted to +HashWithIndifferentAccess+.
     def []=(key, value)
       regular_writer(convert_key(key), convert_value(value, conversion: :assignment))
     end
 
-    alias_method :store, :[]=
+    # Assigns a new value to the hash:
+    #
+    #   hash = ActiveSupport::HashWithIndifferentAccess.new
+    #   hash[:key] = 'value'
+    #
+    # This value can be later fetched using either +:key+ or <tt>'key'</tt>.
+    #
+    # If the value is a Hash or contains one or multiple Hashes, they will be
+    # converted to +HashWithIndifferentAccess+. unless `convert_value: false`
+    # is set.
+    def store(key, value, convert_value: true)
+      value = convert_value(value, conversion: :assignment) if convert_value
+      regular_writer(convert_key(key), value)
+    end
 
     # Updates the receiver in-place, merging in the hashes passed as arguments:
     #


### PR DESCRIPTION
Fix: https://github.com/rails/rails/issues/54433

And use it to avoid casting hash values in ActiveModel::Dirty.

This is a tentative fix, I'm not particularly happy with it, but I can't think of any better solution. @matthewd what do you think?