### PR TITLE
Fix `ActiveRecord::Result#dup` consistency

### DIFF
--- a/activerecord/lib/active_record/result.rb
+++ b/activerecord/lib/active_record/result.rb
@@ -208,7 +208,6 @@ module ActiveRecord
 
     def initialize_copy(other)
       @rows = rows.dup
-      @column_types = column_types.dup
       @hash_rows    = nil
     end
 
@@ -238,6 +237,11 @@ module ActiveRecord
         @rows.map { |row| IndexedRow.new(columns, row) }.freeze
       end
     end
+
+    protected
+      def raw_column_types
+        @column_types
+      end
 
     private
       def column_type(name, index, type_overrides)

--- a/activerecord/test/cases/result_test.rb
+++ b/activerecord/test/cases/result_test.rb
@@ -129,5 +129,23 @@ module ActiveRecord
         assert_equal "col 2", row["foo"]
       end
     end
+
+    test "dup preserve all attributes" do
+      a = result
+      b = a.dup
+
+      assert_equal a.column_types, b.column_types
+      assert_equal a.columns, b.columns
+      assert_equal a.rows, b.rows
+      assert_equal a.column_indexes, b.column_indexes
+
+      # Second round in case of mutation
+      b = b.dup
+
+      assert_equal a.column_types, b.column_types
+      assert_equal a.columns, b.columns
+      assert_equal a.rows, b.rows
+      assert_equal a.column_indexes, b.column_indexes
+    end
   end
 end


### PR DESCRIPTION
`@column_types = column_types.dup` is incorrect since https://github.com/rails/rails/pull/54594 because the `column_types` method is no longer a simple attribute reader of `@column_type`.
