### PR TITLE
[ci skip] docs: Fix form_with model binding example in guides

### DIFF
--- a/guides/source/form_helpers.md
+++ b/guides/source/form_helpers.md
@@ -282,7 +282,7 @@ It will generate this HTML:
     <label for="book_author">Author</label>
     <input type="text" name="book[author]" id="book_author">
   </div>
-  <input type="submit" name="commit" value="Create Book" data-disable-with="Create Book">
+  <input type="submit" name="commit" value="Update Book" data-disable-with="Update Book">
 </form>
 ```
 
@@ -290,7 +290,7 @@ Some important things to notice when using `form_with` with a model object:
 
 * The form `action` is automatically filled with an appropriate value, `action="/books"`. If you were updating a book, it would be `action="/books/42"`.
 * The form field names are scoped with `book[...]`. This means that `params[:book]` will be a hash containing all these field's values. You can read more about the significance of input names in chapter [Form Input Naming Conventions and Params Hash](#form-input-naming-conventions-and-params-hash) of this guide.
-* The submit button is automatically given an appropriate text value, "Create Book" in this case.
+* The submit button is automatically given an appropriate text value, "Update Book" in this case.
 
 TIP: Typically your form inputs will mirror model attributes. However, they don't have to. If there is other information you need you can include a field in your form and access it via `params[:book][:my_non_attribute_input]`.
 

--- a/guides/source/form_helpers.md
+++ b/guides/source/form_helpers.md
@@ -288,7 +288,7 @@ It will generate this HTML:
 
 Some important things to notice when using `form_with` with a model object:
 
-* The form `action` is automatically filled with an appropriate value, `action="/books"`. If you were updating a book, it would be `action="/books/42"`.
+* The form `action` is automatically filled with an appropriate value, `action="/books/42"`. If you were creating a book, it would be `action="/books"`.
 * The form field names are scoped with `book[...]`. This means that `params[:book]` will be a hash containing all these field's values. You can read more about the significance of input names in chapter [Form Input Naming Conventions and Params Hash](#form-input-naming-conventions-and-params-hash) of this guide.
 * The submit button is automatically given an appropriate text value, "Update Book" in this case.
 


### PR DESCRIPTION
### Motivation / Background

The current form_helpers guide shows an incorrect example where a form for an existing record displays "Create Book" as the submit button text. This is misleading because Rails automatically sets the submit button text to "Update [Model]" for existing records.

In the example, `@book = Book.find(42)` is used to fetch an existing record, so the submit button should show "Update Book" instead of "Create Book".

### Detail

This Pull Request updates the form_helpers guide to show the correct submit button text ("Update Book") in the HTML output example when working with an existing record. This change makes the documentation more accurate and helps prevent confusion for developers learning Rails form helpers.

### Additional information

When using `form_with` with a model, Rails determines the submit button text based on whether the record is persisted:
- For new records: "Create [Model]"
- For existing records: "Update [Model]"

The example in the guide uses `Book.find(42)`, which returns a persisted record, so the submit button text should be "Update Book".

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why.
* [x] No tests needed as this is a documentation-only change.
* [x] No CHANGELOG update needed as this is a documentation correction.