### PR TITLE
Allowing label interpolation modifiers on fixtures

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,16 @@
+*   Fixture label modifiers
+
+    Label on fixtures can be transformed using a chain of string methods:
+
+    ```yml
+    john_doe:
+        slug: $LABEL(titleize)                 # => "John Doe"
+        username: $LABEL(dasherize.capitalize) # => "John-doe"
+        raw_label: $LABEL()                    # => "john_doe" (same as $LABEL)
+    ```
+
+    *Jose Carlos Arenas*
+
 *   Add `rename_schema` method for PostgreSQL.
 
     *T S Vallender*

--- a/activerecord/lib/active_record/fixture_set/table_row.rb
+++ b/activerecord/lib/active_record/fixture_set/table_row.rb
@@ -112,7 +112,7 @@ module ActiveRecord
         def interpolate_label
           # interpolate the fixture label
           @row.each do |key, value|
-            @row[key] = value.gsub("$LABEL", @label.to_s) if value.is_a?(String)
+            @row[key] = value.gsub(/\$LABEL(\((.*?)\))?/) { ($2 || "").split(".").reduce(@label.to_s, :send) } if value.is_a?(String)
           end
         end
 

--- a/activerecord/lib/active_record/fixtures.rb
+++ b/activerecord/lib/active_record/fixtures.rb
@@ -430,6 +430,15 @@ module ActiveRecord
   #
   #   ActiveRecord::FixtureSet.identify(:boaty_mcboatface, :uuid)
   #
+  # === Fixture label modifiers
+  #
+  # The label can be transformed using a chain of string methods:
+  #
+  #   john_doe:
+  #     slug: $LABEL(titleize)                 # => "John Doe"
+  #     username: $LABEL(dasherize.capitalize) # => "John-doe"
+  #     raw_label: $LABEL()                    # => "john_doe" (same as $LABEL)
+  #
   # === Support for YAML defaults
   #
   # You can set and reuse defaults in your fixtures YAML file.

--- a/activerecord/test/cases/fixtures_test.rb
+++ b/activerecord/test/cases/fixtures_test.rb
@@ -1460,6 +1460,18 @@ class FoxyFixturesTest < ActiveRecord::TestCase
     assert_equal("#1 pirate!", pirates(1).catchphrase)
   end
 
+  def test_supports_label_interpolation_with_multiple_modifiers
+    assert_equal("You almost cacth Jack Sparrow", pirates(:jack_sparrow).catchphrase)
+  end
+
+  def test_supports_label_interpolation_with_single_modifier
+    assert_equal("Henry-morgan-catchphrase", pirates(:henry_morgan).catchphrase)
+  end
+
+  def test_supports_label_interpolation_empty_modifiers
+    assert_equal("henry_avery_treasure", pirates(:henry_avery).catchphrase)
+  end
+
   def test_supports_polymorphic_belongs_to
     assert_equal(pirates(:redbeard), treasures(:sapphire).looter)
     assert_equal(parrots(:louis), treasures(:ruby).looter)

--- a/activerecord/test/fixtures/pirates.yml
+++ b/activerecord/test/fixtures/pirates.yml
@@ -13,3 +13,12 @@ mark:
 
 1:
   catchphrase: "#$LABEL pirate!"
+
+jack_sparrow:
+  catchphrase: You almost cacth $LABEL(titleize)
+
+henry_morgan:
+  catchphrase: $LABEL(dasherize.capitalize)-catchphrase
+
+henry_avery:
+  catchphrase: $LABEL()_treasure


### PR DESCRIPTION
### Motivation / Background

Label interpolation is a useful feature on fixtures but it could be pretty restrictive when fixture label doesn't meet a field validation (ex. a slug not allowing underscores). Multiple times I have found myself limited by this behaviour and having to manually override interpolated fields on fixtures.
That's why label modifiers can bring some flexibility to label interpolation. Modifiers allows chaining simple String methods and apply them to the label.

```
john_doe:
    slug: $LABEL(titleize)                 # => "John Doe"
    username: $LABEL(dasherize.capitalize) # => "John-doe"
    raw_label: $LABEL()                    # => "john_doe" (same as $LABEL)
```

This will allow more flexibility when using $LABEL on fixtures.

### Detail

Label substitution was extended to look for chaining methods wrapped by parenthesis and separated by points to dynamically apply them to the inserted label.

Now, instead of looking for $LABEL and replacing it with fixture label, a regexp is being matched as in the provided examples applying the chain of methods to label before inserting it.

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [X] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
