### PR TITLE
Include cookie name in length calculation

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Include cookie name when calculating maximum allowed size.
+
+    *Hartley McGuire*
+
 *   Implement `must-understand` directive according to RFC 9111.
 
     The `must-understand` directive indicates that a cache must understand the semantics of the response status code, or discard the response. This directive is enforced to be used only with `no-store` to ensure proper cache behavior.

--- a/actionpack/lib/action_dispatch/middleware/cookies.rb
+++ b/actionpack/lib/action_dispatch/middleware/cookies.rb
@@ -610,8 +610,10 @@ module ActionDispatch
         end
 
         def check_for_overflow!(name, options)
-          if options[:value].bytesize > MAX_COOKIE_SIZE
-            raise CookieOverflow, "#{name} cookie overflowed with size #{options[:value].bytesize} bytes"
+          total_size = name.to_s.bytesize + options[:value].bytesize
+
+          if total_size > MAX_COOKIE_SIZE
+            raise CookieOverflow, "#{name} cookie overflowed with size #{total_size} bytes"
           end
         end
     end

--- a/actionpack/test/dispatch/cookies_test.rb
+++ b/actionpack/test/dispatch/cookies_test.rb
@@ -972,7 +972,7 @@ class CookiesTest < ActionController::TestCase
     error = assert_raise(ActionDispatch::Cookies::CookieOverflow) do
       get :raise_data_overflow
     end
-    assert_equal "foo cookie overflowed with size 5522 bytes", error.message
+    assert_equal "foo cookie overflowed with size 5525 bytes", error.message
   end
 
   def test_tampered_cookies

--- a/actionpack/test/dispatch/session/cookie_store_test.rb
+++ b/actionpack/test/dispatch/session/cookie_store_test.rb
@@ -203,7 +203,7 @@ class CookieStoreTest < ActionDispatch::IntegrationTest
       error = assert_raise(ActionDispatch::Cookies::CookieOverflow) {
         get "/raise_data_overflow"
       }
-      assert_equal "_myapp_session cookie overflowed with size 5612 bytes", error.message
+      assert_equal "_myapp_session cookie overflowed with size 5626 bytes", error.message
     end
   end
 


### PR DESCRIPTION
### Detail

Fix #54838 

Browsers add the length of the name and content when validating that a cookie is under 4kb, so this commit updates Rails to do the same.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
