### PR TITLE
ActiveJob: Improve compatibility with Zeitwerk

### DIFF
--- a/activejob/lib/active_job/logging.rb
+++ b/activejob/lib/active_job/logging.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
-require "active_support/tagged_logging"
-require "active_support/logger"
+require "active_support"
 
 module ActiveJob
   module Logging


### PR DESCRIPTION
Following are removed because `active_support` autoloads them:

    require "active_support/tagged_logging"
    require "active_support/logger"

In accordance with Rails Guides' documentation on how to load active_support, and in compliance with patterns (the good ones, not the bad ones) everywhere else in Rails code.

- See: https://guides.rubyonrails.org/active_support_core_extensions.html

### Motivation / Background

According to documentation [here on Rails Guides](https://guides.rubyonrails.org/active_support_core_extensions.html)
libraries that are not `active_support` that depend on parts of `active_support` should first do:

```
require "active_support"
```

and then whatever specific part they need.

Or, if they need the whole thing they should instead do:
```
require "active_support/all"
```

They should never drop in like a bird of prey and pluck out some internal part of `active_support` without first doing:

```
require "active_support"
```

Unfortunately this is what [active_job does](https://github.com/rails/rails/blob/main/activejob/lib/active_job/logging.rb#L3-L4), and it breaks some libraries I am working on.

Currently the top of `active_job/logging.rb` has:

```
require "active_support/tagged_logging"
require "active_support/logger"
```

It should be changed to:

```
require "active_support"
```

Since TaggedLogging and Logger will be loaded by `autoload`.

This affects every version of Rails that has active_job, tested with 7.2 and 8.0.

Tellingly, it is the only violation of the pattern set forth in the Rails Guides in the entire Rails code base, which is a strong indicator that it should be fixed.

### Detail

This Pull Request changes `activejob/lib/active_job/logging.rb`

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.