### PR TITLE
Refactor IsolatedExecutionState and ExecutionContext to be classes

### DIFF
--- a/activesupport/lib/active_support/execution_context.rb
+++ b/activesupport/lib/active_support/execution_context.rb
@@ -1,53 +1,63 @@
 # frozen_string_literal: true
 
 module ActiveSupport
-  module ExecutionContext # :nodoc:
-    @after_change_callbacks = []
+  class ExecutionContext # :nodoc:
     class << self
-      def after_change(&block)
-        @after_change_callbacks << block
+      def instance
+        @instance ||= new(IsolatedExecutionState)
       end
 
-      # Updates the execution context. If a block is given, it resets the provided keys to their
-      # previous value once the block exits.
-      def set(**options)
-        options.symbolize_keys!
-        keys = options.keys
-
-        store = self.store
-
-        previous_context = keys.zip(store.values_at(*keys)).to_h
-
-        store.merge!(options)
-        @after_change_callbacks.each(&:call)
-
-        if block_given?
-          begin
-            yield
-          ensure
-            store.merge!(previous_context)
-            @after_change_callbacks.each(&:call)
-          end
-        end
-      end
-
-      def []=(key, value)
-        store[key.to_sym] = value
-        @after_change_callbacks.each(&:call)
-      end
-
-      def to_h
-        store.dup
-      end
-
-      def clear
-        store.clear
-      end
-
-      private
-        def store
-          IsolatedExecutionState[:active_support_execution_context] ||= {}
-        end
+      delegate :after_change, :set, :to_h, :clear, :[]=, to: :instance
     end
+
+    def initialize(isolated_execution_state)
+      @isolated_execution_state = isolated_execution_state
+      @after_change_callbacks = []
+    end
+
+    def after_change(&block)
+      @after_change_callbacks << block
+    end
+
+    def set(**options)
+      options.symbolize_keys!
+      keys = options.keys
+
+      previous_context = keys.zip(store.values_at(*keys)).to_h
+
+      store.merge!(options)
+      notify_callbacks
+
+      if block_given?
+        begin
+          yield
+        ensure
+          store.merge!(previous_context)
+          notify_callbacks
+        end
+      end
+    end
+
+    def []=(key, value)
+      store[key.to_sym] = value
+      notify_callbacks
+    end
+
+    def to_h
+      store.dup
+    end
+
+    def clear
+      store.clear
+    end
+
+    private
+      def notify_callbacks
+        @after_change_callbacks.each(&:call)
+      end
+
+      def store
+        @isolated_execution_state[:active_support_execution_context] ||= {}
+      end
   end
 end

--- a/activesupport/lib/active_support/isolated_execution_state.rb
+++ b/activesupport/lib/active_support/isolated_execution_state.rb
@@ -1,14 +1,11 @@
 # frozen_string_literal: true
 
 module ActiveSupport
-  module IsolatedExecutionState # :nodoc:
-    @isolation_level = nil
-
-    Thread.attr_accessor :active_support_execution_state
-    Fiber.attr_accessor :active_support_execution_state
+  class IsolatedExecutionState # :nodoc:
+    @isolation_level = :thread
 
     class << self
-      attr_reader :isolation_level, :scope
+      attr_reader :isolation_level
 
       def isolation_level=(level)
         return if level == @isolation_level
@@ -17,56 +14,77 @@ module ActiveSupport
           raise ArgumentError, "isolation_level must be `:thread` or `:fiber`, got: `#{level.inspect}`"
         end
 
-        clear if @isolation_level
-
-        @scope =
-          case level
-          when :thread; Thread
-          when :fiber; Fiber
-          end
-
+        clear if @instance
         @isolation_level = level
+        @instance = nil
       end
 
-      def unique_id
-        self[:__id__] ||= Object.new
-      end
-
-      def [](key)
-        if state = @scope.current.active_support_execution_state
-          state[key]
+      def instance
+        @instance ||= case isolation_level
+        when :thread; ThreadIsolatedExecutionState.new
+        when :fiber; FiberIsolatedExecutionState.new
         end
       end
 
-      def []=(key, value)
-        state = (@scope.current.active_support_execution_state ||= {})
-        state[key] = value
-      end
+      delegate :[], :[]=, :key?, :delete, :clear, :context, :share_with, :scope, to: :instance
+    end
 
-      def key?(key)
-        @scope.current.active_support_execution_state&.key?(key)
-      end
-
-      def delete(key)
-        @scope.current.active_support_execution_state&.delete(key)
-      end
-
-      def clear
-        @scope.current.active_support_execution_state&.clear
-      end
-
-      def context
-        scope.current
-      end
-
-      def share_with(other)
-        # Action Controller streaming spawns a new thread and copy thread locals.
-        # We do the same here for backward compatibility, but this is very much a hack
-        # and streaming should be rethought.
-        context.active_support_execution_state = other.active_support_execution_state.dup
+    def [](key)
+      if (state = context.active_support_execution_state)
+        state[key]
       end
     end
 
-    self.isolation_level = :thread
+    def []=(key, value)
+      state = (context.active_support_execution_state ||= {})
+      state[key] = value
+    end
+
+    def key?(key)
+      context.active_support_execution_state&.key?(key)
+    end
+
+    def delete(key)
+      context.active_support_execution_state&.delete(key)
+    end
+
+    def clear
+      context.active_support_execution_state&.clear
+    end
+
+    def context
+      scope.current
+    end
+
+    def share_with(other)
+      # Action Controller streaming spawns a new thread and copy thread locals.
+      # We do the same here for backward compatibility, but this is very much a hack
+      # and streaming should be rethought.
+      context.active_support_execution_state = other.active_support_execution_state.dup
+    end
+  end
+
+  class ThreadIsolatedExecutionState < IsolatedExecutionState
+    Thread.attr_accessor :active_support_execution_state
+
+    def scope
+      Thread
+    end
+
+    def isolation_level
+      :thread
+    end
+  end
+
+  class FiberIsolatedExecutionState < IsolatedExecutionState
+    Fiber.attr_accessor :active_support_execution_state
+
+    def scope
+      Fiber
+    end
+
+    def isolation_level
+      :fiber
+    end
   end
 end


### PR DESCRIPTION
### Motivation / Background

This PR refactors `ActiveSupport::IsolatedExecutionState` and `ActiveSupport::ExecutionContext` to be classes, allowing independent execution contexts to exist. At Shopify, we'd like to leverage `ExecutionContext` to store [Error Reporter metadata](https://github.com/rails/rails/blob/3235827585d87661942c91bc81f64f56d710f0b2/activesupport/lib/active_support/error_reporter.rb#L201), but we want the context object to use Fiber storage under the hood so that metadata is inherited by child threads / fibers without clobbering context in the main thread. 

Originally, this work began with changes to support a `:fiber_storage` option on the `IsolatedExecutionState` singleton, but we realized this created issues with other aspects of the framework that rely on `IsolatedExecutionState`, such as DB connections and `CurrentAttributes`. @tenderlove and I settled on first refactoring the execution context modules to allow independent execution states to exist; this will enable us to configure the behaviour for the Error Reporter's execution context without impacting the global isolation level.

Future PRs will add support for `:fiber_storage` isolation, and allow the Error Reporter to instantiate its own execution context.

### Detail

We maintain the singleton interface and delegate to an instance, so these changes are fully backwards compatible. `IsolatedExecutionState` now has two classes, one for thread-specific isolation, and the other for fiber-specific isolation. We instantiate the appropriate one based on the isolation level.

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature. (N/A)
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included. (N/A)
