### PR TITLE
Handle `PG::ConnectionBad` from `PG#server_version` similarly to version 0

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -636,7 +636,7 @@ module ActiveRecord
         with_raw_connection do |conn|
           version = conn.server_version
           if version == 0
-            raise ActiveRecord::ConnectionFailed, "Could not determine PostgreSQL version"
+            raise ActiveRecord::ConnectionNotEstablished, "Could not determine PostgreSQL version"
           end
           version
         end

--- a/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
@@ -95,7 +95,7 @@ module ActiveRecord
         end
       end
 
-      def test_reconnect_after_bad_connection_on_check_version
+      def test_reconnect_after_bad_connection_on_check_version_with_0_return
         db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", name: "primary")
         connection = ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.new(db_config.configuration_hash.merge(connection_retries: 0))
         connection.connect!
@@ -103,10 +103,31 @@ module ActiveRecord
         # mimic a connection that hasn't checked and cached the server version yet i.e. without a raw_connection
         connection.pool.instance_variable_set(:@server_version, nil)
         connection.raw_connection.stub(:server_version, 0) do
-          error = assert_raises ActiveRecord::ConnectionFailed do
+          error = assert_raises ActiveRecord::ConnectionNotEstablished do
             connection.reconnect!
           end
           assert_equal "Could not determine PostgreSQL version", error.message
+        end
+
+        # can reconnect after a bad connection
+        assert_nothing_raised do
+          connection.reconnect!
+        end
+      end
+
+      def test_reconnect_after_bad_connection_on_check_version_with_native_exception
+        db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", name: "primary")
+        connection = ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.new(db_config.configuration_hash.merge(connection_retries: 0))
+        connection.connect!
+
+        # mimic a connection that hasn't checked and cached the server version yet i.e. without a raw_connection
+        connection.pool.instance_variable_set(:@server_version, nil)
+        # https://github.com/ged/ruby-pg/commit/a565e153d4d05955342ad24d4845378eee956935
+        connection.raw_connection.stub(:server_version, -> { raise PG::ConnectionBad, "PQserverVersion() can't get server version" }) do
+          error = assert_raises ActiveRecord::ConnectionNotEstablished do
+            connection.reconnect!
+          end
+          assert_equal "PQserverVersion() can't get server version", error.message
         end
 
         # can reconnect after a bad connection


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

Follow-up to https://github.com/rails/rails/pull/54713 and https://github.com/ged/ruby-pg/pull/632.

### Detail

Now that in future versions pg will raise `PG::ConnectionBad` when attempting to get the database version with a bad connection, we should handle it the same as when a version of 0 returned.

I opted to not preserve the error message from pg cause it's a bit too specific to the native implementation. Getting the message across to the user that the root of the failure is a bad connection should suffice imo.

cc @byroot

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

N/A

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.