### PR TITLE
Fix :blank error message in i18n guide to match default [ci skip]

### DIFF
--- a/guides/source/i18n.md
+++ b/guides/source/i18n.md
@@ -960,7 +960,7 @@ This way you can provide special translations for various error messages at diff
 
 The translated model name, translated attribute name, and value are always available for interpolation as `model`, `attribute` and `value` respectively.
 
-So, for example, instead of the default error message `"cannot be blank"` you could use the attribute name like this : `"Please fill in your %{attribute}"`.
+So, for example, instead of the default error message `"can't be blank"` you could use the attribute name like this : `"Please fill in your %{attribute}"`.
 
 * `count`, where available, can be used for pluralization if present:
 


### PR DESCRIPTION
### Motivation / Background

The i18n guide mentions the default error message for the `:blank` error. It's given as `cannot be blank`, however the actual default is `can't be blank`, found in [active_model/locale/en.yml](https://github.com/rails/rails/blob/acf7698858e6dbfee44260067b5d79b9bf4979b2/activemodel/lib/active_model/locale/en.yml#L16).

### Detail

Fix the guide to use the correct default error message.

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
