### PR TITLE
 Fix markdown formatting error at AR 8.0-stable changelog [ci skip]

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -11,7 +11,7 @@
     Use of `Timeout.timeout` could result in improperly initialized database connection.
 
     This could lead to a partially configured connection being used, resulting in various exceptions,
-    the most common being with the PostgreSQLAdapter raising `undefined method `key?' for nil`
+    the most common being with the PostgreSQLAdapter raising `undefined method 'key?' for nil`
     or `TypeError: wrong argument type nil (expected PG::TypeMap)`.
 
     *Jean Boussier*


### PR DESCRIPTION
### Old version

This could lead to a partially configured connection being used, resulting in various  the most common being with the PostgreSQLAdapter raising `undefined method `key?' for nil` or `TypeError: wrong argument type nil (expected PG::TypeMap)`.


### Fixed version

This could lead to a partially configured connection being used, resulting in various  the most common being with the PostgreSQLAdapter raising `undefined method 'key?' for nil` or `TypeError: wrong argument type nil (expected PG::TypeMap)`.