### PR TITLE
Avoid undefined String#squish in Rails::TestUnit

### DIFF
--- a/railties/lib/rails/test_unit/runner.rb
+++ b/railties/lib/rails/test_unit/runner.rb
@@ -11,10 +11,7 @@ module Rails
   module TestUnit
     class InvalidTestError < StandardError
       def initialize(path, suggestion)
-        super(<<~MESSAGE.squish)
-          Could not load test file: #{path}.
-          #{suggestion}
-        MESSAGE
+        super("Could not load test file: #{path}. #{suggestion}")
       end
     end
 


### PR DESCRIPTION
Fix: https://github.com/rails/rails/issues/54487

We could also load the method, but it doesn't seem really necessary here. Might as well simpligy the code.
