### PR TITLE
[ci skip] Fix typo on active record querying running explain

### DIFF
--- a/guides/source/active_record_querying.md
+++ b/guides/source/active_record_querying.md
@@ -2635,9 +2635,9 @@ EXPLAIN SELECT `customers`.* FROM `customers` INNER JOIN `orders` ON `orders`.`c
 2 rows in set (0.00 sec)
 ```
 
-Active Record performs a pretty printing that emulates that of the
-corresponding database shell. So, the same query running with the
-PostgreSQL adapter would yield instead:
+Active Record performs pretty printing that emulates the output of
+the corresponding database shell. So, the same query run with the
+PostgreSQL adapter would instead yield:
 
 ```sql
 EXPLAIN SELECT "customers".* FROM "customers" INNER JOIN "orders" ON "orders"."customer_id" = "customers"."id" WHERE "customers"."id" = $1 [["id", 1]]


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because the original text had minor grammatical and stylistic issues that could hinder understanding. The revision improves clarity and flow without altering the technical meaning.

### Detail

This Pull Request changes a sentence in the Active Record documentation to:

- Remove an unnecessary article ("a") before "pretty printing"
- Replace awkward phrasing ("that of the corresponding database shell") with clearer wording
- Adjust the verb form for grammatical correctness
- Improve the sentence structure for readability

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
