### PR TITLE
Add UniquenessAmongValidator to validate attribute uniqueness within a model

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,3 +1,25 @@
+*   Add `UniquenessAmongValidator` to validate attribute uniqueness within a model.
+
+    ```ruby
+    class User < ApplicationRecord
+      # Validates that primary and secondary emails are different
+      validates_uniqueness_of_among :primary_email, :secondary_email
+
+      # Validates that all phone numbers are unique
+      validates_uniqueness_of_among :home_phone, :work_phone, :mobile_phone,
+                                    message: "must be different from other phone numbers"
+
+      # Validates that all tag sets are unique
+      validates_uniqueness_of_among :primary_tags, :secondary_tags
+
+      # Validates that metadata fields are unique, treating string and symbol keys as equivalent
+      validates_uniqueness_of_among :primary_metadata, :secondary_metadata,
+                                    compare_hash_keys_as_strings: true
+    end
+    ```
+
+    *Zakaria Fatahi*
+
 *   Add `except_on:` option for validation callbacks.
 
     *Ben Sheldon*

--- a/activemodel/lib/active_model/locale/en.yml
+++ b/activemodel/lib/active_model/locale/en.yml
@@ -36,3 +36,4 @@ en:
       in: "must be in %{count}"
       odd: "must be odd"
       even: "must be even"
+      taken_among: "has already been taken among %{attributes}"

--- a/activemodel/lib/active_model/validations/uniqueness_among.rb
+++ b/activemodel/lib/active_model/validations/uniqueness_among.rb
@@ -1,0 +1,132 @@
+# frozen_string_literal: true
+
+module ActiveModel
+  module Validations
+    class UniquenessAmongValidator < EachValidator # :nodoc:
+      DEFAULTS = { case_sensitive: true }.freeze
+
+      def initialize(options)
+        super(DEFAULTS.merge(options))
+      end
+
+      def validate_each(record, attribute, value)
+        return if value.blank? && options[:allow_blank]
+        return if value.nil? && options[:allow_nil]
+
+        other_attributes = Array(options[:in] || options[:within] || attributes) - [attribute]
+        return if other_attributes.empty?
+
+        duplicates = []
+        other_attributes.each do |attr|
+          other_value = record.public_send(attr)
+          next if other_value.nil? && options[:allow_nil]
+          next if other_value.blank? && options[:allow_blank]
+
+          if value_equal?(value, other_value)
+            duplicates << attr
+          end
+        end
+
+        if duplicates.any?
+          error_options = options.except(:case_sensitive, :in, :within, :compare_hash_keys_as_strings).merge!(
+            value: value,
+            attributes: duplicates.join(", ")
+          )
+          record.errors.add(attribute, :taken_among, **error_options)
+        end
+      end
+
+      private
+        def value_equal?(value, other_value)
+          if !options[:case_sensitive] && value.is_a?(String) && other_value.is_a?(String)
+            value.casecmp(other_value) == 0
+          elsif value.is_a?(Array) && other_value.is_a?(Array)
+            return false if value.size != other_value.size
+            sorted_value = value.sort rescue value
+            sorted_other = other_value.sort rescue other_value
+            sorted_value == sorted_other
+          elsif value.is_a?(Hash) && other_value.is_a?(Hash)
+            return false if value.size != other_value.size
+
+            if options[:compare_hash_keys_as_strings]
+              # Convert all keys to strings for comparison
+              normalized_value = normalize_hash_keys(value)
+              normalized_other = normalize_hash_keys(other_value)
+              normalized_value == normalized_other
+            else
+              # Compare as-is but sort to handle different insertion orders
+              value.to_a.sort_by { |k, _| k.to_s } == other_value.to_a.sort_by { |k, _| k.to_s }
+            end
+          else
+            value == other_value
+          end
+        end
+
+        def normalize_hash_keys(hash)
+          result = {}
+          hash.each do |k, v|
+            key = k.to_s
+            value = v.is_a?(Hash) ? normalize_hash_keys(v) : v
+            result[key] = value
+          end
+          result
+        end
+    end
+
+    module HelperMethods
+      # Validates that the attribute is unique among a set of attributes within the same object.
+      #
+      #   class Person < ActiveRecord::Base
+      #     # Validates that primary and secondary emails are different
+      #     validates_uniqueness_of_among :primary_email, :secondary_email
+      #
+      #     # Validates that all phone numbers are unique
+      #     validates_uniqueness_of_among :home_phone, :work_phone, :mobile_phone,
+      #                                   message: "must be different from other phone numbers"
+      #
+      #     # Validates that all tag sets are unique
+      #     validates_uniqueness_of_among :primary_tags, :secondary_tags
+      #
+      #     # Validates that metadata fields are unique, treating string and symbol keys as equivalent
+      #     validates_uniqueness_of_among :primary_metadata, :secondary_metadata,
+      #                                   compare_hash_keys_as_strings: true
+      #   end
+      #
+      # === Special data types
+      #
+      # The validator handles different data types with special considerations:
+      #
+      # * Strings: Can be compared with or without case sensitivity
+      # * Arrays: Compared by content regardless of element order
+      # * Hashes: Compared by content regardless of key order
+      # * Nested structures: Hash values containing other hashes are compared recursively
+      #
+      # This makes the validator particularly useful for:
+      #
+      # * Multilingual content stored in hashes like +{en: "Title", es: "Título"}+
+      # * Tag lists or category arrays that should not duplicate across fields
+      # * Multiple contact information fields that should contain unique values
+      #
+      # === Configuration options
+      # * <tt>:message</tt> - A custom error message (default is: "has already been taken among %{attributes}").
+      #   The message can include %{attributes} which will be replaced with the names of the duplicated attributes.
+      # * <tt>:case_sensitive</tt> - Looks for an exact match for string comparisons. Default is +true+.
+      # * <tt>:allow_nil</tt> - If set to +true+, skips this validation if the attribute is +nil+ (default is +false+).
+      # * <tt>:allow_blank</tt> - If set to +true+, skips this validation if the attribute is blank (default is +false+).
+      # * <tt>:in</tt> or <tt>:within</tt> - Specifies an array of attributes to check against.
+      # * <tt>:compare_hash_keys_as_strings</tt> - When +true+, hash keys are compared as strings,
+      #   so <tt>{ a: 1 }</tt> and <tt>{ "a" => 1 }</tt> are considered equal. Default is +false+.
+      #
+      # For array attributes, the validator checks if the arrays contain the same elements,
+      # regardless of their order. Similarly, for hash attributes, the validator checks if
+      # the hashes contain the same key-value pairs, regardless of internal ordering.
+      #
+      # There is also a list of default options supported by every validator:
+      # +:if+, +:unless+, +:on+, +:allow_nil+, +:allow_blank+, and +:strict+.
+      # See ActiveModel::Validations::ClassMethods#validates for more information.
+      def validates_uniqueness_of_among(*attr_names)
+        validates_with UniquenessAmongValidator, _merge_attributes(attr_names)
+      end
+    end
+  end
+end

--- a/activemodel/test/cases/validations/uniqueness_among_validation_test.rb
+++ b/activemodel/test/cases/validations/uniqueness_among_validation_test.rb
@@ -1,0 +1,298 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+require "models/topic"
+require "models/person"
+
+class UniquenessAmongValidationTest < ActiveModel::TestCase
+  def setup
+    # Define accessors for Person if needed
+    unless Person.method_defined?(:first_name)
+      Person.class_eval do
+        attr_accessor :first_name, :last_name
+      end
+    end
+  end
+
+  def teardown
+    Topic.clear_validators!
+    Person.clear_validators!
+  end
+
+  # Helper method to define array accessors
+  def define_array_accessors_on_topic
+    # Only define them once to avoid warnings
+    unless Topic.method_defined?(:tags_list)
+      Topic.class_eval do
+        def tags_list
+          @tags_list ||= []
+        end
+
+        attr_writer :tags_list
+
+        def categories
+          @categories ||= []
+        end
+
+        attr_writer :categories
+      end
+    end
+  end
+
+  # Helper method to define hash accessors
+  def define_hash_accessors_on_topic
+    # Only define them once to avoid warnings
+    unless Topic.method_defined?(:metadata)
+      Topic.class_eval do
+        def metadata
+          @metadata ||= {}
+        end
+
+        attr_writer :metadata
+
+        def properties
+          @properties ||= {}
+        end
+
+        attr_writer :properties
+      end
+    end
+  end
+
+  def test_validates_uniqueness_of_among_with_same_values
+    Topic.validates_uniqueness_of_among :title, :author_name
+
+    t = Topic.new(title: "Same Value", author_name: "Same Value")
+    assert_predicate t, :invalid?
+    assert_equal ["has already been taken among author_name"], t.errors[:title]
+    assert_equal ["has already been taken among title"], t.errors[:author_name]
+  end
+
+  def test_validates_uniqueness_of_among_with_different_values
+    Topic.validates_uniqueness_of_among :title, :author_name
+
+    t = Topic.new(title: "Different Title", author_name: "Different Author")
+    assert_predicate t, :valid?
+  end
+
+  def test_validates_uniqueness_of_among_with_custom_message
+    Topic.validates_uniqueness_of_among :title, :author_name, message: "must be different from %{attributes}"
+
+    t = Topic.new(title: "Same Value", author_name: "Same Value")
+    assert_predicate t, :invalid?
+    assert_equal ["must be different from author_name"], t.errors[:title]
+    assert_equal ["must be different from title"], t.errors[:author_name]
+  end
+
+  def test_validates_uniqueness_of_among_with_allow_nil
+    Topic.validates_uniqueness_of_among :title, :author_name, allow_nil: true
+
+    t = Topic.new(title: nil, author_name: "Value")
+    assert_predicate t, :valid?
+
+    t.author_name = nil
+    assert_predicate t, :valid?
+
+    # Both nil should be valid since they're not compared
+    t.title = nil
+    assert_predicate t, :valid?
+  end
+
+  def test_validates_uniqueness_of_among_with_allow_blank
+    Topic.validates_uniqueness_of_among :title, :author_name, allow_blank: true
+
+    t = Topic.new(title: "", author_name: "Value")
+    assert_predicate t, :valid?
+
+    t.author_name = ""
+    assert_predicate t, :valid?
+
+    # Both blank should be valid since they're not compared
+    t.title = ""
+    assert_predicate t, :valid?
+  end
+
+  def test_validates_uniqueness_of_among_with_case_sensitivity
+    Topic.validates_uniqueness_of_among :title, :author_name, case_sensitive: true
+
+    t = Topic.new(title: "Value", author_name: "value")
+    assert_predicate t, :valid?
+
+    t.author_name = "Value"
+    assert_predicate t, :invalid?
+  end
+
+  def test_validates_uniqueness_of_among_without_case_sensitivity
+    Topic.validates_uniqueness_of_among :title, :author_name, case_sensitive: false
+
+    t = Topic.new(title: "Value", author_name: "value")
+    assert_predicate t, :invalid?
+    assert_equal ["has already been taken among author_name"], t.errors[:title]
+    assert_equal ["has already been taken among title"], t.errors[:author_name]
+  end
+
+  def test_validates_uniqueness_of_among_with_custom_attributes
+    Topic.validates_uniqueness_of_among :title, in: [:author_name, :content]
+
+    t = Topic.new(title: "Value", author_name: "Value", content: "Different")
+    assert_predicate t, :invalid?
+    assert_equal ["has already been taken among author_name"], t.errors[:title]
+
+    t.title = "Value"
+    t.author_name = "Different"
+    t.content = "Value"
+    assert_predicate t, :invalid?
+    assert_equal ["has already been taken among content"], t.errors[:title]
+  end
+
+  def test_validates_uniqueness_of_among_with_multiple_duplicates
+    Topic.validates_uniqueness_of_among :title, :author_name, :content
+
+    t = Topic.new(title: "Same", author_name: "Same", content: "Same")
+    assert_predicate t, :invalid?
+    assert_equal ["has already been taken among author_name, content"], t.errors[:title]
+    assert_equal ["has already been taken among title, content"], t.errors[:author_name]
+    assert_equal ["has already been taken among title, author_name"], t.errors[:content]
+  end
+
+  def test_validates_uniqueness_of_among_for_ruby_class
+    Person.validates_uniqueness_of_among :first_name, :last_name
+
+    p = Person.new
+    p.first_name = "John"
+    p.last_name = "John"
+    assert_predicate p, :invalid?
+    assert_equal ["has already been taken among last_name"], p.errors[:first_name]
+    assert_equal ["has already been taken among first_name"], p.errors[:last_name]
+
+    p.last_name = "Doe"
+    assert_predicate p, :valid?
+  end
+
+  def test_validates_uniqueness_of_among_with_array_values
+    define_array_accessors_on_topic
+    Topic.validates_uniqueness_of_among :tags_list, :categories
+
+    topic = Topic.new
+    topic.tags_list = [1, 2, 3]
+    topic.categories = [4, 5, 6]
+    assert_predicate topic, :valid?
+
+    topic.categories = [1, 2, 3]
+    assert_predicate topic, :invalid?
+    assert_equal ["has already been taken among categories"], topic.errors[:tags_list]
+    assert_equal ["has already been taken among tags_list"], topic.errors[:categories]
+  end
+
+  def test_validates_uniqueness_of_among_with_array_values_different_order
+    define_array_accessors_on_topic
+    Topic.validates_uniqueness_of_among :tags_list, :categories
+
+    topic = Topic.new
+    topic.tags_list = [1, 2, 3]
+    topic.categories = [3, 2, 1]
+    assert_predicate topic, :invalid?
+    assert_equal ["has already been taken among categories"], topic.errors[:tags_list]
+    assert_equal ["has already been taken among tags_list"], topic.errors[:categories]
+  end
+
+  def test_validates_uniqueness_of_among_with_partial_array_overlap
+    define_array_accessors_on_topic
+    Topic.validates_uniqueness_of_among :tags_list, :categories
+
+    topic = Topic.new
+    topic.tags_list = [1, 2, 3]
+    topic.categories = [3, 4, 5]
+    assert_predicate topic, :valid?, "Arrays with partial overlap should be valid"
+
+    topic.categories = [1, 2, 3, 4]
+    assert_predicate topic, :valid?, "Arrays with partial overlap should be valid"
+  end
+
+  def test_validates_uniqueness_of_among_with_unsortable_array_elements
+    define_array_accessors_on_topic
+    Topic.validates_uniqueness_of_among :tags_list, :categories
+
+    # Complex objects that can't be sorted
+    complex1 = Object.new
+    complex2 = Object.new
+
+    topic = Topic.new
+    topic.tags_list = [complex1, complex2]
+    topic.categories = [complex1, complex2]
+
+    # Should be invalid because the arrays contain the same elements even though they can't be sorted
+    assert_predicate topic, :invalid?
+    assert_equal ["has already been taken among categories"], topic.errors[:tags_list]
+    assert_equal ["has already been taken among tags_list"], topic.errors[:categories]
+  end
+
+  def test_validates_uniqueness_of_among_with_hash_values
+    define_hash_accessors_on_topic
+    Topic.validates_uniqueness_of_among :metadata, :properties
+
+    topic = Topic.new
+    topic.metadata = { "author" => "John", "year" => 2023 }
+    topic.properties = { "year" => 2023, "author" => "John" }
+
+    assert_predicate topic, :invalid?
+    assert_equal ["has already been taken among properties"], topic.errors[:metadata]
+    assert_equal ["has already been taken among metadata"], topic.errors[:properties]
+
+    # Different hashes should be valid
+    topic = Topic.new
+    topic.metadata = { "author" => "John", "year" => 2023 }
+    topic.properties = { "author" => "Jane", "year" => 2023 }
+    assert_predicate topic, :valid?
+  end
+
+  def test_validates_uniqueness_of_among_with_hash_values_different_key_types
+    define_hash_accessors_on_topic
+    Topic.validates_uniqueness_of_among :metadata, :properties
+
+    topic = Topic.new
+    # String keys vs Symbol keys should be considered different by default
+    topic.metadata = { "author" => "John", "year" => 2023 }
+    topic.properties = { author: "John", year: 2023 }
+
+    assert_predicate topic, :valid?
+
+    # Explicitly compare as strings to consider them the same
+    Topic.clear_validators!
+    Topic.validates_uniqueness_of_among :metadata, :properties, compare_hash_keys_as_strings: true
+
+    assert_predicate topic, :invalid?
+    assert_equal ["has already been taken among properties"], topic.errors[:metadata]
+    assert_equal ["has already been taken among metadata"], topic.errors[:properties]
+  end
+
+  def test_validates_uniqueness_of_among_with_nested_hash_values
+    define_hash_accessors_on_topic
+    Topic.validates_uniqueness_of_among :metadata, :properties
+
+    topic = Topic.new
+    topic.metadata = { "author" => { "name" => "John", "email" => "john@example.com" }, "year" => 2023 }
+    topic.properties = { "year" => 2023, "author" => { "name" => "John", "email" => "john@example.com" } }
+
+    assert_predicate topic, :invalid?
+
+    # Different nested hash values should be valid
+    topic = Topic.new
+    topic.metadata = { "author" => { "name" => "John", "email" => "john@example.com" }, "year" => 2023 }
+    topic.properties = { "year" => 2023, "author" => { "name" => "Jane", "email" => "jane@example.com" } }
+    assert_predicate topic, :valid?
+  end
+
+  def test_validates_uniqueness_of_among_with_nested_hash_values_and_different_key_types
+    define_hash_accessors_on_topic
+    Topic.validates_uniqueness_of_among :metadata, :properties, compare_hash_keys_as_strings: true
+
+    topic = Topic.new
+    topic.metadata = { "author" => { "name" => "John", "email" => "john@example.com" }, "year" => 2023 }
+    topic.properties = { year: 2023, author: { name: "John", email: "john@example.com" } }
+
+    assert_predicate topic, :invalid?
+    assert_equal ["has already been taken among properties"], topic.errors[:metadata]
+    assert_equal ["has already been taken among metadata"], topic.errors[:properties]
+  end
+end


### PR DESCRIPTION
### Motivation / Background
This Pull Request has been created because there is currently no built-in way to validate that multiple attributes within the same model have unique values. While ActiveRecord provides `validates_uniqueness_of` for database-level uniqueness, there is no equivalent for validating uniqueness among attributes in the same model instance.

This validator is useful for various scenarios including:
- Ensuring that a user's primary email differs from their secondary email
- Validating that contact information fields (e.g., home phone, work phone, mobile) contain distinct values
- Checking that tag fields or categorization attributes don't contain duplicates
- Verifying that shipping and billing addresses are different when required
- Ensuring internationalized content fields don't duplicate content across attributes

### Detail
This Pull Request adds:
1. A new `UniquenessAmongValidator` class to validate that an attribute's value is distinct from other specified attributes
2. A `validates_uniqueness_of_among` helper method to easily apply this validation
3. Support for standard validation options (allow_nil, allow_blank, case_sensitive, etc.)
4. Comprehensive handling of different data types:
   - String comparison with optional case insensitivity
   - Array comparison regardless of element order
   - Hash comparison regardless of key order
   - Support for nested data structures
5. An optional `compare_hash_keys_as_strings` setting to treat string and symbol hash keys as equivalent
6. Comprehensive tests to verify functionality with various data types and edge cases

Example usage:

```ruby
class User < ApplicationRecord
  # Ensure primary and secondary emails are different (case insensitive)
  validates_uniqueness_of_among :primary_email, :secondary_email, case_sensitive: false
  
  # Ensure phone numbers are unique
  validates_uniqueness_of_among :phone_numbers, :emergency_contact_phone
  
  # Ensure translated profile fields don't duplicate content across attributes
  validates_uniqueness_of_among :bio, :tagline, :headline, compare_hash_keys_as_strings: true
end
```

### Additional information
The implementation supports various data types including strings, arrays, hashes, and primitive values. For string comparisons, it respects the `case_sensitive` option similar to other validators. For array and hash comparisons, it checks if they contain the same elements regardless of order.

For hashes, the validator can compare keys as strings with the `compare_hash_keys_as_strings` option, which is useful for internationalized content where keys might be strings in one attribute and symbols in another.

### Checklist
- [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added for the new validator, covering various cases and edge scenarios.
- [x] CHANGELOG updated to reflect the new functionality.