### PR TITLE
Improve the default exceptions app:

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,14 @@
+*   All error pages (404, 422 ...) can now be rendered dynamically.
+
+    Rendering error pages to display dynamic content required to modify the
+    default Rails `exceptions_app`. It was not possible to style the pages
+    with tailwind or have layouts.
+
+    This is now possible by renaming the `404.html` to `404.html.erb` and
+    modifying the templates as any other views.
+
+    *Edouard Chin*
+
 *   Add assert_in_body/assert_not_in_body as the simplest way to check if a piece of text is in the response body.
 
     *DHH*

--- a/actionpack/lib/action_dispatch.rb
+++ b/actionpack/lib/action_dispatch.rb
@@ -88,6 +88,7 @@ module ActionDispatch
   end
 
   autoload :Constants
+  autoload :ExceptionsController, "action_dispatch/middleware/public_exceptions"
   autoload :Journey
   autoload :MiddlewareStack, "action_dispatch/middleware/stack"
   autoload :Routing

--- a/actionpack/lib/action_dispatch/middleware/public_exceptions.rb
+++ b/actionpack/lib/action_dispatch/middleware/public_exceptions.rb
@@ -2,7 +2,117 @@
 
 # :markup: markdown
 
+require "action_view"
+require "action_controller"
+
 module ActionDispatch
+  # = Action Dispatch ExceptionsController
+  #
+  # This controller is used to render error pages, it is used by the Rails'
+  # default `exceptions_app`.
+  # To enable dynamic rendering of error pages, make sure the templates have the
+  # `.erb` file extension, as previous versions of Rails were generating bare
+  # html files.
+  #
+  # All Rails helpers are available in the views
+  # (.e.g `stylesheet_link_tag`, `link_to` ...), and you also have access to all
+  # routing url helpers.
+  # The templates will be rendered with the `errors` layout, in the event that
+  # this layout exists, otherwise no layout will be used.
+  #
+  # The controller will try to return the most suitable response based on the
+  # request's format. If you'd like to render an error format differently,
+  # you can create new error template (e.g. `422.json.erb`).
+  # Any valid HTTP error code may be rendered with its own template, if that
+  # template exists (e.g. `401.html.erb`).
+  # If no template exists for an error code, a `404` with the `x-cascade` header
+  # will be returned.
+  #
+  # The controller is stripped down on purpose and has the minimal
+  # functionalities to display dynamic error pages as any other views in your
+  # application.
+  # If you have to perform logic before displaying an error page
+  # (i.e. adding response headers), you can insert a middleware for that
+  # controller only:
+  #
+  #   # lib/my_middleware.rb
+  #   class MyMiddleware
+  #     def initialize(app)
+  #       @app = app
+  #     end
+  #
+  #     def call(env)
+  #       result = @app.call(env)
+  #       result[1]["some-headers"] = "value"
+  #       result
+  #     end
+  #   end
+  #
+  #   # config/application.rb
+  #   ActionDispatch::ExceptionsController.use(MyMiddleware)
+  #
+  # In the event that you require more advanced control over,
+  # creating your own {Exception App is preferred}[https://guides.rubyonrails.org/configuring.html#config-exceptions-app].
+  class ExceptionsController < ActionController::Metal # :nodoc:
+    include AbstractController::Rendering
+    include ActionController::Rendering
+    include ActionView::Layouts
+    include ActionController::Renderers::All
+    include ActionController::Head
+
+    layout -> do
+      layout_name = "layouts/errors"
+
+      template_exists?(layout_name) ? layout_name : false
+    end
+
+    def self.local_prefixes
+      []
+    end
+
+    def action_missing(status_code, *args)
+      return pass_response unless Rack::Utils::HTTP_STATUS_CODES.include?(status_code.to_i)
+
+      if template_for_content_type?(status_code)
+        render(status_code, status: status_code)
+      elsif generic_response.respond_to?("to_#{format.to_sym}")
+        render(format.to_sym => generic_response(status_code), status: status_code)
+      elsif template_exists?(status_code, formats: [:html])
+        render(status_code, status: status_code, formats: [:html], content_type: :html)
+      else
+        pass_response
+      end
+    end
+
+    private
+      # This is a workaround to `LookupContext#template_exists?`. Because the legacy files were
+      # called 404.html, the `html` part is considered as the handler, which leaves us with a empty
+      # format, resulting in rendering that template for any kind of request's format.
+      def template_for_content_type?(name)
+        template = lookup_context.find_all(name).first
+        return false unless template
+
+        template_format = template.format
+        if template_format.nil? && template.handler.is_a?(ActionView::Template::Handlers::Html)
+          template_format = :html
+        end
+
+        format.to_sym == template_format
+      end
+
+      def pass_response
+        head(:not_found, { ActionDispatch::Constants::X_CASCADE => "pass" })
+      end
+
+      def format
+        request.format
+      end
+
+      def generic_response(status = nil)
+        { status: status&.to_i, error: Rack::Utils::HTTP_STATUS_CODES.fetch(status.to_i, Rack::Utils::HTTP_STATUS_CODES[500]) }
+      end
+  end
+
   # # Action Dispatch PublicExceptions
   #
   # When called, this middleware renders an error page. By default if an HTML
@@ -18,43 +128,25 @@ module ActionDispatch
   class PublicExceptions
     attr_accessor :public_path
 
-    def initialize(public_path)
+    def initialize(public_path, routes = nil)
       @public_path = public_path
+
+      @controller = Class.new(ExceptionsController) do
+        self.middleware_stack = ExceptionsController.middleware_stack
+        self.view_paths = [public_path]
+
+        if routes
+          include(ActionController::UrlFor)
+          include(routes.url_helpers)
+        end
+      end
     end
 
     def call(env)
-      request      = ActionDispatch::Request.new(env)
-      status       = request.path_info[1..-1].to_i
-      content_type = request.formats.first
-      body = { status: status, error: Rack::Utils::HTTP_STATUS_CODES.fetch(status, Rack::Utils::HTTP_STATUS_CODES[500]) }
+      request = ActionDispatch::Request.new(env)
+      status  = request.path_info[1..-1].to_i
 
-      render(status, content_type, body)
+      @controller.action(status).call(env)
     end
-
-    private
-      def render(status, content_type, body)
-        format = "to_#{content_type.to_sym}" if content_type
-        if format && body.respond_to?(format)
-          render_format(status, content_type, body.public_send(format))
-        else
-          render_html(status)
-        end
-      end
-
-      def render_format(status, content_type, body)
-        [status, { Rack::CONTENT_TYPE => "#{content_type}; charset=#{ActionDispatch::Response.default_charset}",
-                  Rack::CONTENT_LENGTH => body.bytesize.to_s }, [body]]
-      end
-
-      def render_html(status)
-        path = "#{public_path}/#{status}.#{I18n.locale}.html"
-        path = "#{public_path}/#{status}.html" unless (found = File.exist?(path))
-
-        if found || File.exist?(path)
-          render_format(status, "text/html", File.read(path))
-        else
-          [404, { Constants::X_CASCADE => "pass" }, []]
-        end
-      end
   end
 end

--- a/actionpack/test/dispatch/public_exceptions_test.rb
+++ b/actionpack/test/dispatch/public_exceptions_test.rb
@@ -1,0 +1,255 @@
+# frozen_string_literal: true
+
+require "abstract_unit"
+
+class PublicExceptionsTest < ActiveSupport::TestCase
+  setup do
+    @tmpdir = Dir.mktmpdir
+    @public_exception = ActionDispatch::PublicExceptions.new(@tmpdir)
+  end
+
+  teardown do
+    FileUtils.rm_rf(@tmpdir)
+  end
+
+  test "render the 404 page when a 404.html file exists and the request format is text/html" do
+    write_template("404.html", "This page doesn't exist")
+
+    status, _, body = @public_exception.call(
+      "REQUEST_METHOD" => "GET",
+      "HTTP_ACCEPT" => "text/html",
+      "PATH_INFO" => "/404",
+      "rack.input" => "",
+    )
+
+    assert_equal(404, status)
+    assert_equal("This page doesn't exist", body.body)
+  end
+
+  test "render the 404 page when a 404.html.erb file exists and the request format is text/html" do
+    write_template("404.html.erb", "<%= link_to('Back', 'https://example.org') %>")
+
+    status, _, body = @public_exception.call(
+      "REQUEST_METHOD" => "GET",
+      "HTTP_ACCEPT" => "text/html",
+      "PATH_INFO" => "/404",
+      "rack.input" => "",
+    )
+
+    assert_equal(404, status)
+    assert_equal('<a href="https://example.org">Back</a>', body.body)
+  end
+
+  test "render the 404 page when a 404.json.erb file exists and the request format is application/json" do
+    write_template("404.json.erb", '{"request_id":<%= request.request_id %>}')
+
+    status, _, body = @public_exception.call(
+      "REQUEST_METHOD" => "GET",
+      "HTTP_ACCEPT" => "application/json",
+      "PATH_INFO" => "/404",
+      "action_dispatch.request_id" => "1234",
+      "rack.input" => "",
+    )
+
+    assert_equal(404, status)
+    assert_equal('{"request_id":1234}', body.body)
+  end
+
+  test "render a generic response when no template exists for a given content-type" do
+    write_template("404.html", "This page doesn't exist")
+
+    status, _, body = @public_exception.call(
+      "REQUEST_METHOD" => "GET",
+      "HTTP_ACCEPT" => "application/json",
+      "PATH_INFO" => "/404",
+      "rack.input" => "",
+    )
+
+    assert_equal(404, status)
+    assert_equal('{"status":404,"error":"Not Found"}', body.body)
+  end
+
+  test "render a 404 html page when a generic response for a content-type can't be returned" do
+    write_template("404.html", "This page doesn't exist")
+
+    status, _, body = @public_exception.call(
+      "REQUEST_METHOD" => "GET",
+      "HTTP_ACCEPT" => "application/rss+xml",
+      "PATH_INFO" => "/404",
+      "rack.input" => "",
+    )
+
+    assert_equal(404, status)
+    assert_equal("This page doesn't exist", body.body)
+  end
+
+  test "render a 404 html page when no formats can be determined" do
+    write_template("404.html", "This page doesn't exist")
+
+    status, _, body = @public_exception.call(
+      "REQUEST_METHOD" => "GET",
+      "HTTP_ACCEPT" => "application/foo+bar",
+      "PATH_INFO" => "/404",
+      "rack.input" => "",
+    )
+
+    assert_equal(404, status)
+    assert_equal("This page doesn't exist", body.body)
+  end
+
+  test "return a 404 when the code is not a http status code" do
+    status, headers, body = @public_exception.call(
+      "REQUEST_METHOD" => "GET",
+      "HTTP_ACCEPT" => "text/html",
+      "PATH_INFO" => "/314141241",
+      "rack.input" => "",
+    )
+
+    assert_equal(404, status)
+    assert_equal({ ActionDispatch::Constants::X_CASCADE => "pass", Rack::CONTENT_TYPE => "text/html" }, headers)
+    assert_empty(body.body)
+  end
+
+  test "render a page if the corresponding error template exists" do
+    write_template("401.html", "You are not authorized")
+
+    status, _, body = @public_exception.call(
+      "REQUEST_METHOD" => "GET",
+      "HTTP_ACCEPT" => "text/html",
+      "PATH_INFO" => "/401",
+      "rack.input" => "",
+    )
+
+    assert_equal(401, status)
+    assert_equal("You are not authorized", body.body)
+  end
+
+  test "return a 404 if no corresponding template exists and no generic response can be returned for a content-type" do
+    status, headers, body = @public_exception.call(
+      "REQUEST_METHOD" => "GET",
+      "HTTP_ACCEPT" => "text/html",
+      "PATH_INFO" => "/401",
+      "rack.input" => "",
+    )
+
+    assert_equal(404, status)
+    assert_equal({ ActionDispatch::Constants::X_CASCADE => "pass", Rack::CONTENT_TYPE => "text/html" }, headers)
+    assert_empty(body.body)
+  end
+
+  test "render the translated error page in priority" do
+    write_template("404.html", "This page doesn't exist")
+    write_template("404.fr.html", "Cette page est introuvable")
+
+    old_locale = I18n.locale
+    I18n.locale = :fr
+
+    status, _, body = @public_exception.call(
+      "REQUEST_METHOD" => "GET",
+      "HTTP_ACCEPT" => "text/html",
+      "PATH_INFO" => "/404",
+      "rack.input" => "",
+    )
+
+    assert_equal(404, status)
+    assert_equal("Cette page est introuvable", body.body)
+  ensure
+    I18n.locale = old_locale
+  end
+
+  test "render the page with the 'errors' layout when it exists" do
+    Dir.mkdir("#{@tmpdir}/layouts")
+    write_template("layouts/errors.html.erb", <<~ERB)
+      <!DOCTYPE html>
+      <html lang="en">
+        <body>
+          <%= yield %>
+        </body>
+      </html>
+    ERB
+    write_template("404.html.erb", "This page doesn't exist")
+
+    status, _, body = @public_exception.call(
+      "REQUEST_METHOD" => "GET",
+      "HTTP_ACCEPT" => "text/html",
+      "PATH_INFO" => "/404",
+      "rack.input" => "",
+    )
+
+    assert_equal(404, status)
+    assert_equal(<<~EXPECTED, body.body)
+      <!DOCTYPE html>
+      <html lang="en">
+        <body>
+          This page doesn't exist
+        </body>
+      </html>
+    EXPECTED
+  end
+
+  test "has access to thes routes url helpers when available" do
+    route_set = ActionDispatch::Routing::RouteSet.new.tap do |routes|
+      routes.draw { root to: redirect("") }
+    end
+
+    @public_exception = ActionDispatch::PublicExceptions.new(@tmpdir, route_set)
+
+    write_template("404.html.erb", <<~ERB)
+      Return to the <%= link_to('home page', root_path) %>.
+      View our <%= link_to('docs', root_url) %>.
+    ERB
+
+    status, _, body = @public_exception.call(
+      "REQUEST_METHOD" => "GET",
+      "HTTP_ACCEPT" => "text/html",
+      "PATH_INFO" => "/404",
+      "HTTP_HOST" => "example.org",
+      "HTTPS" => "on",
+      "rack.input" => "",
+    )
+
+    assert_equal(404, status)
+    assert_equal(<<~EXPECTED, body.body)
+      Return to the <a href="/">home page</a>.
+      View our <a href="https://example.org/">docs</a>.
+    EXPECTED
+  end
+
+  test "inserting a middleware on the controller" do
+    previous = ActionDispatch::ExceptionsController.middleware_stack.dup
+    my_middleware = Class.new do
+      def initialize(app)
+        @app = app
+      end
+
+      def call(env)
+        result = @app.call(env)
+        result[1]["canary-app.throttled"] = "1"
+
+        result
+      end
+    end
+
+    ActionDispatch::ExceptionsController.use(my_middleware)
+
+    write_template("404.html", "This page doesn't exist")
+
+    status, headers, body = @public_exception.call(
+      "REQUEST_METHOD" => "GET",
+      "HTTP_ACCEPT" => "text/html",
+      "PATH_INFO" => "/404",
+      "rack.input" => "",
+    )
+
+    assert_equal(404, status)
+    assert_equal("This page doesn't exist", body.body)
+    assert_equal("1", headers["canary-app.throttled"])
+  ensure
+    ActionDispatch::ExceptionsController.middleware_stack = previous
+  end
+
+  private
+    def write_template(name, content)
+      File.write("#{@tmpdir}/#{name}", content)
+    end
+end

--- a/railties/lib/rails/application/default_middleware_stack.rb
+++ b/railties/lib/rails/application/default_middleware_stack.rb
@@ -133,7 +133,7 @@ module Rails
         end
 
         def show_exceptions_app
-          config.exceptions_app || ActionDispatch::PublicExceptions.new(Rails.public_path)
+          config.exceptions_app || ActionDispatch::PublicExceptions.new(Rails.public_path, app.routes)
         end
     end
   end

--- a/railties/test/application/middleware/exceptions_test.rb
+++ b/railties/test/application/middleware/exceptions_test.rb
@@ -52,6 +52,98 @@ module ApplicationTests
       assert_equal 405, last_response.status
     end
 
+    test "renders and evaluated a 422 erb page" do
+      controller :foo, <<-RUBY
+        class FooController < ActionController::Base
+          def root
+            raise ActionController::InvalidAuthenticityToken
+          end
+        end
+      RUBY
+
+      app_file "config/routes.rb", <<-RUBY
+        Rails.application.routes.draw do
+          root to: "foo#root"
+        end
+      RUBY
+
+      app_file "public/422.html.erb", <<-RUBY
+        <%= stylesheet_link_tag("application") %>
+        Return to the <%= link_to("home page", root_path) %>
+      RUBY
+
+      get "/", {}, { "HTTPS" => "on" }
+      assert_equal 422, last_response.status
+      assert_match('<link rel="stylesheet" href="/assets/application', last_response.body)
+      assert_match('Return to the <a href="/">home page</a>', last_response.body)
+    end
+
+    test "renders a 406 page when an invalid content-type and accept header are passed" do
+      controller :foo, <<-RUBY
+        class FooController < ActionController::Base
+          def root
+            raise ActionController::InvalidAuthenticityToken
+          end
+        end
+      RUBY
+
+      app_file "config/routes.rb", <<-RUBY
+        Rails.application.routes.draw do
+          root to: "foo#root"
+        end
+      RUBY
+
+      app_file "public/406.html.erb", <<-RUBY
+        <%= stylesheet_link_tag("application") %>
+        Return to the <%= link_to("home page", root_path) %>
+      RUBY
+
+      get "/", {}, { "HTTP_ACCEPT" => "invalid", "CONTENT_TYPE" => "invalid", "HTTPS" => "on" }
+      assert_equal 406, last_response.status
+      assert_match('<link rel="stylesheet" href="/assets/application', last_response.body)
+      assert_match('Return to the <a href="/">home page</a>', last_response.body)
+    end
+
+    test "add responde headers with a middleware before sending the response" do
+      controller :foo, <<-RUBY
+        class FooController < ActionController::Base
+          def root
+            head(:ok)
+          end
+        end
+      RUBY
+
+      app_file "config/routes.rb", <<-RUBY
+        Rails.application.routes.draw do
+          root to: "foo#root"
+        end
+      RUBY
+
+      add_to_config(<<~CODE)
+        my_middleware = Class.new do
+          def initialize(app)
+            @app = app
+          end
+
+          def call(env)
+            result = @app.call(env)
+            result[1]["some-header"] = "foo"
+            result
+          end
+        end
+
+        ActionDispatch::ExceptionsController.use(my_middleware)
+      CODE
+
+      get "/abc", {}, { "HTTPS" => "on" }
+      assert_equal 404, last_response.status
+      assert_equal("foo", last_response.headers["some-header"])
+
+      get "/", {}, { "HTTPS" => "on" }
+      assert_equal 200, last_response.status
+      assert_not(last_response.headers.key?("some-header"))
+    end
+
     test "renders unknown http methods as 405 when routes are used as the custom exceptions app" do
       app_file "config/routes.rb", <<-RUBY
         Rails.application.routes.draw do


### PR DESCRIPTION
### Motivation / Background

I'd like to make it easier to do simple things on error pages, such as:

* Customising them with tailwind, or allow to add stylesheets
* Add dynamic rendering to allow for displaying links
* Display images

### Detail

The Rails default exception app is very limited in term of features because it can only render static page. While the recent redesign of the error pages are super nice, branding error pages is a feature that should be easy to do, but unfortunately in Rails, it's not.

There is 3 ways to solve this problem, but none are easy:

1) Set the `exceptions_app = routes`
2) Add a bunch of `rescue_from` in your ApplicationController. This effectively bypass the exception app.
3) Create your own exception app from scratch.

-----------------

Here are all the issues with those 3 approach:

1) Setting the `exceptions_app` to `routes` is overkilled, as the error is re-routed and the entire middleware stack is reperformed.
Some exceptions that originally triggered the exception app, will resurface (as the same codepath will get called). See [#43094](43094) [#51228](51228) [#54925](51228).
This solution (while the most popular) was also never officialy documented.
2) It works okay ish, but you may miss some exceptions to rescue, it also bloats your controller with rescue_from clause. An example of a real app using this approach is Mastodon.
3) This is the official way, works great but you have to implement the rendering logic from scratch.

Worth remembering that we have to do all of this to simply display an image :( .

### Additional information

I'd like to provide a stripped down controller with minimum functionalities to be able to do all of the above without writing any line of code.
I went with a Metal controller and added the necessary rendering concerns.

All previous behaviours were conserved. It's also backward compatible and will allow rendering existing and static `404.html` page.

This PR is big enough and if this feature is accepted, I'd like to rename the 404.html files generated by Rails, and maybe move them from the public folder? Not sure if those shouldn't belong to the views.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
