### PR TITLE
Explain setting `active_support.to_time_preserves_timezone` default

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_8_0.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_8_0.rb.tt
@@ -10,12 +10,14 @@
 # https://guides.rubyonrails.org/upgrading_ruby_on_rails.html
 
 ###
+# ** Please read carefully, this must be configured in config/application.rb **
+#
 # Specifies whether `to_time` methods preserve the UTC offset of their receivers or preserves the timezone.
 # If set to `:zone`, `to_time` methods will use the timezone of their receivers.
 # If set to `:offset`, `to_time` methods will use the UTC offset.
 # If `false`, `to_time` methods will convert to the local system UTC offset instead.
-#++
-# Rails.application.config.active_support.to_time_preserves_timezone = :zone
+# When you're ready to change, add the following line to `config/application.rb` (NOT this file):
+#   config.active_support.to_time_preserves_timezone = :zone
 
 ###
 # When both `If-Modified-Since` and `If-None-Match` are provided by the client


### PR DESCRIPTION
### Motivation / Background

It's very likely `ActiveSupport` gets loaded during the start up process before any `config/initializers` get loaded.
The ActiveSupport railtie will run [the initializer](https://github.com/rails/rails/blob/b5d60f0736fb1f84c40133fb1f1ba5633f9e6955/activesupport/lib/active_support/railtie.rb#L101) that sets `ActiveSupport.to_time_preserves_timezone`.

So setting `to_time_preserves_timezone` needs to be set in `config/application.rb` instead of the new frameworks defaults initializer.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
