### PR TITLE
Backport #54458 to `7-2-stable`

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Fix a case where a non-retryable query could be marked retryable.
+
+    *Hartley McGuire*
+
 *   Handle circular references when autosaving associations.
 
     *zzak*

--- a/activerecord/lib/arel/visitors/to_sql.rb
+++ b/activerecord/lib/arel/visitors/to_sql.rb
@@ -763,7 +763,7 @@ module Arel # :nodoc: all
 
         def visit_Arel_Nodes_SqlLiteral(o, collector)
           collector.preparable = false
-          collector.retryable = o.retryable
+          collector.retryable &&= o.retryable
           collector << o.to_s
         end
 

--- a/activerecord/test/cases/arel/visitors/to_sql_test.rb
+++ b/activerecord/test/cases/arel/visitors/to_sql_test.rb
@@ -72,6 +72,7 @@ module Arel
       it "should mark collector as non-retryable when visiting named function" do
         function = Nodes::NamedFunction.new("ABS", [@table])
         collector = Collectors::SQLString.new
+        collector.retryable = true
         @visitor.accept(function, collector)
 
         assert_equal false, collector.retryable
@@ -80,22 +81,37 @@ module Arel
       it "should mark collector as non-retryable when visiting SQL literal" do
         node = Nodes::SqlLiteral.new("COUNT(*)")
         collector = Collectors::SQLString.new
+        collector.retryable = true
         @visitor.accept(node, collector)
 
         assert_equal false, collector.retryable
       end
 
-      it "should mark collector as retryable if SQL literal is marked as retryable" do
+      it "should not change retryable if SQL literal is marked as retryable" do
         node = Nodes::SqlLiteral.new("COUNT(*)", retryable: true)
         collector = Collectors::SQLString.new
+        collector.retryable = true
         @visitor.accept(node, collector)
 
-        assert collector.retryable
+        assert_predicate collector, :retryable
+      end
+
+      it "should mark collector as non-retryable if SQL literal is not retryable" do
+        node = Nodes::As.new(
+          Nodes::SqlLiteral.new("`product.id`"),
+          Nodes::SqlLiteral.new("`product.id`", retryable: true)
+        )
+        collector = Collectors::SQLString.new
+        collector.retryable = true
+        @visitor.accept(node, collector)
+
+        assert_equal false, collector.retryable
       end
 
       it "should mark collector as non-retryable when visiting bound SQL literal" do
         node = Nodes::BoundSqlLiteral.new("id IN (?)", [[1, 2, 3]], {})
         collector = Collectors::SQLString.new
+        collector.retryable = true
         @visitor.accept(node, collector)
 
         assert_equal false, collector.retryable
@@ -104,6 +120,7 @@ module Arel
       it "should mark collector as non-retryable when visiting insert statement node" do
         statement = Arel::Nodes::InsertStatement.new(@table)
         collector = Collectors::SQLString.new
+        collector.retryable = true
         @visitor.accept(statement, collector)
 
         assert_equal false, collector.retryable
@@ -112,6 +129,7 @@ module Arel
       it "should mark collector as non-retryable when visiting update statement node" do
         statement = Arel::Nodes::UpdateStatement.new(@table)
         collector = Collectors::SQLString.new
+        collector.retryable = true
         @visitor.accept(statement, collector)
 
         assert_equal false, collector.retryable
@@ -120,6 +138,7 @@ module Arel
       it "should mark collector as non-retryable when visiting delete statement node" do
         statement = Arel::Nodes::DeleteStatement.new(@table)
         collector = Collectors::SQLString.new
+        collector.retryable = true
         @visitor.accept(statement, collector)
 
         assert_equal false, collector.retryable


### PR DESCRIPTION
Ref #54458

The cherry-pick didn't apply cleanly due to Arel test refactoring, so I fixed that up manually
