### PR TITLE
Stop eagerly computing `request.route_uri_pattern`

### DIFF
--- a/actionpack/lib/action_dispatch/http/request.rb
+++ b/actionpack/lib/action_dispatch/http/request.rb
@@ -157,11 +157,16 @@ module ActionDispatch
     #
     #     request.route_uri_pattern # => "/:controller(/:action(/:id))(.:format)"
     def route_uri_pattern
-      get_header("action_dispatch.route_uri_pattern")
+      unless pattern = get_header("action_dispatch.route_uri_pattern")
+        route = get_header("action_dispatch.route")
+        pattern = route.path.spec.to_s
+        set_header("action_dispatch.route_uri_pattern", pattern)
+      end
+      pattern
     end
 
-    def route_uri_pattern=(pattern) # :nodoc:
-      set_header("action_dispatch.route_uri_pattern", pattern)
+    def route=(route) # :nodoc:
+      set_header("action_dispatch.route", route)
     end
 
     def routes # :nodoc:

--- a/actionpack/lib/action_dispatch/journey/router.rb
+++ b/actionpack/lib/action_dispatch/journey/router.rb
@@ -43,7 +43,7 @@ module ActionDispatch
           }
 
           req.path_parameters = tmp_params
-          req.route_uri_pattern = route.path.spec.to_s
+          req.route = route
 
           _, headers, _ = response = route.app.serve(req)
 


### PR DESCRIPTION
This was introduced in https://github.com/rails/rails/pull/47129/ by GitHub folks because they need the route pattern in HTML for some reason.

But the overwhelming majority of applications don't need that information, so there is no point wasting time precomputing it.

Followup: https://github.com/rails/rails/pull/54504 (cc @skipkayhil )
Followup: https://github.com/rails/rails/pull/54491
Followup: https://github.com/rails/rails/pull/54505

Same benchmark as: https://github.com/rails/rails/pull/54491#issuecomment-2650542281

```
== index ==
ruby 3.4.1 (2024-12-25 revision 48d4efcb85) +YJIT +PRISM [arm64-darwin23]
Warming up --------------------------------------
               after    46.519k i/100ms
Calculating -------------------------------------
               after    468.807k (± 0.5%) i/s    (2.13 μs/i) -      2.372M in   5.060781s

Comparison:
              before:   363898.7 i/s
               after:   468807.2 i/s - 1.29x  faster

== show ==
ruby 3.4.1 (2024-12-25 revision 48d4efcb85) +YJIT +PRISM [arm64-darwin23]
Warming up --------------------------------------
               after    36.443k i/100ms
Calculating -------------------------------------
               after    363.585k (± 0.6%) i/s    (2.75 μs/i) -      1.822M in   5.011832s

Comparison:
              before:   276473.5 i/s
               after:   363584.9 i/s - 1.32x  faster

== show_nested ==
ruby 3.4.1 (2024-12-25 revision 48d4efcb85) +YJIT +PRISM [arm64-darwin23]
Warming up --------------------------------------
               after    33.943k i/100ms
Calculating -------------------------------------
               after    339.724k (± 0.2%) i/s    (2.94 μs/i) -      1.731M in   5.095599s

Comparison:
              before:   246010.1 i/s
               after:   339724.5 i/s - 1.38x  faster
```
