### PR TITLE
Enable `MYSQL_CODESPACES` environment variable in the devcontainer

### DIFF
--- a/.devcontainer/boot.sh
+++ b/.devcontainer/boot.sh
@@ -14,4 +14,4 @@ cd activerecord || { echo "activerecord directory doesn't exist"; exit; }
 bundle exec rake db:postgresql:rebuild
 
 # Create MySQL databases
-MYSQL_CODESPACES=1 bundle exec rake db:mysql:rebuild
+bundle exec rake db:mysql:rebuild

--- a/.devcontainer/compose.yaml
+++ b/.devcontainer/compose.yaml
@@ -16,6 +16,9 @@ services:
       - redis
       - memcached
 
+    environment:
+      MYSQL_CODESPACES: "1"
+
     # Use "forwardPorts" in **devcontainer.json** to forward an app port locally.
     # (Adding the "ports" property to this file will not forward from a Codespace.)
 

--- a/railties/test/isolation/abstract_unit.rb
+++ b/railties/test/isolation/abstract_unit.rb
@@ -539,6 +539,9 @@ module TestHelpers
             adapter: mysql2
             pool: 5
             username: root
+          <% if ENV['MYSQL_CODESPACES'] %>
+            password: 'root'
+          <% end %>
           <% if ENV['MYSQL_HOST'] %>
             host: <%= ENV['MYSQL_HOST'] %>
           <% end %>
@@ -562,6 +565,9 @@ module TestHelpers
             adapter: mysql2
             pool: 5
             username: root
+          <% if ENV['MYSQL_CODESPACES'] %>
+            password: 'root'
+          <% end %>
           <% if ENV['MYSQL_HOST'] %>
             host: <%= ENV['MYSQL_HOST'] %>
           <% end %>


### PR DESCRIPTION
### Motivation / Background

This commit addresses the following error because it creates database as a root user without a password.

### Detail
In the devcontainer, the root password is set to `root` in the `docker-compose.yaml` file.

https://github.com/rails/rails/blob/78de0fae2289e47738441549aa80451875a8b4bc/.devcontainer/compose.yaml#L37-L38

- Error addressed by this commit:
```ruby
$ cd railties
$ bin/test test/application/test_runner_test.rb -n test_parallel_testing_when_schema_is_not_up_to_date
Run options: -n test_parallel_testing_when_schema_is_not_up_to_date --seed 56426

E

Error:
ApplicationTests::TestRunnerTest#test_parallel_testing_when_schema_is_not_up_to_date:
RuntimeError: rails command failed (1): bin/rails db:create 2>&1
/home/vscode/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/rake-13.2.1/lib/rake/application.rb:717: warning: conflicting chdir during another chdir block
/workspaces/rails/railties/test/application/test_runner_test.rb:828: note: previous chdir was here
/home/vscode/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/rake-13.2.1/lib/rake/application.rb:738: warning: conflicting chdir during another chdir block
/workspaces/rails/railties/test/application/test_runner_test.rb:828: note: previous chdir was here
There is an issue connecting to your database with your username/password, username: root.

Please check your database configuration to ensure the username/password are valid.
Couldn't create 'railties_5059_development' database. Please check your configuration.
bin/rails aborted!
ActiveRecord::DatabaseConnectionError: There is an issue connecting to your database with your username/password, username: root. (ActiveRecord::DatabaseConnectionError)

Please check your database configuration to ensure the username/password are valid.
/workspaces/rails/tmp/d20250305-5059-hve3ds/app/bin/rails:4:in '<top (required)>'

Caused by:
Mysql2::Error::ConnectionError: Access denied for user 'root'@'172.18.0.6' (using password: NO) (Mysql2::Error::ConnectionError)
/workspaces/rails/tmp/d20250305-5059-hve3ds/app/bin/rails:4:in '<top (required)>'
Tasks: TOP => db:create
(See full trace by running task with --trace)

    test/isolation/abstract_unit.rb:420:in 'TestHelpers::Generation#rails'
    test/application/test_runner_test.rb:834:in 'block in ApplicationTests::TestRunnerTest#test_parallel_testing_when_schema_is_not_up_to_date'
    test/application/test_runner_test.rb:828:in 'Dir.chdir'
    test/application/test_runner_test.rb:828:in 'ApplicationTests::TestRunnerTest#test_parallel_testing_when_schema_is_not_up_to_date'

bin/test test/application/test_runner_test.rb:826

Finished in 4.847434s, 0.2063 runs/s, 0.0000 assertions/s.
1 runs, 0 assertions, 0 failures, 1 errors, 0 skips
$
```

### Additional information

No need to set MYSQL_CODESPACES explicitly in the boot.sh script that allows users to run `exec rake db:mysql:rebuild` in the devcontainer without setting MYSQL_CODESPACES in the command line.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
