### PR TITLE
Fix uninitialized constant ActiveSupport::LoggerThreadSafeLevel::Logger error

### DIFF
--- a/activesupport/lib/active_support/logger_thread_safe_level.rb
+++ b/activesupport/lib/active_support/logger_thread_safe_level.rb
@@ -4,6 +4,7 @@ require "active_support/concern"
 require "active_support/core_ext/module/attribute_accessors"
 require "concurrent"
 require "fiber"
+require "logger"
 
 module ActiveSupport
   module LoggerThreadSafeLevel # :nodoc:


### PR DESCRIPTION
🔹 Pull Request Title
Fix missing logger dependency in `activesupport/lib/active_support/logger_thread_safe_level.rb`

📌 Description
This PR fixes an issue in `activesupport/lib/active_support/logger_thread_safe_level.rb`caused by a missing `require "logger"`

🚀 Issue
After upgrading the concurrent-ruby gem, the library removed an implicit require "logger" statement. As a result, `activesupport/lib/active_support/logger_thread_safe_level.rb` fails due to an uninitialized constant.

https://github.com/ruby-concurrency/concurrent-ruby/pull/1062

🔍 Fix
Explicitly add require "logger" in `activesupport/lib/active_support/logger_thread_safe_level.rb` to ensure the dependency is always loaded.

✅ Checklist
 - [x] Verified the fix locally
 - [x] Ensured no other dependencies are affected
 - [x]  All tests pass successfully
