### PR TITLE
Remove documentation for non existing ColumnMethods#column [ci skip]

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
@@ -328,17 +328,6 @@ module ActiveRecord
         column(name, type, **options, primary_key: true)
       end
 
-      ##
-      # :method: column
-      # :call-seq: column(name, type, **options)
-      #
-      # Appends a column or columns of a specified type.
-      #
-      #  t.string(:goat)
-      #  t.string(:goat, :sheep)
-      #
-      # See TableDefinition#column
-
       define_column_methods :bigint, :binary, :boolean, :date, :datetime, :decimal,
         :float, :integer, :json, :string, :text, :time, :timestamp, :virtual
 


### PR DESCRIPTION
### Motivation / Background

The `column` method is [defined](https://github.com/rails/rails/blob/1921f0fef60983d6423b937884de5e83b2619960/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb#L495) (and documented) on `TableDefinition` not on `ColumnMethods`.
So there is no need to document it on `ColumnMethods`.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
