### PR TITLE
Active Job Continuations

### DIFF
--- a/activejob/CHANGELOG.md
+++ b/activejob/CHANGELOG.md
@@ -1,3 +1,42 @@
+*   Allow jobs to the interrupted and resumed with Continuations
+
+    A job can use Continuations by including the `ActiveJob::Continuable`
+    concern. Continuations split jobs into steps. When the queuing system
+    is shutting down jobs can be interrupted and their progress saved.
+
+    ```ruby
+    class ProcessImportJob
+      include ActiveJob::Continuable
+
+      def perform(import_id)
+        @import = Import.find(import_id)
+
+        # block format
+        step :initialize do
+          @import.initialize
+        end
+
+        # step with cursor, the cursor is saved when the job is interrupted
+        step :process do |step|
+          @import.records.find_each(start: step.cursor) do |record|
+            record.process
+            step.advance! from: record.id
+          end
+        end
+
+        # method format
+        step :finalize
+
+        private
+          def finalize
+            @import.finalize
+          end
+      end
+    end
+    ```
+
+    *Donal McBreen*
+
 *   Defer invocation of ActiveJob enqueue callbacks until after commit when
     `enqueue_after_transaction_commit` is enabled.
 

--- a/activejob/README.md
+++ b/activejob/README.md
@@ -95,6 +95,10 @@ their gem, or as a stand-alone gem. For discussion about this see the
 following PRs: [23311](https://github.com/rails/rails/issues/23311#issuecomment-176275718),
 [21406](https://github.com/rails/rails/pull/21406#issuecomment-138813484), and [#32285](https://github.com/rails/rails/pull/32285).
 
+## Continuations
+
+Continuations allow jobs to be interrupted and resumed. See more at ActiveJob::Continuation.
+
 
 ## Download and installation
 

--- a/activejob/lib/active_job.rb
+++ b/activejob/lib/active_job.rb
@@ -41,6 +41,7 @@ module ActiveJob
   autoload :SerializationError, "active_job/arguments"
   autoload :UnknownJobClassError, "active_job/core"
   autoload :EnqueueAfterTransactionCommit
+  autoload :Continuation
 
   eager_autoload do
     autoload :Serializers

--- a/activejob/lib/active_job/continuable.rb
+++ b/activejob/lib/active_job/continuable.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+module ActiveJob
+  # = Active Job Continuable
+  #
+  # Mix ActiveJob::Continuable into your job to enable continuations.
+  #
+  # See +ActiveJob::Continuation+ for usage. # The Continuable module provides the ability to track the progress of your jobs,
+  # and continue from where they left off if interrupted.
+  #
+  module Continuable
+    extend ActiveSupport::Concern
+
+    CONTINUATION_KEY = "continuation"
+
+    included do
+      retry_on Continuation::Interrupt, attempts: :unlimited
+      retry_on Continuation::AfterAdvancingError, attempts: :unlimited
+
+      around_perform :continue
+    end
+
+    def step(step_name, start: nil, &block)
+      continuation.step(step_name, start: start) do |step|
+        if block_given?
+          block.call(step)
+        else
+          step_method = method(step_name)
+
+          raise ArgumentError, "Step method '#{step_name}' must accept 0 or 1 arguments" if step_method.arity > 1
+
+          if step_method.parameters.any? { |type, name| type == :key || type == :keyreq }
+            raise ArgumentError, "Step method '#{step_name}' must not accept keyword arguments"
+          end
+
+          step_method.arity == 0 ? step_method.call : step_method.call(step)
+        end
+      end
+    end
+
+    def serialize
+      super.merge(CONTINUATION_KEY => continuation.to_h)
+    end
+
+    def deserialize(job_data)
+      super
+      @continuation = Continuation.new(self, job_data.fetch(CONTINUATION_KEY, {}))
+    end
+
+    private
+      def continuation
+        @continuation ||= Continuation.new(self, {})
+      end
+
+      def continue(&block)
+        continuation.continue(&block)
+      end
+  end
+end

--- a/activejob/lib/active_job/continuation.rb
+++ b/activejob/lib/active_job/continuation.rb
@@ -1,0 +1,321 @@
+# frozen_string_literal: true
+
+require "active_support/core_ext/numeric/time"
+require "active_job/continuable"
+
+module ActiveJob
+  # = Active Job \Continuation
+  #
+  # Continuations provide a mechanism for interrupting and resuming jobs. This allows
+  # long-running jobs to make progress across application restarts.
+  #
+  # Jobs should include the ActiveJob::Continuable module to enable continuations.
+  # \Continuable jobs are automatically retried when interrupted.
+  #
+  # Use the +step+ method to define the steps in your job. Steps can use an optional
+  # cursor to track progress in the step.
+  #
+  # Steps are executed as soon as they are encountered. If a job is interrupted, previously
+  # completed steps will be skipped. If a step is in progress, it will be resumed
+  # with the last recorded cursor.
+  #
+  # Code that is not part of a step will be executed on each job run.
+  #
+  # You can pass a block or a method name to the step method. The block will be called with
+  # the step object as an argument. Methods can either take no arguments or a single argument
+  # for the step object.
+  #
+  #   class ProcessImportJob < ApplicationJob
+  #     include ActiveJob::Continuable
+  #
+  #     def perform(import_id)
+  #       # This always runs, even if the job is resumed.
+  #       @import = Import.find(import_id)
+  #
+  #       step :validate do
+  #         @import.validate!
+  #       end
+  #
+  #       step(:process_records) do |step|
+  #         @import.records.find_each(start: step.cursor)
+  #           record.process
+  #           step.advance! from: record.id
+  #         end
+  #       end
+  #
+  #       step :reprocess_records
+  #       step :finalize
+  #     end
+  #
+  #     def reprocess_records(step)
+  #       @import.records.find_each(start: step.cursor)
+  #         record.reprocess
+  #         step.advance! from: record.id
+  #       end
+  #     end
+  #
+  #     def finalize
+  #       @import.finalize!
+  #     end
+  #   end
+  #
+  # === Cursors
+  #
+  # Cursors are used to track progress within a step. The cursor can be any object that is
+  # serializable as an argument to +ActiveJob::Base.serialize+. It defaults to +nil+.
+  #
+  # When a step is resumed, the last cursor value is restored. The code in the step is responsible
+  # for using the cursor to continue from the right point.
+  #
+  # +set!+ sets the cursor to a specific value.
+  #
+  #   step :iterate_items do |step|
+  #     items[step.cursor..].each do |item|
+  #       process(item)
+  #       step.set! (step.cursor || 0) + 1
+  #     end
+  #   end
+  #
+  # An starting value for the cursor can be set when defining the step:
+  #
+  #   step :iterate_items, start: 0 do |step|
+  #     items[step.cursor..].each do |item|
+  #       process(item)
+  #       step.set! step.cursor + 1
+  #     end
+  #   end
+  #
+  # The cursor can be advanced with +advance!+. This calls +succ+ on the current cursor value.
+  # It raises an ActiveJob::Continuation::UnadvanceableCursorError if the cursor does not implement +succ+.
+  #
+  #   step :iterate_items, start: 0 do |step|
+  #     items[step.cursor..].each do |item|
+  #       process(item)
+  #       step.advance!
+  #     end
+  #   end
+  #
+  # You can optionally pass a +from+ argument to +advance!+. This is useful when iterating
+  # over a collection of records where IDs may not be contiguous.
+  #
+  #   step :process_records do |step|
+  #     import.records.find_each(start: step.cursor)
+  #       record.process
+  #       step.advance! from: record.id
+  #     end
+  #   end
+  #
+  # You can use an array to iterate over nested records:
+  #
+  #   step :process_nested_records, start: [ 0, 0 ] do |step|
+  #     Account.find_each(start: step.cursor[0]) do |account|
+  #       account.records.find_each(start: step.cursor[1]) do |record|
+  #         record.process
+  #         step.set! [ account.id, record.id + 1 ]
+  #       end
+  #       step.set! [ account.id + 1, 0 ]
+  #     end
+  #   end
+  #
+  # Setting or advancing the cursor creates a checkpoint. You can also create a checkpoint
+  # manually by calling the +checkpoint!+ method on the step. This is useful if you want to
+  # allow interruptions, but don't need to update the cursor.
+  #
+  #   step :destroy_records do |step|
+  #     import.records.find_each do |record|
+  #       record.destroy!
+  #       step.checkpoint!
+  #     end
+  #   end
+  #
+  # === Checkpoints
+  #
+  # A checkpoint is where a job can be interrupted. At a checkpoint the job will call
+  # +queue_adapter.stopping?+. If it returns true, the job will raise an
+  # ActiveJob::Continuation::Interrupt exception.
+  #
+  # There is an automatic checkpoint at the end of each step. Within a step one is
+  # created when calling +set!+, +advance!+ or +checkpoint!+.
+  #
+  # Jobs are not automatically interrupted when the queue adapter is marked as stopping - they
+  # will continue to run either until the next checkpoint, or when the process is stopped.
+  #
+  # This is to allow jobs to be interrupted at a safe point, but it also means that the jobs
+  # should checkpoint more frequently than the shutdown timeout to ensure a graceful restart.
+  #
+  # When interrupted, the job will automatically retry with the progress serialized
+  # in the job data under the +continuation+ key.
+  #
+  # The serialized progress contains:
+  # - a list of the completed steps
+  # - the current step and its cursor value (if one is in progress)
+  #
+  # === Errors
+  #
+  # If a job raises an error and is not retried via Active Job, it will be passed back to the underlying
+  # queue backend and any progress in this execution will be lost.
+  #
+  # To mitigate this, the job will be automatically retried if it raises an error after it has made progress.
+  # Making progress is defined as having completed a step or advanced the cursor within the current step.
+  #
+  class Continuation
+    extend ActiveSupport::Autoload
+
+    autoload :Step
+
+    # Raised when a job is interrupted, allowing Active Job to requeue it.
+    # This inherits from +Exception+ rather than +StandardError+, so it's not
+    # caught by normal exception handling.
+    class Interrupt < Exception; end
+
+    # Base error class for all Continuation errors.
+    class Error < StandardError; end
+
+    # Raised when a step is invalid.
+    class InvalidStepError < Error; end
+
+    # Raised when attempting to advance a cursor that doesn't implement `succ`.
+    class UnadvanceableCursorError < Error; end
+
+    # Raised when an error occurs after a job has made progress.
+    #
+    # The job will be automatically retried to ensure that the progress is serialized
+    # in the retried job.
+    class AfterAdvancingError < Error; end
+
+    def initialize(job, serialized_progress)
+      @job = job
+      @completed = serialized_progress.fetch("completed", []).map(&:to_sym)
+      @current = new_step(*serialized_progress["current"], resumed: true) if serialized_progress.key?("current")
+      @encountered_step_names = []
+      @advanced = false
+      @running_step = false
+    end
+
+    def continue(&block)
+      wrapping_errors_after_advancing do
+        instrument_job :resume if started?
+        block.call
+      end
+    end
+
+    def step(name, start:, &block)
+      validate_step!(name)
+
+      if completed?(name)
+        skip_step(name)
+      else
+        run_step(name, start: start, &block)
+      end
+    end
+
+    def to_h
+      {
+        "completed" => completed.map(&:to_s),
+        "current" => current&.to_a
+      }.compact
+    end
+
+    def description
+      if current
+        current.description
+      elsif completed.any?
+        "after '#{completed.last}'"
+      else
+        "not started"
+      end
+    end
+
+    private
+      attr_reader :job, :encountered_step_names, :completed, :current
+
+      def advanced?
+        @advanced
+      end
+
+      def running_step?
+        @running_step
+      end
+
+      def started?
+        completed.any? || current.present?
+      end
+
+      def completed?(name)
+        completed.include?(name)
+      end
+
+      def validate_step!(name)
+        raise InvalidStepError, "Step '#{name}' must be a Symbol, found '#{name.class}'" unless name.is_a?(Symbol)
+        raise InvalidStepError, "Step '#{name}' has already been encountered" if encountered_step_names.include?(name)
+        raise InvalidStepError, "Step '#{name}' is nested inside step '#{current.name}'" if running_step?
+        raise InvalidStepError, "Step '#{name}' found, expected to resume from '#{current.name}'" if current && current.name != name && !completed?(name)
+
+        encountered_step_names << name
+      end
+
+      def new_step(*args, **options)
+        Step.new(*args, **options) { checkpoint! }
+      end
+
+      def skip_step(name)
+        instrument :step_skipped, step: name
+      end
+
+      def run_step(name, start:, &block)
+        @running_step = true
+        @current ||= new_step(name, start, resumed: false)
+
+        instrumenting_step(current) do
+          block.call(current)
+        end
+
+        @completed << current.name
+        @current = nil
+        @advanced = true
+
+        checkpoint!
+      ensure
+        @running_step = false
+        @advanced ||= current&.advanced?
+      end
+
+      def interrupt!
+        instrument_job :interrupt
+        raise Interrupt, "Interrupted #{description}"
+      end
+
+      def checkpoint!
+        interrupt! if job.queue_adapter.stopping?
+      end
+
+      def wrapping_errors_after_advancing(&block)
+        block.call
+      rescue StandardError => e
+        if !e.is_a?(Error) && advanced?
+          raise AfterAdvancingError, "Advanced job failed with error: #{e.message}"
+        else
+          raise
+        end
+      end
+
+      def instrumenting_step(step, &block)
+        instrument (step.resumed? ? :step_resumed : :step_started), step: step
+
+        block.call
+
+        instrument :step_completed, step: step
+      rescue Interrupt
+        instrument :step_interrupted, step: step
+        raise
+      end
+
+      def instrument_job(event)
+        instrument event, description: description, completed_steps: completed, current_step: current
+      end
+
+      def instrument(event, payload = {})
+        job.send(:instrument, event, **payload)
+      end
+  end
+end

--- a/activejob/lib/active_job/continuation/step.rb
+++ b/activejob/lib/active_job/continuation/step.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+module ActiveJob
+  class Continuation
+    # = Active Job Continuation Step
+    #
+    # Represents a step within a continuable job.
+    #
+    # When a step is completed, it is recorded in the job's continuation state.
+    # If the job is interrupted, it will be resumed from after the last completed step.
+    #
+    # Steps also have an optional cursor that can be used to track progress within the step.
+    # If a job is interrupted during a step, the cursor will be saved and passed back when
+    # the job is resumed.
+    #
+    # It is the responsibility of the code in the step to use the cursor correctly to resume
+    # from where it left off.
+    class Step
+      # The name of the step.
+      attr_reader :name
+
+      # The cursor for the step.
+      attr_reader :cursor
+
+      def initialize(name, cursor, resumed:, &checkpoint_callback)
+        @name = name.to_sym
+        @initial_cursor = cursor
+        @cursor = cursor
+        @resumed = resumed
+        @checkpoint_callback = checkpoint_callback
+      end
+
+      # Check if the job should be interrupted, and if so raise an Interrupt exception.
+      # The job will be requeued for retry.
+      def checkpoint!
+        checkpoint_callback.call
+      end
+
+      # Set the cursor and interrupt the job if necessary.
+      def set!(cursor)
+        @cursor = cursor
+        checkpoint!
+      end
+
+      # Advance the cursor from the current or supplied value
+      #
+      # The cursor will be advanced by calling the +succ+ method on the cursor.
+      # An UnadvanceableCursorError error will be raised if the cursor does not implement +succ+.
+      def advance!(from: nil)
+        from = cursor if from.nil?
+        raise UnadvanceableCursorError, "Cursor class '#{from.class}' does not implement succ, " unless from.respond_to?(:succ)
+        set! from.succ
+      end
+
+      # Has this step been resumed from a previous job execution?
+      def resumed?
+        @resumed
+      end
+
+      # Has the cursor been advanced during this job execution?
+      def advanced?
+        initial_cursor != cursor
+      end
+
+      def to_a
+        [ name.to_s, cursor ]
+      end
+
+      def description
+        "at '#{name}', cursor '#{cursor.inspect}'"
+      end
+
+      private
+        attr_reader :checkpoint_callback, :initial_cursor
+    end
+  end
+end

--- a/activejob/lib/active_job/continuation/test_helper.rb
+++ b/activejob/lib/active_job/continuation/test_helper.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require "active_job/test_helper"
+require "active_job/continuation"
+
+module ActiveJob
+  class Continuation
+    # Test helper for ActiveJob::Continuable jobs.
+    #
+    module TestHelper
+      include ::ActiveJob::TestHelper
+
+      # Interrupt a job during a step.
+      #
+      #  class MyJob < ApplicationJob
+      #    include ActiveJob::Continuable
+      #
+      #    cattr_accessor :items, default: []
+      #    def perform
+      #      step :my_step, start: 1 do |step|
+      #        (step.cursor..10).each do |i|
+      #          items << i
+      #          step.advance!
+      #        end
+      #      end
+      #    end
+      #  end
+      #
+      #  test "interrupt job during step" do
+      #    MyJob.perform_later
+      #    interrupt_job_during_step(MyJob, :my_step, cursor: 6) { perform_enqueued_jobs }
+      #    assert_equal [1, 2, 3, 4, 5], MyJob.items
+      #    perform_enqueued_jobs
+      #    assert_equal [1, 2, 3, 4, 5, 6, 7, 8, 9, 10], MyJob.items
+      #  end
+      def interrupt_job_during_step(job, step, cursor: nil, &block)
+        require_active_job_test_adapter!("interrupt_job_during_step")
+        queue_adapter.with(stopping: ->() { during_step?(job, step, cursor: cursor) }, &block)
+      end
+
+      # Interrupt a job after a step.
+      #
+      #  class MyJob < ApplicationJob
+      #    include ActiveJob::Continuable
+      #
+      #    cattr_accessor :items, default: []
+      #
+      #    def perform
+      #      step :step_one { items << 1 }
+      #      step :step_two { items << 2 }
+      #      step :step_three { items << 3 }
+      #      step :step_four { items << 4 }
+      #    end
+      #  end
+      #
+      #  test "interrupt job after step" do
+      #    MyJob.perform_later
+      #    interrupt_job_after_step(MyJob, :step_two) { perform_enqueued_jobs }
+      #    assert_equal [1, 2], MyJob.items
+      #    perform_enqueued_jobs
+      #    assert_equal [1, 2, 3, 4], MyJob.items
+      #  end
+      def interrupt_job_after_step(job, step, &block)
+        require_active_job_test_adapter!("interrupt_job_after_step")
+        queue_adapter.with(stopping: ->() { after_step?(job, step) }, &block)
+      end
+
+      private
+        def continuation_for(klass)
+          job = ActiveSupport::ExecutionContext.to_h[:job]
+          job.send(:continuation)&.to_h if job && job.is_a?(klass)
+        end
+
+        def during_step?(job, step, cursor: nil)
+          if (continuation = continuation_for(job))
+            continuation["current"] == [ step.to_s, cursor ]
+          end
+        end
+
+        def after_step?(job, step)
+          if (continuation = continuation_for(job))
+            continuation["completed"].last == step.to_s && continuation["current"].nil?
+          end
+        end
+    end
+  end
+end

--- a/activejob/lib/active_job/log_subscriber.rb
+++ b/activejob/lib/active_job/log_subscriber.rb
@@ -138,6 +138,62 @@ module ActiveJob
     end
     subscribe_log_level :discard, :error
 
+    def interrupt(event)
+      job = event.payload[:job]
+      info do
+        "Interrupted #{job.class} (Job ID: #{job.job_id}) #{event.payload[:description]}"
+      end
+    end
+    subscribe_log_level :interrupt, :info
+
+    def resume(event)
+      job = event.payload[:job]
+      info do
+        "Resuming #{job.class} (Job ID: #{job.job_id}) #{event.payload[:description]}"
+      end
+    end
+    subscribe_log_level :resume, :info
+
+    def step_skipped(event)
+      job = event.payload[:job]
+      info do
+        "Step '#{event.payload[:step].name}' skipped #{job.class}"
+      end
+    end
+    subscribe_log_level :step_skipped, :info
+
+    def step_started(event)
+      job = event.payload[:job]
+      info do
+        "Step '#{event.payload[:step].name}' started #{job.class}"
+      end
+    end
+    subscribe_log_level :step_started, :info
+
+    def step_interrupted(event)
+      job = event.payload[:job]
+      info do
+        "Step '#{event.payload[:step].name}' interrupted at cursor '#{event.payload[:step].cursor}' #{job.class}"
+      end
+    end
+    subscribe_log_level :step_completed, :info
+
+    def step_resumed(event)
+      job = event.payload[:job]
+      info do
+        "Step '#{event.payload[:step].name}' resumed from cursor '#{event.payload[:step].cursor}' #{job.class}"
+      end
+    end
+    subscribe_log_level :step_resumed, :info
+
+    def step_completed(event)
+      job = event.payload[:job]
+      info do
+        "Step '#{event.payload[:step].name}' completed #{job.class}"
+      end
+    end
+    subscribe_log_level :step_completed, :info
+
     private
       def queue_name(event)
         ActiveJob.adapter_name(event.payload[:adapter]) + "(#{event.payload[:job].queue_name})"

--- a/activejob/lib/active_job/queue_adapters/abstract_adapter.rb
+++ b/activejob/lib/active_job/queue_adapters/abstract_adapter.rb
@@ -7,12 +7,18 @@ module ActiveJob
     # Active Job supports multiple job queue systems. ActiveJob::QueueAdapters::AbstractAdapter
     # forms the abstraction layer which makes this possible.
     class AbstractAdapter
+      attr_accessor :stopping
+
       def enqueue(job)
         raise NotImplementedError
       end
 
       def enqueue_at(job, timestamp)
         raise NotImplementedError
+      end
+
+      def stopping?
+        !!@stopping
       end
     end
   end

--- a/activejob/lib/active_job/queue_adapters/sidekiq_adapter.rb
+++ b/activejob/lib/active_job/queue_adapters/sidekiq_adapter.rb
@@ -18,6 +18,18 @@ module ActiveJob
     #
     #   Rails.application.config.active_job.queue_adapter = :sidekiq
     class SidekiqAdapter < AbstractAdapter
+      def initialize(*) # :nodoc:
+        @stopping = false
+
+        Sidekiq.configure_server do |config|
+          config.on(:quiet) { @stopping = true }
+        end
+
+        Sidekiq.configure_client do |config|
+          config.on(:quiet) { @stopping = true }
+        end
+      end
+
       def enqueue(job) # :nodoc:
         job.provider_job_id = JobWrapper.set(
           wrapped: job.class,

--- a/activejob/lib/active_job/queue_adapters/test_adapter.rb
+++ b/activejob/lib/active_job/queue_adapters/test_adapter.rb
@@ -12,7 +12,7 @@ module ActiveJob
     #
     #   Rails.application.config.active_job.queue_adapter = :test
     class TestAdapter < AbstractAdapter
-      attr_accessor(:perform_enqueued_jobs, :perform_enqueued_at_jobs, :filter, :reject, :queue, :at)
+      attr_accessor(:perform_enqueued_jobs, :perform_enqueued_at_jobs, :filter, :reject, :queue, :at, :stopping)
       attr_writer(:enqueued_jobs, :performed_jobs)
 
       # Provides a store of all the enqueued jobs with the TestAdapter so you can check them.
@@ -33,6 +33,10 @@ module ActiveJob
       def enqueue_at(job, timestamp) # :nodoc:
         job_data = job_to_hash(job, at: timestamp)
         perform_or_enqueue(perform_enqueued_at_jobs && !filtered?(job), job, job_data)
+      end
+
+      def stopping?
+        @stopping.is_a?(Proc) ? @stopping.call : @stopping
       end
 
       private

--- a/activejob/test/cases/continuation_test.rb
+++ b/activejob/test/cases/continuation_test.rb
@@ -1,0 +1,348 @@
+# frozen_string_literal: true
+
+require "helper"
+require "active_job/continuation/test_helper"
+require "active_support/testing/stream"
+require "active_support/core_ext/object/with"
+require "support/test_logger"
+require "support/do_not_perform_enqueued_jobs"
+require "jobs/continuable_array_cursor_job"
+require "jobs/continuable_iterating_job"
+require "jobs/continuable_linear_job"
+require "jobs/continuable_deleting_job"
+require "jobs/continuable_duplicate_step_job"
+require "jobs/continuable_nested_steps_job"
+require "jobs/continuable_string_step_name_job"
+require "jobs/continuable_resume_wrong_step_job"
+require "jobs/continuable_nested_cursor_job"
+
+return unless adapter_is?(:test)
+
+class ActiveJob::TestContinuation < ActiveSupport::TestCase
+  include ActiveJob::Continuation::TestHelper
+  include ActiveSupport::Testing::Stream
+  include DoNotPerformEnqueuedJobs
+  include TestLoggerHelper
+
+  test "iterates" do
+    ContinuableIteratingRecord.records = [ 123, 432, 6565, 3243, 234, 13, 22 ].map { |i| ContinuableIteratingRecord.new(i, "item_#{i}") }
+
+    ContinuableIteratingJob.perform_later
+
+    assert_enqueued_jobs 0, only: ContinuableIteratingJob do
+      perform_enqueued_jobs
+    end
+
+    assert_equal %w[ new_item_123 new_item_432 new_item_6565 new_item_3243 new_item_234 new_item_13 new_item_22 ], ContinuableIteratingRecord.records.map(&:name)
+  end
+
+  test "iterates and continues" do
+    ContinuableIteratingRecord.records = [ 123, 432, 6565, 3243, 234, 13, 22 ].map { |i| ContinuableIteratingRecord.new(i, "item_#{i}") }
+
+    ContinuableIteratingJob.perform_later
+
+    interrupt_job_during_step ContinuableIteratingJob, :rename, cursor: 433 do
+      assert_enqueued_jobs 1, only: ContinuableIteratingJob do
+        perform_enqueued_jobs
+      end
+    end
+
+    assert_equal %w[ new_item_123 new_item_432 item_6565 item_3243 new_item_234 new_item_13 new_item_22 ], ContinuableIteratingRecord.records.map(&:name)
+
+    assert_enqueued_jobs 0 do
+      perform_enqueued_jobs
+    end
+
+    assert_equal %w[ new_item_123 new_item_432 new_item_6565 new_item_3243 new_item_234 new_item_13 new_item_22 ], ContinuableIteratingRecord.records.map(&:name)
+  end
+
+  test "linear steps" do
+    ContinuableLinearJob.items = []
+    ContinuableLinearJob.perform_later
+
+    assert_enqueued_jobs 0 do
+      perform_enqueued_jobs
+    end
+
+    assert_equal %w[ item1 item2 item3 item4 ], ContinuableLinearJob.items
+  end
+
+  test "linear steps continues from last point" do
+    ContinuableLinearJob.items = []
+    ContinuableLinearJob.perform_later
+
+    interrupt_job_after_step ContinuableLinearJob, :step_one do
+      assert_enqueued_jobs 1, only: ContinuableLinearJob do
+        perform_enqueued_jobs
+      end
+    end
+
+    assert_equal %w[ item1 ], ContinuableLinearJob.items
+
+    assert_enqueued_jobs 0 do
+      perform_enqueued_jobs
+    end
+
+    assert_equal %w[ item1 item2 item3 item4 ], ContinuableLinearJob.items
+  end
+
+  test "runs with perform_now" do
+    ContinuableLinearJob.items = []
+    ContinuableLinearJob.perform_now
+
+    assert_equal %w[ item1 item2 item3 item4 ], ContinuableLinearJob.items
+  end
+
+  test "does not retry jobs that error without updating the cursor" do
+    ContinuableDeletingJob.items = 10.times.map { |i| "item_#{i}" }
+    ContinuableDeletingJob.perform_later
+
+    assert_enqueued_jobs 0, only: ContinuableDeletingJob do
+      assert_raises StandardError do
+        queue_adapter.with(stopping: ->() { raise StandardError if during_step?(ContinuableDeletingJob, :delete) }) do
+          perform_enqueued_jobs
+        end
+      end
+    end
+
+    assert_equal %w[ item_1 item_2 item_3 item_4 item_5 item_6 item_7 item_8 item_9 ], ContinuableDeletingJob.items
+  end
+
+  test "saves progress when there is an error" do
+    ContinuableIteratingRecord.records = [ 123, 432, 6565, 3243, 234, 13, 22 ].map { |i| ContinuableIteratingRecord.new(i, "item_#{i}") }
+
+    ContinuableIteratingJob.perform_later
+
+    queue_adapter.with(stopping: ->() { raise StandardError if during_step?(ContinuableIteratingJob, :rename, cursor: 433) }) do
+      assert_enqueued_jobs 1, only: ContinuableIteratingJob do
+        perform_enqueued_jobs
+      end
+    end
+
+    job = queue_adapter.enqueued_jobs.first
+    assert_equal 1, job["executions"]
+
+    assert_equal %w[ new_item_123 new_item_432 item_6565 item_3243 new_item_234 new_item_13 new_item_22 ], ContinuableIteratingRecord.records.map(&:name)
+
+    assert_enqueued_jobs 0 do
+      perform_enqueued_jobs
+    end
+
+    assert_equal %w[ new_item_123 new_item_432 new_item_6565 new_item_3243 new_item_234 new_item_13 new_item_22 ], ContinuableIteratingRecord.records.map(&:name)
+  end
+
+  test "does not retry a second error if the cursor did not advance" do
+    ContinuableIteratingRecord.records = [ 123, 432, 6565, 3243, 234, 13, 22 ].map { |i| ContinuableIteratingRecord.new(i, "item_#{i}") }
+
+    ContinuableIteratingJob.perform_later(raise_when_cursor: 433)
+
+    assert_enqueued_jobs 1, only: ContinuableIteratingJob do
+      perform_enqueued_jobs
+    end
+
+    job = queue_adapter.enqueued_jobs.first
+    assert_equal 1, job["executions"]
+
+    assert_enqueued_jobs 0, only: ContinuableIteratingJob do
+      assert_raises StandardError do
+        perform_enqueued_jobs
+      end
+    end
+  end
+
+  test "logs interruptions after steps" do
+    ContinuableLinearJob.items = []
+    ContinuableLinearJob.perform_later
+
+    interrupt_job_after_step ContinuableLinearJob, :step_one do
+      perform_enqueued_jobs
+      assert_no_match "Resuming", @logger.messages
+      assert_match(/Step 'step_one' started/, @logger.messages)
+      assert_match(/Step 'step_one' completed/, @logger.messages)
+      assert_match(/Interrupted ContinuableLinearJob \(Job ID: [0-9a-f-]{36}\) after 'step_one'/, @logger.messages)
+    end
+
+    perform_enqueued_jobs
+
+    assert_match(/Step 'step_one' skipped/, @logger.messages)
+    assert_match(/Resuming ContinuableLinearJob \(Job ID: [0-9a-f-]{36}\) after 'step_one'/, @logger.messages)
+    assert_match(/Step 'step_two' started/, @logger.messages)
+    assert_match(/Step 'step_two' completed/, @logger.messages)
+  end
+
+  test "logs interruptions during steps" do
+    ContinuableIteratingRecord.records = [ 123, 432, 6565, 3243, 234, 13, 22 ].map { |i| ContinuableIteratingRecord.new(i, "item_#{i}") }
+    ContinuableIteratingJob.perform_later
+
+    interrupt_job_during_step ContinuableIteratingJob, :rename, cursor: 433 do
+      perform_enqueued_jobs
+      assert_no_match "Resuming", @logger.messages
+      assert_match(/Step 'rename' started/, @logger.messages)
+      assert_match(/Step 'rename' interrupted at cursor '433'/, @logger.messages)
+      assert_match(/Interrupted ContinuableIteratingJob \(Job ID: [0-9a-f-]{36}\) at 'rename', cursor '433'/, @logger.messages)
+    end
+
+    perform_enqueued_jobs
+    assert_match(/Resuming ContinuableIteratingJob \(Job ID: [0-9a-f-]{36}\) at 'rename', cursor '433'/, @logger.messages)
+    assert_match(/Step 'rename' resumed from cursor '433'/, @logger.messages)
+    assert_match(/Step 'rename' completed/, @logger.messages)
+  end
+
+  test "interrupts without cursors" do
+    ContinuableDeletingJob.items = 10.times.map { |i| "item_#{i}" }
+    ContinuableDeletingJob.perform_later
+
+    interrupt_job_during_step ContinuableDeletingJob, :delete do
+      assert_enqueued_jobs 1, only: ContinuableDeletingJob do
+        perform_enqueued_jobs
+      end
+    end
+
+    assert_equal 9, ContinuableDeletingJob.items.count
+
+    assert_enqueued_jobs 0 do
+      perform_enqueued_jobs
+    end
+
+    assert_equal 0, ContinuableDeletingJob.items.count
+  end
+
+  test "duplicate steps raise an error" do
+    ContinuableDuplicateStepJob.perform_later
+
+    exception = assert_raises ActiveJob::Continuation::InvalidStepError do
+      perform_enqueued_jobs
+    end
+
+    assert_equal "Step 'duplicate' has already been encountered", exception.message
+  end
+
+  test "nested steps raise an error" do
+    ContinuableNestedStepsJob.perform_later
+
+    exception = assert_raises ActiveJob::Continuation::InvalidStepError do
+      perform_enqueued_jobs
+    end
+
+    assert_equal "Step 'inner_step' is nested inside step 'outer_step'", exception.message
+  end
+
+  test "string named steps raise an error" do
+    ContinuableStringStepNameJob.perform_later
+
+    exception = assert_raises ActiveJob::Continuation::InvalidStepError do
+      perform_enqueued_jobs
+    end
+
+    assert_equal "Step 'string_step_name' must be a Symbol, found 'String'", exception.message
+  end
+
+  test "unexpected step on resumption raises an error" do
+    ContinuableResumeWrongStepJob.perform_later
+
+    interrupt_job_during_step ContinuableResumeWrongStepJob, :iterating, cursor: 2 do
+      perform_enqueued_jobs
+    end
+
+    exception = assert_raises ActiveJob::Continuation::InvalidStepError do
+      perform_enqueued_jobs
+    end
+
+    assert_equal "Step 'unexpected' found, expected to resume from 'iterating'", exception.message
+  end
+
+  test "deserializes a job with no continuation" do
+    ContinuableDeletingJob.items = 10.times.map { |i| "item_#{i}" }
+    ContinuableDeletingJob.perform_later
+
+    queue_adapter.enqueued_jobs.each { |job| job.delete("continuation") }
+
+    assert_enqueued_jobs 0 do
+      perform_enqueued_jobs
+    end
+
+    assert_equal 0, ContinuableDeletingJob.items.count
+  end
+
+  test "nested cursor" do
+    ContinuableNestedCursorJob.items = [
+      3.times.map { |i| "subitem_0_#{i}" },
+      1.times.map { |i| "subitem_1_#{i}" },
+      2.times.map { |i| "subitem_2_#{i}" }
+    ]
+    ContinuableNestedCursorJob.perform_later
+
+    assert_enqueued_jobs 0 do
+      perform_enqueued_jobs
+    end
+
+    assert_equal [ %w[ new_subitem_0_0 new_subitem_0_1 new_subitem_0_2 ], %w[ new_subitem_1_0 ], %w[ new_subitem_2_0 new_subitem_2_1 ] ], ContinuableNestedCursorJob.items
+  end
+
+  test "nested cursor resumes" do
+    ContinuableNestedCursorJob.items = [
+      3.times.map { |i| "subitem_0_#{i}" },
+      1.times.map { |i| "subitem_1_#{i}" },
+      2.times.map { |i| "subitem_2_#{i}" }
+    ]
+
+    ContinuableNestedCursorJob.perform_later
+
+    interrupt_job_during_step ContinuableNestedCursorJob, :updating_sub_items, cursor: [ 0, 2 ] do
+      assert_enqueued_jobs 1 do
+        perform_enqueued_jobs
+      end
+    end
+
+    assert_equal [ %w[ new_subitem_0_0 new_subitem_0_1 subitem_0_2 ], %w[ subitem_1_0 ], %w[ subitem_2_0 subitem_2_1 ] ], ContinuableNestedCursorJob.items
+
+    assert_enqueued_jobs 0 do
+      perform_enqueued_jobs
+    end
+
+    assert_equal [ %w[ new_subitem_0_0 new_subitem_0_1 new_subitem_0_2 ], %w[ new_subitem_1_0 ], %w[ new_subitem_2_0 new_subitem_2_1 ] ], ContinuableNestedCursorJob.items
+  end
+
+  test "iterates over array cursor" do
+    ContinuableArrayCursorJob.items = []
+
+    objects = [ :hello, "world", 1, 1.2, nil, true, false, [ 1, 2, 3 ], { a: 1, b: 2, c: 3 } ]
+
+    ContinuableArrayCursorJob.perform_later(objects)
+
+    assert_enqueued_jobs 0 do
+      perform_enqueued_jobs
+    end
+
+    assert_equal objects, ContinuableArrayCursorJob.items
+  end
+
+  test "interrupts and resumes array cursor" do
+    ContinuableArrayCursorJob.items = []
+
+    objects = [ :hello, "world", 1, 1.2, nil, true, false, [ 1, 2, 3 ], { a: 1, b: 2, c: 3 } ]
+
+    ContinuableArrayCursorJob.perform_later(objects)
+
+    assert_enqueued_jobs 1, only: ContinuableArrayCursorJob do
+      interrupt_job_during_step ContinuableArrayCursorJob, :iterate_objects, cursor: 3 do
+        perform_enqueued_jobs
+      end
+    end
+
+    assert_equal objects[0...3], ContinuableArrayCursorJob.items
+
+    assert_enqueued_jobs 0, only: ContinuableArrayCursorJob do
+      perform_enqueued_jobs
+    end
+
+    assert_equal objects, ContinuableArrayCursorJob.items
+  end
+
+  private
+    def capture_info_stdout(&block)
+      ActiveJob::Base.logger.with(level: :info) do
+        capture(:stdout, &block)
+      end
+    end
+end

--- a/activejob/test/cases/logging_test.rb
+++ b/activejob/test/cases/logging_test.rb
@@ -3,6 +3,7 @@
 require "helper"
 require "active_support/log_subscriber/test_helper"
 require "active_support/core_ext/numeric/time"
+require "support/test_logger"
 require "jobs/hello_job"
 require "jobs/logging_job"
 require "jobs/overridden_logging_job"
@@ -18,37 +19,7 @@ class LoggingTest < ActiveSupport::TestCase
   include ActiveJob::TestHelper
   include ActiveSupport::LogSubscriber::TestHelper
   include ActiveSupport::Logger::Severity
-
-  class TestLogger < ActiveSupport::Logger
-    def initialize
-      @file = StringIO.new
-      super(@file)
-    end
-
-    def messages
-      @file.rewind
-      @file.read
-    end
-  end
-
-  def setup
-    super
-    JobBuffer.clear
-    @old_logger = ActiveJob::Base.logger
-    @logger = ActiveSupport::TaggedLogging.new(TestLogger.new)
-    set_logger @logger
-    ActiveJob::LogSubscriber.attach_to :active_job
-  end
-
-  def teardown
-    super
-    ActiveJob::LogSubscriber.log_subscribers.pop
-    set_logger @old_logger
-  end
-
-  def set_logger(logger)
-    ActiveJob::Base.logger = logger
-  end
+  include TestLoggerHelper
 
   def test_uses_active_job_as_tag
     HelloJob.perform_later "Cristian"

--- a/activejob/test/cases/test_helper_test.rb
+++ b/activejob/test/cases/test_helper_test.rb
@@ -14,26 +14,7 @@ require "jobs/retry_job"
 require "jobs/inherited_job"
 require "jobs/multiple_kwargs_job"
 require "models/person"
-
-module DoNotPerformEnqueuedJobs
-  extend ActiveSupport::Concern
-
-  included do
-    setup do
-      # /rails/activejob/test/adapters/test.rb sets these configs to true, but
-      # in this specific case we want to test enqueueing behaviour.
-      @perform_enqueued_jobs = queue_adapter.perform_enqueued_jobs
-      @perform_enqueued_at_jobs = queue_adapter.perform_enqueued_at_jobs
-      queue_adapter.perform_enqueued_jobs = queue_adapter.perform_enqueued_at_jobs = false
-    end
-
-    teardown do
-      queue_adapter.perform_enqueued_jobs = @perform_enqueued_jobs
-      queue_adapter.perform_enqueued_at_jobs = @perform_enqueued_at_jobs
-    end
-  end
-end
-
+require "support/do_not_perform_enqueued_jobs"
 
 class EnqueuedJobsTest < ActiveJob::TestCase
   if adapter_is?(:test)

--- a/activejob/test/integration/queuing_test.rb
+++ b/activejob/test/integration/queuing_test.rb
@@ -46,6 +46,20 @@ class QueuingTest < ActiveSupport::TestCase
         assert_equal "Provider Job ID: #{job.provider_job_id}", JobBuffer.last_value
       end
     end
+
+    test "should interrupt jobs" do
+      ContinuableTestJob.perform_later @id
+      wait_for_jobs_to_finish_for(1.seconds)
+
+      jobs_manager.stop_workers
+      wait_for_jobs_to_finish_for(1.seconds)
+      assert_not job_executed
+      assert continuable_job_started
+
+      jobs_manager.start_workers
+      wait_for_jobs_to_finish_for(10.seconds)
+      assert job_executed
+    end
   end
 
   if adapter_is?(:delayed_job)

--- a/activejob/test/jobs/continuable_array_cursor_job.rb
+++ b/activejob/test/jobs/continuable_array_cursor_job.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class ContinuableArrayCursorJob < ActiveJob::Base
+  include ActiveJob::Continuable
+
+  cattr_accessor :items, default: []
+
+  def perform(objects)
+    step :iterate_objects, start: 0 do |step|
+      objects[step.cursor..].each do |object|
+        items << object
+        step.advance!
+      end
+    end
+  end
+end

--- a/activejob/test/jobs/continuable_deleting_job.rb
+++ b/activejob/test/jobs/continuable_deleting_job.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class ContinuableDeletingJob < ActiveJob::Base
+  include ActiveJob::Continuable
+
+  cattr_accessor :items
+
+  def perform
+    step :delete do |step|
+      loop do
+        break if items.empty?
+        items.shift
+        step.checkpoint!
+      end
+    end
+  end
+end

--- a/activejob/test/jobs/continuable_duplicate_step_job.rb
+++ b/activejob/test/jobs/continuable_duplicate_step_job.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class ContinuableDuplicateStepJob < ActiveJob::Base
+  include ActiveJob::Continuable
+
+  def perform
+    step :duplicate do |step|
+    end
+    step :duplicate do |step|
+    end
+  end
+end

--- a/activejob/test/jobs/continuable_iterating_job.rb
+++ b/activejob/test/jobs/continuable_iterating_job.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+# Rough approximation of the AR batch iterator
+ContinuableIteratingRecord = Struct.new(:id, :name) do
+  cattr_accessor :records
+
+  def self.find_each(start: nil)
+    records.sort_by(&:id).each do |record|
+      next if start && record.id < start
+
+      yield record
+    end
+  end
+end
+
+class ContinuableIteratingJob < ActiveJob::Base
+  include ActiveJob::Continuable
+
+  def perform(raise_when_cursor: nil)
+    step :rename do |step|
+      ContinuableIteratingRecord.find_each(start: step.cursor) do |record|
+        raise StandardError, "Cursor error" if raise_when_cursor && step.cursor == raise_when_cursor
+        record.name = "new_#{record.name}"
+        step.advance! from: record.id
+      end
+    end
+  end
+end

--- a/activejob/test/jobs/continuable_linear_job.rb
+++ b/activejob/test/jobs/continuable_linear_job.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+class ContinuableLinearJob < ActiveJob::Base
+  include ActiveJob::Continuable
+
+  cattr_accessor :items
+
+  def perform
+    step :step_one
+    step :step_two
+    step :step_three
+    step :step_four
+  end
+
+  private
+    def step_one
+      items << "item1"
+    end
+
+    def step_two
+      items << "item2"
+    end
+
+    def step_three
+      items << "item3"
+    end
+
+    def step_four
+      items << "item4"
+    end
+end

--- a/activejob/test/jobs/continuable_nested_cursor_job.rb
+++ b/activejob/test/jobs/continuable_nested_cursor_job.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class ContinuableNestedCursorJob < ActiveJob::Base
+  include ActiveJob::Continuable
+
+  cattr_accessor :items
+
+  def perform
+    step :updating_sub_items, start: [ 0, 0 ] do |step|
+      items[step.cursor[0]..].each do |inner_items|
+        inner_items[step.cursor[1]..].each do |item|
+          items[step.cursor[0]][step.cursor[1]] = "new_#{item}"
+
+          step.set! [ step.cursor[0], step.cursor[1] + 1 ]
+        end
+
+        step.set! [ step.cursor[0] + 1, 0 ]
+      end
+    end
+  end
+end

--- a/activejob/test/jobs/continuable_nested_steps_job.rb
+++ b/activejob/test/jobs/continuable_nested_steps_job.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class ContinuableNestedStepsJob < ActiveJob::Base
+  include ActiveJob::Continuable
+
+  def perform
+    step :outer_step do
+      # Not allowed!
+      step :inner_step do
+      end
+    end
+  end
+
+  private
+    def inner_step; end
+end

--- a/activejob/test/jobs/continuable_resume_wrong_step_job.rb
+++ b/activejob/test/jobs/continuable_resume_wrong_step_job.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class ContinuableResumeWrongStepJob < ActiveJob::Base
+  include ActiveJob::Continuable
+
+  def perform
+    if continuation.send(:started?)
+      step :unexpected do |step|
+      end
+    else
+      step :iterating, start: 0 do |step|
+        ((step.cursor || 1)..4).each do |i|
+          step.advance!
+        end
+      end
+    end
+  end
+end

--- a/activejob/test/jobs/continuable_string_step_name_job.rb
+++ b/activejob/test/jobs/continuable_string_step_name_job.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class ContinuableStringStepNameJob < ActiveJob::Base
+  include ActiveJob::Continuable
+
+  def perform
+    step "string_step_name" do |step|
+    end
+  end
+end

--- a/activejob/test/support/do_not_perform_enqueued_jobs.rb
+++ b/activejob/test/support/do_not_perform_enqueued_jobs.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module DoNotPerformEnqueuedJobs
+  extend ActiveSupport::Concern
+
+  included do
+    setup do
+      # /rails/activejob/test/adapters/test.rb sets these configs to true, but
+      # in this specific case we want to test enqueueing behaviour.
+      @perform_enqueued_jobs = queue_adapter.perform_enqueued_jobs
+      @perform_enqueued_at_jobs = queue_adapter.perform_enqueued_at_jobs
+      queue_adapter.perform_enqueued_jobs = queue_adapter.perform_enqueued_at_jobs = false
+    end
+
+    teardown do
+      queue_adapter.perform_enqueued_jobs = @perform_enqueued_jobs
+      queue_adapter.perform_enqueued_at_jobs = @perform_enqueued_at_jobs
+    end
+  end
+end

--- a/activejob/test/support/integration/adapters/sidekiq.rb
+++ b/activejob/test/support/integration/adapters/sidekiq.rb
@@ -58,7 +58,7 @@ module SidekiqJobsManager
         config = Sidekiq.default_configuration
         config.queues = ["integration_tests"]
         config.concurrency = 1
-        config.average_scheduled_poll_interval = 0.5
+        config.average_scheduled_poll_interval = 0.1
         config.merge!(
           environment: "test",
           timeout: 1,
@@ -107,6 +107,7 @@ module SidekiqJobsManager
       Process.kill "TERM", @pid
       Process.wait @pid
     end
+    @pid = nil
   end
 
   def can_run?

--- a/activejob/test/support/integration/test_case_helpers.rb
+++ b/activejob/test/support/integration/test_case_helpers.rb
@@ -44,6 +44,10 @@ module TestCaseHelpers
       job_file(id).exist?
     end
 
+    def continuable_job_started(id = @id)
+      job_file("#{id}.started").exist?
+    end
+
     def job_data(id)
       Marshal.load(File.binread(job_file(id)))
     end

--- a/activejob/test/support/test_logger.rb
+++ b/activejob/test/support/test_logger.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+class TestLogger < ActiveSupport::Logger
+  def initialize
+    @file = StringIO.new
+    super(@file)
+  end
+
+  def messages
+    @file.rewind
+    @file.read
+  end
+end
+
+module TestLoggerHelper
+  def setup
+    super
+    JobBuffer.clear
+    @old_logger = ActiveJob::Base.logger
+    @logger = ActiveSupport::TaggedLogging.new(TestLogger.new)
+    set_logger @logger
+    ActiveJob::LogSubscriber.attach_to :active_job
+  end
+
+  def teardown
+    super
+    ActiveJob::LogSubscriber.log_subscribers.pop
+    set_logger @old_logger
+  end
+
+  def set_logger(logger)
+    ActiveJob::Base.logger = logger
+  end
+end


### PR DESCRIPTION
Continuations provide a mechanism for interrupting and resuming jobs. This allows long running jobs to make progress across application restarts.

Jobs should include the `ActiveJob::Continuable` module to enable continuations. Continuable jobs are automatically retried when interrupted.

Use the `step` method to define the steps in your job. Steps can use an optional cursor to track progress in the step.

Steps are executed as soon as they are encountered. If a job is interrupted, previously completed steps will be skipped. If a step is in progress, it will be resumed with the last recorded cursor.

Code that is not part of a step will be executed on each job execution.

You can pass a block or a method name to the step method. The block will be called with the step object as an argument. Methods can either take no arguments or a single argument for the step object.

```ruby
class ProcessImportJob < ApplicationJob
  include ActiveJob::Continuable

  def perform(import_id)
    # This always runs, even if the job is resumed.
    @import = Import.find(import_id)

    step :validate do
      @import.validate!
    end

    step :process_records do |step|
      @import.records.find_each(start: step.cursor)
        record.process
        step.advance! from: record.id
      end
    end

    step :reprocess_records
    step :finalize
  end

  def reprocess_records(step)
    @import.records.find_each(start: step.cursor)
      record.reprocess
      step.advance! from: record.id
    end
  end

  def finalize
    @import.finalize!
  end
end
```

**Cursors**

Cursors are used to track progress within a step. The cursor can be any object that is serializable as an argument to
`ActiveJob::Base.serialize`. It defaults to `nil`.

When a step is resumed, the last cursor value is restored. The code in the step is responsible for using the cursor to continue from the right point.

`set!` sets the cursor to a specific value.

```ruby
step :iterate_items do |step|
  items[step.cursor..].each do |item|
    process(item)
    step.set! (step.cursor || 0) + 1
  end
end
```

A starting value for the cursor can be set when defining the step:

```ruby
step :iterate_items, start: 0 do |step|
  items[step.cursor..].each do |item|
    process(item)
    step.set! step.cursor + 1
  end
end
```

The cursor can be advanced with `advance!`. This calls `succ` on the current cursor value. It raises an
`ActiveJob::Continuation::UnadvanceableCursorError` if the cursor does not implement `succ`.

```ruby
step :iterate_items, start: 0 do |step|
  items[step.cursor..].each do |item|
    process(item)
    step.advance!
  end
end
```

You can optionally pass a `from` argument to `advance!`. This is useful when iterating over a collection of records where IDs may not be contiguous.

```ruby
step :process_records do |step|
  import.records.find_each(start: step.cursor)
    record.process
    step.advance! from: record.id
  end
end
```

You can use an array to iterate over nested records:

```ruby
step :process_nested_records, start: [ 0, 0 ] do |step|
  Account.find_each(start: step.cursor[0]) do |account|
    account.records.find_each(start: step.cursor[1]) do |record|
      record.process
      step.set! [ account.id, record.id + 1 ]
    end
    step.set! [ account.id + 1, 0 ]
  end
end
```

Setting or advancing the cursor creates a checkpoint. You can also create a checkpoint manually by calling the `checkpoint!` method on the step. This is useful if you want to allow interruptions, but don't need to update the cursor.

```ruby
step :destroy_records do |step|
  import.records.find_each do |record|
    record.destroy!
    step.checkpoint!
  end
end
```

**Checkpoints**

A checkpoint is where a job can be interrupted. At a checkpoint the job will call `queue_adapter.stopping?`. If it returns true, the job will raise an `ActiveJob::Continuation::Interrupt` exception.

There is an automatic checkpoint at the end of each step. Within a step calling one is created when calling `set!`, `advance!` or `checkpoint!`.

Jobs are not automatically interrupted when the queue adapter is marked as stopping - they will continue to run either until the next checkpoint, or when the process is stopped.

This is to allow jobs to be interrupted at a safe point, but it also means that the jobs should checkpoint more frequently than the shutdown timeout to ensure a graceful restart.

When interrupted, the job will automatically retry with the progress serialized in the job data under the `continuation` key.

The serialized progress contains:
- a list of the completed steps
- the current step and its cursor value (if one is in progress)

**Errors**

If a job raises an error and is not retried via ActiveJob, it will be passed back to the queue adapter and any progress in this execution will be lost.

To mitigate this, the job will automatically retried if it raises an error after it has made progress. Making progress is defined as having completed a step or advanced the cursor within the current step.

**Queue Adapter support**

Active Job Continuations call the `stopping?` method on the queue adapter to check if we are in the shutdown phase. By default this will return false, so the adapters will need to be updated to implement this method.

This implements the `stopping?` method in the Test and Sidekiq adapters.

It would be possible to add support to Delayed Job via a plugin, but it would probably be better to add a new lifecycle callback to DJ for when it is shutting down.

Resque also will require a new hook before it can be supported.

Solid Queue's adapter is not part of Rails, but support can be added there via the `on_worker_stop` hook.

**Inspiration**

This took a lot inspiration from Shopify's [job-iteration](https://github.com/Shopify/job-iteration) gem.

The main differences are:
- Continuations are Active Job only, so they don't provide the custom enumerators that job-iteration does.
- They allow multi-step flows
- They don't intercept the perform method
- Continuations are a sharp knife - you need to manually checkpoint and update the cursor. But you could build a job-iteration-like API on top of them.

**Future work**

It would be a good exercise to see if the job-iteration gem could be adapted to run on top of Active Job Continuations to highlight any missing features - we'd want to add things like max iteration time, max job runtime and forcing a job to stop.

Another thing to consider is a mechanism for checking whether it is safe to call a checkpoint. Ideally you wouldn't allow them within database transactions as they'll cause a rollback. We can maybe inject checkpoint safety handlers and add a default one that checks whether we are in any active transactions.