### PR TITLE
Add RuboCop cache to GHA workflow templates

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add RuboCop cache restoration to RuboCop job in GitHub Actions workflow templates.
+
+    *Lovro Bikić*
+
 *   Skip generating mailer-related files in authentication generator if the application does
     not use ActionMailer
 

--- a/railties/lib/rails/generators/rails/app/templates/github/ci.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/github/ci.yml.tt
@@ -48,6 +48,8 @@ jobs:
 <%- unless skip_rubocop? -%>
   lint:
     runs-on: ubuntu-latest
+    env:
+      RUBOCOP_CACHE_ROOT: tmp/rubocop
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -57,6 +59,16 @@ jobs:
         with:
           ruby-version: .ruby-version
           bundler-cache: true
+
+      - name: Prepare RuboCop cache
+        uses: actions/cache@v4
+        env:
+          DEPENDENCIES_HASH: ${{ hashFiles('.ruby-version', '**/.rubocop.yml', 'Gemfile.lock') }}
+        with:
+          path: ${{ env.RUBOCOP_CACHE_ROOT }}
+          key: rubocop-${{ runner.os }}-${{ env.DEPENDENCIES_HASH }}-${{ github.ref_name == github.event.repository.default_branch && github.run_id || 'default' }}
+          restore-keys: |
+            rubocop-${{ runner.os }}-${{ env.DEPENDENCIES_HASH }}-
 
       - name: Lint code for consistent style
         run: bin/rubocop -f github

--- a/railties/lib/rails/generators/rails/plugin/templates/github/ci.yml.tt
+++ b/railties/lib/rails/generators/rails/plugin/templates/github/ci.yml.tt
@@ -9,6 +9,9 @@ jobs:
 <%- unless skip_rubocop? -%>
   lint:
     runs-on: ubuntu-latest
+    env:
+      RUBY_VERSION: <%= ENV["RBENV_VERSION"] || ENV["rvm_ruby_string"] || "#{RUBY_ENGINE}-#{RUBY_ENGINE_VERSION}" %>
+      RUBOCOP_CACHE_ROOT: tmp/rubocop
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -16,8 +19,18 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: <%= ENV["RBENV_VERSION"] || ENV["rvm_ruby_string"] || "#{RUBY_ENGINE}-#{RUBY_ENGINE_VERSION}" %>
+          ruby-version: ${{ env.RUBY_VERSION }}
           bundler-cache: true
+
+      - name: Prepare RuboCop cache
+        uses: actions/cache@v4
+        env:
+          DEPENDENCIES_HASH: ${{ hashFiles('**/.rubocop.yml', 'Gemfile.lock') }}
+        with:
+          path: ${{ env.RUBOCOP_CACHE_ROOT }}
+          key: rubocop-${{ runner.os }}-${{ env.RUBY_VERSION }}-${{ env.DEPENDENCIES_HASH }}-${{ github.ref_name == github.event.repository.default_branch && github.run_id || 'default' }}
+          restore-keys: |
+            rubocop-${{ runner.os }}-${{ env.RUBY_VERSION }}-${{ env.DEPENDENCIES_HASH }}-
 
       - name: Lint code for consistent style
         run: bin/rubocop -f github


### PR DESCRIPTION
Opening this PR as follow-up to https://github.com/rails/rails/pull/54703#issuecomment-2703802664 (cc @byroot, @Earlopain).

Adds RuboCop cache restoration to RuboCop job in GitHub Actions app and plugin workflow templates. The aim is to speed up RuboCop checks by sharing the cache between workflow runs, when possible. This speed-up is most evident as your codebase grows (personal example: codebase I'm working on takes 8 minutes to scan for RuboCop offenses without cache, and about 40 seconds with cache on subsequent runs).

The reasoning behind this implementation is explained in detail [here](https://lovro-bikic.github.io/github-actions-rubocop-workflow/) ([Wayback](https://web.archive.org/web/20250313210604/https://lovro-bikic.github.io/github-actions-rubocop-workflow/) link, for posterity). Recapping important points:
- Cache is invalidated when either GHA runner OS, Ruby version, any `.rubocop.yml` file in the codebase or `Gemfile.lock` change. This closely follows RuboCop's [cache validity](https://docs.rubocop.org/rubocop/usage/caching.html#cache-validity) rules and [cache action practice](https://github.com/actions/cache) to invalidate cache when runner OS changes
- On the default branch (master/main), a new cache entry is created after each workflow run. This ensures up-to-date RuboCop cache. It's implemented this way because [GHA cache is immutable and the only way to "update" it is to create a new entry](https://github.com/actions/cache/blob/main/tips-and-workarounds.md#update-a-cache)
- On branches other than the default, cache is restored from the base branch (if available) and saved for that branch after the RuboCop run finishes as a new entry. These branches have a **single** cache (unless invalidation happens; see first bullet)

  The choice to have a single cache for these branches is a trade-off between using more cache storage and having slightly slower RuboCop checks if later commits change many source files (which would invalidate RuboCop's cache for those files and create new ones). On the default branch, creating a new cache entry for each commit is necessary to keep it up-to-date, but on other branches I don't think it's cost-effective to cache every commit (especially if not much has changed between commits)

Old cache entries are [deleted after not being used for at least 7 days](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/caching-dependencies-to-speed-up-workflows#usage-limits-and-eviction-policy). Users are also free to create [custom workflows to delete cache entries](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/caching-dependencies-to-speed-up-workflows#force-deleting-cache-entries) sooner.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
