### PR TITLE
fix: sqlite3 adapter should quote Infinity and NaN

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/sqlite3/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3/quoting.rb
@@ -50,6 +50,19 @@ module ActiveRecord
           end
         end
 
+        def quote(value) # :nodoc:
+          case value
+          when Numeric
+            if value.finite?
+              super
+            else
+              "'#{value}'"
+            end
+          else
+            super
+          end
+        end
+
         def quote_string(s)
           ::SQLite3::Database.quote(s)
         end

--- a/activerecord/test/cases/adapters/sqlite3/quoting_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/quoting_test.rb
@@ -95,4 +95,16 @@ class SQLite3QuotingTest < ActiveRecord::SQLite3TestCase
       end
     end
   end
+
+  def test_quote_numeric_infinity
+    assert_equal "'Infinity'", @conn.quote(Float::INFINITY)
+    assert_equal "'-Infinity'", @conn.quote(-Float::INFINITY)
+    assert_equal "'Infinity'", @conn.quote(BigDecimal(Float::INFINITY))
+    assert_equal "'-Infinity'", @conn.quote(BigDecimal(-Float::INFINITY))
+  end
+
+  def test_quote_float_nan
+    assert_equal "'NaN'", @conn.quote(Float::NAN)
+    assert_equal "'NaN'", @conn.quote(BigDecimal(Float::NAN))
+  end
 end


### PR DESCRIPTION
### Motivation / Background

When literal SQL strings are built by the sqlite3 adapter, the values "Infinity", "-Infinity", and "NaN" must be quoted. (This isn't a problem if the value is provided as a parameter to a prepared statement.)

For example, if `.upsert` is passed one of these values, the exception raised is:

```
>> Shirt.upsert({id: 1, size: Float::INFINITY})

sqlite3-2.6.0-x86_64-linux-gnu/lib/sqlite3/statement.rb:36:in 'SQLite3::Statement#prepare': no such column: Infinity: (SQLite3::SQLException)
INSERT INTO "shirts" ("id","size","created_at","updated_at") VALUES (1, Infinity, STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW'), STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW')) ON CONFLICT ("id") DO UPDATE SET updated_at=(CASE WHEN ("size" IS excluded."size") THEN "shirts".updated_at ELSE STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW') END),"size"=excluded."size" RETURNING "id"
                                                                        ^
from sqlite3-2.6.0-x86_64-linux-gnu/lib/sqlite3/statement.rb:36:in 'SQLite3::Statement#initialize'
from sqlite3-2.6.0-x86_64-linux-gnu/lib/sqlite3/database.rb:216:in 'Class#new'
from sqlite3-2.6.0-x86_64-linux-gnu/lib/sqlite3/database.rb:216:in 'SQLite3::Database#prepare'
from rails/activerecord/lib/active_record/connection_adapters/sqlite3/database_statements.rb:94:in 'ActiveRecord::ConnectionAdapters::SQLite3::DatabaseStatements#perform_query'
...
from rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:558:in 'block in ActiveRecord::ConnectionAdapters::DatabaseStatements#raw_execute'
...
from rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:557:in 'ActiveRecord::ConnectionAdapters::DatabaseStatements#raw_execute'
from rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:601:in 'ActiveRecord::ConnectionAdapters::DatabaseStatements#internal_execute'
from rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:550:in 'ActiveRecord::ConnectionAdapters::DatabaseStatements#internal_exec_query'
from rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:180:in 'ActiveRecord::ConnectionAdapters::DatabaseStatements#exec_insert_all'
from rails/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb:27:in 'ActiveRecord::ConnectionAdapters::AbstractAdapter#exec_insert_all'
from rails/activerecord/lib/active_record/insert_all.rb:54:in 'ActiveRecord::InsertAll#execute'
from rails/activerecord/lib/active_record/insert_all.rb:13:in 'block in ActiveRecord::InsertAll.execute'
...
```

Quoting these values does what's intended.


### Detail

This is similar to the fix applied to the postgresql adapter in #3713.


### Additional information

1. This may be a partial fix for #32888.
2. Based on comments in #21262, it's possible that these values should be quoted in the [abstract Quoting module](https://github.com/flavorjones/rails/blob/0085043a6e26589c43793a8d6f8af2af801c8f5e/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb#L72), but I have not investigated the behavior of MySQL2 or Trilogy to determine if this same problem exists there.


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
