### PR TITLE
Fix configuring `RedisCacheStore` with `raw: true`

### DIFF
--- a/activesupport/lib/active_support/cache.rb
+++ b/activesupport/lib/active_support/cache.rb
@@ -35,6 +35,7 @@ module ActiveSupport
       :race_condition_ttl,
       :serializer,
       :skip_nil,
+      :raw,
     ]
 
     # Mapping of canonical option names to aliases that a store will recognize.

--- a/activesupport/test/cache/behaviors/cache_store_behavior.rb
+++ b/activesupport/test/cache/behaviors/cache_store_behavior.rb
@@ -742,6 +742,12 @@ module CacheStoreBehavior
     end
   end
 
+  def test_configuring_store_with_raw
+    cache = lookup_store(raw: true)
+    cache.write("foo", "bar")
+    assert_equal "bar", cache.read("foo")
+  end
+
   private
     def with_raise_on_invalid_cache_expiration_time(new_value, &block)
       old_value = ActiveSupport::Cache::Store.raise_on_invalid_cache_expiration_time


### PR DESCRIPTION
It is currently not possible to configure redis cache store with `raw: true` (works for memcache store):

```ruby
c = ActiveSupport::Cache.lookup_store(:redis_cache_store, raw: true)
c.read("foo") # => raises 'unknown keyword: :raw (ArgumentError)'
```