### PR TITLE
Add ActiveRecord::Relation#destroy_by! method

### DIFF
--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -1125,6 +1125,21 @@ module ActiveRecord
       where(*args).destroy_all
     end
 
+    # Finds and destroys all records matching the specified conditions.
+    # This is short-hand for <tt>relation.where(condition).destroy_all!</tt>.
+    # Returns the collection of objects that were destroyed.
+    #
+    # If no record is found, returns empty array.
+    #
+    #   Person.destroy_by!(id: 13)
+    #   Person.destroy_by!(name: 'Spartacus', rating: 4)
+    #   Person.destroy_by!("published_at < ?", 2.weeks.ago)
+    #
+    # If one record isn't destroyed, it raises ActiveRecord::RecordNotDestroyed.
+    def destroy_by!(*args)
+      where(*args).destroy_all!
+    end
+
     # Finds and deletes all records matching the specified conditions.
     # This is short-hand for <tt>relation.where(condition).delete_all</tt>.
     # Returns the number of rows affected.

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -2052,6 +2052,15 @@ class RelationTest < ActiveRecord::TestCase
     assert_equal [david], destroyed
   end
 
+  def test_destroy_by!
+    david = authors(:david)
+
+    assert_difference("Post.count", -3) { david.posts.destroy_by!(body: "hello") }
+
+    destroyed = Author.destroy_by!(id: david.id)
+    assert_equal [david], destroyed
+  end
+
   test "find_by with hash conditions returns the first matching record" do
     assert_equal posts(:eager_other), Post.order(:id).find_by(author_id: 2)
   end


### PR DESCRIPTION
ActiveRecord already provides a `destroy_by` method, which is equivalent to `where(*args).destroy_all`.

However, until now, there was no corresponding `destroy_by!` method which means we had to manually change the call to `where(*args).destroy_all!` whenever we wanted to raise an exception if any record couldn't be destroyed.

This commit adds the missing `destroy_by!` method for consistency and convenience.