### PR TITLE
Improve route visualizer regexp labels

### DIFF
--- a/actionpack/lib/action_dispatch/journey/gtg/transition_table.rb
+++ b/actionpack/lib/action_dispatch/journey/gtg/transition_table.rb
@@ -13,7 +13,6 @@ module ActionDispatch
         attr_reader :memos
 
         DEFAULT_EXP = /[^.\/?]+/
-        DEFAULT_EXP_ANCHORED = /\A#{DEFAULT_EXP}\Z/
 
         def initialize
           @stdparam_states = {}
@@ -193,12 +192,15 @@ module ActionDispatch
         end
 
         def transitions
+          # double escaped because dot evaluates escapes
+          default_exp_anchored = "\\\\A#{DEFAULT_EXP.source}\\\\Z"
+
           @string_states.flat_map { |from, hash|
             hash.map { |s, to| [from, s, to] }
           } + @stdparam_states.map { |from, to|
-            [from, DEFAULT_EXP_ANCHORED, to]
+            [from, default_exp_anchored, to]
           } + @regexp_states.flat_map { |from, hash|
-            hash.map { |s, to| [from, s, to] }
+            hash.map { |r, to| [from, r.source.gsub("\\") { "\\\\" }, to] }
           }
         end
       end


### PR DESCRIPTION
### Motivation / Background

The visualizer previously had two problems:
- `\A` and `\Z` displayed as `A` and `Z` because `dot` evaluates escaped characters in labels.
- `Regexp#to_s` wraps the regular expression in a capture group, `(?-mix:`, which adds a lot of noise (especially since all Regexps in the state machine are wrapped with the "anchoring" Regexp that doesn't enable these options).

### Detail

This commit fixes both of these problems by using `Regexp#source` for the labels as well as adding extra `\` so that `\A` and `\Z` will display properly.

Note: `transitions` is only used by the `visualizer` (development only), so the `DEFAULT_EXP_ANCHORED` constant is inlined

### Additional information

Before:

![image](https://github.com/user-attachments/assets/26d04515-53e4-406d-ae31-0cf569372437)

After:

![image](https://github.com/user-attachments/assets/9a81e308-80ac-44ae-b0c7-9b337b2abc00)

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
