### PR TITLE
Add assert_in_body/assert_not_in_body

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add assert_in_body/assert_not_in_body as the simplest way to check if a piece of text is in the response body.
+
+    *DHH*
+
 *   Include cookie name when calculating maximum allowed size.
 
     *Hartley McGuire*

--- a/actionpack/lib/action_dispatch/testing/assertions/response.rb
+++ b/actionpack/lib/action_dispatch/testing/assertions/response.rb
@@ -71,6 +71,20 @@ module ActionDispatch
         assert_operator redirect_expected, :===, redirect_is, message
       end
 
+      # Asserts that the given +text+ is present somewhere in the response body.
+      #
+      #     assert_in_body fixture(:name).description
+      def assert_in_body(text)
+        assert_match /#{text}/, @response.body
+      end
+
+      # Asserts that the given +text+ is not present anywhere in the response body.
+      #
+      #     assert_not_in_body fixture(:name).description
+      def assert_not_in_body(text)
+        assert_no_match /#{text}/, @response.body
+      end
+
       private
         # Proxy to to_param if the object will respond to it.
         def parameterize(value)

--- a/actionpack/lib/action_dispatch/testing/assertions/response.rb
+++ b/actionpack/lib/action_dispatch/testing/assertions/response.rb
@@ -75,14 +75,14 @@ module ActionDispatch
       #
       #     assert_in_body fixture(:name).description
       def assert_in_body(text)
-        assert_match /#{text}/, @response.body
+        assert_match(/#{text}/, @response.body)
       end
 
       # Asserts that the given +text+ is not present anywhere in the response body.
       #
       #     assert_not_in_body fixture(:name).description
       def assert_not_in_body(text)
-        assert_no_match /#{text}/, @response.body
+        assert_no_match(/#{text}/, @response.body)
       end
 
       private

--- a/actionpack/lib/action_dispatch/testing/assertions/response.rb
+++ b/actionpack/lib/action_dispatch/testing/assertions/response.rb
@@ -75,14 +75,14 @@ module ActionDispatch
       #
       #     assert_in_body fixture(:name).description
       def assert_in_body(text)
-        assert_match(/#{text}/, @response.body)
+        assert_match(/#{Regexp.escape(text)}/, @response.body)
       end
 
       # Asserts that the given +text+ is not present anywhere in the response body.
       #
       #     assert_not_in_body fixture(:name).description
       def assert_not_in_body(text)
-        assert_no_match(/#{text}/, @response.body)
+        assert_no_match(/#{Regexp.escape(text)}/, @response.body)
       end
 
       private

--- a/actionpack/test/controller/action_pack_assertions_test.rb
+++ b/actionpack/test/controller/action_pack_assertions_test.rb
@@ -496,6 +496,12 @@ class ActionPackAssertionsControllerTest < ActionController::TestCase
     assert_response 500
     assert_equal "Boom", response.body
   end
+
+  def test_assert_in_body
+    post :raise_exception_on_get
+    assert_in_body "request method: POST"
+    assert_not_in_body "request method: GET"
+  end
 end
 
 class ActionPackHeaderTest < ActionController::TestCase


### PR DESCRIPTION
As a simple encapsulation of checking a response body for a piece of text without having to go through a heavy-duty DOM operation.
