### PR TITLE
Change proc to lambda in active record callback docs [ci skip]

### DIFF
--- a/guides/source/active_record_callbacks.md
+++ b/guides/source/active_record_callbacks.md
@@ -85,7 +85,7 @@ class User < ApplicationRecord
 end
 ```
 
-Alternatively, you can **pass a proc to the callback** to be triggered.
+Alternatively, you can **pass a lambda to the callback** to be triggered.
 
 ```ruby
 class User < ApplicationRecord


### PR DESCRIPTION
### Motivation / Background
This Pull Request has been created because the example of passing a proc to a callback is in fact a _lambda_ in the example provided in the code. The `->` is unique to lambdas in Ruby.
