### PR TITLE
Only generate an UPDATE/FROM if the first join is an INNER JOIN

### DIFF
--- a/activerecord/lib/arel/visitors/postgresql.rb
+++ b/activerecord/lib/arel/visitors/postgresql.rb
@@ -54,7 +54,11 @@ module Arel # :nodoc: all
         # query. However, this does not allow for LIMIT, OFFSET and ORDER. To support
         # these, we must use a subquery.
         def prepare_update_statement(o)
-          if has_join_sources?(o) && !has_limit_or_offset_or_orders?(o) && !has_group_by_and_having?(o)
+          if has_join_sources?(o) && !has_limit_or_offset_or_orders?(o) && !has_group_by_and_having?(o) &&
+            # The PostgreSQL dialect isn't flexible enough to allow anything other than a inner join
+            # for the first join:
+            #   UPDATE table SET .. FROM joined_table WHERE ...
+            (o.relation.right.first.is_a?(Arel::Nodes::InnerJoin))
             o
           else
             super

--- a/activerecord/lib/arel/visitors/sqlite.rb
+++ b/activerecord/lib/arel/visitors/sqlite.rb
@@ -54,7 +54,11 @@ module Arel # :nodoc: all
         def prepare_update_statement(o)
           # Sqlite need to be built with the SQLITE_ENABLE_UPDATE_DELETE_LIMIT compile-time option
           # to support LIMIT/OFFSET/ORDER in UPDATE and DELETE statements.
-          if has_join_sources?(o) && !has_limit_or_offset_or_orders?(o) && !has_group_by_and_having?(o)
+          if has_join_sources?(o) && !has_limit_or_offset_or_orders?(o) && !has_group_by_and_having?(o) &&
+            # The SQLite3 dialect isn't flexible enough to allow anything other than a inner join
+            # for the first join:
+            #   UPDATE table SET .. FROM joined_table WHERE ...
+            (o.relation.right.first.is_a?(Arel::Nodes::InnerJoin))
             o
           else
             super

--- a/activerecord/test/cases/relation/update_all_test.rb
+++ b/activerecord/test/cases/relation/update_all_test.rb
@@ -125,6 +125,13 @@ class UpdateAllTest < ActiveRecord::TestCase
     assert_equal pets.count, pets.update_all(name: "Bob")
   end
 
+  def test_update_all_with_left_outer_joins
+    pets = Pet.left_outer_joins(:toys)
+
+    assert_equal true, pets.exists?
+    assert_equal pets.count, pets.update_all(name: "Boby")
+  end
+
   def test_update_all_with_includes
     pets = Pet.includes(:toys).where(toys: { name: "Bone" })
 


### PR DESCRIPTION
Fix: https://github.com/rails/rails/issues/54518
Followup: https://github.com/rails/rails/pull/53950

SQLite3 and PostgreSQL dialects aren't flexible enough to allow more than a simple join.

```sql
UPDATE "main_table"
SET ...
FROM "joined_table"
WHERE joined_table.foreign_key = main_table.primary_key
```

So if the first join is anything other than a regular INNER JOIN we have no choice but to degrade to the subquery scheme.
