### PR TITLE
Fix image path in Getting Started guide [ci skip]

### DIFF
--- a/guides/source/getting_started.md
+++ b/guides/source/getting_started.md
@@ -203,7 +203,7 @@ Use Ctrl-C to stop
 To see your Rails application, open http://localhost:3000 in your browser. You
 will see the default Rails welcome page:
 
-![Rails welcome page](images/getting_started/rails_welcome.png)
+![Rails welcome page](../assets/images/getting_started/rails_welcome.png)
 
 It works!
 


### PR DESCRIPTION
### Motivation / Background

Fixes #54527 

The Rails Getting Started guide currently references an outdated path for the welcome page image. As a result, the image does not render when viewing the guide.

### Detail

This PR updates the reference to the Rails welcome page image in `getting_started.md`, ensuring it points to the correct path in the assets directory. The path previously looked at `guides/source` which does not contain the getting started images. 

The old path was trying to reference:
guides/source/images/getting_started/rails_welcome.png

The new path references:
guides/assets/images/getting_started/rails_welcome.png

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
