### PR TITLE
Expose ActiveSupport::Cache::MemCacheStore client

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Add `client` method to `ActiveSupport::Cache::MemCacheStore` to provide access to the underlying Dalli client.
+
+    ```ruby
+    Rails.cache.client.close if Rails.cache.is_a?(ActiveSupport::Cache::MemCacheStore)
+    ```
+
+    *Patrick Tulskie*
+
 *   Allow to configure maximum cache key sizes
 
     When the key exceeds the configured limit (250 bytes by default), it will be truncated and

--- a/activesupport/lib/active_support/cache/mem_cache_store.rb
+++ b/activesupport/lib/active_support/cache/mem_cache_store.rb
@@ -98,6 +98,24 @@ module ActiveSupport
         "#<#{self.class} options=#{options.inspect} mem_cache=#{instance.inspect}>"
       end
 
+      # Returns the underlying Dalli client instance.
+      #
+      # This provides direct access to the Dalli client or connection pool to perform operations
+      # not exposed by the cache store interface.
+      #
+      # For example, to close the connection before forking:
+      #
+      #   Rails.cache.client.close if Rails.cache.is_a?(ActiveSupport::Cache::MemCacheStore)
+
+      # To perform operations on a pooled connection:
+      #
+      #   Rails.cache.client.with do |c|
+      #     c.close
+      #   end
+      def client
+        @data
+      end
+
       ##
       # :method: write
       # :call-seq: write(name, value, options = nil)

--- a/activesupport/test/cache/stores/mem_cache_store_test.rb
+++ b/activesupport/test/cache/stores/mem_cache_store_test.rb
@@ -387,6 +387,18 @@ class MemCacheStoreTest < ActiveSupport::TestCase
     assert_equal 5, pool.instance_variable_get(:@timeout)
   end
 
+  def test_client_returns_direct_dalli_client_when_not_pooled
+    cache = lookup_store(pool: false)
+    assert_same cache.instance_variable_get(:@data), cache.client
+    assert_instance_of Dalli::Client, cache.client
+  end
+
+  def test_client_returns_connection_pool_when_pooled
+    cache = ActiveSupport::Cache.lookup_store(:mem_cache_store)
+    assert_same cache.instance_variable_get(:@data), cache.client
+    assert_instance_of ConnectionPool, cache.client
+  end
+
   private
     def random_string(length)
       (0...length).map { (65 + rand(26)).chr }.join


### PR DESCRIPTION
### Motivation / Background

My team maintains several Rails monoliths where we have begun to leverage [Pitchfork's reforking](https://github.com/Shopify/pitchfork/blob/master/docs/REFORKING.md). One issue with that is that when you refork and you are using the native Rails MemCacheStore, the underlying Dalli connection actually [closes and then raises an exception](https://github.com/petergoldstein/dalli/blob/1eb5efd0e162f33d3ef7349623ffc91c25c1ca3e/lib/dalli/protocol/connection_manager.rb#L221-L228) when a fork was detected. The recommended course of action is to call `.close` on the connection when forking (before making a call to the cache), but in recent versions of Rails, the underlying client is not accessible.

### Detail

This pull request introduces a new `client` method to the `ActiveSupport::Cache::MemCacheStore` class, providing direct access to the underlying Dalli client or connection pool. This change enhances flexibility for advanced operations not exposed by the standard cache store interface. Additionally, a corresponding test has been added to ensure proper functionality.

### Additional information

In some applications, we simply call `Rails.cache.instance_variable_get(:@data).close` in the `after_mold_fork` callback  and that seems to work as intended. This change would allow us and others to replace that with `Rails.cache.client.close` though which feels like less of a hack.

I had also considered just adding a close method to the cache store itself which just proxies that on to the `@data` client, but after some thought I saw a situation where that would lead to other people just adding lots of extra proxy methods to the `MemCacheStore`.

As far as naming, I just called it `client` because that's what it is, but I'm happy to change it to `connection` like some other libraries use for similar patterns. I could also call it `dalli` like it was called in Rails until 7+ for those who crave nostalgia but that introduces a loose coupling to the name of the client.

Lastly, there are a bunch of other tests that use `cache.instance_variable_get(:@data)` that I did not touch in order to keep this diff simple. If so desired, I can go through and update those to use the new `client` method as well.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.