### PR TITLE
Fix regression in ActiveRecord::Result#column_types

### DIFF
--- a/activerecord/lib/active_record/result.rb
+++ b/activerecord/lib/active_record/result.rb
@@ -163,7 +163,8 @@ module ActiveRecord
         @types_hash ||= begin
           types = {}
           @columns.each_with_index do |name, index|
-            types[name] = types[index] = @column_types[index]
+            type = @column_types[index] || Type.default_value
+            types[name] = types[index] = type
           end
           types.freeze
         end

--- a/activerecord/test/cases/result_test.rb
+++ b/activerecord/test/cases/result_test.rb
@@ -147,5 +147,21 @@ module ActiveRecord
       assert_equal a.rows, b.rows
       assert_equal a.column_indexes, b.column_indexes
     end
+
+    test "column_types handles nil types in the column_types array" do
+      values = [["1.1", "2.2"], ["3.3", "4.4"]]
+      columns = ["col1", "col2"]
+      types = [Type::Integer.new, nil]  # Deliberately nil type for col2
+      result = Result.new(columns, values, types)
+
+      assert_not_nil result.column_types["col1"]
+      assert_not_nil result.column_types["col2"]
+
+      assert_instance_of ActiveRecord::Type::Value, result.column_types["col2"]
+
+      assert_nothing_raised do
+        result.column_types["col2"].deserialize("test value")
+      end
+    end
   end
 end


### PR DESCRIPTION
## What problem are you solving?

Fixes a regression in https://github.com/rails/rails/commit/f37a6dd2184082c9954016f32d64905ab873e0f1

When a column type is `nil` in the original `column_types` array, the new implementation was returning `nil` instead of falling back to the default type. This caused `undefined method 'deserialize' for nil` errors when accessing model attributes through ActiveModel::LazyAttributeSet#fetch_value.

Reproduction script:

```ruby
# frozen_string_literal: true

require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"
  gem "rails", github: "rails/rails", branch: "main"
end

require "active_record"

# Create a result object with a nil type for the managed_by column
columns = ["id", "name", "managed_by"]
rows = [[1, "Test", "Admin"]]
column_types = [
  ActiveModel::Type::Integer.new,
  ActiveModel::Type::String.new,
  nil  # Deliberately nil type for managed_by
]

result = ActiveRecord::Result.new(columns, rows, column_types)

puts "=== Current Implementation ==="
puts "Column types hash: #{result.column_types.inspect}"
puts ""
puts "Type for 'managed_by': #{result.column_types['managed_by'].inspect}"

additional_types = {}
name = "managed_by"
fallback_type = additional_types.fetch(name, result.column_types[name])
puts "Fallback type: #{fallback_type.inspect}"

begin
  value = "some_value"
  deserialized = fallback_type&.deserialize(value)
  puts "Deserialized value: #{deserialized.inspect}"
rescue NoMethodError => e
  puts "ERROR: #{e.message}"
end

puts "\n=== With Fix Applied ==="

# Monkey patch to fix the issue
class ActiveRecord::Result
  def column_types
    if @column_types
      @types_hash ||= begin
        types = {}
        @columns.each_with_index do |name, index|
          type = @column_types[index] || ActiveRecord::Type.default_value
          types[name] = types[index] = type
        end
        types.freeze
      end
    else
      EMPTY_HASH
    end
  end
end

fixed_result = ActiveRecord::Result.new(columns, rows, column_types)

puts "Fixed column types hash: #{fixed_result.column_types.inspect}"
puts ""
puts "Fixed type for 'managed_by': #{fixed_result.column_types['managed_by'].inspect}"

fixed_fallback = additional_types.fetch(name, fixed_result.column_types[name])
puts "Fixed fallback type: #{fixed_fallback.inspect}"

value = "some_value"
deserialized = fixed_fallback.deserialize(value)
puts "Deserialized value: #{deserialized.inspect}"
```

<details><summary> Repro Script Output </summary>

=== Current Implementation ===
Column types hash: {0 => #<ActiveModel::Type::Integer:0x000000013c759940 @precision=nil, @scale=nil, @limit=nil, @max=2147483648, @min=-2147483648>, "id" => #<ActiveModel::Type::Integer:0x000000013c759940 @precision=nil, @scale=nil, @limit=nil, @max=2147483648, @min=-2147483648>, 1 => #<ActiveModel::Type::String:0x000000013c759850 @true="t", @false="f", @precision=nil, @scale=nil, @limit=nil>, "name" => #<ActiveModel::Type::String:0x000000013c759850 @true="t", @false="f", @precision=nil, @scale=nil, @limit=nil>, 2 => nil, "managed_by" => nil}

Type for 'managed_by': nil
Fallback type: nil
Deserialized value: nil

=== With Fix Applied ===
Fixed column types hash: {0 => #<ActiveModel::Type::Integer:0x000000013c759940 @precision=nil, @scale=nil, @limit=nil, @max=2147483648, @min=-2147483648>, "id" => #<ActiveModel::Type::Integer:0x000000013c759940 @precision=nil, @scale=nil, @limit=nil, @max=2147483648, @min=-2147483648>, 1 => #<ActiveModel::Type::String:0x000000013c759850 @true="t", @false="f", @precision=nil, @scale=nil, @limit=nil>, "name" => #<ActiveModel::Type::String:0x000000013c759850 @true="t", @false="f", @precision=nil, @scale=nil, @limit=nil>, 2 => #<ActiveModel::Type::Value:0x0000000138f51048 @precision=nil, @scale=nil, @limit=nil>, "managed_by" => #<ActiveModel::Type::Value:0x0000000138f51048 @precision=nil, @scale=nil, @limit=nil>}

Fixed type for 'managed_by': #<ActiveModel::Type::Value:0x0000000138f51048 @precision=nil, @scale=nil, @limit=nil>
Fixed fallback type: #<ActiveModel::Type::Value:0x0000000138f51048 @precision=nil, @scale=nil, @limit=nil>
Deserialized value: "some_value"

</details>


