### PR TITLE
Docs: Add link to Turbo Streams docs in ActionCable guide [ci skip]

### DIFF
--- a/guides/source/action_cable_overview.md
+++ b/guides/source/action_cable_overview.md
@@ -27,6 +27,13 @@ client-side JavaScript framework and a server-side Ruby framework. You have
 access to your entire domain model written with Active Record or your ORM of
 choice.
 
+Turbo Streams, part of [Hotwire](https://hotwired.dev/), provides a higher-level
+abstraction of many common ActionCable uses, such as delivering real-time UI
+updates. Depending on an app's needs, it may not be necessary to work directly
+with ActionCable. Learn more in the
+[Turbo Handbook](https://turbo.hotwired.dev/handbook/streams)
+and [turbo-rails](https://github.com/hotwired/turbo-rails/) docs.
+
 Terminology
 -----------
 


### PR DESCRIPTION
I've been learning about Turbo Streams recently, and noted a few places in the docs for potential improvements. 

One is that the first place searches like "rails websockets" lead to is the ActionCable guide, which doesn't currently make any references to Hotwire.

If this proposed change seems in the ballpark but not quite right, I'm happy to do additional wordsmithing. 
