### PR TITLE
Add Relation method for updating many records with different values

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -559,6 +559,14 @@ module ActiveRecord
         false
       end
 
+      def supports_derived_values_table?
+        true
+      end
+
+      def supports_derived_table_column_aliases?
+        false
+      end
+
       def return_value_after_insert?(column) # :nodoc:
         column.auto_populated?
       end

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -188,6 +188,14 @@ module ActiveRecord
         end
       end
 
+      def supports_derived_values_table?
+        mariadb? || database_version >= "8.0.0"
+      end
+
+      def supports_derived_table_column_aliases?
+        !mariadb? || database_version >= "11.7.0"
+      end
+
       def get_advisory_lock(lock_name, timeout = 0) # :nodoc:
         query_value("SELECT GET_LOCK(#{quote(lock_name.to_s)}, #{timeout})") == 1
       end

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -288,6 +288,10 @@ module ActiveRecord
         database_version >= 10_00_00 # >= 10.0
       end
 
+      def supports_derived_table_column_aliases?
+        true
+      end
+
       def index_algorithms
         { concurrently: "CONCURRENTLY" }
       end

--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "active_record/insert_all"
+require "active_record/uniform_update_all"
 
 module ActiveRecord
   # = Active Record \Persistence

--- a/activerecord/lib/active_record/querying.rb
+++ b/activerecord/lib/active_record/querying.rb
@@ -19,7 +19,7 @@ module ActiveRecord
       :count, :average, :minimum, :maximum, :sum, :calculate,
       :pluck, :pick, :ids, :async_ids, :strict_loading, :excluding, :without, :with, :with_recursive,
       :async_count, :async_average, :async_minimum, :async_maximum, :async_sum, :async_pluck, :async_pick,
-      :insert, :insert_all, :insert!, :insert_all!, :upsert, :upsert_all
+      :insert, :insert_all, :insert!, :insert_all!, :upsert, :upsert_all, :uniform_update_all
     ].freeze # :nodoc:
     delegate(*QUERYING_METHODS, to: :all)
 

--- a/activerecord/lib/active_record/uniform_update_all.rb
+++ b/activerecord/lib/active_record/uniform_update_all.rb
@@ -1,0 +1,142 @@
+# frozen_string_literal: true
+
+require "active_support/core_ext/enumerable"
+
+module ActiveRecord
+  class UniformUpdateAll # :nodoc:
+    attr_reader :model, :connection, :updates, :read_keys, :write_keys
+
+    def initialize(relation, connection, updates, record_timestamps: nil)
+      @model, @connection = relation.model, connection
+      @updates = normalize_updates(updates)
+      @record_timestamps = record_timestamps.nil? ? model.record_timestamps : record_timestamps
+
+      resolve_attribute_aliases
+      @read_keys = @updates.first[0].keys.to_set
+      @write_keys = @updates.first[1].keys.to_set
+
+      verify_input_keys
+    end
+
+    def column_types
+      columns_hash = model.columns_hash
+      @column_types ||= read_keys.to_a.concat(write_keys.to_a).map! { |key| columns_hash.fetch(key) }
+    end
+
+    def build_arel
+      types = extract_types_from_columns_on(model.table_name, keys: read_keys | write_keys)
+
+      rows = map_key_with_value do |key, value|
+        next value if Arel::Nodes::SqlLiteral === value
+        ActiveModel::Type::SerializeCastValue.serialize(type = types[key], type.cast(value))
+      end
+
+      values_table = Arel::ValuesTable.new(:__active_record_uua_temp, rows, column_types: column_types)
+
+      join_conditions = read_keys.map.with_index do |key, index|
+        model.arel_table[key].eq(values_table[index])
+      end
+      set_assignments = write_keys.map.with_index do |key, index|
+        [model.arel_table[key], values_table[index + read_keys.size]]
+      end
+      set_assignments += timestamp_assignments(set_assignments) if timestamp_keys.any?
+
+      [values_table, join_conditions, set_assignments]
+    end
+
+    private
+      def timestamp_assignments(set_assignments)
+        case_conditions = set_assignments.map do |left, right|
+          left.is_not_distinct_from(right)
+        end
+
+        timestamp_keys.map do |key|
+          case_assignment = Arel::Nodes::Case.new.when(Arel::Nodes::And.new(case_conditions))
+                                             .then(model.arel_table[key])
+                                             .else(connection.high_precision_current_timestamp)
+          [model.arel_table[key], Arel::Nodes::Grouping.new(case_assignment)]
+        end
+      end
+
+      def verify_input_keys
+        if updates.empty?
+          raise ArgumentError, "Empty updates object"
+        end
+        if read_keys.empty?
+          raise ArgumentError, "Empty conditions object"
+        end
+        if write_keys.empty?
+          raise ArgumentError, "Empty values object"
+        end
+      end
+
+      def verify_attributes(conditions, assigns)
+        if read_keys != conditions.keys.to_set
+          raise ArgumentError, "All objects being updated must have the same condition keys"
+        end
+        if write_keys != assigns.keys.to_set
+          raise ArgumentError, "All objects being updated must have the same assignment keys"
+        end
+      end
+
+      def normalize_updates(updates)
+        if updates.is_a?(Hash)
+          if model.composite_primary_key?
+            updates.map { |id, assigns| [model.primary_key.zip(id).to_h, assigns] }
+          elsif updates.keys.first.is_a?(Array)
+            updates.map { |id, assigns| [{ model.primary_key => id.fetch(0) }, assigns] }
+          else
+            updates.map { |id, assigns| [{ model.primary_key => id }, assigns] }
+          end
+        else
+          updates
+        end.map do |conditions, assigns|
+          [conditions.stringify_keys, assigns.stringify_keys]
+        end
+      end
+
+      def map_key_with_value
+        updates.map do |conditions, assigns|
+          verify_attributes(conditions, assigns)
+
+          condition_values = read_keys.map { |key| yield key, conditions[key] }
+          write_values = write_keys.map { |key| yield key, assigns[key] }
+          condition_values.concat(write_values)
+        end
+      end
+
+      def record_timestamps?
+        @record_timestamps
+      end
+
+      def timestamp_keys
+        @timestamp_keys ||= record_timestamps? ? model.timestamp_attributes_for_update_in_model.to_set - write_keys : []
+      end
+
+      def resolve_attribute_aliases
+        return unless has_attribute_aliases?(@updates.first.first) || has_attribute_aliases?(@updates.first.last)
+
+        @updates.map! do |conditions, assigns|
+          [conditions.transform_keys { |attribute| resolve_attribute_alias(attribute) },
+           assigns.transform_keys { |attribute| resolve_attribute_alias(attribute) }]
+        end
+      end
+
+      def resolve_attribute_alias(attribute)
+        model.attribute_alias(attribute) || attribute
+      end
+
+      def has_attribute_aliases?(attributes)
+        attributes.keys.any? { |attribute| model.attribute_alias?(attribute) }
+      end
+
+      def extract_types_from_columns_on(table_name, keys:)
+        columns = @model.schema_cache.columns_hash(table_name)
+
+        unknown_column = (keys - columns.keys).first
+        raise UnknownAttributeError.new(model.new, unknown_column) if unknown_column
+
+        keys.index_with { |key| model.type_for_attribute(key) }
+      end
+  end
+end

--- a/activerecord/lib/arel.rb
+++ b/activerecord/lib/arel.rb
@@ -13,6 +13,7 @@ require "arel/math"
 require "arel/alias_predication"
 require "arel/order_predications"
 require "arel/table"
+require "arel/values_table"
 require "arel/attributes/attribute"
 
 require "arel/visitors"

--- a/activerecord/lib/arel/values_table.rb
+++ b/activerecord/lib/arel/values_table.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module Arel # :nodoc: all
+  class ValuesTable < Table
+    attr_reader :rows, :column_aliases, :column_types
+
+    # PostgreSQL uses column_types to cast the values and type the whole table
+    def initialize(name, rows, column_aliases: nil, column_types: nil)
+      super(name, as: name)
+      @width = rows.first.size
+      @rows = rows
+      @column_aliases = column_aliases&.map(&:to_s)
+      @column_types = column_types
+    end
+
+    # Pick default names so that :[] works even if aliases haven't been given
+    def column_aliases_or_default_names
+      @column_aliases_or_default_names ||= @column_aliases || (1..@width).map { |i| "column#{i}" }
+    end
+
+    def [](name, table = self)
+      name = column_aliases_or_default_names[name] if name.is_a?(Integer)
+      name = name.name if name.is_a?(Symbol)
+      Arel::Attribute.new(table, name)
+    end
+
+    def hash
+      super ^ [@rows, @column_aliases, @column_types].hash
+    end
+
+    def eql?(other)
+      super(other) &&
+        @rows == other.rows &&
+        @column_aliases == other.column_aliases &&
+        @column_types == other.column_types
+    end
+    alias :== :eql?
+  end
+end

--- a/activerecord/lib/arel/visitors/to_sql.rb
+++ b/activerecord/lib/arel/visitors/to_sql.rb
@@ -93,22 +93,11 @@ module Arel # :nodoc: all
 
         def visit_Arel_Nodes_ValuesList(o, collector)
           collector << "VALUES "
+          values_rows_list o.rows, collector
+        end
 
-          o.rows.each_with_index do |row, i|
-            collector << ", " unless i == 0
-            collector << "("
-            row.each_with_index do |value, k|
-              collector << ", " unless k == 0
-              case value
-              when Nodes::SqlLiteral, Nodes::BindParam, ActiveModel::Attribute
-                collector = visit(value, collector)
-              else
-                collector << quote(value).to_s
-              end
-            end
-            collector << ")"
-          end
-          collector
+        def visit_Arel_ValuesTable(o, collector)
+          raise NotImplementedError, "VALUES ... AS table not implemented for this db"
         end
 
         def visit_Arel_Nodes_SelectStatement(o, collector)
@@ -1008,6 +997,24 @@ module Arel # :nodoc: all
             visit child.to_cte, collector
           end
 
+          collector
+        end
+
+        def values_rows_list(rows, collector, row_prefix = "")
+          rows.each_with_index do |row, i|
+            collector << ", " unless i == 0
+            collector << row_prefix << "("
+            row.each_with_index do |value, i|
+              collector << ", " unless i == 0
+              case value
+              when Nodes::SqlLiteral, Nodes::BindParam, ActiveModel::Attribute
+                collector = visit(value, collector)
+              else
+                collector << quote(value).to_s
+              end
+            end
+            collector << ")"
+          end
           collector
         end
     end

--- a/activerecord/test/cases/arel/support/fake_record.rb
+++ b/activerecord/test/cases/arel/support/fake_record.rb
@@ -5,6 +5,7 @@ require "date"
 
 module FakeRecord
   class Column < Struct.new(:name, :type)
+    alias :sql_type :type
   end
 
   class Connection
@@ -89,6 +90,10 @@ module FakeRecord
 
     def cast_bound_value(thing)
       thing
+    end
+
+    def mariadb?
+      false
     end
   end
 

--- a/activerecord/test/cases/arel/table_test.rb
+++ b/activerecord/test/cases/arel/table_test.rb
@@ -202,5 +202,18 @@ module Arel
         assert_equal 2, array.uniq.size
       end
     end
+
+    describe "ValuesTable" do
+      it "responds to :[] with default or given column aliases" do
+        rows = [[1, "one"], [2, "two"]]
+        table1 = Arel::ValuesTable.new(:data, rows)
+        table2 = Arel::ValuesTable.new(:data, rows, column_aliases: %i[id name])
+
+        assert_equal "column2", table1[1].name
+        assert_equal "name", table1[:name].name
+        assert_equal "name", table2[1].name
+        assert_equal "name", table2[:name].name
+      end
+    end
   end
 end

--- a/activerecord/test/cases/arel/visitors/mysql_test.rb
+++ b/activerecord/test/cases/arel/visitors/mysql_test.rb
@@ -200,6 +200,39 @@ module Arel
           }
         end
       end
+
+      describe "ValuesTable" do
+        before do
+          @rows = [[1, "one"], [2, "two"]]
+          @column_types = [FakeRecord::Column.new("id", :integer), FakeRecord::Column.new("name", :string)]
+        end
+
+        describe "MySQL syntax" do
+          it "outputs default sqlite column aliases if none given" do
+            values_table = Arel::ValuesTable.new(:data, @rows)
+
+            _(compile(values_table)).must_be_like %{
+              (VALUES ROW(1, 'one'), ROW(2, 'two')) "data" ("column1", "column2")
+            }
+          end
+
+          it "outputs column aliases if given" do
+            values_table = Arel::ValuesTable.new(:data, @rows, column_aliases: %i[id name])
+
+            _(compile(values_table)).must_be_like %{
+              (VALUES ROW(1, 'one'), ROW(2, 'two')) "data" ("id", "name")
+            }
+          end
+
+          it "ignores column_types" do
+            values_table = Arel::ValuesTable.new(:data, @rows, column_types: @column_types)
+
+            _(compile(values_table)).must_be_like %{
+              (VALUES ROW(1, 'one'), ROW(2, 'two')) "data" ("column1", "column2")
+            }
+          end
+        end
+      end
     end
   end
 end

--- a/activerecord/test/cases/arel/visitors/sqlite_test.rb
+++ b/activerecord/test/cases/arel/visitors/sqlite_test.rb
@@ -70,6 +70,37 @@ module Arel
           _(sql).must_be_like %{ "users"."name" IS NOT NULL }
         end
       end
+
+      describe "ValuesTable" do
+        before do
+          @rows = [[1, "one"], [2, "two"]]
+          @column_types = [FakeRecord::Column.new("id", :integer), FakeRecord::Column.new("name", :string)]
+        end
+
+        it "outputs no column aliases" do
+          values_table = Arel::ValuesTable.new(:data, @rows)
+
+          _(compile(values_table)).must_be_like %{
+            (VALUES (1, 'one'), (2, 'two')) "data"
+          }
+        end
+
+        it "outputs column aliases as subquery if given" do
+          values_table = Arel::ValuesTable.new(:data, @rows, column_aliases: %i[id name])
+
+          _(compile(values_table)).must_be_like %{
+            (SELECT "column1" AS "id", "column2" AS "name" FROM (VALUES (1, 'one'), (2, 'two'))) "data"
+          }
+        end
+
+        it "ignores column_types" do
+          values_table = Arel::ValuesTable.new(:data, @rows, column_types: @column_types)
+
+          _(compile(values_table)).must_be_like %{
+            (VALUES (1, 'one'), (2, 'two')) "data"
+          }
+        end
+      end
     end
   end
 end

--- a/activerecord/test/cases/relation/delegation_test.rb
+++ b/activerecord/test/cases/relation/delegation_test.rb
@@ -68,7 +68,7 @@ module ActiveRecord
         :find_or_create_by, :find_or_create_by!, :find_or_initialize_by,
         :create_or_find_by, :create_or_find_by!,
         :destroy, :destroy_all, :delete, :delete_all, :update_all, :touch_all, :delete_by, :destroy_by,
-        :insert, :insert_all, :insert!, :insert_all!, :upsert, :upsert_all,
+        :insert, :insert_all, :insert!, :insert_all!, :upsert, :upsert_all, :uniform_update_all,
       ]
 
     def test_delegate_querying_methods

--- a/activerecord/test/cases/uniform_update_all_test.rb
+++ b/activerecord/test/cases/uniform_update_all_test.rb
@@ -1,0 +1,541 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+require "models/admin"
+require "models/admin/user"
+require "models/admin/account"
+require "models/author"
+require "models/book"
+require "models/category"
+require "models/comment"
+require "models/cpk/car"
+require "models/developer"
+require "models/essay"
+require "models/pet"
+require "models/post"
+require "models/subscriber"
+require "models/subscription"
+require "models/tag"
+require "models/toy"
+
+class UniformUpdateAllTest < ActiveRecord::TestCase
+  fixtures :'admin/users', :books, :comments, :cpk_cars, :developers, :posts,
+    :taggings, :tags, :pets, :toys
+
+  def setup
+    Arel::Table.engine = nil # should not rely on the global Arel::Table.engine
+    @original_db_warnings_action = :ignore
+
+    skip unless ActiveRecord::Base.lease_connection.supports_derived_values_table?
+  end
+
+  def teardown
+    Arel::Table.engine = ActiveRecord::Base
+  end
+
+  def test_values_table_default_column_names_are_column1_column2
+    table = Arel::ValuesTable.new(:data, [[1, "one"], [2, "two"]])
+    sql = table.from.project(Arel.star).to_sql(ActiveRecord::Base)
+    result = ActiveRecord::Base.lease_connection.execute(sql)
+    fields = result.is_a?(Array) ? result[0].keys : result.fields
+
+    assert_equal ["column1", "column2"], fields
+  end
+
+  def test_uniform_update_all
+    Book.uniform_update_all [
+      [{ id: 1 }, { name: "Updated Book 1" }],
+      [{ id: 2 }, { name: "Updated Book 2" }]
+    ]
+
+    assert_equal "Updated Book 1", Book.find(1).name
+    assert_equal "Updated Book 2", Book.find(2).name
+  end
+
+  def test_uniform_update_all_by_primary_key
+    Book.uniform_update_all({
+      1 => { name: "Updated Book 1" },
+      2 => { name: "Updated Book 2" }
+    })
+
+    assert_equal "Updated Book 1", Book.find(1).name
+    assert_equal "Updated Book 2", Book.find(2).name
+  end
+
+  def test_uniform_update_all_by_primary_key_as_array
+    Book.uniform_update_all({
+      [1] => { name: "Updated Book 1" },
+      [2] => { name: "Updated Book 2" }
+    })
+
+    assert_equal "Updated Book 1", Book.find(1).name
+    assert_equal "Updated Book 2", Book.find(2).name
+  end
+
+  def test_uniform_update_all_without_conditions
+    assert_raises(IndexError) do
+      Book.uniform_update_all({ [] => { name: "Updated Book 1" } })
+    end
+    assert_raises(ArgumentError) do
+      Book.uniform_update_all [[{}, { name: "Updated Book 1" }]]
+    end
+  end
+
+  def test_uniform_update_all_without_values
+    assert_raises(ArgumentError) do
+      Book.uniform_update_all({ 1 => {} })
+    end
+    assert_raises(ArgumentError) do
+      Book.uniform_update_all [[{ id: 1 }, {}]]
+    end
+  end
+
+  def test_uniform_update_all_by_composite_primary_key
+    Cpk::Car.uniform_update_all({
+      ["Toyota", "Camry"] => { year: 2001 },
+      ["Honda", "Civic"]  => { year: 2002 },
+      ["Ford", "Civic"]   => { year: 2003 },
+      ["Toyota", "Prius"] => { year: 2004 }
+    })
+
+    assert_equal 2001, Cpk::Car.find(["Toyota", "Camry"]).year
+    assert_equal 2002, Cpk::Car.find(["Honda", "Civic"]).year
+    assert_equal 1964, Cpk::Car.find(["Ford", "Mustang"]).year
+  end
+
+  def test_uniform_update_all_with_multiple_conditions
+    Cpk::Car.uniform_update_all [
+      [{ make: "Toyota", model: "Camry" }, { year: 2001 }],
+      [{ make: "Honda", model: "Civic" },  { year: 2002 }],
+      [{ make: "Ford", model: "Civic" },   { year: 2003 }],
+      [{ make: "Toyota", model: "Prius" }, { year: 2004 }]
+    ]
+
+    assert_equal 2001, Cpk::Car.find(["Toyota", "Camry"]).year
+    assert_equal 2002, Cpk::Car.find(["Honda", "Civic"]).year
+    assert_equal 1964, Cpk::Car.find(["Ford", "Mustang"]).year
+  end
+
+  def test_uniform_update_all_performs_a_single_update
+    affected_rows = Cpk::Car.uniform_update_all({
+      ["Toyota", "Camry"] => { make: "Nissan", model: "Altima" },
+      ["Nissan", "Altima"] => { make: "Chevy", model: "Corvette" }
+    })
+
+    # if the updates were "chained" the result would be Chevy Corvette
+    car = Cpk::Car.find_by!(year: 1982)
+    assert_equal 1, affected_rows
+    assert_equal ["Nissan", "Altima"], [car.make, car.model]
+  end
+
+  def test_uniform_update_all_with_empty_updates
+    assert_no_queries do
+      assert_equal 0, Book.uniform_update_all([])
+      assert_equal 0, Book.uniform_update_all({})
+    end
+  end
+
+  def test_uniform_update_all_with_unknown_attribute_in_conditions
+    assert_raises(ActiveRecord::UnknownAttributeError) do
+      Book.uniform_update_all [[{ invalid_column: "David" }, { status: :written }]]
+    end
+  end
+
+  def test_uniform_update_all_with_unknown_attribute_in_values
+    assert_raises(ActiveRecord::UnknownAttributeError) do
+      Book.uniform_update_all [[{ id: 1 }, { invalid_column: "Invalid" }]]
+    end
+  end
+
+  def test_uniform_update_all_cannot_reference_joined_tables_in_conditions
+    assert_raises(ActiveRecord::UnknownAttributeError) do
+      Book.joins(:author).uniform_update_all [[{ "author.nick": "David" }, { status: :written }]]
+    end
+  end
+
+  def test_uniform_update_all_with_aliased_attributes
+    Book.uniform_update_all [
+      [{ id: 1 }, { title: "Updated Book 1" }],
+      [{ id: 2 }, { title: "Updated Book 2" }]
+    ]
+
+    assert_equal "Updated Book 1", Book.find(1).name
+    assert_equal "Updated Book 2", Book.find(2).name
+  end
+
+  def test_uniform_update_all_returns_number_of_rows_affected_across_all_value_rows
+    affected_rows = Comment.uniform_update_all [
+      [{ post_id: 1 }, { body: "A" }],
+      [{ post_id: 2 }, { body: "B" }],
+      [{ post_id: 4 }, { body: "C" }]
+    ]
+
+    comments = Comment.where(post_id: [1, 2, 4]).order(:post_id).group(:post_id, :body).pluck(:post_id, :body, Arel.star.count)
+    assert_equal 8, affected_rows
+    assert_equal [[1, "A", 2], [2, "B", 1], [4, "C", 5]], comments
+    assert_equal "go wild", Comment.find(11).body
+  end
+
+  def test_uniform_update_all_with_duplicate_keys_does_not_error
+    Book.uniform_update_all [
+      [{ id: 1 }, { name: "Reword" }],
+      [{ id: 1 }, { name: "Peopleware" }]
+    ]
+
+    assert_includes ["Reword", "Peopleware"], Book.find(1).name
+  end
+
+  def test_uniform_update_all_with_no_hits_does_not_error
+    affected_rows = Book.uniform_update_all [
+      [{ id: 1234 }, { name: "Reword" }],
+      [{ id: 4567 }, { name: "Peopleware" }]
+    ]
+
+    assert_equal 0, affected_rows
+  end
+
+  def test_uniform_update_all_conditions_are_and_combined
+    Comment.uniform_update_all [
+      [{ post_id: 4, type: "Comment" },        { body: "A" }],
+      [{ post_id: 4, type: "SpecialComment" }, { body: "B" }],
+      [{ post_id: 5, type: "SpecialComment" }, { body: "C" }]
+    ]
+
+    comments = Comment.where(body: ["A", "B", "C"]).pluck(:id, :body).sort
+    assert_equal [[6, "B"], [7, "B"], [8, "A"], [10, "C"]], comments
+  end
+
+  def test_uniform_update_all_supports_typecasting_for_rails_enums_and_booleans
+    Book.uniform_update_all({
+      1 => { cover: :hard,  status: :proposed,  boolean_status: :disabled,  author_id: "2" },
+      2 => { cover: "soft", status: :published, boolean_status: :enabled,   author_id: nil }
+    })
+
+    books = Book.where(id: 1..2).order(:id).pluck(:cover, :status, :boolean_status, :author_id)
+    assert_equal ["hard", "proposed", "disabled", 2], books[0]
+    assert_equal ["soft", "published", "enabled", nil], books[1]
+  end
+
+  def test_uniform_update_all_supports_typecasting_for_jsons
+    skip unless ActiveRecord::Base.connection.supports_json?
+
+    Admin::User.uniform_update_all [
+      [{ name: "David" }, { json_options: { color: "blue" } }],
+      [{ name: "Jamis" }, { json_options: { "width" => 1440 } }]
+    ]
+
+    assert_equal({ "color" => "blue" }, Admin::User.find_by(name: "David").json_options)
+    assert_equal({ "width" => 1440 }, Admin::User.find_by(name: "Jamis").json_options)
+  end
+
+  def test_uniform_update_all_does_not_support_referential_arel_sql_in_conditions
+    assert_raises(ActiveRecord::StatementInvalid) do
+      Comment.uniform_update_all [[{ parent_id: Arel.sql("comments.post_id") }, { body: "Root comment" }]]
+    end
+  end
+
+  def test_uniform_update_all_does_not_support_referential_arel_sql_in_values
+    assert_raises(ActiveRecord::StatementInvalid) do
+      Book.uniform_update_all [[{ name: "Jamis" }, { name: Arel.sql("UPPER(name)") }]]
+    end
+  end
+
+  def test_uniform_update_all_supports_non_referential_arel_sql_in_conditions
+    Comment.uniform_update_all [[{ id: Arel.sql("(SELECT id FROM books ORDER BY id ASC LIMIT 1)") }, { body: "First comment" }]]
+    assert_equal "First comment", Comment.find(1).body
+  end
+
+  def test_uniform_update_all_supports_non_referential_arel_sql_in_values
+    Comment.uniform_update_all [[{ id: 1 }, { body: Arel.sql("(SELECT name FROM books WHERE id = 1)") }]]
+    assert_equal "Agile Web Development with Rails", Comment.find(1).body
+  end
+
+  def test_uniform_update_all_timestamp_updates_are_wrapped_in_parentheses
+    assert_queries_match(/ = \(CASE/) do
+      Book.uniform_update_all({ 1 => { name: "Updated Book 1", status: :proposed } })
+    end
+  end
+
+  def test_uniform_update_all_large_input
+    Book.delete_all
+    Book.insert_all! (1..1001).map { |id| { id: id, name: Random.hex, status: %i[proposed written published].sample } }
+    names = Array.new(1001) { Random.hex }
+    Book.uniform_update_all((1..1001).zip(names.map { |name| { name: name, status: %i[proposed written published].sample } }).to_h)
+
+    assert_equal names[0...10], Book.order(:id).limit(10).pluck(:name)
+  end
+
+  def test_uniform_update_all_does_not_touch_updated_at_when_values_do_not_change
+    created_at = Time.now.utc - 8.years
+    updated_at = Time.now.utc - 5.years
+    Book.insert_all [{ id: 101, name: "Out of the Silent Planet", published_on: Date.new(1938, 4, 1), created_at: created_at, updated_at: updated_at }]
+    Book.uniform_update_all({ 101 => { name: "Out of the Silent Planet", published_on: Date.new(1938, 4, 1) } })
+
+    assert_in_delta updated_at, Book.find(101).updated_at, 1
+  end
+
+  def test_uniform_update_all_touches_updated_at_and_updated_on_and_not_created_at_when_values_change
+    Book.insert_all [{ id: 101, name: "Out of the Silent Planet", published_on: Date.new(1938, 4, 1), created_at: 8.years.ago, updated_at: 5.years.ago, updated_on: 5.years.ago }]
+    Book.uniform_update_all({ 101 => { name: "Out of the Silent Planet", published_on: Date.new(1938, 4, 8) } })
+
+    book = Book.find(101)
+    assert_equal 8.years.ago.year, book.created_at.year
+    assert_equal Time.now.utc.year, book.updated_at.year
+    assert_equal Time.now.utc.year, book.updated_on.year
+  end
+
+  def test_uniform_update_all_respects_updated_at_precision_when_touched_implicitly
+    Book.insert_all [{ id: 101, name: "Out of the Silent Planet", published_on: Date.new(1938, 4, 1), updated_at: 5.years.ago, updated_on: 5.years.ago }]
+
+    # A single update can occur exactly at the seconds boundary (when usec is naturally zero), so try multiple times.
+    has_subsecond_precision = (1..100).any? do |i|
+      Book.uniform_update_all({ 101 => { name: "Out of the Silent Planet (Edition #{i})" } })
+      Book.find(101).updated_at.usec > 0
+    end
+
+    assert has_subsecond_precision, "updated_at should have sub-second precision"
+  end
+
+  def test_uniform_update_all_respects_updated_at_precision_when_touched_explicitly
+    Book.insert_all [{ id: 101, name: "Out of the Silent Planet", published_on: Date.new(1938, 4, 1), updated_at: 5.years.ago, updated_on: 5.years.ago }]
+
+    # A single update can occur exactly at the seconds boundary (when usec is naturally zero), so try multiple times.
+    has_subsecond_precision = (1..100).any? do |i|
+      Book.uniform_update_all({ 101 => { name: "Out of the Silent Planet (Edition #{i})", updated_at: Time.now.utc, updated_on: Time.now.utc } })
+      Book.find(101).updated_at.usec > 0 && Book.find(101).updated_on == Time.now.to_date
+    end
+
+    assert has_subsecond_precision, "updated_at should have sub-second precision"
+  end
+
+  def test_uniform_update_all_uses_given_updated_at_over_implicit_updated_at
+    updated_at = Time.now.utc - 1.year
+    Book.insert_all [{ id: 101, name: "Out of the Silent Planet", published_on: Date.new(1938, 4, 1), updated_at: 5.years.ago }]
+    Book.uniform_update_all({ 101 => { name: "Out of the Silent Planet", published_on: Date.new(1938, 4, 8), updated_at: updated_at } })
+
+    assert_in_delta updated_at, Book.find(101).updated_at, 1
+  end
+
+  def test_uniform_update_all_uses_given_updated_on_over_implicit_updated_on
+    updated_on = Time.now.utc.to_date - 30
+    Book.insert_all [{ id: 101, name: "Out of the Silent Planet", published_on: Date.new(1938, 4, 1), updated_on: 5.years.ago }]
+    Book.uniform_update_all({ 101 => { name: "Out of the Silent Planet", published_on: Date.new(1938, 4, 8), updated_on: updated_on } })
+
+    assert_equal updated_on, Book.find(101).updated_on
+  end
+
+  def test_uniform_update_all_does_not_implicitly_set_timestamps_when_model_record_timestamps_is_true_but_overridden
+    with_record_timestamps(Book, true) do
+      Book.insert_all [{ id: 101, name: "Out of the Silent Planet", published_on: Date.new(1938, 4, 1), updated_at: 5.years.ago, updated_on: 5.years.ago }]
+      Book.uniform_update_all({ 101 => { name: "Out of the Silent Planet", published_on: Date.new(1938, 4, 8) } }, record_timestamps: false)
+
+      assert_in_delta 5.years.ago.year, Book.find(101).updated_at.year
+      assert_in_delta 5.years.ago.year, Book.find(101).updated_on.year
+    end
+  end
+
+  def test_uniform_update_all_does_not_implicitly_set_timestamps_when_model_record_timestamps_is_false
+    with_record_timestamps(Book, false) do
+      Book.insert_all [{ id: 101, name: "Out of the Silent Planet", published_on: Date.new(1938, 4, 1), updated_at: 5.years.ago, updated_on: 5.years.ago }]
+      Book.uniform_update_all({ 101 => { name: "Out of the Silent Planet", published_on: Date.new(1938, 4, 8) } })
+
+      assert_in_delta 5.years.ago.year, Book.find(101).updated_at.year
+      assert_in_delta 5.years.ago.year, Book.find(101).updated_on.year
+    end
+  end
+
+  def test_uniform_update_all_implicitly_sets_timestamps_when_model_record_timestamps_is_false_but_overridden
+    with_record_timestamps(Book, false) do
+      Book.insert_all [{ id: 101, name: "Out of the Silent Planet", published_on: Date.new(1938, 4, 1), updated_at: 5.years.ago, updated_on: 5.years.ago }]
+      Book.uniform_update_all({ 101 => { name: "Out of the Silent Planet", published_on: Date.new(1938, 4, 8) } }, record_timestamps: true)
+
+      assert_in_delta Time.now.utc, Book.find(101).updated_at, 1
+      assert_equal Time.now.utc.to_date, Book.find(101).updated_on, 1
+    end
+  end
+
+  def test_uniform_update_all_resets_relation
+    audit_logs = Developer.create!(name: "Alice").audit_logs.load
+
+    assert_changes "audit_logs.loaded?", from: true, to: false do
+      audit_logs.uniform_update_all({ 1 => { message: "event" } })
+    end
+  end
+
+  def test_uniform_update_all_does_not_reset_relation_if_updates_is_empty
+    audit_logs = Developer.create!(name: "Alice").audit_logs.load
+
+    assert_no_changes "audit_logs.loaded?" do
+      audit_logs.uniform_update_all({})
+    end
+  end
+
+  def test_uniform_update_all_on_has_many_relation
+    author = Author.create!(id: 123, name: "Jimmy")
+    author.books.insert_all! [
+      { id: 10, name: "Apple 1", status: :proposed },
+      { id: 11, name: "Apple 2", status: :written },
+      { id: 12, name: "Apple 3", status: :published }
+    ]
+
+    affected_rows = author.books.uniform_update_all [
+      [{ status: :proposed }, { name: "Banana 1" }],
+      [{ status: :written }, { name: "Banana 2" }]
+    ]
+    assert_equal 2, affected_rows
+    assert_equal ["Ruby for Rails", "proposed"], Book.find(2).values_at(:name, :status)
+    assert_equal ["Banana 1", "Banana 2", "Apple 3"], author.books.sort_by(&:id).map(&:name)
+  end
+
+  def test_uniform_update_all_with_group_by
+    minimum_comments_count = 2
+    good_post = Post.joins(:comments).group("posts.id").having("count(comments.id) < #{minimum_comments_count}").first.id
+    bad_post = Post.joins(:comments).group("posts.id").having("count(comments.id) >= #{minimum_comments_count}").first.id
+
+    assert_raises(NotImplementedError) do
+      Post.most_commented(minimum_comments_count).uniform_update_all({
+        good_post => { title: "ig" },
+        bad_post => { title: "ig" }
+      })
+    end
+    # assert_equal "ig", Post.find(good_post).title
+    # assert_not_equal "ig", Post.find(bad_post).title
+  end
+
+  def test_uniform_update_all_with_order_limit_offset
+    assert_raises(NotImplementedError) do
+      Post.where(id: 1..6).order(id: :desc).limit(2).offset(2).uniform_update_all([
+        [{ author_id: 0 }], { body: "ig0" },
+        [{ author_id: 1 }], { body: "ig1" }
+      ])
+    end
+    # assert_equal "ig0", Post.find(3).body
+    # assert_equal "ig1", Post.find(4).body
+    # assert_equal "hello", Post.find(5).body
+  end
+
+  def test_uniform_update_all_with_nil_primary_key
+    affected_rows = Book.uniform_update_all [
+      [{ id: 4 }, { name: "Reword" }],
+      [{ id: nil }, { name: "Peopleware" }]
+    ]
+
+    assert_equal 1, affected_rows
+    assert_not_includes Book.pluck(:name), "Peopleware"
+  end
+
+  def test_uniform_update_all_with_nil_composite_primary_key
+    affected_rows = Cpk::Car.uniform_update_all [
+      [{ make: "Toyota", model: "Camry" }, { year: 1024 }],
+      [{ make: "Honda",  model: nil },     { year: 1025 }]
+    ]
+
+    assert_equal 1, affected_rows
+    assert_not_includes Cpk::Car.pluck(:year), 1025
+  end
+
+  def test_uniform_update_all_with_sti_can_override_sti_type
+    Category.delete_all
+    Category.insert_all! [
+      { id: 1, name: "First", type: "SpecialCategory" },
+      { id: 2, name: "Second", type: "SpecialCategory" },
+      { id: 3, name: "Third", type: "Category" }
+    ]
+    SpecialCategory.uniform_update_all({
+      1 => { name: "1st", type: "SpecialCategory" },
+      2 => { name: "2nd", type: "Category" },
+      3 => { name: "3rd", type: "SpecialCategory" }
+    })
+
+    assert_equal ["1st", "2nd", "Third"], Category.order(:id).pluck(:name)
+    assert_equal ["SpecialCategory", "Category", "Category"], Category.order(:id).pluck(:type)
+  end
+
+  def test_uniform_update_all_logs_message_including_model_name
+    capture_log_output do |output|
+      Book.uniform_update_all({
+        1 => { name: "Updated Book 1" },
+        2 => { name: "Updated Book 2" }
+      })
+      assert_match "Book Uniform Update All", output.string
+    end
+  end
+
+  if current_adapter?(:Mysql2Adapter, :TrilogyAdapter)
+    def test_uniform_update_all_with_left_joins
+      pets = Pet.left_joins(:toys).where(toys: { name: ["Bone", nil] })
+
+      assert_equal true, pets.exists?
+      assert_equal 2, pets.uniform_update_all({
+        1 => { name: "Rex" },
+        2 => { name: "Rex" },
+        3 => { name: "Rex" }
+      })
+    end
+
+    def test_uniform_update_all_with_left_outer_joins
+      pets = Pet.left_outer_joins(:toys).where(toys: { name: ["Bone", nil] })
+
+      assert_equal true, pets.exists?
+      assert_equal 2, pets.uniform_update_all({
+        1 => { name: "Rex" },
+        2 => { name: "Rex" },
+        3 => { name: "Rex" }
+      })
+    end
+
+    def test_uniform_update_all_with_includes
+      pets = Pet.includes(:toys).where(toys: { name: "Bone" })
+
+      assert_equal true, pets.exists?
+      assert_equal 1, pets.uniform_update_all({
+        1 => { name: "Rex" },
+        2 => { name: "Rex" }
+      })
+    end
+
+    def test_uniform_update_all_with_scope
+      tag = Tag.first # posts: [1, 2]
+      Post.tagged_with(tag.id).uniform_update_all({
+        1 => { title: "first" },
+        2 => { title: "second" }
+      })
+
+      posts = Post.tagged_with(tag.id).all.to_a.sort_by(&:id)
+      assert_operator posts.length, :>, 0
+      assert_equal "first", posts[0].title
+      assert_equal "second", posts[1].title
+    end
+
+    def test_uniform_update_all_when_table_name_contains_database
+      database_name = Book.connection_db_config.database
+      Book.table_name = "#{database_name}.books"
+
+      assert_nothing_raised do
+        Book.uniform_update_all [[{ id: 1 }, { name: "Rework" }]]
+      end
+    ensure
+      Book.table_name = "books"
+    end
+  end
+
+  private
+    def capture_log_output
+      output = StringIO.new
+      old_logger, ActiveRecord::Base.logger = ActiveRecord::Base.logger, ActiveSupport::Logger.new(output)
+
+      begin
+        yield output
+      ensure
+        ActiveRecord::Base.logger = old_logger
+      end
+    end
+
+    def with_record_timestamps(model, value)
+      original = model.record_timestamps
+      model.record_timestamps = value
+      yield
+    ensure
+      model.record_timestamps = original
+    end
+end

--- a/activerecord/test/fixtures/cpk_cars.yml
+++ b/activerecord/test/fixtures/cpk_cars.yml
@@ -1,0 +1,17 @@
+_fixture:
+  model_class: Cpk::Car
+
+toyota:
+  make: Toyota
+  model: Camry
+  year: 1982
+
+honda:
+  make: Honda
+  model: Civic
+  year: 1972
+
+ford:
+  make: Ford
+  model: Mustang
+  year: 1964

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -309,6 +309,7 @@ ActiveRecord::Schema.define do
   create_table :cpk_cars, force: true, primary_key: [:make, :model] do |t|
     t.string :make, null: false
     t.string :model, null: false
+    t.integer :year, null: false, default: 0
   end
 
   create_table :cpk_car_reviews, force: true do |t|


### PR DESCRIPTION
### Motivation / Background

Rails lacks an abstraction to update many records in a table while setting different values for each one. Workarounds include using `Relation.upsert_all` with conflicting primary keys or multiple queries to update the records one by one.

This adds a method `Relation.uniform_update_all` which implements a limited version of this abstraction. The interface resembles `upsert_all` and does not instantiate records. The update query generated uses the pattern of joining with a handwritten [VALUES table](https://www.postgresql.org/docs/current/sql-values.html) that holds the row matching condition values and the assignment values. The construct is supported on all the engines with modest variation in syntax to account for typing and column aliasing.

### Detail

A simple example of the construct with a join on the primary key (postgres syntax):
```sql
UPDATE "books" SET "name" = "data"."column2"
  FROM (VALUES (1, "Reword"), (2, "Peopleware")) AS "data" ("column1", "column2")
  WHERE "books".id = "data"."column1";
```

It would be generated from this code:
```rb
# [[conditions, updates], ...] syntax
Book.uniform_update_all([
  [{ id: 1 }, { name: "Reword" }],
  [{ id: 2 }, { name: "Peopleware" }]
])

# shorthand syntax when conditions is the primary key
Book.uniform_update_all({
  1 => { name: "Reword" },
  2 => { name: "Peopleware" },
})
```

All rows of the `VALUES` table have identical schema, so we require that the conditions and assignments objects all have the same set of keys, just like `Relation.upsert_all` does.

Another example, here the conditions are not the primary key:
```rb
# one-shot migration to combine two columns into one
Book.uniform_update_all [
  [{ written: false, published: false }, { status: :proposed }],
  [{ written: true,  published: false }, { status: :written }],
  [{ written: true,  published: true },  { status: :published }]
]
```

An example of the construct from the postgres docs linked above, which this abstraction cannot assemble (non-trivial assignment and join):
```sql
UPDATE employees SET salary = salary * v.increase
  FROM (VALUES(1, 200000, 1.2), (2, 400000, 1.4)) AS v (depno, target, increase)
  WHERE employees.depno = v.depno AND employees.sales >= v.target;
```

### Additional information

Running `EXPLAIN` on all engines suggests they do run these queries as one would expect, using the correct index based on the join condition, but I have no benchmarks yet.

This was dependent on #53950 for postgres and sqlite, with the same caveats noted there. Since the derived table is mentioned in the `SET` clause, the query cannot have its join fully converted to a subquery, which is currently done when there are `order`, `limit`, `offset`, `group` or `having` clauses in the relation.

Bonus: the constraint that the assignment objects need to have the same keys can be lifted by introducing boolean columns to flag blank entries (or inplace `NULL` if none of the assignment values is `NULL`), this is not implemented:

```sql
UPDATE "products"
SET "price" = (CASE WHEN "data"."update_price" THEN "data"."price" ELSE "products"."price" END),
    "name"  = (CASE WHEN "data"."update_name"  THEN "data"."name"  ELSE "products"."name" END)
FROM (VALUES (1, 'Electronics', 199.99, NULL, TRUE, FALSE), (2, 'Books', NULL, 'New Book', FALSE, TRUE))
    AS "data" ("category_id", "type", "price", "name", "update_price", "update_name")
WHERE "products"."category_id" = "data"."category_id" AND "products"."type" = "data"."type";
```