### PR TITLE
Split `bin/rails test test:system` into two steps:

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/ci.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/ci.rb.tt
@@ -19,7 +19,8 @@ CI.run do
 <% if options[:api] || options[:skip_system_test] -%>
   step "Tests: Rails", "bin/rails test"
 <% else %>
-  step "Tests: Rails", "bin/rails test test:system"
+  step "Tests: Rails", "bin/rails test"
+  step "Tests: System", "bin/rails test:system"
 <% end -%>
   step "Tests: Seeds", "env RAILS_ENV=test bin/rails db:seed:replant"
 

--- a/railties/test/application/bin_ci_test.rb
+++ b/railties/test/application/bin_ci_test.rb
@@ -19,7 +19,8 @@ module ApplicationTests
         # Default steps
         assert_match(/bin\/rubocop/, content)
         assert_match(/bin\/brakeman/, content)
-        assert_match(/bin\/rails test/, content)
+        assert_match(/"bin\/rails test"$/, content)
+        assert_match(/"bin\/rails test:system"$/, content)
         assert_match(/bin\/rails db:seed:replant/, content)
 
         # Node-specific steps excluded by default


### PR DESCRIPTION
`bin/rails test test:system` is not a thing. The `test:system` part is silently discarded.

This should be loudly failing with the change I'm trying to add in https://github.com/rails/rails/pull/54741, and there are discussions in #54736 whether running multiple commands à la rake should be supported.

But in the meantime, modifying this into two steps would ensure your system tests actually run.

