### PR TITLE
Fix `update_all` producing a broken query when using more than one join on the target:

### DIFF
--- a/activerecord/lib/arel/visitors/postgresql.rb
+++ b/activerecord/lib/arel/visitors/postgresql.rb
@@ -64,7 +64,7 @@ module Arel # :nodoc: all
             # The PostgreSQL dialect isn't flexible enough to allow anything other than a inner join
             # for the first join:
             #   UPDATE table SET .. FROM joined_table WHERE ...
-            (o.relation.right.first.is_a?(Arel::Nodes::InnerJoin))
+            (o.relation.right.all? { |join| join.is_a?(Arel::Nodes::InnerJoin) || join.right.expr.right.relation != o.relation.left })
             o
           else
             super

--- a/activerecord/lib/arel/visitors/sqlite.rb
+++ b/activerecord/lib/arel/visitors/sqlite.rb
@@ -64,7 +64,7 @@ module Arel # :nodoc: all
             # The SQLite3 dialect isn't flexible enough to allow anything other than a inner join
             # for the first join:
             #   UPDATE table SET .. FROM joined_table WHERE ...
-            (o.relation.right.first.is_a?(Arel::Nodes::InnerJoin))
+            (o.relation.right.all? { |join| join.is_a?(Arel::Nodes::InnerJoin) || join.right.expr.right.relation != o.relation.left })
             o
           else
             super

--- a/activerecord/lib/arel/visitors/sqlite.rb
+++ b/activerecord/lib/arel/visitors/sqlite.rb
@@ -30,7 +30,12 @@ module Arel # :nodoc: all
 
             collector << " FROM "
             first_join, *remaining_joins = o.relation.right
-            visit first_join.left, collector
+            from_items = remaining_joins.extract! do |join|
+              join.right.expr.right.relation == o.relation.left
+            end
+
+            from_where = [first_join.left] + from_items.map(&:left)
+            collect_nodes_for from_where, collector, " ", ", "
 
             if remaining_joins && !remaining_joins.empty?
               collector << " "
@@ -40,7 +45,8 @@ module Arel # :nodoc: all
               end
             end
 
-            collect_nodes_for [first_join.right.expr] + o.wheres, collector, " WHERE ", " AND "
+            from_where = [first_join.right.expr] + from_items.map { |i| i.right.expr }
+            collect_nodes_for from_where + o.wheres, collector, " WHERE ", " AND "
           else
             collector = visit o.relation, collector
             collect_nodes_for o.values, collector, " SET "

--- a/activerecord/test/cases/relation/update_all_test.rb
+++ b/activerecord/test/cases/relation/update_all_test.rb
@@ -13,8 +13,11 @@ require "models/owner"
 require "models/post"
 require "models/person"
 require "models/pet"
+require "models/pet_treasure"
+require "models/ship"
 require "models/toy"
 require "models/topic"
+require "models/treasure"
 require "models/tag"
 require "models/tagging"
 require "models/warehouse_thing"
@@ -22,7 +25,7 @@ require "models/cpk"
 
 class UpdateAllTest < ActiveRecord::TestCase
   fixtures :authors, :author_addresses, :comments, :companies, :developers, :owners, :posts, :people, :pets, :toys, :tags,
-    :taggings, "warehouse-things", :cpk_orders, :cpk_order_agreements
+    :taggings, :treasures, "warehouse-things", :cpk_orders, :cpk_order_agreements
 
   class TopicWithCallbacks < ActiveRecord::Base
     self.table_name = :topics
@@ -103,6 +106,16 @@ class UpdateAllTest < ActiveRecord::TestCase
     toys.each do |toy|
       assert_equal toy.pet.name, toy.name
     end
+  end
+
+  def test_dynamic_update_all_with_a_through_join
+    pet = pets(:parrot)
+    treasure = treasures(:diamond)
+
+    PetTreasure.create(pet: pet, treasure: treasure)
+
+    assert_operator pet.treasures.left_joins(:ship).update_all(name: "Gold"), :>, 0
+    assert_equal("Gold", treasure.reload.name)
   end
 
   def test_dynamic_update_all_with_one_join_on_the_target_and_one_indirect_join

--- a/activerecord/test/cases/relation/update_all_test.rb
+++ b/activerecord/test/cases/relation/update_all_test.rb
@@ -4,8 +4,11 @@ require "cases/helper"
 require "models/author"
 require "models/category"
 require "models/comment"
+require "models/company"
 require "models/computer"
+require "models/contract"
 require "models/developer"
+require "models/mentor"
 require "models/owner"
 require "models/post"
 require "models/person"
@@ -18,7 +21,7 @@ require "models/warehouse_thing"
 require "models/cpk"
 
 class UpdateAllTest < ActiveRecord::TestCase
-  fixtures :authors, :author_addresses, :comments, :developers, :owners, :posts, :people, :pets, :toys, :tags,
+  fixtures :authors, :author_addresses, :comments, :companies, :developers, :owners, :posts, :people, :pets, :toys, :tags,
     :taggings, "warehouse-things", :cpk_orders, :cpk_order_agreements
 
   class TopicWithCallbacks < ActiveRecord::Base
@@ -102,7 +105,7 @@ class UpdateAllTest < ActiveRecord::TestCase
     end
   end
 
-  def test_dynamic_update_all_with_two_joined_table
+  def test_dynamic_update_all_with_one_join_on_the_target_and_one_indirect_join
     update_fragment = if current_adapter?(:TrilogyAdapter, :Mysql2Adapter)
       "toys.name = owners.name"
     else # PostgreSQLAdapter, SQLite3Adapter
@@ -115,6 +118,36 @@ class UpdateAllTest < ActiveRecord::TestCase
 
     toys.each do |toy|
       assert_equal toy.pet.owner.name, toy.name
+    end
+  end
+
+  def test_dynamic_update_all_with_two_joins_on_the_target
+    update_fragment = if current_adapter?(:TrilogyAdapter, :Mysql2Adapter)
+      "developers.name = mentors.name"
+    else # PostgreSQLAdapter, SQLite3Adapter
+      "name = mentors.name"
+    end
+
+    jamis, david, poor_jamis = developers(:jamis, :david, :poor_jamis)
+    jamis.update_columns(
+      firm_id: companies(:first_firm).id,
+      mentor_id: Mentor.create!(name: "John").id,
+    )
+    david.update_columns(
+      firm_id: companies(:another_firm).id,
+      mentor_id: Mentor.create!(name: "Goliath").id,
+    )
+    poor_jamis.update_columns(
+      firm_id: companies(:another_firm).id,
+      mentor_id: Mentor.create!(name: "Doe").id,
+    )
+
+    developers = Developer.joins(:firm, :mentor)
+    assert_equal 3, developers.count
+    assert_equal 3, developers.update_all(update_fragment)
+
+    developers.each do |developer|
+      assert_equal developer.name, developer.mentor.name
     end
   end
 


### PR DESCRIPTION
- Fix #54560
- `update_all` would produce a broken query when using more than one JOIN on the target.

```ruby
Developer.join(:computer, :mentor).update_all(ready: true)
```

### Before

```sql
UPDATE developers SET ready = true FROM computers JOIN mentors on mentors.id = developers.mentor_id WHERE developer.computer_id = computer.id; # We can't make a JOIN on the developer table, this should in the FROM clause.
# We can't make a join on the target, that's what the FROM clause is used for.
```

### After

```sql
UPDATE developers SET ready = true FROM computers, mentors WHERE developer.computer_id = computer.id AND developers.mentor_id = mentors.id;
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
