### PR TITLE
Ignore .rubocop.yml when building Docker image

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/dockerignore.tt
+++ b/railties/lib/rails/generators/rails/app/templates/dockerignore.tt
@@ -55,6 +55,9 @@
 <% end -%>
 # Ignore development files
 /.devcontainer
+<% unless options.skip_rubocop? -%>
+/.rubocop.yml
+<% end -%>
 
 # Ignore Docker-related files
 /.dockerignore

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -1222,6 +1222,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
       assert_match(/config\/master\.key/, content)
       assert_match(/config\/deploy\*\.yml/, content)
       assert_match(/\.kamal/, content)
+      assert_match(/\.rubocop\.yml/, content)
     end
   end
 
@@ -1231,6 +1232,14 @@ class AppGeneratorTest < Rails::Generators::TestCase
     assert_file ".dockerignore" do |content|
       assert_no_match(/config\/deploy\*\.yml/, content)
       assert_no_match(/\.kamal/, content)
+    end
+  end
+
+  def test_dockerignore_skip_rubocop
+    run_generator [destination_root, "--skip-rubocop"]
+
+    assert_file ".dockerignore" do |content|
+      assert_no_match(/\.rubocop\.yml/, content)
     end
   end
 


### PR DESCRIPTION
### Motivation / Background

Since rubocop gem is required in development and test environments only, we can ignore its configuration file when building the Docker image for deployment.

### Detail

I was not 100% sure about where to place the new ignore line, but I think the "# Ignore development files" section was a good one.

### Additional information

Since users can skip rubocop installation, the template can react to this.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
