### PR TITLE
Allow prepending error middleware

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Allow prepending error middleware
+
+    ActiveSupport::ErrorReporter#add_middleware now receives an `insert` kwarg. If this is set to `:prepend`,
+    the middleware will be added to the top of the stack, rather than the bottom. The default behavior remains
+    to append middleware.
+
+    *Sam Schmidt*
+
 *   Allow to configure maximum cache key sizes
 
     When the key exceeds the configured limit (250 bytes by default), it will be truncated and

--- a/activesupport/test/error_reporter_test.rb
+++ b/activesupport/test/error_reporter_test.rb
@@ -415,4 +415,13 @@ class ErrorReporterTest < ActiveSupport::TestCase
 
     assert_equal [[reported_error, true, :warning, "application", { foo: :bar }]], @subscriber.events
   end
+
+  test "error context middleware can be prepended" do
+    @reporter.add_middleware(-> (_, context:, **kwargs) { context.merge({ foo: :right }) }, insert: :append)
+    @reporter.add_middleware(-> (_, context:, **kwargs) { context.merge({ foo: :wrong, bar: :right }) }, insert: :prepend)
+    error = ArgumentError.new("Oops")
+    @reporter.report(error)
+
+    assert_equal [[error, true, :warning, "application", { foo: :right, bar: :right }]], @subscriber.events
+  end
 end


### PR DESCRIPTION
ActiveSupport::ErrorReporter#add_middleware now receives an `insert` kwarg. If this is set to `:prepend`, the middleware will be added to the top of the stack, rather than the bottom. The default behavior remains to append middleware.

This provides better control over middleware provided automatically vs context dependent middleware in an app.

I chose to pass symbols to set the behavior instead of a boolean to allow for additional behaviors in the future.