### PR TITLE
Rate limit password resets in auth generator

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Rate limit password resets in authentication generator
+
+    This helps mitigate abuse from attackers spamming the password reset form.
+
+    *Chris Oliver*
+
 *   Update `rails new --minimal` option
 
     Extend the `--minimal` flag to exlcude recently added features:

--- a/railties/lib/rails/generators/rails/authentication/templates/app/controllers/passwords_controller.rb.tt
+++ b/railties/lib/rails/generators/rails/authentication/templates/app/controllers/passwords_controller.rb.tt
@@ -1,6 +1,7 @@
 class PasswordsController < ApplicationController
   allow_unauthenticated_access
   before_action :set_user_by_token, only: %i[ edit update ]
+  rate_limit to: 10, within: 3.minutes, only: :create, with: -> { redirect_to new_password_path, alert: "Try again later." }
 
   def new
   end


### PR DESCRIPTION
### Motivation / Background

An attacker could spam the password reset form and send unlimited emails for an application. This should probably be rate limited to prevent abuse.

### Detail

This implements a matching `rate_limit` to what is used for `SessionController#create`.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
