### PR TITLE
[ci skip] Document pluralize_table_names limitation with Rails generators

### DIFF
--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -1072,6 +1072,13 @@ Lets you set an array of names of environments where destructive actions should 
 
 Specifies whether Rails will look for singular or plural table names in the database. If set to `true` (the default), then the Customer class will use the `customers` table. If set to `false`, then the Customer class will use the `customer` table.
 
+WARNING: Some Rails generators and installers (notably `active_storage:install`
+and `action_text:install`) create tables with plural names regardless of this
+setting. If you set `pluralize_table_names` to `false`, you will need to
+manually rename those tables after installation to maintain consistency.
+This limitation exists because these installers use fixed table names
+in their migrations for compatibility reasons.
+
 #### `config.active_record.default_timezone`
 
 Determines whether to use `Time.local` (if set to `:local`) or `Time.utc` (if set to `:utc`) when pulling dates and times from the database. The default is `:utc`.


### PR DESCRIPTION
### Motivation / Background

Fixes #54529

Some Rails installers (like Active Storage and Action Text) create tables with plural names regardless of the `pluralize_table_names` setting. This can cause confusion for users who have set `pluralize_table_names` to `false` expecting all table names to be singular. This PR adds documentation to clearly warn users about this limitation and the necessary manual steps they need to take.

### Detail

This Pull Request adds a warning note in the `config.active_record.pluralize_table_names` section of the configuration guide (`guides/source/configuring.md`).

### Additional information

Related discussions:
- Active Storage plural tables: #52970
- Action Text plural tables: #54529

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. 
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature.