### PR TITLE
Add json_key option to customize attribute names in serialization

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,3 +1,19 @@
+*   Add `json_key` option for attributes to customize serialization key names.
+
+    ```ruby
+    class Person
+      include ActiveModel::Serializers::JSON
+      include ActiveModel::Attributes
+
+      attribute :first_name, json_key: "firstName"
+    end
+
+    person = Person.new(first_name: "John")
+    person.as_json # => {"firstName"=>"John"}
+    ```
+
+    *heka1024*
+
 *   Add `except_on:` option for validation callbacks.
 
     *Ben Sheldon*

--- a/activemodel/lib/active_model/attribute_registration.rb
+++ b/activemodel/lib/active_model/attribute_registration.rb
@@ -9,13 +9,15 @@ module ActiveModel
     extend ActiveSupport::Concern
 
     module ClassMethods # :nodoc:
-      def attribute(name, type = nil, default: (no_default = true), **options)
+      def attribute(name, type = nil, default: (no_default = true), json_key: nil, **options)
         name = resolve_attribute_name(name)
         type = resolve_type_name(type, **options) if type.is_a?(Symbol)
         type = hook_attribute_type(name, type) if type
 
         pending_attribute_modifications << PendingType.new(name, type) if type || no_default
         pending_attribute_modifications << PendingDefault.new(name, default) unless no_default
+
+        self.json_key_mapping[name] = json_key if json_key
 
         reset_default_attributes
       end
@@ -48,6 +50,17 @@ module ActiveModel
         else
           attribute_types[attribute_name]
         end
+      end
+
+      # :nodoc:
+      def json_key_for(attribute_name)
+        attribute_name = resolve_attribute_name(attribute_name)
+        json_key_mapping[attribute_name]
+      end
+
+      # :nodoc:
+      def json_key_mapping
+        @json_key_mapping ||= {}
       end
 
       private

--- a/activemodel/lib/active_model/serialization.rb
+++ b/activemodel/lib/active_model/serialization.rb
@@ -172,7 +172,15 @@ module ActiveModel
       end
 
       def serializable_attributes(attribute_names)
-        attribute_names.index_with { |n| read_attribute_for_serialization(n) }
+        attribute_names.each_with_object({}) do |name, result|
+          result_key = json_key_for_attribute(name) || name
+          result[result_key] = read_attribute_for_serialization(name)
+        end
+      end
+
+      def json_key_for_attribute(name)
+        return nil unless self.class.respond_to?(:json_key_for)
+        self.class.json_key_for(name)
       end
 
       # Add associations specified via the <tt>:include</tt> option.

--- a/guides/source/active_model_basics.md
+++ b/guides/source/active_model_basics.md
@@ -1203,6 +1203,28 @@ irb> person.serializable_hash(except: :name)
 => {"age" => 22}
 ```
 
+When using `ActiveModel::Attributes` with `ActiveModel::Serialization`, you can customize the JSON key names for attributes using the `json_key` option. This is particularly useful when you want to follow different naming conventions in your Ruby code and JSON output (like using snake_case in Ruby and camelCase in JSON).
+
+```ruby
+class Person
+  include ActiveModel::Serializers::JSON
+  include ActiveModel::Attributes
+
+  attribute :first_name, :string, json_key: "firstName"
+  attribute :last_name, :string, json_key: "lastName"
+end
+```
+
+```irb
+irb> person = Person.new
+irb> person.first_name = "John"
+irb> person.last_name = "Doe"
+irb> person.as_json
+=> {"firstName" => "John", "lastName" => "Doe"}
+```
+
+As you can see, even though the attribute names in the Ruby code are `first_name` and `last_name`, they are serialized as `firstName` and `lastName` in the JSON output.
+
 The example to utilize the `includes` option requires a slightly more complex
 scenario as defined below:
 


### PR DESCRIPTION
### Motivation / Background

ActiveModel's serialization currently doesn't provide a built-in way to customize JSON key names. When working with external APIs or JavaScript frontends that use camelCase naming conventions, developers must manually transform attribute names or implement custom serializers.

Fixes the need for custom serializers or manual transformations when Rails models use snake_case but need to produce camelCase JSON.

### Detail

This Pull Request adds a new `json_key` option to the `attribute` method in ActiveModel. This allows developers to specify a custom key name used during JSON serialization while keeping Ruby-style snake_case attribute names in their models.

Example usage:
```ruby
class Person
  include ActiveModel::Serializers::JSON
  include ActiveModel::Attributes
  
  attribute :first_name, json_key: "firstName"
end

person = Person.new(first_name: "John")
person.as_json # => {"firstName"=>"John"} instead of {"first_name"=>"John"}
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
