### PR TITLE
Show line numbers in Rails console

### DIFF
--- a/railties/lib/rails/commands/console/irb_console.rb
+++ b/railties/lib/rails/commands/console/irb_console.rb
@@ -90,9 +90,9 @@ module Rails
         IRB.conf[:IRB_NAME] = @app.name
 
         IRB.conf[:PROMPT][:RAILS_PROMPT] = {
-          PROMPT_I: "#{prompt_prefix}> ",
-          PROMPT_S: "#{prompt_prefix}%l ",
-          PROMPT_C: "#{prompt_prefix}* ",
+          PROMPT_I: "#{prompt_prefix}:%03n> ",
+          PROMPT_S: "#{prompt_prefix}:%03n%l ",
+          PROMPT_C: "#{prompt_prefix}:%03n* ",
           RETURN: "=> %s\n"
         }
 

--- a/railties/test/application/console_test.rb
+++ b/railties/test/application/console_test.rb
@@ -119,7 +119,7 @@ class FullStackConsoleTest < ActiveSupport::TestCase
     options = "-e test -- --verbose"
     spawn_console(options)
 
-    write_prompt "a = 1", "a = 1", prompt: "app-template(test)>"
+    write_prompt "a = 1", "a = 1", prompt: "app-template(test):"
   end
 
   def test_prompt_allows_changing_irb_name
@@ -127,7 +127,7 @@ class FullStackConsoleTest < ActiveSupport::TestCase
     spawn_console(options)
 
     write_prompt "conf.irb_name = 'foo'"
-    write_prompt "a = 1", "a = 1", prompt: "foo(test)>"
+    write_prompt "a = 1", "a = 1", prompt: "foo(test):"
     @primary.puts "quit"
   end
 
@@ -144,21 +144,21 @@ class FullStackConsoleTest < ActiveSupport::TestCase
     options = "-e production"
     spawn_console(options)
 
-    write_prompt "123", prompt: "app-template(prod)>"
+    write_prompt "123", prompt: "app-template(prod):"
   end
 
   def test_development_console_prompt
     options = "-e development"
     spawn_console(options)
 
-    write_prompt "123", prompt: "app-template(dev)> "
+    write_prompt "123", prompt: "app-template(dev):"
   end
 
   def test_test_console_prompt
     options = "-e test"
     spawn_console(options)
 
-    write_prompt "123", prompt: "app-template(test)> "
+    write_prompt "123", prompt: "app-template(test):"
   end
 
   def test_helper_helper_method


### PR DESCRIPTION
### Motivation / Background

Currently, Rails console does not show line numbers, making it harder to immediately understand where an error is pointing, especially when multiple classes or methods are defined in the console and one of them causes an error. I believe this information is very helpful for debugging.

Before:
```
% bin/rails c
Loading development environment (Rails 8.1.0.alpha)
example(dev)>
example(dev)>
example(dev)>
example(dev)> def foo(a) = nil
=> :foo
example(dev)> foo
(example):4:in 'foo': wrong number of arguments (given 0, expected 1) (ArgumentError)
  from (example):10:in '<main>'
example(dev)>
```

After:
```
% bin/rails c
Loading development environment (Rails 8.1.0.alpha)
example(dev):001>
example(dev):002> def foo(a) = nil
=> :foo
example(dev):003>
example(dev):004> foo
(example):2:in 'foo': wrong number of arguments (given 0, expected 1) (ArgumentError)
	from (example):4:in '<main>'
```

### Detail

Previously, Rails showed line numbers in the console, as seen in the following example:

```
% bin/rails c
Loading development environment (Rails 7.1.5.1)
irb(main):001>
irb(main):002>
irb(main):003>
```

To restore this behavior, I updated the prompt configuration to follow [the IRB default setting](https://github.com/ruby/irb/blob/master/lib/irb/init.rb#L108-L110).

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
