### PR TITLE
Use TRUE and FALSE for more SQLite queries

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/sqlite3/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3/quoting.rb
@@ -80,16 +80,8 @@ module ActiveRecord
           "x'#{value.hex}'"
         end
 
-        def quoted_true
-          "1"
-        end
-
         def unquoted_true
           1
-        end
-
-        def quoted_false
-          "0"
         end
 
         def unquoted_false

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -564,6 +564,8 @@ module ActiveRecord
           # Binary columns
           when /x'(.*)'/
             [ $1 ].pack("H*")
+          when "TRUE", "FALSE"
+            default
           else
             # Anything else is blank or some function
             # and we can't know the value of that, so return nil.

--- a/activerecord/test/cases/adapters/sqlite3/bind_parameter_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/bind_parameter_test.rb
@@ -22,7 +22,7 @@ module ActiveRecord
         end
 
         def test_where_with_boolean_for_string_column_using_bind_parameters
-          assert_quoted_as "0", false
+          assert_quoted_as "FALSE", false
         end
 
         def test_where_with_decimal_for_string_column_using_bind_parameters


### PR DESCRIPTION
A [previous commit][0] updated the SQLite Arel visitor to use `TRUE` and `FALSE` literals instead of `1` and `0` for `True` and `False` Arel Nodes.

This commit takes the change further by making SQLite quote `true` and `false` values as `TRUE` and `FALSE` instead of `1` and `0`. This additionally required adding support for `DEFAULT TRUE` and `DEFAULT FALSE` SQLite column definitions (which is more correct anyways in case someone made `TRUE` or `FALSE` the default value of a column using `default: -> { "TRUE" }`, etc).

[0]: https://github.com/rails/rails/commit/34bebf383e18243a1cdadc461e3a84c66125cb9b
