### PR TITLE
Defer ActiveJob enqueue callbacks until after commit when `enqueue_after_transaction_commit` enabled

### DIFF
--- a/activejob/CHANGELOG.md
+++ b/activejob/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Defer invocation of ActiveJob enqueue callbacks until after commit when
+    `enqueue_after_transaction_commit` is enabled.
+
+    *Will Roever*
+
 *   Add `report:` option to `ActiveJob::Base#retry_on` and `#discard_on`
 
     When the `report:` option is passed, errors will be reported to the error reporter

--- a/activejob/lib/active_job/enqueuing.rb
+++ b/activejob/lib/active_job/enqueuing.rb
@@ -113,9 +113,7 @@ module ActiveJob
       set(options)
       self.successfully_enqueued = false
 
-      run_callbacks :enqueue do
-        raw_enqueue
-      end
+      raw_enqueue
 
       if successfully_enqueued?
         self
@@ -126,6 +124,12 @@ module ActiveJob
 
     private
       def raw_enqueue
+        run_callbacks :enqueue do
+          _raw_enqueue
+        end
+      end
+
+      def _raw_enqueue
         if scheduled_at
           queue_adapter.enqueue_at self, scheduled_at.to_f
         else


### PR DESCRIPTION
### Motivation / Background

At work we use an `around_enqueue` callback to handle lapses in connectivity to Sidekiq by temporarily storing job payloads we’re unable to deliver to Sidekiq in our database (so that we can manually enqueue them later, if needed).

The code looks roughly like this:
```ruby
class ApplicationJob < ActiveJob::Base

  around_enqueue do |job, block|
    block.call
  rescue RedisClient::Error => e
    FailedEnqueueAttempt.create!(
      job: job,
      error_message: e.detailed_message
    )
    # Log/report error, etc.
  end

  # ...
end
```

I recently noticed this wasn’t working as I expected with the `enqueue_after_transaction_commit` setting enabled. Looking at the [ActiveJob code](https://github.com/rails/rails/blob/v7.2.2.1/activejob/lib/active_job/enqueuing.rb#L117), I noticed that when `enqueue_after_transaction_commit` is enabled, `enqueue` callbacks fire at the time `perform_later` is called, as opposed to the time at which the job is later enqueued via the queue adapter.

While I see that this has always been the behavior since `enqueue_after_transaction_commit` was first added (#51426), I think this is likely not the desired behavior when the setting is enabled. My understanding is that `enqueue` callbacks are designed to instrument the enqueueing interaction with the queue adapter. Looking around at other usage examples ([example](https://github.com/newrelic/newrelic-ruby-agent/blob/dev/lib/new_relic/agent/instrumentation/active_job.rb#L18), [example](https://github.com/NREL/OpenStudio-server/blob/v3.9.0-rc3/server/app/jobs/resque_jobs/run_simulate_data_point.rb#L11)), it seems likely to me that the current behavior might catch other folks by surprise too.

This is my attempt at a Rails contribution so please do guide me if I've missed something here - thanks! 🙏

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.