### PR TITLE
Clean backtrace from Active Job perform exceptions

### DIFF
--- a/activejob/lib/active_job/log_subscriber.rb
+++ b/activejob/lib/active_job/log_subscriber.rb
@@ -87,8 +87,9 @@ module ActiveJob
       job = event.payload[:job]
       ex = event.payload[:exception_object]
       if ex
+        cleaned_backtrace = backtrace_cleaner.clean(ex.backtrace)
         error do
-          "Error performing #{job.class.name} (Job ID: #{job.job_id}) from #{queue_name(event)} in #{event.duration.round(2)}ms: #{ex.class} (#{ex.message}):\n" + Array(ex.backtrace).join("\n")
+          "Error performing #{job.class.name} (Job ID: #{job.job_id}) from #{queue_name(event)} in #{event.duration.round(2)}ms: #{ex.class} (#{ex.message}):\n" + Array(cleaned_backtrace).join("\n")
         end
       elsif event.payload[:aborted]
         error do

--- a/activejob/test/cases/logging_test.rb
+++ b/activejob/test/cases/logging_test.rb
@@ -284,6 +284,18 @@ class LoggingTest < ActiveSupport::TestCase
     end
   end
 
+  def test_job_error_logging_backtrace_cleaner
+    perform_enqueued_jobs do
+      assert_raises(RescueJob::OtherError) do
+        RescueJob.perform_later "other"
+      end
+    end
+
+    assert_match(/rescue_job\.rb:\d+:in .*perform'/, @logger.messages)
+    assert_empty(@logger.messages.lines.grep(/minitest\//))
+    assert_empty(@logger.messages.lines.grep(/gems\//))
+  end
+
   def test_job_no_error_logging_on_rescuable_job
     perform_enqueued_jobs { RescueJob.perform_later "david" }
     assert_match(/Performing RescueJob \(Job ID: .*?\) from .*? with arguments:.*david/, @logger.messages)


### PR DESCRIPTION
Diff:

```diff
--- before      2025-04-07 21:44:58.312363548 +0900
+++ after       2025-04-07 21:44:23.768140010 +0900
@@ -22,7 +22,6 @@
 "/home/zzak/code/rails/activejob/lib/active_job/execution_state.rb:7:in 'block (2 levels) in ActiveJob::ExecutionState#perform_now'\n" +
 "/home/zzak/code/rails/activesupport/lib/active_support/core_ext/time/zones.rb:65:in 'Time.use_zone'\n" +
 "/home/zzak/code/rails/activejob/lib/active_job/execution_state.rb:7:in 'block in ActiveJob::ExecutionState#perform_now'\n" +
-"/home/zzak/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/i18n-1.14.6/lib/i18n.rb:353:in 'I18n::Base#with_locale'\n" +
 "/home/zzak/code/rails/activejob/lib/active_job/execution_state.rb:6:in 'ActiveJob::ExecutionState#perform_now'\n" +
 "/home/zzak/code/rails/activejob/lib/active_job/execution.rb:29:in 'block in ActiveJob::Execution::ClassMethods#execute'\n" +
 "/home/zzak/code/rails/activesupport/lib/active_support/callbacks.rb:100:in 'ActiveSupport::Callbacks#run_callbacks'\n" +
@@ -55,23 +54,5 @@
 "/home/zzak/code/rails/activesupport/lib/active_support/testing/assertions.rb:311:in 'ActiveSupport::Testing::Assertions#_assert_nothing_raised_or_warn'\n" +
 "/home/zzak/code/rails/activejob/lib/active_job/test_helper.rb:626:in 'ActiveJob::TestHelper#perform_enqueued_jobs'\n" +
 "/home/zzak/code/rails/activejob/test/cases/logging_test.rb:288:in 'LoggingTest#test_job_error_logging_backtrace_cleaner'\n" +
-"/home/zzak/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/minitest-5.25.4/lib/minitest/test.rb:94:in 'block (2 levels) in Minitest::Test#run'\n" +
-"/home/zzak/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/minitest-5.25.4/lib/minitest/test.rb:190:in 'Minitest::Test#capture_exceptions'\n" +
-"/home/zzak/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/minitest-5.25.4/lib/minitest/test.rb:89:in 'block in Minitest::Test#run'\n" +
-"/home/zzak/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/minitest-5.25.4/lib/minitest.rb:368:in 'Minitest::Runnable#time_it'\n" +
-"/home/zzak/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/minitest-5.25.4/lib/minitest/test.rb:88:in 'Minitest::Test#run'\n" +
-"/home/zzak/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/minitest-5.25.4/lib/minitest.rb:1208:in 'Minitest.run_one_method'\n" +
-"/home/zzak/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/minitest-5.25.4/lib/minitest.rb:447:in 'Minitest::Runnable.run_one_method'\n" +
-"/home/zzak/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/minitest-5.25.4/lib/minitest.rb:434:in 'block (2 levels) in Minitest::Runnable.run'\n" +
-"/home/zzak/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/minitest-5.25.4/lib/minitest.rb:430:in 'Array#each'\n" +
-"/home/zzak/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/minitest-5.25.4/lib/minitest.rb:430:in 'block in Minitest::Runnable.run'\n" +
-"/home/zzak/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/minitest-5.25.4/lib/minitest.rb:472:in 'Minitest::Runnable.on_signal'\n" +
-"/home/zzak/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/minitest-5.25.4/lib/minitest.rb:459:in 'Minitest::Runnable.with_info_handler'\n" +
-"/home/zzak/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/minitest-5.25.4/lib/minitest.rb:429:in 'Minitest::Runnable.run'\n" +
 "/home/zzak/code/rails/railties/lib/rails/test_unit/line_filtering.rb:10:in 'Rails::LineFiltering#run'\n" +
-"/home/zzak/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/minitest-5.25.4/lib/minitest.rb:332:in 'block in Minitest.__run'\n" +
-"/home/zzak/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/minitest-5.25.4/lib/minitest.rb:332:in 'Array#map'\n" +
-"/home/zzak/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/minitest-5.25.4/lib/minitest.rb:332:in 'Minitest.__run'\n" +
-"/home/zzak/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/minitest-5.25.4/lib/minitest.rb:288:in 'Minitest.run'\n" +
-"/home/zzak/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/minitest-5.25.4/lib/minitest.rb:86:in 'block in Minitest.autorun'\n" +
 "[ActiveJob] Failed enqueuing RescueJob to Inline(default): RescueJob::OtherError (Bad hair)\n"

```

Rebases #46555 and adds a test, using `assert_empty` for a slightly better error message than `assert_match` on a giant string.

With `assert_match`:

```
LoggingTest#test_job_error_logging_backtrace_cleaner [/home/zzak/code/rails/activesupport/lib/active_support/testing/assertions.rb:311]:
Expected /gems\// to not match "[ActiveJob] [RescueJob] [59f964f8-3aad-4eca-96b1-08f3a96cba6b] Performing RescueJob (Job ID: 59f964f8-3aad-4eca-96b1-08f3a96cba6b) from Inline(default) enqueued at 2025-04-07T12:50:30.085624358Z with arguments: \"other\"\n[ActiveJob] [RescueJob] [59f964f8-3aad-4eca-96b1-08f3a96cba6b] Error performing RescueJob (Job ID: 59f964f8-3aad-4eca-96b1-08f3a96cba6b) from Inline(default) in 1.1ms: RescueJob::OtherError (Bad hair):\n/home/zzak/code/rails/activejob/test/jobs/rescue_job.rb:30:in 'RescueJob#perform'\n/home/zzak/code/rails/activejob/lib/active_job/execution.rb:68:in 'block in ActiveJob::Execution#_perform_job'\n/home/zzak/code/rails/activesupport/lib/active_support/callbacks.rb:100:in 'ActiveSupport::Callbacks#run_callbacks'\n/home/zzak/code/rails/activejob/lib/active_job/execution.rb:67:in 'ActiveJob::Execution#_perform_job'\n/home/zzak/code/rails/activejob/lib/active_job/instrumentation.rb:32:in 'ActiveJob::Instrumentation#_perform_job'\n/home/zzak/code/rails/activejob/lib/active_job/execution.rb:51:in 'ActiveJob::Execution#perform_now'\n/home/zzak/code/rails/activejob/lib/active_job/instrumentation.rb:26:in 'block in ActiveJob::Instrumentation#perform_now'\n/home/zzak/code/rails/activejob/lib/active_job/instrumentation.rb:40:in 'block in ActiveJob::Instrumentation#instrument'\n/home/zzak/code/rails/activesupport/lib/active_support/notifications.rb:210:in 'block in ActiveSupport::Notifications.instrument'\n/home/zzak/code/rails/activesupport/lib/active_support/notifications/instrumenter.rb:58:in 'ActiveSupport::Notifications::Instrumenter#instrument'\n/home/zzak/code/rails/activesupport/lib/active_support/notifications.rb:210:in 'ActiveSupport::Notifications.instrument'\n/home/zzak/code/rails/activejob/lib/active_job/instrumentation.rb:39:in 'ActiveJob::Instrumentation#instrument'\n/home/zzak/code/rails/activejob/lib/active_job/instrumentation.rb:26:in 'ActiveJob::Instrumentation#perform_now'\n/home/zzak/code/rails/activejob/lib/active_job/logging.rb:32:in 'block in ActiveJob::Logging#perform_now'\n/home/zzak/code/rails/activesupport/lib/active_support/tagged_logging.rb:143:in 'block in ActiveSupport::TaggedLogging#tagged'\n/home/zzak/code/rails/activesupport/lib/active_support/tagged_logging.rb:38:in 'ActiveSupport::TaggedLogging::Formatter#tagged'\n/home/zzak/code/rails/activesupport/lib/active_support/tagged_logging.rb:143:in 'ActiveSupport::TaggedLogging#tagged'\n/home/zzak/code/rails/activejob/lib/active_job/logging.rb:39:in 'ActiveJob::Logging#tag_logger'\n/home/zzak/code/rails/activejob/lib/active_job/logging.rb:32:in 'ActiveJob::Logging#perform_now'\n/home/zzak/code/rails/activejob/lib/active_job/execution_state.rb:7:in 'block (2 levels) in ActiveJob::ExecutionState#perform_now'\n/home/zzak/code/rails/activesupport/lib/active_support/core_ext/time/zones.rb:65:in 'Time.use_zone'\n/home/zzak/code/rails/activejob/lib/active_job/execution_state.rb:7:in 'block in ActiveJob::ExecutionState#perform_now'\n/home/zzak/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/i18n-1.14.6/lib/i18n.rb:353:in 'I18n::Base#with_locale'\n/home/zzak/code/rails/activejob/lib/active_job/execution_state.rb:6:in 'ActiveJob::ExecutionState#perform_now'\n/home/zzak/code/rails/activejob/lib/active_job/execution.rb:29:in 'block in ActiveJob::Execution::ClassMethods#execute'\n/home/zzak/code/rails/activesupport/lib/active_support/callbacks.rb:100:in 'ActiveSupport::Callbacks#run_callbacks'\n/home/zzak/code/rails/activejob/lib/active_job/execution.rb:27:in 'ActiveJob::Execution::ClassMethods#execute'\n/home/zzak/code/rails/activejob/lib/active_job/queue_adapters/inline_adapter.rb:15:in 'ActiveJob::QueueAdapters::InlineAdapter#enqueue'\n/home/zzak/code/rails/activejob/lib/active_job/enqueuing.rb:132:in 'ActiveJob::Enqueuing#raw_enqueue'\n/home/zzak/code/rails/activejob/lib/active_job/enqueue_after_transaction_commit.rb:40:in 'ActiveJob::EnqueueAfterTransactionCommit#raw_enqueue'\n/home/zzak/code/rails/activejob/lib/active_job/enqueuing.rb:117:in 'block in ActiveJob::Enqueuing#enqueue'\n/home/zzak/code/rails/activesupport/lib/active_support/callbacks.rb:120:in 'block in ActiveSupport::Callbacks#run_callbacks'\n/home/zzak/code/rails/activejob/lib/active_job/instrumentation.rb:40:in 'block in ActiveJob::Instrumentation#instrument'\n/home/zzak/code/rails/activesupport/lib/active_support/notifications.rb:210:in 'block in ActiveSupport::Notifications.instrument'\n/home/zzak/code/rails/activesupport/lib/active_support/notifications/instrumenter.rb:58:in 'ActiveSupport::Notifications::Instrumenter#instrument'\n/home/zzak/code/rails/activesupport/lib/active_support/notifications.rb:210:in 'ActiveSupport::Notifications.instrument'\n/home/zzak/code/rails/activejob/lib/active_job/instrumentation.rb:39:in 'ActiveJob::Instrumentation#instrument'\n/home/zzak/code/rails/activejob/lib/active_job/instrumentation.rb:21:in 'block (2 levels) in <module:Instrumentation>'\n/home/zzak/code/rails/activesupport/lib/active_support/callbacks.rb:129:in 'BasicObject#instance_exec'\n/home/zzak/code/rails/activesupport/lib/active_support/callbacks.rb:129:in 'block in ActiveSupport::Callbacks#run_callbacks'\n/home/zzak/code/rails/activesupport/lib/active_support/tagged_logging.rb:143:in 'block in ActiveSupport::TaggedLogging#tagged'\n/home/zzak/code/rails/activesupport/lib/active_support/tagged_logging.rb:38:in 'ActiveSupport::TaggedLogging::Formatter#tagged'\n/home/zzak/code/rails/activesupport/lib/active_support/tagged_logging.rb:143:in 'ActiveSupport::TaggedLogging#tagged'\n/home/zzak/code/rails/activejob/lib/active_job/logging.rb:39:in 'ActiveJob::Logging#tag_logger'\n/home/zzak/code/rails/activejob/lib/active_job/logging.rb:28:in 'block (2 levels) in <module:Logging>'\n/home/zzak/code/rails/activesupport/lib/active_support/callbacks.rb:129:in 'BasicObject#instance_exec'\n/home/zzak/code/rails/activesupport/lib/active_support/callbacks.rb:129:in 'block in ActiveSupport::Callbacks#run_callbacks'\n/home/zzak/code/rails/activesupport/lib/active_support/callbacks.rb:140:in 'ActiveSupport::Callbacks#run_callbacks'\n/home/zzak/code/rails/activejob/lib/active_job/enqueuing.rb:116:in 'ActiveJob::Enqueuing#enqueue'\n/home/zzak/code/rails/activejob/lib/active_job/enqueuing.rb:83:in 'ActiveJob::Enqueuing::ClassMethods#perform_later'\n/home/zzak/code/rails/activejob/test/cases/logging_test.rb:289:in 'block in LoggingTest#test_job_error_logging_backtrace_cleaner'\n/home/zzak/code/rails/activesupport/lib/active_support/testing/assertions.rb:49:in 'ActiveSupport::Testing::Assertions#assert_nothing_raised'\n/home/zzak/code/rails/activesupport/lib/active_support/testing/assertions.rb:311:in 'ActiveSupport::Testing::Assertions#_assert_nothing_raised_or_warn'\n/home/zzak/code/rails/activejob/lib/active_job/test_helper.rb:626:in 'ActiveJob::TestHelper#perform_enqueued_jobs'\n/home/zzak/code/rails/activejob/test/cases/logging_test.rb:288:in 'LoggingTest#test_job_error_logging_backtrace_cleaner'\n/home/zzak/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/minitest-5.25.4/lib/minitest/test.rb:94:in 'block (2 levels) in Minitest::Test#run'\n/home/zzak/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/minitest-5.25.4/lib/minitest/test.rb:190:in 'Minitest::Test#capture_exceptions'\n/home/zzak/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/minitest-5.25.4/lib/minitest/test.rb:89:in 'block in Minitest::Test#run'\n/home/zzak/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/minitest-5.25.4/lib/minitest.rb:368:in 'Minitest::Runnable#time_it'\n/home/zzak/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/minitest-5.25.4/lib/minitest/test.rb:88:in 'Minitest::Test#run'\n/home/zzak/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/minitest-5.25.4/lib/minitest.rb:1208:in 'Minitest.run_one_method'\n/home/zzak/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/minitest-5.25.4/lib/minitest.rb:447:in 'Minitest::Runnable.run_one_method'\n/home/zzak/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/minitest-5.25.4/lib/minitest.rb:434:in 'block (2 levels) in Minitest::Runnable.run'\n/home/zzak/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/minitest-5.25.4/lib/minitest.rb:430:in 'Array#each'\n/home/zzak/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/minitest-5.25.4/lib/minitest.rb:430:in 'block in Minitest::Runnable.run'\n/home/zzak/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/minitest-5.25.4/lib/minitest.rb:472:in 'Minitest::Runnable.on_signal'\n/home/zzak/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/minitest-5.25.4/lib/minitest.rb:459:in 'Minitest::Runnable.with_info_handler'\n/home/zzak/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/minitest-5.25.4/lib/minitest.rb:429:in 'Minitest::Runnable.run'\n/home/zzak/code/rails/railties/lib/rails/test_unit/line_filtering.rb:10:in 'Rails::LineFiltering#run'\n/home/zzak/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/minitest-5.25.4/lib/minitest.rb:332:in 'block in Minitest.__run'\n/home/zzak/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/minitest-5.25.4/lib/minitest.rb:332:in 'Array#map'\n/home/zzak/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/minitest-5.25.4/lib/minitest.rb:332:in 'Minitest.__run'\n/home/zzak/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/minitest-5.25.4/lib/minitest.rb:288:in 'Minitest.run'\n/home/zzak/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/minitest-5.25.4/lib/minitest.rb:86:in 'block in Minitest.autorun'\n[ActiveJob] Failed enqueuing RescueJob to Inline(default): RescueJob::OtherError (Bad hair)\n".
```


With `assert_empty`:

```
LoggingTest#test_job_error_logging_backtrace_cleaner [/home/zzak/code/rails/activesupport/lib/active_support/testing/assertions.rb:311]:
Expected ["/home/zzak/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/minitest-5.25.4/lib/minitest/test.rb:94:in 'block (2 levels) in Minitest::Test#run'\n", "/home/zzak/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/minitest-5.25.4/lib/minitest/test.rb:190:in 'Minitest::Test#capture_exceptions'\n", "/home/zzak/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/minitest-5.25.4/lib/minitest/test.rb:89:in 'block in Minitest::Test#run'\n", "/home/zzak/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/minitest-5.25.4/lib/minitest/test.rb:88:in 'Minitest::Test#run'\n"] to be empty.

LoggingTest#test_job_error_logging_backtrace_cleaner [/home/zzak/code/rails/activesupport/lib/active_support/testing/assertions.rb:311]:
Expected ["/home/zzak/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/i18n-1.14.6/lib/i18n.rb:353:in 'I18n::Base#with_locale'\n", "/home/zzak/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/minitest-5.25.4/lib/minitest/test.rb:94:in 'block (2 levels) in Minitest::Test#run'\n", "/home/zzak/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/minitest-5.25.4/lib/minitest/test.rb:190:in 'Minitest::Test#capture_exceptions'\n", "/home/zzak/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/minitest-5.25.4/lib/minitest/test.rb:89:in 'block in Minitest::Test#run'\n", "/home/zzak/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/minitest-5.25.4/lib/minitest.rb:368:in 'Minitest::Runnable#time_it'\n", "/home/zzak/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/minitest-5.25.4/lib/minitest/test.rb:88:in 'Minitest::Test#run'\n", "/home/zzak/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/minitest-5.25.4/lib/minitest.rb:1208:in 'Minitest.run_one_method'\n", "/home/zzak/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/minitest-5.25.4/lib/minitest.rb:447:in 'Minitest::Runnable.run_one_method'\n", "/home/zzak/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/minitest-5.25.4/lib/minitest.rb:434:in 'block (2 levels) in Minitest::Runnable.run'\n", "/home/zzak/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/minitest-5.25.4/lib/minitest.rb:430:in 'Array#each'\n", "/home/zzak/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/minitest-5.25.4/lib/minitest.rb:430:in 'block in Minitest::Runnable.run'\n", "/home/zzak/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/minitest-5.25.4/lib/minitest.rb:472:in 'Minitest::Runnable.on_signal'\n", "/home/zzak/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/minitest-5.25.4/lib/minitest.rb:459:in 'Minitest::Runnable.with_info_handler'\n", "/home/zzak/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/minitest-5.25.4/lib/minitest.rb:429:in 'Minitest::Runnable.run'\n", "/home/zzak/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/minitest-5.25.4/lib/minitest.rb:332:in 'block in Minitest.__run'\n", "/home/zzak/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/minitest-5.25.4/lib/minitest.rb:332:in 'Array#map'\n", "/home/zzak/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/minitest-5.25.4/lib/minitest.rb:332:in 'Minitest.__run'\n", "/home/zzak/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/minitest-5.25.4/lib/minitest.rb:288:in 'Minitest.run'\n", "/home/zzak/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/minitest-5.25.4/lib/minitest.rb:86:in 'block in Minitest.autorun'\n"] to be empty.
```

Since #47839 added the backtrace_cleaner to AJ the PR also could get smaller.

