### PR TITLE
Pass existing connection to #arel in #to_sql

### DIFF
--- a/activerecord/lib/active_record/associations/join_dependency/join_association.rb
+++ b/activerecord/lib/active_record/associations/join_dependency/join_association.rb
@@ -53,7 +53,7 @@ module ActiveRecord
               end
             end
 
-            arel = scope.arel(alias_tracker.aliases)
+            arel = scope.arel(aliases: alias_tracker.aliases)
             nodes = arel.constraints.first
 
             if nodes.is_a?(Arel::Nodes::And)

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -628,14 +628,13 @@ module ActiveRecord
         arel = eager_loading? ? apply_join_dependency.arel : build_arel(c)
         arel.source.left = table
 
-        group_values_arel_columns = arel_columns(group_values.uniq)
         having_clause_ast = having_clause.ast unless having_clause.empty?
         key = if model.composite_primary_key?
           primary_key.map { |pk| table[pk] }
         else
           table[primary_key]
         end
-        stmt = arel.compile_update(values, key, having_clause_ast, group_values_arel_columns)
+        stmt = arel.compile_update(values, key, having_clause_ast)
         c.update(stmt, "#{model} Update All").tap { reset }
       end
     end
@@ -1045,14 +1044,13 @@ module ActiveRecord
         arel = eager_loading? ? apply_join_dependency.arel : build_arel(c)
         arel.source.left = table
 
-        group_values_arel_columns = arel_columns(group_values.uniq)
         having_clause_ast = having_clause.ast unless having_clause.empty?
         key = if model.composite_primary_key?
           primary_key.map { |pk| table[pk] }
         else
           table[primary_key]
         end
-        stmt = arel.compile_delete(key, having_clause_ast, group_values_arel_columns)
+        stmt = arel.compile_delete(key, having_clause_ast)
 
         c.delete(stmt, "#{model} Delete All").tap { reset }
       end

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -628,13 +628,12 @@ module ActiveRecord
         arel = eager_loading? ? apply_join_dependency.arel : build_arel(c)
         arel.source.left = table
 
-        having_clause_ast = having_clause.ast unless having_clause.empty?
         key = if model.composite_primary_key?
           primary_key.map { |pk| table[pk] }
         else
           table[primary_key]
         end
-        stmt = arel.compile_update(values, key, having_clause_ast)
+        stmt = arel.compile_update(values, key)
         c.update(stmt, "#{model} Update All").tap { reset }
       end
     end
@@ -1044,13 +1043,12 @@ module ActiveRecord
         arel = eager_loading? ? apply_join_dependency.arel : build_arel(c)
         arel.source.left = table
 
-        having_clause_ast = having_clause.ast unless having_clause.empty?
         key = if model.composite_primary_key?
           primary_key.map { |pk| table[pk] }
         else
           table[primary_key]
         end
-        stmt = arel.compile_delete(key, having_clause_ast)
+        stmt = arel.compile_delete(key)
 
         c.delete(stmt, "#{model} Delete All").tap { reset }
       end

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -625,7 +625,7 @@ module ActiveRecord
       end
 
       model.with_connection do |c|
-        arel = eager_loading? ? apply_join_dependency.arel : build_arel(c)
+        arel = eager_loading? ? apply_join_dependency.arel : arel(c)
         arel.source.left = table
 
         key = if model.composite_primary_key?
@@ -1040,7 +1040,7 @@ module ActiveRecord
       end
 
       model.with_connection do |c|
-        arel = eager_loading? ? apply_join_dependency.arel : build_arel(c)
+        arel = eager_loading? ? apply_join_dependency.arel : arel(c)
         arel.source.left = table
 
         key = if model.composite_primary_key?
@@ -1233,7 +1233,7 @@ module ActiveRecord
         end
       else
         model.with_connection do |conn|
-          conn.unprepared_statement { conn.to_sql(arel) }
+          conn.unprepared_statement { conn.to_sql(arel(conn)) }
         end
       end
     end

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -1591,8 +1591,12 @@ module ActiveRecord
     end
 
     # Returns the Arel object associated with the relation.
-    def arel(aliases = nil) # :nodoc:
-      @arel ||= with_connection { |c| build_arel(c, aliases) }
+    def arel(conn = nil, aliases: nil) # :nodoc:
+      @arel ||= if conn
+        build_arel(conn, aliases)
+      else
+        with_connection { |c| build_arel(c, aliases) }
+      end
     end
 
     def construct_join_dependency(associations, join_type) # :nodoc:

--- a/activerecord/lib/arel/crud.rb
+++ b/activerecord/lib/arel/crud.rb
@@ -17,8 +17,7 @@ module Arel # :nodoc: all
     def compile_update(
       values,
       key = nil,
-      having_clause = nil,
-      group_values_columns = []
+      having_clause = nil
     )
       um = UpdateManager.new(source)
       um.set(values)
@@ -28,19 +27,19 @@ module Arel # :nodoc: all
       um.wheres = constraints
       um.key = key
 
-      um.group(group_values_columns) unless group_values_columns.empty?
+      um.ast.groups = @ctx.groups
       um.having(having_clause) unless having_clause.nil?
       um
     end
 
-    def compile_delete(key = nil, having_clause = nil, group_values_columns = [])
+    def compile_delete(key = nil, having_clause = nil)
       dm = DeleteManager.new(source)
       dm.take(limit)
       dm.offset(offset)
       dm.order(*orders)
       dm.wheres = constraints
       dm.key = key
-      dm.group(group_values_columns) unless group_values_columns.empty?
+      dm.ast.groups = @ctx.groups
       dm.having(having_clause) unless having_clause.nil?
       dm
     end

--- a/activerecord/lib/arel/crud.rb
+++ b/activerecord/lib/arel/crud.rb
@@ -14,11 +14,7 @@ module Arel # :nodoc: all
       InsertManager.new
     end
 
-    def compile_update(
-      values,
-      key = nil,
-      having_clause = nil
-    )
+    def compile_update(values, key = nil)
       um = UpdateManager.new(source)
       um.set(values)
       um.take(limit)
@@ -28,11 +24,11 @@ module Arel # :nodoc: all
       um.key = key
 
       um.ast.groups = @ctx.groups
-      um.having(having_clause) unless having_clause.nil?
+      @ctx.havings.each { |h| um.having(h) }
       um
     end
 
-    def compile_delete(key = nil, having_clause = nil)
+    def compile_delete(key = nil)
       dm = DeleteManager.new(source)
       dm.take(limit)
       dm.offset(offset)
@@ -40,7 +36,7 @@ module Arel # :nodoc: all
       dm.wheres = constraints
       dm.key = key
       dm.ast.groups = @ctx.groups
-      dm.having(having_clause) unless having_clause.nil?
+      @ctx.havings.each { |h| dm.having(h) }
       dm
     end
   end


### PR DESCRIPTION
Ref #54943 

[Don't recalculate GROUP BY in {update,delete}_all](https://github.com/rails/rails/commit/e0d14918643cb9121f33aeb49c8cdb1445c7252e)

These values are already calculated when building the SelectManager
arel, so we can use them instead of recalculating/rebuilding them.
Specifically, this prevents calling `arel_columns` after building the
relation, which opens up the possibility to cache the built Arel ast. It
couldn't be cached before because `arel_columns` may modify the
relation.

Going through the {Update,Delete}Manager's ast in `Crud` is necessary to
prevent `Group(Group(SQL))` because `#group` will wrap its arguments in
`Group` nodes.

---

[Don't recalculate HAVING in {update,delete}_all](https://github.com/rails/rails/commit/019f16239aa8000a700ddaac4dff89da091605a2)

These values are already calculated when building the SelectManager
arel, so we can use theminstead of recalculating/rebuilding them.

---

[Pass existing connection to #arel in #to_sql](https://github.com/rails/rails/commit/6ff9e82e4774d494298d6bfca2ceebe92aec64a1)

This prevents having to do another connection lookup when manually
generating SQL for a Relation.

Additionally, by adding a connection parameter to `#arel` the
`{update,delete}_all` methods can now go through `#arel` instead of
`#build_arel`. This prevents having to rebuild the Arel AST in cases
where a relation is re-used for querying after calling
`{update,delete}_all`.