### PR TITLE
Improve explanation of path/link_to helpers in Getting Started guide

### DIFF
--- a/guides/source/getting_started.md
+++ b/guides/source/getting_started.md
@@ -1093,15 +1093,19 @@ domain.
 
 `_url` returns a full URL including the protocol, host, and port.
 
-URL helpers are useful for rendering emails that will be viewed outside of the
+URL generating helpers are useful for rendering emails that will be viewed outside of the
 browser.
 
-Combined with the `link_to` helper, we can generate anchor tags and use the URL
-helper to do this cleanly in Ruby. `link_to` accepts the display content for the
-link (`product.name`) and the path or URL to link to for the `href` attribute
-(`product`).
+We can use the `link_to` helper method together with the path or URL generating helper methods to create very clean anchor tags in Ruby. `link_to` takes an argument for the link's display content and an argument for the link's `href` attribute (the path or URL to link to). We could therefore create a link in Ruby like so:
+```
+link_to product.name, product_path(product.id)
+```
+We can make this even cleaner, however. When `link_to` is given an Active Record object as its path, it generates the path for that record’s show action, so we only need:
+```
+link_to product.name, product
+```
 
-Let's refactor this to use these helpers:
+We will see a similar approach shortly when we use the `redirect_to` method. Let's refactor to use these helpers:
 
 ```erb#6
 <h1>Products</h1>
@@ -1109,7 +1113,7 @@ Let's refactor this to use these helpers:
 <div id="products">
   <% @products.each do |product| %>
     <div>
-      <%= link_to product.name, product_path(product.id) %>
+      <%= link_to product.name, product %>
     </div>
   <% end %>
 </div>
@@ -1156,7 +1160,7 @@ We can update `app/views/products/index.html.erb` to link to the new action.
 <div id="products">
   <% @products.each do |product| %>
     <div>
-      <%= link_to product.name, product_path(product.id) %>
+      <%= link_to product.name, product %>
     </div>
   <% end %>
 </div>
@@ -1845,7 +1849,7 @@ Add `:featured_image` as a permitted parameter in
 ```
 
 Lastly, we want to display the featured image for our product in
-`app/views/products/show.html.erb`. Add the following to the top.
+`app/views/products/show.html.erb`. Add the following to the top (above the cache block).
 
 ```erb
 <%= image_tag @product.featured_image if @product.featured_image.attached? %>


### PR DESCRIPTION
I followed through the **Getting Started with Rails** guide and found a few things unclear, in particular section [10.4. Showing Individual Products](https://guides.rubyonrails.org/getting_started.html#showing-individual-products) describing url and link_to helpers, so tried to improve it.

This is my first contribution, so very happy to receive feedback if I have not followed the protocols correctly.