### PR TITLE
Fix `remove_foreign_key` when multiple columns are found

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -1815,7 +1815,20 @@ module ActiveRecord
 
         def foreign_key_for(from_table, **options)
           return unless use_foreign_keys?
-          foreign_keys(from_table).detect { |fk| fk.defined_for?(**options) }
+
+          keys = foreign_keys(from_table)
+
+          if options[:_skip_column_match]
+            return keys.find { |fk| fk.defined_for?(**options) }
+          end
+
+          if options[:column].nil?
+            default_column = foreign_key_column_for(options[:to_table], "id")
+            matches = keys.select { |fk| fk.column == default_column }
+            keys = matches if matches.any?
+          end
+
+          keys.find { |fk| fk.defined_for?(**options) }
         end
 
         def foreign_key_for!(from_table, to_table: nil, **options)

--- a/activerecord/lib/active_record/migration/compatibility.rb
+++ b/activerecord/lib/active_record/migration/compatibility.rb
@@ -50,9 +50,7 @@ module ActiveRecord
 
         private
           def compatible_table_definition(t)
-            class << t
-              prepend TableDefinition
-            end
+            t.singleton_class.prepend(TableDefinition)
             super
           end
       end
@@ -180,9 +178,7 @@ module ActiveRecord
 
         private
           def compatible_table_definition(t)
-            class << t
-              prepend TableDefinition
-            end
+            t.singleton_class.prepend(TableDefinition)
             super
           end
       end
@@ -243,9 +239,7 @@ module ActiveRecord
 
         private
           def compatible_table_definition(t)
-            class << t
-              prepend TableDefinition
-            end
+            t.singleton_class.prepend(TableDefinition)
             super
           end
       end
@@ -286,9 +280,7 @@ module ActiveRecord
 
         private
           def compatible_table_definition(t)
-            class << t
-              prepend TableDefinition
-            end
+            t.singleton_class.prepend(TableDefinition)
             super
           end
       end
@@ -334,17 +326,13 @@ module ActiveRecord
 
         private
           def compatible_table_definition(t)
-            class << t
-              prepend TableDefinition
-            end
+            t.singleton_class.prepend(TableDefinition)
             super
           end
 
           def command_recorder
             recorder = super
-            class << recorder
-              prepend CommandRecorder
-            end
+            recorder.singleton_class.prepend(CommandRecorder)
             recorder
           end
       end
@@ -432,9 +420,7 @@ module ActiveRecord
 
         private
           def compatible_table_definition(t)
-            class << t
-              prepend TableDefinition
-            end
+            t.singleton_class.prepend(TableDefinition)
             super
           end
       end
@@ -486,9 +472,7 @@ module ActiveRecord
 
         private
           def compatible_table_definition(t)
-            class << t
-              prepend TableDefinition
-            end
+            t.singleton_class.prepend(TableDefinition)
             super
           end
 

--- a/activerecord/lib/active_record/migration/compatibility.rb
+++ b/activerecord/lib/active_record/migration/compatibility.rb
@@ -32,6 +32,29 @@ module ActiveRecord
       V8_1 = Current
 
       class V8_0 < V8_1
+        module RemoveForeignKeyColumnMatch
+          def remove_foreign_key(from_table, to_table = nil, **options)
+            options[:_skip_column_match] = true
+            super
+          end
+        end
+
+        module TableDefinition
+          def remove_foreign_key(to_table = nil, **options)
+            options[:_skip_column_match] = true
+            super
+          end
+        end
+
+        include RemoveForeignKeyColumnMatch
+
+        private
+          def compatible_table_definition(t)
+            class << t
+              prepend TableDefinition
+            end
+            super
+          end
       end
 
       class V7_2 < V8_0

--- a/activerecord/test/cases/migration/compatibility_test.rb
+++ b/activerecord/test/cases/migration/compatibility_test.rb
@@ -664,6 +664,60 @@ module ActiveRecord
         end
       end
 
+      def test_remove_foreign_key_on_8_1
+        connection.create_table(:sub_testings) do |t|
+          t.references :testing, foreign_key: true, type: :bigint
+          t.references :experiment, foreign_key: { to_table: :testings }, type: :bigint
+        end
+
+        migration = Class.new(ActiveRecord::Migration[8.1]) do
+          def up
+            change_table(:sub_testings) do |t|
+              t.remove_foreign_key :testings
+              t.remove_foreign_key :testings, column: :experiment_id
+            end
+          end
+        end
+
+        ActiveRecord::Migrator.new(:up, [migration], @schema_migration, @internal_metadata).migrate
+
+        foreign_keys = @connection.foreign_keys("sub_testings")
+        assert_equal 0, foreign_keys.size
+      ensure
+        connection.drop_table(:sub_testings, if_exists: true)
+        ActiveRecord::Base.clear_cache!
+      end
+
+      def test_remove_foreign_key_on_8_0
+        connection.create_table(:sub_testings) do |t|
+          t.references :testing, foreign_key: true, type: :bigint
+          t.references :experiment, foreign_key: { to_table: :testings }, type: :bigint
+        end
+
+        migration = Class.new(ActiveRecord::Migration[8.0]) do
+          def up
+            change_table(:sub_testings) do |t|
+              t.remove_foreign_key :testings
+              t.remove_foreign_key :testings, column: :experiment_id
+            end
+          end
+        end
+
+        assert_raise(StandardError, match: /Table 'sub_testings' has no foreign key for testings$/) {
+          ActiveRecord::Migrator.new(:up, [migration], @schema_migration, @internal_metadata).migrate
+        }
+
+        foreign_keys = @connection.foreign_keys("sub_testings")
+        if current_adapter?(:PostgreSQLAdapter, :SQLite3Adapter)
+          assert_equal 2, foreign_keys.size
+        else
+          assert_equal 1, foreign_keys.size
+        end
+      ensure
+        connection.drop_table(:sub_testings, if_exists: true)
+        ActiveRecord::Base.clear_cache!
+      end
+
       private
         def precision_implicit_default
           if current_adapter?(:Mysql2Adapter, :TrilogyAdapter)


### PR DESCRIPTION
Fixes #55078

This PR has been updated to fix the behavior using 8.1 migration for backwards compatibilty.

/cc @kei-s 