### PR TITLE
Set default for primary keys in `insert_all`/`upsert_all`

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Set default for primary keys in `insert_all`/`upsert_all`.
+
+    Previously in Postgres, updating and inserting new records in one upsert wasn't possible
+    due to null primary key values. `nil` primary key values passed into `insert_all`/`upsert_all`
+    are now implicitly set to the default insert value specified by adapter.
+
+    *Jenny Shen*
+
 *   Add a load hook `active_record_database_configurations` for `ActiveRecord::DatabaseConfigurations`
 
     *Mike Dalessio*

--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -550,7 +550,14 @@ module ActiveRecord
         cast_result(internal_execute(...))
       end
 
+      def default_insert_value(column) # :nodoc:
+        DEFAULT_INSERT_VALUE
+      end
+
       private
+        DEFAULT_INSERT_VALUE = Arel.sql("DEFAULT").freeze
+        private_constant :DEFAULT_INSERT_VALUE
+
         # Lowest level way to execute a query. Doesn't check for illegal writes, doesn't annotate queries, yields a native result object.
         def raw_execute(sql, name = nil, binds = [], prepare: false, async: false, allow_retry: false, materialize_transactions: true, batch: false)
           type_casted_binds = type_casted_binds(binds)
@@ -605,13 +612,6 @@ module ActiveRecord
           statements.each do |statement|
             raw_execute(statement, name, **kwargs)
           end
-        end
-
-        DEFAULT_INSERT_VALUE = Arel.sql("DEFAULT").freeze
-        private_constant :DEFAULT_INSERT_VALUE
-
-        def default_insert_value(column)
-          DEFAULT_INSERT_VALUE
         end
 
         def build_fixture_sql(fixtures, table_name)

--- a/activerecord/lib/active_record/connection_adapters/mysql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/database_statements.rb
@@ -45,14 +45,14 @@ module ActiveRecord
           end
         end
 
+        def default_insert_value(column) # :nodoc:
+          super unless column.auto_increment?
+        end
+
         private
           # https://mariadb.com/kb/en/analyze-statement/
           def analyze_without_explain?
             mariadb? && database_version >= "10.1.0"
-          end
-
-          def default_insert_value(column)
-            super unless column.auto_increment?
           end
 
           def returning_column_values(result)

--- a/activerecord/lib/active_record/connection_adapters/sqlite3/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3/database_statements.rb
@@ -61,6 +61,14 @@ module ActiveRecord
           @previous_read_uncommitted = nil
         end
 
+        def default_insert_value(column) # :nodoc:
+          if column.default_function
+            Arel.sql(column.default_function)
+          else
+            column.default
+          end
+        end
+
         private
           def internal_begin_transaction(mode, isolation)
             if isolation
@@ -135,14 +143,6 @@ module ActiveRecord
 
           def returning_column_values(result)
             result.rows.first
-          end
-
-          def default_insert_value(column)
-            if column.default_function
-              Arel.sql(column.default_function)
-            else
-              column.default
-            end
           end
       end
     end

--- a/activerecord/test/cases/insert_all_test.rb
+++ b/activerecord/test/cases/insert_all_test.rb
@@ -409,6 +409,24 @@ class InsertAllTest < ActiveRecord::TestCase
     assert_equal "New edition", Book.find(1).name
   end
 
+  def test_upsert_all_implicitly_sets_primary_keys_when_nil
+    assert_difference "Book.count", 2 do
+      Book.upsert_all [
+        { id: 1, name: "New edition" },
+        { id: nil, name: "New edition 2" },
+        { id: nil, name: "New edition 3" },
+      ]
+    end
+
+    assert_equal "New edition", Book.find(1).name
+  end
+
+  def test_insert_all_implicitly_sets_primary_keys_when_nil
+    assert_difference "Book.count", 1 do
+      Book.insert_all [ { id: nil, name: "New edition" } ]
+    end
+  end
+
   def test_upsert_all_only_applies_last_value_when_given_duplicate_identifiers
     skip unless supports_insert_on_duplicate_update? && !current_adapter?(:PostgreSQLAdapter)
 


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->
In MySQL/SQLite, when a null value for a primary key gets passed into an insert, the auto increment will automatically set the value. However, in Postgres, a null value for a primary key will raise a `PG::NotNullViolation`. This limits the ability to update and insert new records in one bulk upsert.

```ruby
Book.upsert_all [
  { id: 1, name: "New edition" },
  { id: nil, name: "New edition 2" },
  { id: nil, name: "New edition 3" },
]
```

### Detail

When determining the value to insert, I chose to set the value to `default_insert_value` if the attribute was the primary key and the value is `nil`. This would translate to `Arel.sql("DEFAULT")` for Postgres but remain `nil` for some adapters like MySQL as primary key columns are auto increment columns.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
