### PR TITLE
Fix {Public,Debug}Exceptions rendering body for HEAD

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Always return empty body for HEAD requests in `PublicExceptions` and
+    `DebugExceptions`.
+
+    This is required by `Rack::Lint` (per RFC9110).
+
+    *Hartley McGuire*
+
 *   Add comprehensive support for HTTP Cache-Control request directives according to RFC 9111.
 
     Provides a `request.cache_control_directives` object that gives access to request cache directives:

--- a/actionpack/lib/action_dispatch/middleware/debug_exceptions.rb
+++ b/actionpack/lib/action_dispatch/middleware/debug_exceptions.rb
@@ -65,7 +65,9 @@ module ActionDispatch
             content_type = Mime[:text]
           end
 
-          if api_request?(content_type)
+          if request.head?
+            render(wrapper.status_code, "", content_type)
+          elsif api_request?(content_type)
             render_for_api_request(content_type, wrapper)
           else
             render_for_browser_request(request, wrapper)

--- a/actionpack/lib/action_dispatch/middleware/public_exceptions.rb
+++ b/actionpack/lib/action_dispatch/middleware/public_exceptions.rb
@@ -28,7 +28,11 @@ module ActionDispatch
       content_type = request.formats.first
       body = { status: status, error: Rack::Utils::HTTP_STATUS_CODES.fetch(status, Rack::Utils::HTTP_STATUS_CODES[500]) }
 
-      render(status, content_type, body)
+      if env["action_dispatch.original_request_method"] == "HEAD"
+        render_format(status, content_type, "")
+      else
+        render(status, content_type, body)
+      end
     end
 
     private

--- a/actionpack/test/dispatch/debug_exceptions_test.rb
+++ b/actionpack/test/dispatch/debug_exceptions_test.rb
@@ -183,6 +183,15 @@ class DebugExceptionsTest < ActionDispatch::IntegrationTest
     assert boomer.closed, "Expected to close the response body"
   end
 
+  test "returns empty body on HEAD cascade pass" do
+    @app = DevelopmentApp
+
+    head "/pass"
+
+    assert_response 404
+    assert_equal "", body
+  end
+
   test "displays routes in a table when a RoutingError occurs" do
     @app = DevelopmentApp
     get "/pass", headers: { "action_dispatch.show_exceptions" => :all }

--- a/actionpack/test/dispatch/show_exceptions_test.rb
+++ b/actionpack/test/dispatch/show_exceptions_test.rb
@@ -69,6 +69,32 @@ class ShowExceptionsTest < ActionDispatch::IntegrationTest
     assert_equal "", body
   end
 
+  test "rescue with no body for HEAD requests" do
+    head "/", env: { "action_dispatch.show_exceptions" => :all }
+    assert_response 500
+    assert_equal "", body
+
+    head "/bad_params", env: { "action_dispatch.show_exceptions" => :all }
+    assert_response 400
+    assert_equal "", body
+
+    head "/not_found", env: { "action_dispatch.show_exceptions" => :all }
+    assert_response 404
+    assert_equal "", body
+
+    head "/method_not_allowed", env: { "action_dispatch.show_exceptions" => :all }
+    assert_response 405
+    assert_equal "", body
+
+    head "/unknown_http_method", env: { "action_dispatch.show_exceptions" => :all }
+    assert_response 405
+    assert_equal "", body
+
+    head "/invalid_mimetype", headers: { "Accept" => "text/html,*", "action_dispatch.show_exceptions" => :all }
+    assert_response 406
+    assert_equal "", body
+  end
+
   test "localize rescue error page" do
     old_locale, I18n.locale = I18n.locale, :da
 


### PR DESCRIPTION
Fix #55131

Rack::Lint already errors in this case, it just wasn't being covered.

```
Error:
DebugExceptionsTest#test_returns_empty_body_on_HEAD_cascade_pass:
Rack::Lint::LintError: Response body was given for HEAD request, but should be empty
    /home/hartley/.local/share/mise/installs/ruby/3.4.4/lib/ruby/gems/3.4.0/gems/rack-3.1.15/lib/rack/lint.rb:773:in 'Rack::Lint::Wrapper#verify_content_length'
    /home/hartley/.local/share/mise/installs/ruby/3.4.4/lib/ruby/gems/3.4.0/gems/rack-3.1.15/lib/rack/lint.rb:899:in 'Rack::Lint::Wrapper#each'
    /home/hartley/.local/share/mise/installs/ruby/3.4.4/lib/ruby/gems/3.4.0/gems/rack-3.1.15/lib/rack/response.rb:345:in 'Rack::Response::Helpers#buffered_body!'
    /home/hartley/.local/share/mise/installs/ruby/3.4.4/lib/ruby/gems/3.4.0/gems/rack-3.1.15/lib/rack/mock_response.rb:65:in 'Rack::MockResponse#initialize'
    /home/hartley/.local/share/mise/installs/ruby/3.4.4/lib/ruby/gems/3.4.0/gems/rack-test-2.2.0/lib/rack/test.rb:362:in 'Class#new'
    /home/hartley/.local/share/mise/installs/ruby/3.4.4/lib/ruby/gems/3.4.0/gems/rack-test-2.2.0/lib/rack/test.rb:362:in 'Rack::Test::Session#process_request'
    /home/hartley/.local/share/mise/installs/ruby/3.4.4/lib/ruby/gems/3.4.0/gems/rack-test-2.2.0/lib/rack/test.rb:153:in 'Rack::Test::Session#request'
    lib/action_dispatch/testing/integration.rb:297:in 'ActionDispatch::Integration::Session#process'
    lib/action_dispatch/testing/integration.rb:49:in 'ActionDispatch::Integration::RequestHelpers#head'
    lib/action_dispatch/testing/integration.rb:388:in 'ActionDispatch::Integration::Runner#head'
    test/dispatch/debug_exceptions_test.rb:189:in 'block in <class:DebugExceptionsTest>'

Error:
ShowExceptionsTest#test_rescue_with_no_body_for_HEAD_requests:
Rack::Lint::LintError: Response body was given for HEAD request, but should be empty
    /home/hartley/.local/share/mise/installs/ruby/3.4.4/lib/ruby/gems/3.4.0/gems/rack-3.1.15/lib/rack/lint.rb:773:in 'Rack::Lint::Wrapper#verify_content_length'
    /home/hartley/.local/share/mise/installs/ruby/3.4.4/lib/ruby/gems/3.4.0/gems/rack-3.1.15/lib/rack/lint.rb:900:in 'Rack::Lint::Wrapper#each'
    /home/hartley/.local/share/mise/installs/ruby/3.4.4/lib/ruby/gems/3.4.0/gems/rack-3.1.15/lib/rack/response.rb:345:in 'Rack::Response::Helpers#buffered_body!'
    /home/hartley/.local/share/mise/installs/ruby/3.4.4/lib/ruby/gems/3.4.0/gems/rack-3.1.15/lib/rack/mock_response.rb:65:in 'Rack::MockResponse#initialize'
    /home/hartley/.local/share/mise/installs/ruby/3.4.4/lib/ruby/gems/3.4.0/gems/rack-test-2.2.0/lib/rack/test.rb:362:in 'Class#new'
    /home/hartley/.local/share/mise/installs/ruby/3.4.4/lib/ruby/gems/3.4.0/gems/rack-test-2.2.0/lib/rack/test.rb:362:in 'Rack::Test::Session#process_request'
    /home/hartley/.local/share/mise/installs/ruby/3.4.4/lib/ruby/gems/3.4.0/gems/rack-test-2.2.0/lib/rack/test.rb:153:in 'Rack::Test::Session#request'
    lib/action_dispatch/testing/integration.rb:297:in 'ActionDispatch::Integration::Session#process'
    lib/action_dispatch/testing/integration.rb:49:in 'ActionDispatch::Integration::RequestHelpers#head'
    lib/action_dispatch/testing/integration.rb:388:in 'ActionDispatch::Integration::Runner#head'
    test/dispatch/show_exceptions_test.rb:73:in 'block in <class:ShowExceptionsTest>'
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
