### PR TITLE
Allow having a default of `false` for `support_unencrypted_data`

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,16 @@
+*   Add `support_unencrypted_data_default_value` configuration option for ActiveRecord::Encryption
+
+    Adds a new configuration option that allows changing the default behavior for model-level
+    `support_unencrypted_data` configuration when `ActiveRecord::Encryption.config.support_unencrypted_data`
+    is true. When global `support_unencrypted_data` is false, unencrypted data is still never
+    supported, regardless of default value or model-level settings.
+
+    Previously, if you had `ActiveRecord::Encryption.config.support_unencrypted_data` enabled
+    at all, you had to have a default of `support_unencrypted_data=true` for all encrypted
+    attributes in the app.
+
+    *Jordan Brough*
+
 *   Allow bypassing primary key/constraint addition in `implicit_order_column`
 
     When specifying multiple columns in an array for `implicit_order_column`, adding

--- a/activerecord/lib/active_record/encryption/config.rb
+++ b/activerecord/lib/active_record/encryption/config.rb
@@ -7,7 +7,7 @@ module ActiveRecord
     # Container of configuration options
     class Config
       attr_accessor :primary_key, :deterministic_key, :store_key_references, :key_derivation_salt, :hash_digest_class,
-                    :support_unencrypted_data, :encrypt_fixtures, :validate_column_size, :add_to_filter_parameters,
+                    :support_unencrypted_data, :support_unencrypted_data_default_value, :encrypt_fixtures, :validate_column_size, :add_to_filter_parameters,
                     :excluded_from_filter_parameters, :extend_queries, :previous_schemes, :forced_encoding_for_deterministic_encryption,
                     :compressor
 
@@ -49,6 +49,7 @@ module ActiveRecord
         def set_defaults
           self.store_key_references = false
           self.support_unencrypted_data = false
+          self.support_unencrypted_data_default_value = true
           self.encrypt_fixtures = false
           self.validate_column_size = true
           self.add_to_filter_parameters = true

--- a/activerecord/lib/active_record/encryption/encryptable_record.rb
+++ b/activerecord/lib/active_record/encryption/encryptable_record.rb
@@ -30,10 +30,10 @@ module ActiveRecord
         #   will use the oldest encryption scheme to encrypt new data by default. You can change this by setting
         #   <tt>deterministic: { fixed: false }</tt>. That will make it use the newest encryption scheme for encrypting new
         #   data.
-        # * <tt>:support_unencrypted_data</tt> - If `config.active_record.encryption.support_unencrypted_data` is +true+,
-        #   you can set this to +false+ to opt out of unencrypted data support for this attribute. This is useful for
-        #   scenarios where you encrypt one column, and want to disable support for unencrypted data without having to tweak
-        #   the global setting.
+        # * <tt>:support_unencrypted_data</tt> - If `config.active_record.encryption.support_unencrypted_data` is +false+,
+        #   this setting is ignored. Otherwise: You can set this to +true+ or +false+ to to opt in or out of unencrypted data
+        #   support for this attribute. This can be useful when migrating previously unencrypted data. If this is not explicitly
+        #   set, the value of`config.active_record.encryption.support_unencrypted_data_default_value` is used.
         # * <tt>:downcase</tt> - When true, it converts the encrypted content to downcase automatically. This allows to
         #   effectively ignore case when querying data. Notice that the case is lost. Use +:ignore_case+ if you are interested
         #   in preserving it.

--- a/activerecord/lib/active_record/encryption/scheme.rb
+++ b/activerecord/lib/active_record/encryption/scheme.rb
@@ -46,7 +46,7 @@ module ActiveRecord
       end
 
       def support_unencrypted_data?
-        @support_unencrypted_data.nil? ? ActiveRecord::Encryption.config.support_unencrypted_data : @support_unencrypted_data
+        @support_unencrypted_data.nil? ? ActiveRecord::Encryption.config.support_unencrypted_data_default_value : @support_unencrypted_data
       end
 
       def fixed?

--- a/activerecord/test/cases/encryption/unencrypted_attributes_test.rb
+++ b/activerecord/test/cases/encryption/unencrypted_attributes_test.rb
@@ -1,27 +1,85 @@
 # frozen_string_literal: true
 
 require "cases/encryption/helper"
-require "models/post_encrypted"
+require "models/book_encrypted"
 
 class ActiveRecord::Encryption::UnencryptedAttributesTest < ActiveRecord::EncryptionTestCase
-  test "when :support_unencrypted_data is off, it works with unencrypted attributes normally" do
-    ActiveRecord::Encryption.config.support_unencrypted_data = true
-
-    post = ActiveRecord::Encryption.without_encryption { EncryptedPost.create!(title: "The Starfleet is here!", body: "take cover!") }
-    assert_not_encrypted_attribute(post, :title, "The Starfleet is here!")
-
-    # It will encrypt on saving
-    post.update! title: "Other title"
-    assert_encrypted_attribute(post.reload, :title, "Other title")
+  setup do
+    @_support_unencrypted_data_was = ActiveRecord::Encryption.config.support_unencrypted_data
+    @_support_unencrypted_data_default_value_was = ActiveRecord::Encryption.config.support_unencrypted_data_default_value
   end
 
-  test "when :support_unencrypted_data is on, it won't work with unencrypted attributes" do
+  teardown do
+    ActiveRecord::Encryption.config.support_unencrypted_data = @_support_unencrypted_data_was
+    ActiveRecord::Encryption.config.support_unencrypted_data_default_value = @_support_unencrypted_data_default_value_was
+  end
+
+  test "when :support_unencrypted_data is on, it works with unencrypted attributes normally" do
+    ActiveRecord::Encryption.config.support_unencrypted_data = true
+
+    book = ActiveRecord::Encryption.without_encryption { EncryptedBook.create!(name: "The Secrets of Starfleet") }
+    assert_not_encrypted_attribute(book, :name, "The Secrets of Starfleet")
+
+    # It will encrypt on saving
+    book.update! name: "Other name"
+    assert_encrypted_attribute(book.reload, :name, "Other name")
+  end
+
+  test "when :support_unencrypted_data is on, :support_unencrypted_data_default_value can take effect" do
+    ActiveRecord::Encryption.config.support_unencrypted_data = true
+    ActiveRecord::Encryption.config.support_unencrypted_data_default_value = false
+
+    book = ActiveRecord::Encryption.without_encryption { EncryptedBook.create!(name: "The Secrets of Starfleet") }
+
+    # this would succeed if the default were `true`
+    assert_raises ActiveRecord::Encryption::Errors::Decryption do
+      book.name
+    end
+  end
+
+  test "when :support_unencrypted_data is on, the model config takes precedence over the default value" do
+    ActiveRecord::Encryption.config.support_unencrypted_data = true
+    ActiveRecord::Encryption.config.support_unencrypted_data_default_value = false
+
+    book = ActiveRecord::Encryption.without_encryption { EncryptedBookWithUnencryptedDataOptedIn.create!(name: "The Secrets of Starfleet") }
+    # this would fail if the default were being used
+    assert_not_encrypted_attribute(book, :name, "The Secrets of Starfleet")
+
+    # It will encrypt on saving
+    book.update! name: "Other name"
+    assert_encrypted_attribute(book.reload, :name, "Other name")
+  end
+
+  test "when :support_unencrypted_data is off, it won't work with unencrypted attributes" do
     ActiveRecord::Encryption.config.support_unencrypted_data = false
 
-    post = ActiveRecord::Encryption.without_encryption { EncryptedPost.create!(title: "The Starfleet is here!", body: "take cover!") }
+    book = ActiveRecord::Encryption.without_encryption { EncryptedBook.create!(name: "The Secrets of Starfleet") }
 
     assert_raises ActiveRecord::Encryption::Errors::Decryption do
-      post.title
+      book.name
+    end
+  end
+
+  test "when :support_unencrypted_data is off it ignores :support_unencrypted_data_default_value" do
+    ActiveRecord::Encryption.config.support_unencrypted_data = false
+    ActiveRecord::Encryption.config.support_unencrypted_data_default_value = true
+
+    book = ActiveRecord::Encryption.without_encryption { EncryptedBook.create!(name: "The Secrets of Starfleet") }
+
+    # would succeed here if it the default was being used
+    assert_raises ActiveRecord::Encryption::Errors::Decryption do
+      book.name
+    end
+  end
+
+  test "when :support_unencrypted_data is off it ignores the model config" do
+    ActiveRecord::Encryption.config.support_unencrypted_data = false
+
+    book = ActiveRecord::Encryption.without_encryption { EncryptedBookWithUnencryptedDataOptedIn.create!(name: "The Secrets of Starfleet") }
+
+    # would succeed here if it the model config was being used
+    assert_raises ActiveRecord::Encryption::Errors::Decryption do
+      book.name
     end
   end
 end


### PR DESCRIPTION
Adds a new configuration option: `ActiveRecord::Encryption.config.support_unencrypted_data_default_value`.

Previously, if you had `ActiveRecord::Encryption.config.support_unencrypted_data` enabled at all, you had to have a default of `support_unencrypted_data=true` for all encrypted attributes in the app.

When transitioning existing attributes over to encrypted attributes, it's helpful to be able to allow unencrypted attributes where needed, but still have a default of `support_unencrypted_data=false`.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
