### PR TITLE
Abstract high precision timestamp in `rb` schema

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   High precision timestamp column is dumped as `high_precision_current_timestamp` in `.rb` schemas.
+
+    *Nikita Vasilevsky*
+
 *   Fix migrating multiple databases with `ActiveRecord::PendingMigration` action.
 
     *Gannon McGibbon*

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_dumper.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_dumper.rb
@@ -96,7 +96,13 @@ module ActiveRecord
         end
 
         def schema_expression(column)
-          "-> { #{column.default_function.inspect} }" if column.default_function
+          return unless column.default_function
+
+          if column.default_function.match?(/^#{Regexp.escape(@connection.high_precision_current_timestamp)}$/i)
+            "-> { high_precision_current_timestamp } "
+          else
+            "-> { #{column.default_function.inspect} }"
+          end
         end
 
         def schema_collation(column)

--- a/activerecord/test/cases/defaults_test.rb
+++ b/activerecord/test/cases/defaults_test.rb
@@ -151,9 +151,9 @@ class PostgresqlDefaultExpressionTest < ActiveRecord::TestCase
       output = dump_table_schema("defaults")
       if ActiveRecord::Base.lease_connection.database_version >= 100000
         assert_match %r/t\.date\s+"modified_date",\s+default: -> { "CURRENT_DATE" }/, output
-        assert_match %r/t\.datetime\s+"modified_time",\s+default: -> { "CURRENT_TIMESTAMP" }/, output
-        assert_match %r/t\.datetime\s+"modified_time_without_precision",\s+precision: nil,\s+default: -> { "CURRENT_TIMESTAMP" }/, output
-        assert_match %r/t\.datetime\s+"modified_time_with_precision_0",\s+precision: 0,\s+default: -> { "CURRENT_TIMESTAMP" }/, output
+        assert_match %r/t\.datetime\s+"modified_time",\s+default: -> { high_precision_current_timestamp }/, output
+        assert_match %r/t\.datetime\s+"modified_time_without_precision",\s+precision: nil,\s+default: -> { high_precision_current_timestamp }/, output
+        assert_match %r/t\.datetime\s+"modified_time_with_precision_0",\s+precision: 0,\s+default: -> { high_precision_current_timestamp }/, output
       else
         assert_match %r/t\.date\s+"modified_date",\s+default: -> { "\('now'::text\)::date" }/, output
         assert_match %r/t\.datetime\s+"modified_time",\s+default: -> { "now\(\)" }/, output
@@ -189,7 +189,7 @@ class MysqlDefaultExpressionTest < ActiveRecord::TestCase
 
     test "schema dump datetime includes precise default expression" do
       output = dump_table_schema("datetime_defaults")
-      assert_match %r/t\.datetime\s+"precise_datetime",\s+default: -> { "CURRENT_TIMESTAMP\(6\)" }/i, output
+      assert_match %r/t\.datetime\s+"precise_datetime",\s+default: -> { high_precision_current_timestamp }/i, output
     end
 
     test "schema dump datetime includes precise default expression with on update" do
@@ -204,7 +204,7 @@ class MysqlDefaultExpressionTest < ActiveRecord::TestCase
 
     test "schema dump timestamp includes precise default expression" do
       output = dump_table_schema("timestamp_defaults")
-      assert_match %r/t\.timestamp\s+"precise_timestamp",.+default: -> { "CURRENT_TIMESTAMP\(6\)" }/i, output
+      assert_match %r/t\.timestamp\s+"precise_timestamp",.+default: -> { high_precision_current_timestamp }/i, output
     end
 
     test "schema dump timestamp includes precise default expression with on update" do

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -61,6 +61,7 @@ ActiveRecord::Schema.define do
     t.integer :wheels_count, default: 0, null: false
     t.datetime :wheels_owned_at
     t.timestamp :manufactured_at, default: -> { "CURRENT_TIMESTAMP" }
+    t.datetime :manufactured_precicely_at, default: -> { high_precision_current_timestamp }
   end
 
   create_table :articles, force: true do |t|


### PR DESCRIPTION
We would like to make `.rb` schema dumps as database-agnostic as possible. 

This PR proposes default high precision timestamp functions for datetime columns to be dumped as `high_precision_current_timestamp` abstraction.

Since schema is loaded in a context of an adapter lambda with `high_precision_timestamp_function` call in it resolves to adapter-specific high precision timestamp function