### PR TITLE
Add the action mailer callbacks sequence to the document [ci skip]

### DIFF
--- a/guides/source/action_mailer_basics.md
+++ b/guides/source/action_mailer_basics.md
@@ -793,13 +793,18 @@ end
 Action Mailer Callbacks
 -----------------------
 
-Action Mailer allows for you to specify a [`before_action`][],
-[`after_action`][], and [`around_action`][] to configure the message, and
-[`before_deliver`][], [`after_deliver`][] and [`around_deliver`][] to control
-the delivery.
+Action Mailer allows for you to specify `*_action` callbacks to configure the message, and `*_deliver` callbacks to control the delivery.
 
-Callbacks can be specified with a block or a symbol representing a method name
-in the mailer class, similar to other callbacks (in controllers or models).
+Here is a list with all the available Action Mailer callbacks, listed **in the order in which they will get called** when sending an email:
+
+* [`before_action`][]
+* [`around_action`][]
+* [`after_action`][]
+* [`before_deliver`][]
+* [`around_deliver`][]
+* [`after_deliver`][]
+
+Callbacks can be specified with a block or a symbol representing a method name in the mailer class, similar to other callbacks (in controllers or models).
 
 Here are some examples of when you may use one of these callbacks with mailers.
 


### PR DESCRIPTION
### Motivation / Background

I was not sure if the `before_deliver` callback will be called before `after_action` or after it, had to find out from the internet/running it in code. So just updating the guide to have this information.