### PR TITLE
Ensure sessions controller redirects authenticated users instead of raising an error on Sign in

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   Add `redirect_if_authenticated` to sessions controller when running `rails g authentication`
+
+    When using rails default `rails g authentication`, attempting to sign in while
+    already authenticated resulted in an error. This change updates the
+    sessions controller to redirect users to `after_authentication_url`
+    instead of raising an error when they try to sign in while already
+    logged in.
+
+    *Atul Kanswal*
+
 *   Remove unnecessary `ruby-version` input from `ruby/setup-ruby`
 
     *TangRufus*

--- a/railties/lib/rails/generators/rails/authentication/templates/app/controllers/concerns/authentication.rb.tt
+++ b/railties/lib/rails/generators/rails/authentication/templates/app/controllers/concerns/authentication.rb.tt
@@ -49,4 +49,8 @@ module Authentication
       Current.session.destroy
       cookies.delete(:session_id)
     end
+
+    def redirect_if_authenticated
+      redirect_to(after_authentication_url, alert: "Already Authenticated.") if authenticated?
+    end
 end

--- a/railties/lib/rails/generators/rails/authentication/templates/app/controllers/sessions_controller.rb.tt
+++ b/railties/lib/rails/generators/rails/authentication/templates/app/controllers/sessions_controller.rb.tt
@@ -1,4 +1,5 @@
 class SessionsController < ApplicationController
+  before_action :redirect_if_authenticated, only: %i[ new create ]
   allow_unauthenticated_access only: %i[ new create ]
   rate_limit to: 10, within: 3.minutes, only: :create, with: -> { redirect_to new_session_path, alert: "Try again later." }
 


### PR DESCRIPTION
#### **Motivation / Background**
When a user tries to sign in while already authenticated using the default sessions controller, an error occurs. This Pull Request ensures that instead of raising an error, the user is redirected to `after_authentication_url`.

#### **Detail**
- Added `redirect_if_authenticated` to the sessions controller to handle cases where an already authenticated user tries to sign in.
- Now, instead of throwing an error, the controller will redirect the user to `after_authentication_url`.

#### **Additional Information**
This change improves the user experience by preventing unnecessary authentication errors and ensuring a smooth redirection flow.

#### **Checklist**
- [x] This Pull Request is related to one change.  
- [x] Commit message has a detailed description of what changed and why.  
- [x] Tests are added or updated if applicable.  
- [x] CHANGELOG files are updated if this change affects behavior or adds a new feature.  