### PR TITLE
Freeze reflection options after validation

### DIFF
--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -634,6 +634,7 @@ module ActiveRecord
           end
         end
 
+        options.freeze
         @validated = true
       end
 
@@ -1190,6 +1191,7 @@ module ActiveRecord
 
         check_validity_of_inverse!
 
+        options.freeze
         @validated = true
       end
 

--- a/activerecord/test/cases/reflection_test.rb
+++ b/activerecord/test/cases/reflection_test.rb
@@ -708,6 +708,23 @@ class ReflectionTest < ActiveRecord::TestCase
     end
   end
 
+  test "association reflection options are frozen after successful validation" do
+    reflection = ActiveRecord::Reflection.create(:has_many, :posts, nil, { dependent: :destroy }, Author)
+
+    assert_not_predicate reflection.options, :frozen?
+    reflection.check_validity!
+    assert_predicate reflection.options, :frozen?
+  end
+
+  test "through reflection options are frozen after successful validation" do
+    reflection = ActiveRecord::Reflection.create(:has_many, :comments, nil, { through: :posts }, Author)
+
+    assert_predicate reflection, :through_reflection?
+    assert_not_predicate reflection.options, :frozen?
+    reflection.check_validity!
+    assert_predicate reflection.options, :frozen?
+  end
+
   private
     def assert_reflection(klass, association, options)
       assert reflection = klass.reflect_on_association(association)


### PR DESCRIPTION
This is a followup to #55115.

Reflections hold the metadata that describes one particular association.

Since we now memoize a successful validation status, it makes sense to freeze the options. This is also aligned with the idea that associations are not meant to be mutable objects anyway.
