### PR TITLE
Use `#report` parameters in error context middleware

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -2,7 +2,7 @@
 
     When reporting an error, the error context middleware will be called with the reported error
     and base execution context. The stack may mutate the context hash. The mutated context will
-    then be passed to error subscribers.
+    then be passed to error subscribers. Middleware receives the same parameters as `ErrorReporter#report`.
 
     *Andrew Novoselac*, *Sam Schmidt*
 

--- a/activesupport/lib/active_support/error_reporter.rb
+++ b/activesupport/lib/active_support/error_reporter.rb
@@ -209,7 +209,7 @@ module ActiveSupport
     # before passing to subscribers. Allows creation of entries in error context that
     # are shared by all subscribers.
     #
-    # A context middleware receives the error and current state of the context hash.
+    # A context middleware receives the same parameters as #report.
     # It must return a hash - the middleware stack returns the hash after it has
     # run through all middlewares. A middleware can mutate or replace the hash.
     #
@@ -242,7 +242,10 @@ module ActiveSupport
 
       full_context = @context_middlewares.execute(
         error,
-        ActiveSupport::ExecutionContext.to_h.merge(context || {})
+        context: ActiveSupport::ExecutionContext.to_h.merge(context || {}),
+        handled:,
+        severity:,
+        source:
       )
 
       disabled_subscribers = ActiveSupport::IsolatedExecutionState[self]
@@ -308,9 +311,9 @@ module ActiveSupport
           @stack << middleware
         end
 
-        # Run all middlewares in the stack on an error and context.
-        def execute(error, context)
-          @stack.inject(context) { |c, middleware| middleware.call(error, c) }
+        # Run all middlewares in the stack
+        def execute(error, handled:, severity:, context:, source:)
+          @stack.inject(context) { |c, middleware| middleware.call(error, context: c, handled:, severity:, source:) }
         end
       end
   end


### PR DESCRIPTION
### Motivation / Background

I was building against the error context middleware introduced in https://github.com/rails/rails/pull/54512. I realized that I also needed the `source` parameter that is passed to `ErrorReporter#report`.

### Detail

Instead of adding parameters piecemeal, the signature for `#call` on error context middleware is now expected to be the same as `#report`.

`ErrorReporter#report` has a number of other parameters besides error and context. `source` in particular can be useful for creating metadata based on the source of the error.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
