### PR TITLE
Update the `db:postgresql:drop` and `db:postgresql:build` Rake tasks

### DIFF
--- a/activerecord/Rakefile
+++ b/activerecord/Rakefile
@@ -258,18 +258,34 @@ namespace :db do
   end
 
   namespace :postgresql do
+    config = ARTest.config["connections"]["postgresql"]
+    postgres_connection_arguments = lambda do |connection|
+      [
+        ("-h #{connection["host"]}" if connection["host"]),
+        ("-h #{connection["socket"]}" if connection["socket"]),
+        ("-U #{connection["username"]}" if connection["username"]),
+        ("-p #{connection["port"]}" if connection["port"]),
+      ].join(" ")
+    end
+    env_variables = lambda do |connection|
+      [
+        ("PGPASSWORD=#{connection["password"]}" if connection["password"]),
+      ].join(" ")
+    end
+    postgres_configs = ["arunit", "arunit2"].map { |db| config[db] }
+
     desc "Build the PostgreSQL test databases"
     task :build do
-      config = ARTest.config["connections"]["postgresql"]
-      %x( createdb -E UTF8 -T template0 #{config["arunit"]["database"]} --lc-collate en_US.UTF-8 )
-      %x( createdb -E UTF8 -T template0 #{config["arunit2"]["database"]} --lc-collate en_US.UTF-8 )
+      postgres_configs.each do |connection|
+        %x( #{env_variables[connection]} createdb -E UTF8 -T template0 #{connection["database"]} #{postgres_connection_arguments[connection]} --lc-collate en_US.UTF-8 )
+      end
     end
 
     desc "Drop the PostgreSQL test databases"
     task :drop do
-      config = ARTest.config["connections"]["postgresql"]
-      %x( dropdb --if-exists #{config["arunit"]["database"]} )
-      %x( dropdb --if-exists #{config["arunit2"]["database"]} )
+      postgres_configs.each do |connection|
+        %x( #{env_variables[connection]} dropdb --if-exists #{connection["database"]} #{postgres_connection_arguments[connection]} )
+      end
     end
 
     desc "Rebuild the PostgreSQL test databases"

--- a/activerecord/test/config.example.yml
+++ b/activerecord/test/config.example.yml
@@ -73,11 +73,47 @@ connections:
 
   postgresql:
     arunit:
+      <% if ENV['POSTGRES_USER'] %>
+        username: <%= ENV['POSTGRES_USER'] %>
+      <% end %>
+      <% if ENV['POSTGRES_HOST'] %>
+        host: <%= ENV['POSTGRES_HOST'] %>
+      <% end %>
+      <% if ENV['POSTGRES_PORT'] %>
+        port: <%= ENV['POSTGRES_PORT'] %>
+      <% end %>
+      <% if ENV['POSTGRES_SOCK'] %>
+        socket: "<%= ENV['POSTGRES_SOCK'] %>"
+      <% end %>
       min_messages: warning
     arunit_without_prepared_statements:
+      <% if ENV['POSTGRES_USER'] %>
+        username: <%= ENV['POSTGRES_USER'] %>
+      <% end %>
+      <% if ENV['POSTGRES_HOST'] %>
+        host: <%= ENV['POSTGRES_HOST'] %>
+      <% end %>
+      <% if ENV['POSTGRES_PORT'] %>
+        port: <%= ENV['POSTGRES_PORT'] %>
+      <% end %>
+      <% if ENV['POSTGRES_SOCK'] %>
+        socket: "<%= ENV['POSTGRES_SOCK'] %>"
+      <% end %>
       min_messages: warning
       prepared_statements: false
     arunit2:
+      <% if ENV['POSTGRES_USER'] %>
+        username: <%= ENV['POSTGRES_USER'] %>
+      <% end %>
+      <% if ENV['POSTGRES_HOST'] %>
+        host: <%= ENV['POSTGRES_HOST'] %>
+      <% end %>
+      <% if ENV['POSTGRES_PORT'] %>
+        port: <%= ENV['POSTGRES_PORT'] %>
+      <% end %>
+      <% if ENV['POSTGRES_SOCK'] %>
+        socket: "<%= ENV['POSTGRES_SOCK'] %>"
+      <% end %>
       min_messages: warning
 
   sqlite3:


### PR DESCRIPTION
This Pull Request addresses an issue I encountered when trying to create a PostgreSQL database for testing Active Record. The following commands fail to successfully build the database:
```
cd activerecord
bundle exec rake db:postgresql:build
```

### Detail
The `db:postgresql:build` task uses default connection parameters to connect to the PostgreSQL database. For example, when PostgreSQL is running inside a Docker container, the task attempts to connect via a Unix socket, which may not be available.

This Pull Request updates the `db:postgresql:drop` and `db:postgresql:build` Rake tasks to respect the configuration specified in the `activerecord/test/config.yml` file.


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why.
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
