### PR TITLE
Fix the indentation and whitespaces in the generated PasswordsController

### DIFF
--- a/railties/lib/rails/generators/rails/authentication/templates/app/controllers/passwords_controller.rb.tt
+++ b/railties/lib/rails/generators/rails/authentication/templates/app/controllers/passwords_controller.rb.tt
@@ -1,13 +1,13 @@
 class PasswordsController < ApplicationController
   allow_unauthenticated_access
   before_action :set_user_by_token, only: %i[ edit update ]
-  <% if defined?(ActionMailer::Railtie) -%>
+  <%- if defined?(ActionMailer::Railtie) -%>
   rate_limit to: 10, within: 3.minutes, only: :create, with: -> { redirect_to new_password_path, alert: "Try again later." }
-  <% end -%>
+  <%- end -%>
 
   def new
   end
-  <% if defined?(ActionMailer::Railtie) -%>
+  <%- if defined?(ActionMailer::Railtie) -%>
 
   def create
     if user = User.find_by(email_address: params[:email_address])
@@ -16,7 +16,7 @@ class PasswordsController < ApplicationController
 
     redirect_to new_session_path, notice: "Password reset instructions sent (if user with that email address exists)."
   end
-  <% end -%>
+  <%- end -%>
 
   def edit
   end


### PR DESCRIPTION
Before this PR, the generated PasswordsController indents the `rate_limit` call with 4 spaces instead of 2 and the file has trailing whitespaces that lead to the following Rubocop warnings:

```
Offenses:

app/controllers/passwords_controller.rb:5:1: C: [Correctable] Layout/TrailingWhitespace: Trailing whitespace detected.
app/controllers/passwords_controller.rb:8:1: C: [Correctable] Layout/TrailingWhitespace: Trailing whitespace detected.
app/controllers/passwords_controller.rb:16:1: C: [Correctable] Layout/TrailingWhitespace: Trailing whitespace detected.
```