### PR TITLE
Do not store the value when checking if key exists in the local cache

### DIFF
--- a/activesupport/lib/active_support/cache/null_store.rb
+++ b/activesupport/lib/active_support/cache/null_store.rb
@@ -43,6 +43,10 @@ module ActiveSupport
           deserialize_entry(read_serialized_entry(key))
         end
 
+        def read_multi_entries(names, **options)
+          names.index_with(nil)
+        end
+
         def read_serialized_entry(_key, **)
         end
 

--- a/activesupport/test/cache/behaviors/local_cache_behavior.rb
+++ b/activesupport/test/cache/behaviors/local_cache_behavior.rb
@@ -111,7 +111,7 @@ module LocalCacheBehavior
     @cache.with_local_cache do
       assert_nil @cache.read(key)
       @cache.send(:bypass_local_cache) { @cache.write(key, value) }
-      assert_nil @cache.read(key)
+      assert_equal value, @cache.read(key)
     end
   end
 
@@ -183,6 +183,11 @@ module LocalCacheBehavior
       @cache.write(key, SecureRandom.alphanumeric)
       @peek.delete(key)
       assert @cache.exist?(key)
+
+      @cache.delete(key)
+      assert_not @cache.exist?(key)
+      result = @cache.fetch_multi(key) { "value" }
+      assert_equal({ key => "value" }, result)
     end
   end
 


### PR DESCRIPTION
Fixes #54497.

Previously, when calling `exist?`, local cache stored `nil` as key's value, which was returned in further cache accesses by that key. 