### PR TITLE
Fixed code sample overflowing when viewed on mobile [ci skip]

### DIFF
--- a/guides/assets/stylesrc/_main.scss
+++ b/guides/assets/stylesrc/_main.scss
@@ -372,6 +372,12 @@ body.guide {
     word-wrap: break-word; /* Internet Explorer 5.5+ */
   }
 
+  pre {
+    code {
+      white-space: pre;
+    }
+  }
+
   // Back to Top element
 
   a.back-to-top {

--- a/guides/assets/stylesrc/components/_code-container.scss
+++ b/guides/assets/stylesrc/components/_code-container.scss
@@ -37,6 +37,10 @@ dl dd .interstitial {
     }
   }
 
+  .pre-wrapper {
+    overflow-x: auto;
+  }
+
   &.code {
     border: none !important;
     background-color: $gray-900;

--- a/guides/rails_guides/markdown/renderer.rb
+++ b/guides/rails_guides/markdown/renderer.rb
@@ -36,7 +36,9 @@ module RailsGuides
         formatted_code = formatter.format(lexer.lex(code))
         <<~HTML
           <div class="interstitial code">
-          <pre><code class="highlight #{lexer_language(language)}">#{formatted_code}</code></pre>
+          <div class="pre-wrapper">
+           <pre><code class="highlight #{lexer_language(language)}">#{formatted_code}</code></pre>
+          </div>
           <button class="clipboard-button" data-clipboard-text="#{clipboard_content(code, language)}">Copy</button>
           </div>
         HTML


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

This pull request addresses an issue where code samples in the Rails documentation were overflowing their containers resulting in undesirable horizontal scrolling. This deviates from standard industry practices and expected user experience, where code samples should be contained and scrollable within their designated area, rather than causing page-wide horizontal scrollbars. This overflow negatively impacted the readability and usability of the documentation.

### Detail

To resolve this, the pull request modifies the CSS styling for code samples. It introduces a `pre-wrapper` div that allows code blocks to scroll horizontally within their defined container. This change:

* Limits code block width to the container.
* Enables horizontal scrolling when content exceeds the container width.
* Prevents page-level horizontal scrollbars.
* Preserves the functionality of the clipboard button.

### Additional Information

This improvement ensures code examples are displayed correctly across various screen sizes, enhancing the learning experience for users.

### Checklist
Before submitting the PR make sure the following are checked:

[x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
[x] Commit message has a detailed description of what changed and why. 
