### PR TITLE
To import Google Workbox in a service worker remove the default CSP

### DIFF
--- a/railties/lib/rails/pwa_controller.rb
+++ b/railties/lib/rails/pwa_controller.rb
@@ -4,6 +4,7 @@ require "rails/application_controller"
 
 class Rails::PwaController < Rails::ApplicationController # :nodoc:
   skip_forgery_protection
+  content_security_policy false, only: :service_worker
 
   def service_worker
     render template: "pwa/service-worker", layout: false


### PR DESCRIPTION
Adding the line:
```js
importScripts("https://storage.googleapis.com/workbox-cdn/releases/7.3.0/workbox-sw.js");
```

in the file `app/views/pwa/service-worker.js` causes a CSP violation `"script-src 'self' 'unsafe-inline'"` since this is the default inherited from `Rails::ApplicationController`.

For details of Google Workbox library usage see https://alicia-paz.medium.com/make-your-rails-app-work-offline-part-2-caching-assets-and-adding-an-offline-fallback-334729ade904

<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created because a standard Rails service worker causes a CSP violation when used in conjunction with [Google Workbox SW via a CDN](https://developer.chrome.com/docs/workbox/modules/workbox-sw).

### Detail

This Pull Request changes the `rails/pwa#service_worker` action by removing the default CSP that prevents the usage of [Google Workbox](https://developer.chrome.com/docs/workbox) with the Google CDN. 

A workaround is to have the [Workbox files locally](https://developer.chrome.com/docs/workbox/modules/workbox-sw#using_local_workbox_files_instead_of_cdn).

Having the option of using the CDN seems like a good option assuming that there is no downside to removing the CSP for this one controller action.

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
