### PR TITLE
Use `default-mysql-client` in Dockerfile to support `rails dbconsole` with Trilogy

### DIFF
--- a/railties/lib/rails/generators/database.rb
+++ b/railties/lib/rails/generators/database.rb
@@ -218,7 +218,7 @@ module Rails
         end
 
         def base_package
-          nil
+          "default-mysql-client"
         end
 
         def build_package

--- a/railties/test/generators/db_system_change_generator_test.rb
+++ b/railties/test/generators/db_system_change_generator_test.rb
@@ -156,7 +156,7 @@ module Rails
 
             assert_file("Dockerfile") do |content|
               assert_match "build-essential git", content
-              assert_match "curl libvips", content
+              assert_match "curl default-mysql-client libvips", content
               assert_no_match "default-libmysqlclient-dev", content
             end
           end


### PR DESCRIPTION
Use `default-mysql-client` in Dockerfile to support `rails dbconsole` from a container when using trilogy database adapter. 

### Motivation / Background

This Pull Request has been created because `bin/rails dbconsole` from a container (e.g `kamal dbc`) doesn't work when using trilogy database adapter.

### Detail

The Dockerfile generated by `rails new trilogy-test --database=trilogy` doesn't include `default-mysql-client` in the base packages. As a result, running `kamal dbc` results in the following error:

```
Couldn't find database client: mysql, mysql5. Check your $PATH and try again
```

### Checklist

Before submitting the PR make sure the following are checked:

* [✅] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [✅] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [✅] Tests are added or updated if you fix a bug or add a feature.
* [❎] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
