### PR TITLE
Modify the Test Runner to allow running test at root:

### DIFF
--- a/railties/test/application/test_runner_test.rb
+++ b/railties/test/application/test_runner_test.rb
@@ -222,6 +222,54 @@ module ApplicationTests
       end
     end
 
+    def test_run_test_at_root
+      app_file "my_test.rb", <<-RUBY
+        require "test_helper"
+
+        class MyTest < ActiveSupport::TestCase
+          def test_rikka
+            puts 'Rikka'
+          end
+        end
+      RUBY
+
+      run_test_command("my_test.rb").tap do |output|
+        assert_match "Rikka", output
+      end
+    end
+
+    def test_run_test_having_a_slash_in_its_name
+      app_file "my_test.rb", <<-RUBY
+        require "test_helper"
+
+        class MyTest < ActiveSupport::TestCase
+          test "foo/foo" do
+            puts 'Rikka'
+          end
+        end
+      RUBY
+
+      run_test_command("my_test.rb -n foo\/foo").tap do |output|
+        assert_match "Rikka", output
+      end
+    end
+
+    def test_run_test_with_flags_unordered
+      app_file "my_test.rb", <<-RUBY
+        require "test_helper"
+
+        class MyTest < ActiveSupport::TestCase
+          test "foo/foo" do
+            puts 'Rikka'
+          end
+        end
+      RUBY
+
+      run_test_command("--seed 344 my_test.rb --fail-fast -n foo\/foo").tap do |output|
+        assert_match "Rikka", output
+      end
+    end
+
     def test_run_matched_test
       app_file "test/unit/chu_2_koi_test.rb", <<-RUBY
         require "test_helper"


### PR DESCRIPTION
### Motivation / Background

I'd like to be able to do `bin/rails my_test.rb`. But I can't, as `my_test.rb` is not considered a path by the runner, so Rails ends up running the entire test suite.

This is also confusing, when I run `bin/rails test unexisting.rb` I don't get a load error, and the whole suite runs.

### Solution

Don't make the assumptions about the `/` character to consider the arg as a path. Instead, skip over any arg that is preceded by a flag, and consider all others to be a path.

### Caveat

(Not really one, since you could never do that.)
Running a file named `--file` or `-file` is not possible.
But this isn't anything new, Minitest will trip over when running the OptionParser and see that this "flag" isn't defined.

### Bonus point

You can now run a test that has a slash in its name. `bin/rails test -n foo\/bar`

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
