### PR TITLE
[7.1] Disconnect if `configure_connection` failed

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Fix error handling during connection configuration.
+
+    Active Record wasn't properly handling errors during the connection configuration phase.
+    This could lead to a partially configured connection being used, resulting in various exceptions,
+    the most common being with the PostgreSQLAdapter raising `undefined method `key?' for nil`
+    or `TypeError: wrong argument type nil (expected PG::TypeMap)`.
+
+    *Jean Boussier*
+
 *   Fix a race condition in `ActiveRecord::Base#method_missing` when lazily defining attributes.
 
     If multiple thread were concurrently triggering attribute definition on the same model,

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -690,7 +690,7 @@ module ActiveRecord
 
           reset_transaction(restore: restore_transactions) do
             clear_cache!(new_connection: true)
-            configure_connection
+            attempt_configure_connection
           end
         rescue => original_exception
           translated_exception = translate_exception_class(original_exception, nil, nil)
@@ -742,7 +742,7 @@ module ActiveRecord
       def reset!
         clear_cache!(new_connection: true)
         reset_transaction
-        configure_connection
+        attempt_configure_connection
       end
 
       # Removes the connection from the pool and disconnect it.
@@ -778,7 +778,7 @@ module ActiveRecord
             if @unconfigured_connection
               @raw_connection = @unconfigured_connection
               @unconfigured_connection = nil
-              configure_connection
+              attempt_configure_connection
               @verified = true
               return
             end
@@ -1223,6 +1223,13 @@ module ActiveRecord
         # Implementations may assume this method will only be called while
         # holding @lock (or from #initialize).
         def configure_connection
+        end
+
+        def attempt_configure_connection
+          configure_connection
+        rescue
+          disconnect!
+          raise
         end
 
         def default_prepared_statements

--- a/activerecord/test/cases/adapter_test.rb
+++ b/activerecord/test/cases/adapter_test.rb
@@ -752,6 +752,27 @@ module ActiveRecord
         @connection.execute("SELECT 1", allow_retry: true)
       end
 
+      test "disconnect and recover on #configure_connection failure" do
+        connection = ActiveRecord::Base.connection_pool.send(:new_connection)
+
+        failures = [ActiveRecord::ConnectionFailed.new("Oops"), ActiveRecord::ConnectionFailed.new("Oops 2")]
+        connection.singleton_class.define_method(:configure_connection) do
+          if error = failures.pop
+            raise error
+          else
+            super()
+          end
+        end
+        assert_raises ActiveRecord::ConnectionFailed do
+          connection.exec_query("SELECT 1")
+        end
+
+        assert_equal [[1]], connection.exec_query("SELECT 1").rows
+        assert_empty failures
+      ensure
+        connection&.disconnect!
+      end
+
       private
         def raw_transaction_open?(connection)
           case connection.class::ADAPTER_NAME

--- a/activerecord/test/cases/adapters/sqlite3/dbconsole_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/dbconsole_test.rb
@@ -46,7 +46,7 @@ module ActiveRecord
         root = method(:root)
         mod = Module.new { define_singleton_method(:root, &root) }
 
-        stub_const(Object, :Rails, mod, exists: defined?(Rails)) do
+        stub_const(Object, :Rails, mod) do
           assert_find_cmd_and_exec_called_with(["sqlite3", Rails.root.join("config/db.sqlite3").to_s]) do
             SQLite3Adapter.dbconsole(config)
           end


### PR DESCRIPTION
Fix: https://github.com/rails/rails/issues/51780
Backport: https://github.com/rails/rails/pull/54711

There are a number of scenarios in which one of the queries performed as part of `configure_connection` fails, and leave the `Adapter` in an half initialized state.

Up to Rails 7.0, this could likely happen during a call to `reconnect!`, so relatively rare. For the more classic initial connection, the `Adapter` instance would only be added to the pool on a successful connect.

But in 7.1 I made the connection fully lazy, meaning the `Adapter` instance is now added to the pool before attempting to connect.

This made this bug much more likely.

The solution is to disconnect if `configure_connection` raises an error. This way on a retry we'll reconnect and reconfigure from scratch.
