### PR TITLE
[ci skip] Fix rails' guides dropdown when navigating with browser back button

### DIFF
--- a/guides/assets/javascripts/guides.js
+++ b/guides/assets/javascripts/guides.js
@@ -79,13 +79,6 @@
     // pressing escape, which is the standard key to collapse expanded elements.
     var guidesMenuButton = document.getElementById("guides-menu-button");
 
-    // The link is now acting as a button (but still allows for open in new tab).
-    guidesMenuButton.setAttribute('role', 'button')
-    guidesMenuButton.setAttribute('aria-controls', guidesMenuButton.getAttribute('data-aria-controls'));
-    guidesMenuButton.setAttribute('aria-expanded', guidesMenuButton.getAttribute('data-aria-expanded'));
-    guidesMenuButton.removeAttribute('data-aria-controls');
-    guidesMenuButton.removeAttribute('data-aria-expanded');
-
     var guides = document.getElementById(
       guidesMenuButton.getAttribute("aria-controls")
     );

--- a/guides/source/layout.html.erb
+++ b/guides/source/layout.html.erb
@@ -78,7 +78,7 @@
         <ul class="nav">
           <li><a class="nav-item" id="home_nav" href="https://rubyonrails.org/">Home</a></li>
           <li class="guides-index guides-index-large">
-            <a href="index.html" id="guides-menu-button" data-aria-controls="guides" data-aria-expanded="false" class="guides-index-item nav-item">Guides Index</a>
+            <a href="index.html" id="guides-menu-button" role="button" aria-controls="guides" aria-expanded="false" class="guides-index-item nav-item">Guides Index</a>
             <div id="guides" class="clearfix" style="display: none;">
               <hr />
               <dl class="guides-section-container">
@@ -161,6 +161,7 @@
               documentation is very welcome on the <%= link_to 'official Ruby on Rails Forum', 'https://discuss.rubyonrails.org/c/rubyonrails-docs' %>.
             </p>
           </footer>
+        </div>
       </div>
     </article>
   </main>


### PR DESCRIPTION
- Removes *potentially* unnecessary js from the code
- Closes a div in the layout file

### Motivation / Background

There is an issue with the guide index not opening after navigating through history. I've provided a video below of the issue.

https://github.com/user-attachments/assets/f824df30-c0a8-4a04-a8d6-1bf9d106b734

This Pull Request has been created because the guides index was not working in this scenario.

### Detail

This Pull Request changes 
- Removes setting and removing of attributes in the JS code

The main issue is that because we set the aria attributes based off of psuedo aria attributes i.e. data-aria-expanded and then remove the psuedo aria attributes we have no way to set the actual aria attributes that are referenced throughout the code when navigating through partial refreshes. From my understanding, hotwire is being used for the main content frames, but the guides index is in the layout so we'll never see that HTML refresh unless a full reload is requested. Therefore, once those attributes are removed we have no way to select the guides dropdown from that point on.

I removed setting and adding of the attributes because from my perspective I don't see it as necessary since the original data-aria attributes are being statically set in the index.html.erb file and then we set the attributes on DOMContentLoad/Turbo load event, which in this case is roughly doing the same thing. 

My only assumption of why it was written that way is because you want it to act as a link to the index of the guides page, but also act as a dropdown. That isn't how it is working today, so there shouldn't be any regression in functionality. If we wanted that functionality, we may want to change how that is done. For accessibility, we'd probably want to keep it as a button and have the index/home page be listed along side the guides.

https://github.com/user-attachments/assets/7cc86774-0dd1-4393-9bac-326a1d0c2e3e

Alternatively if we don't want these changes, I'd suggest we just do something that checks if the aria attributes are present first and use those otherwise use the psuedo attributes. That may be the easier solution, but I'm wondering if this is working as intended in production.



