### PR TITLE
[ci skip] docs: clarify has_one association replacement behavior in Guides

### DIFF
--- a/guides/source/association_basics.md
+++ b/guides/source/association_basics.md
@@ -605,8 +605,16 @@ end
 ##### Saving Behavior of Associated Objects
 
 When you assign an object to a `has_one` association, that object is
-automatically saved to update its foreign key. Additionally, any object being
-replaced is also automatically saved, as its foreign key will change too.
+automatically saved to update its foreign key. If there is an existing
+associated object being replaced, the way the previous association is removed
+and saved depends on the `:dependent` option set on the association. For
+example, if `dependent: :destroy` is specified, the previous associated object
+will be destroyed by calling its `destroy` method. If `dependent: :delete` is
+specified, it will be deleted directly from the database. If no `:dependent`
+option is set, the foreign key on the previous associated object will be set to
+`NULL`. In all cases, the previous associated object is also saved as needed to
+reflect the change in association. This ensures that the removal of the
+previous association is handled according to your configuration.
 
 If either of these saves fails due to validation errors, the assignment
 statement returns `false`, and the assignment itself is canceled.


### PR DESCRIPTION
### Motivation / Background

Previously, the Rails Guides didn't explain what happens when a has_one association is replaced with a new object — specifically, how the existing associated object is handled depending on the :dependent option. This behavior can be non-obvious, especially for developers unfamiliar with the internal implementation. By documenting that the previous association is removed according to the :dependent setting (e.g., :destroy, :delete, or :nullify), we can make the framework's behavior clearer and help prevent confusion or unintended data loss.

### Detail

This Pull Request changes the section "Saving Behavior of Associated Objects" in `guides/source/association_basics.md`.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.

