### PR TITLE
docs: clarify async adapter limitation

### DIFF
--- a/guides/source/action_cable_overview.md
+++ b/guides/source/action_cable_overview.md
@@ -749,6 +749,8 @@ Below is a list of the subscription adapters available for end-users.
 
 The async adapter is intended for development/testing and should not be used in production.
 
+NOTE: The async adapter only works within the same process, so for manually triggering cable updates from a console and seeing results in the browser, you must do so from the web console (running inside the dev process), not a terminal started via `bin/rails console`! Add `console` to any action or any ERB template view to make the web console appear.
+
 ##### Redis Adapter
 
 The Redis adapter requires users to provide a URL pointing to the Redis server.


### PR DESCRIPTION
### Motivation / Background

When creating a new Rails 8.0.1 project, the generated cable.yml file includes the following warning:

```
# Async adapter only works within the same process, so for manually triggering cable updates from a console,
# and seeing results in the browser, you must do so from the web console (running inside the dev process),
# not a terminal started via bin/rails console! Add "console" to any action or any ERB template view
# to make the web console appear.
```

This Pull Request adds this valuable warning to the documentation.

Closes #54602

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
