### PR TITLE
[ci skip]Fix the incorrect version where `allow_browser` was added in the guide

### DIFF
--- a/guides/source/action_controller_advanced_topics.md
+++ b/guides/source/action_controller_advanced_topics.md
@@ -101,7 +101,7 @@ in the [Security Guide](security.html#cross-site-request-forgery-csrf).
 Controlling Allowed Browser Versions
 ------------------------------------
 
-Starting with version 8.0, Rails controllers use [`allow_browser`](https://api.rubyonrails.org/classes/ActionController/AllowBrowser/ClassMethods.html#method-i-allow_browser) method in `ApplicationController` to allow only modern browsers by default.
+Starting with version 7.2, Rails controllers use [`allow_browser`](https://api.rubyonrails.org/classes/ActionController/AllowBrowser/ClassMethods.html#method-i-allow_browser) method in `ApplicationController` to allow only modern browsers by default.
 
 ```ruby
 class ApplicationController < ActionController::Base


### PR DESCRIPTION
`allow_browser` was added in Rails 7.2 and is set by default in `ApplicationController` when running `rails new`.

ref: https://github.com/rails/rails/commit/e3da4fc53d5da7be1d5b93d5659e77c8daddccea#diff-f355d10a96623990e497d37948436731adb5dc46d9f447d00f1a2590811ac606R4

