### PR TITLE
Modified FormBuilder#field_id to now support items[] object name

### DIFF
--- a/actionview/lib/action_view/helpers/form_helper.rb
+++ b/actionview/lib/action_view/helpers/form_helper.rb
@@ -1775,6 +1775,7 @@ module ActionView
       # element, sharing a common <tt>id</tt> root (<tt>article_title</tt>, in this
       # case).
       def field_id(method, *suffixes, namespace: @options[:namespace], index: @options[:index])
+        index ||= @auto_index
         @template.field_id(@object_name, method, *suffixes, namespace: namespace, index: index)
       end
 

--- a/actionview/lib/action_view/helpers/form_tag_helper.rb
+++ b/actionview/lib/action_view/helpers/form_tag_helper.rb
@@ -104,8 +104,15 @@ module ActionView
           object_name = object_name.model_name.singular
         end
 
-        sanitized_object_name = object_name.to_s.gsub(/\]\[|[^-a-zA-Z0-9:.]/, "_").delete_suffix("_")
+        base_name = object_name.to_s
+        if base_name.end_with?("[]")
+          base_name = base_name[0..-3]
+          if index.nil? && (object = @object)
+            index = object.to_param
+          end
+        end
 
+        sanitized_object_name = base_name.gsub(/\]\[|[^-a-zA-Z0-9:.]/, "_").delete_suffix("_")
         sanitized_method_name = method_name.to_s.delete_suffix("?")
 
         [

--- a/actionview/test/template/form_helper/field_id_test.rb
+++ b/actionview/test/template/form_helper/field_id_test.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require "abstract_unit"
+
+class Item
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+
+  attribute :id, :integer
+  attribute :name, :string
+
+  def to_param
+    id
+  end
+
+  def self.find(id)
+    new(id: id)
+  end
+end
+
+class FieldIdTest < ActionView::TestCase
+  def test_form_builder_field_id_without_index
+    item = Item.new(id: 1)
+    render inline: <<~ERB, locals: {item:}
+      <%= fields_for("items[]", item) do |form| %>
+        <%= form.hidden_field :name %>
+        <p><%= form.field_id :name %></p>
+      <% end %>
+    ERB
+
+    hidden_field = rendered.html.at("input")
+    p_tag = rendered.html.at("p")
+
+    assert_equal hidden_field["id"], p_tag.text
+  end
+
+  def test_form_builder_field_id_with_index
+    item = Item.new(id: 1)
+    render inline: <<~ERB, locals: {item:}
+      <%= fields_for("items", item, index: item.id) do |form| %>
+        <%= form.hidden_field :name %>
+        <p><%= form.field_id :name %></p>
+      <% end %>
+    ERB
+
+    hidden_field = rendered.html.at("input")
+    p_tag = rendered.html.at("p")
+
+    assert_equal hidden_field["id"], p_tag.text
+  end
+
+  def test_bug_report_example
+    render inline: <<~ERB
+      <%= fields_for("items[]", Item.find(1)) do |form| %>
+        <%= form.field_id :name %>
+      <% end %>
+    ERB
+
+    assert_equal "items_1_name", rendered.strip
+  end
+end

--- a/actionview/test/template/form_helper/field_id_test.rb
+++ b/actionview/test/template/form_helper/field_id_test.rb
@@ -21,7 +21,7 @@ end
 class FieldIdTest < ActionView::TestCase
   def test_form_builder_field_id_without_index
     item = Item.new(id: 1)
-    render inline: <<~ERB, locals: {item:}
+    render inline: <<~ERB, locals: { item: }
       <%= fields_for("items[]", item) do |form| %>
         <%= form.hidden_field :name %>
         <p><%= form.field_id :name %></p>
@@ -36,7 +36,7 @@ class FieldIdTest < ActionView::TestCase
 
   def test_form_builder_field_id_with_index
     item = Item.new(id: 1)
-    render inline: <<~ERB, locals: {item:}
+    render inline: <<~ERB, locals: { item: }
       <%= fields_for("items", item, index: item.id) do |form| %>
         <%= form.hidden_field :name %>
         <p><%= form.field_id :name %></p>


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because it resolves issue #54815

### Detail

The original problem stemmed from the fact that when using fields_for("items[]", item), there was a mismatch between both: 
- the ID generated by form.hidden_field :name (which was "items_1_name")
- The ID generated by form.field_id :name (which was "item__name")

The solution was to have the forms field_id pass through and auto_indexer (@auto_index ) when no index is provided which would allow you to deal with indexes the same way other forms do.

### Checklist

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
