### PR TITLE
Keep the original job object when using `retry_job`

### DIFF
--- a/activejob/lib/active_job/exceptions.rb
+++ b/activejob/lib/active_job/exceptions.rb
@@ -157,8 +157,10 @@ module ActiveJob
     #  end
     def retry_job(options = {})
       instrument :enqueue_retry, options.slice(:error, :wait) do
-        job = dup
-        job.enqueue options
+        scheduled_at, queue_name, priority = self.scheduled_at, self.queue_name, self.priority
+        enqueue options
+      ensure
+        self.scheduled_at, self.queue_name, self.priority = scheduled_at, queue_name, priority
       end
     end
 

--- a/activejob/test/cases/exceptions_test.rb
+++ b/activejob/test/cases/exceptions_test.rb
@@ -2,6 +2,7 @@
 
 require "helper"
 require "jobs/retry_job"
+require "jobs/retries_job"
 require "jobs/after_discard_retry_job"
 require "models/person"
 require "minitest/mock"
@@ -341,6 +342,13 @@ class ExceptionsTest < ActiveSupport::TestCase
       end
 
       assert_equal ["Raised DefaultsError for the 5th time"], JobBuffer.values
+    end
+
+    test "retrying a job when before_enqueue raised uses the same job object" do
+      job = RetriesJob.new
+      assert_nothing_raised do
+        job.enqueue
+      end
     end
 
     test "retrying a job reports error when report: true" do

--- a/activejob/test/jobs/retries_job.rb
+++ b/activejob/test/jobs/retries_job.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+class BeforeEnqueueError < StandardError; end
+
+class RetriesJob < ActiveJob::Base
+  attr_accessor :raise_before_enqueue
+
+  # The job fails in before_enqueue the first time it retries itself.
+  before_perform do
+    self.raise_before_enqueue = true
+  end
+
+  # The job fails once to enqueue/retry itself, then succeeds.
+  before_enqueue do
+    raise BeforeEnqueueError if raise_before_enqueue
+  ensure
+    @raise_before_enqueue = false
+  end
+
+  # The job retries on BeforeEnqueueError errors.
+  retry_on BeforeEnqueueError
+
+  def perform
+    retry_job if executions <= 1
+  end
+end


### PR DESCRIPTION
Fix https://github.com/rails/rails/issues/55116
Follow-up to https://github.com/rails/rails/pull/54447
cc @jenshenny @fatkodima @byroot 

When the job is retried, we want to preserve the original `scheduled_at`, `queue_name` and `priority`. Instead of using `dup`, this copies and restores the necessary attributes.

---

As described in the issue, previously the same job object was used when enqueuing a retry, which allowed to mutate the state of the object from `before_enqueue` and then raise an error which was rescued with `retry_on`, which was enqueuing another retry. During that second retry's `before_enqueue` callback, the changes from the first callback would be available.

By switching to another instance with the call to `dup`, we lost that ability. As far as I can tell, based on #54444, what we want is the attributes changed by `set` to be restored.

In terms of implementation, this adds some coupling between `retry_job` and `set` (knowledge of the changed attributes).
An alternative would be to introduce a new API, maybe `set(**options, &block)` which would restore the attributes. Instead of calling `enqueue options`, we would call `set(options) { enqueue }`, and the attributes would be restored by `set` after the block is called.