### PR TITLE
[Fix #54502] Retrieve column from connection's schema cache when computing default attribute types

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Fix race condition in column-based type lookups when defining attribute methods with
+    multiple databases in a multi-threaded environment.
+
+    When using PostgreSQL with the hstore extension, this would result in hstore column
+    attribute type lookups to fail and fallback to the default string type due to differing
+    OID values for the same type across different connections.
+
+    *Joshua Young*
+
 *   Fix a case where a non-retryable query could be marked retryable.
 
     *Hartley McGuire*

--- a/activerecord/lib/active_record/attributes.rb
+++ b/activerecord/lib/active_record/attributes.rb
@@ -241,7 +241,9 @@ module ActiveRecord
       def _default_attributes # :nodoc:
         @default_attributes ||= begin
           attributes_hash = with_connection do |connection|
+            connection_columns = connection.schema_cache.columns_hash(table_name)
             columns_hash.transform_values do |column|
+              column = connection_columns[column.name] || column
               ActiveModel::Attribute.from_database(column.name, column.default, type_for_column(connection, column))
             end
           end


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

Fixes https://github.com/rails/rails/issues/54502 (I've tested against that repro script)
Some discussion in https://discord.com/channels/849034466856665118/974005005768069211/1339360740057944075

### Detail

Ensures columns used when defining default attribute types are retrieved from the schema cache for the current connection instead of from the model schema, which may have been set by different connection in another thread.

I've targeted `7-2-stable` cause this doesn't really make sense on `main`, and we'd want to do the same for `8-0-stable`. Alternatively as I mentioned in the issue we could backport https://github.com/rails/rails/commit/9ad36e067222478090b36a985090475bb03e398c.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.