### PR TITLE
`ActiveSupport::ErrorReporter#report` assigns a cause to unraised exceptions

### DIFF
--- a/activesupport/lib/active_support/error_reporter.rb
+++ b/activesupport/lib/active_support/error_reporter.rb
@@ -276,14 +276,12 @@ module ActiveSupport
 
     private
       def ensure_backtrace(error)
-        return if error.frozen? # re-raising won't add a backtrace
+        return if error.frozen? # re-raising won't add a backtrace or set the cause
         return unless error.backtrace.nil?
 
         begin
-          # We could use Exception#set_backtrace, but until Ruby 3.4
-          # it only support setting `Exception#backtrace` and not
-          # `Exception#backtrace_locations`. So raising the exception
-          # is a good way to build a real backtrace.
+          # As of Ruby 3.4, we could use Exception#set_backtrace to set the backtrace,
+          # but there's nothing like Exception#set_cause. Raising+rescuing is the only way to set the cause.
           raise error
         rescue error.class => error
         end

--- a/activesupport/test/error_reporter_test.rb
+++ b/activesupport/test/error_reporter_test.rb
@@ -172,6 +172,17 @@ class ErrorReporterTest < ActiveSupport::TestCase
     assert_equal __FILE__, error.backtrace_locations.first.path
   end
 
+  test "#report assigns a cause if it's missing" do
+    raise "the original cause"
+  rescue => cause
+    new_error = StandardError.new("A new error that should wrap the StandardError")
+    assert_nil new_error.cause
+
+    @reporter.report(new_error)
+
+    assert_same cause, new_error.cause
+  end
+
   test "#record passes through the return value" do
     result = @reporter.record do
       2 + 2

--- a/activesupport/test/error_reporter_test.rb
+++ b/activesupport/test/error_reporter_test.rb
@@ -166,9 +166,10 @@ class ErrorReporterTest < ActiveSupport::TestCase
     assert_nil error.backtrace
     assert_nil error.backtrace_locations
 
-    assert_nil @reporter.report(error)
-    assert_not_predicate error.backtrace, :empty?
-    assert_not_predicate error.backtrace_locations, :empty?
+    @reporter.report(error)
+
+    assert error.backtrace.first.start_with?(__FILE__)
+    assert_equal __FILE__, error.backtrace_locations.first.path
   end
 
   test "#record passes through the return value" do


### PR DESCRIPTION
### Motivation / Background

`#report` has an undocumented side-effect of setting the `cause` on a never-raised exception.

### Detail

This Pull Request adds a test to document this behaviour.

The fact that this sets the cause is desirable, because it makes it possible to report a newly-constructed error. This can be useful for rewrapping a genetic error into a more domain-specific error with a more contextual message.

```ruby
begin
  do_something
rescue ActiveRecord::RecordNotFound
  Rails.report.unexpected(SomeMoreSpecificException.new("A domain-specific explanation of what went wrong"))
  return
end
```

If `#report` didn't set the cause, then the link to the `ActiveRecord::RecordNotFound` would be lost. And there's no way for the user to set it themselves, without doing the same `raise`+`rescue` trick that we use. It's good that the framework does it, so they don't have to.

### Additional information

See also: #52684

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
