### PR TITLE
Omit charset for application/json Content-Types (IANA-compliant)

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -385,4 +385,8 @@
 
     *Petrik de Heus*
 
+*   Omit `charset=utf-8` for `Content-Type: application/json`, per IANA spec (#55063) – @rebase-master
+
+    *Mansoor Khan*
+
 Please check [8-0-stable](https://github.com/rails/rails/blob/8-0-stable/actionpack/CHANGELOG.md) for previous changes.

--- a/actionpack/lib/action_dispatch/http/response.rb
+++ b/actionpack/lib/action_dispatch/http/response.rb
@@ -301,8 +301,14 @@ module ActionDispatch # :nodoc:
       prev_header_info = parsed_content_type_header
       charset = new_header_info.charset || prev_header_info.charset
       charset ||= self.class.default_charset unless prev_header_info.mime_type
-      set_content_type new_header_info.mime_type, charset
+
+      if new_header_info.mime_type == "application/json"
+        set_content_type new_header_info.mime_type, nil
+      else
+        set_content_type new_header_info.mime_type, charset
+      end
     end
+
 
     # Content type of response.
     def content_type
@@ -327,7 +333,10 @@ module ActionDispatch # :nodoc:
     #     response.charset = nil      # => 'utf-8'
     def charset=(charset)
       content_type = parsed_content_type_header.mime_type
-      if false == charset
+
+      # omit charset for pure JSON per IANA spec
+      # https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Content-Type#content-type_in_a_rest_api_using_json
+      if false == charset || content_type == "application/json"
         set_content_type content_type, nil
       else
         set_content_type content_type, charset || self.class.default_charset

--- a/actionpack/test/dispatch/response_test.rb
+++ b/actionpack/test/dispatch/response_test.rb
@@ -665,4 +665,22 @@ class ResponseIntegrationTest < ActionDispatch::IntegrationTest
     # The body should be the same enumerator object, i.e. it should be passed through unchanged:
     assert_equal body, response.body
   end
+
+  test "application/json content type omits charset" do
+    response = ActionDispatch::Response.new
+    # Set content type to pure JSON
+    response.content_type = "application/json"
+    # Should not append charset parameter
+    assert_equal "application/json", response.headers["Content-Type"]
+  end
+
+  test "non-json content type includes default charset" do
+    response = ActionDispatch::Response.new
+    # Set content type to HTML
+    response.content_type = "text/html"
+
+    # Should append default charset when none provided
+    expected = "text/html; charset=#{ActionDispatch::Response.default_charset}"
+    assert_equal expected, response.headers["Content-Type"]
+  end
 end


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background
This Pull Request has been created because Rails was appending `; charset=utf-8` to pure JSON responses (`Content-Type: application/json; charset=utf-8`), which contradicts the IANA registration for `application/json` (no charset parameter defined). [Nik Clayton](https://github.com/nikclayton) reported this in issue [#55063](https://github.com/rails/rails/issues/55063) and we need to align Rails’ behavior with the spec.

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->
This pull request needs to be merged because:

- Bug fix: Corrects non-spec-compliant behavior in JSON APIs so that consumers see exactly Content-Type: application/json. Fixes #55063 
- Interoperability: Some HTTP frameworks and clients strictly parse Content-Type parameters; removing the charset prevents subtle bugs or middleware rejections.
- Consistency with MDN and IANA: Aligns Rails with widely-cited documentation (MDN) and the official media-type registration.
- User impact: Applications serving JSON via Rails APIs will immediately benefit and no longer need manual workarounds.


### Detail

This Pull Request changes:

- Overrides `ActionDispatch::Response#content_type=` so that when the MIME type is exactly `application/json`, Rails uses `set_content_type 'application/json', nil` instead of defaulting to UTF-8.
- Leaves all other content types unchanged, preserving existing charset logic.

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [X] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [X] Tests are added or updated if you fix a bug or add a feature.
* [X] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
