### PR TITLE
Fix capture view helper to pass keyword arguments

### DIFF
--- a/actionview/lib/action_view/helpers/capture_helper.rb
+++ b/actionview/lib/action_view/helpers/capture_helper.rb
@@ -44,10 +44,10 @@ module ActionView
       #
       #   @greeting # => "Welcome to my shiny new web page! The date and time is 2018-09-06 11:09:16 -0500"
       #
-      def capture(*args, &block)
+      def capture(*, **, &block)
         value = nil
         @output_buffer ||= ActionView::OutputBuffer.new
-        buffer = @output_buffer.capture { value = yield(*args) }
+        buffer = @output_buffer.capture { value = yield(*, **) }
 
         string = if @output_buffer.equal?(value)
           buffer

--- a/actionview/test/template/capture_helper_test.rb
+++ b/actionview/test/template/capture_helper_test.rb
@@ -26,6 +26,13 @@ class CaptureHelperTest < ActionView::TestCase
     assert_equal "foobar", string
   end
 
+  def test_capture_with_keyword_arguments
+    string = @av.capture("foo", b: "bar") do |a, b:|
+      a + b
+    end
+    assert_equal "foobar", string
+  end
+
   def test_capture_returns_nil_if_the_returned_value_is_not_a_string
     assert_nil @av.capture { 1 }
   end


### PR DESCRIPTION
This is a very small fix that allows using blocks that have keyword arguments with `capture` by passing them on.

To reproduce the issue you can simply add `capture(arg: 1, &(->(arg:){ }))` to any view

Should I add a test case and changelog?
