### PR TITLE
Action Cable: Allow setting nil as subscription connection identifier for Redis

### DIFF
--- a/actioncable/CHANGELOG.md
+++ b/actioncable/CHANGELOG.md
@@ -1,2 +1,5 @@
+*   Allow setting nil as subscription connection identifier for Redis.
+
+    *Nguyen Nguyen*
 
 Please check [8-0-stable](https://github.com/rails/rails/blob/8-0-stable/actioncable/CHANGELOG.md) for previous changes.

--- a/actioncable/lib/action_cable/subscription_adapter/base.rb
+++ b/actioncable/lib/action_cable/subscription_adapter/base.rb
@@ -29,7 +29,8 @@ module ActionCable
       end
 
       def identifier
-        @server.config.cable[:id] ||= "ActionCable-PID-#{$$}"
+        @server.config.cable[:id] = "ActionCable-PID-#{$$}" unless @server.config.cable.key?(:id)
+        @server.config.cable[:id]
       end
     end
   end

--- a/actioncable/test/subscription_adapter/redis_test.rb
+++ b/actioncable/test/subscription_adapter/redis_test.rb
@@ -113,6 +113,16 @@ class RedisAdapterTest::ConnectorCustomID < RedisAdapterTest::ConnectorDefaultID
   end
 end
 
+class RedisAdapterTest::ConnectorCustomIDNil < RedisAdapterTest::ConnectorDefaultID
+  def cable_config
+    super.merge(id: connection_id)
+  end
+
+  def connection_id
+    nil
+  end
+end
+
 class RedisAdapterTest::ConnectorWithExcluded < RedisAdapterTest::ConnectorDefaultID
   def cable_config
     super.merge(adapter: "redis", channel_prefix: "custom")


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX19eqj6uP10u4bBkn7Pv3QGVjjxe02jp4is%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://moontower.gitstream.cm/v2/badge/collaboration-page?magicLinkId=f3nHQXY)

<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

I ran into the same issue as https://github.com/rails/rails/issues/38244. Google Cloud Memorystore and some other platforms block the command `CLIENT SETNAME` in redis so I need to set `id` to `nil`. I think it would be nice to be able to set `id: nil` in the config file instead of overwriting the redis connections factory as suggested [here](https://github.com/rails/rails/issues/38244#issuecomment-575454444) since people won't have to check if their overwritten method needs to be updated whenever they upgrade rails.



### Detail

- Check if `@server.config.cable[:id]` is already `nil` and don't fallback with `||=`
- Setting `identifier` to `nil` won't work for postgres since `pg_conn.escape_identifier(identifier)` can't convert `nil` to a string so this change is only for Redis

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
