### PR TITLE
Avoid a module named `Namespace` for Ruby 3.5

### DIFF
--- a/activemodel/test/cases/validations/validates_test.rb
+++ b/activemodel/test/cases/validations/validates_test.rb
@@ -4,7 +4,7 @@ require "cases/helper"
 require "models/person"
 require "models/topic"
 require "models/person_with_validator"
-require "validators/namespace/email_validator"
+require "validators/namespaced/email_validator"
 
 class ValidatesTest < ActiveModel::TestCase
   setup :reset_callbacks
@@ -55,7 +55,7 @@ class ValidatesTest < ActiveModel::TestCase
   end
 
   def test_validates_with_namespaced_validator_class
-    Person.validates :karma, 'namespace/email': true
+    Person.validates :karma, 'namespaced/email': true
     person = Person.new
     person.valid?
     assert_equal ["is not an email"], person.errors[:karma]

--- a/activemodel/test/validators/namespaced/email_validator.rb
+++ b/activemodel/test/validators/namespaced/email_validator.rb
@@ -2,7 +2,7 @@
 
 require "validators/email_validator"
 
-module Namespace
+module Namespaced
   class EmailValidator < ::EmailValidator
   end
 end


### PR DESCRIPTION
This will be a feature in Ruby 3.5 and fails:
> Namespace is not a module (TypeError)

Other places in rails already use `Namespaced` for this purpose.

Also reported upstream: https://bugs.ruby-lang.org/issues/21341

cc @yahonda