### PR TITLE
Updated ruby version to 3.4.4 in Devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,7 +1,7 @@
 # See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.191.1/containers/ruby/.devcontainer/base.Dockerfile
 
 # [Choice] Ruby version: 3.4, 3.3, 3.2
-ARG VARIANT="3.4.3"
+ARG VARIANT="3.4.4"
 FROM ghcr.io/rails/devcontainer/images/ruby:${VARIANT}
 
 RUN sudo apt-get update && export DEBIAN_FRONTEND=noninteractive \


### PR DESCRIPTION
## Update Ruby Version to 3.4.4 in Dev Container

This PR updates the Ruby version in the development container to **3.4.4**. We have started using Ruby 3.4.4 in both development and production environments at GitHub, so this change ensures consistency across all environments.

**What changed?**
- Updated the Ruby version in the dev container configuration to 3.4.4.
