### PR TITLE
Fix missing autoload for ActionView::StrictLocalsError

### DIFF
--- a/actionview/lib/action_view.rb
+++ b/actionview/lib/action_view.rb
@@ -81,6 +81,7 @@ module ActionView
       autoload :MissingTemplate
       autoload :ActionViewError
       autoload :EncodingError
+      autoload :StrictLocalsError
       autoload :TemplateError
       autoload :SyntaxErrorInTemplate
       autoload :WrongEncodingError


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request adds an autoload for `ActionView::StrictLocalsError` which I think was overlooked because I hit a missing constant error and it seems like the other error constants in the file _are_ autoloaded. 

Seems pretty minor, though I'm surprised no one else hit it. I didn't think it warrants a changelog entry but happy to do so.

<details><summary>Example backtrace</summary>

```
❯ bin/rspec spec/system/admin/conference_calls_spec.rb --backtrace

Randomized with seed 31140
#<ConferenceCallParticipant:0x00000001264027d0>
F

Failures:

  1) Conference Calls creates a conference call and adds participants
     Failure/Error:
       broadcast_action_later_to(
         self,
         action: :prepend,
         target: ActionView::RecordIdentifier.dom_id(conference_call, :participants),
         partial: "admin/conference_calls/participant",
         locals: { participant: self }
       )

     ActionView::Template::Error:
       uninitialized constant ActionView::Base::StrictLocalsError
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/actionview-8.0.2/lib/action_view/base.rb:273:in 'ActionView::Base#_run'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/actionview-8.0.2/lib/action_view/template.rb:284:in 'block in ActionView::Template#render'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/activesupport-8.0.2/lib/active_support/notifications.rb:212:in 'ActiveSupport::Notifications.instrument'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/actionview-8.0.2/lib/action_view/template.rb:583:in 'ActionView::Template#instrument_render_template'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/actionview-8.0.2/lib/action_view/template.rb:272:in 'ActionView::Template#render'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/actionview-8.0.2/lib/action_view/renderer/partial_renderer.rb:252:in 'block in ActionView::PartialRenderer#render_partial_template'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/activesupport-8.0.2/lib/active_support/notifications.rb:210:in 'block in ActiveSupport::Notifications.instrument'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/activesupport-8.0.2/lib/active_support/notifications/instrumenter.rb:58:in 'ActiveSupport::Notifications::Instrumenter#instrument'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/activesupport-8.0.2/lib/active_support/notifications.rb:210:in 'ActiveSupport::Notifications.instrument'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/actionview-8.0.2/lib/action_view/renderer/partial_renderer.rb:246:in 'ActionView::PartialRenderer#render_partial_template'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/actionview-8.0.2/lib/action_view/renderer/partial_renderer.rb:237:in 'ActionView::PartialRenderer#render'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/actionview-8.0.2/lib/action_view/renderer/renderer.rb:78:in 'ActionView::Renderer#render_partial_to_object'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/actionview-8.0.2/lib/action_view/renderer/renderer.rb:29:in 'ActionView::Renderer#render_to_object'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/actionview-8.0.2/lib/action_view/rendering.rb:136:in 'block in ActionView::Rendering#_render_template'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/actionview-8.0.2/lib/action_view/base.rb:305:in 'ActionView::Base#in_rendering_context'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/actionview-8.0.2/lib/action_view/rendering.rb:135:in 'ActionView::Rendering#_render_template'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/actionpack-8.0.2/lib/action_controller/metal/streaming.rb:179:in 'ActionController::Streaming#_render_template'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/actionview-8.0.2/lib/action_view/rendering.rb:122:in 'ActionView::Rendering#render_to_body'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/actionpack-8.0.2/lib/action_controller/metal/rendering.rb:186:in 'ActionController::Rendering#render_to_body'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/actionpack-8.0.2/lib/action_controller/metal/renderers.rb:140:in 'ActionController::Renderers#render_to_body'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/actionpack-8.0.2/lib/abstract_controller/rendering.rb:46:in 'AbstractController::Rendering#render_to_string'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/actionpack-8.0.2/lib/action_controller/metal/rendering.rb:175:in 'ActionController::Rendering#render_to_string'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/actionpack-8.0.2/lib/action_controller/renderer.rb:136:in 'ActionController::Renderer#render'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/actionpack-8.0.2/lib/action_controller/metal/rendering.rb:13:in 'ActionController::Rendering::ClassMethods#render'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/turbo-rails-2.0.13/app/channels/turbo/streams/broadcasts.rb:111:in 'Turbo::Streams::Broadcasts#render_format'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/turbo-rails-2.0.13/app/channels/turbo/streams/broadcasts.rb:122:in 'Turbo::Streams::Broadcasts#render_broadcast_action'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/turbo-rails-2.0.13/app/channels/turbo/streams/broadcasts.rb:42:in 'Turbo::Streams::Broadcasts#broadcast_action_to'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/turbo-rails-2.0.13/app/jobs/turbo/streams/action_broadcast_job.rb:6:in 'Turbo::Streams::ActionBroadcastJob#perform'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/activejob-8.0.2/lib/active_job/execution.rb:68:in 'block in ActiveJob::Execution#_perform_job'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/activesupport-8.0.2/lib/active_support/callbacks.rb:120:in 'block in ActiveSupport::Callbacks#run_callbacks'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/i18n-1.14.7/lib/i18n.rb:353:in 'I18n::Base#with_locale'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/activejob-8.0.2/lib/active_job/translation.rb:9:in 'block (2 levels) in <module:Translation>'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/activesupport-8.0.2/lib/active_support/callbacks.rb:129:in 'BasicObject#instance_exec'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/activesupport-8.0.2/lib/active_support/callbacks.rb:129:in 'block in ActiveSupport::Callbacks#run_callbacks'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/activesupport-8.0.2/lib/active_support/core_ext/time/zones.rb:65:in 'Time.use_zone'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/activejob-8.0.2/lib/active_job/timezones.rb:9:in 'block (2 levels) in <module:Timezones>'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/activesupport-8.0.2/lib/active_support/callbacks.rb:129:in 'BasicObject#instance_exec'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/activesupport-8.0.2/lib/active_support/callbacks.rb:129:in 'block in ActiveSupport::Callbacks#run_callbacks'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/activesupport-8.0.2/lib/active_support/callbacks.rb:140:in 'ActiveSupport::Callbacks#run_callbacks'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/activejob-8.0.2/lib/active_job/execution.rb:67:in 'ActiveJob::Execution#_perform_job'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/activejob-8.0.2/lib/active_job/instrumentation.rb:32:in 'ActiveJob::Instrumentation#_perform_job'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/activejob-8.0.2/lib/active_job/execution.rb:51:in 'ActiveJob::Execution#perform_now'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/activejob-8.0.2/lib/active_job/instrumentation.rb:26:in 'block in ActiveJob::Instrumentation#perform_now'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/activerecord-8.0.2/lib/active_record/railties/job_runtime.rb:13:in 'block in ActiveRecord::Railties::JobRuntime#instrument'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/activejob-8.0.2/lib/active_job/instrumentation.rb:40:in 'block in ActiveJob::Instrumentation#instrument'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/activesupport-8.0.2/lib/active_support/notifications.rb:210:in 'block in ActiveSupport::Notifications.instrument'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/activesupport-8.0.2/lib/active_support/notifications/instrumenter.rb:58:in 'ActiveSupport::Notifications::Instrumenter#instrument'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/activesupport-8.0.2/lib/active_support/notifications.rb:210:in 'ActiveSupport::Notifications.instrument'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/activejob-8.0.2/lib/active_job/instrumentation.rb:39:in 'ActiveJob::Instrumentation#instrument'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/activerecord-8.0.2/lib/active_record/railties/job_runtime.rb:11:in 'ActiveRecord::Railties::JobRuntime#instrument'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/activejob-8.0.2/lib/active_job/instrumentation.rb:26:in 'ActiveJob::Instrumentation#perform_now'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/activejob-8.0.2/lib/active_job/logging.rb:32:in 'block in ActiveJob::Logging#perform_now'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/activesupport-8.0.2/lib/active_support/tagged_logging.rb:143:in 'block in ActiveSupport::TaggedLogging#tagged'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/activesupport-8.0.2/lib/active_support/tagged_logging.rb:38:in 'ActiveSupport::TaggedLogging::Formatter#tagged'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/activesupport-8.0.2/lib/active_support/tagged_logging.rb:143:in 'ActiveSupport::TaggedLogging#tagged'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/activesupport-8.0.2/lib/active_support/broadcast_logger.rb:241:in 'ActiveSupport::BroadcastLogger#method_missing'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/activejob-8.0.2/lib/active_job/logging.rb:39:in 'ActiveJob::Logging#tag_logger'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/activejob-8.0.2/lib/active_job/logging.rb:32:in 'ActiveJob::Logging#perform_now'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/sentry-rails-5.23.0/lib/sentry/rails/active_job.rb:11:in 'block in Sentry::Rails::ActiveJobExtensions#perform_now'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/sentry-rails-5.23.0/lib/sentry/rails/active_job.rb:43:in 'block in Sentry::Rails::ActiveJobExtensions::SentryReporter.record'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/sentry-ruby-5.23.0/lib/sentry/hub.rb:89:in 'Sentry::Hub#with_scope'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/sentry-ruby-5.23.0/lib/sentry-ruby.rb:408:in 'Sentry.with_scope'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/sentry-rails-5.23.0/lib/sentry/rails/active_job.rb:26:in 'Sentry::Rails::ActiveJobExtensions::SentryReporter.record'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/sentry-rails-5.23.0/lib/sentry/rails/active_job.rb:10:in 'Sentry::Rails::ActiveJobExtensions#perform_now'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/activejob-8.0.2/lib/active_job/execution.rb:29:in 'block in ActiveJob::Execution::ClassMethods#execute'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/activesupport-8.0.2/lib/active_support/callbacks.rb:120:in 'block in ActiveSupport::Callbacks#run_callbacks'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/activejob-8.0.2/lib/active_job/railtie.rb:95:in 'block (4 levels) in <class:Railtie>'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/activesupport-8.0.2/lib/active_support/reloader.rb:77:in 'block in ActiveSupport::Reloader.wrap'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/activesupport-8.0.2/lib/active_support/execution_wrapper.rb:87:in 'ActiveSupport::ExecutionWrapper.wrap'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/activesupport-8.0.2/lib/active_support/reloader.rb:74:in 'ActiveSupport::Reloader.wrap'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/activejob-8.0.2/lib/active_job/railtie.rb:94:in 'block (3 levels) in <class:Railtie>'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/activesupport-8.0.2/lib/active_support/callbacks.rb:129:in 'BasicObject#instance_exec'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/activesupport-8.0.2/lib/active_support/callbacks.rb:129:in 'block in ActiveSupport::Callbacks#run_callbacks'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/activesupport-8.0.2/lib/active_support/callbacks.rb:140:in 'ActiveSupport::Callbacks#run_callbacks'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/activejob-8.0.2/lib/active_job/execution.rb:27:in 'ActiveJob::Execution::ClassMethods#execute'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/good_job-4.9.3/app/models/good_job/job.rb:638:in 'block (3 levels) in GoodJob::Job#perform'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/activesupport-8.0.2/lib/active_support/notifications.rb:210:in 'block in ActiveSupport::Notifications.instrument'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/activesupport-8.0.2/lib/active_support/notifications/instrumenter.rb:58:in 'ActiveSupport::Notifications::Instrumenter#instrument'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/activesupport-8.0.2/lib/active_support/notifications.rb:210:in 'ActiveSupport::Notifications.instrument'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/good_job-4.9.3/app/models/good_job/job.rb:637:in 'block (2 levels) in GoodJob::Job#perform'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/good_job-4.9.3/lib/good_job/current_thread.rb:113:in 'GoodJob::CurrentThread.within'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/good_job-4.9.3/app/models/good_job/job.rb:595:in 'block in GoodJob::Job#perform'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/activesupport-8.0.2/lib/active_support/callbacks.rb:120:in 'block in ActiveSupport::Callbacks#run_callbacks'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/good_job-4.9.3/app/models/good_job/batch.rb:80:in 'GoodJob::Batch.within_thread'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/good_job-4.9.3/app/models/good_job/job.rb:786:in 'GoodJob::Job#reset_batch_values'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/activesupport-8.0.2/lib/active_support/callbacks.rb:129:in 'block in ActiveSupport::Callbacks#run_callbacks'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/activesupport-8.0.2/lib/active_support/callbacks.rb:140:in 'ActiveSupport::Callbacks#run_callbacks'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/good_job-4.9.3/app/models/good_job/job.rb:589:in 'GoodJob::Job#perform'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/good_job-4.9.3/lib/good_job/adapter.rb:247:in 'block in GoodJob::Adapter#perform_inline'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/good_job-4.9.3/lib/good_job/adapter.rb:246:in 'GoodJob::Adapter#perform_inline'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/good_job-4.9.3/lib/good_job/adapter.rb:157:in 'block (3 levels) in GoodJob::Adapter#enqueue_at'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/good_job-4.9.3/lib/good_job/capsule_tracker.rb:94:in 'GoodJob::CapsuleTracker#register'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/good_job-4.9.3/lib/good_job/adapter.rb:156:in 'block (2 levels) in GoodJob::Adapter#enqueue_at'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/good_job-4.9.3/lib/good_job/adapter/inline_buffer.rb:50:in 'GoodJob::Adapter::InlineBuffer.perform_now_or_defer'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/good_job-4.9.3/lib/good_job/adapter.rb:155:in 'block in GoodJob::Adapter#enqueue_at'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/activesupport-8.0.2/lib/active_support/execution_wrapper.rb:87:in 'ActiveSupport::ExecutionWrapper.wrap'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/good_job-4.9.3/lib/good_job/adapter.rb:140:in 'GoodJob::Adapter#enqueue_at'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/good_job-4.9.3/lib/good_job/adapter.rb:42:in 'GoodJob::Adapter#enqueue'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/activejob-8.0.2/lib/active_job/enqueuing.rb:132:in 'ActiveJob::Enqueuing#raw_enqueue'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/activejob-8.0.2/lib/active_job/enqueue_after_transaction_commit.rb:40:in 'ActiveJob::EnqueueAfterTransactionCommit#raw_enqueue'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/activejob-8.0.2/lib/active_job/enqueuing.rb:117:in 'block in ActiveJob::Enqueuing#enqueue'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/activesupport-8.0.2/lib/active_support/callbacks.rb:120:in 'block in ActiveSupport::Callbacks#run_callbacks'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/activejob-8.0.2/lib/active_job/instrumentation.rb:40:in 'block in ActiveJob::Instrumentation#instrument'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/activesupport-8.0.2/lib/active_support/notifications.rb:210:in 'block in ActiveSupport::Notifications.instrument'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/activesupport-8.0.2/lib/active_support/notifications/instrumenter.rb:58:in 'ActiveSupport::Notifications::Instrumenter#instrument'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/activesupport-8.0.2/lib/active_support/notifications.rb:210:in 'ActiveSupport::Notifications.instrument'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/activejob-8.0.2/lib/active_job/instrumentation.rb:39:in 'ActiveJob::Instrumentation#instrument'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/activerecord-8.0.2/lib/active_record/railties/job_runtime.rb:18:in 'ActiveRecord::Railties::JobRuntime#instrument'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/activejob-8.0.2/lib/active_job/instrumentation.rb:21:in 'block (2 levels) in <module:Instrumentation>'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/activesupport-8.0.2/lib/active_support/callbacks.rb:129:in 'BasicObject#instance_exec'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/activesupport-8.0.2/lib/active_support/callbacks.rb:129:in 'block in ActiveSupport::Callbacks#run_callbacks'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/activesupport-8.0.2/lib/active_support/tagged_logging.rb:143:in 'block in ActiveSupport::TaggedLogging#tagged'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/activesupport-8.0.2/lib/active_support/tagged_logging.rb:38:in 'ActiveSupport::TaggedLogging::Formatter#tagged'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/activesupport-8.0.2/lib/active_support/tagged_logging.rb:143:in 'ActiveSupport::TaggedLogging#tagged'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/activesupport-8.0.2/lib/active_support/broadcast_logger.rb:241:in 'ActiveSupport::BroadcastLogger#method_missing'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/activejob-8.0.2/lib/active_job/logging.rb:39:in 'ActiveJob::Logging#tag_logger'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/activejob-8.0.2/lib/active_job/logging.rb:28:in 'block (2 levels) in <module:Logging>'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/activesupport-8.0.2/lib/active_support/callbacks.rb:129:in 'BasicObject#instance_exec'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/activesupport-8.0.2/lib/active_support/callbacks.rb:129:in 'block in ActiveSupport::Callbacks#run_callbacks'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/activesupport-8.0.2/lib/active_support/callbacks.rb:140:in 'ActiveSupport::Callbacks#run_callbacks'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/activejob-8.0.2/lib/active_job/enqueuing.rb:116:in 'ActiveJob::Enqueuing#enqueue'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/activejob-8.0.2/lib/active_job/enqueuing.rb:83:in 'ActiveJob::Enqueuing::ClassMethods#perform_later'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/turbo-rails-2.0.13/app/channels/turbo/streams/broadcasts.rb:83:in 'Turbo::Streams::Broadcasts#broadcast_action_later_to'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/turbo-rails-2.0.13/app/models/concerns/turbo/broadcastable.rb:456:in 'Turbo::Broadcastable#broadcast_action_later_to'
     # ./app/models/conference_call_participant.rb:37:in 'ConferenceCallParticipant#broadcast_create'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/activesupport-8.0.2/lib/active_support/callbacks.rb:361:in 'block in ActiveSupport::Callbacks::CallTemplate::MethodCall#make_lambda'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/activesupport-8.0.2/lib/active_support/callbacks.rb:207:in 'ActiveSupport::Callbacks::Filters::After#call'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/activesupport-8.0.2/lib/active_support/callbacks.rb:563:in 'block in ActiveSupport::Callbacks::CallbackSequence#invoke_after'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/activesupport-8.0.2/lib/active_support/callbacks.rb:563:in 'Array#each'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/activesupport-8.0.2/lib/active_support/callbacks.rb:563:in 'ActiveSupport::Callbacks::CallbackSequence#invoke_after'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/activesupport-8.0.2/lib/active_support/callbacks.rb:110:in 'ActiveSupport::Callbacks#run_callbacks'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/activesupport-8.0.2/lib/active_support/callbacks.rb:913:in 'ActiveRecord::Base#_run_commit_callbacks'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/activerecord-8.0.2/lib/active_record/transactions.rb:384:in 'ActiveRecord::Transactions#committed!'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/activerecord-8.0.2/lib/active_record/connection_adapters/abstract/transaction.rb:307:in 'block in ActiveRecord::ConnectionAdapters::Transaction#commit_records'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/activerecord-8.0.2/lib/active_record/connection_adapters/abstract/transaction.rb:344:in 'ActiveRecord::ConnectionAdapters::Transaction#run_action_on_records'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/activerecord-8.0.2/lib/active_record/connection_adapters/abstract/transaction.rb:306:in 'ActiveRecord::ConnectionAdapters::Transaction#commit_records'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/activerecord-8.0.2/lib/active_record/connection_adapters/abstract/transaction.rb:606:in 'block in ActiveRecord::ConnectionAdapters::TransactionManager#commit_transaction'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/activesupport-8.0.2/lib/active_support/concurrency/load_interlock_aware_monitor.rb:23:in 'Thread.handle_interrupt'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/activesupport-8.0.2/lib/active_support/concurrency/load_interlock_aware_monitor.rb:23:in 'block in ActiveSupport::Concurrency::LoadInterlockAwareMonitorMixin#synchronize'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/activesupport-8.0.2/lib/active_support/concurrency/load_interlock_aware_monitor.rb:19:in 'Thread.handle_interrupt'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/activesupport-8.0.2/lib/active_support/concurrency/load_interlock_aware_monitor.rb:19:in 'ActiveSupport::Concurrency::LoadInterlockAwareMonitorMixin#synchronize'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/activerecord-8.0.2/lib/active_record/connection_adapters/abstract/transaction.rb:594:in 'ActiveRecord::ConnectionAdapters::TransactionManager#commit_transaction'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/activerecord-8.0.2/lib/active_record/connection_adapters/abstract/transaction.rb:638:in 'block in ActiveRecord::ConnectionAdapters::TransactionManager#within_new_transaction'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/activesupport-8.0.2/lib/active_support/concurrency/load_interlock_aware_monitor.rb:23:in 'Thread.handle_interrupt'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/activesupport-8.0.2/lib/active_support/concurrency/load_interlock_aware_monitor.rb:23:in 'block in ActiveSupport::Concurrency::LoadInterlockAwareMonitorMixin#synchronize'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/activesupport-8.0.2/lib/active_support/concurrency/load_interlock_aware_monitor.rb:19:in 'Thread.handle_interrupt'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/activesupport-8.0.2/lib/active_support/concurrency/load_interlock_aware_monitor.rb:19:in 'ActiveSupport::Concurrency::LoadInterlockAwareMonitorMixin#synchronize'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/activerecord-8.0.2/lib/active_record/connection_adapters/abstract/transaction.rb:623:in 'ActiveRecord::ConnectionAdapters::TransactionManager#within_new_transaction'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/activerecord-8.0.2/lib/active_record/connection_adapters/abstract/database_statements.rb:367:in 'ActiveRecord::ConnectionAdapters::DatabaseStatements#within_new_transaction'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/activerecord-8.0.2/lib/active_record/connection_adapters/abstract/database_statements.rb:359:in 'ActiveRecord::ConnectionAdapters::DatabaseStatements#transaction'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/activerecord-8.0.2/lib/active_record/transactions.rb:233:in 'block in ActiveRecord::Transactions::ClassMethods#transaction'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/activerecord-8.0.2/lib/active_record/connection_adapters/abstract/connection_pool.rb:418:in 'ActiveRecord::ConnectionAdapters::ConnectionPool#with_connection'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/activerecord-8.0.2/lib/active_record/connection_handling.rb:310:in 'ActiveRecord::ConnectionHandling#with_connection'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/activerecord-8.0.2/lib/active_record/transactions.rb:232:in 'ActiveRecord::Transactions::ClassMethods#transaction'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/activerecord-8.0.2/lib/active_record/transactions.rb:353:in 'ActiveRecord::Transactions#transaction'
     # ./app/models/conference_call.rb:49:in 'ConferenceCall#add_participant'
     # ./app/controllers/admin/conference_calls_controller.rb:26:in 'Admin::ConferenceCallsController#add_participant'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/actionpack-8.0.2/lib/action_controller/metal/basic_implicit_render.rb:8:in 'ActionController::BasicImplicitRender#send_action'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/actionpack-8.0.2/lib/abstract_controller/base.rb:226:in 'AbstractController::Base#process_action'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/actionpack-8.0.2/lib/action_controller/metal/rendering.rb:193:in 'ActionController::Rendering#process_action'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/actionpack-8.0.2/lib/abstract_controller/callbacks.rb:261:in 'block in AbstractController::Callbacks#process_action'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/activesupport-8.0.2/lib/active_support/callbacks.rb:120:in 'block in ActiveSupport::Callbacks#run_callbacks'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/turbo-rails-2.0.13/lib/turbo-rails.rb:24:in 'Turbo.with_request_id'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/turbo-rails-2.0.13/app/controllers/concerns/turbo/request_id_tracking.rb:10:in 'Turbo::RequestIdTracking#turbo_tracking_request_id'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/activesupport-8.0.2/lib/active_support/callbacks.rb:129:in 'block in ActiveSupport::Callbacks#run_callbacks'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/actiontext-8.0.2/lib/action_text/rendering.rb:25:in 'ActionText::Rendering::ClassMethods#with_renderer'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/actiontext-8.0.2/lib/action_text/engine.rb:71:in 'block (4 levels) in <class:Engine>'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/activesupport-8.0.2/lib/active_support/callbacks.rb:129:in 'BasicObject#instance_exec'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/activesupport-8.0.2/lib/active_support/callbacks.rb:129:in 'block in ActiveSupport::Callbacks#run_callbacks'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/sentry-rails-5.23.0/lib/sentry/rails/controller_transaction.rb:34:in 'block in Sentry::Rails::ControllerTransaction#sentry_around_action'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/sentry-ruby-5.23.0/lib/sentry/hub.rb:138:in 'Sentry::Hub#with_child_span'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/sentry-ruby-5.23.0/lib/sentry-ruby.rb:515:in 'Sentry.with_child_span'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/sentry-rails-5.23.0/lib/sentry/rails/controller_transaction.rb:18:in 'Sentry::Rails::ControllerTransaction#sentry_around_action'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/activesupport-8.0.2/lib/active_support/callbacks.rb:129:in 'block in ActiveSupport::Callbacks#run_callbacks'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/activesupport-8.0.2/lib/active_support/callbacks.rb:140:in 'ActiveSupport::Callbacks#run_callbacks'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/actionpack-8.0.2/lib/abstract_controller/callbacks.rb:260:in 'AbstractController::Callbacks#process_action'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/actionpack-8.0.2/lib/action_controller/metal/rescue.rb:27:in 'ActionController::Rescue#process_action'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/actionpack-8.0.2/lib/action_controller/metal/instrumentation.rb:76:in 'block in ActionController::Instrumentation#process_action'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/activesupport-8.0.2/lib/active_support/notifications.rb:210:in 'block in ActiveSupport::Notifications.instrument'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/activesupport-8.0.2/lib/active_support/notifications/instrumenter.rb:58:in 'ActiveSupport::Notifications::Instrumenter#instrument'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/activesupport-8.0.2/lib/active_support/notifications.rb:210:in 'ActiveSupport::Notifications.instrument'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/actionpack-8.0.2/lib/action_controller/metal/instrumentation.rb:75:in 'ActionController::Instrumentation#process_action'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/actionpack-8.0.2/lib/action_controller/metal/params_wrapper.rb:259:in 'ActionController::ParamsWrapper#process_action'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/activerecord-8.0.2/lib/active_record/railties/controller_runtime.rb:39:in 'ActiveRecord::Railties::ControllerRuntime#process_action'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/actionpack-8.0.2/lib/abstract_controller/base.rb:163:in 'AbstractController::Base#process'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/actionview-8.0.2/lib/action_view/rendering.rb:40:in 'ActionView::Rendering#process'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/actionpack-8.0.2/lib/action_controller/metal.rb:252:in 'ActionController::Metal#dispatch'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/actionpack-8.0.2/lib/action_controller/metal.rb:335:in 'ActionController::Metal.dispatch'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/actionpack-8.0.2/lib/action_dispatch/routing/route_set.rb:67:in 'ActionDispatch::Routing::RouteSet::Dispatcher#dispatch'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/actionpack-8.0.2/lib/action_dispatch/routing/route_set.rb:50:in 'ActionDispatch::Routing::RouteSet::Dispatcher#serve'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/actionpack-8.0.2/lib/action_dispatch/journey/router.rb:53:in 'block in ActionDispatch::Journey::Router#serve'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/actionpack-8.0.2/lib/action_dispatch/journey/router.rb:133:in 'block in ActionDispatch::Journey::Router#find_routes'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/actionpack-8.0.2/lib/action_dispatch/journey/router.rb:126:in 'Array#each'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/actionpack-8.0.2/lib/action_dispatch/journey/router.rb:126:in 'ActionDispatch::Journey::Router#find_routes'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/actionpack-8.0.2/lib/action_dispatch/journey/router.rb:34:in 'ActionDispatch::Journey::Router#serve'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/actionpack-8.0.2/lib/action_dispatch/routing/route_set.rb:908:in 'ActionDispatch::Routing::RouteSet#call'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/railties-8.0.2/lib/rails/engine/lazy_route_set.rb:68:in 'Rails::Engine::LazyRouteSet#call'
     # ./config/middleware/reject_badly_encoded_headers.rb:10:in 'Middleware::RejectBadlyEncodedHeaders#call'
     # ./config/middleware/allow_web_crawlers.rb:12:in 'Middleware::AllowWebCrawlers#call'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/rack-3.1.12/lib/rack/tempfile_reaper.rb:20:in 'Rack::TempfileReaper#call'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/rack-3.1.12/lib/rack/etag.rb:29:in 'Rack::ETag#call'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/rack-3.1.12/lib/rack/conditional_get.rb:43:in 'Rack::ConditionalGet#call'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/rack-3.1.12/lib/rack/head.rb:15:in 'Rack::Head#call'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/actionpack-8.0.2/lib/action_dispatch/http/permissions_policy.rb:38:in 'ActionDispatch::PermissionsPolicy::Middleware#call'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/actionpack-8.0.2/lib/action_dispatch/http/content_security_policy.rb:38:in 'ActionDispatch::ContentSecurityPolicy::Middleware#call'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/rack-session-2.1.0/lib/rack/session/abstract/id.rb:274:in 'Rack::Session::Abstract::Persisted#context'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/rack-session-2.1.0/lib/rack/session/abstract/id.rb:268:in 'Rack::Session::Abstract::Persisted#call'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/actionpack-8.0.2/lib/action_dispatch/middleware/cookies.rb:706:in 'ActionDispatch::Cookies#call'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/actionpack-8.0.2/lib/action_dispatch/middleware/callbacks.rb:31:in 'block in ActionDispatch::Callbacks#call'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/activesupport-8.0.2/lib/active_support/callbacks.rb:100:in 'ActiveSupport::Callbacks#run_callbacks'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/actionpack-8.0.2/lib/action_dispatch/middleware/callbacks.rb:30:in 'ActionDispatch::Callbacks#call'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/actionpack-8.0.2/lib/action_dispatch/middleware/actionable_exceptions.rb:18:in 'ActionDispatch::ActionableExceptions#call'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/sentry-rails-5.23.0/lib/sentry/rails/rescued_exception_interceptor.rb:14:in 'Sentry::Rails::RescuedExceptionInterceptor#call'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/actionpack-8.0.2/lib/action_dispatch/middleware/debug_exceptions.rb:31:in 'ActionDispatch::DebugExceptions#call'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/sentry-ruby-5.23.0/lib/sentry/rack/capture_exceptions.rb:30:in 'block (2 levels) in Sentry::Rack::CaptureExceptions#call'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/sentry-ruby-5.23.0/lib/sentry/hub.rb:296:in 'Sentry::Hub#with_session_tracking'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/sentry-ruby-5.23.0/lib/sentry-ruby.rb:428:in 'Sentry.with_session_tracking'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/sentry-ruby-5.23.0/lib/sentry/rack/capture_exceptions.rb:21:in 'block in Sentry::Rack::CaptureExceptions#call'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/sentry-ruby-5.23.0/lib/sentry/hub.rb:89:in 'Sentry::Hub#with_scope'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/sentry-ruby-5.23.0/lib/sentry-ruby.rb:408:in 'Sentry.with_scope'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/sentry-ruby-5.23.0/lib/sentry/rack/capture_exceptions.rb:20:in 'Sentry::Rack::CaptureExceptions#call'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/actionpack-8.0.2/lib/action_dispatch/middleware/show_exceptions.rb:32:in 'ActionDispatch::ShowExceptions#call'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/railties-8.0.2/lib/rails/rack/logger.rb:41:in 'Rails::Rack::Logger#call_app'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/railties-8.0.2/lib/rails/rack/logger.rb:29:in 'Rails::Rack::Logger#call'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/actionpack-8.0.2/lib/action_dispatch/middleware/remote_ip.rb:96:in 'ActionDispatch::RemoteIp#call'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/actionpack-8.0.2/lib/action_dispatch/middleware/request_id.rb:34:in 'ActionDispatch::RequestId#call'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/rack-3.1.12/lib/rack/method_override.rb:28:in 'Rack::MethodOverride#call'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/rack-3.1.12/lib/rack/runtime.rb:24:in 'Rack::Runtime#call'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/activesupport-8.0.2/lib/active_support/cache/strategy/local_cache_middleware.rb:29:in 'ActiveSupport::Cache::Strategy::LocalCache::Middleware#call'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/actionpack-8.0.2/lib/action_dispatch/middleware/executor.rb:16:in 'ActionDispatch::Executor#call'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/actionpack-8.0.2/lib/action_dispatch/middleware/static.rb:27:in 'ActionDispatch::Static#call'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/rack-3.1.12/lib/rack/sendfile.rb:114:in 'Rack::Sendfile#call'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/railties-8.0.2/lib/rails/engine.rb:535:in 'Rails::Engine#call'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/rack-3.1.12/lib/rack/urlmap.rb:76:in 'block in Rack::URLMap#call'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/rack-3.1.12/lib/rack/urlmap.rb:60:in 'Array#each'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/rack-3.1.12/lib/rack/urlmap.rb:60:in 'Rack::URLMap#call'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/rack-3.1.12/lib/rack/builder.rb:277:in 'Rack::Builder#call'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/rack-test-2.2.0/lib/rack/test.rb:360:in 'Rack::Test::Session#process_request'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/rack-test-2.2.0/lib/rack/test.rb:163:in 'Rack::Test::Session#custom_request'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/rack-test-2.2.0/lib/rack/test.rb:112:in 'Rack::Test::Session#post'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/3.4.0/forwardable.rb:240:in 'Rack::Test::Methods#post'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/capybara-3.40.0/lib/capybara/rack_test/browser.rb:81:in 'Capybara::RackTest::Browser#process'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/capybara-3.40.0/lib/capybara/rack_test/browser.rb:56:in 'Capybara::RackTest::Browser#process_and_follow_redirects'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/capybara-3.40.0/lib/capybara/rack_test/browser.rb:40:in 'Capybara::RackTest::Browser#submit'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/capybara-3.40.0/lib/capybara/rack_test/form.rb:57:in 'Capybara::RackTest::Form#submit'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/capybara-3.40.0/lib/capybara/rack_test/node.rb:69:in 'Capybara::RackTest::Node#click'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/capybara-3.40.0/lib/capybara/rack_test/node.rb:131:in 'Method#call'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/capybara-3.40.0/lib/capybara/rack_test/node.rb:131:in 'Capybara::RackTest::Node#click'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/capybara-3.40.0/lib/capybara/node/element.rb:172:in 'block in Capybara::Node::Element#click'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/capybara-3.40.0/lib/capybara/node/element.rb:608:in 'block in Capybara::Node::Element#perform_click_action'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/capybara-3.40.0/lib/capybara/node/base.rb:84:in 'Capybara::Node::Base#synchronize'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/capybara-3.40.0/lib/capybara/node/element.rb:608:in 'Capybara::Node::Element#perform_click_action'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/capybara-3.40.0/lib/capybara/node/element.rb:171:in 'Capybara::Node::Element#click'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/capybara-3.40.0/lib/capybara/node/actions.rb:26:in 'Capybara::Node::Actions#click_link_or_button'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/capybara-3.40.0/lib/capybara/session.rb:774:in 'Capybara::Session#click_on'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/capybara-3.40.0/lib/capybara/dsl.rb:52:in 'Method#call'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/capybara-3.40.0/lib/capybara/dsl.rb:52:in 'Capybara::DSL#click_on'
     # ./spec/system/admin/conference_calls_spec.rb:39:in 'block (2 levels) in <top (required)>'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/rspec-core-3.13.3/lib/rspec/core/example.rb:263:in 'BasicObject#instance_exec'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/rspec-core-3.13.3/lib/rspec/core/example.rb:263:in 'block in RSpec::Core::Example#run'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/rspec-core-3.13.3/lib/rspec/core/example.rb:511:in 'block in RSpec::Core::Example#with_around_and_singleton_context_hooks'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/rspec-core-3.13.3/lib/rspec/core/example.rb:468:in 'block in RSpec::Core::Example#with_around_example_hooks'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/rspec-core-3.13.3/lib/rspec/core/hooks.rb:486:in 'block in RSpec::Core::Hooks::HookCollections#run'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/rspec-core-3.13.3/lib/rspec/core/hooks.rb:626:in 'block in RSpec::Core::Hooks::HookCollections#run_around_example_hooks_for'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/rspec-core-3.13.3/lib/rspec/core/example.rb:352:in 'RSpec::Core::Example::Procsy#call'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/rspec-rails-7.1.1/lib/rspec/rails/example/system_example_group.rb:174:in 'block (2 levels) in <module:SystemExampleGroup>'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/rspec-core-3.13.3/lib/rspec/core/example.rb:457:in 'BasicObject#instance_exec'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/rspec-core-3.13.3/lib/rspec/core/example.rb:457:in 'RSpec::Core::Example#instance_exec'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/rspec-core-3.13.3/lib/rspec/core/hooks.rb:390:in 'RSpec::Core::Hooks::AroundHook#execute_with'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/rspec-core-3.13.3/lib/rspec/core/hooks.rb:628:in 'block (2 levels) in RSpec::Core::Hooks::HookCollections#run_around_example_hooks_for'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/rspec-core-3.13.3/lib/rspec/core/example.rb:352:in 'RSpec::Core::Example::Procsy#call'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/rspec-rails-7.1.1/lib/rspec/rails/adapters.rb:75:in 'block (2 levels) in <module:MinitestLifecycleAdapter>'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/rspec-core-3.13.3/lib/rspec/core/example.rb:457:in 'BasicObject#instance_exec'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/rspec-core-3.13.3/lib/rspec/core/example.rb:457:in 'RSpec::Core::Example#instance_exec'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/rspec-core-3.13.3/lib/rspec/core/hooks.rb:390:in 'RSpec::Core::Hooks::AroundHook#execute_with'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/rspec-core-3.13.3/lib/rspec/core/hooks.rb:628:in 'block (2 levels) in RSpec::Core::Hooks::HookCollections#run_around_example_hooks_for'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/rspec-core-3.13.3/lib/rspec/core/example.rb:352:in 'RSpec::Core::Example::Procsy#call'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/webmock-3.25.1/lib/webmock/rspec.rb:39:in 'block (2 levels) in <main>'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/rspec-core-3.13.3/lib/rspec/core/example.rb:457:in 'BasicObject#instance_exec'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/rspec-core-3.13.3/lib/rspec/core/example.rb:457:in 'RSpec::Core::Example#instance_exec'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/rspec-core-3.13.3/lib/rspec/core/hooks.rb:390:in 'RSpec::Core::Hooks::AroundHook#execute_with'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/rspec-core-3.13.3/lib/rspec/core/hooks.rb:628:in 'block (2 levels) in RSpec::Core::Hooks::HookCollections#run_around_example_hooks_for'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/rspec-core-3.13.3/lib/rspec/core/example.rb:352:in 'RSpec::Core::Example::Procsy#call'
     # ./spec/support/system_tests.rb:33:in 'block (2 levels) in <main>'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/rspec-core-3.13.3/lib/rspec/core/example.rb:457:in 'BasicObject#instance_exec'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/rspec-core-3.13.3/lib/rspec/core/example.rb:457:in 'RSpec::Core::Example#instance_exec'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/rspec-core-3.13.3/lib/rspec/core/hooks.rb:390:in 'RSpec::Core::Hooks::AroundHook#execute_with'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/rspec-core-3.13.3/lib/rspec/core/hooks.rb:628:in 'block (2 levels) in RSpec::Core::Hooks::HookCollections#run_around_example_hooks_for'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/rspec-core-3.13.3/lib/rspec/core/example.rb:352:in 'RSpec::Core::Example::Procsy#call'
     # ./spec/support/active_job.rb:16:in 'block (2 levels) in <main>'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/rspec-core-3.13.3/lib/rspec/core/example.rb:457:in 'BasicObject#instance_exec'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/rspec-core-3.13.3/lib/rspec/core/example.rb:457:in 'RSpec::Core::Example#instance_exec'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/rspec-core-3.13.3/lib/rspec/core/hooks.rb:390:in 'RSpec::Core::Hooks::AroundHook#execute_with'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/rspec-core-3.13.3/lib/rspec/core/hooks.rb:628:in 'block (2 levels) in RSpec::Core::Hooks::HookCollections#run_around_example_hooks_for'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/rspec-core-3.13.3/lib/rspec/core/example.rb:352:in 'RSpec::Core::Example::Procsy#call'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/rspec-core-3.13.3/lib/rspec/core/hooks.rb:629:in 'RSpec::Core::Hooks::HookCollections#run_around_example_hooks_for'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/rspec-core-3.13.3/lib/rspec/core/hooks.rb:486:in 'RSpec::Core::Hooks::HookCollections#run'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/rspec-core-3.13.3/lib/rspec/core/example.rb:468:in 'RSpec::Core::Example#with_around_example_hooks'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/rspec-core-3.13.3/lib/rspec/core/example.rb:511:in 'RSpec::Core::Example#with_around_and_singleton_context_hooks'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/rspec-core-3.13.3/lib/rspec/core/example.rb:259:in 'RSpec::Core::Example#run'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/rspec-core-3.13.3/lib/rspec/core/example_group.rb:646:in 'block in RSpec::Core::ExampleGroup.run_examples'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/rspec-core-3.13.3/lib/rspec/core/example_group.rb:642:in 'Array#map'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/rspec-core-3.13.3/lib/rspec/core/example_group.rb:642:in 'RSpec::Core::ExampleGroup.run_examples'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/rspec-core-3.13.3/lib/rspec/core/example_group.rb:607:in 'RSpec::Core::ExampleGroup.run'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/rspec-core-3.13.3/lib/rspec/core/runner.rb:121:in 'block (3 levels) in RSpec::Core::Runner#run_specs'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/rspec-core-3.13.3/lib/rspec/core/runner.rb:121:in 'Array#map'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/rspec-core-3.13.3/lib/rspec/core/runner.rb:121:in 'block (2 levels) in RSpec::Core::Runner#run_specs'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/rspec-core-3.13.3/lib/rspec/core/configuration.rb:2097:in 'RSpec::Core::Configuration#with_suite_hooks'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/rspec-core-3.13.3/lib/rspec/core/runner.rb:116:in 'block in RSpec::Core::Runner#run_specs'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/rspec-core-3.13.3/lib/rspec/core/reporter.rb:74:in 'RSpec::Core::Reporter#report'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/rspec-core-3.13.3/lib/rspec/core/runner.rb:115:in 'RSpec::Core::Runner#run_specs'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/rspec-core-3.13.3/lib/rspec/core/runner.rb:89:in 'RSpec::Core::Runner#run'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/rspec-core-3.13.3/lib/rspec/core/runner.rb:71:in 'RSpec::Core::Runner.run'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/rspec-core-3.13.3/lib/rspec/core/runner.rb:45:in 'RSpec::Core::Runner.invoke'
     # /Users/bensheldon/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/rspec-core-3.13.3/exe/rspec:4:in '<top (required)>'
     # bin/rspec:3:in 'Kernel#load'
     # bin/rspec:3:in '<main>'
     # ------------------
     # --- Caused by: ---
     # ArgumentError:
     #   unknown keyword: :conference_call_participant
     #   ./app/views/admin/conference_calls/_participant.erb:in '_app_views_admin_conference_calls__participant_erb__1566491194546528003_24960'
```

</details> 

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] ~Tests are added or updated if you fix a bug or add a feature.~
* [ ] ~CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.~
