### PR TITLE
fix(pk_and_sequence_for): handle composite primary keys for sequence …

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -370,13 +370,14 @@ module ActiveRecord
                  pg_attribute  attr,
                  pg_depend     dep,
                  pg_constraint cons,
-                 pg_namespace  nsp
+                 pg_namespace  nsp,
+                 unnest(cons.conkey) AS key(attnum)
             WHERE seq.oid           = dep.objid
               AND seq.relkind       = 'S'
               AND attr.attrelid     = dep.refobjid
               AND attr.attnum       = dep.refobjsubid
               AND attr.attrelid     = cons.conrelid
-              AND attr.attnum       = cons.conkey[1]
+              AND attr.attnum       = key.attnum
               AND seq.relnamespace  = nsp.oid
               AND cons.contype      = 'p'
               AND dep.classid       = 'pg_class'::regclass

--- a/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
@@ -247,6 +247,13 @@ module ActiveRecord
         end
       end
 
+      def test_pk_and_sequence_for_composite_primary_key
+        with_example_table("id serial, tenant_id serial, PRIMARY KEY (tenant_id, id)") do
+          seq = @connection.pk_and_sequence_for("ex").last
+          assert_equal PostgreSQL::Name.new("public", "ex_id_seq"), seq
+        end
+      end
+
       def test_pk_and_sequence_for_returns_nil_if_no_pk
         with_example_table "id integer" do
           assert_nil @connection.pk_and_sequence_for("ex")


### PR DESCRIPTION
Previously, pk_and_sequence_for only worked correctly when the primary key consisted of a single column, always selecting the first value. This behavior is often incorrect in multitenant environments, where the first column in the primary key (e.g., tenant_id) is the most significant in terms of indexing and data locality.

This change updates the SQL query to support composite primary keys by unnesting conkey and matching each key column individually.

Example:
```
  class User < ApplicationRecord
    self.primary_key = :id
  end

  # in schema.rb
  create_table "users", primary_key: ["tenant_id", "id"], force: :cascade do |t|
    t.bigserial "id"
    t.bigserial "tenant_id"
    ...
  end
```