### PR TITLE
Add fixture-level support for `json` column types

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,6 +1,6 @@
 *   Add fixture-level support for `json` column types
 
-    Sets default fixture value to `{}` for any json-backed column
+    Sets default fixture value to `'{"key": "value"}'` for any json-backed column
 
     *Steve Polito*
 

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Add fixture-level support for `json` column types
+
+    Sets default fixture value to `{}` for any json-backed column
+
+    *Steve Polito*
+
 *   Add RuboCop cache restoration to RuboCop job in GitHub Actions workflow templates.
 
     *Lovro Bikić*

--- a/railties/lib/rails/generators/generated_attribute.rb
+++ b/railties/lib/rails/generators/generated_attribute.rb
@@ -148,6 +148,7 @@ module Rails
                      when :references, :belongs_to,
                           :attachment, :attachments,
                           :rich_text                   then nil
+                     when :json                        then {}
                      else
                        ""
         end

--- a/railties/lib/rails/generators/generated_attribute.rb
+++ b/railties/lib/rails/generators/generated_attribute.rb
@@ -148,7 +148,7 @@ module Rails
                      when :references, :belongs_to,
                           :attachment, :attachments,
                           :rich_text                   then nil
-                     when :json                        then {}
+                     when :json                        then '{"key": "value"}'
                      else
                        ""
         end

--- a/railties/test/generators/generated_attribute_test.rb
+++ b/railties/test/generators/generated_attribute_test.rb
@@ -137,7 +137,7 @@ class GeneratedAttributeTest < Rails::Generators::TestCase
   end
 
   def test_default_value_is_empty_hash
-    assert_field_default_value :json, {}
+    assert_field_default_value :json, '{"key": "value"}'
   end
 
   def test_human_name

--- a/railties/test/generators/generated_attribute_test.rb
+++ b/railties/test/generators/generated_attribute_test.rb
@@ -136,6 +136,10 @@ class GeneratedAttributeTest < Rails::Generators::TestCase
     end
   end
 
+  def test_default_value_is_empty_hash
+    assert_field_default_value :json, {}
+  end
+
   def test_human_name
     assert_equal(
       "Full name",

--- a/railties/test/generators/generated_attribute_test.rb
+++ b/railties/test/generators/generated_attribute_test.rb
@@ -136,7 +136,7 @@ class GeneratedAttributeTest < Rails::Generators::TestCase
     end
   end
 
-  def test_default_value_is_empty_hash
+  def test_default_value_is_json
     assert_field_default_value :json, '{"key": "value"}'
   end
 


### PR DESCRIPTION
### Motivation / Background

It's not clear how best to set a JSON-backed column in a Fixture, so I figured providing a sensible default would help people get started.

Since `json` is a [supported type][1], I figured we should support it in a Fixture.

[1]: https://api.rubyonrails.org/classes/ActiveRecord/Type/Json.html

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
