### PR TITLE
Ensure yarn and bun version fallback

### DIFF
--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -540,20 +540,27 @@ module Rails
       end
 
       def dockerfile_yarn_version
-        using_node? and `yarn --version`[/\d+\.\d+\.\d+/]
-      rescue
-        "latest"
+        version = begin
+          `yarn --version`[/\d+\.\d+\.\d+/]
+        rescue
+          nil
+        end
+
+        version || "latest"
       end
 
       def yarn_through_corepack?
-        true if dockerfile_yarn_version == "latest"
-        dockerfile_yarn_version >= "2"
+        using_node? and "#{dockerfile_yarn_version}" >= "2"
       end
 
       def dockerfile_bun_version
-        using_bun? and `bun --version`[/\d+\.\d+\.\d+/]
-      rescue
-        BUN_VERSION
+        version = begin
+          `bun --version`[/\d+\.\d+\.\d+/]
+        rescue
+          nil
+        end
+
+        version || BUN_VERSION
       end
 
       def dockerfile_binfile_fixups

--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -529,24 +529,22 @@ module Rails
         using_js_runtime? && %w[bun].include?(options[:javascript])
       end
 
+      def capture_command(command, pattern)
+        `#{command}`[pattern]
+      rescue SystemCallError
+        nil
+      end
+
       def node_version
         if using_node?
           ENV.fetch("NODE_VERSION") do
-            `node --version`[/\d+\.\d+\.\d+/]
-          rescue
-            NODE_LTS_VERSION
+            capture_command("node --version", /\d+\.\d+\.\d+/) || NODE_LTS_VERSION
           end
         end
       end
 
       def dockerfile_yarn_version
-        version = begin
-          `yarn --version`[/\d+\.\d+\.\d+/]
-        rescue
-          nil
-        end
-
-        version || "latest"
+        capture_command("yarn --version", /\d+\.\d+\.\d+/) || "latest"
       end
 
       def yarn_through_corepack?
@@ -554,13 +552,7 @@ module Rails
       end
 
       def dockerfile_bun_version
-        version = begin
-          `bun --version`[/\d+\.\d+\.\d+/]
-        rescue
-          nil
-        end
-
-        version || BUN_VERSION
+        capture_command("bun --version", /\d+\.\d+\.\d+/) || BUN_VERSION
       end
 
       def dockerfile_binfile_fixups


### PR DESCRIPTION
If we allow the `version` methods to return nil, it's possible to end up
in a situation where Dockerfile contains something like

```
ARG BUN_VERSION=
```

This can occur when bun or yarn are not installed locally on the current
version of node, and using a version manager like `nodenv`.

In this case, `rails new` would previously raise an error:

```
nodenv: yarn: command not found

The `yarn' command exists in these Node versions:
  20.15.0

E

Error:
AppGeneratorTest#test_css_option_with_cssbundling_gem_does_not_force_jsbundling_gem:
NoMethodError: undefined method '>=' for nil
    lib/rails/generators/app_base.rb:550:in 'Rails::Generators::AppBase#yarn_through_corepack?'
    lib/rails/generators/rails/app/templates/Dockerfile.tt:41:in 'Thor::Actions#template'
```

By ensuring we fallback to a non-nil value we can ensure this case
doesn't occur.

<details>
<summary>Full example:</summary>

```
$ bundle exec railties/exe/rails new ~/code/apps/TestApp_EsBuild_Tailwind_Pg -j=esbuild -c=tailwind -d=postgresql --dev

nodenv: yarn: command not found

The `yarn' command exists in these Node versions:
  20.15.0

nodenv: yarn: command not found

The `yarn' command exists in these Node versions:
  20.15.0

nodenv: yarn: command not found

The `yarn' command exists in these Node versions:
  20.15.0

bundler: failed to load command: railties/exe/rails (railties/exe/rails)
/home/zzak/code/rails/railties/lib/rails/generators/app_base.rb:550:in 'Rails::Generators::AppBase#yarn_through_corepack?': undefined method '>=' for nil (NoMethodError)

        dockerfile_yarn_version >= "2"
                                ^^
        from /home/zzak/code/rails/railties/lib/rails/generators/rails/app/templates/Dockerfile.tt:41:in 'Thor::Actions#template'
        from /home/zzak/.rbenv/versions/3.4.4/lib/ruby/3.4.0/erb.rb:429:in 'Kernel#eval'
        from /home/zzak/.rbenv/versions/3.4.4/lib/ruby/3.4.0/erb.rb:429:in 'ERB#result'
        from /home/zzak/.rbenv/versions/3.4.4/lib/ruby/gems/3.4.0/gems/thor-1.3.2/lib/thor/actions/file_manipulation.rb:128:in 'block in Thor::Actions#template'
        from /home/zzak/.rbenv/versions/3.4.4/lib/ruby/gems/3.4.0/gems/thor-1.3.2/lib/thor/actions/create_file.rb:54:in 'Thor::Actions::CreateFile#render'
        from /home/zzak/.rbenv/versions/3.4.4/lib/ruby/gems/3.4.0/gems/thor-1.3.2/lib/thor/actions/create_file.rb:64:in 'block (2 levels) in Thor::Actions::CreateFile#invoke!'
        from /home/zzak/.rbenv/versions/3.4.4/lib/ruby/gems/3.4.0/gems/thor-1.3.2/lib/thor/actions/create_file.rb:64:in 'IO.open'
        from /home/zzak/.rbenv/versions/3.4.4/lib/ruby/gems/3.4.0/gems/thor-1.3.2/lib/thor/actions/create_file.rb:64:in 'block in Thor::Actions::CreateFile#invoke!'
        from /home/zzak/.rbenv/versions/3.4.4/lib/ruby/gems/3.4.0/gems/thor-1.3.2/lib/thor/actions/empty_directory.rb:117:in 'Thor::Actions::EmptyDirectory#invoke_with_conflict_check'
        from /home/zzak/.rbenv/versions/3.4.4/lib/ruby/gems/3.4.0/gems/thor-1.3.2/lib/thor/actions/create_file.rb:61:in 'Thor::Actions::CreateFile#invoke!'
        from /home/zzak/.rbenv/versions/3.4.4/lib/ruby/gems/3.4.0/gems/thor-1.3.2/lib/thor/actions.rb:93:in 'Thor::Actions#action'
        from /home/zzak/.rbenv/versions/3.4.4/lib/ruby/gems/3.4.0/gems/thor-1.3.2/lib/thor/actions/create_file.rb:25:in 'Thor::Actions#create_file'
        from /home/zzak/.rbenv/versions/3.4.4/lib/ruby/gems/3.4.0/gems/thor-1.3.2/lib/thor/actions/file_manipulation.rb:124:in 'Thor::Actions#template'
        from /home/zzak/code/rails/railties/lib/rails/generators/rails/app/app_generator.rb:20:in 'Rails::ActionMethods#template'
        from /home/zzak/code/rails/railties/lib/rails/generators/rails/app/app_generator.rb:79:in 'Rails::AppBuilder#dockerfiles'
        from /home/zzak/code/rails/railties/lib/rails/generators/app_base.rb:174:in 'Kernel#public_send'
        from /home/zzak/code/rails/railties/lib/rails/generators/app_base.rb:174:in 'Rails::Generators::AppBase#build'
        from /home/zzak/code/rails/railties/lib/rails/generators/rails/app/app_generator.rb:402:in 'Rails::Generators::AppGenerator#create_dockerfiles'
        from /home/zzak/.rbenv/versions/3.4.4/lib/ruby/gems/3.4.0/gems/thor-1.3.2/lib/thor/command.rb:28:in 'Thor::Command#run'
        from /home/zzak/.rbenv/versions/3.4.4/lib/ruby/gems/3.4.0/gems/thor-1.3.2/lib/thor/invocation.rb:127:in 'Thor::Invocation#invoke_command'
        from /home/zzak/.rbenv/versions/3.4.4/lib/ruby/gems/3.4.0/gems/thor-1.3.2/lib/thor/invocation.rb:134:in 'block in Thor::Invocation#invoke_all'
        from /home/zzak/.rbenv/versions/3.4.4/lib/ruby/gems/3.4.0/gems/thor-1.3.2/lib/thor/invocation.rb:134:in 'Hash#each'
        from /home/zzak/.rbenv/versions/3.4.4/lib/ruby/gems/3.4.0/gems/thor-1.3.2/lib/thor/invocation.rb:134:in 'Enumerable#map'
        from /home/zzak/.rbenv/versions/3.4.4/lib/ruby/gems/3.4.0/gems/thor-1.3.2/lib/thor/invocation.rb:134:in 'Thor::Invocation#invoke_all'
        from /home/zzak/.rbenv/versions/3.4.4/lib/ruby/gems/3.4.0/gems/thor-1.3.2/lib/thor/group.rb:243:in 'Thor::Group.dispatch'
        from /home/zzak/.rbenv/versions/3.4.4/lib/ruby/gems/3.4.0/gems/thor-1.3.2/lib/thor/base.rb:584:in 'Thor::Base::ClassMethods#start'
        from /home/zzak/code/rails/railties/lib/rails/commands/application/application_command.rb:28:in 'Rails::Command::ApplicationCommand#perform'
        from /home/zzak/.rbenv/versions/3.4.4/lib/ruby/gems/3.4.0/gems/thor-1.3.2/lib/thor/command.rb:28:in 'Thor::Command#run'
        from /home/zzak/.rbenv/versions/3.4.4/lib/ruby/gems/3.4.0/gems/thor-1.3.2/lib/thor/invocation.rb:127:in 'Thor::Invocation#invoke_command'
        from /home/zzak/code/rails/railties/lib/rails/command/base.rb:176:in 'Rails::Command::Base#invoke_command'
        from /home/zzak/.rbenv/versions/3.4.4/lib/ruby/gems/3.4.0/gems/thor-1.3.2/lib/thor.rb:538:in 'Thor.dispatch'
        from /home/zzak/code/rails/railties/lib/rails/command/base.rb:71:in 'Rails::Command::Base.perform'
        from /home/zzak/code/rails/railties/lib/rails/command.rb:65:in 'block in Rails::Command.invoke'
        from /home/zzak/code/rails/railties/lib/rails/command.rb:143:in 'Rails::Command.with_argv'
        from /home/zzak/code/rails/railties/lib/rails/command.rb:63:in 'Rails::Command.invoke'
        from /home/zzak/code/rails/railties/lib/rails/cli.rb:20:in '<top (required)>'
        from /home/zzak/.rbenv/versions/3.4.4/lib/ruby/3.4.0/bundled_gems.rb:82:in 'Kernel.require'
        from /home/zzak/.rbenv/versions/3.4.4/lib/ruby/3.4.0/bundled_gems.rb:82:in 'block (2 levels) in Kernel#replace_require'
        from railties/exe/rails:10:in '<top (required)>'
        from /home/zzak/.rbenv/versions/3.4.4/lib/ruby/gems/3.4.0/gems/bundler-2.6.2/lib/bundler/cli/exec.rb:59:in 'Kernel.load'
        from /home/zzak/.rbenv/versions/3.4.4/lib/ruby/gems/3.4.0/gems/bundler-2.6.2/lib/bundler/cli/exec.rb:59:in 'Bundler::CLI::Exec#kernel_load'
        from /home/zzak/.rbenv/versions/3.4.4/lib/ruby/gems/3.4.0/gems/bundler-2.6.2/lib/bundler/cli/exec.rb:23:in 'Bundler::CLI::Exec#run'
        from /home/zzak/.rbenv/versions/3.4.4/lib/ruby/gems/3.4.0/gems/bundler-2.6.2/lib/bundler/cli.rb:452:in 'Bundler::CLI#exec'
        from /home/zzak/.rbenv/versions/3.4.4/lib/ruby/gems/3.4.0/gems/bundler-2.6.2/lib/bundler/vendor/thor/lib/thor/command.rb:28:in 'Bundler::Thor::Command#run'
        from /home/zzak/.rbenv/versions/3.4.4/lib/ruby/gems/3.4.0/gems/bundler-2.6.2/lib/bundler/vendor/thor/lib/thor/invocation.rb:127:in 'Bundler::Thor::Invocation#invoke_command'
        from /home/zzak/.rbenv/versions/3.4.4/lib/ruby/gems/3.4.0/gems/bundler-2.6.2/lib/bundler/vendor/thor/lib/thor.rb:538:in 'Bundler::Thor.dispatch'
        from /home/zzak/.rbenv/versions/3.4.4/lib/ruby/gems/3.4.0/gems/bundler-2.6.2/lib/bundler/cli.rb:35:in 'Bundler::CLI.dispatch'
        from /home/zzak/.rbenv/versions/3.4.4/lib/ruby/gems/3.4.0/gems/bundler-2.6.2/lib/bundler/vendor/thor/lib/thor/base.rb:584:in 'Bundler::Thor::Base::ClassMethods#start'
        from /home/zzak/.rbenv/versions/3.4.4/lib/ruby/gems/3.4.0/gems/bundler-2.6.2/lib/bundler/cli.rb:29:in 'Bundler::CLI.start'
        from /home/zzak/.rbenv/versions/3.4.4/lib/ruby/gems/3.4.0/gems/bundler-2.6.2/exe/bundle:28:in 'block in <top (required)>'
        from /home/zzak/.rbenv/versions/3.4.4/lib/ruby/gems/3.4.0/gems/bundler-2.6.2/lib/bundler/friendly_errors.rb:117:in 'Bundler.with_friendly_errors'
        from /home/zzak/.rbenv/versions/3.4.4/lib/ruby/gems/3.4.0/gems/bundler-2.6.2/exe/bundle:20:in '<top (required)>'
        from /home/zzak/.rbenv/versions/3.4.4/bin/bundle:25:in 'Kernel#load'
        from /home/zzak/.rbenv/versions/3.4.4/bin/bundle:25:in '<main>'
[ble: exit 1]
```

</details>