### PR TITLE
Fix check for remote databases when host is a socket path

### DIFF
--- a/activerecord/lib/active_record/tasks/database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/database_tasks.rb
@@ -617,7 +617,7 @@ module ActiveRecord
 
         def local_database?(db_config)
           host = db_config.host
-          host.blank? || LOCAL_HOSTS.include?(host)
+          host.blank? || LOCAL_HOSTS.include?(host) || File.exist?(host)
         end
 
         def schema_sha1(file)

--- a/activerecord/test/cases/tasks/database_tasks_test.rb
+++ b/activerecord/test/cases/tasks/database_tasks_test.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "tempfile"
 require "cases/helper"
 require "active_record/tasks/database_tasks"
 require "models/course"
@@ -468,6 +469,19 @@ module ActiveRecord
 
     def test_creates_configurations_with_blank_hosts
       @configurations["development"]["host"] = nil
+
+      with_stubbed_configurations_establish_connection do
+        assert_called(ActiveRecord::Tasks::DatabaseTasks, :create) do
+          ActiveRecord::Tasks::DatabaseTasks.create_all
+        end
+      end
+    end
+
+    def test_creates_configurations_with_local_socket_host
+      file = Tempfile.new(".PG.5432")
+      file.write("puppy doggy")  # Not actually a socket, but it's fine.
+
+      @configurations["development"]["host"] = file.path
 
       with_stubbed_configurations_establish_connection do
         assert_called(ActiveRecord::Tasks::DatabaseTasks, :create) do


### PR DESCRIPTION
### Motivation / Background

We're configuring our database by setting `PGHOST` to a local Unix socket path.

Unfortunately, this causes Rails to think that the database is on a remote host:

    This task only modifies local databases. example-database is on a remote host.

Let's fix this by checking if the host is a path to a file.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
