### PR TITLE
Only create one config per AV::Base

### DIFF
--- a/actionview/lib/action_view/base.rb
+++ b/actionview/lib/action_view/base.rb
@@ -242,8 +242,6 @@ module ActionView # :nodoc:
     # :startdoc:
 
     def initialize(lookup_context, assigns, controller) # :nodoc:
-      @_config = ActiveSupport::InheritableOptions.new
-
       @lookup_context = lookup_context
 
       @view_renderer = ActionView::Renderer.new @lookup_context

--- a/actionview/lib/action_view/helpers/controller_helper.rb
+++ b/actionview/lib/action_view/helpers/controller_helper.rb
@@ -20,11 +20,15 @@ module ActionView
       def assign_controller(controller)
         if @_controller = controller
           @_request = controller.request if controller.respond_to?(:request)
-          @_config  = controller.config.inheritable_copy if controller.respond_to?(:config)
+          if controller.respond_to?(:config)
+            @_config = controller.config.inheritable_copy
+          else
+            @_config = ActiveSupport::InheritableOptions.new
+          end
           @_default_form_builder = controller.default_form_builder if controller.respond_to?(:default_form_builder)
         else
           @_request ||= nil
-          @_config ||= nil
+          @_config = ActiveSupport::InheritableOptions.new
           @_default_form_builder ||= nil
         end
       end


### PR DESCRIPTION
Currently, AV::Base's config is always initialized to a blank InheritableOptions, and then later config is overridden with the given controller's config if it responds to config (which it will most of the time since AbstractController::Base has a config).

This commit moves the blank config instantiation into the ControllerHelper so that only a single InheritableOptions is ever instantiated for an AV::Base.
