### PR TITLE
Add a run hook to `ActiveRecord::Migration`

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add a load hook for `ActiveRecord::Migration`
+
+    *Simon Booth*
+
 *   Allow bypassing primary key/constraint addition in `implicit_order_column`
 
     When specifying multiple columns in an array for `implicit_order_column`, adding

--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -1627,4 +1627,6 @@ module ActiveRecord
         MIGRATOR_SALT * db_name_hash
       end
   end
+
+  ActiveSupport.run_load_hooks(:active_record_migration, Migration)
 end


### PR DESCRIPTION
### Motivation / Background

In order to support our deployment process, we'd like to include a module in `ActiveRecord::Migration`.  We don't want to load the class unnecessarily.  `ActiveSupport` provides a method to run code when a class is loaded, but it depends on a hook having been defined for the class in question.  

### Detail

This commit adds such a hook when the Migration class, and its support classes in the same file, have been loaded.

### Additional information

The only test I could find involving load hooks was `test_inclusion_runs_active_record_fixtures_load_hook`.  If there's a way to test this change, please let me know!

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature. (checked, but see above)
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
