### PR TITLE
Bump bundler inside the devcontainer

### DIFF
--- a/.devcontainer/boot.sh
+++ b/.devcontainer/boot.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 
+bundle update --bundler
 bundle install
 
 if [ -n "${NVM_DIR}" ]; then

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -815,4 +815,4 @@ DEPENDENCIES
   websocket-client-simple
 
 BUNDLED WITH
-   2.5.16
+   2.6.5


### PR DESCRIPTION
### Motivation / Background

This commit updates the Bundler version in Gemfile.lock and modifies the boot.sh script to install the latest Bundler version to avoid similar warnings in the future.

### Detail

- Steps to reproduce
1. Startup the devcontainer
2. Run
```bash
$ bundle exec rake test
```

- Actual result This results in the following warning:

```
/home/vscode/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/bundler-2.5.16/lib/bundler/rubygems_ext.rb:250: warning: method redefined; discarding old encode_with
/home/vscode/.rbenv/versions/3.4.2/lib/ruby/3.4.0/rubygems/dependency.rb:341: warning: previous definition of encode_with was here
```

### Additional information
When Ruby is upgraded, the gem command is updated as well. However, Bundler installs the version specified in Gemfile.lock under BUNDLED WITH, which can cause outdated versions and trigger the warning above.

The fix in rubygems/rubygems#7867 has been available since RubyGems 3.6.0 and Bundler 2.6.0. Since Bundler 2.5.16 lacks this commit, upgrading is necessary to prevent these warnings.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
