### PR TITLE
Modify the transactional callbacks order to match the SQL sequence: 

### DIFF
--- a/activerecord/lib/active_record.rb
+++ b/activerecord/lib/active_record.rb
@@ -354,6 +354,9 @@ module ActiveRecord
   singleton_class.attr_accessor :run_after_transaction_callbacks_in_order_defined
   self.run_after_transaction_callbacks_in_order_defined = false
 
+  singleton_class.attr_accessor :run_transaction_callbacks_in_same_sequence
+  self.run_transaction_callbacks_in_same_sequence = false
+
   singleton_class.attr_accessor :application_record_class
   self.application_record_class = nil
 

--- a/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
@@ -338,13 +338,15 @@ module ActiveRecord
         end
 
         def run_action_on_records(records, instances_to_run_callbacks_on)
-          records = records.sort do |a, b|
-            if a._stmt_timestamp && b._stmt_timestamp
-              a._stmt_timestamp <=> b._stmt_timestamp
-            elsif a._stmt_timestamp
-              -1
-            else
-              1
+          if ActiveRecord.run_transaction_callbacks_in_same_sequence
+            records = records.sort do |a, b|
+              if a._stmt_timestamp && b._stmt_timestamp
+                a._stmt_timestamp <=> b._stmt_timestamp
+              elsif a._stmt_timestamp
+                -1
+              else
+                1
+              end
             end
           end
 

--- a/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
@@ -338,6 +338,16 @@ module ActiveRecord
         end
 
         def run_action_on_records(records, instances_to_run_callbacks_on)
+          records = records.sort do |a, b|
+            if a._stmt_timestamp && b._stmt_timestamp
+              a._stmt_timestamp <=> b._stmt_timestamp
+            elsif a._stmt_timestamp
+              -1
+            else
+              1
+            end
+          end
+
           while record = records.shift
             should_run_callbacks = record.__id__ == instances_to_run_callbacks_on[record].__id__
 

--- a/activerecord/test/cases/transaction_callbacks_test.rb
+++ b/activerecord/test/cases/transaction_callbacks_test.rb
@@ -690,6 +690,86 @@ class CallbackOrderTest < ActiveRecord::TestCase
   end
   ActiveRecord.run_after_transaction_callbacks_in_order_defined = run_after_transaction_callbacks_in_order_defined_was
 
+  def define_model(&block)
+    Class.new(ActiveRecord::Base) do
+      self.table_name = :topics
+
+      instance_eval(&block)
+    end
+  end
+
+  def test_before_commit_callbacks_called_in_the_same_order_as_the_executed_statements
+    history = []
+
+    another_model = define_model do
+      before_commit -> { history << 1 }
+    end
+
+    model = define_model do
+      before_save -> { another_model.create! }
+      before_commit -> { history << 2 }
+    end
+
+    old, ActiveRecord.before_committed_on_all_records = ActiveRecord.before_committed_on_all_records, true
+    model.new.save
+    assert_equal([1, 2], history)
+  ensure
+    ActiveRecord.before_committed_on_all_records = old
+  end
+
+  def test_after_commit_callbacks_called_in_the_same_order_as_the_executed_statements
+    history = []
+
+    another_model = define_model do
+      after_commit -> { history << 1 }
+    end
+
+    model = define_model do
+      before_save -> { another_model.create! }
+      after_commit -> { history << 2 }
+    end
+
+    model.new.save
+    assert_equal([1, 2], history)
+  end
+
+  def test_before_commit_callbacks_called_in_the_same_order_as_the_executed_statements_when_a_record_gets_created_after_a_transaction_opens
+    history = []
+
+    another_model = define_model do
+      after_commit -> { history << 2 }
+    end
+
+    model = define_model do
+      before_commit do
+        history << 1
+        another_model.create!
+      end
+    end
+
+    model.new.save
+    assert_equal([1, 2], history)
+  end
+
+  def test_after_rollback_when_the_transaction_is_aborted_and_a_record_was_added_to_the_transaction
+    history = []
+
+    another_model = define_model do
+      after_save -> { throw(:abort) }
+      after_rollback -> { history << 1 }
+    end
+
+    # This record wouldn't have a chance to set its `committed_timestamp` as the
+    # transaction will be aborted before. This test checks whether the `sort` comparison works
+    # on records that have their `committed_timestamp` set to nil.
+    model = define_model do
+      before_save -> { another_model.create }
+    end
+
+    model.new.save
+    assert_equal([1], history)
+  end
+
   def test_callbacks_run_in_order_defined_in_model_if_using_run_after_transaction_callbacks_in_order_defined
     topic = TopicWithCallbacksWithSpecificOrderWithSettingTrue.new
     topic.save

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -1496,6 +1496,39 @@ The default value depends on the `config.load_defaults` target version:
 | (original)            | `false`              |
 | 7.1                   | `true`               |
 
+#### `config.active_record.run_transaction_callbacks_in_same_sequence`
+
+When `true`, all transactional callbacks such as `before_commit`, `after_commit` and their rollbacks counterpart will
+be executed in the same sequence as the executed SQL statements.
+
+When `false`, the transactional callbacks will be run in the same order that persistence methods, (such as `save`)
+gets called.
+
+```ruby
+class Post < ApplicationRecord
+  before_commit -> { puts "Hello" }
+end
+
+class Comment < ApplicationRecord
+  before_save -> { Post.create }
+  before_commit -> { puts "World" }
+end
+
+Comment.create!
+
+# The resulting SQL query will be: (This doesn't change)
+# BEGIN TRANSACTION
+#   INSERT INTO posts ...
+#   INSERT INTO comments ...
+# COMMIT
+
+# When `run_transaction_callbacks_in_same_sequence` is `true` the callback order will match
+# the sequence of the transaction. "Hello World" is output.
+
+# When `run_transaction_callbacks_in_same_sequence` is `false` the callback order will match
+# the order of `save`. "World Hello" is output.
+```
+
 #### `config.active_record.query_log_tags_enabled`
 
 Specifies whether or not to enable adapter-level query comments. Defaults to


### PR DESCRIPTION
### Motivation / Background

Fix https://github.com/rails/rails/issues/54623

### Detail

- ### Problem

  Previously, transactional callbacks such as `before_commit`, `after_commit` and their `rollbacks`
  counterpart, were running in the same order as when persistence methods such as `save` gets called.

  Once opted-in to the new behaviour, transaction callbacks will run in the same order as the SQL
  statements execution sequence.

  ```ruby
  class Post < ApplicationRecord
    after_commit -> { puts "Hello" }
  end

  class Comment < ApplicationRecord
    belongs_to :post, autosave: true

    after_commit -> { puts "World" }
  end

  Comment.create

  # The resulting SQL would look like: (Note that this doesn't change)
  # BEGIN TRANSACTION
  #   INSERT_INTO posts ...
  #   INSERT_INTO comments ...
  # COMMIT

  # Previously, the callback order was [Comment, Post]. The output would be "World Hello".
  # The new behaviour matches the SQL execution statements, and the callback order is [Post, Comment],
  # the output is "Hello World".
  ```

  This new behaviour is disabled by default. To opt-in, set the
  `config.active_record.run_transaction_callbacks_in_same_sequence = true`
  in your application's configuration.

  ### Solution

  Set a timestamp on the record, higher up the stack, just before we
  run the SQL statement. Before running the transactional callbacks,
  order the records by this timestamp.

### Additional details

Although I believe that this behaviour is the correct one, I added this new behaviour behind a flag because I was worried this could break existing apps.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
