### PR TITLE
Avoid unnecessary splat allocations

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/stack.rb
+++ b/actionpack/lib/action_dispatch/middleware/stack.rb
@@ -41,6 +41,7 @@ module ActionDispatch
       end
 
       def build(app)
+        block = self.block
         klass.new(app, *args, &block)
       end
 

--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -897,7 +897,8 @@ module ActionDispatch
             assign_deprecated_options(deprecated_options, mapping, :connect)
           end
 
-          match(*path_or_actions, as:, to:, controller:, action:, on:, defaults:, constraints:, anchor:, format:, path:, internal:, **mapping, via: [:get, :connect], &block)
+          via = [:get, :connect]
+          match(*path_or_actions, as:, to:, controller:, action:, on:, defaults:, constraints:, anchor:, format:, path:, internal:, **mapping, via:, &block)
           self
         end
       end

--- a/activerecord/lib/active_record/type/adapter_specific_registry.rb
+++ b/activerecord/lib/active_record/type/adapter_specific_registry.rb
@@ -115,7 +115,8 @@ module ActiveRecord
       end
 
       def call(registry, *args, **kwargs)
-        subtype = registry.lookup(*args, **kwargs.except(*options.keys))
+        kwargs = kwargs.except(*options.keys)
+        subtype = registry.lookup(*args, **kwargs)
         klass.new(subtype)
       end
 

--- a/activesupport/lib/active_support/evented_file_update_checker.rb
+++ b/activesupport/lib/active_support/evented_file_update_checker.rb
@@ -111,7 +111,10 @@ module ActiveSupport
       def start
         normalize_dirs!
         @dtw, @missing = [*@dtw, *@missing].partition(&:exist?)
-        @listener = @dtw.any? ? Listen.to(*@dtw, &method(:changed)) : nil
+        @listener = if @dtw.any?
+          changed = method(:changed)
+          Listen.to(*@dtw, &changed)
+        end
         @listener&.start
 
         # Wait for the listener to be ready to avoid race conditions

--- a/railties/lib/rails/initializable.rb
+++ b/railties/lib/rails/initializable.rb
@@ -21,6 +21,7 @@ module Rails
       end
 
       def run(*args)
+        block = self.block
         @context.instance_exec(*args, &block)
       end
 


### PR DESCRIPTION
In these 5 calls, an array is allocated for the splat, as the Ruby compiler cannot determine that the keyword/block expressions will not have side effects that will affect the splat. By assigning the related expression to a local variable and using the local variable, you can avoid the allocation for the splat.

CC @tenderlove (not even tens!)

### Motivation / Background

This is just a micro-optimization to avoid allocations and thus improve performance.  All behavior should be the same.

### Detail

These were the issue flagged by the performance warning in Ruby feature 21274 (not yet merged into Ruby itself): https://bugs.ruby-lang.org/issues/21274

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature (not applicable).
* [X] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included (not applicable).