### PR TITLE
Document through + polymorphic

### DIFF
--- a/activerecord/lib/active_record/associations.rb
+++ b/activerecord/lib/active_record/associations.rb
@@ -1208,8 +1208,10 @@ module ActiveRecord
         # [+:as+]
         #   Specifies a polymorphic interface (See #belongs_to).
         # [+:through+]
-        #   Specifies an association through which to perform the query. This can be any other type
-        #   of association, including other <tt>:through</tt> associations. Options for <tt>:class_name</tt>,
+        #   Specifies an association through which to perform the query.
+        #
+        #   This can be any other type of association, including other <tt>:through</tt> associations,
+        #   but it cannot be a polymorphic association. Options for <tt>:class_name</tt>,
         #   <tt>:primary_key</tt> and <tt>:foreign_key</tt> are ignored, as the association uses the
         #   source reflection.
         #
@@ -1411,10 +1413,12 @@ module ActiveRecord
         # [+:as+]
         #   Specifies a polymorphic interface (See #belongs_to).
         # [+:through+]
-        #   Specifies a Join Model through which to perform the query. Options for <tt>:class_name</tt>,
-        #   <tt>:primary_key</tt>, and <tt>:foreign_key</tt> are ignored, as the association uses the
-        #   source reflection. You can only use a <tt>:through</tt> query through a #has_one
-        #   or #belongs_to association on the join model.
+        #   Specifies an association through which to perform the query.
+        #
+        #   This can be any other type of association, including other <tt>:through</tt> associations,
+        #   but it cannot be a polymorphic association. Options for <tt>:class_name</tt>, <tt>:primary_key</tt>,
+        #   and <tt>:foreign_key</tt> are ignored, as the association uses the source reflection. You can only
+        #   use a <tt>:through</tt> query through a #has_one or #belongs_to association on the join model.
         #
         #   If the association on the join model is a #belongs_to, the collection can be modified
         #   and the records on the <tt>:through</tt> model will be automatically created and removed

--- a/guides/source/association_basics.md
+++ b/guides/source/association_basics.md
@@ -953,7 +953,7 @@ object, use the `collection.build` method.
 A [`has_many :through`][`has_many`] association is often used to set up a
 many-to-many relationship with another model. This association indicates that
 the declaring model can be matched with zero or more instances of another model
-by proceeding _through_ a third model.
+by proceeding _through_ an intermediate "join" model.
 
 For example, consider a medical practice where patients make appointments to see
 physicians. The relevant association declarations could look like this:
@@ -1011,6 +1011,9 @@ In this migration the `physicians` and `patients` tables are created with a
 `name` column. The `appointments` table, which acts as the join table, is
 created with `physician_id` and `patient_id` columns, establishing the
 many-to-many relationship between `physicians` and `patients`.
+
+INFO: The through association can be any type of association, including other
+through associations, but it cannot be a polymorphic association.
 
 You could also consider using a [composite primary
 key](active_record_composite_primary_keys.html) for the join table in the
@@ -1149,6 +1152,9 @@ class CreateAccountHistories < ActiveRecord::Migration[8.1]
   end
 end
 ```
+
+INFO: The through association can be any type of association, including other
+through associations, but it cannot be a polymorphic association.
 
 ### `has_and_belongs_to_many`
 


### PR DESCRIPTION
Documents that polymorphic associations are not allowed as through associations.

If you try to set a polymorphic as through, Active Record [raises](https://github.com/rails/rails/blob/6e4a09efdbb43fb965b3f9a414ee2f4877ce07f0/activerecord/lib/active_record/reflection.rb#L1149-L1155) when the reflection is validated. Those exceptions are undocumented. I think we do not need to make them public, at least without a use case. Stating that is an error condition may suffice.