### PR TITLE
Fix `nil` values for `@after_generate_callbacks` in tests

### DIFF
--- a/railties/lib/rails/generators.rb
+++ b/railties/lib/rails/generators.rb
@@ -319,7 +319,7 @@ module Rails
 
         def run_after_generate_callback
           if defined?(@@generated_files) && !@@generated_files.empty?
-            @after_generate_callbacks.each do |callback|
+            after_generate_callbacks.each do |callback|
               callback.call(@@generated_files)
             end
             @@generated_files = []


### PR DESCRIPTION
### Motivation / Background

As I've been upgrading an application from Rails 6.0, I found test failures with the custom generators we'd implemented. In particular, these failures overrode `Rails::Generators::Base#generate` for clearer argument logging and to pass along the configured `destination_root`, for which they used `Rails::Generators.invoke` directly.

From within the context of the `Rails::Generators::TestCase`, the calls to `run_generator` would pass iff they didn't dispatch to a secondary generator, owing in part to the introduction of the `after_generate_callbacks`. Since these generators were being run from within a test (note: suspicion), the `Rails::Generators.configure!` method wasn't being called, and the `@after_generate_callbacks` instance variable wasn't being initialized, leading to a failure when attempting to call `#each` on a `nil` value.

Absent a better understanding of how to properly ensure that `Rails::Generators` is configured within tests, the next best option seems to be using the defined accessor to access that data indirectly. Since that accessor provides an empty array as a default value, this handily remedies the issue.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
