### PR TITLE
Skip JSON escaping when writing into JSON columns

### DIFF
--- a/activerecord/lib/active_record/coders/json.rb
+++ b/activerecord/lib/active_record/coders/json.rb
@@ -1,14 +1,19 @@
 # frozen_string_literal: true
 
+require "active_support/json"
+
 module ActiveRecord
   module Coders # :nodoc:
     class JSON # :nodoc:
-      def initialize(options = {})
-        @options = options
+      DEFAULT_OPTIONS = { escape: false }.freeze
+
+      def initialize(options = nil)
+        @options = options ? DEFAULT_OPTIONS.merge(options) : DEFAULT_OPTIONS
+        @encoder = ActiveSupport::JSON::Encoding.json_encoder.new(options)
       end
 
       def dump(obj)
-        ActiveSupport::JSON.encode(obj)
+        @encoder.encode(obj)
       end
 
       def load(json)

--- a/activerecord/lib/active_record/type/json.rb
+++ b/activerecord/lib/active_record/type/json.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "active_support/json"
+
 module ActiveRecord
   module Type
     class Json < ActiveModel::Type::Value
@@ -14,8 +16,10 @@ module ActiveRecord
         ActiveSupport::JSON.decode(value) rescue nil
       end
 
+      JSON_ENCODER = ActiveSupport::JSON::Encoding.json_encoder.new(escape: false)
+
       def serialize(value)
-        ActiveSupport::JSON.encode(value) unless value.nil?
+        JSON_ENCODER.encode(value) unless value.nil?
       end
 
       def changed_in_place?(raw_old_value, new_value)

--- a/activesupport/lib/active_support/json/encoding.rb
+++ b/activesupport/lib/active_support/json/encoding.rb
@@ -20,8 +20,8 @@ module ActiveSupport
       #   ActiveSupport::JSON.encode({ team: 'rails', players: '36' })
       #   # => "{\"team\":\"rails\",\"players\":\"36\"}"
       #
-      # Generates JSON that is safe to include in JavaScript as it escapes
-      # U+2028 (Line Separator) and U+2029 (Paragraph Separator):
+      # By default, it generates JSON that is safe to include in JavaScript, as
+      # it escapes U+2028 (Line Separator) and U+2029 (Paragraph Separator):
       #
       #   ActiveSupport::JSON.encode({ key: "\u2028" })
       #   # => "{\"key\":\"\\u2028\"}"
@@ -32,11 +32,17 @@ module ActiveSupport
       #   ActiveSupport::JSON.encode({ key: "<>&" })
       #   # => "{\"key\":\"\\u003c\\u003e\\u0026\"}"
       #
-      # This can be changed with the +escape_html_entities+ option, or the
+      # This behavior can be changed with the +escape_html_entities+ option, or the
       # global escape_html_entities_in_json configuration option.
       #
       #   ActiveSupport::JSON.encode({ key: "<>&" }, escape_html_entities: false)
       #   # => "{\"key\":\"<>&\"}"
+      #
+      # For performance reasons, you can set the +escape+ option to false,
+      # which will skip all escaping:
+      #
+      #   ActiveSupport::JSON.encode({ key: "\u2028<>&" }, escape: false)
+      #   # => "{\"key\":\"\u2028<>&\"}"
       def encode(value, options = nil)
         if options.nil? || options.empty?
           Encoding.encode_without_options(value)
@@ -75,6 +81,8 @@ module ActiveSupport
             value = value.as_json(options.dup.freeze)
           end
           json = stringify(jsonify(value))
+
+          return json unless @options.fetch(:escape, true)
 
           # Rails does more escaping than the JSON gem natively does (we
           # escape \u2028 and \u2029 and optionally >, <, & to work around
@@ -161,6 +169,8 @@ module ActiveSupport
             value = value.as_json(@options) unless @options.empty?
 
             json = CODER.dump(value)
+
+            return json unless @options.fetch(:escape, true)
 
             # Rails does more escaping than the JSON gem natively does (we
             # escape \u2028 and \u2029 and optionally >, <, & to work around

--- a/activesupport/test/json/encoding_test.rb
+++ b/activesupport/test/json/encoding_test.rb
@@ -52,6 +52,11 @@ class TestJSONEncoding < ActiveSupport::TestCase
     assert_equal %({\"a\":\"b\",\"c\":\"d\"}), sorted_json(ActiveSupport::JSON.encode(a: :b, c: :d))
   end
 
+  def test_unicode_escape
+    assert_equal %{{"\\u2028":"\\u2029"}}, ActiveSupport::JSON.encode("\u2028" => "\u2029")
+    assert_equal %{{"\u2028":"\u2029"}}, ActiveSupport::JSON.encode({ "\u2028" => "\u2029" }, escape: false)
+  end
+
   def test_hash_keys_encoding
     ActiveSupport.escape_html_entities_in_json = true
     assert_equal "{\"\\u003c\\u003e\":\"\\u003c\\u003e\"}", ActiveSupport::JSON.encode("<>" => "<>")


### PR DESCRIPTION
This extra escaping is only needed if the JSON end up included in a `<script>` tag, so entirely unnecessary when writing into a database column.

This is tengential to https://github.com/rails/rails/pull/54643. For `render json:` we need to decide if we should introduce a new framework default, but for JSON columns we can perform that same optimization safely, so it can be merged now.

cc @etiennebarrie 