### PR TITLE
Expose all `BatchEnumerator` attributes

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Expose `cursor`, `order` and `use_ranges` attributes for `BatchEnumerator`
+
+    *fatkodima*
+
 *   Fix `ActiveRecord::QueryMethods#in_order_of` when passing an out-of-range Integer
 
     To match the behavior of the `Enumerable` version, `in_order_of` now ignores an out-of-range Integer.

--- a/activerecord/lib/active_record/relation/batches.rb
+++ b/activerecord/lib/active_record/relation/batches.rb
@@ -257,7 +257,6 @@ module ActiveRecord
     # NOTE: By its nature, batch processing is subject to race conditions if
     # other processes are modifying the database.
     def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, cursor: primary_key, order: DEFAULT_ORDER, use_ranges: nil, &block)
-      cursor = Array(cursor).map(&:to_s)
       ensure_valid_options_for_batching!(cursor, start, finish, order)
 
       if arel.orders.present?
@@ -268,6 +267,7 @@ module ActiveRecord
         return BatchEnumerator.new(of: of, start: start, finish: finish, relation: self, cursor: cursor, order: order, use_ranges: use_ranges)
       end
 
+      cursor = Array(cursor).map(&:to_s)
       batch_limit = of
 
       if limit_value
@@ -303,6 +303,8 @@ module ActiveRecord
 
     private
       def ensure_valid_options_for_batching!(cursor, start, finish, order)
+        cursor = Array(cursor).map(&:to_s)
+
         if start && Array(start).size != cursor.size
           raise ArgumentError, ":start must contain one value per cursor column"
         end

--- a/activerecord/lib/active_record/relation/batches/batch_enumerator.rb
+++ b/activerecord/lib/active_record/relation/batches/batch_enumerator.rb
@@ -15,14 +15,23 @@ module ActiveRecord
         @use_ranges = use_ranges
       end
 
-      # The primary key value from which the BatchEnumerator starts, inclusive of the value.
+      # The cursor column value from which the BatchEnumerator starts, inclusive of the value.
       attr_reader :start
 
-      # The primary key value at which the BatchEnumerator ends, inclusive of the value.
+      # The cursor column value at which the BatchEnumerator ends, inclusive of the value.
       attr_reader :finish
 
       # The relation from which the BatchEnumerator yields batches.
       attr_reader :relation
+
+      # The column to use for batching.
+      attr_reader :cursor
+
+      # The cursor column order.
+      attr_reader :order
+
+      # Specifies whether to use range iteration (id >= x AND id <= y).
+      attr_reader :use_ranges
 
       # The size of the batches yielded by the BatchEnumerator.
       def batch_size

--- a/activerecord/test/cases/batches_test.rb
+++ b/activerecord/test/cases/batches_test.rb
@@ -327,11 +327,14 @@ class EachTest < ActiveRecord::TestCase
   end
 
   def test_in_batches_has_attribute_readers
-    enumerator = Post.no_comments.in_batches(of: 2, start: 42, finish: 84)
+    enumerator = Post.no_comments.in_batches(of: 2, start: 42, finish: 84, use_ranges: true)
     assert_equal Post.no_comments, enumerator.relation
     assert_equal 2, enumerator.batch_size
     assert_equal 42, enumerator.start
     assert_equal 84, enumerator.finish
+    assert_equal "id", enumerator.cursor
+    assert_equal :asc, enumerator.order
+    assert_equal true, enumerator.use_ranges
   end
 
   def test_in_batches_should_yield_relation_if_block_given


### PR DESCRIPTION
Follow up to #42312.

There are already some attributes exposed by `BatchEnumerator`. In my gem, I currently have a need to be able to access all of the attributes from `BatchEnumerator` to do some more logic based on them.

* `cursor`
* `order`
* `use_ranges`