### PR TITLE
Update devcontainer to use ruby version 3.4.2

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,7 +1,7 @@
 # See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.191.1/containers/ruby/.devcontainer/base.Dockerfile
 
 # [Choice] Ruby version: 3.4, 3.3, 3.2
-ARG VARIANT="3.4.1"
+ARG VARIANT="3.4.2"
 FROM ghcr.io/rails/devcontainer/images/ruby:${VARIANT}
 
 RUN sudo apt-get update && export DEBIAN_FRONTEND=noninteractive \


### PR DESCRIPTION
### Motivation / Background

This commit updates the devcontainer to use ruby version 3.4.2

### Detail

- Ruby version installed with this commit:
```ruby
vscode ➜ /workspaces/rails (ruby342_devcontainer) $ ruby -v
ruby 3.4.2 (2025-02-15 revision d2930f8e7a) +PRISM [aarch64-linux]
```

### Additional information

Ruby 3.4.2 is available at:
https://github.com/rails/devcontainer/pkgs/container/devcontainer%2Fimages%2Fruby/356224599?tag=3.4.2 https://github.com/rails/devcontainer/commit/00a473ab3efefa8102dd3c174d416d9934c49a4d

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
