### PR TITLE
Add  warning of query_log_tags_enabled [ci skip]

### DIFF
--- a/guides/source/debugging_rails_applications.md
+++ b/guides/source/debugging_rails_applications.md
@@ -264,6 +264,8 @@ To enable, add in `application.rb` or any environment initializer:
 config.active_record.query_log_tags_enabled = true
 ```
 
+NOTE: Enabling Query tags automatically disables prepared statements, because it makes most queries unique.
+
 By default the name of the application, the name and action of the controller, or the name of the job are logged. The
 default format is [SQLCommenter](https://open-telemetry.github.io/opentelemetry-sqlcommenter/). For example:
 


### PR DESCRIPTION
### Motivation / Background

When `query_log_tags_enabled` is set to `true` in railtie, it automatically disables prepared statements and enables query logging. This configuration impacts application performance, as mentioned in [#54405](https://github.com/rails/rails/issues/54405).
This PR adds a warning to the documentation to highlight this behavior.

### Detail

Added warning message about `query_log_tags_enabled` configuration to documentation

FIx  [#54405](https://github.com/rails/rails/issues/54405)

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
