### PR TITLE
Add option to defer persisting additions/removals on collection associations. Add `marked_for_deletion`.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add option to defer persisting added/removed records on autosave collection associations. Add `marked_for_deletion`, a mirror of `marked_for_destruction` that calls `delete` instead of `destroy`.
+
+    *WelpThatWorked*
+
 *   `:class_name` is now invalid in polymorphic `belongs_to` associations.
 
     Reason is `:class_name` does not make sense in those associations because

--- a/activerecord/lib/active_record/associations.rb
+++ b/activerecord/lib/active_record/associations.rb
@@ -184,6 +184,8 @@ module ActiveRecord
       #   others.distinct                   |   X   |    X     |    X
       #   others.reset                      |   X   |    X     |    X
       #   others.reload                     |   X   |    X     |    X
+      #   others_added_records              |   X   |    X     |    X
+      #   others_previously_added_records   |   X   |    X     |    X
       #
       # === Overriding generated methods
       #
@@ -1042,7 +1044,7 @@ module ActiveRecord
         # [<tt>collection<<(object, ...)</tt>]
         #   Adds one or more objects to the collection by setting their foreign keys to the collection's primary key.
         #   Note that this operation instantly fires update SQL without waiting for the save or update call on the
-        #   parent object, unless the parent object is a new record.
+        #   parent object, unless the parent object is a new record or <tt>:defer</tt> is set to <tt>true</tt>.
         #   This will also run validations and callbacks of associated object(s).
         # [<tt>collection.delete(object, ...)</tt>]
         #   Removes one or more objects from the collection by setting their foreign keys to +NULL+.
@@ -1098,6 +1100,10 @@ module ActiveRecord
         # [<tt>collection.reload</tt>]
         #   Returns a Relation of all of the associated objects, forcing a database read.
         #   An empty Relation is returned if none are found.
+        # [<tt>collection_added_records</tt>]
+        #   Returns any records added to the association in memory only which will be persisted in the next save.
+        # [<tt>collection_previously_added_records</tt>]
+        #   Returns any records added to the association in the previous save.
         #
         # ==== Example
         #
@@ -1253,6 +1259,9 @@ module ActiveRecord
         #
         #   Note that NestedAttributes::ClassMethods#accepts_nested_attributes_for sets
         #   <tt>:autosave</tt> to <tt>true</tt>.
+        # [+:defer+]
+        #   If true, and <tt>:autosave</tt> is true, persist additions and removals to the collection when the parent object is saved,
+        #   instead of persisting them immediately.
         # [+:inverse_of+]
         #   Specifies the name of the #belongs_to association on the associated object
         #   that is the inverse of this #has_many association.
@@ -1736,7 +1745,7 @@ module ActiveRecord
         #   Adds one or more objects to the collection by creating associations in the join table
         #   (<tt>collection.push</tt> and <tt>collection.concat</tt> are aliases to this method).
         #   Note that this operation instantly fires update SQL without waiting for the save or update call on the
-        #   parent object, unless the parent object is a new record.
+        #   parent object, unless the parent object is a new record or <tt>:defer</tt> is set to <tt>true</tt>.
         # [<tt>collection.delete(object, ...)</tt>]
         #   Removes one or more objects from the collection by removing their associations from the join table.
         #   This does not destroy the objects.
@@ -1772,6 +1781,10 @@ module ActiveRecord
         # [<tt>collection.reload</tt>]
         #   Returns a Relation of all of the associated objects, forcing a database read.
         #   An empty Relation is returned if none are found.
+        # [<tt>collection_added_records</tt>]
+        #   Returns any records added to the association in memory only which will be persisted in the next save.
+        # [<tt>collection_previously_added_records</tt>]
+        #   Returns any records added to the association in the previous save.
         #
         # ==== Example
         #
@@ -1863,6 +1876,9 @@ module ActiveRecord
         #
         #   Note that NestedAttributes::ClassMethods#accepts_nested_attributes_for sets
         #   <tt>:autosave</tt> to <tt>true</tt>.
+        # [+:defer+]
+        #   If true, and <tt>:autosave</tt> is true, persist additions and removals to the collection when the parent object is saved,
+        #   instead of persisting them immediately.
         # [+:strict_loading+]
         #   Enforces strict loading every time an associated record is loaded through this association.
         #
@@ -1903,7 +1919,7 @@ module ActiveRecord
           hm_options[:through] = middle_reflection.name
           hm_options[:source] = join_model.right_reflection.name
 
-          [:before_add, :after_add, :before_remove, :after_remove, :autosave, :validate, :join_table, :class_name, :extend, :strict_loading].each do |k|
+          [:before_add, :after_add, :before_remove, :after_remove, :autosave, :defer, :validate, :join_table, :class_name, :extend, :strict_loading].each do |k|
             hm_options[k] = options[k] if options.key?(k)
           end
 

--- a/activerecord/lib/active_record/associations/builder/collection_association.rb
+++ b/activerecord/lib/active_record/associations/builder/collection_association.rb
@@ -7,7 +7,9 @@ module ActiveRecord::Associations::Builder # :nodoc:
     CALLBACKS = [:before_add, :after_add, :before_remove, :after_remove]
 
     def self.valid_options(options)
-      super + [:class_name, :before_add, :after_add, :before_remove, :after_remove, :extend]
+      valid = super + [:class_name, :before_add, :after_add, :before_remove, :after_remove, :extend, :defer]
+      valid += [:defer] if options[:autosave]
+      valid
     end
 
     def self.define_callbacks(model, reflection)

--- a/activerecord/lib/active_record/associations/builder/has_many.rb
+++ b/activerecord/lib/active_record/associations/builder/has_many.rb
@@ -18,6 +18,18 @@ module ActiveRecord::Associations::Builder # :nodoc:
       [:destroy, :delete_all, :nullify, :restrict_with_error, :restrict_with_exception, :destroy_async]
     end
 
-    private_class_method :macro, :valid_options, :valid_dependent_options
+    def self.define_change_tracking_methods(model, reflection)
+      model.generated_association_methods.class_eval <<-CODE, __FILE__, __LINE__ + 1
+        def #{reflection.name}_added_records
+          association(:#{reflection.name}).target_added_records
+        end
+
+        def #{reflection.name}_previously_added_records
+          association(:#{reflection.name}).target_previously_added_records
+        end
+      CODE
+    end
+
+    private_class_method :macro, :valid_options, :valid_dependent_options, :define_change_tracking_methods
   end
 end

--- a/activerecord/lib/active_record/associations/has_many_association.rb
+++ b/activerecord/lib/active_record/associations/has_many_association.rb
@@ -63,6 +63,18 @@ module ActiveRecord
         super
       end
 
+      def target_added_records
+        added = []
+        @target.each { |record| added << record if record.association(reflection.inverse_of.name).target_changed? }
+        added
+      end
+
+      def target_previously_added_records
+        added = []
+        @target.each { |record| added << record if record.association(reflection.inverse_of.name).target_previously_changed? }
+        added
+      end
+
       private
         # Returns the number of records in this collection.
         #

--- a/activerecord/lib/active_record/associations/has_many_through_association.rb
+++ b/activerecord/lib/active_record/associations/has_many_through_association.rb
@@ -21,6 +21,11 @@ module ActiveRecord
         super
       end
 
+      def add_to_target(record, skip_callbacks: false, replace: false, &block)
+        build_through_record(record) if reflection.options[:defer]
+        super
+      end
+
       def insert_record(record, validate = true, raise = false)
         ensure_not_nested
 
@@ -31,6 +36,18 @@ module ActiveRecord
         save_through_record(record)
 
         record
+      end
+
+      def target_added_records
+        added = []
+        @target.each { |record| added << record if through_records_for(record).any? { |trecord| trecord.new_record? } }
+        added
+      end
+
+      def target_previously_added_records
+        added = []
+        @target.each { |record| added << record if through_records_for(record).any? { |trecord| trecord.new_record_before_save? } }
+        added
       end
 
       private

--- a/activerecord/lib/active_record/associations/through_association.rb
+++ b/activerecord/lib/active_record/associations/through_association.rb
@@ -6,6 +6,11 @@ module ActiveRecord
     module ThroughAssociation # :nodoc:
       delegate :source_reflection, to: :reflection
 
+      def reload(force = false)
+        through_association.reset
+        super
+      end
+
       private
         def transaction(&block)
           through_reflection.klass.transaction(&block)

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -834,8 +834,6 @@ module ActiveRecord
         @readonly                 = false
         @previously_new_record    = false
         @destroyed                = false
-        @marked_for_destruction   = false
-        @destroyed_by_association = nil
         @_start_transaction_state = nil
 
         klass = self.class

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -3200,7 +3200,7 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
       Unknown key: :trough. Valid keys are:
       :anonymous_class, :primary_key, :foreign_key, :dependent, :validate, :inverse_of,
       :strict_loading, :query_constraints, :autosave, :class_name, :before_add,
-      :after_add, :before_remove, :after_remove, :extend, :counter_cache, :join_table,
+      :after_add, :before_remove, :after_remove, :extend, :defer, :counter_cache, :join_table,
       :index_errors, :as, :through
     MESSAGE
   end

--- a/activerecord/test/cases/autosave_association_test.rb
+++ b/activerecord/test/cases/autosave_association_test.rb
@@ -2148,6 +2148,20 @@ class TestAutosaveAssociationOnAHasManyAssociation < ActiveRecord::TestCase
     @child_2 = @pirate.birds.create(name: "Killer bandita Dionne")
   end
 
+  def test_should_not_persist_add_remove_immediately_when_defer_is_true
+    @pirate.defered_birds = []
+    assert_equal 2, @pirate.defered_birds.reload.count
+    @pirate.defered_birds = []
+    @pirate.save
+    assert_equal 0, @pirate.defered_birds.reload.count
+
+    @pirate.defered_birds << Bird.first
+    assert_equal 0, @pirate.defered_birds.reload.count
+    @pirate.defered_birds << Bird.first
+    @pirate.save
+    assert_equal 1, @pirate.defered_birds.reload.count
+  end
+
   include AutosaveAssociationOnACollectionAssociationTests
 end
 
@@ -2161,6 +2175,20 @@ class TestAutosaveAssociationOnAHasAndBelongsToManyAssociation < ActiveRecord::T
     @pirate = Pirate.create(catchphrase: "Don' botharrr talkin' like one, savvy?")
     @child_1 = @pirate.parrots.create(name: "Posideons Killer")
     @child_2 = @pirate.parrots.create(name: "Killer bandita Dionne")
+  end
+
+  def test_should_not_persist_add_remove_immediately_when_defer_is_true
+    @pirate.defered_parrots = []
+    assert_equal 2, @pirate.defered_parrots.reload.count
+    @pirate.defered_parrots = []
+    @pirate.save
+    assert_equal 0, @pirate.defered_parrots.reload.count
+
+    @pirate.defered_parrots << Parrot.first
+    assert_equal 0, @pirate.defered_parrots.reload.count
+    @pirate.defered_parrots << Parrot.first
+    @pirate.save
+    assert_equal 1, @pirate.defered_parrots.reload.count
   end
 
   include AutosaveAssociationOnACollectionAssociationTests

--- a/activerecord/test/models/pirate.rb
+++ b/activerecord/test/models/pirate.rb
@@ -16,6 +16,7 @@ class Pirate < ActiveRecord::Base
     before_remove: proc { |p, pa| p.ship_log << "before_removing_proc_parrot_#{pa.id}" },
     after_remove: proc { |p, pa| p.ship_log << "after_removing_proc_parrot_#{pa.id}" }
   has_and_belongs_to_many :autosaved_parrots, class_name: "Parrot", autosave: true
+  has_and_belongs_to_many :defered_parrots, class_name: "Parrot", autosave: true, defer: true
 
   module PostTreasuresExtension
     def build(attributes = {})
@@ -41,6 +42,7 @@ class Pirate < ActiveRecord::Base
     before_remove: proc { |p, b| p.ship_log << "before_removing_proc_bird_#{b.id}" },
     after_remove: proc { |p, b| p.ship_log << "after_removing_proc_bird_#{b.id}" }
   has_many :birds_with_reject_all_blank, class_name: "Bird"
+  has_many :defered_birds, class_name: "Bird", autosave: true, defer: true
 
   has_one :foo_bulb, -> { where name: "foo" }, foreign_key: :car_id, class_name: "Bulb"
 

--- a/guides/source/association_basics.md
+++ b/guides/source/association_basics.md
@@ -845,12 +845,12 @@ an empty Relation.
 ##### Assigning the Collection
 
 The `collection=(objects)` method makes the collection contain only the supplied
-objects, by adding and deleting as appropriate. The changes are persisted to the
-database.
+objects, by adding and deleting as appropriate. The changes are immediately persisted to the
+database unless `defer: true` is set.
 
 The `collection_singular_ids=(ids)` method makes the collection contain only the
 objects identified by the supplied primary key values, by adding and deleting as
-appropriate. The changes are persisted to the database.
+appropriate. The changes are immediately persisted to the database unless `defer: true` is set.
 
 ##### Querying the Collection
 
@@ -1340,12 +1340,11 @@ objects.
 ##### Assigning the Collection
 
 The `collection=` method makes the collection contain only the supplied objects,
-by adding and deleting as appropriate. The changes are persisted to the
-database.
+by adding and deleting as appropriate. The changes are immediately persisted to the database unless `defer: true` is set.
 
 The `collection_singular_ids=` method makes the collection contain only the
 objects identified by the supplied primary key values, by adding and deleting as
-appropriate. The changes are persisted to the database.
+appropriate. The changes are immediately persisted to the database unless `defer: true` is set.
 
 ##### Querying the Collection
 


### PR DESCRIPTION
### Motivation / Background

Presently, any additions or removals of existing records to a collection association are persisted to the database immediately, rather than waiting for save to be called manually. This can be unexpected or undesirable in cases such as generating a preview or looking back at what changes just occurred. While there exist some workarounds, they seem a bit cumbersome, and there have occasionally been requests for it to not be persisted immediately, so I thought having a toggle on that behavior might be more convenient.

### Detail

- Add the `:defer` option for collection associations with autosave enabled. Setting this to true will defer the persisting of additions/removals until the parent (or child, in the case of has_many) is saved.
    - Applies to methods using `concat()` or `replace()`. Using `collection.destroy(record)` or `collection.delete(record)` still persists immediately, since `mark_for_deletion`/`destruction` is simultaneously available.
    - Removals are flagged for deletion, while additions are autosaved due to changes in the record (`has_many`) or changes in the through record (`habtm`, `has_many :through`)
    - Reloading a `habtm` or `has_many :through` association now resets the internal through association to keep the records listed on both targets in sync.
- Add `marked_for_deletion` to Autosave Associations, a mirror of `marked_for_destruction` that calls `delete` instead of `destroy`. 
    - Add `marked_for_removal?` which checks if either flag is set. 
    - If both flags are set, destruction takes precedence.
    - I'm concerned the wording of some of the documentation in [autosave_association.rb](https://github.com/rails/rails/compare/main...WelpThatWorked:rails:defer-autosave-collection?expand=1#diff-d88c50e3eec9509f3060d7847e8d6f3d82ad951b9f586698241d324eafc59cfd) might be a bit messy where the two overlap, but I'm unsure.
- Add change-tracking methods `<association>_added_records` and `<association>_previously_added_records`
    - I'm not sure this is worthwhile, as it might be more flexibly accomplished by the use of added/removed callback, and implementing similar methods for removals seems it would require keeping a copy of deleted/destroyed records in memory regardless of if the function would be used.
    - Not sure about the name.


### Additional information

Other previous related discussion:
#17368
#42097
#46685
[Rails Forum](https://discuss.rubyonrails.org/t/using-accepts-nested-attributes-for-with-assign-attributes-means-immediate-saving-of-associated-model/70525)