### PR TITLE
Active Job Continuation isolated steps

### DIFF
--- a/activejob/lib/active_job/continuable.rb
+++ b/activejob/lib/active_job/continuable.rb
@@ -33,7 +33,7 @@ module ActiveJob
     attr_accessor :continuation # :nodoc:
 
     # Start a new continuation step
-    def step(step_name, start: nil, &block)
+    def step(step_name, start: nil, isolated: false, &block)
       unless block_given?
         step_method = method(step_name)
 
@@ -46,7 +46,7 @@ module ActiveJob
         block = step_method.arity == 0 ? -> (_) { step_method.call } : step_method
       end
       checkpoint! if continuation.advanced?
-      continuation.step(step_name, start: start, &block)
+      continuation.step(step_name, start: start, isolated: isolated, &block)
     end
 
     def serialize # :nodoc:
@@ -60,7 +60,12 @@ module ActiveJob
     end
 
     def checkpoint! # :nodoc:
-      interrupt! if queue_adapter.stopping?
+      interrupt!(reason: :stopping) if queue_adapter.stopping?
+    end
+
+    def interrupt!(reason:) # :nodoc:
+      instrument :interrupt, reason: reason, **continuation.instrumentation
+      raise Continuation::Interrupt, "Interrupted #{continuation.description} (#{reason})"
     end
 
     private
@@ -90,11 +95,6 @@ module ActiveJob
         else
           raise Continuation::ResumeLimitError, "Job was resumed a maximum of #{max_resumptions} times"
         end
-      end
-
-      def interrupt! # :nodoc:
-        instrument :interrupt, **continuation.instrumentation
-        raise Continuation::Interrupt, "Interrupted #{continuation.description}"
       end
   end
 

--- a/activejob/lib/active_job/continuation.rb
+++ b/activejob/lib/active_job/continuation.rb
@@ -150,6 +150,21 @@ module ActiveJob
   # - a list of the completed steps
   # - the current step and its cursor value (if one is in progress)
   #
+  # === Isolated Steps
+  #
+  # Steps run sequentially in a single job execution, unless the job is interrupted.
+  #
+  # You can specify that a step should always run in its own execution by passing the +isolated: true+ option.
+  #
+  # This is useful for long-running steps where it may not be possible to checkpoint within
+  # the job grace period - it ensures that progress is serialized back into the job data before
+  # the step starts.
+  #
+  #   step :quick_step1
+  #   step :slow_step, isolated: true
+  #   step :quick_step2
+  #   step :quick_step3
+  #
   # === Errors
   #
   # If a job raises an error and is not retried via Active Job, it will be passed back to the underlying
@@ -204,23 +219,24 @@ module ActiveJob
       @encountered = []
       @advanced = false
       @running_step = false
+      @isolating = false
     end
 
-    def step(name, start:, &block) # :nodoc:
+    def step(name, **options, &block) # :nodoc:
       validate_step!(name)
       encountered << name
 
       if completed?(name)
         skip_step(name)
       else
-        run_step(name, start: start, &block)
+        run_step(name, **options, &block)
       end
     end
 
     def to_h # :nodoc:
       {
         "completed" => completed.map(&:to_s),
-        "current" => current&.to_a
+        "current" => current&.to_a,
       }.compact
     end
 
@@ -255,6 +271,10 @@ module ActiveJob
         @running_step
       end
 
+      def isolating?
+        @isolating
+      end
+
       def completed?(name)
         completed.include?(name)
       end
@@ -267,7 +287,17 @@ module ActiveJob
         instrument :step_skipped, step: name
       end
 
-      def run_step(name, start:, &block)
+      def run_step(name, start:, isolated:, &block)
+        @isolating ||= isolated
+
+        if isolating? && advanced?
+          job.interrupt!(reason: :isolating)
+        else
+          run_step_inline(name, start: start, &block)
+        end
+      end
+
+      def run_step_inline(name, start:, **options, &block)
         @running_step = true
         @current ||= new_step(name, start, resumed: false)
 

--- a/activejob/lib/active_job/log_subscriber.rb
+++ b/activejob/lib/active_job/log_subscriber.rb
@@ -141,7 +141,7 @@ module ActiveJob
     def interrupt(event)
       job = event.payload[:job]
       info do
-        "Interrupted #{job.class} (Job ID: #{job.job_id}) #{event.payload[:description]}"
+        "Interrupted #{job.class} (Job ID: #{job.job_id}) #{event.payload[:description]} (#{event.payload[:reason]})"
       end
     end
     subscribe_log_level :interrupt, :info


### PR DESCRIPTION
Add an isolated option to steps. Defaults to false.

Isolated steps are always run in their own job execution. We do this by interrupting the job before running a step if both:

1. It is not the first step we've run in this execution
2. Either this step or the previous one was marked as isolated.

The first to be run in an execution is always run inline so we don't end up in an infinite loop of interruptions.

This allows you to execute a long running step separately which is useful to ensure that progress is saved before it runs.

