### PR TITLE
Clarify docs for upsert_all :unique_by option

### DIFF
--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -852,13 +852,14 @@ module ActiveRecord
     #
     # [:unique_by]
     #   (PostgreSQL and SQLite only) By default rows are considered to be unique
-    #   by every unique index on the table. Any duplicate rows are skipped.
+    #   by the table's primary key. Any duplicate rows are updated.
     #
-    #   To skip rows according to just one unique index pass <tt>:unique_by</tt>.
+    #   To update rows according to a unique index pass <tt>:unique_by</tt>.
     #
-    #   Consider a Book model where no duplicate ISBNs make sense, but if any
-    #   row has an existing id, or is not unique by another unique index,
-    #   ActiveRecord::RecordNotUnique is raised.
+    #   Consider a Book model where duplicate ISBNs are not permitted. If you specify
+    #   <tt>unique_by: :isbn</tt> it will be used to identify duplicates. However, if
+    #   any row has an existing primary key id, or violates another unique index,
+    #   ActiveRecord::RecordNotUnique will be raised.
     #
     #   Unique indexes can be identified by columns or name:
     #
@@ -866,9 +867,9 @@ module ActiveRecord
     #     unique_by: %i[ author_id name ]
     #     unique_by: :index_books_on_isbn
     #
-    # Because it relies on the index information from the database
-    # <tt>:unique_by</tt> is recommended to be paired with
-    # Active Record's schema_cache.
+    #   Because it relies on the index information from the database
+    #   <tt>:unique_by</tt> is recommended to be paired with
+    #   Active Record's schema_cache.
     #
     # [:on_duplicate]
     #   Configure the SQL update sentence that will be used in case of conflict.


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

The code from [InsertAll#conflict_target](https://github.com/rails/rails/blob/42a71a03a0adb465dc49b4e21dec8e0ea29e8e35/activerecord/lib/active_record/insert_all.rb#L270-L271) is falling back to primary key in case of an update conflict resolution (the most common use case) which means these docs can be misleading.

We could also clarify the difference in default behavior when using skip vs update, what do you think?

### Detail

Based on [the PostgreSQL docs](https://www.postgresql.org/docs/current/sql-insert.html#SQL-ON-CONFLICT) the _conflict_target_ is only optional when skipping duplicates:
  - `ON CONFLICT DO NOTHING` (skips duplicates, tries to infer unique index to use for conflict detection)
  - `ON CONFLICT conflict_target DO UPDATE` (mandatory _conflict_target_)

So the implementation is correct, but the docs could explain this behavior a bit better.

And AFAICT the same behavior applies to both PostgreSQL and SQLite, even though SQLite [relaxed the mandatory conflict target](https://sqlite.org/lang_upsert.html#history) since 3.35.0.

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
