### PR TITLE
[ci skip] Add missing step for using Turbo in Getting Started docs

### DIFF
--- a/guides/source/getting_started.md
+++ b/guides/source/getting_started.md
@@ -1527,7 +1527,17 @@ When this button is clicked, it submits the form which makes a `DELETE` request
 to `/products/:id` which triggers the `destroy` action in our controller.
 
 The `turbo_confirm` data attribute tells the Turbo JavaScript library to ask the
-user to confirm before submitting the form. We'll dig more into that shortly.
+user to confirm before submitting the form. To use this functionality, we first need to set up Turbo.
+
+Run these commands to set up importmap and import Turbo:
+
+```bash
+$ bin/rails importmap:install
+$ bin/rails turbo:install
+```
+
+NOTE: Check out the [Working with JavaScript in Rails](working_with_javascript_in_rails.html)
+for more details.
 
 Adding Authentication
 ---------------------


### PR DESCRIPTION
### Motivation / Background
This Pull Request was created because I found that Turbo does not alert me as described in the [Getting Started with Rails](https://guides.rubyonrails.org/getting_started.html#deleting-products) guide.
The issue was caused by a missing import statement, so I added the necessary steps to import it.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
