### PR TITLE
Prevent (de)serializing values multiple times in MemCacheStore

### DIFF
--- a/activesupport/lib/active_support/cache/mem_cache_store.rb
+++ b/activesupport/lib/active_support/cache/mem_cache_store.rb
@@ -43,6 +43,16 @@ module ActiveSupport
 
       ESCAPE_KEY_CHARS = /[\x00-\x20%\x7F-\xFF]/n
 
+      class NullSerializer
+        def self.dump(value)
+          value
+        end
+
+        def self.load(value)
+          value
+        end
+      end
+
       # Creates a new Dalli::Client instance with specified addresses and options.
       # If no addresses are provided, we give nil to Dalli::Client, so it uses its fallbacks:
       # - ENV["MEMCACHE_SERVERS"] (if defined)
@@ -89,7 +99,9 @@ module ActiveSupport
         @mem_cache_options = options.dup
         # The value "compress: false" prevents duplicate compression within Dalli.
         @mem_cache_options[:compress] = false
-        (OVERRIDDEN_OPTIONS - %i(compress)).each { |name| @mem_cache_options.delete(name) }
+        # The value "serializer: NullSerializer" prevents duplicate serialization within Dalli.
+        @mem_cache_options[:serializer] = NullSerializer
+        (OVERRIDDEN_OPTIONS - %i(compress) - %i(serializer)).each { |name| @mem_cache_options.delete(name) }
         @data = self.class.build_mem_cache(*(addresses + [@mem_cache_options]))
       end
 

--- a/activesupport/test/cache/cache_store_setting_test.rb
+++ b/activesupport/test/cache/cache_store_setting_test.rb
@@ -28,7 +28,7 @@ class CacheStoreSettingTest < ActiveSupport::TestCase
   end
 
   def test_mem_cache_fragment_cache_store
-    assert_called_with(Dalli::Client, :new, [%w[localhost], { compress: false }]) do
+    assert_called_with(Dalli::Client, :new, [%w[localhost], { compress: false, serializer: ActiveSupport::Cache::MemCacheStore::NullSerializer }]) do
       store = ActiveSupport::Cache.lookup_store :mem_cache_store, "localhost", pool: false
       assert_kind_of(ActiveSupport::Cache::MemCacheStore, store)
     end
@@ -44,14 +44,14 @@ class CacheStoreSettingTest < ActiveSupport::TestCase
   end
 
   def test_mem_cache_fragment_cache_store_with_multiple_servers
-    assert_called_with(Dalli::Client, :new, [%w[localhost 192.168.1.1], { compress: false }]) do
+    assert_called_with(Dalli::Client, :new, [%w[localhost 192.168.1.1], { compress: false, serializer: ActiveSupport::Cache::MemCacheStore::NullSerializer }]) do
       store = ActiveSupport::Cache.lookup_store :mem_cache_store, "localhost", "192.168.1.1", pool: false
       assert_kind_of(ActiveSupport::Cache::MemCacheStore, store)
     end
   end
 
   def test_mem_cache_fragment_cache_store_with_options
-    assert_called_with(Dalli::Client, :new, [%w[localhost 192.168.1.1], { timeout: 10, compress: false }]) do
+    assert_called_with(Dalli::Client, :new, [%w[localhost 192.168.1.1], { timeout: 10, compress: false, serializer: ActiveSupport::Cache::MemCacheStore::NullSerializer }]) do
       store = ActiveSupport::Cache.lookup_store :mem_cache_store, "localhost", "192.168.1.1", namespace: "foo", timeout: 10, pool: false
       assert_kind_of(ActiveSupport::Cache::MemCacheStore, store)
       assert_equal "foo", store.options[:namespace]

--- a/activesupport/test/cache/stores/mem_cache_store_test.rb
+++ b/activesupport/test/cache/stores/mem_cache_store_test.rb
@@ -289,6 +289,22 @@ class MemCacheStoreTest < ActiveSupport::TestCase
     end
   end
 
+  def test_no_multiple_serialize
+    cache = lookup_store(serializer: :message_pack)
+    val = random_string(8.bytes)
+    serialized_value = MessagePack.dump(val)
+
+    assert_called(
+      Marshal,
+      :dump,
+      "Memcached writes should not perform duplicate serialization.",
+      times: 0,
+      returns: serialized_value
+    ) do
+      cache.write("foo", val)
+    end
+  end
+
   def test_unless_exist_expires_when_configured
     cache = lookup_store(namespace: nil)
 


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created because it seems that we are currently (de)serializing values multiple times since Dalli's serialization layer is not disabled. By default, [Dalli uses Marshal](https://github.com/petergoldstein/dalli/blob/main/lib/dalli/client.rb#L40) unless the [`raw: true` request option](https://github.com/petergoldstein/dalli/blob/e5378846becf6382e6ca38b24ac89ff2ec88e8df/lib/dalli/protocol/value_serializer.rb#L30) is sent on every storage request.

Here is a simple reproduction:

```ruby
require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org/"

  gem "activesupport"
  gem "dalli"
  gem "msgpack"
end

require "active_support"

C = ActiveSupport::Cache.lookup_store(:mem_cache_store, serializer: :message_pack)
C.write("foo", "bar")

puts "cache: #{C.inspect}"
```

The important part of the output is: `@value_serializer=#<Dalli::Protocol::ValueSerializer:0x0000000133373780 @serialization_options={serializer: Marshal}>`. This means ActiveSupport::Cache will use MessagePack to (de)serialize the payload and then Dalli will marshal it.

### Detail

Similar to how we disable Dalli's compression layer, the change I am proposing will _effectively_ disable Dalli's serialization by configuring it with a null/no-op serializer. An alternative approach would be to pass in the `raw: true` request option but I've found that it does not work well with some coder configurations when determining when to deserialize a payload https://github.com/petergoldstein/dalli/blob/e5378846becf6382e6ca38b24ac89ff2ec88e8df/lib/dalli/protocol/value_serializer.rb#L37.
 
### Additional information

A couple (3) of `MemCacheStoreTest` tests are failing because they relied on Dalli's marshal behaviour for non-string values ([example](https://github.com/rails/rails/blob/0367cbf265ff25546230d2f668aa887e09995509/activesupport/test/cache/stores/mem_cache_store_test.rb#L339-L345)). I'm not sure if this was explicitly intentional but it doesn't seem correct. 

This may be a breaking change since now payloads will be marshaled when attempting to deserialize them via ActiveSupport's `coder` / `serializer`. Perhaps when reading an entry from the cache, we will need to unmarshal it first or rescue deserialization errors and attempt to unmarshal it before returning an error? I'm curious to hear others' thoughts.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
