### PR TITLE
Respect users configured `IRB.conf[:IRB_NAME]`

### DIFF
--- a/railties/lib/rails/commands/console/irb_console.rb
+++ b/railties/lib/rails/commands/console/irb_console.rb
@@ -87,7 +87,8 @@ module Rails
 
         env = colorized_env
         prompt_prefix = "%N(#{env})"
-        IRB.conf[:IRB_NAME] = @app.name
+        # Respect user's configured irb name.
+        IRB.conf[:IRB_NAME] = @app.name if IRB.conf[:IRB_NAME] == "irb"
 
         IRB.conf[:PROMPT][:RAILS_PROMPT] = {
           PROMPT_I: "#{prompt_prefix}:%03n> ",

--- a/railties/test/application/console_test.rb
+++ b/railties/test/application/console_test.rb
@@ -242,6 +242,21 @@ class FullStackConsoleTest < ActiveSupport::TestCase
     write_prompt "User.new.respond_to?(:age)", "=> true"
   end
 
+  def test_console_respects_user_defined_irb_name
+    irbrc = Tempfile.new("irbrc")
+    irbrc.write <<-RUBY
+      IRB.conf[:IRB_NAME] = "jarretts-irb"
+    RUBY
+    irbrc.close
+
+    options = "-e test"
+    spawn_console(options, env: { "IRBRC" => irbrc.path })
+
+    write_prompt "123", prompt: "jarretts-irb(test):002> "
+  ensure
+    File.unlink(irbrc)
+  end
+
   def test_console_respects_user_defined_prompt_mode
     irbrc = Tempfile.new("irbrc")
     irbrc.write <<-RUBY


### PR DESCRIPTION
### Details

If a user has configured `IRB_NAME` in their IRB configuration, Rails is overriding it. This PR makes it so the `IRB_NAME` is only set if it is not the default, similar to the way the `PROMPT_MODE` is set.

### Example

In my projects `.irbrc` I had the following. I had to dig into the Rails code to figure out why this no longer worked after upgrading to the latest version because of the override.

```ruby
project_name = colorize(File.basename(Dir.pwd), :blue)
if Rails.env.development?
  IRB.conf[:IRB_NAME] = project_name
else
  environment = case Rails.env
    when 'staging' then colorize('STAG', :yellow)
    when 'production' then colorize('PROD', :red)
    when 'test' then colorize('TEST', :yellow)
  end
  IRB.conf[:IRB_NAME] = "#{project_name}[#{environment}]"
end
IRB.conf[:PROMPT][:RAILS] = {
  PROMPT_I: '%N(%m):%n> ',
  PROMPT_S: '%N(%m):%n%l ',
  PROMPT_C: '%N(%m):%n* ',
  RETURN: "=> %s\n",
  AUTO_INDENT: true
}
IRB.conf[:PROMPT_MODE] = :RAILS
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
