### PR TITLE
Extract system test setup to system_helper

### DIFF
--- a/actionpack/test/abstract_unit.rb
+++ b/actionpack/test/abstract_unit.rb
@@ -515,20 +515,4 @@ module HeadersAssertions
   end
 end
 
-class DrivenByRackTest < ActionDispatch::SystemTestCase
-  driven_by :rack_test
-end
-
-class DrivenBySeleniumWithChrome < ActionDispatch::SystemTestCase
-  driven_by :selenium, using: :chrome
-end
-
-class DrivenBySeleniumWithHeadlessChrome < ActionDispatch::SystemTestCase
-  driven_by :selenium, using: :headless_chrome
-end
-
-class DrivenBySeleniumWithHeadlessFirefox < ActionDispatch::SystemTestCase
-  driven_by :selenium, using: :headless_firefox
-end
-
 require_relative "../../tools/test_common"

--- a/actionpack/test/dispatch/system_testing/driver_test.rb
+++ b/actionpack/test/dispatch/system_testing/driver_test.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "abstract_unit"
+require "support/system_helper"
 require "action_dispatch/system_testing/driver"
 require "selenium/webdriver"
 

--- a/actionpack/test/dispatch/system_testing/screenshot_helper_test.rb
+++ b/actionpack/test/dispatch/system_testing/screenshot_helper_test.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "abstract_unit"
+require "support/system_helper"
 require "action_dispatch/system_testing/test_helpers/screenshot_helper"
 require "capybara/dsl"
 require "selenium/webdriver"

--- a/actionpack/test/dispatch/system_testing/system_test_case_test.rb
+++ b/actionpack/test/dispatch/system_testing/system_test_case_test.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "abstract_unit"
+require "support/system_helper"
 require "selenium/webdriver"
 
 class SetDriverToRackTestTest < DrivenByRackTest

--- a/actionpack/test/support/system_helper.rb
+++ b/actionpack/test/support/system_helper.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class DrivenByRackTest < ActionDispatch::SystemTestCase
+  driven_by :rack_test
+end
+
+class DrivenBySeleniumWithChrome < ActionDispatch::SystemTestCase
+  driven_by :selenium, using: :chrome
+end
+
+class DrivenBySeleniumWithHeadlessChrome < ActionDispatch::SystemTestCase
+  driven_by :selenium, using: :headless_chrome
+end
+
+class DrivenBySeleniumWithHeadlessFirefox < ActionDispatch::SystemTestCase
+  driven_by :selenium, using: :headless_firefox
+end


### PR DESCRIPTION
Defining these classes in abstract_unit makes running all Action Pack tests slower because they have to download/setup browsers for system tests (even if the tests being run never end up using the system test classes).

This commit moves the system test class definitions into a helper which is only included in the two test files that use them. This will make running non-system Action Pack test files much much faster.