### PR TITLE
Make assert_driver_capabilities flexible with unexpected keys

### DIFF
--- a/actionpack/test/dispatch/system_testing/driver_test.rb
+++ b/actionpack/test/dispatch/system_testing/driver_test.rb
@@ -144,6 +144,21 @@ class DriverTest < ActiveSupport::TestCase
     assert_driver_capabilities driver, expected
   end
 
+  test "assert_driver_capabilities ignores unexpected options" do
+    driver = ActionDispatch::SystemTesting::Driver.new(:selenium, screen_size: [1400, 1400], using: :chrome) do |option|
+      option.binary = "/usr/bin/chromium-browser"
+    end
+    driver.use
+
+    expected = {
+      "goog:chromeOptions" => {
+        "args" => ["--disable-search-engine-choice-screen"],
+      },
+      "browserName" => "chrome"
+    }
+    assert_driver_capabilities driver, expected
+  end
+
   test "does not define extra capabilities" do
     driver = ActionDispatch::SystemTesting::Driver.new(:selenium, screen_size: [1400, 1400], using: :firefox)
 
@@ -202,6 +217,20 @@ class DriverTest < ActiveSupport::TestCase
     def assert_driver_capabilities(driver, expected_capabilities)
       capabilities = driver.__send__(:browser_options)[:options].as_json
 
-      assert_equal expected_capabilities, capabilities.slice(*expected_capabilities.keys)
+      expected_capabilities.each do |key, expected_value|
+        actual_value = capabilities[key]
+
+        case expected_value
+        when Array
+          expected_value.each { |item| assert_includes actual_value, item, "Expected #{key} to include #{item}" }
+        when Hash
+          expected_value.each do |sub_key, sub_value|
+            real_value = actual_value&.dig(sub_key)
+            assert_equal sub_value, real_value, "Expected #{key}[#{sub_key}] to be #{sub_value}, got #{real_value}"
+          end
+        else
+          assert_equal expected_value, actual_value, "Expected #{key} to be #{expected_value}, got #{actual_value}"
+        end
+      end
     end
 end


### PR DESCRIPTION
Fixes #54740

```
Failure:
DriverTest#test_assert_driver_capabilities_ignores_unexpected_options [test/dispatch/system_testing/driver_test.rb:159]:
--- expected
+++ actual
@@ -1 +1 @@
-{"goog:chromeOptions"=>{"args"=>["--disable-search-engine-choice-screen"]}, "browserName"=>"chrome"}
+{"goog:chromeOptions"=>{"args"=>["--disable-search-engine-choice-screen"], "binary"=>"/usr/bin/chromium-browser"}, "browserName"=>"chrome"}
```

For example, with failing assertion:

```
Failure:
DriverTest#test_assert_driver_capabilities_ignores_unexpected_options [test/dispatch/system_testing/driver_test.rb:160]:
Expected goog:chromeOptions[binary] to be /usr/bin/chromium-browsers, got /usr/bin/chromium-browser.
Expected: "/usr/bin/chromium-browsers"
  Actual: "/usr/bin/chromium-browser"
```