### PR TITLE
Enhance `ActionCable::Channel#stream_for` to allow composite model channels similar to Turbo::Broadcastable.

### DIFF
--- a/actioncable/CHANGELOG.md
+++ b/actioncable/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Allow passing composite channels to `ActionCable::Channel#stream_for` – e.g. `stream_for [ group, group.owner ]`
+
+    *hey-leon*
+
 *   Allow setting nil as subscription connection identifier for Redis.
 
     *Nguyen Nguyen*

--- a/actioncable/lib/action_cable/channel/broadcasting.rb
+++ b/actioncable/lib/action_cable/channel/broadcasting.rb
@@ -10,19 +10,19 @@ module ActionCable
       extend ActiveSupport::Concern
 
       module ClassMethods
-        # Broadcast a hash to a unique broadcasting for this `model` in this channel.
-        def broadcast_to(model, message)
-          ActionCable.server.broadcast(broadcasting_for(model), message)
+        # Broadcast a hash to a unique broadcasting for this array of `broadcastables` in this channel.
+        def broadcast_to(broadcastables, message)
+          ActionCable.server.broadcast(broadcasting_for(broadcastables), message)
         end
 
         # Returns a unique broadcasting identifier for this `model` in this channel:
         #
         #     CommentsChannel.broadcasting_for("all") # => "comments:all"
         #
-        # You can pass any object as a target (e.g. Active Record model), and it would
+        # You can pass an array of objects as a target (e.g. Active Record model), and it would
         # be serialized into a string under the hood.
-        def broadcasting_for(model)
-          serialize_broadcasting([ channel_name, model ])
+        def broadcasting_for(broadcastables)
+          serialize_broadcasting([ channel_name ] + Array(broadcastables))
         end
 
         private

--- a/actioncable/lib/action_cable/channel/streams.rb
+++ b/actioncable/lib/action_cable/channel/streams.rb
@@ -108,15 +108,15 @@ module ActionCable
         end
       end
 
-      # Start streaming the pubsub queue for the `model` in this channel. Optionally,
+      # Start streaming the pubsub queue for the `broadcastables` in this channel. Optionally,
       # you can pass a `callback` that'll be used instead of the default of just
       # transmitting the updates straight to the subscriber.
       #
       # Pass `coder: ActiveSupport::JSON` to decode messages as JSON before passing to
       # the callback. Defaults to `coder: nil` which does no decoding, passes raw
       # messages.
-      def stream_for(model, callback = nil, coder: nil, &block)
-        stream_from(broadcasting_for(model), callback || block, coder: coder)
+      def stream_for(broadcastables, callback = nil, coder: nil, &block)
+        stream_from(broadcasting_for(broadcastables), callback || block, coder: coder)
       end
 
       # Unsubscribes streams from the named `broadcasting`.

--- a/actioncable/test/channel/broadcasting_test.rb
+++ b/actioncable/test/channel/broadcasting_test.rb
@@ -12,7 +12,7 @@ class ActionCable::Channel::BroadcastingTest < ActionCable::TestCase
     @connection = TestConnection.new
   end
 
-  test "broadcasts_to" do
+  test "broadcasts_to with an object" do
     assert_called_with(
       ActionCable.server,
       :broadcast,
@@ -22,6 +22,32 @@ class ActionCable::Channel::BroadcastingTest < ActionCable::TestCase
       ]
     ) do
       ChatChannel.broadcast_to(Room.new(1), "Hello World")
+    end
+  end
+
+  test "broadcasts_to with an array" do
+    assert_called_with(
+      ActionCable.server,
+      :broadcast,
+      [
+        "action_cable:channel:broadcasting_test:chat:Room#1-Campfire:Room#2-Campfire",
+        "Hello World"
+      ]
+    ) do
+      ChatChannel.broadcast_to([ Room.new(1), Room.new(2) ], "Hello World")
+    end
+  end
+
+  test "broadcasts_to with a string" do
+    assert_called_with(
+      ActionCable.server,
+      :broadcast,
+      [
+        "action_cable:channel:broadcasting_test:chat:hello",
+        "Hello World"
+      ]
+    ) do
+      ChatChannel.broadcast_to("hello", "Hello World")
     end
   end
 


### PR DESCRIPTION
<!--
If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)
-->

### Motivation / Background
The `Turbo::Broadcastable#broadcasting_to` API allows you to specify composite channels. Here is an example:

```rb
class DocumentSuggestion < ApplicationModel
  belongs_to :document
  broadcasts_refreshes_to -> { [ it.document, it.document.owner ] }
end
```

This has really useful utility for a lot of use cases. It would be good if `ActionCable::Channel#stream_for` had similar ergonomics.

This Pull Request has been created because I believe it is likely others will find this a nice API to use and likely even expected by others (I did at least).

I do understand that using `Turbo::Streams` is likely a good solution for most ActionCable use cases but there are definitely use cases where piping data instead of HTML still makes sense – e.g. Using ActionCable to facilitate [WebRTC signalling](https://webrtc.org/getting-started/peer-connections).

### Detail
This Pull Request changes `ActionCable::Channel::Broadcasting#stream_for` to allow passing multiple models similar to `Turbo::Broadcastable#broadcasting_to` works.

```rb
class BroadcastSignalChannel < ApplicationCable::Channel
  def subscribed
    return reject unless set_account_broadcast

    stream_for [ @account_broadcast, current_user ]
  end
  
  #...
end
```

### Additional information
I have updated the test suite to include cases covering the enhancements to the API.

### Checklist
Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
