### PR TITLE
Fix test when Rails may not be defined:

### DIFF
--- a/activerecord/test/cases/adapters/sqlite3/dbconsole_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/dbconsole_test.rb
@@ -43,13 +43,14 @@ module ActiveRecord
       def test_sqlite3_db_with_defined_rails_root
         config = make_db_config(adapter: "sqlite3", database: "config/db.sqlite3")
 
-        Rails.define_singleton_method(:root, &method(:root))
+        root = method(:root)
+        mod = Module.new { define_singleton_method(:root, &root) }
 
-        assert_find_cmd_and_exec_called_with(["sqlite3", Rails.root.join("config/db.sqlite3").to_s]) do
-          SQLite3Adapter.dbconsole(config)
+        stub_const(Object, :Rails, mod, exists: defined?(Rails)) do
+          assert_find_cmd_and_exec_called_with(["sqlite3", Rails.root.join("config/db.sqlite3").to_s]) do
+            SQLite3Adapter.dbconsole(config)
+          end
         end
-      ensure
-        Rails.singleton_class.remove_method(:root)
       end
 
       def test_sqlite3_can_use_alternative_cli


### PR DESCRIPTION
Fix test when Rails may not be defined:

- Fix #54579
- I don't think it's worth moving that test to the railties suite, it's simple enough that we can stub a constant.
- Worth to note: Reproducing the problem is dependent on the gem you have globally installed. But if you have never installed railties, and you run this test without activating the bundler spec (.e.g `ruby -I"lib:test test_file.rb`), this would cause the problem.

>[!NOTE]
> To backport please

