### PR TITLE
[ci skip] guides/getting_started: fix route param for "Unsubscribe links"

### DIFF
--- a/guides/source/getting_started.md
+++ b/guides/source/getting_started.md
@@ -2364,7 +2364,7 @@ First, we need a route for unsubscribing that will be the URL we include in
 emails.
 
 ```ruby
-  resource :unsubscribe, only: [ :show ]
+  resource :unsubscribe, param: :token, only: [ :show ]
 ```
 
 Active Record has a feature called `generates_token_for` that can generate


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because I was following [unsubscribe-links](https://guides.rubyonrails.org/getting_started.html#unsubscribe-links) in Getting Starting Guides page. In this section, code was written on assumption that routes that are generated by `resources` use parameter `token`, but it uses `id`.

### Detail

This Pull Request changes `guides/source/getting_started.md` file to override route for `UnsubscribesController` parameter from `id` to `token`

### Additional information


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.

[ci skip]