### PR TITLE
Default to SHA-256 for cookie signing

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,18 @@
+*   Default to SHA256 for the signed cookie digest, replacing the previous SHA1 default.
+
+    To ensure the legacy SHA1-signed cookies can still be read, Rails applications relying on the
+    previous default should define a signed cookie rotation until all these cookies have expired
+    or been replaced. For example:
+
+    ```ruby
+    # config/initializers/cookie_rotations.rb
+    Rails.application.config.action_dispatch.cookies_rotations.tap do |cookies|
+      cookies.rotate :signed, digest: "SHA1"
+    end
+    ```
+
+    *Jan Gulan*
+
 *   Add assert_in_body/assert_not_in_body as the simplest way to check if a piece of text is in the response body.
 
     *DHH*

--- a/actionpack/lib/action_dispatch/middleware/cookies.rb
+++ b/actionpack/lib/action_dispatch/middleware/cookies.rb
@@ -306,7 +306,7 @@ module ActionDispatch
         end
 
         def signed_cookie_digest
-          request.signed_cookie_digest || "SHA1"
+          request.signed_cookie_digest || "SHA256"
         end
     end
 

--- a/actionpack/lib/action_dispatch/middleware/cookies.rb
+++ b/actionpack/lib/action_dispatch/middleware/cookies.rb
@@ -306,7 +306,7 @@ module ActionDispatch
         end
 
         def signed_cookie_digest
-          request.signed_cookie_digest || "SHA256"
+          request.signed_cookie_digest || "SHA1"
         end
     end
 

--- a/actionpack/test/dispatch/cookies_test.rb
+++ b/actionpack/test/dispatch/cookies_test.rb
@@ -352,14 +352,14 @@ class CookiesTest < ActionController::TestCase
 
     def rails_5_2_stable_signed_cookie_with_metadata
       # cookies.signed[:favorite] = { value: "5-2-Stable Choco Chip Cookie", expires: 1000.years }
-      cookies[:favorite] = "eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaUUxTFRJdFUzUmhZbXhsSUVOb2IyTnZJRU5vYVhBZ1EyOXZhMmxsQmpvR1JWUT0iLCJleHAiOiIzMDE4LTA3LTExVDE2OjExOjI2Ljc1M1oiLCJwdXIiOm51bGx9fQ==--5682db22b5165c2fcd20ecc0b7de2787a1412e4ad4ee96f320869f9dd39aa6af"
+      cookies[:favorite] = "eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaUUxTFRJdFUzUmhZbXhsSUVOb2IyTnZJRU5vYVhBZ1EyOXZhMmxsQmpvR1JWUT0iLCJleHAiOiIzMDE4LTA3LTExVDE2OjExOjI2Ljc1M1oiLCJwdXIiOm51bGx9fQ==--7df5d885b78b70a501d6e82140ae91b24060ac00"
 
       head :ok
     end
 
     def rails_5_2_stable_signed_cookie_without_metadata
       # cookies.signed[:favorite] = "5-2-Stable Choco Chip Cookie"
-      cookies[:favorite] = "BAhJIiE1LTItU3RhYmxlIENob2NvIENoaXAgQ29va2llBjoGRVQ=--6a6bbde3780ee877bcd78de77b5336fb4fe3b218c7d836583d72ac1ac56a70ab"
+      cookies[:favorite] = "BAhJIiE1LTItU3RhYmxlIENob2NvIENoaXAgQ29va2llBjoGRVQ=--50bbdbf8d64f5a3ec3e54878f54d4f55b6cb3aff"
 
       head :ok
     end
@@ -624,7 +624,7 @@ class CookiesTest < ActionController::TestCase
     key_generator = @request.env["action_dispatch.key_generator"]
     secret = key_generator.generate_key(@request.env["action_dispatch.signed_cookie_salt"])
 
-    verifier = ActiveSupport::MessageVerifier.new(secret, serializer: Marshal, digest: "SHA256")
+    verifier = ActiveSupport::MessageVerifier.new(secret, serializer: Marshal, digest: "SHA1")
     assert_equal verifier.generate(45), cookies[:user_id]
   end
 
@@ -665,7 +665,7 @@ class CookiesTest < ActionController::TestCase
     key_generator = @request.env["action_dispatch.key_generator"]
     secret = key_generator.generate_key(@request.env["action_dispatch.signed_cookie_salt"])
 
-    verifier = ActiveSupport::MessageVerifier.new(secret, serializer: Marshal, digest: "SHA256")
+    verifier = ActiveSupport::MessageVerifier.new(secret, serializer: Marshal, digest: "SHA1")
     message = verifier.generate(45)
 
     @request.headers["Cookie"] = "user_id=#{Marshal.dump 45}--#{message.split("--").last}"
@@ -725,7 +725,7 @@ class CookiesTest < ActionController::TestCase
     key_generator = @request.env["action_dispatch.key_generator"]
     secret = key_generator.generate_key(@request.env["action_dispatch.signed_cookie_salt"])
 
-    json_value = ActiveSupport::MessageVerifier.new(secret, serializer: JSON, digest: "SHA256").generate(45)
+    json_value = ActiveSupport::MessageVerifier.new(secret, serializer: JSON).generate(45)
     @request.headers["Cookie"] = "user_id=#{json_value}"
 
     get :get_signed_cookie
@@ -743,7 +743,7 @@ class CookiesTest < ActionController::TestCase
     key_generator = @request.env["action_dispatch.key_generator"]
     secret = key_generator.generate_key(@request.env["action_dispatch.signed_cookie_salt"])
 
-    marshal_value = ActiveSupport::MessageVerifier.new(secret, serializer: Marshal, digest: "SHA256").generate(45)
+    marshal_value = ActiveSupport::MessageVerifier.new(secret, serializer: Marshal).generate(45)
     @request.headers["Cookie"] = "user_id=#{marshal_value}"
 
     get :get_signed_cookie
@@ -752,7 +752,7 @@ class CookiesTest < ActionController::TestCase
     assert_not_equal 45, cookies[:user_id]
     assert_equal 45, cookies.signed[:user_id]
 
-    verifier = ActiveSupport::MessageVerifier.new(secret, serializer: JSON, digest: "SHA256")
+    verifier = ActiveSupport::MessageVerifier.new(secret, serializer: JSON)
     assert_equal 45, verifier.verify(@response.cookies["user_id"])
   end
 
@@ -762,7 +762,7 @@ class CookiesTest < ActionController::TestCase
     key_generator = @request.env["action_dispatch.key_generator"]
     secret = key_generator.generate_key(@request.env["action_dispatch.signed_cookie_salt"])
 
-    json_value = ActiveSupport::MessageVerifier.new(secret, serializer: JSON, digest: "SHA256").generate(45)
+    json_value = ActiveSupport::MessageVerifier.new(secret, serializer: JSON).generate(45)
     @request.headers["Cookie"] = "user_id=#{json_value}"
 
     get :get_signed_cookie
@@ -798,7 +798,7 @@ class CookiesTest < ActionController::TestCase
     key_generator = @request.env["action_dispatch.key_generator"]
     secret = key_generator.generate_key(@request.env["action_dispatch.signed_cookie_salt"])
 
-    json_value = ActiveSupport::MessageVerifier.new(secret, serializer: JSON, digest: "SHA256").generate(45)
+    json_value = ActiveSupport::MessageVerifier.new(secret, serializer: JSON).generate(45)
     @request.headers["Cookie"] = "user_id=#{json_value}"
 
     get :get_signed_cookie
@@ -807,7 +807,7 @@ class CookiesTest < ActionController::TestCase
     assert_not_equal 45, cookies[:user_id]
     assert_equal 45, cookies.signed[:user_id]
 
-    verifier = ActiveSupport::MessageVerifier.new(secret, serializer: ActiveSupport::MessagePack, digest: "SHA256")
+    verifier = ActiveSupport::MessageVerifier.new(secret, serializer: ActiveSupport::MessagePack)
     assert_equal 45, verifier.verify(@response.cookies["user_id"])
   end
 

--- a/guides/source/8_1_release_notes.md
+++ b/guides/source/8_1_release_notes.md
@@ -76,6 +76,8 @@ Please refer to the [Changelog][action-pack] for detailed changes.
 
 ### Notable changes
 
+*   Default to SHA256 for the signed cookie digest, replacing the previous SHA1 default.
+
 Action View
 -----------
 

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -61,6 +61,7 @@ Below are the default values associated with each target version. In cases of co
 #### Default Values for Target Version 8.1
 
 - [`config.action_controller.escape_json_responses`](#config-action-controller-escape-json-responses): `false`
+- [`config.action_dispatch.signed_cookie_digest`](#config-action-dispatch-signed-cookie-digest): `"SHA256"`
 - [`config.yjit`](#config-yjit): `!Rails.env.local?`
 
 #### Default Values for Target Version 8.0
@@ -151,6 +152,7 @@ Below are the default values associated with each target version. In cases of co
 #### Default Values for Target Version 5.2
 
 - [`config.action_controller.default_protect_from_forgery`](#config-action-controller-default-protect-from-forgery): `true`
+- [`config.action_dispatch.signed_cookie_digest`](#config-action-dispatch-signed-cookie-digest): `"SHA1"`
 - [`config.action_dispatch.use_authenticated_cookie_encryption`](#config-action-dispatch-use-authenticated-cookie-encryption): `true`
 - [`config.action_view.form_with_generates_ids`](#config-action-view-form-with-generates-ids): `true`
 - [`config.active_record.cache_versioning`](#config-active-record-cache-versioning): `true`
@@ -2067,7 +2069,7 @@ Sets the cipher to be used for encrypted cookies. This defaults to
 
 #### `config.action_dispatch.signed_cookie_digest`
 
-Sets the digest to be used for signed cookies. This defaults to `"SHA1"`.
+Sets the digest to be used for signed cookies. This defaults to `"SHA256"`.
 
 #### `config.action_dispatch.cookies_rotations`
 

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -152,7 +152,6 @@ Below are the default values associated with each target version. In cases of co
 #### Default Values for Target Version 5.2
 
 - [`config.action_controller.default_protect_from_forgery`](#config-action-controller-default-protect-from-forgery): `true`
-- [`config.action_dispatch.signed_cookie_digest`](#config-action-dispatch-signed-cookie-digest): `"SHA1"`
 - [`config.action_dispatch.use_authenticated_cookie_encryption`](#config-action-dispatch-use-authenticated-cookie-encryption): `true`
 - [`config.action_view.form_with_generates_ids`](#config-action-view-form-with-generates-ids): `true`
 - [`config.active_record.cache_versioning`](#config-active-record-cache-versioning): `true`

--- a/guides/source/security.md
+++ b/guides/source/security.md
@@ -330,31 +330,31 @@ users have had their chance to get their cookies upgraded.
 
 It's possible to rotate the ciphers and digests used for encrypted and signed cookies.
 
-For instance to change the digest used for signed cookies from SHA1 to SHA256,
+For instance to change the digest used for signed cookies from SHA256 to SHA512,
 you would first assign the new configuration value:
 
 ```ruby
-Rails.application.config.action_dispatch.signed_cookie_digest = "SHA256"
+Rails.application.config.action_dispatch.signed_cookie_digest = "SHA512"
 ```
 
-Now add a rotation for the old SHA1 digest so existing cookies are
-seamlessly upgraded to the new SHA256 digest.
+Now add a rotation for the old SHA256 digest so existing cookies are
+seamlessly upgraded to the new SHA512 digest.
 
 ```ruby
 Rails.application.config.action_dispatch.cookies_rotations.tap do |cookies|
-  cookies.rotate :signed, digest: "SHA1"
+  cookies.rotate :signed, digest: "SHA256"
 end
 ```
 
-Then any written signed cookies will be digested with SHA256. Old cookies
-that were written with SHA1 can still be read, and if accessed will be written
+Then any written signed cookies will be digested with SHA512. Old cookies
+that were written with SHA256 can still be read, and if accessed will be written
 with the new digest so they're upgraded and won't be invalid when you remove the
 rotation.
 
-Once users with SHA1 digested signed cookies should no longer have a chance to
+Once users with SHA256 digested signed cookies should no longer have a chance to
 have their cookies rewritten, remove the rotation.
 
-While you can set up as many rotations as you'd like it's not common to have many
+While you can set up as many rotations as you'd like, it's not common to have many
 rotations going at any one time.
 
 For more details on key rotation with encrypted and signed messages as

--- a/guides/source/upgrading_ruby_on_rails.md
+++ b/guides/source/upgrading_ruby_on_rails.md
@@ -82,6 +82,25 @@ Upgrading from Rails 8.0 to Rails 8.1
 
 For more information on changes made to Rails 8.1 please see the [release notes](8_1_release_notes.html).
 
+### Default signed cookie digest is changing to SHA256
+
+The default signed cookie digest is changing to SHA256, replacing the previous SHA1 default.
+
+For Rails applications that make use of signed cookies and that use the default signed cookie digest (i.e.
+not overriding `config.action_dispatch.signed_cookie_digest`), a signed cookie rotator should be registered
+to ensure a smooth upgrade. Without the cookie rotation, the upgraded application will fail to read any
+provided cookies that use the SHA1 digest.
+
+The following example rotation will allow SHA1 signed cookies to be read and replaced with the SHA256 signed variant:
+
+```ruby
+# config/initializers/cookie_rotations.rb
+Rails.application.config.action_dispatch.cookies_rotations.tap do |cookies|
+  cookies.rotate :signed, digest: "SHA1"
+end
+```
+
+The cookie rotation can be removed once all these cookies have expired or been replaced.
 
 Upgrading from Rails 7.2 to Rails 8.0
 -------------------------------------

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -145,6 +145,7 @@ module Rails
 
           if respond_to?(:action_dispatch)
             action_dispatch.use_authenticated_cookie_encryption = true
+            action_dispatch.signed_cookie_digest = "SHA1"
           end
 
           if respond_to?(:active_support)
@@ -358,6 +359,10 @@ module Rails
 
           if respond_to?(:action_controller)
             action_controller.escape_json_responses = false
+          end
+
+          if respond_to?(:action_dispatch)
+            action_dispatch.signed_cookie_digest = "SHA256"
           end
         else
           raise "Unknown version #{target_version.to_s.inspect}"

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -145,7 +145,6 @@ module Rails
 
           if respond_to?(:action_dispatch)
             action_dispatch.use_authenticated_cookie_encryption = true
-            action_dispatch.signed_cookie_digest = "SHA1"
           end
 
           if respond_to?(:active_support)

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_8_1.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_8_1.rb.tt
@@ -26,3 +26,11 @@
 # Applications that want to keep the escaping behavior can set the config to `true`.
 #++
 # Rails.configuration.action_controller.escape_json_responses = false
+
+# Change the default signed cookie digest to SHA256.
+# Changing this default means that signed cookies created using a different digest
+# (e.g. SHA1, which was the previous default) can no longer be read. In this case, a
+# signed cookie rotation should be registered as described in the upgrade guide:
+# https://guides.rubyonrails.org/upgrading_ruby_on_rails.html#upgrading-from-rails-8-0-to-rails-8-1
+#
+# Rails.application.config.action_dispatch.signed_cookie_digest = "SHA256"

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -829,7 +829,7 @@ module ApplicationTests
       get "/"
 
       secret = app.key_generator.generate_key("signed cookie")
-      verifier = ActiveSupport::MessageVerifier.new(secret, digest: "SHA256")
+      verifier = ActiveSupport::MessageVerifier.new(secret)
       assert_equal "some_value", verifier.verify(last_response.body)
     end
 
@@ -3573,15 +3573,6 @@ module ApplicationTests
       app "development"
 
       assert_equal :lax, Rails.application.config.action_dispatch.cookies_same_site_protection
-    end
-
-    test "Rails.application.config.action_dispatch.signed_cookie_digest defaults to SHA1 in 5.2 defaults" do
-      remove_from_config '.*config\.load_defaults.*\n'
-      add_to_config 'config.load_defaults "5.2"'
-
-      app "development"
-
-      assert_equal "SHA1", Rails.application.config.action_dispatch.signed_cookie_digest
     end
 
     test "Rails.application.config.action_dispatch.signed_cookie_digest defaults to SHA256" do


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

Fixes #54926. This pull request has been created so that we use the SHA256 algorithm by default for signed cookies, moving away from SHA1.

Unless overriding `config.action_dispatch.signed_cookie_digest`, Rails currently defaults to SHA1 for the generation of the signed cookie HMAC.

As the [issue](https://github.com/rails/rails/issues/54926) implies, use of the SHA1 algorithm is [no longer recommended](https://www.nist.gov/news-events/news/2022/12/nist-retires-sha-1-cryptographic-algorithm), even if there is currently no known attack vector specifically for HMACs. Rails is already migrating to SHA256 in related areas.

### Detail

This pull request changes the default value of `signed_cookie_digest`.

**Note**: Rails applications relying on the previous SHA1 default will no longer read these SHA1-signed cookies unless a cookie rotation is configured:

```
Rails.application.config.action_dispatch.cookies_rotations.tap do |cookies|
  cookies.rotate :signed, digest: "SHA1"
end
```

This rotation allows the upgrading applications to read SHA1 signed cookies created prior to this change without breaking sessions or user data.

The rotation can be removed once no clients are sending cookies signed using the previous digest (e.g. the session lifetimes or cookie expiration times have passed). 

### Additional information

#### Example

Prior to this change, imagine we have the following action method where we set a signed cookie:

```ruby
def index
  cookies.signed[:foo] = { value: 'bar' }
end
```

Cookie value:

```
eyJfcmFpbHMiOnsibWVzc2FnZSI6IkltSmhjaUk9IiwiZXhwIjpudWxsLCJwdXIiOiJjb29raWUuZm9vIn19--a1d2517adb63df049f06fe652040f18b10555ebd
```

Base64 decoding the first part, we see: `{"_rails":{"message":"ImJhciI=","exp":null,"pur":"cookie.foo"}}`. The SHA1 HMAC follows: `a1d2517adb63df049f06fe652040f18b10555ebd`.

After applying this PR's change, restarting the server and attempting to read the cookie using another action method:

```ruby
def foo
  message = cookies.signed[:foo]
  render plain: "#{message || "Unable to read cookie"}\n"
end
```

We see `Unable to read cookie` because the client presented a SHA1-signed cookie, but we're now using SHA256.

We can apply the rotation to gracefully handle this scenario:

```ruby
# config/initializers/cookie_rotations.rb
Rails.application.config.action_dispatch.cookies_rotations.tap do |cookies|
  cookies.rotate :signed, digest: "SHA1"
end
```

The action method now renders `bar` and the cookie's value is updated, including the new SHA256 HMAC:

```
eyJfcmFpbHMiOnsibWVzc2FnZSI6IkltSmhjaUk9IiwiZXhwIjpudWxsLCJwdXIiOiJjb29raWUuZm9vIn19--80d33014a7c363278ff169d809a8740399f0fbaec9d6e944cd6dfed89581f83c
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
