### PR TITLE
[ci skip] Fix the link to "Active Record Query Interface" docs in the "Composite Primary Keys" guide

### DIFF
--- a/guides/source/active_record_composite_primary_keys.md
+++ b/guides/source/active_record_composite_primary_keys.md
@@ -118,7 +118,7 @@ Take caution when using `find_by(id:)` on models where `:id` is not the primary
 key, such as composite primary key models. See the [Active Record Querying][]
 guide to learn more.
 
-[Active Record Querying]: active_record_querying.html#using-id-as-a-condition
+[Active Record Querying]: active_record_querying.html#conditions-with-id
 
 Associations between Models with Composite Primary Keys
 -------------------------------------------------------


### PR DESCRIPTION
### Detail

This Pull Request fixes the stale "Active Record Query Interface" documentation URL.