### PR TITLE
Don't rebuild the middleware stack when using `with_routing`

### DIFF
--- a/actionpack/lib/action_dispatch/testing/assertions/routing.rb
+++ b/actionpack/lib/action_dispatch/testing/assertions/routing.rb
@@ -5,6 +5,7 @@
 require "uri"
 require "active_support/core_ext/hash/indifferent_access"
 require "active_support/core_ext/string/access"
+require "active_support/core_ext/module/redefine_method"
 require "action_controller/metal/exceptions"
 
 module ActionDispatch
@@ -20,38 +21,43 @@ module ActionDispatch
         module ClassMethods
           def with_routing(&block)
             old_routes = nil
+            old_routes_call_method = nil
             old_integration_session = nil
 
             setup do
               old_routes = app.routes
+              old_routes_call_method = old_routes.method(:call)
               old_integration_session = integration_session
               create_routes(&block)
             end
 
             teardown do
-              reset_routes(old_routes, old_integration_session)
+              reset_routes(old_routes, old_routes_call_method, old_integration_session)
             end
           end
         end
 
         def with_routing(&block)
           old_routes = app.routes
+          old_routes_call_method = old_routes.method(:call)
           old_integration_session = integration_session
           create_routes(&block)
         ensure
-          reset_routes(old_routes, old_integration_session)
+          reset_routes(old_routes, old_routes_call_method, old_integration_session)
         end
 
         private
           def create_routes
             app = self.app
             routes = ActionDispatch::Routing::RouteSet.new
-            rack_app = app.config.middleware.build(routes)
+
+            @original_routes ||= app.routes
+            @original_routes.singleton_class.redefine_method(:call, &routes.method(:call))
+
             https = integration_session.https?
             host = integration_session.host
 
             app.instance_variable_set(:@routes, routes)
-            app.instance_variable_set(:@app, rack_app)
             @integration_session = Class.new(ActionDispatch::Integration::Session) do
               include app.routes.url_helpers
               include app.routes.mounted_helpers
@@ -63,11 +69,9 @@ module ActionDispatch
             yield routes
           end
 
-          def reset_routes(old_routes, old_integration_session)
-            old_rack_app = app.config.middleware.build(old_routes)
-
+          def reset_routes(old_routes, old_routes_call_method, old_integration_session)
             app.instance_variable_set(:@routes, old_routes)
-            app.instance_variable_set(:@app, old_rack_app)
+            @original_routes.singleton_class.redefine_method(:call, &old_routes_call_method)
             @integration_session = old_integration_session
             @routes = old_routes
           end


### PR DESCRIPTION
### Motivation / Background

Fix #54595

### Detail

#### Problem

When using the `with_routing` helper method in an integration test, we rebuild the middleware stack so that the entrypoint of our new stack is the new RouteSet object.

By rebuilding the middleware stack from scratch, we may end un-configuring a middleware from an application. We also break the contract of the Rails initialization process.

For instance, if you have a middleware that needs to be configured, after the Rails routes are loaded, this is what it would look like:

```ruby
# config/application.rb

warden_config = nil

config.middleware.use Warden::Manager do |config|
  # The Warden middleware yields its config when the middleware is
  # instantiated. We can't configure warden yet as the routes
  # are not yet loaded.

  warden_config = config
end

initializer :configure_warden do
  ActiveSupport.on_load(:after_routes_loaded) do
    # The routes are now loaded, we can configure warden
  end
end
```

This snippet follows the order of the documented Rails initialization process where first the middleware stack is built and then the routes gets loaded.

--------------------

By rebuilding the middleware stack, we unconfigure what was done in the initializer.

### Solution

Since rebuilding the middleware stack has some caveats, my idea is to modify the middleware stack original entry point and redefine `call` so that it calls our new RouteSet middleware.
We have a reference to the original RouteSet middleware thanks to the `application.routes` method.


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
