### PR TITLE
activerecord: Don't always append primary keys etc. to order conditions

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   Allow bypassing primary key/constraint addition in `implicit_order_column`
+
+    When specifying multiple columns in an array for `implicit_order_column`, adding
+    `nil` as the last element will prevent appending the primary key to order
+    conditions. This allows more precise control of indexes used by
+    generated queries. It should be noted that this feature does introduce the risk
+    of API misbehavior if the specified columns are not fully unique.
+
+    *Issy Long*
+
 *   Allow setting the `schema_format` via database configuration.
 
     ```

--- a/activerecord/lib/active_record/model_schema.rb
+++ b/activerecord/lib/active_record/model_schema.rb
@@ -113,17 +113,19 @@ module ActiveRecord
     # :singleton-method: implicit_order_column
     # :call-seq: implicit_order_column
     #
-    # The name of the column records are ordered by if no explicit order clause
+    # The name of the column(s) records are ordered by if no explicit order clause
     # is used during an ordered finder call. If not set the primary key is used.
 
     ##
     # :singleton-method: implicit_order_column=
     # :call-seq: implicit_order_column=(column_name)
     #
-    # Sets the column to sort records by when no explicit order clause is used
-    # during an ordered finder call. Useful when the primary key is not an
-    # auto-incrementing integer, for example when it's a UUID. Records are subsorted
-    # by the primary key if it exists to ensure deterministic results.
+    # Sets the column(s) to sort records by when no explicit order clause is used
+    # during an ordered finder call. Useful for models where the primary key isn't an
+    # auto-incrementing integer (such as UUID).
+    #
+    # By default, records are subsorted by primary key to ensure deterministic results.
+    # To disable this subsort behavior, set `implicit_order_column` to `["column_name", nil]`.
 
     ##
     # :singleton-method: immutable_strings_by_default=

--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -646,16 +646,13 @@ module ActiveRecord
       end
 
       def _order_columns
-        oc = []
+        columns = Array(model.implicit_order_column)
 
-        oc << model.implicit_order_column if model.implicit_order_column
-        oc << model.query_constraints_list if model.query_constraints_list
+        return columns.compact if columns.length.positive? && columns.last.nil?
 
-        if model.primary_key && model.query_constraints_list.nil?
-          oc << model.primary_key
-        end
+        columns += Array(model.query_constraints_list || model.primary_key)
 
-        oc.flatten.uniq.compact
+        columns.uniq.compact
       end
   end
 end


### PR DESCRIPTION
### Motivation / Background

- If `nil` is the last element of an array passed to `implicit_order_column`, do not append the primary key or the query constraints. For example, `self.implicit_order_column = ["author_name", nil]` will generate `ORDER BY author_name DESC` and not `ORDER BY author_name DESC, id DESC` (with or without a LIMIT).

- There wasn't a test for `implicit_order_column` supporting arrays for ordering by multiple columns, so I added one.

### Detail

- The reasoning is that in some cases, like database sharding, the primary key is not the best column to order by for performance reasons and thus users should have the choice of whether to append it by default.

### Additional information

/cc @matthewd 

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
