### PR TITLE
Address MultibyteCharsExtrasTest#test_should_compute_grapheme_lengthfailure with Ruby 3.5.0dev

### DIFF
--- a/activesupport/test/multibyte_chars_test.rb
+++ b/activesupport/test/multibyte_chars_test.rb
@@ -599,7 +599,7 @@ class MultibyteCharsExtrasTest < ActiveSupport::TestCase
       ["", 0],
       ["abc", 3],
       ["こにちわ", 4],
-      [[0x0924, 0x094D, 0x0930].pack("U*"), 2],
+      [[0x0924, 0x094D, 0x0930].pack("U*"), RbConfig::CONFIG["UNICODE_VERSION"] >= "15.1.0" ? 1 : 2],
       # GB3
       [%w(cr lf), 1],
       # GB4


### PR DESCRIPTION
### Motivation / Background
Fix #54794

### Detail

This commit addresses the following failure with Ruby 3.5.0dev since https://github.com/ruby/ruby/commit/6670926a91734ddb92d01ce4578b1bb48d26b7de

```ruby
% ruby -v
ruby 3.5.0dev (2025-03-21T06:17:15Z master d868922ea8) +PRISM [arm64-darwin24]
% bin/test test/multibyte_chars_test.rb -n test_should_compute_grapheme_length
Running 90 tests in parallel using 10 processes
Run options: -n test_should_compute_grapheme_length --seed 52859

F

Failure:
MultibyteCharsExtrasTest#test_should_compute_grapheme_length [test/multibyte_chars_test.rb:512]:
"त्र".
Expected: 2
  Actual: 1

bin/test test/multibyte_chars_test.rb:595

Finished in 0.209643s, 4.7700 runs/s, 38.1601 assertions/s.
1 runs, 8 assertions, 1 failures, 0 errors, 0 skips
%
```

### Additional information
According to https://github.com/ruby/ruby/pull/12798 ,this is an expected change since Ruby 3.5.0dev uses Unicode 15.1.0.

> As a result, an orthographic syllable in scripts like Devanagari (e.g. “क्या”, consisting of KA + VIRAMA + YA)
> is now treated as a single extended grapheme cluster rather than split into two.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
