### PR TITLE
Allow BacktraceCleaner to present the backtrace of locally sourced gems

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Allow BacktraceCleaner to present the backtrace of locally sourced gems
+
+    *TheNotary*
+
 *   Add RuboCop cache restoration to RuboCop job in GitHub Actions workflow templates.
 
     *Lovro Bikić*

--- a/railties/lib/rails/backtrace_cleaner.rb
+++ b/railties/lib/rails/backtrace_cleaner.rb
@@ -26,9 +26,7 @@ module Rails
           line
         end
       end
-      add_silencer do |line|
-        !APP_DIRS_PATTERN.match?(line)
-      end
+      add_silencer { |line| !APP_DIRS_PATTERN.match?(line) }
     end
 
     def clean(backtrace, kind = :silent)


### PR DESCRIPTION
…gems


### Motivation / Background

This Pull Request has been created because it would be really nice to have in-house gems sourced locally via `path:` in the Gemfile to be logged at the same level as the rest of the rails app.  

### Detail

This Pull Request changes BacktraceCleaner's default filters to not silence the backtraces of Gems that have been sourced locally which would imply their in development and should log exceptions occuring within their root path.  

### Additional information

See #54937

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
