### PR TITLE
Alias `allow_nil` and `allow_blank` to `ignore_if_nil` and `ignore_if_blank`

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Add `:ignore_if_nil` and `:ignore_if_blank` validation aliases.
+
+    They are aliases for the `:allow_nil` and `:allow_blank` validation options.
+
+    *Jerome Dalbert*
+
 *   Add `except_on:` option for validation callbacks.
 
     *Ben Sheldon*

--- a/activemodel/lib/active_model/validations.rb
+++ b/activemodel/lib/active_model/validations.rb
@@ -75,7 +75,9 @@ module ActiveModel
       #   <tt>except_on: :custom_validation_context</tt> or
       #   <tt>except_on: [:create, :custom_validation_context]</tt>)
       # * <tt>:allow_nil</tt> - Skip validation if attribute is +nil+.
+      #   Also aliased as `:ignore_if_nil`.
       # * <tt>:allow_blank</tt> - Skip validation if attribute is blank.
+      #   Also aliased as `:ignore_if_blank`.
       # * <tt>:if</tt> - Specifies a method, proc, or string to call to determine
       #   if the validation should occur (e.g. <tt>if: :allow_validation</tt>,
       #   or <tt>if: Proc.new { |user| user.signup_step > 2 }</tt>). The method,

--- a/activemodel/lib/active_model/validations/validates.rb
+++ b/activemodel/lib/active_model/validations/validates.rb
@@ -93,7 +93,9 @@ module ActiveModel
       #   method, proc, or string should return or evaluate to a +true+ or
       #   +false+ value.
       # * <tt>:allow_nil</tt> - Skip validation if the attribute is +nil+.
+      #   Also aliased as <tt>:ignore_if_nil</tt>.
       # * <tt>:allow_blank</tt> - Skip validation if the attribute is blank.
+      #   Also aliased as <tt>:ignore_if_blank</tt>.
       # * <tt>:strict</tt> - If the <tt>:strict</tt> option is set to true
       #   will raise ActiveModel::StrictValidationFailed instead of adding the error.
       #   <tt>:strict</tt> option can also be set to any other exception.
@@ -110,6 +112,7 @@ module ActiveModel
       #   validates :password, presence: { if: :password_required?, message: 'is forgotten.' }, confirmation: true
       def validates(*attributes)
         defaults = attributes.extract_options!.dup
+        defaults.transform_keys!(ignore_if_nil: :allow_nil, ignore_if_blank: :allow_blank)
         validations = defaults.slice!(*_validates_default_keys)
 
         raise ArgumentError, "You need to supply at least one attribute" if attributes.empty?

--- a/activemodel/lib/active_model/validator.rb
+++ b/activemodel/lib/active_model/validator.rb
@@ -140,6 +140,7 @@ module ActiveModel
     def initialize(options)
       @attributes = Array(options.delete(:attributes))
       raise ArgumentError, ":attributes cannot be blank" if @attributes.empty?
+      options.transform_keys!(ignore_if_nil: :allow_nil, ignore_if_blank: :allow_blank)
       super
       check_validity!
     end

--- a/activemodel/test/cases/validations/format_validation_test.rb
+++ b/activemodel/test/cases/validations/format_validation_test.rb
@@ -34,6 +34,14 @@ class FormatValidationTest < ActiveModel::TestCase
     assert_predicate Topic.new("title" => "Validation macros rule!"), :valid?
   end
 
+  def test_validate_format_with_ignore_if_blank_alias
+    Topic.validates_format_of(:title, with: /\AValidation\smacros \w+!\z/, ignore_if_blank: true)
+    assert_predicate Topic.new("title" => "Shouldn't be valid"), :invalid?
+    assert_predicate Topic.new("title" => ""), :valid?
+    assert_predicate Topic.new("title" => nil), :valid?
+    assert_predicate Topic.new("title" => "Validation macros rule!"), :valid?
+  end
+
   # testing ticket #3142
   def test_validate_format_numeric
     Topic.validates_format_of(:title, :content, with: /\A[1-9][0-9]*\z/, message: "is bad data")

--- a/activemodel/test/cases/validations/inclusion_validation_test.rb
+++ b/activemodel/test/cases/validations/inclusion_validation_test.rb
@@ -105,6 +105,14 @@ class InclusionValidationTest < ActiveModel::TestCase
     assert_predicate Topic.new("title" => nil,  "content" => "abc"), :valid?
   end
 
+  def test_validates_inclusion_of_with_ignore_if_nil_alias
+    Topic.validates_inclusion_of(:title, in: %w( a b c d e f g ), ignore_if_nil: true)
+
+    assert_predicate Topic.new("title" => "a!", "content" => "abc"), :invalid?
+    assert_predicate Topic.new("title" => "",   "content" => "abc"), :invalid?
+    assert_predicate Topic.new("title" => nil,  "content" => "abc"), :valid?
+  end
+
   def test_validates_inclusion_of_with_formatted_message
     Topic.validates_inclusion_of(:title, in: %w( a b c d e f g ), message: "option %{value} is not in the list")
 

--- a/activemodel/test/cases/validations/length_validation_test.rb
+++ b/activemodel/test/cases/validations/length_validation_test.rb
@@ -19,8 +19,26 @@ class LengthValidationTest < ActiveModel::TestCase
     assert_predicate Topic.new("title" => "abcde"), :valid?
   end
 
+  def test_validates_length_of_with_ignore_if_nil_alias
+    Topic.validates_length_of(:title, is: 5, ignore_if_nil: true)
+
+    assert_predicate Topic.new("title" => "ab"), :invalid?
+    assert_predicate Topic.new("title" => ""), :invalid?
+    assert_predicate Topic.new("title" => nil), :valid?
+    assert_predicate Topic.new("title" => "abcde"), :valid?
+  end
+
   def test_validates_length_of_with_allow_blank
     Topic.validates_length_of(:title, is: 5, allow_blank: true)
+
+    assert_predicate Topic.new("title" => "ab"), :invalid?
+    assert_predicate Topic.new("title" => ""), :valid?
+    assert_predicate Topic.new("title" => nil), :valid?
+    assert_predicate Topic.new("title" => "abcde"), :valid?
+  end
+
+  def test_validates_length_of_with_ignore_if_blank_alias
+    Topic.validates_length_of(:title, is: 5, ignore_if_blank: true)
 
     assert_predicate Topic.new("title" => "ab"), :invalid?
     assert_predicate Topic.new("title" => ""), :valid?

--- a/activemodel/test/cases/validations/presence_validation_test.rb
+++ b/activemodel/test/cases/validations/presence_validation_test.rb
@@ -89,8 +89,42 @@ class PresenceValidationTest < ActiveModel::TestCase
     assert_predicate t, :valid?
   end
 
+  def test_validates_presence_of_with_ignore_if_nil_alias
+    Topic.validates_presence_of(:title, ignore_if_nil: true)
+
+    t = Topic.new(title: "something")
+    assert_predicate t, :valid?
+
+    t.title = ""
+    assert_predicate t, :invalid?
+    assert_equal ["can't be blank"], t.errors[:title]
+
+    t.title = "  "
+    assert_predicate t, :invalid?
+    assert_equal ["can't be blank"], t.errors[:title]
+
+    t.title = nil
+    assert_predicate t, :valid?
+  end
+
   def test_validates_presence_of_with_allow_blank_option
     Topic.validates_presence_of(:title, allow_blank: true)
+
+    t = Topic.new(title: "something")
+    assert_predicate t, :valid?
+
+    t.title = ""
+    assert_predicate t, :valid?
+
+    t.title = "  "
+    assert_predicate t, :valid?
+
+    t.title = nil
+    assert_predicate t, :valid?
+  end
+
+  def test_validates_presence_of_with_ignore_if_blank_alias
+    Topic.validates_presence_of(:title, ignore_if_blank: true)
 
     t = Topic.new(title: "something")
     assert_predicate t, :valid?

--- a/activemodel/test/cases/validations/validates_test.rb
+++ b/activemodel/test/cases/validations/validates_test.rb
@@ -93,6 +93,26 @@ class ValidatesTest < ActiveModel::TestCase
     assert_predicate person, :valid?
   end
 
+  def test_validates_with_ignore_if_nil_alias
+    Person.validates :karma, length: { minimum: 20 }, ignore_if_nil: true
+    person = Person.new
+    assert_predicate person, :valid?
+  end
+
+  def test_validates_with_allow_blank_shared_conditions
+    Person.validates :karma, length: { minimum: 20 }, email: true, allow_blank: true
+    person = Person.new
+    person.karma = ""
+    assert_predicate person, :valid?
+  end
+
+  def test_validates_with_ignore_if_blank_alias
+    Person.validates :karma, length: { minimum: 20 }, ignore_if_blank: true
+    person = Person.new
+    person.karma = ""
+    assert_predicate person, :valid?
+  end
+
   def test_validates_with_regexp
     Person.validates :karma, format: /positive|negative/
     person = Person.new

--- a/activemodel/test/cases/validations/with_validation_test.rb
+++ b/activemodel/test/cases/validations/with_validation_test.rb
@@ -143,8 +143,24 @@ class ValidatesWithTest < ActiveModel::TestCase
     assert_equal ["Value is "], topic.errors[:content]
   end
 
+  test "each validator skip nil values if :ignore_if_nil alias is set to true" do
+    Topic.validates_with(ValidatorPerEachAttribute, attributes: [:title, :content], ignore_if_nil: true)
+    topic = Topic.new content: ""
+    assert_predicate topic, :invalid?
+    assert_empty topic.errors[:title]
+    assert_equal ["Value is "], topic.errors[:content]
+  end
+
   test "each validator skip blank values if :allow_blank is set to true" do
     Topic.validates_with(ValidatorPerEachAttribute, attributes: [:title, :content], allow_blank: true)
+    topic = Topic.new content: ""
+    assert_predicate topic, :valid?
+    assert_empty topic.errors[:title]
+    assert_empty topic.errors[:content]
+  end
+
+  test "each validator skip blank values if :ignore_if_blank alias is set to true" do
+    Topic.validates_with(ValidatorPerEachAttribute, attributes: [:title, :content], ignore_if_blank: true)
     topic = Topic.new content: ""
     assert_predicate topic, :valid?
     assert_empty topic.errors[:title]

--- a/guides/source/active_model_basics.md
+++ b/guides/source/active_model_basics.md
@@ -1448,8 +1448,10 @@ documentation](https://api.rubyonrails.org/classes/ActiveModel/Validations/Class
   return or evaluate to a `true` or `false` value.
 
 - `:allow_nil`: Skip the validation if the attribute is `nil`.
+  Also aliased as `:ignore_if_nil`.
 
 - `:allow_blank`: Skip the validation if the attribute is blank.
+  Also aliased as `:ignore_if_blank`.
 
 - `:strict`: If the `:strict` option is set to true, it will raise
   `ActiveModel::StrictValidationFailed` instead of adding the error. `:strict`

--- a/guides/source/active_record_validations.md
+++ b/guides/source/active_record_validations.md
@@ -1148,6 +1148,8 @@ irb> Coffee.create(size: "mega").valid?
 For full options to the message argument please see the [message
 documentation](#message).
 
+Also aliased as `:ignore_if_nil`.
+
 ### `:allow_blank`
 
 The `:allow_blank` option is similar to the `:allow_nil` option. This option
@@ -1168,6 +1170,8 @@ irb> Topic.create(title: nil).valid?
 irb> Topic.create(title: "short").valid?
 => false # 'short' is not of length 6, so validation fails even though it's not blank
 ```
+
+Also aliased as `:ignore_if_blank`.
 
 ### `:message`
 


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because some users find the names of the `allow_blank` and `allow_nil` validation options to be unintuitive.

I realized this at work when reviewing a PR that looked like this:

```ruby
class Fruit < ApplicationRecord
  validates :name, presence: true
  validates :name, inclusion: { in: %w[apple banana] }, if: -> { name.present? }
end
```

I mentioned that this could be a use case for `allow_blank`:

```diff
class Fruit < ApplicationRecord
  validates :name, presence: true
-  validates :name, inclusion: { in: %w[apple banana] }, if: -> { name.present? }
+  validates :name, inclusion: { in: %w[apple banana] }, allow_blank: true
end
```

My coworker did not have any strong feelings either way, but mentioned that `allow_blank` makes them think that the field can be blank from a wording perspective. It didn't feel very clear to them.

While the intended Rails meaning is "allow the validation to pass (aka ignore or skip it) if the field is blank", I think that my coworker had a point: this is not the most intuitive wording. I have been using `allow_blank` for years, so my brain is used to it and I do not think twice about it, but I could see how it could be confusing at first with a pair of fresh eyes.

A name like `ignore_validation_if_field_is_blank: true` would be extra clear albeit clunky, so more realistically we thought that a name like `ignore_if_blank` would be nice. Some other names could be `skip_if_blank` or `if_present`.

### Detail

This Pull Request adds `ignore_if_nil` and `ignore_if_blank` as aliases for the `allow_nil` and `allow_blank` validation options. If those aliases are present, they are internally converted to `allow_nil` and `allow_blank` keys.

While different people may have different opinions about this, there is precedent in the Rails codebase for more intuitive aliases, such as ActiveRecord's `t.references`/`t.belongs_to` and `add_reference`/`add_belongs_to`.

If the maintainers think that some form of this PR is worth merging, the implementation details could be tweaked, or different names like `skip_if_nil`/`skip_if_blank` or `if_present`/`if_not_nil` could be used based on preference.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
