### PR TITLE
Allow JSON::Fragment as a return value for as_json

### DIFF
--- a/activesupport/lib/active_support/json/encoding.rb
+++ b/activesupport/lib/active_support/json/encoding.rb
@@ -85,6 +85,7 @@ module ActiveSupport
           # to +object.as_json+, not any of this method's recursive +#as_json+
           # calls.
           def jsonify(value)
+            return value if value.class.name == "JSON::Fragment"
             case value
             when String, Integer, Symbol, nil, true, false
               value

--- a/activesupport/lib/active_support/json/encoding.rb
+++ b/activesupport/lib/active_support/json/encoding.rb
@@ -112,7 +112,7 @@ module ActiveSupport
 
       if defined?(::JSON::Coder)
         class JSONGemCoderEncoder # :nodoc:
-          JSON_NATIVE_TYPES = [Hash, Array, Float, String, Symbol, Integer, NilClass, TrueClass, FalseClass].freeze
+          JSON_NATIVE_TYPES = [Hash, Array, Float, String, Symbol, Integer, NilClass, TrueClass, FalseClass, ::JSON::Fragment].freeze
           CODER = ::JSON::Coder.new do |value|
             json_value = value.as_json
             # Handle objects returning self from as_json

--- a/activesupport/test/json/encoding_test_cases.rb
+++ b/activesupport/test/json/encoding_test_cases.rb
@@ -56,6 +56,16 @@ module JSONTest
     end
   end
 
+  class CustomNumericFixed < Numeric
+    def initialize(str)
+      @str = str
+    end
+
+    def as_json
+      ::JSON::Fragment.new(@str)
+    end
+  end
+
   module EncodingTestCases
     TrueTests     = [[ true,  %(true)  ]]
     FalseTests    = [[ false, %(false) ]]
@@ -68,7 +78,8 @@ module JSONTest
                      [ BigDecimal("0.0") / BigDecimal("0.0"),  %(null) ],
                      [ BigDecimal("2.5"), %("#{BigDecimal('2.5')}") ],
                      [ RomanNumeral.new("MCCCXXXVII"), %("MCCCXXXVII") ],
-                     [ [CustomNumeric.new("123")], %([123]) ]
+                     [ [CustomNumeric.new("123")], %([123]) ],
+                     [ [CustomNumericFixed.new("123")], %([123]) ],
     ]
 
     StringTests   = [[ "this is the <string>",     %("this is the \\u003cstring\\u003e")],


### PR DESCRIPTION
Follow-up to #54481 

Instead of overriding to_json to return a String of JSON to be directly embedded in the JSON document, we can now return a JSON::Fragment from as_json.

Since both JSON::Coder and JSON::Fragment were shipped together in json 2.10.0, I didn't update the `defined?` guards.

---

I don't know if this was even used out there, but with the current default JSON encoder, it's possible to return a JSON fragment by inheriting from some of the native types and returning the fragment with `to_json`. With String, Integer, or Numeric as an ancestor, the object isn't touched by `jsonify` and passed to the `json` gem, which ultimately calls `to_json` on it. It's used in the test suite with `JSONTest::CustomNumeric`.

The new encoder uses `JSON::Coder` which doesn't call `to_json`, but we can return a `JSON::Fragment` from `as_json` to let `json` know this doesn't need to be serialized further. So it needs to be added to the list of acceptable classes.
