### PR TITLE
Fix #54848: Change redirect status code in SessionsController#destroy template from 302 to 303

### DIFF
--- a/railties/lib/rails/generators/rails/authentication/templates/app/controllers/sessions_controller.rb.tt
+++ b/railties/lib/rails/generators/rails/authentication/templates/app/controllers/sessions_controller.rb.tt
@@ -16,6 +16,6 @@ class SessionsController < ApplicationController
 
   def destroy
     terminate_session
-    redirect_to new_session_path
+    redirect_to new_session_path, status: :see_other
   end
 end


### PR DESCRIPTION
### Motivation / Background

The new Authentication generator (introduced in Rails 8.0) creates a SessionsController that is returning a 302 Redirect response in its destroy action. This should be avoided since it leaves the decision up to the Browser to apply the same HTTP Verb to the redirected location or change to a GET Request.

This is documented in the [HTML specs here](https://www.rfc-editor.org/rfc/rfc9110#status.302)
The problem is also mentioned in the [Rails API docs](https://api.rubyonrails.org/classes/ActionController/Redirecting.html#method-i-redirect_to) for potential cause of "double deletes".

Test show that many modern browser indeed change the HTTP Verb to `GET`, however, since this behavior can change, respecting the HTTP spec is the right call imho.

### Detail

Fixes #54848 (opened by me)
This Pull Request changes the status code of the redirect in the `SessionsController#destroy` action template used by the generator from 302 to 303.

### Additional information

An empirical test show that the following browsers change the HTTP Verb to GET:
- Firefox 136.0.4
- Chrome 134.0.6998.89
- Safari 18.3.1

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature. 
  _Note: the generator tests do not cover cases like this_
* [X] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
