### PR TITLE
Fix ActiveStorage filename sanitization for consecutive spaces

### DIFF
--- a/activestorage/app/models/active_storage/filename.rb
+++ b/activestorage/app/models/active_storage/filename.rb
@@ -57,7 +57,7 @@ class ActiveStorage::Filename
   #
   # Characters considered unsafe for storage (e.g. \, $, and the RTL override character) are replaced with a dash.
   def sanitized
-    @filename.encode(Encoding::UTF_8, invalid: :replace, undef: :replace, replace: "�").strip.tr("\u{202E}%$|:;/<>?*\"\t\r\n\\", "-")
+    @filename.encode(Encoding::UTF_8, invalid: :replace, undef: :replace, replace: "�").strip.squeeze(" ").tr("\u{202E}%$|:;/<>?*\"\t\r\n\\", "-")
   end
 
   # Returns the sanitized version of the filename.

--- a/activestorage/test/models/filename_test.rb
+++ b/activestorage/test/models/filename_test.rb
@@ -46,6 +46,13 @@ class ActiveStorage::FilenameTest < ActiveSupport::TestCase
     assert_equal "evil-fdp.exe", ActiveStorage::Filename.new("evil\u{202E}fdp.exe").sanitized
   end
 
+  test "sanitize normalizes consecutive spaces" do
+    assert_equal "my file.txt", ActiveStorage::Filename.new("my  file.txt").sanitized
+    assert_equal "my file.txt", ActiveStorage::Filename.new("my   file.txt").sanitized
+    assert_equal "my file.txt", ActiveStorage::Filename.new("  my  file.txt  ").sanitized
+    assert_equal "file-with-tabs.txt", ActiveStorage::Filename.new("file\twith\ttabs.txt").sanitized
+  end
+
   test "compare case-insensitively" do
     assert_operator ActiveStorage::Filename.new("foobar.pdf"), :==, ActiveStorage::Filename.new("FooBar.PDF")
   end


### PR DESCRIPTION
Fixes S3 signature mismatch errors when filenames contain consecutive spaces. The issue occurred because Content-Disposition headers had inconsistent encoding between ASCII and UTF-8 parts when consecutive spaces were present.

Changes:
- Add squeeze(" ") in ActiveStorage::Filename#sanitized to normalize consecutive spaces into single spaces while preserving other sanitization
- Add test coverage for consecutive space normalization

This maintains existing behavior for other whitespace characters (tabs, newlines) which are still converted to dashes as before.

Fixes #55158