### PR TITLE
Fix CurrentAttributes not setting an attribute's default:

### DIFF
--- a/activesupport/lib/active_support/current_attributes.rb
+++ b/activesupport/lib/active_support/current_attributes.rb
@@ -187,7 +187,7 @@ module ActiveSupport
           super
           return if name == :initialize
           return unless public_method_defined?(name)
-          return if respond_to?(name, true)
+          return if singleton_class.method_defined?(name) || singleton_class.private_method_defined?(name)
           Delegation.generate(singleton_class, [name], to: :instance, as: self, nilable: false)
         end
     end

--- a/activesupport/test/current_attributes_test.rb
+++ b/activesupport/test/current_attributes_test.rb
@@ -262,4 +262,18 @@ class CurrentAttributesTest < ActiveSupport::TestCase
       end
     end
   end
+
+  test "method_added hook doesn't reach the instance. Fix for #54646" do
+    current = Class.new(ActiveSupport::CurrentAttributes) do
+      def self.name
+        "MyCurrent"
+      end
+
+      def foo; end # Sets the cache because of a `method_added` hook
+
+      attribute :bar, default: {}
+    end
+
+    assert_instance_of(Hash, current.bar)
+  end
 end


### PR DESCRIPTION
### Motivation / Background

- Fix #54636

### Detail

- ### Problem

  When calling an attribute that has a default, `nil` would be returned instead.

  ### Context

  CurrentAttributes uses a cache to store each CurrentAttributes subclasses instance. When the class method `instance` gets called, we instantiate the class and populate the cache. The defaults of each attributes are set when the class is instantiated.

  This basically means that once we instantiate the class, all attribute having a default that are later defined will be ignored.

  ### Details

  CurrentAttributes has a `method_added` hook which also call the `instance` class method. So depending on how your class is setup (e.g. you define a method and then define an attribute with a default), you'd hit the bug.

  This is even more sneaky when using a `delgate_to`:

  ```ruby
  class Current < CurrentAttributes
    attribute :user_session
    delegate :user, to: :user_session # Ends up triggering the `method_added` hook

    attribute :foo, default: 0 # Default would be ignored.
  end
  ```

  ### Solution

  Remove the instance from the cache each time we define an attribute.

  ### Alternative

  We could modify the `method_added` hook instead but we'd still be prone to this issue anytime `respond_to_missing` or the `method_missing` hooks are called as they also trigger the bug.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
