### PR TITLE
Deserialize column defaults

### DIFF
--- a/activerecord/lib/active_record/attributes.rb
+++ b/activerecord/lib/active_record/attributes.rb
@@ -244,7 +244,10 @@ module ActiveRecord
           # TODO: Remove the need for a connection after we release 8.1.
           attributes_hash = with_connection do |connection|
             columns_hash.transform_values do |column|
-              ActiveModel::Attribute.from_database(column.name, column.default, type_for_column(connection, column))
+              type = type_for_column(connection, column)
+              default = column.default
+              default = type.deserialize(default) unless default.nil?
+              ActiveModel::Attribute.from_database(column.name, default, type)
             end
           end
 

--- a/activerecord/test/cases/adapters/postgresql/geometric_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/geometric_test.rb
@@ -131,11 +131,11 @@ class PostgresqlPointTest < ActiveRecord::PostgreSQLTestCase
   end
 
   def test_legacy_default
-    assert_equal [12.2, 13.3], PostgresqlPoint.column_defaults["legacy_y"]
-    assert_equal [12.2, 13.3], PostgresqlPoint.new.legacy_y
+    assert_equal ActiveRecord::Point.new(12.2, 13.3), PostgresqlPoint.column_defaults["legacy_y"]
+    assert_equal ActiveRecord::Point.new(12.2, 13.3), PostgresqlPoint.new.legacy_y
 
-    assert_equal [14.4, 15.5], PostgresqlPoint.column_defaults["legacy_z"]
-    assert_equal [14.4, 15.5], PostgresqlPoint.new.legacy_z
+    assert_equal ActiveRecord::Point.new(14.4, 15.5), PostgresqlPoint.column_defaults["legacy_z"]
+    assert_equal ActiveRecord::Point.new(14.4, 15.5), PostgresqlPoint.new.legacy_z
   end
 
   def test_legacy_schema_dumping

--- a/activerecord/test/cases/adapters/postgresql/money_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/money_test.rb
@@ -37,7 +37,7 @@ class PostgresqlMoneyTest < ActiveRecord::PostgreSQLTestCase
   def test_default
     assert_equal BigDecimal("150.55"), PostgresqlMoney.column_defaults["depth"]
     assert_equal BigDecimal("150.55"), PostgresqlMoney.new.depth
-    assert_equal "150.55", PostgresqlMoney.new.depth_before_type_cast
+    assert_equal BigDecimal("150.55"), PostgresqlMoney.new.depth_before_type_cast
   end
 
   def test_money_values

--- a/activerecord/test/cases/defaults_test.rb
+++ b/activerecord/test/cases/defaults_test.rb
@@ -42,19 +42,19 @@ class DefaultNumbersTest < ActiveRecord::TestCase
   def test_default_positive_integer
     record = DefaultNumber.new
     assert_equal 7, record.positive_integer
-    assert_equal "7", record.positive_integer_before_type_cast
+    assert_equal 7, record.positive_integer_before_type_cast
   end
 
   def test_default_negative_integer
     record = DefaultNumber.new
     assert_equal (-5), record.negative_integer
-    assert_equal "-5", record.negative_integer_before_type_cast
+    assert_equal (-5), record.negative_integer_before_type_cast
   end
 
   def test_default_decimal_number
     record = DefaultNumber.new
     assert_equal BigDecimal("2.78"), record.decimal_number
-    assert_equal "2.78", record.decimal_number_before_type_cast
+    assert_equal BigDecimal("2.78"), record.decimal_number_before_type_cast
   end
 end
 


### PR DESCRIPTION
Fix: https://github.com/rails/rails/issues/54556

When getting an integer value from the database, all adapters will create return a real integer. But when we initialize an attribute from the column defaults, the attribute is given a string, that's inconsistent.
