### PR TITLE
Test if `insert_all` / `upsert_all` apply correct values when given duplicate identifiers in same call

### DIFF
--- a/activerecord/test/cases/insert_all_test.rb
+++ b/activerecord/test/cases/insert_all_test.rb
@@ -185,6 +185,16 @@ class InsertAllTest < ActiveRecord::TestCase
     end
   end
 
+  def test_insert_all_only_applies_last_value_when_given_duplicate_identifiers
+    skip unless supports_insert_on_duplicate_skip?
+
+    Book.insert_all [
+      { id: 111, name: "expected_new_name" },
+      { id: 111, name: "unexpected_new_name" }
+    ]
+    assert_equal "expected_new_name", Book.find(111).name
+  end
+
   def test_skip_duplicates_strategy_does_not_secretly_upsert
     skip unless supports_insert_on_duplicate_skip?
 
@@ -397,6 +407,18 @@ class InsertAllTest < ActiveRecord::TestCase
     Book.upsert_all [{ id: 1, name: "New edition" }], unique_by: :id
 
     assert_equal "New edition", Book.find(1).name
+  end
+
+  def test_upsert_all_only_applies_last_value_when_given_duplicate_identifiers
+    skip unless supports_insert_on_duplicate_update? && !current_adapter?(:PostgreSQLAdapter)
+
+    Book.create!(id: 112, name: "original_name")
+
+    Book.upsert_all [
+      { id: 112, name: "unexpected_new_name" },
+      { id: 112, name: "expected_new_name" }
+    ]
+    assert_equal "expected_new_name", Book.find(112).name
   end
 
   def test_upsert_all_does_notupdates_existing_record_by_when_there_is_no_key


### PR DESCRIPTION
### Motivation / Background

I recently implemented `insert_all` and `upsert_all` support for the [Microsoft SQL Server adapter](https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/1312). MSSQL does not support something like `ON DUPLICATE UPDATE`, so I had to resort to `MERGE`, which essentially joins your new data together with the existing data in the table, then you give it a `CASE` statement what should happen if the entry was found in the database or not.

The current implementation passes all of Rails' tests, but I am unsure if our ordering of the source values is correct.

### Detail

This PR adds two additional tests. The first one checks that `insert_all` only applies the first value for a column that is not an identifier. For `upsert_all`, it is checked that only the last given value is applied.

### Additional information

The SQL server adapter uses the test cases by ActiveRecord to verify its functionality. While this PR only really tests if the `ON UPDATE` clause is set correctly on the adapters supported directly by Rails, it will greatly help us in the SQL adapter to see if we do our `MERGE` statement correctly.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
