### PR TITLE
Fix ActionDispatch::Routing::RouteSet#recognize_path regression against symbols and give clear error for other types

### DIFF
--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -910,7 +910,10 @@ module ActionDispatch
 
       def recognize_path(path, environment = {})
         method = (environment[:method] || "GET").to_s.upcase
-        path = Journey::Router::Utils.normalize_path(path) unless path&.include?("://")
+
+        raise TypeError, "path must be a String or Symbol" if path && !(path.is_a?(String) || path.is_a?(Symbol))
+
+        path = Journey::Router::Utils.normalize_path(path) unless path&.to_s&.include?("://")
         extras = environment[:extras] || {}
 
         begin

--- a/actionpack/test/controller/routing_test.rb
+++ b/actionpack/test/controller/routing_test.rb
@@ -2125,6 +2125,7 @@ class RackMountIntegrationTests < ActiveSupport::TestCase
 
     assert_equal({ controller: "posts", action: "ping" }, @routes.recognize_path("/posts/ping", method: :get))
     assert_equal({ controller: "posts", action: "index" }, @routes.recognize_path("/posts", method: :get))
+    assert_equal({ controller: "posts", action: "index" }, @routes.recognize_path(:posts, method: :get))
     assert_equal({ controller: "posts", action: "index" }, @routes.recognize_path("/posts/index", method: :get))
     assert_equal({ controller: "posts", action: "show" }, @routes.recognize_path("/posts/show", method: :get))
     assert_equal({ controller: "posts", action: "show", id: "1" }, @routes.recognize_path("/posts/show/1", method: :get))
@@ -2140,6 +2141,7 @@ class RackMountIntegrationTests < ActiveSupport::TestCase
     assert_equal({ controller: "news", action: "index", format: "rss" }, @routes.recognize_path("/news.rss", method: :get))
 
     assert_raise(ActionController::RoutingError) { @routes.recognize_path("/none", method: :get) }
+    assert_raise(TypeError) { @routes.recognize_path({ controller: "news", action: "index" }) }
   end
 
   def test_generate_extras


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

Similar to #47310, I noticed a regression in `ActionDispatch::Routing::RouteSet#recognize_path` against symbols that was introduced in #47262. Rails 7.0 accepted symbols in this method.

Rails 7.0:

```ruby
[1] pry(main)> Rails.application.routes.recognize_path(:accounts)
=> {:controller=>"accounts", :action=>"index"}
[2] pry(main)> Rails.application.routes.recognize_path({ controller: 'test' })
TypeError: no implicit conversion of Hash into String
from /Users/araishikeiwai/.rbenv/versions/3.2.7/lib/ruby/gems/3.2.0/gems/actionpack-7.0.8.5/lib/action_dispatch/routing/route_set.rb:857:in `match?'
```

vs 7.1 and above:

```ruby
[1] pry(main)> Rails.application.routes.recognize_path(:accounts)
NoMethodError: undefined method `include?' for :accounts:Symbol
from /Users/araishikeiwai/.rbenv/versions/3.2.7/lib/ruby/gems/3.2.0/gems/actionpack-7.1.5.1/lib/action_dispatch/routing/route_set.rb:887:in `recognize_path'
[2] pry(main)> Rails.application.routes.recognize_path({ controller: 'test' })
NoMethodError: undefined method `encoding' for {:controller=>"test"}:Hash
from /Users/araishikeiwai/.rbenv/versions/3.2.7/lib/ruby/gems/3.2.0/gems/actionpack-7.1.5.1/lib/action_dispatch/journey/router/utils.rb:19:in `normalize_path'
```

### Detail

This Pull Request keeps the method behaviour similar to previous version when given a symbol, and gives a clear indication of the error when given anything else

### Additional information

Alternative solution would be to outright reject symbols and raise `TypeError`

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
