### PR TITLE
Fix Active Record custom encryption context:

### DIFF
--- a/activerecord/lib/active_record/encryption.rb
+++ b/activerecord/lib/active_record/encryption.rb
@@ -13,6 +13,7 @@ module ActiveRecord
       autoload :Config
       autoload :Configurable
       autoload :Context
+      autoload :ContextForAttribute
       autoload :Contexts
       autoload :DerivedSecretKeyProvider
       autoload :EncryptableRecord

--- a/activerecord/lib/active_record/encryption/context.rb
+++ b/activerecord/lib/active_record/encryption/context.rb
@@ -13,6 +13,7 @@ module ActiveRecord
       PROPERTIES = %i[ key_provider key_generator cipher message_serializer encryptor frozen_encryption ]
 
       attr_accessor(*PROPERTIES)
+      attr_accessor :non_defaults # :nodoc:
 
       def initialize
         set_defaults
@@ -23,6 +24,22 @@ module ActiveRecord
       silence_redefinition_of_method :key_provider
       def key_provider
         @key_provider ||= build_default_key_provider
+      end
+
+      def to_h # :nodoc:
+        PROPERTIES.index_with { |property| instance_variable_get("@#{property}") }.freeze
+      end
+
+      def merge(other) # :nodoc:
+        assign_properties(other.to_h.except(*non_defaults.keys))
+      end
+
+      def assign_properties(properties) # :nodoc:
+        properties.each do |property, value|
+          public_send("#{property}=", value)
+
+          non_defaults[property] = value
+        end
       end
 
       private

--- a/activerecord/lib/active_record/encryption/context_for_attribute.rb
+++ b/activerecord/lib/active_record/encryption/context_for_attribute.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module ActiveRecord
+  module Encryption
+    class ContextForAttribute < Context
+      def merge(other) # :nodoc:
+        assign_properties(other.non_defaults)
+      end
+    end
+  end
+end

--- a/activerecord/lib/active_record/encryption/contexts.rb
+++ b/activerecord/lib/active_record/encryption/contexts.rb
@@ -30,12 +30,19 @@ module ActiveRecord
         #     end
         #
         # Encryption contexts can be nested.
-        def with_encryption_context(properties)
+        def with_encryption_context(properties, context_class = nil)
           self.custom_contexts ||= []
-          self.custom_contexts << default_context.dup
+          properties = properties.symbolize_keys
+          context_to_be_added = (context_class || Context).new
+          context_to_be_added.non_defaults = properties.dup
+
+          properties = default_context.to_h.merge(properties)
           properties.each do |key, value|
-            self.current_custom_context.send("#{key}=", value)
+            context_to_be_added.send("#{key}=", value)
           end
+
+          context_to_be_added.merge(current_custom_context) if current_custom_context
+          self.custom_contexts << context_to_be_added
 
           yield
         ensure

--- a/activerecord/lib/active_record/encryption/scheme.rb
+++ b/activerecord/lib/active_record/encryption/scheme.rb
@@ -69,7 +69,7 @@ module ActiveRecord
 
       def with_context(&block)
         if @context_properties.present?
-          ActiveRecord::Encryption.with_encryption_context(**@context_properties, &block)
+          ActiveRecord::Encryption.with_encryption_context(@context_properties, ContextForAttribute, &block)
         else
           block.call
         end

--- a/activerecord/test/cases/encryption/contexts_test.rb
+++ b/activerecord/test/cases/encryption/contexts_test.rb
@@ -51,6 +51,118 @@ class ActiveRecord::Encryption::ContextsTest < ActiveRecord::EncryptionTestCase
     end
   end
 
+  test ".with_encryption_context can be nested, inner context inherit from outer context" do
+    ActiveRecord::Encryption.with_encryption_context(encryptor: encryptor_1 = ActiveRecord::Encryption::NullEncryptor.new) do
+      ActiveRecord::Encryption.with_encryption_context(key_generator: key_generator = Object.new) do
+        assert_equal(key_generator, ActiveRecord::Encryption.key_generator)
+        assert_equal(encryptor_1, ActiveRecord::Encryption.encryptor)
+
+        ActiveRecord::Encryption.with_encryption_context(key_provider: key_provider = Object.new) do
+          assert_equal(key_generator, ActiveRecord::Encryption.key_generator)
+          assert_equal(encryptor_1, ActiveRecord::Encryption.encryptor)
+          assert_equal(key_provider, ActiveRecord::Encryption.key_provider)
+        end
+      end
+    end
+  end
+
+  test "nested .with_encryption context when mixing string and symbols" do
+    ActiveRecord::Encryption.with_encryption_context(encryptor: encryptor_1 = ActiveRecord::Encryption::NullEncryptor.new) do
+      ActiveRecord::Encryption.with_encryption_context("encryptor" => encryptor_2 = ActiveRecord::Encryption::NullEncryptor.new) do
+        assert_equal encryptor_2, ActiveRecord::Encryption.encryptor
+
+        assert_includes(ActiveRecord::Encryption.context.to_h.keys, :encryptor)
+        assert_not_includes(ActiveRecord::Encryption.context.to_h.keys, "encryptor")
+      end
+      assert_equal encryptor_1, ActiveRecord::Encryption.encryptor
+    end
+  end
+
+  test "nested .with_encryption_context values propagates when encrypting an attribute" do
+    encryptor = Class.new do
+      def binary?
+        false
+      end
+
+      def encrypt(value, **)
+        ActiveRecord::Encryption.message_serializer.dump("The encryptor was used.")
+      end
+
+      def decrypt(value, **)
+        value
+      end
+    end.new
+
+    message_serializer = Class.new do
+      def dump(value)
+        "#{value} The serializer was used."
+      end
+    end.new
+
+    post = EncryptedPostNoCompression.create(title: "abc", body: "")
+
+    ActiveRecord::Encryption.with_encryption_context(encryptor: encryptor) do
+      ActiveRecord::Encryption.with_encryption_context(message_serializer: message_serializer) do
+        post.update!(body: "<Will be replaced>")
+      end
+    end
+
+    assert_equal("The encryptor was used. The serializer was used.", post.body)
+  end
+
+  test ".with_encryption_context uses properties from the default_context" do
+    encryptor = ActiveRecord::Encryption::Encryptor.new
+    ActiveRecord::Encryption.default_context.encryptor = encryptor
+
+    ActiveRecord::Encryption.with_encryption_context({}) do
+      assert_equal(encryptor, ActiveRecord::Encryption.encryptor)
+    end
+  end
+
+  test ".with_encryption_context not explicitly passed properties doesn't override an attibute context property" do
+    post = EncryptedPostNoCompression.create(title: "abc", body: "")
+
+    ActiveRecord::Encryption.with_encryption_context({}) do
+      post_body = "a" * (ActiveRecord::Encryption::Encryptor::THRESHOLD_TO_JUSTIFY_COMPRESSION + 1)
+      post.update!(body: post_body)
+    end
+
+    body_ciphertext = post.ciphertext_for(:body)
+    message = ActiveRecord::Encryption.message_serializer.load(body_ciphertext)
+    assert_nil(message.headers.compressed)
+  end
+
+  test ".with_encryption_context overrides attribute's context" do
+    post_body = "a" * (ActiveRecord::Encryption::Encryptor::THRESHOLD_TO_JUSTIFY_COMPRESSION + 1)
+    post = EncryptedPostNoCompression.create(title: "", body: post_body)
+    body_ciphertext = post.ciphertext_for(:body)
+
+    message = ActiveRecord::Encryption.message_serializer.load(body_ciphertext)
+    assert_nil(message.headers.compressed)
+
+    ActiveRecord::Encryption.with_encryption_context(encryptor: ActiveRecord::Encryption::Encryptor.new(compress: true)) do
+      new_post_body = "b" * (ActiveRecord::Encryption::Encryptor::THRESHOLD_TO_JUSTIFY_COMPRESSION + 1)
+      post.update!(body: new_post_body)
+    end
+
+    new_body_ciphertext = post.ciphertext_for(:body)
+    message = ActiveRecord::Encryption.message_serializer.load(new_body_ciphertext)
+    assert(message.headers.compressed)
+  end
+
+  test ".without_encryption when attribute defines a custom context property" do
+    post = EncryptedPostNoCompression.create(title: "", body: "Some body")
+    body_ciphertext = post.ciphertext_for(:body)
+
+    ActiveRecord::Encryption.without_encryption do
+      assert_equal(body_ciphertext, post.reload.body)
+
+      post.update!(body: "Some new body")
+    end
+
+    assert_not_encrypted_attribute post, :body, "Some new body"
+  end
+
   test ".without_encryption won't decrypt or encrypt data automatically" do
     ActiveRecord::Encryption.without_encryption do
       assert_equal @title_ciphertext, @post.reload.title
@@ -99,6 +211,16 @@ class ActiveRecord::Encryption::ContextsTest < ActiveRecord::EncryptionTestCase
     ActiveRecord::Encryption.protecting_encrypted_data do
       assert_raises ActiveRecord::RecordInvalid do
         @post.update!(title: "Some new title")
+      end
+    end
+  end
+
+  test ".protecting_encrypted_data works when an attribute uses a custom context" do
+    post = EncryptedPostNoCompression.create(title: "", body: "foo")
+
+    ActiveRecord::Encryption.protecting_encrypted_data do
+      assert_raises ActiveRecord::RecordInvalid do
+        post.update!(body: "Some new body")
       end
     end
   end

--- a/activerecord/test/models/post_encrypted.rb
+++ b/activerecord/test/models/post_encrypted.rb
@@ -13,3 +13,9 @@ class EncryptedPost < Post
   encrypts :title
   encrypts :body, key_provider: MutableDerivedSecretKeyProvider.new("my post body secret!")
 end
+
+class EncryptedPostNoCompression < Post
+  self.table_name = "posts"
+
+  encrypts :body, compress: false
+end


### PR DESCRIPTION
### Motivation / Background

- Fix #54785
- Fix #52748
- Fix #51297

## Detail

#### Problem

Active Record `.with_encryption_context` method and custom contexts methods using it such as `.without_encryption` and `protecting_encrypted_data` have no effect for attributes having their own encryption context.

The problems are more easily explained with a couple snippets:

```ruby
class User < ApplicationRecord
  encrypts :password, encryptor: MyEncryptor.new
  # The `encryptor` sets a custom encryption Context for this attribute.
end

ActiveRecord::Encryption.without_encryption do
  puts User.first.password
  # Wrongly display the unencrypted password. We should not be able
  # to either decrypt or encrypt inside the block.
end

ActiveRecord::Encryption.protecting_encrypted_data do 
  User.create!(password: "foo")
  # Wrongly create as new user. It should have raised a Validation Error
end

ActiveRecord::Encryption.with_encryption_context(encryptor: custom_encryptor) do
  User.create!(password: "foo")
  # Doesn't use the `custom_encryptor`.
end
```

In addition to theses bugs, `.with_encryption_context` is inconsistent and nesting them according to the doc have a surprising behaviour:

```ruby
ActiveRecord::Encryption.with_encryption_context(encryptor: custom_encryptor) do 
  ActiveRecord::Encryption.with_encryption_context(key_generator: custom_generator) do
    puts ActiveRecord::Encryption.encryptor # Default encryptor

    # There is no point of nesting if the inner context doesn't reuse the properties from the outer one.
  end
end
```

### Solution

This patch does two things:

1) It modifies the behaviour of `with_encryption_context` so inner context reuse the properties of the outer one instead of the default.
2) It fixes the features that straight doesn't work. And part of the solution relies on the behaviour change from 1).

To fix the bug described, this patch uses a strategy approach as the properties from a context should either have least or most priority, depending on who is the caller:

```ruby
ActiveRecord::Encryption.with_encryption_context(encryptor: encryptor) do 
  ActiveRecord::Encryption.with_encryption_context(encryptor: another_encryptor) do
    # The inner context should be able to override the property from the outer one.
  end
end

ActiveRecord::Encryption.with_encryption_context(encryptor: my_encryptor) do
  User.first.update!(password: "...") # This ends up calling `with_encryption_context` internally.

  # The properties from the outer context should have precedence.
end
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
