### PR TITLE
Fix `polymorphic_url` and `polymorphic_path` not working when routes are not loaded:

### DIFF
--- a/railties/lib/rails/engine/lazy_route_set.rb
+++ b/railties/lib/rails/engine/lazy_route_set.rb
@@ -34,16 +34,6 @@ module Rails
           Rails.application&.reload_routes_unless_loaded
           super
         end
-
-        def polymorphic_url(record_or_hash_or_array, options = {})
-          Rails.application&.reload_routes_unless_loaded
-          super
-        end
-
-        def polymorphic_path(record_or_hash_or_array, options = {})
-          Rails.application&.reload_routes_unless_loaded
-          super
-        end
       end
 
       def initialize(config = DEFAULT_CONFIG)
@@ -64,6 +54,11 @@ module Rails
       end
 
       def call(req)
+        Rails.application&.reload_routes_unless_loaded
+        super
+      end
+
+      def polymorphic_mappings
         Rails.application&.reload_routes_unless_loaded
         super
       end

--- a/railties/test/engine/lazy_route_set_test.rb
+++ b/railties/test/engine/lazy_route_set_test.rb
@@ -52,6 +52,26 @@ module Rails
         assert_equal(200, response.first)
       end
 
+      test "app lazily loads routes when polymorphic_url is called" do
+        app_file "test/integration/my_test.rb", <<~RUBY
+          require "test_helper"
+
+          class MyTest < ActionDispatch::IntegrationTest
+            test "polymorphic_url works" do
+              puts polymorphic_url(Comment.new)
+            end
+          end
+        RUBY
+
+        app_file "app/models/comment.rb", <<~RUBY
+          class Comment
+          end
+        RUBY
+
+        output = rails("test", "test/integration/my_test.rb")
+        assert_match("https://example.org", output)
+      end
+
       test "engine lazily loads routes when making a request" do
         require "#{app_path}/config/environment"
 
@@ -137,6 +157,7 @@ module Rails
 
               resources :products
               resources :users, module: "rails/engine/lazy_route_set_test"
+              resolve("Comment") { "https://example.org" }
 
               mount Plugin::Engine, at: "/plugin"
             end


### PR DESCRIPTION
### Motivation / Background

Fix #54890

### Detail

#### Problem

Calling `polyphormic_url` in a integration test or anywhere else when routes may not be loaded yet will result in either crashing or returning a wrong url.

#### Details

When the routes are not yet loaded, any `resolve` routes are not taken in consideration when calling `polymorphic_url`.

```ruby
  # config/routes.rb
  resolve("Post") { "https://example.org" }

  # test.rb
  polymorphic_url(@post) # Crash: `post_url` is not defined.
```

#### Solution

Load the routes when `polymorphic_mappings` ultimately gets called by `polymorphic_url` https://github.com/rails/rails/blob/42a71a03a0adb465dc49b4e21dec8e0ea29e8e35/actionpack/lib/action_dispatch/routing/polymorphic_routes.rb#L179


### Additional information

It's worth to note that `polymorphic_url` was previously overriden to load the routes, but it only worked if one attempted to call it on the singleton route's url_helpers:

```ruby
  class MyTest < ActionDispatch::IntegrationTest
    test "example" do
      # Works correctly on main
      Rails.application.routes.url_helpers.polymorphic_url(@post)

      # Does not work without this patch
      polymorphic_url(@post)
    end
  end
```

I removed the previous implementation as it was overidden on the wrong methods.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
