### PR TITLE
Only load from `cgi` what is required for Ruby 3.5 compatibility

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -34,7 +34,6 @@ PATH
     actionpack (8.1.0.alpha)
       actionview (= 8.1.0.alpha)
       activesupport (= 8.1.0.alpha)
-      cgi
       nokogiri (>= 1.8.5)
       rack (>= 2.2.4)
       rack-session (>= 1.0.1)
@@ -52,7 +51,6 @@ PATH
     actionview (8.1.0.alpha)
       activesupport (= 8.1.0.alpha)
       builder (~> 3.1)
-      cgi
       erubi (~> 1.11)
       rails-dom-testing (~> 2.2)
       rails-html-sanitizer (~> 1.6)
@@ -101,7 +99,6 @@ PATH
     railties (8.1.0.alpha)
       actionpack (= 8.1.0.alpha)
       activesupport (= 8.1.0.alpha)
-      cgi
       irb (~> 1.13)
       rackup (>= 1.0.0)
       rake (>= 12.2)
@@ -180,7 +177,6 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
-    cgi (0.4.2)
     chef-utils (18.6.2)
       concurrent-ruby
     childprocess (5.1.0)

--- a/actionpack/actionpack.gemspec
+++ b/actionpack/actionpack.gemspec
@@ -35,7 +35,6 @@ Gem::Specification.new do |s|
 
   s.add_dependency "activesupport", version
 
-  s.add_dependency "cgi"
   s.add_dependency "nokogiri", ">= 1.8.5"
   s.add_dependency "rack",      ">= 2.2.4"
   s.add_dependency "rack-session", ">= 1.0.1"

--- a/actionpack/lib/action_dispatch/journey/router.rb
+++ b/actionpack/lib/action_dispatch/journey/router.rb
@@ -2,7 +2,8 @@
 
 # :markup: markdown
 
-require "cgi"
+require "cgi/escape"
+require "cgi/util" if RUBY_VERSION < "3.5"
 require "action_dispatch/journey/router/utils"
 require "action_dispatch/journey/routes"
 require "action_dispatch/journey/formatter"

--- a/actionview/actionview.gemspec
+++ b/actionview/actionview.gemspec
@@ -35,7 +35,6 @@ Gem::Specification.new do |s|
 
   s.add_dependency "activesupport", version
 
-  s.add_dependency "cgi"
   s.add_dependency "builder",       "~> 3.1"
   s.add_dependency "erubi",         "~> 1.11"
   s.add_dependency "rails-html-sanitizer", "~> 1.6"

--- a/actionview/lib/action_view/helpers/form_helper.rb
+++ b/actionview/lib/action_view/helpers/form_helper.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
-require "cgi"
+require "cgi/escape"
+require "cgi/util" if RUBY_VERSION < "3.5"
 require "action_view/helpers/date_helper"
 require "action_view/helpers/url_helper"
 require "action_view/helpers/form_tag_helper"

--- a/actionview/lib/action_view/helpers/form_options_helper.rb
+++ b/actionview/lib/action_view/helpers/form_options_helper.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
-require "cgi"
+require "cgi/escape"
+require "cgi/util" if RUBY_VERSION < "3.5"
 require "erb"
 require "active_support/core_ext/string/output_safety"
 require "active_support/core_ext/array/extract_options"

--- a/actionview/lib/action_view/helpers/form_tag_helper.rb
+++ b/actionview/lib/action_view/helpers/form_tag_helper.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
-require "cgi"
+require "cgi/escape"
+require "cgi/util" if RUBY_VERSION < "3.5"
 require "action_view/helpers/content_exfiltration_prevention_helper"
 require "action_view/helpers/url_helper"
 require "action_view/helpers/text_helper"

--- a/activesupport/lib/active_support/core_ext/object/to_query.rb
+++ b/activesupport/lib/active_support/core_ext/object/to_query.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
-require "cgi"
+require "cgi/escape"
+require "cgi/util" if RUBY_VERSION < "3.5"
 
 class Object
   # Alias of <tt>to_s</tt>.

--- a/railties/lib/rails/info.rb
+++ b/railties/lib/rails/info.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
-require "cgi"
+require "cgi/escape"
+require "cgi/util" if RUBY_VERSION < "3.5"
 
 module Rails
   # This module helps build the runtime properties that are displayed in

--- a/railties/railties.gemspec
+++ b/railties/railties.gemspec
@@ -40,7 +40,6 @@ Gem::Specification.new do |s|
   s.add_dependency "activesupport", version
   s.add_dependency "actionpack",    version
 
-  s.add_dependency "cgi"
   s.add_dependency "rackup", ">= 1.0.0"
   s.add_dependency "rake", ">= 12.2"
   s.add_dependency "thor", "~> 1.0", ">= 1.2.2"

--- a/tools/preview_docs.rb
+++ b/tools/preview_docs.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 require "erb"
-require "cgi"
+require "cgi/escape"
+require "cgi/util" if RUBY_VERSION < "3.5"
 
 # How to test:
 #


### PR DESCRIPTION
### Motivation / Background

In Ruby 3.5 most of the `cgi` gem will be removed (bundled gem). Only the various escape/unescape methods will be retained by default, which is luckily the only ones that rails actually uses.

Practically, requiring `cgi` will still work, it just emits a warning (and other things like `CGI::Cookie` obviously won't be available).

### Detail

https://bugs.ruby-lang.org/issues/21258

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
