### PR TITLE
Fix affected_rows for SQLite adapter (again)

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/sqlite3/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3/database_statements.rb
@@ -103,11 +103,23 @@ module ActiveRecord
                 end
                 result = if stmt.column_count.zero? # No return
                   stmt.step
-                  affected_rows = raw_connection.total_changes - total_changes_before_query
+
+                  affected_rows = if (raw_connection.total_changes - total_changes_before_query) > 0
+                    raw_connection.changes
+                  else
+                    0
+                  end
+
                   ActiveRecord::Result.empty(affected_rows: affected_rows)
                 else
                   rows = stmt.to_a
-                  affected_rows = raw_connection.total_changes - total_changes_before_query
+
+                  affected_rows = if (raw_connection.total_changes - total_changes_before_query) > 0
+                    raw_connection.changes
+                  else
+                    0
+                  end
+
                   ActiveRecord::Result.new(stmt.columns, rows, stmt.types.map { |t| type_map.lookup(t) }, affected_rows: affected_rows)
                 end
               ensure

--- a/activerecord/test/cases/relation/delete_all_test.rb
+++ b/activerecord/test/cases/relation/delete_all_test.rb
@@ -2,8 +2,10 @@
 
 require "cases/helper"
 require "models/author"
+require "models/lesson"
 require "models/post"
 require "models/pet"
+require "models/student"
 require "models/toy"
 require "models/comment"
 require "models/cpk"
@@ -31,8 +33,17 @@ class DeleteAllTest < ActiveRecord::TestCase
   def test_delete_all
     davids = Author.where(name: "David")
 
-    assert_difference("Author.count", -1) { davids.delete_all }
+    assert_difference("Author.count", -1) do
+      assert_equal 1, davids.delete_all
+    end
     assert_not_predicate davids, :loaded?
+  end
+
+  def test_delete_all_return_value_ignores_cascades
+    student = Student.create(name: "Ruy Rocha")
+    lesson = Lesson.create(name: "Anything Possible")
+    student.lessons << lesson
+    assert_equal 1, Student.delete_all
   end
 
   def test_delete_all_with_index_hint


### PR DESCRIPTION
### Motivation / Background

Fixes #55178

The [previous change][1] to SQLite's `affected_rows` value switched from `#changes` to `#total_changes` due to `#changes` not being cleared on non-`INSERT/UPDATE/DELETE` statements (meaning `SELECT`s would have `affected_rows` of whatever the last `INSERT/UPDATE/DELETE` was). However, it was pointed out that this value is _also_ inaccurate because it can include "foreign key actions" (specifically, `DELETE` cascades).

### Detail

This commit aims to address both of these issues by combining the usage of `#total_changes` and `#changes`: it uses `#total_changes` to determine whether _any_ rows are affected, and if so, calls `#changes` to get the most accurate value.

[1]: https://github.com/rails/rails/commit/44324036ee0540908f3d1ed53695b95450c74b5d

### Additional information

No CHANGELOG because `affected_rows` in instrumentation/Result is an unreleased feature.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
