### PR TITLE
Use adapter support flags instead of checking adapter type in `INDEX INCLUDE` tests

### DIFF
--- a/activerecord/test/cases/migration/index_test.rb
+++ b/activerecord/test/cases/migration/index_test.rb
@@ -257,71 +257,68 @@ module ActiveRecord
         connection.add_index("testings", %w(last_name first_name administrator), name: "named_admin")
         connection.remove_index("testings", name: "named_admin")
 
-        # Selected adapters support index sort order
-        if current_adapter?(:SQLite3Adapter, :Mysql2Adapter, :TrilogyAdapter, :PostgreSQLAdapter)
-          connection.add_index("testings", ["last_name"], order: { last_name: :desc })
-          connection.remove_index("testings", ["last_name"])
-          connection.add_index("testings", ["last_name", "first_name"], order: { last_name: :desc })
-          connection.remove_index("testings", ["last_name", "first_name"])
-          connection.add_index("testings", ["last_name", "first_name"], order: { last_name: :desc, first_name: :asc })
-          connection.remove_index("testings", ["last_name", "first_name"])
-          connection.add_index("testings", ["last_name", "first_name"], order: :desc)
-          connection.remove_index("testings", ["last_name", "first_name"])
-        end
+        connection.add_index("testings", ["last_name"], order: { last_name: :desc })
+        connection.remove_index("testings", ["last_name"])
+        connection.add_index("testings", ["last_name", "first_name"], order: { last_name: :desc })
+        connection.remove_index("testings", ["last_name", "first_name"])
+        connection.add_index("testings", ["last_name", "first_name"], order: { last_name: :desc, first_name: :asc })
+        connection.remove_index("testings", ["last_name", "first_name"])
+        connection.add_index("testings", ["last_name", "first_name"], order: :desc)
+        connection.remove_index("testings", ["last_name", "first_name"])
       end
 
-      if current_adapter?(:PostgreSQLAdapter)
-        def test_add_partial_index
-          connection.add_index("testings", "last_name", where: "first_name = 'john doe'")
-          assert connection.index_exists?("testings", "last_name")
+      def test_add_partial_index
+        skip("current adapter doesn't support partial indexes") unless supports_partial_index?
 
-          connection.remove_index("testings", "last_name")
-          assert_not connection.index_exists?("testings", "last_name")
-        end
+        connection.add_index("testings", "last_name", where: "first_name = 'john doe'")
+        assert connection.index_exists?("testings", "last_name")
 
-        def test_add_index_with_included_column
-          skip("current adapter doesn't support include indexes") unless supports_index_include?
+        connection.remove_index("testings", "last_name")
+        assert_not connection.index_exists?("testings", "last_name")
+      end
 
-          connection.add_index("testings", "last_name", include: :foo)
-          assert connection.index_exists?("testings", "last_name", include: :foo)
+      def test_add_index_with_included_column
+        skip("current adapter doesn't support include indexes") unless supports_index_include?
 
-          connection.remove_index("testings", "last_name")
-          assert_not connection.index_exists?("testings", "last_name")
-        end
+        connection.add_index("testings", "last_name", include: :foo)
+        assert connection.index_exists?("testings", "last_name", include: :foo)
 
-        def test_add_index_with_multiple_included_columns
-          skip("current adapter doesn't support include indexes") unless supports_index_include?
+        connection.remove_index("testings", "last_name")
+        assert_not connection.index_exists?("testings", "last_name")
+      end
 
-          connection.add_index("testings", "last_name", include: [:foo, :bar])
-          assert connection.index_exists?("testings", "last_name", include: [:foo, :bar])
+      def test_add_index_with_multiple_included_columns
+        skip("current adapter doesn't support include indexes") unless supports_index_include?
 
-          connection.remove_index("testings", "last_name")
-          assert_not connection.index_exists?("testings", "last_name")
-        end
+        connection.add_index("testings", "last_name", include: [:foo, :bar])
+        assert connection.index_exists?("testings", "last_name", include: [:foo, :bar])
 
-        def test_add_index_with_included_column_and_where_clause
-          skip("current adapter doesn't support include indexes") unless supports_index_include?
+        connection.remove_index("testings", "last_name")
+        assert_not connection.index_exists?("testings", "last_name")
+      end
 
-          connection.add_index("testings", "last_name", include: :foo, where: "first_name = 'john doe'")
-          assert connection.index_exists?("testings", "last_name", include: :foo, where: "first_name = 'john doe'")
+      def test_add_index_with_included_column_and_where_clause
+        skip("current adapter doesn't support include indexes") unless supports_index_include?
 
-          connection.remove_index("testings", "last_name")
-          assert_not connection.index_exists?("testings", "last_name", include: :foo, where: "first_name = 'john doe'")
-        end
+        connection.add_index("testings", "last_name", include: :foo, where: "first_name = 'john doe'")
+        assert connection.index_exists?("testings", "last_name", include: :foo, where: "first_name = 'john doe'")
 
-        def test_add_index_with_nulls_not_distinct_assert_exists_with_same_values
-          skip("current adapter doesn't support nulls not distinct") unless supports_nulls_not_distinct?
+        connection.remove_index("testings", "last_name")
+        assert_not connection.index_exists?("testings", "last_name", include: :foo, where: "first_name = 'john doe'")
+      end
 
-          connection.add_index("testings", "last_name", nulls_not_distinct: true)
-          assert connection.index_exists?("testings", "last_name", nulls_not_distinct: true)
-        end
+      def test_add_index_with_nulls_not_distinct_assert_exists_with_same_values
+        skip("current adapter doesn't support nulls not distinct") unless supports_nulls_not_distinct?
 
-        def test_add_index_with_nulls_not_distinct_assert_exists_with_different_values
-          skip("current adapter doesn't support nulls not distinct") unless supports_nulls_not_distinct?
+        connection.add_index("testings", "last_name", nulls_not_distinct: true)
+        assert connection.index_exists?("testings", "last_name", nulls_not_distinct: true)
+      end
 
-          connection.add_index("testings", "last_name", nulls_not_distinct: false)
-          assert_not connection.index_exists?("testings", "last_name", nulls_not_distinct: true)
-        end
+      def test_add_index_with_nulls_not_distinct_assert_exists_with_different_values
+        skip("current adapter doesn't support nulls not distinct") unless supports_nulls_not_distinct?
+
+        connection.add_index("testings", "last_name", nulls_not_distinct: false)
+        assert_not connection.index_exists?("testings", "last_name", nulls_not_distinct: true)
       end
 
       private


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This PR updates the `INDEX INCLUDE` tests in `activerecord/test/cases/migration/index_test.rb` to run based on support flags rather than the adapter type. 

### Detail

PostgreSQL is the only core adapter (PostgreSQL/MySQL/SQLite/Trilogy) that support `INDEX INCLUDE`. However, SQL Server also supports `INDEX INCLUDE` and I would like to reuse the Rails tests in [ActiveRecord SQL Server Adapter](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter) instead of recreating them in the adapter.

The tests currently check if the adapter is PostgreSQL and that `INDEX INCLUDE` is supported. The check to see if the adapter is PostgreSQL is not needed.

Removing the PostgreSQL adapter check makes it necessary to check if `PARTIAL INDEX` is supported in a separate test.

Also, removed the following check as its a list of all the core adapters and so does nothing:

```ruby
if current_adapter?(:SQLite3Adapter, :Mysql2Adapter, :TrilogyAdapter, :PostgreSQLAdapter)
```

_The changes are small and better viewed in the diff with the `Hide whitespace` option enabled._

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
