### PR TITLE
[ci skip] docs: pluck silently ignore select statement

### DIFF
--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -287,6 +287,11 @@ module ActiveRecord
     #   # SELECT DATEDIFF(updated_at, created_at) FROM people
     #   # => ['0', '27761', '173']
     #
+    # Be aware that #pluck ignores any previous select clauses
+    #
+    #   Person.select(:name).pluck(:id)
+    #   # SELECT people.id FROM people
+    #
     # See also #ids.
     def pluck(*column_names)
       if @none


### PR DESCRIPTION
### Motivation / Background

based on [this test](https://github.com/rails/rails/blob/main/activerecord/test/cases/calculations_test.rb#L1277) (from [this PR](https://github.com/rails/rails/pull/8176) - fixing [this issue](https://github.com/rails/rails/issues/7551)) it is expected, but it might be obscure and possibly dangerous behavior.

QUESTION: in [pluck API doc](https://github.com/rails/rails/blob/main/activerecord/lib/active_record/relation/calculations.rb#L286) there's an explicit example if you happen to require advanced select statements, is it worth to add a mention there? imo no, but please advise.

### Additional information

had a presentation to ~100 people in my company and most (almost totality) were surprised/confused, this is why I'm trying to add it to the official pluck guide