### PR TITLE
doc: Explicitly state that modifying sanitizer allowlists is unsafe

### DIFF
--- a/actionview/lib/action_view/helpers/sanitize_helper.rb
+++ b/actionview/lib/action_view/helpers/sanitize_helper.rb
@@ -24,6 +24,12 @@ module ActionView
       #
       # Custom sanitization rules can also be provided.
       #
+      # <b>Warning</b>: Adding disallowed tags or attributes to the allowlists may introduce
+      # vulnerabilities into your application. Please rely on the default allowlists whenever
+      # possible, because they are curated to maintain security and safety. If you think that the
+      # default allowlists should be expanded, please {open an issue on the rails-html-sanitizer
+      # project}[https://github.com/rails/rails-html-sanitizer/issues].
+      #
       # Please note that sanitizing user-provided text does not guarantee that the
       # resulting markup is valid or even well-formed.
       #


### PR DESCRIPTION

### Motivation / Background

The allowlists in rails-html-sanitizer are curated to balance security and usability. Because Rails is a sharp knife, it's possible to add to these allowlists to suit specific edge cases.

However, doing so may introduce security vulnerabilities into an app.

We recently updated the Rails security program explicitly placing "disallowed tags" into the "out of scope" category. This documentation is the user-facing companion to that update.


### Detail

This PR updates the documentation to be clear that Rails cannot protect them if they insist on allowing unsafe tags or attributes.

Hopefully this change also encourages folks to open an issue if the allowlists are missing some obvious tags or attributes, so that rather than individual developers modifying the allowlists, we can improve the functionality for everyone.


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
