### PR TITLE
Use `Parameters#expect` in the templates for the authentication generator too

### DIFF
--- a/guides/source/security.md
+++ b/guides/source/security.md
@@ -190,7 +190,7 @@ in the database (e.g. password) for that user:
 ```ruby
 class SessionsController < ApplicationController
   def create
-    if user = User.authenticate_by(params.permit(:email_address, :password))
+    if user = User.authenticate_by(params.expect(:email_address, :password))
       start_new_session_for user
       redirect_to after_authentication_url
     else

--- a/railties/lib/rails/generators/rails/authentication/templates/app/controllers/passwords_controller.rb.tt
+++ b/railties/lib/rails/generators/rails/authentication/templates/app/controllers/passwords_controller.rb.tt
@@ -22,7 +22,7 @@ class PasswordsController < ApplicationController
   end
 
   def update
-    if @user.update(params.permit(:password, :password_confirmation))
+    if @user.update(params.expect(:password, :password_confirmation))
       @user.sessions.destroy_all
       redirect_to new_session_path, notice: "Password has been reset."
     else

--- a/railties/lib/rails/generators/rails/authentication/templates/app/controllers/sessions_controller.rb.tt
+++ b/railties/lib/rails/generators/rails/authentication/templates/app/controllers/sessions_controller.rb.tt
@@ -6,7 +6,7 @@ class SessionsController < ApplicationController
   end
 
   def create
-    if user = User.authenticate_by(params.permit(:email_address, :password))
+    if user = User.authenticate_by(params.expect(:email_address, :password))
       start_new_session_for user
       redirect_to after_authentication_url
     else


### PR DESCRIPTION
The templates used in `rails g authentication` were still using `Parameters#permit`, while the scaffold templates were already updated to use `Parameters#expect` in https://github.com/rails/rails/pull/51674 . This change makes them consistent.

