### PR TITLE
Fix .devcontainer/boot.sh when using devcontainer in vscode

### DIFF
--- a/.devcontainer/boot.sh
+++ b/.devcontainer/boot.sh
@@ -1,6 +1,8 @@
+#!/usr/bin/env sh
+
 bundle install
 
-if [[ ! -z "${NVM_DIR}" ]]; then
+if [ "${NVM_DIR}" ]; then
   . ${NVM_DIR}/nvm.sh && nvm install --lts
   yarn install
 fi


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created because `.devcontainer/boot.sh` exits with an error when using devcontainer in vscode.

### Detail

Devcontainer "postCreateCommand" is executed with `sh` shell while script `devcontainer/boot.sh` is written in `bash` and it fails when using devcontainer in vscode.

`.devcontainer/boot.sh` is now a valid `sh` script and works with both `tools/devcontainer run-user-commands` and devcontainer in vscode.

### Additional information

When using devcontainer in vscode there's an error when it executes `.devcontainer/boot.sh`:
```bash
[165346 ms] Start: Run in container: /bin/sh -c .devcontainer/boot.sh
Bundle complete! 84 Gemfile dependencies, 242 gems now installed.
Use `bundle info [gemname]` to see where a bundled gem is installed.
1 installed gem you directly depend on is looking for funding.
  Run `bundle fund` for details
.devcontainer/boot.sh: 3: [[: not found
```

With this PR it works as expected:
```bash
[163401 ms] Start: Run in container: /bin/sh -c .devcontainer/boot.sh
Bundle complete! 84 Gemfile dependencies, 242 gems now installed.
Use `bundle info [gemname]` to see where a bundled gem is installed.
1 installed gem you directly depend on is looking for funding.
  Run `bundle fund` for details
Installing latest LTS version.
Downloading and installing node v22.14.0...
Downloading https://nodejs.org/dist/v22.14.0/node-v22.14.0-linux-arm64.tar.xz...
# (... cut ...)
Computing checksum with sha256sum
Checksums matched!
Now using node v22.14.0 (npm v10.9.2)
yarn install v1.22.22
[1/4] Resolving packages...
[2/4] Fetching packages...
# (... cut ...)
[3/4] Linking dependencies...
warning " > @rails/actiontext@8.1.0-alpha" has unmet peer dependency "trix@^2.0.0".
# (... cut ...)
[4/4] Building fresh packages...
success Saved lockfile.
Done in 30.25s.
```

Also it makes `checkbashisms` happy. Without this PR:
```bash
vscode ➜ /workspaces/rails (fix_boot.sh_when_using_devcontainer_in_vscode) $ checkbashisms .devcontainer/boot.sh
script .devcontainer/boot.sh does not appear to have a #! interpreter line;
you may get strange results
possible bashism in .devcontainer/boot.sh line 3 (alternative test command ([[ foo ]] should be [ foo ])):
if [[ ! -z "${NVM_DIR}" ]]; then
```
With this PR:
```bash
vscode ➜ /workspaces/rails (fix_boot.sh_when_using_devcontainer_in_vscode) $ checkbashisms .devcontainer/boot.sh
vscode ➜ /workspaces/rails (fix_boot.sh_when_using_devcontainer_in_vscode) $ echo $?
0
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
