### PR TITLE
Add an easy way to translate your enum invalid value

### DIFF
--- a/activerecord/lib/active_record/locale/en.yml
+++ b/activerecord/lib/active_record/locale/en.yml
@@ -9,6 +9,7 @@ en:
     messages:
       required: "must exist"
       taken: "has already been taken"
+      invalid_enum: "'%{value}' is not a valid %{name}"
 
   # Active Record models configuration
   activerecord:

--- a/activerecord/test/cases/enum_test.rb
+++ b/activerecord/test/cases/enum_test.rb
@@ -310,7 +310,7 @@ class EnumTest < ActiveRecord::TestCase
     e = assert_raises(ArgumentError) do
       @book.status = :unknown
     end
-    assert_equal "'unknown' is not a valid status", e.message
+    assert_equal "'unknown' is not a valid Status", e.message
   end
 
   test "validation with 'validate: true' option" do


### PR DESCRIPTION
### Motivation / Background

When an application supports multiple languages, one issue that arises is the initialization of a class with enums. If the application populates enum fields in bulk, Rails immediately validates the passed values and raises an ArgumentError if they are invalid. However, the error message is always fixed, and the enum name appears exactly as defined in the code—including underscores—rather than being properly translated.

### Detail

This change introduces custom translations for enum values and includes the class name where the enum is defined, improving clarity and localization.
