### PR TITLE
Active Job Continuations 3

### DIFF
--- a/activejob/lib/active_job/continuation/step.rb
+++ b/activejob/lib/active_job/continuation/step.rb
@@ -22,18 +22,18 @@ module ActiveJob
       # The cursor for the step.
       attr_reader :cursor
 
-      def initialize(name, cursor, resumed:, &checkpoint_callback)
+      def initialize(name, cursor, job:, resumed:)
         @name = name.to_sym
         @initial_cursor = cursor
         @cursor = cursor
         @resumed = resumed
-        @checkpoint_callback = checkpoint_callback
+        @job = job
       end
 
       # Check if the job should be interrupted, and if so raise an Interrupt exception.
       # The job will be requeued for retry.
       def checkpoint!
-        checkpoint_callback.call
+        job.checkpoint!
       end
 
       # Set the cursor and interrupt the job if necessary.
@@ -77,7 +77,7 @@ module ActiveJob
       end
 
       private
-        attr_reader :checkpoint_callback, :initial_cursor
+        attr_reader :initial_cursor, :job
     end
   end
 end

--- a/activejob/lib/active_job/continuation/test_helper.rb
+++ b/activejob/lib/active_job/continuation/test_helper.rb
@@ -40,6 +40,8 @@ module ActiveJob
 
       # Interrupt a job after a step.
       #
+      # Note that there's no checkpoint after the final step so it won't be interrupted.
+      #
       #  class MyJob < ApplicationJob
       #    include ActiveJob::Continuable
       #

--- a/activejob/lib/active_job/continuation/validation.rb
+++ b/activejob/lib/active_job/continuation/validation.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+module ActiveJob
+  class Continuation
+    module Validation # :nodoc:
+      private
+        def validate_step!(name)
+          validate_step_symbol!(name)
+          validate_step_not_encountered!(name)
+          validate_step_not_nested!(name)
+          validate_step_resume_expected!(name)
+          validate_step_expected_order!(name)
+        end
+
+        def validate_step_symbol!(name)
+          unless name.is_a?(Symbol)
+            raise_step_error! "Step '#{name}' must be a Symbol, found '#{name.class}'"
+          end
+        end
+
+        def validate_step_not_encountered!(name)
+          if encountered.include?(name)
+            raise_step_error! "Step '#{name}' has already been encountered"
+          end
+        end
+
+        def validate_step_not_nested!(name)
+          if running_step?
+            raise_step_error! "Step '#{name}' is nested inside step '#{current.name}'"
+          end
+        end
+
+        def validate_step_resume_expected!(name)
+          if current && current.name != name && !completed?(name)
+            raise_step_error! "Step '#{name}' found, expected to resume from '#{current.name}'"
+          end
+        end
+
+        def validate_step_expected_order!(name)
+          if completed.size > encountered.size && completed[encountered.size] != name
+            raise_step_error! "Step '#{name}' found, expected to see '#{completed[encountered.size]}'"
+          end
+        end
+
+        def raise_step_error!(message)
+          raise InvalidStepError, message
+        end
+    end
+  end
+end

--- a/activejob/lib/active_job/instrumentation.rb
+++ b/activejob/lib/active_job/instrumentation.rb
@@ -30,8 +30,8 @@ module ActiveJob
       payload[:job] = self
       payload[:adapter] = queue_adapter
 
-      ActiveSupport::Notifications.instrument("#{operation}.active_job", payload) do
-        value = block.call if block
+      ActiveSupport::Notifications.instrument("#{operation}.active_job", payload) do |payload|
+        value = block.call(payload) if block
         payload[:aborted] = @_halted_callback_hook_called if defined?(@_halted_callback_hook_called)
         @_halted_callback_hook_called = nil
         value

--- a/activerecord/lib/active_record/railtie.rb
+++ b/activerecord/lib/active_record/railtie.rb
@@ -278,6 +278,13 @@ To keep using the current cache store, you can turn off cache versioning entirel
       end
     end
 
+    initializer "active_record.job_checkpoints" do
+      require "active_record/railties/job_checkpoints"
+      ActiveSupport.on_load(:active_job_continuable) do
+        prepend ActiveRecord::Railties::JobCheckpoints
+      end
+    end
+
     initializer "active_record.set_reloader_hooks" do
       ActiveSupport.on_load(:active_record) do
         ActiveSupport::Reloader.before_class_unload do

--- a/activerecord/lib/active_record/railties/job_checkpoints.rb
+++ b/activerecord/lib/active_record/railties/job_checkpoints.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module ActiveRecord
+  module Railties # :nodoc:
+    module JobCheckpoints # :nodoc:
+      def checkpoint!
+        if ActiveRecord.all_open_transactions.any?
+          raise ActiveJob::Continuation::CheckpointError, "Cannot checkpoint job with open transactions"
+        else
+          super
+        end
+      end
+    end
+  end
+end

--- a/activerecord/test/activejob/job_checkpoints_test.rb
+++ b/activerecord/test/activejob/job_checkpoints_test.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require "activejob/helper"
+require "active_job/continuable"
+require "active_record/railties/job_checkpoints"
+
+class JobCheckpointTest < ActiveSupport::TestCase
+  class CheckpointInTransactionJob < ActiveJob::Base
+    include ActiveJob::Continuable
+    include ActiveRecord::Railties::JobCheckpoints
+
+    def perform(*)
+      step :checkpoint_in_transaction do |step|
+        ActiveRecord::Base.transaction do
+          step.checkpoint!
+        end
+      end
+    end
+  end
+
+  class CheckpointOutsideTransactionJob < ActiveJob::Base
+    include ActiveJob::Continuable
+    include ActiveRecord::Railties::JobCheckpoints
+
+    def perform(*)
+      step :checkpoint_outside_transaction do |step|
+        ActiveRecord::Base.transaction do
+        end
+        step.checkpoint!
+      end
+    end
+  end
+
+  test "checkpoints in transactions raise" do
+    exception = assert_raises { CheckpointInTransactionJob.perform_now }
+    assert_equal "Cannot checkpoint job with open transactions", exception.message
+  end
+
+  test "checkpoints outside transactions complete" do
+    assert_nothing_raised { CheckpointOutsideTransactionJob.perform_now }
+  end
+end

--- a/railties/test/application/active_record_railtie_test.rb
+++ b/railties/test/application/active_record_railtie_test.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require "isolation/abstract_unit"
+
+module ApplicationTests
+  class ActiveRecordRailtieTest < ActiveSupport::TestCase
+    include ActiveSupport::Testing::Isolation
+
+    setup :build_app
+    teardown :teardown_app
+
+    test "continuable jobs raise when checkpointing in a transaction" do
+      app_file "app/jobs/continuable_job.rb", <<~RUBY
+        require "active_job/continuable"
+
+        class ContinuableJob < ActiveJob::Base
+          include ActiveJob::Continuable
+
+          def perform(*)
+            step :checkpoint_in_transaction do |step|
+              ActiveRecord::Base.transaction do
+                step.checkpoint!
+              end
+            end
+          end
+        end
+      RUBY
+
+      exception = assert_raises do
+        rails("runner", "ContinuableJob.perform_now")
+      end
+      assert_includes exception.message, "ActiveJob::Continuation::CheckpointError: Cannot checkpoint job with open transactions"
+    end
+  end
+end


### PR DESCRIPTION
Follow up to https://github.com/rails/rails/pull/55127 and https://github.com/rails/rails/pull/55151

- Instrument steps in a block so that runtime is recorded (matching `perform`/`perform_started`)
- Allow job resumption configuration - `max_resumptions`, `resume_options`, `resume_errors_after_advancing`
- Add Active Record Railtie to prevent checkpoints in database transactions
- Checkpoint before each step except the first, rather than after each step.
- Error if order of completed steps changes when re-running
