### PR TITLE
Move `prevent_writes` defaulting to params of role switching methods

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Move the defaulting of `prevent_writes` to `true` when using the `reading` role into the parameters
+    of the role switching methods, and raise an `ArgumentError` if `prevent_writes: false` is provided
+    with the `reading` role.
+
+    *Joshua Young*
+
 *   Fix incorrect callback execution order when `config.active_record.run_after_transaction_callbacks_in_order_defined = true`
     and using `after_commit` and `after_rollback` callbacks with `prepend: true`.
 

--- a/activerecord/lib/active_record/connection_handling.rb
+++ b/activerecord/lib/active_record/connection_handling.rb
@@ -134,7 +134,10 @@ module ActiveRecord
     #   ActiveRecord::Base.connected_to(role: :reading, shard: :shard_one_replica) do
     #     Dog.first # finds first Dog record stored on the shard one replica
     #   end
-    def connected_to(role: nil, shard: nil, prevent_writes: false, &blk)
+    #
+    # The +prevent_writes+ option can be passed to block writes on a connection;
+    # it defaults to +true+ when using the +reading+ role.
+    def connected_to(role: nil, shard: nil, prevent_writes: role == ActiveRecord.reading_role, &blk)
       if self != Base && !abstract_class
         raise NotImplementedError, "calling `connected_to` is only allowed on ActiveRecord::Base or abstract classes."
       end
@@ -147,12 +150,16 @@ module ActiveRecord
         raise ArgumentError, "must provide a `shard` and/or `role`."
       end
 
+      if role == ActiveRecord.reading_role && !prevent_writes
+        raise ArgumentError, "cannot set `prevent_writes` to false when `role` is `reading`."
+      end
+
       with_role_and_shard(role, shard, prevent_writes, &blk)
     end
 
-    # Connects a role and/or shard to the provided connection names. Optionally +prevent_writes+
-    # can be passed to block writes on a connection. +reading+ will automatically set
-    # +prevent_writes+ to true.
+    # Connects a role and optionally shard to the provided connection names.
+    # The +prevent_writes+ option can be passed to block writes on a connection;
+    # it defaults to +true+ when using the +reading+ role.
     #
     # +connected_to_many+ is an alternative to deeply nested +connected_to+ blocks.
     #
@@ -163,14 +170,16 @@ module ActiveRecord
     #     Dinner.first # Read from meals replica
     #     Person.first # Read from primary writer
     #   end
-    def connected_to_many(*classes, role:, shard: nil, prevent_writes: false)
+    def connected_to_many(*classes, role:, shard: nil, prevent_writes: role == ActiveRecord.reading_role)
       classes = classes.flatten
 
       if self != Base || classes.include?(Base)
         raise NotImplementedError, "connected_to_many can only be called on ActiveRecord::Base."
       end
 
-      prevent_writes = true if role == ActiveRecord.reading_role
+      if role == ActiveRecord.reading_role && !prevent_writes
+        raise ArgumentError, "cannot set `prevent_writes` to false when `role` is `reading`."
+      end
 
       append_to_connected_to_stack(role: role, shard: shard, prevent_writes: prevent_writes, klasses: classes)
       begin
@@ -185,22 +194,27 @@ module ActiveRecord
     # results in an array.
     #
     # Optionally, +role+ and/or +prevent_writes+ can be passed which
-    # will be forwarded to each +connected_to+ call.
-    def connected_to_all_shards(role: nil, prevent_writes: false, &blk)
+    # will be forwarded to each +connected_to+ call. +prevent_writes+
+    # defaults to +true+ when using the +reading+ role.
+    def connected_to_all_shards(role: nil, prevent_writes: role == ActiveRecord.reading_role, &blk)
       shard_keys.map do |shard|
         connected_to(shard: shard, role: role, prevent_writes: prevent_writes, &blk)
       end
     end
 
-    # Use a specified connection.
+    # Use a specified connection to a role and/or shard.
+    # The +prevent_writes+ option can be passed to block writes on a connection;
+    # it defaults to +true+ when using the +reading+ role.
     #
     # This method is useful for ensuring that a specific connection is
     # being used. For example, when booting a console in readonly mode.
     #
     # It is not recommended to use this method in a request since it
     # does not yield to a block like +connected_to+.
-    def connecting_to(role: default_role, shard: default_shard, prevent_writes: false)
-      prevent_writes = true if role == ActiveRecord.reading_role
+    def connecting_to(role: default_role, shard: default_shard, prevent_writes: role == ActiveRecord.reading_role)
+      if role == ActiveRecord.reading_role && !prevent_writes
+        raise ArgumentError, "cannot set `prevent_writes` to false when `role` is `reading`."
+      end
 
       append_to_connected_to_stack(role: role, shard: shard, prevent_writes: prevent_writes, klasses: [self])
     end
@@ -244,9 +258,8 @@ module ActiveRecord
       connected_to(role: current_role, prevent_writes: enabled, &block)
     end
 
-    # Returns true if role is the current connected role and/or
-    # current connected shard. If no shard is passed, the default will be
-    # used.
+    # Returns true if +role+ is the current connected role and if +shard+ is the
+    # current connected shard. If no shard is passed, the default will be used.
     #
     #   ActiveRecord::Base.connected_to(role: :writing) do
     #     ActiveRecord::Base.connected_to?(role: :writing) #=> true
@@ -400,8 +413,6 @@ module ActiveRecord
       end
 
       def with_role_and_shard(role, shard, prevent_writes)
-        prevent_writes = true if role == ActiveRecord.reading_role
-
         append_to_connected_to_stack(role: role, shard: shard, prevent_writes: prevent_writes, klasses: [self])
         begin
           return_value = yield

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -1994,7 +1994,7 @@ class BasicsTest < ActiveRecord::TestCase
     assert_equal "`connects_to` can only be called on ActiveRecord::Base or abstract classes", error.message
   end
 
-  test "cannot call connected_to with role and shard on non-abstract classes" do
+  test "cannot call #connected_to with role and shard on non-abstract classes" do
     error = assert_raises(NotImplementedError) do
       Bird.connected_to(role: :reading, shard: :default) { }
     end
@@ -2002,18 +2002,36 @@ class BasicsTest < ActiveRecord::TestCase
     assert_equal "calling `connected_to` is only allowed on ActiveRecord::Base or abstract classes.", error.message
   end
 
-  test "can call connected_to with role and shard on abstract classes" do
+  test "can call #connected_to with role and shard on abstract classes" do
     SecondAbstractClass.connected_to(role: :reading, shard: :default) do
       assert SecondAbstractClass.connected_to?(role: :reading, shard: :default)
     end
   end
 
-  test "cannot call connected_to on the abstract class that did not establish the connection" do
+  test "cannot call #connected_to on the abstract class that did not establish the connection" do
     error = assert_raises(NotImplementedError) do
       ThirdAbstractClass.connected_to(role: :reading) { }
     end
 
     assert_equal "calling `connected_to` is only allowed on the abstract class that established the connection.", error.message
+  end
+
+  test "#connected_to sets prevent_writes if role is reading" do
+    assert_not SecondAbstractClass.connected_to?(role: :reading)
+    assert_not SecondAbstractClass.current_preventing_writes
+
+    SecondAbstractClass.connected_to(role: :reading) do
+      assert SecondAbstractClass.connected_to?(role: :reading)
+      assert SecondAbstractClass.current_preventing_writes
+    end
+  end
+
+  test "#connected_to cannot be called with the reading role and prevent_writes: false" do
+    error = assert_raises ArgumentError do
+      SecondAbstractClass.connected_to(role: :reading, prevent_writes: false) { }
+    end
+
+    assert_equal "cannot set `prevent_writes` to false when `role` is `reading`.", error.message
   end
 
   test "#connecting_to with role" do
@@ -2042,6 +2060,26 @@ class BasicsTest < ActiveRecord::TestCase
     ActiveRecord::Base.connected_to_stack.pop
   end
 
+  test "#connecting_to sets prevent_writes if role is reading" do
+    assert_not SecondAbstractClass.connected_to?(role: :reading)
+    assert_not SecondAbstractClass.current_preventing_writes
+
+    SecondAbstractClass.connecting_to(role: :reading)
+
+    assert SecondAbstractClass.connected_to?(role: :reading)
+    assert SecondAbstractClass.current_preventing_writes
+  ensure
+    ActiveRecord::Base.connected_to_stack.pop
+  end
+
+  test "#connecting_to cannot be called with the reading role and prevent_writes: false" do
+    error = assert_raises ArgumentError do
+      SecondAbstractClass.connecting_to(role: :reading, prevent_writes: false)
+    end
+
+    assert_equal "cannot set `prevent_writes` to false when `role` is `reading`.", error.message
+  end
+
   test "#connected_to_many cannot be called on anything but ActiveRecord::Base" do
     assert_raises NotImplementedError do
       SecondAbstractClass.connected_to_many([SecondAbstractClass], role: :writing)
@@ -2055,24 +2093,35 @@ class BasicsTest < ActiveRecord::TestCase
   end
 
   test "#connected_to_many sets prevent_writes if role is reading" do
+    assert_not SecondAbstractClass.current_preventing_writes
+    assert_not ActiveRecord::Base.current_preventing_writes
+
     ActiveRecord::Base.connected_to_many([SecondAbstractClass], role: :reading) do
       assert SecondAbstractClass.current_preventing_writes
       assert_not ActiveRecord::Base.current_preventing_writes
     end
   end
 
+  test "#connected_to_many cannot be called with the reading role and prevent_writes: false" do
+    error = assert_raises ArgumentError do
+      ActiveRecord::Base.connected_to_many([SecondAbstractClass], role: :reading, prevent_writes: false) { }
+    end
+
+    assert_equal "cannot set `prevent_writes` to false when `role` is `reading`.", error.message
+  end
+
   test "#connected_to_many with a single argument for classes" do
     ActiveRecord::Base.connected_to_many(SecondAbstractClass, role: :reading) do
-      assert SecondAbstractClass.current_preventing_writes
-      assert_not ActiveRecord::Base.current_preventing_writes
+      assert SecondAbstractClass.connected_to?(role: :reading)
+      assert_not ActiveRecord::Base.connected_to?(role: :reading)
     end
   end
 
   test "#connected_to_many with a multiple classes without brackets works" do
     ActiveRecord::Base.connected_to_many(FirstAbstractClass, SecondAbstractClass, role: :reading) do
-      assert FirstAbstractClass.current_preventing_writes
-      assert SecondAbstractClass.current_preventing_writes
-      assert_not ActiveRecord::Base.current_preventing_writes
+      assert FirstAbstractClass.connected_to?(role: :reading)
+      assert SecondAbstractClass.connected_to?(role: :reading)
+      assert_not ActiveRecord::Base.connected_to?(role: :reading)
     end
   end
 

--- a/activerecord/test/cases/shard_keys_test.rb
+++ b/activerecord/test/cases/shard_keys_test.rb
@@ -121,5 +121,21 @@ module ActiveRecord
 
       assert_equal([true, true], results)
     end
+
+    def test_connected_to_all_shards_sets_prevent_writes_if_role_is_reading
+      assert_not ShardedBase.current_preventing_writes
+
+      ShardedBase.connected_to_all_shards(role: :reading) do
+        assert ShardedBase.current_preventing_writes
+      end
+    end
+
+    def test_connected_to_all_shards_cannot_be_called_with_the_reading_role_and_prevent_writes_false
+      error = assert_raises ArgumentError do
+        ShardedBase.connected_to_all_shards(role: :reading, prevent_writes: false) { }
+      end
+
+      assert_equal "cannot set `prevent_writes` to false when `role` is `reading`.", error.message
+    end
   end
 end


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

In all public connection role switching methods, `prevent_writes` is set to `true` if the given role is the `reading` role. This 'defaulting' (overriding really) logic lives in the bodies of these methods (and in one case a private method - `#with_role_and_shard`), and isn't consistently documented.

I believe it's better to have this defaulting logic live in the params so that looking up the method signature documentation makes this obvious at first glance, and that instead of overriding the argument we should be raising an `ArgumentError` instead - it doesn't make sense to call `connected_to(role: :reading, prevent_writes: false)`, and with the current logic `prevent_writes` will be overridden to `true` anyway.

This PR implements these changes and also ensures that the defaulting logic is consistently documented in all of these methods.

<!-- ### Detail -->

<!-- This Pull Request changes [REPLACE ME] -->

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

Also includes some minor corrections to the method docs to differentiate between when a role argument is required and a shard argument is optional, and when either a role or shard or both can be provided ('and/or').

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
