### PR TITLE
Support selenium-webdriver 4.32.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -574,7 +574,7 @@ GEM
     sass-embedded (1.83.4-x86_64-linux-musl)
       google-protobuf (~> 4.29)
     securerandom (0.4.1)
-    selenium-webdriver (4.29.1)
+    selenium-webdriver (4.32.0)
       base64 (~> 0.2)
       logger (~> 1.4)
       rexml (~> 3.2, >= 3.2.5)

--- a/actionpack/test/dispatch/system_testing/driver_test.rb
+++ b/actionpack/test/dispatch/system_testing/driver_test.rb
@@ -121,7 +121,7 @@ class DriverTest < ActiveSupport::TestCase
     expected = {
       "moz:firefoxOptions" => {
         "args" => ["--host=127.0.0.1"],
-        "prefs" => { "remote.active-protocols" => 3, "browser.startup.homepage" => "http://www.seleniumhq.com/" }
+        "prefs" => { "remote.active-protocols" => 1, "browser.startup.homepage" => "http://www.seleniumhq.com/" }
       },
       "browserName" => "firefox"
     }
@@ -138,7 +138,7 @@ class DriverTest < ActiveSupport::TestCase
     expected = {
       "moz:firefoxOptions" => {
         "args" => ["-headless", "--host=127.0.0.1"],
-        "prefs" => { "remote.active-protocols" => 3, "browser.startup.homepage" => "http://www.seleniumhq.com/" }
+        "prefs" => { "remote.active-protocols" => 1, "browser.startup.homepage" => "http://www.seleniumhq.com/" }
       },
       "browserName" => "firefox"
     }


### PR DESCRIPTION
Addressed Rails Nightly CI failure at https://buildkite.com/rails/rails-nightly/builds/2159#019692cd-ed93-43ce-97eb-eab34ab72432/1170-1180 and found these failures also reproduce with released versions of Ruby.

### Motivation / Background

This pull request supports selenium-webdriver 4.32.0 that sets remote.active-protocols => 1 via https://github.com/SeleniumHQ/selenium/commit/a1ff120a9fd

### Detail

- Steps to reproduce and this commit fixes these two failures:
```ruby
$ bundle update selenium-webdriver --conservative
... snip ...
$ git diff
diff --git a/Gemfile.lock b/Gemfile.lock
index db3f0d1517..07f40b95f5 100644
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -574,7 +574,7 @@ GEM
     sass-embedded (1.83.4-x86_64-linux-musl)
       google-protobuf (~> 4.29)
     securerandom (0.4.1)
-    selenium-webdriver (4.29.1)
+    selenium-webdriver (4.32.0)
       base64 (~> 0.2)
       logger (~> 1.4)
       rexml (~> 3.2, >= 3.2.5)
$ bin/test test/dispatch/system_testing/driver_test.rb -n '/^test_define_extra_capabilities_using_(headless_)?firefox$/'
... snip ...

F

Failure:
DriverTest#test_define_extra_capabilities_using_firefox [test/dispatch/system_testing/driver_test.rb:128]:
--- expected
+++ actual
@@ -1 +1 @@
-{"moz:firefoxOptions" => {"args" => ["--host=127.0.0.1"], "prefs" => {"remote.active-protocols" => 3, "browser.startup.homepage" => "http://www.seleniumhq.com/"}}, "browserName" => "firefox"}
+{"moz:firefoxOptions" => {"args" => ["--host=127.0.0.1"], "prefs" => {"remote.active-protocols" => 1, "browser.startup.homepage" => "http://www.seleniumhq.com/"}}, "browserName" => "firefox"}

bin/test test/dispatch/system_testing/driver_test.rb:114

F

Failure:
DriverTest#test_define_extra_capabilities_using_headless_firefox [test/dispatch/system_testing/driver_test.rb:145]:
--- expected
+++ actual
@@ -1 +1 @@
-{"moz:firefoxOptions" => {"args" => ["-headless", "--host=127.0.0.1"], "prefs" => {"remote.active-protocols" => 3, "browser.startup.homepage" => "http://www.seleniumhq.com/"}}, "browserName" => "firefox"}
+{"moz:firefoxOptions" => {"args" => ["-headless", "--host=127.0.0.1"], "prefs" => {"remote.active-protocols" => 1, "browser.startup.homepage" => "http://www.seleniumhq.com/"}}, "browserName" => "firefox"}

bin/test test/dispatch/system_testing/driver_test.rb:131

Finished in 0.009594s, 208.4566 runs/s, 208.4566 assertions/s.
2 runs, 2 assertions, 2 failures, 0 errors, 0 skips
$
```

### Additional information
Related to #52172

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
