### PR TITLE
Implement ability to opt out of parallel database hooks

### DIFF
--- a/activerecord/lib/active_record/test_databases.rb
+++ b/activerecord/lib/active_record/test_databases.rb
@@ -5,11 +5,15 @@ require "active_support/testing/parallelization"
 module ActiveRecord
   module TestDatabases # :nodoc:
     ActiveSupport::Testing::Parallelization.before_fork_hook do
-      ActiveRecord::Base.connection_handler.clear_all_connections!
+      if ActiveSupport.parallelize_test_databases
+        ActiveRecord::Base.connection_handler.clear_all_connections!
+      end
     end
 
     ActiveSupport::Testing::Parallelization.after_fork_hook do |i|
-      create_and_load_schema(i, env_name: ActiveRecord::ConnectionHandling::DEFAULT_ENV.call)
+      if ActiveSupport.parallelize_test_databases
+        create_and_load_schema(i, env_name: ActiveRecord::ConnectionHandling::DEFAULT_ENV.call)
+      end
     end
 
     def self.create_and_load_schema(i, env_name:)

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,24 @@
+*   Implement ability to skip creating parallel testing databases.
+
+    With parallel testing, Rails will create a database per process. If this isn't
+    desirable or you would like to implement databases handling on your own, you can
+    now turn off this default behavior.
+
+    To skip creating a database per process, you can change it via the
+    `parallelize` method:
+
+    ```ruby
+    parallelize(workers: 10, parallelize_databases: false)
+    ```
+
+    or via the application configuration:
+
+    ```ruby
+    config.active_support.parallelize_databases = false
+    ```
+
+    *Eileen M. Uchitelle*
+
 *   Allow to configure maximum cache key sizes
 
     When the key exceeds the configured limit (250 bytes by default), it will be truncated and

--- a/activesupport/lib/active_support.rb
+++ b/activesupport/lib/active_support.rb
@@ -104,6 +104,7 @@ module ActiveSupport
 
   cattr_accessor :test_order # :nodoc:
   cattr_accessor :test_parallelization_threshold, default: 50 # :nodoc:
+  cattr_accessor :parallelize_test_databases, default: true # :nodoc:
 
   @error_reporter = ActiveSupport::ErrorReporter.new
   singleton_class.attr_accessor :error_reporter # :nodoc:

--- a/activesupport/lib/active_support/test_case.rb
+++ b/activesupport/lib/active_support/test_case.rb
@@ -79,12 +79,25 @@ module ActiveSupport
       # Because parallelization presents an overhead, it is only enabled when the
       # number of tests to run is above the +threshold+ param. The default value is
       # 50, and it's configurable via +config.active_support.test_parallelization_threshold+.
-      def parallelize(workers: :number_of_processors, with: :processes, threshold: ActiveSupport.test_parallelization_threshold)
+      #
+      # If you want to skip Rails default creation of one database per process in favor of
+      # writing your own implementation, you can set +parallelize_databases+, or configure it
+      # via +config.active_support.parallelize_test_databases+.
+      #
+      #   parallelize(workers: :number_of_processes, parallelize_databases: false)
+      #
+      # Note that your test suite may deadlock if you attempt to use only one database
+      # with multiple processes.
+      def parallelize(workers: :number_of_processors, with: :processes, threshold: ActiveSupport.test_parallelization_threshold, parallelize_databases: ActiveSupport.parallelize_test_databases)
         case
         when ENV["PARALLEL_WORKERS"]
           workers = ENV["PARALLEL_WORKERS"].to_i
         when workers == :number_of_processors
           workers = (Concurrent.available_processor_count || Concurrent.processor_count).floor
+        end
+
+        if with == :processes
+          ActiveSupport.parallelize_test_databases = parallelize_databases
         end
 
         Minitest.parallel_executor = ActiveSupport::Testing::ParallelizeExecutor.new(size: workers, with: with, threshold: threshold)

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -3204,6 +3204,20 @@ module ApplicationTests
       assert_equal 1234, ActiveSupport.test_parallelization_threshold
     end
 
+    test "ActiveSupport.parallelize_test_databases can be configured via config.active_support.parallelize_test_databases" do
+      remove_from_config '.*config\.load_defaults.*\n'
+
+      app_file "config/environments/test.rb", <<-RUBY
+        Rails.application.configure do
+          config.active_support.parallelize_test_databases = false
+        end
+      RUBY
+
+      app "test"
+
+      assert_not ActiveSupport.parallelize_test_databases
+    end
+
     test "custom serializers should be able to set via config.active_job.custom_serializers in an initializer" do
       class ::DummySerializer < ActiveJob::Serializers::ObjectSerializer; end
 


### PR DESCRIPTION
Preivously, you could append your own hooks to parallel tests, but there was no way to skip the Rails database parallelization hooks. There may be cases where you want to implement your own database handling, so this allows you to implement all of that in a `parallelize_setup` block without having Rails create any databases for you.

To skip Rails database parallelization when running parallel tests you can set it in the `parallelize` caller:

```ruby
parallelize(workers: 10, parallelize_databases: false)
```

Or in your application config:

```ruby
config.active_support.parallelize_test_databases = false
```

This is set to true by default.

Note: if you do not create databases for the processes, it is possible for your test suite to deadlock. If you're seeing frequent deadlocks, you may need to create more databases for the processes to use or adjust your tests/code so it's less likely to cause database contention.