### PR TITLE
Respect table aliases in through association scope

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Respect table aliases in through associations.
+
+    Previously when the same table was joined multiple times in the same query,
+    such as with tree structures and through STI models, any default scope or
+    STI type would only apply to the base table. Default scope and STI type are
+    now applied to the correct table alias.
+
+    *Colin Kuebler*
+
 *   Enable passing retryable SqlLiterals to `#where`.
 
     *Hartley McGuire*

--- a/activerecord/lib/active_record/associations/association.rb
+++ b/activerecord/lib/active_record/associations/association.rb
@@ -307,8 +307,7 @@ module ActiveRecord
           end
         end
 
-        # Can be overridden (i.e. in ThroughAssociation) to merge in other scopes (i.e. the
-        # through association's scope)
+        # Can be overridden to merge in other scopes
         def target_scope
           AssociationRelation.create(klass, self).merge!(klass.scope_for_association)
         end

--- a/activerecord/lib/active_record/associations/through_association.rb
+++ b/activerecord/lib/active_record/associations/through_association.rb
@@ -27,21 +27,6 @@ module ActiveRecord
           @through_association ||= owner.association(through_reflection.name)
         end
 
-        # We merge in these scopes for two reasons:
-        #
-        #   1. To get the default_scope conditions for any of the other reflections in the chain
-        #   2. To get the type conditions for any STI models in the chain
-        def target_scope
-          scope = super
-          reflection.chain.drop(1).each do |reflection|
-            relation = reflection.klass.scope_for_association
-            scope.merge!(
-              relation.except(:select, :create_with, :includes, :preload, :eager_load, :joins, :left_outer_joins)
-            )
-          end
-          scope
-        end
-
         # Construct attributes for :through pointing to owner and associate. This is used by the
         # methods which create and delete records on the association.
         #

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -427,11 +427,11 @@ module ActiveRecord
           end
         end
 
-        def relation
-          relation = Relation.create(self)
+        def relation(table: arel_table)
+          relation = Relation.create(self, table:)
 
           if finder_needs_type_condition? && !ignore_default_scope?
-            relation.where!(type_condition)
+            relation.where!(type_condition(table))
           else
             relation
           end

--- a/activerecord/test/cases/associations/nested_through_associations_test.rb
+++ b/activerecord/test/cases/associations/nested_through_associations_test.rb
@@ -29,6 +29,7 @@ require "models/department"
 require "models/chef"
 require "models/cake_designer"
 require "models/drink_designer"
+require "models/location"
 
 class NestedThroughAssociationsTest < ActiveRecord::TestCase
   fixtures :authors, :author_addresses, :books, :posts, :subscriptions, :subscribers, :tags, :taggings,
@@ -479,6 +480,19 @@ class NestedThroughAssociationsTest < ActiveRecord::TestCase
     assert_empty scope.where("comments.type" => "Comment")
     assert_not_empty scope.where("comments.type" => "SpecialComment")
     assert_not_empty scope.where("comments.type" => "SubSpecialComment")
+  end
+
+  def test_has_many_through_with_sti_on_through_association
+    state = State.create!
+    county = state.counties.create!
+    city = county.cities.create!
+    people(:david).update(city: city)
+
+    assert_not_empty Person.joins(:county).where(county: { parent_id: state.id })
+
+    assert_not_empty city.people
+    assert_not_empty county.people
+    assert_not_empty state.people
   end
 
   def test_has_many_through_with_sti_on_nested_through_reflection

--- a/activerecord/test/models/location.rb
+++ b/activerecord/test/models/location.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class Location < ActiveRecord::Base; end
+
+class City < Location
+  belongs_to :county, foreign_key: :parent_id
+  has_one :state, through: :county
+
+  has_many :people
+end
+
+class County < Location
+  belongs_to :state, foreign_key: :parent_id
+
+  has_many :cities, foreign_key: :parent_id
+  has_many :people, through: :cities
+end
+
+class State < Location
+  has_many :counties, foreign_key: :parent_id
+  has_many :cities, through: :counties
+  has_many :people, through: :cities
+end

--- a/activerecord/test/models/person.rb
+++ b/activerecord/test/models/person.rb
@@ -33,6 +33,10 @@ class Person < ActiveRecord::Base
   has_many :agents_of_agents, through: :agents, source: :agents
   belongs_to :number1_fan, class_name: "Person"
 
+  belongs_to :city, optional: true
+  has_one :county, through: :city
+  has_one :state, through: :county
+
   has_many :personal_legacy_things, dependent: :destroy
 
   has_many :agents_posts,         through: :agents,       source: :posts

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -752,6 +752,11 @@ ActiveRecord::Schema.define do
     t.boolean :is_vegetarian, default: false
   end
 
+  create_table :locations, force: true do |t|
+    t.string :type
+    t.integer :parent_id
+  end
+
   create_table :lock_without_defaults, force: true do |t|
     t.column :title, :string
     t.column :lock_version, :integer
@@ -954,6 +959,7 @@ ActiveRecord::Schema.define do
     t.timestamp :born_at
     t.integer :cars_count, default: 0
     t.timestamps null: false
+    t.integer :city_id
   end
 
   create_table :peoples_treasures, id: false, force: true do |t|


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created because currently table aliases are not taken into account in the core relation while building through associations. This concerns default_scope and STI type in nested through associations or self joins.

For example, when building a nested through association with STI models of the same table, the table is aliased for the purpose of the join, however the type condition is incorrectly applied to the unaliased table. If multiple criteria are applied to the same table, only the latest prevails, potentially resulting in a query with contradictory or otherwise unsatisfiable criteria.

This is inconsistent with the behavior of `joins`. When joining an association that gets aliased, the conditions on the association are applied to the appropriate table alias.

```ruby
# frozen_string_literal: true

require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"

  gem "rails"
  # If you want to test against edge Rails replace the previous line with this:
  # gem "rails", github: "rails/rails", branch: "main"

  gem "sqlite3"
end

require "active_record/railtie"
require "minitest/autorun"

# This connection will do for database-independent bug reports.
ENV["DATABASE_URL"] = "sqlite3::memory:"

class TestApp < Rails::Application
  config.load_defaults Rails::VERSION::STRING.to_f
  config.eager_load = false
  config.logger = Logger.new($stdout)
  config.secret_key_base = "secret_key_base"

  config.active_record.encryption.primary_key = "primary_key"
  config.active_record.encryption.deterministic_key = "deterministic_key"
  config.active_record.encryption.key_derivation_salt = "key_derivation_salt"
end
Rails.application.initialize!

ActiveRecord::Schema.define do
  create_table :locations, force: true do |t|
    t.string :type
    t.integer :parent_id
  end

  create_table :people, force: true do |t|
    t.integer :city_id
  end
end

class Location < ActiveRecord::Base; end

class City < Location
  belongs_to :county, foreign_key: :parent_id
  has_one :state, through: :county

  has_many :people
end

class County < Location
  belongs_to :state, foreign_key: :parent_id

  has_many :cities, foreign_key: :parent_id
  has_many :people, through: :cities
end

class State < Location
  has_many :counties, foreign_key: :parent_id
  has_many :cities, through: :counties
  has_many :people, through: :cities
end

class Person < ActiveRecord::Base
  belongs_to :city
  has_one :county, through: :city
  has_one :state, through: :county
end

class BugTest < ActiveSupport::TestCase
  def test_association_through_multiple_sti
    state = State.create!
    county = state.counties.create!
    city = county.cities.create!
    person = city.people.create!

    assert_not_empty Person.joins(:county).
      where(county: {parent_id: state.id}) # passes - join already respects table aliases

    assert_not_empty county.people # passes - table is only joined once

    assert_not_empty state.people # fails - table is joined twice and aliased
  end
end
```

### Detail

This Pull Request
* changes `ActiveRecord::Core#relation` to accept an optional `table` argument with which to build a base relation
* moves the merging of reflection chain scopes from `ActiveRecord::Associations::ThroughAssociation::target_scope` to `ActiveRecord::Associations::AssociationScope#next_chain_scope`, where we have a reference to the aliased table
* uses the aliased table to construct the `#scope_for_association` that is merged into the association scope

This is my first contribution to ActiveRecord, I welcome any suggestions or feedback about this approach.

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

An earlier patch modified `ActiveRecord::Associations::AssociationScope#next_chain_scope` to add `type_condition` to the join constraints. `ThroughAssociation::target_scope` still needed to be removed to avoid adding `type_condition` to the wrong table. This fixed the issue for STI models, but did not take `default_scope` into account.

This approach uses the same code from `target_scope`, which merges the `type_condition` with `where`. Ideally I believe the merged conditions should apply to the join constraints, as with `joins`. However this is only semantically relevant with outer joins, so this proposal is sufficient to fix the currently incorrect behavior. Moving merged where conditions to join constraints may be a future exploration.

Another area for future improvement is in addressing the duplication of code for merging through association criteria in both association scopes (`ActiveRecord::Associations::AssociationScope#next_chain_scope`) and joins (`ActiveRecord::Reflection::AbstractReflection#join_scope`). `joins` will actually convert `where` criteria into join criteria, which I believe is a better default for reasons mentioned above.

A related issue that is not addressed with this proposal is the lack of an API for merging scopes on a particular table alias. See eg. #54880

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
