### PR TITLE
Add ActiveRecord::Tasks::AbstractTasks for subclassing per adapter behavior

### DIFF
--- a/activerecord/lib/active_record.rb
+++ b/activerecord/lib/active_record.rb
@@ -174,7 +174,8 @@ module ActiveRecord
     extend ActiveSupport::Autoload
 
     autoload :DatabaseTasks
-    autoload :MySQLDatabaseTasks,  "active_record/tasks/mysql_database_tasks"
+    autoload :AbstractTasks, "active_record/tasks/abstract_tasks"
+    autoload :MySQLDatabaseTasks, "active_record/tasks/mysql_database_tasks"
     autoload :PostgreSQLDatabaseTasks, "active_record/tasks/postgresql_database_tasks"
     autoload :SQLiteDatabaseTasks, "active_record/tasks/sqlite_database_tasks"
   end

--- a/activerecord/lib/active_record/tasks/abstract_tasks.rb
+++ b/activerecord/lib/active_record/tasks/abstract_tasks.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+module ActiveRecord
+  module Tasks # :nodoc:
+    class AbstractTasks # :nodoc:
+      def self.using_database_configurations?
+        true
+      end
+
+      def initialize(db_config)
+        @db_config = db_config
+        @configuration_hash = db_config.configuration_hash
+      end
+
+      def charset
+        connection.encoding
+      end
+
+      def collation
+        connection.collation
+      end
+
+      def check_current_protected_environment!(db_config, migration_class)
+        with_temporary_pool(db_config, migration_class) do |pool|
+          migration_context = pool.migration_context
+          current = migration_context.current_environment
+          stored  = migration_context.last_stored_environment
+
+          if migration_context.protected_environment?
+            raise ActiveRecord::ProtectedEnvironmentError.new(stored)
+          end
+
+          if stored && stored != current
+            raise ActiveRecord::EnvironmentMismatchError.new(current: current, stored: stored)
+          end
+        rescue ActiveRecord::NoDatabaseError
+        end
+      end
+
+      private
+        attr_reader :db_config, :configuration_hash
+
+        def connection
+          ActiveRecord::Base.lease_connection
+        end
+
+        def establish_connection(config = db_config)
+          ActiveRecord::Base.establish_connection(config)
+        end
+
+        def configuration_hash_without_database
+          configuration_hash.merge(database: nil)
+        end
+
+        def run_cmd(cmd, *args, **opts)
+          fail run_cmd_error(cmd, args) unless Kernel.system(cmd, *args, opts)
+        end
+
+        def run_cmd_error(cmd, args)
+          msg = +"failed to execute:\n"
+          msg << "#{cmd} #{args.join(' ')}\n\n"
+          msg << "Please check the output above for any errors and make sure that `#{cmd}` is installed in your PATH and has proper permissions.\n\n"
+          msg
+        end
+
+        def with_temporary_pool(db_config, migration_class, clobber: false)
+          original_db_config = migration_class.connection_db_config
+          pool = migration_class.connection_handler.establish_connection(db_config, clobber: clobber)
+
+          yield pool
+        ensure
+          migration_class.connection_handler.establish_connection(original_db_config, clobber: clobber)
+        end
+    end
+  end
+end

--- a/activerecord/lib/active_record/tasks/database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/database_tasks.rb
@@ -66,7 +66,7 @@ module ActiveRecord
         return if ENV["DISABLE_DATABASE_ENVIRONMENT_CHECK"]
 
         configs_for(env_name: environment).each do |db_config|
-          check_current_protected_environment!(db_config)
+          database_adapter_for(db_config).check_current_protected_environment!(db_config, migration_class)
         end
       end
 
@@ -637,23 +637,6 @@ module ActiveRecord
             structure_load_flags[adapter.to_sym]
           else
             structure_load_flags
-          end
-        end
-
-        def check_current_protected_environment!(db_config)
-          with_temporary_pool(db_config) do |pool|
-            migration_context = pool.migration_context
-            current = migration_context.current_environment
-            stored  = migration_context.last_stored_environment
-
-            if migration_context.protected_environment?
-              raise ActiveRecord::ProtectedEnvironmentError.new(stored)
-            end
-
-            if stored && stored != current
-              raise ActiveRecord::EnvironmentMismatchError.new(current: current, stored: stored)
-            end
-          rescue ActiveRecord::NoDatabaseError
           end
         end
 

--- a/activerecord/lib/active_record/tasks/postgresql_database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/postgresql_database_tasks.rb
@@ -4,19 +4,10 @@ require "tempfile"
 
 module ActiveRecord
   module Tasks # :nodoc:
-    class PostgreSQLDatabaseTasks # :nodoc:
+    class PostgreSQLDatabaseTasks < AbstractTasks # :nodoc:
       DEFAULT_ENCODING = ENV["CHARSET"] || "utf8"
       ON_ERROR_STOP_1 = "ON_ERROR_STOP=1"
       SQL_COMMENT_BEGIN = "--"
-
-      def self.using_database_configurations?
-        true
-      end
-
-      def initialize(db_config)
-        @db_config = db_config
-        @configuration_hash = db_config.configuration_hash
-      end
 
       def create(connection_already_established = false)
         establish_connection(public_schema_config) unless connection_already_established
@@ -27,14 +18,6 @@ module ActiveRecord
       def drop
         establish_connection(public_schema_config)
         connection.drop_database(db_config.database)
-      end
-
-      def charset
-        connection.encoding
-      end
-
-      def collation
-        connection.collation
       end
 
       def purge
@@ -72,7 +55,7 @@ module ActiveRecord
         end
 
         args << db_config.database
-        run_cmd("pg_dump", args, "dumping")
+        run_cmd("pg_dump", *args)
         remove_sql_header_comments(filename)
         File.open(filename, "a") { |f| f << "SET search_path TO #{connection.schema_search_path};\n\n" }
       end
@@ -82,20 +65,10 @@ module ActiveRecord
         args.concat(Array(extra_flags)) if extra_flags
         args.concat(["--file", filename])
         args << db_config.database
-        run_cmd("psql", args, "loading")
+        run_cmd("psql", *args)
       end
 
       private
-        attr_reader :db_config, :configuration_hash
-
-        def connection
-          ActiveRecord::Base.lease_connection
-        end
-
-        def establish_connection(config = db_config)
-          ActiveRecord::Base.establish_connection(config)
-        end
-
         def encoding
           configuration_hash[:encoding] || DEFAULT_ENCODING
         end
@@ -117,15 +90,8 @@ module ActiveRecord
           end
         end
 
-        def run_cmd(cmd, args, action)
-          fail run_cmd_error(cmd, args, action) unless Kernel.system(psql_env, cmd, *args)
-        end
-
-        def run_cmd_error(cmd, args, action)
-          msg = +"failed to execute:\n"
-          msg << "#{cmd} #{args.join(' ')}\n\n"
-          msg << "Please check the output above for any errors and make sure that `#{cmd}` is installed in your PATH and has proper permissions.\n\n"
-          msg
+        def run_cmd(cmd, *args, **opts)
+          fail run_cmd_error(cmd, args) unless Kernel.system(psql_env, cmd, *args, **opts)
         end
 
         def remove_sql_header_comments(filename)

--- a/activerecord/lib/active_record/tasks/sqlite_database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/sqlite_database_tasks.rb
@@ -2,11 +2,7 @@
 
 module ActiveRecord
   module Tasks # :nodoc:
-    class SQLiteDatabaseTasks # :nodoc:
-      def self.using_database_configurations?
-        true
-      end
-
+    class SQLiteDatabaseTasks < AbstractTasks # :nodoc:
       def initialize(db_config, root = ActiveRecord::Tasks::DatabaseTasks.root)
         @db_config = db_config
         @root = root
@@ -37,10 +33,6 @@ module ActiveRecord
         connection.reconnect!
       end
 
-      def charset
-        connection.encoding
-      end
-
       def structure_dump(filename, extra_flags)
         args = []
         args.concat(Array(extra_flags)) if extra_flags
@@ -54,7 +46,8 @@ module ActiveRecord
         else
           args << ".schema --nosys"
         end
-        run_cmd("sqlite3", args, filename)
+
+        run_cmd("sqlite3", *args, out: filename)
       end
 
       def structure_load(filename, extra_flags)
@@ -62,27 +55,22 @@ module ActiveRecord
         `sqlite3 #{flags} #{db_config.database} < "#{filename}"`
       end
 
-      private
-        attr_reader :db_config, :root
-
-        def connection
-          ActiveRecord::Base.lease_connection
+      def check_current_protected_environment!(db_config, migration_class)
+        super
+      rescue ActiveRecord::StatementInvalid => e
+        case e.cause
+        when SQLite3::ReadOnlyException
+        else
+          raise e
         end
+      end
+
+      private
+        attr_reader :root
 
         def establish_connection(config = db_config)
           ActiveRecord::Base.establish_connection(config)
           connection.connect!
-        end
-
-        def run_cmd(cmd, args, out)
-          fail run_cmd_error(cmd, args) unless Kernel.system(cmd, *args, out: out)
-        end
-
-        def run_cmd_error(cmd, args)
-          msg = +"failed to execute:\n"
-          msg << "#{cmd} #{args.join(' ')}\n\n"
-          msg << "Please check the output above for any errors and make sure that `#{cmd}` is installed in your PATH and has proper permissions.\n\n"
-          msg
         end
     end
   end

--- a/activerecord/test/cases/adapters/mysql2/mysql2_rake_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/mysql2_rake_test.rb
@@ -271,7 +271,7 @@ module ActiveRecord
       assert_called_with(
         Kernel,
         :system,
-        ["mysqldump", "--result-file", filename, "--no-data", "--routines", "--skip-comments", "test-db"],
+        ["mysqldump", "--result-file", filename, "--no-data", "--routines", "--skip-comments", "test-db", {}],
         returns: true
       ) do
         ActiveRecord::Tasks::DatabaseTasks.structure_dump(@configuration, filename)
@@ -280,7 +280,7 @@ module ActiveRecord
 
     def test_structure_dump_with_extra_flags
       filename = "awesome-file.sql"
-      expected_command = ["mysqldump", "--noop", "--result-file", filename, "--no-data", "--routines", "--skip-comments", "test-db"]
+      expected_command = ["mysqldump", "--noop", "--result-file", filename, "--no-data", "--routines", "--skip-comments", "test-db", {}]
 
       assert_called_with(Kernel, :system, expected_command, returns: true) do
         with_structure_dump_flags(["--noop"]) do
@@ -291,7 +291,7 @@ module ActiveRecord
 
     def test_structure_dump_with_hash_extra_flags_for_a_different_driver
       filename = "awesome-file.sql"
-      expected_command = ["mysqldump", "--result-file", filename, "--no-data", "--routines", "--skip-comments", "test-db"]
+      expected_command = ["mysqldump", "--result-file", filename, "--no-data", "--routines", "--skip-comments", "test-db", {}]
 
       assert_called_with(Kernel, :system, expected_command, returns: true) do
         with_structure_dump_flags({ postgresql: ["--noop"] }) do
@@ -302,7 +302,7 @@ module ActiveRecord
 
     def test_structure_dump_with_hash_extra_flags_for_the_correct_driver
       filename = "awesome-file.sql"
-      expected_command = ["mysqldump", "--noop", "--result-file", filename, "--no-data", "--routines", "--skip-comments", "test-db"]
+      expected_command = ["mysqldump", "--noop", "--result-file", filename, "--no-data", "--routines", "--skip-comments", "test-db", {}]
 
       assert_called_with(Kernel, :system, expected_command, returns: true) do
         with_structure_dump_flags({ mysql2: ["--noop"] }) do
@@ -318,7 +318,7 @@ module ActiveRecord
           assert_called_with(
             Kernel,
             :system,
-            ["mysqldump", "--result-file", filename, "--no-data", "--routines", "--skip-comments", "--ignore-table=test-db.prefix_foo", "--ignore-table=test-db.ignored_foo", "test-db"],
+            ["mysqldump", "--result-file", filename, "--no-data", "--routines", "--skip-comments", "--ignore-table=test-db.prefix_foo", "--ignore-table=test-db.ignored_foo", "test-db", {}],
             returns: true
           ) do
             ActiveRecord::Tasks::DatabaseTasks.structure_dump(@configuration, filename)
@@ -332,13 +332,13 @@ module ActiveRecord
       assert_called_with(
         Kernel,
         :system,
-        ["mysqldump", "--result-file", filename, "--no-data", "--routines", "--skip-comments", "test-db"],
+        ["mysqldump", "--result-file", filename, "--no-data", "--routines", "--skip-comments", "test-db", {}],
         returns: false
       ) do
         e = assert_raise(RuntimeError) {
           ActiveRecord::Tasks::DatabaseTasks.structure_dump(@configuration, filename)
         }
-        assert_match(/^failed to execute: `mysqldump`$/, e.message)
+        assert_match(/^failed to execute:\nmysqldump/, e.message)
       end
     end
 
@@ -347,7 +347,7 @@ module ActiveRecord
       assert_called_with(
         Kernel,
         :system,
-        ["mysqldump", "--port=10000", "--result-file", filename, "--no-data", "--routines", "--skip-comments", "test-db"],
+        ["mysqldump", "--port=10000", "--result-file", filename, "--no-data", "--routines", "--skip-comments", "test-db", {}],
         returns: true
       ) do
         ActiveRecord::Tasks::DatabaseTasks.structure_dump(
@@ -361,7 +361,7 @@ module ActiveRecord
       assert_called_with(
         Kernel,
         :system,
-        ["mysqldump", "--ssl-ca=ca.crt", "--result-file", filename, "--no-data", "--routines", "--skip-comments", "test-db"],
+        ["mysqldump", "--ssl-ca=ca.crt", "--result-file", filename, "--no-data", "--routines", "--skip-comments", "test-db", {}],
         returns: true
       ) do
           ActiveRecord::Tasks::DatabaseTasks.structure_dump(
@@ -390,7 +390,7 @@ module ActiveRecord
 
     def test_structure_load
       filename = "awesome-file.sql"
-      expected_command = ["mysql", "--noop", "--execute", %{SET FOREIGN_KEY_CHECKS = 0; SOURCE #{filename}; SET FOREIGN_KEY_CHECKS = 1}, "--database", "test-db"]
+      expected_command = ["mysql", "--noop", "--execute", %{SET FOREIGN_KEY_CHECKS = 0; SOURCE #{filename}; SET FOREIGN_KEY_CHECKS = 1}, "--database", "test-db", {}]
 
       assert_called_with(Kernel, :system, expected_command, returns: true) do
         with_structure_load_flags(["--noop"]) do
@@ -401,7 +401,7 @@ module ActiveRecord
 
     def test_structure_load_with_hash_extra_flags_for_a_different_driver
       filename = "awesome-file.sql"
-      expected_command = ["mysql", "--execute", %{SET FOREIGN_KEY_CHECKS = 0; SOURCE #{filename}; SET FOREIGN_KEY_CHECKS = 1}, "--database", "test-db"]
+      expected_command = ["mysql", "--execute", %{SET FOREIGN_KEY_CHECKS = 0; SOURCE #{filename}; SET FOREIGN_KEY_CHECKS = 1}, "--database", "test-db", {}]
 
       assert_called_with(Kernel, :system, expected_command, returns: true) do
         with_structure_load_flags({ postgresql: ["--noop"] }) do
@@ -412,7 +412,7 @@ module ActiveRecord
 
     def test_structure_load_with_hash_extra_flags_for_the_correct_driver
       filename = "awesome-file.sql"
-      expected_command = ["mysql", "--noop", "--execute", %{SET FOREIGN_KEY_CHECKS = 0; SOURCE #{filename}; SET FOREIGN_KEY_CHECKS = 1}, "--database", "test-db"]
+      expected_command = ["mysql", "--noop", "--execute", %{SET FOREIGN_KEY_CHECKS = 0; SOURCE #{filename}; SET FOREIGN_KEY_CHECKS = 1}, "--database", "test-db", {}]
 
       assert_called_with(Kernel, :system, expected_command, returns: true) do
         with_structure_load_flags({ mysql2: ["--noop"] }) do

--- a/activerecord/test/cases/adapters/sqlite3/sqlite_rake_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/sqlite_rake_test.rb
@@ -214,9 +214,8 @@ module ActiveRecord
       assert_called_with(
         Kernel,
         :system,
-        ["sqlite3", "--noop", "db_create.sqlite3", ".schema --nosys"],
+        ["sqlite3", "--noop", "db_create.sqlite3", ".schema --nosys", { out: "awesome-file.sql" }],
         returns: nil,
-        out: "awesome-file.sql"
       ) do
         e = assert_raise(RuntimeError) do
           with_structure_dump_flags(["--noop"]) do

--- a/activerecord/test/cases/adapters/trilogy/trilogy_rake_test.rb
+++ b/activerecord/test/cases/adapters/trilogy/trilogy_rake_test.rb
@@ -271,7 +271,7 @@ module ActiveRecord
       assert_called_with(
         Kernel,
         :system,
-        ["mysqldump", "--result-file", filename, "--no-data", "--routines", "--skip-comments", "test-db"],
+        ["mysqldump", "--result-file", filename, "--no-data", "--routines", "--skip-comments", "test-db", {}],
         returns: true
       ) do
         ActiveRecord::Tasks::DatabaseTasks.structure_dump(@configuration, filename)
@@ -280,7 +280,7 @@ module ActiveRecord
 
     def test_structure_dump_with_extra_flags
       filename = "awesome-file.sql"
-      expected_command = ["mysqldump", "--noop", "--result-file", filename, "--no-data", "--routines", "--skip-comments", "test-db"]
+      expected_command = ["mysqldump", "--noop", "--result-file", filename, "--no-data", "--routines", "--skip-comments", "test-db", {}]
 
       assert_called_with(Kernel, :system, expected_command, returns: true) do
         with_structure_dump_flags(["--noop"]) do
@@ -291,7 +291,7 @@ module ActiveRecord
 
     def test_structure_dump_with_hash_extra_flags_for_a_different_driver
       filename = "awesome-file.sql"
-      expected_command = ["mysqldump", "--result-file", filename, "--no-data", "--routines", "--skip-comments", "test-db"]
+      expected_command = ["mysqldump", "--result-file", filename, "--no-data", "--routines", "--skip-comments", "test-db", {}]
 
       assert_called_with(Kernel, :system, expected_command, returns: true) do
         with_structure_dump_flags({ postgresql: ["--noop"] }) do
@@ -302,7 +302,7 @@ module ActiveRecord
 
     def test_structure_dump_with_hash_extra_flags_for_the_correct_driver
       filename = "awesome-file.sql"
-      expected_command = ["mysqldump", "--noop", "--result-file", filename, "--no-data", "--routines", "--skip-comments", "test-db"]
+      expected_command = ["mysqldump", "--noop", "--result-file", filename, "--no-data", "--routines", "--skip-comments", "test-db", {}]
 
       assert_called_with(Kernel, :system, expected_command, returns: true) do
         with_structure_dump_flags({ trilogy: ["--noop"] }) do
@@ -318,7 +318,7 @@ module ActiveRecord
           assert_called_with(
             Kernel,
             :system,
-            ["mysqldump", "--result-file", filename, "--no-data", "--routines", "--skip-comments", "--ignore-table=test-db.prefix_foo", "--ignore-table=test-db.ignored_foo", "test-db"],
+            ["mysqldump", "--result-file", filename, "--no-data", "--routines", "--skip-comments", "--ignore-table=test-db.prefix_foo", "--ignore-table=test-db.ignored_foo", "test-db", {}],
             returns: true
           ) do
             ActiveRecord::Tasks::DatabaseTasks.structure_dump(@configuration, filename)
@@ -332,13 +332,13 @@ module ActiveRecord
       assert_called_with(
         Kernel,
         :system,
-        ["mysqldump", "--result-file", filename, "--no-data", "--routines", "--skip-comments", "test-db"],
+        ["mysqldump", "--result-file", filename, "--no-data", "--routines", "--skip-comments", "test-db", {}],
         returns: false
       ) do
         e = assert_raise(RuntimeError) {
           ActiveRecord::Tasks::DatabaseTasks.structure_dump(@configuration, filename)
         }
-        assert_match(/^failed to execute: `mysqldump`$/, e.message)
+        assert_match(/^failed to execute:\nmysqldump/, e.message)
       end
     end
 
@@ -347,7 +347,7 @@ module ActiveRecord
       assert_called_with(
         Kernel,
         :system,
-        ["mysqldump", "--port=10000", "--result-file", filename, "--no-data", "--routines", "--skip-comments", "test-db"],
+        ["mysqldump", "--port=10000", "--result-file", filename, "--no-data", "--routines", "--skip-comments", "test-db", {}],
         returns: true
       ) do
         ActiveRecord::Tasks::DatabaseTasks.structure_dump(
@@ -361,7 +361,7 @@ module ActiveRecord
       assert_called_with(
         Kernel,
         :system,
-        ["mysqldump", "--ssl-ca=ca.crt", "--result-file", filename, "--no-data", "--routines", "--skip-comments", "test-db"],
+        ["mysqldump", "--ssl-ca=ca.crt", "--result-file", filename, "--no-data", "--routines", "--skip-comments", "test-db", {}],
         returns: true
       ) do
           ActiveRecord::Tasks::DatabaseTasks.structure_dump(
@@ -390,7 +390,7 @@ module ActiveRecord
 
     def test_structure_load
       filename = "awesome-file.sql"
-      expected_command = ["mysql", "--noop", "--execute", %{SET FOREIGN_KEY_CHECKS = 0; SOURCE #{filename}; SET FOREIGN_KEY_CHECKS = 1}, "--database", "test-db"]
+      expected_command = ["mysql", "--noop", "--execute", %{SET FOREIGN_KEY_CHECKS = 0; SOURCE #{filename}; SET FOREIGN_KEY_CHECKS = 1}, "--database", "test-db", {}]
 
       assert_called_with(Kernel, :system, expected_command, returns: true) do
         with_structure_load_flags(["--noop"]) do
@@ -401,7 +401,7 @@ module ActiveRecord
 
     def test_structure_load_with_hash_extra_flags_for_a_different_driver
       filename = "awesome-file.sql"
-      expected_command = ["mysql", "--execute", %{SET FOREIGN_KEY_CHECKS = 0; SOURCE #{filename}; SET FOREIGN_KEY_CHECKS = 1}, "--database", "test-db"]
+      expected_command = ["mysql", "--execute", %{SET FOREIGN_KEY_CHECKS = 0; SOURCE #{filename}; SET FOREIGN_KEY_CHECKS = 1}, "--database", "test-db", {}]
 
       assert_called_with(Kernel, :system, expected_command, returns: true) do
         with_structure_load_flags({ postgresql: ["--noop"] }) do
@@ -412,7 +412,7 @@ module ActiveRecord
 
     def test_structure_load_with_hash_extra_flags_for_the_correct_driver
       filename = "awesome-file.sql"
-      expected_command = ["mysql", "--noop", "--execute", %{SET FOREIGN_KEY_CHECKS = 0; SOURCE #{filename}; SET FOREIGN_KEY_CHECKS = 1}, "--database", "test-db"]
+      expected_command = ["mysql", "--noop", "--execute", %{SET FOREIGN_KEY_CHECKS = 0; SOURCE #{filename}; SET FOREIGN_KEY_CHECKS = 1}, "--database", "test-db", {}]
 
       assert_called_with(Kernel, :system, expected_command, returns: true) do
         with_structure_load_flags({ trilogy: ["--noop"] }) do

--- a/activerecord/test/cases/tasks/database_tasks_test.rb
+++ b/activerecord/test/cases/tasks/database_tasks_test.rb
@@ -63,10 +63,12 @@ module ActiveRecord
 
       def setup
         recreate_metadata_tables
+        @before_root = ActiveRecord::Tasks::DatabaseTasks.root = Dir.pwd
       end
 
       def teardown
         recreate_metadata_tables
+        ActiveRecord::Tasks::DatabaseTasks.root = @before_root
       end
 
       def test_raises_an_error_when_called_with_protected_environment
@@ -156,6 +158,14 @@ module ActiveRecord
   class DatabaseTasksCheckProtectedEnvironmentsMultiDatabaseTest < ActiveRecord::TestCase
     if current_adapter?(:SQLite3Adapter) && !in_memory_db?
       self.use_transactional_tests = false
+
+      def setup
+        @before_root = ActiveRecord::Tasks::DatabaseTasks.root = Dir.pwd
+      end
+
+      def teardown
+        ActiveRecord::Tasks::DatabaseTasks.root = @before_root
+      end
 
       def test_with_multiple_databases
         env = ActiveRecord::ConnectionHandling::DEFAULT_ENV.call

--- a/railties/test/application/rake/dbs_test.rb
+++ b/railties/test/application/rake/dbs_test.rb
@@ -258,6 +258,7 @@ module ApplicationTests
           end
         end
       end
+
       test "db:create works when schema cache exists and database does not exist" do
         use_postgresql
 


### PR DESCRIPTION
The main motivation was to be able to override `check_current_protected_environment!` in the case of SQLite3 which raises an error on read-only databases in Linux.

As an alternative to #49930, which aims to fix #49928.

There might be a little more refactoring in there, but I wanted to open a PR to get feedback and see if anything fails in CI.