### PR TITLE
Use a self-join for UPDATE with outer joins on PostgreSQL and SQLite

### DIFF
--- a/activerecord/lib/arel/visitors/postgresql.rb
+++ b/activerecord/lib/arel/visitors/postgresql.rb
@@ -12,46 +12,21 @@ module Arel # :nodoc: all
 
           # UPDATE with JOIN is in the form of:
           #
-          #   UPDATE t1
+          #   UPDATE t1 AS __active_record_update_alias
           #   SET ..
-          #   FROM t2
-          #   WHERE t1.join_id = t2.join_id
-          #
-          # Or if more than one join is present:
-          #
-          #   UPDATE t1
-          #   SET ..
-          #   FROM t2
-          #   JOIN t3 ON t2.join_id = t3.join_id
-          #   WHERE t1.join_id = t2.join_id
+          #   FROM t1 JOIN t2 ON t2.join_id = t1.join_id ..
+          #   WHERE t1.id = __active_record_update_alias.id AND ..
           if has_join_sources?(o)
-            visit o.relation.left, collector
+            collector = visit o.relation.left, collector
             collect_nodes_for o.values, collector, " SET "
             collector << " FROM "
-            first_join, *remaining_joins = o.relation.right
-            from_items = remaining_joins.extract! do |join|
-              join.right.expr.right.relation == o.relation.left
-            end
-
-            from_where = [first_join.left] + from_items.map(&:left)
-            collect_nodes_for from_where, collector, " ", ", "
-
-            if remaining_joins && !remaining_joins.empty?
-              collector << " "
-              remaining_joins.each do |join|
-                visit join, collector
-                collector << " "
-              end
-            end
-
-            from_where = [first_join.right.expr] + from_items.map { |i| i.right.expr }
-            collect_nodes_for from_where + o.wheres, collector, " WHERE ", " AND "
+            collector = inject_join o.relation.right, collector, " "
           else
             collector = visit o.relation, collector
             collect_nodes_for o.values, collector, " SET "
-            collect_nodes_for o.wheres, collector, " WHERE ", " AND "
           end
 
+          collect_nodes_for o.wheres, collector, " WHERE ", " AND "
           collect_nodes_for o.orders, collector, " ORDER BY "
           maybe_visit o.limit, collector
         end
@@ -60,12 +35,18 @@ module Arel # :nodoc: all
         # query. However, this does not allow for LIMIT, OFFSET and ORDER. To support
         # these, we must use a subquery.
         def prepare_update_statement(o)
-          if has_join_sources?(o) && !has_limit_or_offset_or_orders?(o) && !has_group_by_and_having?(o) &&
-            # The PostgreSQL dialect isn't flexible enough to allow anything other than a inner join
-            # for the first join:
-            #   UPDATE table SET .. FROM joined_table WHERE ...
-            (o.relation.right.all? { |join| join.is_a?(Arel::Nodes::InnerJoin) || join.right.expr.right.relation != o.relation.left })
-            o
+          if o.key && has_join_sources?(o) && !has_group_by_and_having?(o) && !has_limit_or_offset_or_orders?(o)
+            # Join clauses cannot reference the target table, so alias the
+            # updated table, place the entire relation in the FROM clause, and
+            # add a self-join (which requires the primary key)
+            stmt = o.clone
+            stmt.relation, stmt.wheres = o.relation.clone, o.wheres.clone
+            stmt.relation.right = [stmt.relation.left, *stmt.relation.right]
+            stmt.relation.left = stmt.relation.left.alias("__active_record_update_alias")
+            Array.wrap(o.key).each do |key|
+              stmt.wheres << key.eq(stmt.relation.left[key.name])
+            end
+            stmt
           else
             super
           end
@@ -131,6 +112,12 @@ module Arel # :nodoc: all
         def visit_Arel_Nodes_Lateral(o, collector)
           collector << "LATERAL "
           grouping_parentheses o.expr, collector
+        end
+
+        def visit_Arel_Nodes_InnerJoin(o, collector)
+          return super if o.right
+          collector << "CROSS JOIN "
+          visit o.left, collector
         end
 
         def visit_Arel_Nodes_IsNotDistinctFrom(o, collector)

--- a/activerecord/lib/arel/visitors/sqlite.rb
+++ b/activerecord/lib/arel/visitors/sqlite.rb
@@ -12,47 +12,21 @@ module Arel # :nodoc: all
 
           # UPDATE with JOIN is in the form of:
           #
-          #   UPDATE t1
+          #   UPDATE t1 AS __active_record_update_alias
           #   SET ..
-          #   FROM t2
-          #   WHERE t1.join_id = t2.join_id
-          #
-          # Or if more than one join is present:
-          #
-          #   UPDATE t1
-          #   SET ..
-          #   FROM t2
-          #   JOIN t3 ON t2.join_id = t3.join_id
-          #   WHERE t1.join_id = t2.join_id
+          #   FROM t1 JOIN t2 ON t2.join_id = t1.join_id ..
+          #   WHERE t1.id = __active_record_update_alias.id AND ..
           if has_join_sources?(o)
-            visit o.relation.left, collector
+            collector = visit o.relation.left, collector
             collect_nodes_for o.values, collector, " SET "
-
             collector << " FROM "
-            first_join, *remaining_joins = o.relation.right
-            from_items = remaining_joins.extract! do |join|
-              join.right.expr.right.relation == o.relation.left
-            end
-
-            from_where = [first_join.left] + from_items.map(&:left)
-            collect_nodes_for from_where, collector, " ", ", "
-
-            if remaining_joins && !remaining_joins.empty?
-              collector << " "
-              remaining_joins.each do |join|
-                visit join, collector
-                collector << " "
-              end
-            end
-
-            from_where = [first_join.right.expr] + from_items.map { |i| i.right.expr }
-            collect_nodes_for from_where + o.wheres, collector, " WHERE ", " AND "
+            collector = inject_join o.relation.right, collector, " "
           else
             collector = visit o.relation, collector
             collect_nodes_for o.values, collector, " SET "
-            collect_nodes_for o.wheres, collector, " WHERE ", " AND "
           end
 
+          collect_nodes_for o.wheres, collector, " WHERE ", " AND "
           collect_nodes_for o.orders, collector, " ORDER BY "
           maybe_visit o.limit, collector
         end
@@ -60,15 +34,28 @@ module Arel # :nodoc: all
         def prepare_update_statement(o)
           # Sqlite need to be built with the SQLITE_ENABLE_UPDATE_DELETE_LIMIT compile-time option
           # to support LIMIT/OFFSET/ORDER in UPDATE and DELETE statements.
-          if has_join_sources?(o) && !has_limit_or_offset_or_orders?(o) && !has_group_by_and_having?(o) &&
-            # The SQLite3 dialect isn't flexible enough to allow anything other than a inner join
-            # for the first join:
-            #   UPDATE table SET .. FROM joined_table WHERE ...
-            (o.relation.right.all? { |join| join.is_a?(Arel::Nodes::InnerJoin) || join.right.expr.right.relation != o.relation.left })
-            o
+          if o.key && has_join_sources?(o) && !has_group_by_and_having?(o) && !has_limit_or_offset_or_orders?(o)
+            # Join clauses cannot reference the target table, so alias the
+            # updated table, place the entire relation in the FROM clause, and
+            # add a self-join (which requires the primary key)
+            stmt = o.clone
+            stmt.relation, stmt.wheres = o.relation.clone, o.wheres.clone
+            stmt.relation.right = [stmt.relation.left, *stmt.relation.right]
+            stmt.relation.left = stmt.relation.left.alias("__active_record_update_alias")
+            Array.wrap(o.key).each do |key|
+              stmt.wheres << key.eq(stmt.relation.left[key.name])
+            end
+            stmt
           else
             super
           end
+        end
+
+        def visit_Arel_Nodes_TableAlias(o, collector)
+          # "AS" is not optional in "{UPDATE | DELETE} table AS alias ..."
+          collector = visit o.relation, collector
+          collector << " AS "
+          collector << quote_table_name(o.name)
         end
 
         # Locks are not supported in SQLite

--- a/activerecord/test/cases/relation_test.rb
+++ b/activerecord/test/cases/relation_test.rb
@@ -268,7 +268,7 @@ module ActiveRecord
       assert_equal 3, nb_inner_join, "Wrong amount of INNER JOIN in query"
 
       # using `\W` as the column separator
-      assert queries.any? { |sql| %r[INNER\s+JOIN\s+#{Regexp.escape(Author.quoted_table_name)}\s+\Wauthors_categorizations\W]i.match?(sql) }, "Should be aliasing the child INNER JOINs in query"
+      assert queries.any? { |sql| %r[INNER\s+JOIN\s+#{Regexp.escape(Author.quoted_table_name)}\s+(AS\s+)?\Wauthors_categorizations\W]i.match?(sql) }, "Should be aliasing the child INNER JOINs in query"
     end
 
     def test_relation_with_merged_joins_aliased_works


### PR DESCRIPTION
In PostgreSQL and SQLite `UPDATE` when an `OUTER JOIN` references the updated table in the `ON` clause, the join condition cannot be moved to the `WHERE` clause without breaking the query, so the current implementation is forced to use a subquery. We can support this with a more aggressive manipulation: we duplicate the updated table into the `FROM` clause with a self-join on the primary key. So, transform

```sql
UPDATE "products" SET ...
LEFT JOIN "categories" ON "products"."category_id" = "categories"."id"
  ... other joins ...
WHERE ...
```

into

```sql
UPDATE "products" AS "alias" SET ...
FROM "products"
LEFT JOIN "categories" ON "products"."category_id" = "categories"."id"
  ... other joins ...
WHERE "alias"."id" = "products"."id" AND ...
```

The table referenced by `"products"."?"` changes with this transformation. Top-level `FULL|RIGHT OUTER JOIN` are converted to `LEFT|INNER JOIN`. This should be fine given the update context.

On PostgreSQL this appends an index scan step to the query plan, just like a subquery.

Unfortunately it introduces a possible ambiguity: when the `SET` or `WHERE` references an unqualified column of the target table, as there are now two candidate tables. This shouldn't happen with AR generated nodes but it will affect users with handcrafted nodes.