### PR TITLE
Do cheap/happy check first in `verified_request?`

### DIFF
--- a/actionpack/lib/action_controller/metal/request_forgery_protection.rb
+++ b/actionpack/lib/action_controller/metal/request_forgery_protection.rb
@@ -468,7 +468,7 @@ module ActionController # :nodoc:
       # *   Does the `X-CSRF-Token` header match the form_authenticity_token?
       #
       def verified_request? # :doc:
-        !protect_against_forgery? || request.get? || request.head? ||
+        request.get? || request.head? || !protect_against_forgery? ||
           (valid_request_origin? && any_authenticity_token_valid?)
       end
 


### PR DESCRIPTION
Since Rails 5.2, Action Controller enables `protect_from_forgery` by default. `verified_request?` is called in a `before_action` to perform a series of checks to ensure the request should proceed.

This commit reorders the checks so that the cheaper ones happen first, which allows the method to return more quickly in cases that the request does not need to be protected (GET/HEAD requests).

In the `r10k` benchmark, `verified_request?` shows up as ~2% in a profile before this change and does not show up afterwards.