### PR TITLE
Allow params with nested brackets to be parsed similar to how it worked on Rails 7

### DIFF
--- a/actionpack/test/dispatch/param_builder_test.rb
+++ b/actionpack/test/dispatch/param_builder_test.rb
@@ -33,6 +33,28 @@ class ParamBuilderTest < ActiveSupport::TestCase
         assert_equal({ "foo" => { "bar" => "baz" } }, result)
       end
     end
+
+    test "(rack 2) when nested brackets are used in parameters" do
+      assert_deprecated(ActionDispatch.deprecator) do
+        query_string = "subscription[included_prices_attributes[0][price_id[1][name]]]=3"
+
+        result = ActionDispatch::ParamBuilder.from_query_string(query_string)
+        expected = {
+          "subscription" => {
+            "included_prices_attributes" => {
+              "0" => {
+                "price_id" => {
+                  "1" => {
+                    "name" => "3"
+                  }
+                }
+              }
+            }
+          }
+        }
+        assert_equal(expected, result)
+      end
+    end
   else
     test "(rack 3) defaults to retaining leading bracket" do
       result = ActionDispatch::ParamBuilder.from_query_string("[foo]=bar")
@@ -40,6 +62,24 @@ class ParamBuilderTest < ActiveSupport::TestCase
 
       result = ActionDispatch::ParamBuilder.from_query_string("[foo][bar]=baz")
       assert_equal({ "[foo]" => { "bar" => "baz" } }, result)
+    end
+
+    test "(rack 3) when nested brackets are used in parameters" do
+      query_string = "subscription[included_prices_attributes[0][price_id[1][name]]]=3"
+
+      result = ActionDispatch::ParamBuilder.from_query_string(query_string)
+      expected = {
+        "subscription" => {
+          "included_prices_attributes[0" => {
+            "price_id[1" => {
+              "name" => {
+                "]]" => "3"
+              }
+            }
+          }
+        }
+      }
+      assert_equal(expected, result)
     end
   end
 


### PR DESCRIPTION
### Motivation / Background

- Fix #54334

### Detail

- ### Problem

  Sending such param `subscription[prices_attributes[0][price_id]]=3`, where there is nested brackets would parse to this hash on Rails 7.2.2 and Rack 2:

  ```ruby
  {
    "subscription" => {
      "prices_attributes" => {
        "0" => {
          "price_id" => "3"
        }
      }
    }
  }
  ```

  On Rail 8.0, *with* Rack 2, the params are no longer parsed the same way and the result is:

  ```ruby
  {
    "subscription" => {
      "prices_attributes[0" => {
        "price_id" => {
          "[" => "456",
        }
      }
    }
  }
  ```

  ### Context

  On Rack 2, the content inside brackets is [extracted using a regex](https://github.com/rack/rack/blob/aa5a0f532aac7a57e4bc7e857eca1c38229f7b30/lib/rack/query_parser.rb#L90), whereas our parser uses a simpler solution and extract the content up until a "]" token is found, without taking in consideration that there could be a nested brack opening.

  ### Solution

  Tweaked the param builder to check if we have a nested bracket opening and trigger a deprecation message, while continuing to parse as it used to work on Rails 7.

  ### Rack 3

  On Rack 3, the params no longer parses as it used to on Rack 2. And the result is similar to what the param builder parses. 


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
