### PR TITLE
Enable query-cacheable queries to be retryable

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb
@@ -239,7 +239,7 @@ module ActiveRecord
         # If arel is locked this is a SELECT ... FOR UPDATE or somesuch.
         # Such queries should not be cached.
         if @query_cache&.enabled? && !(arel.respond_to?(:locked) && arel.locked)
-          sql, binds, preparable, allow_retry = to_sql_and_binds(arel, binds, preparable)
+          sql, binds, preparable, allow_retry = to_sql_and_binds(arel, binds, preparable, allow_retry)
 
           if async
             result = lookup_sql_cache(sql, name, binds) || super(sql, name, binds, preparable: preparable, async: async, allow_retry: allow_retry)


### PR DESCRIPTION
### Motivation / Background

The query cache implementation calls `to_sql_and_binds` inside its `select_all` override so that it can use the generated sql and binds as a cache key. However, the current implementation does not pass the `allow_retry` parameter into `to_sql_and_binds`. This is an issue when the `arel` parameter is a String, because query cache's `select_all` will override the `allow_retry` parameter with the value returned from `to_sql_and_binds` (and because it isn't passed through, it will always be the default, false).

### Detail

This commit fixes the issue by passing the `allow_retry` parameter through to `to_sql_and_binds`. This will ensure that when `select_all` is called with a String query, `allow_retry: true`, and the query cache enabled that the query will maintain its retryable state.

### Additional information

This combination of prerequisites can occur when a query is executed from the Statement Cache since the Statement Cache does its own query compilation.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
