### PR TITLE
Make internal query() retryable for postgresql

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
@@ -11,8 +11,8 @@ module ActiveRecord
         end
 
         # Queries the database and returns the results in an Array-like object
-        def query(sql, name = nil) # :nodoc:
-          result = internal_execute(sql, name)
+        def query(sql, name = nil, allow_retry: true, materialize_transactions: true) # :nodoc:
+          result = internal_execute(sql, name, allow_retry:, materialize_transactions:)
           result.map_types!(@type_map_for_results).values
         end
 


### PR DESCRIPTION
### Motivation / Background

Ref  #53425

In a [previous commit][1], the abstract adapter's `query` method was changed to automatically retry (since the method is used for SCHEMA type queries, which are idempotent SELECTs). However, the postgresql adapter has its own `query` method and it was not changed.

### Detail

This commit makes the same change to the postgresql adapter's `query` so that it can also benefit from automatically retryable SCHEMA queries.

[1]: https://github.com/rails/rails/commit/b4c19d038e558d12c3e13317759ca13587c41a16

### Additional information

Note: not adding a CHANGELOG because its an internal change

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
