### PR TITLE
fix show exception backtrace if backtrace_locations is empty

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/exception_wrapper.rb
+++ b/actionpack/lib/action_dispatch/middleware/exception_wrapper.rb
@@ -52,7 +52,7 @@ module ActionDispatch
       @exception_class_name = exception.class.name
       @wrapped_causes = wrapped_causes_for(exception, backtrace_cleaner)
       @exception = exception
-      if exception.is_a?(SyntaxError)
+      if exception.is_a?(SyntaxError) || !exception.backtrace_locations
         @exception = ActiveSupport::SyntaxErrorProxy.new(exception)
       end
       @backtrace = build_backtrace

--- a/actionpack/lib/action_dispatch/middleware/exception_wrapper.rb
+++ b/actionpack/lib/action_dispatch/middleware/exception_wrapper.rb
@@ -262,10 +262,13 @@ module ActionDispatch
 
         backtrace_locations =
           @exception.backtrace_locations ||
-            @exception.backtrace.map do |trace|
-            file, line = trace.match(/^(.+?):(\d+).*$/, &:captures) || trace
-            ActiveSupport::SyntaxErrorProxy::BacktraceLocation.new(file, line.to_i, trace)
-          end
+            @exception.backtrace&.filter_map do |trace|
+              next if trace.start_with?("(eval")
+              file, line = trace.match(/^(.+?):(\d+).*$/, &:captures)
+              ActiveSupport::SyntaxErrorProxy::BacktraceLocation.new(file, line.to_i, trace)
+            end
+
+        return [] unless backtrace_locations
 
         backtrace_locations.map do |loc|
           if built_methods.key?(loc.base_label)

--- a/activesupport/lib/active_support/syntax_error_proxy.rb
+++ b/activesupport/lib/active_support/syntax_error_proxy.rb
@@ -45,7 +45,7 @@ module ActiveSupport
           # proxy object that's generating these
         } + orig.map { |loc| BacktraceLocationProxy.new(loc, self) }
       else
-        backtrace.map do |trace|
+        exception.backtrace&.map do |trace|
           file, line = trace.match(/^(.+?):(\d+).*$/, &:captures) || trace
           BacktraceLocation.new(file, line.to_i, trace)
         end

--- a/activesupport/lib/active_support/syntax_error_proxy.rb
+++ b/activesupport/lib/active_support/syntax_error_proxy.rb
@@ -35,21 +35,15 @@ module ActiveSupport
     end
 
     def backtrace_locations
-      orig = super
-      if orig
-        parse_message_for_trace.map { |trace|
-          file, line = trace.match(/^(.+?):(\d+).*$/, &:captures) || trace
-          BacktraceLocation.new(file, line.to_i, trace)
-          # We have to wrap these backtrace locations because we need the
-          # spot information to come from the originating exception, not the
-          # proxy object that's generating these
-        } + orig.map { |loc| BacktraceLocationProxy.new(loc, self) }
-      else
-        exception.backtrace&.map do |trace|
-          file, line = trace.match(/^(.+?):(\d+).*$/, &:captures) || trace
-          BacktraceLocation.new(file, line.to_i, trace)
-        end
-      end
+      return nil if super.nil?
+
+      parse_message_for_trace.map { |trace|
+        file, line = trace.match(/^(.+?):(\d+).*$/, &:captures) || trace
+        BacktraceLocation.new(file, line.to_i, trace)
+        # We have to wrap these backtrace locations because we need the
+        # spot information to come from the originating exception, not the
+        # proxy object that's generating these
+      } + super.map { |loc| BacktraceLocationProxy.new(loc, self) }
     end
 
     private

--- a/activesupport/lib/active_support/syntax_error_proxy.rb
+++ b/activesupport/lib/active_support/syntax_error_proxy.rb
@@ -48,7 +48,7 @@ module ActiveSupport
 
     private
       def parse_message_for_trace
-        if __getobj__.to_s.start_with?("(eval")
+        if __getobj__.to_s.start_with?("(eval") && __getobj__.backtrace_locations
           # If the exception is coming from a call to eval, we need to keep
           # the path of the file in which eval was called to ensure we can
           # return the right source fragment to show the location of the


### PR DESCRIPTION
### Motivation / Background

Some gems (or code in the app) in a `rescue` block create new errors, passing the backtrace, but the `backtrace_locations` will be empty.

This makes it impossible to understand where the error occurred, increasing debugging difficulties.

Currently, for some errors, only the error name is shown without a backtrace.

### Detail

#### some problems gems
[redis-rb 1](https://github.com/redis/redis-rb/blob/317a0204d8361927757117845f825b42c26fac14/lib/redis/client.rb#L35)
[redis-rb 2](https://github.com/redis/redis-rb/blob/317a0204d8361927757117845f825b42c26fac14/cluster/lib/redis/cluster/client.rb#L32)


[redis-client 1](https://github.com/redis-rb/redis-client/blob/0acc9184f066ec3ebbe3335a922a7ff35a5e2152/lib/redis_client/ruby_connection.rb#L159)
[redis-client 2](https://github.com/redis-rb/redis-client/blob/0acc9184f066ec3ebbe3335a922a7ff35a5e2152/lib/redis_client.rb#L808)

#### example for emulate nil backtrace_locations

```ruby

require 'json'

NewError = Class.new(StandardError)

def parse_payload(text)
  JSON.parse(text)
rescue JSON::ParserError => ex
  raise NewError, "error", ex.backtrace
  # only ruby 3.4 support backtrace_locations as 3-th arg
  # raise NewError, "error", ex.backtrace_locations
end

begin
  parse_payload('{"wrong: "json"')
rescue => ex
  p ex.backtrace.size # => 4
  p ex.backtrace_locations&.size # => nil
end
```

https://docs.ruby-lang.org/en/3.4/Exception.html#method-i-set_backtrace