### PR TITLE
Introduce `config.active_record.strict_safe_http_methods`

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Introduce `config.active_record.strict_safe_http_methods` to prevent database writes while serving a "safe" HTTP request (`GET`, `HEAD`, or `OPTIONS`).
+
+    *Mike Dalessio*
+
 *   Encryption now supports `support_unencrypted_data: true` being set per-attribute.
 
     Previously this only worked if `ActiveRecord::Encryption.config.support_unencrypted_data == true`.

--- a/activerecord/lib/active_record.rb
+++ b/activerecord/lib/active_record.rb
@@ -167,6 +167,7 @@ module ActiveRecord
 
     autoload :DatabaseSelector
     autoload :ShardSelector
+    autoload :StrictSafeHTTPMethods
   end
 
   module Tasks

--- a/activerecord/lib/active_record/middleware/strict_safe_http_methods.rb
+++ b/activerecord/lib/active_record/middleware/strict_safe_http_methods.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+# :markup: markdown
+
+module ActiveRecord
+  module Middleware
+    # # Strict Safe HTTP Methods \Middleware
+    #
+    # This middleware prevents database writes while serving a "safe" HTTP request (`GET`, `HEAD`, or
+    # `OPTIONS`) by raising an `ActiveRecord::ReadOnlyError` exception if a database write is
+    # attempted.
+    #
+    # Disabled by default, this middleware can be added by setting
+    # `config.active_record.strict_safe_http_methods` to `true`.
+    class StrictSafeHTTPMethods
+      def initialize(app)
+        @app = app
+      end
+
+      def call(env)
+        request = ActionDispatch::Request.new(env)
+
+        if request.get? || request.head? || request.options?
+          ActiveRecord::Base.while_preventing_writes do
+            @app.call(env)
+          end
+        else
+          @app.call(env)
+        end
+      end
+    end
+  end
+end

--- a/activerecord/lib/active_record/railtie.rb
+++ b/activerecord/lib/active_record/railtie.rb
@@ -39,6 +39,7 @@ module ActiveRecord
     config.active_record.belongs_to_required_validates_foreign_key = true
     config.active_record.generate_secure_token_on = :create
     config.active_record.use_legacy_signed_id_verifier = :generate_and_verify
+    config.active_record.strict_safe_http_methods = false
 
     config.active_record.queues = ActiveSupport::InheritableOptions.new
 
@@ -235,6 +236,7 @@ To keep using the current cache store, you can turn off cache versioning entirel
           :use_schema_cache_dump,
           :postgresql_adapter_decode_dates,
           :use_legacy_signed_id_verifier,
+          :strict_safe_http_methods,
         )
 
         configs_used_in_other_initializers.each do |k, v|

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -1817,6 +1817,12 @@ config.active_record.protocol_adapters.mysql = "trilogy"
 
 If no mapping is found, the protocol is used as the adapter name.
 
+#### `config.active_record.strict_safe_http_methods`
+
+When enabled, prevents database writes while serving a "safe" HTTP request (`GET`, `HEAD`, or `OPTIONS`).
+
+The default value is `false`.
+
 ### Configuring Action Controller
 
 `config.action_controller` includes a number of configuration settings:

--- a/railties/lib/rails/application/default_middleware_stack.rb
+++ b/railties/lib/rails/application/default_middleware_stack.rb
@@ -105,6 +105,10 @@ module Rails
 
               middleware.use ::ActiveRecord::Middleware::ShardSelector, shard_resolver, options
             end
+
+            if config.active_record.strict_safe_http_methods
+              middleware.use ::ActiveRecord::Middleware::StrictSafeHTTPMethods
+            end
           end
         end
       end

--- a/railties/test/application/middleware/strict_safe_http_methods_test.rb
+++ b/railties/test/application/middleware/strict_safe_http_methods_test.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+require "isolation/abstract_unit"
+require "rack/test"
+
+module ApplicationTests
+  class MiddlewareStrictSafeHTTPMethodsTest < ActiveSupport::TestCase
+    include ActiveSupport::Testing::Isolation
+
+    SAFE_VERBS = [:get, :head, :options]
+    UNSAFE_VERBS = [:put, :delete, :post, :patch]
+    VERBS = SAFE_VERBS + UNSAFE_VERBS
+
+    def setup
+      build_app
+
+      app_file "app/models/post.rb", <<~RUBY
+        class Post < ApplicationRecord
+        end
+      RUBY
+
+      app_file "app/controllers/posts_controller.rb", <<~RUBY
+        class PostsController < ApplicationController
+          def read
+            render plain: Post.first.title
+          end
+
+          def write
+            post = Post.create! title: "New post \#{SecureRandom.uuid}"
+            render plain: post.title
+          end
+        end
+      RUBY
+
+      app_file "config/routes.rb", <<~RUBY
+        Rails.application.routes.draw do
+          match "/read" => "posts#read", via: #{VERBS.inspect}
+          match "/write" => "posts#write", via: #{VERBS.inspect}
+        end
+      RUBY
+
+      add_to_config <<~RUBY
+        config.active_record.strict_safe_http_methods = true
+      RUBY
+
+      require "#{rails_root}/config/environment"
+
+      ActiveRecord::Base.establish_connection
+      ActiveRecord::Migration.verbose = false
+      ActiveRecord::Schema.define(version: 1) do
+        create_table :posts do |t|
+          t.string :title
+        end
+      end
+
+      extend Rack::Test::Methods
+    end
+
+    def teardown
+      teardown_app
+    end
+
+    VERBS.each do |verb|
+      test "#{verb.upcase} allows read" do
+        Post.create! title: "Hello"
+
+        send verb, "/read"
+
+        assert_equal 200, last_response.status
+        assert_equal "Hello", last_response.body unless verb == :head
+      end
+    end
+
+    SAFE_VERBS.each do |verb|
+      test "#{verb.upcase} disallows write" do
+        send verb, "/write"
+
+        assert_equal 500, last_response.status
+      end
+    end
+
+    UNSAFE_VERBS.each do |verb|
+      test "#{verb.upcase} allows write" do
+        send verb, "/write"
+
+        assert_equal 200, last_response.status
+        assert_equal Post.last.title, last_response.body
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Motivation / Background

Well-behaved web applications should not mutate database state in a ["safe" HTTP request](https://developer.mozilla.org/en-US/docs/Glossary/Safe/HTTP) (e.g., a GET). There are a few benefits to following this guidance:

- Browsers can safely pre-fetch pages via GET for performance benefits
- Applications reap the benefits of Rails's CSRF protection by reserving mutations to POST et al
- Applications can use a proxy to route GET requests to a read-only replica, with all the benefits of geo locality and load balancing

Rails doesn't enforce this property of "safe" HTTP verbs today, providing little help and no safeguards for developers who want their application to follow the safe request semantics.

This PR introduces a configuration option that allows developers to enforce strict "safe" requests. When enabled, an exception is raised if database writes are attempted while serving a GET/HEAD/OPTIONS request.

### Detail

This PR introduces new middleware, `ActiveRecord::Middleware::StrictSafeHTTPMethods`, that wraps the request handling with a `ActiveRecord::Base.while_preventing_writes` block if the request is a `GET`, `HEAD`, or `OPTIONS`.

By setting `config.active_record.strict_safe_http_methods` to `true`, this middleware is added.

The config option defaults to `false` for now, but the intention is for a future Rails release to default to `true`.

When enabled during development, a readable error page is displayed showing the `ActiveRecord::ReadOnlyError` exception.

When enabled in production, will return a 500 status code.


### Additional information

- https://developer.mozilla.org/en-US/docs/Glossary/Safe/HTTP


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
