### PR TITLE
Fix broken test when using rails-dom-testing 2.3:

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -469,7 +469,7 @@ GEM
       rack (>= 1.3)
     rackup (2.2.1)
       rack (>= 3)
-    rails-dom-testing (2.2.0)
+    rails-dom-testing (2.3.0)
       activesupport (>= 5.0.0)
       minitest
       nokogiri (>= 1.6)

--- a/actionpack/test/controller/caching_test.rb
+++ b/actionpack/test/controller/caching_test.rb
@@ -414,7 +414,7 @@ class CollectionCacheTest < ActionController::TestCase
 
     get :index_ordered
     assert_equal 3, @controller.partial_rendered_times
-    assert_select ":root", "david, 1\n  david, 2\n  david, 3"
+    assert_select ":root", html: "<body><p>david, 1\n  david, 2\n  david, 3\n\n</p></body>"
   end
 
   def test_explicit_render_call_with_options


### PR DESCRIPTION
### Motivation / Background

Fix #55093 (cc/ @yahonda)

### Detail

The new version of dom testing now strip whitespaces when making a `text` assertion (See https://github.com/rails/rails-dom-testing/pull/123). Changing to an html assertion to preserve the previous behaviour and make the test pass on rails-dom-testing 2.3

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
