### PR TITLE
Fix migrating multiple DBs with pending migration action

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Fix migrating multiple databases with `ActiveRecord::PendingMigration` action.
+
+    *Gannon McGibbon*
+
 *   Enable automatically retrying idempotent association queries on connection
     errors.
 

--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -148,11 +148,10 @@ module ActiveRecord
     include ActiveSupport::ActionableError
 
     action "Run pending migrations" do
-      ActiveRecord::Tasks::DatabaseTasks.migrate
+      ActiveRecord::Tasks::DatabaseTasks.migrate_all
 
       if ActiveRecord.dump_schema_after_migration
-        connection = ActiveRecord::Tasks::DatabaseTasks.migration_connection
-        ActiveRecord::Tasks::DatabaseTasks.dump_schema(connection.pool.db_config)
+        ActiveRecord::Tasks::DatabaseTasks.dump_all
       end
     end
 

--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -447,11 +447,7 @@ db_namespace = namespace :db do
   namespace :schema do
     desc "Create a database schema file (either db/schema.rb or db/structure.sql, depending on `ENV['SCHEMA_FORMAT']` or `config.active_record.schema_format`)"
     task dump: :load_config do
-      ActiveRecord::Tasks::DatabaseTasks.with_temporary_pool_for_each do |pool|
-        db_config = pool.db_config
-        schema_format = ENV.fetch("SCHEMA_FORMAT", ActiveRecord.schema_format).to_sym
-        ActiveRecord::Tasks::DatabaseTasks.dump_schema(db_config, schema_format)
-      end
+      ActiveRecord::Tasks::DatabaseTasks.dump_all
 
       db_namespace["schema:dump"].reenable
     end

--- a/activerecord/lib/active_record/tasks/database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/database_tasks.rb
@@ -428,6 +428,14 @@ module ActiveRecord
         end
       end
 
+      def dump_all
+        with_temporary_pool_for_each do |pool|
+          db_config = pool.db_config
+          schema_format = ENV.fetch("SCHEMA_FORMAT", ActiveRecord.schema_format).to_sym
+          ActiveRecord::Tasks::DatabaseTasks.dump_schema(db_config, schema_format)
+        end
+      end
+
       def dump_schema(db_config, format = ActiveRecord.schema_format) # :nodoc:
         return unless db_config.schema_dump
 


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because migrating multiple DBs with the pending migration action is currently broken. This was supposed to work with multiple DBs, but the task code and the migration code have fallen out of sync and the pending migration action only works against primary. With this patch, we use `ActiveRecord::Tasks::DatabaseTasks.migrate_all` for both, and introduce `ActiveRecord::Tasks::DatabaseTasks.dump_all` to use in the task and action.

### Detail

This Pull Request changes two things:
- The pending migration action to use the same code path as the `db:migrate` task (migrating _all_ DBs)
- Introduces `ActiveRecord::Tasks::DatabaseTasks.dump_all` to unify schema bumping logic for all DBs in one place so it may be called by the migrate/dump task and pending migration action

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
