### PR TITLE
Extract `Or#or` from `WhereClause`

### DIFF
--- a/activerecord/lib/active_record/relation/where_clause.rb
+++ b/activerecord/lib/active_record/relation/where_clause.rb
@@ -47,13 +47,7 @@ module ActiveRecord
           right = right.ast
           right = right.expr if right.is_a?(Arel::Nodes::Grouping)
 
-          or_clause = if left.is_a?(Arel::Nodes::Or)
-            Arel::Nodes::Or.new(left.children + [right])
-          else
-            Arel::Nodes::Or.new([left, right])
-          end
-
-          common.predicates << Arel::Nodes::Grouping.new(or_clause)
+          common.predicates << left.or(right)
           common
         end
       end

--- a/activerecord/lib/arel/nodes/nary.rb
+++ b/activerecord/lib/arel/nodes/nary.rb
@@ -34,6 +34,11 @@ module Arel # :nodoc: all
     end
 
     And = Class.new(Nary)
-    Or = Class.new(Nary)
+
+    class Or < Nary
+      def or(other)
+        Nodes::Grouping.new(Nodes::Or.new(children + [other]))
+      end
+    end
   end
 end

--- a/activerecord/lib/arel/nodes/sql_literal.rb
+++ b/activerecord/lib/arel/nodes/sql_literal.rb
@@ -27,6 +27,10 @@ module Arel # :nodoc: all
 
         Fragments.new([self, other])
       end
+
+      def or(other)
+        Nodes::Grouping.new Nodes::Or.new([self, other])
+      end
     end
   end
 end


### PR DESCRIPTION
This code was added to `WhereClause` when `Or` was [changed][1] from `Binary` to `Nary`.

By defining `Or#or`, we can simplify `WhereClause`.

Since `Grouping` nodes are unwrapped, this also requires defining `#or`
on `SqlLiteral` (since it's a `String` and not a `Node`).

[1]: https://github.com/rails/rails/commit/bfcc13ab7cd9837bb60d9e5da4a2f9a7c371f9d0