### PR TITLE
Fix Horizontal Scroll on Mobile [ci skip]

### DIFF
--- a/guides/assets/stylesrc/components/_code-container.scss
+++ b/guides/assets/stylesrc/components/_code-container.scss
@@ -44,10 +44,13 @@ dl dd .interstitial {
     padding-left: 1em !important; // remove if icon is restored
     direction: ltr !important;
     text-align: left !important;
+    width: 100%;
+    white-space: normal;
 
     pre {
       margin: 0;
-      overflow: visible; // allows for the blue highlight to be seen
+      overflow: scroll;
+      white-space: pre;
     }
 
     button.clipboard-button {


### PR DESCRIPTION
Closes #54590

### Motivation / Background

On mobile devices, the Rails Guides have horizontal scroll which is not ideal for responsive design. C.f. [See here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#follow-the-coding-conventions) on a mobile device as an example.

### Solution

This can be fixed by adjusting the width, white-space and overflow attributes on .code and .code > pre respectively.


