### PR TITLE
Don't always escape JSON when calling `render json:`

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,7 +1,7 @@
 *   The JSON renderer doesn't escape HTML entities or Unicode line separators anymore.
 
-    Using `render json:` will no longer escape a few characters that can cause errors when the resulting JSON is
-    embedded in JavaScript, or vulnerabilities when the resulting JSON is embedded in HTML.
+    Using `render json:` will no longer escape `<`, `>`, `&`, `U+2028` and `U+2029` characters that can cause errors
+    when the resulting JSON is embedded in JavaScript, or vulnerabilities when the resulting JSON is embedded in HTML.
 
     Since the renderer is used to return a JSON document as `application/json`, it's typically not necessary to escape
     those characters, and it improves performance.
@@ -9,7 +9,8 @@
     Escaping will still occur when the `:callback` option is set, since the JSON is used as JavaScript code in this
     situation (JSONP).
 
-    You can use the `:escape` option to restore the escaping behavior.
+    You can use the `:escape` option or set `config.action_controller.escape_json_responses` to `true` to restore the
+    escaping behavior.
 
     ```ruby
     class PostsController < ApplicationController

--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,26 @@
+*   The JSON renderer doesn't escape HTML entities or Unicode line separators anymore.
+
+    Using `render json:` will no longer escape a few characters that can cause errors when the resulting JSON is
+    embedded in JavaScript, or vulnerabilities when the resulting JSON is embedded in HTML.
+
+    Since the renderer is used to return a JSON document as `application/json`, it's typically not necessary to escape
+    those characters, and it improves performance.
+
+    Escaping will still occur when the `:callback` option is set, since the JSON is used as JavaScript code in this
+    situation (JSONP).
+
+    You can use the `:escape` option to restore the escaping behavior.
+
+    ```ruby
+    class PostsController < ApplicationController
+      def index
+        render json: Post.last(30), escape: true
+      end
+    end
+    ```
+
+    *Étienne Barrié*, *Jean Boussier*
+
 *   Load lazy route sets before inserting test routes
 
     Without loading lazy route sets early, we miss `after_routes_loaded` callbacks, or risk

--- a/actionpack/lib/action_controller/metal/renderers.rb
+++ b/actionpack/lib/action_controller/metal/renderers.rb
@@ -86,7 +86,7 @@ module ActionController
       remove_possible_method(method_name)
     end
 
-    def self._render_with_renderer_method_name(key)
+    def self._render_with_renderer_method_name(key) # :nodoc:
       "_render_with_renderer_#{key}"
     end
 
@@ -140,7 +140,7 @@ module ActionController
       _render_to_body_with_renderer(options) || super
     end
 
-    def _render_to_body_with_renderer(options)
+    def _render_to_body_with_renderer(options) # :nodoc:
       _renderers.each do |name|
         if options.key?(name)
           _process_options(options)
@@ -153,6 +153,7 @@ module ActionController
 
     add :json do |json, options|
       json_options = options.except(:callback, :content_type, :status)
+      json_options[:escape] ||= false unless options[:callback].present?
       json = json.to_json(json_options) unless json.kind_of?(String)
 
       if options[:callback].present?

--- a/actionpack/lib/action_controller/metal/renderers.rb
+++ b/actionpack/lib/action_controller/metal/renderers.rb
@@ -29,6 +29,7 @@ module ActionController
 
     included do
       class_attribute :_renderers, default: Set.new.freeze
+      class_attribute :escape_json_responses, instance_accessor: false, default: true
     end
 
     # Used in ActionController::Base and ActionController::API to include all
@@ -153,7 +154,7 @@ module ActionController
 
     add :json do |json, options|
       json_options = options.except(:callback, :content_type, :status)
-      json_options[:escape] ||= false unless options[:callback].present?
+      json_options[:escape] ||= false if !self.class.escape_json_responses? && options[:callback].blank?
       json = json.to_json(json_options) unless json.kind_of?(String)
 
       if options[:callback].present?

--- a/actionpack/lib/action_controller/railtie.rb
+++ b/actionpack/lib/action_controller/railtie.rb
@@ -133,5 +133,18 @@ module ActionController
         ActionController::TestCase.executor_around_each_request = app.config.active_support.executor_around_test_case
       end
     end
+
+    initializer "action_controller.escape_json_responses_deprecated_warning" do
+      config.after_initialize do
+        ActiveSupport.on_load(:action_controller) do
+          if ActionController::Base.escape_json_responses
+            ActionController.deprecator.warn(<<~MSG.squish)
+              Setting action_controller.escape_json_responses = true is deprecated and will have no effect in Rails 8.2.
+              Set it to `false` or use `config.load_defaults(8.1)`.
+            MSG
+          end
+        end
+      end
+    end
   end
 end

--- a/actionpack/test/controller/render_json_test.rb
+++ b/actionpack/test/controller/render_json_test.rb
@@ -3,6 +3,7 @@
 require "abstract_unit"
 require "controller/fake_models"
 require "active_support/logger"
+require "active_support/core_ext/object/with"
 
 class RenderJsonTest < ActionController::TestCase
   class JsonRenderable
@@ -120,10 +121,12 @@ class RenderJsonTest < ActionController::TestCase
     assert_equal "text/javascript", @response.media_type
   end
 
-  def test_render_json_without_callback_does_not_escape_js_chars
-    get :render_json_unsafe_chars_without_callback
-    assert_equal %({"hello":"\u2028\u2029<script>"}), @response.body
-    assert_equal "application/json", @response.media_type
+  def test_render_json_with_new_default_and_without_callback_does_not_escape_js_chars
+    TestController.with(escape_json_responses: false) do
+      get :render_json_unsafe_chars_without_callback
+      assert_equal %({"hello":"\u2028\u2029<script>"}), @response.body
+      assert_equal "application/json", @response.media_type
+    end
   end
 
   def test_render_json_with_custom_content_type
@@ -157,6 +160,6 @@ class RenderJsonTest < ActionController::TestCase
 
   def test_render_json_avoids_view_options
     get :render_json_inspect_options
-    assert_equal '{"options":{"escape":false}}', @response.body
+    assert_equal '{"options":{}}', @response.body
   end
 end

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -60,6 +60,7 @@ Below are the default values associated with each target version. In cases of co
 
 #### Default Values for Target Version 8.1
 
+- [`config.action_controller.escape_json_responses`](#config-action-controller-escape-json-responses): `false`
 - [`config.yjit`](#config-yjit): `!Rails.env.local?`
 
 #### Default Values for Target Version 8.0
@@ -1963,6 +1964,21 @@ The default value depends on the `config.load_defaults` target version:
 
 Configures the [`ParamsWrapper`](https://api.rubyonrails.org/classes/ActionController/ParamsWrapper.html). This can be called at
 the top level, or on individual controllers.
+
+#### `config.action_controller.escape_json_responses`
+
+Configures the JSON renderer to escape HTML entities and Unicode characters that are invalid in JavaScript.
+
+This is useful if you relied on the JSON response having those characters escaped to embed the JSON document in
+\<script> tags in HTML.
+
+This is mainly for compatibility when upgrading Rails applications, otherwise you can use the `:escape` option for
+`render json:` in specific controller actions.
+
+| Starting with version | The default value is |
+| --------------------- | -------------------- |
+| (original)            | `true`               |
+| 8.1                   | `false`              |
 
 ### Configuring Action Dispatch
 

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -355,6 +355,10 @@ module Rails
           # redefine methods (e.g. mocking), hence YJIT isn't generally
           # faster in these environments.
           self.yjit = !Rails.env.local?
+
+          if respond_to?(:action_controller)
+            action_controller.escape_json_responses = false
+          end
         else
           raise "Unknown version #{target_version.to_s.inspect}"
         end

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_8_1.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_8_1.rb.tt
@@ -8,3 +8,21 @@
 #
 # Read the Guide for Upgrading Ruby on Rails for more info on each option.
 # https://guides.rubyonrails.org/upgrading_ruby_on_rails.html
+
+###
+# Skips escaping HTML entities and line separators. When set to `false`, the
+# JSON renderer no longer escapes these to improve performance.
+#
+# Example:
+#   class PostsController < ApplicationController
+#     def index
+#       render json: { key: "\u2028\u2029<>&" }
+#     end
+#   end
+#
+# Renders `{"key":"\u2028\u2029\u003c\u003e\u0026"}` with the previous default, but `{"key":"  <>&"}` with the config
+# set to `false`.
+#
+# Applications that want to keep the escaping behavior can set the config to `true`.
+#++
+# Rails.configuration.action_controller.escape_json_responses = false


### PR DESCRIPTION
When `render json:` is used in a controller, and there's no callback option (used for JSONP), the resulting JSON document doesn't need to be HTML-safe (no need to escape HTML entities) or embeddable into JavaScript (no need to escape U+2028 and U+2029).

This both saves a costly operation (the gsub optimized in #54484) and renders cleaner JSON.

This may break some apps or make them vulnerable so I think we'll need a new framework default. Also the name `html_safe` isn't great, by it we mean both JSON that can be included in a script tag in HTML and JSON that can be interpreted as JS (e.g. in a script tag or in a JSONP response). Maybe `browser_safe`?

cc @byroot 