### PR TITLE
Add `affected_rows` to `ActiveRecord::Result`

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add `affected_rows` to `ActiveRecord::Result`.
+
+    *Jenny Shen*
+
 *   Enable passing retryable SqlLiterals to `#where`.
 
     *Hartley McGuire*

--- a/activerecord/lib/active_record/connection_adapters/mysql2/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql2/database_statements.rb
@@ -114,12 +114,12 @@ module ActiveRecord
           end
 
           def cast_result(raw_result)
-            return ActiveRecord::Result.empty if raw_result.nil?
+            return ActiveRecord::Result.empty(affected_rows: @affected_rows_before_warnings) if raw_result.nil?
 
             fields = raw_result.fields
 
             result = if fields.empty?
-              ActiveRecord::Result.empty
+              ActiveRecord::Result.empty(affected_rows: @affected_rows_before_warnings)
             else
               ActiveRecord::Result.new(fields, raw_result.to_a)
             end

--- a/activerecord/lib/active_record/connection_adapters/trilogy/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/trilogy/database_statements.rb
@@ -41,9 +41,9 @@ module ActiveRecord
 
           def cast_result(result)
             if result.fields.empty?
-              ActiveRecord::Result.empty
+              ActiveRecord::Result.empty(affected_rows: result.affected_rows)
             else
-              ActiveRecord::Result.new(result.fields, result.rows)
+              ActiveRecord::Result.new(result.fields, result.rows, affected_rows: result.affected_rows)
             end
           end
 

--- a/activerecord/test/cases/adapter_test.rb
+++ b/activerecord/test/cases/adapter_test.rb
@@ -153,6 +153,23 @@ module ActiveRecord
       assert_not_empty result.columns
     end
 
+    test "#exec_query queries return an ActiveRecord::Result with affected rows" do
+      result = @connection.exec_query "INSERT INTO subscribers(nick, name) VALUES('me', 'me'), ('you', 'you')"
+      assert_equal 2, result.affected_rows
+
+      update_result = @connection.exec_query "UPDATE subscribers SET name = 'you' WHERE name = 'me'"
+      assert_equal 1, update_result.affected_rows
+
+      select_result = @connection.exec_query "SELECT * FROM subscribers"
+      assert_not_equal update_result.affected_rows, select_result.affected_rows
+
+      result = @connection.exec_query "DELETE FROM subscribers WHERE name = 'you'"
+      assert_equal 2, result.affected_rows
+
+      result = @connection.exec_query "DELETE FROM subscribers WHERE name = 'you'"
+      assert_equal 0, result.affected_rows
+    end
+
     if current_adapter?(:Mysql2Adapter, :TrilogyAdapter)
       def test_charset
         assert_not_nil @connection.charset

--- a/activerecord/test/cases/result_test.rb
+++ b/activerecord/test/cases/result_test.rb
@@ -9,7 +9,7 @@ module ActiveRecord
         ["row 1 col 1", "row 1 col 2"],
         ["row 2 col 1", "row 2 col 2"],
         ["row 3 col 1", "row 3 col 2"],
-      ])
+      ], affected_rows: 3)
     end
 
     test "includes_column?" do
@@ -138,6 +138,7 @@ module ActiveRecord
       assert_equal a.columns, b.columns
       assert_equal a.rows, b.rows
       assert_equal a.column_indexes, b.column_indexes
+      assert_equal a.affected_rows, b.affected_rows
 
       # Second round in case of mutation
       b = b.dup
@@ -146,6 +147,7 @@ module ActiveRecord
       assert_equal a.columns, b.columns
       assert_equal a.rows, b.rows
       assert_equal a.column_indexes, b.column_indexes
+      assert_equal a.affected_rows, b.affected_rows
     end
 
     test "column_types handles nil types in the column_types array" do


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

For database adapters that do not support insert `RETURNING`, the result for `insert_all` and `upsert_all` does not provide any information on the rows that has been affected. Adding `affected_rows` to the result allows this information to be accessed similar to the return value of other bulk operations (like `delete_all` and `update_all`).

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

### Detail

I added an `affected_rows` reader for the result. Database specific adapters would provide the value as a keyword arg when the result is initialized (often in `cast_result`).

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

One note to point out is that different adapters have different behaviour for affected rows in a `SELECT` statement.

#### MySQL `@affected_rows_before_warnings` / Trilogy `result.affected_rows` 
 `nil`  eg. https://github.com/trilogy-libraries/trilogy/commit/ddbefb06e5c6bd8c15b0b02edc2a8a2a309b1a76

#### Postgres `result.cmd_tuples` 
Number of rows returned in the `SELECT` https://www.postgresql.org/docs/current/libpq-exec.html#LIBPQ-PQCMDTUPLES

#### SQLite `raw_connection.changes` 
Number of rows affected by the last `UPDATE`/`DELETE`/`INSERT` https://www.sqlite.org/c3ref/changes.html

I think MySQL / Postgres is fine since the value relates to the query itself but exposing this value for SQLite might not be the best idea. Though the same `affected_rows` is shared in `sql.active_record` notifications. https://github.com/rails/rails/commit/a029da566f0b9716d90aa670edf04f90b8d72b89

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
