### PR TITLE
Respect SCHEMA_FORMAT in db:schema:load

### DIFF
--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -473,7 +473,8 @@ db_namespace = namespace :db do
 
     desc "Load a database schema file (either db/schema.rb or db/structure.sql, depending on `ENV['SCHEMA_FORMAT']` or `config.active_record.schema_format`) into the database"
     task load: [:load_config, :check_protected_environments] do
-      ActiveRecord::Tasks::DatabaseTasks.load_schema_current(ActiveRecord.schema_format, ENV["SCHEMA"])
+      schema_format = ENV.fetch("SCHEMA_FORMAT", ActiveRecord.schema_format).to_sym
+      ActiveRecord::Tasks::DatabaseTasks.load_schema_current(schema_format, ENV["SCHEMA"])
     end
 
     namespace :dump do


### PR DESCRIPTION
Considering how we go forward in Rails >= 8 (see #53666), this has been an oversight when introducing the `SCHEMA_FORMAT` environment variable. This bugfix now respects it as described in the task description and should only be applied to Rails 7.2.
