### PR TITLE
Speed up GTG Simulator by reducing slices/matches

### DIFF
--- a/actionpack/lib/action_dispatch/journey/gtg/transition_table.rb
+++ b/actionpack/lib/action_dispatch/journey/gtg/transition_table.rb
@@ -47,25 +47,22 @@ module ActionDispatch
           Array(t)
         end
 
-        def move(t, full_string, start_index, end_index)
+        def move(t, full_string, token, start_index, token_matches_default)
           return [] if t.empty?
 
           next_states = []
-
-          tok = full_string.slice(start_index, end_index - start_index)
-          token_matches_default_component = DEFAULT_EXP_ANCHORED.match?(tok)
 
           t.each { |s, previous_start|
             if previous_start.nil?
               # In the simple case of a "default" param regex do this fast-path and add all
               # next states.
-              if token_matches_default_component && std_state = @stdparam_states[s]
+              if token_matches_default && std_state = @stdparam_states[s]
                 next_states << [std_state, nil].freeze
               end
 
               # When we have a literal string, we can just pull the next state
               if states = @string_states[s]
-                next_states << [states[tok], nil].freeze unless states[tok].nil?
+                next_states << [states[token], nil].freeze unless states[token].nil?
               end
             end
 
@@ -80,7 +77,7 @@ module ActionDispatch
                 previous_start
               end
 
-              slice_length = end_index - slice_start
+              slice_length = start_index + token.length - slice_start
               curr_slice = full_string.slice(slice_start, slice_length)
 
               states.each { |re, v|

--- a/actionpack/test/journey/gtg/builder_test.rb
+++ b/actionpack/test/journey/gtg/builder_test.rb
@@ -8,13 +8,13 @@ module ActionDispatch
       class TestBuilder < ActiveSupport::TestCase
         def test_following_states_multi
           table = tt ["a|a"]
-          assert_equal 1, table.move([[0, nil]], "a", 0, 1).length
+          assert_equal 1, table.move([[0, nil]], "a", "a", 0, true).length
         end
 
         def test_following_states_multi_regexp
           table = tt [":a|b"]
-          assert_equal 1, table.move([[0, nil]], "fooo", 0, 4).length
-          assert_equal 2, table.move([[0, nil]], "b", 0, 1).length
+          assert_equal 1, table.move([[0, nil]], "fooo", "fooo", 0, true).length
+          assert_equal 2, table.move([[0, nil]], "b", "b", 0, true).length
         end
 
         def test_multi_path
@@ -26,7 +26,7 @@ module ActionDispatch
             [2, "/"],
             [1, "c"],
           ].inject([[0, nil]]) { |state, (exp, sym)|
-            new = table.move(state, sym, 0, sym.length)
+            new = table.move(state, sym, sym, 0, sym != "/")
             assert_equal exp, new.length
             new
           }


### PR DESCRIPTION
### Motivation / Background

At a high level, the while loop in `#memos` breaks up the string into parts where each part is one of the three "special characters" or a group of consecutive characters that aren't one of those "special characters". However, the current implementation does a lot of duplicate or unnecessary work.

The StringScanner allocates the scanned string, but then only uses its length. The string is then re-allocated with `#slice` inside `#move`. Additionally, because the StringScanner scans for both the "special characters" and non-"special characters" cases, `#move` has to `#match?` to figure out which of the two cases was scanned.

### Detail

This commit improves the performance of routing by 10-20% in simple cases by removing the duplication and preventing excess string allocations. The improvement is larger for routes deeper in the tree.

First, it avoids string allocations and scanning by peeking at the next byte in the StringScanner. Only if the next byte is not one of the "special characters" does the StringScanner do a scan to consume as many non "special characters" as it can. And because the two cases are now separated, the `#match?` in `#move` can be replaced with a boolean parameter.

### Additional information

Benchmark:

```ruby
require "action_dispatch"

routes = ActionDispatch::Routing::RouteSet.new
routes.draw do
  get "/products", to: ->(e) { [200, {}, ["p"]] }
  get "/products/:id", to: ->(e) { [200, {}, ["pid"]] }
  get "/collections", to: ->(e) { [200, {}, ["c"]] }
  get "/collections/:id/products", to: ->(e) { [200, {}, ["cidp"]] }
end

one_env = {
  "REQUEST_METHOD" => "GET",
  "PATH_INFO" => "/products",
  "SCRIPT_NAME" => "",
  "rack.input" => File.open("/dev/null"),
}.freeze

two_env = {
  "REQUEST_METHOD" => "GET",
  "PATH_INFO" => "/products/1",
  "SCRIPT_NAME" => "",
  "rack.input" => File.open("/dev/null"),

}.freeze

three_env = {
  "REQUEST_METHOD" => "GET",
  "PATH_INFO" => "/collections/1/products",
  "SCRIPT_NAME" => "",
  "rack.input" => File.open("/dev/null"),
}.freeze

Benchmark.ips do |x|
  x.report("index") { routes.call(one_env.dup) }
  x.report("show") { routes.call(two_env.dup) }
  x.report("show nested") { routes.call(three_env.dup) }

  x.compare!
end
```

Before:

```
$ RUBY_YJIT_ENABLE=1 ruby bench.rb
ruby 3.4.1 (2024-12-25 revision 48d4efcb85) +YJIT +PRISM [arm64-darwin23]
Warming up --------------------------------------
               index    21.150k i/100ms
                show    15.622k i/100ms
         show nested    12.829k i/100ms
Calculating -------------------------------------
               index    214.204k (± 1.7%) i/s    (4.67 μs/i) -      1.079M in   5.037184s
                show    156.091k (± 1.6%) i/s    (6.41 μs/i) -    781.100k in   5.005409s
         show nested    130.048k (± 1.3%) i/s    (7.69 μs/i) -    654.279k in   5.031956s

Comparison:
               index:   214203.9 i/s
                show:   156091.4 i/s - 1.37x  slower
         show nested:   130048.3 i/s - 1.65x  slower
```

After:

```
$ RUBY_YJIT_ENABLE=1 ruby bench.rb
ruby 3.4.1 (2024-12-25 revision 48d4efcb85) +YJIT +PRISM [arm64-darwin23]
Warming up --------------------------------------
               index    22.372k i/100ms
                show    17.973k i/100ms

         show nested    15.102k i/100ms
Calculating -------------------------------------
               index    239.153k (± 1.7%) i/s    (4.18 μs/i) -      1.208M in   5.053032s
                show    180.589k (± 1.4%) i/s    (5.54 μs/i) -    916.623k in   5.076755s
         show nested    154.812k (± 1.2%) i/s    (6.46 μs/i) -    785.304k in   5.073411s

Comparison:
               index:   239152.9 i/s
                show:   180588.6 i/s - 1.32x  slower
         show nested:   154811.8 i/s - 1.54x  slower
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
