### PR TITLE
Remove redundant package install for shellcheck

### DIFF
--- a/.github/workflows/devcontainer-shellcheck.yml
+++ b/.github/workflows/devcontainer-shellcheck.yml
@@ -21,5 +21,4 @@ jobs:
 
       - name: Lint Devcontainer Scripts
         run: |
-          sudo apt install -y shellcheck
           find .devcontainer/ -name '*.sh' -print0 | xargs -0 shellcheck


### PR DESCRIPTION
Pre-installed on ubuntu-latest (aka 24.04):
https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md#installed-apt-packages

Follow up to #54569 /cc @byroot