### PR TITLE
Fix channel generator import statement:

### DIFF
--- a/actioncable/lib/rails/generators/channel/channel_generator.rb
+++ b/actioncable/lib/rails/generators/channel/channel_generator.rb
@@ -59,17 +59,17 @@ module Rails
         def create_channel_javascript_file
           channel_js_path = File.join("app/javascript/channels", class_path, "#{file_name}_channel")
           js_template "javascript/channel", channel_js_path
-          gsub_file "#{channel_js_path}.js", /\.\/consumer/, "channels/consumer" unless using_js_runtime?
+          gsub_file "#{channel_js_path}.js", /\.\/consumer/, "channels/consumer" if using_importmap?
         end
 
         def import_channels_in_javascript_entrypoint
           append_to_file "app/javascript/application.js",
-            using_js_runtime? ? %(import "./channels"\n) : %(import "channels"\n)
+            using_importmap? ? %(import "channels"\n) : %(import "./channels"\n)
         end
 
         def import_channel_in_javascript_entrypoint
           append_to_file "app/javascript/channels/index.js",
-            using_js_runtime? ? %(import "./#{file_name}_channel"\n) : %(import "channels/#{file_name}_channel"\n)
+            using_importmap? ? %(import "channels/#{file_name}_channel"\n) : %(import "./#{file_name}_channel"\n)
         end
 
         def install_javascript_dependencies

--- a/railties/test/generators/channel_generator_test.rb
+++ b/railties/test/generators/channel_generator_test.rb
@@ -78,6 +78,16 @@ class ChannelGeneratorTest < Rails::Generators::TestCase
     end
   end
 
+  test "import channels in javascript entrypoint when using a css processor" do
+    FileUtils.touch("#{destination_root}/package.json")
+
+    run_generator ["books"]
+
+    assert_file "app/javascript/application.js" do |entrypoint|
+      assert_match %r|import "channels"|, entrypoint
+    end
+  end
+
   test "import channels in javascript entrypoint under node" do
     use_under_node
     generator(["chat"]).stub(:install_javascript_dependencies, true) do


### PR DESCRIPTION
### Motivation / Background

Fix #54241

### Detail

#### Problem

The `import` statement generated is incorrect for Rails applications using importmap and a css processor.

#### Context

Rails applications using `importmap` and having a `package.json`, would get a `channel.js` file generated with a relative path, whereas the correct import statement needs to match the name of the importmap json keys.

This is because the generator assumes that if a `package.json` exists in the project, this means it uses a javascript bundling tool. This assumption is not correct as one can be using importmap while still having `package.json` for processing css. This is the case when you generate your application like this: `rails new blorgh --css postcss`

#### Solution

Add the right import statement by checking if the project uses importmap.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
