### PR TITLE
Add `dom_target` helper to create `dom_id`-like strings from an unlimited number of objects

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Add `dom_target` helper to create `dom_id`-like strings from an unlimited
+    number of objects.
+
+    *Ben Sheldon*
+
 *   Respect `html_options[:form]` when `collection_checkboxes` generates the
     hidden `<input>`.
 

--- a/actionview/lib/action_view/record_identifier.rb
+++ b/actionview/lib/action_view/record_identifier.rb
@@ -101,6 +101,27 @@ module ActionView
       end
     end
 
+    # The DOM target convention is to concatenate any number of parameters into a string.
+    # Records are passed through dom_id, while string and symbols are retained.
+    #
+    #   dom_target(Post.find(45))                  # => "post_45"
+    #   dom_target(Post.find(45), :edit)           # => "post_45_edit"
+    #   dom_target(Post.find(45), :edit, :special) # => "post_45_edit_special"
+    #   dom_target(Post.find(45), Comment.find(1)) # => "post_45_comment_1"
+    def dom_target(*objects)
+      objects.map! do |object|
+        case object
+        when Symbol, String
+          object
+        when Class
+          dom_class(object)
+        else
+          dom_id(object)
+        end
+      end
+      objects.join(JOIN)
+    end
+
   private
     # Returns a string representation of the key attribute(s) that is suitable for use in an HTML DOM id.
     # This can be overwritten to customize the default generated string representation if desired.

--- a/actionview/test/template/record_identifier_test.rb
+++ b/actionview/test/template/record_identifier_test.rb
@@ -56,6 +56,16 @@ class RecordIdentifierTest < ActiveSupport::TestCase
   def test_dom_class_as_singleton_method
     assert_equal @singular, ActionView::RecordIdentifier.dom_class(@record)
   end
+
+  def test_dom_target_with_multiple_objects
+    @record.save
+    assert_equal "foo_bar_comment_comment_1_new_comment", dom_target(:foo, "bar", @klass, @record, @klass.new)
+  end
+
+  def test_dom_target_as_singleton_method
+    @record.save
+    assert_equal "#{@singular}_#{@record.id}", ActionView::RecordIdentifier.dom_target(@record)
+  end
 end
 
 class RecordIdentifierWithoutActiveModelTest < ActiveSupport::TestCase
@@ -109,5 +119,15 @@ class RecordIdentifierWithoutActiveModelTest < ActiveSupport::TestCase
 
   def test_dom_class_as_singleton_method
     assert_equal "airplane", ActionView::RecordIdentifier.dom_class(@record)
+  end
+
+  def test_dom_target_with_multiple_objects
+    @record.save
+    assert_equal "foo_bar_airplane_airplane_1_new_airplane", dom_target(:foo, "bar", @klass, @record, @klass.new)
+  end
+
+  def test_dom_target_as_singleton_method
+    @record.save
+    assert_equal "airplane_1", ActionView::RecordIdentifier.dom_target(@record)
   end
 end


### PR DESCRIPTION
<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created because it's increasingly necessary to create complex DOM identifiers and the existing `dom_id` is limited.

This PR creates a new method `ActionView::RecordIdentifier#dom_target` that can create a unique identifier from an unlimited number of objects, which differentiates it from `dom_id` which only takes a single object and an optional string prefix.

```ruby
dom_target(Post.find(45))                  # => "post_45"
dom_target(Post.find(45), :edit)           # => "post_45_edit"
dom_target(Post.find(45), :edit, :special) # => "post_45_edit_special"
dom_target(Post.find(45), Comment.find(1)) # => "post_45_comment_1"
```

I chose the name of `target` because I found myself wanting this for generating `turbo-rails` Turbo Broadcast targets. `dom_target` is inspired by the structure of `turbo_stream_from(*streamables)`, which concatenates an unlimited number of objects into a single identifier.

Adding an new helper method is proposed as an alternative to adding new behavior to existing `dom_id` or `dom_class` helper methods, which had questions/objections. Related:

- #44081
- #50608
- https://github.com/hotwired/turbo-rails/issues/543

### Additional information

<!-- Provide additional information such as benchmarks, references to other repositories, or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
