### PR TITLE
Rescue connection related errors in MemCacheStore#read_multi_entries

### DIFF
--- a/activesupport/lib/active_support/cache/mem_cache_store.rb
+++ b/activesupport/lib/active_support/cache/mem_cache_store.rb
@@ -219,26 +219,24 @@ module ActiveSupport
         def read_multi_entries(names, **options)
           keys_to_names = names.index_by { |name| normalize_key(name, options) }
 
-          raw_values = begin
-            @data.with { |c| c.get_multi(keys_to_names.keys) }
-          rescue Dalli::UnmarshalError
-            {}
-          end
+          rescue_error_with({}) do
+            raw_values = @data.with { |c| c.get_multi(keys_to_names.keys) }
 
-          values = {}
+            values = {}
 
-          raw_values.each do |key, value|
-            entry = deserialize_entry(value, raw: options[:raw])
+            raw_values.each do |key, value|
+              entry = deserialize_entry(value, raw: options[:raw])
 
-            unless entry.nil? || entry.expired? || entry.mismatched?(normalize_version(keys_to_names[key], options))
-              begin
-                values[keys_to_names[key]] = entry.value
-              rescue DeserializationError
+              unless entry.nil? || entry.expired? || entry.mismatched?(normalize_version(keys_to_names[key], options))
+                begin
+                  values[keys_to_names[key]] = entry.value
+                rescue DeserializationError
+                end
               end
             end
-          end
 
-          values
+            values
+          end
         end
 
         # Delete an entry from the cache.


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created because Rails is not managing network blips when reading multiple values from memcached.

### Detail

This Pull Request changes `MemCacheStore` to swallow various connection exceptions when reading multiple values. The class already does this for every other read and write method, `read_multi_entries` was the only one not implementing the behavior.

### Additional information

For further validation, see how `RedisCacheStore` implements `failsafe` (equivalent to `rescue_error_with` in `MemCacheStore`) for all read and write methods, including `read_multi_entries`: https://github.com/rails/rails/blob/main/activesupport/lib/active_support/cache/redis_cache_store.rb#L356

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
