### PR TITLE
Use `TRUE` and `FALSE` for booleans in SQLite

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Use `TRUE` and `FALSE` for SQLite queries with boolean columns.
+
+    *Hartley McGuire*
+
 *   Bump minimum supported SQLite to 3.23.0.
 
     *Hartley McGuire*

--- a/activerecord/lib/arel/visitors/sqlite.rb
+++ b/activerecord/lib/arel/visitors/sqlite.rb
@@ -68,14 +68,6 @@ module Arel # :nodoc: all
           super
         end
 
-        def visit_Arel_Nodes_True(o, collector)
-          collector << "1"
-        end
-
-        def visit_Arel_Nodes_False(o, collector)
-          collector << "0"
-        end
-
         def visit_Arel_Nodes_IsNotDistinctFrom(o, collector)
           collector = visit o.left, collector
           collector << " IS "

--- a/activerecord/test/cases/arel/visitors/sqlite_test.rb
+++ b/activerecord/test/cases/arel/visitors/sqlite_test.rb
@@ -25,13 +25,6 @@ module Arel
         assert_equal "", @visitor.accept(node, Collectors::SQLString.new).value
       end
 
-      it "does not support boolean" do
-        node = Nodes::True.new()
-        assert_equal "1", @visitor.accept(node, Collectors::SQLString.new).value
-        node = Nodes::False.new()
-        assert_equal "0", @visitor.accept(node, Collectors::SQLString.new).value
-      end
-
       describe "Nodes::IsNotDistinctFrom" do
         it "should construct a valid generic SQL statement" do
           test = Table.new(:users)[:name].is_not_distinct_from "Aaron Patterson"


### PR DESCRIPTION
### Motivation / Background

Ref #54907

Previously, queries generated with boolean comparisons for MySQL and Postgres used `TRUE` and `FALSE` (these are actual booleans in Postgres and aliases for `1`/`0` in MySQL) but used `1` and `0` for SQLite. This makes it more difficult to write database-agnostic query assertions, since the values are different.

### Detail

SQLite 3.23.0 added support for `TRUE` and `FALSE` as aliases for `1`/`0` (similar to MySQL). A [previous commit][1] bumped the minimum required SQLite version in Active Record to 3.23.0, and this commit updates the boolean query generation for SQLite to use `TRUE` and `FALSE`.

[1]: https://github.com/rails/rails/commit/809abd3ed3c7700bae1edf104c0ad61acb638d4b

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
