### PR TITLE
Update Saucelabs configuration

### DIFF
--- a/actioncable/karma.conf.js
+++ b/actioncable/karma.conf.js
@@ -25,7 +25,7 @@ if (process.env.CI) {
   config.customLaunchers = {
     sl_chrome: sauce("chrome", 70),
     sl_ff: sauce("firefox", 63),
-    sl_safari: sauce("safari", 12.0, "macOS 10.13"),
+    sl_safari: sauce("safari", "latest"),
     sl_edge: sauce("microsoftedge", 17.17134, "Windows 10"),
   }
 


### PR DESCRIPTION
It seems like Safari 12 is no longer supported by Saucelabs:

```
UnhandledRejection: Error: [init({"version":"12","platform":"macOS 10.13","tags":[],"name":"ActionCable JS Client"
...,"browserName":" safari"})] The environment you requested was unavailable.
```
