### PR TITLE
Prevent stack overflow in ActionText PlaintextConversion

### DIFF
--- a/actiontext/lib/action_text/plain_text_conversion.rb
+++ b/actiontext/lib/action_text/plain_text_conversion.rb
@@ -95,7 +95,7 @@ module ActionText
 
       def bullet_for_li_node(node)
         if list_node_name_for_li_node(node) == "ol"
-          index = node.parent.children.index(node)
+          index = node.parent.elements.index(node)
           "#{index + 1}."
         else
           "•"

--- a/actiontext/lib/action_text/plain_text_conversion.rb
+++ b/actiontext/lib/action_text/plain_text_conversion.rb
@@ -123,7 +123,7 @@ module ActionText
         end
       end
 
-      class BottomUpReducer
+      class BottomUpReducer # :nodoc:
         def initialize(node)
           @node = node
           @values = {}

--- a/actiontext/lib/action_text/plain_text_conversion.rb
+++ b/actiontext/lib/action_text/plain_text_conversion.rb
@@ -7,31 +7,29 @@ module ActionText
     extend self
 
     def node_to_plain_text(node)
-      remove_trailing_newlines(node_to_plain_text_content_tree(node).content)
+      BottomUpReducer.new(node).reduce do |n, child_values|
+        plain_text_for_node(n, child_values)
+      end.then(&method(:remove_trailing_newlines))
     end
 
     private
-      def node_to_plain_text_content_tree(node)
-        BottomUpReplacer.replace_content(node.dup) { |n| plain_text_for_node(n) }
-      end
-
-      def plain_text_for_node(node)
+      def plain_text_for_node(node, child_values)
         if respond_to?(plain_text_method_for_node(node), true)
-          send(plain_text_method_for_node(node), node)
+          send(plain_text_method_for_node(node), node, child_values)
         else
-          plain_text_for_node_children(node)
+          plain_text_for_child_values(child_values)
         end
-      end
-
-      def plain_text_for_node_children(node)
-        node.children.map(&:content).join
       end
 
       def plain_text_method_for_node(node)
         :"plain_text_for_#{node.name}_node"
       end
 
-      def plain_text_for_unsupported_node(node)
+      def plain_text_for_child_values(child_values)
+        child_values.join
+      end
+
+      def plain_text_for_unsupported_node(node, _child_values)
         ""
       end
 
@@ -39,40 +37,40 @@ module ActionText
         alias_method :"plain_text_for_#{element}_node", :plain_text_for_unsupported_node
       end
 
-      def plain_text_for_block(node)
-        "#{remove_trailing_newlines(plain_text_for_node_children(node))}\n\n"
+      def plain_text_for_block(node, child_values)
+        "#{remove_trailing_newlines(plain_text_for_child_values(child_values))}\n\n"
       end
 
       %i[ h1 p ].each do |element|
         alias_method :"plain_text_for_#{element}_node", :plain_text_for_block
       end
 
-      def plain_text_for_list(node)
-        "#{break_if_nested_list(node, plain_text_for_block(node))}"
+      def plain_text_for_list(node, child_values)
+        "#{break_if_nested_list(node, plain_text_for_block(node, child_values))}"
       end
 
       %i[ ul ol ].each do |element|
         alias_method :"plain_text_for_#{element}_node", :plain_text_for_list
       end
 
-      def plain_text_for_br_node(node)
+      def plain_text_for_br_node(node, _child_values)
         "\n"
       end
 
-      def plain_text_for_text_node(node)
+      def plain_text_for_text_node(node, _child_values)
         remove_trailing_newlines(node.text)
       end
 
-      def plain_text_for_div_node(node)
-        "#{remove_trailing_newlines(plain_text_for_node_children(node))}\n"
+      def plain_text_for_div_node(node, child_values)
+        "#{remove_trailing_newlines(plain_text_for_child_values(child_values))}\n"
       end
 
-      def plain_text_for_figcaption_node(node)
-        "[#{remove_trailing_newlines(plain_text_for_node_children(node))}]"
+      def plain_text_for_figcaption_node(node, child_values)
+        "[#{remove_trailing_newlines(plain_text_for_child_values(child_values))}]"
       end
 
-      def plain_text_for_blockquote_node(node)
-        text = plain_text_for_block(node)
+      def plain_text_for_blockquote_node(node, child_values)
+        text = plain_text_for_block(node, child_values)
         return "“”" if text.blank?
 
         text = text.dup
@@ -81,9 +79,9 @@ module ActionText
         text
       end
 
-      def plain_text_for_li_node(node)
+      def plain_text_for_li_node(node, child_values)
         bullet = bullet_for_li_node(node)
-        text = remove_trailing_newlines(plain_text_for_node_children(node))
+        text = remove_trailing_newlines(plain_text_for_child_values(child_values))
         indentation = indentation_for_li_node(node)
 
         "#{indentation}#{bullet} #{text}\n"
@@ -125,21 +123,18 @@ module ActionText
         end
       end
 
-      class BottomUpReplacer
-        def self.replace_content(node, &block)
-          new(node).replace_content(&block)
-        end
-
+      class BottomUpReducer
         def initialize(node)
           @node = node
+          @values = {}
         end
 
-        def replace_content(&block)
-          @node.tap do |node|
-            traverse_bottom_up(node) do |n|
-              n.content = block.call(n)
-            end
+        def reduce(&block)
+          traverse_bottom_up(@node) do |n|
+            child_values = @values.values_at(*n.children)
+            @values[n] = block.call(n, child_values)
           end
+          @values[@node]
         end
 
         private

--- a/actiontext/test/unit/plain_text_conversion_test.rb
+++ b/actiontext/test/unit/plain_text_conversion_test.rb
@@ -120,7 +120,7 @@ class ActionText::PlainTextConversionTest < ActiveSupport::TestCase
       "Hello world!\nHow are you?",
       ActionText::Fragment.wrap("<div>Hello world!</div><div></div>").tap do |fragment|
         node = fragment.source.children.last
-        1_000.times do
+        10_000.times do
           child = node.clone
           child.parent = node
           node = child
@@ -128,6 +128,14 @@ class ActionText::PlainTextConversionTest < ActiveSupport::TestCase
         node.inner_html = "How are you?"
       end
     )
+  end
+
+  test "preserves the original tree" do
+    html = "<div>Hello <span>world!</span></div>"
+    fragment = ActionText::Fragment.wrap(html)
+    assert_no_changes -> { fragment.source.to_html } do
+      assert_equal "Hello world!", fragment.to_plain_text
+    end
   end
 
   test "preserves non-linebreak whitespace after text" do

--- a/actiontext/test/unit/plain_text_conversion_test.rb
+++ b/actiontext/test/unit/plain_text_conversion_test.rb
@@ -34,7 +34,7 @@ class ActionText::PlainTextConversionTest < ActiveSupport::TestCase
   test "<ol> tags are separated by two new lines" do
     assert_converted_to(
       "Hello world!\n\n1. list1\n\n1. list2\n\nHow are you?",
-      "<p>Hello world!</p><ol><li>list1</li></ol><ol><li>list2</li></ol><p>How are you?</p>"
+      "<p>Hello world!</p><ol>\n<li>list1</li>\n</ol><ol>\n<li>list2</li>\n</ol><p>How are you?</p>"
     )
   end
 

--- a/actiontext/test/unit/plain_text_conversion_test.rb
+++ b/actiontext/test/unit/plain_text_conversion_test.rb
@@ -34,7 +34,7 @@ class ActionText::PlainTextConversionTest < ActiveSupport::TestCase
   test "<ol> tags are separated by two new lines" do
     assert_converted_to(
       "Hello world!\n\n1. list1\n\n1. list2\n\nHow are you?",
-      "<p>Hello world!</p><ol>\n<li>list1</li>\n</ol><ol>\n<li>list2</li>\n</ol><p>How are you?</p>"
+      "<p>Hello world!</p><ol><li>list1</li></ol><ol><li>list2</li></ol><p>How are you?</p>"
     )
   end
 
@@ -128,14 +128,6 @@ class ActionText::PlainTextConversionTest < ActiveSupport::TestCase
         node.inner_html = "How are you?"
       end
     )
-  end
-
-  test "preserves the original tree" do
-    html = "<div>Hello <span>world!</span></div>"
-    fragment = ActionText::Fragment.wrap(html)
-    assert_no_changes -> { fragment.source.to_html } do
-      assert_equal "Hello world!", fragment.to_plain_text
-    end
   end
 
   test "preserves non-linebreak whitespace after text" do


### PR DESCRIPTION
### Motivation / Background

In our app, we encountered edge cases where the ActionText plaintext conversion caused stack overflows. 
To address this, traverse a copy of the tree iteratively bottom-up, converting each node's content to plaintext using the already-converted children content. Finally, extract the result from the root node. This approach avoids recursion preventing stack overflows.

### Checklist

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
