### PR TITLE
Add method to find Rails tz by IANA identifier

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -163,7 +163,7 @@ platforms :ruby, :windows do
   end
 end
 
-gem "tzinfo-data", platforms: [:windows, :jruby]
+gem "tzinfo-data", "~> 1.2025", ">= 1.2025.2"
 gem "wdm", ">= 0.1.0", platforms: [:windows]
 
 gem "launchy"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -153,6 +153,8 @@ GEM
     base64 (0.2.0)
     bcrypt (3.1.20)
     bcrypt_pbkdf (1.1.1)
+    bcrypt_pbkdf (1.1.1-arm64-darwin)
+    bcrypt_pbkdf (1.1.1-x86_64-darwin)
     beaneater (1.1.3)
     benchmark (0.4.0)
     bigdecimal (3.1.9)
@@ -682,6 +684,8 @@ GEM
       railties (>= 6.0.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
+    tzinfo-data (1.2025.2)
+      tzinfo (>= 1.0.0)
     uber (0.1.0)
     unicode-display_width (3.1.4)
       unicode-emoji (~> 4.0, >= 4.0.4)
@@ -805,7 +809,7 @@ DEPENDENCIES
   thruster
   trilogy (>= 2.7.0)
   turbo-rails
-  tzinfo-data
+  tzinfo-data (~> 1.2025, >= 1.2025.2)
   uri (>= 0.13.1)
   useragent
   w3c_validators (~> 1.3.6)

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,7 @@
+*  Add `find_by_identifier` to `ActiveSupport::TimeZone` for resolving both canonical and linked IANA identifiers to Rails time zones.
+
+    *Jan Piotrzkowski*
+
 *   Use `UNLINK` command instead of `DEL` in `ActiveSupport::Cache::RedisCacheStore` for non-blocking deletion.
 
     *Aron Roh*

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,4 +1,4 @@
-*  Add `find_by_identifier` to `ActiveSupport::TimeZone` for resolving both canonical and linked IANA identifiers to Rails time zones.
+*   Add `find_by_identifier` to `ActiveSupport::TimeZone` for resolving both canonical and linked IANA identifiers to Rails time zones.
 
     *Jan Piotrzkowski*
 

--- a/activesupport/test/time_zone_test.rb
+++ b/activesupport/test/time_zone_test.rb
@@ -920,4 +920,22 @@ class TimeZoneTest < ActiveSupport::TestCase
     assert_equal "EDT", time.strftime("%Z")
     assert_equal true, time.isdst
   end
+
+  def test_find_by_identifier
+    expected_zone = ActiveSupport::TimeZone["Pacific Time (US & Canada)"]
+
+    canonical_identifier = "America/Los_Angeles" # Included in the ActiveSupport::TimeZone::MAPPING
+    zone = ActiveSupport::TimeZone.find_by_identifier(canonical_identifier)
+    assert_equal expected_zone, zone
+
+    linked_identifier = "US/Pacific" # Not included in the ActiveSupport::TimeZone::MAPPING, but linked to "America/Los_Angeles"
+    zone = ActiveSupport::TimeZone.find_by_identifier(linked_identifier)
+    assert_equal expected_zone, zone
+    assert_equal "Pacific Time (US & Canada)", zone.name
+    assert_equal TZInfo::Timezone.get("America/Los_Angeles"), zone.tzinfo
+
+    unknown_identifier = "Dummy"
+    zone = ActiveSupport::TimeZone.find_by_identifier(unknown_identifier)
+    assert_nil zone
+  end
 end


### PR DESCRIPTION
This commit introduces a method that allows mapping an IANA time zone identifier to a corresponding Rails time zone, even if the identifier is a linked (non-canonical) one.

Rails’ MAPPING only includes a subset of IANA canonical identifiers. Some identifiers—like US/Pacific—are valid IANA time zones but are not directly included in MAPPING. However, they often point to canonical zones that are mapped by Rails (e.g., US/Pacific links to America/Los_Angeles).

This method is useful when handling user input based on IANA time zones, allowing consistent mapping to Rails time zones regardless of whether the identifier is canonical or linked.

To ensure consistent behavior across platforms, this commit also makes tzinfo-data available on all platforms (not just Windows or JRuby). Without it, platforms like macOS and Linux may treat linked time zones as distinct, making canonical resolution unreliable. For example:

    TZInfo::Timezone.get("US/Pacific").canonical_identifier
    # => "US/Pacific" on macOS/Linux (without tzinfo-data)
    # => "America/Los_Angeles" with tzinfo-data

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
