### PR TITLE
Use ntuples to populate row_count instead of count for Postgres

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Use ntuples to populate row_count instead of count for Postgres
+
+    *Jonathan Calvert*
+
 *   Fix checking whether an unpersisted record is `include?`d in a strictly
     loaded `has_and_belongs_to_many` association.
 

--- a/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
@@ -165,7 +165,7 @@ module ActiveRecord
             verified!
 
             notification_payload[:affected_rows] = result.cmd_tuples
-            notification_payload[:row_count] = result.count
+            notification_payload[:row_count] = result.ntuples
             result
           end
 


### PR DESCRIPTION
### Motivation / Background

`PG::Result#ntuples` ([doc](https://deveiate.org/code/pg/PG/Result.html#method-i-ntuples)) uses a libpq function for getting the number of rows returned from a query, whereas `#count` is provided by `Enumerable` and thus iterates through the entire result set. 

### Detail

I first noticed this because upgrading an application where #50887 was added resulted in a performance regression for a number of queries. For larger result sets, iterating through the result set via `#count` makes a noticeable performance difference, whereas `ntuples` will read the returned count directly from the result which is sent as part of the underlying protocol.

### Additional information

Benchmarking with 100k queries that retrieve 10 rows in my development instance this change was 18% faster in wall clock time and a whopping 44% less user CPU time. This also results in fewer `T_DATA` allocations in ObjectSpace to be garbage collected later. The performance of iterating through the results is linear time complexity so with more rows the difference is more pronounced 

```
ActiveRecord::Base.with_connection do |conn|
  Benchmark.ips do |x|
    x.report("count") do
      conn.raw_execute("SELECT * FROM schema_migrations", "SQL")
    end
    x.hold! "count_ntuple" # apply patch here
    x.report("ntuple") do
      conn.raw_execute("SELECT * FROM schema_migrations", "SQL")
    end
  end
end
```

With a 1000 rows gives me 

```
Warming up --------------------------------------
             ntuples   487.000  i/100ms
Calculating -------------------------------------
             ntuples      4.921k (± 4.2%) i/s -     24.837k in   5.058571s

Comparison:
             ntuples:     4920.6 i/s
               count:     2309.9 i/s - 2.13x  slower
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
