### PR TITLE
Make lint optional, so we can pass invalid host name.

### DIFF
--- a/actionpack/test/dispatch/host_authorization_test.rb
+++ b/actionpack/test/dispatch/host_authorization_test.rb
@@ -443,7 +443,7 @@ class HostAuthorizationTest < ActionDispatch::IntegrationTest
   end
 
   test "blocks requests with invalid hostnames" do
-    @app = build_app(".example.com")
+    @app = build_app(".example.com", lint: false)
 
     get "/", env: {
       "HOST" => "attacker.com#x.example.com",
@@ -493,11 +493,17 @@ class HostAuthorizationTest < ActionDispatch::IntegrationTest
   end
 
   private
-    def build_app(hosts, exclude: nil, response_app: nil)
-      Rack::Lint.new(
-        ActionDispatch::HostAuthorization.new(
-          Rack::Lint.new(App), hosts, exclude: exclude, response_app: response_app
-        )
-      )
+    def build_app(hosts, exclude: nil, response_app: nil, lint: true, app: App)
+      if lint
+        app = Rack::Lint.new(app)
+      end
+
+      app = ActionDispatch::HostAuthorization.new(app, hosts, exclude: exclude, response_app: response_app)
+
+      if lint
+        Rack::Lint.new(app)
+      end
+
+      app
     end
 end


### PR DESCRIPTION
See <https://github.com/rack/rack/pull/2298> for context. If you are passing an invalid host name, as this test is doing, `Rack::Lint` will soon start raising an error. Allow bypassing `Rack::Lint` so that we can pass the invalid host name in the test.