### PR TITLE
Speed up `password_digest` in fixtures templates

### DIFF
--- a/railties/lib/rails/generators/test_unit/authentication/templates/test/fixtures/users.yml.tt
+++ b/railties/lib/rails/generators/test_unit/authentication/templates/test/fixtures/users.yml.tt
@@ -1,4 +1,4 @@
-<%% password_digest = BCrypt::Password.create("password") %>
+<%% password_digest = BCrypt::Password.create("password", cost: BCrypt::Engine::MIN_COST) %>
 
 one:
   email_address: one@example.com

--- a/railties/lib/rails/generators/test_unit/model/templates/fixtures.yml.tt
+++ b/railties/lib/rails/generators/test_unit/model/templates/fixtures.yml.tt
@@ -4,7 +4,7 @@
 <%= name %>:
 <% attributes.each do |attribute| -%>
   <%- if attribute.password_digest? -%>
-  password_digest: <%%= BCrypt::Password.create("secret") %>
+  password_digest: <%%= BCrypt::Password.create("secret", cost: BCrypt::Engine::MIN_COST) %>
   <%- elsif attribute.reference? -%>
   <%= yaml_key_value(attribute.column_name.delete_suffix("_id"), attribute.default || name) %>
   <%- elsif !attribute.virtual? -%>

--- a/railties/test/generators/scaffold_generator_test.rb
+++ b/railties/test/generators/scaffold_generator_test.rb
@@ -564,7 +564,7 @@ class ScaffoldGeneratorTest < Rails::Generators::TestCase
     end
 
     assert_file "test/fixtures/users.yml" do |content|
-      assert_match(/password_digest: <%= BCrypt::Password.create\("secret"\) %>/, content)
+      assert_match(/password_digest: <%= BCrypt::Password.create\("secret", cost: BCrypt::Engine::MIN_COST\) %>/, content)
     end
   end
 


### PR DESCRIPTION
When you launch one of the following commands:
 - `bin/rails g model user name password:digest`
 - `bin/rails g authentication`

you end up with fixtures that create a `password_digest` with `BCrypt::Password.create("...")`.

Since those digests will only be used in tests, it might be a good idea to specify the minimum allowed bcrypt cost so that the digests will take less time to be computed, and as a result tests will run faster.