### PR TITLE
[ci skip] Add documentation for configuring non-primary databases using an environment variable

### DIFF
--- a/guides/source/active_record_multiple_databases.md
+++ b/guides/source/active_record_multiple_databases.md
@@ -86,6 +86,13 @@ production:
     replica: true
 ```
 
+Connection URLs for databases can also be configured using environment variables. The variable
+name is formed by concatenating the connection name with `_DATABASE_URL`. For example, setting
+`ANIMALS_DATABASE_URL="mysql2://username:password@host/database"` is merged into the `animals`
+configuration in `database.yml` in the `production` environment. See
+[Configuring a Database](configuring.html#configuring-a-database) for details about how the
+merging works.
+
 When using multiple databases, there are a few important settings.
 
 First, the database name for `primary` and `primary_replica` should be the same because they contain

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/mysql.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/mysql.yml.tt
@@ -49,6 +49,14 @@ test:
 #   production:
 #     url: <%%= ENV["MY_APP_DATABASE_URL"] %>
 #
+<%- unless options.skip_solid? -%>
+# Connection URLs for non-primary databases can also be configured using
+# environment variables. The variable name is formed by concatenating the
+# connection name with `_DATABASE_URL`. For example:
+#
+#   CACHE_DATABASE_URL="mysql2://cacheuser:cachepass@localhost/cachedatabase"
+#
+<%- end -%>
 # Read https://guides.rubyonrails.org/configuring.html#configuring-a-database
 # for a full overview on how database connection configuration can be specified.
 #

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/postgresql.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/postgresql.yml.tt
@@ -81,6 +81,14 @@ test:
 #   production:
 #     url: <%%= ENV["MY_APP_DATABASE_URL"] %>
 #
+<%- unless options.skip_solid? -%>
+# Connection URLs for non-primary databases can also be configured using
+# environment variables. The variable name is formed by concatenating the
+# connection name with `_DATABASE_URL`. For example:
+#
+#   CACHE_DATABASE_URL="postgres://cacheuser:cachepass@localhost/cachedatabase"
+#
+<%- end -%>
 # Read https://guides.rubyonrails.org/configuring.html#configuring-a-database
 # for a full overview on how database connection configuration can be specified.
 #

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/trilogy.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/trilogy.yml.tt
@@ -51,6 +51,14 @@ test:
 #   production:
 #     url: <%%= ENV["MY_APP_DATABASE_URL"] %>
 #
+<%- unless options.skip_solid? -%>
+# Connection URLs for non-primary databases can also be configured using
+# environment variables. The variable name is formed by concatenating the
+# connection name with `_DATABASE_URL`. For example:
+#
+#   CACHE_DATABASE_URL="trilogy://cacheuser:cachepass@localhost/cachedatabase"
+#
+<%- end -%>
 # Read https://guides.rubyonrails.org/configuring.html#configuring-a-database
 # for a full overview on how database connection configuration can be specified.
 #


### PR DESCRIPTION
This documents the behaviour added in #36773 which allows setting a database connection URL in an environment variable named `#{name.upcase}_DATABASE_URL`.

Unless the `--skip-solid` option to `rails new` is set, an explanatory comment is also added to the `database.yml` config file to complement the solid-related multi-database configurations.
