### PR TITLE
Make `nonce: false` remove the nonce attribute for `javascript_tag`, `javascript_include_tag` and `stylesheet_link_tag`

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Make `nonce: false` remove the nonce attribute from `javascript_tag`, `javascript_include_tag`, and `stylesheet_link_tag`.
+
+    *francktrouillez*
+
 *   Add `dom_target` helper to create `dom_id`-like strings from an unlimited
     number of objects.
 

--- a/actionview/lib/action_view/helpers/asset_tag_helper.rb
+++ b/actionview/lib/action_view/helpers/asset_tag_helper.rb
@@ -139,6 +139,8 @@ module ActionView
           }.merge!(options)
           if tag_options["nonce"] == true || (!tag_options.key?("nonce") && auto_include_nonce_for_scripts)
             tag_options["nonce"] = content_security_policy_nonce
+          elsif tag_options["nonce"] == false
+            tag_options.delete("nonce")
           end
           content_tag("script", "", tag_options)
         }.join("\n").html_safe
@@ -229,6 +231,8 @@ module ActionView
           }.merge!(options)
           if tag_options["nonce"] == true || (!tag_options.key?("nonce") && auto_include_nonce_for_styles)
             tag_options["nonce"] = content_security_policy_nonce
+          elsif tag_options["nonce"] == false
+            tag_options.delete("nonce")
           end
 
           if apply_stylesheet_media_default && tag_options["media"].blank?

--- a/actionview/lib/action_view/helpers/javascript_helper.rb
+++ b/actionview/lib/action_view/helpers/javascript_helper.rb
@@ -85,6 +85,8 @@ module ActionView
 
         if html_options[:nonce] == true || (!html_options.key?(:nonce) && auto_include_nonce)
           html_options[:nonce] = content_security_policy_nonce
+        elsif html_options[:nonce] == false
+          html_options.delete(:nonce)
         end
 
         content_tag("script", javascript_cdata_section(content), html_options)

--- a/actionview/test/template/asset_tag_helper_test.rb
+++ b/actionview/test/template/asset_tag_helper_test.rb
@@ -564,6 +564,10 @@ class AssetTagHelperTest < ActionView::TestCase
     end
   end
 
+  def test_javascript_include_tag_nonce_false
+    assert_dom_equal %(<script src="/javascripts/bank.js"></script>), javascript_include_tag("bank", nonce: false)
+  end
+
   def test_stylesheet_path
     StylePathToTag.each { |method, tag| assert_dom_equal(tag, eval(method)) }
   end
@@ -592,6 +596,10 @@ class AssetTagHelperTest < ActionView::TestCase
     with_auto_include_nonce_for_styles do
       assert_dom_equal %(<link rel="stylesheet" href="/stylesheets/foo.css" nonce="iyhD0Yc0W+c="></link>), stylesheet_link_tag("foo.css")
     end
+  end
+
+  def test_stylesheet_link_tag_nonce_false
+    assert_dom_equal %(<link rel="stylesheet" href="/stylesheets/foo.css"></link>), stylesheet_link_tag("foo.css", nonce: false)
   end
 
   def test_stylesheet_link_tag_with_missing_source

--- a/actionview/test/template/javascript_helper_test.rb
+++ b/actionview/test/template/javascript_helper_test.rb
@@ -87,4 +87,16 @@ class JavaScriptHelperTest < ActionView::TestCase
     assert_dom_equal "<script nonce=\"iyhD0Yc0W+c=\">\n//<![CDATA[\nalert('hello')\n//]]>\n</script>",
       javascript_tag("alert('hello')")
   end
+
+  def test_javascript_tag_nonce_true
+    instance_eval { def content_security_policy_nonce = "iyhD0Yc0W+c=" }
+    assert_dom_equal "<script nonce=\"iyhD0Yc0W+c=\">\n//<![CDATA[\nalert('hello')\n//]]>\n</script>",
+      javascript_tag("alert('hello')", nonce: true)
+  end
+
+  def test_javascript_tag_nonce_false
+    instance_eval { def content_security_policy_nonce = "iyhD0Yc0W+c=" }
+    assert_dom_equal "<script>\n//<![CDATA[\nalert('hello')\n//]]>\n</script>",
+      javascript_tag("alert('hello')", nonce: false)
+  end
 end


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

Currently, when using `javascript_tag`, `javascript_include_tag` and `stylesheet_link_tag`, adding `nonce: false` option adds `nonce="false"` to the generated tag, instead of not adding the `nonce` attribute at all.

Since `nonce: true` option adds the `nonce` attribute, with an actual nonce as value, I would expect that `nonce: false` would not add the `nonce` attribute at all.

Currently, using `nonce: false` technically says that the tag has a nonce set to `"false"`, which I believe is not the intended behavior.

Let me know if I'm missing something here.

### Detail

This PR changes the behavior of `nonce: false` to not add the `nonce` attribute at all.

**It changes current behavior**, but I don't expect this to break any production code, as I strongly believe no one relies on a nonce with value `nonce="false"`, and even if they do, I don't think that it should be a practice Rails promotes.

Let me know your thoughts on this.

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

This was spotted when working on #53835.

Current solution to mitigate this issue is to set `nonce: nil` instead, but I think that `nonce: false` should do the opposite of `nonce: true`, which is not adding a `nonce`.

Please let me know if you have any questions or concerns.

Thank you for your time and consideration!

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
