### PR TITLE
fix(devcontainer): support DB switching when containerEnv is not defined

### DIFF
--- a/railties/lib/rails/generators/rails/db/system/change/change_generator.rb
+++ b/railties/lib/rails/generators/rails/db/system/change/change_generator.rb
@@ -145,7 +145,7 @@ module Rails
             end
 
             def update_devcontainer_db_host
-              container_env = devcontainer_json["containerEnv"]
+              container_env = devcontainer_json["containerEnv"] || {}
               db_name = database.name
 
               if container_env["DB_HOST"]
@@ -162,7 +162,13 @@ module Rails
 
               new_json = JSON.pretty_generate(container_env, indent: "  ", object_nl: "\n  ")
 
-              gsub_file(".devcontainer/devcontainer.json", /("containerEnv"\s*:\s*)(.|\n)*?(^\s{2}})/, "\\1#{new_json}")
+              if devcontainer_json["containerEnv"].present?
+                gsub_file(".devcontainer/devcontainer.json", /("containerEnv"\s*:\s*)(.|\n)*?(^\s{2}})/, "\\1#{new_json}")
+              else
+                gsub_file ".devcontainer/devcontainer.json", /(\s+\S+":.*)(?=\n\s*})/m do |match|
+                  "#{match},\n\n  \"containerEnv\": #{new_json}"
+                end
+              end
             end
 
             def update_devcontainer_db_feature

--- a/railties/test/fixtures/.devcontainer/no_env/devcontainer.json
+++ b/railties/test/fixtures/.devcontainer/no_env/devcontainer.json
@@ -1,0 +1,25 @@
+// For format details, see https://containers.dev/implementors/json_reference/.
+// For config options, see the README at: https://github.com/devcontainers/templates/tree/main/src/ruby
+{
+  "name": "tmp",
+  "dockerComposeFile": "compose.yaml",
+  "service": "rails-app",
+  "workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
+
+  // Features to add to the dev container. More info: https://containers.dev/features.
+  "features": {
+    "ghcr.io/devcontainers/features/github-cli:1": {}
+  },
+
+  // Use 'forwardPorts' to make a list of ports inside the container available locally.
+  // "forwardPorts": [],
+
+  // Configure tool-specific properties.
+  // "customizations": {},
+
+  // Uncomment to connect as root instead. More info: https://containers.dev/implementors/json_reference/#remoteUser.
+  // "remoteUser": "root",
+
+  // Use 'postCreateCommand' to run commands after the container is created.
+  "postCreateCommand": "bin/setup --skip-server"
+}

--- a/railties/test/generators/db_system_change_generator_test.rb
+++ b/railties/test/generators/db_system_change_generator_test.rb
@@ -218,6 +218,16 @@ module Rails
               assert_not_includes compose_config.keys, "volumes"
             end
           end
+
+          test "adds containerEnv property to devcontainer when missing" do
+            copy_devcontainer_no_env_file
+
+            run_generator ["--to", "postgresql"]
+
+            assert_devcontainer_json_file do |content|
+              assert_equal "postgres", content["containerEnv"]["DB_HOST"]
+            end
+          end
         end
       end
     end

--- a/railties/test/generators/generators_test_helper.rb
+++ b/railties/test/generators/generators_test_helper.rb
@@ -111,6 +111,14 @@ module GeneratorsTestHelper
     File.write File.join(destination, "compose.yaml"), compose_yaml
   end
 
+  def copy_devcontainer_no_env_file
+    destination = File.join(destination_root, ".devcontainer")
+    mkdir_p(destination)
+
+    devcontainer_json = File.read(File.expand_path("../fixtures/.devcontainer/no_env/devcontainer.json", __dir__))
+    File.write File.join(destination, "devcontainer.json"), devcontainer_json
+  end
+
   def evaluate_template(file, locals = {})
     erb = ERB.new(File.read(file), trim_mode: "-", eoutvar: "@output_buffer")
     context = Class.new do


### PR DESCRIPTION
### Motivation / Background

This Pull Request fixes an issue with the `bin/rails db:system:change --to=postgresql` command when environment variables are not defined using containerEnv in the devcontainer configuration.

### Detail

When running the command:

```bash
bin/rails db:system:change --to=postgresql
```

Rails attempts to update the devcontainer.json file and assumes container_env is always present. If that's not the case, it raises the following error:

```
/usr/local/bundle/ruby/3.3.0/gems/railties-8.0.2/lib/rails/generators/rails/db/system/change/change_generator.rb:151:in `update_devcontainer_db_host': undefined method `[]' for nil (NoMethodError)

              if container_env["DB_HOST"]
                              ^^^^^^^^^^^
        from /usr/local/bundle/ruby/3.3.0/gems/railties-8.0.2/lib/rails/generators/rails/db/system/change/change_generator.rb:116:in `edit_devcontainer_json'
        from /usr/local/bundle/ruby/3.3.0/gems/railties-8.0.2/lib/rails/generators/rails/db/system/change/change_generator.rb:58:in `edit_devcontainer_files'
        from /usr/local/bundle/ruby/3.3.0/gems/thor-1.3.2/lib/thor/command.rb:28:in `run'
        from /usr/local/bundle/ruby/3.3.0/gems/thor-1.3.2/lib/thor/invocation.rb:127:in `invoke_command'
        from /usr/local/bundle/ruby/3.3.0/gems/thor-1.3.2/lib/thor/invocation.rb:134:in `block in invoke_all'
        from /usr/local/bundle/ruby/3.3.0/gems/thor-1.3.2/lib/thor/invocation.rb:134:in `each'
        from /usr/local/bundle/ruby/3.3.0/gems/thor-1.3.2/lib/thor/invocation.rb:134:in `map'
        from /usr/local/bundle/ruby/3.3.0/gems/thor-1.3.2/lib/thor/invocation.rb:134:in `invoke_all'
        from /usr/local/bundle/ruby/3.3.0/gems/thor-1.3.2/lib/thor/group.rb:243:in `dispatch'
        from /usr/local/bundle/ruby/3.3.0/gems/thor-1.3.2/lib/thor/base.rb:584:in `start'
        from /usr/local/bundle/ruby/3.3.0/gems/railties-8.0.2/lib/rails/commands/db/system/change/change_command.rb:20:in `perform'
        from /usr/local/bundle/ruby/3.3.0/gems/thor-1.3.2/lib/thor/command.rb:28:in `run'
        from /usr/local/bundle/ruby/3.3.0/gems/thor-1.3.2/lib/thor/invocation.rb:127:in `invoke_command'
        from /usr/local/bundle/ruby/3.3.0/gems/railties-8.0.2/lib/rails/command/base.rb:178:in `invoke_command'
        from /usr/local/bundle/ruby/3.3.0/gems/thor-1.3.2/lib/thor.rb:538:in `dispatch'
        from /usr/local/bundle/ruby/3.3.0/gems/railties-8.0.2/lib/rails/command/base.rb:73:in `perform'
        from /usr/local/bundle/ruby/3.3.0/gems/railties-8.0.2/lib/rails/command.rb:65:in `block in invoke'
        from /usr/local/bundle/ruby/3.3.0/gems/railties-8.0.2/lib/rails/command.rb:143:in `with_argv'
        from /usr/local/bundle/ruby/3.3.0/gems/railties-8.0.2/lib/rails/command.rb:63:in `invoke'
        from /usr/local/bundle/ruby/3.3.0/gems/railties-8.0.2/lib/rails/commands.rb:18:in `<main>'
        from /usr/local/lib/ruby/3.3.0/bundled_gems.rb:69:in `require'
        from /usr/local/lib/ruby/3.3.0/bundled_gems.rb:69:in `block (2 levels) in replace_require'
        from /usr/local/bundle/ruby/3.3.0/gems/bootsnap-1.18.4/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30:in `require'
        from bin/rails:4:in `<main>'
```

This PR adds a check to skip modifications to containerEnv if it's not defined. 


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
