### PR TITLE
Respect default_shard if already set

### DIFF
--- a/activerecord/lib/active_record/connection_handling.rb
+++ b/activerecord/lib/active_record/connection_handling.rb
@@ -93,7 +93,7 @@ module ActiveRecord
         shards[:default] = database
       end
 
-      self.default_shard = shards.keys.first
+      self.default_shard ||= shards.keys.first
 
       shards.each do |shard, database_keys|
         database_keys.each do |role, database_key|


### PR DESCRIPTION
This PR ensure that the default shard is respected if it is already set elsewhere.
