### PR TITLE
Bump libxml-ruby to compile with GCC 15

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -346,7 +346,7 @@ GEM
     launchy (3.0.1)
       addressable (~> 2.8)
       childprocess (~> 5.0)
-    libxml-ruby (5.0.3)
+    libxml-ruby (5.0.4)
     lint_roller (1.1.0)
     listen (3.9.0)
       rb-fsevent (~> 0.10, >= 0.10.3)


### PR DESCRIPTION
Trying to compile 5.0.3 errors:

```
$ gcc --version
gcc (GCC) 15.1.1 20250425

$ bundle install
Fetching gem metadata from https://rubygems.org/.........
Installing libxml-ruby 5.0.3 with native extensions
Gem::Ext::BuildError: ERROR: Failed to build gem native extension.

    current directory: /home/hartley/.local/share/mise/installs/ruby/3.4.4/lib/ruby/gems/3.4.0/gems/libxml-ruby-5.0.3/ext/libxml
/home/hartley/.local/share/mise/installs/ruby/3.4.4/bin/ruby extconf.rb
checking for libxml/xmlversion.h in
/opt/include/libxml2,/opt/local/include/libxml2,/opt/homebrew/opt/libxml2/include/libxml2,/usr/local/include/libxml2,/usr/include/libxml2,/usr/local/include,/usr/local/opt/libxml2/include/libxml2...
yes
checking for xmlParseDoc() in -lxml2... yes
creating extconf.h
creating Makefile

current directory: /home/hartley/.local/share/mise/installs/ruby/3.4.4/lib/ruby/gems/3.4.0/gems/libxml-ruby-5.0.3/ext/libxml
make DESTDIR\= sitearchdir\=./.gem.20250522-279916-ldqtcq sitelibdir\=./.gem.20250522-279916-ldqtcq clean

current directory: /home/hartley/.local/share/mise/installs/ruby/3.4.4/lib/ruby/gems/3.4.0/gems/libxml-ruby-5.0.3/ext/libxml
make DESTDIR\= sitearchdir\=./.gem.20250522-279916-ldqtcq sitelibdir\=./.gem.20250522-279916-ldqtcq
compiling libxml.c
compiling ruby_xml.c
compiling ruby_xml_attr.c
ruby_xml_attr.c: In function ‘rxml_attr_wrap’:
ruby_xml_attr.c:45:3: warning: ‘rb_data_object_wrap_warning’ is deprecated: by TypedData [-Wdeprecated-declarations]
   45 |   return Data_Wrap_Struct(cXMLAttr, rxml_attr_mark, NULL, xattr);
      |   ^~~~~~
In file included from /home/hartley/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/core.h:27,
                 from /home/hartley/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/ruby.h:29,
                 from /home/hartley/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby.h:38,
                 from ruby_libxml.h:6,
                 from ruby_xml_attr.c:30:
/home/hartley/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/core/rdata.h:293:1: note: declared here
  293 | rb_data_object_wrap_warning(VALUE klass, void *ptr, RUBY_DATA_FUNC mark, RUBY_DATA_FUNC free)
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~~
ruby_xml_attr.c: In function ‘rxml_attr_alloc’:
ruby_xml_attr.c:50:3: warning: ‘rb_data_object_wrap_warning’ is deprecated: by TypedData [-Wdeprecated-declarations]
   50 |   return Data_Wrap_Struct(klass, rxml_attr_mark, NULL, NULL);
      |   ^~~~~~
/home/hartley/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/core/rdata.h:293:1: note: declared here
  293 | rb_data_object_wrap_warning(VALUE klass, void *ptr, RUBY_DATA_FUNC mark, RUBY_DATA_FUNC free)
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~~
ruby_xml_attr.c: In function ‘rxml_attr_initialize’:
ruby_xml_attr.c:81:3: warning: ‘rb_data_object_get_warning’ is deprecated: by TypedData [-Wdeprecated-declarations]
   81 |   Data_Get_Struct(node, xmlNode, xnode);
      |   ^~~~~~~~~~~~~~~
/home/hartley/.local/share/mise/installs/ruby/3.4.4/include/ruby-3.4.0/ruby/internal/core/rdata.h:325:1: note: declared here
  325 | rb_data_object_get_warning(VALUE obj)
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~
ruby_xml_attr.c:93:5: warning: ‘rb_data_object_get_warning’ is deprecated: by TypedData [-Wdeprecated-declarations]
   93 |     Data_Get_Struct(ns, xmlNs, xns);

...
```
