### PR TITLE
Provide more control for error context middleware in ErrorReporter

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Provide more control for error context middleware in ErrorReporter.
+
+    The error context middleware can now insert, swap, and remove middleware
+    based on integer indexes and relative to other middleware in stack. This simplifies
+    managing apps with middleware from multiple sources (gems or the app).
+
+    *Sam Schmidt*
+
 *   Add public API for `before_fork_hook` in parallel testing.
 
     Introduces a public API for calling the before fork hooks implemented by parallel testing.


### PR DESCRIPTION
### Motivation / Background

Error context middleware in `ActiveSupport::ErrorReporter` can currently only be added. This PR adds simple `insert`/`swap`/`delete` capabilities, inspired from `ActionDispatch::MiddlewareStack`. (Additional context in [this PR](https://github.com/rails/rails/pull/55053) - the features were reimplemented instead of reusing the same class to preserve the simpler middleware interface).

This will allow error context middleware to be reorganized by the Rails app, which is especially useful if the middleware is being provided from a gem Railtie.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
