### PR TITLE
:class_name should be invalid in polymorphic belongs_to

### DIFF
--- a/activerecord/lib/active_record/associations/builder/association.rb
+++ b/activerecord/lib/active_record/associations/builder/association.rb
@@ -19,7 +19,7 @@ module ActiveRecord::Associations::Builder # :nodoc:
     self.extensions = []
 
     VALID_OPTIONS = [
-      :class_name, :anonymous_class, :primary_key, :foreign_key, :dependent, :validate, :inverse_of, :strict_loading, :query_constraints
+      :anonymous_class, :primary_key, :foreign_key, :dependent, :validate, :inverse_of, :strict_loading, :query_constraints
     ].freeze # :nodoc:
 
     def self.build(model, name, scope, options, &block)

--- a/activerecord/lib/active_record/associations/builder/belongs_to.rb
+++ b/activerecord/lib/active_record/associations/builder/belongs_to.rb
@@ -8,8 +8,9 @@ module ActiveRecord::Associations::Builder # :nodoc:
 
     def self.valid_options(options)
       valid = super + [:polymorphic, :counter_cache, :optional, :default]
-      valid += [:foreign_type] if options[:polymorphic]
-      valid += [:ensuring_owner_was] if options[:dependent] == :destroy_async
+      valid << :class_name unless options[:polymorphic]
+      valid << :foreign_type if options[:polymorphic]
+      valid << :ensuring_owner_was if options[:dependent] == :destroy_async
       valid
     end
 

--- a/activerecord/lib/active_record/associations/builder/collection_association.rb
+++ b/activerecord/lib/active_record/associations/builder/collection_association.rb
@@ -7,7 +7,7 @@ module ActiveRecord::Associations::Builder # :nodoc:
     CALLBACKS = [:before_add, :after_add, :before_remove, :after_remove]
 
     def self.valid_options(options)
-      super + [:before_add, :after_add, :before_remove, :after_remove, :extend]
+      super + [:class_name, :before_add, :after_add, :before_remove, :after_remove, :extend]
     end
 
     def self.define_callbacks(model, reflection)

--- a/activerecord/lib/active_record/associations/builder/has_one.rb
+++ b/activerecord/lib/active_record/associations/builder/has_one.rb
@@ -7,7 +7,7 @@ module ActiveRecord::Associations::Builder # :nodoc:
     end
 
     def self.valid_options(options)
-      valid = super + [:as, :through]
+      valid = super + [:class_name, :as, :through]
       valid += [:foreign_type] if options[:as]
       valid += [:ensuring_owner_was] if options[:dependent] == :destroy_async
       valid += [:source, :source_type, :disable_joins] if options[:through]

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -3198,8 +3198,8 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
 
     assert_equal(<<~MESSAGE.squish, error.message)
       Unknown key: :trough. Valid keys are:
-      :class_name, :anonymous_class, :primary_key, :foreign_key, :dependent,
-      :validate, :inverse_of, :strict_loading, :query_constraints, :autosave, :before_add,
+      :anonymous_class, :primary_key, :foreign_key, :dependent, :validate, :inverse_of,
+      :strict_loading, :query_constraints, :autosave, :class_name, :before_add,
       :after_add, :before_remove, :after_remove, :extend, :counter_cache, :join_table,
       :index_errors, :as, :through
     MESSAGE

--- a/activerecord/test/models/cpk/comment.rb
+++ b/activerecord/test/models/cpk/comment.rb
@@ -3,7 +3,7 @@
 module Cpk
   class Comment < ActiveRecord::Base
     self.table_name = :cpk_comments
-    belongs_to :commentable, class_name: "Cpk::Post", foreign_key: %i[commentable_title commentable_author], polymorphic: true
-    belongs_to :post, class_name: "Cpk::Post", foreign_key: %i[commentable_title commentable_author]
+    belongs_to :commentable, foreign_key: %i[commentable_title commentable_author], polymorphic: true
+    belongs_to :post, foreign_key: %i[commentable_title commentable_author]
   end
 end

--- a/activerecord/test/models/sharded/blog_post.rb
+++ b/activerecord/test/models/sharded/blog_post.rb
@@ -5,7 +5,7 @@ module Sharded
     self.table_name = :sharded_blog_posts
     query_constraints :blog_id, :id
 
-    belongs_to :parent, class_name: name, polymorphic: true
+    belongs_to :parent, polymorphic: true
     belongs_to :blog
     has_many :comments
     has_many :delete_comments, class_name: "Sharded::Comment", dependent: :delete_all


### PR DESCRIPTION
## Rationale

_(Preliminary cleanup for a forthcoming patch that will allow users to declare the targets of polymorphic `belongs_to`.)_

In polymorphic `belongs_to`, you can customize `:foreign_type`, but setting `:class_name` makes no sense, since the class name of target records is determined at runtime from the value in the type column.

## The patch

We take `:class_name` out of the generic valid options in the parent class of association builders, and move it down to the subclasses that support it.

## Deprecating the option comes next

Interestingly, our own test suite had a few of these! That was doing nothing!

This is also telling us we should warn users. I'll followup with a deprecation in `8-0-stable`.