### PR TITLE
Deprecate :class_name for polymorphic belongs_to

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Passing `:class_name` to a polymorphic `belongs_to` is deprecated and it
+    will be removed in Rails 8.1.
+
+    The class name of associated records is stored in the type column. If you
+    have this option set, please just delete it.
+
+    *Xavier Noria*
+
 *   `create_or_find_by` will now correctly rollback a transaction.
 
     When using `create_or_find_by`, raising a ActiveRecord::Rollback error

--- a/activerecord/lib/active_record/associations/builder/belongs_to.rb
+++ b/activerecord/lib/active_record/associations/builder/belongs_to.rb
@@ -10,6 +10,17 @@ module ActiveRecord::Associations::Builder # :nodoc:
       valid = super + [:polymorphic, :counter_cache, :optional, :default]
       valid += [:foreign_type] if options[:polymorphic]
       valid += [:ensuring_owner_was] if options[:dependent] == :destroy_async
+
+      if options[:polymorphic] && options.key?(:class_name)
+        ActiveRecord.deprecator.warn(<<~MSG)
+          The :class_name option for polymorphic associations is deprecated
+          and it will be removed in Rails 8.1.
+
+          The class name of associated records is stored in the type column.
+          You can just delete the option.
+        MSG
+      end
+
       valid
     end
 

--- a/activerecord/test/cases/associations/belongs_to_associations_test.rb
+++ b/activerecord/test/cases/associations/belongs_to_associations_test.rb
@@ -1888,3 +1888,32 @@ class AsyncBelongsToAssociationsTest < ActiveRecord::TestCase
     end
   end
 end
+
+class DeprecatedClassNameOptionInPolymorphicBelongsToTest < ActiveRecord::TestCase
+  test "issues a deprecation for :class_name in polymorphic belongs_to" do
+    test = self
+    Class.new(ActiveRecord::Base) do
+      test.assert_deprecated(ActiveRecord.deprecator) do
+        belongs_to :foo, class_name: "Foo", polymorphic: true
+      end
+    end
+  end
+
+  test "issues no deprecation if :class_name is not passed for a polymorphic belongs_to" do
+    test = self
+    Class.new(ActiveRecord::Base) do
+      test.assert_not_deprecated(ActiveRecord.deprecator) do
+        belongs_to :foo, polymorphic: true
+      end
+    end
+  end
+
+  test "issues no deprecation if :class_name is passed for a regular belongs_to" do
+    test = self
+    Class.new(ActiveRecord::Base) do
+      test.assert_not_deprecated(ActiveRecord.deprecator) do
+        belongs_to :foo, class_name: "Foo"
+      end
+    end
+  end
+end

--- a/activerecord/test/models/cpk/comment.rb
+++ b/activerecord/test/models/cpk/comment.rb
@@ -3,7 +3,7 @@
 module Cpk
   class Comment < ActiveRecord::Base
     self.table_name = :cpk_comments
-    belongs_to :commentable, class_name: "Cpk::Post", foreign_key: %i[commentable_title commentable_author], polymorphic: true
-    belongs_to :post, class_name: "Cpk::Post", foreign_key: %i[commentable_title commentable_author]
+    belongs_to :commentable, foreign_key: %i[commentable_title commentable_author], polymorphic: true
+    belongs_to :post, foreign_key: %i[commentable_title commentable_author]
   end
 end

--- a/activerecord/test/models/sharded/blog_post.rb
+++ b/activerecord/test/models/sharded/blog_post.rb
@@ -5,7 +5,7 @@ module Sharded
     self.table_name = :sharded_blog_posts
     query_constraints :blog_id, :id
 
-    belongs_to :parent, class_name: name, polymorphic: true
+    belongs_to :parent, polymorphic: true
     belongs_to :blog
     has_many :comments
     has_many :delete_comments, class_name: "Sharded::Comment", dependent: :delete_all


### PR DESCRIPTION
This is a deprecation followup for #55089.

The option `:class_name` is invalid for polymorphic `belongs_to` in the `main` branch. This patch adds a deprecation to `8-0-stable`.