### PR TITLE
Always fully clear current attributes

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,17 @@
+*   Always clear `CurrentAttribute` instances.
+
+    Previously `CurrentAttribute` instance would be reset at the end of requests.
+    Meaning its attributes would be re-initialized.
+
+    This is problematic because it assume these objects don't hold any state
+    other than their declared attribute, which isn't always the case, and
+    can lead to state leak across request.
+
+    Now `CurrentAttribute` instances are abandonned at the end of a request,
+    and a new instance is created at the start of the next request.
+
+    *Jean Boussier*, *Janko Marohnić*
+
 *   Add public API for `before_fork_hook` in parallel testing.
 
     Introduces a public API for calling the before fork hooks implemented by parallel testing.

--- a/activesupport/lib/active_support/current_attributes.rb
+++ b/activesupport/lib/active_support/current_attributes.rb
@@ -153,12 +153,8 @@ module ActiveSupport
 
       delegate :set, :reset, to: :instance
 
-      def reset_all # :nodoc:
-        current_instances.each_value(&:reset)
-      end
-
       def clear_all # :nodoc:
-        reset_all
+        current_instances.each_value(&:reset)
         current_instances.clear
       end
 

--- a/activesupport/lib/active_support/current_attributes/test_helper.rb
+++ b/activesupport/lib/active_support/current_attributes/test_helper.rb
@@ -2,12 +2,12 @@
 
 module ActiveSupport::CurrentAttributes::TestHelper # :nodoc:
   def before_setup
-    ActiveSupport::CurrentAttributes.reset_all
+    ActiveSupport::CurrentAttributes.clear_all
     super
   end
 
   def after_teardown
     super
-    ActiveSupport::CurrentAttributes.reset_all
+    ActiveSupport::CurrentAttributes.clear_all
   end
 end

--- a/activesupport/lib/active_support/railtie.rb
+++ b/activesupport/lib/active_support/railtie.rb
@@ -44,10 +44,10 @@ module ActiveSupport
       app.executor.to_complete         { ActiveSupport::ExecutionContext.clear }
     end
 
-    initializer "active_support.reset_all_current_attributes_instances" do |app|
+    initializer "active_support.clear_all_current_attributes_instances" do |app|
       app.reloader.before_class_unload { ActiveSupport::CurrentAttributes.clear_all }
-      app.executor.to_run              { ActiveSupport::CurrentAttributes.reset_all }
-      app.executor.to_complete         { ActiveSupport::CurrentAttributes.reset_all }
+      app.executor.to_run              { ActiveSupport::CurrentAttributes.clear_all }
+      app.executor.to_complete         { ActiveSupport::CurrentAttributes.clear_all }
 
       ActiveSupport.on_load(:active_support_test_case) do
         if app.config.active_support.executor_around_test_case


### PR DESCRIPTION
Attempting to reset instances is a recipe for causing state leak.

Regular instance variables in `Current` subclasses aren't cleared, so unless you remember to undefine them in the `reset` callback they will leak across requests.

We could of course document that, but it's just too much of a footgun, and I see no benefit of trying to re-use that object instance.

It's much safer to just always drop it and start fresh.

FYI: @janko 

Closes: https://github.com/rails/rails/pull/55125/
