### PR TITLE
Replace triple dot speed optimization for newer ruby versions:

### DIFF
--- a/activesupport/lib/active_support/delegation.rb
+++ b/activesupport/lib/active_support/delegation.rb
@@ -79,7 +79,9 @@ module ActiveSupport
               signature
             elsif /[^\]]=\z/.match?(method)
               "arg"
-            else
+            elsif RUBY_VERSION >= "3.4"
+              "..."
+            else # Speed optimization for prior Ruby versions.
               method_object = if receiver_class
                 begin
                   receiver_class.public_instance_method(method)

--- a/activesupport/test/core_ext/module_test.rb
+++ b/activesupport/test/core_ext/module_test.rb
@@ -633,15 +633,15 @@ class ModuleTest < ActiveSupport::TestCase
     c = Class.new do
       delegate :zero, :one, :two, to: ArityTester
     end
-    assert_equal 0, c.instance_method(:zero).arity
-    assert_equal 1, c.instance_method(:one).arity
-    assert_equal 2, c.instance_method(:two).arity
+    assert_equal expected_arity(0), c.instance_method(:zero).arity
+    assert_equal expected_arity(1), c.instance_method(:one).arity
+    assert_equal expected_arity(2), c.instance_method(:two).arity
 
     e = Class.new do
       delegate :zero, to: ArityTesterModule
     end
 
-    assert_equal 0, e.instance_method(:zero).arity
+    assert_equal expected_arity(0), e.instance_method(:zero).arity
     assert_nothing_raised do
       e.new.zero
     end
@@ -653,12 +653,12 @@ class ModuleTest < ActiveSupport::TestCase
         :kwargs, :kwargs_with_block, :opt_kwargs, :opt_kwargs_with_block, to: :class
     end
 
-    assert_equal 0, d.instance_method(:zero).arity
-    assert_equal 0, d.instance_method(:zero_with_block).arity
-    assert_equal 0, d.instance_method(:zero_with_implicit_block).arity
-    assert_equal 1, d.instance_method(:one).arity
-    assert_equal 1, d.instance_method(:one_with_block).arity
-    assert_equal 2, d.instance_method(:two).arity
+    assert_equal expected_arity(0), d.instance_method(:zero).arity
+    assert_equal expected_arity(0), d.instance_method(:zero_with_block).arity
+    assert_equal expected_arity(0), d.instance_method(:zero_with_implicit_block).arity
+    assert_equal expected_arity(1), d.instance_method(:one).arity
+    assert_equal expected_arity(1), d.instance_method(:one_with_block).arity
+    assert_equal expected_arity(2), d.instance_method(:two).arity
     assert_equal(-1, d.instance_method(:opt).arity)
     assert_equal(-1, d.instance_method(:kwargs).arity)
     assert_equal(-1, d.instance_method(:kwargs_with_block).arity)
@@ -678,4 +678,9 @@ class ModuleTest < ActiveSupport::TestCase
       d.new.opt_kwargs_with_block(a: 1, b: 2, c: 3)
     end
   end
+
+  private
+    def expected_arity(on_prior_ruby, on_ruby_34 = -1)
+      RUBY_VERSION >= "3.4" ? on_ruby_34 : on_prior_ruby
+    end
 end


### PR DESCRIPTION
### Motivation / Background

Simplify the code and prevent a few minor caveats when delegating methods.

### Detail

#### Context

Prior to #46875, the delegation code used a simple `...` to forward all arguments. This changed because `...` was slow, and instead we crafted the method signature by hand. The original benchmark showed that `...` was 3.5x slower. (Thank you @amatsuda !)

Aaron mentioned on the [Ruby ticket](https://bugs.ruby-lang.org/issues/19165#note-6) that the speed was drastically improved on Ruby **3.5**. I tried on Ruby **3.4** and I get similar results. This isn't the case on **3.3.6** where it is still much slower.

> [!NOTE]
> Starting from Ruby 3.4, the speed was greatly improved, but it's still slower (~1,5x) than passing arguments normally. But it's worth considering whether this optimization is still worth doing.

#### Problem

This optimization creates a few minor caveats/limitation

1) Overriding a method with delegation and modifing the arity can't work without redefining the delegation. [Ref](https://github.com/rails/rails/pull/46875#issuecomment-1820666716)
2) In order to be able to handcraft the method signature, the delegation needs to be defined after the target method. A new `as:` argument was added to workaround this limitation.
3) Tools that introspect method signature (like sorbet) may trip over anonymous block passing. [Ref](https://github.com/rails/rails/pull/54646#issuecomment-2719186938)

### Additional information

#### Benchmark

  ```
  ruby 3.3.6 (2024-11-05 revision 75015d4c1f) [x86_64-darwin22]
  Warming up --------------------------------------
         simple call     1.391M i/100ms
         triple dots     485.883k i/100ms
  Calculating -------------------------------------
         simple call     13.462M (± 6.5%) i/s   (74.28 ns/i) -     68.149M in   5.086204s
         triple dots     4.625M (± 5.6%) i/s  (216.20 ns/i) -     23.322M in   5.058731s

  Comparison: simple call: 13462226.3 i/s triple dots:  4625414.2 i/s - 2.91x  slower
  ```

  ------------------

  ```
  ruby 3.4.1 (2024-12-25 revision 48d4efcb85) +PRISM [x86_64-darwin22]
  Warming up --------------------------------------
         simple call     1.375M i/100ms
         triple dots     903.709k i/100ms
  Calculating -------------------------------------
         simple call     13.650M (± 3.4%) i/s   (73.26 ns/i) -     68.735M in   5.041673s
         triple dots     8.950M (± 3.8%) i/s  (111.74 ns/i) -     45.185M in   5.056217s

  Comparison:
         simple call: 13649761.3 i/s
         triple dots:  8949617.8 i/s - 1.53x  slower
  ```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.

cc/ @byroot (Thanks for the suggestion!)