### PR TITLE
perf: prevent unnecesary query on schema_search

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -280,6 +280,7 @@ module ActiveRecord
         #
         # This should be not be called manually but set in database.yml.
         def schema_search_path=(schema_csv)
+          return if schema_csv == @schema_search_path
           if schema_csv
             internal_execute("SET search_path TO #{schema_csv}")
             @schema_search_path = schema_csv


### PR DESCRIPTION

### Motivation / Background

While working on a project, I noticed that the PostgreSQL adapter executes an unnecessary query when setting schema_search_path to the same schema that the application is already using.

### Details

This PR optimizes the schema_search_path setter by skipping the query if the new schema matches the current one. This avoids redundant database calls and improves efficiency.
### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature. This is not a bug, only a micro optimization
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
