### PR TITLE
Fix creating fsm visualizer with lazy routes

### DIFF
--- a/actionpack/lib/action_dispatch/journey/router.rb
+++ b/actionpack/lib/action_dispatch/journey/router.rb
@@ -98,24 +98,7 @@ module ActionDispatch
         end
       end
 
-      def visualizer
-        tt     = GTG::Builder.new(ast).transition_table
-        groups = partitioned_routes.first.map(&:ast).group_by(&:to_s)
-        asts   = groups.values.map(&:first)
-        tt.visualizer(asts)
-      end
-
       private
-        def partitioned_routes
-          routes.partition { |r|
-            r.path.anchored && r.path.requirements_anchored?
-          }
-        end
-
-        def ast
-          routes.ast
-        end
-
         def simulator
           routes.simulator
         end
@@ -125,7 +108,6 @@ module ActionDispatch
         end
 
         def filter_routes(path)
-          return [] unless ast
           simulator.memos(path) { [] }
         end
 

--- a/actionpack/lib/action_dispatch/journey/routes.rb
+++ b/actionpack/lib/action_dispatch/journey/routes.rb
@@ -72,6 +72,13 @@ module ActionDispatch
         route
       end
 
+      def visualizer
+        tt     = GTG::Builder.new(ast).transition_table
+        groups = anchored_routes.map(&:ast).group_by(&:to_s)
+        asts   = groups.values.map(&:first)
+        tt.visualizer(asts)
+      end
+
       private
         def clear_cache!
           @ast                = nil


### PR DESCRIPTION
Ref #54558 

Previously, the visualizer html could be created very simply with

```
$ rails runner "Rails.application.routes.router.visualizer" > viz.html
```

This doesn't work with `LazyRouteSet` because it doesn't trigger route loading when calling `router` (so the visualizer ends up displaying no routes). This could be fixed by added `router` to `LazyRouteSet`, but since `.router.visualizer` is undocumented I'd like to propose moving it to `Routes` instead. `LazyRouteSet#routes` already triggers loading routes, and `Router#visualizer` ended up delegating all of its logic to `Routes` anyways.

The command changes slightly, but remains as simple as before

```
$ rails runner "Rails.application.routes.routes.visualizer" > viz.html
```

This commit also includes two small changes along with the move.

The first is that `partitioned_routes` is replaced with `Routes#anchored_routes`. This is an improvement because `partitioned_routes` previously relied on `requirements_anchored?` which can't be called after `eager_load` (it uses the path's `Journey::Ast`, which is cleared on `eager_load`). `anchored_routes` get filtered with the same conditions as `partitioned_routes` except the filtering is done as `Route`s are added to `Routes`.

The other change is removing `return [] unless ast` from `Router#find_routes`. This is safe because `Routes#ast` already always returns a `Journey::Node` (and it enables removing `Router#ast` because `#find_routes` and `Router#visualizer` were the only two users of the method).