### PR TITLE
Validate options when setting or skipping callbacks

### DIFF
--- a/actioncable/lib/action_cable/channel/callbacks.rb
+++ b/actioncable/lib/action_cable/channel/callbacks.rb
@@ -45,8 +45,8 @@ module ActionCable
       end
 
       module ClassMethods
-        def before_subscribe(*methods, &block)
-          set_callback(:subscribe, :before, *methods, &block)
+        def before_subscribe(...)
+          set_callback(:subscribe, :before, ...)
         end
 
         # This callback will be triggered after the Base#subscribed method is called,
@@ -57,17 +57,17 @@ module ActionCable
         #
         #     after_subscribe :my_method, unless: :subscription_rejected?
         #
-        def after_subscribe(*methods, &block)
-          set_callback(:subscribe, :after, *methods, &block)
+        def after_subscribe(...)
+          set_callback(:subscribe, :after, ...)
         end
         alias_method :on_subscribe, :after_subscribe
 
-        def before_unsubscribe(*methods, &block)
-          set_callback(:unsubscribe, :before, *methods, &block)
+        def before_unsubscribe(...)
+          set_callback(:unsubscribe, :before, ...)
         end
 
-        def after_unsubscribe(*methods, &block)
-          set_callback(:unsubscribe, :after, *methods, &block)
+        def after_unsubscribe(...)
+          set_callback(:unsubscribe, :after, ...)
         end
         alias_method :on_unsubscribe, :after_unsubscribe
       end

--- a/actioncable/lib/action_cable/connection/callbacks.rb
+++ b/actioncable/lib/action_cable/connection/callbacks.rb
@@ -40,16 +40,16 @@ module ActionCable
       end
 
       module ClassMethods
-        def before_command(*methods, &block)
-          set_callback(:command, :before, *methods, &block)
+        def before_command(...)
+          set_callback(:command, :before, ...)
         end
 
-        def after_command(*methods, &block)
-          set_callback(:command, :after, *methods, &block)
+        def after_command(...)
+          set_callback(:command, :after, ...)
         end
 
-        def around_command(*methods, &block)
-          set_callback(:command, :around, *methods, &block)
+        def around_command(...)
+          set_callback(:command, :around, ...)
         end
       end
     end

--- a/actionmailbox/lib/action_mailbox/callbacks.rb
+++ b/actionmailbox/lib/action_mailbox/callbacks.rb
@@ -20,16 +20,16 @@ module ActionMailbox
     end
 
     class_methods do
-      def before_processing(*methods, &block)
-        set_callback(:process, :before, *methods, &block)
+      def before_processing(...)
+        set_callback(:process, :before, ...)
       end
 
-      def after_processing(*methods, &block)
-        set_callback(:process, :after, *methods, &block)
+      def after_processing(...)
+        set_callback(:process, :after, ...)
       end
 
-      def around_processing(*methods, &block)
-        set_callback(:process, :around, *methods, &block)
+      def around_processing(...)
+        set_callback(:process, :around, ...)
       end
     end
   end

--- a/actionmailer/lib/action_mailer/callbacks.rb
+++ b/actionmailer/lib/action_mailer/callbacks.rb
@@ -12,19 +12,19 @@ module ActionMailer
     module ClassMethods
       # Defines a callback that will get called right before the
       # message is sent to the delivery method.
-      def before_deliver(*filters, &blk)
-        set_callback(:deliver, :before, *filters, &blk)
+      def before_deliver(...)
+        set_callback(:deliver, :before, ...)
       end
 
       # Defines a callback that will get called right after the
       # message's delivery method is finished.
-      def after_deliver(*filters, &blk)
-        set_callback(:deliver, :after, *filters, &blk)
+      def after_deliver(...)
+        set_callback(:deliver, :after, ...)
       end
 
       # Defines a callback that will get called around the message's deliver method.
-      def around_deliver(*filters, &blk)
-        set_callback(:deliver, :around, *filters, &blk)
+      def around_deliver(...)
+        set_callback(:deliver, :around, ...)
       end
     end
   end

--- a/actionpack/lib/action_controller/metal/request_forgery_protection.rb
+++ b/actionpack/lib/action_controller/metal/request_forgery_protection.rb
@@ -206,10 +206,10 @@ module ActionController # :nodoc:
       def protect_from_forgery(options = {})
         options = options.reverse_merge(prepend: false)
 
-        self.forgery_protection_strategy = protection_method_class(options[:with] || :null_session)
+        self.forgery_protection_strategy = protection_method_class(options.delete(:with) || :null_session)
         self.request_forgery_protection_token ||= :authenticity_token
 
-        self.csrf_token_storage_strategy = storage_strategy(options[:store] || SessionStore.new)
+        self.csrf_token_storage_strategy = storage_strategy(options.delete(:store) || SessionStore.new)
 
         before_action :verify_authenticity_token, options
         append_after_action :verify_same_origin_request

--- a/actionpack/lib/action_dispatch/middleware/callbacks.rb
+++ b/actionpack/lib/action_dispatch/middleware/callbacks.rb
@@ -12,12 +12,12 @@ module ActionDispatch
     define_callbacks :call
 
     class << self
-      def before(*args, &block)
-        set_callback(:call, :before, *args, &block)
+      def before(...)
+        set_callback(:call, :before, ...)
       end
 
-      def after(*args, &block)
-        set_callback(:call, :after, *args, &block)
+      def after(...)
+        set_callback(:call, :after, ...)
       end
     end
 

--- a/actionpack/test/abstract/callbacks_test.rb
+++ b/actionpack/test/abstract/callbacks_test.rb
@@ -26,6 +26,33 @@ module AbstractController
         controller.process(:index)
         assert_equal "Hello world", controller.response_body
       end
+
+      def test_before_action_doesnt_allow_on_option
+        exception = assert_raises ArgumentError do
+          Class.new(ControllerWithCallbacks) do
+            before_action(on: :create) { }
+          end
+        end
+        assert_equal "Unknown key: :on. Valid keys are: :if, :unless, :prepend, :only, :except", exception.message
+      end
+
+      def test_around_action_doesnt_allow_on_option
+        exception = assert_raises ArgumentError do
+          Class.new(ControllerWithCallbacks) do
+            around_action(on: :create) { }
+          end
+        end
+        assert_equal "Unknown key: :on. Valid keys are: :if, :unless, :prepend, :only, :except", exception.message
+      end
+
+      def test_after_action_doesnt_allow_on_option
+        exception = assert_raises ArgumentError do
+          Class.new(ControllerWithCallbacks) do
+            after_action(on: :create) { }
+          end
+        end
+        assert_equal "Unknown key: :on. Valid keys are: :if, :unless, :prepend, :only, :except", exception.message
+      end
     end
 
     class Callback2 < ControllerWithCallbacks

--- a/activejob/lib/active_job/callbacks.rb
+++ b/activejob/lib/active_job/callbacks.rb
@@ -47,8 +47,8 @@ module ActiveJob
       #     end
       #   end
       #
-      def before_perform(*filters, &blk)
-        set_callback(:perform, :before, *filters, &blk)
+      def before_perform(...)
+        set_callback(:perform, :before, ...)
       end
 
       # Defines a callback that will get called right after the
@@ -66,8 +66,8 @@ module ActiveJob
       #     end
       #   end
       #
-      def after_perform(*filters, &blk)
-        set_callback(:perform, :after, *filters, &blk)
+      def after_perform(...)
+        set_callback(:perform, :after, ...)
       end
 
       # Defines a callback that will get called around the job's perform method.
@@ -99,8 +99,8 @@ module ActiveJob
       #     end
       #   end
       #
-      def around_perform(*filters, &blk)
-        set_callback(:perform, :around, *filters, &blk)
+      def around_perform(...)
+        set_callback(:perform, :around, ...)
       end
 
       # Defines a callback that will get called right before the
@@ -118,8 +118,8 @@ module ActiveJob
       #     end
       #   end
       #
-      def before_enqueue(*filters, &blk)
-        set_callback(:enqueue, :before, *filters, &blk)
+      def before_enqueue(...)
+        set_callback(:enqueue, :before, ...)
       end
 
       # Defines a callback that will get called right after the
@@ -138,8 +138,8 @@ module ActiveJob
       #     end
       #   end
       #
-      def after_enqueue(*filters, &blk)
-        set_callback(:enqueue, :after, *filters, &blk)
+      def after_enqueue(...)
+        set_callback(:enqueue, :after, ...)
       end
 
       # Defines a callback that will get called around the enqueuing
@@ -159,8 +159,8 @@ module ActiveJob
       #     end
       #   end
       #
-      def around_enqueue(*filters, &blk)
-        set_callback(:enqueue, :around, *filters, &blk)
+      def around_enqueue(...)
+        set_callback(:enqueue, :around, ...)
       end
     end
   end

--- a/activemodel/lib/active_model/callbacks.rb
+++ b/activemodel/lib/active_model/callbacks.rb
@@ -128,21 +128,18 @@ module ActiveModel
     private
       def _define_before_model_callback(klass, callback)
         klass.define_singleton_method("before_#{callback}") do |*args, **options, &block|
-          options.assert_valid_keys(:if, :unless, :prepend)
           set_callback(:"#{callback}", :before, *args, options, &block)
         end
       end
 
       def _define_around_model_callback(klass, callback)
         klass.define_singleton_method("around_#{callback}") do |*args, **options, &block|
-          options.assert_valid_keys(:if, :unless, :prepend)
           set_callback(:"#{callback}", :around, *args, options, &block)
         end
       end
 
       def _define_after_model_callback(klass, callback)
         klass.define_singleton_method("after_#{callback}") do |*args, **options, &block|
-          options.assert_valid_keys(:if, :unless, :prepend)
           options[:prepend] = true
           conditional = ActiveSupport::Callbacks::Conditionals::Value.new { |v|
             v != false

--- a/activemodel/lib/active_model/validations.rb
+++ b/activemodel/lib/active_model/validations.rb
@@ -170,13 +170,14 @@ module ActiveModel
 
         if options.key?(:on)
           options = options.merge(if: [predicate_for_validation_context(options[:on]), *options[:if]])
+          options.delete(:on)
         end
 
         if options.key?(:except_on)
           options = options.dup
-          options[:except_on] = Array(options[:except_on])
+          except_on = Array(options.delete(:except_on))
           options[:unless] = [
-            ->(o) { options[:except_on].intersect?(Array(o.validation_context)) },
+            ->(o) { except_on.intersect?(Array(o.validation_context)) },
             *options[:unless]
           ]
         end

--- a/activemodel/lib/active_model/validations/callbacks.rb
+++ b/activemodel/lib/active_model/validations/callbacks.rb
@@ -98,20 +98,20 @@ module ActiveModel
         private
           def set_options_for_callback(options)
             if options.key?(:on)
-              options[:on] = Array(options[:on])
+              on = Array(options.delete(:on))
               options[:if] = [
                 ->(o) {
-                  options[:on].intersect?(Array(o.validation_context))
+                  on.intersect?(Array(o.validation_context))
                 },
                 *options[:if]
               ]
             end
 
             if options.key?(:except_on)
-              options[:except_on] = Array(options[:except_on])
+              except_on = Array(options.delete(:except_on))
               options[:unless] = [
                 ->(o) {
-                  options[:except_on].intersect?(Array(o.validation_context))
+                  except_on.intersect?(Array(o.validation_context))
                 },
                 *options[:unless]
               ]

--- a/activemodel/lib/active_model/validations/with.rb
+++ b/activemodel/lib/active_model/validations/with.rb
@@ -89,6 +89,7 @@ module ActiveModel
         options = args.extract_options!
         options[:class] = self
 
+        validate_options = options.slice(*VALID_OPTIONS_FOR_VALIDATE)
         args.each do |klass|
           validator = klass.new(options.dup, &block)
 
@@ -100,7 +101,7 @@ module ActiveModel
             _validators[nil] << validator
           end
 
-          validate(validator, options)
+          validate(validator, validate_options)
         end
       end
     end

--- a/activerecord/lib/active_record/transactions.rb
+++ b/activerecord/lib/active_record/transactions.rb
@@ -264,9 +264,8 @@ module ActiveRecord
         connection_pool.active_connection&.current_transaction&.user_transaction || Transaction::NULL_TRANSACTION
       end
 
-      def before_commit(*args, &block) # :nodoc:
-        set_options_for_callbacks!(args)
-        set_callback(:before_commit, :before, *args, &block)
+      def before_commit(...) # :nodoc:
+        set_callback(:before_commit, :before, ...)
       end
 
       # This callback is called after a record has been created, updated, or destroyed.
@@ -325,14 +324,8 @@ module ActiveRecord
         filter_list << options
 
         if name.in?([:commit, :rollback]) && options[:on]
-          fire_on = Array(options[:on])
-          assert_valid_transaction_action(fire_on)
-          options[:if] = [
-            -> { transaction_include_any_action?(fire_on) },
-            *options[:if]
-          ]
+          set_options_for_callbacks!(filter_list)
         end
-
 
         super(name, *filter_list, &block)
       end
@@ -351,7 +344,7 @@ module ActiveRecord
           args << options
 
           if options[:on]
-            fire_on = Array(options[:on])
+            fire_on = Array(options.delete(:on))
             assert_valid_transaction_action(fire_on)
             options[:if] = [
               -> { transaction_include_any_action?(fire_on) },

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Validate options when setting or skipping callbacks
+
+    *ccutrer*
+
 *   Allow to configure maximum cache key sizes
 
     When the key exceeds the configured limit (250 bytes by default), it will be truncated and

--- a/activesupport/lib/active_support/callbacks.rb
+++ b/activesupport/lib/active_support/callbacks.rb
@@ -243,6 +243,7 @@ module ActiveSupport
         attr_reader :chain_config, :filter
 
         def initialize(name, filter, kind, options, chain_config)
+          options.assert_valid_keys(:if, :unless)
           @chain_config = chain_config
           @name    = name
           @kind    = kind
@@ -736,14 +737,16 @@ module ActiveSupport
         #   existing chain rather than appended.
         def set_callback(name, *filter_list, &block)
           type, filters, options = normalize_callback_params(filter_list, block)
+          options.assert_valid_keys(:if, :unless, :prepend)
 
+          prepend = options.delete(:prepend)
           self_chain = get_callbacks name
           mapped = filters.map do |filter|
             Callback.build(self_chain, filter, type, options)
           end
 
           __update_callbacks(name) do |target, chain|
-            options[:prepend] ? chain.prepend(*mapped) : chain.append(*mapped)
+            prepend ? chain.prepend(*mapped) : chain.append(*mapped)
             target.set_callbacks name, chain
           end
         end
@@ -785,6 +788,8 @@ module ActiveSupport
         # already been set (unless the <tt>:raise</tt> option is set to <tt>false</tt>).
         def skip_callback(name, *filter_list, &block)
           type, filters, options = normalize_callback_params(filter_list, block)
+
+          options.assert_valid_keys(:if, :unless, :raise)
 
           options[:raise] = true unless options.key?(:raise)
 

--- a/activesupport/lib/active_support/current_attributes.rb
+++ b/activesupport/lib/active_support/current_attributes.rb
@@ -141,13 +141,13 @@ module ActiveSupport
       end
 
       # Calls this callback before #reset is called on the instance. Used for resetting external collaborators that depend on current values.
-      def before_reset(*methods, &block)
-        set_callback :reset, :before, *methods, &block
+      def before_reset(...)
+        set_callback(:reset, :before, ...)
       end
 
       # Calls this callback after #reset is called on the instance. Used for resetting external collaborators, like Time.zone.
-      def resets(*methods, &block)
-        set_callback :reset, :after, *methods, &block
+      def resets(...)
+        set_callback(:reset, :after, ...)
       end
       alias_method :after_reset, :resets
 

--- a/activesupport/lib/active_support/execution_wrapper.rb
+++ b/activesupport/lib/active_support/execution_wrapper.rb
@@ -14,12 +14,12 @@ module ActiveSupport
     define_callbacks :run
     define_callbacks :complete
 
-    def self.to_run(*args, &block)
-      set_callback(:run, *args, &block)
+    def self.to_run(...)
+      set_callback(:run, ...)
     end
 
-    def self.to_complete(*args, &block)
-      set_callback(:complete, *args, &block)
+    def self.to_complete(...)
+      set_callback(:complete, ...)
     end
 
     RunHook = Struct.new(:hook) do # :nodoc:

--- a/activesupport/lib/active_support/reloader.rb
+++ b/activesupport/lib/active_support/reloader.rb
@@ -31,18 +31,18 @@ module ActiveSupport
     define_callbacks :class_unload
 
     # Registers a callback that will run once at application startup and every time the code is reloaded.
-    def self.to_prepare(*args, &block)
-      set_callback(:prepare, *args, &block)
+    def self.to_prepare(...)
+      set_callback(:prepare, ...)
     end
 
     # Registers a callback that will run immediately before the classes are unloaded.
-    def self.before_class_unload(*args, &block)
-      set_callback(:class_unload, *args, &block)
+    def self.before_class_unload(...)
+      set_callback(:class_unload, ...)
     end
 
     # Registers a callback that will run immediately after the classes are unloaded.
-    def self.after_class_unload(*args, &block)
-      set_callback(:class_unload, :after, *args, &block)
+    def self.after_class_unload(...)
+      set_callback(:class_unload, :after, ...)
     end
 
     to_run(:after) { self.class.prepare! }

--- a/activesupport/lib/active_support/testing/setup_and_teardown.rb
+++ b/activesupport/lib/active_support/testing/setup_and_teardown.rb
@@ -26,13 +26,13 @@ module ActiveSupport
 
       module ClassMethods
         # Add a callback, which runs before <tt>TestCase#setup</tt>.
-        def setup(*args, &block)
-          set_callback(:setup, :before, *args, &block)
+        def setup(...)
+          set_callback(:setup, :before, ...)
         end
 
         # Add a callback, which runs after <tt>TestCase#teardown</tt>.
-        def teardown(*args, &block)
-          set_callback(:teardown, :after, *args, &block)
+        def teardown(...)
+          set_callback(:teardown, :after, ...)
         end
       end
 

--- a/activesupport/test/callbacks_test.rb
+++ b/activesupport/test/callbacks_test.rb
@@ -9,12 +9,12 @@ module CallbacksTest
 
     define_callbacks :save
 
-    def self.before_save(*filters, &blk)
-      set_callback(:save, :before, *filters, &blk)
+    def self.before_save(...)
+      set_callback(:save, :before, ...)
     end
 
-    def self.after_save(*filters, &blk)
-      set_callback(:save, :after, *filters, &blk)
+    def self.after_save(...)
+      set_callback(:save, :after, ...)
     end
 
     class << self
@@ -1113,7 +1113,7 @@ module CallbacksTest
         define_callbacks :foo
         n.times { set_callback :foo, :before, callback }
         def run; run_callbacks :foo; end
-        def self.skip(*things); skip_callback :foo, :before, *things; end
+        def self.skip(...); skip_callback(:foo, :before, ...); end
       }
     end
 
@@ -1282,6 +1282,34 @@ module CallbacksTest
       klass = AllSaveCallbacks.new
       klass.run_callbacks :save, :after
       assert_equal ["after_save_2", "after_save_1"], klass.history
+    end
+  end
+
+  class ValidateArgsCallbackTest < ActiveSupport::TestCase
+    def test_invalid_args_are_not_permitted
+      klass = Class.new(Record)
+
+      assert_raises(ArgumentError) do
+        klass.before_save :foo, other: :bar
+      end
+    end
+
+    def test_invalid_skip_args_are_not_permitted
+      klass = Class.new(Record)
+
+      assert_raises(ArgumentError) do
+        klass.before_save :foo
+        klass.skip_callback :save, :before, :foo, other: :bar
+      end
+    end
+
+    def test_invalid_prepend_args_are_not_permitted
+      klass = Class.new(Record)
+
+      assert_raises(ArgumentError) do
+        klass.before_save :foo
+        klass.set_callback :save, :before, :bar, prepend: true, other: :baz
+      end
     end
   end
 end


### PR DESCRIPTION
### Motivation / Background

We had a production bug because a developer accidentally wrote `skip_before_action :do_something, from: [:create]` instead of `skip_before_action :do_something, only: [:create]`. We were surprised Rails did not check for invalid options.

### Detail

For any callers that add additional functionality, I had to make sure they took out the options they processed, to avoid sending extra (unsupported) options down. ActiveModel already validated them, but I took it out since it's handled at a lower level now. In ActiveRecord Transactions, I also called the helper method in one spot that the helper method's body was duplicated inline.

### Additional information

Originally I was going to use kwargs, but backed out of that because I realized several of these methods are technically public APIs, and with Ruby 3.1+ that could be considered a breaking change if someone is passing a hash (and therefore wouldn't be `**` splatting it when passing it in).  I did leave conversions of methods to `...` in, since that wouldn't be breaking, and might help someone in the future from having to track as many of these down if they do decide to switch to kwargs.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
