### PR TITLE
[ci skip] Fix typos in the Multiple Databases with Active Record guide

### DIFF
--- a/guides/source/active_record_multiple_databases.md
+++ b/guides/source/active_record_multiple_databases.md
@@ -24,7 +24,7 @@ At this time the following features are supported:
 * Multiple writer databases and a replica for each
 * Automatic connection switching for the model you're working with
 * Automatic swapping between the writer and replica depending on the HTTP verb and recent writes
-* Rails tasks for creating, dropping, migrating, and interacting with multiple databases
+* Rails tasks for creating, dropping, migrating, and interacting with the multiple databases
 
 The following features are not (yet) supported:
 
@@ -166,8 +166,8 @@ config.active_record.reading_role = :readonly
 ```
 
 It's important to connect to your database in a single model and then inherit from that model
-for the tables rather than connecting multiple individual models to the same database. Database
-clients have a limit to the number of open connections that can be, and if you do this, it will
+for the tables rather than connect multiple individual models to the same database. Database
+clients have a limit to the number of open connections there can be, and if you do this, it will
 multiply the number of connections you have since Rails uses the model class name for the
 connection specification name.
 

--- a/guides/source/active_record_multiple_databases.md
+++ b/guides/source/active_record_multiple_databases.md
@@ -24,7 +24,7 @@ At this time the following features are supported:
 * Multiple writer databases and a replica for each
 * Automatic connection switching for the model you're working with
 * Automatic swapping between the writer and replica depending on the HTTP verb and recent writes
-* Rails tasks for creating, dropping, migrating, and interacting with the multiple databases
+* Rails tasks for creating, dropping, migrating, and interacting with multiple databases
 
 The following features are not (yet) supported:
 
@@ -138,7 +138,7 @@ class Person < PrimaryApplicationRecord
 end
 ```
 
-On the other hand, we need to setup our models persisted in the "animals" database:
+On the other hand, we need to set up our models persisted in the "animals" database:
 
 ```ruby
 class AnimalsRecord < ApplicationRecord
@@ -166,8 +166,8 @@ config.active_record.reading_role = :readonly
 ```
 
 It's important to connect to your database in a single model and then inherit from that model
-for the tables rather than connect multiple individual models to the same database. Database
-clients have a limit to the number of open connections there can be, and if you do this, it will
+for the tables rather than connecting multiple individual models to the same database. Database
+clients have a limit to the number of open connections that can be, and if you do this, it will
 multiply the number of connections you have since Rails uses the model class name for the
 connection specification name.
 
@@ -212,7 +212,7 @@ db:setup:primary                   # Create the primary database, loads the sche
 
 Running a command like `bin/rails db:create` will create both the primary and animals databases.
 Note that there is no command for creating the database users, and you'll need to do that manually
-to support the readonly users for your replicas. If you want to create just the animals
+to support the read-only users for your replicas. If you want to create just the animals
 database you can run `bin/rails db:create:animals`.
 
 ## Connecting to Databases without Managing Schema and Migrations
@@ -295,8 +295,8 @@ use a different parent class.
 Finally, in order to use the read-only replica in your application, you'll need to activate
 the middleware for automatic switching.
 
-Automatic switching allows the application to switch from the writer to replica or replica
-to writer based on the HTTP verb and whether there was a recent write by the requesting user.
+Automatic switching allows the application to switch from the writer to the replica or the replica
+to the writer based on the HTTP verb and whether there was a recent write by the requesting user.
 
 If the application receives a POST, PUT, DELETE, or PATCH request, the application will
 automatically write to the writer database. If the request is not one of those methods,
@@ -328,7 +328,7 @@ to the replicas unless they wrote recently.
 
 The automatic connection switching in Rails is relatively primitive and deliberately doesn't
 do a whole lot. The goal is a system that demonstrates how to do automatic connection
-switching that was flexible enough to be customizable by app developers.
+switching that is flexible enough to be customizable by app developers.
 
 The setup in Rails allows you to easily change how the switching is done and what
 parameters it's based on. Let's say you want to use a cookie instead of a session to
@@ -392,7 +392,7 @@ using the connection specification name. This means that if you pass an unknown 
 like `connected_to(role: :nonexistent)` you will get an error that says
 `ActiveRecord::ConnectionNotEstablished (No connection pool for 'ActiveRecord::Base' found for the 'nonexistent' role.)`
 
-If you want Rails to ensure any queries performed are read only, pass `prevent_writes: true`.
+If you want Rails to ensure any queries performed are read-only, pass `prevent_writes: true`.
 This just prevents queries that look like writes from being sent to the database.
 You should also configure your replica database to run in read-only mode.
 
@@ -517,7 +517,7 @@ end
 ```
 
 Applications must provide a resolver to provide application-specific logic. An example resolver that
-uses subdomain to determine the shard might look like this:
+uses a subdomain to determine the shard might look like this:
 
 ```ruby
 config.active_record.shard_resolver = ->(request) {


### PR DESCRIPTION
### Detail

This Pull Request fixes several typos in the 'Multiple Databases with Active Record' guide.

