### PR TITLE
Allow execution wrapper to handle all exceptions

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/executor.rb
+++ b/actionpack/lib/action_dispatch/middleware/executor.rb
@@ -21,7 +21,7 @@ module ActionDispatch
         end
 
         returned = response << ::Rack::BodyProxy.new(response.pop) { state.complete! }
-      rescue => error
+      rescue Exception => error
         request = ActionDispatch::Request.new env
         backtrace_cleaner = request.get_header("action_dispatch.backtrace_cleaner")
         wrapper = ExceptionWrapper.new(backtrace_cleaner, error)

--- a/actionpack/test/dispatch/executor_test.rb
+++ b/actionpack/test/dispatch/executor_test.rb
@@ -122,9 +122,9 @@ class ExecutorTest < ActiveSupport::TestCase
 
   def test_error_reporting
     raised_error = nil
-    error_report = assert_error_reported do
-      raised_error = assert_raises TypeError do
-        call_and_return_body { 1 + "1" }
+    error_report = assert_error_reported(Exception) do
+      raised_error = assert_raises Exception do
+        call_and_return_body { raise Exception }
       end
     end
     assert_same raised_error, error_report.error

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Allow execution wrapping to handle all exceptions
+
+    If a more serious error like `SystemStackError` or `NoMemoryError` happens,
+    the error reporter should be able to report these kinds of exceptions.
+    Some are not recoverable, but many are, so we should at least try to
+    report them.
+
+    *Gannon McGibbon*
+
 *   `ActiveSupport::Testing::Parallelization.before_fork_hook` allows declaration of callbacks that
     are invoked immediately before forking test workers.
 

--- a/activesupport/lib/active_support/execution_wrapper.rb
+++ b/activesupport/lib/active_support/execution_wrapper.rb
@@ -89,7 +89,7 @@ module ActiveSupport
       instance = run!
       begin
         yield
-      rescue => error
+      rescue Exception => error
         error_reporter&.report(error, handled: false, source: source)
         raise
       ensure

--- a/activesupport/test/executor_test.rb
+++ b/activesupport/test/executor_test.rb
@@ -3,7 +3,7 @@
 require_relative "abstract_unit"
 
 class ExecutorTest < ActiveSupport::TestCase
-  class DummyError < RuntimeError
+  class DummyError < Exception
   end
 
   class ErrorSubscriber


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because the execution wrapper doesn't catch _all_ errors an application can throw. If a more serious error like `SystemStackError` or `NoMemoryError` happens, the error reporter should be able to report these kinds of exceptions. Some are not recoverable, but many are, so we should at least try to report them.

### Detail

This Pull Request changes the execution wrapper and execution middleware to default to catching all `Exception`s instead of all `StandardError`s.

### Additional information

Essentially, before this change:
```rb
Rails.error.handle do
  raise Exception
end
```
would not handle the exception, but now it does.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
