### PR TITLE
Aborts generating Auth when ActionMailer is not defined

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Prevent authentication generation if the ActionMailer is not part of the application.
+
+    *juanvqz*
+
 *   Add a `SessionTestHelper` module with `sign_in_as(user)` and `sign_out` test helpers when
     running `rails g authentication`. Simplifies authentication in integration tests.
 

--- a/railties/lib/rails/generators/rails/authentication/authentication_generator.rb
+++ b/railties/lib/rails/generators/rails/authentication/authentication_generator.rb
@@ -21,12 +21,13 @@ module Rails
 
         template "app/channels/application_cable/connection.rb" if defined?(ActionCable::Engine)
 
-        template "app/mailers/passwords_mailer.rb"
+        if action_mailer?
+          template "app/mailers/passwords_mailer.rb"
+          template "app/views/passwords_mailer/reset.html.erb"
+          template "app/views/passwords_mailer/reset.text.erb"
+          template "test/mailers/previews/passwords_mailer_preview.rb"
+        end
 
-        template "app/views/passwords_mailer/reset.html.erb"
-        template "app/views/passwords_mailer/reset.text.erb"
-
-        template "test/mailers/previews/passwords_mailer_preview.rb"
         template "test/helpers/session_test_helper.rb"
       end
 
@@ -59,6 +60,11 @@ module Rails
       end
 
       hook_for :test_framework
+
+      private
+        def action_mailer?
+          defined?(ActionMailer::Railtie) || raise("Action Mailer is not defined in the application.")
+        end
     end
   end
 end

--- a/railties/test/generators/authentication_generator_test.rb
+++ b/railties/test/generators/authentication_generator_test.rb
@@ -136,6 +136,18 @@ class AuthenticationGeneratorTest < Rails::Generators::TestCase
     ActionCable.const_set(:Engine, old_value)
   end
 
+  def test_aborts_when_action_mailer_is_not_defined
+    old_value = ActionMailer.const_get(:Railtie)
+    ActionMailer.send(:remove_const, :Railtie)
+    generator([destination_root])
+
+    assert_raises RuntimeError, match: "Action Mailer is not defined in the application." do
+      run_generator_instance
+    end
+  ensure
+    ActionMailer.const_set(:Railtie, old_value)
+  end
+
   private
     def run_generator_instance
       commands = []


### PR DESCRIPTION
### Motivation / Background


This Pull Request has been created because we must be able to send emails from the generated authentication system.

- **[Fix #54501] Abort generating the Auth whne the `ActionMailer::Base` is not defined**

### Detail

This Pull Request araises when the app does not have the `ActionMailer::Base` defined.

### Additional information

is it needed to add a CHANGELOG entry?

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
