### PR TITLE
[docs] Use 'valid' instead of 'legal' for cache key

### DIFF
--- a/guides/source/caching_with_rails.md
+++ b/guides/source/caching_with_rails.md
@@ -784,7 +784,7 @@ and record id.
 You can use Hashes and Arrays of values as cache keys.
 
 ```ruby
-# This is a legal cache key
+# This is a valid cache key
 Rails.cache.read(site: "mysite", owners: [owner_1, owner_2])
 ```
 


### PR DESCRIPTION
'Valid' is a more appropriate word than 'Legal'

existing: This is a legal cache key

updated: This is a valid cache key