### PR TITLE
Simplify stdparam state to reduce retained hashes

### DIFF
--- a/actionpack/lib/action_dispatch/journey/visualizer/fsm.js
+++ b/actionpack/lib/action_dispatch/journey/visualizer/fsm.js
@@ -105,12 +105,10 @@ function match(input) {
         }
 
         if(stdparam_states[state] && default_re.test(token)) {
-          for(var key in stdparam_states[state]) {
-            var new_state = stdparam_states[state][key];
-            highlight_edge(state, new_state);
-            highlight_state(new_state);
-            new_states.push([new_state, null]);
-          }
+          var new_state = stdparam_states[state];
+          highlight_edge(state, new_state);
+          highlight_state(new_state);
+          new_states.push([new_state, null]);
         }
       }
 


### PR DESCRIPTION
### Motivation / Background

Previously, the stdparam_state would look somthing like:

```
{
  13 => { /\A(?-mix:[^.\/?]+)\Z/ => 24 },
  14 => { /\A(?-mix:[^.\/?]+)\Z/ => 25 },
  15 => { /\A(?-mix:[^.\/?]+)\Z/ => 26 },
  16 => { /\A(?-mix:[^.\/?]+)\Z/ => 27 },
  17 => { /\A(?-mix:[^.\/?]+)\Z/ => 28 },
  18 => { /\A(?-mix:[^.\/?]+)\Z/ => 29 },
  19 => { /\A(?-mix:[^.\/?]+)\Z/ => 30 },
  20 => { /\A(?-mix:[^.\/?]+)\Z/ => 31 },
  ...
}
```

Every single value is a hash with DEFAULT_EXP_ANCHORED as the only key and a state as the only value. Additionally, because these values are hashes, the Transition Table used `#each` to iterate over them even though the iteration ignores the key, DEFAULT_EXP_ANCHORED (since the `match?` is cached outside the loop), and the hash will only ever contain a single entry.

### Detail

This commit refactors the `stdparam_state` to be a simple hash mapping `from` to `to` values:

```
{
  13 => 24,
  14 => 25,
  15 => 26,
  16 => 27,
  17 => 28,
  18 => 29,
  19 => 30,
  20 => 31,
  ...
}
```

In a large application this can save thousands of retained hashes (concretely, in [jeremyevans/r10k][1]'s `rails_4_10.rb` benchmark this saves 21111 hashes).

[1]: https://github.com/jeremyevans/r10k

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
