### PR TITLE
Fix has_many, through joins for self references with `.missing`

### DIFF
--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -126,7 +126,7 @@ module ActiveRecord
           reflection = scope_association_reflection(association)
           @scope.left_outer_joins!(association)
           association_conditions = Array(reflection.association_primary_key).index_with(nil)
-          if reflection.options[:class_name]
+          if reflection.options[:class_name] || @scope.table_name == reflection.table_name
             @scope.where!(association => association_conditions)
           else
             @scope.where!(reflection.table_name => association_conditions)

--- a/activerecord/test/cases/relation/where_chain_test.rb
+++ b/activerecord/test/cases/relation/where_chain_test.rb
@@ -202,6 +202,10 @@ module ActiveRecord
       assert_predicate Cpk::Book.where.missing(:author), :any?
     end
 
+    def test_missing_with_self_reference_has_many
+      assert_equal 1, Author.where(id: 2).where.missing(:favorite_authors).count
+    end
+
     def test_not_inverts_where_clause
       relation = Post.where.not(title: "hello")
       expected_where_clause = Post.where(title: "hello").where_clause.invert


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created in order to address https://github.com/rails/rails/issues/55130

When using a model with a `has_many :through` association that references itself, `where.missing` does not properly handle table aliasing, causing SQL ambiguity errors or incorrect results.

```ruby
class Person < ActiveRecord::Base
  has_many :leadership_roles, foreign_key: "boss_id"
  has_many :subordinates, through: :leadership_roles

  has_many :subordinate_roles, foreign_key: "subordinate_id", class_name: "LeadershipRole"
  has_many :bosses, through: :subordinate_roles
end

class LeadershipRole < ActiveRecord::Base
  belongs_to :subordinate, class_name: "Person"
  belongs_to :boss, class_name: "Person"
end

Person.where.missing(:subordinates)
#   SELECT COUNT(*)
#   FROM "people"
#     LEFT OUTER JOIN "leadership_roles" ON "leadership_roles"."boss_id" = "people"."id"
#     LEFT OUTER JOIN "people" AS "subordinates_people" ON "subordinates_people"."id" = "leadership_roles"."subordinate_id"
#   WHERE "people"."id" IS NULL
#   -- expect to be WHERE "subordinates_people"."id" IS NULL
```

The issue occurs because when the scope's table name matches the association's table name (self-referential relationships), the method incorrectly uses the table name instead of the association alias in the WHERE clause.

A minimal reproduction script is available below.

### Additional information

Previously, the `.missing` method performed a check to see if the table name of `@scope`was the same as the `reflection`, but it was replaced with a few alternatives in
https://github.com/rails/rails/pull/48738/files and https://github.com/rails/rails/pull/48861

After reviewing the test cases from both PRs and related issues, adding this check back introduces no regressions while fixing the self-referential association case in https://github.com/rails/rails/issues/55130.

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.

### Minimal Reproduction Script

```ruby

# Github issue: https://github.com/rails/rails/issues/55130
# Link: https://github.com/rails/rails/raw/refs/heads/main/guides/bug_report_templates/active_record.rb
# ================================================================================
# frozen_string_literal: true

require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"

  # If you want to test against edge Rails replace the previous line with this:
  gem "rails", github: "rails/rails", branch: "main"

  gem "sqlite3"
end

require "active_record/railtie"
require "minitest/autorun"

# This connection will do for database-independent bug reports.
ENV["DATABASE_URL"] = "sqlite3::memory:"

class TestApp < Rails::Application
  config.load_defaults Rails::VERSION::STRING.to_f
  config.eager_load = false
  config.logger = Logger.new($stdout)
  config.secret_key_base = "secret_key_base"

  config.active_record.encryption.primary_key = "primary_key"
  config.active_record.encryption.deterministic_key = "deterministic_key"
  config.active_record.encryption.key_derivation_salt = "key_derivation_salt"
end
Rails.application.initialize!

ActiveRecord::Schema.define do
  create_table :people, force: true do |t|
    t.string :first_name
  end

  create_table :leadership_roles, force: true do |t|
    t.integer :subordinate_id
    t.integer :boss_id
  end
end

class Person < ActiveRecord::Base
  has_many :leadership_roles, foreign_key: "boss_id"
  has_many :subordinates, through: :leadership_roles

  has_many :subordinate_roles, foreign_key: "subordinate_id", class_name: "LeadershipRole"
  has_many :bosses, through: :subordinate_roles
end

class LeadershipRole < ActiveRecord::Base
  belongs_to :subordinate, class_name: "Person"
  belongs_to :boss, class_name: "Person"
end

class BugTest < ActiveSupport::TestCase
  # ACTUAL QUERY:
  #   SELECT COUNT(*)
  #   FROM "people"
  #     LEFT OUTER JOIN "leadership_roles" ON "leadership_roles"."boss_id" = "people"."id"
  #     LEFT OUTER JOIN "people" AS "subordinates_people" ON "subordinates_people"."id" = "leadership_roles"."subordinate_id"
  #   WHERE "people"."id" IS NULL -- expect to be WHERE "subordinates_people"."id" IS NULL
  def test_missing_with_self_has_many
    Person.create!(first_name: 'test-first-name')

    assert_equal 1, Person.where.missing(:subordinates).count
  end
end
```