### PR TITLE
Fix rails guides navigation [ci skip]

### DIFF
--- a/guides/assets/javascripts/guides.js
+++ b/guides/assets/javascripts/guides.js
@@ -80,15 +80,12 @@
     var guidesMenuButton = document.getElementById("guides-menu-button");
 
     // The link is now acting as a button (but still allows for open in new tab).
-    guidesMenuButton.setAttribute('role', 'button')
-    guidesMenuButton.setAttribute('aria-controls', guidesMenuButton.getAttribute('data-aria-controls'));
-    guidesMenuButton.setAttribute('aria-expanded', guidesMenuButton.getAttribute('data-aria-expanded'));
-    guidesMenuButton.removeAttribute('data-aria-controls');
-    guidesMenuButton.removeAttribute('data-aria-expanded');
+    guidesMenuButton.setAttribute('role', 'button');
+    // Set aria-controls to point to the guides element
+    guidesMenuButton.setAttribute('aria-controls', 'guides');
+    guidesMenuButton.setAttribute('aria-expanded', 'false');
 
-    var guides = document.getElementById(
-      guidesMenuButton.getAttribute("aria-controls")
-    );
+    var guides = document.getElementById('guides');
 
     var toggleGuidesMenu = function () {
       var nextExpanded = guidesMenuButton.getAttribute("aria-expanded") === "false";


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background
<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->
This Pull Request has been created because there is a bug on Rails guides navigation. When you try to use the 'Guides Index' dropdown it no longer functions after using Back button.

In the HTML layout, there's a button with id `guides-menu-button` that controls a div with id guides. The div is initially hidden with `style="display: none;"`.

The JavaScript error occurs because there's a mismatch between how the button's `aria-controls` attribute is being handled. Looking at the JavaScript code:

1. The code first sets `aria-controls` attribute based on a `data-aria-controls` attribute
2. Then it removes the `data-aria-controls` attribute
3. When trying to find the element later, it's using `getAttribute("aria-controls")` but something is going wrong with this process.

### Detail
I've made the following changes to fix the issue:

1. Removed the code that was trying to get values from `data-aria-controls` and `data-aria-expanded` attributes
2. Directly set the `aria-controls` attribute to 'guides' since we know that's the ID of the target element
3. Set the initial `aria-expanded state` to `'false'` since the menu starts hidden
4. Simplified the code to directly get the guides element by its ID

### Additional information 
To replicate the bug:
1. Start on the Docs index page: https://guides.rubyonrails.org/
2. Use the 'Guides Index' drop down menu in the top right to navigate to any other guide.
3. Hit back button in browser
4. BUG: when you try to use the 'Guides Index' dropdown it no longer functions

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
