### PR TITLE
Fix `ActionMailer::Base.default` docs [skip-ci]

### DIFF
--- a/actionmailer/lib/action_mailer/base.rb
+++ b/actionmailer/lib/action_mailer/base.rb
@@ -574,18 +574,13 @@ module ActionMailer
       attr_writer :mailer_name
       alias :controller_path :mailer_name
 
-      # Sets the defaults through app configuration:
+      # Allows to set defaults through app configuration:
       #
-      #     config.action_mailer.default(from: "no-reply@example.org")
-      #
-      # Aliased by ::default_options=
+      #    config.action_mailer.default_options = { from: "no-reply@example.org" }
       def default(value = nil)
         self.default_params = default_params.merge(value).freeze if value
         default_params
       end
-      # Allows to set defaults through app configuration:
-      #
-      #    config.action_mailer.default_options = { from: "no-reply@example.org" }
       alias :default_options= :default
 
       # Wraps an email delivery inside of ActiveSupport::Notifications instrumentation.


### PR DESCRIPTION
Fixes #54700.

`config.action_mailer.default(..)` example is wrong, because `action_mailer` is an instance of `OrderedOptions` and this is calling a `Hash#default(..)` method, which does not make sense.