### PR TITLE
Regex escape table names and quoted table names used in regex

### DIFF
--- a/activerecord/lib/active_record/associations/alias_tracker.rb
+++ b/activerecord/lib/active_record/associations/alias_tracker.rb
@@ -26,16 +26,18 @@ module ActiveRecord
       end
 
       def self.initial_count_for(connection, name, table_joins)
-        quoted_name = nil
+        quoted_name_escaped = nil
+        name_escaped = nil
 
         counts = table_joins.map do |join|
           if join.is_a?(Arel::Nodes::StringJoin)
-            # quoted_name should be case ignored as some database adapters (Oracle) return quoted name in uppercase
-            quoted_name ||= connection.quote_table_name(name)
+            # quoted_name_escaped should be case ignored as some database adapters (Oracle) return quoted name in uppercase
+            quoted_name_escaped ||= Regexp.escape(connection.quote_table_name(name))
+            name_escaped ||= Regexp.escape(name)
 
             # Table names + table aliases
             join.left.scan(
-              /JOIN(?:\s+\w+)?\s+(?:\S+\s+)?(?:#{quoted_name}|#{name})\sON/i
+              /JOIN(?:\s+\w+)?\s+(?:\S+\s+)?(?:#{quoted_name_escaped}|#{name_escaped})\sON/i
             ).size
           elsif join.is_a?(Arel::Nodes::Join)
             join.left.name == name ? 1 : 0


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

Table names and quoted table names are being used in regular expression without first being regex escaped. 

### Detail

In SQL Server table names are quoted using square brackets `[]`, which are regex characters. This is causing Ruby warning messages like:

```
rails-2e34511f8854/activerecord/lib/active_record/associations/alias_tracker.rb:38: warning: character class has duplicated range: /JOIN(?:\s+\w+)?\s+(?:\S+\s+)?(?:[posts]|posts)\sON/
```

AFAIK PostgreSQL/MySQL/SQLite table names could contain regex characters, such as periods `.`, and so regex escaping the tables names for all adapters seems prudent. 

The PR does not contain a test case as the change is small but I can add one if needed. 

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.