### PR TITLE
[skip ci] Add cancel button to first version of the new Product page

### DIFF
--- a/guides/source/getting_started.md
+++ b/guides/source/getting_started.md
@@ -1178,6 +1178,8 @@ Let's create `app/views/products/new.html.erb` to render the form for this new
     <%= form.submit %>
   </div>
 <% end %>
+
+<%= link_to "Cancel", products_path %>
 ```
 
 In this view, we are using the Rails `form_with` helper to generate an HTML form


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

In "Getting Started" guide, the section "Extracting Partials" introduces a cancel button in `app/views/products/new.html.erb` in addition to the code change showing how to extract a partial view. This sudden appearance of an additional button distracts slightly from the focus on the new code for partial extraction.

### Detail

To me, it feels more natural for the cancel button to appear in the first version of the new product view. That has the additional benefit of ensuring the only change needed for the Extract Partials code snippet is the actual refactoring of the form into a partial.

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

Some alternative options:
 - **Do Nothing**: It's a minor tweak that may be deemed not worthwhile. One may also believe that adding the cancel button earlier means the original form now has too many concerns for that stage of the guide.
 - **Explain the Cancel button within the Extracting Partials section**: One might prefer to introduce the cancel button alongside the partial extraction.

Personally, seeing the new button in the code snippet -- especially since it wasn't marked as a new line by the diff -- briefly knocked me out of the zone as I doubled checked to see if I had missed an earlier step in the guide. Neither of these alternatives would have prevented that disruption.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
