### PR TITLE
Memoize successful reflection cache validation

### DIFF
--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -520,6 +520,8 @@ module ActiveRecord
 
       def initialize(name, scope, options, active_record)
         super
+
+        @validated = false
         @type = -(options[:foreign_type]&.to_s || "#{options[:as]}_type") if options[:as]
         @foreign_type = -(options[:foreign_type]&.to_s || "#{name}_type") if options[:polymorphic]
         @join_table = nil
@@ -620,6 +622,8 @@ module ActiveRecord
       end
 
       def check_validity!
+        return if @validated
+
         check_validity_of_inverse!
 
         if !polymorphic? && (klass.composite_primary_key? || active_record.composite_primary_key?)
@@ -629,6 +633,8 @@ module ActiveRecord
             raise CompositePrimaryKeyMismatchError.new(self)
           end
         end
+
+        @validated = true
       end
 
       def check_eager_loadable!
@@ -979,6 +985,8 @@ module ActiveRecord
 
       def initialize(delegate_reflection)
         super()
+
+        @validated = false
         @delegate_reflection = delegate_reflection
         @klass = delegate_reflection.options[:anonymous_class]
         @source_reflection_name = delegate_reflection.options[:source]
@@ -1142,6 +1150,8 @@ module ActiveRecord
       end
 
       def check_validity!
+        return if @validated
+
         if through_reflection.nil?
           raise HasManyThroughAssociationNotFoundError.new(active_record, self)
         end
@@ -1179,6 +1189,8 @@ module ActiveRecord
         end
 
         check_validity_of_inverse!
+
+        @validated = true
       end
 
       def constraints


### PR DESCRIPTION
Association reflections are objects that store metadata about an association.

Once an association has been defined, it is all set, the association cannot be mutated, and the reflection should not be mutated either (though, technically, Active Record does not freeze the related state, something I might look at later).

Associations are lazy, to delay accessing models as much as possible. In particular, the validity of the association is not checked when the macro is processed, but later on when/if the association is used in one particular record, for every record. That is why association initializers have `reflection.check_validity!` calls ([here](https://github.com/rails/rails/blob/ca372893014050ace4c7f58eade51772ab810fa6/activerecord/lib/active_record/associations/association.rb#L42)).

But this is overkill, because that means that for every instantiated record and every association accessed in that record, the corresponding reflection is validated again, and again. However, one time should suffice!

With everything being so lazy, I don't quite see some class-level spot in which to validate the reflections. But, at least, we can memoize the reflection validation if it was successful. This is what this patch does.

I benchmarked

```ruby
Author.new.posts
```

and the speedup is about 6%.