### PR TITLE
Flatten the transition table state arrays

### DIFF
--- a/actionpack/lib/action_dispatch/journey/gtg/simulator.rb
+++ b/actionpack/lib/action_dispatch/journey/gtg/simulator.rb
@@ -20,7 +20,7 @@ module ActionDispatch
         STATIC_TOKENS["?".ord] = "?"
         STATIC_TOKENS.freeze
 
-        INITIAL_STATE = [ [0, nil] ].freeze
+        INITIAL_STATE = [0, nil].freeze
 
         attr_reader :tt
 
@@ -50,9 +50,9 @@ module ActionDispatch
             end
           end
 
-          acceptance_states = state.each_with_object([]) do |s_d, memos|
-            s, idx = s_d
-            memos.concat(tt.memo(s)) if idx.nil? && tt.accepting?(s)
+          acceptance_states = []
+          state.each_slice(2) do |s, idx|
+            acceptance_states.concat(tt.memo(s)) if idx.nil? && tt.accepting?(s)
           end
 
           acceptance_states.empty? ? yield : acceptance_states

--- a/actionpack/lib/action_dispatch/journey/gtg/simulator.rb
+++ b/actionpack/lib/action_dispatch/journey/gtg/simulator.rb
@@ -51,8 +51,16 @@ module ActionDispatch
           end
 
           acceptance_states = []
-          state.each_slice(2) do |s, idx|
-            acceptance_states.concat(tt.memo(s)) if idx.nil? && tt.accepting?(s)
+          states_count = state.size
+          i = 0
+          while i < states_count
+            if state[i + 1].nil?
+              s = state[i]
+              if tt.accepting?(s)
+                acceptance_states.concat(tt.memo(s))
+              end
+            end
+            i += 2
           end
 
           acceptance_states.empty? ? yield : acceptance_states

--- a/actionpack/lib/action_dispatch/journey/gtg/transition_table.rb
+++ b/actionpack/lib/action_dispatch/journey/gtg/transition_table.rb
@@ -52,7 +52,11 @@ module ActionDispatch
 
           next_states = []
 
-          t.each_slice(2) { |s, previous_start|
+          transitions_count = t.size
+          i = 0
+          while i < transitions_count
+            s = t[i]
+            previous_start = t[i + 1]
             if previous_start.nil?
               # In the simple case of a "default" param regex do this fast-path and add all
               # next states.
@@ -90,7 +94,9 @@ module ActionDispatch
               # need to remember where we started as well so we can take bigger slices.
               next_states << s << slice_start
             end
-          }
+
+            i += 2
+          end
 
           next_states
         end

--- a/actionpack/lib/action_dispatch/journey/gtg/transition_table.rb
+++ b/actionpack/lib/action_dispatch/journey/gtg/transition_table.rb
@@ -52,17 +52,18 @@ module ActionDispatch
 
           next_states = []
 
-          t.each { |s, previous_start|
+          t.each_slice(2) { |s, previous_start|
             if previous_start.nil?
               # In the simple case of a "default" param regex do this fast-path and add all
               # next states.
               if token_matches_default && std_state = @stdparam_states[s]
-                next_states << [std_state, nil].freeze
+                next_states << std_state << nil
               end
 
               # When we have a literal string, we can just pull the next state
               if states = @string_states[s]
-                next_states << [states[token], nil].freeze unless states[token].nil?
+                state = states[token]
+                next_states << state << nil unless state.nil?
               end
             end
 
@@ -82,12 +83,12 @@ module ActionDispatch
 
               states.each { |re, v|
                 # if we match, we can try moving past this
-                next_states << [v, nil].freeze if !v.nil? && re.match?(curr_slice)
+                next_states << v << nil if !v.nil? && re.match?(curr_slice)
               }
 
               # and regardless, we must continue accepting tokens and retrying this regexp. we
               # need to remember where we started as well so we can take bigger slices.
-              next_states << [s, slice_start].freeze
+              next_states << s << slice_start
             end
           }
 

--- a/actionpack/test/journey/gtg/builder_test.rb
+++ b/actionpack/test/journey/gtg/builder_test.rb
@@ -8,13 +8,13 @@ module ActionDispatch
       class TestBuilder < ActiveSupport::TestCase
         def test_following_states_multi
           table = tt ["a|a"]
-          assert_equal 1, table.move([[0, nil]], "a", "a", 0, true).length
+          assert_equal 1, table.move([0, nil], "a", "a", 0, true).each_slice(2).count
         end
 
         def test_following_states_multi_regexp
           table = tt [":a|b"]
-          assert_equal 1, table.move([[0, nil]], "fooo", "fooo", 0, true).length
-          assert_equal 2, table.move([[0, nil]], "b", "b", 0, true).length
+          assert_equal 1, table.move([0, nil], "fooo", "fooo", 0, true).each_slice(2).count
+          assert_equal 2, table.move([0, nil], "b", "b", 0, true).each_slice(2).count
         end
 
         def test_multi_path
@@ -25,9 +25,9 @@ module ActionDispatch
             [2, "b"],
             [2, "/"],
             [1, "c"],
-          ].inject([[0, nil]]) { |state, (exp, sym)|
+          ].inject([0, nil]) { |state, (exp, sym)|
             new = table.move(state, sym, sym, 0, sym != "/")
-            assert_equal exp, new.length
+            assert_equal exp, new.each_slice(2).count
             new
           }
         end


### PR DESCRIPTION
Followup: https://github.com/rails/rails/pull/54491 (cc @skipkayhil)

Using arrays of arrays means lots of extra small allocations we can instead store it all in a single array.

```
== index ==
ruby 3.4.1 (2024-12-25 revision 48d4efcb85) +YJIT +PRISM [arm64-darwin23]
Warming up --------------------------------------
               after    38.103k i/100ms
Calculating -------------------------------------
               after    378.205k (± 1.6%) i/s    (2.64 μs/i) -      1.905M in   5.038726s

Comparison:
              before:   343597.9 i/s
               after:   378205.0 i/s - 1.10x  faster

== show ==
ruby 3.4.1 (2024-12-25 revision 48d4efcb85) +YJIT +PRISM [arm64-darwin23]
Warming up --------------------------------------
               after    28.557k i/100ms
Calculating -------------------------------------
               after    289.310k (± 0.4%) i/s    (3.46 μs/i) -      1.456M in   5.034143s

Comparison:
              before:   262410.8 i/s
               after:   289309.5 i/s - 1.10x  faster

== show_nested ==
ruby 3.4.1 (2024-12-25 revision 48d4efcb85) +YJIT +PRISM [arm64-darwin23]
Warming up --------------------------------------
               after    24.577k i/100ms
Calculating -------------------------------------
               after    248.257k (± 2.2%) i/s    (4.03 μs/i) -      1.253M in   5.051315s

Comparison:
              before:   224815.2 i/s
               after:   248256.6 i/s - 1.10x  faster
```

The benchmark is the same as in: https://github.com/rails/rails/pull/54491#issuecomment-2650542281

The logical method to use would have been `Array#each_slice`,unfortunately that perform really badly because it's not specialized for array, but is part of `Enumerable`. So the loop has to be done manually with a `while`.