### PR TITLE
Isolate `AS::Message{Encryptor,Verifier}` rotations on `dup`

### DIFF
--- a/activesupport/lib/active_support/messages/rotator.rb
+++ b/activesupport/lib/active_support/messages/rotator.rb
@@ -45,6 +45,11 @@ module ActiveSupport
         end
       end
 
+      def initialize_dup(*)
+        super
+        @rotations = @rotations.dup
+      end
+
       private
         def build_rotation(*args, **options)
           self.class.new(*args, *@args.drop(args.length), **@options, **options)

--- a/activesupport/test/messages/message_rotator_tests.rb
+++ b/activesupport/test/messages/message_rotator_tests.rb
@@ -81,6 +81,22 @@ module MessageRotatorTests
       assert_equal DATA, decode(old_message, codec, on_rotation: proc { called += "via method" })
       assert_equal "via method", called
     end
+
+    test "dup isolates rotations" do
+      foo_codec = make_codec(secret("foo"))
+      foo_message = encode(DATA, foo_codec)
+      bar_codec = make_codec(secret("bar"))
+      bar_message = encode(DATA, bar_codec)
+
+      foobar_codec = foo_codec.dup
+      foobar_codec.rotate(secret("bar"))
+
+      assert_equal DATA, decode(foo_message, foobar_codec)
+      assert_equal DATA, decode(bar_message, foobar_codec)
+
+      assert_equal DATA, decode(foo_message, foo_codec)
+      assert_nil decode(bar_message, foo_codec)
+    end
   end
 
   private


### PR DESCRIPTION
This ensures that calling `rotate` on a `dup`ed instance of `ActiveSupport::MessageEncryptor` or `ActiveSupport::MessageVerifier` does not affect the original instance.
