### PR TITLE
feat: set html lang attribute dynamically based on locale

### DIFF
--- a/guides/source/action_view_overview.md
+++ b/guides/source/action_view_overview.md
@@ -749,7 +749,7 @@ Here is an example of a simple layout in `application.html.erb` file:
 
 ```html+erb
 <!DOCTYPE html>
-<html>
+<html lang="<%= I18n.locale %>">
 <head>
   <title><%= "Your Rails App" %></title>
   <%= csrf_meta_tags %>

--- a/railties/lib/rails/generators/rails/app/templates/app/views/layouts/application.html.erb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/app/views/layouts/application.html.erb.tt
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="<%%= I18n.locale %>">
   <head>
     <title><%%= content_for(:title) || "<%= app_name.titleize %>" %></title>
     <meta name="viewport" content="width=device-width,initial-scale=1">

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -444,6 +444,13 @@ class AppGeneratorTest < Rails::Generators::TestCase
     assert_file "hats/config/environment.rb", /Rails\.application\.initialize!/
   end
 
+  def test_application_layout_sets_html_lang
+    run_generator [destination_root]
+    assert_file "app/views/layouts/application.html.erb" do |contents|
+      assert_match(/<html lang="<%= I18n\.locale %>">/, contents)
+    end
+  end
+
   def test_application_name_is_normalized_in_config
     run_generator [File.join(destination_root, "MyWebSite"), "-d", "postgresql"]
     assert_file "MyWebSite/app/views/layouts/application.html.erb", /content_for\(:title\) \|\| "My Web Site"/


### PR DESCRIPTION
### Motivation / Background
This Pull Request was created because a new Rails app does not follow the WCAG 2.1 rules. Specifically: "The default language of each web page cannot be found by a computer program". [See WCAG 2.1 - Language of Page](https://www.w3.org/TR/WCAG21/#language-of-page).

### Detail

This Pull Request changes `application.html.erb.tt` so that the `<html>` tag uses `lang="<%= I18n.locale %>"`.

### Additional information
The EU asks more and more every year that websites follow the WCAG 2.1 standard ([see more](https://digital-strategy.ec.europa.eu/policies/web-accessibility-directive-standards-and-harmonisation)). I don’t know the rules in other countries, but I know that in The Netherlands for example, government websites and most universities (maybe all) must use software that meets these rules, even if the software comes from other companies.

Including the `lang` tag also helps make the page better for SEO [according to Google](https://developers.google.com/search/docs/specialty/international/localized-versions#language). It is also a best practice according to [Mozilla](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/lang#best_practices). It also helps new developers like me learn to do things the right way! :-)

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
