### PR TITLE
fix: use a temporary connection pool for db purging

### DIFF
--- a/activerecord/lib/active_record/tasks/database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/database_tasks.rb
@@ -346,7 +346,9 @@ module ActiveRecord
 
       def purge(configuration)
         db_config = resolve_configuration(configuration)
-        database_adapter_for(db_config).purge
+        with_temporary_connection(db_config) do
+          database_adapter_for(db_config).purge
+        end
       end
 
       def purge_all


### PR DESCRIPTION
### Motivation / Background

I think this should have been part of 901828f2, but was missed.

We shouldn't be using the ActiveRecord::Base connection to purge non-primary databases. This PR updates these tasks to use the pattern introduced by Eileen in that (and subsequent) commits:

- db:purge
- db:purge:all
- db:test:purge

### Detail

@eileencodes did related work in #46270 to decouple rake tasks from the Base connection. This PR extends that work to cover the purge tasks.


### Additional information

In practice I guess this doesn't affect most apps; but I'm working in an app with multiple databases, and using the ActiveRecord::Base connection to purge non-primary databases isn't working as expected.

I'm not sure how to add tests for this, since this is largely an implementation detail (and #46270 also didn't add test coverage for the connection decoupling). But it works locally in my app! 😬

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [-] Tests are added or updated if you fix a bug or add a feature.
* [-] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
