### PR TITLE
Don't deserialize mutable defaults

### DIFF
--- a/activerecord/lib/active_record/attributes.rb
+++ b/activerecord/lib/active_record/attributes.rb
@@ -244,10 +244,7 @@ module ActiveRecord
           # TODO: Remove the need for a connection after we release 8.1.
           attributes_hash = with_connection do |connection|
             columns_hash.transform_values do |column|
-              type = type_for_column(connection, column)
-              default = column.default
-              default = type.deserialize(default) unless default.nil?
-              ActiveModel::Attribute.from_database(column.name, default, type)
+              ActiveModel::Attribute.from_database(column.name, column.default, type_for_column(connection, column))
             end
           end
 

--- a/activerecord/lib/active_record/connection_adapters/column.rb
+++ b/activerecord/lib/active_record/connection_adapters/column.rb
@@ -22,7 +22,7 @@ module ActiveRecord
         @cast_type = cast_type
         @sql_type_metadata = sql_type_metadata
         @null = null
-        @default = default
+        @default = default.nil? || cast_type.mutable? ? default : cast_type.deserialize(default)
         @default_function = default_function
         @collation = collation
         @comment = comment
@@ -117,7 +117,7 @@ module ActiveRecord
         def deduplicated
           @name = -name
           @sql_type_metadata = sql_type_metadata.deduplicate if sql_type_metadata
-          @default = -default if default
+          @default = -default if String === default
           @default_function = -default_function if default_function
           @collation = -collation if collation
           @comment = -comment if comment

--- a/activerecord/test/cases/adapters/postgresql/geometric_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/geometric_test.rb
@@ -131,11 +131,11 @@ class PostgresqlPointTest < ActiveRecord::PostgreSQLTestCase
   end
 
   def test_legacy_default
-    assert_equal ActiveRecord::Point.new(12.2, 13.3), PostgresqlPoint.column_defaults["legacy_y"]
-    assert_equal ActiveRecord::Point.new(12.2, 13.3), PostgresqlPoint.new.legacy_y
+    assert_equal [12.2, 13.3], PostgresqlPoint.column_defaults["legacy_y"]
+    assert_equal [12.2, 13.3], PostgresqlPoint.new.legacy_y
 
-    assert_equal ActiveRecord::Point.new(14.4, 15.5), PostgresqlPoint.column_defaults["legacy_z"]
-    assert_equal ActiveRecord::Point.new(14.4, 15.5), PostgresqlPoint.new.legacy_z
+    assert_equal [14.4, 15.5], PostgresqlPoint.column_defaults["legacy_z"]
+    assert_equal [14.4, 15.5], PostgresqlPoint.new.legacy_z
   end
 
   def test_legacy_schema_dumping

--- a/activerecord/test/cases/adapters/postgresql/json_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/json_test.rb
@@ -10,6 +10,7 @@ module PostgresqlJSONSharedTestCases
     super
     @connection.create_table("json_data_type") do |t|
       t.public_send column_type, "payload", default: {} # t.json 'payload', default: {}
+      t.public_send column_type, "with_defaults", default: { list: [] }
       t.public_send column_type, "settings"             # t.json 'settings'
       t.public_send column_type, "objects", array: true # t.json 'objects', array: true
     end
@@ -23,6 +24,10 @@ module PostgresqlJSONSharedTestCases
 
     assert_equal({ "users" => "read", "posts" => ["read", "write"] }, klass.column_defaults["permissions"])
     assert_equal({ "users" => "read", "posts" => ["read", "write"] }, klass.new.permissions)
+  end
+
+  def test_default_before_type_cast
+    assert_equal '{"list":[]}', klass.new.with_defaults_before_type_cast.gsub(" ", "")
   end
 
   def test_deserialize_with_array

--- a/activerecord/test/cases/adapters/sqlite3/json_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/json_test.rb
@@ -10,6 +10,7 @@ class SQLite3JSONTest < ActiveRecord::SQLite3TestCase
     super
     @connection.create_table("json_data_type") do |t|
       t.json "payload", default: {}
+      t.json "with_defaults", default: { list: [] }
       t.json "settings"
     end
   end
@@ -20,6 +21,10 @@ class SQLite3JSONTest < ActiveRecord::SQLite3TestCase
 
     assert_equal({ "users" => "read", "posts" => ["read", "write"] }, klass.column_defaults["permissions"])
     assert_equal({ "users" => "read", "posts" => ["read", "write"] }, klass.new.permissions)
+  end
+
+  def test_default_before_type_cast
+    assert_equal '{"list":[]}', klass.new.with_defaults_before_type_cast
   end
 
   private

--- a/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
@@ -636,7 +636,7 @@ module ActiveRecord
           column = @conn.columns("ex").find { |x|
             x.name == "number"
           }
-          assert_equal "10", column.default
+          assert_equal 10, column.default
         end
       end
 

--- a/activerecord/test/cases/migration/change_schema_test.rb
+++ b/activerecord/test/cases/migration/change_schema_test.rb
@@ -72,7 +72,7 @@ module ActiveRecord
         assert_equal "hello", one.default
         assert_equal true, two.fetch_cast_type(connection).deserialize(two.default)
         assert_equal false, three.fetch_cast_type(connection).deserialize(three.default)
-        assert_equal "1", four.default
+        assert_equal 1, four.default
         assert_equal "hello", five.default unless mysql
       end
 

--- a/activerecord/test/cases/migration/columns_test.rb
+++ b/activerecord/test/cases/migration/columns_test.rb
@@ -55,13 +55,13 @@ module ActiveRecord
         add_column "test_models", "salary", :integer, default: 70000
 
         default_before = connection.columns("test_models").find { |c| c.name == "salary" }.default
-        assert_equal "70000", default_before
+        assert_equal 70000, default_before
 
         rename_column "test_models", "salary", "annual_salary"
 
         assert_includes TestModel.column_names, "annual_salary"
         default_after = connection.columns("test_models").find { |c| c.name == "annual_salary" }.default
-        assert_equal "70000", default_after
+        assert_equal 70000, default_after
       end
 
       if current_adapter?(:Mysql2Adapter, :TrilogyAdapter)

--- a/activerecord/test/cases/migration_test.rb
+++ b/activerecord/test/cases/migration_test.rb
@@ -1254,7 +1254,7 @@ if ActiveRecord::Base.lease_connection.supports_bulk_alter?
 
       assert_equal 8, columns.size
       [:name, :qualification, :experience].each { |s| assert_equal :string, column(s).type }
-      assert_equal "0", column(:age).default
+      assert_equal 0, column(:age).default
       assert_equal "This is a comment", column(:birthdate).comment
     end
 


### PR DESCRIPTION
Fix: https://github.com/rails/rails/issues/54681
Followup: https://github.com/rails/rails/pull/54585

We can't deserialize mutable types because otherwise mutations would leak, or we'd need to deep dup them. It's more efficient to keep them serialized in default.

However for immutable types like Integer, it's both faster and more correct to eagerly deserialize them.
