### PR TITLE
Fix crash when trying to attach a Blob to a Record:

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Prevent `ActiveStorage.touch_attachment_records = false` from crashing the attachment of a Blob.
+
+    When `ActiveStorage.touch_attachment_records` was set to `false`, attaching a existing Blob to a Record
+    would raise an error. This is now fixed.
+
+    *Edouard Chin*
+
 *   Parallelize `exist?` checks and uploads in `MirrorService#mirror` using
     the existing internal thread pool. With N mirrors, wall time drops from
     O(N) to O(1) network round-trips for both phases.

--- a/activestorage/app/models/active_storage/blob.rb
+++ b/activestorage/app/models/active_storage/blob.rb
@@ -433,7 +433,7 @@ class ActiveStorage::Blob < ActiveStorage::Record
             relation
           end
         end.each do |attachment|
-          attachment.touch
+          attachment.touch unless attachment.new_record?
         end
       end
     end

--- a/activestorage/test/models/attachment_test.rb
+++ b/activestorage/test/models/attachment_test.rb
@@ -53,6 +53,23 @@ class ActiveStorage::AttachmentTest < ActiveSupport::TestCase
     assert_equal(1, user.callback_counter)
   end
 
+  test "attaching a blob to a record works when ActiveStorage.touch_attachment_records is false" do
+    ActiveStorage.with(touch_attachment_records: false) do
+      data = "Something else entirely!"
+      io = StringIO.new(data)
+      blob = create_blob_before_direct_upload byte_size: data.size, checksum: ActiveStorage.checksum_implementation.base64digest(data)
+      blob.upload(io)
+
+      assert_nothing_raised do
+        User.create!(
+          name: "Roger",
+          avatar: blob.signed_id,
+          record_callbacks: true,
+        )
+      end
+    end
+  end
+
   test "attaching a record doesn't reset the previously_new_record flag" do
     @user.highlights.attach(io: ::StringIO.new("dummy"), filename: "dummy.txt")
 


### PR DESCRIPTION
### Motivation / Background

- Fix #55144

### Detail

#### Problem

Setting `ActiveStorage.touch_attachment_records` to `false` will make the application crash if it uses the Active Storage direct upload feature.

#### Context

When an existing Blob is attached to a Record, Active Storage tries to `touch` its Attachment, but the Attachment is not yet persisted, resulting in an exception.

Before #53623, a Blob was responsible to autosave its Attachment, which would result in:

1) Creating a Blob
2) Autosaving its Attachment
3) Touching the just saved Attachment

We were basically making an unnecessary SQL query in 3).

This problem only happens when `ActiveStorage.touch_attachment_records` is set to false. When it's set to true (the default), the bug doesn't reproduce because of [this line](https://github.com/rails/rails/blob/fc55e5b812f75b70bc10c99c6a81d1bff5412438/activestorage/app/models/active_storage/blob.rb#L366) which returns an empty Relation (an Attachment doesn't yet have a Record at this stage)

#### Solution

Now that a Blob no longer autosave its Attachment, we need to manually check whether the Attachment is persisted before trying to `touch` it.


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
