### PR TITLE
Use updated Sidekiq wrapper class name in test

### DIFF
--- a/activejob/test/integration/queuing_test.rb
+++ b/activejob/test/integration/queuing_test.rb
@@ -34,8 +34,8 @@ class QueuingTest < ActiveSupport::TestCase
     test "should supply a wrapped class name to Sidekiq" do
       Sidekiq::Testing.fake! do
         ::HelloJob.perform_later
-        hash = ActiveJob::QueueAdapters::SidekiqAdapter::JobWrapper.jobs.first
-        assert_equal "ActiveJob::QueueAdapters::SidekiqAdapter::JobWrapper", hash["class"]
+        hash = Sidekiq::ActiveJob::Wrapper.jobs.first
+        assert_equal "Sidekiq::ActiveJob::Wrapper", hash["class"]
         assert_equal "HelloJob", hash["wrapped"]
       end
     end


### PR DESCRIPTION
This is due to sidekiq/sidekiq@4d80a26 changing the name used when queueing jobs.

/cc @yahonda @seuros 