### PR TITLE
Support virtual (not persisted) generated columns on PostgreSQL 18+

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,18 @@
+*   Support virtual (not persisted) generated columns on PostgreSQL 18+
+
+    PostgreSQL 18 introduces virtual (not persisted) generated columns,
+    which are now the default unless the `stored: true` option is explicitly specified on PostgreSQL 18+.
+
+    ```ruby
+    create_table :users do |t|
+      t.string :name
+      t.virtual :lower_name,  type: :string,  as: "LOWER(name)", stored: false
+      t.virtual :name_length, type: :integer, as: "LENGTH(name)"
+    end
+    ```
+
+    *Yasuo Honda*
+
 *   Optimize schema dumping to prevent duplicate file generation.
 
     `ActiveRecord::Tasks::DatabaseTasks.dump_all` now tracks which schema files

--- a/activerecord/lib/active_record/connection_adapters/postgresql/column.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/column.rb
@@ -30,6 +30,10 @@ module ActiveRecord
           @generated.present?
         end
 
+        def virtual_stored?
+          @generated == "s"
+        end
+
         def has_default?
           super && !virtual?
         end

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_dumper.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_dumper.rb
@@ -103,7 +103,7 @@ module ActiveRecord
 
             if @connection.supports_virtual_columns? && column.virtual?
               spec[:as] = extract_expression_for_virtual_column(column)
-              spec[:stored] = true
+              spec[:stored] = "true" if column.virtual_stored?
               spec = { type: schema_type(column).inspect }.merge!(spec)
             end
 


### PR DESCRIPTION
### Motivation / Background

This commit adds support for virtual generated columns on PostgreSQL 18 and later.

```ruby
create_table :users do |t|
    t.string :name
    t.virtual :lower_name,  type: :string,  as: "LOWER(name)", stored: false
    t.virtual :name_length, type: :integer, as: "LENGTH(name)"
end
```

### Detail

PostgreSQL 18 Beta 1 introduces virtual (not persisted) generated columns, which are now the default unless the STORED option is explicitly specified. Rails previously supported only stored generated columns on PostgreSQL 12+, via https://github.com/rails/rails/pull/41856, as only stored generated columns were supported by PostgreSQL at the time.

This commit adds support for virtual generated columns on PostgreSQL 18 and later:

- `t.virtual ... stored: false` now generates virtual generated columns.
- Omitting `stored:` also creates virtual generated columns on PostgreSQL 18+.

On PostgreSQL < 18, specifying `stored: false` or omitting `stored:` raises ArgumentError. consistent with the existing behavior in earlier Rails versions.

### Additional information

Reference: PostgreSQL 18 release notes
https://www.postgresql.org/docs/18/release-18.html

> Allow generated columns to be virtual, and make them the default
> (Peter Eisentraut, Jian He, Richard Guo, Dean Rasheed)
>
> Virtual generated columns generate their values when the columns are read, not written.
> The write behavior can still be specified via the STORED option.

Source:
- https://git.postgresql.org/gitweb/?p=postgresql.git;a=commitdiff;h=83ea6c540
- https://git.postgresql.org/gitweb/?p=postgresql.git;a=commitdiff;h=cdc168ad4
- https://git.postgresql.org/gitweb/?p=postgresql.git;a=commitdiff;h=1e4351af3

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
