### PR TITLE
Revert "Modify the Test Runner to allow running test at root:"

### DIFF
--- a/railties/lib/rails/test_unit/runner.rb
+++ b/railties/lib/rails/test_unit/runner.rb
@@ -91,22 +91,12 @@ module Rails
 
         private
           def extract_filters(argv)
-            previous_arg_was_a_flag = false
             # Extract absolute and relative paths but skip -n /.*/ regexp filters.
             argv.filter_map do |path|
-              current_arg_is_a_flag = /^-{1,2}[a-zA-Z0-9\-_.]+=?.*\Z/.match?(path)
-
-              if previous_arg_was_a_flag && !current_arg_is_a_flag
-                # Handle the case where a flag is followed by another flag (e.g. --fail-fast --seed ...)
-                previous_arg_was_a_flag = false
-                next
-              end
+              next unless path_argument?(path)
 
               path = path.tr("\\", "/")
               case
-              when current_arg_is_a_flag
-                previous_arg_was_a_flag = true unless path.include?("=") # Handle the case when "--foo=bar" is used.
-                next
               when /(:\d+(-\d+)?)+$/.match?(path)
                 file, *lines = path.split(":")
                 filters << [ file, lines ]
@@ -130,6 +120,10 @@ module Rails
 
           def regexp_filter?(arg)
             arg.start_with?("/") && arg.end_with?("/")
+          end
+
+          def path_argument?(arg)
+            PATH_ARGUMENT_PATTERN.match?(arg)
           end
 
           def list_tests(patterns)

--- a/railties/test/application/test_runner_test.rb
+++ b/railties/test/application/test_runner_test.rb
@@ -222,54 +222,6 @@ module ApplicationTests
       end
     end
 
-    def test_run_test_at_root
-      app_file "my_test.rb", <<-RUBY
-        require "test_helper"
-
-        class MyTest < ActiveSupport::TestCase
-          def test_rikka
-            puts 'Rikka'
-          end
-        end
-      RUBY
-
-      run_test_command("my_test.rb").tap do |output|
-        assert_match "Rikka", output
-      end
-    end
-
-    def test_run_test_having_a_slash_in_its_name
-      app_file "my_test.rb", <<-RUBY
-        require "test_helper"
-
-        class MyTest < ActiveSupport::TestCase
-          test "foo/foo" do
-            puts 'Rikka'
-          end
-        end
-      RUBY
-
-      run_test_command("my_test.rb -n foo\/foo").tap do |output|
-        assert_match "Rikka", output
-      end
-    end
-
-    def test_run_test_with_flags_unordered
-      app_file "my_test.rb", <<-RUBY
-        require "test_helper"
-
-        class MyTest < ActiveSupport::TestCase
-          test "foo/foo" do
-            puts 'Rikka'
-          end
-        end
-      RUBY
-
-      run_test_command("--seed 344 my_test.rb --fail-fast -n foo\/foo").tap do |output|
-        assert_match "Rikka", output
-      end
-    end
-
     def test_run_matched_test
       app_file "test/unit/chu_2_koi_test.rb", <<-RUBY
         require "test_helper"


### PR DESCRIPTION
Reverts rails/rails#54647
Fix: https://github.com/rails/rails/pull/54693#pullrequestreview-2675820144

This breaks the fairly common `bin/rails test test:system`.



