### PR TITLE
Fixes `ActionDispatch::Request#route_uri_pattern` in `ActionController::TestCase` context

### DIFF
--- a/actionpack/lib/action_dispatch/http/request.rb
+++ b/actionpack/lib/action_dispatch/http/request.rb
@@ -159,6 +159,7 @@ module ActionDispatch
     def route_uri_pattern
       unless pattern = get_header("action_dispatch.route_uri_pattern")
         route = get_header("action_dispatch.route")
+        return if route.nil?
         pattern = route.path.spec.to_s
         set_header("action_dispatch.route_uri_pattern", pattern)
       end

--- a/actionpack/test/controller/base_test.rb
+++ b/actionpack/test/controller/base_test.rb
@@ -72,6 +72,29 @@ class ActionMissingController < ActionController::Base
   end
 end
 
+class WithoutRouterController < ActionController::Base
+  after_action :log_request_details
+
+  def index
+    head :ok
+  end
+
+  private
+    def log_request_details
+      request.route_uri_pattern
+    end
+end
+
+class WithoutRouterTest < ActionController::TestCase
+  tests WithoutRouterController
+
+  def test_request_route_uri_pattern_in_after_action_callback
+    assert_nothing_raised do
+      get :index
+    end
+  end
+end
+
 class ControllerClassTests < ActiveSupport::TestCase
   def test_controller_path
     assert_equal "empty", EmptyController.controller_path


### PR DESCRIPTION
Ref: https://github.com/rails/rails/commit/6fd05c92b4820eeb537d5213812ad2f76e92b533

`ActionController::TestCase` does not use the router. So in the below case you will see the failure of `undefined method path for nil`. We fix this with an early return.

Repro:

```ruby
require "bundler/inline"

gemfile(true) do |g|
  g.source "https://rubygems.org"

  # Bad
  g.gem "rails", github: "rails/rails", ref: "6fd05c92b4820eeb537d5213812ad2f76e92b533"
  # Good
  # g.gem "rails", github: "rails/rails", ref: "3ff8c45e7b525c6b947d6f4f3350366b0d7e97ed"
  g.gem "sqlite3"
end

require "action_controller/railtie"
require "active_record/railtie"
require "minitest/autorun"

# Create a minimal Rails application
class TestApp < Rails::Application
  config.root = __dir__
  config.hosts.clear
  config.eager_load = false
  config.active_support.deprecation = :stderr
  config.secret_key_base = "test" * 10
  config.session_store :cookie_store, key: "anything"
  config.cache_classes = true

  def require_environment!
  end
end

Rails.application = TestApp.new
Rails.application.config.active_support.deprecation = :stderr
Rails.application.initialize!

module CustomMonitor
  extend ActiveSupport::Concern

  included do
    after_action :log_request_details
  end

  private

  def log_request_details
    pattern = request.route_uri_pattern
  end
end

class ProductsController < ActionController::Base
  include CustomMonitor

  def show
    render json: { status: "ok" }
  end
end

Rails.application.routes.draw do
  resources :products, only: [:show]
end

class ProductsControllerTest < ActionController::TestCase
  tests ProductsController

  setup do
    @routes = Rails.application.routes
  end

  def test_deprecation_warning_header
    get :show, params: { id: 1, format: "json" }

    assert_response :success
  end
end
```


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
