### PR TITLE
Improve issue template formatting [skip ci]

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -4,6 +4,7 @@ about: Report an issue with Rails you've discovered
 ---
 
 ### Steps to reproduce
+
 <!-- (Guidelines for creating a bug report are [available
 here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#creating-a-bug-report)) -->
 
@@ -13,12 +14,15 @@ here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#crea
 ```
 
 ### Expected behavior
+
 <!-- Tell us what should happen -->
 
 ### Actual behavior
+
 <!-- Tell us what happens instead -->
 
 ### System configuration
-**Rails version**:
 
-**Ruby version**:
+**Rails version**: 
+
+**Ruby version**: 


### PR DESCRIPTION
- Add a space after `version:` in the issue template, so it becomes `version: `. This saves issue reporters a couple keystrokes and ensures a space by default if they forget to type it, resulting in better formatted bug reports.

- Add some new lines after titles to make the issue template more consistent with the pull request template, resulting in a more readable and breathable markdown by default.