### PR TITLE
Laying some ground work to remove AR::Base from the modules

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_handler.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_handler.rb
@@ -73,9 +73,12 @@ module ActiveRecord
         end
       end
 
+      attr_accessor :default_role
+
       def initialize
         # These caches are keyed by pool_config.connection_name (PoolConfig#connection_name).
         @connection_name_to_pool_manager = Concurrent::Map.new(initial_capacity: 2)
+        @default_role = ActiveRecord.writing_role
       end
 
       def prevent_writes # :nodoc:


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because I was looking into giving engines more complete control of their database connections. A consistent foil is that everything goes through ActiveRecord::Base. To make the hard change easy, the first thing to do is to fix the cohesion of the AR modules.

### Detail

This Pull Request moves all the methods that the connection handling module was calling that were located in the core module. This will not result in functionality changes to ActiveRecord::Base, but will increase cohesion in the Core and ConnectionHandling modules.

### Why this is okay to merge (edited in)

The current state of Core and ConnectionHandling modules is that it is impossible to use ConnectionHandling without Core and also, those specific connection handling methods in core cannot be used without including ConnectionHandling. The modules are incoherent.

Given that Core and ConnectionHandling must always be used together currently, then there should be no danger in increasing the coherence of the connection handling code by putting it in ConnectionHandling.

Thus, the only outcome of this PR is that it will become possible to utilize ConnectionHandling without Core.

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [X] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.