### PR TITLE
[ci skip] Fix typo in The Rails Command Line guide

### DIFF
--- a/guides/source/command_line.md
+++ b/guides/source/command_line.md
@@ -687,7 +687,7 @@ vendor/tools.rb:
 
 INFO: A good description of unit testing in Rails is given in [A Guide to Testing Rails Applications](testing.html)
 
-Rails comes with a test framework called minitest. Rails owes its stability to the use of tests. The commands available in the `test:` namespace helps in running the different tests you will hopefully write.
+Rails comes with a test framework called minitest. Rails owes its stability to the use of tests. The commands available in the `test:` namespace help in running the different tests you will hopefully write.
 
 ### `bin/rails tmp:`
 


### PR DESCRIPTION
### Detail

This Pull Request fixes a minor typo in the "2.12. bin/rails test" section of the Rails Command Line guide.


