### PR TITLE
Make the executor hooks in AR::QueryCache private

### DIFF
--- a/activerecord/lib/active_record/query_cache.rb
+++ b/activerecord/lib/active_record/query_cache.rb
@@ -3,6 +3,7 @@
 module ActiveRecord
   # = Active Record Query Cache
   class QueryCache
+    # ActiveRecord::Base extends this module, so these methods are available in models.
     module ClassMethods
       # Enable the query cache within the block if Active Record is configured.
       # If it's not, it will execute the given block.
@@ -20,11 +21,15 @@ module ActiveRecord
         end
       end
 
-      # Disable the query cache within the block if Active Record is configured.
-      # If it's not, it will execute the given block.
+      # Runs the block with the query cache disabled.
       #
-      # Set <tt>dirties: false</tt> to prevent query caches on all connections from being cleared by write operations.
-      # (By default, write operations dirty all connections' query caches in case they are replicas whose cache would now be outdated.)
+      # If the query cache was enabled before the block was executed, it is
+      # enabled again after it.
+      #
+      # Set <tt>dirties: false</tt> to prevent query caches on all connections
+      # from being cleared by write operations. (By default, write operations
+      # dirty all connections' query caches in case they are replicas whose
+      # cache would now be outdated.)
       def uncached(dirties: true, &block)
         if connected? || !configurations.empty?
           connection_pool.disable_query_cache(dirties: dirties, &block)
@@ -34,22 +39,24 @@ module ActiveRecord
       end
     end
 
-    def self.run
-      ActiveRecord::Base.connection_handler.each_connection_pool.reject(&:query_cache_enabled).each do |pool|
-        next if pool.db_config&.query_cache == false
-        pool.enable_query_cache!
+    module ExecutorHooks # :nodoc:
+      def self.run
+        ActiveRecord::Base.connection_handler.each_connection_pool.reject(&:query_cache_enabled).each do |pool|
+          next if pool.db_config&.query_cache == false
+          pool.enable_query_cache!
+        end
+      end
+
+      def self.complete(pools)
+        pools.each do |pool|
+          pool.disable_query_cache!
+          pool.clear_query_cache
+        end
       end
     end
 
-    def self.complete(pools)
-      pools.each do |pool|
-        pool.disable_query_cache!
-        pool.clear_query_cache
-      end
-    end
-
-    def self.install_executor_hooks(executor = ActiveSupport::Executor)
-      executor.register_hook(self)
+    def self.install_executor_hooks(executor = ActiveSupport::Executor) # :nodoc:
+      executor.register_hook(ExecutorHooks)
     end
   end
 end


### PR DESCRIPTION
API docs [show](https://api.rubyonrails.org/v8.0/classes/ActiveRecord/QueryCache.html#method-c-run) the executor hooks in `ActiveRecord::QueryCache` and their installer. These should be private, they are not supposed to be callable or overridden by external code.

The patch also groups the hooks to ease making sense of this class, [just like the connection pool does](https://github.com/rails/rails/blob/e0bfbb2da5c7bd550d3576a38bcdd6fe00d56dfd/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb#L218).

This grouping is also coherent with `ActiveRecord::QueryCache::ClassMethods`, though, if you ask me, that extends `ActiveRecord::Base` and I personally would _not_ group those methods.

Technically, this is a breaking change, but this stuff seems too internal to me. However, happy to reconsider if someone sees it differently.

There are also some documentation tweaks since I was on it.