### PR TITLE
Add a load hook for `ActiveRecord::DatabaseConfigurations`

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add a load hook `active_record_database_configurations` for `ActiveRecord::DatabaseConfigurations`
+
+    *Mike Dalessio*
+
 *   Use `TRUE` and `FALSE` for SQLite queries with boolean columns.
 
     *Hartley McGuire*

--- a/activerecord/lib/active_record/database_configurations.rb
+++ b/activerecord/lib/active_record/database_configurations.rb
@@ -36,9 +36,11 @@ module ActiveRecord
     # to respond to `sharded?`. To implement this define the following in an
     # initializer:
     #
-    #   ActiveRecord::DatabaseConfigurations.register_db_config_handler do |env_name, name, url, config|
-    #     next unless config.key?(:vitess)
-    #     VitessConfig.new(env_name, name, config)
+    #   ActiveSupport.on_load(:active_record_database_configurations) do
+    #     ActiveRecord::DatabaseConfigurations.register_db_config_handler do |env_name, name, url, config|
+    #       next unless config.key?(:vitess)
+    #       VitessConfig.new(env_name, name, config)
+    #     end
     #   end
     #
     # Note: applications must handle the condition in which custom config should be
@@ -306,4 +308,6 @@ module ActiveRecord
         url
       end
   end
+
+  ActiveSupport.run_load_hooks(:active_record_database_configurations, DatabaseConfigurations)
 end

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -3820,6 +3820,7 @@ These are the load hooks you can use in your own code. To hook into the initiali
 | `ActiveModel::Model`                 | `active_model`                       |
 | `ActiveModel::Translation`           | `active_model_translation`           |
 | `ActiveRecord::Base`                 | `active_record`                      |
+| `ActiveRecord::DatabaseConfigurations` | `active_record_database_configurations` |
 | `ActiveRecord::Encryption`           | `active_record_encryption`           |
 | `ActiveRecord::TestFixtures`         | `active_record_fixtures`             |
 | `ActiveRecord::ConnectionAdapters::PostgreSQLAdapter`    | `active_record_postgresqladapter`    |


### PR DESCRIPTION
### Motivation / Background

Summary: Rails does not offer a way to use an initializer to register a database config handler before database tasks are defined.

I'm using `ActiveRecord::DatabaseConfigurations.register_db_config_handler` in an engine to extend the default database configuration. One of the things the custom config class does is to conditionally override `#database_tasks?` to `false` so that the default database tasks are not defined for that database.

I would like to be able to call `.register_db_config_handler` from a railtie initializer, something like:

``` ruby
class Railtie < ::Rails::Railtie
  config.before_configuration do
    ActiveSupport.on_load(:active_record) do
      ActiveRecord::DatabaseConfigurations.register_db_config_handler { ... }
    end
  end
end
```

However, the default rake tasks in `active_record/railties/databases.rake` are loaded before the Active Record load hook is invoked. As a result, the database tasks that I want to omit are nevertheless created for the database.

Worth mentioning that `ActiveRecord::DatabaseConfigurations` seems to generally get autoloaded transitively by [this line](https://github.com/rails/rails/blob/556881c9a7846fd379e003ec3187c6d5bef5a832/activerecord/lib/active_record/railties/databases.rake#L7) when `ActiveRecord::Tasks::DatabaseTasks` gets resolved:

``` ruby
databases = ActiveRecord::Tasks::DatabaseTasks.setup_initial_database_yaml
```

### Detail

This PR adds a load hook to `activerecord/lib/active_record/database_configurations.rb`.

Using that load hook, a db config handler may be registered in a railtie before rake tasks are generated:

``` ruby
class Railtie < ::Rails::Railtie
  config.before_configuration do
    ActiveSupport.on_load(:active_record_database_configurations) do
      ActiveRecord::DatabaseConfigurations.register_db_config_handler { ... }
    end
  end
end
```

### Alternative approaches

One alternative, which I'm using now, is to explicitly require `database_configurations` and immediately register the db config handler, something like:

```ruby
# in the railtie
require "active_record/database_configurations"
ActiveRecord::DatabaseConfigurations.register_db_config_handler { ... }
```

and maybe this is OK, but I'd prefer to use a load hook.


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [-] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
