### PR TITLE
Fix `update_all` when right expression is an instance of Arel::Nodes::Equality

### DIFF
--- a/activerecord/lib/arel/visitors/postgresql.rb
+++ b/activerecord/lib/arel/visitors/postgresql.rb
@@ -30,7 +30,7 @@ module Arel # :nodoc: all
             collector << " FROM "
             first_join, *remaining_joins = o.relation.right
             from_items = remaining_joins.extract! do |join|
-              join.right.expr.right.relation == o.relation.left
+              join.right.expr.right.try(:relation) == o.relation.left
             end
 
             from_where = [first_join.left] + from_items.map(&:left)
@@ -64,7 +64,7 @@ module Arel # :nodoc: all
             # The PostgreSQL dialect isn't flexible enough to allow anything other than a inner join
             # for the first join:
             #   UPDATE table SET .. FROM joined_table WHERE ...
-            (o.relation.right.all? { |join| join.is_a?(Arel::Nodes::InnerJoin) || join.right.expr.right.relation != o.relation.left })
+            (o.relation.right.all? { |join| join.is_a?(Arel::Nodes::InnerJoin) || join.right.expr.right.try(:relation) != o.relation.left })
             o
           else
             super

--- a/activerecord/test/cases/relation/update_all_test.rb
+++ b/activerecord/test/cases/relation/update_all_test.rb
@@ -179,6 +179,14 @@ class UpdateAllTest < ActiveRecord::TestCase
     assert_equal pets.count, pets.update_all("name = toys.name")
   end
 
+
+  def test_update_all_with_multiple_condition_join
+    relation = Toy.left_joins(:sponsors)
+
+    assert_equal(3, relation.count)
+    assert_equal(3, relation.update_all(name: "sponsor-toy"))
+  end
+
   def test_update_all_with_left_outer_joins
     pets = Pet.left_outer_joins(:toys)
 

--- a/activerecord/test/cases/relation/update_all_test.rb
+++ b/activerecord/test/cases/relation/update_all_test.rb
@@ -5,6 +5,8 @@ require "models/author"
 require "models/category"
 require "models/comment"
 require "models/company"
+require "models/sponsor"
+require "models/club"
 require "models/computer"
 require "models/contract"
 require "models/developer"
@@ -169,6 +171,12 @@ class UpdateAllTest < ActiveRecord::TestCase
 
     assert_equal true, pets.exists?
     assert_equal pets.count, pets.update_all(name: "Bob")
+  end
+
+  def test_update_all_with_scoped_has_many
+    pets = Pet.joins(:custom_toys)
+
+    assert_equal pets.count, pets.update_all("name = toys.name")
   end
 
   def test_update_all_with_left_outer_joins

--- a/activerecord/test/models/pet.rb
+++ b/activerecord/test/models/pet.rb
@@ -6,6 +6,7 @@ class Pet < ActiveRecord::Base
   self.primary_key = :pet_id
   belongs_to :owner, touch: true
   has_many :toys
+  has_many :custom_toys, -> { joins(:sponsors).merge(Sponsor.left_joins(:sponsor_club).where(sponsor_club: { name: "123" }).or(Sponsor.left_joins(:sponsor_club).where(sponsor_club: { name: "" }))) }, class_name: "Toy"
   has_many :pet_treasures
   has_many :treasures, through: :pet_treasures
   has_many :persons, through: :treasures, source: :looter, source_type: "Person"


### PR DESCRIPTION
Followup to #54561 

in https://github.com/rails/rails/pull/54561 it was assumed that the right expression would always respond to `#relation`. However in some instances the right expression returns an `Arel::Nodes::Equality` instance which does not respond to `relation`

Not sure if this is the right fix @Edouard-chin @byroot. But it did fix my query on a production app. I'll try to reproduce with a failing test. ( sorry I'm still not well used to testing the `activerecord` gem )


<img width="1008" alt="image" src="https://github.com/user-attachments/assets/3391e850-675c-4d5d-ac9a-895d52cecf69" />


### Checklist

Before submitting the PR make sure the following are checked:

* [ ] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [ ] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
