### PR TITLE
Cache Journey Node#to_s

### DIFF
--- a/actionpack/lib/action_dispatch/journey/nodes/node.rb
+++ b/actionpack/lib/action_dispatch/journey/nodes/node.rb
@@ -74,6 +74,7 @@ module ActionDispatch
         def initialize(left)
           @left = left
           @memo = nil
+          @to_s = nil
         end
 
         def each(&block)
@@ -81,7 +82,7 @@ module ActionDispatch
         end
 
         def to_s
-          Visitors::String::INSTANCE.accept(self, "".dup)
+          @to_s ||= Visitors::String::INSTANCE.accept(self, "".dup).freeze
         end
 
         def to_dot


### PR DESCRIPTION
Followup: https://github.com/rails/rails/pull/54504
Followup: https://github.com/rails/rails/pull/54491
Followup: https://github.com/rails/rails/pull/54505
Followup: https://github.com/rails/rails/pull/54515

Even though the generation has been optimized, it is wasteful to keep generating the same string again and again.

Initially I wasn't really for adding this cache, but @matthewd  pointed that the `uri_pattern` is accessed by Open Telemetry, so lazily memoizing seem sound.
