### PR TITLE
Expose method_name as attr_reader in Tags::Base

### DIFF
--- a/actionview/lib/action_view/helpers/tags/base.rb
+++ b/actionview/lib/action_view/helpers/tags/base.rb
@@ -6,7 +6,7 @@ module ActionView
       class Base # :nodoc:
         include Helpers::ActiveModelInstanceTag, Helpers::TagHelper, Helpers::FormTagHelper
 
-        attr_reader :object
+        attr_reader :object, :method_name
 
         def initialize(object_name, method_name, template_object, options = {})
           @object_name, @method_name = object_name.to_s.dup, method_name.to_s.dup

--- a/actionview/test/template/active_model_helper_test.rb
+++ b/actionview/test/template/active_model_helper_test.rb
@@ -159,11 +159,12 @@ class ActiveModelHelperTest < ActionView::TestCase
   def test_field_error_proc
     old_proc = ActionView::Base.field_error_proc
     ActionView::Base.field_error_proc = Proc.new do |html_tag, instance|
-      raw(%(<div class=\"field_with_errors\">#{html_tag} <span class="error">#{[instance.error_message].join(', ')}</span></div>))
+      messages = instance.error_message.map { |msg| "#{instance.method_name} #{msg}" }
+      raw(%(<div class=\"field_with_errors\">#{html_tag} <span class="error">#{messages.join(', ')}</span></div>))
     end
 
     assert_dom_equal(
-      %(<div class="field_with_errors"><input id="post_author_name" name="post[author_name]" type="text" value="" /> <span class="error">can't be empty</span></div>),
+      %(<div class="field_with_errors"><input id="post_author_name" name="post[author_name]" type="text" value="" /> <span class="error">author_name can't be empty</span></div>),
       text_field("post", "author_name")
     )
   ensure


### PR DESCRIPTION
### Motivation / Background

Makes the `@method_name` instance variable in `ActionView::Helpers::Tags::Base` accessible externally via an `attr_reader`. This allows consumers of `Tags::Base` (and subclasses) to easily determine the method name associated with the tag.

This is particularly useful for customizing error handling, such as within `config.action_view.field_error_proc`. Previously, while the `instance` object provides access to an `error_message` method (defined in `ActiveModelInstanceTag`), this method returns messages *without* the attribute name (e.g., "can't be blank"). This makes it difficult to provide user-friendly error messages that clearly indicated the field with the error.

With access to `method_name`, developers can now use methods like `ActiveModel::Errors#full_messages_for`, which require the attribute name, to generate more informative and complete error messages (e.g., "Name can't be blank"). This significantly improves the flexibility and user experience when handling validation errors.

Example use case within `field_error_proc`:

```ruby
config.action_view.field_error_proc = Proc.new do |html_tag, instance|
  if instance.kind_of?(ActionView::Helpers::Tags::Label)
    html_tag
  else
    message = instance.object.errors.full_messages_for(instance.method_name).first
    field_error = content_tag(:div, message, class: "field-error")
    safe_join([html_tag, field_error])
  end
end
```

### Detail

This Pull Request adds `:method_name` to `attr_reader` in `ActionView::Helpers::Tags::Base`.


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* ~[ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.~
    - This is a minor change and I haven't updated the CHANGELOG.
