### PR TITLE
[Guides] removed routing_filter gem reference as it is outdated [ci-skip]

### DIFF
--- a/guides/source/i18n.md
+++ b/guides/source/i18n.md
@@ -275,7 +275,7 @@ get "/:locale" => "dashboard#index"
 
 Do take special care about the **order of your routes**, so this route declaration does not "eat" other ones. (You may want to add it directly before the `root :to` declaration.)
 
-NOTE: Have a look at various gems which simplify working with routes: [routing_filter](https://github.com/svenfuchs/routing-filter/tree/master), [route_translator](https://github.com/enriclluelles/route_translator).
+NOTE: Have a look at a gem which simplifies working with routes: [route_translator](https://github.com/enriclluelles/route_translator).
 
 #### Setting the Locale from User Preferences
 


### PR DESCRIPTION
### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created to fix [i18n docs should remove reference to routing_filter gem as it's not been updated for 3 years and is not compatible with version > 7.0](https://github.com/rails/rails/issues/54496)

Fixes #54496 

### Detail

This Pull Request removed reference of routing-filter gem from i18n docs

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
