### PR TITLE
docs: add the dev containers chapter to the home page [ci skip]

### DIFF
--- a/guides/source/documents.yaml
+++ b/guides/source/documents.yaml
@@ -9,6 +9,11 @@
       name: Install Ruby on Rails
       url: install_ruby_on_rails.html
       description: Learn how to install the Ruby programming language and Ruby on Rails.
+
+    -
+      name: Getting Started with Dev Containers
+      url: getting_started_with_devcontainer.html
+      description: Learn how to set up and use development containers for a Rails application.
 -
   name: Models
   documents:


### PR DESCRIPTION
Fixes #54475 
### Detail

This pull request includes an update to the `guides/source/documents.yaml` file to add a new guide for setting up and using development containers for a Rails application.

Documentation update:

* [`guides/source/documents.yaml`](diffhunk://#diff-a0867d42959b49e1f89c29632fb3c227fbcc5f2f9f647dc4bf1b38842284a671R12-R16): Added a new entry for "Getting Started with Dev Containers" including its name, URL, and description.

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
