### PR TITLE
Do not autoload ActionText::ContentHelper helper on boot

### DIFF
--- a/actiontext/lib/action_text/engine.rb
+++ b/actiontext/lib/action_text/engine.rb
@@ -88,7 +88,9 @@ module ActionText
 
     config.after_initialize do |app|
       if klass = app.config.action_text.sanitizer_vendor
-        ActionText::ContentHelper.sanitizer = klass.safe_list_sanitizer.new
+        ActiveSupport.on_load(:action_view) do
+          ActionText::ContentHelper.sanitizer = klass.safe_list_sanitizer.new
+        end
       end
     end
   end

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -4896,6 +4896,8 @@ module ApplicationTests
     test "Action Text uses the best supported safe list sanitizer in new apps" do
       app "development"
 
+      require "action_view/base"
+
       assert_kind_of(
         Rails::HTML::Sanitizer.best_supported_vendor.safe_list_sanitizer,
         ActionText::ContentHelper.sanitizer,
@@ -4915,7 +4917,10 @@ module ApplicationTests
 
     test "Action Text uses the specified vendor's safe list sanitizer" do
       add_to_config "config.action_text.sanitizer_vendor = ::MySanitizerVendor"
+
       app "development"
+
+      require "action_view/base"
 
       assert_kind_of(
         ::MySafeListSanitizer,


### PR DESCRIPTION

### Motivation / Background

After watching [@bensheldon 's talk](https://www.youtube.com/watch?v=9-PWz9nbrT8&t=275) `An ok compromise. Faster development by designing for the Rails Autoloader` I got motivated to try and run the script mentionned in the video on my production rails app (which runs on edge rails ).

Ben mentions that `ActionText::ContentHelper` is autoloaded at [this timestamp](https://youtu.be/9-PWz9nbrT8?si=Lw7qsF2_VmBperId&t=1487)

I've managed to replicate it on my own application.

Along with this script ( which I've edited a bit to display more messages and add it to our CI ): 
```ruby
# frozen_string_literal: true

require_relative "../../config/application"

autoloaded_constants = []

Rails.autoloaders.each do |loader|
  loader.on_load do |cpath, _value, _abspath|
    autoloaded_constants << [cpath, caller]
  end
end

Rails.application.initialize!

autoloaded_constants.each do |x|
  x[1] = Rails.backtrace_cleaner.clean(x[1]).first
end

# ActionText::ContentHelper
#
if autoloaded_constants.any?
  puts
  puts
  puts "ERROR: Autoloaded constants were referenced during during boot."
  puts
  puts "These files/constants were autoloaded during the boot process, which will result in" \
       "inconsistent behavior and will slow down and may break development mode. " \
       "Remove references to these constants from code loaded at boot. "
  puts
  puts
  w = autoloaded_constants.map { _1.first.length }.max
  autoloaded_constants.each do |name, location|
    puts "`#{name.ljust(w)}` referenced by #{location}"
  end

  exit 1
else
  puts "SUCCESS! No autoloaded constants were found during the boot process."
  exit 0
end
```

### Detail

- I've wrapped the setting of the sanitizer around the loading of `ActionView::Base`
- I've removed `app/helpers` from the autoload once paths

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
