### PR TITLE
Add a test for the email normalization in the authentication generator

### DIFF
--- a/railties/lib/rails/generators/test_unit/authentication/templates/test/models/user_test.rb.tt
+++ b/railties/lib/rails/generators/test_unit/authentication/templates/test/models/user_test.rb.tt
@@ -1,7 +1,8 @@
 require "test_helper"
 
 class UserTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  test "downcases and strips email_address" do
+    user = User.new(email_address: " DOWNCASED@EXAMPLE.COM ")
+    assert_equal("downcased@example.com", user.email_address)
+  end
 end


### PR DESCRIPTION
### Motivation / Background

The authentication generator started generating controller tests e.g. in #53726 or #53255. This PR changes the generator template for the generated user test  to include a simple test for the email normalization. Accidentally changing the normalization in an app would probably be bad, so I'd propose to generate a simple test for it :).

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
