### PR TITLE
Fix "ERROR [launcher.sauce]: Can not start safari latest"

### DIFF
--- a/actioncable/karma.conf.js
+++ b/actioncable/karma.conf.js
@@ -25,7 +25,7 @@ if (process.env.CI) {
   config.customLaunchers = {
     sl_chrome: sauce("chrome", 70),
     sl_ff: sauce("firefox", 63),
-    sl_safari: sauce("safari", "latest"),
+    sl_safari: sauce("safari", "16", "macOS 13"),
     sl_edge: sauce("microsoftedge", 17.17134, "Windows 10"),
   }
 


### PR DESCRIPTION
### Motivation / Background

This commit addresses the following error in the Action Cable integration test:

https://buildkite.com/rails/rails/builds/118358#01969a38-6324-4e5f-9ced-bff4b8b87599

```
04 05 2025 07:36:27.081:ERROR [launcher.sauce]: Can not start safari latest
... snip ...
UnsupportedPlatform - no images found for the specified caps
```

### Detail
According to https://saucelabs.com/products/platform-configurator, macOS Sonoma 14 is currently in beta on SauceLabs. Therefore, this change uses macOS 13 Ventura and specifies Safari version 16, which is the default Safari version for macOS 13 Ventura.

### Additional information
None

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
