### PR TITLE
Add column types to `ActiveRecord::Result` for the mysql2 adapter

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add column types to `ActiveRecord::Result` for the mysql2 adapter.
+
+    *Andrew Kane*
+
 *   Support disabling indexes for MySQL v8.0.0+ and MariaDB v10.6.0+
 
     MySQL 8.0.0 added an option to disable indexes from being used by the query

--- a/activerecord/lib/active_record/connection_adapters/mysql2/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql2/database_statements.rb
@@ -121,7 +121,8 @@ module ActiveRecord
             result = if fields.empty?
               ActiveRecord::Result.empty
             else
-              ActiveRecord::Result.new(fields, raw_result.to_a)
+              types = raw_result.field_types.map { |t| type_map.lookup(t) }
+              ActiveRecord::Result.new(fields, raw_result.to_a, types)
             end
 
             free_raw_result(raw_result)

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -1681,6 +1681,13 @@ class BasicsTest < ActiveRecord::TestCase
     assert_equal "t.lo", topic.author_name
   end
 
+  if current_adapter?(:Mysql2Adapter)
+    def test_column_types_on_queries_on_mysql2
+      result = ActiveRecord::Base.lease_connection.exec_query("SELECT approved FROM topics")
+      assert_equal ActiveModel::Type::Boolean, result.column_types["approved"].class
+    end
+  end
+
   if current_adapter?(:PostgreSQLAdapter)
     def test_column_types_on_queries_on_postgresql
       result = ActiveRecord::Base.lease_connection.exec_query("SELECT 1 AS test")


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

Applies #54594 to the mysql2 adapter. This is useful for casting boolean columns.

I did not see a way to get the SQL column types with Trilogy.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
