### PR TITLE
[ci skip] Fix a typo in the Tuning Performance for Deployment guide

### DIFF
--- a/guides/source/tuning_performance_for_deployment.md
+++ b/guides/source/tuning_performance_for_deployment.md
@@ -111,7 +111,7 @@ The Puma configuration resides in the `config/puma.rb` file.
 The two most important Puma configurations are the number of threads per process, and the number of processes,
 which Puma calls `workers`.
 
-The number of threads per process is configured via the `thread` directive.
+The number of threads per process is configured via the `threads` directive.
 In the default generated configuration, it is set to `3`.
 You can modify it either by setting the `RAILS_MAX_THREADS` environment variable or simply editing the configuration
 file.


### PR DESCRIPTION
### Detail

This Pull Request fixes a typo in the section describing Puma configuration.
See https://github.com/puma/puma/blob/b836667e9fde7e982880d28e03da9c0f87085de2/lib/puma/dsl.rb#L557-L586




