### PR TITLE
Micro-Optimize Router#find_routes

### DIFF
--- a/actionpack/lib/action_dispatch/http/parameters.rb
+++ b/actionpack/lib/action_dispatch/http/parameters.rb
@@ -65,14 +65,14 @@ module ActionDispatch
       alias :params :parameters
 
       def path_parameters=(parameters) # :nodoc:
-        delete_header("action_dispatch.request.parameters")
+        @env.delete("action_dispatch.request.parameters")
 
         parameters = Request::Utils.set_binary_encoding(self, parameters, parameters[:controller], parameters[:action])
         # If any of the path parameters has an invalid encoding then raise since it's
         # likely to trigger errors further on.
         Request::Utils.check_param_encoding(parameters)
 
-        set_header PARAMETERS_KEY, parameters
+        @env[PARAMETERS_KEY] = parameters
       rescue Rack::Utils::ParameterTypeError, Rack::Utils::InvalidParameterError => e
         raise ActionController::BadRequest.new("Invalid path parameters: #{e.message}")
       end
@@ -82,7 +82,7 @@ module ActionDispatch
       #
       #     { action: "my_action", controller: "my_controller" }
       def path_parameters
-        get_header(PARAMETERS_KEY) || set_header(PARAMETERS_KEY, {})
+        @env[PARAMETERS_KEY] ||= {}
       end
 
       private

--- a/actionpack/lib/action_dispatch/http/request.rb
+++ b/actionpack/lib/action_dispatch/http/request.rb
@@ -166,7 +166,7 @@ module ActionDispatch
     end
 
     def route=(route) # :nodoc:
-      set_header("action_dispatch.route", route)
+      @env["action_dispatch.route"] = route
     end
 
     def routes # :nodoc:

--- a/actionpack/lib/action_dispatch/journey/router.rb
+++ b/actionpack/lib/action_dispatch/journey/router.rb
@@ -117,7 +117,11 @@ module ActionDispatch
             routes.select! { |r| r.matches?(req) }
           end
 
-          routes.sort_by!(&:precedence)
+          if routes.size > 1
+            routes.sort! do |a, b|
+              a.precedence <=> b.precedence
+            end
+          end
 
           routes.each do |r|
             match_data = r.path.match(path_info)

--- a/actionpack/lib/action_dispatch/journey/router.rb
+++ b/actionpack/lib/action_dispatch/journey/router.rb
@@ -2,6 +2,7 @@
 
 # :markup: markdown
 
+require "cgi"
 require "action_dispatch/journey/router/utils"
 require "action_dispatch/journey/routes"
 require "action_dispatch/journey/formatter"
@@ -123,8 +124,13 @@ module ActionDispatch
             path_parameters = {}
             index = 1
             match_data.names.each do |name|
-              val = match_data[index]
-              path_parameters[name.to_sym] = Utils.unescape_uri(val) if val
+              if val = match_data[index]
+                path_parameters[name.to_sym] = if val.include?("%")
+                  CGI.unescapeURIComponent(val)
+                else
+                  val
+                end
+              end
               index += 1
             end
             yield [match_data, path_parameters, r]

--- a/actionpack/lib/action_dispatch/journey/router.rb
+++ b/actionpack/lib/action_dispatch/journey/router.rb
@@ -118,15 +118,17 @@ module ActionDispatch
 
           routes.sort_by!(&:precedence)
 
-          routes.each { |r|
+          routes.each do |r|
             match_data = r.path.match(path_info)
             path_parameters = {}
-            match_data.names.each_with_index { |name, i|
-              val = match_data[i + 1]
+            index = 1
+            match_data.names.each do |name|
+              val = match_data[index]
               path_parameters[name.to_sym] = Utils.unescape_uri(val) if val
-            }
+              index += 1
+            end
             yield [match_data, path_parameters, r]
-          }
+          end
         end
 
         def match_head_routes(routes, req)

--- a/actionpack/lib/action_dispatch/journey/router/utils.rb
+++ b/actionpack/lib/action_dispatch/journey/router/utils.rb
@@ -61,11 +61,6 @@ module ActionDispatch
             escape(segment, SEGMENT)
           end
 
-          def unescape_uri(uri)
-            encoding = uri.encoding == US_ASCII ? UTF_8 : uri.encoding
-            uri.gsub(ESCAPED) { |match| [match[1, 2].hex].pack("C") }.force_encoding(encoding)
-          end
-
           private
             def escape(component, pattern)
               component.gsub(pattern) { |unsafe| percent_encode(unsafe) }.force_encoding(US_ASCII)
@@ -90,14 +85,6 @@ module ActionDispatch
 
         def self.escape_fragment(fragment)
           ENCODER.escape_fragment(fragment.to_s)
-        end
-
-        # Replaces any escaped sequences with their unescaped representations.
-        #
-        #     uri = "/topics?title=Ruby%20on%20Rails"
-        #     unescape_uri(uri)  #=> "/topics?title=Ruby on Rails"
-        def self.unescape_uri(uri)
-          ENCODER.unescape_uri(uri)
         end
       end
     end

--- a/actionpack/lib/action_dispatch/journey/router/utils.rb
+++ b/actionpack/lib/action_dispatch/journey/router/utils.rb
@@ -17,7 +17,14 @@ module ActionDispatch
         #     normalize_path("")      # => "/"
         #     normalize_path("/%ab")  # => "/%AB"
         def self.normalize_path(path)
-          path ||= ""
+          return "/".dup unless path
+
+          # Fast path for the overwhelming majority of paths that don't need to be normalized
+          if path == "/" || (path.start_with?("/") && !path.end_with?("/") && !path.match?(%r{%|//}))
+            return path.dup
+          end
+
+          # Slow path
           encoding = path.encoding
           path = +"/#{path}"
           path.squeeze!("/")

--- a/actionpack/test/journey/router/utils_test.rb
+++ b/actionpack/test/journey/router/utils_test.rb
@@ -18,12 +18,12 @@ module ActionDispatch
           assert_equal "a/b%20c+d%25?e", Utils.escape_fragment("a/b c+d%?e")
         end
 
-        def test_uri_unescape
-          assert_equal "a/b c+d", Utils.unescape_uri("a%2Fb%20c+d")
+        def test_CGI_unescapeURIComponent
+          assert_equal "a/b c+d", CGI.unescapeURIComponent("a%2Fb%20c+d")
         end
 
-        def test_uri_unescape_with_utf8_string
-          assert_equal "Šašinková", Utils.unescape_uri((+"%C5%A0a%C5%A1inkov%C3%A1").force_encoding(Encoding::US_ASCII))
+        def test_CGI_unescapeURIComponent_with_utf8_string
+          assert_equal "Šašinková", CGI.unescapeURIComponent((+"%C5%A0a%C5%A1inkov%C3%A1").force_encoding(Encoding::US_ASCII))
         end
 
         def test_normalize_path_not_greedy
@@ -36,7 +36,7 @@ module ActionDispatch
 
         def test_normalize_path_maintains_string_encoding
           path = "/foo%AAbar%AAbaz".b
-          assert_equal Encoding::ASCII_8BIT, Utils.normalize_path(path).encoding
+          assert_equal Encoding::BINARY, Utils.normalize_path(path).encoding
         end
 
         def test_normalize_path_with_nil


### PR DESCRIPTION
Followup: https://github.com/rails/rails/pull/54504
Followup: https://github.com/rails/rails/pull/54491
Followup: https://github.com/rails/rails/pull/54505
Followup: https://github.com/rails/rails/pull/54515
Followup: https://github.com/rails/rails/pull/54516

These are all small micro-optimizations, but they add up.

Same benchmark as: https://github.com/rails/rails/pull/54491#issuecomment-2650542281

```
== index ==
ruby 3.4.1 (2024-12-25 revision 48d4efcb85) +YJIT +PRISM [arm64-darwin23]
Warming up --------------------------------------
               after    57.954k i/100ms
Calculating -------------------------------------
               after    589.889k (± 0.5%) i/s    (1.70 μs/i) -      2.956M in   5.010651s

Comparison:
              before:   448751.6 i/s
               after:   589888.6 i/s - 1.31x  faster

== show ==
ruby 3.4.1 (2024-12-25 revision 48d4efcb85) +YJIT +PRISM [arm64-darwin23]
Warming up --------------------------------------
               after    46.760k i/100ms
Calculating -------------------------------------
               after    462.541k (± 1.0%) i/s    (2.16 μs/i) -      2.338M in   5.055185s

Comparison:
              before:   352192.0 i/s
               after:   462541.4 i/s - 1.31x  faster

== show_nested ==
ruby 3.4.1 (2024-12-25 revision 48d4efcb85) +YJIT +PRISM [arm64-darwin23]
Warming up --------------------------------------
               after    42.082k i/100ms
Calculating -------------------------------------
               after    420.114k (± 0.2%) i/s    (2.38 μs/i) -      2.104M in   5.008430s

Comparison:
              before:   327672.8 i/s
               after:   420113.6 i/s - 1.28x  faster
```

If we compare to 8-0-stable to account for all the recent PRs, the overhead was cut by more than half:

```
== index ==
ruby 3.4.1 (2024-12-25 revision 48d4efcb85) +YJIT +PRISM [arm64-darwin23]
Warming up --------------------------------------
               after    58.569k i/100ms
Calculating -------------------------------------
               after    590.724k (± 0.9%) i/s    (1.69 μs/i) -      2.987M in   5.056914s

Comparison:
              before:   272012.7 i/s
               after:   590724.1 i/s - 2.17x  faster

== show ==
ruby 3.4.1 (2024-12-25 revision 48d4efcb85) +YJIT +PRISM [arm64-darwin23]
Warming up --------------------------------------
               after    46.784k i/100ms
Calculating -------------------------------------
               after    459.828k (± 0.5%) i/s    (2.17 μs/i) -      2.339M in   5.087265s

Comparison:
              before:   198611.2 i/s
               after:   459828.4 i/s - 2.32x  faster

== show_nested ==
ruby 3.4.1 (2024-12-25 revision 48d4efcb85) +YJIT +PRISM [arm64-darwin23]
Warming up --------------------------------------
               after    41.386k i/100ms
Calculating -------------------------------------
               after    416.197k (± 0.5%) i/s    (2.40 μs/i) -      2.111M in   5.071520s

Comparison:
              before:   168787.4 i/s
               after:   416196.5 i/s - 2.47x  faster
```

Of course this is a micro-benchmark, at best you stand to save 4μs per request, which in the grand scheme of things is peanuts, but if that can appease the micro-benchmark crowd and help change perception, why not.

cc @skipkayhil 
