### PR TITLE
Validate size of all cookies

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Validate maximum cookie size even when not signed or encrypted.
+
+    *Hartley McGuire*
+
 *   Include cookie name when calculating maximum allowed size.
 
     *Hartley McGuire*

--- a/actionpack/lib/action_dispatch/middleware/cookies.rb
+++ b/actionpack/lib/action_dispatch/middleware/cookies.rb
@@ -387,12 +387,14 @@ module ActionDispatch
 
         handle_options(options)
 
-        check_for_overflow!(name, options)
+        cookie_name_string = name.to_s
 
-        if @cookies[name.to_s] != value || options[:expires]
-          @cookies[name.to_s] = value
-          @set_cookies[name.to_s] = options
-          @delete_cookies.delete(name.to_s)
+        check_for_overflow!(cookie_name_string, options)
+
+        if @cookies[cookie_name_string] != value || options[:expires]
+          @cookies[cookie_name_string] = value
+          @set_cookies[cookie_name_string] = options
+          @delete_cookies.delete(cookie_name_string)
         end
 
         value
@@ -452,7 +454,7 @@ module ActionDispatch
         end
 
         def check_for_overflow!(name, options)
-          total_size = name.to_s.bytesize + options[:value].bytesize
+          total_size = name.bytesize + options[:value].bytesize
 
           if total_size > MAX_COOKIE_SIZE
             raise CookieOverflow, "#{name} cookie overflowed with size #{total_size} bytes"

--- a/actionpack/test/dispatch/cookies_test.rb
+++ b/actionpack/test/dispatch/cookies_test.rb
@@ -49,17 +49,17 @@ class CookieJarTest < ActiveSupport::TestCase
   end
 
   def test_each
-    request.cookie_jar["foo"] = :bar
+    request.cookie_jar["foo"] = "bar"
     list = []
     request.cookie_jar.each do |k, v|
       list << [k, v]
     end
 
-    assert_equal [["foo", :bar]], list
+    assert_equal [["foo", "bar"]], list
   end
 
   def test_enumerable
-    request.cookie_jar["foo"] = :bar
+    request.cookie_jar["foo"] = "bar"
     actual = request.cookie_jar.map { |k, v| [k.to_s, v.to_s] }
     assert_equal [["foo", "bar"]], actual
   end
@@ -68,7 +68,7 @@ class CookieJarTest < ActiveSupport::TestCase
     assert_not request.cookie_jar.key?(:foo)
     assert_not request.cookie_jar.has_key?("foo")
 
-    request.cookie_jar[:foo] = :bar
+    request.cookie_jar[:foo] = "bar"
     assert request.cookie_jar.key?(:foo)
     assert request.cookie_jar.has_key?("foo")
   end
@@ -214,7 +214,7 @@ class CookiesTest < ActionController::TestCase
     end
 
     def raise_data_overflow
-      cookies.signed[:foo] = "bye!" * 1024
+      cookies[:foo] = "!" * 4094
       head :ok
     end
 
@@ -972,7 +972,7 @@ class CookiesTest < ActionController::TestCase
     error = assert_raise(ActionDispatch::Cookies::CookieOverflow) do
       get :raise_data_overflow
     end
-    assert_equal "foo cookie overflowed with size 5525 bytes", error.message
+    assert_equal "foo cookie overflowed with size 4097 bytes", error.message
   end
 
   def test_tampered_cookies


### PR DESCRIPTION
### Motivation / Background

Previously, cookie size validation was only performed for signed/encrypted cookies, but not plaintext ones.

### Detail

This commit refactors the base CookieJar to perform cookie size validation so that even non-{signed,encrypted} cookies have their size validated.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
