### PR TITLE
Handle when `routes` object is explicitly called inside `config/application.rb`

### DIFF
--- a/railties/lib/rails/engine.rb
+++ b/railties/lib/rails/engine.rb
@@ -588,7 +588,22 @@ module Rails
     end
 
     initializer :make_routes_lazy, before: :bootstrap_hook do |app|
-      config.route_set_class = LazyRouteSet if Rails.env.local?
+      if Rails.env.local?
+        config.route_set_class = LazyRouteSet
+
+        # If routes already exists we duplicate it
+        if @routes
+          appends = @routes.instance_variable_get(:@append).dup
+          prepends = @routes.instance_variable_get(:@prepend).dup
+          default_url_options = @routes.default_url_options.dup
+
+          @routes = config.route_set_class.new_with_config(config)
+
+          @routes.instance_variable_set(:@append, appends)
+          @routes.instance_variable_set(:@prepend, prepends)
+          @routes.default_url_options = default_url_options
+        end
+      end
     end
 
     initializer :add_routing_paths do |app|

--- a/railties/lib/rails/engine.rb
+++ b/railties/lib/rails/engine.rb
@@ -587,25 +587,6 @@ module Rails
       config.eager_load_paths.freeze
     end
 
-    initializer :make_routes_lazy, before: :bootstrap_hook do |app|
-      if Rails.env.local?
-        config.route_set_class = LazyRouteSet
-
-        # If routes already exists we duplicate it
-        if @routes
-          appends = @routes.instance_variable_get(:@append).dup
-          prepends = @routes.instance_variable_get(:@prepend).dup
-          default_url_options = @routes.default_url_options.dup
-
-          @routes = config.route_set_class.new_with_config(config)
-
-          @routes.instance_variable_set(:@append, appends)
-          @routes.instance_variable_set(:@prepend, prepends)
-          @routes.default_url_options = default_url_options
-        end
-      end
-    end
-
     initializer :add_routing_paths do |app|
       routing_paths = paths["config/routes.rb"].existent
       external_paths = self.paths["config/routes"].paths

--- a/railties/lib/rails/engine/configuration.rb
+++ b/railties/lib/rails/engine/configuration.rb
@@ -44,7 +44,7 @@ module Rails
         @generators = app_generators.dup
         @middleware = Rails::Configuration::MiddlewareStackProxy.new
         @javascript_path = "javascript"
-        @route_set_class = ActionDispatch::Routing::RouteSet
+        @route_set_class = Rails.env.local? ? Rails::Engine::LazyRouteSet : ActionDispatch::Routing::RouteSet
         @default_scope = nil
 
         @autoload_paths = []

--- a/railties/test/engine/lazy_route_set_test.rb
+++ b/railties/test/engine/lazy_route_set_test.rb
@@ -52,6 +52,15 @@ module Rails
         assert_equal(200, response.first)
       end
 
+      test "app does not eager load routes when `routes` is explicily added in config/application.rb" do
+        add_to_config "config.exceptions_app = self.routes"
+        require "#{app_path}/config/environment"
+
+        @app = Rails.application
+
+        assert_not_operator(:root_path, :in?, app_url_helpers.methods)
+      end
+
       test "app lazily loads routes when polymorphic_url is called" do
         app_file "test/integration/my_test.rb", <<~RUBY
           require "test_helper"

--- a/railties/test/rails_info_controller_test.rb
+++ b/railties/test/rails_info_controller_test.rb
@@ -88,6 +88,7 @@ class InfoControllerTest < ActionController::TestCase
     assert_select("table tr") do
       assert_select("td", text: "test_nested_route_path")
       assert_select("td", text: "test/test#show")
+      assert_select("td", text: "#{__FILE__}:79")
     end
   end
 

--- a/railties/test/rails_info_controller_test.rb
+++ b/railties/test/rails_info_controller_test.rb
@@ -81,12 +81,13 @@ class InfoControllerTest < ActionController::TestCase
       get "/rails/info/routes" => "rails/info#routes"
     end
 
+    assert_kind_of(Rails::Engine::LazyRouteSet, Rails.application.routes)
+
     get :routes
 
     assert_select("table tr") do
       assert_select("td", text: "test_nested_route_path")
       assert_select("td", text: "test/test#show")
-      assert_select("td", text: "#{__FILE__}:79")
     end
   end
 


### PR DESCRIPTION
Related to https://github.com/rails/rails/pull/52353 cc @gmcgibbon 
More context here: https://github.com/rails/rails/pull/52353/files#r2041134698

## Motivation
I was investigating in my application why routes were loaded very early on. and I couldn't figure out why `LazyRouteSet` was never set on `config/route_set_class` then I realized that it was because of an explicit mention of `self.routes` inside of my `config/application.rb`

https://github.com/rails/rails/blob/b97917da8a801bf5360c3a9da913415bc8582735/railties/lib/rails/engine.rb#L544-L548

When it's first called, `config.route_set_class` is set to `ActionDispatch::Routing::RouteSet`
https://github.com/rails/rails/blob/b97917da8a801bf5360c3a9da913415bc8582735/railties/lib/rails/engine/configuration.rb#L47

The issue is that this initializer becomes useless, because it's already too late since `routes` was already initialized AND **memoized**
https://github.com/rails/rails/blob/b97917da8a801bf5360c3a9da913415bc8582735/railties/lib/rails/engine.rb#L590-L592

## Detail

I've created a failing test. one alternative is to wrap the explicit calls to `routes` in a `after_initialize`
```ruby
    config.after_initialize do
      config.exceptions_app = routes
    end
```
And update the docs ( https://guides.rubyonrails.org/configuring.html#config-exceptions-app ) accordingly

Or try to find a solution so that we duplicate the existing routes object inside the initializer
