### PR TITLE
Improve leap years counting performance in distance_of_time_in_words

### DIFF
--- a/actionview/lib/action_view/helpers/date_helper.rb
+++ b/actionview/lib/action_view/helpers/date_helper.rb
@@ -136,8 +136,15 @@ module ActionView
             from_year += 1 if from_time.month >= 3
             to_year = to_time.year
             to_year -= 1 if to_time.month < 3
-            leap_years = (from_year > to_year) ? 0 : (from_year..to_year).count { |x| Date.leap?(x) }
+
+            leap_years = if from_year > to_year
+              0
+            else
+              fyear = from_year - 1
+              (to_year / 4 - to_year / 100 + to_year / 400) - (fyear / 4 - fyear / 100 + fyear / 400)
+            end
             minute_offset_for_leap_year = leap_years * 1440
+
             # Discount the leap year days when calculating year distance.
             # e.g. if there are 20 leap year days between 2 dates having the same day
             # and month then based on 365 days calculation


### PR DESCRIPTION
### Motivation / Background

The `distance_of_time_in_words` function can lead to a denial of service if the given `from_time` and `to_time` arguments are far apart. I replaced the concerning code with a constant calculation.

### Detail

The `distance_of_time_in_words` function counts the leap years by using a range and the `count` function:

```
  def distance_of_time_in_words(from_time, to_time = 0, options = {})
    # ...    
    leap_years = (from_year > to_year) ? 0 : (from_year..to_year).count { |x| Date.leap?(x) }
    # ...    
```

This code can lead to a denial of service if `from_year` and `to_year` are far apart, as it iterates over a range generated from the difference of the two arguments, effectively blocking execution. I replaced the code with the following, which calculates the leap years in constant time:

```
    leap_years_up_to = ->(year) { (year / 4) - (year / 100) + (year / 400) }
    leap_years = (from_year > to_year) ? 0 : leap_years_up_to.call(to_year) - leap_years_up_to.call(from_year - 1)
```

This particular case may seem irrelevant at first, but I discovered this problem in a project of mine. Users who are able to set a timestamp can easily trigger this problem when the timestamp is passed somewhere to the `distance_of_time_in_words` function.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
