### PR TITLE
Use inline queue adapter in bug report template

### DIFF
--- a/guides/bug_report_templates/active_storage.rb
+++ b/guides/bug_report_templates/active_storage.rb
@@ -37,6 +37,8 @@ class TestApp < Rails::Application
       service: "Disk"
     }
   }
+
+  config.active_job.queue_adapter = :inline
 end
 Rails.application.initialize!
 


### PR DESCRIPTION
With the default async adapter, some jobs like ActiveStorage::AnalyzeJob fail because they don't share the SQLite3 in-memory database.

<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background
During make reproduce script for #50835, I faced the issue. no such table: active_storage_blobs:
<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->


### Detail
Use inline queue adapter on template will share database with original thread. Default is async adapter and it doesn't share database so raise error.

```
D, [2025-05-12T15:12:24.799085 #49473] DEBUG -- :   ActiveStorage::Blob Load (0.4ms)  SELECT "active_storage_blobs".* FROM "active_storage_blobs" WHERE "active_storage_blobs"."id" = ? LIMIT ?  [["id", 1], ["LIMIT", 1]]
E, [2025-05-12T15:12:24.800027 #49473] ERROR -- : Error performing ActiveStorage::AnalyzeJob (Job ID: 580418cb-61e5-4c8f-8c6a-0ece6e315e61) from Async(default) in 8.9ms: ActiveJob::DeserializationError (Error while trying to deserialize arguments: SQLite3::SQLException: no such table: active_storage_blobs:
SELECT "active_storage_blobs".* FROM "active_storage_blobs" WHERE "active_storage_blobs"."id" = ? LIMIT ?):
/usr/local/rvm/gems/ruby-3.3.4/gems/sqlite3-2.6.0-x86_64-linux-gnu/lib/sqlite3/statement.rb:36:in `prepare'
/usr/local/rvm/gems/ruby-3.3.4/gems/sqlite3-2.6.0-x86_64-linux-gnu/lib/sqlite3/statement.rb:36:in `initialize'
/usr/local/rvm/gems/ruby-3.3.4/gems/sqlite3-2.6.0-x86_64-linux-gnu/lib/sqlite3/database.rb:216:in `new'
/usr/local/rvm/gems/ruby-3.3.4/gems/sqlite3-2.6.0-x86_64-linux-gnu/lib/sqlite3/database.rb:216:in `prepare'
/usr/local/rvm/gems/ruby-3.3.4/gems/activerecord-8.0.2/lib/active_record/connection_adapters/sqlite3/database_statements.rb:82:in `perform_query'
/usr/local/rvm/gems/ruby-3.3.4/gems/activerecord-8.0.2/lib/active_record/connection_adapters/abstract/database_statements.rb:556:in `block (2 levels) in raw_execute'
/usr/local/rvm/gems/ruby-3.3.4/gems/activerecord-8.0.2/lib/active_record/connection_adapters/abstract_adapter.rb:1015:in `block in with_raw_connection'
/usr/local/rvm/gems/ruby-3.3.4/gems/activesupport-8.0.2/lib/active_support/concurrency/null_lock.rb:9:in `synchronize'
/usr/local/rvm/gems/ruby-3.3.4/gems/activerecord-8.0.2/lib/active_record/connection_adapters/abstract_adapter.rb:984:in `with_raw_connection'
/usr/local/rvm/gems/ruby-3.3.4/gems/activerecord-8.0.2/lib/active_record/connection_adapters/abstract/database_statements.rb:555:in `block in raw_execute'
/usr/local/rvm/gems/ruby-3.3.4/gems/activesupport-8.0.2/lib/active_support/notifications/instrumenter.rb:58:in `instrument'
/usr/local/rvm/gems/ruby-3.3.4/gems/activerecord-8.0.2/lib/active_record/connection_adapters/abstract_adapter.rb:1135:in `log'
/usr/local/rvm/gems/ruby-3.3.4/gems/activerecord-8.0.2/lib/active_record/connection_adapters/abstract/database_statements.rb:554:in `raw_execute'
/usr/local/rvm/gems/ruby-3.3.4/gems/activerecord-8.0.2/lib/active_record/connection_adapters/abstract/database_statements.rb:591:in `internal_execute'
/usr/local/rvm/gems/ruby-3.3.4/gems/activerecord-8.0.2/lib/active_record/connection_adapters/abstract/database_statements.rb:547:in `internal_exec_query'
/usr/local/rvm/gems/ruby-3.3.4/gems/activerecord-8.0.2/lib/active_record/connection_adapters/abstract/database_statements.rb:693:in `select'
/usr/local/rvm/gems/ruby-3.3.4/gems/activerecord-8.0.2/lib/active_record/connection_adapters/abstract/database_statements.rb:73:in `select_all'
/usr/local/rvm/gems/ruby-3.3.4/gems/activerecord-8.0.2/lib/active_record/connection_adapters/abstract/query_cache.rb:248:in `block in select_all'
/usr/local/rvm/gems/ruby-3.3.4/gems/activerecord-8.0.2/lib/active_record/connection_adapters/abstract/query_cache.rb:286:in `block (2 levels) in cache_sql'
/usr/local/rvm/gems/ruby-3.3.4/gems/activerecord-8.0.2/lib/active_record/connection_adapters/abstract/query_cache.rb:80:in `compute_if_absent'
/usr/local/rvm/gems/ruby-3.3.4/gems/activerecord-8.0.2/lib/active_record/connection_adapters/abstract/query_cache.rb:284:in `block in cache_sql'
/usr/local/rvm/gems/ruby-3.3.4/gems/activesupport-8.0.2/lib/active_support/concurrency/null_lock.rb:9:in `synchronize'
/usr/local/rvm/gems/ruby-3.3.4/gems/activerecord-8.0.2/lib/active_record/connection_adapters/abstract/query_cache.rb:283:in `cache_sql'
/usr/local/rvm/gems/ruby-3.3.4/gems/activerecord-8.0.2/lib/active_record/connection_adapters/abstract/query_cache.rb:248:in `select_all'
/usr/local/rvm/gems/ruby-3.3.4/gems/activerecord-8.0.2/lib/active_record/querying.rb:68:in `_query_by_sql'
/usr/local/rvm/gems/ruby-3.3.4/gems/activerecord-8.0.2/lib/active_record/relation.rb:1449:in `block (2 levels) in exec_main_query'
/usr/local/rvm/gems/ruby-3.3.4/gems/activerecord-8.0.2/lib/active_record/connection_adapters/abstract/connection_pool.rb:412:in `with_connection'
/usr/local/rvm/gems/ruby-3.3.4/gems/activerecord-8.0.2/lib/active_record/connection_handling.rb:310:in `with_connection'
/usr/local/rvm/gems/ruby-3.3.4/gems/activerecord-8.0.2/lib/active_record/relation.rb:1448:in `block in exec_main_query'
/usr/local/rvm/gems/ruby-3.3.4/gems/activerecord-8.0.2/lib/active_record/relation.rb:1470:in `skip_query_cache_if_necessary'
/usr/local/rvm/gems/ruby-3.3.4/gems/activerecord-8.0.2/lib/active_record/relation.rb:1432:in `exec_main_query'
/usr/local/rvm/gems/ruby-3.3.4/gems/activerecord-8.0.2/lib/active_record/relation.rb:1410:in `block in exec_queries'
/usr/local/rvm/gems/ruby-3.3.4/gems/activerecord-8.0.2/lib/active_record/relation.rb:1470:in `skip_query_cache_if_necessary'
/usr/local/rvm/gems/ruby-3.3.4/gems/activerecord-8.0.2/lib/active_record/relation.rb:1404:in `exec_queries'
/usr/local/rvm/gems/ruby-3.3.4/gems/activerecord-8.0.2/lib/active_record/relation.rb:1181:in `load'
/usr/local/rvm/gems/ruby-3.3.4/gems/activerecord-8.0.2/lib/active_record/relation.rb:343:in `records'
/usr/local/rvm/gems/ruby-3.3.4/gems/activerecord-8.0.2/lib/active_record/relation/finder_methods.rb:586:in `find_take'
/usr/local/rvm/gems/ruby-3.3.4/gems/activerecord-8.0.2/lib/active_record/relation/finder_methods.rb:129:in `take'
/usr/local/rvm/gems/ruby-3.3.4/gems/activerecord-8.0.2/lib/active_record/relation/finder_methods.rb:534:in `find_one'
/usr/local/rvm/gems/ruby-3.3.4/gems/activerecord-8.0.2/lib/active_record/relation/finder_methods.rb:513:in `find_with_ids'
/usr/local/rvm/gems/ruby-3.3.4/gems/activerecord-8.0.2/lib/active_record/relation/finder_methods.rb:100:in `find'
/usr/local/rvm/gems/ruby-3.3.4/gems/activerecord-8.0.2/lib/active_record/querying.rb:24:in `find'
/usr/local/rvm/gems/ruby-3.3.4/gems/activerecord-8.0.2/lib/active_record/core.rb:273:in `find'
/usr/local/rvm/gems/ruby-3.3.4/gems/globalid-1.2.1/lib/global_id/locator.rb:162:in `locate'
/usr/local/rvm/gems/ruby-3.3.4/gems/globalid-1.2.1/lib/global_id/locator.rb:210:in `block in locate'
/usr/local/rvm/gems/ruby-3.3.4/gems/globalid-1.2.1/lib/global_id/locator.rb:220:in `block in unscoped'
/usr/local/rvm/gems/ruby-3.3.4/gems/activerecord-8.0.2/lib/active_record/relation.rb:1373:in `_scoping'
/usr/local/rvm/gems/ruby-3.3.4/gems/activerecord-8.0.2/lib/active_record/relation.rb:548:in `scoping'
/usr/local/rvm/gems/ruby-3.3.4/gems/activerecord-8.0.2/lib/active_record/scoping/default.rb:51:in `unscoped'
/usr/local/rvm/gems/ruby-3.3.4/gems/globalid-1.2.1/lib/global_id/locator.rb:220:in `unscoped'
/usr/local/rvm/gems/ruby-3.3.4/gems/globalid-1.2.1/lib/global_id/locator.rb:210:in `locate'
/usr/local/rvm/gems/ruby-3.3.4/gems/globalid-1.2.1/lib/global_id/locator.rb:31:in `locate'
/usr/local/rvm/gems/ruby-3.3.4/gems/activejob-8.0.2/lib/active_job/arguments.rb:134:in `deserialize_global_id'
/usr/local/rvm/gems/ruby-3.3.4/gems/activejob-8.0.2/lib/active_job/arguments.rb:118:in `deserialize_argument'
/usr/local/rvm/gems/ruby-3.3.4/gems/activejob-8.0.2/lib/active_job/arguments.rb:43:in `block in deserialize'
/usr/local/rvm/gems/ruby-3.3.4/gems/activejob-8.0.2/lib/active_job/arguments.rb:43:in `map'
/usr/local/rvm/gems/ruby-3.3.4/gems/activejob-8.0.2/lib/active_job/arguments.rb:43:in `deserialize'
/usr/local/rvm/gems/ruby-3.3.4/gems/activejob-8.0.2/lib/active_job/core.rb:195:in `deserialize_arguments'
/usr/local/rvm/gems/ruby-3.3.4/gems/activejob-8.0.2/lib/active_job/core.rb:185:in `deserialize_arguments_if_needed'
/usr/local/rvm/gems/ruby-3.3.4/gems/activejob-8.0.2/lib/active_job/execution.rb:49:in `perform_now'
/usr/local/rvm/gems/ruby-3.3.4/gems/activejob-8.0.2/lib/active_job/instrumentation.rb:26:in `block in perform_now'
/usr/local/rvm/gems/ruby-3.3.4/gems/activerecord-8.0.2/lib/active_record/railties/job_runtime.rb:13:in `block in instrument'
/usr/local/rvm/gems/ruby-3.3.4/gems/activejob-8.0.2/lib/active_job/instrumentation.rb:40:in `block in instrument'
/usr/local/rvm/gems/ruby-3.3.4/gems/activesupport-8.0.2/lib/active_support/notifications.rb:210:in `block in instrument'
/usr/local/rvm/gems/ruby-3.3.4/gems/activesupport-8.0.2/lib/active_support/notifications/instrumenter.rb:58:in `instrument'
/usr/local/rvm/gems/ruby-3.3.4/gems/activesupport-8.0.2/lib/active_support/notifications.rb:210:in `instrument'
/usr/local/rvm/gems/ruby-3.3.4/gems/activejob-8.0.2/lib/active_job/instrumentation.rb:39:in `instrument'
/usr/local/rvm/gems/ruby-3.3.4/gems/activerecord-8.0.2/lib/active_record/railties/job_runtime.rb:11:in `instrument'
/usr/local/rvm/gems/ruby-3.3.4/gems/activejob-8.0.2/lib/active_job/instrumentation.rb:26:in `perform_now'
/usr/local/rvm/gems/ruby-3.3.4/gems/activejob-8.0.2/lib/active_job/logging.rb:32:in `block in perform_now'
/usr/local/rvm/gems/ruby-3.3.4/gems/activejob-8.0.2/lib/active_job/logging.rb:41:in `tag_logger'
/usr/local/rvm/gems/ruby-3.3.4/gems/activejob-8.0.2/lib/active_job/logging.rb:32:in `perform_now'
/usr/local/rvm/gems/ruby-3.3.4/gems/activejob-8.0.2/lib/active_job/execution.rb:29:in `block in execute'
/usr/local/rvm/gems/ruby-3.3.4/gems/activesupport-8.0.2/lib/active_support/callbacks.rb:120:in `block in run_callbacks'
/usr/local/rvm/gems/ruby-3.3.4/gems/activejob-8.0.2/lib/active_job/railtie.rb:95:in `block (4 levels) in <class:Railtie>'
/usr/local/rvm/gems/ruby-3.3.4/gems/activesupport-8.0.2/lib/active_support/reloader.rb:77:in `block in wrap'
/usr/local/rvm/gems/ruby-3.3.4/gems/activesupport-8.0.2/lib/active_support/execution_wrapper.rb:91:in `wrap'
/usr/local/rvm/gems/ruby-3.3.4/gems/activesupport-8.0.2/lib/active_support/reloader.rb:74:in `wrap'
/usr/local/rvm/gems/ruby-3.3.4/gems/activejob-8.0.2/lib/active_job/railtie.rb:94:in `block (3 levels) in <class:Railtie>'
/usr/local/rvm/gems/ruby-3.3.4/gems/activesupport-8.0.2/lib/active_support/callbacks.rb:129:in `instance_exec'
/usr/local/rvm/gems/ruby-3.3.4/gems/activesupport-8.0.2/lib/active_support/callbacks.rb:129:in `block in run_callbacks'
/usr/local/rvm/gems/ruby-3.3.4/gems/activesupport-8.0.2/lib/active_support/callbacks.rb:140:in `run_callbacks'
/usr/local/rvm/gems/ruby-3.3.4/gems/activejob-8.0.2/lib/active_job/execution.rb:27:in `execute'
/usr/local/rvm/gems/ruby-3.3.4/gems/activejob-8.0.2/lib/active_job/queue_adapters/async_adapter.rb:71:in `perform'
/usr/local/rvm/gems/ruby-3.3.4/gems/concurrent-ruby-1.3.5/lib/concurrent-ruby/concurrent/executor/ruby_thread_pool_executor.rb:359:in `run_task'
/usr/local/rvm/gems/ruby-3.3.4/gems/concurrent-ruby-1.3.5/lib/concurrent-ruby/concurrent/executor/ruby_thread_pool_executor.rb:350:in `block (3 levels) in create_worker'
<internal:kernel>:187:in `loop'
/usr/local/rvm/gems/ruby-3.3.4/gems/concurrent-ruby-1.3.5/lib/concurrent-ruby/concurrent/executor/ruby_thread_pool_executor.rb:341:in `block (2 levels) in create_worker'
/usr/local/rvm/gems/ruby-3.3.4/gems/concurrent-ruby-1.3.5/lib/concurrent-ruby/concurrent/executor/ruby_thread_pool_executor.rb:340:in `catch'
/usr/local/rvm/gems/ruby-3.3.4/gems/concurrent-ruby-1.3.5/lib/concurrent-ruby/concurrent/executor/ruby_thread_pool_executor.rb:340:in `block in create_worker'
```

