### PR TITLE
Prevent Action View digestor from tracking random "render":

### DIFF
--- a/actionview/lib/action_view/dependency_tracker/erb_tracker.rb
+++ b/actionview/lib/action_view/dependency_tracker/erb_tracker.rb
@@ -91,7 +91,7 @@ module ActionView
 
         def render_dependencies
           dependencies = []
-          render_calls = source.split(/\brender\b/).drop(1)
+          render_calls = source.scan(/<%(?:(?:(?!<%).)*?\brender\b((?:(?!%>).)*?))%>/m).flatten
 
           render_calls.each do |arguments|
             add_dependencies(dependencies, arguments, LAYOUT_DEPENDENCY)

--- a/actionview/test/template/dependency_tracker_test.rb
+++ b/actionview/test/template/dependency_tracker_test.rb
@@ -118,6 +118,29 @@ module SharedTrackerTests
     assert_equal [], tracker.dependencies
   end
 
+  def test_finds_no_dependency_when_render_is_not_a_ruby_call
+    template = FakeTemplate.new("<div class='render foo'>", :erb)
+    tracker = make_tracker("resources/_resource", template)
+
+    assert_equal [], tracker.dependencies
+  end
+
+  def test_find_dependencies_and_respect_erb_tag_boundaries
+    template = FakeTemplate.new("<p>Hello</p> <% link_to abc %> <%= render 'single/quote' %>", :erb)
+    tracker = make_tracker("resources/_resource", template)
+
+    assert_equal ["single/quote"], tracker.dependencies
+  end
+
+  def test_find_all_dependencies_and_respect_erb_tag_boundaries
+    template = FakeTemplate.new("<p>Hello</p> <%=
+      render object: @all_posts,
+             partial: 'posts' %> <% link_to abc %> <%= render 'single/quote' %>", :erb)
+    tracker = make_tracker("resources/_resource", template)
+
+    assert_equal ["resources/posts", "single/quote"], tracker.dependencies
+  end
+
   def test_finds_dependency_on_multiline_render_calls
     template = FakeTemplate.new("<%=
       render object: @all_posts,


### PR DESCRIPTION
### Motivation / Background

Fix #55161

### Detail

#### Problem

Caching a partial that contains the word "render" (literally, not the `render` method), would create a false positive in AV's digestor.
This results in a rather confusing log message.

```html+erb
<%# _partial.html.erb %>

<% cache "key" do %>
  <div class="render flex"></div>
<% end %>
```

The log error: "Couldn't find template for digesting: flexes/flex"

#### Solution

Tweak the regex and check for surrounding erb tags.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
