### PR TITLE
Fix `create_or_find_by` not rolling back a transaction:

### DIFF
--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -272,7 +272,12 @@ module ActiveRecord
     # such situation.
     def create_or_find_by(attributes, &block)
       with_connection do |connection|
-        transaction(requires_new: true) { create(attributes, &block) }
+        record = nil
+        transaction(requires_new: true) do
+          record = new(attributes, &block)
+          record.save || raise(ActiveRecord::Rollback)
+        end
+        record
       rescue ActiveRecord::RecordNotUnique
         if connection.transaction_open?
           where(attributes).lock.find_by!(attributes)
@@ -287,7 +292,12 @@ module ActiveRecord
     # is raised if the created record is invalid.
     def create_or_find_by!(attributes, &block)
       with_connection do |connection|
-        transaction(requires_new: true) { create!(attributes, &block) }
+        record = nil
+        transaction(requires_new: true) do
+          record = new(attributes, &block)
+          record.save! || raise(ActiveRecord::Rollback)
+        end
+        record
       rescue ActiveRecord::RecordNotUnique
         if connection.transaction_open?
           where(attributes).lock.find_by!(attributes)

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -1593,6 +1593,24 @@ class RelationTest < ActiveRecord::TestCase
     assert_not_equal subscriber, Subscriber.create_or_find_by(nick: "cat")
   end
 
+  def test_create_or_find_by_rollbacks_a_transaction
+    assert_no_difference(-> { Car.count }) do
+      car = BrokenCar.create_or_find_by(name: "Civic")
+
+      assert_instance_of(BrokenCar, car)
+      assert_not_predicate(car, :persisted?)
+    end
+  end
+
+  def test_create_or_find_by_bang_rollbacks_a_transaction
+    assert_no_difference(-> { Car.count }) do
+      car = BrokenCar.create_or_find_by!(name: "Civic")
+
+      assert_instance_of(BrokenCar, car)
+      assert_not_predicate(car, :persisted?)
+    end
+  end
+
   def test_create_or_find_by_with_block
     assert_nil Subscriber.find_by(nick: "bob")
 

--- a/activerecord/test/models/car.rb
+++ b/activerecord/test/models/car.rb
@@ -35,3 +35,9 @@ end
 class FastCar < Car
   default_scope { order("name desc") }
 end
+
+class BrokenCar < Car
+  after_save do
+    raise ActiveRecord::Rollback
+  end
+end


### PR DESCRIPTION
### Motivation / Background

Fix #54830 (This indirectly fix the issue)

### Problem

The `create_or_find_by` method doesn't allow rolling back a transaction. This is a different behaviour `create`. The reason is because we are in the double transaction edge case and the outer transaction doesn't see the rollback.

### Details

```ruby
class User < ApplicationRecord
  after_save do
    raise ActiveRecord::Rollback
  end
end

User.create(name: "John") #=> Correctly rolled back
User.find_or_create_by(name: "John") #=> Correctly rolled back on Rails 7.0, stopped rolling back since commit 023a3eb3c046091a5d52027393a6d29d0576da01
User.create_or_find_by(name: "John") #=> Does not roll back
```

### Solution

We need to be able to know whether the inner transaction succeeded, which is not possible using `.create`, as this method always returns the record (rather than the status of the transaction). https://github.com/rails/rails/blob/1eac7f27748ffa43c5ce91c036c928fc22d4c597/activerecord/lib/active_record/persistence.rb#L39

Using `new` followed by a save is equivalent to `create`, but with `save` we get the transaction return status and we can properly rollback the outer transaction.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
