### PR TITLE
Reset execution context in jobs and controllers

### DIFF
--- a/actionpack/test/controller/base_test.rb
+++ b/actionpack/test/controller/base_test.rb
@@ -358,3 +358,13 @@ class BaseTest < ActiveSupport::TestCase
     )
   end
 end
+
+class BaseInstrumentationTest < ActionController::TestCase
+  tests SimpleController
+
+  def test_clears_controller_execution_context
+    get :hello
+
+    assert_nil ActiveSupport::ExecutionContext.to_h[:controller]
+  end
+end

--- a/activejob/lib/active_job/execution.rb
+++ b/activejob/lib/active_job/execution.rb
@@ -63,9 +63,10 @@ module ActiveJob
 
     private
       def _perform_job
-        ActiveSupport::ExecutionContext[:job] = self
-        run_callbacks :perform do
-          perform(*arguments)
+        ActiveSupport::ExecutionContext.set(job: self) do
+          run_callbacks :perform do
+            perform(*arguments)
+          end
         end
       end
   end

--- a/activejob/test/cases/instrumentation_test.rb
+++ b/activejob/test/cases/instrumentation_test.rb
@@ -36,4 +36,9 @@ class InstrumentationTest < ActiveSupport::TestCase
   test "discard emits a discard event" do
     assert_notifications_count("discard.active_job", 1) { RetryJob.perform_later("DiscardableError", 6) }
   end
+
+  test "clears execution context" do
+    HelloJob.perform_now("World!")
+    assert_nil ActiveSupport::ExecutionContext.to_h[:job]
+  end
 end


### PR DESCRIPTION
### Motivation / Background

At GitHub we're spiking out tooling that identifies queries in CI, highlighting them to the PR author, linting for index usage, etc. While building this functionality we discovered that the query logs attributed a significant number of queries to a common job that's run inline in our test suite. After some investigation, we discovered that the cause was due to `:job` (and `:controller`) context values not being cleared after the job or controller had completed execution.

The job in question is commonly run in our test suite and we saw a ~4x reduction in the number of queries attributed to it after a small monkey patch to clear `ActiveSupport::ExecutionContext[:job]` post perform.

The accuracy of this tag is valuable in this testing context since it's highlighting a lot of potential optimizations we can make to our test suite and avoids potential confusion why when queries are attributed incorrectly. This can also impact production in some circumstances, like mistakenly attributing queries to the wrong source (e.g. running a `perform_now` could incorrectly begin attributing queries to that job instead its parent job, or queries made in a controller post-perform).

### Detail

Currently `ActiveSupport::ExecutionContext#[]` is used to set the `:job` and `:controller` attributes, which does not reset the values once the job or controller have completed execution. This can result in that context leaking, resulting in query logs that are misattributed.

This leaky behavior can be seen in production (e.g. performing a job via `perform_now`) but is much more noticeable in the test environment where it's not uncommon to run some combination of jobs/controller actions in a single test.

This updates both uses of `ActiveSupport::ExecutionContext#[]` to avoid leaking the context and generating inaccurate query logs.

### Additional information

I wasn't 100% positive if there was a better place to put these tests but thought they'd be valuable as small/cheap regression tests.

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.