### PR TITLE
Load lazy route set before inserting test routes

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Load lazy route sets before inserting test routes
+
+    Without loading lazy route sets early, we miss `after_routes_loaded` callbacks, or risk
+    invoking them with the test routes instead of the real ones if another load is triggered by an engine.
+
+    *Gannon McGibbon*
+
 *   Raise `AbstractController::DoubleRenderError` if `head` is called after rendering.
 
     After this change, invoking `head` will lead to an error if response body is already set:

--- a/actionpack/lib/action_dispatch/testing/assertions/routing.rb
+++ b/actionpack/lib/action_dispatch/testing/assertions/routing.rb
@@ -25,7 +25,7 @@ module ActionDispatch
             old_integration_session = nil
 
             setup do
-              old_routes = app.routes
+              old_routes = initialize_lazy_routes(app.routes)
               old_routes_call_method = old_routes.method(:call)
               old_integration_session = integration_session
               create_routes(&block)
@@ -38,7 +38,7 @@ module ActionDispatch
         end
 
         def with_routing(&block)
-          old_routes = app.routes
+          old_routes = initialize_lazy_routes(app.routes)
           old_routes_call_method = old_routes.method(:call)
           old_integration_session = integration_session
           create_routes(&block)
@@ -47,6 +47,14 @@ module ActionDispatch
         end
 
         private
+          def initialize_lazy_routes(routes)
+            if defined?(Rails::Engine::LazyRouteSet) && routes.is_a?(Rails::Engine::LazyRouteSet)
+              routes.tap(&:routes)
+            else
+              routes
+            end
+          end
+
           def create_routes
             app = self.app
             routes = ActionDispatch::Routing::RouteSet.new


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because in some instances, inserting test routes break route loading hooks. Without loading lazy route sets early, we miss after_routes_loaded callbacks, or risk invoking them with the test routes instead of the real ones if another load is triggered by an engine.

### Detail

This Pull Request changes routing assertions to load lazy routes early.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
