### PR TITLE
Make `belongs_to` association with `optional: true` necessary when using inverse associations with `dependent: :nullify`

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Make `belongs_to` association with `optional: true` necessary when using
+    inverse associations with `dependent: :nullify`.
+
+    *francktrouillez*
+
 *   Fix upsert_all when using repeated timestamp attributes.
 
     *Gannon McGibbon*

--- a/activerecord/lib/active_record/associations/errors.rb
+++ b/activerecord/lib/active_record/associations/errors.rb
@@ -200,6 +200,16 @@ module ActiveRecord
     end
   end
 
+  class BelongsToCantBeRequiredWithHasOneOrHasManyDependentNullifyError < ActiveRecordError # :nodoc:
+    def initialize(reflection = nil, nullifiable_associations = nil)
+      if reflection && nullifiable_associations
+        super("Association #{reflection.active_record}##{reflection.name} can't be required because #{nullifiable_associations.map(&:active_record).to_sentence} have an inverse association with dependent: :nullify. Please make the #{reflection.active_record}##{reflection.name} belongs_to association optional, or use another dependent strategy for the inverse association.")
+      else
+        super("Association belongs_to can't be required since there exists an inverse association with dependent: :nullify. Please make the belongs_to association optional, or use another dependent strategy for the inverse associations.")
+      end
+    end
+  end
+
   class AmbiguousSourceReflectionForThroughAssociation < ActiveRecordError # :nodoc:
     def initialize(klass, macro, association_name, options, possible_sources)
       example_options = options.dup

--- a/activerecord/test/cases/reflection_test.rb
+++ b/activerecord/test/cases/reflection_test.rb
@@ -7,6 +7,7 @@ require "models/comment"
 require "models/company"
 require "models/company_in_module"
 require "models/ship"
+require "models/developer"
 require "models/pirate"
 require "models/price_estimate"
 require "models/essay"
@@ -641,6 +642,18 @@ class ReflectionTest < ActiveRecord::TestCase
   def test_reflect_on_missing_source_association_raise_exception
     assert_raises(ActiveRecord::HasManyThroughSourceAssociationNotFoundError) do
       Hotel.reflect_on_association(:lost_items).check_validity!
+    end
+  end
+
+  def test_reflect_on_optional_belongs_to_association_when_inverse_has_dependent_nullify_doesnt_raise_exception
+    assert_nothing_raised do
+      Ship.reflect_on_association(:developer).check_validity!
+    end
+  end
+
+  def test_reflect_on_required_belongs_to_association_when_inverse_has_dependent_nullify_raise_exception
+    assert_raises(ActiveRecord::BelongsToCantBeRequiredWithHasOneOrHasManyDependentNullifyError) do
+      ShipWithRequiredDeveloper.reflect_on_association(:developer).check_validity!
     end
   end
 

--- a/activerecord/test/models/developer.rb
+++ b/activerecord/test/models/developer.rb
@@ -87,6 +87,7 @@ class Developer < ActiveRecord::Base
   has_many :ratings, through: :comments
 
   has_one :ship, dependent: :nullify
+  has_one :ship_with_required_developer, dependent: :nullify
   has_one :strict_loading_ship, strict_loading: true, class_name: "Ship"
 
   belongs_to :firm

--- a/activerecord/test/models/ship.rb
+++ b/activerecord/test/models/ship.rb
@@ -5,7 +5,7 @@ class Ship < ActiveRecord::Base
 
   belongs_to :pirate
   belongs_to :update_only_pirate, class_name: "Pirate"
-  belongs_to :developer, dependent: :destroy
+  belongs_to :developer, dependent: :destroy, optional: true
   has_many :parts, class_name: "ShipPart"
   has_many :treasures
 
@@ -20,6 +20,11 @@ class Ship < ActiveRecord::Base
   def cancel_save_callback_method
     throw(:abort)
   end
+end
+
+class ShipWithRequiredDeveloper < ActiveRecord::Base
+  self.table_name = "ships"
+  belongs_to :developer, optional: false
 end
 
 class ShipWithoutNestedAttributes < ActiveRecord::Base


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

Today, when using `has_many` or `has_one` associations with `dependent: :nullify`, Rails will set the foreign key (or the column used for the reference) to `NULL` for each associated record. This is very convenient, but it can lead to data integrity issues from an application level if the associated model doesn't allow for `nil` association.

This means that if we have a model `MyModel` with `has_many :my_sub_models, dependent: :nullify`, and a second model `MySubModel` that has a `belongs_to :my_model`, destroying a record of `MyModel` with associated `MySubModel` records will set the `my_model_id` to `NULL` in the `my_sub_models` table, which will lead to invalid records from the application point of view.

In this PR, I'm implementing a new validation for the reflection generated by a `belongs_to` association with `optional: true` if the inverse associations are using `dependent: :nullify`. This allows to raise an error whenever the association is loaded.

Please let me know if I'm missing something or if there is a better way to solve this issue.

### Detail

This PR introduces a new validity check in the reflection for `belongs_to` associations with `optional: true`. It checks if there are any inverse associations with `dependent: :nullify`, and if so, it raises an error.

This prevents creating invalid records, which would be impossible to modify without fixing the association first.

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

Here is a reproducible example:
```ruby
# frozen_string_literal: true

require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"

  gem "rails"
  gem "sqlite3"
end

require "active_record/railtie"
require "minitest/autorun"

ENV["DATABASE_URL"] = "sqlite3::memory:"

class TestApp < Rails::Application
  config.load_defaults Rails::VERSION::STRING.to_f
  config.eager_load = false
  config.logger = Logger.new($stdout)
  config.secret_key_base = "secret_key_base"

  config.active_record.encryption.primary_key = "primary_key"
  config.active_record.encryption.deterministic_key = "deterministic_key"
  config.active_record.encryption.key_derivation_salt = "key_derivation_salt"
end
Rails.application.initialize!

ActiveRecord::Schema.define do
  create_table :posts, force: true do |t|
  end

  create_table :comments, force: true do |t|
    t.integer :post_id
  end
end

class Post < ActiveRecord::Base
  has_many :comments, dependent: :nullify
end

class Comment < ActiveRecord::Base
  belongs_to :post
end

class BugTest < ActiveSupport::TestCase
  def test_nullify_creates_invalid_records
    post = Post.create!
    post.comments.create!

    assert_equal 1, Post.count
    assert_equal 1, post.comments.count
    assert_equal 1, Comment.count
    assert_equal post.id, Comment.first.post.id
    assert_equal Comment.first.valid?, true
    assert_nothing_raised { Comment.first.save! }


    post.destroy

    assert_equal 0, Post.count
    assert_equal 0, post.comments.count
    assert_equal 1, Comment.count
    assert_nil Comment.first.post&.id
    assert_equal Comment.first.valid?, true # Fails
    assert_nothing_raised { Comment.first.save! } # Fails but is not visible because previous assertion fails
  end
end
```

Running it produces the following output:
```
Fetching gem metadata from https://rubygems.org/...........
Resolving dependencies...
-- create_table(:posts, {:force=>true})
D, [2025-03-20T03:55:55.257872 #2247179] DEBUG -- :    (1.2ms)  DROP TABLE IF EXISTS "posts"
D, [2025-03-20T03:55:55.258077 #2247179] DEBUG -- :    (0.1ms)  CREATE TABLE "posts" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL)
   -> 0.0018s
-- create_table(:comments, {:force=>true})
D, [2025-03-20T03:55:55.258218 #2247179] DEBUG -- :    (0.0ms)  DROP TABLE IF EXISTS "comments"
D, [2025-03-20T03:55:55.258308 #2247179] DEBUG -- :    (0.0ms)  CREATE TABLE "comments" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "post_id" integer)
   -> 0.0002s
D, [2025-03-20T03:55:55.258860 #2247179] DEBUG -- :    (0.0ms)  CREATE TABLE "schema_migrations" ("version" varchar NOT NULL PRIMARY KEY)
D, [2025-03-20T03:55:55.259691 #2247179] DEBUG -- :    (0.1ms)  CREATE TABLE "ar_internal_metadata" ("key" varchar NOT NULL PRIMARY KEY, "value" varchar, "created_at" datetime(6) NOT NULL, "updated_at" datetime(6) NOT NULL)
D, [2025-03-20T03:55:55.269787 #2247179] DEBUG -- :   ActiveRecord::InternalMetadata Load (0.1ms)  SELECT * FROM "ar_internal_metadata" WHERE "ar_internal_metadata"."key" = ? ORDER BY "ar_internal_metadata"."key" ASC LIMIT 1  [[nil, "environment"]]
D, [2025-03-20T03:55:55.270138 #2247179] DEBUG -- :   ActiveRecord::InternalMetadata Create (0.1ms)  INSERT INTO "ar_internal_metadata" ("key", "value", "created_at", "updated_at") VALUES ('environment', 'development', '2025-03-20 02:55:55.269843', '2025-03-20 02:55:55.269845') RETURNING "key"
Run options: --seed 65000

# Running:

I, [2025-03-20T03:55:55.293281 #2247179]  INFO -- : ---------------------------------------------
I, [2025-03-20T03:55:55.293307 #2247179]  INFO -- : BugTest: test_nullify_creates_invalid_records
I, [2025-03-20T03:55:55.293314 #2247179]  INFO -- : ---------------------------------------------
D, [2025-03-20T03:55:55.295729 #2247179] DEBUG -- :   TRANSACTION (0.0ms)  BEGIN immediate TRANSACTION
D, [2025-03-20T03:55:55.295860 #2247179] DEBUG -- :   Post Create (0.2ms)  INSERT INTO "posts" DEFAULT VALUES RETURNING "id"
D, [2025-03-20T03:55:55.296038 #2247179] DEBUG -- :   TRANSACTION (0.0ms)  COMMIT TRANSACTION
D, [2025-03-20T03:55:55.306579 #2247179] DEBUG -- :   TRANSACTION (0.0ms)  BEGIN immediate TRANSACTION
D, [2025-03-20T03:55:55.306726 #2247179] DEBUG -- :   Comment Create (0.2ms)  INSERT INTO "comments" ("post_id") VALUES (?) RETURNING "id"  [["post_id", 1]]
D, [2025-03-20T03:55:55.306855 #2247179] DEBUG -- :   TRANSACTION (0.0ms)  COMMIT TRANSACTION
D, [2025-03-20T03:55:55.307226 #2247179] DEBUG -- :   Post Count (0.0ms)  SELECT COUNT(*) FROM "posts"
D, [2025-03-20T03:55:55.307546 #2247179] DEBUG -- :   Comment Count (0.0ms)  SELECT COUNT(*) FROM "comments" WHERE "comments"."post_id" = ?  [["post_id", 1]]
D, [2025-03-20T03:55:55.307677 #2247179] DEBUG -- :   Comment Count (0.0ms)  SELECT COUNT(*) FROM "comments"
D, [2025-03-20T03:55:55.307928 #2247179] DEBUG -- :   Comment Load (0.0ms)  SELECT "comments".* FROM "comments" ORDER BY "comments"."id" ASC LIMIT ?  [["LIMIT", 1]]
D, [2025-03-20T03:55:55.308419 #2247179] DEBUG -- :   Post Load (0.0ms)  SELECT "posts".* FROM "posts" WHERE "posts"."id" = ? LIMIT ?  [["id", 1], ["LIMIT", 1]]
D, [2025-03-20T03:55:55.308613 #2247179] DEBUG -- :   CACHE Comment Load (0.0ms)  SELECT "comments".* FROM "comments" ORDER BY "comments"."id" ASC LIMIT ?  [["LIMIT", 1]]
D, [2025-03-20T03:55:55.308766 #2247179] DEBUG -- :   CACHE Comment Load (0.0ms)  SELECT "comments".* FROM "comments" ORDER BY "comments"."id" ASC LIMIT ?  [["LIMIT", 1]]
D, [2025-03-20T03:55:55.309163 #2247179] DEBUG -- :   TRANSACTION (0.0ms)  BEGIN immediate TRANSACTION
D, [2025-03-20T03:55:55.309216 #2247179] DEBUG -- :   Comment Update All (0.1ms)  UPDATE "comments" SET "post_id" = ? WHERE "comments"."post_id" = ?  [["post_id", nil], ["post_id", 1]]
D, [2025-03-20T03:55:55.309368 #2247179] DEBUG -- :   Post Destroy (0.0ms)  DELETE FROM "posts" WHERE "posts"."id" = ?  [["id", 1]]
D, [2025-03-20T03:55:55.309424 #2247179] DEBUG -- :   TRANSACTION (0.0ms)  COMMIT TRANSACTION
D, [2025-03-20T03:55:55.309535 #2247179] DEBUG -- :   Post Count (0.0ms)  SELECT COUNT(*) FROM "posts"
D, [2025-03-20T03:55:55.309678 #2247179] DEBUG -- :   Comment Count (0.0ms)  SELECT COUNT(*) FROM "comments" WHERE "comments"."post_id" = ?  [["post_id", 1]]
D, [2025-03-20T03:55:55.309771 #2247179] DEBUG -- :   Comment Count (0.0ms)  SELECT COUNT(*) FROM "comments"
D, [2025-03-20T03:55:55.309889 #2247179] DEBUG -- :   Comment Load (0.0ms)  SELECT "comments".* FROM "comments" ORDER BY "comments"."id" ASC LIMIT ?  [["LIMIT", 1]]
D, [2025-03-20T03:55:55.310046 #2247179] DEBUG -- :   CACHE Comment Load (0.0ms)  SELECT "comments".* FROM "comments" ORDER BY "comments"."id" ASC LIMIT ?  [["LIMIT", 1]]
F

Finished in 0.019151s, 52.2162 runs/s, 574.3784 assertions/s.

  1) Failure:
BugTest#test_nullify_creates_invalid_records [test.rb:65]:
Expected: false
  Actual: true

1 runs, 11 assertions, 1 failures, 0 errors, 0 skips
```


#### Alternative solutions

- I explored the possibility of triggering the validation process whenever we update the records, as I (naively) believe that `dependent: :nullify` should basically do `my_record.my_association.each { |record| record.update!(my_foreign_key: nil) }` when destroying the record.

  This however could lead to unexpected behavior, where people could rely on the current behavior of validations, and wouldn't expect their callbacks to be run when destroying a parent record. This is why I decided to go on a less intrusive approach, where we don't make this validation on a per-record basis, but on a per-association basis.

  It could also happen that there are some records that are already invalid, and we wouldn't want to prevent the destruction of the parent record because of that.

  On another note, this would also prevent persisting records if there is an explicit presence validation on the association (instead of relying on the `belongs_to` helper), which is not the case with the current implementation.

- I also tried going with the validation in the association building process, but this leads to some technical challenges, where the active record classes wouldn't be loaded yet, which makes it harder to get the inverse associations. Also, I could see that just executing/computing the `reflection.klass` during the association building process would lead to some failing tests.

This is why I decided to go with the current approach.

#### Closing notes

I believe that this change would be a great addition, as it prevents one of the "non-explicit" ways of creating invalid records in the database (again, from the application layer), and it doesn't change the current behavior of the `dependent: :nullify` option. The only change required for developers is to add `optional: true` to the `belongs_to` association, which is already something allowed if the column in the database allows for `NULL` values, and expected since the `dependent: :nullify` option is already allowed.

I'd be really happy to discuss this further if you have any questions or suggestions.
Please let me know if I'm missing something or if there is a better way to solve this issue.

Thanks!

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
