### PR TITLE
Support `with` and `with_recursive` in conjunction with `update_all` and `delete_all`

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -308,4 +308,25 @@
 
     *Kazuma Watanabe*
 
+*   Support `with` and `with_recursive` methods in conjunction with `update_all` and `delete_all`
+
+    This is mostly useful for using `UPDATE` and `DELETE` statements with recursive
+    Common Table Expressions:
+
+    ```ruby
+    comments = Comment.arel_table
+    calculated = Arel::Table.new('calculated')
+
+    Comment
+        .with_recursive(calculated: [
+            comments.project(comments[:id].as('comment_id'), Arel::Nodes.build_quoted(0).as('depth'))
+                .where(comments[:parent_id].eq(nil)),
+            comments.project(comments[:id], calculated[:depth] + 1)
+                .join(calculated).on(calculated[:comment_id].eq(comments[:parent_id]))
+        ])
+        .joins(:calculated).update_all(depth: calculated[:depth])
+    ```
+
+    *cryptogopher*
+
 Please check [8-0-stable](https://github.com/rails/rails/blob/8-0-stable/activerecord/CHANGELOG.md) for previous changes.

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -60,7 +60,7 @@ module ActiveRecord
                             :reverse_order, :distinct, :create_with, :skip_query_cache]
 
     CLAUSE_METHODS = [:where, :having, :from]
-    INVALID_METHODS_FOR_UPDATE_AND_DELETE_ALL = [:distinct, :with, :with_recursive]
+    INVALID_METHODS_FOR_UPDATE_AND_DELETE_ALL = [:distinct]
 
     VALUE_METHODS = MULTI_VALUE_METHODS + SINGLE_VALUE_METHODS + CLAUSE_METHODS
 
@@ -585,6 +585,23 @@ module ActiveRecord
     #
     #   # Update all books with 'Rails' in their title
     #   Book.where('title LIKE ?', '%Rails%').update_all(title: Arel.sql("title + ' - volume 1'"))
+    #
+    #   # Update all posts with '[discussion]' in their title if there are many comments
+    #   Post.with(commented_posts:
+    #     Comment.select(:post_id).distinct.group(:post_id).having('COUNT(post_id) > 1')
+    #   ).joins(:commented_posts).update_all("title = CONCAT('[discussion] ', title)")
+    #
+    #   # Update all comments and set comment depth in a hierarchy
+    #   comments = Comment.arel_table
+    #   calculated = Arel::Table.new('calculated')
+    #   Comment
+    #     .with_recursive(calculated: [
+    #       comments.project(comments[:id].as('comment_id'), Arel::Nodes.build_quoted(0).as('depth'))
+    #         .where(comments[:parent_id].eq(nil)),
+    #       comments.project(comments[:id], calculated[:depth] + 1)
+    #         .join(calculated).on(calculated[:comment_id].eq(comments[:parent_id]))
+    #     ])
+    #     .joins(:calculated).update_all(depth: calculated[:depth])
     def update_all(updates)
       raise ArgumentError, "Empty list of attributes to change" if updates.blank?
 
@@ -1020,6 +1037,11 @@ module ActiveRecord
     #
     #   Post.distinct.delete_all
     #   # => ActiveRecord::ActiveRecordError: delete_all doesn't support distinct
+    #
+    # ==== Examples
+    #
+    #   # Delete all posts with at least one comment
+    #   Post.with(commented: Comment.select(:post_id).distinct).joins(:commented).delete_all
     def delete_all
       return 0 if @none
 

--- a/activerecord/lib/arel/crud.rb
+++ b/activerecord/lib/arel/crud.rb
@@ -27,6 +27,7 @@ module Arel # :nodoc: all
       um.order(*orders)
       um.wheres = constraints
       um.key = key
+      um.with = subqueries
 
       um.group(group_values_columns) unless group_values_columns.empty?
       um.having(having_clause) unless having_clause.nil?
@@ -40,6 +41,7 @@ module Arel # :nodoc: all
       dm.order(*orders)
       dm.wheres = constraints
       dm.key = key
+      dm.with = subqueries
       dm.group(group_values_columns) unless group_values_columns.empty?
       dm.having(having_clause) unless having_clause.nil?
       dm

--- a/activerecord/lib/arel/nodes/delete_statement.rb
+++ b/activerecord/lib/arel/nodes/delete_statement.rb
@@ -3,7 +3,7 @@
 module Arel # :nodoc: all
   module Nodes
     class DeleteStatement < Arel::Nodes::Node
-      attr_accessor :relation, :wheres, :groups, :havings, :orders, :limit, :offset, :key
+      attr_accessor :relation, :wheres, :groups, :havings, :orders, :limit, :offset, :key, :with
 
       def initialize(relation = nil, wheres = [])
         super()
@@ -15,6 +15,7 @@ module Arel # :nodoc: all
         @limit = nil
         @offset = nil
         @key = nil
+        @with = nil
       end
 
       def initialize_copy(other)
@@ -24,7 +25,7 @@ module Arel # :nodoc: all
       end
 
       def hash
-        [self.class, @relation, @wheres, @orders, @limit, @offset, @key].hash
+        [self.class, @relation, @wheres, @orders, @limit, @offset, @key, @with].hash
       end
 
       def eql?(other)
@@ -36,7 +37,8 @@ module Arel # :nodoc: all
           self.havings == other.havings &&
           self.limit == other.limit &&
           self.offset == other.offset &&
-          self.key == other.key
+          self.key == other.key &&
+          self.with == other.with
       end
       alias :== :eql?
     end

--- a/activerecord/lib/arel/nodes/update_statement.rb
+++ b/activerecord/lib/arel/nodes/update_statement.rb
@@ -3,7 +3,7 @@
 module Arel # :nodoc: all
   module Nodes
     class UpdateStatement < Arel::Nodes::Node
-      attr_accessor :relation, :wheres, :values, :groups, :havings, :orders, :limit, :offset, :key
+      attr_accessor :relation, :wheres, :values, :groups, :havings, :orders, :limit, :offset, :key, :with
 
       def initialize(relation = nil)
         super()
@@ -16,6 +16,7 @@ module Arel # :nodoc: all
         @limit    = nil
         @offset   = nil
         @key      = nil
+        @with     = nil
       end
 
       def initialize_copy(other)
@@ -25,7 +26,7 @@ module Arel # :nodoc: all
       end
 
       def hash
-        [@relation, @wheres, @values, @orders, @limit, @offset, @key].hash
+        [@relation, @wheres, @values, @orders, @limit, @offset, @key, @with].hash
       end
 
       def eql?(other)
@@ -38,7 +39,8 @@ module Arel # :nodoc: all
           self.orders == other.orders &&
           self.limit == other.limit &&
           self.offset == other.offset &&
-          self.key == other.key
+          self.key == other.key &&
+          self.with == other.with
       end
       alias :== :eql?
     end

--- a/activerecord/lib/arel/select_manager.rb
+++ b/activerecord/lib/arel/select_manager.rb
@@ -231,6 +231,10 @@ module Arel # :nodoc: all
       self
     end
 
+    def subqueries
+      @ast.with
+    end
+
     def take(limit)
       if limit
         @ast.limit = Nodes::Limit.new(limit)

--- a/activerecord/lib/arel/tree_manager.rb
+++ b/activerecord/lib/arel/tree_manager.rb
@@ -40,6 +40,11 @@ module Arel # :nodoc: all
         @ast.wheres << expr
         self
       end
+
+      def with=(expr)
+        @ast.with = expr
+        self
+      end
     end
 
     attr_reader :ast

--- a/activerecord/lib/arel/visitors/postgresql.rb
+++ b/activerecord/lib/arel/visitors/postgresql.rb
@@ -8,6 +8,11 @@ module Arel # :nodoc: all
           collector.retryable = false
           o = prepare_update_statement(o)
 
+          if o.with
+            collector = visit o.with, collector
+            collector << " "
+          end
+
           collector << "UPDATE "
 
           # UPDATE with JOIN is in the form of:

--- a/activerecord/lib/arel/visitors/sqlite.rb
+++ b/activerecord/lib/arel/visitors/sqlite.rb
@@ -8,6 +8,11 @@ module Arel # :nodoc: all
           collector.retryable = false
           o = prepare_update_statement(o)
 
+          if o.with
+            collector = visit o.with, collector
+            collector << " "
+          end
+
           collector << "UPDATE "
 
           # UPDATE with JOIN is in the form of:

--- a/activerecord/lib/arel/visitors/to_sql.rb
+++ b/activerecord/lib/arel/visitors/to_sql.rb
@@ -23,6 +23,11 @@ module Arel # :nodoc: all
           collector.retryable = false
           o = prepare_delete_statement(o)
 
+          if o.with
+            collector = visit o.with, collector
+            collector << " "
+          end
+
           if has_join_sources?(o)
             collector << "DELETE "
             visit o.relation.left, collector
@@ -40,6 +45,11 @@ module Arel # :nodoc: all
         def visit_Arel_Nodes_UpdateStatement(o, collector)
           collector.retryable = false
           o = prepare_update_statement(o)
+
+          if o.with
+            collector = visit o.with, collector
+            collector << " "
+          end
 
           collector << "UPDATE "
           collector = visit o.relation, collector

--- a/activerecord/test/cases/relation/delete_all_test.rb
+++ b/activerecord/test/cases/relation/delete_all_test.rb
@@ -71,7 +71,6 @@ class DeleteAllTest < ActiveRecord::TestCase
 
   def test_delete_all_with_unpermitted_relation_raises_error
     assert_raises(ActiveRecord::ActiveRecordError) { Author.distinct.delete_all }
-    assert_raises(ActiveRecord::ActiveRecordError) { Author.with(limited: Author.limit(2)).delete_all }
   end
 
   def test_delete_all_with_joins_and_where_part_is_hash

--- a/activerecord/test/cases/relation/update_all_test.rb
+++ b/activerecord/test/cases/relation/update_all_test.rb
@@ -86,10 +86,6 @@ class UpdateAllTest < ActiveRecord::TestCase
     assert_deprecated("`distinct` is not supported by `update_all`", ActiveRecord.deprecator) do
       Author.distinct.update_all(name: "Bob")
     end
-
-    assert_deprecated("`with` is not supported by `update_all`", ActiveRecord.deprecator) do
-      Author.with(limited: Author.where(name: "")).update_all(name: "Bob")
-    end
   end
 
   def test_dynamic_update_all_with_one_joined_table


### PR DESCRIPTION
Support `with` and `with_recursive` in conjunction with `update_all` and `delete_all`
    
    This is mostly useful for using `UPDATE` and `DELETE` statements with recursive
    Common Table Expressions:
    
        comments = Comment.arel_table
        calculated = Arel::Table.new('calculated')
    
        Comment
            .with_recursive(calculated: [
                comments.project(comments[:id].as('comment_id'),
                                 Arel::Nodes.build_quoted(0).as('depth'))
                    .where(comments[:parent_id].eq(nil)),
                comments.project(comments[:id], calculated[:depth] + 1)
                    .join(calculated).on(calculated[:comment_id].eq(comments[:parent_id]))
            ])
            .joins(:calculated).update_all(depth: calculated[:depth])
    
    Does not work in MariaDB, as CTE support for UPDATE and DELETE
    statements is still work in progress:
    https://jira.mariadb.org/browse/MDEV-18511