### PR TITLE
Make ActiveStorage::Record's superclass configurable

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   `ActiveStorage::Record`'s superclass is configurable through `config.active_storage.record_superclass`.
+
+    *Andrea Lorenzetti*
+
 *   Delegate `ActiveStorage::Filename#to_str` to `#to_s`
 
     Supports checking String equality:

--- a/activestorage/app/models/active_storage/record.rb
+++ b/activestorage/app/models/active_storage/record.rb
@@ -1,7 +1,13 @@
 # frozen_string_literal: true
 
-class ActiveStorage::Record < ActiveRecord::Base # :nodoc:
-  self.abstract_class = true
-end
+module ActiveStorage
+  record_superclass = Rails.application.config.active_storage.record_superclass&.constantize || ActiveRecord::Base
 
-ActiveSupport.run_load_hooks :active_storage_record, ActiveStorage::Record
+  klass = Class.new(record_superclass) do
+    self.abstract_class = true
+  end
+
+  ActiveStorage.const_set "Record", klass
+
+  ActiveSupport.run_load_hooks :active_storage_record, ActiveStorage::Record
+end

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -3204,6 +3204,22 @@ The default value depends on the `config.load_defaults` target version:
 Determines whether the Active Storage assets should be added to the asset pipeline precompilation. It
 has no effect if Sprockets is not used. The default value is `true`.
 
+#### `config.active_storage.record_superclass`
+
+Configure the superclass for `ActiveStorage::Record`. It needs to be a string. The default value is `"ActiveRecord::Base"`.
+
+```ruby
+# record_superclass must be a string
+config.active_storage.record_superclass = "MyModel"
+```
+
+```ruby
+class MyModel < ::ApplicationRecord
+  self.abstract_class = true
+  #....
+end
+```
+
 ### Configuring Action Text
 
 #### `config.action_text.attachment_tag_name`

--- a/railties/test/application/active_storage/record_superclass_test.rb
+++ b/railties/test/application/active_storage/record_superclass_test.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require "isolation/abstract_unit"
+
+module ApplicationTests
+  class RecordSuperclassTest < ActiveSupport::TestCase
+    include ActiveSupport::Testing::Isolation
+
+    def setup
+      build_app
+    end
+
+    def teardown
+      teardown_app
+    end
+
+    def test_default_superclass_for_activestorage_record_is_activerecord_base
+      app("development")
+
+      assert_equal ActiveRecord::Base, ActiveStorage::Record.superclass
+    end
+
+    def test_activestorage_record_superclass_is_configurable
+      app_file "app/models/private_application_record.rb", <<~RUBY
+        class PrivateApplicationRecord < ::ApplicationRecord
+          self.abstract_class = true
+        end
+      RUBY
+
+      add_to_config <<-RUBY
+        config.active_storage.record_superclass = "PrivateApplicationRecord"
+      RUBY
+
+      app("development")
+
+      assert_equal PrivateApplicationRecord, ActiveStorage::Record.superclass
+    end
+
+    def test_activestorage_record_superclass_config_breaks_if_not_string
+      add_to_config <<-RUBY
+        config.active_storage.record_superclass = ActiveRecord::Base
+      RUBY
+
+      app("development")
+
+      assert_raises NameError do
+        ActiveStorage::Record
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Motivation / Background

On an application using horizontal sharding, we can achieve "active_storage's horizontal sharding" with an initializer like
```ruby
# config/initializers/active_storage_connection.rb
ActiveSupport.on_load(:active_storage_record) do
  connects_to shards: {
    private: { writing: :private }
  }
end
```
This is working but it creates an unessential additional connection to the same database (it creates another connection_pool) as we could reuse the one used by the other application models:
```ruby
# app/models/private/application_record.rb 
module Private
  class ApplicationRecord < ::ApplicationRecord
    self.abstract_class = true

    connects_to shards: {
      private: { writing: :private }
    }
  end
end
```
The unessential connection is an issue on deploys with a lot of small workers (ex. k8s) as it doubles the connections to a db. 

With this PR `ActiveStorage::Record` can inherit from `Private::ApplicationRecord` and so they could "share" the connection/connection_pool.

### Detail

`ActiveStorage::Record` is declared on the fly and inherits by default from `ActiveRecord::Base` so it is backward compatible.

### Additional information

A longer description of the issue is present in [rails forum](https://discuss.rubyonrails.org/t/horizontal-sharding-activestorage-and-number-of-connection-pools/88538).

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
