### PR TITLE
Fix `find_or_create_by!` not checking owner persistence:

### DIFF
--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -274,8 +274,8 @@ module ActiveRecord
       with_connection do |connection|
         record = nil
         transaction(requires_new: true) do
-          record = new(attributes, &block)
-          record.save || raise(ActiveRecord::Rollback)
+          record = create(attributes, &block)
+          record._last_transaction_return_status || raise(ActiveRecord::Rollback)
         end
         record
       rescue ActiveRecord::RecordNotUnique
@@ -294,8 +294,8 @@ module ActiveRecord
       with_connection do |connection|
         record = nil
         transaction(requires_new: true) do
-          record = new(attributes, &block)
-          record.save! || raise(ActiveRecord::Rollback)
+          record = create!(attributes, &block)
+          record._last_transaction_return_status || raise(ActiveRecord::Rollback)
         end
         record
       rescue ActiveRecord::RecordNotUnique

--- a/activerecord/lib/active_record/transactions.rb
+++ b/activerecord/lib/active_record/transactions.rb
@@ -13,7 +13,7 @@ module ActiveRecord
                        scope: [:kind, :name]
     end
 
-    attr_accessor :_new_record_before_last_commit # :nodoc:
+    attr_accessor :_new_record_before_last_commit, :_last_transaction_return_status # :nodoc:
 
     # = Active Record \Transactions
     #
@@ -436,6 +436,7 @@ module ActiveRecord
           status = yield
           raise ActiveRecord::Rollback unless status
         end
+        @_last_transaction_return_status = status
         status
       end
     end
@@ -451,6 +452,7 @@ module ActiveRecord
       def init_internals
         super
         @_start_transaction_state = nil
+        @_last_transaction_status = nil
         @_committed_already_called = nil
         @_new_record_before_last_commit = nil
       end

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -26,6 +26,7 @@ require "models/reader"
 require "models/category"
 require "models/categorization"
 require "models/edge"
+require "models/wheel"
 require "models/subscriber"
 require "models/cpk"
 
@@ -1608,6 +1609,15 @@ class RelationTest < ActiveRecord::TestCase
 
       assert_instance_of(BrokenCar, car)
       assert_not_predicate(car, :persisted?)
+    end
+  end
+
+  def test_create_or_find_by_on_a_collections_rollbacks_a_transaction_when_owner_is_not_persisted
+    car = BrokenCar.create(name: "Civic")
+    assert_not_predicate(car, :persisted?)
+
+    assert_raises(ActiveRecord::RecordNotSaved) do
+      car.wheels.create_or_find_by!(size: 1500)
     end
   end
 


### PR DESCRIPTION
### Motivation / Background

Fix #54920

### Detail

#### Problem

In #54845, I modified a call to `Record#create` for `Record#new` followed by `Record#save`. I didn't seen that the behaviour between both is different on associations.

  https://github.com/rails/rails/blob/b97917da8a801bf5360c3a9da913415bc8582735/activerecord/lib/active_record/associations/collection_association.rb#L354-L356

```ruby
  car = Car.new
  car.wheels.create # Check if `car` is persisted before creating a wheel.

  wheel = car.wheels.new
  wheel.save # Doesn't check if `car` is persisted
```

#### Solution

The original reason why I modified `#create` is because it doesn't allow to get the result of the transaction status within a nested transaction. The documentation explains it and mention to raise a rollback so that the outer transaction sees it but it misses an important detail: 

**How to know whether something happened in the inner transaction since the Rollback error is silently swallowed.**
  https://github.com/rails/rails/blob/b97917da8a801bf5360c3a9da913415bc8582735/activerecord/lib/active_record/transactions.rb#L159-L165

The solution in this patch is to provide a flag on the record to know whether the last transaction was succesful.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
