### PR TITLE
Expose ability to prepend query log tags via application configuration

### DIFF
--- a/activerecord/lib/active_record/query_logs.rb
+++ b/activerecord/lib/active_record/query_logs.rb
@@ -65,7 +65,7 @@ module ActiveRecord
   #
   # Tag comments can be prepended to the query:
   #
-  #    ActiveRecord::QueryLogs.prepend_comment = true
+  #     config.active_record.query_log_tags_prepend_comment = true
   #
   # For applications where the content will not change during the lifetime of
   # the request or job execution, the tags can be cached for reuse in every query:

--- a/activerecord/lib/active_record/railtie.rb
+++ b/activerecord/lib/active_record/railtie.rb
@@ -35,6 +35,7 @@ module ActiveRecord
     config.active_record.query_log_tags = [ :application ]
     config.active_record.query_log_tags_format = :legacy
     config.active_record.cache_query_log_tags = false
+    config.active_record.query_log_tags_prepend_comment = false
     config.active_record.raise_on_assign_to_attr_readonly = false
     config.active_record.belongs_to_required_validates_foreign_key = true
     config.active_record.generate_secure_token_on = :create
@@ -229,6 +230,7 @@ To keep using the current cache store, you can turn off cache versioning entirel
           :query_log_tags,
           :query_log_tags_format,
           :cache_query_log_tags,
+          :query_log_tags_prepend_comment,
           :sqlite3_adapter_strict_strings_by_default,
           :check_schema_cache_dump_version,
           :use_schema_cache_dump,
@@ -386,6 +388,10 @@ To keep using the current cache store, you can turn off cache versioning entirel
 
           if app.config.active_record.cache_query_log_tags
             ActiveRecord::QueryLogs.cache_query_log_tags = true
+          end
+
+          if app.config.active_record.query_log_tags_prepend_comment
+            ActiveRecord::QueryLogs.prepend_comment = true
           end
         end
       end

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -1532,6 +1532,17 @@ that have a large number of queries, caching query log tags can provide a
 performance benefit when the context does not change during the lifetime of the
 request or job execution. Defaults to `false`.
 
+#### `config.active_record.query_log_tags_prepend_comment`
+
+Specifies whether or not to prepend query log tags comment to the query.
+
+By default comments are appended at the end of the query. Certain databases, such as MySQL will
+truncate the query text. This is the case for slow query logs and the results of querying
+some InnoDB internal tables where the length of the query is more than 1024 bytes.
+In order to not lose the log tags comments from the queries, you can prepend the comments using this option.
+
+Defaults to `false`.
+
 #### `config.active_record.schema_cache_ignored_tables`
 
 Define the list of table that should be ignored when generating the schema


### PR DESCRIPTION
Follow up to #42240.

There is a way to prepend query log tags comments. But it is hard to know this feature exists without looking at the source code - it is not described in the `configuring.md` docs. There is also an inconsistency between how to enable it (directly via `ActiveRecord::QueryLogs.prepend_comment` call) vs other query log tags options (via `config.active_record` setters).

This PR fixes this inconsistency and improves the docs.