### PR TITLE
[7-2-stable] Merge pull request #54908 from sebaherrera07/update_rails_7_2_release_notes

### DIFF
--- a/guides/source/7_2_release_notes.md
+++ b/guides/source/7_2_release_notes.md
@@ -478,6 +478,8 @@ Please refer to the [Changelog][active-record] for detailed changes.
 
 ### Notable changes
 
+*   `ActiveRecord::Base.establish_connection` no longer sets `ActiveRecord::Base.connection.active?` to `true`. If you need this behavior, you can use `ActiveRecord::Base.connection.verify!` instead.
+
 Active Storage
 --------------
 


### PR DESCRIPTION
Backports #54908 to 7-2-stable

Add ActiveRecord::Base.establish_connection behavior change to Rails 7.2 release notes

---

We should backport release note changes if the branch is maintained, assuming that users upgrading are reading the docs generated for that version. (Although branches aren't built on docs site, yet)