### PR TITLE
With postgres adapter, prepend `structure_load_flags` instead of appending them.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Prepend `extra_flags` in postgres' `structure_load`
+
+    When specifying `structure_load_flags` with a postgres adapter, the flags
+    were appended to the default flags, instead of prepended.
+    This caused issues with flags not being taken into account by postgres.
+
+    *Alice Loeser*
+
 *   Allow bypassing primary key/constraint addition in `implicit_order_column`
 
     When specifying multiple columns in an array for `implicit_order_column`, adding

--- a/activerecord/lib/active_record/tasks/postgresql_database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/postgresql_database_tasks.rb
@@ -78,8 +78,9 @@ module ActiveRecord
       end
 
       def structure_load(filename, extra_flags)
-        args = ["--set", ON_ERROR_STOP_1, "--quiet", "--no-psqlrc", "--output", File::NULL, "--file", filename]
+        args = ["--set", ON_ERROR_STOP_1, "--quiet", "--no-psqlrc", "--output", File::NULL]
         args.concat(Array(extra_flags)) if extra_flags
+        args.concat(["--file", filename])
         args << db_config.database
         run_cmd("psql", args, "loading")
       end

--- a/activerecord/test/cases/adapters/postgresql/postgresql_rake_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/postgresql_rake_test.rb
@@ -517,7 +517,7 @@ module ActiveRecord
 
     def test_structure_load_with_extra_flags
       filename = "awesome-file.sql"
-      expected_command = [{}, "psql", "--set", "ON_ERROR_STOP=1", "--quiet", "--no-psqlrc", "--output", File::NULL, "--file", filename, "--noop", @configuration["database"]]
+      expected_command = [{}, "psql", "--set", "ON_ERROR_STOP=1", "--quiet", "--no-psqlrc", "--output", File::NULL, "--noop", "--file", filename, @configuration["database"]]
 
       assert_called_with(Kernel, :system, expected_command, returns: true) do
         with_structure_load_flags(["--noop"]) do
@@ -529,7 +529,7 @@ module ActiveRecord
     def test_structure_load_with_env
       filename = "awesome-file.sql"
       expected_env = { "PGHOST" => "my.server.tld", "PGPORT" => "2345", "PGUSER" => "jane", "PGPASSWORD" => "s3cr3t" }
-      expected_command = [expected_env, "psql", "--set", "ON_ERROR_STOP=1", "--quiet", "--no-psqlrc", "--output", File::NULL, "--file", filename, "--noop", @configuration["database"]]
+      expected_command = [expected_env, "psql", "--set", "ON_ERROR_STOP=1", "--quiet", "--no-psqlrc", "--output", File::NULL, "--noop", "--file", filename, @configuration["database"]]
 
       assert_called_with(Kernel, :system, expected_command, returns: true) do
         with_structure_load_flags(["--noop"]) do
@@ -544,7 +544,7 @@ module ActiveRecord
     def test_structure_load_with_ssl_env
       filename = "awesome-file.sql"
       expected_env = { "PGSSLMODE" => "verify-full", "PGSSLCERT" => "client.crt", "PGSSLKEY" => "client.key", "PGSSLROOTCERT" => "root.crt" }
-      expected_command = [expected_env, "psql", "--set", "ON_ERROR_STOP=1", "--quiet", "--no-psqlrc", "--output", File::NULL, "--file", filename, "--noop", @configuration["database"]]
+      expected_command = [expected_env, "psql", "--set", "ON_ERROR_STOP=1", "--quiet", "--no-psqlrc", "--output", File::NULL, "--noop", "--file", filename, @configuration["database"]]
 
       assert_called_with(Kernel, :system, expected_command, returns: true) do
         with_structure_load_flags(["--noop"]) do
@@ -569,7 +569,7 @@ module ActiveRecord
 
     def test_structure_load_with_hash_extra_flags_for_the_correct_driver
       filename = "awesome-file.sql"
-      expected_command = [{}, "psql", "--set", "ON_ERROR_STOP=1", "--quiet", "--no-psqlrc", "--output", File::NULL, "--file", filename, "--noop", @configuration["database"]]
+      expected_command = [{}, "psql", "--set", "ON_ERROR_STOP=1", "--quiet", "--no-psqlrc", "--output", File::NULL, "--noop", "--file", filename, @configuration["database"]]
 
       assert_called_with(Kernel, :system, expected_command, returns: true) do
         with_structure_load_flags({ postgresql: ["--noop"] }) do


### PR DESCRIPTION
When using postgres adapter and the `structure_load_flags` options, the extra flags were appended instead of prepended to the default ones, causing the `psql` command to ignore some of the extra flags.

Now, the default arguments `args` are appended to the `extra_flags` instead of the opposite.

Example of `extra_flags` that were ignored by postgres:

    ActiveRecord::Tasks::DatabaseTasks.structure_load_flags = ['-c', 'SET my_extension.level=off;'].freeze

Now, they will be taken into account.

Resolves issue #54805. 

<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created because of the following issue: https://github.com/rails/rails/issues/54805

### Detail

This Pull Request changes how `structure_load` uses the `extra_flags` argument, prepending it instead of appending it (for postgres only). 

### Additional information

Alternative solutions considered:

1. Add a new argument to structure_load, with default set to nil (no breaking change), that would be extra_flags_prepended or something like that, and would be set the same way structure_load_flags is
2. Change the structure of structure_load's extra_flags: now instead of being an array/a hash with array value, it would be a 2-dimensional array, [[flags_prepended], [flags_appended]]. Breaking change but an easy fix.

### Checklist

Before submitting the PR make sure the following are checked:

* [ ] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [ ] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
