### PR TITLE
Allow other database adapters in support joins `update_all` tests for Postgresql and SQLite

### DIFF
--- a/activerecord/test/cases/relation/update_all_test.rb
+++ b/activerecord/test/cases/relation/update_all_test.rb
@@ -89,10 +89,8 @@ class UpdateAllTest < ActiveRecord::TestCase
   def test_dynamic_update_all_with_one_joined_table
     update_fragment = if current_adapter?(:TrilogyAdapter, :Mysql2Adapter)
       "toys.name = pets.name"
-    elsif current_adapter?(:PostgreSQLAdapter, :SQLite3Adapter)
+    else # PostgreSQLAdapter, SQLite3Adapter
       "name = pets.name"
-    else
-      raise NotImplementedError
     end
 
     toys = Toy.joins(:pet)
@@ -107,10 +105,8 @@ class UpdateAllTest < ActiveRecord::TestCase
   def test_dynamic_update_all_with_two_joined_table
     update_fragment = if current_adapter?(:TrilogyAdapter, :Mysql2Adapter)
       "toys.name = owners.name"
-    elsif current_adapter?(:PostgreSQLAdapter, :SQLite3Adapter)
+    else # PostgreSQLAdapter, SQLite3Adapter
       "name = owners.name"
-    else
-      raise NotImplementedError
     end
 
     toys = Toy.joins(pet: [:owner])


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This PR updates the tests introduced by https://github.com/rails/rails/pull/53950 to allow for database adapters other than the core adapters (PostgreSQL/MySQL/SQLite/Trilogy).

### Detail

The SQL Server database can handle the `update_fragment` in the same way as PostgreSQL & SQLite. However, the tests throw an exception if the database adapter is not one of the core adapters. Rather than having to recreate the test in [ActiveRecord SQL Server Adapter](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter), it would be handier to just change the logic of the test in Rails. 

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
