### PR TITLE
docs: add podman instructions for devcontainers [ci skip]

### DIFF
--- a/guides/source/contributing_to_ruby_on_rails.md
+++ b/guides/source/contributing_to_ruby_on_rails.md
@@ -192,13 +192,30 @@ If you have [Visual Studio Code](https://code.visualstudio.com) and [Docker](htt
 
 #### Using Dev Container CLI
 
-Alternatively, with [Docker](https://www.docker.com) and [npm](https://github.com/npm/cli) installed, you can run [Dev Container CLI](https://github.com/devcontainers/cli) to utilize the [`.devcontainer`](https://github.com/rails/rails/tree/main/.devcontainer) configuration from the command line.
+With [npm](https://github.com/npm/cli) and [Docker](https://www.docker.com) installed, you can run [Dev Container CLI](https://github.com/devcontainers/cli) to utilize the [`.devcontainer`](https://github.com/rails/rails/tree/main/.devcontainer) configuration from the command line.
 
 ```bash
 $ npm install -g @devcontainers/cli
 $ cd rails
 $ devcontainer up --workspace-folder .
 $ devcontainer exec --workspace-folder . bash
+```
+
+#### Using Dev Container with Podman
+
+You can use the [`.devcontainer`](https://github.com/rails/rails/tree/main/.devcontainer) configuration with [Podman](https://podman.io/). This method does not require any other tools besides Podman.
+
+```bash
+$ podman machine init
+$ podman machine start
+$ tools/devcontainer up
+```
+
+Then in a separate terminal:
+
+```bash
+$ tools/devcontainer run-user-commands
+$ tools/devcontainer sh
 ```
 
 #### Using rails-dev-box


### PR DESCRIPTION
### Motivation / Background

`tools/devcontainer` is a script that allows use of devcontainers with only `podman`, added in https://github.com/rails/rails/pull/54378. The contribution docs currently only reference setup instructions with Docker.

### Detail

This PR copies the instructions from the `tools/devcontainer` script up to the contribution docs so it's clear that either podman or docker can be used for devcontainers.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
