### PR TITLE
Deprecate ActionController.escape_json_responses= at the method

### DIFF
--- a/actionpack/lib/action_controller/metal/renderers.rb
+++ b/actionpack/lib/action_controller/metal/renderers.rb
@@ -27,9 +27,23 @@ module ActionController
     # Default values are `:json`, `:js`, `:xml`.
     RENDERERS = Set.new
 
+    module DeprecatedEscapeJsonResponses # :nodoc:
+      def escape_json_responses=(value)
+        if value
+          ActionController.deprecator.warn(<<~MSG.squish)
+            Setting action_controller.escape_json_responses = true is deprecated and will have no effect in Rails 8.2.
+            Set it to `false`, or remove the config.
+          MSG
+        end
+        super
+      end
+    end
+
     included do
       class_attribute :_renderers, default: Set.new.freeze
-      class_attribute :escape_json_responses, instance_accessor: false, default: true
+      class_attribute :escape_json_responses, instance_writer: false, instance_accessor: false, default: true
+
+      singleton_class.prepend DeprecatedEscapeJsonResponses
     end
 
     # Used in ActionController::Base and ActionController::API to include all

--- a/actionpack/lib/action_controller/railtie.rb
+++ b/actionpack/lib/action_controller/railtie.rb
@@ -133,18 +133,5 @@ module ActionController
         ActionController::TestCase.executor_around_each_request = app.config.active_support.executor_around_test_case
       end
     end
-
-    initializer "action_controller.escape_json_responses_deprecated_warning" do
-      config.after_initialize do
-        ActiveSupport.on_load(:action_controller) do
-          if ActionController::Base.escape_json_responses
-            ActionController.deprecator.warn(<<~MSG.squish)
-              Setting action_controller.escape_json_responses = true is deprecated and will have no effect in Rails 8.2.
-              Set it to `false` or use `config.load_defaults(8.1)`.
-            MSG
-          end
-        end
-      end
-    end
   end
 end

--- a/actionpack/test/controller/render_json_test.rb
+++ b/actionpack/test/controller/render_json_test.rb
@@ -122,10 +122,96 @@ class RenderJsonTest < ActionController::TestCase
   end
 
   def test_render_json_with_new_default_and_without_callback_does_not_escape_js_chars
-    TestController.with(escape_json_responses: false) do
-      get :render_json_unsafe_chars_without_callback
-      assert_equal %({"hello":"\u2028\u2029<script>"}), @response.body
-      assert_equal "application/json", @response.media_type
+    msg = <<~MSG.squish
+      Setting action_controller.escape_json_responses = true is deprecated and will have no effect in Rails 8.2.
+      Set it to `false`, or remove the config.
+    MSG
+
+    assert_deprecated(msg, ActionController.deprecator) do
+      TestController.with(escape_json_responses: false) do
+        get :render_json_unsafe_chars_without_callback
+        assert_equal %({"hello":"\u2028\u2029<script>"}), @response.body
+        assert_equal "application/json", @response.media_type
+      end
+    end
+  end
+
+  def test_render_json_with_optional_escape_option_is_not_deprecated
+    @before_escape_json_responses = @controller.class.escape_json_responses
+
+    assert_not_deprecated(ActionController.deprecator) do
+      @controller.class.escape_json_responses = false
+    end
+
+    get :render_json_unsafe_chars_without_callback
+    assert_equal %({"hello":"\u2028\u2029<script>"}), @response.body
+    assert_equal "application/json", @response.media_type
+  ensure
+    ActionController.deprecator.silence do
+      @controller.class.escape_json_responses = @before_escape_json_responses
+    end
+  end
+
+  def test_render_json_with_redundant_escape_option_is_deprecated
+    @before_escape_json_responses = @controller.class.escape_json_responses
+
+    msg = <<~MSG.squish
+      Setting action_controller.escape_json_responses = true is deprecated and will have no effect in Rails 8.2.
+      Set it to `false`, or remove the config.
+    MSG
+
+    assert_deprecated(msg, ActionController.deprecator) do
+      @controller.class.escape_json_responses = true
+    end
+
+    get :render_json_unsafe_chars_without_callback
+    assert_equal '{"hello":"\\u2028\\u2029\\u003cscript\\u003e"}', @response.body
+    assert_equal "application/json", @response.media_type
+  ensure
+    ActionController.deprecator.silence do
+      @controller.class.escape_json_responses = @before_escape_json_responses
+    end
+  end
+
+  def test_set_escape_json_responses_class_method_is_deprecated
+    @before_escape_json_responses = @controller.class.escape_json_responses
+
+    msg = <<~MSG.squish
+      Setting action_controller.escape_json_responses = true is deprecated and will have no effect in Rails 8.2.
+      Set it to `false`, or remove the config.
+    MSG
+
+    assert_deprecated(msg, ActionController.deprecator) do
+      @controller.class.escape_json_responses = true
+    end
+
+    get :render_json_unsafe_chars_without_callback
+    assert_equal '{"hello":"\\u2028\\u2029\\u003cscript\\u003e"}', @response.body
+    assert_equal "application/json", @response.media_type
+  ensure
+    ActionController.deprecator.silence do
+      @controller.class.escape_json_responses = @before_escape_json_responses
+    end
+  end
+
+  def test_set_escape_json_responses_controller_method_is_deprecated
+    @before_escape_json_responses = @controller.class.escape_json_responses
+
+    msg = <<~MSG.squish
+      Setting action_controller.escape_json_responses = true is deprecated and will have no effect in Rails 8.2.
+      Set it to `false`, or remove the config.
+    MSG
+
+    assert_deprecated(msg, ActionController.deprecator) do
+      @controller.class.escape_json_responses = true
+    end
+
+    get :render_json_unsafe_chars_without_callback
+    assert_equal '{"hello":"\\u2028\\u2029\\u003cscript\\u003e"}', @response.body
+    assert_equal "application/json", @response.media_type
+  ensure
+    ActionController.deprecator.silence do
+      @controller.class.escape_json_responses = @before_escape_json_responses
     end
   end
 


### PR DESCRIPTION
Follow up to #54643

Instead of emitting the deprecation in an initializer, we should emit the deprecation when calling the writer method.

In order to reduce warnings when users are updating their apps to use the new default `true`, we check the value before emitting.

This includes the class attribute method as well.

In order to set the value for the internal attribute, we need to find out the name of the internal setter[^1].

In the future, it would be nice if `class_attribute` and `mattr_*`, etc had a way to easily deprecate parts of the methods being defined, or provide a callback (so we can emit warnings based on the value, etc).

/cc @byroot @etiennebarrie 

[^1]: https://github.com/rails/rails/blob/1c094d762d25805cc2d110ee2f7b54b33352e293/activesupport/lib/active_support/core_ext/class/attribute.rb#L95-L102