### PR TITLE
Locally, prefer tmp/local_secret.txt over config/credentials.yml.enc

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Use `tmp/local_secret.txt` as the source for `secret_key_base` in `development` and
+    `test` unless an environment specific credentials file exists with `secret_key_base` in it
+    such as `config/credentials/development.yml.enc` as opposed to the generic
+    `config/credentials.yml.enc` generally used for production purposes.
+
+    *Brendon Muir*
+
 *   Rate limit password resets in authentication generator
 
     This helps mitigate abuse from attackers spamming the password reset form.

--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -465,9 +465,10 @@ module Rails
     # +credentials.secret_key_base+. For most applications, the correct place
     # to store it is in the encrypted credentials file.
     #
-    # In development and test, if the secret_key_base is still empty, it is
-    # randomly generated and stored in a temporary file in
-    # <tt>tmp/local_secret.txt</tt>.
+    # In development and test, if the secret_key_base doesn't come from an explicit
+    # environment credentials file (e.g. config/credentials/development.yml.enc) as opposed
+    # to config/credentials.yml.enc (that is generally considered for production use), it is
+    # randomly generated and stored in a temporary file in <tt>tmp/local_secret.txt</tt>.
     #
     # Generating a random secret_key_base and storing it in
     # <tt>tmp/local_secret.txt</tt> can also be triggered by setting

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -887,7 +887,10 @@ module ApplicationTests
       ENV.delete "SECRET_KEY_BASE"
     end
 
-    test "application will use secret_key_base from credentials if present in local env" do
+    test "application will use secret_key_base from credentials if present in explicit local env" do
+      FileUtils.mkdir "#{app_path}/config/credentials"
+      FileUtils.mv "#{app_path}/config/credentials.yml.enc", "#{app_path}/config/credentials/development.yml.enc"
+
       credentials_secret = "credentials_secret"
       add_to_config <<-RUBY
         Rails.application.credentials.secret_key_base = "#{credentials_secret}"
@@ -896,6 +899,9 @@ module ApplicationTests
       app "development"
 
       assert_equal credentials_secret, app.secret_key_base
+    ensure
+      FileUtils.mv "#{app_path}/config/credentials/development.yml.enc", "#{app_path}/config/credentials.yml.enc"
+      FileUtils.rmdir "#{app_path}/config/credentials"
     end
 
     test "application will not generate secret_key_base in tmp file if blank in production" do


### PR DESCRIPTION
### Motivation / Background

Reverts #53705, which restored broken behaviour begun in Rails 7.1 (but fixed again in 7.2 and 8.0) that would load secret_key_base from config/credentials.yml.enc instead of tmp/local_secret.txt.

Traditionally `tmp/local_secret.txt` was always used in local environments over `config/credentials.yml.enc`.

This PR provides a middle ground where if an explicit local environment credential file is used (e.g. `config/credentials/development.yml.enc`), and `secret_key_base` is provided in that file, then that will be used over `tmp/local_secret.txt`.

### Additional information

I had trouble coming up with a test for the case where `config/credentials/development.yml.enc` exists but there is no `secret_key_base` in it, just because of how these tests are written. None of them are actually checking the content of the credentials file as far as I could tell.

Concerns: @p8, @rafaelfranca