### PR TITLE
[ci skip] Modify all remaining references of `rails <command>`

### DIFF
--- a/guides/source/caching_with_rails.md
+++ b/guides/source/caching_with_rails.md
@@ -43,7 +43,7 @@ Types of Caching
 This is an introduction to some of the common types of caching.
 
 By default, Action Controller caching is only enabled in your production environment. You can play
-around with caching locally by running `rails dev:cache`, or by setting
+around with caching locally by running `bin/rails dev:cache`, or by setting
 [`config.action_controller.perform_caching`][] to `true` in `config/environments/development.rb`.
 
 NOTE: Changing the value of `config.action_controller.perform_caching` will
@@ -398,7 +398,7 @@ rails new app_name --skip-solid
 
 WARNING: Both Solid Cache and Solid Queue are bundled behind the `--skip-solid`
 flag. If you still want to use Solid Queue but not Solid Cache, you can enable
-Solid Queue by running `rails app:enable-solid-queue`.
+Solid Queue by running `bin/rails app:enable-solid-queue`.
 
 ### Configuring the Database
 

--- a/guides/source/command_line.md
+++ b/guides/source/command_line.md
@@ -478,9 +478,9 @@ You can even execute ruby code written in a file with runner.
 $ bin/rails runner lib/code_to_be_run.rb
 ```
 
-By default, `rails runner` scripts are automatically wrapped with the Rails Executor, which helps report uncaught exceptions for tasks like cron jobs.
+By default, `bin/rails runner` scripts are automatically wrapped with the Rails Executor, which helps report uncaught exceptions for tasks like cron jobs.
 
-Therefore, executing `rails runner lib/long_running_scripts.rb` is functionally equivalent to the following:
+Therefore, executing `bin/rails runner lib/long_running_scripts.rb` is functionally equivalent to the following:
 
 ```ruby
 Rails.application.executor.wrap do

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -1673,7 +1673,7 @@ warning, or neither.
 
 #### `config.active_record.database_cli`
 
-Controls which CLI tool will be used for accessing the database when running `rails dbconsole`. By default
+Controls which CLI tool will be used for accessing the database when running `bin/rails dbconsole`. By default
 the standard tool for the database will be used (e.g. `psql` for PostgreSQL and `mysql` for MySQL). The option
 takes a hash which specifies the tool per-database system, and an array can be used where fallback options are
 required:

--- a/guides/source/generators.md
+++ b/guides/source/generators.md
@@ -479,7 +479,7 @@ First, the template asks the user whether they would like to install Devise.
 If the user replies "yes" (or "y"), the template adds Devise to the `Gemfile`,
 and asks the user for the name of the Devise user model (defaulting to `User`).
 Later, after `bundle install` has been run, the template will run the Devise
-generators and `rails db:migrate` if a Devise model was specified. Finally, the
+generators and `bin/rails db:migrate` if a Devise model was specified. Finally, the
 template will `git add` and `git commit` the entire app directory.
 
 We can run our template when generating a new Rails application by passing the

--- a/guides/source/routing.md
+++ b/guides/source/routing.md
@@ -166,7 +166,7 @@ Parameters to the path helpers, such as `:id` above, are passed to the generated
 
 Each of these `_path` helpers also have a corresponding `_url` helper (such as `photos_url`) which returns the same path prefixed with the current host, port, and path prefix.
 
-TIP: The prefix used before "_path" and "_url" is the route name and can be identified by looking at the "prefix" column of the `rails routes` command output. To learn more see [Listing Existing Routes](#listing-existing-routes) below.
+TIP: The prefix used before "_path" and "_url" is the route name and can be identified by looking at the "prefix" column of the `bin/rails routes` command output. To learn more see [Listing Existing Routes](#listing-existing-routes) below.
 
 ### Defining Multiple Resources at the Same Time
 

--- a/guides/source/security.md
+++ b/guides/source/security.md
@@ -45,7 +45,7 @@ The authentication generator adds all of the relevant models, controllers,
 views, routes, and migrations needed for basic authentication and password reset
 functionality.
 
-To use this feature in your application, you can run `rails generate
+To use this feature in your application, you can run `bin/rails generate
 authentication`. Here are all of the files the generator modifies and new files
 it adds:
 

--- a/guides/source/upgrading_ruby_on_rails.md
+++ b/guides/source/upgrading_ruby_on_rails.md
@@ -54,7 +54,7 @@ You can find a list of all released Rails gems [here](https://rubygems.org/gems/
 
 ### The Update Task
 
-Rails provides the `rails app:update` command. After updating the Rails version
+Rails provides the `bin/rails app:update` command. After updating the Rails version
 in the `Gemfile`, run this command.
 This will help you with the creation of new files and changes of old files in an
 interactive session.
@@ -752,7 +752,7 @@ You can invalidate the cache either by touching the product, or changing the cac
 Rails 7.0 changed some default values for some column types. To avoid that application upgrading from 6.1 to 7.0
 load the current schema using the new 7.0 defaults, Rails now includes the version of the framework in the schema dump.
 
-Before loading the schema for the first time in Rails 7.0, make sure to run `rails app:update` to ensure that the
+Before loading the schema for the first time in Rails 7.0, make sure to run `bin/rails app:update` to ensure that the
 version of the schema is included in the schema dump.
 
 The schema file will look like this:


### PR DESCRIPTION
- Some leftover mentions of `rails <command>` in the doc edited to make use of the `bin/rails` binstub instead.


