### PR TITLE
Allow `direct` and `resolve` in engine routes at the root level

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Allow `direct` and `resolve` in engine routes at the root level
+
+    The detection of being at the root level of an engine's routeset was failing because an isolated engine
+    would always have a default scope for the module and would call the `with_default_scope` method causing
+    it to be always one level down. Fix the problem by initializing the root scope with the default scope so
+    there's no need to call the `with_default_scope` method.
+
+    *Andrew White*
+
 *   Add assert_in_body/assert_not_in_body as the simplest way to check if a piece of text is in the response body.
 
     *DHH*

--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -2528,11 +2528,15 @@ module ActionDispatch
 
       DEFAULT = Object.new # :nodoc:
 
-      def initialize(set) # :nodoc:
+      def initialize(set, scope = nil) # :nodoc:
         @set = set
         @draw_paths = set.draw_paths
-        @scope = Scope.new(path_names: @set.resources_path_names)
         @concerns = {}
+
+        hash = { path_names: @set.resources_path_names }
+        hash.merge!(scope) unless scope.nil?
+
+        @scope = Scope.new(hash)
       end
 
       include Base

--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -472,12 +472,7 @@ module ActionDispatch
       end
 
       def eval_block(block)
-        mapper = Mapper.new(self)
-        if default_scope
-          mapper.with_default_scope(default_scope, &block)
-        else
-          mapper.instance_exec(&block)
-        end
+        Mapper.new(self, default_scope).instance_exec(&block)
       end
       private :eval_block
 


### PR DESCRIPTION
### Motivation / Background

The detection of being at the root level of an engine's routeset was failing because an isolated engine would always have a default scope for the module and would call the `with_default_scope` method causing it to be always one level down. 

### Detail

This pull request fixes the problem by initializing the root scope with the default scope so there's no need to call the `with_default_scope` method.

### Additional information

This is the first stage in an attempt to fix #31325. The complete fix would require the `main_app` mounted helper to be present in the context of the block passed to `resolve` so an engine author could do this:

``` ruby
ShopApp::Engine.routes.draw do
  resolve("ActiveStorage::Blob") do |blob, options|
    main_app.route_for(ActiveStorage.resolve_model_to_route, blob, options)
  end
end
```

However that is currently not the case and it should be done in a different PR since this change is worthwhile outside of the context of the above issue.

### Checklist

* [x] This Pull Request is related to one change
* [x] Commit message has a detailed description of what changed and why
* [x] Tests are added or updated
* [x] CHANGELOG files are updated for the changed libraries
