### PR TITLE
Add more explicit NotImplementedErrors in AbstractAdapter

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -119,7 +119,7 @@ module ActiveRecord
 
       # Opens a database console session.
       def self.dbconsole(config, options = {})
-        raise NotImplementedError
+        raise NotImplementedError.new("#{self.class} should define `dbconsole` that accepts a db config and options to implement connecting to the db console")
       end
 
       def initialize(config_or_deprecated_connection, deprecated_logger = nil, deprecated_connection_options = nil, deprecated_config = nil) # :nodoc:
@@ -1084,7 +1084,7 @@ module ActiveRecord
         end
 
         def reconnect
-          raise NotImplementedError
+          raise NotImplementedError.new("#{self.class} should define `reconnect` to implement adapter-specific logic for reconnecting to the database")
         end
 
         # Returns a raw connection for internal use with methods that are known


### PR DESCRIPTION
Adding this so that when folks are adding a new db adapter and run into an error related to defining methods in abstract classes, then the error is explicit for what is not implemented.

### Motivation / Background

This Pull Request makes NotImplementedErrors in the AbstractAdapter explicit.  It is a quality of life improvement that will help people creating db adapters.

### Detail

While implementing a DB Adapter I was getting this ambiguous not implemented error. 

![image](https://github.com/user-attachments/assets/b7e63064-435b-4194-9cee-d01c7e1d4862)

After some pry'ing and following the code path I realized i needed to implement reconnect in my adapter, figured an error that was explicit about the location would have been easier and i followed the path that `build_insert_sql` already uses to make sure people know what to define

```
# this already exists in the abstract adapter

def build_insert_sql(insert) # :nodoc:
  if insert.skip_duplicates? || insert.update_duplicates?
    raise NotImplementedError, "#{self.class} should define `build_insert_sql` to implement adapter-specific logic for handling duplicates during INSERT"
  end

  "INSERT #{insert.into} #{insert.values_list}"
end
```

Now implementation errors show very explicit errors

![image](https://github.com/user-attachments/assets/b35a0c2b-1af3-489a-a44f-fa6ddad78492)

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
