### PR TITLE
[skip ci] Include Action Text pins in Import Maps section

### DIFF
--- a/guides/source/getting_started.md
+++ b/guides/source/getting_started.md
@@ -2533,6 +2533,8 @@ pin "@hotwired/turbo-rails", to: "turbo.min.js"
 pin "@hotwired/stimulus", to: "stimulus.min.js"
 pin "@hotwired/stimulus-loading", to: "stimulus-loading.js"
 pin_all_from "app/javascript/controllers", under: "controllers"
+pin "trix"
+pin "@rails/actiontext", to: "actiontext.esm.js"
 ```
 
 TIP: Each pin maps a JavaScript package name (e.g., `"@hotwired/turbo-rails"`)


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

If readers work through the Getting Started guide linearly, their `config/importmap.rb` will contain two additional pins beyond those shown in the code snippet in "Import Maps" section.

The additional pins come from the prior section "Rich Text Fields with Action Text", specifically the command `bin/rails action_text:install`

### Detail

This Pull Request adds the two additional `pin`s to the `importmap.rb` in the "Import Maps" section so the snippet will match the reader's version on disk (assuming the reader had also completed the earlier "Rich Text Fields with Action Text" section).

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

Alternatively, one might sensibly prefer for the `importmap.rb` to match the one scaffolded in a new Rails project (i.e. maintain the status quo).

This wasn't a meaningful distraction for me as I worked through the guide, but it was a small inconsistency from my point of view.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
