### PR TITLE
Docs: Action Text clarification for getting images to work [ci skip]

### DIFF
--- a/guides/source/getting_started.md
+++ b/guides/source/getting_started.md
@@ -1795,6 +1795,8 @@ this rich text in the text area.
 
 Check out the [Action Text Overview](action_text_overview.html) to learn more.
 
+NOTE: The [Attachments](https://guides.rubyonrails.org/action_text_overview.html#attachments) section on Active Storage dependencies explains what to install to render images through Action Text.
+
 File Uploads with Active Storage
 --------------------------------
 


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because the guide doesn't mention that [libvips](https://github.com/libvips/libvips) is required at the system level in order for images to render through Action Text fields. The reader needs to be nudged to look at the Active Storage section of the Action Text Overview guide if they want to render images.

Working through the Rails _Getting Started_ guide sequentially, I found myself wondering if there was a bug in the docs or the frameworks because Section [14. File Uploads with Active Storage](https://guides.rubyonrails.org/getting_started.html#file-uploads-with-active-storage) encourages use of images in Action Text fields:

> Try editing a product and dragging an image into the rich text editor, then update the record. You'll see that Rails uploads this image and renders it inside the rich text editor. Cool, right?!

Following along diligently from the very beginning of the guide, when I got to this point, the image was rendering in the _edit_ and _new_ actions, but was rendering a broken image symbol in the _show_ action. 

Only after a lot of searching and AI prompting, did I try a `brew install vips` command and got it all working.

The earlier suggestion in the docs to see the Action Text Overview: 

> Check out the [Action Text Overview](https://guides.rubyonrails.org/action_text_overview.html) to learn more.

is insufficient to preempt this confusion. That line doesn't clarify that one would _need_ to look through that for critical dependencies in order to get subsequent suggested behaviours to work.

### Detail

This Pull Request adds the tip:

> The [Attachments](https://guides.rubyonrails.org/action_text_overview.html#attachments) section on Active Storage dependencies explains what to install to render images through Action Text.

At the end of the section [13. Rich Text Fields with Action Text](https://guides.rubyonrails.org/getting_started.html#rich-text-fields-with-action-text).

### Additional information

This applies to 8‑0‑stable as well; feel free to back‑port.

#### My Background

I was an active Rails developer from 2007 to 2013. Re-learning the framework after a 12-year hiatus, I was struggling with this issue because the docs implied images should work. This is why I've suggested this pull request. I'm working in Rails 8.0.2.



