### PR TITLE
[ci skip] Clarify nested transaction and exception behavior

### DIFF
--- a/activerecord/lib/active_record/transactions.rb
+++ b/activerecord/lib/active_record/transactions.rb
@@ -136,7 +136,7 @@ module ActiveRecord
     #
     # #transaction calls can be nested. By default, this makes all database
     # statements in the nested transaction block become part of the parent
-    # transaction. For example, the following behavior may be surprising:
+    # transaction. This can lead to suprising behavior with ActiveRecord::Rollback.
     #
     #   User.transaction do
     #     User.create(username: 'Kotori')
@@ -165,6 +165,10 @@ module ActiveRecord
     #   end
     #
     # only "Kotori" is created.
+    #
+    # The above only applies to ActiveRecord::Rollback, as it is a special case that
+    # is explicitly prevented from being passed on. Any other exception will rollback the
+    # transaction and pass on the exception.
     #
     # Most databases don't support true nested transactions. At the time of
     # writing, the only database that we're aware of that supports true nested


### PR DESCRIPTION
### Motivation / Background

The documentation on [nested transactions and rollbacks](https://api.rubyonrails.org/v8.0/classes/ActiveRecord/Transactions/ClassMethods.html) can be confusing. The situation described in the documentation is specific to `ActiveRecord::Rollback` - however I've encountered many developers that thought this was the behavior for any raised exception in a nested transaction.

### Detail

I've updated the docs to call out that this applies only to ActiveRecord::Rollback. Any other exception will be passed on, not hidden.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
