### PR TITLE
Introduce `capture_error_reports`

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,22 @@
+*   Introduce ActiveSupport::Testing::ErrorReporterAssertions#capture_error_reports
+
+    Captures all reported errors from within the block that match the given
+    error class.
+
+    ```ruby
+    reports = capture_error_reports(IOError) do
+      Rails.error.report(IOError.new("Oops"))
+      Rails.error.report(IOError.new("Oh no"))
+      Rails.error.report(StandardError.new)
+    end
+
+    assert_equal 2, reports.size
+    assert_equal "Oops", reports.first.error.message
+    assert_equal "Oh no", reports.last.error.message
+    ```
+
+    *Andrew Novoselac*
+
 *   Introduce ActiveSupport::ErrorReporter#add_middleware
 
     When reporting an error, the error context middleware will be called with the reported error

--- a/activesupport/lib/active_support/testing/error_reporter_assertions.rb
+++ b/activesupport/lib/active_support/testing/error_reporter_assertions.rb
@@ -102,6 +102,23 @@ module ActiveSupport
           assert(false, message)
         end
       end
+
+      # Captures reported errors from within the block that match the given
+      # error class.
+      #
+      #   reports = capture_error_reports(IOError) do
+      #     Rails.error.report(IOError.new("Oops"))
+      #     Rails.error.report(IOError.new("Oh no"))
+      #     Rails.error.report(StandardError.new)
+      #   end
+      #
+      #   assert_equal 2, reports.size
+      #   assert_equal "Oops", reports.first.error.message
+      #   assert_equal "Oh no", reports.last.error.message
+      def capture_error_reports(error_class = StandardError, &block)
+        reports = ErrorCollector.record(&block)
+        reports.select { |r| error_class === r.error }
+      end
     end
   end
 end


### PR DESCRIPTION
### Motivation / Background

I want to use `assert_error_reported` to test that an error is raised a certain number of times. For example, when testing retry logic for an external dependency.

### Detail

~I introduced a `times` option for this assertion. If it is supplied, we assert that there are an equal number of reports and then return them in an array.~

I introduced `capture_error_reports` which captures all the reports from that passed block that match the expected exception. Then you can do assertions on those reports.

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
