### PR TITLE
Fix unreadable output when running `rails test`:

### DIFF
--- a/railties/lib/rails/commands/test/test_command.rb
+++ b/railties/lib/rails/commands/test/test_command.rb
@@ -31,8 +31,6 @@ module Rails
         Rails::TestUnit::Runner.parse_options(args)
         run_prepare_task if self.args.none?(EXACT_TEST_ARGUMENT_PATTERN)
         Rails::TestUnit::Runner.run(args)
-      rescue Rails::TestUnit::InvalidTestError => error
-        raise ArgumentError, error.message
       end
 
       # Define Thor tasks to avoid going through Rake and booting twice when using bin/rails test:*

--- a/railties/lib/rails/test_unit/runner.rb
+++ b/railties/lib/rails/test_unit/runner.rb
@@ -9,9 +9,16 @@ require "rails/test_unit/test_parser"
 
 module Rails
   module TestUnit
-    class InvalidTestError < StandardError
+    class InvalidTestError < ArgumentError
       def initialize(path, suggestion)
-        super("Could not load test file: #{path}. #{suggestion}")
+        super(<<~MESSAGE.rstrip)
+          Could not load test file: #{path}.
+          #{suggestion}
+        MESSAGE
+      end
+
+      def backtrace(*args)
+        []
       end
     end
 
@@ -65,7 +72,7 @@ module Rails
               if corrections.empty?
                 raise exception
               end
-              raise InvalidTestError.new(path, DidYouMean::Formatter.message_for(corrections))
+              raise(InvalidTestError.new(path, DidYouMean::Formatter.message_for(corrections)), cause: nil)
             else
               raise
             end

--- a/railties/test/application/test_runner_test.rb
+++ b/railties/test/application/test_runner_test.rb
@@ -969,8 +969,13 @@ module ApplicationTests
       create_test_file :models, "account"
       output = run_test_command("test/models/accnt.rb")
 
-      assert_match(%r{Could not load test file.+test/models/accnt\.rb}, output)
-      assert_match(%r{Did you mean?.+test/models/account_test\.rb}, output)
+      expected = <<~MSG
+        bin/rails: Could not load test file: test/models/accnt.rb. (Rails::TestUnit::InvalidTestError)
+
+        Did you mean?  test/models/account_test.rb
+      MSG
+
+      assert_equal(expected, output)
       assert_not_predicate $?, :success?
     end
 

--- a/railties/test/generators/plugin_test_runner_test.rb
+++ b/railties/test/generators/plugin_test_runner_test.rb
@@ -93,7 +93,7 @@ class PluginTestRunnerTest < ActiveSupport::TestCase
 
   def test_raise_error_when_specified_file_does_not_exist
     error = capture(:stderr) { run_test_command("test/not_exists.rb") }
-    assert_match(%r{cannot load such file.+test/not_exists\.rb}, error)
+    assert_match(%r{Could not load test file.+test/not_exists\.rb}, error)
   end
 
   def test_executed_only_once


### PR DESCRIPTION
Fix unreadable output when running `rails test`:

- When running `rails test test/unexisting_file.rb`, the output is dozens of line long which makes it hard to read.

  346f516fa17 originally added a one liner to display the message, but this change in 0f6b122bb54 to re-raise the error.

  This commit keeps the behaviour of 0f6b122bb54 but allow for a more readable output, as originally intended in 346f516fa17.


### Before

<img width="626" alt="image" src="https://github.com/user-attachments/assets/33b92a5b-8e16-47a2-b204-fdbb67f0abb8" />



### After

<img width="784" alt="image" src="https://github.com/user-attachments/assets/5d8af37b-3669-47d7-8d4a-b8eea452491e" />

FYI @byroot (Saw you just merged a related change 😄)
