### PR TITLE
Fallback to application/octet-stream content-type when a invalid multipart request is received:

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Sending a invalid multipart request will no longer present a 500 error to the user.
+
+    For applications using `Rails.application.routes` as their `exceptions_app`,
+    an invalid `multipart/form-data` request would present the 500 error page,
+    instead of routing it to the "/400" endpoint.
+
+    *Edouard Chin*
+
 *   Include cookie name when calculating maximum allowed size.
 
     *Hartley McGuire*


### PR DESCRIPTION
### Motivation / Background

Fix #54096

### Detail

#### Problem

When an application uses the `routes` object as its exceptions app, then it can't rescue invalid multipart requests, resulting in a 500 instead of gracefully show a 400.

```ruby
# config/application.rb
config.exceptions_app = routes

# Browser request
post "/send_photo", { "CONTENT_TYPE" => "multipart/form-data; boundary=..." }
# The 500 page is displayed to the user as there is no parts in the body.
```

#### Details

When sending a `multipart/form-data` request, the [RFC](https://tools.ietf.org/html/rfc2046#section-5.1) mentions that the body must contain one or more valid body parts.
If the body contains invalid parts or no parts at all, Rack raises a EOFError.

Rails rescue that error and raises a `BadRequest` instead.
https://github.com/rails/rails/blob/73761aae49cbefd4d825a7071f0a2fd215ad9740/actionpack/lib/action_dispatch/http/request.rb#L437-L438

When Rails calls the `routes` exceptions app, the same codepath is called again and the exception is raised again, this time not caught, resulting in a 500.

I originally figured that this should be handled by the application and create a wrapper around `routes` to rescue this, but we fixed 2 similar issues: #43094 and #51228.

#### Solution

Fallback to a text/html request.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
