### PR TITLE
Fix `include?` on strict-loaded HABTM association

### DIFF
--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -259,10 +259,10 @@ module ActiveRecord
         klass = reflection.klass
         return false unless record.is_a?(klass)
 
-        if record.new_record?
-          include_in_memory?(record)
-        elsif loaded?
+        if loaded?
           target.include?(record)
+        elsif record.new_record?
+          include_in_memory?(record)
         else
           record_id = klass.composite_primary_key? ? klass.primary_key.zip(record.id).to_h : record.id
           scope.exists?(record_id)

--- a/activerecord/test/cases/strict_loading_test.rb
+++ b/activerecord/test/cases/strict_loading_test.rb
@@ -636,6 +636,14 @@ class StrictLoadingTest < ActiveRecord::TestCase
     end
   end
 
+  def test_does_not_raise_when_checking_if_new_record_included_in_eager_loaded_habtm_relation
+    Developer.first.projects << Project.first
+
+    developer = Developer.includes(:projects).strict_loading.first
+
+    assert_nothing_raised { developer.projects.include?(Project.new) }
+  end
+
   def test_strict_loading_violation_raises_by_default
     assert_equal :raise, ActiveRecord.action_on_strict_loading_violation
 


### PR DESCRIPTION
### Motivation / Background

Fix #55183

Previously, trying to check whether a `new_record?` (`Post.new`) is `include?`d in a strict-loaded HABTM association would raise a `StrictLoadingViolationError` even when the HABTM association is already loaded.

### Detail

This commit fixes the issue by always using the `target` if the association is `loaded?` instead of querying the Through association (which is only needed when the association is dirty/has newly built records).

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
