### PR TITLE
Disconnect if `configure_connection` failed

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -677,7 +677,7 @@ module ActiveRecord
 
           reset_transaction(restore: restore_transactions) do
             clear_cache!(new_connection: true)
-            configure_connection
+            attempt_configure_connection
           end
         rescue => original_exception
           translated_exception = translate_exception_class(original_exception, nil, nil)
@@ -730,7 +730,7 @@ module ActiveRecord
       def reset!
         clear_cache!(new_connection: true)
         reset_transaction
-        configure_connection
+        attempt_configure_connection
       end
 
       # Removes the connection from the pool and disconnect it.
@@ -766,7 +766,7 @@ module ActiveRecord
             if @unconfigured_connection
               @raw_connection = @unconfigured_connection
               @unconfigured_connection = nil
-              configure_connection
+              attempt_configure_connection
               @last_activity = Process.clock_gettime(Process::CLOCK_MONOTONIC)
               @verified = true
               return
@@ -1217,6 +1217,13 @@ module ActiveRecord
         # holding @lock (or from #initialize).
         def configure_connection
           check_version
+        end
+
+        def attempt_configure_connection
+          configure_connection
+        rescue
+          disconnect!
+          raise
         end
 
         def default_prepared_statements

--- a/activerecord/test/cases/adapter_test.rb
+++ b/activerecord/test/cases/adapter_test.rb
@@ -873,6 +873,27 @@ module ActiveRecord
         @connection.execute("SELECT 1", allow_retry: true)
       end
 
+      test "disconnect and recover on #configure_connection failure" do
+        connection = ActiveRecord::Base.connection_pool.send(:new_connection)
+
+        failures = [ActiveRecord::ConnectionFailed.new("Oops"), ActiveRecord::ConnectionFailed.new("Oops 2")]
+        connection.singleton_class.define_method(:configure_connection) do
+          if error = failures.pop
+            raise error
+          else
+            super()
+          end
+        end
+        assert_raises ActiveRecord::ConnectionFailed do
+          connection.exec_query("SELECT 1")
+        end
+
+        assert_equal [[1]], connection.exec_query("SELECT 1").rows
+        assert_empty failures
+      ensure
+        connection&.disconnect!
+      end
+
       private
         def raw_transaction_open?(connection)
           case connection.adapter_name


### PR DESCRIPTION
Fix: https://github.com/rails/rails/issues/51780

There are a number of scenarios in which one of the queries performed as part of `configure_connection` fails, and leave the `Adapter` in an half initialized state.

Up to Rails 7.0, this could likely happen during a call to `reconnect!`, so relatively rare. For the more classic initial connection, the `Adapter` instance would only be added to the pool on a successful connect.

But in 7.1 I made the connection fully lazy, meaning the `Adapter` instance is now added to the pool before attempting to connect.

This made this bug much more likely.

The solution is to disconnect if `configure_connection` raises an error. This way on a retry we'll reconnect and reconfigure from scratch.
