### PR TITLE
Generate mailer files in auth generator only if ActionMailer is used

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Skip generating mailer-related files in authentication generator if the application does
+    not use ActionMailer
+
+    *Rami Massoud*
+
 *   Introduce `bin/ci` for running your tests, style checks, and security audits locally or in the cloud.
 
     The specific steps are defined by a new DSL in `config/ci.rb`.

--- a/railties/lib/rails/generators/rails/authentication/authentication_generator.rb
+++ b/railties/lib/rails/generators/rails/authentication/authentication_generator.rb
@@ -25,12 +25,15 @@ module Rails
 
         template "app/channels/application_cable/connection.rb" if defined?(ActionCable::Engine)
 
-        template "app/mailers/passwords_mailer.rb"
+        if defined?(ActionMailer::Railtie)
+          template "app/mailers/passwords_mailer.rb"
 
-        template "app/views/passwords_mailer/reset.html.erb"
-        template "app/views/passwords_mailer/reset.text.erb"
+          template "app/views/passwords_mailer/reset.html.erb"
+          template "app/views/passwords_mailer/reset.text.erb"
 
-        template "test/mailers/previews/passwords_mailer_preview.rb"
+          template "test/mailers/previews/passwords_mailer_preview.rb"
+        end
+
         template "test/test_helpers/session_test_helper.rb"
       end
 

--- a/railties/lib/rails/generators/rails/authentication/templates/app/controllers/passwords_controller.rb.tt
+++ b/railties/lib/rails/generators/rails/authentication/templates/app/controllers/passwords_controller.rb.tt
@@ -1,10 +1,13 @@
 class PasswordsController < ApplicationController
   allow_unauthenticated_access
   before_action :set_user_by_token, only: %i[ edit update ]
+  <% if defined?(ActionMailer::Railtie) -%>
   rate_limit to: 10, within: 3.minutes, only: :create, with: -> { redirect_to new_password_path, alert: "Try again later." }
+  <% end -%>
 
   def new
   end
+  <% if defined?(ActionMailer::Railtie) -%>
 
   def create
     if user = User.find_by(email_address: params[:email_address])
@@ -13,6 +16,7 @@ class PasswordsController < ApplicationController
 
     redirect_to new_session_path, notice: "Password reset instructions sent (if user with that email address exists)."
   end
+  <% end -%>
 
   def edit
   end

--- a/railties/test/generators/authentication_generator_test.rb
+++ b/railties/test/generators/authentication_generator_test.rb
@@ -138,6 +138,26 @@ class AuthenticationGeneratorTest < Rails::Generators::TestCase
     ActionCable.const_set(:Engine, old_value)
   end
 
+  def test_authentication_generator_without_action_mailer
+    old_value = ActionMailer.const_get(:Railtie)
+    ActionMailer.send(:remove_const, :Railtie)
+    generator([destination_root])
+    run_generator_instance
+
+    assert_no_file "app/mailers/application_mailer.rb"
+    assert_no_file "app/mailers/passwords_mailer.rb"
+    assert_no_file "app/views/passwords_mailer/reset.html.erb"
+    assert_no_file "app/views/passwords_mailer/reset.text.erb"
+    assert_no_file "test/mailers/previews/passwords_mailer_preview.rb"
+
+    assert_file "app/controllers/passwords_controller.rb" do |content|
+      assert_no_match(/def create\n    end/, content)
+      assert_no_match(/rate_limit/, content)
+    end
+  ensure
+    ActionCable.const_set(:Railtie, old_value)
+  end
+
   private
     def run_generator_instance
       @bundle_commands = []


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because if the authentication generator is run in an app created with `--skip-action-mailer`, the app will be silently broken. When deployed to an environment where `eager_load` is true, the app will fail to start as the generated `PasswordMailer` inherits from a nonexistent `ApplicationMailer`.

Fixes #54501 

### Detail

This Pull Request changes the authentication generator to skip all of the mailer-related files if `ActionMailer` is not defined. Also leave `PasswordsController#create` as blank to be implemented by the user.

### Additional information

In my use case, a simple login was enough, and I created user(s) manually in a console. I do not need a password reset flow. An alternative approach would be to require an app to have `ActionMailer` to run the generator.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
