### PR TITLE
Add namespaced version of the `db:migrate:reset` command.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add support for multiple databases to `db:migrate:reset`.
+
+    *Joé Dupuis*
+
 *   Add `affected_rows` to `ActiveRecord::Result`.
 
     *Jenny Shen*

--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -163,6 +163,18 @@ db_namespace = namespace :db do
     desc "Resets your database using your migrations for the current environment"
     task reset: ["db:drop", "db:create", "db:schema:dump", "db:migrate"]
 
+    namespace :reset do
+      ActiveRecord::Tasks::DatabaseTasks.for_each(databases) do |name|
+        desc "Drop and recreate the #{name} database using migrations"
+        task name => :load_config do
+          db_namespace["drop:#{name}"].invoke
+          db_namespace["create:#{name}"].invoke
+          db_namespace["schema:dump:#{name}"].invoke
+          db_namespace["migrate:#{name}"].invoke
+        end
+      end
+    end
+
     desc 'Run the "up" for a given migration VERSION.'
     task up: :load_config do
       ActiveRecord::Tasks::DatabaseTasks.raise_for_multi_db(command: "db:migrate:up")


### PR DESCRIPTION
Add namespaced version of the `db:migrate:reset` command.
Allowing reseting only the primary with `db:migrate:reset:primary`

Fixes #55045

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
