### PR TITLE
Allow using aliases for unions in `from` clause

### DIFF
--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -1777,14 +1777,16 @@ module ActiveRecord
 
       def build_from
         opts = from_clause.value
-        name = from_clause.name
+        name = from_clause.name&.to_s || "subquery"
         case opts
         when Relation
           if opts.eager_loading?
             opts = opts.send(:apply_join_dependency)
           end
-          name ||= "subquery"
-          opts.arel.as(name.to_s)
+          opts.arel.as(name)
+        when Arel::Nodes::Union, Arel::Nodes::UnionAll,
+             Arel::Nodes::Intersect, Arel::Nodes::Except
+          opts.as(name)
         else
           opts
         end

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -259,6 +259,18 @@ class RelationTest < ActiveRecord::TestCase
     assert_equal relation.to_a, Comment.select("a.*").from(relation, :a).to_a
   end
 
+  unless current_adapter?(:SQLite3Adapter)
+    def test_select_with_union_in_from
+      arel1 = Comment.where(id: 1).arel
+      arel2 = Comment.where(id: 2).arel
+      union = Arel::Nodes::Union.new(arel1, arel2)
+      expected = [comments(:greetings), comments(:more_greetings)]
+
+      assert_equal expected, Comment.select("subquery.*").from(union).to_a
+      assert_equal expected, Comment.select("a.*").from(union, :a).to_a
+    end
+  end
+
   def test_finding_with_subquery_with_eager_loading_in_where
     relation = Comment.includes(:post).where("posts.type": "Post")
     assert_equal relation.sort_by(&:id), Comment.where(id: relation).sort_by(&:id)


### PR DESCRIPTION
I am optimizing one query in my project and rewrote it using `UNION` instead of `OR`.
 
The new query was like this: `SomeModel.from(union, :some_models)`. It produced an error `missing FROM-clause entry for table "some_models"` in PostgreSQL. The problem is that `#from` happily accepts unions, but silently ignores passed aliases.