### PR TITLE
Allow BacktraceCleaner to log backtraces of files in the app's tmp dir

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Allow BacktraceCleaner to present backtraces of files in the project tmp dir
+
+    *TheNotary*
+
 *   Add RuboCop cache restoration to RuboCop job in GitHub Actions workflow templates.
 
     *Lovro Bikić*

--- a/railties/lib/rails/backtrace_cleaner.rb
+++ b/railties/lib/rails/backtrace_cleaner.rb
@@ -5,7 +5,7 @@ require "active_support/core_ext/string/access"
 
 module Rails
   class BacktraceCleaner < ActiveSupport::BacktraceCleaner # :nodoc:
-    APP_DIRS_PATTERN = /\A(?:\.\/)?(?:app|config|lib|test|tmp|\(\w+(?:-\w+)*\))/
+    APP_DIRS_PATTERN = /\A(?:\.\/)?(?:app|config|lib|test|tmp|db|\(\w+(?:-\w+)*\))/
     RENDER_TEMPLATE_PATTERN = /:in [`'].*_\w+_{2,3}\d+_\d+'/
 
     def initialize

--- a/railties/lib/rails/backtrace_cleaner.rb
+++ b/railties/lib/rails/backtrace_cleaner.rb
@@ -5,7 +5,7 @@ require "active_support/core_ext/string/access"
 
 module Rails
   class BacktraceCleaner < ActiveSupport::BacktraceCleaner # :nodoc:
-    APP_DIRS_PATTERN = /\A(?:\.\/)?(?:app|config|lib|test|\(\w+(?:-\w+)*\))/
+    APP_DIRS_PATTERN = /\A(?:\.\/)?(?:app|config|lib|test|tmp|\(\w+(?:-\w+)*\))/
     RENDER_TEMPLATE_PATTERN = /:in [`'].*_\w+_{2,3}\d+_\d+'/
 
     def initialize

--- a/railties/test/backtrace_cleaner_test.rb
+++ b/railties/test/backtrace_cleaner_test.rb
@@ -36,6 +36,12 @@ class BacktraceCleanerTest < ActiveSupport::TestCase
     assert_equal 2, result.length
   end
 
+  test "#clean should consider traces in the project tmp directory" do
+    backtrace = [ "tmp/storage/lasted_dsl.rb:4:in `start'"]
+    result = @cleaner.clean(backtrace)
+    assert_equal "tmp/storage/lasted_dsl.rb:4:in `start'", result[0]
+  end
+
   test "#clean should consider traces that include dasherized Rails application name" do
     backtrace = [ "(my-app):1",
                   "/Path/to/rails/railties/lib/rails/commands/console.rb:77:in `start'",


### PR DESCRIPTION
### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

A minor aspect of #54937 but worth considering independently.  

This Pull Request has been created because it's common for tests to leave behind temporary files and instruct the user to review them when an exception occurs (e.g. Selenium's screenshots).  In the case of processing a DSL, the pattern should probably follow, and more closely relates to logging.  With `instance_eval` for instance, you can actually get the contextual backtrace relevant to the file by specifying a filepath string.  It seems sensible to write failed DSLs to `tmp/storage` so the debugger can take a look at what was being interpreted.  By allowlisting the app's `tmp` folder, the backtrace can be printed to the screen by default in the case of an exception.  

### Detail

This Pull Request changes 

```
APP_DIRS_PATTERN = /\A(?:\.\/)?(?:app|config|lib|test|\(\w+(?:-\w+)*\))/
```

to be 

```
APP_DIRS_PATTERN = /\A(?:\.\/)?(?:app|config|lib|test|tmp|\(\w+(?:-\w+)*\))/
```

### Additional information

#54937

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
