### PR TITLE
Model generator should be able to run without a database connection

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Model generator no longer needs a database connection to validate column types.
+
+    *Mike Dalessio*
+
 *   Allow signed ID verifiers to be configurable via `Rails.application.message_verifiers`
 
     Prior to this change, the primary way to configure signed ID verifiers was

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -260,7 +260,11 @@ module ActiveRecord
       end
 
       def valid_type?(type) # :nodoc:
-        !native_database_types[type].nil?
+        self.class.valid_type?(type)
+      end
+
+      def native_database_types # :nodoc:
+        self.class.native_database_types
       end
 
       # this method must only be called while holding connection pool's mutex
@@ -884,6 +888,10 @@ module ActiveRecord
             register_class_with_precision m, %r(\A[^\(]*datetime)i, Type::DateTime, timezone: default_timezone
             m.alias_type %r(\A[^\(]*timestamp)i, "datetime"
           end
+        end
+
+        def valid_type?(type) # :nodoc:
+          !native_database_types[type].nil?
         end
 
         private

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -81,6 +81,10 @@ module ActiveRecord
 
           find_cmd_and_exec(ActiveRecord.database_cli[:mysql], *args)
         end
+
+        def native_database_types # :nodoc:
+          NATIVE_DATABASE_TYPES
+        end
       end
 
       def get_database_version # :nodoc:
@@ -194,10 +198,6 @@ module ActiveRecord
 
       def release_advisory_lock(lock_name) # :nodoc:
         query_value("SELECT RELEASE_LOCK(#{quote(lock_name.to_s)})") == 1
-      end
-
-      def native_database_types
-        NATIVE_DATABASE_TYPES
       end
 
       def index_algorithms

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -397,10 +397,6 @@ module ActiveRecord
         @raw_connection = nil
       end
 
-      def native_database_types # :nodoc:
-        self.class.native_database_types
-      end
-
       def self.native_database_types # :nodoc:
         @native_database_types ||= begin
           types = NATIVE_DATABASE_TYPES.dup

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -66,6 +66,10 @@ module ActiveRecord
 
           find_cmd_and_exec(ActiveRecord.database_cli[:sqlite], *args)
         end
+
+        def native_database_types # :nodoc:
+          NATIVE_DATABASE_TYPES
+        end
       end
 
       include SQLite3::Quoting
@@ -256,10 +260,6 @@ module ActiveRecord
 
       def supports_index_sort_order?
         true
-      end
-
-      def native_database_types # :nodoc:
-        NATIVE_DATABASE_TYPES
       end
 
       # Returns the current database encoding format as a string, e.g. 'UTF-8'

--- a/activerecord/test/cases/adapter_test.rb
+++ b/activerecord/test/cases/adapter_test.rb
@@ -48,11 +48,13 @@ module ActiveRecord
     def test_valid_column
       @connection.native_database_types.each_key do |type|
         assert @connection.valid_type?(type)
+        assert @connection.class.valid_type?(type)
       end
     end
 
     def test_invalid_column
       assert_not @connection.valid_type?(:foobar)
+      assert_not @connection.class.valid_type?(:foobar)
     end
 
     def test_tables

--- a/railties/lib/rails/generators/generated_attribute.rb
+++ b/railties/lib/rails/generators/generated_attribute.rb
@@ -73,7 +73,7 @@ module Rails
         def valid_type?(type)
           DEFAULT_TYPES.include?(type.to_s) ||
             !defined?(ActiveRecord::Base) ||
-            ActiveRecord::Base.lease_connection.valid_type?(type)
+            ActiveRecord::Base.connection_db_config.adapter_class.valid_type?(type)
         end
 
         def valid_index_type?(index_type)


### PR DESCRIPTION
### Motivation / Background

The instance method `AbstractAdapter#valid_type?` does not actually require a database connection in order to answer the validity question. This commit makes the method available as a class method for use in situations where there isn't already a connection checked out.

This commit also updates the model generator to call `valid_type?` on the database connection class, to avoid making an unnecessary connection.


### Detail

Move `AbstractAdapter#valid_type?` to a class method, since this method only needs access to a constant, and does not actually need a live connection.

Continue to support instance methods `#valid_type?` and `#native_database_types`, but both of these methods now forward to a class method of the same name. (All the concrete adapters now implement a class method `.native_database_types`.)


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
