### PR TITLE
Optimize String visitor by hand

### DIFF
--- a/actionpack/lib/action_dispatch/journey/nodes/node.rb
+++ b/actionpack/lib/action_dispatch/journey/nodes/node.rb
@@ -81,7 +81,7 @@ module ActionDispatch
         end
 
         def to_s
-          Visitors::String::INSTANCE.accept(self, "")
+          Visitors::String::INSTANCE.accept(self, "".dup)
         end
 
         def to_dot


### PR DESCRIPTION
Followup: https://github.com/rails/rails/pull/54504 (cc @skipkayhil)
Followup: https://github.com/rails/rails/pull/54491

The existing inheritence based visitor cause a lot of extra method calls and rely on `send` a lot, defeating method caches.

Since that visitor in particular is part of the hot path of finding a route for the incomming request, it's worth optimizing it specifically.

And in the end, I could argue it's much easier to grok than the previous implementation.

In addition, we can append to the seed rather than to allocate a lot of sub strings.

Same benchmark as: https://github.com/rails/rails/pull/54491#issuecomment-2650542281

```
== index ==
ruby 3.4.1 (2024-12-25 revision 48d4efcb85) +YJIT +PRISM [arm64-darwin23]
Warming up --------------------------------------
               after    40.563k i/100ms
Calculating -------------------------------------
               after    405.756k (± 2.5%) i/s    (2.46 μs/i) -      2.028M in   5.001706s

Comparison:
              before:   361017.1 i/s
               after:   405756.2 i/s - 1.12x  faster

== show ==
ruby 3.4.1 (2024-12-25 revision 48d4efcb85) +YJIT +PRISM [arm64-darwin23]
Warming up --------------------------------------
               after    31.235k i/100ms
Calculating -------------------------------------
               after    316.240k (± 1.2%) i/s    (3.16 μs/i) -      1.593M in   5.038025s

Comparison:
              before:   274268.3 i/s
               after:   316240.2 i/s - 1.15x  faster

== show_nested ==
ruby 3.4.1 (2024-12-25 revision 48d4efcb85) +YJIT +PRISM [arm64-darwin23]
Warming up --------------------------------------
               after    29.238k i/100ms
Calculating -------------------------------------
               after    286.828k (± 1.4%) i/s    (3.49 μs/i) -      1.462M in   5.097862s

Comparison:
              before:   246428.3 i/s
               after:   286828.0 i/s - 1.16x  faster
```

That's another 10-15% gain.