### PR TITLE
Upgrade RedCarpet to fix a Ruby deprecation warning

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -64,7 +64,7 @@ end
 group :doc do
   gem "sdoc", git: "https://github.com/rails/sdoc.git", branch: "main"
   gem "rdoc", "< 6.10"
-  gem "redcarpet", "~> 3.2.3", platforms: :ruby
+  gem "redcarpet", "~> 3.6.1", platforms: :ruby
   gem "w3c_validators", "~> 1.3.6"
   gem "rouge"
   gem "rubyzip", "~> 2.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -453,7 +453,7 @@ GEM
     rbtree (0.4.6)
     rdoc (6.9.1)
       psych (>= 4.0.0)
-    redcarpet (3.2.3)
+    redcarpet (3.6.1)
     redis (5.3.0)
       redis-client (>= 0.22.0)
     redis-client (0.23.1)
@@ -706,7 +706,7 @@ DEPENDENCIES
   rails!
   rake (>= 13)
   rdoc (< 6.10)
-  redcarpet (~> 3.2.3)
+  redcarpet (~> 3.6.1)
   redis (>= 4.0.1)
   redis-namespace
   releaser!


### PR DESCRIPTION
Ref: https://github.com/vmg/redcarpet/pull/785
