### PR TITLE
[ci skip] docs: Fix form_with model binding example in guides #54616

### DIFF
--- a/guides/source/form_helpers.md
+++ b/guides/source/form_helpers.md
@@ -249,8 +249,8 @@ The `form_with` helper has a `:model` option that allows you to bind the form bu
 For example, if we have a `@book` model object:
 
 ```ruby
-@book = Book.find(42)
-# => #<Book id: 42, title: "Walden", author: "Henry David Thoreau">
+@book = Book.new
+# => #<Book id: nil, title: nil, author: nil>
 ```
 
 And the following form to create a new book:


### PR DESCRIPTION
### Motivation / Background

The current form_helpers guide shows an inconsistency where the example uses `@book = Book.find(42)` (an existing record) while demonstrating a form for creating a new book. The generated HTML shows `action="/books"` (POST for creating new records) and the submit button text is "Create Book".

> Note: This is a resubmission of PR #54616 which was accidentally closed. This new PR contains the same fix but with commits squashed as requested by reviewers.

### Detail

This Pull Request updates the form_helpers guide to use `@book = Book.new` in the example, making it consistent with the form's purpose (creating a new book) and the generated HTML output. This change makes the documentation more accurate and helps prevent confusion for developers learning Rails form helpers.

### Additional information

When using `form_with` with a model, Rails determines the form's action and submit button text based on whether the record is persisted:
- For new records: action is `/books` with POST method and button text is "Create [Model]"
- For existing records: action is `/books/42` with PATCH/PUT method and button text is "Update [Model]"

Since the example is demonstrating a form for creating a new book (as evidenced by the HTML output), using `Book.new` is more appropriate than `Book.find(42)`.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why.
* [x] No tests needed as this is a documentation-only change.
* [x] No CHANGELOG update needed as this is a documentation correction.