### PR TITLE
Fix mounted helper generating URL not respecting literal constraints

### DIFF
--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -321,7 +321,7 @@ module ActionDispatch
             end
 
             overriden_url_parts = inner_options.slice(*literal_constraints.keys)
-            if overriden_url_parts.empty?
+            if inner_options.delete(RoutesProxy::INTERNAL) || overriden_url_parts.empty?
               result.merge(inner_options).merge(literal_constraints)
             else
               ActionDispatch.deprecator.warn(<<~MSG)

--- a/actionpack/lib/action_dispatch/routing/routes_proxy.rb
+++ b/actionpack/lib/action_dispatch/routing/routes_proxy.rb
@@ -9,6 +9,8 @@ module ActionDispatch
     class RoutesProxy # :nodoc:
       include ActionDispatch::Routing::UrlFor
 
+      INTERNAL = Object.new
+
       attr_accessor :scope, :routes
       alias :_routes :routes
 
@@ -32,6 +34,7 @@ module ActionDispatch
       def method_missing(method, *args)
         if @helpers.respond_to?(method)
           options = args.extract_options!
+          options[INTERNAL] = true unless options.keys.intersect?(Mapper::URL_OPTIONS)
           options = url_options.merge((options || {}).symbolize_keys)
 
           if @script_namer

--- a/actionpack/test/dispatch/prefix_generation_test.rb
+++ b/actionpack/test/dispatch/prefix_generation_test.rb
@@ -157,6 +157,10 @@ module TestGenerationPrefix
     class Service
       include RailsApplication.routes.url_helpers
       include RailsApplication.routes.mounted_helpers
+
+      def url_options
+        { host: "www.example.com" }
+      end
     end
 
     def app
@@ -341,6 +345,15 @@ module TestGenerationPrefix
 
       path = engine_object.polymorphic_url(Post.new, host: "www.example.com")
       assert_equal "http://www.example.com/awesome/blog/posts/1", path
+    end
+
+    test "[SERVICE] literal url constraints have precedence" do
+      service = Service.new
+
+      assert_not_deprecated(ActionDispatch.deprecator) do
+        assert_equal("http://developer.net/awesome/blog/panel", service.blog_engine.panel_url)
+        assert_equal("http://tools.w3c.org/lint", service.main_app.lint_url)
+      end
     end
 
     test "[SERVICE] overriding a url part that has a literal constraint is deprecated" do


### PR DESCRIPTION
### Motivation / Background

This PR introduces 2 distinct commits, ultimately the goal being to fix #46412:

- First one deprecates a behaviour that seems to a bug to me (explanation will follow), but since it has been there for ages, I figured a deprecation warning would be welcomed.
- Second commit makes use of the first commit and fixes #46412.


### Problem

When you have a route that has a literal constraints on a URL part, it could be overidden by options explicitly passed to a url helper, resulting in Rails generating a URL which the router wouldn't be able to recognize.

```ruby
routes.draw do
  constraints(host: "admin.foo.com") do
    get("panel", to: "admin/dashboard")
  end
end

puts panel_url # "https://admin.foo.com/panel"

puts panel_url(host: "foo.com") # "https://foo.com/panel"
# Clicking on this link would lead to a 404.
```

### Details

While constraints are normally used for route matching, this was changed a while ago in https://github.com/rails/rails/commit/9b4514c3b8ecfbc40a44dbd4c2ebd4ce67f4a459, so that literal constraints would now be taken into consideration when generating urls.

Overriding a url part on a route having literal constraints is something that Rails do internally (in integration testing) and creates issue reported in https://github.com/rails/rails/issues/46412.
While this commit doesn't fix the mentioned issue by itself, I figured this behaviour should be deprecated in a separate commit as generating a URL that Rails wouldn't be able to recognize seems to be a bug to me.

### Solution

The order of priority for routes defaults previously was:

1) Options passed when calling a url helper
2) Literal constraints
3) Route's defaults
4) Controller options

The order of priority will now be:

1) Literal constraints
2) Options passed by a user
3) Route's defaults
4) Controller options


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
