### PR TITLE
[ci skip] Add docs for error context middleware

### DIFF
--- a/guides/source/error_reporting.md
+++ b/guides/source/error_reporting.md
@@ -9,6 +9,7 @@ After reading this guide, you will know:
 
 * How to use Rails' error reporter to capture and report errors.
 * How to create custom subscribers for your error-reporting service.
+* How to add shared error context with middleware.
 
 --------------------------------------------------------------------------------
 
@@ -252,6 +253,37 @@ Rails.error.handle(context: { b: 2 }) { raise }
 Rails.error.handle(context: { b: 3 }) { raise }
 # The reported context will be: {:a=>1, :b=>3}
 ```
+
+### Setting Context with Error Context Middleware
+
+The error reporter has its own middleware stack for modifying the error context before sending it to subscribers.
+Use this to make changes to the error context that can be seen by all error subscribers, instead of replicating
+common functionality inside subscribers.
+
+For example, suppose you run several error subscribers (one for your APM, one for a logging service) and you
+want every reported error to carry the current request ID and tenant. Without middleware, you would have to add
+that lookup to each subscriber. With a context middleware, you enrich the context once and every subscriber
+receives it. This is also how a gem can add common context to error messages without requiring the host app to
+modify its error subscribers. The concerns of "set error context" and "send data to error tracker" should be
+separated between middleware and subscribers.
+
+Context middleware receives the same parameters as `Rails.error.report`. The middleware stack returns the hash
+after running all middleware - each middleware can mutate the context hash and should return the new context hash.
+
+```ruby
+class MyErrorContextMiddleware
+  def call(error, context:, handled:, severity:, source:)
+    context.merge({ foo: :bar })
+  end
+end
+
+Rails.error.add_middleware(MyErrorContextMiddleware.new) # Append the middleware to the error context stack
+
+Rails.error.report(error, context: { bar: :baz }) # Report an error with some context
+# The reported context will include { bar: :baz, foo: :bar }
+```
+
+Context middleware runs after global context set by `Rails.error.set_context` is applied to the context hash.
 
 ### Filtering by Error Classes
 


### PR DESCRIPTION
Add docs to Rails guide for error context middleware in `ActiveSupport::ErrorReporter`. ([preview](https://350ae6eb.rails-docs-preview.pages.dev/guides/error_reporting#setting-context-with-error-context-middleware))

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
