### PR TITLE
Fix ActionCable allowed_request_origin configuration guide typo [ci skip]

### DIFF
--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -2954,7 +2954,7 @@ only the configured origins.
 
 #### `config.action_cable.allowed_request_origins`
 
-Determines the request origins which will be accepted but the cable server.
+Determines the request origins which will be accepted by the cable server.
 The default value is `/https?:\/\/localhost:\d+/` in the `development` environment.
 
 ### Configuring Active Storage


### PR DESCRIPTION
Fix a typo in the [ActionCable Configuration Section 3.16.4](https://guides.rubyonrails.org/configuring.html#config-action-cable-allowed-request-origins) guides changing "accepted but the cable server" to "accepted by the cable server".