### PR TITLE
Let minitest parse ARGV:

### DIFF
--- a/railties/lib/minitest/rails_plugin.rb
+++ b/railties/lib/minitest/rails_plugin.rb
@@ -127,6 +127,11 @@ module Minitest
       options[:profile] = count
     end
 
+    opts.on(/^[^-]/) do |test_file|
+      options[:test_files] ||= []
+      options[:test_files] << test_file
+    end
+
     options[:color] = true
     options[:output_inline] = true
   end
@@ -136,6 +141,10 @@ module Minitest
   def self.plugin_rails_init(options)
     # Don't mess with Minitest unless RAILS_ENV is set
     return unless ENV["RAILS_ENV"] || ENV["RAILS_MINITEST_PLUGIN"]
+
+    if ::Rails::TestUnit::Runner.load_test_files
+      ::Rails::TestUnit::Runner.load_tests(options.fetch(:test_files, []))
+    end
 
     unless options[:full_backtrace]
       # Plugin can run without Rails loaded, check before filtering.

--- a/railties/lib/rails/test_unit/runner.rb
+++ b/railties/lib/rails/test_unit/runner.rb
@@ -26,6 +26,7 @@ module Rails
       TEST_FOLDERS = [:models, :helpers, :channels, :controllers, :mailers, :integration, :jobs, :mailboxes]
       PATH_ARGUMENT_PATTERN = %r"^(?!/.+/$)[.\w]*[/\\]"
       mattr_reader :filters, default: []
+      mattr_reader :load_test_files, default: false
 
       class << self
         def attach_before_load_options(opts)
@@ -52,10 +53,14 @@ module Rails
           success || exit(false)
         end
 
-        def run(argv = [])
-          load_tests(argv)
-
+        def run(args = [])
           require "active_support/testing/autorun"
+
+          @@load_test_files = true
+
+          at_exit do
+            ARGV.replace(args)
+          end
         end
 
         def load_tests(argv)
@@ -93,8 +98,6 @@ module Rails
           def extract_filters(argv)
             # Extract absolute and relative paths but skip -n /.*/ regexp filters.
             argv.filter_map do |path|
-              next unless path_argument?(path)
-
               path = path.tr("\\", "/")
               case
               when /(:\d+(-\d+)?)+$/.match?(path)

--- a/railties/test/application/test_runner_test.rb
+++ b/railties/test/application/test_runner_test.rb
@@ -222,6 +222,69 @@ module ApplicationTests
       end
     end
 
+    def test_run_test_at_root
+      app_file "my_test.rb", <<-RUBY
+        require "test_helper"
+
+        class MyTest < ActiveSupport::TestCase
+          def test_rikka
+            puts 'Rikka'
+          end
+        end
+      RUBY
+
+      run_test_command("my_test.rb").tap do |output|
+        assert_match "Rikka", output
+      end
+    end
+
+    def test_run_test_having_a_slash_in_its_name
+      app_file "my_test.rb", <<-RUBY
+        require "test_helper"
+
+        class MyTest < ActiveSupport::TestCase
+          test "foo/foo" do
+            puts 'Rikka'
+          end
+        end
+      RUBY
+
+      run_test_command("my_test.rb -n foo\/foo").tap do |output|
+        assert_match "Rikka", output
+      end
+    end
+
+    def test_run_test_with_flags_unordered
+      app_file "my_test.rb", <<-RUBY
+        require "test_helper"
+
+        class MyTest < ActiveSupport::TestCase
+          test "foo/foo" do
+            puts 'Rikka'
+          end
+        end
+      RUBY
+
+      run_test_command("--seed 344 my_test.rb --fail-fast -n foo\/foo").tap do |output|
+        assert_match "Rikka", output
+      end
+    end
+
+    def test_run_test_after_a_flag_without_argument
+      app_file "my_test.rb", <<-RUBY
+        require "test_helper"
+        class MyTest < ActiveSupport::TestCase
+          test "foo/foo" do
+            puts 'Rikka'
+          end
+        end
+      RUBY
+
+      run_test_command("--fail-fast my_test.rb -n foo\/foo").tap do |output|
+        assert_match "Rikka", output
+      end
+    end
+
     def test_run_matched_test
       app_file "test/unit/chu_2_koi_test.rb", <<-RUBY
         require "test_helper"


### PR DESCRIPTION
### Problem

See #54647 for the original reason this needs to be fixed.

### Context

[The previous PR](https://github.com/rails/rails/pull/54647) was reverted as we thought it broke running `bin/rails test test:system` where in fact this command was never a valid command, but it was previously silently ignoring the `test:system` arg (anything not considered a path is discarded).
It was in some way a better behaviour as it was at least failing loudly.

Ultimately, #54647 implementation was not broken but the solution wasn't elegant and didn't reach any consensus, so I figured let's try a new approach.

----------------

Whether `bin/rails test test:system` should be supported (as discussed [here](https://github.com/rails/rails/pull/54736#issuecomment-2716156252)), is a different problem that is out of scope of this patch.

----------------

### Solution

Basically the issue is that it's impossible for the Rails test command to know which arguments should be parsed and which should be proxied to minitest. And what it tries to achieve is providing some sort of CLI that minitest lacks.

This implementation relies on letting minitest parse all options **and then** we load the files. Previously it was the opposite, where the rails runner would try to guess what files needs to be required, and then let minitest parse all options. By modifying the order, this allow to provide a "catch-all non-flag arguments" to minitest option parser.

--------------------

Now that we delegate the parsing of ARGV to minitest, I had to workaround two issues:

  1) Running any test subcommand such as `bin/rails test:system` is the equivalent of `bin/rails test test/system`, but in the former, ARGV is empty and the "test/system" string is passed as a ruby parameter to the main test command.

     So we need to mutate ARGV. **But** mutating argv can only be done inside a `at_exit` hook, because any mutation would be rolled back when the command exists. This happens before minitest
has run any test (at process exit).
     https://github.com/rails/rails/blob/f575fca24a72cf0631c59ed797c575392fbbc527/railties/lib/rails/command.rb#L140-L146

2) Running a test **without** the rails command: `ruby test/my_test.rb` would end up loading the `my_test.rb` file twice.
First, because of `ruby`, and then because of our minitest plugin. So we need to let our minitest plugin know whether loading file is required (e.g. did the user end up using the CLI).


cc/ @byroot @matthewd 