### PR TITLE
[8-0-stable] Backport bug fix from "Stop generating bundler binstub"

### DIFF
--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -7,12 +7,14 @@ require "open-uri"
 require "tsort"
 require "uri"
 require "rails/generators"
+require "rails/generators/bundle_helper"
 require "active_support/core_ext/array/extract_options"
 
 module Rails
   module Generators
     class AppBase < Base # :nodoc:
       include AppName
+      include BundleHelper
 
       NODE_LTS_VERSION = "20.11.1"
       BUN_VERSION = "1.0.1"
@@ -639,32 +641,6 @@ module Rails
         if !options[:skip_action_cable] && options[:skip_solid]
           comment = "Use Redis adapter to run Action Cable in production"
           GemfileEntry.new("redis", ">= 4.0.1", comment, {}, true)
-        end
-      end
-
-      def bundle_command(command, env = {})
-        say_status :run, "bundle #{command}"
-
-        # We are going to shell out rather than invoking Bundler::CLI.new(command)
-        # because `rails new` loads the Thor gem and on the other hand bundler uses
-        # its own vendored Thor, which could be a different version. Running both
-        # things in the same process is a recipe for a night with paracetamol.
-        #
-        # Thanks to James Tucker for the Gem tricks involved in this call.
-        _bundle_command = Gem.bin_path("bundler", "bundle")
-
-        require "bundler"
-        Bundler.with_original_env do
-          exec_bundle_command(_bundle_command, command, env)
-        end
-      end
-
-      def exec_bundle_command(bundle_command, command, env)
-        full_command = %Q["#{Gem.ruby}" "#{bundle_command}" #{command}]
-        if options[:quiet]
-          system(env, full_command, out: File::NULL)
-        else
-          system(env, full_command)
         end
       end
 

--- a/railties/lib/rails/generators/bundle_helper.rb
+++ b/railties/lib/rails/generators/bundle_helper.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module Rails
+  module Generators
+    module BundleHelper # :nodoc:
+      def bundle_command(command, env = {}, params = {})
+        say_status :run, "bundle #{command}"
+
+        # We are going to shell out rather than invoking Bundler::CLI.new(command)
+        # because `rails new` loads the Thor gem and on the other hand bundler uses
+        # its own vendored Thor, which could be a different version. Running both
+        # things in the same process is a recipe for a night with paracetamol.
+        #
+        # Thanks to James Tucker for the Gem tricks involved in this call.
+        _bundle_command = Gem.bin_path("bundler", "bundle")
+
+        require "bundler"
+        Bundler.with_original_env do
+          exec_bundle_command(_bundle_command, command, env, params)
+        end
+      end
+
+      private
+        def exec_bundle_command(bundle_command, command, env, params)
+          full_command = %Q["#{Gem.ruby}" "#{bundle_command}" #{command}]
+          if options[:quiet] || params[:quiet]
+            system(env, full_command, out: File::NULL)
+          else
+            system(env, full_command)
+          end
+        end
+    end
+  end
+end

--- a/railties/lib/rails/generators/rails/authentication/authentication_generator.rb
+++ b/railties/lib/rails/generators/rails/authentication/authentication_generator.rb
@@ -1,8 +1,12 @@
 # frozen_string_literal: true
 
+require "rails/generators/bundle_helper"
+
 module Rails
   module Generators
     class AuthenticationGenerator < Base # :nodoc:
+      include BundleHelper
+
       class_option :api, type: :boolean,
         desc: "Generate API-only controllers and models, with no view templates"
 
@@ -41,9 +45,9 @@ module Rails
       def enable_bcrypt
         if File.read("Gemfile").include?('gem "bcrypt"')
           uncomment_lines "Gemfile", /gem "bcrypt"/
-          Bundler.with_original_env { execute_command :bundle, "install --quiet" }
+          bundle_command("install --quiet")
         else
-          Bundler.with_original_env { execute_command :bundle, "add bcrypt", capture: true }
+          bundle_command("add bcrypt", {}, quiet: true)
         end
       end
 

--- a/railties/test/generators/authentication_generator_test.rb
+++ b/railties/test/generators/authentication_generator_test.rb
@@ -62,11 +62,9 @@ class AuthenticationGeneratorTest < Rails::Generators::TestCase
   def test_authentication_generator_without_bcrypt_in_gemfile
     File.write("Gemfile", File.read("Gemfile").sub(/# gem "bcrypt".*\n/, ""))
 
-    run_generator
+    run_generator_instance
 
-    assert_file "Gemfile" do |content|
-      assert_match(/\ngem "bcrypt"/, content)
-    end
+    assert_includes @bundle_commands, ["add bcrypt", {}, { quiet: true }]
   end
 
   def test_authentication_generator_with_api_flag
@@ -125,20 +123,18 @@ class AuthenticationGeneratorTest < Rails::Generators::TestCase
 
   private
     def run_generator_instance
-      commands = []
-      command_stub ||= -> (command, *args) { commands << [command, *args] }
+      @bundle_commands = []
+      command_stub ||= -> (command, *args) { @bundle_commands << [command, *args] }
 
       @rails_commands = []
       @rails_command_stub ||= -> (command, *_) { @rails_commands << command }
 
       content = nil
-      generator.stub(:execute_command, command_stub) do
+      generator.stub(:bundle_command, command_stub) do
         generator.stub(:rails_command, @rails_command_stub) do
           content = super
         end
       end
-
-      @bundle_commands = commands.filter { |command, _| command == :bundle }
 
       content
     end


### PR DESCRIPTION
This is an attempt to backport #54687 to `8-0-stable` which doesn't include the breaking change to `rails new` in order to fix the failing test.

https://buildkite.com/rails/rails-nightly/builds/1908#01958d3b-e3c5-46e6-842b-67bd334fee1f/1495-1560

@Edouard-chin If I'm understanding correctly, this is just an extract method refactor which we can use in our tests. This test is slow (it was before too), but it passes now, so I think that is a step forward.