### PR TITLE
Enforce strict loading violations for associations where joins are disabled

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   `strict_loading` is enforced on associations configured with joins disabled.
+
+    *Garrett Bjerkhoel*
+
 *   `:class_name` is now invalid in polymorphic `belongs_to` associations.
 
     Reason is `:class_name` does not make sense in those associations because

--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -271,6 +271,10 @@ module ActiveRecord
 
       def load_target
         if find_target?
+          if violates_strict_loading?
+            Base.strict_loading_violation!(owner: owner.class, reflection: reflection)
+          end
+
           @target = merge_target_lists(find_target, target)
         end
 

--- a/activerecord/test/models/author.rb
+++ b/activerecord/test/models/author.rb
@@ -23,10 +23,10 @@ class Author < ActiveRecord::Base
   end
 
   has_many :comments_with_order, -> { ordered_by_post_id }, through: :posts, source: :comments
-  has_many :no_joins_comments, through: :posts, disable_joins: :true, source: :comments
+  has_many :no_joins_comments, through: :posts, disable_joins: true, source: :comments
 
   has_many :comments_with_foreign_key, through: :posts, source: :comments, foreign_key: :post_id
-  has_many :no_joins_comments_with_foreign_key, through: :posts, disable_joins: :true, source: :comments, foreign_key: :post_id
+  has_many :no_joins_comments_with_foreign_key, through: :posts, disable_joins: true, source: :comments, foreign_key: :post_id
 
   has_many :members,
     through: :comments_with_order,
@@ -58,7 +58,7 @@ class Author < ActiveRecord::Base
     through: :comments,
     source: :ratings
 
-  has_many :no_joins_ratings, through: :no_joins_comments, disable_joins: :true, source: :ratings
+  has_many :no_joins_ratings, through: :no_joins_comments, disable_joins: true, source: :ratings
   has_many :no_joins_good_ratings,
     -> { where("ratings.value > 5").order(:id) },
     through: :comments,


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

When a model has been marked for strict loading (via [query methods](https://api.rubyonrails.org/classes/ActiveRecord/QueryMethods.html#method-i-strict_loading) or on the [model instance itself](https://api.rubyonrails.org/classes/ActiveRecord/Core.html#method-i-strict_loading-21)) the strict loading requirement is not enforced when joins are disabled on an association.

### Detail

This Pull Request changes where strict loading is enforced in all associations to ensure associations are eager loaded as expected. Currently, on the `main` branch strict loading is enforced in the `ActiveRecord::Associations::Association#find_target` method:

https://github.com/rails/rails/blob/e0bfbb2da5c7bd550d3576a38bcdd6fe00d56dfd/activerecord/lib/active_record/associations/association.rb#L248-L251

Strict loading is enforced as expected until `find_target` is overridden by a subclass. `find_target` is overridden in both `ActiveRecord::Associations::HasManyThroughAssociation` and `ActiveRecord::Associations::SingularAssociation` classes to return early when joins are disabled. `ActiveRecord::Associations::SingularAssociation` in particular is used for both `belongs_to` and `has_one` associations:

https://github.com/rails/rails/blob/e0bfbb2da5c7bd550d3576a38bcdd6fe00d56dfd/activerecord/lib/active_record/associations/has_many_through_association.rb#L225-L230

https://github.com/rails/rails/blob/e0bfbb2da5c7bd550d3576a38bcdd6fe00d56dfd/activerecord/lib/active_record/associations/singular_association.rb#L47-L57

### Additional information

It is desirable when a model is marked for strict loading that even associations with `disable_joins` set to `true` behave similar to when `disable_joins` is set to false.

Developers can still eager load those associations to avoid the strict loading violation. Without this change, strict loading could be bypassed causing additional queries to be performed unexpectedly.

For example:

```ruby
class Author < ActiveRecord::Base
  has_many :posts
  has_many :comments_with_order, -> { ordered_by_post_id }, through: :posts, source: :comments
  has_many :no_joins_comments, through: :posts, disable_joins: true, source: :comments
end

author = Author.strict_loading.first
author.strict_loading!
author.comments_with_order.to_a # => raises ActiveRecord::StrictLoadingViolationError
# Executes:
# SELECT "posts"."id" FROM "posts" WHERE "posts"."author_id" = $1
# SELECT "comments".* FROM "comments" WHERE "comments"."post_id" IN ($1, $2, $3, $4, $5)
author.no_joins_comments.to_a
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
