### PR TITLE
Ensure Rails::Engine::LazyRouteSet, AD::Routing::RouteSet::* are private

### DIFF
--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -29,7 +29,7 @@ module ActionDispatch
       def from_requirements(requirements)
         routes.find { |route| route.requirements == requirements }
       end
-      # :stopdoc:
+      # :enddoc:
 
       # Since the router holds references to many parts of the system like engines,
       # controllers and the application itself, inspecting the route set can actually
@@ -953,6 +953,5 @@ module ActionDispatch
         end
       end
     end
-    # :startdoc:
   end
 end

--- a/railties/lib/rails/engine/lazy_route_set.rb
+++ b/railties/lib/rails/engine/lazy_route_set.rb
@@ -4,9 +4,11 @@
 
 require "action_dispatch/routing/route_set"
 
+# :enddoc:
+
 module Rails
   class Engine
-    class LazyRouteSet < ActionDispatch::Routing::RouteSet # :nodoc:
+    class LazyRouteSet < ActionDispatch::Routing::RouteSet
       class NamedRouteCollection < ActionDispatch::Routing::RouteSet::NamedRouteCollection
         def route_defined?(name)
           Rails.application&.reload_routes_unless_loaded


### PR DESCRIPTION
Before:

* [ActionDispatch::Routing::RouteSet](https://edgeapi.rubyonrails.org/classes/ActionDispatch/Routing/RouteSet.html)
  * [ActionDispatch::Routing::RouteSet::CustomUrlHelper](https://edgeapi.rubyonrails.org/classes/ActionDispatch/Routing/RouteSet/CustomUrlHelper.html)
  * [ActionDispatch::Routing::RouteSet::Dispatcher](https://edgeapi.rubyonrails.org/classes/ActionDispatch/Routing/RouteSet/Dispatcher.html)
  * [ActionDispatch::Routing::RouteSet::Generator](https://edgeapi.rubyonrails.org/classes/ActionDispatch/Routing/RouteSet/Generator.html)
  * [ActionDispatch::Routing::RouteSet::MountedHelpers](https://edgeapi.rubyonrails.org/classes/ActionDispatch/Routing/RouteSet/MountedHelpers.html)
  * [ActionDispatch::Routing::RouteSet::NamedRouteCollection](https://edgeapi.rubyonrails.org/classes/ActionDispatch/Routing/RouteSet/NamedRouteCollection.html)
  * [ActionDispatch::Routing::RouteSet::StaticDispatcher](https://edgeapi.rubyonrails.org/classes/ActionDispatch/Routing/RouteSet/StaticDispatcher.html)

* [Rails::Engine](https://edgeapi.rubyonrails.org/classes/Rails/Engine.html)
  * [Rails::Engine::LazyRouteSet](https://edgeapi.rubyonrails.org/classes/Rails/Engine/LazyRouteSet.html)

After:

* [ActionDispatch::Routing::RouteSet](https://zzak-nodoc-named-routes.rails-docs-preview.pages.dev/api/classes/ActionDispatch/Routing/RouteSet)
* [Rails::Engine](https://zzak-nodoc-named-routes.rails-docs-preview.pages.dev/api/classes/Rails/Engine)