### PR TITLE
Duplicate `context` hash in `ActiveSupport::ErrorHandler#report`

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Duplicate the `context` hash passed to `ActiveSupport::ErrorReport#handle` for each subscriber.
+    This prevents mutations done on the `context` by one subscriber from effecting the others.
+
+    *Andrew Novoselac*
+
 *   Fix `ActiveSupport::Concurrency::ShareLock` to honor `isolation_level`.
 
     Lock ownership was keyed on `Thread.current`. Under

--- a/activesupport/lib/active_support/error_reporter.rb
+++ b/activesupport/lib/active_support/error_reporter.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "active_support/core_ext/object/deep_dup"
+
 module ActiveSupport
   # = Active Support \Error Reporter
   #
@@ -251,7 +253,7 @@ module ActiveSupport
       disabled_subscribers = ActiveSupport::IsolatedExecutionState[self]
       @subscribers.each do |subscriber|
         unless disabled_subscribers&.any? { |s| s === subscriber }
-          subscriber.report(error, handled: handled, severity: severity, context: full_context, source: source)
+          subscriber.report(error, handled: handled, severity: severity, context: full_context.deep_dup, source: source)
         end
       rescue => subscriber_error
         if logger

--- a/activesupport/test/error_reporter_test.rb
+++ b/activesupport/test/error_reporter_test.rb
@@ -427,4 +427,22 @@ class ErrorReporterTest < ActiveSupport::TestCase
 
     assert_equal [[reported_error, true, :warning, "application", { foo: :bar }]], @subscriber.events
   end
+
+  class ContextMutatingSubscriber
+    def report(_error, handled:, severity:, context:, source:)
+      context.delete(:foo)
+    end
+  end
+
+  test "each subscriber gets its own context instance" do
+    reporter = ActiveSupport::ErrorReporter.new
+    reporter.subscribe(ContextMutatingSubscriber.new)
+    subscriber = ActiveSupport::ErrorReporter::TestHelper::ErrorSubscriber.new
+    reporter.subscribe(subscriber)
+    error = StandardError.new
+
+    reporter.report(error, context: { foo: { bar: "baz" } })
+
+    assert_equal [[error, true, :warning, "application", { foo: { bar: "baz" } }]], subscriber.events
+  end
 end


### PR DESCRIPTION

### Motivation / Background

Currently we pass the same instance of the `context` hash to each of the subscribers when calling `ActiveSupport::ErrorHandler#report`. I think this is a footgun since any mutation done on the hash in one subscriber will have a side effect on the others. And it's quite common to want to do things like `Foo.bar(baz: context.delete(:baz)` in my experience, so I think we should avoid this.

### Detail

Let's `deep_dup` the hash before passing it to each subscriber.

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
