### PR TITLE
Add shellcheck to CI to validate dev container entrypoint

### DIFF
--- a/.devcontainer/boot.sh
+++ b/.devcontainer/boot.sh
@@ -1,6 +1,6 @@
 bundle install
 
-if [[ ! -z "${NVM_DIR}" ]]; then
+if [ -n "${NVM_DIR}" ]; then
   . ${NVM_DIR}/nvm.sh && nvm install --lts
   yarn install
 fi

--- a/.devcontainer/boot.sh
+++ b/.devcontainer/boot.sh
@@ -1,11 +1,14 @@
+#!/bin/sh
+
 bundle install
 
 if [ -n "${NVM_DIR}" ]; then
-  . ${NVM_DIR}/nvm.sh && nvm install --lts
+  # shellcheck disable=SC1091
+  . "${NVM_DIR}/nvm.sh" && nvm install --lts
   yarn install
 fi
 
-cd activerecord
+cd activerecord || echo "activerecord directory doesn't exist" && exit
 
 # Create PostgreSQL databases
 bundle exec rake db:postgresql:rebuild

--- a/.github/workflows/devcontainer-shellcheck.yml
+++ b/.github/workflows/devcontainer-shellcheck.yml
@@ -1,0 +1,25 @@
+name: Devcontainer Shellcheck
+
+on:
+  pull_request:
+    paths:
+      - ".devcontainer/**/*.sh"
+  push:
+    paths:
+      - ".devcontainer/**/*.sh"
+
+permissions:
+  contents: read
+
+jobs:
+  devcontainer_shellcheck:
+    name: Devcontainer Shellcheck
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout (GitHub)
+        uses: actions/checkout@v4
+
+      - name: Lint Devcontainer Scripts
+        run: |
+          sudo apt install -y shellcheck
+          find .devcontainer/ -name '*.sh' -print0 | xargs -0 shellcheck

--- a/.github/workflows/devcontainer-smoke-test.yml
+++ b/.github/workflows/devcontainer-smoke-test.yml
@@ -17,6 +17,11 @@ jobs:
       - name: Checkout (GitHub)
         uses: actions/checkout@v4
 
+      - name: Lint Entrypoint Script
+        run: |
+          sudo apt install -y shellcheck
+          shellcheck .devcontainer/boot.sh
+
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:


### PR DESCRIPTION
Fix: https://github.com/rails/rails/issues/54564
Fix: https://github.com/rails/rails/pull/54565

This would catch issues such as https://github.com/rails/rails/pull/54565 early. Shellcheck isn't just a linter, it is really good at catching shell script issues, I never write a script without it.