### PR TITLE
AbstractAdapter#attempt_configure_connection: handle Timeout.timeout

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -1221,7 +1221,7 @@ module ActiveRecord
 
         def attempt_configure_connection
           configure_connection
-        rescue
+        rescue Exception # Need to handle things such as Timeout::ExitException
           disconnect!
           raise
         end

--- a/activerecord/test/cases/adapter_test.rb
+++ b/activerecord/test/cases/adapter_test.rb
@@ -894,6 +894,29 @@ module ActiveRecord
         connection&.disconnect!
       end
 
+      test "disconnect and recover on #configure_connection timeout" do
+        connection = ActiveRecord::Base.connection_pool.send(:new_connection)
+
+        slow = [5]
+        connection.singleton_class.define_method(:configure_connection) do
+          if duration = slow.pop
+            sleep duration
+          end
+          super()
+        end
+
+        assert_raises Timeout::Error do
+          Timeout.timeout(0.2) do
+            connection.exec_query("SELECT 1")
+          end
+        end
+
+        assert_equal [[1]], connection.exec_query("SELECT 1").rows
+        assert_empty failures
+      ensure
+        connection&.disconnect!
+      end
+
       private
         def raw_transaction_open?(connection)
           case connection.adapter_name


### PR DESCRIPTION
Fix: https://github.com/rails/rails/issues/51780
Followup: https://github.com/rails/rails/pull/54711

If `configure_connection` fails because of `Timeout.timeout`, the raised exception is `Timeout::ExitError` which directly inherits `Exception`, so we must rescue `Exception`.
