### PR TITLE
docs: Adding example to assert_difference method

### DIFF
--- a/activesupport/lib/active_support/testing/assertions.rb
+++ b/activesupport/lib/active_support/testing/assertions.rb
@@ -71,25 +71,29 @@ module ActiveSupport
       #     post :delete, params: { id: ... }
       #   end
       #
-      # An array of expressions can also be passed in and evaluated.
+      # An array of expressions can be passed in and evaluated.
       #
       #   assert_difference [ 'Article.count', 'Post.count' ], 2 do
       #     post :create, params: { article: {...} }
       #   end
       #
-      # A hash of expressions/numeric differences can also be passed in and evaluated.
+      # A hash of expressions/numeric differences can be passed in and evaluated.
       #
-      #   assert_difference ->{ Article.count } => 1, ->{ Notification.count } => 2 do
+      #   assert_difference({ 'Article.count' => 1, 'Notification.count' => 2 }) do
       #     post :create, params: { article: {...} }
       #   end
       #
-      # A lambda or a list of lambdas can be passed in and evaluated:
+      # A lambda, a list of lambdas or a hash of lambdas/numeric differences can be passed in and evaluated:
       #
       #   assert_difference ->{ Article.count }, 2 do
       #     post :create, params: { article: {...} }
       #   end
       #
       #   assert_difference [->{ Article.count }, ->{ Post.count }], 2 do
+      #     post :create, params: { article: {...} }
+      #   end
+      #
+      #   assert_difference ->{ Article.count } => 1, ->{ Notification.count } => 2 do
       #     post :create, params: { article: {...} }
       #   end
       #


### PR DESCRIPTION
### Motivation / Background

Just found out that `assert_difference` supports passing a hash of expressions/numeric differences, so, I thought it'd be a good idea to include it as an example.

Example:
```ruby
assert_difference({ 'Article.count' => 1, 'Notification.count' => 2 }) do
  post :create, params: { article: {...} }
end
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] ~~Tests are added or updated if you fix a bug or add a feature.~~
* [ ] ~~CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.~~
