### PR TITLE
Mutate the state array instead of allocating

### DIFF
--- a/actionpack/lib/action_dispatch/journey/gtg/simulator.rb
+++ b/actionpack/lib/action_dispatch/journey/gtg/simulator.rb
@@ -20,8 +20,6 @@ module ActionDispatch
         STATIC_TOKENS["?".ord] = "?"
         STATIC_TOKENS.freeze
 
-        INITIAL_STATE = [0, nil].freeze
-
         attr_reader :tt
 
         def initialize(transition_table)
@@ -29,7 +27,7 @@ module ActionDispatch
         end
 
         def memos(string)
-          state = INITIAL_STATE
+          state = [0, nil]
 
           pos = 0
           eos = string.bytesize
@@ -39,14 +37,14 @@ module ActionDispatch
             pos += 1
 
             if (token = STATIC_TOKENS[string.getbyte(start_index)])
-              state = tt.move(state, string, token, start_index, false)
+              tt.move(state, string, token, start_index, false)
             else
               while pos < eos && STATIC_TOKENS[string.getbyte(pos)].nil?
                 pos += 1
               end
 
               token = string.byteslice(start_index, pos - start_index)
-              state = tt.move(state, string, token, start_index, true)
+              tt.move(state, string, token, start_index, true)
             end
           end
 

--- a/actionpack/lib/action_dispatch/journey/gtg/transition_table.rb
+++ b/actionpack/lib/action_dispatch/journey/gtg/transition_table.rb
@@ -48,26 +48,22 @@ module ActionDispatch
         end
 
         def move(t, full_string, token, start_index, token_matches_default)
-          return [] if t.empty?
-
-          next_states = []
-
           transitions_count = t.size
           i = 0
           while i < transitions_count
-            s = t[i]
-            previous_start = t[i + 1]
+            s = t.shift
+            previous_start = t.shift
             if previous_start.nil?
               # In the simple case of a "default" param regex do this fast-path and add all
               # next states.
               if token_matches_default && std_state = @stdparam_states[s]
-                next_states << std_state << nil
+                t << std_state << nil
               end
 
               # When we have a literal string, we can just pull the next state
               if states = @string_states[s]
                 state = states[token]
-                next_states << state << nil unless state.nil?
+                t << state << nil unless state.nil?
               end
             end
 
@@ -87,18 +83,16 @@ module ActionDispatch
 
               states.each { |re, v|
                 # if we match, we can try moving past this
-                next_states << v << nil if !v.nil? && re.match?(curr_slice)
+                t << v << nil if !v.nil? && re.match?(curr_slice)
               }
 
               # and regardless, we must continue accepting tokens and retrying this regexp. we
               # need to remember where we started as well so we can take bigger slices.
-              next_states << s << slice_start
+              t << s << slice_start
             end
 
             i += 2
           end
-
-          next_states
         end
 
         def as_json(options = nil)

--- a/actionpack/test/journey/gtg/builder_test.rb
+++ b/actionpack/test/journey/gtg/builder_test.rb
@@ -8,13 +8,22 @@ module ActionDispatch
       class TestBuilder < ActiveSupport::TestCase
         def test_following_states_multi
           table = tt ["a|a"]
-          assert_equal 1, table.move([0, nil], "a", "a", 0, true).each_slice(2).count
+
+          state = [0, nil]
+          table.move(state, "a", "a", 0, true)
+          assert_equal 1, state.each_slice(2).count
         end
 
         def test_following_states_multi_regexp
           table = tt [":a|b"]
-          assert_equal 1, table.move([0, nil], "fooo", "fooo", 0, true).each_slice(2).count
-          assert_equal 2, table.move([0, nil], "b", "b", 0, true).each_slice(2).count
+
+          state = [0, nil]
+          table.move(state, "fooo", "fooo", 0, true)
+          assert_equal 1, state.each_slice(2).count
+
+          state = [0, nil]
+          table.move(state, "b", "b", 0, true)
+          assert_equal 2, state.each_slice(2).count
         end
 
         def test_multi_path
@@ -26,9 +35,9 @@ module ActionDispatch
             [2, "/"],
             [1, "c"],
           ].inject([0, nil]) { |state, (exp, sym)|
-            new = table.move(state, sym, sym, 0, sym != "/")
-            assert_equal exp, new.each_slice(2).count
-            new
+            table.move(state, sym, sym, 0, sym != "/")
+            assert_equal exp, state.each_slice(2).count
+            state
           }
         end
 


### PR DESCRIPTION
This commit removes the array allocation each time `#move` is called. The performance increase is larger for routes where `#move` is called more often.

Using the same benchmark as [before][1]:

```
== index ==
ruby 3.4.1 (2024-12-25 revision 48d4efcb85) +YJIT +PRISM [arm64-darwin23]
Warming up --------------------------------------
               after    26.996k i/100ms
Calculating -------------------------------------
               after    271.133k (± 1.8%) i/s    (3.69 μs/i) -      1.377M in   5.079511s

Comparison:
              before:   267578.3 i/s
               after:   271133.3 i/s - same-ish: difference falls within error

== show ==
ruby 3.4.1 (2024-12-25 revision 48d4efcb85) +YJIT +PRISM [arm64-darwin23]
Warming up --------------------------------------
               after    20.660k i/100ms
Calculating -------------------------------------
               after    211.897k (± 2.8%) i/s    (4.72 μs/i) -      1.074M in   5.074017s

Comparison:
              before:   199323.8 i/s
               after:   211897.0 i/s - 1.06x  faster

== show_nested ==
ruby 3.4.1 (2024-12-25 revision 48d4efcb85) +YJIT +PRISM [arm64-darwin23]
Warming up --------------------------------------
               after    18.979k i/100ms
Calculating -------------------------------------
               after    189.324k (± 2.0%) i/s    (5.28 μs/i) -    948.950k in   5.014294s

Comparison:
              before:   173305.6 i/s
               after:   189323.5 i/s - 1.09x  faster
```

[1]: https://github.com/rails/rails/commit/c1c528d9f26195d08028caa0a8cc8bee4e14d962

cc @byroot 
