### PR TITLE
Modify GitHub's CI Files on rails db:system:change

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -96,4 +96,9 @@
 
     *Petrik de Heus*
 
+*   Add `Rails::Generators::Rails::Github::CiGenerator` and `Rails::Generators::Rails::Db::System::Change::Github::CiGenerator`
+    to create and update the database in `.github/workflows/ci.yml` when calling `rails db:system:change`.
+
+    *delCatta*
+
 Please check [8-0-stable](https://github.com/rails/rails/blob/8-0-stable/railties/CHANGELOG.md) for previous changes.

--- a/railties/lib/rails/generators/database.rb
+++ b/railties/lib/rails/generators/database.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "rails/generators/database/devcontainer"
+
 module Rails
   module Generators
     class Database
@@ -12,19 +14,6 @@ module Rails
 
         def port
           3306
-        end
-
-        def service
-          {
-            "image" => "mysql/mysql-server:8.0",
-            "restart" => "unless-stopped",
-            "environment" => {
-              "MYSQL_ALLOW_EMPTY_PASSWORD" => "true",
-              "MYSQL_ROOT_HOST" => "%"
-            },
-            "volumes" => ["mysql-data:/var/lib/mysql"],
-            "networks" => ["default"],
-          }
         end
 
         def socket
@@ -53,18 +42,6 @@ module Rails
 
         def port
           3306
-        end
-
-        def service
-          {
-            "image" => "mariadb:10.5",
-            "restart" => "unless-stopped",
-            "networks" => ["default"],
-            "volumes" => ["mariadb-data:/var/lib/mysql"],
-            "environment" => {
-              "MARIADB_ALLOW_EMPTY_ROOT_PASSWORD" => "true",
-            },
-          }
         end
       end
 
@@ -100,8 +77,8 @@ module Rails
         raise NotImplementedError
       end
 
-      def service
-        raise NotImplementedError
+      def devcontainer
+        "#{Rails::Generators::Devcontainer}::#{self.class.name.demodulize}".constantize.new
       end
 
       def port
@@ -134,7 +111,7 @@ module Rails
       end
 
       def volume
-        return unless service
+        return unless devcontainer.service
 
         "#{name}-data"
       end
@@ -170,19 +147,6 @@ module Rails
 
         def template
           "config/databases/postgresql.yml"
-        end
-
-        def service
-          {
-            "image" => "postgres:16.1",
-            "restart" => "unless-stopped",
-            "networks" => ["default"],
-            "volumes" => ["postgres-data:/var/lib/postgresql/data"],
-            "environment" => {
-              "POSTGRES_USER" => "postgres",
-              "POSTGRES_PASSWORD" => "postgres"
-            }
-          }
         end
 
         def port
@@ -239,10 +203,6 @@ module Rails
           "config/databases/sqlite3.yml"
         end
 
-        def service
-          nil
-        end
-
         def port
           nil
         end
@@ -275,7 +235,7 @@ module Rails
       class Null < Database
         def name; end
         def template; end
-        def service; end
+        def devcontainer; end
         def port; end
         def volume; end
         def base_package; end

--- a/railties/lib/rails/generators/database.rb
+++ b/railties/lib/rails/generators/database.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "rails/generators/database/devcontainer"
+require "rails/generators/database/ci"
 
 module Rails
   module Generators
@@ -80,6 +81,11 @@ module Rails
       def devcontainer
         "#{Rails::Generators::Devcontainer}::#{self.class.name.demodulize}".constantize.new
       end
+
+      def ci
+        "#{Rails::Generators::Ci}::#{self.class.name.demodulize}".constantize.new
+      end
+
 
       def port
         raise NotImplementedError
@@ -236,6 +242,7 @@ module Rails
         def name; end
         def template; end
         def devcontainer; end
+        def ci; end
         def port; end
         def volume; end
         def base_package; end

--- a/railties/lib/rails/generators/database/ci.rb
+++ b/railties/lib/rails/generators/database/ci.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+module Rails
+  module Generators
+    class Ci
+      module MySQL
+        def service
+          {
+            "image" => "mysql",
+            "env" => {
+              "MYSQL_ALLOW_EMPTY_PASSWORD" => true
+            },
+            "ports" => ["3306:3306"],
+            "options" => "--health-cmd=\"mysqladmin ping\" --health-interval=10s --health-timeout=5s --health-retries=3"
+          }
+        end
+      end
+
+      module MariaDB
+        def service; end
+
+        def database_url; end
+      end
+
+      def service; end
+
+      def database_url; end
+
+      class MySQL2 < Ci
+        include MySQL
+
+        def database_url
+          "mysql2://127.0.0.1:3306"
+        end
+      end
+
+      class Trilogy < Ci
+        include MySQL
+
+        def database_url
+          "trilogy://127.0.0.1:3306"
+        end
+      end
+
+      class PostgreSQL < Ci
+        def service
+          {
+            "image" => "postgres",
+            "env" => {
+              "POSTGRES_USER" => "postgres",
+              "POSTGRES_PASSWORD" => "postgres"
+            },
+            "ports" => ["5432:5432"],
+            "options" => "--health-cmd=\"pg_isready\" --health-interval=10s --health-timeout=5s --health-retries=3"
+          }
+        end
+
+        def database_url
+          "postgres://postgres:postgres@localhost:5432"
+        end
+      end
+
+
+      class MariaDBMySQL2 < MySQL2
+        include MariaDB
+      end
+
+      class MariaDBTrilogy < Trilogy
+        include MariaDB
+      end
+
+      class Null < Ci
+        def service; end
+        def database_url; end
+      end
+
+      class SQLite3 < Null; end
+    end
+  end
+end

--- a/railties/lib/rails/generators/database/devcontainer.rb
+++ b/railties/lib/rails/generators/database/devcontainer.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+module Rails
+  module Generators
+    class Devcontainer
+      module MySQL
+        def service
+          {
+            "image" => "mysql/mysql-server:8.0",
+            "restart" => "unless-stopped",
+            "environment" => {
+              "MYSQL_ALLOW_EMPTY_PASSWORD" => "true",
+              "MYSQL_ROOT_HOST" => "%"
+            },
+            "volumes" => ["mysql-data:/var/lib/mysql"],
+            "networks" => ["default"],
+          }
+        end
+      end
+
+      module MariaDB
+        def service
+          {
+            "image" => "mariadb:10.5",
+            "restart" => "unless-stopped",
+            "networks" => ["default"],
+            "volumes" => ["mariadb-data:/var/lib/mysql"],
+            "environment" => {
+              "MARIADB_ALLOW_EMPTY_ROOT_PASSWORD" => "true",
+            },
+          }
+        end
+      end
+
+      def service
+        raise NotImplementedError
+      end
+
+      class MySQL2 < Devcontainer
+        include MySQL
+      end
+
+      class PostgreSQL < Devcontainer
+        def service
+          {
+            "image" => "postgres:16.1",
+            "restart" => "unless-stopped",
+            "networks" => ["default"],
+            "volumes" => ["postgres-data:/var/lib/postgresql/data"],
+            "environment" => {
+              "POSTGRES_USER" => "postgres",
+              "POSTGRES_PASSWORD" => "postgres"
+            }
+          }
+        end
+      end
+
+      class Trilogy < Devcontainer
+        include MySQL
+      end
+
+      class MariaDBMySQL2 < MySQL2
+        include MariaDB
+      end
+
+      class MariaDBTrilogy < Trilogy
+        include MariaDB
+      end
+
+      class Null < Devcontainer
+        def service; end
+      end
+
+      class SQLite3 < Null; end
+    end
+  end
+end

--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -2,6 +2,7 @@
 
 require "rails/generators/app_base"
 require "rails/generators/rails/devcontainer/devcontainer_generator"
+require "rails/generators/rails/github/ci_generator"
 
 module Rails
   module ActionMethods # :nodoc:
@@ -84,9 +85,19 @@ module Rails
     end
 
     def cifiles
-      empty_directory ".github/workflows"
-      template "github/ci.yml", ".github/workflows/ci.yml"
-      template "github/dependabot.yml", ".github/dependabot.yml"
+      cifiles_options = {
+        bun_version: dockerfile_bun_version,
+        ci_packages: ci_packages,
+        database: options[:database],
+        quiet: options[:quiet],
+        skip_brakeman: skip_brakeman?,
+        skip_rubocop: skip_rubocop?,
+        skip_test: options[:skip_test],
+        skip_system_test: options[:api] || options[:skip_system_test],
+        skip_importmap: !using_importmap?,
+        skip_bun: !using_bun?,
+      }
+      Rails::Generators::Github::CiGenerator.new([], cifiles_options).invoke_all
     end
 
     def rubocop

--- a/railties/lib/rails/generators/rails/app/templates/github/ci.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/github/ci.yml.tt
@@ -27,7 +27,7 @@ jobs:
         run: bin/bundler-audit
 
 <% end -%>
-<%- if using_importmap? -%>
+<%- unless skip_importmap? -%>
   scan_js:
     runs-on: ubuntu-latest
 
@@ -74,7 +74,7 @@ jobs:
         run: bin/rubocop -f github
 
 <% end -%>
-<% unless options[:skip_test] -%>
+<% unless skip_test? -%>
   test:
     runs-on: ubuntu-latest
 
@@ -87,24 +87,7 @@ jobs:
     #    options: --health-cmd "redis-cli ping" --health-interval 10s --health-timeout 5s --health-retries 5
     <%- else -%>
     services:
-      <%- if options[:database] == "mysql" || options[:database] == "trilogy" -%>
-      mysql:
-        image: mysql
-        env:
-          MYSQL_ALLOW_EMPTY_PASSWORD: true
-        ports:
-          - 3306:3306
-        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
-      <%- elsif options[:database] == "postgresql" -%>
-      postgres:
-        image: postgres
-        env:
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: postgres
-        ports:
-          - 5432:5432
-        options: --health-cmd="pg_isready" --health-interval=10s --health-timeout=5s --health-retries=3
-      <%- end -%>
+<%= database_service_yaml(indentation: 2, line_width: 100) %>
 
       # redis:
       #   image: valkey/valkey:8
@@ -127,27 +110,21 @@ jobs:
         with:
           ruby-version: .ruby-version
           bundler-cache: true
-      <%- if using_bun? -%>
+      <%- unless skip_bun? -%>
 
       - uses: oven-sh/setup-bun@v1
         with:
-          bun-version: <%= dockerfile_bun_version %>
+          bun-version: <%= bun_version %>
       <%- end -%>
 
       - name: Run tests
         env:
           RAILS_ENV: test
-          <%- if options[:database] == "mysql" -%>
-          DATABASE_URL: mysql2://127.0.0.1:3306
-          <%- elsif options[:database] == "trilogy" -%>
-          DATABASE_URL: trilogy://127.0.0.1:3306
-          <%- elsif options[:database] == "postgresql" -%>
-          DATABASE_URL: postgres://postgres:postgres@localhost:5432
-          <%- end -%>
+          <%= database_url_yaml %>
           # RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_KEY }}
           # REDIS_URL: redis://localhost:6379/0
         run: bin/rails db:test:prepare test
-  <%- unless options[:api] || options[:skip_system_test] -%>
+  <%- unless skip_system_test? -%>
 
   system-test:
     runs-on: ubuntu-latest
@@ -161,24 +138,7 @@ jobs:
     #    options: --health-cmd "redis-cli ping" --health-interval 10s --health-timeout 5s --health-retries 5
     <%- else -%>
     services:
-      <%- if options[:database] == "mysql" || options[:database] == "trilogy" -%>
-      mysql:
-        image: mysql
-        env:
-          MYSQL_ALLOW_EMPTY_PASSWORD: true
-        ports:
-          - 3306:3306
-        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
-      <%- elsif options[:database] == "postgresql" -%>
-      postgres:
-        image: postgres
-        env:
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: postgres
-        ports:
-          - 5432:5432
-        options: --health-cmd="pg_isready" --health-interval=10s --health-timeout=5s --health-retries=3
-      <%- end -%>
+<%= database_service_yaml(indentation: 2, line_width: 100) %>
 
       # redis:
       #   image: valkey/valkey:8
@@ -201,23 +161,17 @@ jobs:
         with:
           ruby-version: .ruby-version
           bundler-cache: true
-      <%- if using_bun? -%>
+      <%- unless skip_bun? -%>
 
       - uses: oven-sh/setup-bun@v1
         with:
-          bun-version: <%= dockerfile_bun_version %>
+          bun-version: <%= bun_version %>
       <%- end -%>
 
       - name: Run System Tests
         env:
           RAILS_ENV: test
-          <%- if options[:database] == "mysql" -%>
-          DATABASE_URL: mysql2://127.0.0.1:3306
-          <%- elsif options[:database] == "trilogy" -%>
-          DATABASE_URL: trilogy://127.0.0.1:3306
-          <%- elsif options[:database] == "postgresql" -%>
-          DATABASE_URL: postgres://postgres:postgres@localhost:5432
-          <%- end -%>
+          <%= database_url_yaml %>
           # RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_KEY }}
           # REDIS_URL: redis://localhost:6379/0
         run: bin/rails db:test:prepare test test:system

--- a/railties/lib/rails/generators/rails/db/system/change/change_generator.rb
+++ b/railties/lib/rails/generators/rails/db/system/change/change_generator.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "rails/generators/base"
+require "rails/generators/rails/db/system/change/github/ci_generator"
 require "yaml"
 require "json"
 
@@ -57,6 +58,10 @@ module Rails
 
             edit_devcontainer_json
             edit_compose_yaml
+          end
+
+          def edit_ci_yml
+            Db::System::Change::Github::CiGenerator.new([], database: options[:database]).invoke_all
           end
 
           private

--- a/railties/lib/rails/generators/rails/db/system/change/change_generator.rb
+++ b/railties/lib/rails/generators/rails/db/system/change/change_generator.rb
@@ -129,8 +129,8 @@ module Rails
                 compose_config["services"]["rails-app"]["depends_on"]&.delete(database.name)
               end
 
-              if database.service
-                compose_config["services"][database.name] = database.service
+              if database.devcontainer.service
+                compose_config["services"][database.name] = database.devcontainer.service
                 compose_config["volumes"] = { database.volume => nil }.merge(compose_config["volumes"] || {})
                 compose_config["services"]["rails-app"]["depends_on"] = [
                   database.name,
@@ -149,13 +149,13 @@ module Rails
               db_name = database.name
 
               if container_env["DB_HOST"]
-                if database.service
+                if database.devcontainer.service
                   container_env["DB_HOST"] = db_name
                 else
                   container_env.delete("DB_HOST")
                 end
               else
-                if database.service
+                if database.devcontainer.service
                   container_env["DB_HOST"] = db_name
                 end
               end

--- a/railties/lib/rails/generators/rails/db/system/change/github/ci_generator.rb
+++ b/railties/lib/rails/generators/rails/db/system/change/github/ci_generator.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+module Rails
+  module Generators
+    module Db
+      module System
+        module Change
+          module Github
+            class CiGenerator < Base # :nodoc:
+              class_option :database, enum: Database::DATABASES, type: :string, default: "sqlite3",
+                desc: "Include configuration for selected database"
+
+              def edit_ci_yml
+                return unless File.exist?(ci_yml_path)
+
+                ci_jobs.each do |job|
+                  next if ci_config["jobs"][job].nil?
+                  cleanup_job_databases job
+                  set_database_service_for job
+                  set_database_url_for job
+                end
+
+                File.write(ci_yml_path, ci_config_yml)
+              end
+
+              private
+                def ci_yml_path
+                  File.expand_path(".github/workflows/ci.yml", destination_root)
+                end
+
+                def database
+                  @database ||= Database.build(options[:database])
+                end
+
+                def ci_jobs
+                  ["test", "system-test"]
+                end
+
+                def ci_config
+                  @ci_config ||= YAML.load_file(ci_yml_path)
+                end
+
+                def cleanup_job_databases(job)
+                  if ci_config["jobs"][job]["services"]
+                    Database.all.each do |database|
+                      ci_config["jobs"][job]["services"].delete(database.name)
+                    end
+                    if ci_config["jobs"][job]["services"].empty?
+                      ci_config["jobs"][job].delete("services")
+                    end
+                  end
+                  if job_step(job)
+                    job_step(job)["env"].delete("DATABASE_URL")
+                  end
+                end
+
+                def set_database_service_for(job)
+                  return unless database.ci.service
+
+                  ci_config["jobs"][job]["services"] ||= {}
+                  ci_config["jobs"][job]["services"][database.name] = database.ci.service
+                  ci_config["jobs"][job] = ci_config["jobs"][job].sort.to_h
+                end
+
+                def set_database_url_for(job)
+                  return unless database.ci.database_url
+
+                  if job_step(job)
+                    job_step(job)["env"]["DATABASE_URL"] = database.ci.database_url
+                  end
+                end
+
+                def job_step(job)
+                  step_name = job == "test" ? "Run tests" : "Run System Tests"
+                  ci_config["jobs"][job]["steps"].find { |s| s["name"] == step_name }
+                end
+
+                def ci_config_yml
+                  ci_config.to_yaml(indentation: 2, line_width: 160)[4..-1].tap do |config|
+                    config.sub!(/true:/, "on:")
+                  end
+                end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/railties/lib/rails/generators/rails/devcontainer/devcontainer_generator.rb
+++ b/railties/lib/rails/generators/rails/devcontainer/devcontainer_generator.rb
@@ -74,7 +74,7 @@ module Rails
 
           @dependencies << "selenium" if options[:system_test]
           @dependencies << "redis" if options[:redis]
-          @dependencies << database.name if database.service
+          @dependencies << database.name if database.devcontainer.service
           @dependencies
         end
 
@@ -87,7 +87,7 @@ module Rails
           @container_env["SELENIUM_HOST"] = "selenium" if options[:system_test]
           @container_env["REDIS_URL"] = "redis://redis:6379/1" if options[:redis]
           @container_env["KAMAL_REGISTRY_PASSWORD"] = "$KAMAL_REGISTRY_PASSWORD" if options[:kamal]
-          @container_env["DB_HOST"] = database.name if database.service
+          @container_env["DB_HOST"] = database.name if database.devcontainer.service
 
           @container_env
         end
@@ -143,10 +143,11 @@ module Rails
           @database ||= Database.build(options[:database])
         end
 
-        def devcontainer_db_service_yaml(**options)
-          return unless service = database.service
 
-          { database.name => service }.to_yaml(**options)[4..-1]
+        def devcontainer_db_service_yaml(**options)
+          return unless database.devcontainer.service
+
+          { database.name => database.devcontainer.service }.to_yaml(**options)[4..-1]
         end
 
         def local_rails_mount

--- a/railties/lib/rails/generators/rails/github/ci_generator.rb
+++ b/railties/lib/rails/generators/rails/github/ci_generator.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require "rails/generators"
+require "yaml"
+
+module Rails
+  module Generators
+    module Github
+      class CiGenerator < Base # :nodoc:
+        class_option :bun_version, type: :string,
+          desc: "Bun version to install in CI"
+
+        class_option :ci_packages, type: :array, default: [],
+          desc: "Additional packages to install in CI"
+
+        class_option :database, enum: Database::DATABASES, type: :string, default: "sqlite3",
+          desc: "Include configuration for selected database"
+
+        class_option :skip_rubocop, type: :boolean, default: false,
+          desc: "Skip RuboCop CI configuration"
+
+        class_option :skip_brakeman, type: :boolean, default: false,
+          desc: "Skip Brakeman CI configuration"
+
+        class_option :skip_test, type: :boolean, default: false,
+          desc: "Skip test CI configuration"
+
+        class_option :skip_system_test, type: :boolean, default: false,
+          desc: "Skip system tests CI configuration"
+
+        class_option :skip_importmap, type: :boolean, default: false,
+          desc: "Skip importmap CI configuration"
+
+        class_option :skip_bun, type: :boolean, default: false,
+          desc: "Skip Bun CI configuration"
+
+
+        source_paths << File.expand_path(File.join(base_name, "app", "templates"), base_root)
+
+        def create_cifiles
+          empty_directory ".github/workflows"
+
+          template "github/ci.yml", ".github/workflows/ci.yml"
+          template "github/dependabot.yml", ".github/dependabot.yml"
+        end
+
+        private
+          delegate :bun_version, :ci_packages, :quiet, :skip_rubocop?,
+                   :skip_brakeman?, :skip_test?, :skip_system_test?,
+                   :skip_importmap?, :skip_bun?, to: :options
+
+          def database
+            @database ||= Database.build(options[:database])
+          end
+
+          def database_service_yaml(**options)
+            return unless service = database.ci.service
+
+            { database.name => service }.to_yaml(**options).gsub("\n", "\n      ")[4..-1]
+          end
+
+          def database_url_yaml
+            return unless url = database.ci.database_url
+            { "DATABASE_URL" => url }.to_yaml[4..-1].delete("\n")
+          end
+      end
+    end
+  end
+end

--- a/railties/test/fixtures/.github/workflows/ci.yml
+++ b/railties/test/fixtures/.github/workflows/ci.yml
@@ -1,0 +1,133 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  scan_ruby:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: .ruby-version
+          bundler-cache: true
+
+      - name: Scan for common Rails security vulnerabilities using static analysis
+        run: bin/brakeman --no-pager
+
+      - name: Scan for known security vulnerabilities in gems used
+        run: bin/bundler-audit
+
+  scan_js:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: .ruby-version
+          bundler-cache: true
+
+      - name: Scan for security vulnerabilities in JavaScript dependencies
+        run: bin/importmap audit
+
+  lint:
+    runs-on: ubuntu-latest
+    env:
+      RUBOCOP_CACHE_ROOT: tmp/rubocop
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: .ruby-version
+          bundler-cache: true
+
+      - name: Prepare RuboCop cache
+        uses: actions/cache@v4
+        env:
+          DEPENDENCIES_HASH: ${{ hashFiles('.ruby-version', '**/.rubocop.yml', 'Gemfile.lock') }}
+        with:
+          path: ${{ env.RUBOCOP_CACHE_ROOT }}
+          key: rubocop-${{ runner.os }}-${{ env.DEPENDENCIES_HASH }}-${{ github.ref_name == github.event.repository.default_branch && github.run_id || 'default' }}
+          restore-keys: |
+            rubocop-${{ runner.os }}-${{ env.DEPENDENCIES_HASH }}-
+
+      - name: Lint code for consistent style
+        run: bin/rubocop -f github
+
+  test:
+    runs-on: ubuntu-latest
+
+    services:
+
+      # redis:
+      #   image: valkey/valkey:8
+      #   ports:
+      #     - 6379:6379
+      #   options: --health-cmd "redis-cli ping" --health-interval 10s --health-timeout 5s --health-retries 5
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: .ruby-version
+          bundler-cache: true
+
+      - name: Run tests
+        env:
+          RAILS_ENV: test
+          # RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_KEY }}
+          # REDIS_URL: redis://localhost:6379/0
+        run: bin/rails db:test:prepare test
+
+  system-test:
+    runs-on: ubuntu-latest
+
+    services:
+
+      # redis:
+      #   image: valkey/valkey:8
+      #   ports:
+      #     - 6379:6379
+      #   options: --health-cmd "redis-cli ping" --health-interval 10s --health-timeout 5s --health-retries 5
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: .ruby-version
+          bundler-cache: true
+
+      - name: Run System Tests
+        env:
+          RAILS_ENV: test
+          # RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_KEY }}
+          # REDIS_URL: redis://localhost:6379/0
+        run: bin/rails db:test:prepare test test:system
+
+      - name: Keep screenshots from failed system tests
+        uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: screenshots
+          path: ${{ github.workspace }}/tmp/screenshots
+          if-no-files-found: ignore

--- a/railties/test/generators/ci_generator_test.rb
+++ b/railties/test/generators/ci_generator_test.rb
@@ -1,0 +1,375 @@
+# frozen_string_literal: true
+
+require "generators/generators_test_helper"
+require "rails/generators/rails/github/ci_generator"
+
+module Rails
+  module Generators
+    class Github::CiGeneratorTest < Rails::Generators::TestCase
+      include GeneratorsTestHelper
+
+      def test_creates_github_ci_files
+        run_generator
+
+        assert_file ".github/workflows/ci.yml"
+        assert_file ".github/dependabot.yml"
+        test_common_config
+      end
+
+      def test_brakeman_option_default
+        run_generator
+
+        expected_steps = [
+              {
+                "name" => "Checkout code",
+                "uses" => "actions/checkout@v4"
+              },
+              {
+                "name" => "Set up Ruby",
+                "uses" => "ruby/setup-ruby@v1",
+                "with" => {
+                  "ruby-version" => ".ruby-version",
+                  "bundler-cache" => true
+                }
+              },
+              {
+                "name" => "Scan for common Rails security vulnerabilities using static analysis",
+                "run" => "bin/brakeman --no-pager"
+              },
+              {
+                "name" => "Scan for known security vulnerabilities in gems used",
+                "run" => "bin/bundler-audit"
+              }
+        ]
+
+        assert_ci_file do |ci|
+          assert_includes ci["jobs"].keys, "scan_ruby"
+          assert_equal "ubuntu-latest", ci["jobs"]["scan_ruby"]["runs-on"]
+          assert_equal expected_steps, ci["jobs"]["scan_ruby"]["steps"]
+        end
+      end
+
+      def test_brakeman_option_skip
+        run_generator [ "--skip-brakeman" ]
+
+        test_common_config
+
+        assert_ci_file do |ci|
+          assert_not_includes ci["jobs"].keys, "scan_ruby"
+        end
+      end
+
+      def test_using_importmap_option_default
+        run_generator
+        expected_steps = [
+          {
+            "name" => "Checkout code",
+            "uses" => "actions/checkout@v4"
+          },
+          {
+            "name" => "Set up Ruby",
+            "uses" => "ruby/setup-ruby@v1",
+            "with" => {
+              "ruby-version" => ".ruby-version",
+              "bundler-cache" => true
+            }
+          },
+          {
+            "name" => "Scan for security vulnerabilities in JavaScript dependencies",
+            "run" => "bin/importmap audit"
+          }
+        ]
+
+        assert_ci_file do |ci|
+          assert_includes ci["jobs"].keys, "scan_js"
+          assert_equal "ubuntu-latest", ci["jobs"]["scan_js"]["runs-on"]
+          assert_equal expected_steps, ci["jobs"]["scan_js"]["steps"]
+        end
+      end
+
+      def test_using_importmap_option_skip
+        run_generator [ "--skip-importmap" ]
+
+        test_common_config
+
+        assert_ci_file do |ci|
+          assert_not_includes ci["jobs"].keys, "scan_js"
+        end
+      end
+
+      def test_using_skip_rubocop_option_default
+        run_generator
+        expected_steps = [
+          {
+            "name" => "Checkout code",
+            "uses" => "actions/checkout@v4"
+          },
+          {
+            "name" => "Set up Ruby",
+            "uses" => "ruby/setup-ruby@v1",
+            "with" => {
+              "ruby-version" => ".ruby-version",
+              "bundler-cache" => true
+            }
+          },
+          {
+            "name" => "Prepare RuboCop cache",
+            "uses" => "actions/cache@v4",
+            "env" => {
+              "DEPENDENCIES_HASH" => "${{ hashFiles('.ruby-version', '**/.rubocop.yml', 'Gemfile.lock') }}"
+            },
+            "with" => {
+              "path" => "${{ env.RUBOCOP_CACHE_ROOT }}",
+              "key" => "rubocop-${{ runner.os }}-${{ env.DEPENDENCIES_HASH }}-${{ github.ref_name == github.event.repository.default_branch && github.run_id || 'default' }}",
+              "restore-keys" => "rubocop-${{ runner.os }}-${{ env.DEPENDENCIES_HASH }}-\n"
+            }
+          },
+          {
+            "name" => "Lint code for consistent style",
+            "run" => "bin/rubocop -f github"
+          }
+        ]
+
+        assert_ci_file do |ci|
+          assert_includes ci["jobs"].keys, "lint"
+          assert_equal "ubuntu-latest", ci["jobs"]["lint"]["runs-on"]
+          assert_equal "tmp/rubocop", ci["jobs"]["lint"]["env"]["RUBOCOP_CACHE_ROOT"]
+          assert_equal expected_steps, ci["jobs"]["lint"]["steps"]
+        end
+      end
+
+      def test_using_skip_rubocop_option_skip
+        run_generator [ "--skip-rubocop" ]
+
+        test_common_config
+
+        assert_ci_file do |ci|
+          assert_not_includes ci["jobs"].keys, "lint"
+        end
+      end
+
+      def test_using_skip_test_option_default
+        run_generator
+
+        assert_ci_file do |ci|
+          assert_includes ci["jobs"].keys, "test"
+          assert_equal "ubuntu-latest", ci["jobs"]["test"]["runs-on"]
+        end
+      end
+
+      def test_using_skip_test_option_skip
+        run_generator [ "--skip-test" ]
+
+        test_common_config
+
+        assert_ci_file do |ci|
+          assert_not_includes ci["jobs"].keys, "test"
+        end
+      end
+
+      def test_using_skip_system_test_option_default
+        run_generator
+
+        assert_ci_file do |ci|
+          assert_includes ci["jobs"].keys, "system-test"
+          assert_equal "ubuntu-latest", ci["jobs"]["system-test"]["runs-on"]
+        end
+      end
+
+      def test_using_skip_system_test_option_skip
+        run_generator [ "--skip-system-test" ]
+
+        test_common_config
+
+        assert_ci_file do |ci|
+          assert_not_includes ci["jobs"].keys, "system-test"
+        end
+      end
+
+      def test_using_ci_packages_option_default
+        run_generator
+
+        assert_ci_file do |ci|
+          assert_nil find_step_by(:name, ci, "test", "Install packages")
+          assert_nil find_step_by(:name, ci, "system-test", "Install packages")
+        end
+      end
+
+      def test_using_ci_packages_option
+        run_generator [ "--ci-packages", "git", "curl" ]
+
+        assert_ci_file do |ci|
+          test_install_packages_step(find_step_by(:name, ci, "test", "Install packages"), "git curl")
+          test_install_packages_step(find_step_by(:name, ci, "system-test", "Install packages"), "git curl")
+        end
+      end
+
+      def test_using_skip_bun_option_default
+        run_generator ["--bun-version", "0.1.0"]
+
+        assert_ci_file do |ci|
+          test_setup_bun_step(find_step_by(:uses, ci, "test", "oven-sh/setup-bun@v1"), "0.1.0")
+          test_setup_bun_step(find_step_by(:uses, ci, "system-test", "oven-sh/setup-bun@v1"), "0.1.0")
+        end
+      end
+
+      def test_using_skip_bun_option_skip
+        run_generator [ "--skip-bun" ]
+        assert_ci_file do |ci|
+          assert_nil find_step_by(:uses, ci, "test", "oven-sh/setup-bun@v1")
+          assert_nil find_step_by(:uses, ci, "system-test", "oven-sh/setup-bun@v1")
+        end
+      end
+
+      def test_database_default_sqlite3
+        run_generator
+
+        assert_ci_file do |ci|
+          assert_nil ci["jobs"]["test"]["services"]
+          assert_nil ci["jobs"]["system-test"]["services"]
+        end
+
+        test_common_tests_steps
+      end
+
+      def test_database_mariadb_mysql
+        run_generator [ "--database", "mariadb-mysql" ]
+
+        test_common_config
+        test_mariadb_config
+        test_common_tests_steps
+      end
+      def test_database_mariadb_trilogy
+        run_generator [ "--database", "mariadb-trilogy" ]
+        test_common_config
+        test_mariadb_config
+        test_common_tests_steps
+      end
+
+      def test_database_mysql
+        run_generator [ "--database", "mysql" ]
+        test_common_config
+        test_mysql_config
+        test_common_tests_steps database_url: "mysql2://127.0.0.1:3306"
+      end
+      def test_database_postgresql
+        run_generator [ "--database", "postgresql" ]
+        test_common_config
+        test_postgresql_config
+        test_common_tests_steps database_url: "postgres://postgres:postgres@localhost:5432"
+      end
+
+      def test_database_trilogy
+        run_generator [ "--database", "trilogy" ]
+        test_common_config
+        test_mysql_config
+        test_common_tests_steps database_url: "trilogy://127.0.0.1:3306"
+      end
+
+      private
+        def test_common_config
+          assert_file(".github/workflows/ci.yml") do |ci|
+            assert_match(/name: CI/, ci)
+            assert_match(/on:\n  pull_request:\n  push:\n    branches: \[ main \]/, ci)
+            assert_match(/jobs:/, ci)
+          end
+        end
+
+        def test_mariadb_config
+          assert_ci_file do |ci|
+            assert_nil ci["jobs"]["test"]["services"]
+            assert_nil ci["jobs"]["system-test"]["services"]
+          end
+        end
+
+        def test_mysql_config
+          expected_mysql_config = {
+            "image" => "mysql",
+            "env" => {
+              "MYSQL_ALLOW_EMPTY_PASSWORD" => true
+            },
+            "ports" => ["3306:3306"],
+            "options" => "--health-cmd=\"mysqladmin ping\" --health-interval=10s --health-timeout=5s --health-retries=3"
+          }
+          assert_ci_file do |ci|
+            assert_equal expected_mysql_config, ci["jobs"]["test"]["services"]["mysql"]
+            assert_equal expected_mysql_config, ci["jobs"]["system-test"]["services"]["mysql"]
+          end
+        end
+
+        def test_postgresql_config
+          expected_postgresql_config = {
+            "image" => "postgres",
+            "env" => {
+              "POSTGRES_USER" => "postgres",
+              "POSTGRES_PASSWORD" => "postgres"
+            },
+            "ports" => ["5432:5432"],
+            "options" => "--health-cmd=\"pg_isready\" --health-interval=10s --health-timeout=5s --health-retries=3"
+          }
+          assert_ci_file do |ci|
+            assert_equal expected_postgresql_config, ci["jobs"]["test"]["services"]["postgres"]
+            assert_equal expected_postgresql_config, ci["jobs"]["system-test"]["services"]["postgres"]
+          end
+        end
+
+        def test_common_tests_steps(**options)
+          test_common_test_steps_for("test", **options)
+          test_common_test_steps_for("system-test", **options)
+        end
+
+        def test_common_test_steps_for(test, **options)
+          test = test.to_s.inquiry
+          database_url = options.delete(:database_url) || nil
+          test_command = test.system? ? "test:system" : "test"
+          test_run_name = test.system? ? "Run System tests" : "Run tests"
+          test_step = test.system? ? "&& bin/rails system-test" : "test"
+
+          assert_ci_file do |ci|
+            test_checkout_code_step(find_step_by(:name, ci, test_step, "Checkout code"))
+            test_setup_ruby_step(find_step_by(:name, ci, test_step, "Set up Ruby"))
+            test_run_tests_step(find_step_by(:name, ci, test_step, test_run_name), test_command, database_url)
+            test_keep_screenshots_step(find_step_by(:name, ci, test_step, "Keep screenshots from failed system tests")) if test.system?
+          end
+        end
+
+        def find_step_by(type, ci, test_step, step_name)
+          ci["jobs"][test_step]["steps"].find { |s| s[type.to_s] == step_name }
+        end
+
+        def test_install_packages_step(step, ci_packages)
+          assert_equal "Install packages", step["name"]
+          assert_equal "sudo apt-get update && sudo apt-get install --no-install-recommends -y #{ci_packages}", step["run"]
+        end
+
+        def test_setup_bun_step(step, bun_version = nil)
+          assert_equal "oven-sh/setup-bun@v1", step["uses"]
+          assert_equal({ "bun-version" => bun_version }, step["with"])
+        end
+
+        def test_checkout_code_step(step)
+          assert_equal "Checkout code", step["name"]
+          assert_equal "actions/checkout@v4", step["uses"]
+        end
+
+        def test_setup_ruby_step(step)
+          assert_equal "Set up Ruby", step["name"]
+          assert_equal "ruby/setup-ruby@v1", step["uses"]
+        end
+
+        def test_run_tests_step(step, test_command, database_url)
+          assert_equal "Run tests", step["name"]
+          assert_equal "bin/rails db:test:prepare #{test_command}", step["run"]
+          expected_env = { "RAILS_ENV" => "test" }
+          expected_env["DATABASE_URL"] = database_url if database_url
+          assert_equal(expected_env, step["env"])
+        end
+
+        def test_keep_screenshots_step(step)
+          assert_equal "Keep screenshots from failed system tests", step["name"]
+          assert_equal "actions/upload-artifact@v4", step["uses"]
+          assert_equal({ "name" => "screenshots", "path" => "${{ github.workspace }}/tmp/screenshots", "if-no-files-found" => "ignore" }, step["with"])
+        end
+    end
+  end
+end

--- a/railties/test/generators/db_system_change_github_ci_generator_test.rb
+++ b/railties/test/generators/db_system_change_github_ci_generator_test.rb
@@ -1,0 +1,124 @@
+# frozen_string_literal: true
+
+require "generators/generators_test_helper"
+require "rails/generators/rails/db/system/change/github/ci_generator"
+
+module Rails
+  module Generators
+    module Db
+      module System
+        module Change
+          module Github
+            class CiGeneratorTest < Rails::Generators::TestCase
+              include GeneratorsTestHelper
+
+              setup do
+                copy_ci_files
+              end
+
+              test "change to invalid database" do
+                output = capture(:stderr) do
+                  run_generator ["--database", "invalid-db"]
+                end
+
+                assert_match <<~MSG.squish, output
+                    Expected '--database' to be one of mysql, trilogy, postgresql, sqlite3, mariadb-mysql, mariadb-trilogy; got invalid-db
+                MSG
+              end
+
+              test "change to postgresql" do
+                run_generator ["--database", "postgresql"]
+
+                test_service_config("postgres", {
+                  "image" => "postgres",
+                  "env" => {
+                    "POSTGRES_USER" => "postgres",
+                    "POSTGRES_PASSWORD" => "postgres"
+                  },
+                  "ports" => ["5432:5432"],
+                  "options" => "--health-cmd=\"pg_isready\" --health-interval=10s --health-timeout=5s --health-retries=3"
+                })
+                test_database_url("postgres://postgres:postgres@localhost:5432")
+              end
+
+              test "change to mysql" do
+                run_generator ["--database", "mysql"]
+                test_service_config("mysql", {
+                 "image" => "mysql",
+                 "env" => {
+                   "MYSQL_ALLOW_EMPTY_PASSWORD" => true
+                 },
+                 "ports" => ["3306:3306"],
+                 "options" => "--health-cmd=\"mysqladmin ping\" --health-interval=10s --health-timeout=5s --health-retries=3"
+               })
+                test_database_url("mysql2://127.0.0.1:3306")
+              end
+
+              test "change to sqlite3" do
+                run_generator ["--database", "sqlite3"]
+                test_no_database_configuration
+              end
+
+              test "change to trilogy" do
+                run_generator ["--database", "trilogy"]
+                test_service_config("mysql", {
+                  "image" => "mysql",
+                  "env" => {
+                    "MYSQL_ALLOW_EMPTY_PASSWORD" => true
+                  },
+                  "ports" => ["3306:3306"],
+                  "options" => "--health-cmd=\"mysqladmin ping\" --health-interval=10s --health-timeout=5s --health-retries=3"
+                })
+                test_database_url("trilogy://127.0.0.1:3306")
+              end
+
+              test "change to mariadb-mysql" do
+                run_generator ["--database", "mariadb-mysql"]
+                test_no_database_configuration
+              end
+
+              test "change to mariadb-trilogy" do
+                run_generator ["--database", "mariadb-trilogy"]
+                test_no_database_configuration
+              end
+
+              test "change from ci with database service" do
+                run_generator ["--database", "postgresql"]
+                run_generator ["--database", "sqlite3"]
+
+                test_no_database_configuration
+              end
+
+              private
+                def test_service_config(name, expected_config)
+                  assert_ci_file do |ci_config|
+                    assert_includes ci_config["jobs"]["test"]["services"].keys, name
+                    assert_includes ci_config["jobs"]["system-test"]["services"].keys, name
+                    assert_equal expected_config, ci_config["jobs"]["test"]["services"][name]
+                    assert_equal expected_config, ci_config["jobs"]["system-test"]["services"][name]
+                  end
+                end
+
+                def test_database_url(expected_url)
+                  assert_ci_file do |ci_config|
+                    assert_includes ci_config["jobs"]["test"]["steps"].find { |s| s["name"] == "Run tests" }["env"]["DATABASE_URL"], expected_url
+                    assert_includes ci_config["jobs"]["system-test"]["steps"].find { |s| s["name"] == "Run System Tests" }["env"]["DATABASE_URL"], expected_url
+                  end
+                end
+
+                def test_no_database_configuration
+                  assert_ci_file do |ci_config|
+                    assert_nil ci_config["jobs"]["test"]["services"]
+                    assert_nil ci_config["jobs"]["system-test"]["services"]
+
+                    assert_nil ci_config["jobs"]["test"]["steps"].find { |s| s["name"] == "Run tests" }["env"]["DATABASE_URL"]
+                    assert_nil ci_config["jobs"]["system-test"]["steps"].find { |s| s["name"] == "Run System Tests" }["env"]["DATABASE_URL"]
+                  end
+                end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/railties/test/generators/generators_test_helper.rb
+++ b/railties/test/generators/generators_test_helper.rb
@@ -3,6 +3,7 @@
 require "abstract_unit"
 require "active_support/testing/stream"
 require "active_support/testing/method_call_assertions"
+require "active_support/core_ext/string/inquiry"
 require "rails/generators"
 require "rails/generators/test_case"
 require "rails/generators/app_base"
@@ -128,6 +129,12 @@ module GeneratorsTestHelper
 
   def assert_compose_file
     assert_file ".devcontainer/compose.yaml" do |content|
+      yield YAML.load(content)
+    end
+  end
+
+  def assert_ci_file
+    assert_file ".github/workflows/ci.yml" do |content|
       yield YAML.load(content)
     end
   end

--- a/railties/test/generators/generators_test_helper.rb
+++ b/railties/test/generators/generators_test_helper.rb
@@ -104,6 +104,14 @@ module GeneratorsTestHelper
     File.write File.join(destination, "compose.yaml"), compose_yaml
   end
 
+  def copy_ci_files
+    destination = File.join(destination_root, ".github/workflows")
+    mkdir_p(destination)
+
+    ci_yml = File.read(File.expand_path("../fixtures/.github/workflows/ci.yml", __dir__))
+    File.write File.join(destination, "ci.yml"), ci_yml
+  end
+
   def copy_minimal_devcontainer_compose_file
     destination = File.join(destination_root, ".devcontainer")
     mkdir_p(destination)


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because when executing `rails db:system:change --to dbname` the `.github/workflows/ci.yml` does not get updated. This is an unexpected/missing behavior since `Gemfile`, `Dockerfile` and `.devcontainer/...` files do get updated.

### Detail

This Pull Request changes the `Db::System::ChangeGenerator` and uses a newly added `Db::System::Change::Github::CiGenerator` to handle the required file changes. These changes are done depending on the `database.ci.service` and `database.ci.database_url`. 

### Additional information

Alternative solutions to get the right CI file are:
- Generate a new Rails application and copy over the newly generated `.github/workflows/ci.yml`,
- Edit the CI file manually for both `test` and `system-test` jobs.
