### PR TITLE
Skip test if upsert/insert-duplicate not supported by database adapter

### DIFF
--- a/activerecord/test/cases/insert_all_test.rb
+++ b/activerecord/test/cases/insert_all_test.rb
@@ -864,6 +864,8 @@ class InsertAllTest < ActiveRecord::TestCase
   end
 
   def test_insert_all_with_unpersisted_records_triggers_deprecation
+    skip unless supports_insert_on_duplicate_skip?
+
     author = Author.create!(name: "Rafael")
     author.books.build(title: "Unpersisted Book")
 
@@ -876,6 +878,8 @@ class InsertAllTest < ActiveRecord::TestCase
   end
 
   def test_insert_all_without_unpersisted_records_has_no_deprecation
+    skip unless supports_insert_on_duplicate_skip?
+
     author = Author.create!(name: "Rafael")
 
     assert_not_deprecated(ActiveRecord.deprecator) do
@@ -884,6 +888,8 @@ class InsertAllTest < ActiveRecord::TestCase
   end
 
   def test_insert_with_unpersisted_records_triggers_deprecation
+    skip unless supports_insert_on_duplicate_skip?
+
     author = Author.create!(name: "Rafael")
     author.books.build(title: "Unpersisted Book")
 
@@ -896,6 +902,8 @@ class InsertAllTest < ActiveRecord::TestCase
   end
 
   def test_insert_without_unpersisted_records_has_no_deprecation
+    skip unless supports_insert_on_duplicate_skip?
+
     author = Author.create!(name: "Rafael")
 
     assert_not_deprecated(ActiveRecord.deprecator) do
@@ -924,6 +932,8 @@ class InsertAllTest < ActiveRecord::TestCase
   end
 
   def test_upsert_all_with_unpersisted_record_triggers_deprecation
+    skip unless supports_insert_on_duplicate_update?
+
     author = Author.create!(name: "Rafael")
     author.books.build(title: "Unpersisted Book")
 
@@ -936,6 +946,8 @@ class InsertAllTest < ActiveRecord::TestCase
   end
 
   def test_upsert_all_without_unpersisted_records_has_no_deprecation
+    skip unless supports_insert_on_duplicate_update?
+
     author = Author.create!(name: "Rafael")
 
     assert_not_deprecated(ActiveRecord.deprecator) do
@@ -944,6 +956,8 @@ class InsertAllTest < ActiveRecord::TestCase
   end
 
   def test_upsert_with_unpersisted_record_triggers_deprecation
+    skip unless supports_insert_on_duplicate_update?
+
     author = Author.create!(name: "Rafael")
     author.books.build(title: "Unpersisted Book")
 
@@ -956,6 +970,8 @@ class InsertAllTest < ActiveRecord::TestCase
   end
 
   def test_upsert_without_unpersisted_records_has_no_deprecation
+    skip unless supports_insert_on_duplicate_update?
+
     author = Author.create!(name: "Rafael")
 
     assert_not_deprecated(ActiveRecord.deprecator) do


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

A number of tests in `activerecord/test/cases/insert_all_test.rb` are:

- Calling `upsert` without first checking `supports_insert_on_duplicate_update?`
- Calling `insert` without first checking `supports_insert_on_duplicate_skip?` 

This is not an issue for the core adapters (MySQL/SQLite/Postgresql) that support upserting. However SQL Server does not support upsert/insert-duplicate and so the missing checks are causing tests to fail.

The affected tests were only added recently by https://github.com/rails/rails/pull/53920

This PR is very similar to https://github.com/rails/rails/pull/53879

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
