### PR TITLE
Pass keyword arguments to PostgreSQL Adapter Table methods

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_definitions.rb
@@ -307,8 +307,8 @@ module ActiveRecord
         #  t.exclusion_constraint("price WITH =, availability_range WITH &&", using: :gist, name: "price_check")
         #
         # See {connection.add_exclusion_constraint}[rdoc-ref:SchemaStatements#add_exclusion_constraint]
-        def exclusion_constraint(*args)
-          @base.add_exclusion_constraint(name, *args)
+        def exclusion_constraint(...)
+          @base.add_exclusion_constraint(name, ...)
         end
 
         # Removes the given exclusion constraint from the table.
@@ -316,8 +316,8 @@ module ActiveRecord
         #  t.remove_exclusion_constraint(name: "price_check")
         #
         # See {connection.remove_exclusion_constraint}[rdoc-ref:SchemaStatements#remove_exclusion_constraint]
-        def remove_exclusion_constraint(*args)
-          @base.remove_exclusion_constraint(name, *args)
+        def remove_exclusion_constraint(...)
+          @base.remove_exclusion_constraint(name, ...)
         end
 
         # Adds a unique constraint.
@@ -325,8 +325,8 @@ module ActiveRecord
         #  t.unique_constraint(:position, name: 'unique_position', deferrable: :deferred, nulls_not_distinct: true)
         #
         # See {connection.add_unique_constraint}[rdoc-ref:SchemaStatements#add_unique_constraint]
-        def unique_constraint(*args)
-          @base.add_unique_constraint(name, *args)
+        def unique_constraint(...)
+          @base.add_unique_constraint(name, ...)
         end
 
         # Removes the given unique constraint from the table.
@@ -334,8 +334,8 @@ module ActiveRecord
         #  t.remove_unique_constraint(name: "unique_position")
         #
         # See {connection.remove_unique_constraint}[rdoc-ref:SchemaStatements#remove_unique_constraint]
-        def remove_unique_constraint(*args)
-          @base.remove_unique_constraint(name, *args)
+        def remove_unique_constraint(...)
+          @base.remove_unique_constraint(name, ...)
         end
 
         # Validates the given constraint on the table.
@@ -344,8 +344,8 @@ module ActiveRecord
         #  t.validate_constraint "price_check"
         #
         # See {connection.validate_constraint}[rdoc-ref:SchemaStatements#validate_constraint]
-        def validate_constraint(*args)
-          @base.validate_constraint(name, *args)
+        def validate_constraint(...)
+          @base.validate_constraint(name, ...)
         end
 
         # Validates the given check constraint on the table
@@ -354,8 +354,8 @@ module ActiveRecord
         #  t.validate_check_constraint name: "price_check"
         #
         # See {connection.validate_check_constraint}[rdoc-ref:SchemaStatements#validate_check_constraint]
-        def validate_check_constraint(*args)
-          @base.validate_check_constraint(name, *args)
+        def validate_check_constraint(...)
+          @base.validate_check_constraint(name, ...)
         end
       end
 

--- a/activerecord/test/cases/migration/change_table_test.rb
+++ b/activerecord/test/cases/migration/change_table_test.rb
@@ -165,28 +165,28 @@ module ActiveRecord
 
         def test_exclusion_constraint_creates_exclusion_constraint
           with_change_table do |t|
-            expect :add_exclusion_constraint, nil, [:delete_me, "daterange(start_date, end_date) WITH &&", using: :gist, where: "start_date IS NOT NULL AND end_date IS NOT NULL", name: "date_overlap"]
+            expect :add_exclusion_constraint, nil, [:delete_me, "daterange(start_date, end_date) WITH &&"], using: :gist, where: "start_date IS NOT NULL AND end_date IS NOT NULL", name: "date_overlap"
             t.exclusion_constraint "daterange(start_date, end_date) WITH &&", using: :gist, where: "start_date IS NOT NULL AND end_date IS NOT NULL", name: "date_overlap"
           end
         end
 
         def test_remove_exclusion_constraint_removes_exclusion_constraint
           with_change_table do |t|
-            expect :remove_exclusion_constraint, nil, [:delete_me, name: "date_overlap"]
+            expect :remove_exclusion_constraint, nil, [:delete_me], name: "date_overlap"
             t.remove_exclusion_constraint name: "date_overlap"
           end
         end
 
         def test_unique_constraint_creates_unique_constraint
           with_change_table do |t|
-            expect :add_unique_constraint, nil, [:delete_me, :foo, deferrable: :deferred, name: "unique_constraint"]
+            expect :add_unique_constraint, nil, [:delete_me, :foo], deferrable: :deferred, name: "unique_constraint"
             t.unique_constraint :foo, deferrable: :deferred, name: "unique_constraint"
           end
         end
 
         def test_remove_unique_constraint_removes_unique_constraint
           with_change_table do |t|
-            expect :remove_unique_constraint, nil, [:delete_me, name: "unique_constraint"]
+            expect :remove_unique_constraint, nil, [:delete_me], name: "unique_constraint"
             t.remove_unique_constraint name: "unique_constraint"
           end
         end


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

Fixes #54471

### Detail

`t.exclusion_constraint` and `t.unique_constraint` are extensions available only for the PostgreSQL adapter. These delegate the given arguments to `SchemaStatements#add_exclusion_constraint` etc., but the current implementation receives all arguments as an array, so keyword arguments cannot be passed correctly.
As a result, method calls that pass keyword arguments always result in an argument error.

This change fixes this issue by forwarding arguments using `...`.

Currently, `t.validate_constraint` and `t.validate_check_constraint` do not accept keyword arguments, but we changes them in preparation for the future.

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
