### PR TITLE
Add public API for `before_fork_hook` in parallel testing

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,15 @@
+*   Add public API for `before_fork_hook` in parallel testing.
+
+    Introduces a public API for calling the before fork hooks implemented by parallel testing.
+
+    ```ruby
+    parallelize_before_fork do
+        # perform an action before test processes are forked
+    end
+    ```
+
+    *Eileen M. Uchitelle*
+
 *   Implement ability to skip creating parallel testing databases.
 
     With parallel testing, Rails will create a database per process. If this isn't

--- a/activesupport/lib/active_support/test_case.rb
+++ b/activesupport/lib/active_support/test_case.rb
@@ -103,7 +103,21 @@ module ActiveSupport
         Minitest.parallel_executor = ActiveSupport::Testing::ParallelizeExecutor.new(size: workers, with: with, threshold: threshold)
       end
 
-      # Set up hook for parallel testing. This can be used if you have multiple
+      # Before fork hook for parallel testing. This can be used to run anything
+      # before the processes are forked.
+      #
+      # In your +test_helper.rb+ add the following:
+      #
+      #   class ActiveSupport::TestCase
+      #     parallelize_before_fork do
+      #       # run this before fork
+      #     end
+      #   end
+      def parallelize_before_fork(&block)
+        ActiveSupport::Testing::Parallelization.before_fork_hook(&block)
+      end
+
+      # Setup hook for parallel testing. This can be used if you have multiple
       # databases or any behavior that needs to be run after the process is forked
       # but before the tests run.
       #


### PR DESCRIPTION
Previously there was no public API implemented for the `before_fork_hook` when using parallel testing. Applications may want to perform actions before fork, and we should provide an API for it like we did for setup and teardown.
