### PR TITLE
Make filters in `rails routes` work on routes from Engines

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Make filters work on Engine routes when using `rails routes`.
+
+    *Dennis Paagman*
+
 *   Add headers to engine routes inspection command
 
     *Petrik de Heus*

--- a/actionpack/test/dispatch/routing/inspector_test.rb
+++ b/actionpack/test/dispatch/routing/inspector_test.rb
@@ -46,6 +46,49 @@ module ActionDispatch
         ], output
       end
 
+      def test_displaying_routes_for_engines_with_filter
+        engine = Class.new(Rails::Engine) do
+          def self.inspect
+            "Blog::Engine"
+          end
+        end
+        engine.routes.draw do
+          get "/cart", to: "cart#show"
+        end
+
+        output = draw(grep: "cart") do
+          get "/custom/assets", to: "custom_assets#show"
+          mount engine => "/blog", :as => "blog"
+        end
+
+        assert_equal [
+          "Routes for Blog::Engine:",
+          "Prefix Verb URI Pattern     Controller#Action",
+          "  cart GET  /cart(.:format) cart#show"
+        ], output
+      end
+
+      def test_displaying_routes_for_engines_with_filter_not_matched
+        engine = Class.new(Rails::Engine) do
+          def self.inspect
+            "Blog::Engine"
+          end
+        end
+        engine.routes.draw do
+          get "/cart", to: "cart#show"
+        end
+
+        output = draw(grep: "dummy") do
+          get "/custom/assets", to: "custom_assets#show"
+          mount engine => "/blog", :as => "blog"
+        end
+
+        assert_equal [
+          "No routes were found for this grep pattern.",
+          "For more information about routes, see the Rails guide: https://guides.rubyonrails.org/routing.html."
+        ], output
+      end
+
       def test_displaying_routes_for_engines_without_routes
         engine = Class.new(Rails::Engine) do
           def self.inspect


### PR DESCRIPTION
### Motivation / Background

I noticed that the filters that you can give as arguments to`rails routes`:

https://github.com/rails/rails/blob/972a52d127ae90915fe68a6802c3213e28d80d45/railties/lib/rails/commands/routes/routes_command.rb#L8-L9

Do not actually filter routes that come from engines and gives false messages that no routes are found.

### Example

I have an app with the [Avo gem](https://github.com/avo-hq/avo) as engine, which has some routes, for example these:

```
Routes for Avo::Engine:
media_library_index GET    /media-library(.:format)     avo/media_library#index
      media_library GET    /media-library/:id(.:format) avo/media_library#show
                    PATCH  /media-library/:id(.:format) avo/media_library#update
                    PUT    /media-library/:id(.:format) avo/media_library#update
                    DELETE /media-library/:id(.:format) avo/media_library#destroy
       attach_media GET    /attach-media(.:format)      avo/media_library#attach
```

but when I apply a filter they are not showing up.

```
❯ bin/rails routes -c avo/media_library
No routes were found for this controller.
For more information about routes, see the Rails guide: https://guides.rubyonrails.org/routing.html.
```

This PR fixes that by making sure all engines routes are parsed/loaded before applying the filters to them as well.

With this fix the filter works as intended:

```
❯ bin/rails routes -c avo/media_library
Routes for Avo::Engine:
             Prefix Verb   URI Pattern                  Controller#Action
media_library_index GET    /media-library(.:format)     avo/media_library#index
      media_library GET    /media-library/:id(.:format) avo/media_library#show
                    PATCH  /media-library/:id(.:format) avo/media_library#update
                    PUT    /media-library/:id(.:format) avo/media_library#update
                    DELETE /media-library/:id(.:format) avo/media_library#destroy
       attach_media GET    /attach-media(.:format)      avo/media_library#attach
```

### Additional information

I also made a slight change in the format itself, it now adds the headers for each engine individually, as they would not show up if only routes from an engine match and it also felt nice to have them in all situations.

It also removes a couple of redundant collect/map calls by only mapping the routes to `RouteWrapper` once and only calling `collect_routes` once.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
