### PR TITLE
Ensure `#reverse_order` respects `implicit_order_column`

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Respect `implicit_order_column` in `ActiveRecord::Relation#reverse_order`.
+
+    *Joshua Young*
+
 *   Add column types to `ActiveRecord::Result` for SQLite3.
 
     *Andrew Kane*

--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -638,7 +638,7 @@ module ActiveRecord
       end
 
       def ordered_relation
-        if order_values.empty? && (model.implicit_order_column || !model.query_constraints_list.nil? || primary_key)
+        if order_values.empty? && !_order_columns.empty?
           order(_order_columns.map { |column| table[column].asc })
         else
           self

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -370,6 +370,19 @@ class RelationTest < ActiveRecord::TestCase
     end
   end
 
+  def test_default_reverse_order_on_table_without_primary_key_with_implicit_order_column
+    ordered_edge = Class.new(Edge) do
+      self.implicit_order_column = "source_id"
+    end
+
+    ordered_edge.delete_all
+
+    edge_1 = ordered_edge.create!(source_id: 1, sink_id: 2)
+    edge_2 = ordered_edge.create!(source_id: 2, sink_id: 3)
+    assert_equal edge_1.source_id, ordered_edge.all.first.source_id
+    assert_equal edge_2.source_id, ordered_edge.all.reverse_order.first.source_id
+  end
+
   def test_order_with_hash_and_symbol_generates_the_same_sql
     assert_equal Topic.order(:id).to_sql, Topic.order(id: :asc).to_sql
   end


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

Addresses https://github.com/rails/rails/issues/54591#issuecomment-2677869549

### Detail

Updates `ActiveRecord::QueryMethods#reverse_sql_order` ~to utilize `_order_columns` similar to `ActiveRecord::FinderMethods#ordered_relation`~ to account for `implicit_order_column`. This ensures that:
1. ~`#reverse_sql_order` is now consistent with `#ordered_relation`.~
2. `#reverse_order` now respects `implicit_order_column` ~as well as `query_constraints`~, and not just `primary_key`.
3. ~We can now simply use `#reverse_order` in `#last` instead of having to order and then reverse the order (this has comprehensive test coverage)~

Edits were made after https://github.com/rails/rails/pull/54607#issuecomment-2678291542

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.