### PR TITLE
Declare dependency on `cgi`

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -34,6 +34,7 @@ PATH
     actionpack (8.1.0.alpha)
       actionview (= 8.1.0.alpha)
       activesupport (= 8.1.0.alpha)
+      cgi
       nokogiri (>= 1.8.5)
       rack (>= 2.2.4)
       rack-session (>= 1.0.1)
@@ -51,6 +52,7 @@ PATH
     actionview (8.1.0.alpha)
       activesupport (= 8.1.0.alpha)
       builder (~> 3.1)
+      cgi
       erubi (~> 1.11)
       rails-dom-testing (~> 2.2)
       rails-html-sanitizer (~> 1.6)
@@ -99,6 +101,7 @@ PATH
     railties (8.1.0.alpha)
       actionpack (= 8.1.0.alpha)
       activesupport (= 8.1.0.alpha)
+      cgi
       irb (~> 1.13)
       rackup (>= 1.0.0)
       rake (>= 12.2)
@@ -177,6 +180,7 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    cgi (0.4.2)
     chef-utils (18.6.2)
       concurrent-ruby
     childprocess (5.1.0)

--- a/actionpack/actionpack.gemspec
+++ b/actionpack/actionpack.gemspec
@@ -35,6 +35,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "activesupport", version
 
+  s.add_dependency "cgi"
   s.add_dependency "nokogiri", ">= 1.8.5"
   s.add_dependency "rack",      ">= 2.2.4"
   s.add_dependency "rack-session", ">= 1.0.1"

--- a/actionview/actionview.gemspec
+++ b/actionview/actionview.gemspec
@@ -35,6 +35,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "activesupport", version
 
+  s.add_dependency "cgi"
   s.add_dependency "builder",       "~> 3.1"
   s.add_dependency "erubi",         "~> 1.11"
   s.add_dependency "rails-html-sanitizer", "~> 1.6"

--- a/railties/railties.gemspec
+++ b/railties/railties.gemspec
@@ -40,6 +40,7 @@ Gem::Specification.new do |s|
   s.add_dependency "activesupport", version
   s.add_dependency "actionpack",    version
 
+  s.add_dependency "cgi"
   s.add_dependency "rackup", ">= 1.0.0"
   s.add_dependency "rake", ">= 12.2"
   s.add_dependency "thor", "~> 1.0", ">= 1.2.2"


### PR DESCRIPTION
It's being (partially) extracted from stdlib in Ruby 3.5

Ref: https://bugs.ruby-lang.org/issues/21258
