### PR TITLE
Add ability to change the transaction isolation for all pools within a block

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,30 @@
+*   Add ability to change transaction isolation for all pools within a block.
+
+    This functionality is useful if your application needs to change the database
+    transaction isolation for a request or action.
+
+    Calling `ActiveRecord.with_transaction_isolation_level(level) {}` in an around filter or
+    middleware will set the transaction isolation for all pools accessed within the block,
+    but not for the pools that aren't.
+
+    This works with explicit and implicit transactions:
+
+    ```ruby
+    ActiveRecord.with_transaction_isolation_level(:read_committed) do
+      Tag.transaction do # opens a transaction explicitly
+        Tag.create!
+      end
+    end
+    ```
+
+    ```ruby
+    ActiveRecord.with_transaction_isolation_level(:read_committed) do
+      Tag.create! # opens a transaction implicitly
+    end
+    ```
+
+    *Eileen M. Uchitelle*
+
 *   `:class_name` is now invalid in polymorphic `belongs_to` associations.
 
     Reason is `:class_name` does not make sense in those associations because

--- a/activerecord/lib/active_record.rb
+++ b/activerecord/lib/active_record.rb
@@ -574,6 +574,23 @@ module ActiveRecord
     end
     open_transactions
   end
+
+  def self.default_transaction_isolation_level=(isolation_level) # :nodoc:
+    ActiveSupport::IsolatedExecutionState[:active_record_transaction_isolation] = isolation_level
+  end
+
+  def self.default_transaction_isolation_level # :nodoc:
+    ActiveSupport::IsolatedExecutionState[:active_record_transaction_isolation]
+  end
+
+  # Sets a transaction isolation level for all connection pools within the block.
+  def self.with_transaction_isolation_level(isolation_level, &block)
+    original_level = self.default_transaction_isolation_level
+    self.default_transaction_isolation_level = isolation_level
+    yield
+  ensure
+    self.default_transaction_isolation_level = original_level
+  end
 end
 
 ActiveSupport.on_load(:active_record) do

--- a/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
@@ -620,7 +620,7 @@ module ActiveRecord
       end
 
       def within_new_transaction(isolation: nil, joinable: true)
-        isolation ||= @connection.pool.default_isolation_level
+        isolation ||= @connection.pool.pool_transaction_isolation_level
         @connection.lock.synchronize do
           transaction = begin_transaction(isolation: isolation, joinable: joinable)
           begin


### PR DESCRIPTION
rails/rails#54836 introduced the ability to change the isolation for the current pool. If you're changing the default transaction isolation for an app with many dbs/shards you would need to loop through all pools and apply the isolation. If there are hundreds of connections, that might create a performance issue.

This change adds a new method
`ActiveRecord.with_transaction_isolation_level` which will change the transaction isolation for any pool accessed within the block. The method can be used in an around filter to update all transactions for an action.

I chose to call this from `with_transaction_returning_status` and `transaction` because called from within `connection.transaction` made it too difficult to tell if we were changing the isolation on an open transaction.

While implementing this I felt that the original method had a confusing name paired with the new one so I updated it to be more explicit that it's for only the currently accessed pool.