### PR TITLE
Add referential integrity note in AR::FixtureSet docs [ci skip]

### DIFF
--- a/activerecord/lib/active_record/fixtures.rb
+++ b/activerecord/lib/active_record/fixtures.rb
@@ -80,6 +80,8 @@ module ActiveRecord
   #
   # The testing environment will automatically load all the fixtures into the database before each
   # test. To ensure consistent data, the environment deletes the fixtures before running the load.
+  # During this deletion and insertion of fixtures before each test, the environment temporarily
+  # disables the database's referential integrity constraints.
   #
   # In addition to being available in the database, the fixture's data may also be accessed by
   # using a special dynamic method, which has the same name as the model.


### PR DESCRIPTION
### Motivation / Background

This PR adds a note into the `ActiveRecord::FixtureSet` API docs to give more visibility to the mechanism Rails uses when deleting/inserting fixtures before each test. Rails disables referential integrity constraints for it, so the data can be loaded in different order than required by their FKs dependencies. This Rails mechanism is so natural once you're aware about it, but it can catch some developers off-guard — it could lead to "non-integral" data in the test suite.

For example, in PostgreSQL, users who implemented custom checks via DB triggers can find their business rules bypassed during fixture loading ([Rails executes `ALTER TABLE ... DISABLE TRIGGER ALL`](https://github.com/rails/rails/blob/1ac40035478cba2e21d698ffa57b43355f5bed7b/activerecord/lib/active_record/connection_adapters/postgresql/referential_integrity.rb#L7-L39)). Rails gracefully [verifies FK constraints later on](https://github.com/rails/rails/blob/1ac40035478cba2e21d698ffa57b43355f5bed7b/activerecord/lib/active_record/connection_adapters/postgresql/referential_integrity.rb#L41-L65), if the config [`config.active_record.verify_foreign_keys_for_fixtures`](https://guides.rubyonrails.org/configuring.html#config-active-record-verify-foreign-keys-for-fixtures) is enabled, but other triggers would remain bypassed.

In MySQL, the functionality to verify FKs via `config.active_record.verify_foreign_keys_for_fixtures` is pending to be implemented. So the test DB could end up with non integral FKs.

### Additional information

- Note that the guides have [a mention about this particularity](https://github.com/rails/rails/blob/1ac40035478cba2e21d698ffa57b43355f5bed7b/guides/source/testing.md?plain=1#L761-L767), probably that's fine enough? What's not mentioned anywhere afaik is the existence of `config.active_record.verify_foreign_keys_for_fixtures`, except in [the config docs themselves](https://guides.rubyonrails.org/configuring.html#config-active-record-verify-foreign-keys-for-fixtures). Perhaps I should add that to my doc addition?
- Instead of just this note, a `== Referential Integrity` section at the bottom of the `ActiveRecord::FixtureSet` class documentation would be an option also. But perhaps it's too much noise. All the docs are very positive-oriented, and somehow this referential integrity topic is slightly be-careful-oriented, which I don't love. That's why I opted for just a very subtle awareness-oriented note: "Rails does this". That should ring a bell to those using PG triggers for example.