### PR TITLE
Create PostgreSQL and MySQL databases at devcontainer

### DIFF
--- a/.devcontainer/boot.sh
+++ b/.devcontainer/boot.sh
@@ -8,7 +8,7 @@ if [ -n "${NVM_DIR}" ]; then
   yarn install
 fi
 
-cd activerecord || echo "activerecord directory doesn't exist" && exit
+cd activerecord || { echo "activerecord directory doesn't exist"; exit; }
 
 # Create PostgreSQL databases
 bundle exec rake db:postgresql:rebuild


### PR DESCRIPTION
### Motivation / Background
This pull request creates PostgreSQL and MySQL databases at devcontainer.

### Detail
The current one runs the last exit even if the `activerecord` directory exists.

```shell
cd activerecord || echo "activerecord directory doesn't exist" && exit
```
As a result, `activerecord_unittest` or `activerecord_unittest2` are not created in both PostgreSQL and MySQL.

- Without this commit: `activerecord_unittest` or `activerecord_unittest2` are not created

```sql
$ mysql -uroot -proot
... snip ...
MariaDB [(none)]> show databases;
+--------------------+
| Database           |
+--------------------+
| information_schema |
| mysql              |
| performance_schema |
| sys                |
+--------------------+
4 rows in set (0.001 sec)
```

```sql
$ psql -d postgres
psql (17.4 (Debian 17.4-1.pgdg120+2))
Type "help" for help.

postgres=# \l
                                                    List of databases
   Name    |  Owner   | Encoding | Locale Provider |  Collate   |   Ctype    | Locale | ICU Rules |   Access privileges
-----------+----------+----------+-----------------+------------+------------+--------+-----------+-----------------------
 postgres  | postgres | UTF8     | libc            | en_US.utf8 | en_US.utf8 |        |           |
 template0 | postgres | UTF8     | libc            | en_US.utf8 | en_US.utf8 |        |           | =c/postgres          +
           |          |          |                 |            |            |        |           | postgres=CTc/postgres
 template1 | postgres | UTF8     | libc            | en_US.utf8 | en_US.utf8 |        |           | =c/postgres          +
           |          |          |                 |            |            |        |           | postgres=CTc/postgres
(3 rows)
```



### Additional information
If there is no `activerecord` directory, it raises "can't cd to activerecord" as expected.
```bash
% git diff .devcontainer/boot.sh
diff --git a/.devcontainer/boot.sh b/.devcontainer/boot.sh
index a25f47a817..00b3388cf8 100755
--- a/.devcontainer/boot.sh
+++ b/.devcontainer/boot.sh
@@ -8,6 +8,7 @@ if [ -n "${NVM_DIR}" ]; then
   yarn install
 fi

+rm -rf activerecord # just to test the error handling
 cd activerecord || { echo "activerecord directory doesn't exist"; exit; }

 # Create PostgreSQL databases
%
```
- Run this boot.sh after the `activerecord` directory is removed.
```bash
Done in 30.76s.
.devcontainer/boot.sh: 12: cd: can't cd to activerecord
activerecord directory doesn't exist
```
---

Follow up #54569

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
