### PR TITLE
Introduce ActiveSupport::ErrorReport#add_middleware

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Introduce ActiveSupport::ErrorReporter#add_middleware
+
+    When reporting an error, the error context middleware will be called with the reported error
+    and base execution context. The stack may mutate the context hash. The mutated context will
+    then be passed to error subscribers.
+
+    *Andrew Novoselac*, *Sam Schmidt*
+
 *   Change execution wrapping to report all exceptions, including `Exception`.
 
     If a more serious error like `SystemStackError` or `NoMemoryError` happens,


### PR DESCRIPTION

### Motivation / Background

This Pull Request has been created because we have a number of subscribers to the error reporter in our app. For each subscriber we build similar or identical metadata for the exception, and that is leading to duplicate work being done in each subscriber. I think there should be a way for the reporter itself to get some metadata and pass it to each subscriber.

### Detail

I introduced `ActiveSupport::ErrorHandler#metadata_provider`. This a callable that takes the error and returns a hash of metadata. We call that with reported error and add the returned hash to the `context` hash that is passed to each subscriber.

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
