### PR TITLE
Fix Error in Rails Routing Guide [ci-skip]

### DIFF
--- a/guides/source/routing.md
+++ b/guides/source/routing.md
@@ -228,7 +228,7 @@ namespace :admin do
 end
 ```
 
-This will create a number of routes for each of the `articles` and `comments` controller. For `Admin::ArticlesController`, Rails will create:
+For `Admin::ArticlesController`, Rails will create the following routes:
 
 | HTTP Verb | Path                     | Controller#Action      | Named Route Helper           |
 | --------- | ------------------------ | ---------------------- | ---------------------------- |


### PR DESCRIPTION
### Motivation / Background

This PR fixes an error in the Rails Routing Guide. The [related code example](https://github.com/higher-pixels/rails-routing-guide/blob/d43b20e43fe69e565425f6ab7a89dbc9bfbf45f8/guides/source/routing.md?plain=1#L225-L229) was changed in https://github.com/rails/rails/pull/52521, however, the explanation beneath it was not updated.

### Detail

This Pull Request removes the incorrect reference to `comments` and rewords the sentence.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
