### PR TITLE
Enable `Minitest/AssertNil` cop to address `DEPRECATED: Use assert_nil if expecting nil` warning

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -382,6 +382,9 @@ Performance/RedundantStringChars:
 Performance/StringInclude:
   Enabled: true
 
+Minitest/AssertNil:
+  Enabled: true
+
 Minitest/AssertPredicate:
   Enabled: true
 

--- a/actionpack/test/controller/integration_test.rb
+++ b/actionpack/test/controller/integration_test.rb
@@ -495,7 +495,7 @@ class IntegrationProcessTest < ActionDispatch::IntegrationTest
       assert_equal "foo=bar", request.env["QUERY_STRING"]
       assert_equal "foo=bar", request.query_string
       assert_equal "bar", request.parameters["foo"]
-      assert_predicate request.parameters["leaks"], :nil?
+      assert_nil request.parameters["leaks"]
     end
   end
 

--- a/actiontext/test/unit/model_test.rb
+++ b/actiontext/test/unit/model_test.rb
@@ -18,7 +18,7 @@ class ActionText::ModelTest < ActiveSupport::TestCase
   test "without content" do
     assert_difference("ActionText::RichText.count" => 0) do
       message = Message.create!(subject: "Greetings")
-      assert_predicate message.content, :nil?
+      assert_nil message.content
       assert_predicate message.content, :blank?
       assert_predicate message.content, :empty?
       assert_not message.content?
@@ -146,7 +146,7 @@ class ActionText::ModelTest < ActiveSupport::TestCase
   test "with blank content and store_if_blank: false" do
     assert_difference("ActionText::RichText.count" => 0) do
       message = MessageWithoutBlanks.create!(subject: "Greetings", content: "")
-      assert_predicate message.content, :nil?
+      assert_nil message.content
       assert_predicate message.content, :blank?
       assert_predicate message.content, :empty?
       assert_not message.content?

--- a/activemodel/test/cases/type/boolean_test.rb
+++ b/activemodel/test/cases/type/boolean_test.rb
@@ -7,8 +7,8 @@ module ActiveModel
     class BooleanTest < ActiveModel::TestCase
       def test_type_cast_boolean
         type = Type::Boolean.new
-        assert_predicate type.cast(""), :nil?
-        assert_predicate type.cast(nil), :nil?
+        assert_nil type.cast("")
+        assert_nil type.cast(nil)
 
         assert type.cast(true)
         assert type.cast(1)

--- a/activemodel/test/cases/validations_test.rb
+++ b/activemodel/test/cases/validations_test.rb
@@ -252,7 +252,7 @@ class ValidationsTest < ActiveModel::TestCase
 
     # If block should not fire
     assert_predicate t, :valid?
-    assert_predicate t.author_name, :nil?
+    assert_nil t.author_name
 
     # If block should fire
     assert t.invalid?(:update)

--- a/activerecord/test/cases/associations/has_many_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_through_associations_test.rb
@@ -1243,7 +1243,7 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
 
     assert_includes post.author_addresses, address
     post.author_addresses.delete(address)
-    assert_predicate post[:author_count], :nil?
+    assert_nil post[:author_count]
   end
 
   def test_primary_key_option_on_source

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -4028,7 +4028,7 @@ module ApplicationTests
 
       app "development"
 
-      assert_equal nil, ActiveStorage.variant_processor
+      assert_nil ActiveStorage.variant_processor
     end
 
     test "ActiveStorage.variant_processor uses vips by default" do


### PR DESCRIPTION
### Motivation / Background

This commit addresses the `DEPRECATED: Use assert_nil if expecting nil` warning at https://buildkite.com/rails/rails/builds/116902#01953bd2-7999-468a-bcd6-5e9b68964fa6/1270-1276

### Detail

```ruby
$ cd railties
$ RAILS_STRICT_WARNINGS=1 bin/test test/application/configuration_test.rb:4031
Run options: --seed 1261

DEPRECATED: Use assert_nil if expecting nil from /home/yahonda/src/github.com/rails/rails/railties/test/application/configuration_test.rb:4031. This will fail in Minitest 6.
E

Error:
ApplicationTests::ConfigurationTest#test_ActiveStorage.variant_processor_uses_mini_magick_without_Rails_7_defaults:
ActiveSupport::RaiseWarnings::WarningError: DEPRECATED: Use assert_nil if expecting nil from /home/yahonda/src/github.com/rails/rails/railties/test/application/configuration_test.rb:4031. This will fail in Minitest 6.

    /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/testing/strict_warnings.rb:38:in 'ActiveSupport::RaiseWarnings#warn'

bin/test test/application/configuration_test.rb:4026

Finished in 1.568723s, 0.6375 runs/s, 0.6375 assertions/s.
1 runs, 1 assertions, 0 failures, 1 errors, 0 skips
$
```

### Additional information
Refer to https://github.com/minitest/minitest/blob/master/History.rdoc#5230--2024-05-15
https://github.com/minitest/minitest/commit/f0f17b99

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
