### PR TITLE
Add support for Cache-Control: only-if-cached directive

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -140,4 +140,26 @@
 
     *Petrik de Heus*
 
+*   Add support for the `Cache-Control: only-if-cached` directive according to RFC 9111.
+
+    Provides a `request.only_if_cached?` method to detect when a request includes this directive.
+    According to RFC 9111, a 504 Gateway Timeout should be returned if no suitable cached response exists.
+
+    ```ruby
+    def show
+      if request.only_if_cached?
+        @article = Rails.cache.read("article/#{params[:id]}")
+        return head(:gateway_timeout) if @article.nil?
+
+        render :show
+        return
+      end
+
+      @article = Article.find(params[:id])
+      render :show
+    end
+    ```
+
+    *egg528*
+
 Please check [8-0-stable](https://github.com/rails/rails/blob/8-0-stable/actionpack/CHANGELOG.md) for previous changes.

--- a/actionpack/lib/action_dispatch/http/cache.rb
+++ b/actionpack/lib/action_dispatch/http/cache.rb
@@ -8,6 +8,9 @@ module ActionDispatch
       module Request
         HTTP_IF_MODIFIED_SINCE = "HTTP_IF_MODIFIED_SINCE"
         HTTP_IF_NONE_MATCH     = "HTTP_IF_NONE_MATCH"
+        HTTP_CACHE_CONTROL    = "HTTP_CACHE_CONTROL"
+
+        ONLY_IF_CACHED = "only-if-cached"
 
         mattr_accessor :strict_freshness, default: false
 
@@ -34,6 +37,14 @@ module ActionDispatch
             validators = if_none_match_etags
             validators.include?(etag) || validators.include?("*")
           end
+        end
+
+        # Returns true when the request includes the `Cache-Control: only-if-cached` directive.
+        # If no suitable cached response exists, recommends responding with `504 Gateway Timeout`.
+        # Reference: https://www.rfc-editor.org/rfc/rfc9111.html#section-5.2.1.7
+        def only_if_cached?
+          cache_control = get_header(HTTP_CACHE_CONTROL)
+          cache_control && cache_control.split(",").any? { |d| d.strip == ONLY_IF_CACHED }
         end
 
         # Check response freshness (`Last-Modified` and `ETag`) against request

--- a/actionpack/test/dispatch/request_test.rb
+++ b/actionpack/test/dispatch/request_test.rb
@@ -1446,3 +1446,20 @@ class RequestSession < BaseRequestTest
     assert_instance_of(ActionDispatch::Request::Session::Options, ActionDispatch::Request::Session::Options.find(@request))
   end
 end
+
+class RequestCacheControlTest < BaseRequestTest
+  test "only_if_cached? is false when Cache-Control header is missing" do
+    request = stub_request
+    assert_not request.only_if_cached?
+  end
+
+  test "only_if_cached? is true when only-if-cached is the sole directive" do
+    request = stub_request("HTTP_CACHE_CONTROL" => "only-if-cached")
+    assert request.only_if_cached?
+  end
+
+  test "only_if_cached? is true when only-if-cached appears among multiple directives" do
+    request = stub_request("HTTP_CACHE_CONTROL" => "max-age=60, only-if-cached, immutable")
+    assert request.only_if_cached?
+  end
+end


### PR DESCRIPTION
### Motivation / Background

Add support for the `Cache-Control: only-if-cached` directive as specified in RFC 9111. This allows Rails applications to properly parse and detect this directive in incoming requests.

### Detail

This PR adds a `request.only_if_cached?` method to detect when a request includes the `only-if-cached` directive, with appropriate tests and documentation.

### Additional information

RFC reference: https://www.rfc-editor.org/rfc/rfc9111.html#section-5.2.1.7

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why.
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature.
