### PR TITLE
Update bundler-audit.tt to reference config/bundler-audit.yml instead

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/bin/bundler-audit.tt
+++ b/railties/lib/rails/generators/rails/app/templates/bin/bundler-audit.tt
@@ -1,5 +1,5 @@
 require_relative "../config/boot"
 require "bundler/audit/cli"
 
-ARGV.concat %w[ --config config/bundler-audit.yaml ] if ARGV.empty? || ARGV.include?("check")
+ARGV.concat %w[ --config config/bundler-audit.yml ] if ARGV.empty? || ARGV.include?("check")
 Bundler::Audit::CLI.start


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created because I noticed the extension for the config file referenced in the new `bin/bundler-audit` binstub  (added in https://github.com/rails/rails/pull/54695)  was referencing `config/bundler-audit.yaml` instead of `config/bundler-audit.yml`. 

### Detail

The bundler audit config file is currently being generated at`config/bundler-audit.yml`, so when we use `--config config/bundler-audit.yaml` in the binstub, it is not actually using our generated `config/bundler-audit.yml` today.

We should update this to match the generated `config/bundler-audit.yml` instead. 

### Additional information

You can see how the bundler-audit gem is currently not picking up the config file when using `--config config/bundler-audit.yaml` as the file doesn't exist as of today in a new Rails application: 

![image](https://github.com/user-attachments/assets/5fc2284f-7f2d-4458-8880-7f0819e4537c)

But after changing the config file to use `--config config/bundler-audit.yml` instead, it can load the file correctly:
![image](https://github.com/user-attachments/assets/b34a9bbf-3a97-40bd-9a65-d3957e1b0358)


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
