### PR TITLE
Use `Minitest#flunk` instead of raising an Assertion error:

### DIFF
--- a/actionmailer/test/base_test.rb
+++ b/actionmailer/test/base_test.rb
@@ -331,7 +331,7 @@ class BaseTest < ActiveSupport::TestCase
         mail body: "yay", from: "welcome@example.com", to: "to@example.com"
 
         unless attachments.map(&:filename) == ["invoice.pdf"]
-          raise Minitest::Assertion, "Should allow access to attachments"
+          flunk("Should allow access to attachments")
         end
       end
     end

--- a/actionpack/lib/action_dispatch/testing/assertions/routing.rb
+++ b/actionpack/lib/action_dispatch/testing/assertions/routing.rb
@@ -336,7 +336,7 @@ module ActionDispatch
         def fail_on(exception_class, message)
           yield
         rescue exception_class => e
-          raise Minitest::Assertion, message || e.message
+          flunk(message || e.message)
         end
     end
   end

--- a/activesupport/lib/active_support/testing/error_reporter_assertions.rb
+++ b/activesupport/lib/active_support/testing/error_reporter_assertions.rb
@@ -44,7 +44,7 @@ module ActiveSupport
                   ActiveSupport.error_reporter.subscribe(self)
                   @subscribed = true
                 else
-                  raise Minitest::Assertion, "No error reporter is configured"
+                  flunk("No error reporter is configured")
                 end
               end
             end

--- a/railties/test/test_unit/reporter_test.rb
+++ b/railties/test/test_unit/reporter_test.rb
@@ -180,7 +180,7 @@ class TestUnitReporterTest < ActiveSupport::TestCase
     def failed_test
       ft = Minitest::Result.from(ExampleTest.new(:woot))
       ft.failures << begin
-                       raise Minitest::Assertion, "boo"
+                       flunk("boo")
                      rescue Minitest::Assertion => e
                        e
                      end


### PR DESCRIPTION
- ### Problem

  Using the `assert_recognizes` assertion will throw a warning message saying "the test is missing an assertion" (in the event that the assertion fails). This is because raising a `Minitest::Assertion` error directly (instead of using a built-in Minitest assertion method), doesn't increment the `Test#assertions` count which is later used by the TestsWithoutAssertions feature https://github.com/rails/rails/blob/8e504b017a68981076746c2d19fd23c788e4293e/activesupport/lib/active_support/testing/tests_without_assertions.rb#L8-L12.

  ### Solution

  Use `flunk` instead of raising. I don't think it's worth changing the `TestsWithoutAssertions` feature, as I don't see the point of raising a `Minitest:Assertion` error anyway.

