### PR TITLE
Fix `affected_rows` for SQLite `sql.active_record` notifications

### DIFF
--- a/activerecord/test/cases/instrumentation_test.rb
+++ b/activerecord/test/cases/instrumentation_test.rb
@@ -165,6 +165,8 @@ module ActiveRecord
         # INSERT ... RETURNING
         Book.insert_all!([{ name: "One" }, { name: "Two" }, { name: "Three" }, { name: "Four" }], returning: false)
 
+        Book.where(name: ["One", "Two", "Three"]).pluck(:id)
+
         Book.where(name: ["One", "Two", "Three"]).update_all(status: :published)
 
         Book.where(name: ["Three", "Four"]).delete_all
@@ -172,7 +174,11 @@ module ActiveRecord
         Book.where(name: ["Three", "Four"]).delete_all
       end
 
-      assert_equal [4, 3, 2, 0], affected_row_values
+      assert_equal 4, affected_row_values.first
+      assert_not_equal affected_row_values.first, affected_row_values.second
+      assert_equal 3, affected_row_values.third
+      assert_equal 2, affected_row_values.fourth
+      assert_equal 0, affected_row_values.fifth
     end
 
     def test_no_instantiation_notification_when_no_records


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background
From https://github.com/rails/rails/pull/55060, it was noticed that `SQLite3::Database.changes` only reflects the number of rows affected by the last `DELETE`/`UPDATE`/`INSERT`, and the number would not change for any other query ([ref](https://www.sqlite.org/c3ref/changes.html)). 

> Executing any other type of SQL statement does not modify the value returned by these functions.

Therefore, `SELECT` statements would have the affected row count of a previous query for `sql.active_record` notifications.

### Detail

@skipkayhil suggested that instead of using `SQLite3::Database.changes`, we should calculate the `affected_rows` by subtracting the `SQLite3::Database.total_changes` before the query was executed from afterwards. This would result `affected_rows` = 0 for `SELECT` statements now.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
