### PR TITLE
Use MySQL instead of MariaDB in devcontainer

### DIFF
--- a/.devcontainer/compose.yaml
+++ b/.devcontainer/compose.yaml
@@ -12,7 +12,7 @@ services:
 
     depends_on:
       - postgres
-      - mariadb
+      - mysql
       - redis
       - memcached
 
@@ -32,13 +32,13 @@ services:
       POSTGRES_DB: postgres
       POSTGRES_PASSWORD: postgres
 
-  mariadb:
-    image: mariadb:lts
+  mysql:
+    image: mysql:latest
     restart: unless-stopped
     volumes:
-      - mariadb-data:/var/lib/mysql
+      - mysql-data:/var/lib/mysql
     environment:
-      MARIADB_ROOT_PASSWORD: root
+      MYSQL_ROOT_PASSWORD: root
 
   redis:
     image: valkey/valkey:8
@@ -53,5 +53,5 @@ services:
 
 volumes:
   postgres-data:
-  mariadb-data:
+  mysql-data:
   redis-data:

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -22,7 +22,7 @@
 		"PGHOST": "postgres",
 		"PGUSER": "postgres",
 		"PGPASSWORD": "postgres",
-		"MYSQL_HOST": "mariadb",
+		"MYSQL_HOST": "mysql",
 		"REDIS_URL": "redis://redis/0",
 		"MEMCACHE_SERVERS": "memcached:11211"
 	},


### PR DESCRIPTION
### Motivation / Background

This pull request uses MySQL container instead of MariaDB one in devcontainer

### Detail

MariaDB was likely chosen because Debian "bookworm" sets it as the default MySQL-compatible database. However, recent changes in MariaDB introduced incompatibilities with MySQL—for example, #53727. This makes MariaDB less suitable as the default for developing the mysql2 and trilogy adapters.

Now that the database runs as a separate container, we are no longer bound by the base OS default. Using the official MySQL container offers a development environment that more closely aligns with the behavior of MySQL itself.

### Additional information
References:
https://lists.debian.org/debian-devel-announce/2016/09/msg00000.html
https://github.com/rails/rails/pull/48891

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
