### PR TITLE
improve `destroy_all` (CollectionProxy) documentation [ci skip]

### DIFF
--- a/activerecord/lib/active_record/associations/collection_proxy.rb
+++ b/activerecord/lib/active_record/associations/collection_proxy.rb
@@ -476,12 +476,12 @@ module ActiveRecord
       end
 
       # Deletes the records of the collection directly from the database
-      # ignoring the +:dependent+ option. Records are instantiated and it
+      # ignoring the +:dependent+ option on the relationship. Records are instantiated and it
       # invokes +before_remove+, +after_remove+, +before_destroy+, and
       # +after_destroy+ callbacks.
       #
       #   class Person < ActiveRecord::Base
-      #     has_many :pets
+      #     has_many :pets, dependent: :nullify
       #   end
       #
       #   person.pets.size # => 3
@@ -492,7 +492,7 @@ module ActiveRecord
       #   #       #<Pet id: 3, name: "Choo-Choo", person_id: 1>
       #   #    ]
       #
-      #   person.pets.destroy_all
+      #   person.pets.destroy_all # ignores the `dependent: :nullify` specified above
       #
       #   person.pets.size # => 0
       #   person.pets      # => []


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because I and others ([1](https://github.com/rails/rails/issues/53876) [2](https://github.com/rails/rails/issues/30026) [3](https://github.com/rails/rails/issues/17159)) have found CollectionProxy's `destroy_all` documentation somewhat confusing.

### Detail

This Pull Request tweaks the RDOC comment for `CollectionProxy#destroy_all` to drive home exactly _which_ dependent option is being ignored; which is the dependent option **specifically** for the relationship we are calling `destroy_all` on (and _**not**_ any of the dependent options below that in the cascade).

Without this change, the documentation for `destroy_all` seems to indicate, at first reading, that CollectionProxy's `destroy_all` is substantially different from Relation's `destroy_all` --perhaps behaving more like `delete_all` and not doing any cascading destroy at all.

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [n/a] Tests are added or updated if you fix a bug or add a feature.
* [n/a] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
