### PR TITLE
Add anchor links to FormOptionsHelper [ci skip]

### DIFF
--- a/actionview/lib/action_view/helpers/form_options_helper.rb
+++ b/actionview/lib/action_view/helpers/form_options_helper.rb
@@ -13,7 +13,7 @@ module ActionView
     #
     # Provides a number of methods for turning different kinds of containers into a set of option tags.
     #
-    # The <tt>collection_select</tt>, <tt>select</tt> and <tt>time_zone_select</tt> methods take an <tt>options</tt> parameter, a hash:
+    # The #collection_select, #select and #time_zone_select methods take an <tt>options</tt> parameter, a hash:
     #
     # * <tt>:include_blank</tt> - set to true or a prompt string if the first option element of the select element is a blank. Useful if there is not a default value required for the select element.
     #
@@ -55,7 +55,7 @@ module ActionView
     #       <option value="3">Rafael</option>
     #     </select>
     #
-    # * <tt>:index</tt> - like the other form helpers, <tt>select</tt> can accept an <tt>:index</tt> option to manually set the ID used in the resulting output. Unlike other helpers, <tt>select</tt> expects this
+    # * <tt>:index</tt> - like the other form helpers, #select can accept an <tt>:index</tt> option to manually set the ID used in the resulting output. Unlike other helpers, #select expects this
     #   option to be in the +html_options+ parameter.
     #
     #     select("album[]", :genre, %w[ rap rock country ], {}, { index: nil })
@@ -80,7 +80,7 @@ module ActionView
     #       <option disabled="disabled" value="restricted">restricted</option>
     #     </select>
     #
-    #   When used with the <tt>collection_select</tt> helper, <tt>:disabled</tt> can also be a Proc that identifies those options that should be disabled.
+    #   When used with the #collection_select helper, <tt>:disabled</tt> can also be a Proc that identifies those options that should be disabled.
     #
     #     collection_select(:post, :category_id, Category.all, :id, :name, { disabled: -> (category) { category.archived? } })
     #
@@ -126,7 +126,7 @@ module ActionView
       # or <tt>selected: nil</tt> to leave all options unselected. Similarly, you can specify values to be disabled in the option
       # tags by specifying the <tt>:disabled</tt> option. This can either be a single value or an array of values to be disabled.
       #
-      # A block can be passed to +select+ to customize how the options tags will be rendered. This
+      # A block can be passed to #select to customize how the options tags will be rendered. This
       # is useful when the options tag has complex attributes.
       #
       #   select(report, :campaign_ids) do
@@ -265,7 +265,7 @@ module ActionView
       # In addition to the <tt>:include_blank</tt> option documented above,
       # this method also supports a <tt>:model</tt> option, which defaults
       # to ActiveSupport::TimeZone. This may be used by users to specify a
-      # different time zone model object. (See +time_zone_options_for_select+
+      # different time zone model object. (See #time_zone_options_for_select
       # for more information.)
       #
       # You can also supply an array of ActiveSupport::TimeZone objects
@@ -294,7 +294,7 @@ module ActionView
       end
 
       # Returns select and option tags for the given object and method, using
-      # <tt>weekday_options_for_select</tt> to generate the list of option tags.
+      # #weekday_options_for_select to generate the list of option tags.
       def weekday_select(object, method, options = {}, html_options = {}, &block)
         Tags::WeekdaySelect.new(object, method, self, options, html_options, &block).render
       end
@@ -411,7 +411,7 @@ module ActionView
         options_for_select(options, select_deselect)
       end
 
-      # Returns a string of <tt><option></tt> tags, like <tt>options_from_collection_for_select</tt>, but
+      # Returns a string of <tt><option></tt> tags, like #options_from_collection_for_select, but
       # groups them by <tt><optgroup></tt> tags based on the object relationships of the arguments.
       #
       # Parameters:
@@ -468,7 +468,7 @@ module ActionView
         end.join.html_safe
       end
 
-      # Returns a string of <tt><option></tt> tags, like <tt>options_for_select</tt>, but
+      # Returns a string of <tt><option></tt> tags, like #options_for_select, but
       # wraps them with <tt><optgroup></tt> tags:
       #
       #   grouped_options = [


### PR DESCRIPTION
The documentation in lib/action_view/helpers/form_options_helper.rb has many references to methods in the same file.

This commit improves the documentation so those references are anchor links.

![Image](https://github.com/user-attachments/assets/57b111a4-9c49-4540-81e1-192f6f009756)

