### PR TITLE
Allow to configure maximum cache key sizes

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,17 @@
+*   Allow to configure maximum cache key sizes
+
+    When the key exceeds the configured limit (250 bytes by default), it will be truncated and
+    the digest of the rest of the key appended to it.
+
+    Note that previously `ActiveSupport::Cache::RedisCacheStore` allowed up to 1kb cache keys before
+    truncation, which is now reduced to 250 bytes.
+
+    ```ruby
+    config.cache_store = :redis_cache_store, { max_key_size: 64 }
+    ```
+
+    *fatkodima*
+
 *   Use `UNLINK` command instead of `DEL` in `ActiveSupport::Cache::RedisCacheStore` for non-blocking deletion.
 
     *Aron Roh*

--- a/activesupport/lib/active_support/cache/mem_cache_store.rb
+++ b/activesupport/lib/active_support/cache/mem_cache_store.rb
@@ -41,7 +41,6 @@ module ActiveSupport
 
       prepend Strategy::LocalCache
 
-      KEY_MAX_SIZE = 250
       ESCAPE_KEY_CHARS = /[\x00-\x20%\x7F-\xFF]/n
 
       # Creates a new Dalli::Client instance with specified addresses and options.
@@ -80,6 +79,7 @@ module ActiveSupport
         if options.key?(:cache_nils)
           options[:skip_nil] = !options.delete(:cache_nils)
         end
+        options[:max_key_size] ||= MAX_KEY_SIZE
         super(options)
 
         unless [String, Dalli::Client, NilClass].include?(addresses.first.class)
@@ -258,19 +258,12 @@ module ActiveSupport
         # before applying the regular expression to ensure we are escaping all
         # characters properly.
         def normalize_key(key, options)
-          key = super
+          key = expand_and_namespace_key(key, options)
           if key
             key = key.dup.force_encoding(Encoding::ASCII_8BIT)
             key = key.gsub(ESCAPE_KEY_CHARS) { |match| "%#{match.getbyte(0).to_s(16).upcase}" }
-
-            if key.size > KEY_MAX_SIZE
-              key_separator = ":hash:"
-              key_hash = ActiveSupport::Digest.hexdigest(key)
-              key_trim_size = KEY_MAX_SIZE - key_separator.size - key_hash.size
-              key = "#{key[0, key_trim_size]}#{key_separator}#{key_hash}"
-            end
           end
-          key
+          truncate_key(key)
         end
 
         def deserialize_entry(payload, raw: false, **)

--- a/activesupport/lib/active_support/cache/redis_cache_store.rb
+++ b/activesupport/lib/active_support/cache/redis_cache_store.rb
@@ -35,9 +35,6 @@ module ActiveSupport
     #   +Redis::Distributed+ 4.0.1+ for distributed mget support.
     # * +delete_matched+ support for Redis KEYS globs.
     class RedisCacheStore < Store
-      # Keys are truncated with the Active Support digest if they exceed 1kB
-      MAX_KEY_BYTESIZE = 1024
-
       DEFAULT_REDIS_OPTIONS = {
         connect_timeout:    1,
         read_timeout:       1,
@@ -106,7 +103,6 @@ module ActiveSupport
           end
       end
 
-      attr_reader :max_key_bytesize
       attr_reader :redis
 
       # Creates a new Redis cache store.
@@ -169,7 +165,6 @@ module ActiveSupport
           @redis = self.class.build_redis(**redis_options)
         end
 
-        @max_key_bytesize = MAX_KEY_BYTESIZE
         @error_handler = error_handler
 
         super(universal_options)
@@ -433,21 +428,6 @@ module ActiveSupport
                 write_entry key, entry, **options
               end
             end
-          end
-        end
-
-        # Truncate keys that exceed 1kB.
-        def normalize_key(key, options)
-          truncate_key super&.b
-        end
-
-        def truncate_key(key)
-          if key && key.bytesize > max_key_bytesize
-            suffix = ":hash:#{ActiveSupport::Digest.hexdigest(key)}"
-            truncate_at = max_key_bytesize - suffix.bytesize
-            "#{key.byteslice(0, truncate_at)}#{suffix}"
-          else
-            key
           end
         end
 

--- a/activesupport/test/cache/behaviors/cache_store_behavior.rb
+++ b/activesupport/test/cache/behaviors/cache_store_behavior.rb
@@ -748,6 +748,20 @@ module CacheStoreBehavior
     assert_equal "bar", cache.read("foo")
   end
 
+  def test_max_key_size
+    cache = lookup_store(max_key_size: 64)
+    key = "foobar" * 20
+    cache.write(key, "bar")
+    assert_equal "bar", cache.read(key)
+  end
+
+  def test_max_key_size_disabled
+    cache = lookup_store(max_key_size: false)
+    key = "a" * 1000
+    cache.write(key, "bar")
+    assert_equal "bar", cache.read(key)
+  end
+
   private
     def with_raise_on_invalid_cache_expiration_time(new_value, &block)
       old_value = ActiveSupport::Cache::Store.raise_on_invalid_cache_expiration_time

--- a/activesupport/test/cache/stores/memory_store_test.rb
+++ b/activesupport/test/cache/stores/memory_store_test.rb
@@ -4,15 +4,13 @@ require_relative "../../abstract_unit"
 require "active_support/cache"
 require_relative "../behaviors"
 
-class MemoryStoreTest < ActiveSupport::TestCase
-  def setup
-    @cache = lookup_store(expires_in: 60)
-  end
-
+class StoreTest < ActiveSupport::TestCase
   def lookup_store(options = {})
     ActiveSupport::Cache.lookup_store(:memory_store, options)
   end
+end
 
+class MemoryStoreTest < StoreTest
   include CacheStoreBehavior
   include CacheStoreVersionBehavior
   include CacheStoreCoderBehavior
@@ -22,6 +20,10 @@ class MemoryStoreTest < ActiveSupport::TestCase
   include CacheIncrementDecrementBehavior
   include CacheInstrumentationBehavior
   include CacheLoggingBehavior
+
+  def setup
+    @cache = lookup_store(expires_in: 60)
+  end
 
   def test_increment_preserves_expiry
     @cache = lookup_store
@@ -92,7 +94,7 @@ class MemoryStoreTest < ActiveSupport::TestCase
     end
 end
 
-class MemoryStorePruningTest < ActiveSupport::TestCase
+class MemoryStorePruningTest < StoreTest
   def setup
     @record_size = ActiveSupport::Cache.lookup_store(:memory_store).send(:cached_size, 1, ActiveSupport::Cache::Entry.new("aaaaaaaaaa"))
     @cache = ActiveSupport::Cache.lookup_store(:memory_store, expires_in: 60, size: @record_size * 10 + 1)
@@ -158,7 +160,7 @@ class MemoryStorePruningTest < ActiveSupport::TestCase
     assert @cache.exist?(8)
     assert @cache.exist?(7)
     assert @cache.exist?(6)
-    assert_not @cache.exist?(5), "no entry"
+    assert @cache.exist?(5)
     assert_not @cache.exist?(4), "no entry"
     assert_not @cache.exist?(3), "no entry"
     assert_not @cache.exist?(2), "no entry"


### PR DESCRIPTION
When analyzing my project's cache store usage (we use redis), I noticed that 30% of the whole cache was used only by keys. I calculated, if we enforce the limit of 64 bytes, then the whole cache will become 15% smaller. There are some pretty large keys (in the order of hundreds of bytes). It will be tedious to ask people to fix their keys in all the places. Or introduce a monkey patch similar to this PR.

The approach used is similar to foreign keys naming scheme - truncate the key and append some digest of the rest to it.

Fortunately, in our codebase all the keys are prefixed with some unique identifiers that will help to find in the codebase where the key is set, so this approach will work perfectly.

<strike>It makes sense for me to only have this config for redis and memcache to reduce their memory usage, so I added this configuration only for them.</strike>

Example usage:
```ruby
# config/application.rb
config.cache_store = :redis_cache_store, { max_key_size: 64 }
``` 