### PR TITLE
The skip_brakeman option should not skip bundle_audit

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/github/ci.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/github/ci.yml.tt
@@ -6,7 +6,6 @@ on:
     branches: [ main ]
 
 jobs:
-<%- unless skip_brakeman? -%>
   scan_ruby:
     runs-on: ubuntu-latest
 
@@ -19,14 +18,15 @@ jobs:
         with:
           ruby-version: .ruby-version
           bundler-cache: true
+      <%- unless skip_brakeman? -%>
 
       - name: Scan for common Rails security vulnerabilities using static analysis
         run: bin/brakeman --no-pager
+      <% end -%>
 
       - name: Scan for known security vulnerabilities in gems used
         run: bin/bundler-audit
 
-<% end -%>
 <%- if options[:javascript] == "importmap" && !options[:api] && !options[:skip_javascript] -%>
   scan_js:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Motivation / Background
While I was working on a skip_bundle_audit option I noticed that skip_brakeman skips also bundle_audit at the moment.

### Detail
This PR fixes the behavior so skip_brakeman actually skips only brakeman.