### PR TITLE
Pass explicit driver name as top-level argument

### DIFF
--- a/actionpack/lib/action_dispatch/system_test_case.rb
+++ b/actionpack/lib/action_dispatch/system_test_case.rb
@@ -155,8 +155,8 @@ module ActionDispatch
     #     driven_by :selenium, using: :firefox
     #
     #     driven_by :selenium, using: :headless_firefox
-    def self.driven_by(driver, using: :chrome, screen_size: [1400, 1400], options: {}, &capabilities)
-      driver_options = { using: using, screen_size: screen_size, options: options }
+    def self.driven_by(driver, using: :chrome, screen_size: [1400, 1400], name: nil, options: {}, &capabilities)
+      driver_options = { using: using, screen_size: screen_size, name: name, options: options }
 
       self.driver = SystemTesting::Driver.new(driver, **driver_options, &capabilities)
     end

--- a/actionpack/lib/action_dispatch/system_testing/driver.rb
+++ b/actionpack/lib/action_dispatch/system_testing/driver.rb
@@ -11,7 +11,15 @@ module ActionDispatch
         @driver_type = driver_type
         @screen_size = options[:screen_size]
         @options = options[:options] || {}
-        @name = @options.delete(:name) || driver_type
+        @name = if @options.key?(:name)
+          ActionDispatch.deprecator.warn(<<-MSG.squish)
+            Passing 'name' into the 'options' hash is deprecated and will be removed in
+            Rails 8.1. Pass it as a top-level argument 'name' instead.
+          MSG
+          @options.delete(:name) || driver_type
+        else
+          options[:name] || driver_type
+        end
         @capabilities = capabilities
 
         if driver_type == :selenium

--- a/actionpack/test/dispatch/system_testing/driver_test.rb
+++ b/actionpack/test/dispatch/system_testing/driver_test.rb
@@ -195,7 +195,14 @@ class DriverTest < ActiveSupport::TestCase
   end
 
   test "driver names can by specified explicitly" do
-    driver = ActionDispatch::SystemTesting::Driver.new(:selenium, options: { name: :best_driver })
+    driver = ActionDispatch::SystemTesting::Driver.new(:selenium, name: :best_driver)
+    assert_equal :best_driver, driver.name
+  end
+
+  test "driver names can by specified explicitly through options hash" do
+    driver = assert_deprecated(ActionDispatch.deprecator) do
+      ActionDispatch::SystemTesting::Driver.new(:selenium, options: { name: :best_driver })
+    end
     assert_equal :best_driver, driver.name
   end
 

--- a/actionpack/test/dispatch/system_testing/system_test_case_test.rb
+++ b/actionpack/test/dispatch/system_testing/system_test_case_test.rb
@@ -19,7 +19,7 @@ class OverrideSeleniumSubclassToRackTestTest < DrivenBySeleniumWithChrome
 end
 
 class OverrideDriverWithExplicitName < DrivenBySeleniumWithChrome
-  driven_by :selenium, options: { name: :best_driver }
+  driven_by :selenium, name: :best_driver
 
   test "uses specified driver name" do
     assert_equal :best_driver, Capybara.current_driver


### PR DESCRIPTION
https://github.com/rails/rails/pull/42511 implemented the ability to pass an explicit `name` for the capybara driver. But the implementation slightly differs from this comment (by the author): https://github.com/rails/rails/issues/32468#issuecomment-946056251

This PR changes it so that `name` is passed as a top-level argument instead of a driver option.
**Before**
```ruby
driven_by :selenium,
          using: :chrome,
          options: {
            name: 'chrome_with_translate_disabled',
            args: ['--disable-translate']
          }
```

**After**
```ruby
driven_by :selenium,
          using: :chrome,
          name: 'chrome_with_translate_disabled'
          options: {
            args: ['--disable-translate']
          }
```