### PR TITLE
Preserve enum methods when using becomes! on STI subclasses

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,30 @@
+*   Fix `becomes!` to correctly rebind enum attributes when converting
+    between STI subclasses that define different enum mappings for the same column.
+
+    Previously, enum methods such as `#published!` or `#published?` could raise
+    `ArgumentError` or return incorrect values after calling `becomes!`,
+     because the enum type was not properly updated to the new subclass.
+
+    Example:
+
+    ```ruby
+    class Foo < ActiveRecord::Base; end
+
+    class Bar < Foo
+      enum :state, { draft: "draft" }
+    end
+
+    class Baz < Foo
+      enum :state, { published: "published" }
+    end
+
+    bar = Bar.create!(state: "draft")
+    baz = bar.becomes!(Baz)
+    baz.published! # Previously: raises ArgumentError
+    ```
+
+    *Yuhi Sato*
+
 *   `:class_name` is now invalid in polymorphic `belongs_to` associations.
 
     Reason is `:class_name` does not make sense in those associations because

--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -495,6 +495,14 @@ module ActiveRecord
         becoming.instance_variable_set(:@previously_new_record, previously_new_record?)
         becoming.instance_variable_set(:@destroyed, destroyed?)
         becoming.errors.copy!(errors)
+
+        klass.attribute_types.each do |name, type|
+          next if type.is_a?(ActiveRecord::Encryption::EncryptedAttributeType)
+
+          if (attribute = @attributes[name])
+            @attributes[name] = attribute.with_type(type)
+          end
+        end
       end
 
       became

--- a/activerecord/test/models/parrot.rb
+++ b/activerecord/test/models/parrot.rb
@@ -35,5 +35,6 @@ class LiveParrot < Parrot
 end
 
 class DeadParrot < Parrot
+  enum :breed, { asian: 10 }
   belongs_to :killer, class_name: "Pirate", foreign_key: :killer_id
 end


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

Fixes [rails#55001](https://github.com/rails/rails/issues/55001)

The `becomes!` method fails to preserve enum-based behavior when converting between STI (Single Table Inheritance) subclasses that define different `enum` values for the same attribute.

This is particularly problematic because `enum` defines predicate (`#published?`) and mutator (`#published!`) methods specific to each class. When switching classes via `becomes!`, the internal type mapping (`EnumType`) from the original class is retained, leading to incorrect validation and method behavior.

### Detail

This change ensures that when performing `becomes!`, each attribute is rebound to the destination class’s attribute type using `with_type`. This guarantees that enum accessors work correctly in the destination class context.

A test case using `LiveParrot` and `DeadParrot` subclasses of `Parrot` (each declaring their own enum `:breed`) demonstrates that the fix allows safe conversion between STI subclasses while maintaining proper enum behavior.

Before this change:

```ruby
    parrot = LiveParrot.create!(name: "Scipio", breed: "african")
    dead_parrot = parrot.becomes!(DeadParrot)
    dead_parrot.asian! # => raises ArgumentError
```

This failed due to the original enum mapping from `LiveParrot` being retained.

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

- The error is raised by `EnumType#assert_valid_value` when the new enum value is not recognized by the old enum mapping.
- This fix ensures consistency with developer expectations when using enums in STI environments.
- To avoid decryption errors for encrypted attributes
  (`ActiveRecord::Encryption::EncryptedAttributeType`), such attributes are
  explicitly skipped when rebinding types.
- This PR is a re-submission of [#55018](https://github.com/rails/rails/pull/55018), which was automatically closed after force-pushing to clean up the commit history. The content is unchanged; only the history was rewritten for clarity.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
