### PR TITLE
Avoid purging the test database when loading a schema:

### DIFF
--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -474,7 +474,7 @@ db_namespace = namespace :db do
     namespace :load do
       ActiveRecord::Tasks::DatabaseTasks.for_each(databases) do |name|
         desc "Load a database schema file (either db/schema.rb or db/structure.sql, depending on configuration) into the #{name} database"
-        task name => "db:test:purge:#{name}" do
+        task name => [:load_config, :check_protected_environments] do
           ActiveRecord::Tasks::DatabaseTasks.with_temporary_pool_for_each(name: name) do |pool|
             db_config = pool.db_config
             ActiveRecord::Tasks::DatabaseTasks.load_schema(db_config, ENV["SCHEMA_FORMAT"] || db_config.schema_format)


### PR DESCRIPTION
### Motivation / Background

Fix #50672
Closes #50946

### Detail

#### Problem

In adb64db, we added a change to purge the test database whenever the `load:schema:<name>` was run. This change meant that in order for the schema to load:
1) the test database configuration needs to be setup
2) can be connected to.

This creates some issues for users if either of both conditions aren't met. (For 1. it can be argued that it's a user error, but for 2., it's likely that a production environment can't connect to the test database).

#### Details

I dug to understand why loading a specific schema requires purging the test database (whereas loading all schema doesn't), but couldn't really see anything obvious, so I concluded that it may just be some overly defensive code.

#### Solution

Whenever we run a test, Rails maintains all test databases schema, and if a schema changes, the equivalent of a purge will be executed on all test databases. https://github.com/rails/rails/blob/b132744e22de64eb530d6ac407fa4b6b4a926143/railties/lib/rails/testing/maintain_test_schema.rb#L5

I couldn't really think of a negative behaviour difference between purging the test database eagerly when we load the schema and lazily when we run the tests, so I simply removed the `purge` rake task dependency on `schema:load:<name>`.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
