### PR TITLE
[skip ci] Prefer `.zero?` over `== 0` to match code extracted into a concern

### DIFF
--- a/guides/source/getting_started.md
+++ b/guides/source/getting_started.md
@@ -2315,7 +2315,7 @@ module Product::Notifications
   end
 
   def back_in_stock?
-    inventory_count_previously_was == 0 && inventory_count > 0
+    inventory_count_previously_was.zero? && inventory_count > 0
   end
 
   def notify_subscribers


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

The code written in the "In Stock Email Notifications" section uses `.zero?` to check if the inventory was empty. In contrast the code snippet shown in the following section, "Extracting a Concern", changes the comparison to `== 0`.

It would be nice if the snippets were consistent one way or the other.

### Detail

This Pull Request chooses to use `.zero?` for both code snippets instead of `== 0`.

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

One may reasonably prefer to use `== 0` over `.zero?`.

I chose `.zero?` because -- to my Ruby newcomer eyes -- it appears that the Ruby community prefers code that reads like plain English. To me, `inventory_count_previously_was.zero?` reads more like English than `inventory_count_previously_was == 0`.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
