### PR TITLE
Make `rails new --quiet` fully quiet

### DIFF
--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -657,6 +657,11 @@ module Rails
         end
       end
 
+      def rails_command(command, command_options = {})
+        command_options[:capture] = true if options[:quiet]
+        super
+      end
+
       def bundle_install?
         !(options[:skip_bundle] || options[:pretend])
       end

--- a/railties/test/generators/actions_test.rb
+++ b/railties/test/generators/actions_test.rb
@@ -569,6 +569,13 @@ class ActionsTest < Rails::Generators::TestCase
     assert_match(/1234567890/, error.message)
   end
 
+  test "rails_command with quiet option" do
+    generator(default_arguments, quiet: true)
+    assert_runs "rails new myapp", capture: true do
+      action :rails_command, "new myapp"
+    end
+  end
+
   test "route should add route" do
     run_generator
     route_commands = ['get "foo"', 'get "bar"', 'get "baz"']


### PR DESCRIPTION
Fixes #54546.

### Motivation / Background

This Pull Request has been created because `rails new myapp --quiet` is not fully quiet when it calls Rails commands like `importmap:install` or `turbo:install stimulus:install`.

### Detail

This Pull Request overrides `rails_command` so any of the Rails commands executed in `Rails::Generators::AppBase` are quiet if the `--quiet` option is passed.

### Additional information

An alternative solution is to change `Rails::Generators::Actions` [`#rails_command`](https://github.com/rails/rails/blob/8e504b017a68981076746c2d19fd23c788e4293e/railties/lib/rails/generators/actions.rb#L391) or [`#execute_command`](https://github.com/rails/rails/blob/8e504b017a68981076746c2d19fd23c788e4293e/railties/lib/rails/generators/actions.rb#L460) to automatically set `capture` to `true` if `options[:quiet]` is present. But these are public API methods and I am not sure it makes sense to change these since the `quiet` option seems internal to the rails app generator itself.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
