### PR TITLE
Stop generating bundler binstub:

### DIFF
--- a/guides/source/working_with_javascript_in_rails.md
+++ b/guides/source/working_with_javascript_in_rails.md
@@ -37,7 +37,7 @@ When using import maps, no separate build process is required, just start your s
 Importmap for Rails is automatically included in Rails 7+ for new applications, but you can also install it manually in existing applications:
 
 ```bash
-$ bin/bundle add importmap-rails
+$ bundle add importmap-rails
 ```
 
 Run the install task:

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Rails no longer generates a `bin/bundle` binstub when creating new applications.
+
+    The `bin/bundle` binstub used to help activate the right version of bundler.
+    This is no longer necessary as this mechanism is now part of Rubygem itself.
+
+    *Edouard Chin*
+
 *   Add a `SessionTestHelper` module with `sign_in_as(user)` and `sign_out` test helpers when
     running `rails g authentication`. Simplifies authentication in integration tests.
 

--- a/railties/lib/rails/generators/bundle_helper.rb
+++ b/railties/lib/rails/generators/bundle_helper.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module Rails
+  module Generators
+    module BundleHelper # :nodoc:
+      def bundle_command(command, env = {}, params = {})
+        say_status :run, "bundle #{command}"
+
+        # We are going to shell out rather than invoking Bundler::CLI.new(command)
+        # because `rails new` loads the Thor gem and on the other hand bundler uses
+        # its own vendored Thor, which could be a different version. Running both
+        # things in the same process is a recipe for a night with paracetamol.
+        #
+        # Thanks to James Tucker for the Gem tricks involved in this call.
+        _bundle_command = Gem.bin_path("bundler", "bundle")
+
+        require "bundler"
+        Bundler.with_original_env do
+          exec_bundle_command(_bundle_command, command, env, params)
+        end
+      end
+
+      private
+        def exec_bundle_command(bundle_command, command, env, params)
+          full_command = %Q["#{Gem.ruby}" "#{bundle_command}" #{command}]
+          if options[:quiet] || params[:quiet]
+            system(env, full_command, out: File::NULL)
+          else
+            system(env, full_command)
+          end
+        end
+    end
+  end
+end

--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -570,7 +570,6 @@ module Rails
       public_task :apply_rails_template
       public_task :run_bundle
       public_task :add_bundler_platforms
-      public_task :generate_bundler_binstub
       public_task :run_javascript
       public_task :run_hotwire
       public_task :run_css

--- a/railties/lib/rails/generators/rails/authentication/authentication_generator.rb
+++ b/railties/lib/rails/generators/rails/authentication/authentication_generator.rb
@@ -1,8 +1,12 @@
 # frozen_string_literal: true
 
+require "rails/generators/bundle_helper"
+
 module Rails
   module Generators
     class AuthenticationGenerator < Base # :nodoc:
+      include BundleHelper
+
       class_option :api, type: :boolean,
         desc: "Generate API-only controllers and models, with no view templates"
 
@@ -42,9 +46,9 @@ module Rails
       def enable_bcrypt
         if File.read(File.expand_path("Gemfile", destination_root)).include?('gem "bcrypt"')
           uncomment_lines "Gemfile", /gem "bcrypt"/
-          Bundler.with_original_env { execute_command :bundle, "install --quiet" }
+          bundle_command("install --quiet")
         else
-          Bundler.with_original_env { execute_command :bundle, "add bcrypt", capture: true }
+          bundle_command("add bcrypt", {}, quiet: true)
         end
       end
 

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -829,13 +829,6 @@ class AppGeneratorTest < Rails::Generators::TestCase
     end
   end
 
-  def test_bundler_binstub
-    generator([destination_root])
-    run_generator_instance
-
-    assert_equal 1, @bundle_commands.count("binstubs bundler")
-  end
-
   def test_skip_active_job_option
     run_generator [destination_root, "--skip-active-job"]
 

--- a/railties/test/generators/authentication_generator_test.rb
+++ b/railties/test/generators/authentication_generator_test.rb
@@ -75,7 +75,7 @@ class AuthenticationGeneratorTest < Rails::Generators::TestCase
 
     run_generator_instance
 
-    assert_includes @bundle_commands, [:bundle, "add bcrypt", { capture: true }]
+    assert_includes @bundle_commands, ["add bcrypt", {}, { quiet: true }]
   end
 
   def test_authentication_generator_with_api_flag
@@ -139,20 +139,18 @@ class AuthenticationGeneratorTest < Rails::Generators::TestCase
 
   private
     def run_generator_instance
-      commands = []
-      command_stub ||= -> (command, *args) { commands << [command, *args] }
+      @bundle_commands = []
+      command_stub ||= -> (command, *args) { @bundle_commands << [command, *args] }
 
       @rails_commands = []
       @rails_command_stub ||= -> (command, *_) { @rails_commands << command }
 
       content = nil
-      generator.stub(:execute_command, command_stub) do
+      generator.stub(:bundle_command, command_stub) do
         generator.stub(:rails_command, @rails_command_stub) do
           content = super
         end
       end
-
-      @bundle_commands = commands.filter { |command, _| command == :bundle }
 
       content
     end


### PR DESCRIPTION
### Motivation / Background

- Fix #54563
- Prevent `rails new` from throwing a warning and `bin/rails g authentication` from crashing when Bundler cuts a new release.

### Detail

In a future version of Bundler, running `bundle binstub bundler` will no longer generate a `bin/bundle` binstub. The reason for this change upstream is well explained in https://github.com/rubygems/rubygems/pull/8345.

#### Problem

When the change in Bundler is cut into a release, generating new rails application will throw a Bundler warning, and the AuthenticationGenerator which makes use of `bin/bundle` will stop working.

#### Solution

Stop generating a bundler binstub and modify the generator to use the same bundler command as the rest of the codebase.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
