### PR TITLE
Use JSON::Coder when available

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -313,7 +313,7 @@ GEM
     jmespath (1.6.2)
     jsbundling-rails (1.3.1)
       railties (>= 6.0.0)
-    json (2.9.1)
+    json (2.10.0)
     jwt (2.10.1)
       base64
     kamal (2.4.0)

--- a/activesupport/lib/active_support/core_ext/string/output_safety.rb
+++ b/activesupport/lib/active_support/core_ext/string/output_safety.rb
@@ -139,6 +139,10 @@ module ActiveSupport # :nodoc:
       self
     end
 
+    def as_json
+      to_str
+    end
+
     def to_param
       to_str
     end


### PR DESCRIPTION
Using JSON::Coder (https://github.com/ruby/json/pull/718) avoids walking through the tree twice. Now the benchmark spends 80% of the time in `gsub!`.

```ruby
# frozen_string_literal: true

require "bundler/inline"

gemfile do
  source 'https://rubygems.org'
  gem 'benchmark-ips'
  gem 'rails', path: '.'
  gem "json", ">= 2.10.0"
end

require "active_support"
require "active_support/json/encoding"

obj = JSON.load_file("../../ruby/json/benchmark/data/twitter.json")

puts ActiveSupport::JSON::Encoding.json_encoder
Benchmark.ips do |x|
  x.report "obj.to_json" do
    obj.to_json
  end
end
```

On my M1 MacBook Air:
Before:
```
ActiveSupport::JSON::Encoding::JSONGemEncoder
ruby 3.4.1 (2024-12-25 revision 48d4efcb85) +YJIT +PRISM [arm64-darwin24]
Warming up --------------------------------------
         obj.to_json    20.000 i/100ms
Calculating -------------------------------------
         obj.to_json    202.027 (± 2.5%) i/s    (4.95 ms/i) -      1.020k in   5.052066s
```

After:
```
ActiveSupport::JSON::Encoding::JSONGemCoderEncoder
ruby 3.4.1 (2024-12-25 revision 48d4efcb85) +YJIT +PRISM [arm64-darwin24]
Warming up --------------------------------------
         obj.to_json    30.000 i/100ms
Calculating -------------------------------------
         obj.to_json    305.519 (± 2.3%) i/s    (3.27 ms/i) -      1.530k in   5.010497s
```