### PR TITLE
Use `mariadb:lts` at Dev Container

### DIFF
--- a/.devcontainer/compose.yaml
+++ b/.devcontainer/compose.yaml
@@ -30,7 +30,7 @@ services:
       POSTGRES_PASSWORD: postgres
 
   mariadb:
-    image: mariadb:latest
+    image: mariadb:lts
     restart: unless-stopped
     volumes:
       - mariadb-data:/var/lib/mysql


### PR DESCRIPTION
### Motivation / Background

This commit pins the MariaDB version to `lts` at the Dev Container because the `latest` tag raises unit test failures.

### Detail
Without this commit:

```ruby
$ ARCONN=mysql2 bin/test test/cases/relations_test.rb -n test_multiple_find_or_create_by_within_transactions
Using mysql2
Run options: -n test_multiple_find_or_create_by_within_transactions --seed 35219

... snip ...
E

Error:
CreateOrFindByWithinTransactions#test_multiple_find_or_create_by_within_transactions:
ActiveRecord::StatementInvalid: Mysql2::Error: SAVEPOINT active_record_1 does not exist
    /home/vscode/.rbenv/versions/3.4.1/lib/ruby/gems/3.4.0/gems/mysql2-0.5.6/lib/mysql2/client.rb:151:in 'Mysql2::Client#_query'
    /home/vscode/.rbenv/versions/3.4.1/lib/ruby/gems/3.4.0/gems/mysql2-0.5.6/lib/mysql2/client.rb:151:in 'block in Mysql2::Client#query'
    /home/vscode/.rbenv/versions/3.4.1/lib/ruby/gems/3.4.0/gems/mysql2-0.5.6/lib/mysql2/client.rb:150:in 'Thread.handle_interrupt'
    /home/vscode/.rbenv/versions/3.4.1/lib/ruby/gems/3.4.0/gems/mysql2-0.5.6/lib/mysql2/client.rb:150:in 'Mysql2::Client#query'
    lib/active_record/connection_adapters/mysql2/database_statements.rb:53:in 'ActiveRecord::ConnectionAdapters::Mysql2::DatabaseStatements#perform_query'
    lib/active_record/connection_adapters/abstract/database_statements.rb:560:in 'block (3 levels) in ActiveRecord::ConnectionAdapters::DatabaseStatements#raw_execute'
    /workspaces/rails/activesupport/lib/active_support/concurrency/share_lock.rb:186:in 'ActiveSupport::Concurrency::ShareLock#yield_shares'
    /workspaces/rails/activesupport/lib/active_support/dependencies/interlock.rb:41:in 'ActiveSupport::Dependencies::Interlock#permit_concurrent_loads'
    lib/active_record/connection_adapters/abstract/database_statements.rb:559:in 'block (2 levels) in ActiveRecord::ConnectionAdapters::DatabaseStatements#raw_execute'
    lib/active_record/connection_adapters/abstract_adapter.rb:1019:in 'block in ActiveRecord::ConnectionAdapters::AbstractAdapter#with_raw_connection'
    /workspaces/rails/activesupport/lib/active_support/concurrency/null_lock.rb:9:in 'ActiveSupport::Concurrency::NullLock#synchronize'
    lib/active_record/connection_adapters/abstract_adapter.rb:988:in 'ActiveRecord::ConnectionAdapters::AbstractAdapter#with_raw_connection'
    lib/active_record/connection_adapters/abstract/database_statements.rb:558:in 'block in ActiveRecord::ConnectionAdapters::DatabaseStatements#raw_execute'
    /workspaces/rails/activesupport/lib/active_support/notifications/instrumenter.rb:58:in 'ActiveSupport::Notifications::Instrumenter#instrument'
    lib/active_record/connection_adapters/abstract_adapter.rb:1139:in 'ActiveRecord::ConnectionAdapters::AbstractAdapter#log'
    lib/active_record/connection_adapters/abstract/database_statements.rb:557:in 'ActiveRecord::ConnectionAdapters::DatabaseStatements#raw_execute'
    lib/active_record/connection_adapters/abstract/database_statements.rb:601:in 'ActiveRecord::ConnectionAdapters::DatabaseStatements#internal_execute'
    lib/active_record/connection_adapters/abstract/savepoints.rb:16:in 'ActiveRecord::ConnectionAdapters::Savepoints#exec_rollback_to_savepoint'
    lib/active_record/connection_adapters/abstract/database_statements.rb:468:in 'ActiveRecord::ConnectionAdapters::DatabaseStatements#rollback_to_savepoint'
    lib/active_record/connection_adapters/abstract/query_cache.rb:27:in 'ActiveRecord::ConnectionAdapters::AbstractAdapter#rollback_to_savepoint'
    lib/active_record/connection_adapters/abstract/transaction.rb:433:in 'ActiveRecord::ConnectionAdapters::SavepointTransaction#rollback'
    lib/active_record/connection_adapters/abstract/transaction.rb:614:in 'block in ActiveRecord::ConnectionAdapters::TransactionManager#rollback_transaction'
    /workspaces/rails/activesupport/lib/active_support/concurrency/null_lock.rb:9:in 'ActiveSupport::Concurrency::NullLock#synchronize'
    lib/active_record/connection_adapters/abstract/transaction.rb:611:in 'ActiveRecord::ConnectionAdapters::TransactionManager#rollback_transaction'
    lib/active_record/connection_adapters/abstract/transaction.rb:628:in 'block in ActiveRecord::ConnectionAdapters::TransactionManager#within_new_transaction'
    /workspaces/rails/activesupport/lib/active_support/concurrency/null_lock.rb:9:in 'ActiveSupport::Concurrency::NullLock#synchronize'
    lib/active_record/connection_adapters/abstract/transaction.rb:623:in 'ActiveRecord::ConnectionAdapters::TransactionManager#within_new_transaction'
    lib/active_record/connection_adapters/abstract/database_statements.rb:370:in 'ActiveRecord::ConnectionAdapters::DatabaseStatements#within_new_transaction'
    lib/active_record/connection_adapters/abstract/database_statements.rb:362:in 'ActiveRecord::ConnectionAdapters::DatabaseStatements#transaction'
    lib/active_record/transactions.rb:233:in 'block in ActiveRecord::Transactions::ClassMethods#transaction'
    lib/active_record/connection_adapters/abstract/connection_pool.rb:412:in 'ActiveRecord::ConnectionAdapters::ConnectionPool#with_connection'
    lib/active_record/connection_handling.rb:310:in 'ActiveRecord::ConnectionHandling#with_connection'
    lib/active_record/transactions.rb:232:in 'ActiveRecord::Transactions::ClassMethods#transaction'
    lib/active_record/relation/delegation.rb:105:in 'ActiveRecord::Delegation#transaction'
    lib/active_record/relation.rb:275:in 'block in ActiveRecord::Relation#create_or_find_by'
    lib/active_record/connection_adapters/abstract/connection_pool.rb:412:in 'ActiveRecord::ConnectionAdapters::ConnectionPool#with_connection'
    lib/active_record/connection_handling.rb:310:in 'ActiveRecord::ConnectionHandling#with_connection'
    lib/active_record/relation/delegation.rb:105:in 'ActiveRecord::Delegation#with_connection'
    lib/active_record/relation.rb:274:in 'ActiveRecord::Relation#create_or_find_by'
    lib/active_record/relation.rb:232:in 'ActiveRecord::Relation#find_or_create_by'
    lib/active_record/querying.rb:24:in 'ActiveRecord::Querying#find_or_create_by'
    test/cases/relations_test.rb:2488:in 'block in CreateOrFindByWithinTransactions#test_multiple_find_or_create_by_within_transactions'
    test/cases/relations_test.rb:2517:in 'block (2 levels) in CreateOrFindByWithinTransactions#duel'
    lib/active_record/connection_adapters/abstract/transaction.rb:626:in 'block in ActiveRecord::ConnectionAdapters::TransactionManager#within_new_transaction'
    /workspaces/rails/activesupport/lib/active_support/concurrency/null_lock.rb:9:in 'ActiveSupport::Concurrency::NullLock#synchronize'
    lib/active_record/connection_adapters/abstract/transaction.rb:623:in 'ActiveRecord::ConnectionAdapters::TransactionManager#within_new_transaction'
    lib/active_record/connection_adapters/abstract/database_statements.rb:370:in 'ActiveRecord::ConnectionAdapters::DatabaseStatements#within_new_transaction'
    lib/active_record/connection_adapters/abstract/database_statements.rb:362:in 'ActiveRecord::ConnectionAdapters::DatabaseStatements#transaction'
    lib/active_record/transactions.rb:233:in 'block in ActiveRecord::Transactions::ClassMethods#transaction'
    lib/active_record/connection_adapters/abstract/connection_pool.rb:418:in 'ActiveRecord::ConnectionAdapters::ConnectionPool#with_connection'
    lib/active_record/connection_handling.rb:310:in 'ActiveRecord::ConnectionHandling#with_connection'
    lib/active_record/transactions.rb:232:in 'ActiveRecord::Transactions::ClassMethods#transaction'
    test/cases/relations_test.rb:2511:in 'block in CreateOrFindByWithinTransactions#duel'

bin/test test/cases/relations_test.rb:2487

Finished in 0.021513s, 46.4840 runs/s, 46.4840 assertions/s.
1 runs, 1 assertions, 0 failures, 1 errors, 0 skips
$
```

### Additional information

Related to https://github.com/rails/buildkite-config/pull/130 https://github.com/rails/rails/issues/53727

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
