### PR TITLE
Fix dumping declaratively partitioned tables in PostgreSQL

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_dumper.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_dumper.rb
@@ -39,6 +39,17 @@ module ActiveRecord
             end
           end
 
+          def table(table, stream)
+            super
+
+            partition_bound_definition = @connection.table_partition_bound_definition(table)
+            if partition_bound_definition
+              partition_table = @connection.inherited_table_names(table).first
+
+              stream.puts "  execute \"ALTER TABLE ONLY #{partition_table} ATTACH PARTITION #{table} #{partition_bound_definition}\""
+            end
+          end
+
           def exclusion_constraints_in_create(table, stream)
             if (exclusion_constraints = @connection.exclusion_constraints(table)).any?
               exclusion_constraint_statements = exclusion_constraints.map do |exclusion_constraint|

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -162,11 +162,14 @@ module ActiveRecord
 
           options[:comment] = comment if comment
 
+          partition_bound_definition = table_partition_bound_definition(table_name)
           inherited_table_names = inherited_table_names(table_name).presence
 
-          options[:options] = "INHERITS (#{inherited_table_names.join(", ")})" if inherited_table_names
-
-          if !options[:options] && supports_native_partitioning?
+          # Can't use :options for declarative partitioning. Partition will be attached
+          # via a separate 'ALTER TABLE ... ATTACH PARTITION ...' call.
+          if inherited_table_names && !partition_bound_definition
+            options[:options] = "INHERITS (#{inherited_table_names.join(", ")})"
+          elsif supports_native_partitioning?
             partition_definition = table_partition_definition(table_name)
 
             options[:options] = "PARTITION BY #{partition_definition}" if partition_definition
@@ -190,7 +193,7 @@ module ActiveRecord
           end
         end
 
-        # Returns the partition definition of a given table
+        # Returns the partitioned table definition of a given table
         def table_partition_definition(table_name) # :nodoc:
           scope = quoted_scope(table_name, type: "BASE TABLE")
 
@@ -217,6 +220,21 @@ module ActiveRecord
             WHERE child.relname = #{scope[:name]}
               AND child.relkind IN (#{scope[:type]})
               AND n.nspname = #{scope[:schema]}
+          SQL
+        end
+
+        # Returns the partition definition of a given table
+        def table_partition_bound_definition(table_name) # :nodoc:
+          scope = quoted_scope(table_name, type: "BASE TABLE")
+
+          query_value(<<~SQL, "SCHEMA")
+            SELECT pg_catalog.pg_get_expr(c.relpartbound, c.oid)
+            FROM pg_catalog.pg_class c
+              LEFT JOIN pg_namespace n ON n.oid = c.relnamespace
+            WHERE c.relname = #{scope[:name]}
+              AND c.relkind IN (#{scope[:type]})
+              AND n.nspname = #{scope[:schema]}
+              AND c.relispartition
           SQL
         end
 

--- a/activerecord/test/cases/adapters/postgresql/schema_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/schema_test.rb
@@ -895,9 +895,14 @@ class SchemaCreateTableOptionsTest < ActiveRecord::PostgreSQLTestCase
       t.string :kind
     end
 
-    output = dump_table_schema "trains"
+    @connection.create_table "trains_a", id: false, options: "PARTITION OF trains FOR VALUES IN ('a')"
+    @connection.create_table "trains_b", id: false, options: "PARTITION OF trains FOR VALUES IN ('b')"
+
+    output = dump_table_schema "trains", "trains_a", "trains_b"
 
     assert_match("options: \"#{options}\"", output)
+    assert_match(/execute "ALTER TABLE ONLY trains ATTACH PARTITION trains_a FOR VALUES IN \('a'\)"/, output)
+    assert_match(/execute "ALTER TABLE ONLY trains ATTACH PARTITION trains_b FOR VALUES IN \('b'\)"/, output)
   end
 
   def test_range_partition_options_is_dumped


### PR DESCRIPTION
Fixes #54841.

The problem was that tables defined with declarative partitioning (https://www.postgresql.org/docs/current/ddl-partitioning.html#DDL-PARTITIONING-DECLARATIVE) weren't correctly dumped. 

In the original PR (https://github.com/rails/rails/pull/50475) it was always assumed that tables are defined with inheritance based partitioning (https://www.postgresql.org/docs/current/ddl-partitioning.html#DDL-PARTITIONING-USING-INHERITANCE).