### PR TITLE
Improve devcontainer volume mount to only include the app folder

### DIFF
--- a/railties/lib/rails/generators/rails/devcontainer/templates/devcontainer/compose.yaml.tt
+++ b/railties/lib/rails/generators/rails/devcontainer/templates/devcontainer/compose.yaml.tt
@@ -7,7 +7,7 @@ services:
       dockerfile: .devcontainer/Dockerfile
 
     volumes:
-    - ../..:/workspaces:cached
+    - ../../<%= options[:app_name] %>:/workspaces/<%= options[:app_name] %>:cached
 
     # Overrides default command so things don't shut down after the process ends.
     command: sleep infinity

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -1400,7 +1400,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
           "context" => "..",
           "dockerfile" => ".devcontainer/Dockerfile"
         },
-        "volumes" => ["../..:/workspaces:cached"],
+        "volumes" => ["../../#{compose_config["name"]}:/workspaces/#{compose_config["name"]}:cached"],
         "command" => "sleep infinity",
         "depends_on" => ["selenium"]
       }

--- a/railties/test/generators/devcontainer_generator_test.rb
+++ b/railties/test/generators/devcontainer_generator_test.rb
@@ -360,7 +360,7 @@ module Rails
                 "context" => "..",
                 "dockerfile" => ".devcontainer/Dockerfile"
               },
-              "volumes" => ["../..:/workspaces:cached"],
+              "volumes" => ["../../#{compose["name"]}:/workspaces/#{compose["name"]}:cached"],
               "command" => "sleep infinity"
             }
             actual_independent_config = compose["services"]["rails-app"].except("depends_on")


### PR DESCRIPTION
**Motivation / Background**

Currently, the `compose.yaml.tt` template mounts the entire parent directory (../..) into the devcontainer workspace. This can lead to unnecessary files being included in the container, which is not ideal.

This PR updates the volume mount path to only include the application folder `../../<%= options[:app_name] %>`. This ensures a cleaner and more isolated workspace inside the devcontainer.

**Detail**

- Updated `railties/lib/rails/generators/rails/devcontainer/templates/devcontainer/compose.yaml.tt`
- Changed the volume mount from `../..:/workspaces:cached` to `../../<%= options[:app_name] %>:/workspaces/<%= options[:app_name] %>:cached`
- This makes sure only the application directory is mounted instead of the entire parent directory

**Additional Information**

This change aligns with best practices for mounting project-specific directories in devcontainers. It prevents mounting unnecessary files and ensures a more focused development environment.


**Checklist**

- This Pull Request is related to one change.
- Commit message has a detailed description of what changed and why.
- Tests have been updated to reflect the volume mount change.
- No behavior change requiring a CHANGELOG update.

