### PR TITLE
Add SafeBuffer to the list of messagepack serializable type:

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,17 @@
+*   The Cookie Serializer can now serialize an Active Support SafeBuffer when using message pack.
+
+    Such code would previously produce an error if an application was using messagepack as its cookie serializer.
+
+    ```ruby
+    class PostController < ApplicationController
+      def index
+        flash.notice = t(:hello_html) # This would try to serialize a SafeBuffer, which was not possible.
+      end
+    end
+    ```
+
+    *Edouard Chin*
+
 *   Fix `Rails.application.reload_routes!` from clearing almost all routes.
 
     When calling `Rails.application.reload_routes!` inside a middleware of

--- a/actionpack/test/controller/flash_test.rb
+++ b/actionpack/test/controller/flash_test.rb
@@ -263,6 +263,11 @@ class FlashIntegrationTest < ActionDispatch::IntegrationTest
       head :ok
     end
 
+    def set_html_flash
+      flash["that"] = ActiveSupport::SafeBuffer.new("<p>Hello world</p>")
+      head :ok
+    end
+
     def set_flash_now
       flash.now["that"] = "hello"
       head :ok
@@ -294,6 +299,18 @@ class FlashIntegrationTest < ActionDispatch::IntegrationTest
       get "/use_flash"
       assert_response :success
       assert_equal "flash: hello", @response.body
+    end
+  end
+
+  def test_flash_safebuffer
+    with_test_route_set do
+      get "/set_html_flash", env: { "action_dispatch.cookies_serializer" => :message_pack }
+      assert_response :success
+      assert_equal "<p>Hello world</p>", @request.flash["that"]
+
+      get "/use_flash", env: { "action_dispatch.cookies_serializer" => :message_pack }
+      assert_response :success
+      assert_equal "flash: <p>Hello world</p>", @response.body
     end
   end
 

--- a/activesupport/lib/active_support/message_pack/extensions.rb
+++ b/activesupport/lib/active_support/message_pack/extensions.rb
@@ -7,6 +7,7 @@ require "pathname"
 require "uri/generic"
 require "msgpack/bigint"
 require "active_support/hash_with_indifferent_access"
+require "active_support/core_ext/string/output_safety"
 require "active_support/time"
 
 module ActiveSupport
@@ -102,6 +103,10 @@ module ActiveSupport
           packer: method(:write_hash_with_indifferent_access),
           unpacker: method(:read_hash_with_indifferent_access),
           recursive: true
+
+        registry.register_type 18, ActiveSupport::SafeBuffer,
+          packer: :to_s,
+          unpacker: :new
       end
 
       def install_unregistered_type_error(registry)

--- a/activesupport/test/message_pack/shared_serializer_tests.rb
+++ b/activesupport/test/message_pack/shared_serializer_tests.rb
@@ -24,6 +24,7 @@ module MessagePackSharedSerializerTests
         15  => Pathname,
         16  => Regexp,
         17  => ActiveSupport::HashWithIndifferentAccess,
+        18  => ActiveSupport::SafeBuffer,
         127 => Object,
       }
 


### PR DESCRIPTION
### Motivation / Background

Fix #54132

### Detail

If an application sets its cookie serializer to message pack, it is not possible to add a SafeBuffer in its flash message.

```ruby
class PostController < ApplicationController
  def index
    flash.notice = t(:hello_html) # Raises an error
  end
end
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
