### PR TITLE
Sort schema cache columns and indexes per table when dumping

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/schema_cache.rb
+++ b/activerecord/lib/active_record/connection_adapters/schema_cache.rb
@@ -271,10 +271,10 @@ module ActiveRecord
       end
 
       def encode_with(coder) # :nodoc:
-        coder["columns"]          = @columns.sort.to_h
+        coder["columns"]          = @columns.sort.to_h.transform_values { _1.sort_by(&:name) }
         coder["primary_keys"]     = @primary_keys.sort.to_h
         coder["data_sources"]     = @data_sources.sort.to_h
-        coder["indexes"]          = @indexes.sort.to_h
+        coder["indexes"]          = @indexes.sort.to_h.transform_values { _1.sort_by(&:name) }
         coder["version"]          = @version
       end
 

--- a/activerecord/test/cases/connection_adapters/schema_cache_test.rb
+++ b/activerecord/test/cases/connection_adapters/schema_cache_test.rb
@@ -467,11 +467,15 @@ module ActiveRecord
         values = [["z", nil], ["y", nil], ["x", nil]]
         expected = values.sort.to_h
 
+        named = Struct.new(:name)
+        named_values = [["z", [named.new("c"), named.new("b")]], ["y", [named.new("c"), named.new("b")]], ["x", [named.new("c"), named.new("b")]]]
+        named_expected = named_values.sort.to_h.transform_values { _1.sort_by(&:name) }
+
         coder = {
-          "columns" => values,
+          "columns" => named_values,
           "primary_keys" => values,
           "data_sources" => values,
-          "indexes" => values,
+          "indexes" => named_values,
           "deduplicated" => true
         }
 
@@ -479,10 +483,10 @@ module ActiveRecord
         schema_cache.init_with(coder)
         schema_cache.encode_with(coder)
 
-        assert_equal expected, coder["columns"]
+        assert_equal named_expected, coder["columns"]
         assert_equal expected, coder["primary_keys"]
         assert_equal expected, coder["data_sources"]
-        assert_equal expected, coder["indexes"]
+        assert_equal named_expected, coder["indexes"]
         assert coder.key?("version")
       end
 


### PR DESCRIPTION
### Motivation / Background

See https://github.com/rails/rails/issues/42717 for the original description of the problem, which is unstable sort order of tables and columns in the schema cache file.

The pull request https://github.com/rails/rails/pull/48824 partially solved this problem by sorting the tables by name, but the columns and indexes in each table may still appear in different order depending on how migrations were applied on a developer workstation.


### Detail

This extends the solution introduced in https://github.com/rails/rails/pull/48824 (3c7f48b8) by additionally sorting each table's columns and indexes by name.


### Additional information

See e403adf8 for prior art in sorting the columns in schema dumps.


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
