### PR TITLE
Add support for regexp query conditions

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,15 @@
+*   Support Regexp values in query hash conditions.
+
+    Active Record now supports accepting a Regexp without modifiers in a
+    hash condition. This will generate SQL using per-database adapter
+    regular expression operators.
+
+    ```ruby
+      Book.where(title: /The/)
+    ```
+
+    *Jenny Shen*
+
 *   Allow bypassing primary key/constraint addition in `implicit_order_column`
 
     When specifying multiple columns in an array for `implicit_order_column`, adding

--- a/activerecord/lib/active_record/relation/predicate_builder.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder.rb
@@ -5,6 +5,7 @@ module ActiveRecord
     require "active_record/relation/predicate_builder/array_handler"
     require "active_record/relation/predicate_builder/basic_object_handler"
     require "active_record/relation/predicate_builder/range_handler"
+    require "active_record/relation/predicate_builder/regexp_handler"
     require "active_record/relation/predicate_builder/relation_handler"
     require "active_record/relation/predicate_builder/association_query_value"
     require "active_record/relation/predicate_builder/polymorphic_array_value"
@@ -18,6 +19,7 @@ module ActiveRecord
       register_handler(Relation, RelationHandler.new)
       register_handler(Array, ArrayHandler.new(self))
       register_handler(Set, ArrayHandler.new(self))
+      register_handler(Regexp, RegexpHandler.new(self))
     end
 
     def build_from_hash(attributes, &block)

--- a/activerecord/lib/active_record/relation/predicate_builder/regexp_handler.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder/regexp_handler.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module ActiveRecord
+  class PredicateBuilder
+    class RegexpHandler # :nodoc:
+      def initialize(predicate_builder)
+        @predicate_builder = predicate_builder
+      end
+
+      def call(attribute, value)
+        unless value.options == 0
+          raise ArgumentError, "Regexp for #{attribute.name} must not have modifiers"
+        end
+
+        attribute.matches_regexp(value.source)
+      end
+
+      private
+        attr_reader :predicate_builder
+    end
+  end
+end

--- a/activerecord/lib/arel/visitors/sqlite.rb
+++ b/activerecord/lib/arel/visitors/sqlite.rb
@@ -71,6 +71,16 @@ module Arel # :nodoc: all
           end
         end
 
+        # REGEXP operator uses regexp() user function. This function is not defined by default.
+        # See: https://www.sqlite.org/lang_expr.html#the_like_glob_regexp_match_and_extract_operators
+        def visit_Arel_Nodes_Regexp(o, collector)
+          infix_value o, collector, " REGEXP "
+        end
+
+        def visit_Arel_Nodes_NotRegexp(o, collector)
+          infix_value o, collector, " NOT REGEXP "
+        end
+
         # Locks are not supported in SQLite
         def visit_Arel_Nodes_Lock(o, collector)
           collector

--- a/activerecord/test/cases/relation/where_test.rb
+++ b/activerecord/test/cases/relation/where_test.rb
@@ -92,6 +92,23 @@ module ActiveRecord
       assert_equal posts(:welcome), Post.rewhere(title: "Welcome to the weblog").first
     end
 
+    # SQLite does not support regexp() user function by default.
+    unless current_adapter?(:SQLite3Adapter)
+      def test_where_with_regexp
+        expected_comments = [comments(:greetings), comments(:more_greetings)]
+
+        assert_equal expected_comments, Comment.where(body: /Thank you( again)? for the welcome/).to_a
+      end
+
+      def test_where_with_regexp_with_options
+        error = assert_raise ArgumentError do
+          Comment.where(body: /Thank you( again)? for the welcome/i)
+        end
+
+        assert_equal "Regexp for body must not have modifiers", error.message
+      end
+    end
+
     def test_where_with_tuple_syntax
       first_topic = topics(:first)
       third_topic = topics(:third)


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

There currently is not a way to use regular expression operators in the Active Record query interface. At Shopify, we're looking to have queries to be db-agnostic to use different DBMSs so raw sql operators wouldn't work. You can write a workable query with Arel but Arel is private API which shouldn't be used.

```ruby
comments = Comment.arel_table
Comment.where(comments[:body].matches_regexp("Thank you( again)? for the welcome"))
```

### Detail

After discussion, @skipkayhil suggested we could expose regex match behaviour as a hash condition.

```ruby
Book.where(title: /The/)
```

This was done by adding a predicate builder handler to handle `Regexp`s. `Regexp` supports options that would modify how the regex should behave that I chose not to support for now at least https://docs.ruby-lang.org/en/3.4/Regexp.html#class-Regexp-label-Modes. There isn't any verification that the regex will be compatible with the database either.

I also added regexp match support for SQLite for this feature to be available for all adapters. SQLite uses `REGEXP` operator, but it doesn't have it implemented by default. I think we should still have it implemented if the database has it supported. I tested it by loading a SQLite extension that implements the `regexp()` user function. Without it, a no such function error is raised `ActiveRecord::StatementInvalid: SQLite3::SQLException: no such function: REGEXP:`.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
