### PR TITLE
Use released version of httpclient

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -128,7 +128,6 @@ end
 # Action Mailbox
 gem "aws-sdk-sns", require: false
 gem "webmock"
-gem "httpclient", github: "nahi/httpclient", branch: "master", require: false
 
 # Add your own local bundler stuff.
 local_gemfile = File.expand_path(".Gemfile", __dir__)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,13 +1,4 @@
 GIT
-  remote: https://github.com/nahi/httpclient.git
-  revision: d57cc6d5ffee1b566b5c189fe6dc8cc89570b812
-  branch: master
-  specs:
-    httpclient (2.8.3)
-      mutex_m
-      webrick
-
-GIT
   remote: https://github.com/rails/sdoc.git
   revision: cd75e36ce2d1acb66734c1390ffe33aa05479380
   branch: main
@@ -294,6 +285,8 @@ GEM
       os (>= 0.9, < 2.0)
       signet (>= 0.16, < 2.a)
     hashdiff (1.1.2)
+    httpclient (2.9.0)
+      mutex_m
     i18n (1.14.6)
       concurrent-ruby (~> 1.0)
     image_processing (1.13.0)
@@ -686,7 +679,6 @@ DEPENDENCIES
   dartsass-rails
   debug (>= 1.1.0)
   google-cloud-storage (~> 1.11)
-  httpclient!
   image_processing (~> 1.2)
   importmap-rails (>= 1.2.3)
   jbuilder


### PR DESCRIPTION
### Motivation / Background
This pull request uses the released version of httpclient 2.9.0.

### Detail
It has been released that supports Ruby 3.4 changes:

- making `mutex_m` as bundled gem
https://github.com/nahi/httpclient/pull/455
https://github.com/nahi/httpclient/pull/472

- Chilled strings
https://github.com/nahi/httpclient/pull/471

### Additional information
Kind of reverting https://github.com/rails/rails/pull/50911

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
