### PR TITLE
Fix table name normalization for non-table methods like :quote in migrations

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Fix `ActiveRecord::Migration.quote` to handle non-string values correctly
+
+    *Yuhi Sato*
+
 *   `:class_name` is now invalid in polymorphic `belongs_to` associations.
 
     Reason is `:class_name` does not make sense in those associations because

--- a/activerecord/test/cases/migration_test.rb
+++ b/activerecord/test/cases/migration_test.rb
@@ -918,6 +918,17 @@ class MigrationTest < ActiveRecord::TestCase
     Person.lease_connection.drop_table :binary_testings, if_exists: true
   end
 
+  def test_quote
+    # rubocop:disable Style/StringLiterals
+    assert_equal 'NULL', ActiveRecord::Migration.quote(nil)
+    assert_equal 'TRUE', ActiveRecord::Migration.quote(true)
+    assert_equal 'FALSE', ActiveRecord::Migration.quote(false)
+    # rubocop:enable Style/StringLiterals
+
+    t = Date.today
+    assert_equal "'#{t.to_fs(:db)}'", ActiveRecord::Migration.quote(t)
+  end
+
   unless mysql_enforcing_gtid_consistency?
     def test_create_table_with_query
       Person.lease_connection.create_table :table_from_query_testings, as: "SELECT id FROM people WHERE id = 1"


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

Fixes #55054 by excluding `:quote` from table name normalization in
`ActiveRecord::Migration#method_missing`, and moving normalization logic into a dedicated helper method.

The root cause was that method_missing applied `proper_table_name `even to arguments for methods like quote, which are not meant to receive table names. This led to incorrect behavior when quoting non-string values like integers or booleans.

A similar issue occurred in [#10798](https://github.com/rails/rails/pull/10798), where `:enable_extension` and `:disable_extension` were excluded from normalization to avoid incorrect processing. While excluding :quote alone could fix the current issue, it doesn't address the underlying problem.

The broader issue is that method_missing has taken on multiple responsibilities—both delegation and argument normalization—which reduces clarity and makes maintenance harder. To improve this, I introduced a constant (`METHODS_WITHOUT_TABLE_NAME `) to clearly define which methods should skip normalization. This separation improves readability and makes future changes more predictable and easier to manage.

### Detail

This Pull Request changes

- Keeps `method_missing` focused on method delegation only
- Makes methods that should skip table name normalization explicit via the `METHODS_WITHOUT_TABLE_NAME ` constant
- Replace `connection.respond_to?(:revert)` with `reverting?` when skipping table name normalization in `revert` blocks.

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
