### PR TITLE
Fix on_rotation for `find_signed!` & `find_signed`

### DIFF
--- a/activerecord/lib/active_record/signed_id.rb
+++ b/activerecord/lib/active_record/signed_id.rb
@@ -52,7 +52,8 @@ module ActiveRecord
       def find_signed(signed_id, purpose: nil, on_rotation: nil)
         raise UnknownPrimaryKey.new(self) if primary_key.nil?
 
-        if id = signed_id_verifier.verified(signed_id, purpose: combine_signed_id_purposes(purpose), on_rotation: on_rotation)
+        options = { on_rotation: on_rotation }.compact
+        if id = signed_id_verifier.verified(signed_id, purpose: combine_signed_id_purposes(purpose), **options)
           find_by primary_key => id
         end
       end
@@ -70,7 +71,8 @@ module ActiveRecord
       #   User.first.destroy
       #   User.find_signed! signed_id # => ActiveRecord::RecordNotFound
       def find_signed!(signed_id, purpose: nil, on_rotation: nil)
-        if id = signed_id_verifier.verify(signed_id, purpose: combine_signed_id_purposes(purpose), on_rotation: on_rotation)
+        options = { on_rotation: on_rotation }.compact
+        if id = signed_id_verifier.verify(signed_id, purpose: combine_signed_id_purposes(purpose), **options)
           find(id)
         end
       end

--- a/activerecord/test/cases/signed_id_test.rb
+++ b/activerecord/test/cases/signed_id_test.rb
@@ -192,6 +192,20 @@ class SignedIdTest < ActiveRecord::TestCase
     Account.signed_id_verifier = old_verifier
   end
 
+  test "on_rotation callback using custom verifier" do
+    old_verifier = Account.signed_id_verifier
+
+    Account.signed_id_verifier = ActiveSupport::MessageVerifier.new("old secret")
+    old_account_signed_id = @account.signed_id
+    on_rotation_is_called = false
+    Account.signed_id_verifier = ActiveSupport::MessageVerifier.new("new secret", on_rotation: -> { on_rotation_is_called = true })
+    Account.signed_id_verifier.rotate("old secret")
+    Account.find_signed(old_account_signed_id)
+    assert on_rotation_is_called
+  ensure
+    Account.signed_id_verifier = old_verifier
+  end
+
   test "on_rotation callback using find_signed & find_signed!" do
     old_verifier = Account.signed_id_verifier
 


### PR DESCRIPTION
#### Ref: #54373 

When `on_rotation` is not provided, `find_signed` and `find_signed!` use `nil` as the default value. Passing `nil` for `on_rotation` prevents the assignment of the `@on_rotation` instance variable.  

Currently the only way to set `@on_rotation` for `signed_id_verifier` is by using a custom verifier.