### PR TITLE
Fix #55099 allowing array syntax for expression indexes in add_index

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,19 @@
+*   Fix handling of expressions in array syntax for `add_index`.
+
+    This change allows passing expressions in array syntax for `add_index` method.
+    For example, `add_index :users, [ "lower(email)" ]` now works the same as
+    `add_index :users, "lower(email)"`.
+
+    ```ruby
+    # This now works properly:
+    add_index :users, [ "lower(email)" ]
+
+    # As does this:
+    add_index :users, [ "lower(email)", :status ]
+    ```
+
+    *Alexandre Camillo*
+
 *   Fix `strict_loading` violations ignored when using `pluck`
 
     *Johnson Chan*

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -1830,11 +1830,14 @@ module ActiveRecord
         end
 
         def index_column_names(column_names)
-          if expression_column_name?(column_names)
-            column_names
-          else
-            Array(column_names)
-          end
+          column_names = Array(column_names)
+          return column_names.join(", ") if has_expression_column_name?(column_names)
+
+          column_names
+        end
+
+        def has_expression_column_name?(column_names)
+          column_names.any? { |name| expression_column_name?(name) }
         end
 
         def index_name_options(column_names)

--- a/activerecord/test/cases/migration/index_test.rb
+++ b/activerecord/test/cases/migration/index_test.rb
@@ -321,6 +321,41 @@ module ActiveRecord
         assert_not connection.index_exists?("testings", "last_name", nulls_not_distinct: true)
       end
 
+      def test_add_index_with_expression
+        skip("current adapter does not support expression indexes") unless supports_expression_index?
+        name = "testings_index_with_expression"
+
+        connection.add_index("testings", "(lower(last_name))", name:)
+        assert connection.index_exists?("testings", name:)
+        connection.remove_index("testings", name:)
+        assert_not connection.index_exists?("testings", name:)
+      end
+
+      def test_add_index_with_expression_using_array_syntax
+        skip("current adapter does not support expression indexes") unless supports_expression_index?
+        name = "testings_index_with_expression_using_array_syntax"
+
+        connection.add_index("testings", ["(lower(last_name))"], name:)
+        assert connection.index_exists?("testings", name:)
+        connection.remove_index("testings", name:)
+        assert_not connection.index_exists?("testings", name:)
+
+        connection.add_index("testings", ["(lower(last_name))", "first_name"], name:)
+        assert connection.index_exists?("testings", name:)
+        connection.remove_index("testings", name:)
+        assert_not connection.index_exists?("testings", name:)
+
+        connection.add_index("testings", [:first_name, "(lower(last_name))"], name:)
+        assert connection.index_exists?("testings", name:)
+        connection.remove_index("testings", name:)
+        assert_not connection.index_exists?("testings", name:)
+
+        connection.add_index("testings", ["(lower(last_name))", "(upper(first_name))"], name:)
+        assert connection.index_exists?("testings", name:)
+        connection.remove_index("testings", name:)
+        assert_not connection.index_exists?("testings", name:)
+      end
+
       if ActiveRecord::Base.lease_connection.supports_disabling_indexes?
         def test_index_visibility_through_add_index
           connection.add_index(:testings, :foo, enabled: false)


### PR DESCRIPTION
Fixes #55099

### Detail

This Pull Request changes the `add_index` method to allow expression indexes using the array syntax. Until now, expression indexes required a raw SQL string, like:
```ruby
t.index 'lower(email), status'
```
With this change, developers can now use array syntax to define expression indexes more clearly and consistently, such as:
```ruby
t.index [ "lower(email)", :status ]
t.index [ "lower(email)" ]
```
It aligns better with the existing syntax for multi-column indexes.

### Notes
This is my first contribution to Rails. I’d appreciate any feedback or suggestions for improvement.