### PR TITLE
Load tests prior to when Minitest load plugins:

### DIFF
--- a/railties/lib/minitest/rails_plugin.rb
+++ b/railties/lib/minitest/rails_plugin.rb
@@ -134,6 +134,12 @@ module Minitest
 
     options[:color] = true
     options[:output_inline] = true
+
+    opts.on do
+      if ::Rails::TestUnit::Runner.load_test_files
+        ::Rails::TestUnit::Runner.load_tests(options.fetch(:test_files, []))
+      end
+    end
   end
 
   # Owes great inspiration to test runner trailblazers like RSpec,
@@ -141,10 +147,6 @@ module Minitest
   def self.plugin_rails_init(options)
     # Don't mess with Minitest unless RAILS_ENV is set
     return unless ENV["RAILS_ENV"] || ENV["RAILS_MINITEST_PLUGIN"]
-
-    if ::Rails::TestUnit::Runner.load_test_files
-      ::Rails::TestUnit::Runner.load_tests(options.fetch(:test_files, []))
-    end
 
     unless options[:full_backtrace]
       # Plugin can run without Rails loaded, check before filtering.


### PR DESCRIPTION
### Motivation / Background

Fix https://github.com/rails/rails/pull/54741#issuecomment-2922863186

### Detail

#### Problem

Custom minitest plugins that require tests to be loaded (such as minitest-focus) may malfunction.
This is due to a behaviour change introduced in #54741.

#### Context

Rails now load the test thanks to a custom plugin, but this creates a caveat: Any plugins running prior than ours may need the tests to be loaded.

The order of thing in a normal minitest setup is:

1) Test files are loaded
2) Minitest load plugins
3) Minitest initialize plugins

Before this patch it was:

1) Minitest load plugins
2) Minitest initialize plugins (This is where some plugins may require tests to be loaded)
3) Our plugin loads the test files

The plugins are loaded/initialized by Minitest in a random order.

#### Solution

I added a OptionsParser callback which get called at the very end of the parsing process and is responsible to load the test files. The order of thing is now:

1) Minitest load plugins
2) Test files are loaded
3) Minitest initialize the plugins

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.

cc/ @issyl0
