### PR TITLE
Update docker-entrypoint.tt to cover more patterns for server command

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/docker-entrypoint.tt
+++ b/railties/lib/rails/generators/rails/app/templates/docker-entrypoint.tt
@@ -1,16 +1,17 @@
 #!/bin/bash -e
 
 # Enable jemalloc for reduced memory usage and latency.
-if [ -z "${LD_PRELOAD+x}" ]; then
+if [[ -z "${LD_PRELOAD+x}" ]]; then
     LD_PRELOAD=$(find /usr/lib -name libjemalloc.so.2 -print -quit)
     export LD_PRELOAD
 fi
 
 <% unless skip_active_record? -%>
 # If running the rails server then create or migrate existing database
-if [ "${@: -2:1}" == "./bin/rails" ] && [ "${@: -1:1}" == "server" ]; then
+if [[ "$*" =~ "rails server"( |$) ]] || [[ "$*" =~ "rails s"( |$) ]]; then
   ./bin/rails db:prepare
 fi
 
 <% end -%>
-exec "${@}"
+echo "Running $*"
+exec "$@"


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because default `bin/docker-entrypoint` does not include most common patterns of Rails server shell command which leads to confusion when switching to Rails core entry script implementation.

### Detail

This Pull Request changes `docker-entrypoint.tt` template and introduces regexp for finding `rails s` or `rails server` patterns.

Additionally fixes few findings by shellcheck and introduces short log line which might be very useful to see if `docker-entrypoint.sh` was actually used (some provisioners might override docker entrypoint).

### Additional information

- https://github.com/koalaman/shellcheck/wiki/SC2199
- https://github.com/koalaman/shellcheck/wiki/SC2292
- https://github.com/koalaman/shellcheck/wiki/SC2145

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
