### PR TITLE
Added tests for verifying content length presence in response headers

### DIFF
--- a/activestorage/test/controllers/blobs/proxy_controller_test.rb
+++ b/activestorage/test/controllers/blobs/proxy_controller_test.rb
@@ -137,6 +137,17 @@ class ActiveStorage::Blobs::ProxyControllerTest < ActionDispatch::IntegrationTes
     assert request.session_options[:skip],
       "Expected request.session_options[:skip] to be true"
   end
+
+  test "rails_storage_proxy include Content-Length header" do
+    Rails.application.config.active_storage.resolve_model_to_route = :rails_storage_proxy
+    blob = create_file_blob(filename: "racecar.jpg")
+
+    get rails_storage_proxy_url(blob)
+
+    assert_response :success
+    assert_not_nil response.headers["Content-Length"], "Content-Length header should be included in proxy mode"
+    assert_equal blob.byte_size.to_s, response.headers["Content-Length"], "Content-Length header should match blob size"
+  end
 end
 
 class ActiveStorage::Blobs::ExpiringProxyControllerTest < ActionDispatch::IntegrationTest


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created to address the issue described in [#54870](https://github.com/rails/rails/issues/54870). The issue pertains to the `rails_storage_proxy` not including the `Content-Length` header in proxy mode, which can cause problems when serving files. This test has been added to reproduce and verify the issue.

### Detail

This Pull Request introduces a test case, `test "rails_storage_proxy include Content-Length header"`, to ensure that the `Content-Length` header is included in the response when using `rails_storage_proxy`. The test verifies that the header matches the blob's byte size and is not nil.

### Additional information

This test helps confirm the behavior of `rails_storage_proxy` and ensures that the issue described in #54870 is reproducible and can be addressed effectively.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #54870]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
