### PR TITLE
Fix url helpers when a engine is mounted:

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,33 @@
+*   Fix `*_url` helpers generation on mounted engine.
+
+    When mounting an engine with a scoped literal constraint, all `*_url`
+    helpers for the routes engine were missing part of the url.
+
+    ```ruby
+    class WorkersEngine < Rails::Engine
+      routes.draw do
+        get "workers", to: "dashboard/workers"
+      end
+    end
+
+    class MyApplication < Rails::Application
+      routes.draw do
+        constraints(subdomain: "admin") do
+          mount WorkersEngine, at: "/"
+        end
+      end
+    end
+
+    ### Inside the engine
+    # Before the fix
+    puts workers_url(host: "example.com") #=> https://example.com/workers
+
+    # After the fix
+    puts workers_url(host: "example.com") #=> https://admin.example.com/workers
+    ```
+
+    *Edouard Chin*
+
 *   Fix `Rails.application.reload_routes!` from clearing almost all routes.
 
     When calling `Rails.application.reload_routes!` inside a middleware of

--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -719,6 +719,9 @@ module ActionDispatch
               _url_helpers.public_send("#{name}_path", prefix_options)
             end
 
+            app.routes.set.each do |route|
+              route.defaults.merge!(_route.defaults)
+            end
             app.routes.define_mounted_helper(name, script_namer)
 
             app.routes.extend Module.new {


### PR DESCRIPTION
### Motivation / Background

Fix #34252 (This issue was closed automatically but never solved)

### Detail

It's a similar issue as the one solved in #54486 but the problem is different.

In this case, when mounting an engine, the routes default that gets set when adding a literal constraints doesn't get applied to the underlying engine route, which results in generating incorrect url.

Note that the constraints feature works correctly without this patch, it's just the url generation part that is broken.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
