### PR TITLE
Add `rails_app` helper for initializing a Rails app inline.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -750,4 +750,4 @@ DEPENDENCIES
   websocket-client-simple
 
 BUNDLED WITH
-   2.5.16
+   2.6.5

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,25 @@
+*   Add `rails_app` helper for initializing a Rails app inline.
+
+    ```ruby
+      require "bundler/inline"
+
+      gemfile(true) do
+        source "https://rubygems.org"
+
+        gem "rails", github: "rails/rails", branch: "main"
+      end
+
+      require "rails/inline"
+
+      rails_app do |config|
+        config.root = __dir__
+      end
+
+      rails :console
+    ```
+
+    *Petrik de Heus*
+
 *   Add a `SessionTestHelper` module with `sign_in_as(user)` and `sign_out` test helpers when
     running `rails g authentication`. Simplifies authentication in integration tests.
 

--- a/railties/lib/rails/inline.rb
+++ b/railties/lib/rails/inline.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module Rails
+  # Inline allows running a \Rails application in a single
+  # script. Use +rails_app+ to initialize the application and
+  # call +rails+ to run a \Rails command.
+  #
+  #   require "bundler/inline"
+  #
+  #   gemfile(true) do
+  #     source "https://rubygems.org"
+  #     gem 'rails'
+  #   end
+  #
+  #   require "rails/inline"
+  #
+  #   rails_app do |config|
+  #     config.root = __dir__
+  #   end
+  #
+  #   rails :console
+  #
+  class Inline < Rails::Application
+    config.load_defaults Rails::VERSION::STRING.to_f
+    config.eager_load = false
+    config.hosts << "example.org"
+    config.secret_key_base = "secret_key_base"
+    config.logger = Logger.new($stdout)
+  end
+end
+
+def rails_app
+  yield(Rails.application.config)
+  Rails.application.initialize!
+end
+
+def rails(command, args = [], **config)
+  require "rails/command"
+  Rails::Command.invoke command, args, **config
+end

--- a/railties/test/isolation/abstract_unit.rb
+++ b/railties/test/isolation/abstract_unit.rb
@@ -105,14 +105,7 @@ module TestHelpers
   module Generation
     # Build an application by invoking the generator and going through the whole stack.
     def build_app(options = {})
-      @prev_rails_app_class = Rails.app_class
-      @prev_rails_application = Rails.application
-      Rails.app_class = Rails.application = nil
-
-      @prev_rails_env = ENV["RAILS_ENV"]
-      ENV["RAILS_ENV"] = "development"
-
-      FileUtils.rm_rf(app_path)
+      setup_app
       FileUtils.cp_r(app_template_path, app_path)
 
       # Delete the initializers unless requested
@@ -152,6 +145,18 @@ module TestHelpers
       add_to_env_config :production, "config.log_level = :error"
     end
 
+    # Store and reset Rails application globals
+    def setup_app
+      @prev_rails_app_class = Rails.app_class
+      @prev_rails_application = Rails.application
+      Rails.app_class = Rails.application = nil
+
+      @prev_rails_env = ENV["RAILS_ENV"]
+      ENV["RAILS_ENV"] = "development"
+      FileUtils.rm_rf(app_path)
+    end
+
+    # Restore Rails application globals
     def teardown_app
       ENV["RAILS_ENV"] = @prev_rails_env if @prev_rails_env
       Rails.app_class = @prev_rails_app_class if @prev_rails_app_class

--- a/railties/test/railties/inline_test.rb
+++ b/railties/test/railties/inline_test.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+require "isolation/abstract_unit"
+
+class Rails::RunnerTest < ActiveSupport::TestCase
+  include ActiveSupport::Testing::Isolation
+
+  setup :setup_app
+  teardown :teardown_app
+
+  def test_default_config
+    app_file "inline.rb", <<-RUBY
+      require "bundler/inline"
+
+      gemfile(true) do
+        source "https://rubygems.org"
+
+        gem "rails", path: "#{File.join(__dir__, "../../..")}"
+      end
+
+      require "rails/inline"
+
+      rails_app do |config|
+        config.root = __dir__
+      end
+
+      config = Rails.application.config
+      puts "root: " + config.root.to_s
+      puts "eager_load: " + config.eager_load.inspect
+      puts "host: " + config.hosts.last
+      puts "secret_key_base: " + config.secret_key_base
+    RUBY
+
+    output = run_inline_script("inline.rb")
+    assert_match(/root: #{app_path}/, output)
+    assert_match(/eager_load: false/, output)
+    assert_match(/host: example.org/, output)
+    assert_match(/secret_key_base: secret_key_base/, output)
+  end
+
+  def test_running_tests
+    app_file "inline.rb", <<-RUBY
+      require "bundler/inline"
+
+      gemfile(true) do
+        source "https://rubygems.org"
+
+        gem "rails", path: "#{File.join(__dir__, "../../..")}"
+      end
+
+      require "rails/inline"
+      require "minitest/autorun"
+
+      rails_app do |config|
+        config.root = __dir__
+      end
+
+      class BugTest < ActiveSupport::TestCase
+        def test_example
+          assert true
+        end
+      end
+    RUBY
+
+    assert_match /1 runs, 1 assertions, 0 failures, 0 errors, 0 skips/, run_inline_script("inline.rb")
+  end
+
+  def test_running_commands
+    app_file "inline.rb", <<-RUBY
+      require "bundler/inline"
+
+      gemfile(true) do
+        source "https://rubygems.org"
+
+        gem "rails", path: "#{File.join(__dir__, "../../..")}"
+      end
+
+      require "rails/inline"
+
+      rails_app do |config|
+        config.root = __dir__
+      end
+
+      rails :version
+    RUBY
+
+    assert_match %r(Rails #{Rails.version}), run_inline_script("inline.rb")
+  end
+
+  private
+    def run_inline_script(name)
+      `ruby #{app_path}/#{name}`
+    end
+end


### PR DESCRIPTION
### Motivation / Background

Initializing a Rails application in a single script currently requires setting multiple application configurations and calling `initialize!` on the application.
It is easy to miss configuration.

For example in the bug report templates we currently need to do the following:

```ruby
class TestApp < Rails::Application
  config.load_defaults Rails::VERSION::STRING.to_f
  config.eager_load = false
  config.hosts << "example.org"
  config.logger = Logger.new($stdout)
  config.secret_key_base = "secret_key_base"
end
Rails.application.initialize!
```

By wrapping this logic into a helper method, similar to `bundler/inline`, we can simplify this:

```ruby
require "rails/inline"

rails_app
```

Now we can create an application and for example start the console:

```ruby
require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"

  gem "rails", github: "rails/rails", branch: "main"
end

require "rails/inline"

rails_app

rails :console
```

### Additional information

~~Setting `config.root` through a block seems required for now, as we need to pass the scripts location to the application.~~

Not all commands are supported yet. For example `rails :server` does not work yet. 

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
