### PR TITLE
Map enums using array to the correct column type

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,18 @@
+*   Auto-detect the column type for enums defined with the array syntax.
+
+    Previously enums defined using an array were always mapped to integers
+    and indexed by position, now it is converted based on the column type,
+    it works for strings and database enums as well.
+
+    ```ruby
+    # Before
+    enum :status, { proposed: "proposed", written: "written", published: "published" }
+
+    # After
+    enum :status, [:proposed, :written, :published]
+    ```
+
+    *Felipe Felix*, *Lázaro Nixon*
 *   Add `connection.current_transaction.isolation` API to check current transaction's isolation level.
 
     Returns the isolation level if it was explicitly set via the `isolation:` parameter

--- a/activerecord/lib/active_record/enum.rb
+++ b/activerecord/lib/active_record/enum.rb
@@ -164,15 +164,16 @@ module ActiveRecord
   #   conversation.status = :unknown # 'unknown' is not a valid status (ArgumentError)
   module Enum
     def self.extended(base) # :nodoc:
-      base.class_attribute(:defined_enums, instance_writer: false, default: {})
+      base.class_attribute(:defined_enums_type, instance_writer: false, default: {})
     end
 
     class EnumType < Type::Value # :nodoc:
       delegate :type, to: :subtype
 
-      def initialize(name, mapping, subtype, raise_on_invalid_values: true)
+      def initialize(klass, name, initial_mapping, subtype, raise_on_invalid_values: true)
+        @klass = klass
         @name = name
-        @mapping = mapping
+        @initial_mapping = initial_mapping
         @subtype = subtype
         @_raise_on_invalid_values = raise_on_invalid_values
       end
@@ -207,10 +208,44 @@ module ActiveRecord
         end
       end
 
-      attr_reader :subtype
+      def mapping
+        @mapping ||= define_enum_values(name, subtype, initial_mapping)
+      end
+
+      def subtype
+        @subtype ||= begin
+          klass.load_schema
+          @subtype
+        end
+      end
+
+      attr_accessor :klass
+      attr_reader :name
+      attr_writer :subtype
 
       private
-        attr_reader :name, :mapping
+        attr_reader :initial_mapping
+        attr_writer :mapping
+
+        def define_enum_values(name, subtype, initial_mapping)
+          pairs = initial_mapping.respond_to?(:each_pair) ? initial_mapping.each_pair : enum_typed_pairs(name, initial_mapping, subtype)
+
+          enum_values = ActiveSupport::HashWithIndifferentAccess.new
+
+          pairs.each do |label, value|
+            enum_values[label] = value
+          end
+
+          enum_values.freeze
+        end
+
+        def enum_typed_pairs(name, initial_mapping, subtype)
+          if subtype.type.in?([:integer, nil])
+            initial_mapping.each_with_index
+          else
+            initial_mapping.index_with { |v| subtype.cast(v) }
+          end
+        end
     end
 
     def enum(name, values = nil, **options)
@@ -218,25 +253,8 @@ module ActiveRecord
       _enum(name, values, **options)
     end
 
-    private
-      def _enum(name, values, prefix: nil, suffix: nil, scopes: true, instance_methods: true, validate: false, **options)
-        values = assert_valid_enum_definition_values(values)
-        assert_valid_enum_options(options)
-
-        # statuses = { }
-        enum_values = ActiveSupport::HashWithIndifferentAccess.new
-        name = name.to_s
-
-        # def self.statuses() statuses end
-        detect_enum_conflict!(name, name.pluralize, true)
-        singleton_class.define_method(name.pluralize) { enum_values }
-        defined_enums[name] = enum_values
-
-        detect_enum_conflict!(name, name)
-        detect_enum_conflict!(name, "#{name}=")
-
-        attribute(name, **options)
-
+    protected
+      def define_pending_decorate_attribute(name)
         decorate_attributes([name]) do |_name, subtype|
           if subtype == ActiveModel::Type.default_value
             raise "Undeclared attribute type for enum '#{name}' in #{self.name}. Enums must be" \
@@ -245,8 +263,36 @@ module ActiveRecord
           end
 
           subtype = subtype.subtype if EnumType === subtype
-          EnumType.new(name, enum_values, subtype, raise_on_invalid_values: !validate)
+
+          enum_type = defined_enums_type[name]
+
+          enum_type.subtype = subtype
+
+          enum_type
         end
+      end
+
+    private
+      def _enum(name, values, prefix: nil, suffix: nil, scopes: true, instance_methods: true, validate: false, **options)
+        values = assert_valid_enum_definition_values(values)
+        assert_valid_enum_options(options)
+
+        name = name.to_s
+
+        # def self.statuses() statuses end
+        detect_enum_conflict!(name, name.pluralize, true)
+        singleton_class.define_method(name.pluralize) { defined_enums_type[name].mapping }
+
+        self.defined_enums_type[name] = EnumType.new(self, name, values, nil, raise_on_invalid_values: !validate)
+
+        detect_enum_conflict!(name, name)
+        detect_enum_conflict!(name, "#{name}=")
+
+        attribute(name, **options)
+
+        define_pending_decorate_attribute(name)
+
+        labels = values.respond_to?(:each_pair) ? values.keys : values
 
         value_method_names = []
         _enum_methods_module.module_eval do
@@ -258,21 +304,17 @@ module ActiveRecord
             suffix == true ? "_#{name}" : "_#{suffix}"
           end
 
-          pairs = values.respond_to?(:each_pair) ? values.each_pair : values.each_with_index
-          pairs.each do |label, value|
-            enum_values[label] = value
-            label = label.to_s
-
+          labels.each do |label|
             value_method_name = "#{prefix}#{label}#{suffix}"
             value_method_names << value_method_name
-            define_enum_methods(name, value_method_name, value, scopes, instance_methods)
+            define_enum_methods(name, value_method_name, label, scopes, instance_methods)
 
-            method_friendly_label = label.gsub(/[\W&&[:ascii:]]+/, "_")
+            method_friendly_label = label.to_s.gsub(/[\W&&[:ascii:]]+/, "_")
             value_method_alias = "#{prefix}#{method_friendly_label}#{suffix}"
 
             if value_method_alias != value_method_name && !value_method_names.include?(value_method_alias)
               value_method_names << value_method_alias
-              define_enum_methods(name, value_method_alias, value, scopes, instance_methods)
+              define_enum_methods(name, value_method_alias, label, scopes, instance_methods)
             end
           end
         end
@@ -280,14 +322,19 @@ module ActiveRecord
 
         if validate
           validate = {} unless Hash === validate
-          validates_inclusion_of name, in: enum_values.keys, **validate
+          validates_inclusion_of name, in: labels.map(&:to_s), **validate
         end
-
-        enum_values.freeze
       end
 
       def inherited(base)
-        base.defined_enums = defined_enums.deep_dup
+        base.defined_enums_type = defined_enums_type.deep_dup
+        base.defined_enums_type.values.each do |enum_type|
+          enum_type.klass = base
+        end
+        base.defined_enums_type.keys.each do |name|
+          base.define_pending_decorate_attribute(name)
+        end
+
         super
       end
 
@@ -299,25 +346,32 @@ module ActiveRecord
         private
           attr_reader :klass
 
-          def define_enum_methods(name, value_method_name, value, scopes, instance_methods)
+          def define_enum_methods(name, value_method_name, label, scopes, instance_methods)
             if instance_methods
               # def active?() status_for_database == 0 end
               klass.send(:detect_enum_conflict!, name, "#{value_method_name}?")
-              define_method("#{value_method_name}?") { public_send(:"#{name}_for_database") == value }
+
+              define_method("#{value_method_name}?") do
+                public_send(:"#{name}_for_database") == defined_enums_type[name].mapping[label]
+              end
 
               # def active!() update!(status: 0) end
               klass.send(:detect_enum_conflict!, name, "#{value_method_name}!")
-              define_method("#{value_method_name}!") { update!(name => value) }
+              define_method("#{value_method_name}!") { update!(name => defined_enums_type[name].mapping[label]) }
             end
 
             if scopes
               # scope :active, -> { where(status: 0) }
               klass.send(:detect_enum_conflict!, name, value_method_name, true)
-              klass.scope value_method_name, -> { where(name => value) }
+              klass.scope value_method_name, -> do
+                where(name => model.defined_enums_type[name].mapping[label])
+              end
 
               # scope :not_active, -> { where.not(status: 0) }
               klass.send(:detect_enum_conflict!, name, "not_#{value_method_name}", true)
-              klass.scope "not_#{value_method_name}", -> { where.not(name => value) }
+              klass.scope "not_#{value_method_name}", -> do
+                where.not(name => model.defined_enums_type[name].mapping[label])
+              end
             end
           end
       end

--- a/activerecord/lib/active_record/fixture_set/table_row.rb
+++ b/activerecord/lib/active_record/fixture_set/table_row.rb
@@ -138,9 +138,9 @@ module ActiveRecord
         end
 
         def resolve_enums
-          reflection_class.defined_enums.each do |name, values|
+          reflection_class.defined_enums_type.each do |name, enum_type|
             if @row.include?(name)
-              @row[name] = values.fetch(@row[name], @row[name])
+              @row[name] = enum_type.mapping.fetch(@row[name], @row[name])
             end
           end
         end

--- a/activerecord/lib/active_record/validations/uniqueness.rb
+++ b/activerecord/lib/active_record/validations/uniqueness.rb
@@ -145,7 +145,7 @@ module ActiveRecord
       end
 
       def map_enum_attribute(klass, attribute, value)
-        mapping = klass.defined_enums[attribute.to_s]
+        mapping = klass.defined_enums_type[attribute.to_s]&.mapping
         value = mapping[value] if value && mapping
         value
       end

--- a/activerecord/test/cases/adapters/abstract_mysql_adapter/mysql_enum_test.rb
+++ b/activerecord/test/cases/adapters/abstract_mysql_adapter/mysql_enum_test.rb
@@ -44,4 +44,13 @@ class MySQLEnumTest < ActiveRecord::AbstractMysqlTestCase
     enum_test = EnumTest.create!(state: :middle)
     assert_equal "middle", enum_test.state
   end
+
+  def test_enum_with_array_arguments
+    klass = Class.new(ActiveRecord::Base) do
+      self.table_name = "enum_tests"
+      enum :enum_column, [:text, :blob, :tiny, :medium, :long, :unsigned, :bigint]
+    end
+
+    assert_equal "tiny", klass.create!(enum_column: :tiny).enum_column
+  end
 end

--- a/activerecord/test/cases/adapters/postgresql/enum_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/enum_test.rb
@@ -98,6 +98,15 @@ class PostgresqlEnumTest < ActiveRecord::PostgreSQLTestCase
     assert_nil model.reload.current_mood
   end
 
+  def test_enum_with_array_arguments
+    klass = Class.new(ActiveRecord::Base) do
+      self.table_name = "postgresql_enums"
+      enum :current_mood, [:sad, :ok, :happy]
+    end
+
+    assert_equal "happy", klass.create!(current_mood: :happy).current_mood
+  end
+
   def test_schema_dump
     @connection.add_column "postgresql_enums", "good_mood", :mood, default: "happy", null: false
 

--- a/activerecord/test/cases/enum_test.rb
+++ b/activerecord/test/cases/enum_test.rb
@@ -313,6 +313,26 @@ class EnumTest < ActiveRecord::TestCase
     assert_equal "'unknown' is not a valid status", e.message
   end
 
+  test "enum with array arguments and integer columns" do
+    klass = Class.new(ActiveRecord::Base) do
+      self.table_name = "books"
+      enum :status, [:proposed, :written]
+    end
+
+    assert_equal 0, klass.create!(status: :proposed).status_for_database
+    assert_equal 1, klass.create!(status: :written).status_for_database
+  end
+
+  test "enum with array arguments and string columns" do
+    klass = Class.new(ActiveRecord::Base) do
+      self.table_name = "books"
+      enum :cover, [:hard, :soft]
+    end
+
+    assert_equal "hard", klass.create!(cover: :hard).cover_for_database
+    assert_equal "soft", klass.create!(cover: :soft).cover_for_database
+  end
+
   test "validation with 'validate: true' option" do
     klass = Class.new(ActiveRecord::Base) do
       def self.name; "Book"; end


### PR DESCRIPTION
### Motivation / Background
This Pull Request closes https://github.com/rails/rails/issues/52604

Previously enums without keywords were always mapped to integers and indexed by position, now it is converted based on the column type, it works for strings and database enums as well.

```ruby
# Before
enum status: { proposed: "proposed", written: "written", published: "published" }

# After
enum status: [:proposed, :written, :published]
```

### Detail
- I create the method `define_enum_values` to do the database type inflection and map the enum values only when the database is connected.
- In Enum inherited method, I had to update the `klass` of `EnumType` and set the `decorate_attribute` because it was just being executed in superclass https://github.com/felixefelip/rails/blob/7844162de0ac3cf75c21d346c2c7d5f67dd24208/activerecord/lib/active_record/enum.rb#L332

### Additional information
- Some things from this PR https://github.com/rails/rails/pull/51124 were reused, such as tests, CHANGELOG and the `enum_typed_pairs` method.


### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [X] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
