### PR TITLE
Enable configuring Action View's render tracker

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Enable configuring the strategy for tracking dependencies between Action
+    View templates.
+
+    The existing `:regex` strategy is kept as the default, but with
+    `load_defaults 8.1` the strategy will be `:ruby` (using a real Ruby parser).
+
+    *Hartley McGuire*
+
 *   Introduce `relative_time_in_words` helper
 
     ```ruby

--- a/actionview/lib/action_view.rb
+++ b/actionview/lib/action_view.rb
@@ -91,6 +91,9 @@ module ActionView
   autoload :CacheExpiry
   autoload :TestCase
 
+  singleton_class.attr_accessor :render_tracker
+  self.render_tracker = :regex
+
   def self.eager_load!
     super
     ActionView::Helpers.eager_load!

--- a/actionview/lib/action_view/dependency_tracker.rb
+++ b/actionview/lib/action_view/dependency_tracker.rb
@@ -36,6 +36,11 @@ module ActionView
       @trackers.delete(handler)
     end
 
-    register_tracker :erb, ERBTracker
+    case ActionView.render_tracker
+    when :ruby
+      register_tracker :erb, RubyTracker
+    else
+      register_tracker :erb, ERBTracker
+    end
   end
 end

--- a/actionview/lib/action_view/railtie.rb
+++ b/actionview/lib/action_view/railtie.rb
@@ -78,8 +78,13 @@ module ActionView
     end
 
     config.after_initialize do |app|
+      config.after_initialize do
+        ActionView.render_tracker = config.action_view.render_tracker
+      end
+
       ActiveSupport.on_load(:action_view) do
         app.config.action_view.each do |k, v|
+          next if k == :render_tracker
           send "#{k}=", v
         end
       end

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -62,6 +62,7 @@ Below are the default values associated with each target version. In cases of co
 
 - [`config.action_controller.action_on_path_relative_redirect`](#config-action-controller-action-on-path-relative-redirect): `:raise`
 - [`config.action_controller.escape_json_responses`](#config-action-controller-escape-json-responses): `false`
+- [`config.action_view.render_tracker`](#config-action-view-render-tracker): `:ruby`
 - [`config.active_record.raise_on_missing_required_finder_order_columns`](#config-active-record-raise-on-missing-required-finder-order-columns): `true`
 - [`config.yjit`](#config-yjit): `!Rails.env.local?`
 
@@ -2483,6 +2484,15 @@ Configures the set of HTML sanitizers used by Action View by setting `ActionView
 | 7.1                   | `Rails::HTML5::Sanitizer` (see NOTE) | HTML5                  |
 
 NOTE: `Rails::HTML5::Sanitizer` is not supported on JRuby, so on JRuby platforms Rails will fall back to `Rails::HTML4::Sanitizer`.
+
+#### `config.action_view.render_tracker`
+
+Configures the strategy for tracking dependencies between Action View templates.
+
+| Starting with version | The default value is |
+| --------------------- | -------------------- |
+| (original)            | `:regex`             |
+| 8.1                   | `:ruby`              |
 
 ### Configuring Action Mailbox
 

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -364,6 +364,10 @@ module Rails
           if respond_to?(:active_record)
             active_record.raise_on_missing_required_finder_order_columns = true
           end
+
+          if respond_to?(:action_view)
+            action_view.render_tracker = :ruby
+          end
         else
           raise "Unknown version #{target_version.to_s.inspect}"
         end

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_8_1.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_8_1.rb.tt
@@ -51,3 +51,8 @@
 # to only log warnings, or `:notify` to send ActiveSupport notifications.
 #++
 # Rails.configuration.action_controller.action_on_path_relative_redirect = :raise
+
+###
+# Use a Ruby parser to track dependencies between Action View templates
+#++
+# Rails.configuration.action_view.render_tracker = :ruby


### PR DESCRIPTION
### Motivation / Background

Ref #55161

In Rails 7, a new render tracking implementation was [added][1] to Rails: the RipperTracker. From that commit message:

> Using a parser finds dependencies that would otherwise be difficult to
> find with the regular expressions. It should also theoretically work
> with other template systems since it operates on the compiled template
> instead of the contents of the file.

It was initially made the default render tracker, but that change was later [backed out][2].

Since then, the Prism parser was released and made the default Ruby parser. A Prism render tracker implementation was also [added][3] to Rails in 7.2.

### Detail

Until now, there hasn't been a "blessed" way for applications to try out the new tracker implementations (you would have to go through private API). This commit adds configuration to not only make it easy for applications to use the new Ruby-parser-based trackers, but it also makes these new trackers the default for new applications on 8.1.

The new trackers are not only better at finding `render` calls, they are also much easier to maintain. When I [added][4] trailing interpolation tracking to the three trackers, the Prism tracker was by far the easiest to work with.

[1]: https://github.com/rails/rails/commit/897b9bf6e29a9aa7c04d3e4cb96a65665565154d
[2]: https://github.com/rails/rails/commit/41c0681fb7626d036005f8dec559a507ff143874
[3]: https://github.com/rails/rails/commit/d743a2b10fb50dc4702ba4e73955c4f94b3bf700
[4]: https://github.com/rails/rails/commit/13df150c06e37a7024baa655000ae2d7eff9fc0c

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
