### PR TITLE
[WIP][2nd] Use MessageVerifier Factory to initialize Signed Id Message Verifier

### DIFF
--- a/activesupport/lib/active_support/message_verifier.rb
+++ b/activesupport/lib/active_support/message_verifier.rb
@@ -166,6 +166,8 @@ module ActiveSupport
     #   +config.active_support.use_message_serializer_for_metadata+.
     def initialize(secret, **options)
       raise ArgumentError, "Secret should not be nil." unless secret
+
+      options[:url_safe] = true if options[:url_safe].nil?
       super(**options)
       @secret = secret
       @digest = options[:digest]&.to_s || "SHA1"


### PR DESCRIPTION
### Ref: Issue #54357, pull-request [#54422](https://github.com/rails/rails/pull/54422)

The current implementation of **Signed ID** only partially utilizes the designed rotation architecture, which is why rotation functionalities are not working as expected.  

### Details  
As suggested by @jonathanhefner [here](https://github.com/rails/rails/pull/54371/files#r1931046047) and [here](https://github.com/rails/rails/pull/54422/files#r1943324806), the best approach to resolve **issue #54357** is to use **MessageVerifiers** factory, similar to how `generated_token_verifier` and `ActiveStorage.verifier` were implemented previously.  

The new implementation will be **backward- and forward-compatible**, ensuring that it does not break any existing applications.  

These changes will enable proper usage of `rotate` and `on_rotation` as shown in the example below:  

```ruby
# Rotate verifier for Signed ID
Rails.application.message_verifiers.rotate do |salt|
  next nil if salt != 'active_record/signed_id'

  secret_generator = ->(_) { 'old_secret' }
  { secret_generator: secret_generator, digest: "SHA256", serializer: JSON, url_safe: true }
end

# Enable `transitional` mode for rolling deployment
Rails.application.message_verifiers.transitional = true

# `on_rotation` callback to log the usage of old verifiers
Rails.application.message_verifiers.on_rotation do
  puts "Old verifier used for verifying! Still in use!"
end
```

### Impacts
- Make `url_safe` default for other message-verifiers (Ref: https://github.com/rails/rails/pull/49507)
- Use `SHA1` instead of `SHA256` for `digest` ([here](https://github.com/rails/rails/blob/main/activesupport/lib/active_support/message_verifier.rb#L171))
- Same `signed_id_verifier` and `signed_id_verifier_secret` for all Models, because we've switched to `mattr_accessor` from `class_attribute`. (?)

### Todos
- [ ] Add tests to cover new scenarios
- [ ] Ensure CI passes
- [ ] Update documentation
