### PR TITLE
Fix docs of has_one :through associations

### DIFF
--- a/activerecord/lib/active_record/associations.rb
+++ b/activerecord/lib/active_record/associations.rb
@@ -1415,8 +1415,8 @@ module ActiveRecord
         # [+:through+]
         #   Specifies an association through which to perform the query.
         #
-        #   This can be any other type of association, including other <tt>:through</tt> associations,
-        #   but it cannot be a polymorphic association. Options for <tt>:class_name</tt>, <tt>:primary_key</tt>,
+        #   The through association must be a `has_one`, `has_one :through`, or non-polymorphic `belongs_to`.
+        #   That is, a non-polymorphic singular association. Options for <tt>:class_name</tt>, <tt>:primary_key</tt>,
         #   and <tt>:foreign_key</tt> are ignored, as the association uses the source reflection. You can only
         #   use a <tt>:through</tt> query through a #has_one or #belongs_to association on the join model.
         #

--- a/guides/source/association_basics.md
+++ b/guides/source/association_basics.md
@@ -1160,9 +1160,10 @@ class CreateAccountHistories < ActiveRecord::Migration[8.1]
 end
 ```
 
-INFO: The through association can be any type of association, including other
-through associations, but it cannot be [polymorphic](#polymorphic-associations).
-Source associations can be polymorphic as long as you provide a source type.
+INFO: The through association must be a `has_one`, `has_one :through`, or
+non-polymorphic `belongs_to`. That is, a non-polymorphic singular association.
+On the other hand, source associations can be polymorphic as long as you provide
+a source type.
 
 ### `has_and_belongs_to_many`
 


### PR DESCRIPTION
You cannot set "any" type of association as a through of a `has_one :through`. Setting a collection association is an [error condition](https://github.com/rails/rails/blob/afad9209387e68f889df6d79bdd65f6385f07324/activerecord/lib/active_record/reflection.rb#L1169-L1171).