### PR TITLE
Fix association inverse in combination with composite foreign key / primary key

### DIFF
--- a/activerecord/lib/active_record/associations/association.rb
+++ b/activerecord/lib/active_record/associations/association.rb
@@ -409,11 +409,13 @@ module ActiveRecord
         end
 
         def matches_foreign_key?(record)
-          if foreign_key_for?(record)
-            record.read_attribute(reflection.foreign_key) == owner.id ||
-              (foreign_key_for?(owner) && owner.read_attribute(reflection.foreign_key) == record.id)
-          else
-            owner.read_attribute(reflection.foreign_key) == record.id
+          primary_key_column_names = Array(reflection.join_primary_key(record.class))
+          foreign_key_column_names = Array(reflection.join_foreign_key)
+
+          primary_foreign_key_pairs = primary_key_column_names.zip(foreign_key_column_names)
+
+          primary_foreign_key_pairs.all? do |primary_key_column_name, foreign_key_column_name|
+            owner.read_attribute(foreign_key_column_name) == record.read_attribute(primary_key_column_name)
           end
         end
     end

--- a/activerecord/test/cases/associations_test.rb
+++ b/activerecord/test/cases/associations_test.rb
@@ -1452,6 +1452,16 @@ class PreloaderTest < ActiveRecord::TestCase
     assert_includes(blog_post.comments.to_a, sharded_comments(:great_comment_blog_post_one))
   end
 
+  def test_inverse_of_has_many_association_with_composite_foreign_key
+    blog_post = sharded_blog_posts(:great_post_blog_one)
+
+    comment = blog_post.comments.first
+
+    assert_no_queries do
+      comment.blog_post
+    end
+  end
+
   def test_preload_belongs_to_association_with_composite_foreign_key
     comment = sharded_comments(:great_comment_blog_post_one)
     comments = [comment, sharded_comments(:great_comment_blog_post_two)]


### PR DESCRIPTION
### Motivation / Background

It looks like association inversion does not work if the association uses a composite foreign key / primary key. This adds a test case that shows this is not working, and fixes the foreign key checking logic to make it work as expected.

/cc @bensheldon @matthewd 

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
