### PR TITLE
Add and use disallow_authenticated_access in authentication generator

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add disallow_authenticated_access to authentication generator.
+
+    *Bradley Johnson*
+
 *   Add RuboCop cache restoration to RuboCop job in GitHub Actions workflow templates.
 
     *Lovro Bikić*

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -2,6 +2,10 @@
 
     *Bradley Johnson*
 
+*   Add --reset option to bin/setup which will call db:reset as part of the setup.
+
+    *DHH*
+
 *   Add RuboCop cache restoration to RuboCop job in GitHub Actions workflow templates.
 
     *Lovro Bikić*

--- a/railties/Rakefile
+++ b/railties/Rakefile
@@ -116,6 +116,7 @@ namespace :test do
           ARGV.clear.concat test_options
           Rake.application = nil
 
+          require "../tools/strict_warnings"
           load file
         }
       else

--- a/railties/lib/rails/generators/rails/app/templates/bin/setup.tt
+++ b/railties/lib/rails/generators/rails/app/templates/bin/setup.tt
@@ -31,6 +31,7 @@ FileUtils.chdir APP_ROOT do
 
   puts "\n== Preparing database =="
   system! "bin/rails db:prepare"
+  system! "bin/rails db:reset" if ARGV.include?("--reset")
 <% end -%>
 
   puts "\n== Removing old logs and tempfiles =="

--- a/railties/lib/rails/generators/rails/authentication/templates/app/controllers/concerns/authentication.rb.tt
+++ b/railties/lib/rails/generators/rails/authentication/templates/app/controllers/concerns/authentication.rb.tt
@@ -10,6 +10,11 @@ module Authentication
     def allow_unauthenticated_access(**options)
       skip_before_action :require_authentication, **options
     end
+
+    def disallow_authenticated_access(**options)
+      allow_unauthenticated_access(**options.except(:fallback_location))
+      before_action -> { redirect_if_authenticated(options[:fallback_location] || root_url) }, **options
+    end
   end
 
   private
@@ -48,5 +53,9 @@ module Authentication
     def terminate_session
       Current.session.destroy
       cookies.delete(:session_id)
+    end
+
+    def redirect_if_authenticated(fallback_location)
+      redirect_back(fallback_location: fallback_location) if authenticated?
     end
 end

--- a/railties/lib/rails/generators/rails/authentication/templates/app/controllers/passwords_controller.rb.tt
+++ b/railties/lib/rails/generators/rails/authentication/templates/app/controllers/passwords_controller.rb.tt
@@ -1,5 +1,6 @@
 class PasswordsController < ApplicationController
-  allow_unauthenticated_access
+  allow_unauthenticated_access only: %i[ edit update ]
+  disallow_authenticated_access only: %i[ new create ]
   before_action :set_user_by_token, only: %i[ edit update ]
   <%- if defined?(ActionMailer::Railtie) -%>
   rate_limit to: 10, within: 3.minutes, only: :create, with: -> { redirect_to new_password_path, alert: "Try again later." }

--- a/railties/lib/rails/generators/rails/authentication/templates/app/controllers/sessions_controller.rb.tt
+++ b/railties/lib/rails/generators/rails/authentication/templates/app/controllers/sessions_controller.rb.tt
@@ -1,5 +1,5 @@
 class SessionsController < ApplicationController
-  allow_unauthenticated_access only: %i[ new create ]
+  disallow_authenticated_access only: %i[ new create ]
   rate_limit to: 10, within: 3.minutes, only: :create, with: -> { redirect_to new_session_path, alert: "Try again later." }
 
   def new

--- a/railties/test/abstract_unit.rb
+++ b/railties/test/abstract_unit.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative "../../tools/strict_warnings"
-
 ENV["RAILS_ENV"] ||= "test"
 
 require "stringio"

--- a/railties/test/configuration/middleware_stack_proxy_test.rb
+++ b/railties/test/configuration/middleware_stack_proxy_test.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require_relative "../../../tools/strict_warnings"
 require "active_support"
 require "active_support/testing/autorun"
 require "rails/configuration"

--- a/railties/test/generators/argv_scrubber_test.rb
+++ b/railties/test/generators/argv_scrubber_test.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require_relative "../../../tools/strict_warnings"
 require "active_support/test_case"
 require "active_support/testing/autorun"
 require "rails/generators/rails/app/app_generator"

--- a/railties/test/generators/generator_test.rb
+++ b/railties/test/generators/generator_test.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require_relative "../../../tools/strict_warnings"
 require "active_support/test_case"
 require "active_support/testing/autorun"
 require "rails/generators/app_base"

--- a/railties/test/isolation/abstract_unit.rb
+++ b/railties/test/isolation/abstract_unit.rb
@@ -8,7 +8,6 @@
 #
 # It is also good to know what is the bare minimum to get
 # Rails booted up.
-require_relative "../../../tools/strict_warnings"
 require "fileutils"
 require "shellwords"
 

--- a/tools/strict_warnings.rb
+++ b/tools/strict_warnings.rb
@@ -30,7 +30,8 @@ module RailsStrictWarnings # :nodoc:
 
     super
 
-    return unless message.include?(PROJECT_ROOT)
+    testpath = message[/test\/.*\.rb/]&.chomp || message
+    return unless message.include?(PROJECT_ROOT) || Pathname.new(testpath).exist?
     return if ALLOWED_WARNINGS.match?(message)
     return unless ENV["RAILS_STRICT_WARNINGS"] || ENV["BUILDKITE"]
 


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because multiple endpoints not only want to allow unauthenticated users, but they want to disallow authenticated users. The goal here is to reduce the "redirect if authenticated" duplication.

### Detail

This Pull Request changes the generated authentication concern by adding and using `disallow_authenticated_access`.

`disallow_authenticated_access` allows unauthenticated users, then it redirects authenticated users. Authenticated users are redirected `back`. If there is no `back`, then the user will be redirected to the `root_url` unless a `fallback_location` is provided in the options.

`disallow_authenticated_access` is applied to `PasswordsController#new` and `create` as well as `SessionsController#new` and `create`.

### Additional information

Alternatively, `disallow_authenticated_access` could accept a `redirect_to` option to supersede redirecting back.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
