### PR TITLE
Add tests ensuring CurrentAttributes eagerly define class methods

### DIFF
--- a/activesupport/lib/active_support/current_attributes.rb
+++ b/activesupport/lib/active_support/current_attributes.rb
@@ -117,6 +117,9 @@ module ActiveSupport
           raise ArgumentError, "Restricted attribute names: #{invalid_attribute_names.join(", ")}"
         end
 
+        Delegation.generate(singleton_class, names, to: :instance, nilable: false, signature: "")
+        Delegation.generate(singleton_class, names.map { |n| "#{n}=" }, to: :instance, nilable: false, signature: "value")
+
         ActiveSupport::CodeGenerator.batch(generated_attribute_methods, __FILE__, __LINE__) do |owner|
           names.each do |name|
             owner.define_cached_method(name, namespace: :current_attributes) do |batch|
@@ -133,9 +136,6 @@ module ActiveSupport
             end
           end
         end
-
-        Delegation.generate(singleton_class, names, to: :instance, nilable: false, signature: "")
-        Delegation.generate(singleton_class, names.map { |n| "#{n}=" }, to: :instance, nilable: false, signature: "value")
 
         self.defaults = defaults.merge(names.index_with { default })
       end
@@ -181,6 +181,21 @@ module ActiveSupport
 
         def respond_to_missing?(name, _)
           instance.respond_to?(name) || super
+        end
+
+        def method_added(name)
+          super
+
+          # We try to generate instance delegators early to not rely on method_missing.
+          return if name == :initialize
+
+          # If the added method isn't public, we don't delegate it.
+          return unless public_method_defined?(name)
+
+          # If we already have a class method by that name, we don't override it.
+          return if singleton_class.method_defined?(name) || singleton_class.private_method_defined?(name)
+
+          Delegation.generate(singleton_class, [name], to: :instance, as: self, nilable: false)
         end
     end
 

--- a/activesupport/lib/active_support/current_attributes.rb
+++ b/activesupport/lib/active_support/current_attributes.rb
@@ -182,14 +182,6 @@ module ActiveSupport
         def respond_to_missing?(name, _)
           instance.respond_to?(name) || super
         end
-
-        def method_added(name)
-          super
-          return if name == :initialize
-          return unless public_method_defined?(name)
-          return if singleton_class.method_defined?(name) || singleton_class.private_method_defined?(name)
-          Delegation.generate(singleton_class, [name], to: :instance, as: self, nilable: false)
-        end
     end
 
     class_attribute :defaults, instance_writer: false, default: {}.freeze

--- a/activesupport/test/current_attributes_test.rb
+++ b/activesupport/test/current_attributes_test.rb
@@ -276,4 +276,35 @@ class CurrentAttributesTest < ActiveSupport::TestCase
 
     assert_instance_of(Hash, current.bar)
   end
+
+  test "instance delegators are eagerly defined" do
+    current = Class.new(ActiveSupport::CurrentAttributes) do
+      def self.name
+        "MyCurrent"
+      end
+
+      def regular
+        :regular
+      end
+
+      attribute :attr, default: :att
+    end
+
+    assert current.singleton_class.method_defined?(:attr)
+    assert current.singleton_class.method_defined?(:attr=)
+    assert current.singleton_class.method_defined?(:regular)
+  end
+
+  test "attribute delegators have precise signature" do
+    current = Class.new(ActiveSupport::CurrentAttributes) do
+      def self.name
+        "MyCurrent"
+      end
+
+      attribute :attr, default: :att
+    end
+
+    assert_equal [], current.method(:attr).parameters
+    assert_equal [[:req, :value]], current.method(:attr=).parameters
+  end
 end


### PR DESCRIPTION
> [!NOTE]
> This patch is all about whether the previous behaviour was a bug or the expected behaviour. I honestly don't know. If this is a legit bug and the current behaviour is the correct one, feel free to close this PR!

- ### Context

  In #54646, I fixed a bug. The patch introduced a behaviour change which was caught by sorbet typechecking.

  ------------------------

  ```ruby
    class Current < ActiveSupport::Current
      def foo
      end
    end
  ```

  Previously:

  ```ruby
  Current.method(:foo).source_location => nil
  ```

  After:

  ```ruby
   Current.method(:foo).source_location => [lib/active_support/current_attributes.rb", 191]
  ```

  --------------------

  Basically, before, we were never creating a delegation method to the class, and instead relied on `method_missing` entirely.

  ### Problem

  There is no problem per se, but this method_added hook used to do nothing. And the previous patch now creates a delegation on the class.

  This is because when a method is added, `respond_to?` on the instance will always return `true` since we have just defined it. When calling `attribute :foo`, a method on the **singleton class** gets created, but doesn't not trigger our method_added hook defined on the **class**.
