### PR TITLE
Add `default_parameter_encoding` method for specifying default parameter encodings in a given action

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Add `default_parameter_encoding` method for specifying default parameter encodings in a given action.
+
+    The new `default_parameter_encoding` method allows developers to specify a default encoding for all parameters within a given action in a single line.
+    This enhancement makes the codebase of applications receiving non-UTF-8 encoded data cleaner and easier to maintain by reducing repetition and the risk of encoding-related errors.
+
+    *fusagiko (takayamaki on GitHub)*
+
 *   Add assert_in_body/assert_not_in_body as the simplest way to check if a piece of text is in the response body.
 
     *DHH*

--- a/actionpack/lib/action_controller/metal/parameter_encoding.rb
+++ b/actionpack/lib/action_controller/metal/parameter_encoding.rb
@@ -48,7 +48,34 @@ module ActionController
       # encoded as ASCII-8BIT. This is useful in the case where an application must
       # handle data but encoding of the data is unknown, like file system data.
       def skip_parameter_encoding(action)
-        @_parameter_encodings[action.to_s] = Hash.new { Encoding::ASCII_8BIT }
+        default_parameter_encoding(action, Encoding::ASCII_8BIT)
+      end
+
+      # Specify a default encoding for all parameters within a given action in a single line.
+      #
+      # For example, a controller would use it like this:
+      #
+      #     class FooController < ActionController::Base
+      #       default_parameter_encoding :create, Encoding::SHIFT_JIS
+      #
+      #       def create
+      #         create_params = params.permit(
+      #           :japanese_string_param1,
+      #           :japanese_string_param2,
+      #           :japanese_string_param3,
+      #           :japanese_string_param4,
+      #           :japanese_string_param5,
+      #           :japanese_string_param6
+      #         ).transform_values! { |param| param.encode(Encoding::UTF_8) }
+      #         Foo.create!(create_params)
+      #         head :ok
+      #       end
+      #     end
+      #
+      # Sometimes, a Rails application implements an inter-system API for an external system.
+      # This method is useful when the external system communicates using a non-UTF-8 encoding.
+      def default_parameter_encoding(action, encoding)
+        @_parameter_encodings[action.to_s] = Hash.new { encoding }
       end
 
       # Specify the encoding for a parameter on an action. If not specified the


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

Developers can use the `param_encoding` method to specify the character encoding for a parameter.  
However, it requires a one line for each parameter.  
This is tiresome for developers and may also lead to bugs if they forget to specify the encoding.

### Detail

This PR introduces the `default_parameter_encoding` method to simplify this.  
`default_parameter_encoding` allows specifying a default encoding for all parameters in a given action.
    
This enhancement makes the codebase of applications receiving non-UTF-8 encoded data cleaner and easier to maintain.

#### before
``` ruby
class FooController < ActionController::Base
  param_encoding :create, :japanese_string_param1, Encoding::SHIFT_JIS
  param_encoding :create, :japanese_string_param2, Encoding::SHIFT_JIS
  param_encoding :create, :japanese_string_param3, Encoding::SHIFT_JIS
  param_encoding :create, :japanese_string_param4, Encoding::SHIFT_JIS
  param_encoding :create, :japanese_string_param5, Encoding::SHIFT_JIS
  param_encoding :create, :japanese_string_param6, Encoding::SHIFT_JIS

  def create
    create_params = params.permit(
      :japanese_string_param1,
      :japanese_string_param2,
      :japanese_string_param3,
      :japanese_string_param4,
      :japanese_string_param5,
      :japanese_string_param6
    ).transform_values! { |param| param.encode(Encoding::UTF_8) }
    Foo.create!(create_params)
    head :ok
  end
end
```

#### after
``` ruby
class FooController < ActionController::Base
  default_parameter_encoding :create, Encoding::SHIFT_JIS

  def create
    create_params = params.permit(
      :japanese_string_param1,
      :japanese_string_param2,
      :japanese_string_param3,
      :japanese_string_param4,
      :japanese_string_param5,
      :japanese_string_param6
    ).transform_values! { |param| param.encode(Encoding::UTF_8) }
    Foo.create!(create_params)
    head :ok
  end
end
```

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
