### PR TITLE
Freeze instance of current attributes

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -201,4 +201,6 @@
 
     *Jonathan del Strother*
 
+*   Freeze instances of `ActiveSupport::CurrentAttributes` to prevent assignment of custom instance variables, which would cause global state to be leaked across requests.
+
 Please check [8-0-stable](https://github.com/rails/rails/blob/8-0-stable/activesupport/CHANGELOG.md) for previous changes.

--- a/activesupport/lib/active_support/current_attributes.rb
+++ b/activesupport/lib/active_support/current_attributes.rb
@@ -100,7 +100,7 @@ module ActiveSupport
     class << self
       # Returns singleton instance for this class in this thread. If none exists, one is created.
       def instance
-        current_instances[current_instances_key] ||= new
+        current_instances[current_instances_key] ||= new.freeze
       end
 
       # Declares one or more attributes that will be given both class and instance accessor methods.
@@ -228,7 +228,7 @@ module ActiveSupport
     # Reset all attributes. Should be called before and after actions, when used as a per-request singleton.
     def reset
       run_callbacks :reset do
-        self.attributes = resolve_defaults
+        @attributes.replace(resolve_defaults)
       end
     end
 

--- a/activesupport/test/current_attributes_test.rb
+++ b/activesupport/test/current_attributes_test.rb
@@ -46,6 +46,10 @@ class CurrentAttributesTest < ActiveSupport::TestCase
       hash
     end
 
+    def mutate
+      @mutated = true
+    end
+
     def respond_to_test; end
 
     def request
@@ -306,5 +310,11 @@ class CurrentAttributesTest < ActiveSupport::TestCase
 
     assert_equal [], current.method(:attr).parameters
     assert_equal [[:req, :value]], current.method(:attr=).parameters
+  end
+
+  test "cannot be mutated" do
+    assert_raises(FrozenError) do
+      Current.mutate
+    end
   end
 end


### PR DESCRIPTION
### Motivation / Background

We used additional memoization inside our current attributes subclass, setting a custom instance variable, which caused the instance variable to persist across requests instead of being reset, resulting in serious issues in our app.

### Detail

This prevents setting custom instance variables inside current attributes, which would necessarily lead to global state being leaked across requests. It does so by freezing the instance.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
