### PR TITLE
Add conditional :if / :unless to ActiveModel::Serialization#include

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,3 +1,14 @@
+*   Allow `:if` and `:unless` inside the `:include` hash passed to
+    `ActiveModel::Serialization#serializable_hash`, so associations can
+    be added conditionally (method, proc, or boolean).
+
+    ```ruby
+    # Example – include notes only for admins
+    user.serializable_hash(include: { notes: { if: :admin? } })
+    ```
+
+    *Zakaria Fatahi*
+
 *   Add `except_on:` option for validation callbacks.
 
     *Ben Sheldon*

--- a/activemodel/test/cases/serialization_test.rb
+++ b/activemodel/test/cases/serialization_test.rb
@@ -7,15 +7,18 @@ class SerializationTest < ActiveModel::TestCase
   class User
     include ActiveModel::Serialization
 
-    attr_accessor :name, :email, :gender, :address, :friends
+    attr_accessor :name, :email, :gender, :address, :friends, :active, :admin, :age
 
     def initialize(name, email, gender)
       @name, @email, @gender = name, email, gender
       @friends = []
+      @active = true
+      @admin = false
+      @age = 30
     end
 
     def attributes
-      instance_values.except("address", "friends")
+      instance_values.except("address", "friends", "active", "admin", "age")
     end
 
     def method_missing(method_name, ...)
@@ -28,6 +31,22 @@ class SerializationTest < ActiveModel::TestCase
 
     def foo
       "i_am_foo"
+    end
+
+    def adult?
+      age >= 18
+    end
+
+    def child?
+      !adult?
+    end
+
+    def admin?
+      admin
+    end
+
+    def active?
+      active
     end
   end
 
@@ -48,8 +67,21 @@ class SerializationTest < ActiveModel::TestCase
     @user.address.city = "Springfield"
     @user.address.state = "CA"
     @user.address.zip = 11111
-    @user.friends = [User.new("Joe", "joe@example.com", "male"),
-                     User.new("Sue", "sue@example.com", "female")]
+
+    # Friends need active and admin attributes for our tests
+    joe = User.new("Joe", "joe@example.com", "male")
+    joe.active = true
+    joe.admin = false
+
+    sue = User.new("Sue", "sue@example.com", "female")
+    sue.active = true
+    sue.admin = false
+
+    @user.friends = [joe, sue]
+
+    # Make sure user has default values for conditional tests
+    @user.active = true
+    @user.admin = false
   end
 
   def test_method_serializable_hash_should_work
@@ -185,5 +217,422 @@ class SerializationTest < ActiveModel::TestCase
                 "address" => { "street" => "123 Lane" },
                 "friends" => [{ "name" => "Joe" }, { "name" => "Sue" }] }
     assert_equal expected, @user.serializable_hash(include: [address: { only: "street" }, friends: { only: "name" }])
+  end
+
+  # Test conditional includes with :if option as symbol
+  def test_serializable_hash_with_if_option_as_symbol
+    expected = { "name" => "David", "email" => "david@example.com", "gender" => "male" }
+
+    # When condition is true, include the association
+    @user.admin = true
+    expected_with_address = expected.merge(
+      "address" => { "street" => "123 Lane", "city" => "Springfield", "state" => "CA", "zip" => 11111 }
+    )
+    result = @user.serializable_hash(include: { address: { if: :admin? } })
+    assert_equal expected_with_address, result
+
+    # When condition is false, don't include the association
+    @user.admin = false
+    result = @user.serializable_hash(include: { address: { if: :admin? } })
+    assert_equal expected, result
+  end
+
+  # Test conditional includes with :unless option as symbol
+  def test_serializable_hash_with_unless_option_as_symbol
+    expected = { "name" => "David", "email" => "david@example.com", "gender" => "male" }
+
+    # When condition is false, include the association
+    @user.admin = false
+    expected_with_address = expected.merge(
+      "address" => { "street" => "123 Lane", "city" => "Springfield", "state" => "CA", "zip" => 11111 }
+    )
+    result = @user.serializable_hash(include: { address: { unless: :admin? } })
+    assert_equal expected_with_address, result
+
+    # When condition is true, don't include the association
+    @user.admin = true
+    result = @user.serializable_hash(include: { address: { unless: :admin? } })
+    assert_equal expected, result
+  end
+
+  # Test conditional includes with :if option as proc
+  def test_serializable_hash_with_if_option_as_proc
+    expected = { "name" => "David", "email" => "david@example.com", "gender" => "male" }
+
+    # When condition is true, include the association
+    @user.admin = true
+    expected_with_address = expected.merge(
+      "address" => { "street" => "123 Lane", "city" => "Springfield", "state" => "CA", "zip" => 11111 }
+    )
+    result = @user.serializable_hash(include: { address: { if: -> { admin } } })
+    assert_equal expected_with_address, result
+
+    # When condition is false, don't include the association
+    @user.admin = false
+    result = @user.serializable_hash(include: { address: { if: -> { admin } } })
+    assert_equal expected, result
+  end
+
+  # Test conditional includes with :unless option as proc
+  def test_serializable_hash_with_unless_option_as_proc
+    expected = { "name" => "David", "email" => "david@example.com", "gender" => "male" }
+
+    # When condition is false, include the association
+    @user.admin = false
+    expected_with_address = expected.merge(
+      "address" => { "street" => "123 Lane", "city" => "Springfield", "state" => "CA", "zip" => 11111 }
+    )
+    result = @user.serializable_hash(include: { address: { unless: -> { admin } } })
+    assert_equal expected_with_address, result
+
+    # When condition is true, don't include the association
+    @user.admin = true
+    result = @user.serializable_hash(include: { address: { unless: -> { admin } } })
+    assert_equal expected, result
+  end
+
+  # Test with both :if and :unless conditions
+  def test_serializable_hash_with_both_if_and_unless_options
+    expected = { "name" => "David", "email" => "david@example.com", "gender" => "male" }
+
+    # Both conditions satisfied (if: true, unless: false) - include the association
+    @user.admin = true
+    @user.active = true
+    expected_with_address = expected.merge(
+      "address" => { "street" => "123 Lane", "city" => "Springfield", "state" => "CA", "zip" => 11111 }
+    )
+    result = @user.serializable_hash(include: { address: { if: :admin?, unless: -> { !active } } })
+    assert_equal expected_with_address, result
+
+    # if condition is false - don't include the association
+    @user.admin = false
+    @user.active = true
+    result = @user.serializable_hash(include: { address: { if: :admin?, unless: -> { !active } } })
+    assert_equal expected, result
+
+    # unless condition is true - don't include the association
+    @user.admin = true
+    @user.active = false
+    result = @user.serializable_hash(include: { address: { if: :admin?, unless: -> { !active } } })
+    assert_equal expected, result
+
+    # Both conditions not satisfied (if: false, unless: true) - don't include the association
+    @user.admin = false
+    @user.active = false
+    result = @user.serializable_hash(include: { address: { if: :admin?, unless: -> { !active } } })
+    assert_equal expected, result
+  end
+
+  # Test conditional includes with collections
+  def test_serializable_hash_with_conditional_includes_on_collections
+    expected = { "name" => "David", "email" => "david@example.com", "gender" => "male", "friends" => [] }
+
+    # When condition is true, include the association
+    @user.admin = true
+    expected_with_friends = expected.merge(
+      "friends" => [{ "name" => "Joe", "email" => "joe@example.com", "gender" => "male" },
+                 { "name" => "Sue", "email" => "sue@example.com", "gender" => "female" }]
+    )
+    result = @user.serializable_hash(include: { friends: { if: :admin? } })
+    assert_equal expected_with_friends, result
+
+    # When condition is false, don't include the association
+    @user.admin = false
+    result = @user.serializable_hash(include: { friends: { if: :admin? } })
+    assert_equal expected, result
+  end
+
+  # Test with nested conditional includes
+  def test_serializable_hash_with_nested_conditional_includes
+    expected = { "name" => "David", "email" => "david@example.com", "gender" => "male", "friends" => [] }
+
+    # Set up a complex scenario with nested associations and conditions
+    @user.admin = true
+    @user.friends.first.friends = [@user]
+    @user.friends.first.admin = true
+
+    # The nested result when all conditions are true
+    expected_with_nested = expected.merge(
+      "friends" => [
+        {
+          "name" => "Joe",
+          "email" => "joe@example.com",
+          "gender" => "male",
+          "friends" => [{ "name" => "David", "email" => "david@example.com", "gender" => "male" }]
+        },
+        {
+          "name" => "Sue",
+          "email" => "sue@example.com",
+          "gender" => "female",
+          "friends" => []
+        }
+      ]
+    )
+
+    # Execute serialization with nested conditions
+    result = @user.serializable_hash(include: {
+      friends: {
+        if: :admin?,
+        include: {
+          friends: {
+            if: :admin?
+          }
+        }
+      }
+    })
+
+    assert_equal expected_with_nested, result
+
+    # When outer condition is false, don't include any associations
+    @user.admin = false
+    result = @user.serializable_hash(include: {
+      friends: {
+        if: :admin?,
+        include: {
+          friends: {
+            if: :admin?
+          }
+        }
+      }
+    })
+
+    assert_equal expected, result
+
+    # When inner condition is false on first friend, don't include nested associations
+    @user.admin = true
+    @user.friends.first.admin = false
+    expected_with_outer_only = expected.merge(
+      "friends" => [
+        {
+          "name" => "Joe",
+          "email" => "joe@example.com",
+          "gender" => "male",
+          "friends" => []
+        },
+        {
+          "name" => "Sue",
+          "email" => "sue@example.com",
+          "gender" => "female",
+          "friends" => []
+        }
+      ]
+    )
+
+    result = @user.serializable_hash(include: {
+      friends: {
+        if: :admin?,
+        include: {
+          friends: {
+            if: :admin?
+          }
+        }
+      }
+    })
+
+    # Check that the nested association is empty because of the condition
+    assert_equal [], result["friends"][0]["friends"]
+    assert_equal expected_with_outer_only, result
+  end
+
+  # Test nested includes with conditions
+  def test_nested_include_with_conditions
+    # Set up user's friend relationships for testing
+    friend1 = @user.friends.first
+    friend1.friends = [@user]
+    friend1.active = false  # This friend is inactive - if: :active? will be false
+
+    friend2 = @user.friends[1]
+    friend2.friends = []
+
+    result = @user.serializable_hash(include: { friends: { include: { friends: { if: :active? } } } })
+
+    # First friend should not have friends in the result since active is false and we use if: :active?
+    assert_equal "Joe", result["friends"][0]["name"]
+    assert_equal [], result["friends"][0]["friends"]
+
+    # Second friend should have empty friends array
+    assert_equal "Sue", result["friends"][1]["name"]
+    assert_equal [], result["friends"][1]["friends"]
+
+    # Test overall structure is as expected
+    assert_equal 2, result["friends"].size
+    assert_equal "David", result["name"]
+  end
+
+  # Test conditional includes with reused data
+  def test_serializable_hash_reuses_conditional_include
+    expected = { "name" => "David", "email" => "david@example.com", "gender" => "male" }
+
+    # Create a reusable include option hash
+    include_opts = { address: { if: :admin? } }
+
+    # When condition is true, include the association
+    @user.admin = true
+    expected_with_address = expected.merge(
+      "address" => { "street" => "123 Lane", "city" => "Springfield", "state" => "CA", "zip" => 11111 }
+    )
+
+    # Serialize with the reusable include option
+    result1 = @user.serializable_hash(include: include_opts)
+    assert_equal expected_with_address, result1
+
+    # Change the condition state and serialize again with the same options
+    @user.admin = false
+    result2 = @user.serializable_hash(include: include_opts)
+    assert_equal expected, result2
+
+    # Verify the include_opts hash hasn't been modified
+    assert_equal({ address: { if: :admin? } }, include_opts)
+  end
+
+  # Test with complex conditions in both :if and :unless
+  def test_serializable_hash_with_complex_conditions
+    expected = { "name" => "David", "email" => "david@example.com", "gender" => "male" }
+
+    # Define a complex if condition - both age and admin status
+    complex_if_proc = -> { age > 25 && admin? }
+
+    # Define a complex unless condition - name length
+    complex_unless_proc = -> { name.length < 4 } # David has 5 letters
+
+    # Set up conditions for test
+    @user.age = 30
+    @user.admin = true
+
+    expected_with_address = expected.merge(
+      "address" => { "street" => "123 Lane", "city" => "Springfield", "state" => "CA", "zip" => 11111 }
+    )
+
+    # Test with complex conditions, should include address
+    result = @user.serializable_hash(include: {
+      address: {
+        if: complex_if_proc,
+        unless: complex_unless_proc
+      }
+    })
+    assert_equal expected_with_address, result
+
+    # Change age to fail the if condition
+    @user.age = 20
+    result = @user.serializable_hash(include: {
+      address: {
+        if: complex_if_proc,
+        unless: complex_unless_proc
+      }
+    })
+    assert_equal expected, result
+
+    # Change name to trigger the unless condition
+    @user.name = "Bob" # 3 letters
+    @user.age = 30 # restore age to pass if condition
+    result = @user.serializable_hash(include: {
+      address: {
+        if: complex_if_proc,
+        unless: complex_unless_proc
+      }
+    })
+    # Name changed, so expected needs to be updated
+    expected = { "name" => "Bob", "email" => "david@example.com", "gender" => "male" }
+    assert_equal expected, result
+  end
+
+  # Test with multiple conditional associations
+  def test_serializable_hash_with_multiple_conditional_includes
+    expected = { "name" => "David", "email" => "david@example.com", "gender" => "male" }
+
+    # Set up conditions for test
+    @user.admin = true
+    @user.active = false
+
+    # Test with multiple associations with different conditions
+    result = @user.serializable_hash(include: {
+      address: { if: :admin? },
+      friends: { if: :active? }
+    })
+
+    # Only address should be included because admin is true but active is false
+    expected_with_address = expected.merge(
+      "address" => { "street" => "123 Lane", "city" => "Springfield", "state" => "CA", "zip" => 11111 },
+      "friends" => []
+    )
+    assert_equal expected_with_address, result
+    assert_equal [], result["friends"]
+
+    # Change conditions and test again
+    @user.admin = false
+    @user.active = true
+
+    result = @user.serializable_hash(include: {
+      address: { if: :admin? },
+      friends: { if: :active? }
+    })
+
+    # Only friends should be included because admin is false but active is true
+    expected_with_friends = expected.merge(
+      "friends" => [{ "name" => "Joe", "email" => "joe@example.com", "gender" => "male" },
+                 { "name" => "Sue", "email" => "sue@example.com", "gender" => "female" }]
+    )
+    assert_equal expected_with_friends, result
+    assert_nil result["address"]
+
+    # With both conditions true, both associations should be included
+    @user.admin = true
+    @user.active = true
+
+    result = @user.serializable_hash(include: {
+      address: { if: :admin? },
+      friends: { if: :active? }
+    })
+
+    expected_with_both = expected.merge(
+      "address" => { "street" => "123 Lane", "city" => "Springfield", "state" => "CA", "zip" => 11111 },
+      "friends" => [{ "name" => "Joe", "email" => "joe@example.com", "gender" => "male" },
+                 { "name" => "Sue", "email" => "sue@example.com", "gender" => "female" }]
+    )
+    assert_equal expected_with_both, result
+  end
+
+  # Test with conditional includes and other options (only, except)
+  def test_serializable_hash_with_conditionals_and_other_options
+    expected = { "name" => "David", "email" => "david@example.com", "gender" => "male" }
+
+    @user.admin = true
+
+    # Test with conditional include combined with only option
+    result = @user.serializable_hash(include: {
+      address: {
+        if: :admin?,
+        only: [:street, :city]
+      }
+    })
+
+    expected_with_partial_address = expected.merge(
+      "address" => { "street" => "123 Lane", "city" => "Springfield" }
+    )
+    assert_equal expected_with_partial_address, result
+
+    # Test with conditional include combined with except option
+    result = @user.serializable_hash(include: {
+      address: {
+        if: :admin?,
+        except: [:zip]
+      }
+    })
+
+    expected_with_partial_address = expected.merge(
+      "address" => { "street" => "123 Lane", "city" => "Springfield", "state" => "CA" }
+    )
+    assert_equal expected_with_partial_address, result
+
+    # When condition is false, association should not be included regardless of other options
+    @user.admin = false
+
+    result = @user.serializable_hash(include: {
+      address: {
+        if: :admin?,
+        only: [:street, :city]
+      }
+    })
+    assert_equal expected, result
   end
 end


### PR DESCRIPTION
### Motivation / Background

This Pull Request introduces conditional inclusion capabilities to `ActiveModel::Serialization`. Currently, when using `serializable_hash` with associations, there isn't a built-in mechanism to conditionally include these associations based on the record's state or other runtime conditions. This often requires developers to implement workarounds, such as creating multiple custom serializers, manually checking conditions before serialization, or implementing complex logic within controllers.

This feature adds `:if` and `:unless` options to the `:include` directive, providing a clean, declarative, and idiomatic Rails way to control association inclusion directly within the serialization options, similar to how these options function in other parts of the framework like validations and callbacks.

### Detail

This Pull Request enhances `ActiveModel::Serialization#serializable_hash` to support `:if` and `:unless` options within the `:include` hash for associations.

These options allow developers to specify conditions that determine whether an association should be included in the serialized output. The conditions can be:

* A `Symbol` or `String` representing an instance method name on the object being serialized.
* A `Proc` that will be evaluated in the context of the object being serialized using `instance_exec`.
* Any other value that evaluates to a boolean.

**Implementation Details:**

1.  The `serializable_add_includes` method is enhanced to evaluate these conditions before processing an association.
2.  Two new private helper methods are introduced:
    * `should_include_association?(options)`: Evaluates both `:if` and `:unless` conditions.
    * `evaluate_condition(condition)`: Handles the evaluation of different condition types (Symbol, Proc, etc.).
3.  The conditional options (`:if`, `:unless`) are removed from the `options` hash before it's passed down to nested `serializable_hash` calls for the included association, ensuring correct behavior with nested includes.

**Examples:**

```ruby
# Only include notes if the user's `admin?` method returns true
user.serializable_hash(include: { notes: { if: :admin? } })

# Using a Proc to check an attribute
user.serializable_hash(include: { notes: { if: -> { active? } } })

# Using :unless option
user.serializable_hash(include: { notes: { unless: -> { inactive? } } })

# Combining conditions
user.serializable_hash(include: { notes: { if: :admin?, unless: -> { name.blank? } } })

# Works with nested conditional includes and other serialization options
user.serializable_hash(include: {
  friends: {
    include: {
      notes: {
        if: :active?,
        only: [:title],
        include: {
          comments: {
            if: :public?
          }
        }
      }
    }
  }
})
```

The implementation follows Rails conventions, using `instance_exec` for Proc evaluation, and is designed to work seamlessly with existing serialization features like `:only`, `:except`, and nested includes.

### Additional information

This feature offers several benefits:

* **Authorization & Permissions:** Easily include associations only if the current context (e.g., current user) permits viewing them.
* **Varying API Responses:** Tailor API response content based on the state of the resource without complex controller logic.
* **Performance & Payload Size:** Reduce payload size and potentially improve performance by omitting associations that aren't necessary under certain conditions.
* **Flexibility:** Customize serialized output based on dynamic runtime conditions in a declarative way.

The implementation is designed to be backward compatible. Comprehensive test coverage is included, verifying various condition types, combinations, nested scenarios, and edge cases.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.