### PR TITLE
Raise `DoubleRenderError` on `head` after rendering

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,18 @@
+*   Raise `AbstractController::DoubleRenderError` if `head` is called after rendering.
+
+    After this change, invoking `head` will lead to an error if response body is already set:
+
+    ```ruby
+    class PostController < ApplicationController
+      def index
+        render locals: {}
+        head :ok
+      end
+    end
+    ```
+
+    *Iaroslav Kurbatov*
+
 *   The Cookie Serializer can now serialize an Active Support SafeBuffer when using message pack.
 
     Such code would previously produce an error if an application was using messagepack as its cookie serializer.

--- a/actionpack/lib/action_controller/metal/head.rb
+++ b/actionpack/lib/action_controller/metal/head.rb
@@ -25,6 +25,8 @@ module ActionController
         raise ArgumentError, "#{status.inspect} is not a valid value for `status`."
       end
 
+      raise ::AbstractController::DoubleRenderError if response_body
+
       status ||= :ok
 
       if options

--- a/actionpack/test/controller/new_base/render_test.rb
+++ b/actionpack/test/controller/new_base/render_test.rb
@@ -49,6 +49,13 @@ module Render
     end
   end
 
+  class DoubleRenderWithHeadController < ActionController::Base
+    def index
+      render plain: "hello"
+      head :bad_request
+    end
+  end
+
   class ChildRenderController < BlankRenderController
     append_view_path ActionView::FixtureResolver.new("render/child_render/overridden_with_own_view_paths_appended.html.erb" => "child content")
     prepend_view_path ActionView::FixtureResolver.new("render/child_render/overridden_with_own_view_paths_prepended.html.erb" => "child content")
@@ -80,6 +87,20 @@ module Render
 
         assert_raises(AbstractController::DoubleRenderError) do
           get "/render/double_render", headers: { "action_dispatch.show_exceptions" => :none }
+        end
+      end
+    end
+
+    test "using head after rendering raises an exception" do
+      with_routing do |set|
+        set.draw do
+          ActionDispatch.deprecator.silence do
+            get ":controller", action: "index"
+          end
+        end
+
+        assert_raises(AbstractController::DoubleRenderError) do
+          get "/render/double_render_with_head", headers: { "action_dispatch.show_exceptions" => :none }
         end
       end
     end


### PR DESCRIPTION
Currently, calling `head` to set the response code silently removes a previously set response body [0]. This can lead to unnecessary and potentially expensive rendering, as shown in the following snippet:

```ruby
def index
  render json: User.all.as_json # expensive rendering
  head :ok # Overwrites `response_body` to ``
end
```

This behavior is inconsistent with calling `render` twice or calling `redirect_to` after `render`: both of which raise a `DoubleRenderError` [1, 2].

Since this change could break existing endpoints when upgrading Rails, it might make sense to introduce a configuration option would allow developers to choose whether this scenario raises an exception or a warning.

[0] https://github.com/rails/rails/blob/b721c62de11c2c29fa2b8ef51b00d95dce163afc/actionpack/lib/action_controller/metal/head.rb#L50
[1] https://github.com/rails/rails/blob/b721c62de11c2c29fa2b8ef51b00d95dce163afc/actionpack/lib/action_controller/metal/redirecting.rb#L103-L105
[2] https://github.com/rails/rails/blob/b721c62de11c2c29fa2b8ef51b00d95dce163afc/actionpack/lib/action_controller/metal/rendering.rb#L171-L174

<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created because [REPLACE ME]

### Detail

This Pull Request changes [REPLACE ME]

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
