### PR TITLE
Ensure allow_retry passed when mysql2 prepared

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/mysql2/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql2/database_statements.rb
@@ -23,7 +23,7 @@ module ActiveRecord
               end
             end
           else
-            exec_stmt_and_free(sql, name, binds, cache_stmt: prepare, async: async) do |_, result|
+            exec_stmt_and_free(sql, name, binds, cache_stmt: prepare, async: async, allow_retry: allow_retry) do |_, result|
               if result
                 build_result(columns: result.fields, rows: result.to_a)
               else
@@ -105,7 +105,7 @@ module ActiveRecord
             end
           end
 
-          def exec_stmt_and_free(sql, name, binds, cache_stmt: false, async: false)
+          def exec_stmt_and_free(sql, name, binds, cache_stmt: false, async: false, allow_retry: false)
             sql = transform_query(sql)
             check_if_write_query(sql)
 
@@ -114,7 +114,7 @@ module ActiveRecord
             type_casted_binds = type_casted_binds(binds)
 
             log(sql, name, binds, type_casted_binds, async: async) do |notification_payload|
-              with_raw_connection do |conn|
+              with_raw_connection(allow_retry: allow_retry) do |conn|
                 sync_timezone_changes(conn)
 
                 if cache_stmt


### PR DESCRIPTION
In Rails 8, adapters were [refactored][1] to have a more uniform interface, and this included unifying the checking out of a `raw_connection` for the prepared and unprepared statement code paths. However, the code paths are distinct on Rails 7.2 and `allow_retry` is not passed to `raw_connection` in the prepared statement path.

This commit passes through `allow_retry` so that prepared statements can also be automatically retried.

[1]: https://github.com/rails/rails/commit/fd24e5bfc9540fc00764a59ddf39a993bbd63ba2

---

Looks like this test has been failing since at least 56aed9d6f2080c24d5152ccab0204d0fe31826ee but I'm not sure why that commit made it suddenly fail.