### PR TITLE
Add method to check if YJIT was enabled successfully

### DIFF
--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -366,6 +366,12 @@ module Rails
         @loaded_config_version = target_version
       end
 
+      def yjit_enabled?
+        RubyVM::YJIT.enabled?
+      rescue NameError # When Ruby isn't built with YJIT support
+        false
+      end
+
       def reloading_enabled?
         enable_reloading
       end


### PR DESCRIPTION
### Motivation / Background

When `config.yjit` is set to `true`, there are still ways for YJIT not to be enabled:
- If the ruby version is lower than 3.3
- If ruby wasn't built with YJIT support (for example, with `ruby-build` you need to pass `--enable-yjit` to `./configure`, otherwise the binary will not have YJIT support)

This Pull Request has been created because Rails currently doesn't provide a method to check if YJIT has been successfully enabled, since the value of `Rails.application.config.yjit` does not change after the finisher runs the [YJIT initializer](https://github.com/rails/rails/blob/747f85f200e7bb2c1a31b4e26e5a5655e2dc0cdc/railties/lib/rails/application/finisher.rb#L230) (and I believe this is the intended behaviour).

### Detail

This Pull Request adds a new method: `Rails.application.config.yjit_enabled?`, which will check the value of [`RubyVM::YJIT.enabled?`](https://ruby-doc.org/3.4.1/RubyVM/YJIT.html#method-c-enabled-3F) (enabled since Ruby 3.1). The aim is to give an indication if YJIT is actually enabled, as an ensurance.
It would also be handy if a message is logged on boot, in case the value is `false`. If you also think this would be necessary I can work it, but might need some guidance on how to.

### Additional information

This is my first contribution, so I was not sure if:
- `Rails::Application::Configuration` was the correct place to add the method, but I believe it's where it makes more sense
- You require a unit test for it
- It's worth an entry on the changelog

### Checklist

Before submitting the PR make sure the following are checked:

* [ ] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [ ] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.