### PR TITLE
Fix: ActiveJob::Exceptions.discard_on report option should default to `false`

### DIFF
--- a/activejob/lib/active_job/exceptions.rb
+++ b/activejob/lib/active_job/exceptions.rb
@@ -85,7 +85,7 @@ module ActiveJob
       # Discard the job with no attempts to retry, if the exception is raised. This is useful when the subject of the job,
       # like an Active Record, is no longer available, and the job is thus no longer relevant.
       #
-      # Passing the <tt>:report</tt> option reporter the error through the error reporter before discarding the job.
+      # Passing the <tt>:report</tt> option reports the error through the error reporter before discarding the job.
       #
       # You can also pass a block that'll be invoked. This block is yielded with the job instance as the first and the error instance as the second parameter.
       #
@@ -106,7 +106,7 @@ module ActiveJob
       #      # Might raise CustomAppException for something domain specific
       #    end
       #  end
-      def discard_on(*exceptions, report: true)
+      def discard_on(*exceptions, report: false)
         rescue_from(*exceptions) do |error|
           instrument :discard, error: error do
             ActiveSupport.error_reporter.report(error, source: "application.active_job") if report


### PR DESCRIPTION
### Motivation / Background

In https://github.com/rails/rails/pull/54541 I introduced the `report_on` option for `ActiveJob::Exceptions.retry_on` and `.discard_on`. But for some reason I made the option default to `true` for `discard_on` which is a behaviour change. This behaviour should be opt in.

### Detail

The default value should be `false`.

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
