### PR TITLE
[ci skip] Fix typo in schema_statements.rb

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -548,7 +548,7 @@ module ActiveRecord
       #
       # See {ActiveRecord::ConnectionAdapters::TableDefinition.column}[rdoc-ref:ActiveRecord::ConnectionAdapters::TableDefinition#column].
       #
-      # The +type+ parameter is normally one of the migrations native types,
+      # The +type+ parameter is normally one of the migration's native types,
       # which is one of the following:
       # <tt>:primary_key</tt>, <tt>:string</tt>, <tt>:text</tt>,
       # <tt>:integer</tt>, <tt>:bigint</tt>, <tt>:float</tt>, <tt>:decimal</tt>, <tt>:numeric</tt>,


### PR DESCRIPTION
I wondered if it should be

```
The +type+ parameter is normally one of the migrations' native types
```

i.e. referring to the native types available to all migrations. But the way I've done it seemed to make more sense.

[I](https://github.com/rails/rails/pulls?q=is%3Apr+is%3Aopen+typo+migration) [checked](https://github.com/rails/rails/pulls?q=is%3Apr+is%3Aopen+schema_statements), and couldn't see any existing PRs covering this. Thanks