### PR TITLE
[ci skip] Fix incorrect `rich_textarea` method in Rails Guides

### DIFF
--- a/guides/source/action_text_overview.md
+++ b/guides/source/action_text_overview.md
@@ -137,7 +137,7 @@ for the form field.
 <%= form_with model: article do |form| %>
   <div class="field">
     <%= form.label :content %>
-    <%= form.rich_textarea :content %>
+    <%= form.rich_text_area :content %>
   </div>
 <% end %>
 ```


### PR DESCRIPTION
Fixed incorrect method `rich_textarea` as it should be `rich_text_area`.