### PR TITLE
Add `Cache#read_counter` and `Cache#write_counter`

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,14 @@
+*   Add `Cache#read_counter` and `Cache#write_counter`
+
+    ```ruby
+    Rails.cache.write_counter("foo", 1)
+    Rails.cache.read_counter("foo") # => 1
+    Rails.cache.increment("foo")
+    Rails.cache.read_counter("foo") # => 2
+    ```
+
+    *Alex Ghiculescu*
+
 *   Introduce ActiveSupport::Testing::ErrorReporterAssertions#capture_error_reports
 
     Captures all reported errors from within the block that match the given

--- a/activesupport/lib/active_support/cache.rb
+++ b/activesupport/lib/active_support/cache.rb
@@ -743,6 +743,32 @@ module ActiveSupport
         raise NotImplementedError.new("#{self.class.name} does not support decrement")
       end
 
+      # Reads a counter that was set by #increment / #decrement.
+      #
+      #   cache.write_counter("foo", 1)
+      #   cache.read_counter("foo") # => 1
+      #   cache.increment("foo")
+      #   cache.read_counter("foo") # => 2
+      #
+      # Options are passed to the underlying cache implementation.
+      def read_counter(name, **options)
+        options = merged_options(options).merge(raw: true)
+        read(name, **options)&.to_i
+      end
+
+      # Writes a counter that can then be modified by #increment / #decrement.
+      #
+      #   cache.write_counter("foo", 1)
+      #   cache.read_counter("foo") # => 1
+      #   cache.increment("foo")
+      #   cache.read_counter("foo") # => 2
+      #
+      # Options are passed to the underlying cache implementation.
+      def write_counter(name, value, **options)
+        options = merged_options(options).merge(raw: true)
+        write(name, value.to_i, **options)
+      end
+
       # Cleans up the cache by removing expired entries.
       #
       # Options are passed to the underlying cache implementation.

--- a/activesupport/lib/active_support/cache/mem_cache_store.rb
+++ b/activesupport/lib/active_support/cache/mem_cache_store.rb
@@ -126,6 +126,11 @@ module ActiveSupport
       #
       # Incrementing a non-numeric value, or a value written without
       # <tt>raw: true</tt>, will fail and return +nil+.
+      #
+      # To read the value later, call #read_counter:
+      #
+      #   cache.increment("baz") # => 7
+      #   cache.read_counter("baz") # 7
       def increment(name, amount = 1, options = nil)
         options = merged_options(options)
         key = normalize_key(name, options)
@@ -152,6 +157,11 @@ module ActiveSupport
       #
       # Decrementing a non-numeric value, or a value written without
       # <tt>raw: true</tt>, will fail and return +nil+.
+      #
+      # To read the value later, call #read_counter:
+      #
+      #   cache.decrement("baz") # => 3
+      #   cache.read_counter("baz") # 3
       def decrement(name, amount = 1, options = nil)
         options = merged_options(options)
         key = normalize_key(name, options)

--- a/activesupport/lib/active_support/cache/redis_cache_store.rb
+++ b/activesupport/lib/active_support/cache/redis_cache_store.rb
@@ -250,6 +250,11 @@ module ActiveSupport
       # Incrementing a non-numeric value, or a value written without
       # <tt>raw: true</tt>, will fail and return +nil+.
       #
+      # To read the value later, call #read_counter:
+      #
+      #   cache.increment("baz") # => 7
+      #   cache.read_counter("baz") # 7
+      #
       # Failsafe: Raises errors.
       def increment(name, amount = 1, options = nil)
         options = merged_options(options)
@@ -276,6 +281,11 @@ module ActiveSupport
       #
       # Decrementing a non-numeric value, or a value written without
       # <tt>raw: true</tt>, will fail and return +nil+.
+      #
+      # To read the value later, call #read_counter:
+      #
+      #   cache.decrement("baz") # => 3
+      #   cache.read_counter("baz") # 3
       #
       # Failsafe: Raises errors.
       def decrement(name, amount = 1, options = nil)

--- a/activesupport/test/cache/behaviors/cache_increment_decrement_behavior.rb
+++ b/activesupport/test/cache/behaviors/cache_increment_decrement_behavior.rb
@@ -31,6 +31,18 @@ module CacheIncrementDecrementBehavior
     assert_equal @cache.is_a?(ActiveSupport::Cache::MemCacheStore) ? 0 : -100, missing
   end
 
+  def test_read_counter_and_write_counter
+    key = SecureRandom.uuid
+    @cache.write_counter(key, 1)
+    assert_equal 1, @cache.read(key, raw: true).to_i
+
+    assert_equal 1, @cache.read_counter(key)
+    assert_equal 2, @cache.increment(key)
+    assert_equal 2, @cache.read_counter(key)
+
+    assert_nil @cache.read_counter(SecureRandom.alphanumeric)
+  end
+
   def test_ttl_isnt_updated
     key = SecureRandom.uuid
 


### PR DESCRIPTION
ref: https://github.com/rails/rails/pull/54821#issuecomment-2768469886

This PR introduces 2 new methods on `Rails.cache`: `read_counter` and `write_counter`.

The idea is that you should use them to read values that are being `increment`ed / `decrement`ed. This is to avoid the code smell of having to pass `raw: true` around on `read`/`write` calls for counters (which is only necessary with some cache implementations).