### PR TITLE
Skip Sidekiq 8.0.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -100,7 +100,7 @@ gem "useragent", require: false
 group :job do
   gem "resque", require: false
   gem "resque-scheduler", require: false
-  gem "sidekiq", require: false
+  gem "sidekiq", "!= 8.0.3", require: false
   gem "sucker_punch", require: false
   gem "queue_classic", ">= 4.0.0", require: false, platforms: :ruby
   gem "sneakers", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -484,7 +484,7 @@ GEM
     redcarpet (3.6.1)
     redis (5.3.0)
       redis-client (>= 0.22.0)
-    redis-client (0.23.1)
+    redis-client (0.24.0)
       connection_pool
     redis-namespace (1.11.0)
       redis (>= 4)
@@ -583,11 +583,12 @@ GEM
     serverengine (2.0.7)
       sigdump (~> 0.2.2)
     set (1.1.1)
-    sidekiq (7.3.7)
-      connection_pool (>= 2.3.0)
-      logger
-      rack (>= 2.2.4)
-      redis-client (>= 0.22.2)
+    sidekiq (8.0.2)
+      connection_pool (>= 2.5.0)
+      json (>= 2.9.0)
+      logger (>= 1.6.2)
+      rack (>= 3.1.0)
+      redis-client (>= 0.23.2)
     sigdump (0.2.5)
     signet (0.19.0)
       addressable (~> 2.8)
@@ -790,7 +791,7 @@ DEPENDENCIES
   rubyzip (~> 2.0)
   sdoc!
   selenium-webdriver (>= 4.20.0)
-  sidekiq
+  sidekiq (!= 8.0.3)
   sneakers
   solid_cable
   solid_cache


### PR DESCRIPTION
### Motivation / Background
This commit skips Sidekiq 8.0.3 until https://github.com/sidekiq/sidekiq/issues/6683 is resolved.

### Detail
- Steps to reproduce

```ruby
git clone https://github.com/rails/rails
cd rails
rm Gemfile.lock
bundle install
cd activejob
bundle exec rake test:integration:sidekiq
```

- Error addressed by this pull request
```ruby
$ bundle exec rake test:integration:sidekiq
/home/yahonda/.rbenv/versions/3.4.3/bin/ruby -w -I"lib:test" /home/yahonda/.rbenv/versions/3.4.3/lib/ruby/gems/3.4.0/gems/rake-13.2.1/lib/rake/rake_test_loader.rb "test/integration/queuing_test.rb"
Using sidekiq
/home/yahonda/.rbenv/versions/3.4.3/lib/ruby/gems/3.4.0/gems/capybara-3.40.0/lib/capybara/session/config.rb:95: warning: URI::RFC3986_PARSER.make_regexp is obsolete. Use URI::RFC2396_PARSER.make_regexp explicitly.
INFO  2025-04-25T05:44:50.800Z pid=163509 tid=3fzh: Sidekiq 8.0.3 connecting to Redis with options {size: 10, pool_name: "internal", url: nil}
Run options: --seed 36183

# Running:

.........E

Error:
QueuingTest#test_should_supply_a_wrapped_class_name_to_Sidekiq:
NoMethodError: undefined method '[]' for nil
    test/integration/queuing_test.rb:38:in 'block (2 levels) in <class:QueuingTest>'
    sidekiq (8.0.3) lib/sidekiq/testing.rb:23:in 'Sidekiq::Testing.__set_test_mode'
    sidekiq (8.0.3) lib/sidekiq/testing.rb:49:in 'Sidekiq::Testing.fake!'
    test/integration/queuing_test.rb:35:in 'block in <class:QueuingTest>'
    minitest (5.25.4) lib/minitest/test.rb:94:in 'block (2 levels) in Minitest::Test#run'
    minitest (5.25.4) lib/minitest/test.rb:190:in 'Minitest::Test#capture_exceptions'
    minitest (5.25.4) lib/minitest/test.rb:89:in 'block in Minitest::Test#run'
    minitest (5.25.4) lib/minitest.rb:368:in 'Minitest::Runnable#time_it'
    minitest (5.25.4) lib/minitest/test.rb:88:in 'Minitest::Test#run'
    /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/executor/test_helper.rb:5:in 'block in ActiveSupport::Executor::TestHelper#run'
    /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/execution_wrapper.rb:104:in 'ActiveSupport::ExecutionWrapper.perform'
    /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/executor/test_helper.rb:5:in 'ActiveSupport::Executor::TestHelper#run'
    minitest (5.25.4) lib/minitest.rb:1208:in 'Minitest.run_one_method'
    minitest (5.25.4) lib/minitest.rb:447:in 'Minitest::Runnable.run_one_method'
    minitest (5.25.4) lib/minitest.rb:434:in 'block (2 levels) in Minitest::Runnable.run'
    minitest (5.25.4) lib/minitest.rb:430:in 'Array#each'
    minitest (5.25.4) lib/minitest.rb:430:in 'block in Minitest::Runnable.run'
    minitest (5.25.4) lib/minitest.rb:472:in 'Minitest::Runnable.on_signal'
    minitest (5.25.4) lib/minitest.rb:459:in 'Minitest::Runnable.with_info_handler'
    minitest (5.25.4) lib/minitest.rb:429:in 'Minitest::Runnable.run'
    /home/yahonda/src/github.com/rails/rails/railties/lib/rails/test_unit/line_filtering.rb:10:in 'Rails::LineFiltering#run'
    minitest (5.25.4) lib/minitest.rb:332:in 'block in Minitest.__run'
    minitest (5.25.4) lib/minitest.rb:332:in 'Array#map'
    minitest (5.25.4) lib/minitest.rb:332:in 'Minitest.__run'
    minitest (5.25.4) lib/minitest.rb:288:in 'Minitest.run'
    minitest (5.25.4) lib/minitest.rb:86:in 'block in Minitest.autorun'


bin/rails test /home/yahonda/src/github.com/rails/rails/activejob/test/integration/queuing_test.rb:34

.

Finished in 19.428889s, 0.5662 runs/s, 0.7206 assertions/s.
11 runs, 14 assertions, 0 failures, 1 errors, 0 skips
rake aborted!
Command failed with status (1): [ruby -w -I"lib:test" /home/yahonda/.rbenv/versions/3.4.3/lib/ruby/gems/3.4.0/gems/rake-13.2.1/lib/rake/rake_test_loader.rb "test/integration/queuing_test.rb" ]
/home/yahonda/.rbenv/versions/3.4.3/bin/bundle:25:in 'Kernel#load'
/home/yahonda/.rbenv/versions/3.4.3/bin/bundle:25:in '<main>'
Tasks: TOP => test:integration:sidekiq
(See full trace by running task with --trace)
$
```

### Additional information
Related to https://github.com/rails/rails/issues/54972

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [ ] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
