### PR TITLE
[ci skip] Fix horizontal overflow issue on mobile by adding overflow-x: auto to .interstitial.code

### DIFF
--- a/guides/assets/stylesrc/components/_code-container.scss
+++ b/guides/assets/stylesrc/components/_code-container.scss
@@ -44,6 +44,7 @@ dl dd .interstitial {
     padding-left: 1em !important; // remove if icon is restored
     direction: ltr !important;
     text-align: left !important;
+    overflow-x: auto; // Fix for horizontal overflow issue
 
     pre {
       margin: 0;


### PR DESCRIPTION
### Motivation / Background

Some code examples in the guides overflow horizontally on small screens, making them unreadable without zooming out or panning. This negatively affects the mobile user experience.

### Detail

This PR adds the following CSS rule:

```scss
.interstitial.code {
  overflow-x: auto;
}
```

This change allows horizontal scrolling within `.interstitial.code` containers when the content exceeds the width of the viewport, ensuring readability on mobile devices.

### Additional Information

This fix enhances the responsiveness and usability of the Rails guides across all screen sizes.

**Screenshot demonstrating the issue before the fix:**
<img width="473" alt="Screenshot 2025-05-04 at 13 47 51" src="https://github.com/user-attachments/assets/1c825291-cc09-425e-bca5-1a2a375535f5" />


### Checklist

- [x] This PR is limited to a single, focused change.
- [x] [ci skip] is used to skip CI since this is a documentation-only change.
- [x] No CHANGELOG update is needed (doc-only).
