### PR TITLE
Remove unnecessary `ruby-version` input from `ruby/setup-ruby`

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Remove unnecessary `ruby-version` input from `ruby/setup-ruby`
+
+    *TangRufus*
+
 *   Add --reset option to bin/setup which will call db:reset as part of the setup.
 
     *DHH*

--- a/railties/lib/rails/generators/rails/app/templates/github/ci.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/github/ci.yml.tt
@@ -17,7 +17,6 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: .ruby-version
           bundler-cache: true
 
       - name: Scan for common Rails security vulnerabilities using static analysis
@@ -38,7 +37,6 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: .ruby-version
           bundler-cache: true
 
       - name: Scan for security vulnerabilities in JavaScript dependencies
@@ -57,7 +55,6 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: .ruby-version
           bundler-cache: true
 
       - name: Prepare RuboCop cache
@@ -125,7 +122,6 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: .ruby-version
           bundler-cache: true
       <%- if using_bun? -%>
 
@@ -199,7 +195,6 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: .ruby-version
           bundler-cache: true
       <%- if using_bun? -%>
 


### PR DESCRIPTION
### Detail

Remove unnecessary `ruby-version` input from the `ruby/setup-ruby` action when generating new Rails app.

### Motivation

One less step when switching to other version files, e.g: `.tool-versions` & `mise.toml`.

### Additional information

> If the ruby-version input is not specified, .ruby-version is tried first, followed by .tool-versions, followed by mise.toml
>
> -- [`ruby/setup-ruby` readme](https://github.com/ruby/setup-ruby/blob/13e7a03dc3ac6c3798f4570bfead2aed4d96abfb/README.md#L148)

Code: https://github.com/ruby/setup-ruby/blob/13e7a03dc3ac6c3798f4570bfead2aed4d96abfb/index.js#L107-L110

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
