### PR TITLE
[actionview] Check choice type before calling .second to detect grouped_choices in Select helper

### DIFF
--- a/actionview/lib/action_view/helpers/tags/select.rb
+++ b/actionview/lib/action_view/helpers/tags/select.rb
@@ -37,7 +37,12 @@ module ActionView
           #   [nil, []]
           #   { nil => [] }
           def grouped_choices?
-            !@choices.blank? && @choices.first.respond_to?(:second) && Array === @choices.first.second
+            return false if @choices.blank?
+
+            first_choice = @choices.first
+            return false unless first_choice.is_a?(Enumerable)
+
+            first_choice.second.is_a?(Array)
           end
       end
     end

--- a/actionview/test/template/form_options_helper_test.rb
+++ b/actionview/test/template/form_options_helper_test.rb
@@ -537,6 +537,13 @@ class FormOptionsHelperTest < ActionView::TestCase
     )
   end
 
+  def test_select_with_class
+    assert_dom_equal(
+      "<select name=\"post[class]\" id=\"post_class\"><option value=\"Struct::Post\">Struct::Post</option></select>",
+      select(:post, :class, [Post])
+    )
+  end
+
   def test_select_without_multiple
     assert_dom_equal(
       "<select id=\"post_category\" name=\"post[category]\"></select>",


### PR DESCRIPTION
### Motivation / Background

Fixes https://github.com/rails/rails/issues/54966

### Detail

This Pull Request changes `ActionView::Helpers::Tags::Select#grouped_choices?` to do type checking instead of duck typing.

This avoids calling `second` on arbitrary objects.

In the issue above, it's calling `.second` on an `ActiveRecord` class, triggering a database call.

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
