### PR TITLE
Update getting_started.md to remove need for an image repository called "store" and other tweaks [ci skip]

### DIFF
--- a/guides/source/getting_started.md
+++ b/guides/source/getting_started.md
@@ -2800,12 +2800,12 @@ To deploy with Kamal, we need:
   Ubuntu operating system with a Long-Term Support (LTS) version so it receives
   regular security and bug fixes. Hetzner, DigitalOcean, and other hosting
   services provide servers to get started.
-- A [Docker Hub](https://hub.docker.com) account and access token. Docker Hub
-  stores the image of the application so it can be downloaded and run on the
-  server.
+- A [Docker Hub](https://hub.docker.com) account and access token with Read and
+  Write privileges. Docker Hub stores the image of the application so it can be
+  downloaded and run on the server. 
 
-On Docker Hub, [create a Repository](https://hub.docker.com/repository/create)
-for your application image. Use "store" as the name for the repository.
+Kamal will automatically create a repository for you using your application name 
+as the name for the repository.
 
 Open `config/deploy.yml` and replace `192.168.0.1` with your server's IP address
 and `your-user` with your Docker Hub username.
@@ -2843,6 +2843,9 @@ proxy:
 with Read & Write permissions on Docker's website so Kamal can push the Docker
 image for your application.
 
+In the next steps, Kamal will automatically create a repository for you using 
+your application name as the name for the repository.
+
 Then export the access token in the terminal so Kamal can find it.
 
 ```bash
@@ -2867,6 +2870,10 @@ production, you can run the following:
 ```bash
 $ bin/kamal deploy
 ```
+
+Note: Kamal will automatically create your repository as public. If using Docker
+Hub or a similar repository hosting solution, you may choose to mark it as 
+"private" if you would like to protect your source code.
 
 ### Adding a User to Production
 


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because the Deployment section in the Getting Started guide was a tad mid-leading and could be clarified a bit more to ensure users' Docker images and thus source code is kept private.

### Detail

This Pull Request changes:

1. Users may notice that a Docker Hub token will be required and thus will be unsure which privileges will be required. Although this is specified further down in the directions, it has also been clarified when it is first mentioned.

2. Kamal creates a public repository by default which, for most, can expose sensitive application source code. Users should either create their own repository that is private or set it to private after `bin/kamal setup` has been run.

3. Users were instructed in the existing guide to create an image repository called "store" yet this is not required and inaccurate AFAICT. Kamal will create one that is the same name as the application name. This has been rectified.

### Additional information

None.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
