### PR TITLE
Allow allocated Active Records to lookup associations

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Allow allocated Active Records to lookup associations.
+
+    Previously, the association cache isn't setup on allocated record objects, so association
+    lookups will crash. Test frameworks like mocha use allocate to check for stubbable instance
+    methods, which can trigger an association lookup.
+
+    *Gannon McGibbon*
+
 *   Encryption now supports `support_unencrypted_data: true` being set per-attribute.
 
     Previously this only worked if `ActiveRecord::Encryption.config.support_unencrypted_data == true`.

--- a/activerecord/lib/active_record/associations.rb
+++ b/activerecord/lib/active_record/associations.rb
@@ -79,7 +79,7 @@ module ActiveRecord
 
       # Returns the specified association instance if it exists, +nil+ otherwise.
       def association_instance_get(name)
-        @association_cache[name]
+        (@association_cache ||= {})[name]
       end
 
       # Set the specified association instance.

--- a/activerecord/test/cases/associations_test.rb
+++ b/activerecord/test/cases/associations_test.rb
@@ -59,6 +59,10 @@ class AssociationsTest < ActiveRecord::TestCase
     assert_equal 1, liquids[0].molecules.length
   end
 
+  def test_allocated_record_can_see_assocations
+    assert_not_nil Ship.allocate.association(:parts)
+  end
+
   def test_subselect
     author = authors :david
     favs = author.author_favorites


### PR DESCRIPTION
Previously, the association cache isn't setup on allocated record objects, so association lookups will crash. Test frameworks like mocha use allocate to check for stubbable instance methods, which can trigger an association lookup (like [this one](https://github.com/rails/rails/blob/c3c33947160e473a3d41555f8cf3aee7f3a48c76/activestorage/app/models/active_storage/attachment.rb#L33) in Rails).

### Motivation / Background

This Pull Request has been created because allocated Active Record object can't lookup associations. I think this is incorrect.

### Detail

This Pull Request changes the association cache to be lazily initialized so that lookups can happen.

### Additional information

We might want to `init_internals` instead on allocated record objects. But, that would require using `send`, or making that method public. I think this makes more sense, unless we can think of a reason the other ivars need to be there too.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
