### PR TITLE
Add System test support in session test helper

### DIFF
--- a/railties/lib/rails/generators/rails/authentication/templates/test/test_helpers/session_test_helper.rb.tt
+++ b/railties/lib/rails/generators/rails/authentication/templates/test/test_helpers/session_test_helper.rb.tt
@@ -4,7 +4,12 @@ module SessionTestHelper
 
     ActionDispatch::TestRequest.create.cookie_jar.tap do |cookie_jar|
       cookie_jar.signed[:session_id] = Current.session.id
-      cookies[:session_id] = cookie_jar[:session_id]
+      if defined?(ApplicationSystemTestCase) && is_a?(ApplicationSystemTestCase)
+        visit new_session_url unless page.current_url.start_with?("http")
+        page.driver.browser.manage.add_cookie(name: :session_id, value: cookie_jar[:session_id], sameSite: :Lax, httpOnly: true)
+      else
+        cookies[:session_id] = cookie_jar[:session_id]
+      end
     end
   end
 


### PR DESCRIPTION
### Motivation / Background

The new SessionTestHelper from #53708 is accessible in system tests but does not work since there is no direct access to cookies. 

Users will find this confusing, so this PR updates the method to also work for system tests.

### Detail

This uses Lewis Buckley's approach for setting cookies directly in the browser.
https://world.hey.com/lewis/faster-rails-system-tests-f01df53b

### Additional information

There might be a cleaner way of doing this than introducing a conditional if anyone has improvements to suggest there.

The visit to a URL (in this case `new_session_url` from the generator) is required so the browser is on the correct domain. Chrome defaults to opening a tab at `data:,` which doesn't allow setting the cookie on the other domain. We can skip this if the browser is already loaded.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
