### PR TITLE
[8.0] Fix default GitHub Actions config

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/github/ci.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/github/ci.yml.tt
@@ -131,7 +131,9 @@ jobs:
         <%- if options[:api] || options[:skip_system_test] -%>
         run: bin/rails db:test:prepare test
         <%- else -%>
-        run: bin/rails db:test:prepare test test:system
+        run: |
+          bin/rails db:test:prepare test
+          bin/rails test:system
         <%- end -%>
       <%- unless options[:api] || options[:skip_system_test] -%>
 

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -647,8 +647,16 @@ class AppGeneratorTest < Rails::Generators::TestCase
 
   def test_inclusion_of_ci_files
     run_generator
-    assert_file ".github/workflows/ci.yml"
-    assert_file ".github/dependabot.yml"
+    assert_file ".github/workflows/ci.yml" do |yaml|
+      assert_nothing_raised do
+        YAML.load(yaml)
+      end
+    end
+    assert_file ".github/dependabot.yml" do |yaml|
+      assert_nothing_raised do
+        YAML.load(yaml)
+      end
+    end
   end
 
   def test_ci_files_are_skipped_if_required


### PR DESCRIPTION
Ref: https://github.com/rails/rails/pull/54742

`bin/rails test test:system` doesn't actually run system tests like `rake` would.

We need to invoke `bin/rails` twice.

cc @Edouard-chin 