### PR TITLE
gitignore all key files in config/credentials

### DIFF
--- a/railties/lib/rails/commands/credentials/credentials_command.rb
+++ b/railties/lib/rails/commands/credentials/credentials_command.rb
@@ -81,7 +81,6 @@ module Rails
 
           encryption_key_file_generator = Rails::Generators::EncryptionKeyFileGenerator.new
           encryption_key_file_generator.add_key_file(key_path)
-          encryption_key_file_generator.ignore_key_file(key_path)
         end
 
         def ensure_credentials_have_been_added

--- a/railties/lib/rails/commands/encrypted/encrypted_command.rb
+++ b/railties/lib/rails/commands/encrypted/encrypted_command.rb
@@ -45,7 +45,6 @@ module Rails
         def ensure_encryption_key_has_been_added
           return if encrypted_configuration.key?
           encryption_key_file_generator.add_key_file(key_path)
-          encryption_key_file_generator.ignore_key_file(key_path)
         end
 
         def ensure_encrypted_configuration_has_been_added

--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -194,7 +194,6 @@ module Rails
       require "rails/generators/rails/master_key/master_key_generator"
       master_key_generator = Rails::Generators::MasterKeyGenerator.new([], quiet: options[:quiet], force: options[:force])
       master_key_generator.add_master_key_file_silently
-      master_key_generator.ignore_master_key_file_silently
     end
 
     def credentials

--- a/railties/lib/rails/generators/rails/encryption_key_file/encryption_key_file_generator.rb
+++ b/railties/lib/rails/generators/rails/encryption_key_file/encryption_key_file_generator.rb
@@ -21,18 +21,20 @@ module Rails
 
           log ""
           add_key_file_silently(key_path, key)
+          ensure_key_files_are_ignored(key_path)
           log ""
         end
       end
 
       def add_key_file_silently(key_path, key = nil)
         create_file key_path, key || ActiveSupport::EncryptedFile.generate_key, perm: 0600
+        ensure_key_files_are_ignored_silently(key_path)
       end
 
-      def ignore_key_file(key_path, ignore: key_ignore(key_path))
+      def ensure_key_files_are_ignored(key_path, ignore: key_ignore(key_path))
         if File.exist?(".gitignore")
           unless File.read(".gitignore").include?(ignore)
-            log "Ignoring #{key_path} so it won't end up in Git history:"
+            log "Ignoring #{ignore} so it won't end up in Git history:"
             log ""
             append_to_file ".gitignore", ignore
             log ""
@@ -44,13 +46,23 @@ module Rails
         end
       end
 
-      def ignore_key_file_silently(key_path, ignore: key_ignore(key_path))
-        append_to_file ".gitignore", ignore if File.exist?(".gitignore")
+      def ensure_key_files_are_ignored_silently(key_path, ignore: key_ignore(key_path))
+        if File.exist?(".gitignore")
+          unless File.read(".gitignore").include?(ignore)
+            append_to_file ".gitignore", ignore
+          end
+        end
       end
 
       private
         def key_ignore(key_path)
-          [ "", "/#{key_path}", "" ].join("\n")
+          key_path = Pathname.new(key_path) unless key_path.is_a?(Pathname)
+          <<~IGNORE
+
+            # Ignore key files for decrypting credentials and more.
+            /#{key_path.dirname.join("*.key")}
+
+          IGNORE
         end
     end
   end

--- a/railties/lib/rails/generators/rails/master_key/master_key_generator.rb
+++ b/railties/lib/rails/generators/rails/master_key/master_key_generator.rb
@@ -32,21 +32,9 @@ module Rails
         end
       end
 
-      def ignore_master_key_file
-        key_file_generator.ignore_key_file(MASTER_KEY_PATH, ignore: key_ignore)
-      end
-
-      def ignore_master_key_file_silently
-        key_file_generator.ignore_key_file_silently(MASTER_KEY_PATH, ignore: key_ignore)
-      end
-
       private
         def key_file_generator
           EncryptionKeyFileGenerator.new([], options)
-        end
-
-        def key_ignore
-          [ "", "# Ignore master key for decrypting credentials and more.", "/#{MASTER_KEY_PATH}", "" ].join("\n")
         end
     end
   end

--- a/railties/test/commands/credentials_test.rb
+++ b/railties/test/commands/credentials_test.rb
@@ -42,7 +42,7 @@ class Rails::Command::CredentialsTest < ActiveSupport::TestCase
 
     Dir.chdir(app_path) do
       gitignore = File.read(".gitignore")
-      assert_equal 1, gitignore.scan(%r|config/master\.key|).length
+      assert_equal 1, gitignore.scan("config/*.key").length
     end
   end
 
@@ -61,7 +61,7 @@ class Rails::Command::CredentialsTest < ActiveSupport::TestCase
     run_edit_command
 
     assert_file "config/master.key"
-    assert_match "config/master.key", read_file(".gitignore")
+    assert_match "config/*.key", read_file(".gitignore")
   end
 
   test "edit command does not overwrite master key file if it already exists" do
@@ -74,7 +74,7 @@ class Rails::Command::CredentialsTest < ActiveSupport::TestCase
   test "edit command does not add duplicate master key entries to gitignore" do
     2.times { run_edit_command }
 
-    assert_equal 1, read_file(".gitignore").scan("config/master.key").length
+    assert_equal 1, read_file(".gitignore").scan("config/*.key").length
   end
 
   test "edit command can add master key when require_master_key is true" do

--- a/railties/test/commands/encrypted_test.rb
+++ b/railties/test/commands/encrypted_test.rb
@@ -46,7 +46,7 @@ class Rails::Command::EncryptedTest < ActiveSupport::TestCase
     run_edit_command
 
     assert_file "config/master.key"
-    assert_match "config/master.key", read_file(".gitignore")
+    assert_match "config/*.key", read_file(".gitignore")
   end
 
   test "edit command does not overwrite master key file if it already exists" do
@@ -58,8 +58,7 @@ class Rails::Command::EncryptedTest < ActiveSupport::TestCase
 
   test "edit command does not add duplicate master key entries to gitignore" do
     2.times { run_edit_command }
-
-    assert_equal 1, read_file(".gitignore").scan("config/master.key").length
+    assert_equal 1, read_file(".gitignore").scan("/config/*.key").length
   end
 
   test "edit command can add master key when require_master_key is true" do
@@ -87,7 +86,7 @@ class Rails::Command::EncryptedTest < ActiveSupport::TestCase
 
     Dir.chdir(app_path) do
       assert File.exist?("config/tokens.key")
-      assert_match "/config/tokens.key", File.read(".gitignore")
+      assert_match "/config/*.key", File.read(".gitignore")
     end
 
     assert_match(/access_key_id: 123/, run_edit_command(key: "config/tokens.key"))

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -1211,7 +1211,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
     run_generator
 
     assert_file ".gitignore" do |content|
-      assert_match(/config\/master\.key/, content)
+      assert_match("config/*.key", content)
     end
   end
 


### PR DESCRIPTION
As mentioned in https://github.com/rails/rails/discussions/54773, it would be a good idea to gitignore all key files with a wildcard. That's how it is done in the dockerignore file too.