### PR TITLE
Bump minimum supported SQLite to 3.23.0

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -186,7 +186,7 @@ module ActiveRecord
       end
 
       def supports_expression_index?
-        database_version >= "3.9.0"
+        true
       end
 
       def requires_reloading?
@@ -214,7 +214,7 @@ module ActiveRecord
       end
 
       def supports_common_table_expressions?
-        database_version >= "3.8.3"
+        true
       end
 
       def supports_insert_returning?
@@ -507,8 +507,8 @@ module ActiveRecord
       end
 
       def check_version # :nodoc:
-        if database_version < "3.8.0"
-          raise "Your version of SQLite (#{database_version}) is too old. Active Record supports SQLite >= 3.8."
+        if database_version < "3.23.0"
+          raise "Your version of SQLite (#{database_version}) is too old. Active Record supports SQLite >= 3.23.0"
         end
       end
 


### PR DESCRIPTION
### Motivation / Background

The change I'm most interested in is support for boolean literals:

> SQLite recognizes the keywords "TRUE" and "FALSE", as of version
> 3.23.0 (2018-04-02) but those keywords are really just alternative
> spellings for the integer literals 1 and 0 respectively.

The last bump to 3.8.0 was [in 2018][1].

- Debian stable (bookworm) packages 3.40.1
- Debian oldstable (bullseye) packages 3.34.1
- Debian oldoldstable (buster) packages 3.27.2
- Ubuntu 20 (focal, EOL next month) packages 3.31
- Ubuntu 22 (jammy) packages 3.37

[1]: https://github.com/rails/rails/commit/d1a74c1e012ed96f7179e53b9190b7da0a369e11

### Additional Information

I started by trying to add some sort of `supports_boolean_literals?` to use in `Arel::Visitors::SQLite`, but the Arel tests use a fake connection class so it didn't feel worth adding that complexity when the current version requirement is so old.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
