### PR TITLE
Avoid DISTINCT on COUNT queries when possible

### DIFF
--- a/activerecord/test/cases/calculations_test.rb
+++ b/activerecord/test/cases/calculations_test.rb
@@ -379,6 +379,24 @@ class CalculationsTest < ActiveRecord::TestCase
     assert_queries_count(1) { assert_equal 11, posts.count(:all) }
   end
 
+  def test_count_with_eager_loading_and_custom_order_from_child_association
+    comments = Comment.includes(:post).order("posts.id")
+    assert_queries_count(1) { assert_equal 12, comments.count }
+    assert_queries_count(1) { assert_equal 12, comments.count(:all) }
+  end
+
+  def test_count_with_eager_loading_and_custom_select_and_order_from_child_association
+    comments = Comment.includes(:post).order("posts.id").select(:type)
+    assert_queries_count(1) { assert_equal 12, comments.count }
+    assert_queries_count(1) { assert_equal 12, comments.count(:all) }
+  end
+
+  def test_count_with_eager_loading_and_custom_order_and_distinct_from_child_association
+    comments = Comment.includes(:post).order("posts.id").distinct
+    assert_queries_count(1) { assert_equal 12, comments.count }
+    assert_queries_count(1) { assert_equal 12, comments.count(:all) }
+  end
+
   def test_distinct_count_all_with_custom_select_and_order
     accounts = Account.distinct.select("credit_limit % 10").order(Arel.sql("credit_limit % 10"))
     assert_queries_count(1) { assert_equal 3, accounts.count(:all) }


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

Fixes #55027

When calling `.count` on an eager-loaded query where the base table `belongs_to` the eager-loaded table, AR switches `COUNT(*)` to a `COUNT(DISTINCT "id")`.  However, this is unnecessary as there will never be duplicates in a `belongs_to` relationship like this.

This isn't normally an issue, but when running COUNT queries on larger tables (at least in Postgres), I've seen this turn ~100ms queries into ~30s queries.

This Pull Request has been created because a very common scenario is paginating data that might have an `order` clause on an included table, which is then paginated with gems like Kaminari that will call `count` on the relation without additional reworking of the query.  e.g.:

```ruby
Comment.includes(:post).order(posts: { title: :asc }, comments: { created_at: :desc }).count
# => SELECT COUNT(DISTINCT "comments"."id") FROM "comments" LEFT OUTER JOIN "posts" ON "posts"."id" = "comments"."post_id"
```

### Detail

This Pull Request changes ActiveRecord's Calculation logic around COUNT queries to only add a `DISTINCT` column when any eager-loaded associations are not belongs_to associations.

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

One workaround we've used is to avoid the eager-load and just change the query to:

```ruby
Comment.left_outer_joins(:post).order(posts: { title: :asc }, comments: { created_at: :desc }).count
```

This works fine, but we lose the eager-loaded `post` association in doing so.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
