### PR TITLE
Make auth generator session controller test pass by default

### DIFF
--- a/railties/lib/rails/generators/test_unit/authentication/authentication_generator.rb
+++ b/railties/lib/rails/generators/test_unit/authentication/authentication_generator.rb
@@ -14,6 +14,14 @@ module TestUnit # :nodoc:
         template "test/controllers/sessions_controller_test.rb"
         template "test/controllers/passwords_controller_test.rb"
       end
+
+      def ensure_root_route
+        in_root do
+          if !File.read("config/routes.rb").match?(/^ *root /)
+            route 'root "fill-me"'
+          end
+        end
+      end
     end
   end
 end

--- a/railties/test/generators/authentication_generator_test.rb
+++ b/railties/test/generators/authentication_generator_test.rb
@@ -53,6 +53,7 @@ class AuthenticationGeneratorTest < Rails::Generators::TestCase
 
     assert_file "config/routes.rb" do |content|
       assert_match(/resource :session/, content)
+      assert_match(/root "fill-me"/, content)
     end
 
     assert_includes @rails_commands, "generate migration CreateUsers email_address:string!:uniq password_digest:string! --force"


### PR DESCRIPTION
The authentication generator [session controller test](https://github.com/rails/rails/blob/182503ca27d4b940da925fb7374b69c4bcebd322/railties/lib/rails/generators/test_unit/authentication/templates/test/controllers/sessions_controller_test.rb) fails by default on new Rails apps, because they do not have a root route set up.

It is arguable whether the session controller test should pass by default on a newly created Rails app. If it should, some version of this PR could achieve that goal (FYI the password controller test passes by default). If it shouldn't, this PR can be closed.