### PR TITLE
Docs: Fix grammar in Active Record validations guide [ci skip]

### DIFF
--- a/guides/source/active_record_validations.md
+++ b/guides/source/active_record_validations.md
@@ -81,7 +81,7 @@ validations.
 There are two kinds of Active Record objects - those that correspond to a row
 inside your database and those that do not. When you instantiate a new object,
 using the `new` method, the object does not get saved in the database as yet.
-Once you call `save` on that object then will it be saved into the appropriate
+Once you call `save` on that object, it will be saved into the appropriate
 database table. Active Record uses an instance method called `persisted?` (and
 its inverse `new_record?`) to determine whether an object is already in the
 database or not. Consider the following Active Record class:


### PR DESCRIPTION
Fixing a small grammar mistake in the guides.