### PR TITLE
Prevent the `stream_from` method throwing RuntimeError

### DIFF
--- a/actioncable/lib/action_cable/channel/base.rb
+++ b/actioncable/lib/action_cable/channel/base.rb
@@ -165,6 +165,7 @@ module ActionCable
 
         @reject_subscription = nil
         @subscription_confirmation_sent = nil
+        @unsubscribed = false
 
         delegate_connection_identifiers
       end
@@ -200,9 +201,14 @@ module ActionCable
       # cleanup with callbacks. This method is not intended to be called directly by
       # the user. Instead, override the #unsubscribed callback.
       def unsubscribe_from_channel # :nodoc:
+        @unsubscribed = true
         run_callbacks :unsubscribe do
           unsubscribed
         end
+      end
+
+      def unsubscribed? # :nodoc:
+        @unsubscribed
       end
 
       private

--- a/actioncable/lib/action_cable/channel/streams.rb
+++ b/actioncable/lib/action_cable/channel/streams.rb
@@ -88,6 +88,8 @@ module ActionCable
       # callback. Defaults to `coder: nil` which does no decoding, passes raw
       # messages.
       def stream_from(broadcasting, callback = nil, coder: nil, &block)
+        return if unsubscribed?
+
         broadcasting = String(broadcasting)
 
         # Don't send the confirmation until pubsub#subscribe is successful

--- a/actioncable/test/channel/base_test.rb
+++ b/actioncable/test/channel/base_test.rb
@@ -126,6 +126,16 @@ class ActionCable::Channel::BaseTest < ActionCable::TestCase
     assert_not_predicate @channel, :subscribed?
   end
 
+  test "unsubscribed? method returns correct status" do
+    assert_not @channel.unsubscribed?
+
+    @channel.subscribe_to_channel
+    assert_not @channel.unsubscribed?
+
+    @channel.unsubscribe_from_channel
+    assert @channel.unsubscribed?
+  end
+
   test "connection identifiers" do
     assert_equal @user.name, @channel.current_user.name
   end

--- a/actioncable/test/stubs/test_adapter.rb
+++ b/actioncable/test/stubs/test_adapter.rb
@@ -1,6 +1,13 @@
 # frozen_string_literal: true
 
 class SuccessAdapter < ActionCable::SubscriptionAdapter::Base
+  attr_accessor :unsubscribe_latency
+
+  def initialize(...)
+    super
+    @unsubscribe_latency = nil
+  end
+
   def broadcast(channel, payload)
   end
 
@@ -10,7 +17,7 @@ class SuccessAdapter < ActionCable::SubscriptionAdapter::Base
   end
 
   def unsubscribe(channel, callback)
-    sleep ENV["UNSUBSCRIBE_SLEEP_TIME"].to_f if ENV["UNSUBSCRIBE_SLEEP_TIME"]
+    sleep @unsubscribe_latency if @unsubscribe_latency
     subscriber_map[channel].delete(callback)
     subscriber_map.delete(channel) if subscriber_map[channel].empty?
     @@unsubscribe_called = { channel: channel, callback: callback }

--- a/actioncable/test/stubs/test_adapter.rb
+++ b/actioncable/test/stubs/test_adapter.rb
@@ -10,6 +10,7 @@ class SuccessAdapter < ActionCable::SubscriptionAdapter::Base
   end
 
   def unsubscribe(channel, callback)
+    sleep ENV["UNSUBSCRIBE_SLEEP_TIME"].to_f if ENV["UNSUBSCRIBE_SLEEP_TIME"]
     subscriber_map[channel].delete(callback)
     subscriber_map.delete(channel) if subscriber_map[channel].empty?
     @@unsubscribe_called = { channel: channel, callback: callback }


### PR DESCRIPTION
Prevent the `stream_from` method throwing  

### Motivation / Background

When the channel's subscribed method executes slowly, and uses stream_from method. 
At same time another thread triggers the channel's unsubscribed method. 
The stream_from method will throw RuntimeError(can't add a new key into hash during iteration).
Because the unsubscribed callback is iterating over the channel's @_streams instance hash, while the stream_from method is also trying to add a new key to the @_streams instance hash.

### Detail

Before executing the `unsubscribed` callback when a channel is unsubscribed, set the `@unsubscribed` instance variable first. Before calling the `stream_from` method, check the status of `@unsubscribed` to decide whether to continue proceeding.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
