### PR TITLE
[ci skip] Add warning note to :source_location tag option

### DIFF
--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -1488,6 +1488,8 @@ Define an `Array` specifying the key/value tags to be inserted in an SQL comment
 `[ :application, :controller, :action, :job ]`. The available tags are: `:application`, `:controller`,
 `:namespaced_controller`, `:action`, `:job`, and `:source_location`.
 
+WARNING: Calculating the caller location via `:source_location` is a costly operation and should be used primarily in development (note, there is also a `config.active_record.verbose_query_logs` that serves the same purpose) or occasionally on production for debugging purposes.
+
 #### `config.active_record.query_log_tags_format`
 
 A `Symbol` specifying the formatter to use for tags. Valid values are `:sqlcommenter` and `:legacy`.

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -1488,7 +1488,7 @@ Define an `Array` specifying the key/value tags to be inserted in an SQL comment
 `[ :application, :controller, :action, :job ]`. The available tags are: `:application`, `:controller`,
 `:namespaced_controller`, `:action`, `:job`, and `:source_location`.
 
-WARNING: Calculating the caller location via `:source_location` is a costly operation and should be used primarily in development (note, there is also a `config.active_record.verbose_query_logs` that serves the same purpose) or occasionally on production for debugging purposes.
+WARNING: Calculating the `:source_location` of a query can be slow, so you should consider its impact if using it in a production environment.
 
 #### `config.active_record.query_log_tags_format`
 


### PR DESCRIPTION
`:source_location` adds significant overhead to each SQL query issued from a Rails application. Although this behavior has been noted in the changelog, it is not immediately apparent when reading the official Rails application [configuration documentation](https://guides.rubyonrails.org/v8.0.2/configuring.html#config-active-record-query-log-tags).

### Motivation / Background

While profiling the application, we observed that a substantial amount of time was spent parsing thread stack frames. We discovered that this overhead is caused by the `:source_location` tag option. Eventually, we found a note [in the changelog](https://github.com/rails/rails/pull/50969/files#diff-353f4f101b1bb04938d761b6e29c88e0f147084e9e276854a77ae5d9a9a3b2a8R1), but it is not necessarily the most discoverable information. In fact, we might not have noticed this issue at all without addressing performance issues in production.

### Detail
This pull request adds a WARNING note to the configuration documentation to highlight this potential performance impact.

### Additional information
If the code path issues multiple SQL queries, the system will attempt to parse the source location for each query. In our case, the total time spent in this process accounts for approximately 20-30% of the overall execution time.

![Screenshot 2025-06-06 at 16 32 31](https://github.com/user-attachments/assets/12bb876c-1468-405a-a22d-c310597b8197)

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
